### PR TITLE
feat(planning): implement planning colony agents

### DIFF
--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -1,0 +1,175 @@
+// plan_reviewer.ag -- Planning colony: assembles the final plan.
+//
+// Listens for scope estimates, risk assessments, and task breakdowns
+// from the three peer agents. Once all three have reported on the
+// same issue, it assembles a combined plan (markdown), checks it
+// against learned review criteria, and either posts it as a comment
+// (high confidence) or emits it for human review (medium confidence).
+//
+// Partial peer outputs are stashed in memo under
+// plan_reviewer:<issue_id>:<slot> so inputs arriving across multiple
+// ticks can still be combined.
+//
+// Run as daemon: agentis daemon agents/plan_reviewer.ag --colony planning
+// Requires: exec_foreign capability, GITLAB_* env vars
+
+cb 600;
+
+type ScopeEstimate {
+    issue_id: int,
+    phases: int,
+    points: int,
+    reasoning: string,
+    confidence: float
+}
+
+type RiskAssessment {
+    issue_id: int,
+    risks: string,
+    severity: string,
+    confidence: float
+}
+
+type TaskBreakdown {
+    issue_id: int,
+    subtasks: string,
+    count: int,
+    confidence: float
+}
+
+type DraftPlan {
+    issue_id: int,
+    plan: string,
+    review_score: float,
+    confidence: float
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("plan_reviewer:confidence");
+    if len(raw) > 0 {
+        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+    };
+    return 0.0;
+}
+
+fn stash(slot: string, issue_id: int, body: string) -> void {
+    if len(body) > 2 {
+        memo_write("plan_reviewer:" + to_string(issue_id) + ":" + slot, body);
+    };
+}
+
+fn tick(reason: string) -> void {
+    // 1. Collect peer outputs emitted this tick (partial over time).
+    let scope = listen("planning:scope_estimate", 500);
+    let risks = listen("planning:risks", 500);
+    let breakdown = listen("planning:breakdown", 500);
+
+    let scope_str = to_string(scope);
+    let risks_str = to_string(risks);
+    let breakdown_str = to_string(breakdown);
+
+    // 2. Stash each partial under the issue id it belongs to.
+    // We need the issue id to route peer outputs; ask the LLM once per
+    // non-empty bucket rather than trying to parse the record ourselves.
+    if len(scope_str) > 2 {
+        let scope_iid = prompt("Return just the issue_id integer from this JSON record. Nothing else.", scope_str) -> int;
+        stash("scope", scope_iid, scope_str);
+    };
+    if len(risks_str) > 2 {
+        let risks_iid = prompt("Return just the issue_id integer from this JSON record. Nothing else.", risks_str) -> int;
+        stash("risks", risks_iid, risks_str);
+    };
+    if len(breakdown_str) > 2 {
+        let bd_iid = prompt("Return just the issue_id integer from this JSON record. Nothing else.", breakdown_str) -> int;
+        stash("breakdown", bd_iid, breakdown_str);
+    };
+
+    // 3. Pick the newest unplanned issue and see if we have all three
+    //    slots filled for it. If not, keep waiting.
+    let issues_raw = try {
+        exec sh "./scripts/gitlab-api.sh issues --needs-planning";
+    } catch e {
+        print("[plan_reviewer] GitLab unplanned-issue poll failed:", e);
+        "";
+    };
+
+    if len(issues_raw) < 3 {
+        return;
+    };
+
+    let target_iid = prompt(
+        "Return just the issue_id integer of the newest issue in this JSON array. Nothing else.",
+        issues_raw
+    ) -> int;
+
+    let s = recall_latest("plan_reviewer:" + to_string(target_iid) + ":scope");
+    let r = recall_latest("plan_reviewer:" + to_string(target_iid) + ":risks");
+    let b = recall_latest("plan_reviewer:" + to_string(target_iid) + ":breakdown");
+
+    if len(s) < 2 {
+        print("[plan_reviewer] Waiting on scope for issue", target_iid);
+        return;
+    };
+    if len(r) < 2 {
+        print("[plan_reviewer] Waiting on risks for issue", target_iid);
+        return;
+    };
+    if len(b) < 2 {
+        print("[plan_reviewer] Waiting on breakdown for issue", target_iid);
+        return;
+    };
+
+    // 4. Assemble the combined plan and score it against learned criteria.
+    let rec = recommend("review_plan", ["completeness"]);
+    let context = "Issue id: " + to_string(target_iid) +
+        "\nScope estimate JSON: " + s +
+        "\nRisk assessment JSON: " + r +
+        "\nTask breakdown JSON: " + b +
+        "\nPast review criteria: " + to_string(rec);
+
+    let draft = prompt(
+        "You are the plan reviewer for the planning colony. You have three peer outputs for one issue: scope, risks, and task breakdown. Assemble a single markdown plan suitable for posting as an issue comment. Sections: **Scope**, **Risks**, **Subtasks**. Then self-review against past criteria and return a completeness score. Return JSON: issue_id (int, the target issue), plan (string, the full markdown plan), review_score (float 0-1, your self-review against past criteria), confidence (float 0-1, aggregate confidence combining all three peer confidences with the review score).",
+        context
+    ) -> DraftPlan;
+
+    let override_conf = get_confidence();
+    let effective = if override_conf > 0.0 { override_conf; } else { draft.confidence; };
+
+    print("[plan_reviewer] Issue", draft.issue_id, "-> review_score:", draft.review_score, "effective:", effective);
+
+    if effective >= 0.85 {
+        let post_cmd = "./scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft.plan);
+        try { exec sh post_cmd; } catch e {
+            print("[plan_reviewer] Failed to post note:", e);
+        };
+        learn(
+            "review_plan",
+            "issue " + to_string(draft.issue_id),
+            "posted: score=" + to_string(draft.review_score),
+            "acted",
+            "planning"
+        );
+        print("[plan_reviewer] Posted plan to issue", draft.issue_id);
+    } else {
+        if effective >= 0.6 {
+            emit("planning:draft_plan", draft);
+            learn(
+                "review_plan",
+                "issue " + to_string(draft.issue_id),
+                "emitted: score=" + to_string(draft.review_score),
+                "emitted",
+                "planning"
+            );
+            print("[plan_reviewer] Emitted draft plan for issue", draft.issue_id);
+        } else {
+            learn(
+                "review_plan",
+                "issue " + to_string(draft.issue_id),
+                "low confidence: score=" + to_string(draft.review_score),
+                "observed",
+                "planning"
+            );
+            print("[plan_reviewer] Observing (confidence:", effective, ")");
+        };
+    };
+}

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -15,28 +15,6 @@
 
 cb 600;
 
