### PR TITLE
fix: make parse_toml section-aware (#13)

### DIFF
--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -26,9 +26,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # shellcheck disable=SC1091  # colony-lint runs shellcheck without -x
 . "$REPO_ROOT/tools/parse-toml.sh"
 
-GITLAB_URL=$(parse_toml "url")
-GITLAB_TOKEN=$(parse_toml "token")
-GITLAB_PROJECT_RAW=$(parse_toml "project")
+GITLAB_URL=$(parse_toml gitlab url)
+GITLAB_TOKEN=$(parse_toml gitlab token)
+GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
 
 if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
     echo "Error: GitLab config incomplete in $CONFIG"
@@ -45,7 +45,7 @@ export GITLAB_PROJECT
 export COLONY_DIR
 
 # Parse LLM backend
-LLM_BACKEND=$(parse_toml "backend")
+LLM_BACKEND=$(parse_toml llm backend)
 
 AGENTS=(
     style_reviewer

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -26,9 +26,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # shellcheck disable=SC1091  # colony-lint runs shellcheck without -x
 . "$REPO_ROOT/tools/parse-toml.sh"
 
-GITLAB_URL=$(parse_toml "url")
-GITLAB_TOKEN=$(parse_toml "token")
-GITLAB_PROJECT_RAW=$(parse_toml "project")
+GITLAB_URL=$(parse_toml gitlab url)
+GITLAB_TOKEN=$(parse_toml gitlab token)
+GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
 
 if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
     echo "Error: GitLab config incomplete in $CONFIG"
@@ -45,7 +45,7 @@ export GITLAB_PROJECT
 export COLONY_DIR
 
 # Parse LLM backend
-LLM_BACKEND=$(parse_toml "backend")
+LLM_BACKEND=$(parse_toml llm backend)
 
 AGENTS=(
     issue_creator

--- a/tools/parse-toml.sh
+++ b/tools/parse-toml.sh
@@ -1,21 +1,30 @@
 #!/bin/bash
 # tools/parse-toml.sh: shared TOML key lookup for colony start scripts.
 #
-# Usage: source this file, then call `parse_toml KEY`. Expects $CONFIG to
-# point at the TOML file to read. Returns the first matching value on
-# stdout, preserving internal whitespace and stripping matching quotes.
+# Usage: source this file, then call `parse_toml SECTION KEY`. Expects
+# $CONFIG to point at the TOML file to read. Returns the first matching
+# value under `[SECTION]` on stdout, preserving internal whitespace and
+# stripping matching quotes. Keys outside the requested section are
+# ignored so same-name keys in sibling sections do not collide.
 #
 # Not executable: source only.
 # shellcheck shell=bash
 
 parse_toml() {
-    python3 - "$CONFIG" "$1" <<'PY'
+    python3 - "$CONFIG" "$1" "$2" <<'PY'
 import sys
-path, key = sys.argv[1], sys.argv[2]
+path, section, key = sys.argv[1], sys.argv[2], sys.argv[3]
+target_header = "[" + section + "]"
+in_section = False
 with open(path, "r", encoding="utf-8") as f:
     for raw in f:
         line = raw.split("#", 1)[0].rstrip("\n")
-        stripped = line.lstrip()
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_section = (stripped == target_header)
+            continue
+        if not in_section:
+            continue
         if not stripped.startswith(key):
             continue
         rest = stripped[len(key):].lstrip()


### PR DESCRIPTION
## Summary

- `tools/parse-toml.sh` now takes a section argument: `parse_toml SECTION KEY`. Matching is restricted to lines under `[SECTION]`, so same-name keys in sibling sections no longer collide silently.
- Both `start-colony.sh` scripts in triage and code-review updated to pass explicit sections: `parse_toml gitlab url`, `parse_toml llm backend`, etc.

Before the fix, a config with `url` under both `[gitlab]` and `[llm]` would always return the `[gitlab]` value regardless of which one the caller wanted, with no error or warning.

## Test plan

- [x] Targeted reproduction: fixture with colliding `url` under `[gitlab]` and `[llm]` now returns the correct value for each section. Before the fix both returned `https://gitlab.example.com`.
- [x] Real example config: `parse_toml gitlab url`, `parse_toml gitlab token`, `parse_toml gitlab project`, `parse_toml llm backend` all extract correct values from `triage/config/colony.example.toml`.
- [x] Array-of-tables regression: `parse_toml colony name` correctly returns `"triage"` and does not bleed into `[[agents]]` entries.
- [x] Quoted value containing `=`: round-trips untouched.
- [x] Missing key and wrong section both return empty string.
- [x] `bash -n` clean on both modified scripts.
- [x] `./tools/colony-lint.sh` passes (25 passed, 0 failed).

Closes #13