### PR TITLE
chore(gitlab-api): delete unused read endpoints in planning and triage

### DIFF
--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -9,11 +9,8 @@
 #
 # Usage:
 #   gitlab-api.sh issues --needs-planning [--since ISO8601]
-#   gitlab-api.sh issue <iid>
-#   gitlab-api.sh issue-notes <iid>
 #   gitlab-api.sh add-note <iid> --body <text>
 #   gitlab-api.sh merge-requests [--state merged] [--since ISO8601]
-#   gitlab-api.sh mr <iid>
 #
 # Planning only reads from GitLab and posts comments. It never changes labels,
 # approves, assigns, or merges — that surface lives in triage / code-review /
@@ -98,16 +95,6 @@ case "$CMD" in
         gl_get_q "$API/issues" "${ARGS[@]}"
         ;;
 
-    issue)
-        ID="${1:?Usage: gitlab-api.sh issue <iid>}"
-        gl_get "$API/issues/$ID"
-        ;;
-
-    issue-notes)
-        ID="${1:?Usage: gitlab-api.sh issue-notes <iid>}"
-        gl_get "$API/issues/$ID/notes?per_page=50&order_by=created_at&sort=desc"
-        ;;
-
     add-note)
         ID="${1:?Usage: gitlab-api.sh add-note <iid> --body <text>}"
         shift
@@ -148,11 +135,6 @@ case "$CMD" in
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
         gl_get_q "$API/merge_requests" "${ARGS[@]}"
-        ;;
-
-    mr)
-        ID="${1:?Usage: gitlab-api.sh mr <iid>}"
-        gl_get "$API/merge_requests/$ID"
         ;;
 
     *)

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -9,9 +9,6 @@
 #
 # Usage:
 #   gitlab-api.sh issues [--since ISO8601] [--state opened|closed|all]
-#   gitlab-api.sh issue <id>
-#   gitlab-api.sh issue-events <id>
-#   gitlab-api.sh issue-notes <id>
 #   gitlab-api.sh create-issue --title <t> --description <d> [--labels l1,l2] [--priority p]
 #   gitlab-api.sh update-issue <id> [--add-labels l1,l2] [--remove-labels l1,l2] [--priority p] [--assignee username]
 #   gitlab-api.sh members
@@ -99,21 +96,6 @@ case "$CMD" in
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
         gl_get_q "$API/issues" "${ARGS[@]}"
-        ;;
-
-    issue)
-        ID="${1:?Usage: gitlab-api.sh issue <id>}"
-        gl_get "$API/issues/$ID"
-        ;;
-
-    issue-events)
-        ID="${1:?Usage: gitlab-api.sh issue-events <id>}"
-        gl_get "$API/issues/$ID/resource_label_events?per_page=50"
-        ;;
-
-    issue-notes)
-        ID="${1:?Usage: gitlab-api.sh issue-notes <id>}"
-        gl_get "$API/issues/$ID/notes?per_page=50&order_by=created_at&sort=desc"
         ;;
 
     create-issue)


### PR DESCRIPTION
## Summary

- Delete six unused endpoints (3 from planning, 3 from triage) that no `.ag` agent in their respective colonies ever calls. Same class of dead code that PR #51 removed from code-review under issue #18.
- The operator explicitly chose delete-dead-code policy when asked. Dead endpoints silently rot and mask real usage, so removing them rather than keeping them as a "toolbox" is the consistent call.
- All six now fall through to the unknown-command arm and emit `unknown command: <name>` with exit 1, so any straggling caller fails fast instead of silently depending on a ghost endpoint.

Closes #55

## Deleted

| Colony | Endpoint | Reason |
|--------|----------|--------|
| planning | `mr <iid>` | no caller — colony only uses `merge-requests` list |
| planning | `issue <iid>` | no caller |
| planning | `issue-notes <iid>` | no caller |
| triage | `issue <id>` | no caller |
| triage | `issue-events <id>` | no caller |
| triage | `issue-notes <id>` | no caller |

Verified via `grep 'gitlab-api\\.sh (mr |issue |issue-notes|issue-events)' dev-apprenticeship/{planning,triage}/agents/*.ag` — zero matches.

## Test plan

- [x] Grep confirms zero callers in both affected colonies
- [x] Each deleted endpoint now returns `unknown command: <name>` with exit 1
- [x] `tools/colony-lint.sh dev-apprenticeship` passes
- [x] shellcheck clean on both modified scripts
- [x] Retained endpoints (issues, add-note, merge-requests, create-issue, update-issue, members, labels) still parse and are reachable
- [ ] QA agent review