### PR TITLE
feat: end-user docs, install script, status legend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-Pre-built agent colonies for the [Agentis](https://github.com/Replikanti/agentis) runtime. The `dev-apprenticeship/` federation contains 5 colonies (21 agents) that learn a developer's workflow by observing how they work on GitLab.
+Pre-built agent colonies for the [Agentis](https://github.com/Replikanti/agentis) runtime. The `dev-apprenticeship/` federation contains 5 colonies (21 agents) that learn a developer's workflow by observing how they work on GitLab. All 21 agents implement the full confidence gradient (observe / suggest / act).
 
 ## Git workflow
 
@@ -47,6 +47,14 @@ colony-name/
 - `start-colony.sh`: symlink-safe `$0` resolution via python3, sources `tools/parse-toml.sh`, exports `GITLAB_URL`/`GITLAB_TOKEN`/`GITLAB_PROJECT`, launches daemons with `--colony <name> --tick-interval 60000`.
 - `gitlab-api.sh`: `emit_error()` for all error messages, `exit 2` for unknown flags, `python3 json.dumps` for all POST/PUT body construction. Read endpoints use `gl_get`/`gl_get_q`, write endpoints use `gl_post`/`gl_put`.
 
+## Federation event wiring
+
+22 colony bus events total: 16 internally wired, 6 extension points (terminal events for external consumption, documented in dev-apprenticeship/README.md).
+
+Cross-colony events:
+- `triage:route_suggestion` -> implementation/code_writer
+- `implementation:mr_ready` -> release/release_checker, code-review/approval_decider
+
 ## Tools
 
 | Tool | Purpose |
@@ -55,3 +63,10 @@ colony-name/
 | `new-colony.sh` | Scaffold a new colony (creates dirs, example config, starter scripts) |
 | `check-exec-sh.sh` | Grep-based check for unsafe string concat into `exec sh`. See `check-exec-sh.md` for known limitations. |
 | `parse-toml.sh` | Shared TOML parser sourced by all start-colony.sh scripts |
+
+## End-user scripts (in dev-apprenticeship/)
+
+| Script | Purpose |
+|--------|---------|
+| `install.sh` | Interactive setup: checks prerequisites, copies configs, writes GitLab credentials, seeds confidence |
+| `start-federation.sh` | Starts all 5 colonies (launches 21 daemon processes) |

--- a/README.md
+++ b/README.md
@@ -36,9 +36,18 @@ graph TD
 
 ## Federations
 
-| Federation | Description | Status |
-|------------|-------------|--------|
-| [dev-apprenticeship](./dev-apprenticeship/) | Learns a developer's complete workflow: code review, planning, implementation, triage, and release | Active |
+| Federation | Description | Agents | Status |
+|------------|-------------|--------|--------|
+| [dev-apprenticeship](./dev-apprenticeship/) | Learns a developer's complete workflow by observing how you work on GitLab. Covers triage, code review, planning, implementation, and release. | 21 | Beta |
+
+### Status
+
+| Badge | Meaning |
+|-------|---------|
+| **Stable** | Battle-tested on real workloads. Safe for production use. |
+| **Beta** | All agents built, audited, and linted clean. Not yet validated on live GitLab projects. |
+| **Alpha** | Core agents work. Some features incomplete or untested. |
+| **Planned** | Design exists, implementation not started. |
 
 ## Prerequisites
 

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -1,18 +1,61 @@
 # Dev Apprenticeship
 
-A federation of agent colonies that learns a developer's complete workflow by observing how they work, from triaging issues to shipping releases.
+A federation of 21 agents across 5 colonies that learns your development workflow by observing how you work on GitLab. It starts silent, watches you triage issues, review code, plan work, write code, and ship releases, then gradually takes over the mechanical parts.
 
-Each colony specializes in one part of the workflow. Together, they form a federation that covers the entire development lifecycle.
+## Quick Start
+
+```bash
+# Clone
+git clone https://github.com/Replikanti/agentis-colonies.git
+cd agentis-colonies/dev-apprenticeship
+
+# Install (interactive: checks prerequisites, configures GitLab, seeds agents)
+./install.sh
+
+# Start all 5 colonies
+./start-federation.sh
+```
+
+The install script will:
+1. Check that `agentis`, `claude`, and `python3` are installed
+2. Create `colony.toml` configs for all 5 colonies from the example templates
+3. Write your GitLab URL, project path, and API token into every config
+4. Seed all 21 agents at your chosen confidence level (default: 0.5, observe-only)
+
+After install, agents run as background daemons polling GitLab every 60 seconds.
+
+### What you need
+
+- [Agentis](https://github.com/Replikanti/agentis) runtime >= v1.1.3
+- [Claude CLI](https://claude.ai/download) (LLM backend)
+- GitLab instance with API access (personal access token with `api` scope)
+- Python 3 (used by config parsing and GitLab API scripts)
+
+### Starting and stopping
+
+```bash
+# Start everything
+./start-federation.sh
+
+# Start a single colony
+./triage/scripts/start-colony.sh
+
+# Monitor
+agentis colony status
+
+# Stop everything
+agentis daemon stop --all
+```
 
 ## Colonies
 
-| Colony | Description | Status |
-|--------|-------------|--------|
-| [triage](./triage/) | Manages issues: creation, prioritization, labeling, routing (4 agents) | Active |
-| [code-review](./code-review/) | Reviews merge requests: style, logic, security, test coverage, approval decisions (5 agents) | Active |
-| [planning](./planning/) | Breaks down work: scope estimation, risk assessment, task decomposition, plan review (4 agents) | Active |
-| [implementation](./implementation/) | Writes and refactors code: code generation, test writing, commit conventions (4 agents) | Active |
-| [release](./release/) | Automates releases: ship decisions, changelogs, versioning, pre-release checks (4 agents) | Active |
+| Colony | Agents | What it learns | Status |
+|--------|--------|---------------|--------|
+| [triage](./triage/) | 4 | Issue creation, labeling, prioritization, routing | Beta |
+| [code-review](./code-review/) | 5 | Style, logic, security, test coverage review, approval decisions | Beta |
+| [planning](./planning/) | 4 | Scope estimation, risk assessment, task decomposition, plan review | Beta |
+| [implementation](./implementation/) | 4 | Code generation, test writing, refactoring, commit conventions | Beta |
+| [release](./release/) | 4 | Pre-release checks, ship decisions, changelogs, versioning | Beta |
 
 ## Why Colonies, Not Individual Agents?
 
@@ -116,19 +159,30 @@ release:ship_decision  -> changelog_writer, version_bumper
 release:changelog_draft -> version_bumper
 ```
 
-## Prerequisites
+## Confidence and Autonomy
 
-- [Agentis](https://github.com/Replikanti/agentis) runtime (>= v1.1.3 for the `memo set`/`memo get` CLI used in Bootstrap below)
-- GitLab instance with API access
-- Claude CLI (LLM backend via Agentis `CliBackend`)
+Every agent starts in **observe-only** mode. A brand new federation will look silent until you seed confidence. Nothing is broken, agents are just watching.
 
-## Bootstrap: seeding agent confidence
+The install script handles seeding automatically. To adjust individual agents later:
 
-Every agent starts in **observe-only** mode. On a fresh colony the confidence memo key does not exist, and `get_confidence()` returns `0.0`, which means the agent listens to the bus but emits nothing and takes no action. This is deliberate, but it means **a brand new federation will look silent until you seed it**. Nothing is broken, confidence just has not been set.
+```bash
+# Check current confidence
+agentis memo get labeler:confidence
 
-### Memo key convention
+# Promote an agent to suggest mode
+agentis memo set labeler:confidence 0.6
 
-Each agent reads its confidence from `recall_latest("<agent_name>:confidence")`. The full set of keys across the five active colonies is:
+# Promote an agent to full autonomy
+agentis memo set labeler:confidence 0.85
+```
+
+### Recommended ramp
+
+1. **Week 1-2**: All agents at `0.5` (observe). Agents watch your GitLab activity, learn patterns, build knowledge. No visible output.
+2. **Week 3+**: Promote to `0.6` (suggest). Agents emit suggestions to the colony bus. Review their output in the logs.
+3. **When ready**: Promote individual agents to `0.85` (autonomous). Agents act on their own: post review comments, assign issues, create branches, open MRs. You can always veto.
+
+### All confidence keys
 
 | Colony | Keys |
 |--------|------|
@@ -138,63 +192,29 @@ Each agent reads its confidence from `recall_latest("<agent_name>:confidence")`.
 | implementation | `code_writer:confidence`, `test_writer:confidence`, `refactorer:confidence`, `commit_composer:confidence` |
 | release | `ship_decider:confidence`, `changelog_writer:confidence`, `version_bumper:confidence`, `release_checker:confidence` |
 
-### Ramp stages
-
-| Confidence | Mode | Behavior |
-|------------|------|----------|
-| `0.0` - `0.5` | Observe only | Agent watches the bus, learns, emits nothing |
-| `0.6` - `0.84` | Suggest | Agent emits suggestions for the human to review |
-| `>= 0.85` | Autonomous | Agent acts on its own (posts comments, sets labels, assigns reviewers), human can veto |
-
-The recommended path for a new operator is to start every agent at `0.5` for a week or two of silent observation, raise to `0.6` once the ingested signal looks sane, then individually promote agents to `0.85` as you get comfortable with their output.
-
-### Seeding via the CLI
-
-Use the `agentis memo set` CLI (available in agentis-core v1.1.3 and later). One call per agent:
+## Monitoring and Troubleshooting
 
 ```bash
-# triage colony
-agentis memo set router:confidence 0.5
-agentis memo set prioritizer:confidence 0.5
-agentis memo set labeler:confidence 0.5
-agentis memo set issue_creator:confidence 0.5
+# Federation status
+agentis colony status
 
-# code-review colony
-agentis memo set logic_reviewer:confidence 0.5
-agentis memo set style_reviewer:confidence 0.5
-agentis memo set security_reviewer:confidence 0.5
-agentis memo set test_reviewer:confidence 0.5
-agentis memo set approval_decider:confidence 0.5
+# Watch a specific agent's log
+tail -f .agentis/logs/logic_reviewer.log
 
-# planning colony
-agentis memo set scope_estimator:confidence 0.5
-agentis memo set risk_assessor:confidence 0.5
-agentis memo set task_decomposer:confidence 0.5
-agentis memo set plan_reviewer:confidence 0.5
+# Inspect what the colony has learned
+agentis knowledge list
 
-# implementation colony
-agentis memo set code_writer:confidence 0.5
-agentis memo set test_writer:confidence 0.5
-agentis memo set refactorer:confidence 0.5
-agentis memo set commit_composer:confidence 0.5
+# Export portable knowledge (carry to another project)
+agentis knowledge export --tags personal > my-preferences.json
 
-# release colony
-agentis memo set ship_decider:confidence 0.5
-agentis memo set changelog_writer:confidence 0.5
-agentis memo set version_bumper:confidence 0.5
-agentis memo set release_checker:confidence 0.5
+# Import on a new project
+agentis knowledge import my-preferences.json --merge
 ```
 
-To inspect the current value of any agent:
+### Common issues
 
-```bash
-agentis memo get labeler:confidence
-```
+**Agents are silent**: Check that confidence is seeded (`agentis memo get <agent>:confidence`). At 0.0, agents observe but produce no output.
 
-To promote a single agent (without touching others) once you trust it:
+**GitLab poll failed**: Verify your token has `api` scope and the project path is correct in `colony.toml`. Test with: `curl -H "PRIVATE-TOKEN: <token>" "https://gitlab.example.com/api/v4/projects/<url-encoded-project>/issues"`
 
-```bash
-agentis memo set labeler:confidence 0.85
-```
-
-Values are stored as strings and parsed as decimals at the agent side, so `0.5`, `0.6`, `0.85` all work the same way.
+**LLM errors**: Make sure `llm.backend = cli` and `llm.command = claude` are set in `.agentis/config`. The Claude CLI must be authenticated.

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -1,40 +1,90 @@
 # Dev Apprenticeship
 
-A federation of 21 agents across 5 colonies that learns your development workflow by observing how you work on GitLab. It starts silent, watches you triage issues, review code, plan work, write code, and ship releases, then gradually takes over the mechanical parts.
+![Agentis >= v1.1.3](https://img.shields.io/badge/agentis-%3E%3D%20v1.1.3-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
 
-## Quick Start
+A federation of 21 agents that learns how you work by watching your GitLab activity. It observes how you triage issues, review merge requests, plan features, write code, and ship releases. Over time it takes over the mechanical parts, while you keep control over the decisions that matter.
 
-```bash
-# Clone
-git clone https://github.com/Replikanti/agentis-colonies.git
-cd agentis-colonies/dev-apprenticeship
+The federation starts completely silent. Agents only watch. As they build confidence from your patterns, you progressively unlock autonomy: first suggestions, then full automation. You can always veto.
 
-# Install (interactive: checks prerequisites, configures GitLab, seeds agents)
-./install.sh
+```mermaid
+graph LR
+    GL["Your GitLab Project"]
+    FED["Dev Apprenticeship Federation"]
+    TR["Triage"]
+    CR["Code Review"]
+    PL["Planning"]
+    IM["Implementation"]
+    RE["Release"]
 
-# Start all 5 colonies
-./start-federation.sh
+    GL <--> FED
+    FED --- TR
+    FED --- CR
+    FED --- PL
+    FED --- IM
+    FED --- RE
+
+    style FED fill:#2d333b,stroke:#539bf5,color:#adbac7
+    style TR fill:#1a1e24,stroke:#57ab5a,color:#adbac7
+    style CR fill:#1a1e24,stroke:#57ab5a,color:#adbac7
+    style PL fill:#1a1e24,stroke:#57ab5a,color:#adbac7
+    style IM fill:#1a1e24,stroke:#57ab5a,color:#adbac7
+    style RE fill:#1a1e24,stroke:#57ab5a,color:#adbac7
 ```
 
-The install script will:
-1. Check that `agentis`, `claude`, and `python3` are installed
-2. Create `colony.toml` configs for all 5 colonies from the example templates
-3. Write your GitLab URL, project path, and API token into every config
-4. Seed all 21 agents at your chosen confidence level (default: 0.5, observe-only)
+## What you need
 
-After install, agents run as background daemons polling GitLab every 60 seconds.
-
-### What you need
-
-- [Agentis](https://github.com/Replikanti/agentis) runtime >= v1.1.3
-- [Claude CLI](https://claude.ai/download) (LLM backend)
+- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.1.3**
+- [Claude CLI](https://claude.ai/download) (LLM backend, must be authenticated)
 - GitLab instance with API access (personal access token with `api` scope)
-- Python 3 (used by config parsing and GitLab API scripts)
+- Python 3 and git
 
-### Starting and stopping
+## Installation
 
 ```bash
-# Start everything
+git clone https://github.com/Replikanti/agentis-colonies.git
+cd agentis-colonies/dev-apprenticeship
+./install.sh
+```
+
+The install script walks you through setup interactively:
+
+1. Checks that `agentis` (>= v1.1.3), `claude`, `python3`, and `git` are installed
+2. Creates `colony.toml` configs for all 5 colonies from the example templates
+3. Asks for your GitLab URL, project path, and API token and writes them to every config
+4. Seeds all 21 agents at your chosen confidence level (default: 0.5, observe-only)
+
+Running `install.sh` again is safe. It detects existing configs and offers to overwrite or update credentials in place.
+
+### Manual setup (without install script)
+
+```bash
+# 1. Copy config templates
+for colony in triage code-review planning implementation release; do
+    cp $colony/config/colony.example.toml $colony/config/colony.toml
+done
+
+# 2. Edit each colony.toml with your GitLab URL, token, and project path
+
+# 3. Make sure agentis is initialized and LLM is configured
+agentis init
+# Set in .agentis/config:
+#   llm.backend = cli
+#   llm.command = claude
+
+# 4. Seed agents (start in observe-only mode)
+for agent in router prioritizer labeler issue_creator \
+    logic_reviewer style_reviewer security_reviewer test_reviewer approval_decider \
+    scope_estimator risk_assessor task_decomposer plan_reviewer \
+    code_writer test_writer refactorer commit_composer \
+    ship_decider changelog_writer version_bumper release_checker; do
+    agentis memo set "${agent}:confidence" 0.5
+done
+```
+
+## Starting and stopping
+
+```bash
+# Start all 5 colonies (21 agents)
 ./start-federation.sh
 
 # Start a single colony
@@ -47,87 +97,165 @@ agentis colony status
 agentis daemon stop --all
 ```
 
-## Colonies
+## What happens after you start
 
-| Colony | Agents | What it learns | Status |
-|--------|--------|---------------|--------|
-| [triage](./triage/) | 4 | Issue creation, labeling, prioritization, routing | Beta |
-| [code-review](./code-review/) | 5 | Style, logic, security, test coverage review, approval decisions | Beta |
-| [planning](./planning/) | 4 | Scope estimation, risk assessment, task decomposition, plan review | Beta |
-| [implementation](./implementation/) | 4 | Code generation, test writing, refactoring, commit conventions | Beta |
-| [release](./release/) | 4 | Pre-release checks, ship decisions, changelogs, versioning | Beta |
-
-## Why Colonies, Not Individual Agents?
-
-A colony is fundamentally different from a bag of standalone agents doing separate jobs. Here is why the colony model matters:
-
-**Shared context.** Agents within a colony communicate via `emit`/`listen` over the colony bus. When the style-reviewer flags a naming issue, the logic-reviewer already knows and won't produce a conflicting suggestion. Standalone agents would each operate in isolation, often contradicting each other.
-
-**Specialization with emergent behavior.** Each agent is an expert in its narrow domain, but the colony as a whole solves problems none of them could handle alone. A code review isn't just five independent checks, it's a coordinated assessment where findings from one reviewer inform the others.
-
-**Shared evolution.** Agents in a colony share evolutionary pressure. When the colony succeeds (the human approves its output), all agents improve together. When it fails, the fitness signal propagates to every agent, not just the one that made the visible mistake.
-
-**Economic efficiency.** Agents share a Cognitive Budget (CB) pool. Resources flow to where they're most needed: a complex MR sends more budget to the logic-reviewer, a routine rename sends more to the style-reviewer. Standalone agents would each burn their fixed budget regardless of what the task actually needs.
-
-**Resilience.** When one agent degrades or fails, the others continue and compensate. The colony adapts its behavior rather than producing incomplete output.
-
-**Colony-level governance.** The operator sets rules, budgets, and autonomy thresholds for the entire colony, not for each agent individually. This makes the system manageable as the number of agents grows.
-
-Colonies form a natural multi-agent team that is more robust and efficient than the same number of standalone agents.
-
-## How It Works
+After launch, agents poll GitLab every 60 seconds. What they do depends on their confidence level.
 
 ```mermaid
 graph TD
-    H["Human (operator)"]
-    FB["approve / dismiss / veto"]
-    F["Federation Bus"]
+    START["Agent starts"]
+    POLL["Poll GitLab (issues, MRs, pipelines)"]
+    CHECK["Check confidence level"]
+    OBS["Observe: learn patterns, store knowledge, stay silent"]
+    SUG["Suggest: emit findings to colony bus for your review"]
+    ACT["Act: post comments, assign issues, create branches, open MRs"]
+
+    START --> POLL
+    POLL --> CHECK
+    CHECK -- "< 0.6" --> OBS
+    CHECK -- "0.6 - 0.84" --> SUG
+    CHECK -- ">= 0.85" --> ACT
+    OBS --> POLL
+    SUG --> POLL
+    ACT --> POLL
+
+    style OBS fill:#1a1e24,stroke:#636e7b,color:#adbac7
+    style SUG fill:#1a1e24,stroke:#c69026,color:#adbac7
+    style ACT fill:#1a1e24,stroke:#57ab5a,color:#adbac7
+```
+
+### Week 1-2: Observe (confidence 0.5)
+
+Agents watch your GitLab activity and build knowledge. The triage colony learns how you label and assign issues. The code-review colony learns what you flag in MR reviews. The planning colony learns how you break down work. No visible output. Check the logs to see what they are learning:
+
+```bash
+tail -f .agentis/logs/labeler.log
+```
+
+### Week 3+: Suggest (confidence 0.6)
+
+Promote agents to the suggest tier when you are comfortable with what they have learned:
+
+```bash
+agentis memo set labeler:confidence 0.6
+agentis memo set logic_reviewer:confidence 0.6
+```
+
+Agents now emit suggestions to the colony bus. Review their output in the logs. They still do not touch GitLab.
+
+### When ready: Autonomous (confidence 0.85)
+
+Promote individual agents to full autonomy:
+
+```bash
+agentis memo set labeler:confidence 0.85
+```
+
+At this level, agents act on their own. What each colony does autonomously:
+
+| Colony | Autonomous actions |
+|--------|--------------------|
+| Triage | Creates issues, applies labels, sets priority, assigns people |
+| Code Review | Posts review comments, approves MRs, requests changes |
+| Planning | Posts scope/risk/breakdown plans as issue comments |
+| Implementation | Creates branches, commits code and tests, opens MRs |
+| Release | Runs pre-release checks, posts ship decisions, creates tags and releases |
+
+You can always veto by reverting the action on GitLab. To demote an agent back to observe:
+
+```bash
+agentis memo set labeler:confidence 0.5
+```
+
+## What to expect
+
+**First day**: Nothing visible. Agents are silent at confidence 0.5. Check logs to confirm they are polling GitLab and ingesting data.
+
+**First week**: Agents accumulate knowledge entries from your GitLab activity. Run `agentis knowledge list` to see what they have learned.
+
+**After promotion to 0.6**: You will see suggestions in the agent logs. The triage colony will suggest labels and assignees. The code-review colony will produce review findings. Review them and decide when each agent is ready for autonomy.
+
+**After promotion to 0.85**: Agents start interacting with GitLab directly. Start with low-risk agents (labeler, style_reviewer) before promoting high-impact ones (code_writer, approval_decider).
+
+**Ongoing**: Knowledge grows with every tick. Agents that make correct predictions gain confidence. Stale knowledge decays. The system improves continuously as long as you keep working on the GitLab project.
+
+## Colonies
+
+| Colony | Agents | What it learns |
+|--------|--------|---------------|
+| [Triage](./triage/) | 4 | Issue creation, labeling, prioritization, routing |
+| [Code Review](./code-review/) | 5 | Style, logic, security, test coverage review, approval decisions |
+| [Planning](./planning/) | 4 | Scope estimation, risk assessment, task decomposition, plan review |
+| [Implementation](./implementation/) | 4 | Code generation, test writing, refactoring, commit conventions |
+| [Release](./release/) | 4 | Pre-release checks, ship decisions, changelogs, versioning |
+
+### How colonies collaborate
+
+Colonies are not isolated. They pass information across the federation bus:
+
+```mermaid
+graph LR
+    TR["Triage Colony"]
     CR["Code Review Colony"]
     PL["Planning Colony"]
     IM["Implementation Colony"]
-    TR["Triage Colony"]
     RE["Release Colony"]
-    GL["GitLab API"]
 
-    H -- feedback --> F
-    F --> CR
-    F --> PL
-    F --> IM
-    F --> TR
-    F --> RE
-    CR --> GL
-    PL --> GL
-    IM --> GL
-    TR --> GL
-    RE --> GL
+    TR -- "route_suggestion" --> IM
+    IM -- "mr_ready" --> CR
+    IM -- "mr_ready" --> RE
 
+    style TR fill:#1a1e24,stroke:#57ab5a,color:#adbac7
+    style CR fill:#1a1e24,stroke:#57ab5a,color:#adbac7
+    style PL fill:#1a1e24,stroke:#57ab5a,color:#adbac7
+    style IM fill:#1a1e24,stroke:#57ab5a,color:#adbac7
+    style RE fill:#1a1e24,stroke:#57ab5a,color:#adbac7
 ```
 
-## Autonomy Gradient
+- **Triage -> Implementation**: When the router assigns an issue, the code_writer picks it up
+- **Implementation -> Code Review**: When commit_composer opens an MR, the approval_decider triggers the review pipeline
+- **Implementation -> Release**: When an MR is ready, the release_checker runs pre-release checks
 
-Every agent starts in **observe** mode, watching the human work, building confidence from accumulated experience. As confidence grows, autonomy increases:
+Within each colony, agents communicate over the colony bus (see individual colony READMEs for internal wiring).
 
-| Confidence | Mode | Behavior |
-|------------|------|----------|
-| < 0.6 | Observe / Suggest | Agent watches and may suggest, human decides |
-| < 0.85 | Draft | Agent drafts output for human review |
-| >= 0.85 | Autonomous | Agent acts on its own, human can veto |
-
-This gradient applies at every level: individual agents gain autonomy within their colony, colonies gain autonomy within the federation, and the federation gains autonomy within the broader Agentis ecosystem. Confidence grows with correct predictions and decays on stale knowledge.
-
-## Knowledge Portability
+## Knowledge portability
 
 Knowledge entries are tagged by scope:
 
-- `personal`: developer preferences, quality bar, review criteria. Portable across projects.
+- `personal`: your preferences, quality bar, review criteria. Portable across projects.
 - `project:<name>`: codebase-specific patterns, file coupling, false positive patterns. Stays with the project.
-- `team:<name>`: shared across team members via federation. (Future)
 
-When onboarding a new project, colonies carry over `personal` knowledge and start fresh on `project:*`. They already know how you work, they just need to learn the codebase.
+When you start a new project, carry over your personal knowledge:
 
-## Extension Points
+```bash
+# Export from current project
+agentis knowledge export --tags personal > my-preferences.json
 
-The following colony bus events are emitted for external consumption. They have no internal listener by design, as they represent the human-facing output of the confidence gradient. Build your own agents, webhooks, or dashboards to consume them.
+# Import on new project
+agentis knowledge import my-preferences.json --merge
+```
+
+The agents already know how you work. They just need to learn the new codebase.
+
+## Troubleshooting
+
+**Agents are silent after starting**: This is expected at confidence 0.5. Check that they are actually running: `agentis colony status`. If running, check logs: `tail -f .agentis/logs/router.log`. You should see `[router] GitLab poll...` lines.
+
+**"GitLab poll failed" in logs**: Your token lacks the `api` scope, or the project path is wrong. Test manually:
+```bash
+curl -H "PRIVATE-TOKEN: <token>" \
+  "https://gitlab.example.com/api/v4/projects/<url-encoded-project>/issues"
+```
+
+**"Config not found" on start**: Run `./install.sh` first, or copy the example config manually: `cp config/colony.example.toml config/colony.toml`
+
+**LLM errors**: Make sure `.agentis/config` has `llm.backend = cli` and `llm.command = claude`. The Claude CLI must be authenticated (`claude` should work in your terminal).
+
+**Agents not learning**: Check `agentis knowledge list`. If empty after several ticks, verify that the GitLab project has recent activity (issues, MRs, reviews) for agents to observe.
+
+## Extension points
+
+The following colony bus events are emitted for external consumption. They have no internal listener by design, as they represent output meant for the operator. Build your own agents, webhooks, or dashboards to consume them.
 
 | Event | Emitter | When |
 |-------|---------|------|
@@ -138,51 +266,30 @@ The following colony bus events are emitted for external consumption. They have 
 | `planning:draft_plan` | plan_reviewer.ag | Confidence 0.6-0.84: assembled plan for human review |
 | `release:version_bumped` | version_bumper.ag | >= 0.85: after tag/release creation; 0.6-0.84: version bump suggestion |
 
-All other events in the federation have internal consumers. The full wiring diagram:
+### Full event wiring
+
+All 22 events in the federation and their consumers:
 
 ```
-triage:new_issue       -> router, prioritizer, labeler
-triage:route_suggestion -> code_writer (cross-colony)
-implementation:code_draft -> test_writer, refactorer, commit_composer
-implementation:test_draft -> commit_composer
+triage:new_issue             -> router, prioritizer, labeler
+triage:route_suggestion      -> code_writer (cross-colony)
+implementation:code_draft    -> test_writer, refactorer, commit_composer
+implementation:test_draft    -> commit_composer
 implementation:refactor_suggestions -> commit_composer
-implementation:mr_ready -> release_checker, approval_decider (cross-colony)
-review:style_findings  -> approval_decider
-review:logic_findings  -> approval_decider
-review:security_findings -> approval_decider
-review:test_findings   -> approval_decider
-planning:scope_estimate -> plan_reviewer
-planning:risks         -> plan_reviewer
-planning:breakdown     -> plan_reviewer
-release:check_result   -> ship_decider
-release:ship_decision  -> changelog_writer, version_bumper
-release:changelog_draft -> version_bumper
+implementation:mr_ready      -> release_checker, approval_decider (cross-colony)
+review:style_findings        -> approval_decider
+review:logic_findings        -> approval_decider
+review:security_findings     -> approval_decider
+review:test_findings         -> approval_decider
+planning:scope_estimate      -> plan_reviewer
+planning:risks               -> plan_reviewer
+planning:breakdown           -> plan_reviewer
+release:check_result         -> ship_decider
+release:ship_decision        -> changelog_writer, version_bumper
+release:changelog_draft      -> version_bumper
 ```
 
-## Confidence and Autonomy
-
-Every agent starts in **observe-only** mode. A brand new federation will look silent until you seed confidence. Nothing is broken, agents are just watching.
-
-The install script handles seeding automatically. To adjust individual agents later:
-
-```bash
-# Check current confidence
-agentis memo get labeler:confidence
-
-# Promote an agent to suggest mode
-agentis memo set labeler:confidence 0.6
-
-# Promote an agent to full autonomy
-agentis memo set labeler:confidence 0.85
-```
-
-### Recommended ramp
-
-1. **Week 1-2**: All agents at `0.5` (observe). Agents watch your GitLab activity, learn patterns, build knowledge. No visible output.
-2. **Week 3+**: Promote to `0.6` (suggest). Agents emit suggestions to the colony bus. Review their output in the logs.
-3. **When ready**: Promote individual agents to `0.85` (autonomous). Agents act on their own: post review comments, assign issues, create branches, open MRs. You can always veto.
-
-### All confidence keys
+## All confidence keys
 
 | Colony | Keys |
 |--------|------|
@@ -191,30 +298,3 @@ agentis memo set labeler:confidence 0.85
 | planning | `scope_estimator:confidence`, `risk_assessor:confidence`, `task_decomposer:confidence`, `plan_reviewer:confidence` |
 | implementation | `code_writer:confidence`, `test_writer:confidence`, `refactorer:confidence`, `commit_composer:confidence` |
 | release | `ship_decider:confidence`, `changelog_writer:confidence`, `version_bumper:confidence`, `release_checker:confidence` |
-
-## Monitoring and Troubleshooting
-
-```bash
-# Federation status
-agentis colony status
-
-# Watch a specific agent's log
-tail -f .agentis/logs/logic_reviewer.log
-
-# Inspect what the colony has learned
-agentis knowledge list
-
-# Export portable knowledge (carry to another project)
-agentis knowledge export --tags personal > my-preferences.json
-
-# Import on a new project
-agentis knowledge import my-preferences.json --merge
-```
-
-### Common issues
-
-**Agents are silent**: Check that confidence is seeded (`agentis memo get <agent>:confidence`). At 0.0, agents observe but produce no output.
-
-**GitLab poll failed**: Verify your token has `api` scope and the project path is correct in `colony.toml`. Test with: `curl -H "PRIVATE-TOKEN: <token>" "https://gitlab.example.com/api/v4/projects/<url-encoded-project>/issues"`
-
-**LLM errors**: Make sure `llm.backend = cli` and `llm.command = claude` are set in `.agentis/config`. The Claude CLI must be authenticated.

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -9,7 +9,8 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 COLONIES=(triage code-review planning implementation release)
 ALL_AGENTS=(
     router prioritizer labeler issue_creator
@@ -18,6 +19,7 @@ ALL_AGENTS=(
     code_writer test_writer refactorer commit_composer
     ship_decider changelog_writer version_bumper release_checker
 )
+MIN_VERSION="1.1.3"
 
 # --- Helpers ---
 
@@ -34,6 +36,11 @@ check_cmd() {
         fail "$1 not found"
         return 1
     fi
+}
+
+# Compare two semver strings. Returns 0 if $1 >= $2.
+version_gte() {
+    printf '%s\n%s\n' "$2" "$1" | sort -t. -k1,1n -k2,2n -k3,3n -C
 }
 
 # --- 1. Prerequisites ---
@@ -61,23 +68,44 @@ if [ "$MISSING" -eq 1 ]; then
 fi
 
 # Check agentis version (need >= 1.1.3 for memo set/get)
-AGENTIS_VERSION=$(agentis --version 2>/dev/null | grep -oP 'v?\K[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0")
-info "agentis version: $AGENTIS_VERSION"
+AGENTIS_VERSION=$(agentis --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
+info "agentis version: $AGENTIS_VERSION (minimum: $MIN_VERSION)"
+
+if ! version_gte "$AGENTIS_VERSION" "$MIN_VERSION"; then
+    fail "agentis >= $MIN_VERSION required (memo set/get support). Please update."
+    exit 1
+fi
 
 # --- 2. Copy configs ---
 
 echo ""
 echo "Setting up colony configs..."
 
+CONFIGS_EXISTED=0
 for colony in "${COLONIES[@]}"; do
     CONFIG_DIR="$SCRIPT_DIR/$colony/config"
     if [ -f "$CONFIG_DIR/colony.toml" ]; then
-        info "$colony: colony.toml already exists, skipping"
+        info "$colony: colony.toml already exists"
+        CONFIGS_EXISTED=$((CONFIGS_EXISTED + 1))
     else
         cp "$CONFIG_DIR/colony.example.toml" "$CONFIG_DIR/colony.toml"
         ok "$colony: created colony.toml"
     fi
 done
+
+if [ "$CONFIGS_EXISTED" -eq 5 ]; then
+    echo ""
+    ask "All configs already exist. Overwrite with fresh templates? [y/N]:"
+    read -r OVERWRITE
+    if [ "$OVERWRITE" = "y" ] || [ "$OVERWRITE" = "Y" ]; then
+        for colony in "${COLONIES[@]}"; do
+            cp "$SCRIPT_DIR/$colony/config/colony.example.toml" "$SCRIPT_DIR/$colony/config/colony.toml"
+            ok "$colony: overwritten"
+        done
+    else
+        info "Keeping existing configs. GitLab credentials will be updated."
+    fi
+fi
 
 # --- 3. GitLab credentials ---
 
@@ -104,15 +132,15 @@ echo "Writing credentials to colony configs..."
 
 for colony in "${COLONIES[@]}"; do
     CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
-    # Use python3 for safe in-place replacement (no sed -i portability issues)
+    # Write credentials by matching TOML keys (works on both fresh and existing configs)
     python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" <<'PY'
-import sys
+import sys, re
 path, url, token, project = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 with open(path) as f:
     content = f.read()
-content = content.replace('https://gitlab.example.com', url)
-content = content.replace('glpat-your-token-here', token)
-content = content.replace('your-org/your-project', project)
+content = re.sub(r'(url\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + url + '"', content)
+content = re.sub(r'(token\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + token + '"', content)
+content = re.sub(r'(project\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + project + '"', content)
 with open(path, 'w') as f:
     f.write(content)
 PY
@@ -148,12 +176,25 @@ read -r CONFIDENCE
 CONFIDENCE="${CONFIDENCE:-0.5}"
 
 if [ "$CONFIDENCE" != "skip" ]; then
+    # Validate: must be a number between 0.0 and 1.0
+    if ! python3 -c "v=float('$CONFIDENCE'); assert 0.0 <= v <= 1.0" 2>/dev/null; then
+        fail "Invalid confidence value: $CONFIDENCE (must be 0.0 to 1.0)"
+        exit 1
+    fi
     echo ""
     echo "Seeding all 21 agents at $CONFIDENCE..."
+    SEED_FAILED=0
     for agent in "${ALL_AGENTS[@]}"; do
-        agentis memo set "${agent}:confidence" "$CONFIDENCE" 2>/dev/null || true
+        if ! agentis memo set "${agent}:confidence" "$CONFIDENCE" 2>/dev/null; then
+            fail "Failed to seed ${agent}:confidence"
+            SEED_FAILED=1
+        fi
     done
-    ok "All agents seeded at $CONFIDENCE"
+    if [ "$SEED_FAILED" -eq 1 ]; then
+        fail "Some seeds failed. Is agentis initialized? Try: agentis init"
+    else
+        ok "All agents seeded at $CONFIDENCE"
+    fi
 fi
 
 # --- 6. LLM backend ---

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# install.sh - Set up the Dev Apprenticeship federation
+#
+# Checks prerequisites, copies config templates, writes GitLab
+# credentials into all 5 colony configs, and optionally seeds
+# agent confidence values.
+#
+# Usage: ./install.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COLONIES=(triage code-review planning implementation release)
+ALL_AGENTS=(
+    router prioritizer labeler issue_creator
+    logic_reviewer style_reviewer security_reviewer test_reviewer approval_decider
+    scope_estimator risk_assessor task_decomposer plan_reviewer
+    code_writer test_writer refactorer commit_composer
+    ship_decider changelog_writer version_bumper release_checker
+)
+
+# --- Helpers ---
+
+info()  { printf '  %s\n' "$*"; }
+ok()    { printf '  [ok] %s\n' "$*"; }
+fail()  { printf '  [!!] %s\n' "$*"; }
+ask()   { printf '\n  %s ' "$1"; }
+
+check_cmd() {
+    if command -v "$1" >/dev/null 2>&1; then
+        ok "$1 found ($(command -v "$1"))"
+        return 0
+    else
+        fail "$1 not found"
+        return 1
+    fi
+}
+
+# --- 1. Prerequisites ---
+
+echo ""
+echo "Dev Apprenticeship - Federation Setup"
+echo "======================================"
+echo ""
+echo "Checking prerequisites..."
+
+MISSING=0
+check_cmd agentis  || MISSING=1
+check_cmd claude   || MISSING=1
+check_cmd python3  || MISSING=1
+check_cmd git      || MISSING=1
+
+if [ "$MISSING" -eq 1 ]; then
+    echo ""
+    fail "Missing prerequisites. Install them and re-run."
+    echo ""
+    info "agentis: https://github.com/Replikanti/agentis"
+    info "claude:  https://claude.ai/download"
+    info "python3: your system package manager"
+    exit 1
+fi
+
+# Check agentis version (need >= 1.1.3 for memo set/get)
+AGENTIS_VERSION=$(agentis --version 2>/dev/null | grep -oP 'v?\K[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0")
+info "agentis version: $AGENTIS_VERSION"
+
+# --- 2. Copy configs ---
+
+echo ""
+echo "Setting up colony configs..."
+
+for colony in "${COLONIES[@]}"; do
+    CONFIG_DIR="$SCRIPT_DIR/$colony/config"
+    if [ -f "$CONFIG_DIR/colony.toml" ]; then
+        info "$colony: colony.toml already exists, skipping"
+    else
+        cp "$CONFIG_DIR/colony.example.toml" "$CONFIG_DIR/colony.toml"
+        ok "$colony: created colony.toml"
+    fi
+done
+
+# --- 3. GitLab credentials ---
+
+echo ""
+echo "GitLab configuration"
+echo "All 5 colonies connect to the same GitLab project."
+echo ""
+
+ask "GitLab URL (e.g. https://gitlab.com):"
+read -r GITLAB_URL
+ask "GitLab project path (e.g. my-org/my-project):"
+read -r GITLAB_PROJECT
+ask "GitLab personal access token (glpat-...):"
+read -rs GITLAB_TOKEN
+echo ""
+
+if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_PROJECT" ] || [ -z "$GITLAB_TOKEN" ]; then
+    fail "All three fields are required."
+    exit 1
+fi
+
+echo ""
+echo "Writing credentials to colony configs..."
+
+for colony in "${COLONIES[@]}"; do
+    CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
+    # Use python3 for safe in-place replacement (no sed -i portability issues)
+    python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" <<'PY'
+import sys
+path, url, token, project = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+with open(path) as f:
+    content = f.read()
+content = content.replace('https://gitlab.example.com', url)
+content = content.replace('glpat-your-token-here', token)
+content = content.replace('your-org/your-project', project)
+with open(path, 'w') as f:
+    f.write(content)
+PY
+    ok "$colony"
+done
+
+# --- 4. Initialize agentis (if not already done) ---
+
+echo ""
+if [ -d "$SCRIPT_DIR/../.agentis" ] || [ -d ".agentis" ]; then
+    info "agentis already initialized"
+else
+    echo "Initializing agentis..."
+    agentis init 2>/dev/null || true
+    ok "agentis init"
+fi
+
+# --- 5. Seed confidence ---
+
+echo ""
+echo "Agent confidence seeding"
+echo ""
+echo "Agents start silent (confidence = 0.0). You choose the starting level:"
+echo ""
+echo "  0.5  - Observe only (recommended for first run)"
+echo "  0.6  - Observe + emit suggestions for your review"
+echo "  0.85 - Full autonomy (agents act on their own)"
+echo "  skip - Do not seed, configure manually later"
+echo ""
+
+ask "Starting confidence [0.5]:"
+read -r CONFIDENCE
+CONFIDENCE="${CONFIDENCE:-0.5}"
+
+if [ "$CONFIDENCE" != "skip" ]; then
+    echo ""
+    echo "Seeding all 21 agents at $CONFIDENCE..."
+    for agent in "${ALL_AGENTS[@]}"; do
+        agentis memo set "${agent}:confidence" "$CONFIDENCE" 2>/dev/null || true
+    done
+    ok "All agents seeded at $CONFIDENCE"
+fi
+
+# --- 6. LLM backend ---
+
+echo ""
+echo "LLM backend"
+echo ""
+info "The federation uses Claude via the agentis CLI backend."
+info "Make sure your .agentis/config has:"
+echo ""
+echo "    llm.backend = cli"
+echo "    llm.command = claude"
+echo ""
+
+# --- Done ---
+
+echo ""
+echo "======================================"
+echo "Setup complete."
+echo ""
+echo "Start the federation:"
+echo "  ./start-federation.sh"
+echo ""
+echo "Or start individual colonies:"
+for colony in "${COLONIES[@]}"; do
+    echo "  ./$colony/scripts/start-colony.sh"
+done
+echo ""
+echo "Monitor:"
+echo "  agentis colony status"
+echo ""

--- a/dev-apprenticeship/start-federation.sh
+++ b/dev-apprenticeship/start-federation.sh
@@ -35,7 +35,6 @@ TOTAL_AGENTS=0
 for colony in "${COLONIES[@]}"; do
     echo "Starting $colony colony..."
     "$FED_DIR/$colony/scripts/start-colony.sh" &
-    COLONY_PID=$!
     # Count agents in this colony's config
     AGENT_COUNT=$(grep -c '^\[\[agents\]\]' "$FED_DIR/$colony/config/colony.toml" 2>/dev/null || echo 0)
     TOTAL_AGENTS=$((TOTAL_AGENTS + AGENT_COUNT))

--- a/dev-apprenticeship/start-federation.sh
+++ b/dev-apprenticeship/start-federation.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# start-federation.sh - Start all 5 colonies of the Dev Apprenticeship federation
+#
+# Launches triage, code-review, planning, implementation, and release colonies
+# in sequence. Each colony starts its agents as background daemon processes.
+#
+# Usage: ./start-federation.sh [path/to/federation-dir]
+#        ./start-federation.sh              # uses script's own directory
+
+set -e
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+FED_DIR="${1:-$SCRIPT_DIR}"
+
+COLONIES=(triage code-review planning implementation release)
+
+echo ""
+echo "Dev Apprenticeship Federation"
+echo "============================="
+echo ""
+
+# Pre-flight: check all configs exist
+for colony in "${COLONIES[@]}"; do
+    CONFIG="$FED_DIR/$colony/config/colony.toml"
+    if [ ! -f "$CONFIG" ]; then
+        echo "[!!] Missing config: $CONFIG"
+        echo "     Run ./install.sh first."
+        exit 1
+    fi
+done
+
+# Start each colony
+TOTAL_AGENTS=0
+for colony in "${COLONIES[@]}"; do
+    echo "Starting $colony colony..."
+    "$FED_DIR/$colony/scripts/start-colony.sh" &
+    COLONY_PID=$!
+    # Count agents in this colony's config
+    AGENT_COUNT=$(grep -c '^\[\[agents\]\]' "$FED_DIR/$colony/config/colony.toml" 2>/dev/null || echo 0)
+    TOTAL_AGENTS=$((TOTAL_AGENTS + AGENT_COUNT))
+    sleep 3  # stagger colony starts
+done
+
+echo ""
+echo "============================="
+echo "Federation started: 5 colonies, $TOTAL_AGENTS agents"
+echo ""
+echo "Monitor:  agentis colony status"
+echo "Logs:     tail -f .agentis/logs/<agent_name>.log"
+echo "Stop:     agentis daemon stop --all"
+echo ""
+
+wait


### PR DESCRIPTION
## Summary

- **Status legend**: Root README now defines Stable/Beta/Alpha/Planned badges. Dev-apprenticeship is Beta (built and audited, not yet validated on live GitLab).
- **End-user README**: Restructured federation README with Quick Start at the top, monitoring/troubleshooting section, recommended confidence ramp schedule.
- **install.sh**: Interactive setup script that checks prerequisites (agentis, claude, python3), copies configs, prompts for GitLab credentials, writes them to all 5 colony configs, and seeds agent confidence.
- **start-federation.sh**: Single command to launch all 5 colonies with pre-flight config check.
- **CLAUDE.md**: Added event wiring reference and end-user scripts table.

## Test plan

- [x] Colony lint: 45/0/5
- [x] `bash -n install.sh` and `bash -n start-federation.sh` pass
- [x] All markdown links verified by colony-lint
- [x] Root README status table renders correctly
- [x] Quick Start section gives a clear 3-command path to running

🤖 Generated with [Claude Code](https://claude.com/claude-code)