### PR TITLE
cleanup: strip em dashes and stale --backend flag from colony scripts

### DIFF
--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -23,7 +23,7 @@ set -e
 # python3 json.dumps. Use this anywhere the message contains user-supplied
 # input (flag names, command names) that could contain quotes, backslashes,
 # or newlines which would otherwise break naive string interpolation.
-# Does NOT exit — the caller controls the exit code.
+# Does NOT exit. The caller controls the exit code.
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
 }

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -56,7 +56,7 @@ cd "$COLONY_DIR"
 
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
-# informational only — operators should mirror it into .agentis/config.
+# informational only. Operators should mirror it into .agentis/config.
 # exec sh is enabled by default on agentis daemon; there is no --enable-exec.
 
 echo "Starting Code Review colony (${#AGENTS[@]} agents)..."

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -13,7 +13,7 @@
 #   gitlab-api.sh merge-requests [--state merged] [--since ISO8601]
 #
 # Planning only reads from GitLab and posts comments. It never changes labels,
-# approves, assigns, or merges — that surface lives in triage / code-review /
+# approves, assigns, or merges. That surface lives in triage / code-review /
 # release colonies. If you are tempted to add a write endpoint here, it
 # probably belongs in a different colony.
 #

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -26,7 +26,7 @@ set -e
 # python3 json.dumps. Use this anywhere the message contains user-supplied
 # input (flag names, command names) that could contain quotes, backslashes,
 # or newlines which would otherwise break naive string interpolation.
-# Does NOT exit — the caller controls the exit code.
+# Does NOT exit. The caller controls the exit code.
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
 }

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -53,7 +53,7 @@ AGENTS=(
 
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
-# informational only — operators should mirror it into .agentis/config.
+# informational only. Operators should mirror it into .agentis/config.
 # exec sh is enabled by default on agentis daemon; there is no --enable-exec.
 
 echo "Starting Planning colony (${#AGENTS[@]} agents)..."

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -23,7 +23,7 @@ set -e
 # python3 json.dumps. Use this anywhere the message contains user-supplied
 # input (flag names, command names) that could contain quotes, backslashes,
 # or newlines which would otherwise break naive string interpolation.
-# Does NOT exit — the caller controls the exit code.
+# Does NOT exit. The caller controls the exit code.
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
 }

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -53,7 +53,7 @@ AGENTS=(
 
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
-# informational only — operators should mirror it into .agentis/config.
+# informational only. Operators should mirror it into .agentis/config.
 # exec sh is enabled by default on agentis daemon; there is no --enable-exec.
 
 echo "Starting Triage colony (${#AGENTS[@]} agents)..."

--- a/tools/new-colony.sh
+++ b/tools/new-colony.sh
@@ -147,7 +147,7 @@ echo "Starting NAME_PLACEHOLDER colony (${#AGENTS[@]} agents)..."
 
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
-# informational only — operators should mirror it into .agentis/config.
+# informational only. Operators should mirror it into .agentis/config.
 
 for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."

--- a/tools/new-colony.sh
+++ b/tools/new-colony.sh
@@ -145,11 +145,14 @@ fi
 
 echo "Starting NAME_PLACEHOLDER colony (${#AGENTS[@]} agents)..."
 
+# Note: LLM backend is read by agentis daemon from the llm.backend key in
+# .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
+# informational only — operators should mirror it into .agentis/config.
+
 for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony COLONY_ID_PLACEHOLDER \
-        --backend claude \
         --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done


### PR DESCRIPTION
## Summary

Two small cleanups bundled from the #69 QA follow-ups.

- **Closes #65** — strip the em dash from the `emit_error()` docblock in all three `dev-apprenticeship/*/scripts/gitlab-api.sh` files. Comment-only, no behavior change.
- **Closes #70** — remove the stale `--backend claude` flag from the `start-colony.sh` template in `tools/new-colony.sh`. Same shape as the #69 fix that cleaned up the five existing dev-apprenticeship start scripts. Added the explanatory "LLM backend is read from `.agentis/config`" comment so the template stays self-documenting.

## Why bundled

Both are one-line "delete stale text" follow-ups from the same QA round (#69). Keeping them in one PR cuts review churn.

## Test plan

- [x] `./tools/new-colony.sh dev-apprenticeship temp-scaffold-test` produces a `start-colony.sh` with no `--backend` flag (test colony then removed)
- [x] `grep -rn "— " dev-apprenticeship/*/scripts/gitlab-api.sh` — no matches
- [x] `./tools/colony-lint.sh` — **32 passed, 0 failed, 5 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)