### PR TITLE
feat: implement release colony (4 agents)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -12,7 +12,7 @@ Each colony specializes in one part of the workflow. Together, they form a feder
 | [code-review](./code-review/) | Reviews merge requests: style, logic, security, test coverage, approval decisions (5 agents) | Active |
 | [planning](./planning/) | Breaks down work: scope estimation, risk assessment, task decomposition, plan review (4 agents) | Active |
 | [implementation](./implementation/) | Writes and refactors code: code generation, test writing, commit conventions (4 agents) | Active |
-| [release](./release/) | Automates releases: ship decisions, changelogs, versioning, pre-release checks (4 agents) | Scaffolded (see [#5](https://github.com/Replikanti/agentis-colonies/issues/5)) |
+| [release](./release/) | Automates releases: ship decisions, changelogs, versioning, pre-release checks (4 agents) | Active |
 
 ## Why Colonies, Not Individual Agents?
 
@@ -94,7 +94,7 @@ Every agent starts in **observe-only** mode. On a fresh colony the confidence me
 
 ### Memo key convention
 
-Each agent reads its confidence from `recall_latest("<agent_name>:confidence")`. The full set of keys across the four active colonies is:
+Each agent reads its confidence from `recall_latest("<agent_name>:confidence")`. The full set of keys across the five active colonies is:
 
 | Colony | Keys |
 |--------|------|
@@ -102,6 +102,7 @@ Each agent reads its confidence from `recall_latest("<agent_name>:confidence")`.
 | code-review | `logic_reviewer:confidence`, `style_reviewer:confidence`, `security_reviewer:confidence`, `test_reviewer:confidence`, `approval_decider:confidence` |
 | planning | `scope_estimator:confidence`, `risk_assessor:confidence`, `task_decomposer:confidence`, `plan_reviewer:confidence` |
 | implementation | `code_writer:confidence`, `test_writer:confidence`, `refactorer:confidence`, `commit_composer:confidence` |
+| release | `ship_decider:confidence`, `changelog_writer:confidence`, `version_bumper:confidence`, `release_checker:confidence` |
 
 ### Ramp stages
 
@@ -142,6 +143,12 @@ agentis memo set code_writer:confidence 0.5
 agentis memo set test_writer:confidence 0.5
 agentis memo set refactorer:confidence 0.5
 agentis memo set commit_composer:confidence 0.5
+
+# release colony
+agentis memo set ship_decider:confidence 0.5
+agentis memo set changelog_writer:confidence 0.5
+agentis memo set version_bumper:confidence 0.5
+agentis memo set release_checker:confidence 0.5
 ```
 
 To inspect the current value of any agent:

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -1,0 +1,131 @@
+// changelog_writer.ag -- Release colony: learns changelog conventions.
+//
+// Observes past release notes and MR descriptions to learn how you write
+// changelogs: grouping style (by type, by scope), what to include/exclude,
+// tone and audience. When a ship decision arrives, compiles release notes
+// from merged MRs since the last release.
+//
+// Run as daemon: agentis daemon agents/changelog_writer.ag --colony release
+// Requires: exec_foreign capability, GITLAB_* env vars
+
+cb 800;
+
+type ChangelogStyle {
+    releases_seen: int,
+    grouping: string,
+    tone: string,
+    inclusions: string,
+    exclusions: string
+}
+
+type ChangelogDraft {
+    version: string,
+    changelog: string,
+    mr_count: int,
+    confidence: float
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("changelog_writer:confidence");
+    if len(raw) > 0 {
+        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+    };
+    return 0.0;
+}
+
+fn tick(reason: string) -> void {
+    // 1. Learn changelog style from past releases
+    let releases_raw = try {
+        exec sh "./scripts/gitlab-api.sh releases --per-page 10";
+    } catch e {
+        print("[changelog_writer] GitLab releases poll failed:", e);
+        "";
+    };
+
+    if len(releases_raw) > 10 {
+        let style = prompt(
+            "Analyze these GitLab release descriptions/notes. Identify: how many have descriptions (releases_seen), how changes are grouped (grouping: by type like feat/fix/chore, by component, flat list), tone (technical, user-facing, mixed), what is included (inclusions: MR titles, commit messages, breaking changes, contributors), what is excluded (exclusions: internal refactors, dependency bumps, CI changes). Return JSON: releases_seen (int), grouping (string), tone (string), inclusions (string), exclusions (string).",
+            releases_raw
+        ) -> ChangelogStyle;
+
+        if style.releases_seen > 0 {
+            learn(
+                "changelog_write",
+                "batch of " + to_string(style.releases_seen) + " releases",
+                "grouping: " + style.grouping + " | tone: " + style.tone + " | include: " + style.inclusions + " | exclude: " + style.exclusions,
+                "observed",
+                "release"
+            );
+            print("[changelog_writer] Learned from", style.releases_seen, "past release notes");
+        };
+    };
+
+    // 2. Listen for ship decision and compile changelog
+    let ship_decision = listen("release:ship_decision", 100);
+    let decision_str = to_string(ship_decision);
+
+    if len(decision_str) < 5 {
+        let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now) > 0 {
+            memo_write("changelog_writer:last_check", now);
+        };
+        return;
+    };
+
+    // Only proceed if the decision is "ship"
+    let is_ship = prompt(
+        "Does this ship decision say 'ship' (not 'no-ship')? Return 'yes' or 'no', nothing else.",
+        decision_str
+    ) -> string;
+
+    if is_ship != "yes" {
+        print("[changelog_writer] Ship decision is no-ship, skipping changelog");
+        let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now) > 0 {
+            memo_write("changelog_writer:last_check", now);
+        };
+        return;
+    };
+
+    // Get the latest release tag to find MRs merged since then
+    let latest_release = try {
+        exec sh "./scripts/gitlab-api.sh releases --per-page 1";
+    } catch e { "[]"; };
+
+    let since_date = prompt(
+        "Extract the created_at or released_at date from this GitLab release JSON array (take the first element). Return just the ISO 8601 date string, nothing else. If the array is empty, return '2000-01-01T00:00:00Z'.",
+        latest_release
+    ) -> string;
+
+    // Fetch MRs merged since last release
+    let mrs_cmd = "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date);
+    let mrs_raw = try { exec sh mrs_cmd; } catch e {
+        print("[changelog_writer] MR fetch failed:", e);
+        "";
+    };
+
+    if len(mrs_raw) > 10 {
+        let rec = recommend("changelog_write", ["accuracy"]);
+        let context = "Merged MRs since last release: " + mrs_raw + "\nShip decision: " + decision_str + "\nLearned changelog conventions: " + to_string(rec);
+
+        let draft = prompt(
+            "You are a changelog writer agent. Compile release notes from the merged MRs following learned conventions. Group changes by type, use the learned tone, include/exclude items as learned. Determine the version string from the MR content (or leave as 'TBD' if unclear). Return JSON: version (string), changelog (string, the formatted release notes in markdown), mr_count (int, number of MRs included), confidence (float 0-1).",
+            context
+        ) -> ChangelogDraft;
+
+        let confidence = get_confidence();
+        print("[changelog_writer] Drafted changelog for", draft.version, "(", draft.mr_count, "MRs, confidence:", confidence, ")");
+
+        if confidence >= 0.6 {
+            emit("release:changelog_draft", draft);
+            learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "emitted", "release");
+        } else {
+            print("[changelog_writer] Observing (confidence:", confidence, ")");
+        };
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("changelog_writer:last_check", now);
+    };
+}

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -1,0 +1,117 @@
+// release_checker.ag -- Release colony: learns pre-release validation.
+//
+// Observes past releases and their CI pipeline outcomes to learn which
+// checks matter before shipping: CI gate status, dependency audit results,
+// migration safety, test coverage thresholds. Reports check results to the
+// colony bus for the ship_decider to evaluate.
+//
+// Run as daemon: agentis daemon agents/release_checker.ag --colony release
+// Requires: exec_foreign capability, GITLAB_* env vars
+
+cb 800;
+
+type CheckPatterns {
+    releases_seen: int,
+    ci_gates: string,
+    validation_steps: string,
+    failure_patterns: string
+}
+
+type CheckResult {
+    branch: string,
+    ci_status: string,
+    issues_found: string,
+    all_passed: int,
+    confidence: float
+}
+
+fn releases_cmd() -> string {
+    return "./scripts/gitlab-api.sh releases --per-page 10";
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("release_checker:confidence");
+    if len(raw) > 0 {
+        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+    };
+    return 0.0;
+}
+
+fn tick(reason: string) -> void {
+    // 1. Learn from past releases and their pipeline outcomes
+    let releases_raw = try {
+        exec sh "./scripts/gitlab-api.sh releases --per-page 10";
+    } catch e {
+        print("[release_checker] GitLab releases poll failed:", e);
+        "";
+    };
+
+    if len(releases_raw) > 10 {
+        let patterns = prompt(
+            "Analyze these GitLab releases. Identify: how many releases (releases_seen), CI gate patterns (did releases happen only after green pipelines, what stages were required), validation steps visible in release notes or tag messages (dependency audits, changelog presence, version consistency), any releases that were followed by hotfixes indicating missed checks (failure_patterns). Return JSON: releases_seen (int), ci_gates (string), validation_steps (string), failure_patterns (string).",
+            releases_raw
+        ) -> CheckPatterns;
+
+        if patterns.releases_seen > 0 {
+            learn(
+                "release_check",
+                "batch of " + to_string(patterns.releases_seen) + " releases",
+                "ci_gates: " + patterns.ci_gates + " | validation: " + patterns.validation_steps + " | failures: " + patterns.failure_patterns,
+                "observed",
+                "release"
+            );
+            print("[release_checker] Learned from", patterns.releases_seen, "past releases");
+        };
+    };
+
+    // 2. Check for pending release candidates (listen from implementation colony)
+    let mr_ready = listen("implementation:mr_ready", 100);
+    let mr_str = to_string(mr_ready);
+
+    // Also check the default branch pipeline status
+    let pipeline_raw = try {
+        exec sh "./scripts/gitlab-api.sh pipelines --ref main";
+    } catch e {
+        print("[release_checker] Pipeline poll failed:", e);
+        "";
+    };
+
+    if len(pipeline_raw) > 10 {
+        let rec = recommend("release_check", ["accuracy"]);
+        let context = "Latest pipelines on main: " + pipeline_raw + "\nLearned validation patterns: " + to_string(rec);
+
+        if len(mr_str) > 5 {
+            let context_full = context + "\nPending MR: " + mr_str;
+            let result = prompt(
+                "You are a release checker agent. Review the latest CI pipeline status and any pending implementation MR. Check: is CI green on main? Are there any failing stages? Any issues visible in pipeline logs? Return JSON: branch (string, the ref checked), ci_status (string, 'green'/'red'/'pending'), issues_found (string, list of problems or 'none'), all_passed (int, 1 if everything looks good, 0 if issues), confidence (float 0-1).",
+                context_full
+            ) -> CheckResult;
+
+            let confidence = get_confidence();
+            print("[release_checker] Checked main pipeline:", result.ci_status, "(confidence:", confidence, ")");
+
+            if confidence >= 0.6 {
+                emit("release:check_result", result);
+                learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "emitted", "release");
+            } else {
+                print("[release_checker] Observing (confidence:", confidence, ")");
+            };
+        } else {
+            // Periodic check even without pending MR
+            let result = prompt(
+                "You are a release checker agent. Review the latest CI pipeline status on main. Is CI green? Are there failing stages? Return JSON: branch (string, 'main'), ci_status (string, 'green'/'red'/'pending'), issues_found (string, list of problems or 'none'), all_passed (int, 1 if OK, 0 if issues), confidence (float 0-1).",
+                context
+            ) -> CheckResult;
+
+            let confidence = get_confidence();
+            if confidence >= 0.6 {
+                emit("release:check_result", result);
+            };
+        };
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("release_checker:last_check", now);
+    };
+}

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -25,9 +25,6 @@ type CheckResult {
     confidence: float
 }
 
-fn releases_cmd() -> string {
-    return "./scripts/gitlab-api.sh releases --per-page 10";
-}
 
 fn get_confidence() -> float {
     let raw = recall_latest("release_checker:confidence");

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -1,0 +1,99 @@
+// ship_decider.ag -- Release colony: learns when to ship.
+//
+// Observes release cadence, blocker patterns, and risk tolerance to learn
+// ship/no-ship thresholds. Weighs pre-release check results against learned
+// patterns and makes the go/no-go decision.
+//
+// Run as daemon: agentis daemon agents/ship_decider.ag --colony release
+// Requires: exec_foreign capability, GITLAB_* env vars
+
+cb 600;
+
+type ShipPatterns {
+    releases_seen: int,
+    cadence: string,
+    blocker_types: string,
+    risk_tolerance: string
+}
+
+type ShipDecision {
+    decision: string,
+    reasoning: string,
+    blockers: string,
+    confidence: float
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("ship_decider:confidence");
+    if len(raw) > 0 {
+        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+    };
+    return 0.0;
+}
+
+fn tick(reason: string) -> void {
+    // 1. Learn release patterns from history
+    let releases_raw = try {
+        exec sh "./scripts/gitlab-api.sh releases --per-page 20";
+    } catch e {
+        print("[ship_decider] GitLab releases poll failed:", e);
+        "";
+    };
+
+    if len(releases_raw) > 10 {
+        let tags_raw = try {
+            exec sh "./scripts/gitlab-api.sh tags --per-page 20";
+        } catch e { "[]"; };
+
+        let patterns = prompt(
+            "Analyze these GitLab releases and tags. Identify: how many releases (releases_seen), release cadence (daily, weekly, per-milestone, irregular), what types of issues block releases (blocker_types: failing CI, open critical bugs, incomplete features), risk tolerance (are hotfixes common, are pre-release tags used, do releases happen on specific days). Return JSON: releases_seen (int), cadence (string), blocker_types (string), risk_tolerance (string).",
+            releases_raw + "\n\nTags: " + tags_raw
+        ) -> ShipPatterns;
+
+        if patterns.releases_seen > 0 {
+            learn(
+                "ship_decide",
+                "batch of " + to_string(patterns.releases_seen) + " releases",
+                "cadence: " + patterns.cadence + " | blockers: " + patterns.blocker_types + " | risk: " + patterns.risk_tolerance,
+                "observed",
+                "release"
+            );
+            print("[ship_decider] Learned from", patterns.releases_seen, "past releases");
+        };
+    };
+
+    // 2. Listen for check results and make ship/no-ship decision
+    let check_result = listen("release:check_result", 100);
+    let check_str = to_string(check_result);
+
+    if len(check_str) < 5 {
+        let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now) > 0 {
+            memo_write("ship_decider:last_check", now);
+        };
+        return;
+    };
+
+    let rec = recommend("ship_decide", ["accuracy"]);
+    let context = "Pre-release check results: " + check_str + "\nLearned shipping patterns: " + to_string(rec);
+
+    let decision = prompt(
+        "You are a ship decider agent. Based on the pre-release check results and learned shipping patterns, make a ship/no-ship decision. Consider: is CI green, are there blockers, does this match the learned cadence and risk tolerance. Return JSON: decision (string, 'ship' or 'no-ship'), reasoning (string, 2-3 sentences explaining the decision), blockers (string, list of blockers or 'none'), confidence (float 0-1).",
+        context
+    ) -> ShipDecision;
+
+    let confidence = get_confidence();
+    print("[ship_decider] Decision:", decision.decision, "(confidence:", confidence, ")");
+
+    if confidence >= 0.6 {
+        emit("release:ship_decision", decision);
+        learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "emitted", "release");
+    } else {
+        print("[ship_decider] Observing (confidence:", confidence, ")");
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("ship_decider:last_check", now);
+    };
+}

--- a/dev-apprenticeship/release/agents/version_bumper.ag
+++ b/dev-apprenticeship/release/agents/version_bumper.ag
@@ -1,0 +1,165 @@
+// version_bumper.ag -- Release colony: learns versioning conventions.
+//
+// Observes past version tags to learn semver strategy: when to bump major,
+// minor, or patch, pre-release tag conventions, and version string format.
+// When a ship decision arrives, determines the correct next version and
+// creates the tag.
+//
+// Run as daemon: agentis daemon agents/version_bumper.ag --colony release
+// Requires: exec_foreign capability, GITLAB_* env vars
+
+cb 400;
+
+type VersionPatterns {
+    tags_seen: int,
+    format: string,
+    bump_strategy: string,
+    prerelease: string
+}
+
+type VersionBump {
+    current: string,
+    next: string,
+    bump_type: string,
+    reasoning: string,
+    confidence: float
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("version_bumper:confidence");
+    if len(raw) > 0 {
+        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+    };
+    return 0.0;
+}
+
+fn tick(reason: string) -> void {
+    // 1. Learn versioning patterns from tags
+    let tags_raw = try {
+        exec sh "./scripts/gitlab-api.sh tags --per-page 20";
+    } catch e {
+        print("[version_bumper] GitLab tags poll failed:", e);
+        "";
+    };
+
+    if len(tags_raw) > 10 {
+        let patterns = prompt(
+            "Analyze these GitLab tags. Identify: how many version tags (tags_seen, count only semver-like tags), version format (format: v1.2.3, 1.2.3, with or without v prefix), bump strategy (bump_strategy: what triggers major/minor/patch bumps based on tag progression), pre-release conventions (prerelease: alpha/beta/rc tags, or 'none'). Return JSON: tags_seen (int), format (string), bump_strategy (string), prerelease (string).",
+            tags_raw
+        ) -> VersionPatterns;
+
+        if patterns.tags_seen > 0 {
+            learn(
+                "version_bump",
+                "batch of " + to_string(patterns.tags_seen) + " version tags",
+                "format: " + patterns.format + " | strategy: " + patterns.bump_strategy + " | prerelease: " + patterns.prerelease,
+                "observed",
+                "release"
+            );
+            print("[version_bumper] Learned from", patterns.tags_seen, "version tags");
+        };
+    };
+
+    // 2. Listen for ship decision and determine next version
+    let ship_decision = listen("release:ship_decision", 100);
+    let decision_str = to_string(ship_decision);
+
+    if len(decision_str) < 5 {
+        let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now) > 0 {
+            memo_write("version_bumper:last_check", now);
+        };
+        return;
+    };
+
+    // Only proceed if the decision is "ship"
+    let is_ship = prompt(
+        "Does this ship decision say 'ship' (not 'no-ship')? Return 'yes' or 'no', nothing else.",
+        decision_str
+    ) -> string;
+
+    if is_ship != "yes" {
+        print("[version_bumper] Ship decision is no-ship, skipping version bump");
+        let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now) > 0 {
+            memo_write("version_bumper:last_check", now);
+        };
+        return;
+    };
+
+    // Also listen for the changelog draft to understand what changed
+    let changelog_draft = listen("release:changelog_draft", 100);
+    let changelog_str = to_string(changelog_draft);
+
+    // Get latest tags for current version context
+    let latest_tags = try {
+        exec sh "./scripts/gitlab-api.sh tags --per-page 5";
+    } catch e { "[]"; };
+
+    // Fetch merged MRs since last release for bump analysis
+    let latest_release = try {
+        exec sh "./scripts/gitlab-api.sh releases --per-page 1";
+    } catch e { "[]"; };
+
+    let since_date = prompt(
+        "Extract the created_at or released_at date from this GitLab release JSON array (take the first element). Return just the ISO 8601 date string, nothing else. If the array is empty, return '2000-01-01T00:00:00Z'.",
+        latest_release
+    ) -> string;
+
+    let mrs_cmd = "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date);
+    let mrs_raw = try { exec sh mrs_cmd; } catch e { "[]"; };
+
+    let rec = recommend("version_bump", ["accuracy"]);
+    let context = "Latest tags: " + latest_tags + "\nMerged MRs since last release: " + mrs_raw + "\nChangelog: " + changelog_str + "\nLearned versioning patterns: " + to_string(rec);
+
+    let bump = prompt(
+        "You are a version bumper agent. Determine the correct next version based on: the current latest tag, what changed in the merged MRs (breaking changes = major, new features = minor, fixes only = patch), and learned versioning conventions. Return JSON: current (string, current version tag), next (string, the next version), bump_type (string, 'major'/'minor'/'patch'), reasoning (string, why this bump type), confidence (float 0-1).",
+        context
+    ) -> VersionBump;
+
+    let confidence = get_confidence();
+    print("[version_bumper] Version bump:", bump.current, "->", bump.next, "(", bump.bump_type, ", confidence:", confidence, ")");
+
+    if confidence >= 0.85 {
+        // Create the tag
+        // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
+        let tag_cmd = "./scripts/gitlab-api.sh create-tag --name " + shell_escape(bump.next) + " --ref main --message " + shell_escape("Release " + bump.next);
+        let tag_result = try { exec sh tag_cmd; } catch e {
+            print("[version_bumper] Tag creation failed:", e);
+            "";
+        };
+
+        if len(tag_result) > 0 {
+            print("[version_bumper] Created tag", bump.next);
+
+            // Build release description from changelog or bump reasoning
+            let release_desc = changelog_str + bump.reasoning;
+
+            // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
+            let release_cmd = "./scripts/gitlab-api.sh create-release --tag " + shell_escape(bump.next) + " --name " + shell_escape("Release " + bump.next) + " --description " + shell_escape(release_desc);
+            let release_result = try { exec sh release_cmd; } catch e {
+                print("[version_bumper] Release creation failed:", e);
+                "";
+            };
+
+            if len(release_result) > 0 {
+                print("[version_bumper] Created release", bump.next);
+            };
+
+            emit("release:version_bumped", bump);
+            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "acted", "release");
+        };
+    } else {
+        if confidence >= 0.6 {
+            emit("release:version_bumped", bump);
+            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "emitted", "release");
+        } else {
+            print("[version_bumper] Observing (confidence:", confidence, ")");
+        };
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("version_bumper:last_check", now);
+    };
+}

--- a/dev-apprenticeship/release/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/release/scripts/gitlab-api.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# GitLab API wrapper for release colony agents.
+# Called by .ag agents via exec sh.
+#
+# Required env vars (set by start-colony.sh from colony.toml):
+#   GITLAB_URL     - GitLab instance URL (e.g. https://gitlab.example.com)
+#   GITLAB_TOKEN   - Personal access token or project token
+#   GITLAB_PROJECT - URL-encoded project path (e.g. your-org%2Fyour-project)
+#
+# Usage:
+#   gitlab-api.sh releases [--per-page N]
+#   gitlab-api.sh tags [--per-page N]
+#   gitlab-api.sh pipelines --ref <branch> [--per-page N]
+#   gitlab-api.sh merge-requests --state merged [--since ISO8601]
+#   gitlab-api.sh mr-commits <iid>
+#   gitlab-api.sh create-tag --name <name> --ref <ref> [--message <m>]
+#   gitlab-api.sh create-release --tag <tag> --name <name> --description <d>
+#   gitlab-api.sh post-note <iid> --body <text>
+#
+# The release colony reads release history, CI status, and merged MRs to learn
+# shipping patterns. Write endpoints create tags and releases. All write
+# endpoints build JSON bodies via python3 json.dumps to handle special characters.
+#
+# Returns JSON to stdout. Exit code 0 on success, 1 on error, 2 on unknown flag.
+
+set -e
+
+# emit_error <message>
+# Print a JSON error object to stderr with <message> safely encoded via
+# python3 json.dumps. Use this anywhere the message contains user-supplied
+# input (flag names, command names) that could contain quotes, backslashes,
+# or newlines which would otherwise break naive string interpolation.
+# Does NOT exit. The caller controls the exit code.
+emit_error() {
+    printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
+    emit_error "GITLAB_URL, GITLAB_TOKEN, and GITLAB_PROJECT must be set"
+    exit 1
+fi
+
+API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
+
+gl_get() {
+    curl -sfS --max-time 30 \
+        -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+        "$1"
+}
+
+# gl_get_q <url> [--data-urlencode k=v ...]
+# Uses curl -G so each key=value pair is URL-encoded safely. Use this
+# for any endpoint whose query string takes values that could contain
+# spaces, '&', '#', or non-ASCII. Plain path-only GETs keep using gl_get.
+gl_get_q() {
+    local url="$1"
+    shift
+    curl -sfS -G --max-time 30 \
+        -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+        "$@" \
+        "$url"
+}
+
+gl_post() {
+    curl -sfS --max-time 30 \
+        -X POST \
+        -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$2" \
+        "$1"
+}
+
+CMD="${1:?Usage: gitlab-api.sh <command> [args...]}"
+shift
+
+case "$CMD" in
+    releases)
+        PER_PAGE="20"
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --per-page) PER_PAGE="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        gl_get_q "$API/releases" \
+            --data-urlencode "per_page=$PER_PAGE" \
+            --data-urlencode "order_by=released_at" \
+            --data-urlencode "sort=desc"
+        ;;
+
+    tags)
+        PER_PAGE="20"
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --per-page) PER_PAGE="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        gl_get_q "$API/repository/tags" \
+            --data-urlencode "per_page=$PER_PAGE" \
+            --data-urlencode "order_by=updated" \
+            --data-urlencode "sort=desc"
+        ;;
+
+    pipelines)
+        REF=""
+        PER_PAGE="5"
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --ref) REF="$2"; shift 2 ;;
+                --per-page) PER_PAGE="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$REF" ]; then
+            emit_error "--ref is required"
+            exit 1
+        fi
+        gl_get_q "$API/pipelines" \
+            --data-urlencode "ref=$REF" \
+            --data-urlencode "per_page=$PER_PAGE" \
+            --data-urlencode "order_by=updated_at" \
+            --data-urlencode "sort=desc"
+        ;;
+
+    merge-requests)
+        STATE="opened"
+        SINCE=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --state) STATE="$2"; shift 2 ;;
+                --since) SINCE="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        ARGS=(
+            --data-urlencode "state=$STATE"
+            --data-urlencode "per_page=100"
+            --data-urlencode "order_by=updated_at"
+            --data-urlencode "sort=desc"
+        )
+        if [ -n "$SINCE" ]; then
+            ARGS+=(--data-urlencode "updated_after=$SINCE")
+        fi
+        gl_get_q "$API/merge_requests" "${ARGS[@]}"
+        ;;
+
+    mr-commits)
+        IID="${1:?Usage: gitlab-api.sh mr-commits <iid>}"
+        gl_get "$API/merge_requests/$IID/commits?per_page=100"
+        ;;
+
+    create-tag)
+        NAME=""
+        REF="main"
+        MESSAGE=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --name) NAME="$2"; shift 2 ;;
+                --ref) REF="$2"; shift 2 ;;
+                --message) MESSAGE="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$NAME" ]; then
+            emit_error "--name is required"
+            exit 1
+        fi
+        JSON_BODY=$(NAME="$NAME" REF="$REF" MESSAGE="$MESSAGE" python3 - <<'PY'
+import os, json
+body = {"tag_name": os.environ["NAME"], "ref": os.environ["REF"]}
+if os.environ.get("MESSAGE"):
+    body["message"] = os.environ["MESSAGE"]
+print(json.dumps(body))
+PY
+)
+        gl_post "$API/repository/tags" "$JSON_BODY"
+        ;;
+
+    create-release)
+        TAG=""
+        NAME=""
+        DESC=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --tag) TAG="$2"; shift 2 ;;
+                --name) NAME="$2"; shift 2 ;;
+                --description) DESC="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$TAG" ] || [ -z "$NAME" ]; then
+            emit_error "--tag and --name are required"
+            exit 1
+        fi
+        JSON_BODY=$(TAG="$TAG" NAME="$NAME" DESC="$DESC" python3 - <<'PY'
+import os, json
+body = {"tag_name": os.environ["TAG"], "name": os.environ["NAME"]}
+if os.environ.get("DESC"):
+    body["description"] = os.environ["DESC"]
+print(json.dumps(body))
+PY
+)
+        gl_post "$API/releases" "$JSON_BODY"
+        ;;
+
+    post-note)
+        IID="${1:?Usage: gitlab-api.sh post-note <iid> --body <text>}"
+        shift
+        BODY=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --body) BODY="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$BODY" ]; then
+            emit_error "--body is required"
+            exit 1
+        fi
+        JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
+        gl_post "$API/merge_requests/$IID/notes" "$JSON_BODY"
+        ;;
+
+    *)
+        emit_error "unknown command: $CMD"
+        exit 1
+        ;;
+esac

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -4,11 +4,13 @@
 # Each agent runs as a separate agentis daemon process.
 # They discover each other via colony UDP and communicate over TCP emit/listen.
 #
-# Usage: ./scripts/start-colony.sh [--config path/to/colony.toml]
+# Usage: ./scripts/start-colony.sh [path/to/colony.toml]
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve symlinks on $0 itself so the script works when invoked via a symlink.
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 COLONY_DIR="$(dirname "$SCRIPT_DIR")"
 CONFIG="${1:-$COLONY_DIR/config/colony.toml}"
 
@@ -18,14 +20,44 @@ if [ ! -f "$CONFIG" ]; then
     exit 1
 fi
 
+# Parse GitLab config from TOML via the shared helper.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=../../../tools/parse-toml.sh
+# shellcheck disable=SC1091  # colony-lint runs shellcheck without -x
+. "$REPO_ROOT/tools/parse-toml.sh"
+
+GITLAB_URL=$(parse_toml gitlab url)
+GITLAB_TOKEN=$(parse_toml gitlab token)
+GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
+
+if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
+    echo "Error: GitLab config incomplete in $CONFIG"
+    echo "Required: url, token, project under [gitlab]"
+    exit 1
+fi
+
+# URL-encode the project path (replace / with %2F)
+GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
+
+export GITLAB_URL
+export GITLAB_TOKEN
+export GITLAB_PROJECT
+export COLONY_DIR
+
 AGENTS=(
+    release_checker
     ship_decider
     changelog_writer
     version_bumper
-    release_checker
 )
 
+# Note: LLM backend is read by agentis daemon from the llm.backend key in
+# .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
+# informational only. Operators should mirror it into .agentis/config.
+# exec sh is enabled by default on agentis daemon; there is no --enable-exec.
+
 echo "Starting Release colony (${#AGENTS[@]} agents)..."
+echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."


### PR DESCRIPTION
## Summary

- Add the 5th and final colony (release) to the dev-apprenticeship federation
- 4 agents: release_checker, ship_decider, changelog_writer, version_bumper
- New gitlab-api.sh with 8 endpoints (releases, tags, pipelines, merge-requests, mr-commits, create-tag, create-release, post-note)
- Updated start-colony.sh to full GitLab-config-parsing pattern
- Federation README updated: all 5 colonies now Active, memo keys and seeding examples complete

## Test plan

- [x] Colony lint: 45 passed, 0 failed, 5 skipped
- [x] Bash syntax check: both scripts pass `bash -n`
- [x] Em dash check: clean
- [x] All 4 .ag files pass agentis parser
- [ ] QA agent review

Closes the release colony portion of #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)