### PR TITLE
chore: add CLAUDE.md with git workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+## Git workflow
+
+- **Never push directly to main.** Always create a feature branch and open a PR.
+- Branch protection is enforced via GitHub rulesets (require PR, no deletion, no force-push).
+- Branches are auto-deleted after merge.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with git workflow rules: always use PRs, never push directly to main

## Test plan

- [x] Verify CLAUDE.md is picked up by Claude Code in future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)