### PR TITLE
chore: hoist emit_error above env-var guard (#63)

### DIFF
--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -18,13 +18,6 @@
 
 set -e
 
-if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
-    echo '{"error": "GITLAB_URL, GITLAB_TOKEN, and GITLAB_PROJECT must be set"}' >&2
-    exit 1
-fi
-
-API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
-
 # emit_error <message>
 # Print a JSON error object to stderr with <message> safely encoded via
 # python3 json.dumps. Use this anywhere the message contains user-supplied
@@ -34,6 +27,13 @@ API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
 }
+
+if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
+    emit_error "GITLAB_URL, GITLAB_TOKEN, and GITLAB_PROJECT must be set"
+    exit 1
+fi
+
+API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
 gl_get() {
     curl -sfS --max-time 30 \

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -21,13 +21,6 @@
 
 set -e
 
-if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
-    echo '{"error": "GITLAB_URL, GITLAB_TOKEN, and GITLAB_PROJECT must be set"}' >&2
-    exit 1
-fi
-
-API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
-
 # emit_error <message>
 # Print a JSON error object to stderr with <message> safely encoded via
 # python3 json.dumps. Use this anywhere the message contains user-supplied
@@ -37,6 +30,13 @@ API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
 }
+
+if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
+    emit_error "GITLAB_URL, GITLAB_TOKEN, and GITLAB_PROJECT must be set"
+    exit 1
+fi
+
+API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
 gl_get() {
     curl -sfS --max-time 30 \

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -18,13 +18,6 @@
 
 set -e
 
-if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
-    echo '{"error": "GITLAB_URL, GITLAB_TOKEN, and GITLAB_PROJECT must be set"}' >&2
-    exit 1
-fi
-
-API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
-
 # emit_error <message>
 # Print a JSON error object to stderr with <message> safely encoded via
 # python3 json.dumps. Use this anywhere the message contains user-supplied
@@ -34,6 +27,13 @@ API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
 }
+
+if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
+    emit_error "GITLAB_URL, GITLAB_TOKEN, and GITLAB_PROJECT must be set"
+    exit 1
+fi
+
+API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
 gl_get() {
     curl -sfS --max-time 30 \


### PR DESCRIPTION
## Summary

- Move `emit_error` helper definition to right after `set -e` in all three colony `gitlab-api.sh` scripts
- Replace the final legacy `echo '{...}' >&2` sites in the env-var guard with `emit_error`
- Eliminates the last hand-rolled JSON error paths. Every error now flows through one helper.

This is the follow-up from PR #62's QA report (issue #63).

## Test plan

- [x] Smoke test: unset env vars, confirm each script emits valid JSON via `emit_error` and exits 1
- [x] `tools/colony-lint.sh dev-apprenticeship` with result 1 passed, 5 skipped
- [x] `shellcheck` clean on all 3 modified scripts

Closes #63