### PR TITLE
docs: remove em dashes from dev-apprenticeship READMEs

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -1,6 +1,6 @@
 # Dev Apprenticeship
 
-A federation of agent colonies that learns a developer's complete workflow by observing how they work — from triaging issues to shipping releases.
+A federation of agent colonies that learns a developer's complete workflow by observing how they work, from triaging issues to shipping releases.
 
 Each colony specializes in one part of the workflow. Together, they form a federation that covers the entire development lifecycle.
 
@@ -8,11 +8,11 @@ Each colony specializes in one part of the workflow. Together, they form a feder
 
 | Colony | Description | Status |
 |--------|-------------|--------|
-| [code-review](./code-review/) | Reviews merge requests — style, logic, security, test coverage, approval decisions (5 agents) | Active |
-| [planning](./planning/) | Breaks down work — scope estimation, risk assessment, task decomposition, plan review (4 agents) | Active |
-| [implementation](./implementation/) | Writes and refactors code — code generation, test writing, commit conventions (4 agents) | Active |
-| [triage](./triage/) | Manages issues — creation, prioritization, labeling, routing (4 agents) | Active |
-| [release](./release/) | Automates releases — ship decisions, changelogs, versioning, pre-release checks (4 agents) | Active |
+| [code-review](./code-review/) | Reviews merge requests: style, logic, security, test coverage, approval decisions (5 agents) | Active |
+| [planning](./planning/) | Breaks down work: scope estimation, risk assessment, task decomposition, plan review (4 agents) | Active |
+| [implementation](./implementation/) | Writes and refactors code: code generation, test writing, commit conventions (4 agents) | Active |
+| [triage](./triage/) | Manages issues: creation, prioritization, labeling, routing (4 agents) | Active |
+| [release](./release/) | Automates releases: ship decisions, changelogs, versioning, pre-release checks (4 agents) | Active |
 
 ## Why Colonies, Not Individual Agents?
 
@@ -20,15 +20,15 @@ A colony is fundamentally different from a bag of standalone agents doing separa
 
 **Shared context.** Agents within a colony communicate via `emit`/`listen` over the colony bus. When the style-reviewer flags a naming issue, the logic-reviewer already knows and won't produce a conflicting suggestion. Standalone agents would each operate in isolation, often contradicting each other.
 
-**Specialization with emergent behavior.** Each agent is an expert in its narrow domain, but the colony as a whole solves problems none of them could handle alone. A code review isn't just five independent checks — it's a coordinated assessment where findings from one reviewer inform the others.
+**Specialization with emergent behavior.** Each agent is an expert in its narrow domain, but the colony as a whole solves problems none of them could handle alone. A code review isn't just five independent checks, it's a coordinated assessment where findings from one reviewer inform the others.
 
-**Shared evolution.** Agents in a colony share evolutionary pressure. When the colony succeeds (the human approves its output), all agents improve together. When it fails, the fitness signal propagates to every agent — not just the one that made the visible mistake.
+**Shared evolution.** Agents in a colony share evolutionary pressure. When the colony succeeds (the human approves its output), all agents improve together. When it fails, the fitness signal propagates to every agent, not just the one that made the visible mistake.
 
 **Economic efficiency.** Agents share a Cognitive Budget (CB) pool. Resources flow to where they're most needed: a complex MR sends more budget to the logic-reviewer, a routine rename sends more to the style-reviewer. Standalone agents would each burn their fixed budget regardless of what the task actually needs.
 
 **Resilience.** When one agent degrades or fails, the others continue and compensate. The colony adapts its behavior rather than producing incomplete output.
 
-**Colony-level governance.** The operator sets rules, budgets, and autonomy thresholds for the entire colony — not for each agent individually. This makes the system manageable as the number of agents grows.
+**Colony-level governance.** The operator sets rules, budgets, and autonomy thresholds for the entire colony, not for each agent individually. This makes the system manageable as the number of agents grows.
 
 Colonies form a natural multi-agent team that is more robust and efficient than the same number of standalone agents.
 
@@ -62,7 +62,7 @@ graph TD
 
 ## Autonomy Gradient
 
-Every agent starts in **observe** mode — watching the human work, building confidence from accumulated experience. As confidence grows, autonomy increases:
+Every agent starts in **observe** mode, watching the human work, building confidence from accumulated experience. As confidence grows, autonomy increases:
 
 | Confidence | Mode | Behavior |
 |------------|------|----------|
