### PR TITLE
fix(triage): use shell_escape for LLM strings in exec sh commands

### DIFF
--- a/dev-apprenticeship/triage/agents/issue_creator.ag
+++ b/dev-apprenticeship/triage/agents/issue_creator.ag
@@ -81,7 +81,7 @@ fn tick(reason: string) -> void {
         ) -> DraftIssue;
 
         if confidence >= 0.85 {
-            let create_cmd = "./scripts/gitlab-api.sh create-issue --title \"" + draft.title + "\" --description \"" + draft.description + "\" --labels \"" + draft.suggested_labels + "\"";
+            let create_cmd = "./scripts/gitlab-api.sh create-issue --title " + shell_escape(draft.title) + " --description " + shell_escape(draft.description) + " --labels " + shell_escape(draft.suggested_labels);
             let result = try {
                 exec sh create_cmd;
             } catch e {

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -81,7 +81,7 @@ fn tick(reason: string) -> void {
         ) -> LabelAction;
 
         if confidence >= 0.85 {
-            let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels \"" + action.labels + "\"";
+            let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.labels);
             let result = try { exec sh update_cmd; } catch e {
                 print("[labeler] Failed to apply labels:", e);
                 "";

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -80,7 +80,7 @@ fn tick(reason: string) -> void {
         ) -> PriorityAction;
 
         if confidence >= 0.85 {
-            let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels \"" + action.priority + "\"";
+            let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.priority);
             let result = try { exec sh update_cmd; } catch e {
                 print("[prioritizer] Failed to set priority:", e);
                 "";

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -83,7 +83,7 @@ fn tick(reason: string) -> void {
         ) -> RouteAction;
 
         if confidence >= 0.85 {
-            let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --assignee \"" + action.assignee + "\"";
+            let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --assignee " + shell_escape(action.assignee);
             let result = try { exec sh update_cmd; } catch e {
                 print("[router] Failed to assign:", e);
                 "";


### PR DESCRIPTION
## Summary

- Wrap LLM-provided strings with `shell_escape()` in the 4 triage `.ag` agents that build `exec sh` command strings (issue_creator title/description/labels, router assignee, prioritizer priority, labeler labels).
- Closes the end-to-end round-trip bug where titles containing double quotes (e.g. `Fix "unterminated string" error`) were silently truncated by shell word-splitting before ever reaching `gitlab-api.sh`, and closes the latent shell-injection vector where a malicious title could execute arbitrary commands via backticks or `$(...)`.
- Uses the existing `shell_escape` builtin added in agentis-core v1.1.0 (Replikanti/agentis#454), matching the same pattern code-review and planning already use for post-note bodies. Triage was the last colony missing it.

Closes #49

## Why this divergence from the options listed in the issue

The original issue body suggested env vars, stdin, or a new `exec sh argv` form. All three require plumbing that `.ag` does not have today. `shell_escape` is a one-builtin-call-per-site fix that uses primitive infrastructure specifically built for this class of bug. Plan was posted on #49 for approval before implementation.

## Test plan

- [x] `agentis commit` parses all 4 edited `.ag` files cleanly
- [x] Python mirror of `shell_escape` + `bash -c` + mock curl: 10 round-trip cases pass (plain, double quotes, single quotes, backslashes, newlines, backtick+cmdsub injection, tabs/unicode, quote mix, multiline description, comma-separated labels)
- [x] Original #44/#49 repro `Fix "unterminated string" error` round-trips intact instead of truncating to `Fix unterminated`
- [x] `tools/colony-lint.sh dev-apprenticeship` passes
- [ ] QA agent review (will run after push)

## Out of scope

- Timestamp and numeric ID concatenations (`--since $ts`, `update-issue $iid`) are not shell-escaped because the values are either own-generated ISO 8601 strings or numeric IDs from parsed JSON, neither of which contain LLM taint or shell metacharacters.
- Code-review and planning already use `shell_escape` for their LLM-provided bodies, so no change needed there.