### PR TITLE
fix(tools): bundle parse_toml hardening fixes (#26, #30, #32, #33)

### DIFF
--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -262,6 +262,21 @@ if command -v shellcheck &>/dev/null; then
     fi
 fi
 
+# --- Tools unit tests ---
+test_scripts=()
+while IFS= read -r -d '' f; do
+    test_scripts+=("$f")
+done < <(find "$REPO_ROOT/tools" -name "test-*.sh" -print0 2>/dev/null)
+
+for t in "${test_scripts[@]}"; do
+    if bash "$t" &>/dev/null; then
+        pass "tools: $(basename "$t") unit tests"
+    else
+        fail "tools: $(basename "$t") unit tests"
+        bash "$t" 2>&1 | tail -20
+    fi
+done
+
 # --- Summary ---
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"

--- a/tools/parse-toml.sh
+++ b/tools/parse-toml.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # tools/parse-toml.sh: shared TOML key lookup for colony start scripts.
 #
 # Usage: source this file, then call `parse_toml SECTION KEY`. Expects
@@ -11,17 +10,51 @@
 # shellcheck shell=bash
 
 parse_toml() {
+    if [ "$#" -ne 2 ]; then
+        echo "parse_toml: usage: parse_toml SECTION KEY (got $# args)" >&2
+        return 2
+    fi
     python3 - "$CONFIG" "$1" "$2" <<'PY'
 import sys
 path, section, key = sys.argv[1], sys.argv[2], sys.argv[3]
-target_header = "[" + section + "]"
+
+
+def strip_inline_comment(line):
+    """Strip a trailing `# comment` from a TOML line, respecting quoted
+    strings so a `#` inside `"..."` or `'...'` is preserved."""
+    out = []
+    quote = None
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if quote:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(line[i + 1])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+        else:
+            if ch == "#":
+                break
+            if ch in ('"', "'"):
+                quote = ch
+            out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 in_section = False
 with open(path, "r", encoding="utf-8") as f:
     for raw in f:
-        line = raw.split("#", 1)[0].rstrip("\n")
+        line = strip_inline_comment(raw).rstrip("\n")
         stripped = line.strip()
         if stripped.startswith("[") and stripped.endswith("]"):
-            in_section = (stripped == target_header)
+            # Allow `[ gitlab ]` with interior whitespace per TOML spec.
+            sect_name = stripped[1:-1].strip()
+            in_section = (sect_name == section)
             continue
         if not in_section:
             continue

--- a/tools/test-parse-toml.sh
+++ b/tools/test-parse-toml.sh
@@ -11,6 +11,7 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=parse-toml.sh
+# shellcheck disable=SC1091  # colony-lint runs shellcheck without -x
 . "$SCRIPT_DIR/parse-toml.sh"
 
 PASS=0
@@ -90,6 +91,17 @@ else
     fail "#33: missing KEY" "rc=2 + stderr msg" "rc=$rc out=$out"
 fi
 
+# Zero-arg call must also fail loudly.
+set +e
+out="$(parse_toml 2>&1 >/dev/null)"
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && [ -n "$out" ]; then
+    pass "#33: zero args exits 2 with stderr message"
+else
+    fail "#33: zero args" "rc=2 + stderr msg" "rc=$rc out=$out"
+fi
+
 # Also verify the too-many-args path.
 set +e
 out="$(parse_toml gitlab url extra 2>&1 >/dev/null)"
@@ -122,6 +134,38 @@ url = "x"
 '
 assert_eq "regression: unknown section" "" "$(parse_toml nope url)"
 assert_eq "regression: unknown key" "" "$(parse_toml gitlab nope)"
+
+# --- Test 8: single-quoted values — `#` inside `'...'` is preserved ---
+fixture "single-quoted" "[gitlab]
+token = 'glpat-single#quoted'
+project = 'org/proj'
+"
+assert_eq "#26: single-quoted hash preserved" "glpat-single#quoted" "$(parse_toml gitlab token)"
+assert_eq "#26: single-quoted plain" "org/proj" "$(parse_toml gitlab project)"
+
+# --- Test 9: tab-separated section brackets ---
+printf '[\tgitlab\t]\nurl = "https://tabbed.example.com"\n' > "$TMPDIR_TEST/tabbed.toml"
+CONFIG="$TMPDIR_TEST/tabbed.toml"
+export CONFIG
+assert_eq "#32: tab-padded section header" "https://tabbed.example.com" "$(parse_toml gitlab url)"
+
+# --- Test 10: empty value ---
+fixture "empty-value" '[gitlab]
+url = ""
+token = "non-empty"
+'
+assert_eq "empty quoted value returns empty" "" "$(parse_toml gitlab url)"
+assert_eq "empty value does not break next key" "non-empty" "$(parse_toml gitlab token)"
+
+# --- Test 11: same-name key in sibling section is ignored ---
+fixture "sibling-same-name" '[gitlab]
+url = "gitlab-url"
+
+[llm]
+url = "llm-url"
+'
+assert_eq "gitlab.url resolves to gitlab section" "gitlab-url" "$(parse_toml gitlab url)"
+assert_eq "llm.url resolves to llm section" "llm-url" "$(parse_toml llm url)"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tools/test-parse-toml.sh
+++ b/tools/test-parse-toml.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# tools/test-parse-toml.sh: unit tests for tools/parse-toml.sh.
+#
+# Self-contained. Creates temporary fixture files, sources parse-toml.sh,
+# asserts each function behavior, cleans up on exit.
+#
+# Usage: ./tools/test-parse-toml.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=parse-toml.sh
+. "$SCRIPT_DIR/parse-toml.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: expected <$2>, got <$3>"; FAIL=$((FAIL + 1)); }
+
+fixture() {
+    local name="$1"
+    local content="$2"
+    CONFIG="$TMPDIR_TEST/$name.toml"
+    printf '%s' "$content" > "$CONFIG"
+    export CONFIG
+}
+
+assert_eq() {
+    local name="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        pass "$name"
+    else
+        fail "$name" "$expected" "$actual"
+    fi
+}
+
+# --- Test 1: regression — plain key/value still works ---
+fixture "regression" '[gitlab]
+url = "https://gitlab.example.com"
+token = "glpat-plain"
+project = "my-org/my-proj"
+'
+assert_eq "regression: url" "https://gitlab.example.com" "$(parse_toml gitlab url)"
+assert_eq "regression: token" "glpat-plain" "$(parse_toml gitlab token)"
+assert_eq "regression: project" "my-org/my-proj" "$(parse_toml gitlab project)"
+
+# --- Test 2: #26 — `#` inside quoted value is preserved ---
+fixture "hash-in-value" '[gitlab]
+token = "glpat-abc#def"
+project = "foo#bar/baz"
+'
+assert_eq "#26: hash in token" "glpat-abc#def" "$(parse_toml gitlab token)"
+assert_eq "#26: hash in project" "foo#bar/baz" "$(parse_toml gitlab project)"
+
+# --- Test 3: #26 — inline comment still stripped when value has no `#` ---
+fixture "inline-comment" '[gitlab]
+url = "https://example.com" # inline comment here
+token = "abc#def" # comment after quoted hash
+'
+assert_eq "#26: inline comment stripped" "https://example.com" "$(parse_toml gitlab url)"
+assert_eq "#26: inline comment after quoted hash" "abc#def" "$(parse_toml gitlab token)"
+
+# --- Test 4: #32 — section header with interior whitespace ---
+fixture "spaced-section" '[ gitlab ]
+url = "https://spaced.example.com"
+[  llm  ]
+backend = "cli"
+'
+assert_eq "#32: spaced [ gitlab ]" "https://spaced.example.com" "$(parse_toml gitlab url)"
+assert_eq "#32: double-spaced [  llm  ]" "cli" "$(parse_toml llm backend)"
+
+# --- Test 5: #33 — missing KEY argument fails loudly ---
+fixture "any" '[gitlab]
+url = "x"
+'
+# Disable set -e for the failing-call check so the whole script does not abort.
+set +e
+out="$(parse_toml gitlab 2>&1 >/dev/null)"
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && [ -n "$out" ]; then
+    pass "#33: missing KEY exits 2 with stderr message"
+else
+    fail "#33: missing KEY" "rc=2 + stderr msg" "rc=$rc out=$out"
+fi
+
+# Also verify the too-many-args path.
+set +e
+out="$(parse_toml gitlab url extra 2>&1 >/dev/null)"
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && [ -n "$out" ]; then
+    pass "#33: extra args exits 2 with stderr message"
+else
+    fail "#33: extra args" "rc=2 + stderr msg" "rc=$rc out=$out"
+fi
+
+# --- Test 6: combined — all four fixes active on one multi-section fixture ---
+fixture "combined" '# top-of-file comment
+[ gitlab ]
+url = "https://combo.example.com" # trailing
+token = "glpat-has#hash"
+project = "my-org/my-proj"
+
+[llm]
+backend = "cli"
+'
+assert_eq "combined: url (spaced section + trailing comment)" "https://combo.example.com" "$(parse_toml gitlab url)"
+assert_eq "combined: token (hash in value)" "glpat-has#hash" "$(parse_toml gitlab token)"
+assert_eq "combined: project" "my-org/my-proj" "$(parse_toml gitlab project)"
+assert_eq "combined: backend (different section)" "cli" "$(parse_toml llm backend)"
+
+# --- Test 7: regression — unknown section returns empty ---
+fixture "unknown" '[gitlab]
+url = "x"
+'
+assert_eq "regression: unknown section" "" "$(parse_toml nope url)"
+assert_eq "regression: unknown key" "" "$(parse_toml gitlab nope)"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Four small fixes to `tools/parse-toml.sh`, bundled because they all touch the same 40-line helper. Every current caller (`triage`, `code-review`, `planning` `start-colony.sh`) still parses a fresh `colony.toml` correctly against the new helper.

| # | Severity | Fix |
|---|---|---|
| #26 | LOW | `#` inside quoted value was silently truncated. Replace naive `split("#", 1)` with state-machine `strip_inline_comment()` that respects `"..."` and `'...'` |
| #30 | NIT | Drop redundant `#!/bin/bash` shebang — file is chmod 644, source only (SC2148) |
| #32 | LOW | Section matching was exact, so `[ gitlab ]` with interior whitespace was skipped. Parse bracket contents and strip whitespace |
| #33 | LOW | `parse_toml` with missing KEY silently returned empty. Add `[ $# -ne 2 ]` guard that exits 2 with stderr message |

## Tests

Adds `tools/test-parse-toml.sh` with 25 assertions covering the four fixes plus regressions:

- `#26`: hash in double-quoted + single-quoted value, inline comment stripped, inline comment after quoted hash
- `#32`: spaced `[ gitlab ]`, double-spaced `[  llm  ]`, tab-padded section header
- `#33`: zero args, missing KEY, extra args — all exit 2 with stderr
- Regression: unknown section, unknown key, empty quoted value, sibling section same-name key, plain key/value
- Combined multi-section fixture exercising all four fixes at once

Adds a test-runner hook at the end of `tools/colony-lint.sh` that discovers and runs every `tools/test-*.sh`, so future regressions fail the lint automatically. This is the first `tools/test-*.sh` in the repo; the hook is general.

## Test plan

- [x] `tools/test-parse-toml.sh` — 25 pass / 0 fail
- [x] `./tools/colony-lint.sh` — 30 pass / 0 fail / 5 skip (shellcheck skipped locally only)
- [x] CI green (colony-lint including shellcheck on CI runners)
- [x] Manual smoke: sourced the new helper and called `parse_toml gitlab url|token|project` + `parse_toml llm backend` from all three sourcing colonies, all return expected values
- [x] `bash -n` clean on all three changed files

## Out of scope

- Moving to a real TOML parser (`python3 -c 'import tomllib'`). Considered and rejected — introduces a Python 3.11+ requirement for the helper, whereas the four targeted fixes keep the blast radius inside 40 lines.

Closes #26
Closes #30
Closes #32
Closes #33