### PR TITLE
fix(planning): URL-encode query parameters in gitlab-api.sh

### DIFF
--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -37,6 +37,19 @@ gl_get() {
         "$1"
 }
 
+# gl_get_q <url> [--data-urlencode k=v ...]
+# Uses curl -G so each key=value pair is URL-encoded safely. Use this
+# for any endpoint whose query string takes values that could contain
+# spaces, '&', '#', or non-ASCII. Plain path-only GETs keep using gl_get.
+gl_get_q() {
+    local url="$1"
+    shift
+    curl -sfS -G --max-time 30 \
+        -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+        "$@" \
+        "$url"
+}
+
 gl_post() {
     curl -sfS --max-time 30 \
         -X POST \
@@ -60,14 +73,19 @@ case "$CMD" in
                 *) shift ;;
             esac
         done
-        URL="$API/issues?state=opened&per_page=20&order_by=updated_at&sort=desc"
+        ARGS=(
+            --data-urlencode "state=opened"
+            --data-urlencode "per_page=20"
+            --data-urlencode "order_by=updated_at"
+            --data-urlencode "sort=desc"
+        )
         if [ "$NEEDS_PLANNING" -eq 1 ]; then
-            URL="$URL&labels=needs-planning"
+            ARGS+=(--data-urlencode "labels=needs-planning")
         fi
         if [ -n "$SINCE" ]; then
-            URL="$URL&updated_after=$SINCE"
+            ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get "$URL"
+        gl_get_q "$API/issues" "${ARGS[@]}"
         ;;
 
     issue)
@@ -110,11 +128,16 @@ case "$CMD" in
                 *) shift ;;
             esac
         done
-        URL="$API/merge_requests?state=$STATE&per_page=20&order_by=updated_at&sort=desc"
+        ARGS=(
+            --data-urlencode "state=$STATE"
+            --data-urlencode "per_page=20"
+            --data-urlencode "order_by=updated_at"
+            --data-urlencode "sort=desc"
+        )
         if [ -n "$SINCE" ]; then
-            URL="$URL&updated_after=$SINCE"
+            ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get "$URL"
+        gl_get_q "$API/merge_requests" "${ARGS[@]}"
         ;;
 
     mr)


### PR DESCRIPTION
## Summary

- Switches `issues` and `merge-requests` endpoints in `planning/scripts/gitlab-api.sh` from raw query-string concatenation to `curl -G --data-urlencode`, so each key=value pair is URL-encoded safely
- Adds a small `gl_get_q` helper alongside the existing `gl_get` (plain path-only GETs keep using `gl_get`)
- Path-only endpoints (`issue`, `issue-notes`, `add-note`, `mr`) are unchanged

## Why

Today the agents only pass ISO8601 timestamps and ASCII labels, so raw concatenation happens to work. Any value containing `&`, `#`, `?`, a space, or non-ASCII would silently fragment the query — a future endpoint or a hand-invoked run could hit this at any time.

## Verified

Ran real curl against a bogus URL with `-w "%{url_effective}"` to observe what it actually sends on the wire:

```
curl -sG --data-urlencode "labels=in progress" \
    --data-urlencode "updated_after=2026-04-11T08:15:02Z" \
    --data-urlencode "title=hash # and & amp" \
    -w "%{url_effective}\n" "https://127.0.0.1:1/test"
```

Result:
```
https://127.0.0.1:1/test?labels=in+progress&updated_after=2026-04-11T08%3a15%3a02Z&title=hash+%23+and+%26+amp
```

Space → `+`, `:` → `%3a`, `#` → `%23`, `&` → `%26`. All dangerous chars encoded.

## Test plan

- [x] `./tools/colony-lint.sh` — 29 pass, 0 fail, 5 shellcheck skips
- [x] `bash -n dev-apprenticeship/planning/scripts/gitlab-api.sh` — clean
- [x] Mock curl smoke test confirms both `issues` and `merge-requests` flow through `gl_get_q` with `-G` and `--data-urlencode` args; path-only endpoints still use plain `gl_get`
- [x] Real curl confirms every dangerous character is encoded by `--data-urlencode`

## Out of scope

- Triage and code-review wrappers have the same raw-concatenation pattern in their `issues` / `merge-requests` endpoints (3 call sites total) — tracked as #41, not bundled here to keep the PR reviewable

Closes #14

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>