### PR TITLE
fix(triage,code-review): URL-encode gitlab-api query parameters

### DIFF
--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -35,6 +35,19 @@ gl_get() {
         "$1"
 }
 
+# gl_get_q <url> [--data-urlencode k=v ...]
+# Uses curl -G so each key=value pair is URL-encoded safely. Use this
+# for any endpoint whose query string takes values that could contain
+# spaces, '&', '#', or non-ASCII. Plain path-only GETs keep using gl_get.
+gl_get_q() {
+    local url="$1"
+    shift
+    curl -sfS -G --max-time 30 \
+        -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+        "$@" \
+        "$url"
+}
+
 gl_post() {
     curl -sfS --max-time 30 \
         -X POST \
@@ -58,11 +71,16 @@ case "$CMD" in
                 *) shift ;;
             esac
         done
-        URL="$API/merge_requests?state=$STATE&per_page=20&order_by=updated_at&sort=desc"
+        ARGS=(
+            --data-urlencode "state=$STATE"
+            --data-urlencode "per_page=20"
+            --data-urlencode "order_by=updated_at"
+            --data-urlencode "sort=desc"
+        )
         if [ -n "$SINCE" ]; then
-            URL="$URL&updated_after=$SINCE"
+            ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get "$URL"
+        gl_get_q "$API/merge_requests" "${ARGS[@]}"
         ;;
 
     mr)
@@ -122,11 +140,16 @@ case "$CMD" in
                 *) shift ;;
             esac
         done
-        URL="$API/issues?state=$STATE&per_page=20&order_by=updated_at&sort=desc"
+        ARGS=(
+            --data-urlencode "state=$STATE"
+            --data-urlencode "per_page=20"
+            --data-urlencode "order_by=updated_at"
+            --data-urlencode "sort=desc"
+        )
         if [ -n "$SINCE" ]; then
-            URL="$URL&updated_after=$SINCE"
+            ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get "$URL"
+        gl_get_q "$API/issues" "${ARGS[@]}"
         ;;
 
     *)

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -34,6 +34,19 @@ gl_get() {
         "$1"
 }
 
+# gl_get_q <url> [--data-urlencode k=v ...]
+# Uses curl -G so each key=value pair is URL-encoded safely. Use this
+# for any endpoint whose query string takes values that could contain
+# spaces, '&', '#', or non-ASCII. Plain path-only GETs keep using gl_get.
+gl_get_q() {
+    local url="$1"
+    shift
+    curl -sfS -G --max-time 30 \
+        -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+        "$@" \
+        "$url"
+}
+
 gl_post() {
     curl -sfS --max-time 30 \
         -X POST \
@@ -66,11 +79,16 @@ case "$CMD" in
                 *) shift ;;
             esac
         done
-        URL="$API/issues?state=$STATE&per_page=20&order_by=updated_at&sort=desc"
+        ARGS=(
+            --data-urlencode "state=$STATE"
+            --data-urlencode "per_page=20"
+            --data-urlencode "order_by=updated_at"
+            --data-urlencode "sort=desc"
+        )
         if [ -n "$SINCE" ]; then
-            URL="$URL&updated_after=$SINCE"
+            ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get "$URL"
+        gl_get_q "$API/issues" "${ARGS[@]}"
         ;;
 
     issue)
@@ -152,8 +170,9 @@ case "$CMD" in
             SEP=","
         fi
         if [ -n "$ASSIGNEE" ]; then
-            # Look up user ID by username
-            USER_JSON=$(gl_get "$GITLAB_URL/api/v4/users?username=$ASSIGNEE")
+            # Look up user ID by username. Use gl_get_q so usernames with
+            # `+`, `&`, or non-ASCII characters survive encoding intact.
+            USER_JSON=$(gl_get_q "$GITLAB_URL/api/v4/users" --data-urlencode "username=$ASSIGNEE")
             USER_ID=$(echo "$USER_JSON" | grep -o '"id":[0-9]*' | head -1 | cut -d: -f2)
             if [ -n "$USER_ID" ]; then
                 BODY="$BODY${SEP}\"assignee_ids\":[$USER_ID]"


### PR DESCRIPTION
## Summary

- Apply the `gl_get_q` + `curl -G --data-urlencode` pattern from PR #40 (planning) to triage and code-review wrappers
- Fix the same query-string injection bug in three places: triage `issues`, code-review `merge-requests`, code-review `issues`
- Bonus: triage `update-issue --assignee` user lookup had the same bug — usernames with `+`, `&`, or spaces silently fragmented the query

## What changed

| File | Endpoints rewritten |
|---|---|
| `dev-apprenticeship/triage/scripts/gitlab-api.sh` | `issues`, `update-issue --assignee` lookup |
| `dev-apprenticeship/code-review/scripts/gitlab-api.sh` | `merge-requests`, `issues` |

Both files now expose `gl_get_q <url> [--data-urlencode k=v ...]` alongside the existing `gl_get`. Path-only GETs (numeric IID lookups, hardcoded `per_page=100`, etc.) keep using `gl_get` — there is no injection vector when no user input flows into the query.

## What did not change

- `mr`, `mr-changes`, `mr-notes`, `mr-approvals`, `members` in code-review — all hardcoded query strings or numeric IID paths
- `issue`, `issue-events`, `issue-notes`, `members`, `labels` in triage — same reason
- JSON body encoding in `create-issue` / `update-issue` — separate bug class, would be a follow-up if it matters

## Test plan

- [x] Mock-curl smoke test on every rewritten endpoint, verifying the `--data-urlencode` pairs flow through with tricky values like `2024-01-01T00:00:00+02:00`, `alice+bob & co`
- [x] Verified the assignee lookup runs `gl_get_q` first, then the PUT, both with correct args
- [x] `./tools/colony-lint.sh` — 30 pass / 0 fail / 5 skip (same as main)
- [x] `bash -n` clean on both files

Closes #41