### PR TITLE
chore(gitlab-api): uniform error emission and multi-flag unknown-user comment

### DIFF
--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -110,7 +110,7 @@ case "$CMD" in
             esac
         done
         if [ -z "$BODY" ]; then
-            echo '{"error": "--body is required"}' >&2
+            emit_error "--body is required"
             exit 1
         fi
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -106,7 +106,7 @@ case "$CMD" in
             esac
         done
         if [ -z "$BODY" ]; then
-            echo '{"error": "--body is required"}' >&2
+            emit_error "--body is required"
             exit 1
         fi
         # Use python3 json.dumps so newlines, quotes, backslashes, and control

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -113,7 +113,7 @@ case "$CMD" in
             esac
         done
         if [ -z "$TITLE" ]; then
-            echo '{"error": "--title is required"}' >&2
+            emit_error "--title is required"
             exit 1
         fi
         # Build JSON body via python3 json.dumps so titles and descriptions
@@ -157,10 +157,16 @@ PY
             # `+`, `&`, or non-ASCII characters survive encoding intact.
             USER_JSON=$(gl_get_q "$GITLAB_URL/api/v4/users" --data-urlencode "username=$ASSIGNEE")
             USER_ID=$(echo "$USER_JSON" | grep -o '"id":[0-9]*' | head -1 | cut -d: -f2)
-            # If the lookup didn't find a user, fail here rather than
-            # silently dropping the assignee. Without this the caller gets
-            # the generic "requires at least one of ..." error below, which
-            # is confusing when they did pass --assignee.
+            # If the lookup didn't find a user, fail here. Without this
+            # guard the outcome depends on which other flags were passed:
+            #   - --assignee only: generic "requires at least one of"
+            #     error below, which is confusing because the caller did
+            #     pass --assignee.
+            #   - --assignee + other flags: silent partial success where
+            #     the assignee is dropped and the other fields are PUT
+            #     anyway. Even worse.
+            # Both paths are confusing, so we fail fast with a clear
+            # "unknown user" message instead.
             if [ -z "$USER_ID" ]; then
                 emit_error "update-issue: unknown user: $ASSIGNEE"
                 exit 1


### PR DESCRIPTION
## Summary

Two small QA follow-ups from PR #58.

- **#60**: Migrate the last three legacy `echo '{"error": ...}' >&2` required-field checks to the `emit_error` helper from #51, so every error path in all three colony `gitlab-api.sh` scripts flows through `python3 json.dumps`. All three messages are static literals today and remain safe, but this future-proofs against a maintainer who changes them to interpolate a variable and accidentally reintroduces a JSON-break.
- **#59**: Refine the inline comment PR #58 added for the `update-issue` unknown-user guard. The old comment only explained the `--assignee`-only case; the real reason to fail fast is that `--assignee ghost` mixed with other flags would silently drop the assignee and partially succeed — even worse than the confusing error when `--assignee` is alone.

Closes #59
Closes #60

## Sites migrated (from #60)

| File | Command | Error |
|------|---------|-------|
| `dev-apprenticeship/triage/scripts/gitlab-api.sh` | `create-issue` | `--title is required` |
| `dev-apprenticeship/code-review/scripts/gitlab-api.sh` | `post-note` | `--body is required` |
| `dev-apprenticeship/planning/scripts/gitlab-api.sh` | `add-note` | `--body is required` |

## Test plan

- [x] All three migrated error paths emit valid JSON and exit 1
- [x] `tools/colony-lint.sh dev-apprenticeship` passes
- [x] shellcheck clean on all three modified scripts
- [x] Comment refinement is comment-only, no behavior change
- [ ] QA agent review

## Out of scope

- The three `GITLAB_URL, GITLAB_TOKEN, and GITLAB_PROJECT must be set` env-var checks at the top of each script also use the legacy echo path. They're unchanged because they run *before* `emit_error` is defined. Migrating them would require reordering the helper definition, which is beyond what #60 asked for.