### PR TITLE
feat(lint): flag unsafe string concat into exec sh (#57)

### DIFF
--- a/tools/check-exec-sh.sh
+++ b/tools/check-exec-sh.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# tools/check-exec-sh.sh: Flag unsafe string concatenation into `exec sh` in .ag files.
+#
+# Colony agents build shell commands by concatenating strings and pass the
+# result to `exec sh`. LLM-tainted values (titles, descriptions, usernames,
+# label names) must be wrapped in `shell_escape(...)` before concatenation
+# or the agent is vulnerable to shell injection. This was the root cause of
+# issue #49 / PR #56 in the triage colony.
+#
+# This checker is a grep-level guardrail: for every variable that is later
+# passed to `exec sh`, it scans `let <var> = ...` assignments in the same
+# file and flags any `+` concatenation segment that is not one of:
+#
+#   - a string literal (starts with `"`)
+#   - `shell_escape(...)`
+#   - `to_string(...)`
+#
+# Indirection through function calls (e.g. `let cmd = issues_cmd()`) is not
+# followed — this is deliberate, per #57 ("grep-level check, not a full
+# parser"). Authors can suppress a finding on a line that the checker
+# cannot prove safe by adding `// colony-lint: safe-exec-concat` to the
+# same line or the preceding line.
+#
+# Usage: ./tools/check-exec-sh.sh [path]
+# Exit 0 if no unsafe patterns, 1 if one or more findings, 2 on usage error.
+
+set -euo pipefail
+
+SCAN_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+if [ ! -e "$SCAN_ROOT" ]; then
+    echo "check-exec-sh: scan root does not exist: $SCAN_ROOT" >&2
+    exit 2
+fi
+
+FAIL=0
+
+# is_safe_segment <trimmed_segment>
+# Return 0 if the segment is one of the known-safe forms, 1 otherwise.
+is_safe_segment() {
+    local seg="$1"
+    case "$seg" in
+        '"'*)            return 0 ;;  # string literal
+        'shell_escape('*) return 0 ;;
+        'to_string('*)   return 0 ;;
+    esac
+    return 1
+}
+
+# trim <string>
+trim() {
+    local s="$1"
+    # strip leading whitespace
+    s="${s#"${s%%[![:space:]]*}"}"
+    # strip trailing whitespace
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+# check_file <path>
+# Scan one .ag file. Prints findings to stdout. Returns 0 always; the
+# caller tracks FAIL via the global counter.
+check_file() {
+    local ag_file="$1"
+
+    # Collect unique identifiers appearing on the RHS of `exec sh`.
+    # We intentionally only match bare identifiers — `exec sh "literal"`
+    # (with a string literal) is always safe and never flagged.
+    # Trailing `|| true` so that a file with zero matches does not trip
+    # `set -e` on the grep-returns-1 path.
+    local exec_vars
+    exec_vars="$(grep -oE 'exec[[:space:]]+sh[[:space:]]+[a-zA-Z_][a-zA-Z_0-9]*' "$ag_file" 2>/dev/null \
+        | awk '{print $NF}' | sort -u || true)"
+
+    [ -z "$exec_vars" ] && return 0
+
+    local var
+    while IFS= read -r var; do
+        [ -z "$var" ] && continue
+
+        # Find every `let <var> = ...` line in this file.
+        local match
+        while IFS= read -r match; do
+            [ -z "$match" ] && continue
+
+            local line_no rhs
+            line_no="${match%%:*}"
+            rhs="${match#*:}"
+
+            # Suppression comment on the same line.
+            if printf '%s' "$rhs" | grep -q 'colony-lint: safe-exec-concat'; then
+                continue
+            fi
+
+            # Suppression comment on the preceding line.
+            local prev=""
+            if [ "$line_no" -gt 1 ]; then
+                prev="$(sed -n "$((line_no - 1))p" "$ag_file" 2>/dev/null || true)"
+            fi
+            if printf '%s' "$prev" | grep -q 'colony-lint: safe-exec-concat'; then
+                continue
+            fi
+
+            # Strip `let <var> =` prefix and trailing `;`.
+            rhs="${rhs#*=}"
+            rhs="${rhs%%;*}"
+
+            # No concatenation → nothing to check (pure literal or function
+            # call, both of which this checker trusts by design).
+            case "$rhs" in
+                *'+'*) ;;
+                *) continue ;;
+            esac
+
+            # Naive split on `+`. This does not correctly tokenize `+`
+            # inside string literals or function arguments, but none of
+            # the colony `.ag` files currently exercise that pattern. If
+            # a future file does, the checker will produce a false
+            # positive and the author can suppress it with the inline
+            # comment — better loud than silent.
+            local IFS_save="$IFS"
+            IFS='+'
+            # shellcheck disable=SC2206  # intentional word-splitting on +
+            local segments=( $rhs )
+            IFS="$IFS_save"
+
+            local seg trimmed
+            for seg in "${segments[@]}"; do
+                trimmed="$(trim "$seg")"
+                [ -z "$trimmed" ] && continue
+                if ! is_safe_segment "$trimmed"; then
+                    # SC2016 disable: the backticked `// colony-lint:
+                    # safe-exec-concat` token is a literal comment that
+                    # authors paste into `.ag` source, not a shell expansion.
+                    # shellcheck disable=SC2016
+                    printf '[UNSAFE] %s:%s: let %s = ... + %s (wrap in shell_escape or to_string, or annotate with `// colony-lint: safe-exec-concat`)\n' \
+                        "$ag_file" "$line_no" "$var" "$trimmed"
+                    FAIL=$((FAIL + 1))
+                fi
+            done
+        done < <(grep -nE "^[[:space:]]*let[[:space:]]+${var}[[:space:]]*=" "$ag_file" || true)
+    done <<< "$exec_vars"
+}
+
+# Main: walk .ag files under SCAN_ROOT.
+if [ -f "$SCAN_ROOT" ]; then
+    check_file "$SCAN_ROOT"
+else
+    while IFS= read -r -d '' f; do
+        check_file "$f"
+    done < <(find "$SCAN_ROOT" -type f -name '*.ag' -print0)
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "check-exec-sh: $FAIL unsafe concat finding(s)"
+    exit 1
+fi
+
+exit 0

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -242,6 +242,21 @@ else
     skip "agentis validation (binary not found)"
 fi
 
