### PR TITLE
fix: rename exec shell to exec sh across all agents (#455)

### DIFF
--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -45,7 +45,7 @@ fn tick(reason: string) -> void {
 
     // Learn from past human approval/rejection patterns
     let mr_cmd = "./scripts/gitlab-api.sh merge-requests --state merged";
-    let recent_merged = try { exec shell mr_cmd; } catch e { "[]"; };
+    let recent_merged = try { exec sh mr_cmd; } catch e { "[]"; };
 
     let approval_patterns = prompt(
         "Analyze these recently merged MRs. What patterns do you see in what gets approved quickly vs what takes multiple rounds? Summarize briefly.",
@@ -72,7 +72,7 @@ fn tick(reason: string) -> void {
     if confidence >= 0.85 {
         if decision.action == "approve" {
             let approve_cmd = "./scripts/gitlab-api.sh approve " + to_string(decision.mr_iid);
-            try { exec shell approve_cmd; } catch e {
+            try { exec sh approve_cmd; } catch e {
                 print("[approval_decider] Failed to approve:", e);
             };
             print("[approval_decider] Approved MR", decision.mr_iid);
@@ -81,7 +81,7 @@ fn tick(reason: string) -> void {
             if decision.action == "request_changes" {
                 let comment = "**Review Summary** (automated)\n\n" + decision.reasoning + "\n\nFindings: " + to_string(decision.total_findings) + " total, " + to_string(decision.critical_count) + " critical";
                 let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment);
-                try { exec shell post_cmd; } catch e {
+                try { exec sh post_cmd; } catch e {
                     print("[approval_decider] Failed to post:", e);
                 };
                 learn("approval_decision", "MR " + to_string(decision.mr_iid), "request_changes: " + decision.reasoning, "acted", "code-review");

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -40,7 +40,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     let cmd = mr_cmd();
     let raw = try {
-        exec shell cmd;
+        exec sh cmd;
     } catch e {
         print("[logic_reviewer] GitLab poll failed:", e);
         "";
@@ -61,7 +61,7 @@ fn tick(reason: string) -> void {
 
     let mr_iid = get(mr_ids, 0);
     let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
-    let changes_raw = try { exec shell changes_cmd; } catch e { ""; };
+    let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
         return;
@@ -69,7 +69,7 @@ fn tick(reason: string) -> void {
 
     // Learn from human logic-related comments
     let notes_cmd = "./scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
-    let notes_raw = try { exec shell notes_cmd; } catch e { "[]"; };
+    let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
     let human_patterns = prompt(
         "Analyze these MR review comments. Find comments about logic bugs: edge cases, off-by-one, null/nil handling, race conditions, incorrect assumptions, missing error handling. Summarize the patterns. If no logic-related comments, return 'none'.",
@@ -98,7 +98,7 @@ fn tick(reason: string) -> void {
         if confidence >= 0.85 {
             let comment = "**Logic Review** (automated)\n\n" + review.summary;
             let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
-            try { exec shell post_cmd; } catch e {
+            try { exec sh post_cmd; } catch e {
                 print("[logic_reviewer] Failed to post comment:", e);
             };
         };
@@ -107,7 +107,7 @@ fn tick(reason: string) -> void {
         emit("review:logic_findings", review);
     };
 
-    let now = try { exec shell "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
         memo_write("logic_reviewer:last_check", now);
     };

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -41,7 +41,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     let cmd = mr_cmd();
     let raw = try {
-        exec shell cmd;
+        exec sh cmd;
     } catch e {
         print("[security_reviewer] GitLab poll failed:", e);
         "";
@@ -62,7 +62,7 @@ fn tick(reason: string) -> void {
 
     let mr_iid = get(mr_ids, 0);
     let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
-    let changes_raw = try { exec shell changes_cmd; } catch e { ""; };
+    let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
         return;
@@ -70,7 +70,7 @@ fn tick(reason: string) -> void {
 
     // Learn from human security-related comments
     let notes_cmd = "./scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
-    let notes_raw = try { exec shell notes_cmd; } catch e { "[]"; };
+    let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
     let human_patterns = prompt(
         "Analyze these MR review comments. Find comments about security: injection, XSS, CSRF, auth, secrets, credentials, dependencies, permissions, input validation. Summarize. If none, return 'none'.",
@@ -99,7 +99,7 @@ fn tick(reason: string) -> void {
         if confidence >= 0.85 {
             let comment = "**Security Review** (automated)\n\n" + review.summary;
             let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
-            try { exec shell post_cmd; } catch e {
+            try { exec sh post_cmd; } catch e {
                 print("[security_reviewer] Failed to post comment:", e);
             };
         };
@@ -108,7 +108,7 @@ fn tick(reason: string) -> void {
         emit("review:security_findings", review);
     };
 
-    let now = try { exec shell "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
         memo_write("security_reviewer:last_check", now);
     };

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -40,7 +40,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     let cmd = mr_cmd();
     let raw = try {
-        exec shell cmd;
+        exec sh cmd;
     } catch e {
         print("[style_reviewer] GitLab poll failed:", e);
         "";
@@ -63,7 +63,7 @@ fn tick(reason: string) -> void {
     // Review the first open MR
     let mr_iid = get(mr_ids, 0);
     let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
-    let changes_raw = try { exec shell changes_cmd; } catch e { ""; };
+    let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
         return;
@@ -71,7 +71,7 @@ fn tick(reason: string) -> void {
 
     // Check for existing human review comments to learn from
     let notes_cmd = "./scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
-    let notes_raw = try { exec shell notes_cmd; } catch e { "[]"; };
+    let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
     // Learn from human style comments
     let human_patterns = prompt(
@@ -103,7 +103,7 @@ fn tick(reason: string) -> void {
             // Post review comment directly
             let comment = "**Style Review** (automated)\n\n" + review.summary;
             let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
-            let result = try { exec shell post_cmd; } catch e {
+            let result = try { exec sh post_cmd; } catch e {
                 print("[style_reviewer] Failed to post comment:", e);
                 "";
             };
@@ -118,7 +118,7 @@ fn tick(reason: string) -> void {
         emit("review:style_findings", review);
     };
 
-    let now = try { exec shell "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
         memo_write("style_reviewer:last_check", now);
     };

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -40,7 +40,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     let cmd = mr_cmd();
     let raw = try {
-        exec shell cmd;
+        exec sh cmd;
     } catch e {
         print("[test_reviewer] GitLab poll failed:", e);
         "";
@@ -61,7 +61,7 @@ fn tick(reason: string) -> void {
 
     let mr_iid = get(mr_ids, 0);
     let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
-    let changes_raw = try { exec shell changes_cmd; } catch e { ""; };
+    let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
         return;
@@ -69,7 +69,7 @@ fn tick(reason: string) -> void {
 
     // Learn from human test-related comments
     let notes_cmd = "./scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
-    let notes_raw = try { exec shell notes_cmd; } catch e { "[]"; };
+    let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
     let human_patterns = prompt(
         "Analyze these MR review comments. Find comments about testing: missing tests, coverage gaps, test quality, assertion issues, edge case tests, flaky tests, test structure. Summarize. If none, return 'none'.",
@@ -98,7 +98,7 @@ fn tick(reason: string) -> void {
         if confidence >= 0.85 {
             let comment = "**Test Review** (automated)\n\n" + review.summary;
             let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
-            try { exec shell post_cmd; } catch e {
+            try { exec sh post_cmd; } catch e {
                 print("[test_reviewer] Failed to post comment:", e);
             };
         };
@@ -107,7 +107,7 @@ fn tick(reason: string) -> void {
         emit("review:test_findings", review);
     };
 
-    let now = try { exec shell "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
         memo_write("test_reviewer:last_check", now);
     };

--- a/dev-apprenticeship/triage/agents/issue_creator.ag
+++ b/dev-apprenticeship/triage/agents/issue_creator.ag
@@ -40,7 +40,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     let cmd = issues_cmd();
     let raw = try {
-        exec shell cmd;
+        exec sh cmd;
     } catch e {
         print("[issue_creator] GitLab poll failed:", e);
         "";
@@ -83,7 +83,7 @@ fn tick(reason: string) -> void {
         if confidence >= 0.85 {
             let create_cmd = "./scripts/gitlab-api.sh create-issue --title \"" + draft.title + "\" --description \"" + draft.description + "\" --labels \"" + draft.suggested_labels + "\"";
             let result = try {
-                exec shell create_cmd;
+                exec sh create_cmd;
             } catch e {
                 print("[issue_creator] Failed to create issue:", e);
                 "";
@@ -102,7 +102,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec shell "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
         memo_write("issue_creator:last_check", now);
     };

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -41,7 +41,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     let cmd = issues_cmd();
     let raw = try {
-        exec shell cmd;
+        exec sh cmd;
     } catch e {
         print("[labeler] GitLab poll failed:", e);
         "";
@@ -72,7 +72,7 @@ fn tick(reason: string) -> void {
     if analysis.unlabeled_count > 0 {
         let confidence = get_confidence();
         let rec = recommend("label", ["accuracy"]);
-        let labels_raw = try { exec shell "./scripts/gitlab-api.sh labels"; } catch e { "[]"; };
+        let labels_raw = try { exec sh "./scripts/gitlab-api.sh labels"; } catch e { "[]"; };
         let context = "Unlabeled issues: " + analysis.unlabeled_issues + "\nAvailable labels: " + labels_raw + "\nPast learning: " + to_string(rec);
 
         let action = prompt(
@@ -82,7 +82,7 @@ fn tick(reason: string) -> void {
 
         if confidence >= 0.85 {
             let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels \"" + action.labels + "\"";
-            let result = try { exec shell update_cmd; } catch e {
+            let result = try { exec sh update_cmd; } catch e {
                 print("[labeler] Failed to apply labels:", e);
                 "";
             };
@@ -105,7 +105,7 @@ fn tick(reason: string) -> void {
         print("[labeler] Received new issue draft, will label on next tick");
     };
 
-    let now = try { exec shell "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
         memo_write("labeler:last_check", now);
     };

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -41,7 +41,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     let cmd = issues_cmd();
     let raw = try {
-        exec shell cmd;
+        exec sh cmd;
     } catch e {
         print("[prioritizer] GitLab poll failed:", e);
         "";
@@ -81,7 +81,7 @@ fn tick(reason: string) -> void {
 
         if confidence >= 0.85 {
             let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels \"" + action.priority + "\"";
-            let result = try { exec shell update_cmd; } catch e {
+            let result = try { exec sh update_cmd; } catch e {
                 print("[prioritizer] Failed to set priority:", e);
                 "";
             };
@@ -104,7 +104,7 @@ fn tick(reason: string) -> void {
         print("[prioritizer] Received new issue draft, will prioritize on next tick");
     };
 
-    let now = try { exec shell "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
         memo_write("prioritizer:last_check", now);
     };

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -41,7 +41,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     let cmd = issues_cmd();
     let raw = try {
-        exec shell cmd;
+        exec sh cmd;
     } catch e {
         print("[router] GitLab poll failed:", e);
         "";
@@ -52,7 +52,7 @@ fn tick(reason: string) -> void {
     };
 
     // Get team members
-    let members_raw = try { exec shell "./scripts/gitlab-api.sh members"; } catch e { "[]"; };
+    let members_raw = try { exec sh "./scripts/gitlab-api.sh members"; } catch e { "[]"; };
 
     // Analyze: find assigned and unassigned issues
     let analysis = prompt(
@@ -84,7 +84,7 @@ fn tick(reason: string) -> void {
 
         if confidence >= 0.85 {
             let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --assignee \"" + action.assignee + "\"";
-            let result = try { exec shell update_cmd; } catch e {
+            let result = try { exec sh update_cmd; } catch e {
                 print("[router] Failed to assign:", e);
                 "";
             };
@@ -107,7 +107,7 @@ fn tick(reason: string) -> void {
         print("[router] Received new issue draft, will route on next tick");
     };
 
-    let now = try { exec shell "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
         memo_write("router:last_check", now);
     };


### PR DESCRIPTION
## Summary

- Rename `exec shell` to `exec sh` in every agent under `dev-apprenticeship/triage/agents/` and `dev-apprenticeship/code-review/agents/`. 37 call sites across 9 files.
- `sh` is the language name the runtime actually honors; `shell` was a silent no-op because the parser accepted any identifier but the runtime whitelist is `["python", "js", "sh"]`.
- The `gitlab-api.sh` scripts under `scripts/` are bash, not agent source. They are deliberately not touched (per the plan in `Replikanti/agentis-core#455`).

## Why

Every agent wrapped the exec call in `try { exec shell cmd; } catch e { ""; };`. The runtime error `unknown language 'shell'` was swallowed by the catch, the caller's `if len(raw) < 3 return;` short-circuited, and the tick did nothing. This is the bug tracked in `Replikanti/agentis-core#455` (QA report on `Replikanti/agentis-colonies#8`, HIGH-1).

## Relationship to upstream fix

`Replikanti/agentis-core#456` rejects unknown `exec` languages at parse time. The downstream rename in this PR does not depend on that upstream fix landing, because `exec sh` is already valid syntax under the current `agentis v1.1.0`. The two PRs are independent and can merge in either order. However, ordering matters for users who already run deployed colonies:

- Merge this PR first: colonies keep working on `v1.1.0` and gain working agents immediately.
- Merge `agentis-core#456` and tag `v1.1.1`: every `exec shell` call starts failing at parse time. Any deployment that has not yet taken this rename will break on upgrade.

Merging this PR before cutting `v1.1.1` avoids the break window.

## Test plan

- [x] `git grep -n 'exec shell' dev-apprenticeship/*.ag` returns zero hits after the rename.
- [x] `git grep -c 'exec sh' dev-apprenticeship/**/*.ag` shows 37 (matches the pre-rename count of `exec shell`).
- [x] `tools/colony-lint.sh` passes on the rename: 25 passed / 0 failed / 5 skipped. All 9 `.ag` files parse cleanly under `agentis v1.1.0`.
- [x] No accidental touches inside string literals, comments, or bash scripts (grep confirmed each of the 37 occurrences was a live `exec shell <expr>` call, not a doc string).
- [x] `gitlab-api.sh` files under `scripts/` untouched (the plan in `agentis-core#455` explicitly says to leave them alone; they are bash, not agent source).

## Files touched

| File | Lines |
|------|------:|
| `dev-apprenticeship/triage/agents/issue_creator.ag` | 3 |
| `dev-apprenticeship/triage/agents/labeler.ag` | 4 |
| `dev-apprenticeship/triage/agents/prioritizer.ag` | 3 |
| `dev-apprenticeship/triage/agents/router.ag` | 4 |
| `dev-apprenticeship/code-review/agents/approval_decider.ag` | 3 |
| `dev-apprenticeship/code-review/agents/logic_reviewer.ag` | 5 |
| `dev-apprenticeship/code-review/agents/security_reviewer.ag` | 5 |
| `dev-apprenticeship/code-review/agents/style_reviewer.ag` | 5 |
| `dev-apprenticeship/code-review/agents/test_reviewer.ag` | 5 |
| **total** | **37** |

## Cross-links

- Upstream parser fix: Replikanti/agentis-core#456
- Root cause issue: Replikanti/agentis-core#455
- Tracking QA report that found this: Replikanti/agentis-colonies#8 (HIGH-1)