### PR TITLE
fix: autonomous tiers + extension point docs (#81, #82)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -93,7 +93,7 @@ The following colony bus events are emitted for external consumption. They have 
 | `review:decision_suggestion` | approval_decider.ag | Confidence 0.6-0.84: approve/reject suggestion for human |
 | `review:escalation` | approval_decider.ag | Confidence >= 0.85: MR requires human attention (edge case) |
 | `planning:draft_plan` | plan_reviewer.ag | Confidence 0.6-0.84: assembled plan for human review |
-| `release:version_bumped` | version_bumper.ag | After tag/release creation: completion notification |
+| `release:version_bumped` | version_bumper.ag | >= 0.85: after tag/release creation; 0.6-0.84: version bump suggestion |
 
 All other events in the federation have internal consumers. The full wiring diagram:
 

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -82,6 +82,40 @@ Knowledge entries are tagged by scope:
 
 When onboarding a new project, colonies carry over `personal` knowledge and start fresh on `project:*`. They already know how you work, they just need to learn the codebase.
 
+## Extension Points
+
+The following colony bus events are emitted for external consumption. They have no internal listener by design, as they represent the human-facing output of the confidence gradient. Build your own agents, webhooks, or dashboards to consume them.
+
+| Event | Emitter | When |
+|-------|---------|------|
+| `triage:label_suggestion` | labeler.ag | Confidence 0.6-0.84: label suggestion for human review |
+| `triage:priority_suggestion` | prioritizer.ag | Confidence 0.6-0.84: priority suggestion for human review |
+| `review:decision_suggestion` | approval_decider.ag | Confidence 0.6-0.84: approve/reject suggestion for human |
+| `review:escalation` | approval_decider.ag | Confidence >= 0.85: MR requires human attention (edge case) |
+| `planning:draft_plan` | plan_reviewer.ag | Confidence 0.6-0.84: assembled plan for human review |
+| `release:version_bumped` | version_bumper.ag | After tag/release creation: completion notification |
+
+All other events in the federation have internal consumers. The full wiring diagram:
+
+```
+triage:new_issue       -> router, prioritizer, labeler
+triage:route_suggestion -> code_writer (cross-colony)
+implementation:code_draft -> test_writer, refactorer, commit_composer
+implementation:test_draft -> commit_composer
+implementation:refactor_suggestions -> commit_composer
+implementation:mr_ready -> release_checker, approval_decider (cross-colony)
+review:style_findings  -> approval_decider
+review:logic_findings  -> approval_decider
+review:security_findings -> approval_decider
+review:test_findings   -> approval_decider
+planning:scope_estimate -> plan_reviewer
+planning:risks         -> plan_reviewer
+planning:breakdown     -> plan_reviewer
+release:check_result   -> ship_decider
+release:ship_decision  -> changelog_writer, version_bumper
+release:changelog_draft -> version_bumper
+```
+
 ## Prerequisites
 
 - [Agentis](https://github.com/Replikanti/agentis) runtime (>= v1.1.3 for the `memo set`/`memo get` CLI used in Bootstrap below)

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -98,11 +98,32 @@ fn tick(reason: string) -> void {
         let confidence = get_confidence();
         print("[refactorer] Reviewed draft for issue", suggestion.issue_id, "(confidence:", confidence, ")");
 
-        if confidence >= 0.6 {
-            emit("implementation:refactor_suggestions", suggestion);
-            learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "emitted", "implementation");
+        if confidence >= 0.85 {
+            // Generate refactored code and commit to branch
+            let branch = prompt("Extract the branch_name from this code draft record. Return just the string, nothing else.", draft_str) -> string;
+            let refactor_context = "Code draft: " + draft_str + "\nSuggestions: " + suggestion.suggestions + "\nPatterns: " + to_string(rec);
+            let actions_json = prompt(
+                "You are a refactorer. Apply these refactoring suggestions to the code draft. Return a JSON array of objects, each with: action (string, 'update'), file_path (string), content (string, the refactored file content). Only return the JSON array, nothing else.",
+                refactor_context
+            ) -> string;
+            // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
+            let commit_cmd = "./scripts/gitlab-api.sh commit-files --branch " + shell_escape(branch) + " --message " + shell_escape("refactor: apply improvements for #" + to_string(suggestion.issue_id)) + " --actions " + shell_escape(actions_json);
+            let commit_result = try { exec sh commit_cmd; } catch e {
+                print("[refactorer] Commit failed:", e);
+                "";
+            };
+            if len(commit_result) > 0 {
+                print("[refactorer] Committed refactoring to", branch);
+                emit("implementation:refactor_suggestions", suggestion);
+                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "acted", "implementation");
+            };
         } else {
-            print("[refactorer] Observing (confidence:", confidence, ")");
+            if confidence >= 0.6 {
+                emit("implementation:refactor_suggestions", suggestion);
+                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "emitted", "implementation");
+            } else {
+                print("[refactorer] Observing (confidence:", confidence, ")");
+            };
         };
     };
 

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -116,11 +116,25 @@ fn tick(reason: string) -> void {
         let confidence = get_confidence();
         print("[changelog_writer] Drafted changelog for", draft.version, "(", draft.mr_count, "MRs, confidence:", confidence, ")");
 
-        if confidence >= 0.6 {
+        if confidence >= 0.85 {
+            let mr_raw = try { exec sh "./scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+            let mr_iid = prompt("Extract the iid integer of the first MR from this JSON array. If empty, return 0.", mr_raw) -> int;
+            if mr_iid > 0 {
+                let note = "**Release Notes Draft** (automated)\n\n" + draft.changelog;
+                let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                try { exec sh post_cmd; } catch e {
+                    print("[changelog_writer] Failed to post note:", e);
+                };
+            };
             emit("release:changelog_draft", draft);
-            learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "emitted", "release");
+            learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "acted", "release");
         } else {
-            print("[changelog_writer] Observing (confidence:", confidence, ")");
+            if confidence >= 0.6 {
+                emit("release:changelog_draft", draft);
+                learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "emitted", "release");
+            } else {
+                print("[changelog_writer] Observing (confidence:", confidence, ")");
+            };
         };
     };
 

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -120,6 +120,7 @@ fn tick(reason: string) -> void {
             } else {
                 if confidence >= 0.6 {
                     emit("release:check_result", result);
+                    learn("release_check", "periodic check", result.ci_status, "emitted", "release");
                 };
             };
         };

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -87,11 +87,24 @@ fn tick(reason: string) -> void {
             let confidence = get_confidence();
             print("[release_checker] Checked main pipeline:", result.ci_status, "(confidence:", confidence, ")");
 
-            if confidence >= 0.6 {
+            if confidence >= 0.85 {
+                let mr_iid = prompt("Extract the iid or issue_id integer from this MR data. Return just the integer. If not found, return 0.", mr_str) -> int;
+                if mr_iid > 0 {
+                    let note = "**Pre-release Check** (automated): " + result.ci_status + "\n\nIssues: " + result.issues_found;
+                    let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                    try { exec sh post_cmd; } catch e {
+                        print("[release_checker] Failed to post note:", e);
+                    };
+                };
                 emit("release:check_result", result);
-                learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "emitted", "release");
+                learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "acted", "release");
             } else {
-                print("[release_checker] Observing (confidence:", confidence, ")");
+                if confidence >= 0.6 {
+                    emit("release:check_result", result);
+                    learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "emitted", "release");
+                } else {
+                    print("[release_checker] Observing (confidence:", confidence, ")");
+                };
             };
         } else {
             // Periodic check even without pending MR
@@ -101,8 +114,13 @@ fn tick(reason: string) -> void {
             ) -> CheckResult;
 
             let confidence = get_confidence();
-            if confidence >= 0.6 {
+            if confidence >= 0.85 {
                 emit("release:check_result", result);
+                learn("release_check", "periodic check", result.ci_status, "acted", "release");
+            } else {
+                if confidence >= 0.6 {
+                    emit("release:check_result", result);
+                };
             };
         };
     };

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -85,11 +85,25 @@ fn tick(reason: string) -> void {
     let confidence = get_confidence();
     print("[ship_decider] Decision:", decision.decision, "(confidence:", confidence, ")");
 
-    if confidence >= 0.6 {
+    if confidence >= 0.85 {
+        let mr_raw = try { exec sh "./scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+        let mr_iid = prompt("Extract the iid integer of the first MR from this JSON array. If empty, return 0.", mr_raw) -> int;
+        if mr_iid > 0 {
+            let note = "**Ship Decision** (automated): " + decision.decision + "\n\n" + decision.reasoning;
+            let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+            try { exec sh post_cmd; } catch e {
+                print("[ship_decider] Failed to post note:", e);
+            };
+        };
         emit("release:ship_decision", decision);
-        learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "emitted", "release");
+        learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "acted", "release");
     } else {
-        print("[ship_decider] Observing (confidence:", confidence, ")");
+        if confidence >= 0.6 {
+            emit("release:ship_decision", decision);
+            learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "emitted", "release");
+        } else {
+            print("[ship_decider] Observing (confidence:", confidence, ")");
+        };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };


### PR DESCRIPTION
## Summary

- **Issue #82**: Added >= 0.85 autonomous tier to 4 agents that were missing it:
  - `refactorer.ag`: generates refactored code and commits to branch via `commit-files`
  - `ship_decider.ag`: posts ship/no-ship decision as MR note via `post-note`
  - `changelog_writer.ag`: posts changelog draft as MR note via `post-note`
  - `release_checker.ag`: posts pre-release check results as MR note via `post-note`
- **Issue #81**: The 6 events listed in the issue were false positives (all have internal consumers). Corrected and documented the actual 6 terminal events as extension points in the federation README. Added full 22-event wiring diagram.

All 21 agents now implement the complete confidence gradient (< 0.6 observe, >= 0.6 suggest, >= 0.85 act).

## Test plan

- [x] Colony lint: 45 passed, 0 failed, 5 skipped
- [x] All 21 .ag files pass syntax check
- [x] check-exec-sh: no unsafe concat findings
- [x] Verified all 4 agents have correct 3-tier nesting (>= 0.85 > >= 0.6 > observe)
- [x] Extension points table lists exactly the 6 terminal events
- [x] Wiring diagram covers all 22 events (16 internally wired + 6 extension points)

Closes #81, closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)