+# --- Check .ag files for unsafe exec sh concatenation (#57) ---
+# Grep-level guardrail against the shell-injection class of bug that
+# slipped through in #49. Scans every .ag file under the repo root and
+# fails the lint if any LLM-tainted value is concatenated into an
+# `exec sh` command without a `shell_escape(...)` or `to_string(...)` wrap.
+if [ -x "$REPO_ROOT/tools/check-exec-sh.sh" ]; then
+    check_out="$("$REPO_ROOT/tools/check-exec-sh.sh" "$REPO_ROOT" 2>&1)" && check_rc=0 || check_rc=$?
+    if [ "$check_rc" -eq 0 ]; then
+        pass "check-exec-sh: no unsafe concat into exec sh"
+    else
+        fail "check-exec-sh: unsafe concat into exec sh"
+        printf '%s\n' "$check_out"
+    fi
+fi
+
 # --- Lint tools themselves ---
 if command -v shellcheck &>/dev/null; then
     tools_dir="$REPO_ROOT/tools"

--- a/tools/test-check-exec-sh.sh
+++ b/tools/test-check-exec-sh.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# tools/test-check-exec-sh.sh: unit tests for tools/check-exec-sh.sh.
+#
+# Self-contained. Creates temporary .ag fixture files, runs the checker
+# against them, asserts exit code + output pattern. Cleans up on exit.
+#
+# Usage: ./tools/test-check-exec-sh.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECKER="$SCRIPT_DIR/check-exec-sh.sh"
+
+if [ ! -x "$CHECKER" ]; then
+    echo "[FAIL] checker not found or not executable: $CHECKER"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# write_fixture <name> <content>
+# Returns: path to the fixture file via stdout.
+write_fixture() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name.ag"
+    printf '%s' "$content" > "$path"
+    printf '%s' "$path"
+}
+
+# run_checker <fixture-path>
+# Captures stdout+stderr in $out, exit code in $rc.
+run_checker() {
+    set +e
+    out="$("$CHECKER" "$1" 2>&1)"
+    rc=$?
+    set -e
+}
+
+# --- Test 1: string-literal-only exec sh is always safe ---
+f="$(write_fixture "literal-only" '
+fn tick(reason: string) -> void {
+    let raw = try { exec sh "./scripts/gitlab-api.sh members"; } catch e { "[]"; };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "literal-only: exec sh \"literal\" not flagged"
+else
+    fail "literal-only" "rc=$rc out=$out"
+fi
+
+# --- Test 2: pure literal assignment (no concat) ---
+f="$(write_fixture "pure-literal-assign" '
+fn tick(reason: string) -> void {
+    let mr_cmd = "./scripts/gitlab-api.sh merge-requests --state merged";
+    let result = try { exec sh mr_cmd; } catch e { "[]"; };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "pure-literal-assign: no concat, not flagged"
+else
+    fail "pure-literal-assign" "rc=$rc out=$out"
+fi
+
+# --- Test 3: safe concat with shell_escape + to_string ---
+f="$(write_fixture "safe-concat" '
+fn tick(reason: string) -> void {
+    let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.labels);
+    let result = try { exec sh update_cmd; } catch e { ""; };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "safe-concat: shell_escape+to_string not flagged"
+else
+    fail "safe-concat" "rc=$rc out=$out"
+fi
+
+# --- Test 4: UNSAFE bare identifier concat ---
+f="$(write_fixture "unsafe-bare-ident" '
+fn tick(reason: string) -> void {
+    let update_cmd = "./scripts/gitlab-api.sh update-issue " + raw_title;
+    let result = try { exec sh update_cmd; } catch e { ""; };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "\[UNSAFE\]" && printf '%s' "$out" | grep -q "raw_title"; then
+    pass "unsafe-bare-ident: flagged"
+else
+    fail "unsafe-bare-ident" "rc=$rc out=$out"
+fi
+
+# --- Test 5: UNSAFE field access concat ---
+f="$(write_fixture "unsafe-field" '
+fn tick(reason: string) -> void {
+    let update_cmd = "./scripts/gitlab-api.sh update-issue " + action.title;
+    let result = try { exec sh update_cmd; } catch e { ""; };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "\[UNSAFE\]" && printf '%s' "$out" | grep -q "action.title"; then
+    pass "unsafe-field: flagged"
+else
+    fail "unsafe-field" "rc=$rc out=$out"
+fi
+
+# --- Test 6: UNSAFE bare string variable (LLM-produced) ---
+f="$(write_fixture "unsafe-llm-string" '
+fn tick(reason: string) -> void {
+    let body = prompt("write a body", "");
+    let post_cmd = "./scripts/gitlab-api.sh post-note 42 --body " + body;
+    let result = try { exec sh post_cmd; } catch e { ""; };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "\[UNSAFE\]"; then
+    pass "unsafe-llm-string: flagged"
+else
+    fail "unsafe-llm-string" "rc=$rc out=$out"
+fi
+
+# --- Test 7: opt-out comment on same line suppresses finding ---
+f="$(write_fixture "optout-same-line" '
+fn tick(reason: string) -> void {
+    let update_cmd = "./scripts/gitlab-api.sh update-issue " + raw_title; // colony-lint: safe-exec-concat
+    let result = try { exec sh update_cmd; } catch e { ""; };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "optout-same-line: suppressed"
+else
+    fail "optout-same-line" "rc=$rc out=$out"
+fi
+
+# --- Test 8: opt-out comment on preceding line suppresses finding ---
+f="$(write_fixture "optout-preceding" '
+fn tick(reason: string) -> void {
+    // colony-lint: safe-exec-concat
+    let update_cmd = "./scripts/gitlab-api.sh update-issue " + raw_title;
+    let result = try { exec sh update_cmd; } catch e { ""; };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "optout-preceding: suppressed"
+else
+    fail "optout-preceding" "rc=$rc out=$out"
+fi
+
+# --- Test 9: variable never passed to exec sh is never flagged ---
+f="$(write_fixture "unused-var" '
+fn tick(reason: string) -> void {
+    let dangerous = "./scripts/gitlab-api.sh " + raw_title;
+    print("built command:", dangerous);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "unused-var: let without exec sh not flagged"
+else
+    fail "unused-var" "rc=$rc out=$out"
+fi
+
+# --- Test 10: function-call assignment (indirection) is not followed ---
+f="$(write_fixture "function-indirection" '
+fn build() -> string {
+    return "./scripts/gitlab-api.sh members";
+}
+
+fn tick(reason: string) -> void {
+    let cmd = build();
+    let result = try { exec sh cmd; } catch e { "[]"; };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "function-indirection: let cmd = fn() not flagged (no concat)"
+else
+    fail "function-indirection" "rc=$rc out=$out"
+fi
+
+# --- Test 11: mixed safe + unsafe segments flags only the unsafe one ---
+f="$(write_fixture "mixed-segments" '
+fn tick(reason: string) -> void {
+    let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --label " + action.label_name;
+    let result = try { exec sh update_cmd; } catch e { ""; };
+}
+')"
+run_checker "$f"
+unsafe_count="$(printf '%s' "$out" | grep -c "\[UNSAFE\]" || true)"
+if [ "$rc" -eq 1 ] && [ "$unsafe_count" -eq 1 ] && printf '%s' "$out" | grep -q "action.label_name"; then
+    pass "mixed-segments: only unsafe segment flagged"
+else
+    fail "mixed-segments" "rc=$rc unsafe_count=$unsafe_count out=$out"
+fi
+
+# --- Test 12: regression — actual dev-apprenticeship codebase must pass ---
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+run_checker "$REPO_ROOT/dev-apprenticeship"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "regression: current dev-apprenticeship codebase clean"
+else
+    fail "regression: current dev-apprenticeship codebase" "rc=$rc out=$out"
+fi
+
+# --- Test 13: directory with no .ag files ---
+empty_dir="$TMPDIR_TEST/empty"
+mkdir -p "$empty_dir"
+run_checker "$empty_dir"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "empty-dir: no .ag files, clean"
+else
+    fail "empty-dir" "rc=$rc out=$out"
+fi
+
+# --- Test 14: nonexistent path exits 2 ---
+run_checker "$TMPDIR_TEST/does-not-exist"
+if [ "$rc" -eq 2 ]; then
+    pass "nonexistent: exit code 2"
+else
+    fail "nonexistent" "rc=$rc out=$out"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- New `tools/check-exec-sh.sh` scans every `.ag` file and flags any `let <var> = "..." + <segment>` where `<var>` is later passed to `exec sh` and `<segment>` is not a string literal, `shell_escape(...)`, or `to_string(...)`
- Wired into `tools/colony-lint.sh` so CI fails any PR that reintroduces the #49-class shell-injection bug
- New `tools/test-check-exec-sh.sh` with 14 unit tests covering safe patterns, unsafe patterns, opt-out comment, function-call indirection, and a regression test against the current `dev-apprenticeship/` codebase

This is a grep-level guardrail, not a full parser. Indirection through function calls (e.g. `let cmd = issues_cmd()`) is deliberately not followed, per the scope in #57. Authors can suppress a finding the checker cannot prove safe by adding `// colony-lint: safe-exec-concat` on the same line or the preceding line.

## Test plan

- [x] `tools/test-check-exec-sh.sh` runs 14 assertions, all pass
- [x] `tools/colony-lint.sh` full run reports `32 passed, 0 failed, 5 skipped` with the new check integrated
- [x] Regression: current `dev-apprenticeship/` codebase passes cleanly (every direct concat already uses `shell_escape` or `to_string`)
- [x] Deliberate-break: injecting a fixture `.ag` with `"..." + draft.title` and no wrap triggers `[UNSAFE]` and exit 1
- [x] `shellcheck` clean on `check-exec-sh.sh`, `test-check-exec-sh.sh`, and the modified `colony-lint.sh`

Closes #57