-type ScopeEstimate {
-    issue_id: int,
-    phases: int,
-    points: int,
-    reasoning: string,
-    confidence: float
-}
-
-type RiskAssessment {
-    issue_id: int,
-    risks: string,
-    severity: string,
-    confidence: float
-}
-
-type TaskBreakdown {
-    issue_id: int,
-    subtasks: string,
-    count: int,
-    confidence: float
-}
-
 type DraftPlan {
     issue_id: int,
     plan: string,
@@ -50,6 +28,15 @@ fn get_confidence() -> float {
         return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
     };
     return 0.0;
+}
+
+// listen() returns Value::Void on timeout, which to_string() renders as the
+// literal string "void". Treat that (and the empty string) as "no message".
+fn received(s: string) -> bool {
+    if s == "void" {
+        return false;
+    };
+    return len(s) > 2;
 }
 
 fn stash(slot: string, issue_id: int, body: string) -> void {
@@ -69,18 +56,19 @@ fn tick(reason: string) -> void {
     let breakdown_str = to_string(breakdown);
 
     // 2. Stash each partial under the issue id it belongs to.
-    // We need the issue id to route peer outputs; ask the LLM once per
-    // non-empty bucket rather than trying to parse the record ourselves.
-    if len(scope_str) > 2 {
-        let scope_iid = prompt("Return just the issue_id integer from this JSON record. Nothing else.", scope_str) -> int;
+    // Peer outputs arrive as struct Display format (not JSON), but the
+    // issue_id field is rendered verbatim either way, so we let the LLM
+    // extract it once per non-void bucket.
+    if received(scope_str) {
+        let scope_iid = prompt("Return just the issue_id integer from this record. Nothing else.", scope_str) -> int;
         stash("scope", scope_iid, scope_str);
     };
-    if len(risks_str) > 2 {
-        let risks_iid = prompt("Return just the issue_id integer from this JSON record. Nothing else.", risks_str) -> int;
+    if received(risks_str) {
+        let risks_iid = prompt("Return just the issue_id integer from this record. Nothing else.", risks_str) -> int;
         stash("risks", risks_iid, risks_str);
     };
-    if len(breakdown_str) > 2 {
-        let bd_iid = prompt("Return just the issue_id integer from this JSON record. Nothing else.", breakdown_str) -> int;
+    if received(breakdown_str) {
+        let bd_iid = prompt("Return just the issue_id integer from this record. Nothing else.", breakdown_str) -> int;
         stash("breakdown", bd_iid, breakdown_str);
     };
 
@@ -122,9 +110,9 @@ fn tick(reason: string) -> void {
     // 4. Assemble the combined plan and score it against learned criteria.
     let rec = recommend("review_plan", ["completeness"]);
     let context = "Issue id: " + to_string(target_iid) +
-        "\nScope estimate JSON: " + s +
-        "\nRisk assessment JSON: " + r +
-        "\nTask breakdown JSON: " + b +
+        "\nScope estimate: " + s +
+        "\nRisk assessment: " + r +
+        "\nTask breakdown: " + b +
         "\nPast review criteria: " + to_string(rec);
 
     let draft = prompt(
@@ -132,12 +120,11 @@ fn tick(reason: string) -> void {
         context
     ) -> DraftPlan;
 
-    let override_conf = get_confidence();
-    let effective = if override_conf > 0.0 { override_conf; } else { draft.confidence; };
+    let confidence = get_confidence();
 
-    print("[plan_reviewer] Issue", draft.issue_id, "-> review_score:", draft.review_score, "effective:", effective);
+    print("[plan_reviewer] Issue", draft.issue_id, "-> review_score:", draft.review_score);
 
-    if effective >= 0.85 {
+    if confidence >= 0.85 {
         let post_cmd = "./scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft.plan);
         try { exec sh post_cmd; } catch e {
             print("[plan_reviewer] Failed to post note:", e);
@@ -151,7 +138,7 @@ fn tick(reason: string) -> void {
         );
         print("[plan_reviewer] Posted plan to issue", draft.issue_id);
     } else {
-        if effective >= 0.6 {
+        if confidence >= 0.6 {
             emit("planning:draft_plan", draft);
             learn(
                 "review_plan",
@@ -162,14 +149,7 @@ fn tick(reason: string) -> void {
             );
             print("[plan_reviewer] Emitted draft plan for issue", draft.issue_id);
         } else {
-            learn(
-                "review_plan",
-                "issue " + to_string(draft.issue_id),
-                "low confidence: score=" + to_string(draft.review_score),
-                "observed",
-                "planning"
-            );
-            print("[plan_reviewer] Observing (confidence:", effective, ")");
+            print("[plan_reviewer] Observing (confidence:", confidence, ")");
         };
     };
 }

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -1,0 +1,110 @@
+// risk_assessor.ag -- Planning colony: learns delivery risks.
+//
+// Observes closed incident/bug/blocker issues and their notes to learn
+// what historically blocks delivery (dependency surprises, integration
+// gotchas, flaky external services). Assesses risks for new unplanned
+// issues against that accumulated history.
+//
+// Run as daemon: agentis daemon agents/risk_assessor.ag --colony planning
+// Requires: exec_foreign capability, GITLAB_* env vars
+
+cb 500;
+
+type RiskAssessment {
+    issue_id: int,
+    risks: string,
+    severity: string,
+    confidence: float
+}
+
+type IncidentPatterns {
+    observed_count: int,
+    recurring_themes: string
+}
+
+fn unplanned_cmd() -> string {
+    let ts = recall_latest("risk_assessor:last_check");
+    if len(ts) > 0 {
+        return "./scripts/gitlab-api.sh issues --needs-planning --since " + ts;
+    };
+    return "./scripts/gitlab-api.sh issues --needs-planning";
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("risk_assessor:confidence");
+    if len(raw) > 0 {
+        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+    };
+    return 0.0;
+}
+
+fn tick(reason: string) -> void {
+    // 1. Observe: pull recent opened issues and skim for incident-style patterns
+    let recent_raw = try {
+        exec sh "./scripts/gitlab-api.sh issues";
+    } catch e {
+        print("[risk_assessor] GitLab issues poll failed:", e);
+        "";
+    };
+
+    if len(recent_raw) > 10 {
+        let patterns = prompt(
+            "Analyze this recent GitLab issues JSON. Focus on issues labeled 'incident', 'bug', or 'blocker'. What recurring themes appear (dependency surprises, integration gotchas, flaky services)? Return JSON: observed_count (int, how many incident-style issues you saw), recurring_themes (string, one short paragraph).",
+            recent_raw
+        ) -> IncidentPatterns;
+
+        if patterns.observed_count > 0 {
+            learn(
+                "risk_assessment",
+                "batch of " + to_string(patterns.observed_count) + " incident-style issues",
+                patterns.recurring_themes,
+                "observed",
+                "planning"
+            );
+            print("[risk_assessor] Observed", patterns.observed_count, "incident-style issues");
+        };
+    };
+
+    // 2. Act: assess risk for the next unplanned issue
+    let cmd = unplanned_cmd();
+    let issues_raw = try {
+        exec sh cmd;
+    } catch e {
+        print("[risk_assessor] GitLab unplanned-issue poll failed:", e);
+        "";
+    };
+
+    if len(issues_raw) < 3 {
+        return;
+    };
+
+    let rec = recommend("risk_assessment", ["accuracy", "safety"]);
+    let context = "Unplanned issues (newest first): " + issues_raw + "\nPast incident patterns: " + to_string(rec);
+
+    let assessment = prompt(
+        "You are a risk assessor. Pick the newest unplanned issue and identify its delivery risks based on historical incident patterns. Return JSON: issue_id (int, from the issues JSON), risks (string, bulleted markdown list of 2-5 risks), severity (string: 'low', 'medium', or 'high'), confidence (float 0-1).",
+        context
+    ) -> RiskAssessment;
+
+    let confidence = get_confidence();
+
+    print("[risk_assessor] Issue", assessment.issue_id, "-> severity:", assessment.severity);
+
+    if confidence >= 0.6 {
+        emit("planning:risks", assessment);
+        learn(
+            "risk_assessment",
+            "issue " + to_string(assessment.issue_id),
+            assessment.severity + ": " + assessment.risks,
+            "emitted",
+            "planning"
+        );
+    } else {
+        print("[risk_assessor] Observing (confidence:", confidence, ")");
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("risk_assessor:last_check", now);
+    };
+}

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -1,0 +1,111 @@
+// scope_estimator.ag -- Planning colony: learns scope calibration.
+//
+// Observes shipped merge requests and the issues they closed, learns
+// how human estimates compare to actual shipped scope, and estimates
+// the scope of newly filed unplanned issues.
+//
+// Run as daemon: agentis daemon agents/scope_estimator.ag --colony planning
+// Requires: exec_foreign capability, GITLAB_* env vars
+
+cb 500;
+
+type ScopeEstimate {
+    issue_id: int,
+    phases: int,
+    points: int,
+    reasoning: string,
+    confidence: float
+}
+
+type CalibrationSummary {
+    observed_pairs: int,
+    ratio_hint: string,
+    tendencies: string
+}
+
+fn unplanned_cmd() -> string {
+    let ts = recall_latest("scope_estimator:last_check");
+    if len(ts) > 0 {
+        return "./scripts/gitlab-api.sh issues --needs-planning --since " + ts;
+    };
+    return "./scripts/gitlab-api.sh issues --needs-planning";
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("scope_estimator:confidence");
+    if len(raw) > 0 {
+        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+    };
+    return 0.0;
+}
+
+fn tick(reason: string) -> void {
+    // 1. Observe: pull recent merged MRs and learn calibration
+    let merged_raw = try {
+        exec sh "./scripts/gitlab-api.sh merge-requests --state merged";
+    } catch e {
+        print("[scope_estimator] GitLab merged-MR poll failed:", e);
+        "";
+    };
+
+    if len(merged_raw) > 10 {
+        let summary = prompt(
+            "Analyze these recently merged GitLab MRs. For each MR that closes an issue, compare the issue body's implied scope (phases, story points, or rough size) to the actual diff size and number of files touched. Summarize patterns (tendencies), give a rough over/under ratio hint (ratio_hint), and count the pairs you could compare (observed_pairs). Return JSON: observed_pairs (int), ratio_hint (string), tendencies (string).",
+            merged_raw
+        ) -> CalibrationSummary;
+
+        if summary.observed_pairs > 0 {
+            learn(
+                "scope_estimate",
+                "batch of " + to_string(summary.observed_pairs) + " shipped MRs",
+                "ratio: " + summary.ratio_hint + " | " + summary.tendencies,
+                "observed",
+                "planning"
+            );
+            print("[scope_estimator] Observed", summary.observed_pairs, "shipped pairs");
+        };
+    };
+
+    // 2. Act: estimate scope for the next unplanned issue
+    let cmd = unplanned_cmd();
+    let issues_raw = try {
+        exec sh cmd;
+    } catch e {
+        print("[scope_estimator] GitLab unplanned-issue poll failed:", e);
+        "";
+    };
+
+    if len(issues_raw) < 3 {
+        return;
+    };
+
+    let rec = recommend("scope_estimate", ["accuracy"]);
+    let context = "Unplanned issues (newest first): " + issues_raw + "\nPast calibration: " + to_string(rec);
+
+    let estimate = prompt(
+        "You are a scope estimator. Pick the newest unplanned issue and estimate its scope. Return JSON: issue_id (int, from the issues JSON), phases (int, 1-5), points (int, Fibonacci 1/2/3/5/8/13), reasoning (string, one short paragraph), confidence (float 0-1).",
+        context
+    ) -> ScopeEstimate;
+
+    let confidence = get_confidence();
+
+    print("[scope_estimator] Issue", estimate.issue_id, "->", estimate.phases, "phases,", estimate.points, "points");
+
+    if confidence >= 0.6 {
+        emit("planning:scope_estimate", estimate);
+        learn(
+            "scope_estimate",
+            "issue " + to_string(estimate.issue_id),
+            to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+            "emitted",
+            "planning"
+        );
+    } else {
+        print("[scope_estimator] Observing (confidence:", confidence, ")");
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("scope_estimator:last_check", now);
+    };
+}

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -1,0 +1,111 @@
+// task_decomposer.ag -- Planning colony: learns subtask granularity.
+//
+// Observes closed epics and their child issues to learn how you split
+// work into subtasks (average breakdown size, size distribution,
+// common ordering patterns). Proposes a subtask breakdown for new
+// unplanned issues.
+//
+// Run as daemon: agentis daemon agents/task_decomposer.ag --colony planning
+// Requires: exec_foreign capability, GITLAB_* env vars
+
+cb 500;
+
+type TaskBreakdown {
+    issue_id: int,
+    subtasks: string,
+    count: int,
+    confidence: float
+}
+
+type DecompositionPatterns {
+    epics_seen: int,
+    avg_subtasks: int,
+    style: string
+}
+
+fn unplanned_cmd() -> string {
+    let ts = recall_latest("task_decomposer:last_check");
+    if len(ts) > 0 {
+        return "./scripts/gitlab-api.sh issues --needs-planning --since " + ts;
+    };
+    return "./scripts/gitlab-api.sh issues --needs-planning";
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("task_decomposer:confidence");
+    if len(raw) > 0 {
+        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+    };
+    return 0.0;
+}
+
+fn tick(reason: string) -> void {
+    // 1. Observe: analyze recent issues to infer decomposition style
+    let recent_raw = try {
+        exec sh "./scripts/gitlab-api.sh issues";
+    } catch e {
+        print("[task_decomposer] GitLab issues poll failed:", e);
+        "";
+    };
+
+    if len(recent_raw) > 10 {
+        let patterns = prompt(
+            "Analyze this recent GitLab issues JSON. Identify epics (issues labeled 'epic' or with subtask-like child references in the description). For each epic you can see, estimate how many subtasks were created. Summarize the decomposition style (checklist vs linked issues, granularity). Return JSON: epics_seen (int), avg_subtasks (int), style (string, one short sentence).",
+            recent_raw
+        ) -> DecompositionPatterns;
+
+        if patterns.epics_seen > 0 {
+            learn(
+                "task_decomposition",
+                "batch of " + to_string(patterns.epics_seen) + " epics",
+                "avg " + to_string(patterns.avg_subtasks) + " subtasks | " + patterns.style,
+                "observed",
+                "planning"
+            );
+            print("[task_decomposer] Observed", patterns.epics_seen, "epics, avg", patterns.avg_subtasks, "subtasks");
+        };
+    };
+
+    // 2. Act: propose a subtask breakdown for the next unplanned issue
+    let cmd = unplanned_cmd();
+    let issues_raw = try {
+        exec sh cmd;
+    } catch e {
+        print("[task_decomposer] GitLab unplanned-issue poll failed:", e);
+        "";
+    };
+
+    if len(issues_raw) < 3 {
+        return;
+    };
+
+    let rec = recommend("task_decomposition", ["accuracy"]);
+    let context = "Unplanned issues (newest first): " + issues_raw + "\nPast decomposition patterns: " + to_string(rec);
+
+    let breakdown = prompt(
+        "You are a task decomposer. Pick the newest unplanned issue and propose a subtask breakdown that matches past granularity (learned average). Return JSON: issue_id (int, from the issues JSON), subtasks (string, numbered markdown list of 3-8 subtasks), count (int, how many subtasks), confidence (float 0-1).",
+        context
+    ) -> TaskBreakdown;
+
+    let confidence = get_confidence();
+
+    print("[task_decomposer] Issue", breakdown.issue_id, "->", breakdown.count, "subtasks");
+
+    if confidence >= 0.6 {
+        emit("planning:breakdown", breakdown);
+        learn(
+            "task_decomposition",
+            "issue " + to_string(breakdown.issue_id),
+            to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+            "emitted",
+            "planning"
+        );
+    } else {
+        print("[task_decomposer] Observing (confidence:", confidence, ")");
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("task_decomposer:last_check", now);
+    };
+}

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -23,23 +23,23 @@ backend = "cli"
 [[agents]]
 name = "scope_estimator"
 source = "agents/scope_estimator.ag"
-cb_budget = 800
+cb_budget = 500
 tick_interval_ms = 60000
 
 [[agents]]
 name = "risk_assessor"
 source = "agents/risk_assessor.ag"
-cb_budget = 600
+cb_budget = 500
 tick_interval_ms = 60000
 
 [[agents]]
 name = "task_decomposer"
 source = "agents/task_decomposer.ag"
-cb_budget = 1000
+cb_budget = 500
 tick_interval_ms = 60000
 
 [[agents]]
 name = "plan_reviewer"
 source = "agents/plan_reviewer.ag"
-cb_budget = 800
+cb_budget = 600
 tick_interval_ms = 60000

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# GitLab API wrapper for planning colony agents.
+# Called by .ag agents via exec sh.
+#
+# Required env vars (set by start-colony.sh from colony.toml):
+#   GITLAB_URL     - GitLab instance URL (e.g. https://gitlab.example.com)
+#   GITLAB_TOKEN   - Personal access token or project token
+#   GITLAB_PROJECT - URL-encoded project path (e.g. your-org%2Fyour-project)
+#
+# Usage:
+#   gitlab-api.sh issues --needs-planning [--since ISO8601]
+#   gitlab-api.sh issue <iid>
+#   gitlab-api.sh issue-notes <iid>
+#   gitlab-api.sh add-note <iid> --body <text>
+#   gitlab-api.sh merge-requests [--state merged] [--since ISO8601]
+#   gitlab-api.sh mr <iid>
+#
+# Planning only reads from GitLab and posts comments. It never changes labels,
+# approves, assigns, or merges — that surface lives in triage / code-review /
+# release colonies. If you are tempted to add a write endpoint here, it
+# probably belongs in a different colony.
+#
+# Returns JSON to stdout. Exit code 0 on success, 1 on error.
+
+set -e
+
+if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
+    echo '{"error": "GITLAB_URL, GITLAB_TOKEN, and GITLAB_PROJECT must be set"}' >&2
+    exit 1
+fi
+
+API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
+
+gl_get() {
+    curl -sfS --max-time 30 \
+        -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+        "$1"
+}
+
+gl_post() {
+    curl -sfS --max-time 30 \
+        -X POST \
+        -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$2" \
+        "$1"
+}
+
+CMD="${1:?Usage: gitlab-api.sh <command> [args...]}"
+shift
+
+case "$CMD" in
+    issues)
+        SINCE=""
+        NEEDS_PLANNING=0
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) SINCE="$2"; shift 2 ;;
+                --needs-planning) NEEDS_PLANNING=1; shift ;;
+                *) shift ;;
+            esac
+        done
+        URL="$API/issues?state=opened&per_page=20&order_by=updated_at&sort=desc"
+        if [ "$NEEDS_PLANNING" -eq 1 ]; then
+            URL="$URL&labels=needs-planning"
+        fi
+        if [ -n "$SINCE" ]; then
+            URL="$URL&updated_after=$SINCE"
+        fi
+        gl_get "$URL"
+        ;;
+
+    issue)
+        ID="${1:?Usage: gitlab-api.sh issue <iid>}"
+        gl_get "$API/issues/$ID"
+        ;;
+
+    issue-notes)
+        ID="${1:?Usage: gitlab-api.sh issue-notes <iid>}"
+        gl_get "$API/issues/$ID/notes?per_page=50&order_by=created_at&sort=desc"
+        ;;
+
+    add-note)
+        ID="${1:?Usage: gitlab-api.sh add-note <iid> --body <text>}"
+        shift
+        BODY=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --body) BODY="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        if [ -z "$BODY" ]; then
+            echo '{"error": "--body is required"}' >&2
+            exit 1
+        fi
+        # Escape double quotes and backslashes for JSON
+        ESCAPED_BODY=$(printf '%s' "$BODY" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')
+        gl_post "$API/issues/$ID/notes" "{\"body\":\"$ESCAPED_BODY\"}"
+        ;;
+
+    merge-requests)
+        STATE="opened"
+        SINCE=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --state) STATE="$2"; shift 2 ;;
+                --since) SINCE="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        URL="$API/merge_requests?state=$STATE&per_page=20&order_by=updated_at&sort=desc"
+        if [ -n "$SINCE" ]; then
+            URL="$URL&updated_after=$SINCE"
+        fi
+        gl_get "$URL"
+        ;;
+
+    mr)
+        ID="${1:?Usage: gitlab-api.sh mr <iid>}"
+        gl_get "$API/merge_requests/$ID"
+        ;;
+
+    *)
+        echo "{\"error\": \"Unknown command: $CMD\"}" >&2
+        exit 1
+        ;;
+esac

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -94,9 +94,10 @@ case "$CMD" in
             echo '{"error": "--body is required"}' >&2
             exit 1
         fi
