### PR TITLE
chore: document shellcheck enforcement in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install shellcheck
-        run: sudo apt-get install -y shellcheck
+      - name: Install shellcheck (required by colony-lint)
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
 
       - name: Run colony-lint
         run: ./tools/colony-lint.sh

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -144,6 +144,9 @@ if errors:
                     shellcheck "${sh_files[@]}" 2>&1 | head -30
                 fi
             else
+                # CI installs shellcheck unconditionally (see .github/workflows/ci.yml),
+                # so this skip only applies to local runs without shellcheck installed.
+                # Shellcheck errors in CI always fail the run via the FAIL counter below.
                 skip "$prefix: shellcheck not installed"
             fi
         fi


### PR DESCRIPTION
## Summary

- Renames the CI install step to `Install shellcheck (required by colony-lint)` so PR log readers immediately see shellcheck is a first-class dependency
- Adds `apt-get update` before `apt-get install` to harden the step against stale apt indexes
- Adds an explanatory comment next to the `skip "shellcheck not installed"` branch in `tools/colony-lint.sh` clarifying that CI installs shellcheck unconditionally and this skip only applies to local runs

No logic changes. Shellcheck failures already fail the CI run via the FAIL counter inside colony-lint.sh (lines 138-148, exit non-zero at line 265).

Closes #17

## Test plan

- [x] `./tools/colony-lint.sh` passes locally (25 passed, 0 failed, 5 skipped)
- [ ] `CI / colony-lint` check runs green on this PR
- [x] Comment rendering reviewed in diff