### PR TITLE
fix: shell_escape recall_latest in _cmd() helpers (15 agents)

### DIFF
--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -24,7 +24,7 @@ type LogicReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("logic_reviewer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --since " + ts;
+        return "./scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh merge-requests";
 }

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -25,7 +25,7 @@ type SecurityReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("security_reviewer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --since " + ts;
+        return "./scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh merge-requests";
 }

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -24,7 +24,7 @@ type StyleReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("style_reviewer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --since " + ts;
+        return "./scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh merge-requests";
 }

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -24,7 +24,7 @@ type TestReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("test_reviewer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --since " + ts;
+        return "./scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh merge-requests";
 }

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -27,7 +27,7 @@ type CodeDraft {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("code_writer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + ts;
+        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh merge-requests --state merged";
 }

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -29,7 +29,7 @@ type MRPlan {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("commit_composer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + ts;
+        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh merge-requests --state merged";
 }

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -25,7 +25,7 @@ type RefactorSuggestion {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("refactorer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + ts;
+        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh merge-requests --state merged";
 }

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -27,7 +27,7 @@ type TestDraft {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("test_writer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + ts;
+        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh merge-requests --state merged";
 }

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -25,7 +25,7 @@ type IncidentPatterns {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("risk_assessor:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --needs-planning --since " + ts;
+        return "./scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh issues --needs-planning";
 }

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -26,7 +26,7 @@ type CalibrationSummary {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("scope_estimator:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --needs-planning --since " + ts;
+        return "./scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh issues --needs-planning";
 }

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -26,7 +26,7 @@ type DecompositionPatterns {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("task_decomposer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --needs-planning --since " + ts;
+        return "./scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh issues --needs-planning";
 }

--- a/dev-apprenticeship/triage/agents/issue_creator.ag
+++ b/dev-apprenticeship/triage/agents/issue_creator.ag
@@ -24,7 +24,7 @@ type ObservationSummary {
 fn issues_cmd() -> string {
     let ts = recall_latest("issue_creator:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --since " + ts;
+        return "./scripts/gitlab-api.sh issues --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh issues";
 }

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -25,7 +25,7 @@ type LabelAction {
 fn issues_cmd() -> string {
     let ts = recall_latest("labeler:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --since " + ts;
+        return "./scripts/gitlab-api.sh issues --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh issues";
 }

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -25,7 +25,7 @@ type PriorityAction {
 fn issues_cmd() -> string {
     let ts = recall_latest("prioritizer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --since " + ts;
+        return "./scripts/gitlab-api.sh issues --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh issues";
 }

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -25,7 +25,7 @@ type RouteAction {
 fn issues_cmd() -> string {
     let ts = recall_latest("router:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --since " + ts;
+        return "./scripts/gitlab-api.sh issues --since " + shell_escape(ts);
     };
     return "./scripts/gitlab-api.sh issues";
 }


### PR DESCRIPTION
## Summary

- Wraps `recall_latest()` timestamp values in `shell_escape()` across all 15 agent `_cmd()` helper functions
- Affected colonies: triage (4 agents), code-review (4 agents), implementation (4 agents), planning (3 agents)
- Release colony was already clean

The `_cmd()` helpers build `exec sh` commands by concatenating `recall_latest("<agent>:last_check")` values directly into the command string. While timestamps from `memo_write()` are unlikely to contain shell metacharacters, the project convention requires all dynamic values in `exec sh` calls to be wrapped in `shell_escape()`.

## Test plan

- [x] Colony lint: 45 passed, 0 failed, 5 skipped (shellcheck not installed)
- [x] All 21 agent .ag files pass syntax check
- [x] check-exec-sh: no unsafe concat findings
- [x] Verified each edit only touches the `+ ts;` -> `+ shell_escape(ts);` pattern in the _cmd() return

🤖 Generated with [Claude Code](https://claude.com/claude-code)