### PR TITLE
tools: harden colony-lint with daemon flag guardrail and known-limitations docs

### DIFF
--- a/tools/check-exec-sh.md
+++ b/tools/check-exec-sh.md
@@ -1,0 +1,88 @@
+# check-exec-sh.sh known limitations
+
+`tools/check-exec-sh.sh` is a grep-level guardrail against the
+shell-injection class of bug that slipped through in agentis-colonies#49.
+It scans every `.ag` file and flags unsafe `+` concatenation segments
+that land in an `exec sh` command without a `shell_escape(...)` or
+`to_string(...)` wrap.
+
+Because it is grep-level by design (per #57), it has a short list of
+known false positives and false negatives. Authors hitting one of
+these cases can suppress a finding on a specific line by adding
+`// colony-lint: safe-exec-concat` to the same line or the line
+immediately above.
+
+## 1. False positive: literal `+` inside a single-line `let`
+
+Symptom:
+```
+[UNSAFE] tick.ag:12: let cmd = "./scripts/search.sh --query foo+bar";
+```
+
+The checker splits on `+` after seeing one in the right-hand side of a
+`let`, so a plain string literal that happens to contain a `+`
+character is flagged even though nothing is being concatenated.
+
+Workaround:
+```
+let cmd = "./scripts/search.sh --query foo+bar"; // colony-lint: safe-exec-concat
+```
+
+Long-term fix candidate: teach the splitter to skip `+` characters
+inside double-quoted segments. A few lines of awk would drop this
+false-positive rate to near zero.
+
+## 2. False negative: multi-line concatenation
+
+The checker is line-oriented. This pattern is silently missed:
+
+```
+let cmd = "./foo "
+    + draft.title;
+```
+
+Because grep sees `let cmd = "./foo "` on one line and `+ draft.title`
+on another, the right-hand side never triggers the concat check.
+Review your own `.ag` files manually for this pattern, especially
+after merging a PR that reformats long lines.
+
+## 3. False negative: `to_string(body)` when `body` is already a string
+
+`to_string` is treated as a known-safe wrapper. It is an identity on
+string values and does not shell-escape. If an LLM-tainted value flows
+through `to_string` before concatenation, the checker trusts it even
+though the value is still dangerous:
+
+```
+let cmd = "gh issue create --title " + to_string(issue_title);
+```
+
+If `issue_title` is LLM-tainted, this is a shell injection even though
+the checker passes it. Use `shell_escape(issue_title)` for
+user-controlled or LLM-controlled values.
+
+## 4. False negative: function-call indirection
+
+The checker does not follow function calls. This is explicit design
+per agentis-colonies#57 ("grep-level check, not a full parser"):
+
+```
+let cmd = build_cmd(raw_title);
+exec sh cmd;
+```
+
+If `build_cmd` internally concatenates `raw_title` into a shell
+command without `shell_escape`, the injection is invisible to the
+checker. The rule of thumb is: keep `exec sh` call sites close to the
+`let` that builds the command, and don't introduce helper functions
+just for command construction.
+
+## When to use the suppression comment
+
+Add `// colony-lint: safe-exec-concat` only when you have manually
+verified that the flagged concatenation is safe. The most common
+legitimate case is case 1 above: a literal `+` inside a hardcoded
+string. If you find yourself using the suppression for case 2, 3, or
+4, that is a signal to refactor instead — pull the value through
+`shell_escape(...)`, inline the helper, or rewrite the `let` to
+appease the grep.

--- a/tools/check-exec-sh.sh
+++ b/tools/check-exec-sh.sh
@@ -21,6 +21,10 @@
 # cannot prove safe by adding `// colony-lint: safe-exec-concat` to the
 # same line or the preceding line.
 #
+# Known limitations (false positives / false negatives) are documented
+# in tools/check-exec-sh.md. Read that file before adding a
+# `// colony-lint: safe-exec-concat` suppression comment to your .ag file.
+#
 # Usage: ./tools/check-exec-sh.sh [path]
 # Exit 0 if no unsafe patterns, 1 if one or more findings, 2 on usage error.
 

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -153,9 +153,9 @@ if errors:
 
         # --- Daemon flag whitelist guardrail (#71) ---
         # Validates that every `agentis daemon` invocation in start-colony.sh
-        # uses only flags from DAEMON_FLAG_ALLOWLIST below. Catches the drift
-        # class that produced #68 (stale --backend / --enable-exec flags that
-        # silently ran for months then started failing after agentis-core
+        # uses only flags from the case-statement allowlist below. Catches the
+        # drift class that produced #68 (stale --backend / --enable-exec flags
+        # that silently ran for months then started failing after agentis-core
         # v1.1.4 added strict flag validation).
         #
         # The allowlist must match DAEMON_FLAGS in agentis-core/src/cli/daemon.rs.
@@ -164,6 +164,7 @@ if errors:
         if [ -f "$start_script" ]; then
             bad_flags=$(awk '
                 /^[[:space:]]*#/ { next }
+                /^[[:space:]]*echo/ { next }
                 /agentis[[:space:]]+daemon/ { in_cmd=1 }
                 in_cmd {
                     for (i=1; i<=NF; i++) {

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -151,6 +151,52 @@ if errors:
             fi
         fi
 
+        # --- Daemon flag whitelist guardrail (#71) ---
+        # Validates that every `agentis daemon` invocation in start-colony.sh
+        # uses only flags from DAEMON_FLAG_ALLOWLIST below. Catches the drift
+        # class that produced #68 (stale --backend / --enable-exec flags that
+        # silently ran for months then started failing after agentis-core
+        # v1.1.4 added strict flag validation).
+        #
+        # The allowlist must match DAEMON_FLAGS in agentis-core/src/cli/daemon.rs.
+        # If core adds a new daemon flag, add it here too.
+        start_script="$col_path/scripts/start-colony.sh"
+        if [ -f "$start_script" ]; then
+            bad_flags=$(awk '
+                /^[[:space:]]*#/ { next }
+                /agentis[[:space:]]+daemon/ { in_cmd=1 }
+                in_cmd {
+                    for (i=1; i<=NF; i++) {
+                        tok = $i
+                        sub(/\\$/, "", tok)
+                        if (tok == "&" || tok == "") continue
+                        if (tok ~ /^--[a-zA-Z][a-zA-Z-]*(=.*)?$/) {
+                            sub(/=.*/, "", tok)
+                            print tok
+                        } else if (tok ~ /^-[a-zA-Z]$/) {
+                            print tok
+                        }
+                    }
+                    if ($0 !~ /\\[[:space:]]*$/) { in_cmd = 0 }
+                }
+            ' "$start_script" | while read -r flag; do
+                case "$flag" in
+                    --tick-interval|--cb-per-tick|--colony|--deadline|--priority|\
+                    --enable-migration|--enable-replication|--allow-replica-replication|\
+                    --help|-h) ;;
+                    *) echo "$flag" ;;
+                esac
+            done)
+
+            if [ -z "$bad_flags" ]; then
+                pass "$prefix: start-colony.sh daemon flags OK"
+            else
+                while IFS= read -r flag; do
+                    fail "$prefix: start-colony.sh uses unknown daemon flag: $flag"
+                done <<< "$bad_flags"
+            fi
+        fi
+
         # --- Markdown link check ---
         md_files=()
         while IFS= read -r -d '' f; do


### PR DESCRIPTION
## Summary

Two follow-ups from the #66/#69 QA round, bundled since both touch `tools/`.

### Closes #71 — DAEMON_FLAG_ALLOWLIST guardrail in colony-lint.sh

Adds a new check to `tools/colony-lint.sh` that walks every `agentis daemon` invocation in every `start-colony.sh` and validates each flag token against a hardcoded allowlist mirroring `DAEMON_FLAGS` from `agentis-core/src/cli/daemon.rs` as of v1.1.5.

Implementation notes:

- Small awk state machine reconstructs multi-line backslash-continued `agentis daemon` blocks
- Extracts `--foo`, `-X`, and `--foo=value` forms (the last via `sub(/=.*/)`)
- Compares each token against the allowlist; unknown tokens fail the lint with a precise message
- Runs inside the existing per-colony loop — one PASS per colony when clean

Chose the hardcoded allowlist (Option B from the issue) over parsing `agentis daemon --help` (Option A) because the help string is not a stable contract and the allowlist only changes once per phase. The check runs standalone and catches drift regardless of whether the agentis binary is installed.

### Closes #67 — check-exec-sh.sh known limitations docs

Adds `tools/check-exec-sh.md` with four sections documenting:

1. **False positive** — literal `+` inside a single-line `let` (workaround: `// colony-lint: safe-exec-concat`)
2. **False negative** — multi-line `+` concatenation on separate lines
3. **False negative** — `to_string(body)` when `body` is LLM-tainted
4. **False negative** — function-call indirection (explicit non-goal per #57)

Each section explains when it fires, why it is wrong, and the escape hatch. A pointer line is added to the header comment of `tools/check-exec-sh.sh` so authors finding a false positive know where to read.

## Test plan

- [x] `./tools/colony-lint.sh` — **37 passed / 0 failed / 5 skipped** (was 32, +5 for the 5 dev-apprenticeship colonies each getting a new daemon-flags PASS)
- [x] Negative test: injected `--backend claude` into a `start-colony.sh`, re-ran lint → `FAIL ... unknown daemon flag: --backend`, reverted
- [x] Edge case: injected `--tick-interval=60000` (`=value` form) → PASS (correctly strips `=value` before allowlist check)
- [x] Short-flag negative test: injected `-X` → `FAIL ... unknown daemon flag: -X`, reverted
- [x] No markdown lint errors on the new `tools/check-exec-sh.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)