### PR TITLE
fix(triage): reject update-issue with no modifying flags

### DIFF
--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -175,6 +175,22 @@ PY
             # `+`, `&`, or non-ASCII characters survive encoding intact.
             USER_JSON=$(gl_get_q "$GITLAB_URL/api/v4/users" --data-urlencode "username=$ASSIGNEE")
             USER_ID=$(echo "$USER_JSON" | grep -o '"id":[0-9]*' | head -1 | cut -d: -f2)
+            # If the lookup didn't find a user, fail here rather than
+            # silently dropping the assignee. Without this the caller gets
+            # the generic "requires at least one of ..." error below, which
+            # is confusing when they did pass --assignee.
+            if [ -z "$USER_ID" ]; then
+                emit_error "update-issue: unknown user: $ASSIGNEE"
+                exit 1
+            fi
+        fi
+        # Fail fast if no modifying flags were passed. A PUT with body {}
+        # is a confusing no-op: GitLab happily returns the unchanged issue
+        # as if the update had happened, so the caller has no signal that
+        # they forgot to pass anything.
+        if [ -z "$ADD_LABELS" ] && [ -z "$REMOVE_LABELS" ] && [ -z "$PRIORITY" ] && [ -z "$USER_ID" ]; then
+            emit_error "update-issue requires at least one of --add-labels, --remove-labels, --priority, --assignee"
+            exit 1
         fi
         # Build JSON body via python3 json.dumps so label names and priority
         # strings containing quotes, backslashes, commas, or control chars


### PR DESCRIPTION
## Summary

- Make `./scripts/gitlab-api.sh update-issue <id>` with no modifying flags fail fast with a clear error instead of sending a confusing `PUT {}` that GitLab silently accepts.
- Distinguish the unknown-user case: when `--assignee ghost` resolves to no user, emit `unknown user: ghost` rather than the generic "requires at least one of ..." error (which would be misleading since the caller *did* pass `--assignee`).
- Both errors flow through the `emit_error` helper from #51, so usernames containing quotes, backslashes, or newlines produce valid JSON output.

Closes #50

## Change shape

After the user-ID lookup, before the python3 body build:
1. If `--assignee` was passed but `USER_ID` is empty → `unknown user: <name>`, exit 1.
2. If all four modifier slots (`ADD_LABELS`, `REMOVE_LABELS`, `PRIORITY`, `USER_ID`) are empty → `requires at least one of ...`, exit 1.

Matches the existing `create-issue --title is required` error path for symmetry.

## Test plan

Smoke-tested against a mocked curl (11 cases, all pass):

- [x] `update-issue 99` (no flags) → exit 1, "requires at least one" error, no PUT sent
- [x] `update-issue 99 --priority high` → exit 0, body `{"priority":"high"}`
- [x] `update-issue 99 --add-labels bug` → exit 0, body `{"add_labels":"bug"}`
- [x] `update-issue 99 --remove-labels stale` → exit 0, body `{"remove_labels":"stale"}`
- [x] `update-issue 99 --assignee alice` (known user) → exit 0, body `{"assignee_ids":[1]}`
- [x] `update-issue 99 --add-labels bug --priority high` (multi) → exit 0, both fields in body
- [x] `update-issue 99 --assignee alice --priority high --add-labels bug` (three together) → exit 0, all three in body
- [x] `update-issue 99 --assignee ghost` (unknown user) → exit 1, "unknown user: ghost"
- [x] All error outputs validate as JSON (including for `--nosuch x` flag)
- [x] `tools/colony-lint.sh dev-apprenticeship` passes
- [x] shellcheck clean
- [ ] QA agent review (will run on PR)