### PR TITLE
fix: test_writer autonomy + wire implementation:mr_ready

### DIFF
--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -98,4 +98,10 @@ fn tick(reason: string) -> void {
             print("[approval_decider] Observing (confidence:", confidence, ")");
         };
     };
+
+    // Listen for new MRs from implementation colony
+    let impl_mr = listen("implementation:mr_ready", 100);
+    if len(to_string(impl_mr)) > 5 {
+        print("[approval_decider] Implementation colony created a new MR, reviewers will pick it up on next tick");
+    };
 }

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -98,8 +98,26 @@ fn tick(reason: string) -> void {
         print("[test_writer] Drafted tests for issue", tests.issue_id, "(confidence:", confidence, ")");
 
         if confidence >= 0.85 {
-            emit("implementation:test_draft", tests);
-            learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "acted", "implementation");
+            // Generate actual test file contents and commit to the branch
+            let test_context = "Code draft: " + draft_str + "\nTest plan: " + tests.test_files + "\nPatterns: " + to_string(rec);
+
+            let actions_json = prompt(
+                "You are a test writer. Generate the actual test file contents for this test plan. Return a JSON array of objects, each with: action (string, 'create' or 'update'), file_path (string), content (string, the full test file content). Follow the learned test structure and assertion patterns. Only return the JSON array, nothing else.",
+                test_context
+            ) -> string;
+
+            // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
+            let commit_cmd = "./scripts/gitlab-api.sh commit-files --branch " + shell_escape(tests.branch_name) + " --message " + shell_escape("test: add tests for #" + to_string(tests.issue_id)) + " --actions " + shell_escape(actions_json);
+            let commit_result = try { exec sh commit_cmd; } catch e {
+                print("[test_writer] Commit failed:", e);
+                "";
+            };
+
+            if len(commit_result) > 0 {
+                print("[test_writer] Committed tests to", tests.branch_name);
+                emit("implementation:test_draft", tests);
+                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "acted", "implementation");
+            };
         } else {
             if confidence >= 0.6 {
                 emit("implementation:test_draft", tests);


### PR DESCRIPTION
## Summary

- test_writer: differentiate autonomous (>= 0.85) vs suggest (>= 0.6) confidence levels. At high confidence, generate actual test files and commit them to the branch. At lower confidence, emit the plan for human review.
- approval_decider: listen for `implementation:mr_ready` cross-colony event so the code-review colony is aware when the implementation colony creates a new MR.

## Test plan

- [x] Colony lint: 45 passed, 0 failed, 5 skipped
- [x] test_writer.ag parses cleanly
- [x] approval_decider.ag parses cleanly
- [x] shell_escape on all dynamic exec sh values
- [ ] QA agent review

Closes #75, closes #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)