-        # Escape double quotes and backslashes for JSON
-        ESCAPED_BODY=$(printf '%s' "$BODY" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')
-        gl_post "$API/issues/$ID/notes" "{\"body\":\"$ESCAPED_BODY\"}"
+        # Use python3 json.dumps so newlines, quotes, backslashes, and control
+        # chars are all escaped correctly and markdown formatting is preserved.
+        JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
+        gl_post "$API/issues/$ID/notes" "$JSON_BODY"
         ;;
 
     merge-requests)

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -8,7 +8,9 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve symlinks on $0 itself so the script works when invoked via a symlink.
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 COLONY_DIR="$(dirname "$SCRIPT_DIR")"
 CONFIG="${1:-$COLONY_DIR/config/colony.toml}"
 
@@ -18,6 +20,33 @@ if [ ! -f "$CONFIG" ]; then
     exit 1
 fi
 
+# Parse GitLab config from TOML via the shared helper.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=../../../tools/parse-toml.sh
+# shellcheck disable=SC1091  # colony-lint runs shellcheck without -x
+. "$REPO_ROOT/tools/parse-toml.sh"
+
+GITLAB_URL=$(parse_toml gitlab url)
+GITLAB_TOKEN=$(parse_toml gitlab token)
+GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
+
+if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
+    echo "Error: GitLab config incomplete in $CONFIG"
+    echo "Required: url, token, project under [gitlab]"
+    exit 1
+fi
+
+# URL-encode the project path (replace / with %2F)
+GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
+
+export GITLAB_URL
+export GITLAB_TOKEN
+export GITLAB_PROJECT
+export COLONY_DIR
+
+# Parse LLM backend
+LLM_BACKEND=$(parse_toml llm backend)
+
 AGENTS=(
     scope_estimator
     risk_assessor
@@ -26,13 +55,23 @@ AGENTS=(
 )
 
 echo "Starting Planning colony (${#AGENTS[@]} agents)..."
+echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
+echo "  LLM: ${LLM_BACKEND:-mock}"
 
 for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
-    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
-        --colony planning \
-        --backend claude \
-        --tick-interval 60000 &
+    if [ -n "$LLM_BACKEND" ]; then
+        agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+            --colony planning \
+            --backend "$LLM_BACKEND" \
+            --tick-interval 60000 \
+            --enable-exec &
+    else
+        agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+            --colony planning \
+            --tick-interval 60000 \
+            --enable-exec &
+    fi
     sleep 2  # stagger starts to reduce API contention
 done
 


### PR DESCRIPTION
## Summary

- Adds the four planning colony agents (scope_estimator, risk_assessor, task_decomposer, plan_reviewer) with learned thresholds for observe/suggest/act
- Adds a lean `scripts/gitlab-api.sh` wrapper (read-only endpoints plus `add-note`) since planning is observe-and-suggest — it never writes labels, approves, or merges
- Hardens `scripts/start-colony.sh` to match the triage template: symlink-safe path resolution, `parse_toml` via shared helper, `GITLAB_*` env export, LLM backend detection, `--enable-exec` flag

## Agent behavior

Each agent runs as its own daemon and follows the same tick shape:

1. **Observe**: pull recent GitLab state (merged MRs, issues, incident patterns), summarize via `prompt() -> Type`, record via `learn(...)` with `"observed"` outcome.
2. **Act**: pick the newest issue labeled `needs-planning` and propose its contribution.
3. **Confidence gate**: read per-agent override from memo; at `>= 0.6` emit the suggestion bus event, otherwise stay in observe mode.
4. **Memoize `last_check`**: use `--since` on the next tick.

### scope_estimator
- Types: `ScopeEstimate { issue_id, phases, points, reasoning, confidence }`, `CalibrationSummary { observed_pairs, ratio_hint, tendencies }`
- Learns from shipped MRs: compares implied scope to actual diff size, remembers over/under ratios
- Emits `planning:scope_estimate`

### risk_assessor
- Types: `RiskAssessment { issue_id, risks, severity, confidence }`, `IncidentPatterns { observed_count, recurring_themes }`
- Learns from recent incident/bug/blocker issues: extracts recurring themes (flaky services, integration gotchas)
- Emits `planning:risks`

### task_decomposer
- Types: `TaskBreakdown { issue_id, subtasks, count, confidence }`, `DecompositionPatterns { epics_seen, avg_subtasks, style }`
- Learns granularity from past epics: average subtask count and decomposition style
- Emits `planning:breakdown` with a 3-8 item numbered markdown list

### plan_reviewer
- Listens on all three peer buses, stashes each partial output in memo under `plan_reviewer:<issue_id>:<slot>` so outputs arriving across multiple ticks can still be combined
- When all three slots are populated for the newest unplanned issue, assembles a single markdown plan with **Scope**, **Risks**, **Subtasks** sections
- Self-reviews against past criteria via `recommend("review_plan", ["completeness"])`
- At effective confidence `>= 0.85`: posts as issue comment via `gitlab-api.sh add-note`
- At `>= 0.6` but `< 0.85`: emits `planning:draft_plan` for human review
- Always calls `learn("review_plan", ...)` on every observation

## gitlab-api.sh endpoints

```
issues --needs-planning [--since ISO8601]
issue <iid>
issue-notes <iid>
add-note <iid> --body <text>
merge-requests [--state merged] [--since ISO8601]
mr <iid>
```

No `label`, `approve`, `assign`, or `merge` endpoints. Planning only reads and comments. The header comment says this explicitly so the next colony implementer does not drift the surface.

## Test plan

- [x] `./tools/colony-lint.sh` passes (structure, config, markdown, .ag syntax for all 4 agents)
- [x] `agentis commit` parses all 4 agent files without errors
- [x] `bash -n` clean on both scripts
- [x] `start-colony.sh` spawns 4 daemons mirroring `AGENTS=(scope_estimator risk_assessor task_decomposer plan_reviewer)`
- [x] `plan_reviewer.ag` uses `listen()` with 500ms timeout on all three peer buses and keys partial outputs by issue_id so multi-tick aggregation works
- [x] `gitlab-api.sh` has no write endpoints beyond `add-note`

Closes #36

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>