@@ -76,11 +76,11 @@ This gradient applies at every level: individual agents gain autonomy within the
 
 Knowledge entries are tagged by scope:
 
-- `personal` — developer preferences, quality bar, review criteria. Portable across projects.
-- `project:<name>` — codebase-specific patterns, file coupling, false positive patterns. Stays with the project.
-- `team:<name>` — shared across team members via federation. (Future)
+- `personal`: developer preferences, quality bar, review criteria. Portable across projects.
+- `project:<name>`: codebase-specific patterns, file coupling, false positive patterns. Stays with the project.
+- `team:<name>`: shared across team members via federation. (Future)
 
-When onboarding a new project, colonies carry over `personal` knowledge and start fresh on `project:*` — they already know how you work, they just need to learn the codebase.
+When onboarding a new project, colonies carry over `personal` knowledge and start fresh on `project:*`. They already know how you work, they just need to learn the codebase.
 
 ## Prerequisites
 

--- a/dev-apprenticeship/code-review/README.md
+++ b/dev-apprenticeship/code-review/README.md
@@ -2,7 +2,7 @@
 
 > Part of the [Dev Apprenticeship](../) federation.
 
-A colony of five specialized agents that learn how you review code. They observe your merge request interactions on GitLab — what you approve, what you flag, what you dismiss — and gradually take over routine review work.
+A colony of five specialized agents that learn how you review code. They observe your merge request interactions on GitLab (what you approve, what you flag, what you dismiss) and gradually take over routine review work.
 
 ## Agents
 
@@ -12,7 +12,7 @@ A colony of five specialized agents that learn how you review code. They observe
 | Logic Reviewer | `agents/logic_reviewer.ag` | Edge cases, off-by-one errors, null handling, race conditions | ~20 observations |
 | Security Reviewer | `agents/security_reviewer.ag` | Injection risks, auth checks, secret exposure, dependency vulnerabilities | ~15 observations |
 | Test Reviewer | `agents/test_reviewer.ag` | Coverage expectations, test quality, missing edge case tests | ~15 observations |
-| Approval Decider | `agents/approval_decider.ag` | When to approve, request changes, or escalate — aggregates findings from other reviewers | ~25 observations |
+| Approval Decider | `agents/approval_decider.ag` | When to approve, request changes, or escalate (aggregates findings from other reviewers) | ~25 observations |
 
 ## How It Works
 
@@ -39,7 +39,7 @@ graph LR
     AD --> GL
 ```
 
-When a new merge request appears, all four reviewers analyze it in parallel, each from their own perspective. They publish findings to the colony bus. The Approval Decider aggregates those findings, weighs severity, and produces the final review action — approve, request changes, or escalate to the human.
+When a new merge request appears, all four reviewers analyze it in parallel, each from their own perspective. They publish findings to the colony bus. The Approval Decider aggregates those findings, weighs severity, and produces the final review action: approve, request changes, or escalate to the human.
 
 ## Setup
 
@@ -70,7 +70,7 @@ When a new merge request appears, all four reviewers analyze it in parallel, eac
 
 ## Providing Feedback
 
-For now, the colony learns passively by watching your existing GitLab review comments — the agents call `learn()` with patterns extracted from human review notes on merge requests. Just keep reviewing code the way you normally do.
+For now, the colony learns passively by watching your existing GitLab review comments: the agents call `learn()` with patterns extracted from human review notes on merge requests. Just keep reviewing code the way you normally do.
 
 An explicit feedback channel (for approving or dismissing individual findings) is planned for a future version.
 

--- a/dev-apprenticeship/implementation/README.md
+++ b/dev-apprenticeship/implementation/README.md
@@ -2,7 +2,7 @@
 
 > Part of the [Dev Apprenticeship](../) federation.
 
-A colony of four agents that learn how you write code. They observe your commits, merge requests, and code patterns on GitLab — learning your conventions, test habits, and refactoring style.
+A colony of four agents that learn how you write code. They observe your commits, merge requests, and code patterns on GitLab, learning your conventions, test habits, and refactoring style.
 
 ## Agents
 
@@ -36,7 +36,7 @@ graph LR
     CC --> GL
 ```
 
