### PR TITLE
fix: preserve whitespace in start-colony parse_toml values

### DIFF
--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -20,8 +20,27 @@ fi
 
 # Parse GitLab config from TOML and export for gitlab-api.sh
 # Accepts both flush ("key = ...") and indented ("  key = ...") TOML keys.
+# Preserves internal whitespace in values (only trims surrounding whitespace
+# and matching quotes). Stops at the first match and ignores inline comments.
 parse_toml() {
-    grep -E "^[[:space:]]*$1[[:space:]]*=" "$CONFIG" 2>/dev/null | head -1 | sed 's/.*= *"\{0,1\}\([^"]*\)"\{0,1\}/\1/' | tr -d ' '
+    python3 - "$CONFIG" "$1" <<'PY'
+import sys
+path, key = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as f:
+    for raw in f:
+        line = raw.split("#", 1)[0].rstrip("\n")
+        stripped = line.lstrip()
+        if not stripped.startswith(key):
+            continue
+        rest = stripped[len(key):].lstrip()
+        if not rest.startswith("="):
+            continue
+        value = rest[1:].strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        print(value)
+        break
+PY
 }
 
 GITLAB_URL=$(parse_toml "url")

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -20,8 +20,27 @@ fi
 
 # Parse GitLab config from TOML and export for gitlab-api.sh
 # Accepts both flush ("key = ...") and indented ("  key = ...") TOML keys.
+# Preserves internal whitespace in values (only trims surrounding whitespace
+# and matching quotes). Stops at the first match and ignores inline comments.
 parse_toml() {
-    grep -E "^[[:space:]]*$1[[:space:]]*=" "$CONFIG" 2>/dev/null | head -1 | sed 's/.*= *"\{0,1\}\([^"]*\)"\{0,1\}/\1/' | tr -d ' '
+    python3 - "$CONFIG" "$1" <<'PY'
+import sys
+path, key = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as f:
+    for raw in f:
+        line = raw.split("#", 1)[0].rstrip("\n")
+        stripped = line.lstrip()
+        if not stripped.startswith(key):
+            continue
+        rest = stripped[len(key):].lstrip()
+        if not rest.startswith("="):
+            continue
+        value = rest[1:].strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        print(value)
+        break
+PY
 }
 
 GITLAB_URL=$(parse_toml "url")


### PR DESCRIPTION
## Summary

The old `parse_toml` function used `tr -d ' '` at the tail of its pipeline, which destroyed all internal whitespace in values. A value like `project = "my org/my project"` was silently mangled to `myorg/myproject` on its way to the GitLab API wrapper.

Replaces the sed/tr pipeline with a python3-based parser that preserves internal whitespace and only trims surrounding whitespace and matching quotes. python3 is already required by `gitlab-api.sh` and `colony-lint.sh`, so no new dependency.

Applied identically to both `start-colony.sh` files that currently parse TOML. Planning, implementation, and release colony start scripts do not call `parse_toml` yet and are out of scope.

Closes #9

## Scope

- `dev-apprenticeship/code-review/scripts/start-colony.sh` (function body only)
- `dev-apprenticeship/triage/scripts/start-colony.sh` (function body only)

## Test plan

- [x] `./tools/colony-lint.sh` passes (25 passed, 0 failed, 5 skipped)
- [x] `bash -n` passes on both patched scripts (shellcheck runs in CI)
- [x] Targeted parse_toml unit test with a fixture TOML containing `command = "claude --model sonnet"`, `project = "my org/my project"`, and `url = "https://gitlab.example.com"`:
  - `backend` returns `cli`
  - `command` returns `claude --model sonnet` (single space preserved)
  - `url` returns `https://gitlab.example.com` (unchanged)
  - `project` returns `my org/my project` (spaces preserved)
  - unknown key returns empty string
- [x] Config-not-found guard still fires: `start-colony.sh /nonexistent/path` exits 1 with the existing error message