### PR TITLE
chore: require agentis >= v1.1.6 (--enable-exec/--enable-messaging)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -1,6 +1,6 @@
 # Dev Apprenticeship
 
-![Agentis >= v1.1.3](https://img.shields.io/badge/agentis-%3E%3D%20v1.1.3-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
+![Agentis >= v1.1.6](https://img.shields.io/badge/agentis-%3E%3D%20v1.1.6-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
 
 A federation of 21 agents that learns how you work by watching your GitLab activity. It observes how you triage issues, review merge requests, plan features, write code, and ship releases. Over time it takes over the mechanical parts, while you keep control over the decisions that matter.
 
@@ -35,7 +35,7 @@ graph LR
 
 ## What you need
 
-- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.1.3**
+- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.1.6**
 - An LLM backend (Claude CLI, Ollama, or any OpenAI-compatible API)
 - GitLab instance with API access (personal access token with `api` scope)
 - Python 3 and git

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -57,7 +57,8 @@ cd "$COLONY_DIR"
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.
-# exec sh is enabled by default on agentis daemon; there is no --enable-exec.
+# `--enable-exec` is required since agentis v1.1.6 (exec sh is opt-in; see #484/#489).
+# `--enable-messaging` is required for cross-agent emit/listen (#484, v1.1.6+).
 
 echo "Starting Code Review colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
@@ -66,6 +67,8 @@ for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony code-review \
+        --enable-exec \
+        --enable-messaging \
         --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -54,7 +54,8 @@ AGENTS=(
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.
-# exec sh is enabled by default on agentis daemon; there is no --enable-exec.
+# `--enable-exec` is required since agentis v1.1.6 (exec sh is opt-in; see #484/#489).
+# `--enable-messaging` is required for cross-agent emit/listen (#484, v1.1.6+).
 
 echo "Starting Implementation colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
@@ -63,6 +64,8 @@ for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony implementation \
+        --enable-exec \
+        --enable-messaging \
         --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -19,7 +19,7 @@ ALL_AGENTS=(
     code_writer test_writer refactorer commit_composer
     ship_decider changelog_writer version_bumper release_checker
 )
-MIN_VERSION="1.1.3"
+MIN_VERSION="1.1.6"
 
 # --- Helpers ---
 
@@ -65,12 +65,17 @@ if [ "$MISSING" -eq 1 ]; then
     exit 1
 fi
 
-# Check agentis version (need >= 1.1.3 for memo set/get)
+# Check agentis version. v1.1.6 is the first release with `--enable-exec` and
+# `--enable-messaging` daemon flags (required by start-colony.sh) and the
+# quarantine oscillation fix (#492), which previously caused silent capability
+# revocations mid-federation. Older builds will appear to start but all agents
+# either fail with `capability denied: exec_foreign` or never receive
+# emit/listen messages.
 AGENTIS_VERSION=$(agentis --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
 info "agentis version: $AGENTIS_VERSION (minimum: $MIN_VERSION)"
 
 if ! version_gte "$AGENTIS_VERSION" "$MIN_VERSION"; then
-    fail "agentis >= $MIN_VERSION required (memo set/get support). Please update."
+    fail "agentis >= $MIN_VERSION required (--enable-exec / --enable-messaging daemon flags, #492 quarantine fix). Please update."
     exit 1
 fi
 

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -54,7 +54,8 @@ AGENTS=(
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.
-# exec sh is enabled by default on agentis daemon; there is no --enable-exec.
+# `--enable-exec` is required since agentis v1.1.6 (exec sh is opt-in; see #484/#489).
+# `--enable-messaging` is required for cross-agent emit/listen (#484, v1.1.6+).
 
 echo "Starting Planning colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
@@ -63,6 +64,8 @@ for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony planning \
+        --enable-exec \
+        --enable-messaging \
         --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -54,7 +54,8 @@ AGENTS=(
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.
-# exec sh is enabled by default on agentis daemon; there is no --enable-exec.
+# `--enable-exec` is required since agentis v1.1.6 (exec sh is opt-in; see #484/#489).
+# `--enable-messaging` is required for cross-agent emit/listen (#484, v1.1.6+).
 
 echo "Starting Release colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
@@ -63,6 +64,8 @@ for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony release \
+        --enable-exec \
+        --enable-messaging \
         --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -54,7 +54,8 @@ AGENTS=(
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.
-# exec sh is enabled by default on agentis daemon; there is no --enable-exec.
+# `--enable-exec` is required since agentis v1.1.6 (exec sh is opt-in; see #484/#489).
+# `--enable-messaging` is required for cross-agent emit/listen (#484, v1.1.6+).
 
 echo "Starting Triage colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
@@ -63,6 +64,8 @@ for agent in "${AGENTS[@]}"; do
     echo "  Starting $agent..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony triage \
+        --enable-exec \
+        --enable-messaging \
         --tick-interval 60000 &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -184,6 +184,7 @@ if errors:
                 case "$flag" in
                     --tick-interval|--cb-per-tick|--colony|--deadline|--priority|\
                     --enable-migration|--enable-replication|--allow-replica-replication|\
+                    --enable-exec|--enable-messaging|--deny-exec|\
                     --help|-h) ;;
                     *) echo "$flag" ;;
                 esac


### PR DESCRIPTION
## Summary

- Bump `MIN_VERSION` and documented prerequisite for `dev-apprenticeship` to agentis **v1.1.6**.
- Add `--enable-exec --enable-messaging` to every colony's `start-colony.sh` — agentis v1.1.6 made `exec sh` and cross-agent `emit`/`listen` opt-in via explicit daemon flags (#484/#489/#490). Without these, daemons silently lose shell exec and inbox routing.
- v1.1.6 also picks up the #492 behavioral-quarantine regression fix (healthy agents were getting `ExecForeign`/`Messaging`/`NetConnect` revoked because `TelemetrySnapshot::new` defaulted `health_score` to `0.0`).
- Extend `tools/colony-lint.sh` daemon-flag allowlist with `--enable-exec`, `--enable-messaging`, `--deny-exec` to match `DAEMON_FLAGS` in `agentis-core/src/cli/daemon.rs`, so future drift is caught.

## Test plan

- [x] `bash -n` on all 7 modified scripts
- [x] `./tools/colony-lint.sh` — 45 passed, 0 failed, 5 skipped (shellcheck skipped locally; CI installs it)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)