-When an issue is assigned, the Code Writer produces an implementation draft. The Test Writer generates tests and the Refactorer suggests improvements — both informed by what the Code Writer produced. The Commit Composer packages everything into well-structured commits following learned conventions and opens a merge request.
+When an issue is assigned, the Code Writer produces an implementation draft. The Test Writer generates tests and the Refactorer suggests improvements, both informed by what the Code Writer produced. The Commit Composer packages everything into well-structured commits following learned conventions and opens a merge request.
 
 ## Setup
 

--- a/dev-apprenticeship/planning/README.md
+++ b/dev-apprenticeship/planning/README.md
@@ -2,7 +2,7 @@
 
 > Part of the [Dev Apprenticeship](../) federation.
 
-A colony of four agents that learn how you plan work. They observe how you break down issues, estimate scope, assess risks, and review plans on GitLab — and gradually take over the routine parts of planning.
+A colony of four agents that learn how you plan work. They observe how you break down issues, estimate scope, assess risks, and review plans on GitLab, and gradually take over the routine parts of planning.
 
 ## Agents
 

--- a/dev-apprenticeship/release/README.md
+++ b/dev-apprenticeship/release/README.md
@@ -2,7 +2,7 @@
 
 > Part of the [Dev Apprenticeship](../) federation.
 
-A colony of four agents that learn how you ship software. They observe your release decisions, changelog writing, versioning, and pre-release checks on GitLab — and gradually automate the routine parts of the release process.
+A colony of four agents that learn how you ship software. They observe your release decisions, changelog writing, versioning, and pre-release checks on GitLab, and gradually automate the routine parts of the release process.
 
 ## Agents
 
@@ -36,7 +36,7 @@ graph LR
     VB -- version tag --> GL
 ```
 
-When a release candidate is ready, the Release Checker runs pre-release validation (CI status, dependency audit, migration safety). The Ship Decider weighs the results against learned thresholds and makes a ship/no-ship call. If shipping, the Changelog Writer compiles the release notes and the Version Bumper determines the correct version number — both following conventions learned from past releases.
+When a release candidate is ready, the Release Checker runs pre-release validation (CI status, dependency audit, migration safety). The Ship Decider weighs the results against learned thresholds and makes a ship/no-ship call. If shipping, the Changelog Writer compiles the release notes and the Version Bumper determines the correct version number, both following conventions learned from past releases.
 
 ## Setup
 

--- a/dev-apprenticeship/triage/README.md
+++ b/dev-apprenticeship/triage/README.md
@@ -2,7 +2,7 @@
 
 > Part of the [Dev Apprenticeship](../) federation.
 
-A colony of four agents that learn how you manage issues. They observe how you create, label, prioritize, and route issues on GitLab — and gradually take over the mechanical parts of issue management.
+A colony of four agents that learn how you manage issues. They observe how you create, label, prioritize, and route issues on GitLab, and gradually take over the mechanical parts of issue management.
 
 ## Agents
 
@@ -36,7 +36,7 @@ graph LR
     IC -- title, description --> GL
 ```
 
-When a new event arrives (bug report, support ticket, alert), the Issue Creator drafts the issue with learned title and description conventions. The Labeler, Prioritizer, and Router each add their metadata — labels, priority level, and assignee — based on patterns learned from past decisions.
+When a new event arrives (bug report, support ticket, alert), the Issue Creator drafts the issue with learned title and description conventions. The Labeler, Prioritizer, and Router each add their metadata (labels, priority level, and assignee) based on patterns learned from past decisions.
 
 ## Setup
 


### PR DESCRIPTION
## Summary

- Removes em dashes from all six dev-apprenticeship README files
- Replaces each with a colon, parentheses, or sentence break while preserving meaning
- Aligns the READMEs with the project writing style rule that prohibits em dashes

Closes #12

## Files changed

- `dev-apprenticeship/README.md` (9 rewrites)
- `dev-apprenticeship/triage/README.md` (2 rewrites)
- `dev-apprenticeship/planning/README.md` (1 rewrite)
- `dev-apprenticeship/code-review/README.md` (4 rewrites)
- `dev-apprenticeship/implementation/README.md` (2 rewrites)
- `dev-apprenticeship/release/README.md` (2 rewrites)

## Test plan

- [x] `./tools/colony-lint.sh` passes (25 passed, 0 failed, 5 skipped shellcheck)
- [x] `grep -rn '—' dev-apprenticeship/` returns zero matches
- [x] Each rewritten sentence reads correctly with its new punctuation