### PR TITLE
fix: drop unread [llm] command key from colony configs

### DIFF
--- a/dev-apprenticeship/code-review/README.md
+++ b/dev-apprenticeship/code-review/README.md
@@ -59,8 +59,8 @@ When a new merge request appears, all four reviewers analyze it in parallel, eac
 3. Configure the LLM backend:
    ```toml
    [llm]
+   # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
    backend = "cli"
-   command = "claude"
    ```
 
 4. Start the colony:

--- a/dev-apprenticeship/code-review/config/colony.example.toml
+++ b/dev-apprenticeship/code-review/config/colony.example.toml
@@ -13,8 +13,8 @@ token = "glpat-your-token-here"
 project = "your-org/your-project"
 
 [llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
 backend = "cli"
-command = "claude"
 
 # Agent definitions
 # Each agent runs as a separate agentis daemon process.

--- a/dev-apprenticeship/implementation/config/colony.example.toml
+++ b/dev-apprenticeship/implementation/config/colony.example.toml
@@ -13,8 +13,8 @@ token = "glpat-your-token-here"
 project = "your-org/your-project"
 
 [llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
 backend = "cli"
-command = "claude"
 
 # Agent definitions
 # Each agent runs as a separate agentis daemon process.

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -13,8 +13,8 @@ token = "glpat-your-token-here"
 project = "your-org/your-project"
 
 [llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
 backend = "cli"
-command = "claude"
 
 # Agent definitions
 # Each agent runs as a separate agentis daemon process.

--- a/dev-apprenticeship/release/config/colony.example.toml
+++ b/dev-apprenticeship/release/config/colony.example.toml
@@ -13,8 +13,8 @@ token = "glpat-your-token-here"
 project = "your-org/your-project"
 
 [llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
 backend = "cli"
-command = "claude"
 
 # Agent definitions
 # Each agent runs as a separate agentis daemon process.

--- a/dev-apprenticeship/triage/config/colony.example.toml
+++ b/dev-apprenticeship/triage/config/colony.example.toml
@@ -13,8 +13,8 @@ token = "glpat-your-token-here"
 project = "your-org/your-project"
 
 [llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
 backend = "cli"
-command = "claude"
 
 # Agent definitions
 # Each agent runs as a separate agentis daemon process.

--- a/tools/new-colony.sh
+++ b/tools/new-colony.sh
@@ -98,8 +98,8 @@ token = "glpat-your-token-here"
 project = "your-org/your-project"
 
 [llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
 backend = "cli"
-command = "claude"
 
 # Agent definitions
 # Each agent runs as a separate agentis daemon process.


### PR DESCRIPTION
## Summary

`start-colony.sh` only parses `[llm] backend`. It never reads `[llm] command`, so the `command = "claude"` line in the example configs is dead wiring.

**Daemon-help check (per the issue plan):** `agentis daemon --help` shows no `--llm-command`, `--backend`, or any LLM-related flag. Verified empirically: running the daemon with unknown flags results in silent acceptance (the flags are ignored). The plan's "preferred path" (wire the key through to a daemon flag) is therefore impossible, so this PR uses the **fallback path**: drop the key and document that only `backend` is read.

Also updates the code-review README snippet to match the new config, and extends the fix to `implementation/` and `release/` example configs (they ship the same dead key even though their start scripts don't exist yet).

Closes #11

## Scope

- `dev-apprenticeship/code-review/config/colony.example.toml` (drop key)
- `dev-apprenticeship/triage/config/colony.example.toml` (drop key)
- `dev-apprenticeship/planning/config/colony.example.toml` (drop key)
- `dev-apprenticeship/implementation/config/colony.example.toml` (drop key)
- `dev-apprenticeship/release/config/colony.example.toml` (drop key)
- `dev-apprenticeship/code-review/README.md` (update snippet)

## Test plan

- [x] `grep -rn 'command = "claude"' dev-apprenticeship/` returns zero matches
- [x] `./tools/colony-lint.sh` passes (25 passed, 0 failed, 5 skipped)
- [x] Each modified TOML still parses (lint validates structure)