### PR TITLE
fix(scripts): remove stale --backend and --enable-exec flags (#68)

### DIFF
--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -44,9 +44,6 @@ export GITLAB_TOKEN
 export GITLAB_PROJECT
 export COLONY_DIR
 
-# Parse LLM backend
-LLM_BACKEND=$(parse_toml llm backend)
-
 AGENTS=(
     style_reviewer
     logic_reviewer
@@ -57,24 +54,19 @@ AGENTS=(
 
 cd "$COLONY_DIR"
 
+# Note: LLM backend is read by agentis daemon from the llm.backend key in
+# .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
+# informational only — operators should mirror it into .agentis/config.
+# exec sh is enabled by default on agentis daemon; there is no --enable-exec.
+
 echo "Starting Code Review colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
-echo "  LLM: ${LLM_BACKEND:-mock}"
 
 for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
-    if [ -n "$LLM_BACKEND" ]; then
-        agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
-            --colony code-review \
-            --backend "$LLM_BACKEND" \
-            --tick-interval 60000 \
-            --enable-exec &
-    else
-        agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
-            --colony code-review \
-            --tick-interval 60000 \
-            --enable-exec &
-    fi
+    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+        --colony code-review \
+        --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done
 

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -31,7 +31,6 @@ for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony implementation \
-        --backend claude \
         --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -44,9 +44,6 @@ export GITLAB_TOKEN
 export GITLAB_PROJECT
 export COLONY_DIR
 
-# Parse LLM backend
-LLM_BACKEND=$(parse_toml llm backend)
-
 AGENTS=(
     scope_estimator
     risk_assessor
@@ -54,24 +51,19 @@ AGENTS=(
     plan_reviewer
 )
 
+# Note: LLM backend is read by agentis daemon from the llm.backend key in
+# .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
+# informational only — operators should mirror it into .agentis/config.
+# exec sh is enabled by default on agentis daemon; there is no --enable-exec.
+
 echo "Starting Planning colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
-echo "  LLM: ${LLM_BACKEND:-mock}"
 
 for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
-    if [ -n "$LLM_BACKEND" ]; then
-        agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
-            --colony planning \
-            --backend "$LLM_BACKEND" \
-            --tick-interval 60000 \
-            --enable-exec &
-    else
-        agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
-            --colony planning \
-            --tick-interval 60000 \
-            --enable-exec &
-    fi
+    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+        --colony planning \
+        --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done
 

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -31,7 +31,6 @@ for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony release \
-        --backend claude \
         --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -44,9 +44,6 @@ export GITLAB_TOKEN
 export GITLAB_PROJECT
 export COLONY_DIR
 
-# Parse LLM backend
-LLM_BACKEND=$(parse_toml llm backend)
-
 AGENTS=(
     issue_creator
     labeler
@@ -54,24 +51,19 @@ AGENTS=(
     router
 )
 
+# Note: LLM backend is read by agentis daemon from the llm.backend key in
+# .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
+# informational only — operators should mirror it into .agentis/config.
+# exec sh is enabled by default on agentis daemon; there is no --enable-exec.
+
 echo "Starting Triage colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
-echo "  LLM: ${LLM_BACKEND:-mock}"
 
 for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
-    if [ -n "$LLM_BACKEND" ]; then
-        agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
-            --colony triage \
-            --backend "$LLM_BACKEND" \
-            --tick-interval 60000 \
-            --enable-exec &
-    else
-        agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
-            --colony triage \
-            --tick-interval 60000 \
-            --enable-exec &
-    fi
+    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+        --colony triage \
+        --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done
 


### PR DESCRIPTION
## Summary

Hotfix for the regression that Replikanti/agentis-core#470 (merged as Replikanti/agentis-core#471) exposes in every `start-colony.sh` in the dev-apprenticeship federation. After the strict flag validation lands, all five scripts would fail on the first `agentis daemon` invocation with:

```
agentis daemon: unknown flag: --backend
Run 'agentis daemon --help' for usage.
```

Closes #68.

## Changes

| Colony | `--backend` | `--enable-exec` |
|--------|:-:|:-:|
| triage | removed | removed |
| code-review | removed | removed |
| planning | removed | removed |
| implementation | removed | n/a |
| release | removed | n/a |

Neither flag was ever parsed by `agentis daemon`:

- `--backend` — LLM backend is read from the `llm.backend` key in `.agentis/config`, not from a CLI flag. See `src/cli/daemon.rs` in core — there is no `--backend` parse.
- `--enable-exec` — `exec sh` is enabled by default. The daemon only has `--deny-exec` (inverse). No code path reads `--enable-exec`.

For triage/code-review/planning I also collapsed the dead `if [ -n "$LLM_BACKEND" ]; then ... else ... fi` daemon launch branches into a single invocation, dropped the unused `LLM_BACKEND=$(parse_toml llm backend)` parse, and removed the `echo "  LLM: ..."` line that was giving operators the false impression that the CLI flag was the source of truth.

## Test plan
- [x] `grep -rn "\-\-backend\|\-\-enable-exec" dev-apprenticeship/` — only the explanatory comments remain
- [x] `tools/colony-lint.sh` — 32 passed, 0 failed, 5 skipped (no regression)
- [x] **Negative test**: with a locally built agentis binary carrying #470:
      ```
      $ agentis daemon agents/foo.ag --colony triage --backend cli --tick-interval 60000 --enable-exec
      agentis daemon: unknown flag: --backend
      exit=2
      ```
- [x] **Positive test**: with the same binary and the fixed invocation:
      ```
      $ agentis daemon agents/issue_creator.ag --colony triage --tick-interval 60000 &
      watchdog [c4dbd1b19a95] colony: triage
      watchdog [c4dbd1b19a95] starting: agents/issue_creator.ag
      watchdog [c4dbd1b19a95] child started (pid=3876046, restarts=0, degrade=0)
      ```

## Follow-up — not in this PR

The `[llm]` section in `colony.toml` is now informational only. Actually wiring `colony.toml` into `.agentis/config` so a per-colony LLM backend can be selected would need either (a) a new `--llm-backend` CLI flag on `agentis daemon` in core, or (b) the start script to write a merged `.agentis/config` before launching. Both are real feature requests, out of scope for this hotfix. Operators who want a non-default backend must mirror their `[llm] backend` setting into `.agentis/config` manually for now.