### PR TITLE
docs: remove em dashes from root README and tools scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Open-source agent colonies built on the [Agentis](https://github.com/Replikanti/agentis) runtime.
 
-**Agentis** is a proprietary AI-native platform for agent emergence — it provides the runtime, language, evolution engine, and distributed infrastructure. **Colonies** (this repo) are open-source (Apache 2.0) configurations of agents that solve real-world problems using that runtime.
+**Agentis** is a proprietary AI-native platform for agent emergence. It provides the runtime, language, evolution engine, and distributed infrastructure. **Colonies** (this repo) are open-source (Apache 2.0) configurations of agents that solve real-world problems using that runtime.
 
 ## Colonies and Federations
 
-A **colony** is a group of specialized agents that collaborate on a single domain. Agents within a colony share context, budget, and evolutionary pressure — they are a team, not a collection of individuals.
+A **colony** is a group of specialized agents that collaborate on a single domain. Agents within a colony share context, budget, and evolutionary pressure. They are a team, not a collection of individuals.
 
 A **federation** is a system of colonies that work together to cover a complete workflow. Each colony handles its domain, and the federation coordinates across them.
 
@@ -38,7 +38,7 @@ graph TD
 
 | Federation | Description | Status |
 |------------|-------------|--------|
-| [dev-apprenticeship](./dev-apprenticeship/) | Learns a developer's complete workflow — code review, planning, implementation, triage, and release | Active |
+| [dev-apprenticeship](./dev-apprenticeship/) | Learns a developer's complete workflow: code review, planning, implementation, triage, and release | Active |
 
 ## Prerequisites
 
@@ -48,6 +48,6 @@ graph TD
 
 ## License
 
-Apache 2.0 — see [LICENSE](./LICENSE).
+Apache 2.0. See [LICENSE](./LICENSE).
 
 Agentis runtime is proprietary software by [Replikanti](https://github.com/Replikanti).

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# colony-lint.sh — validates colony structure, config, and scripts
+# colony-lint.sh: validates colony structure, config, and scripts
 #
 # Autodiscovers federations and colonies in the repo.
 # Exit code 0 = all checks pass, 1 = one or more failures.

--- a/tools/new-colony.sh
+++ b/tools/new-colony.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# new-colony.sh — scaffold a new colony within a federation
+# new-colony.sh: scaffold a new colony within a federation
 #
 # Usage: ./tools/new-colony.sh <federation> <colony-name>
 # Example: ./tools/new-colony.sh dev-apprenticeship planning
@@ -172,8 +172,8 @@ echo ""
 echo "Colony scaffolded at $COL_PATH/"
 echo ""
 echo "Next steps:"
-echo "  1. Edit $COL_PATH/README.md — describe the colony and its agents"
-echo "  2. Edit $COL_PATH/config/colony.example.toml — add agent definitions"
-echo "  3. Edit $COL_PATH/scripts/start-colony.sh — add agent names to AGENTS array"
+echo "  1. Edit $COL_PATH/README.md to describe the colony and its agents"
+echo "  2. Edit $COL_PATH/config/colony.example.toml to add agent definitions"
+echo "  3. Edit $COL_PATH/scripts/start-colony.sh to add agent names to AGENTS array"
 echo "  4. Create .ag files in $COL_PATH/agents/"
-echo "  5. Update $FED_PATH/README.md — add the new colony to the table"
+echo "  5. Update $FED_PATH/README.md to add the new colony to the table"


### PR DESCRIPTION
## Summary

Follow-up from #19 QA scope gap. Removes the remaining em dashes in the repo root so the writing-style rule is uniformly enforced.

- `README.md`: 4 rewrites in overview prose
- `tools/colony-lint.sh`: 1 rewrite in the header comment
- `tools/new-colony.sh`: 5 rewrites in the header comment and the "Next steps" scaffolding output

After this merges, `grep -rn '—' .` returns zero matches repo-wide.

Closes #20

## Test plan

- [x] `grep -rn '—' .` returns zero matches
- [x] `./tools/colony-lint.sh` passes (25 passed, 0 failed, 5 skipped)
- [x] `bash -n` passes for both modified scripts (shellcheck runs in CI)
- [x] Each rewrite preserves original meaning