### PR TITLE
docs: fix stale exec shell comment and add confidence bootstrap docs

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -84,6 +84,69 @@ When onboarding a new project, colonies carry over `personal` knowledge and star
 
 ## Prerequisites
 
-- [Agentis](https://github.com/Replikanti/agentis) runtime
+- [Agentis](https://github.com/Replikanti/agentis) runtime (>= v1.1.3 for the `memo set`/`memo get` CLI used in Bootstrap below)
 - GitLab instance with API access
 - Claude CLI (LLM backend via Agentis `CliBackend`)
+
+## Bootstrap: seeding agent confidence
+
+Every agent starts in **observe-only** mode. On a fresh colony the confidence memo key does not exist, and `get_confidence()` returns `0.0`, which means the agent listens to the bus but emits nothing and takes no action. This is deliberate, but it means **a brand new federation will look silent until you seed it**. Nothing is broken, confidence just has not been set.
+
+### Memo key convention
+
+Each agent reads its confidence from `recall_latest("<agent_name>:confidence")`. The full set of keys across the three active colonies is:
+
+| Colony | Keys |
+|--------|------|
+| triage | `router:confidence`, `prioritizer:confidence`, `labeler:confidence`, `issue_creator:confidence` |
+| code-review | `logic_reviewer:confidence`, `style_reviewer:confidence`, `security_reviewer:confidence`, `test_reviewer:confidence`, `approval_decider:confidence` |
+| planning | `scope_estimator:confidence`, `risk_assessor:confidence`, `task_decomposer:confidence`, `plan_reviewer:confidence` |
+
+### Ramp stages
+
+| Confidence | Mode | Behavior |
+|------------|------|----------|
+| `0.0` - `0.5` | Observe only | Agent watches the bus, learns, emits nothing |
+| `0.6` - `0.84` | Suggest | Agent emits suggestions for the human to review |
+| `>= 0.85` | Autonomous | Agent acts on its own (posts comments, sets labels, assigns reviewers), human can veto |
+
+The recommended path for a new operator is to start every agent at `0.5` for a week or two of silent observation, raise to `0.6` once the ingested signal looks sane, then individually promote agents to `0.85` as you get comfortable with their output.
+
+### Seeding via the CLI
+
+Use the `agentis memo set` CLI (available in agentis-core v1.1.3 and later). One call per agent:
+
+```bash
+# triage colony
+agentis memo set router:confidence 0.5
+agentis memo set prioritizer:confidence 0.5
+agentis memo set labeler:confidence 0.5
+agentis memo set issue_creator:confidence 0.5
+
+# code-review colony
+agentis memo set logic_reviewer:confidence 0.5
+agentis memo set style_reviewer:confidence 0.5
+agentis memo set security_reviewer:confidence 0.5
+agentis memo set test_reviewer:confidence 0.5
+agentis memo set approval_decider:confidence 0.5
+
+# planning colony
+agentis memo set scope_estimator:confidence 0.5
+agentis memo set risk_assessor:confidence 0.5
+agentis memo set task_decomposer:confidence 0.5
+agentis memo set plan_reviewer:confidence 0.5
+```
+
+To inspect the current value of any agent:
+
+```bash
+agentis memo get labeler:confidence
+```
+
+To promote a single agent (without touching others) once you trust it:
+
+```bash
+agentis memo set labeler:confidence 0.85
+```
+
+Values are stored as strings and parsed as decimals at the agent side, so `0.5`, `0.6`, `0.85` all work the same way.

--- a/dev-apprenticeship/code-review/README.md
+++ b/dev-apprenticeship/code-review/README.md
@@ -4,6 +4,8 @@
 
 A colony of five specialized agents that learn how you review code. They observe your merge request interactions on GitLab (what you approve, what you flag, what you dismiss) and gradually take over routine review work.
 
+> **Fresh colony is silent by default.** Every agent's confidence starts at `0.0` (observe-only) and stays there until you seed the memo store. See [Bootstrap: seeding agent confidence](../README.md#bootstrap-seeding-agent-confidence) in the federation README for the ramp procedure.
+
 ## Agents
 
 | Agent | File | Learns | Autonomy after |

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # GitLab API wrapper for code-review colony agents.
-# Called by .ag agents via exec shell.
+# Called by .ag agents via exec sh.
 #
 # Required env vars (set by start-colony.sh from colony.toml):
 #   GITLAB_URL     - GitLab instance URL

--- a/dev-apprenticeship/planning/README.md
+++ b/dev-apprenticeship/planning/README.md
@@ -4,6 +4,8 @@
 
 A colony of four agents that learn how you plan work. They observe how you break down issues, estimate scope, assess risks, and review plans on GitLab, and gradually take over the routine parts of planning.
 
+> **Fresh colony is silent by default.** Every agent's confidence starts at `0.0` (observe-only) and stays there until you seed the memo store. See [Bootstrap: seeding agent confidence](../README.md#bootstrap-seeding-agent-confidence) in the federation README for the ramp procedure.
+
 ## Agents
 
 | Agent | File | Learns | Autonomy after |

--- a/dev-apprenticeship/triage/README.md
+++ b/dev-apprenticeship/triage/README.md
@@ -4,6 +4,8 @@
 
 A colony of four agents that learn how you manage issues. They observe how you create, label, prioritize, and route issues on GitLab, and gradually take over the mechanical parts of issue management.
 
+> **Fresh colony is silent by default.** Every agent's confidence starts at `0.0` (observe-only) and stays there until you seed the memo store. See [Bootstrap: seeding agent confidence](../README.md#bootstrap-seeding-agent-confidence) in the federation README for the ramp procedure.
+
 ## Agents
 
 | Agent | File | Learns | Autonomy after |

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # GitLab API wrapper for triage colony agents.
-# Called by .ag agents via exec shell.
+# Called by .ag agents via exec sh.
 #
 # Required env vars (set by start-colony.sh from colony.toml):
 #   GITLAB_URL     - GitLab instance URL (e.g. https://gitlab.example.com)


### PR DESCRIPTION
## Summary

Bundles two small docs follow-ups that were waiting on agentis-core v1.1.3 (which shipped `agentis memo set`/`agentis memo get` earlier today).

**#35** — triage and code-review `gitlab-api.sh` header comments still said `Called by .ag agents via exec shell.` after the mass rename to `exec sh`. Two one-line edits.

**#38** — fresh colonies look silent because every agent's confidence memo defaults to `0.0` (observe-only) and nothing in the docs explained how to seed it. A new operator spinning up the federation for the first time would see nothing happen and conclude the system is broken.

Adds a `Bootstrap: seeding agent confidence` section to `dev-apprenticeship/README.md` with:
- Full memo key table for all 13 agents in the three active colonies (triage, code-review, planning)
- Ramp stage reference (`0.0`-`0.5` observe, `0.6`-`0.84` suggest, `>= 0.85` act)
- Concrete `agentis memo set <agent>:confidence 0.5` commands, copy-pasteable
- Inspect + promote workflow (`agentis memo get`, promote a single agent to `0.85`)

Adds a 2-line pointer at the top of each colony README (`triage`, `code-review`, `planning`) so operators landing on the colony page rather than the federation page still know to bootstrap.

The earlier plan on #38 used a `.ag` workaround script per colony because no CLI existed. Now that v1.1.3 ships `agentis memo set`, the `.ag` scripts are dropped and docs reference the CLI directly.

Closes #35
Closes #38

## Changes

| File | Change |
|------|--------|
| `dev-apprenticeship/triage/scripts/gitlab-api.sh` | Header comment: `exec shell` -> `exec sh` |
| `dev-apprenticeship/code-review/scripts/gitlab-api.sh` | Header comment: `exec shell` -> `exec sh` |
| `dev-apprenticeship/README.md` | New Bootstrap section (memo key table, ramp stages, seed commands), prerequisite note for v1.1.3 |
| `dev-apprenticeship/triage/README.md` | 2-line pointer to Bootstrap section |
| `dev-apprenticeship/code-review/README.md` | 2-line pointer to Bootstrap section |
| `dev-apprenticeship/planning/README.md` | 2-line pointer to Bootstrap section |

## Test plan

- [x] `tools/colony-lint.sh` -> 30 passed, 0 failed (all .ag files still parse, markdown links still OK)
- [x] No em dashes or en dashes introduced
- [x] Every agent file under `dev-apprenticeship/{triage,code-review,planning}/agents/` is listed in the new memo key table (13 total)
- [ ] QA report posted as comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)