### PR TITLE
docs: mark implementation and release colonies as Scaffolded

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -8,11 +8,11 @@ Each colony specializes in one part of the workflow. Together, they form a feder
 
 | Colony | Description | Status |
 |--------|-------------|--------|
+| [triage](./triage/) | Manages issues: creation, prioritization, labeling, routing (4 agents) | Active |
 | [code-review](./code-review/) | Reviews merge requests: style, logic, security, test coverage, approval decisions (5 agents) | Active |
 | [planning](./planning/) | Breaks down work: scope estimation, risk assessment, task decomposition, plan review (4 agents) | Active |
-| [implementation](./implementation/) | Writes and refactors code: code generation, test writing, commit conventions (4 agents) | Active |
-| [triage](./triage/) | Manages issues: creation, prioritization, labeling, routing (4 agents) | Active |
-| [release](./release/) | Automates releases: ship decisions, changelogs, versioning, pre-release checks (4 agents) | Active |
+| [implementation](./implementation/) | Writes and refactors code: code generation, test writing, commit conventions (4 agents) | Scaffolded (see [#5](https://github.com/Replikanti/agentis-colonies/issues/5)) |
+| [release](./release/) | Automates releases: ship decisions, changelogs, versioning, pre-release checks (4 agents) | Scaffolded (see [#5](https://github.com/Replikanti/agentis-colonies/issues/5)) |
 
 ## Why Colonies, Not Individual Agents?
 


### PR DESCRIPTION
## Summary

Federation status table in `dev-apprenticeship/README.md` claimed all 5 colonies were Active, but `implementation/agents/` and `release/agents/` contain only `.gitkeep` today. A new operator reading the table would expect 21 agents and find 13.

Flips the Status column for those two colonies from `Active` to `Scaffolded (see #5)`, where #5 tracks the umbrella agent implementation roadmap.

Also reorders the table to match the federation bus flow (triage -> code-review -> planning -> implementation -> release), which puts implemented colonies first and pending ones last. This matches the mermaid flow diagram immediately below the table.

Closes #46

## Test plan

- [x] `tools/colony-lint.sh` -> 30 passed, 0 failed (markdown links OK)
- [x] `implementation/agents/` and `release/agents/` actually empty (verified)
- [x] Link to #5 resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)