### PR TITLE
fix(dev-apprenticeship): install.sh writes runtime config, agents use $COLONY_DIR (#88)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -57,6 +57,12 @@ The install script checks prerequisites, creates configs for all 5 colonies, wri
 agentis daemon stop --all       # Stop everything
 ```
 
+> Agents must be launched via `start-federation.sh` or a colony's
+> `start-colony.sh`. Those scripts export `COLONY_DIR`, which the
+> agents expand inside `exec sh "$COLONY_DIR/scripts/..."` at runtime.
+> Launching `agentis daemon <agent>.ag` directly bypasses that export,
+> so `$COLONY_DIR` expands to empty and GitLab polling fails silently.
+
 ## Monitoring
 
 ### Dashboard

--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -44,7 +44,7 @@ fn tick(reason: string) -> void {
     };
 
     // Learn from past human approval/rejection patterns
-    let mr_cmd = "./scripts/gitlab-api.sh merge-requests --state merged";
+    let mr_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
     let recent_merged = try { exec sh mr_cmd; } catch e { "[]"; };
 
     let approval_patterns = prompt(
@@ -53,7 +53,7 @@ fn tick(reason: string) -> void {
     ) -> string;
 
     if len(approval_patterns) > 10 {
-        learn("approval_decision", "merged MRs batch", approval_patterns, "observed", "code-review");
+        learn("approval_decision", "merged MRs batch", approval_patterns, "success", ["observed", "code-review"]);
     };
 
     // Aggregate findings and decide
@@ -71,20 +71,20 @@ fn tick(reason: string) -> void {
 
     if confidence >= 0.85 {
         if decision.action == "approve" {
-            let approve_cmd = "./scripts/gitlab-api.sh approve " + to_string(decision.mr_iid);
+            let approve_cmd = "$COLONY_DIR/scripts/gitlab-api.sh approve " + to_string(decision.mr_iid);
             try { exec sh approve_cmd; } catch e {
                 print("[approval_decider] Failed to approve:", e);
             };
             print("[approval_decider] Approved MR", decision.mr_iid);
-            learn("approval_decision", "MR " + to_string(decision.mr_iid), "approved: " + decision.reasoning, "acted", "code-review");
+            learn("approval_decision", "MR " + to_string(decision.mr_iid), "approved: " + decision.reasoning, "success", ["acted", "code-review"]);
         } else {
             if decision.action == "request_changes" {
                 let comment = "**Review Summary** (automated)\n\n" + decision.reasoning + "\n\nFindings: " + to_string(decision.total_findings) + " total, " + to_string(decision.critical_count) + " critical";
-                let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment);
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment);
                 try { exec sh post_cmd; } catch e {
                     print("[approval_decider] Failed to post:", e);
                 };
-                learn("approval_decision", "MR " + to_string(decision.mr_iid), "request_changes: " + decision.reasoning, "acted", "code-review");
+                learn("approval_decision", "MR " + to_string(decision.mr_iid), "request_changes: " + decision.reasoning, "success", ["acted", "code-review"]);
             } else {
                 print("[approval_decider] Escalating MR", decision.mr_iid, "to human");
                 emit("review:escalation", decision);

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -24,9 +24,9 @@ type LogicReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("logic_reviewer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh merge-requests";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests";
 }
 
 fn get_confidence() -> float {
@@ -60,7 +60,7 @@ fn tick(reason: string) -> void {
     };
 
     let mr_iid = get(mr_ids, 0);
-    let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+    let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -68,7 +68,7 @@ fn tick(reason: string) -> void {
     };
 
     // Learn from human logic-related comments
-    let notes_cmd = "./scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+    let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
     let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
     let human_patterns = prompt(
@@ -77,7 +77,7 @@ fn tick(reason: string) -> void {
     ) -> string;
 
     if len(human_patterns) > 5 {
-        learn("logic_review", "MR " + to_string(mr_iid), human_patterns, "observed", "code-review");
+        learn("logic_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
     };
 
     // Perform logic review
@@ -97,7 +97,7 @@ fn tick(reason: string) -> void {
 
         if confidence >= 0.85 {
             let comment = "**Logic Review** (automated)\n\n" + review.summary;
-            let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             try { exec sh post_cmd; } catch e {
                 print("[logic_reviewer] Failed to post comment:", e);
             };

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -25,9 +25,9 @@ type SecurityReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("security_reviewer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh merge-requests";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests";
 }
 
 fn get_confidence() -> float {
@@ -61,7 +61,7 @@ fn tick(reason: string) -> void {
     };
 
     let mr_iid = get(mr_ids, 0);
-    let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+    let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -69,7 +69,7 @@ fn tick(reason: string) -> void {
     };
 
     // Learn from human security-related comments
-    let notes_cmd = "./scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+    let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
     let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
     let human_patterns = prompt(
@@ -78,7 +78,7 @@ fn tick(reason: string) -> void {
     ) -> string;
 
     if len(human_patterns) > 5 {
-        learn("security_review", "MR " + to_string(mr_iid), human_patterns, "observed", "code-review");
+        learn("security_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
     };
 
     // Perform security review
@@ -98,7 +98,7 @@ fn tick(reason: string) -> void {
 
         if confidence >= 0.85 {
             let comment = "**Security Review** (automated)\n\n" + review.summary;
-            let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             try { exec sh post_cmd; } catch e {
                 print("[security_reviewer] Failed to post comment:", e);
             };

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -24,9 +24,9 @@ type StyleReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("style_reviewer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh merge-requests";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests";
 }
 
 fn get_confidence() -> float {
@@ -62,7 +62,7 @@ fn tick(reason: string) -> void {
 
     // Review the first open MR
     let mr_iid = get(mr_ids, 0);
-    let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+    let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -70,7 +70,7 @@ fn tick(reason: string) -> void {
     };
 
     // Check for existing human review comments to learn from
-    let notes_cmd = "./scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+    let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
     let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
     // Learn from human style comments
@@ -80,7 +80,7 @@ fn tick(reason: string) -> void {
     ) -> string;
 
     if len(human_patterns) > 5 {
-        learn("style_review", "MR " + to_string(mr_iid), human_patterns, "observed", "code-review");
+        learn("style_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
     };
 
     // Perform style review on the diff
@@ -102,13 +102,13 @@ fn tick(reason: string) -> void {
         if confidence >= 0.85 {
             // Post review comment directly
             let comment = "**Style Review** (automated)\n\n" + review.summary;
-            let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             let result = try { exec sh post_cmd; } catch e {
                 print("[style_reviewer] Failed to post comment:", e);
                 "";
             };
             if len(result) > 0 {
-                learn("style_review", "posted on MR " + to_string(mr_iid), review.summary, "acted", "code-review");
+                learn("style_review", "posted on MR " + to_string(mr_iid), review.summary, "success", ["acted", "code-review"]);
             };
         } else {
             print("[style_reviewer] Confidence:", confidence, "- findings emitted to bus only");

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -24,9 +24,9 @@ type TestReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("test_reviewer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh merge-requests";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests";
 }
 
 fn get_confidence() -> float {
@@ -60,7 +60,7 @@ fn tick(reason: string) -> void {
     };
 
     let mr_iid = get(mr_ids, 0);
-    let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+    let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -68,7 +68,7 @@ fn tick(reason: string) -> void {
     };
 
     // Learn from human test-related comments
-    let notes_cmd = "./scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+    let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
     let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
     let human_patterns = prompt(
@@ -77,7 +77,7 @@ fn tick(reason: string) -> void {
     ) -> string;
 
     if len(human_patterns) > 5 {
-        learn("test_review", "MR " + to_string(mr_iid), human_patterns, "observed", "code-review");
+        learn("test_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
     };
 
     // Perform test review
@@ -97,7 +97,7 @@ fn tick(reason: string) -> void {
 
         if confidence >= 0.85 {
             let comment = "**Test Review** (automated)\n\n" + review.summary;
-            let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             try { exec sh post_cmd; } catch e {
                 print("[test_reviewer] Failed to post comment:", e);
             };

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -135,7 +135,7 @@ fn tick(reason: string) -> void {
         } else {
             if confidence >= 0.6 {
                 emit("implementation:code_draft", draft);
-                learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["emitted", "implementation"]);
+                learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["emitted", "implementation"]);
             } else {
                 print("[code_writer] Observing (confidence:", confidence, ")");
             };

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -27,9 +27,9 @@ type CodeDraft {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("code_writer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh merge-requests --state merged";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
 }
 
 fn get_confidence() -> float {
@@ -58,7 +58,7 @@ fn tick(reason: string) -> void {
 
         if len(mr_ids) > 0 {
             let mr_iid = get(mr_ids, 0);
-            let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+            let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
             if len(changes_raw) > 10 {
@@ -71,8 +71,8 @@ fn tick(reason: string) -> void {
                     "code_write",
                     "MR " + to_string(mr_iid),
                     "naming: " + patterns.naming + " | structure: " + patterns.structure + " | errors: " + patterns.error_handling,
-                    "observed",
-                    "implementation"
+                    "success",
+                    ["observed", "implementation"]
                 );
                 print("[code_writer] Learned from MR", mr_iid);
             };
@@ -80,7 +80,7 @@ fn tick(reason: string) -> void {
     };
 
     // 2. Check for assigned issues needing implementation
-    let issues_cmd = "./scripts/gitlab-api.sh assigned-issues";
+    let issues_cmd = "$COLONY_DIR/scripts/gitlab-api.sh assigned-issues";
     let issues_raw = try {
         exec sh issues_cmd;
     } catch e {
@@ -102,7 +102,7 @@ fn tick(reason: string) -> void {
 
         if confidence >= 0.85 {
             // Create branch
-            let branch_cmd = "./scripts/gitlab-api.sh create-branch --name " + shell_escape(draft.branch_name) + " --ref main";
+            let branch_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-branch --name " + shell_escape(draft.branch_name) + " --ref main";
             let branch_result = try { exec sh branch_cmd; } catch e {
                 print("[code_writer] Branch creation failed:", e);
                 "";
@@ -110,7 +110,7 @@ fn tick(reason: string) -> void {
 
             if len(branch_result) > 0 {
                 // Generate actual code and commit it to the branch
-                let issue_cmd = "./scripts/gitlab-api.sh issue " + to_string(draft.issue_id);
+                let issue_cmd = "$COLONY_DIR/scripts/gitlab-api.sh issue " + to_string(draft.issue_id);
                 let issue_detail = try { exec sh issue_cmd; } catch e { ""; };
                 let code_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec);
 
@@ -120,7 +120,7 @@ fn tick(reason: string) -> void {
                 ) -> string;
 
                 // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-                let commit_cmd = "./scripts/gitlab-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json);
+                let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json);
                 let commit_result = try { exec sh commit_cmd; } catch e {
                     print("[code_writer] Commit failed:", e);
                     "";
@@ -129,13 +129,13 @@ fn tick(reason: string) -> void {
                 if len(commit_result) > 0 {
                     print("[code_writer] Committed code to", draft.branch_name);
                     emit("implementation:code_draft", draft);
-                    learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "acted", "implementation");
+                    learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation"]);
                 };
             };
         } else {
             if confidence >= 0.6 {
                 emit("implementation:code_draft", draft);
-                learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "emitted", "implementation");
+                learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["emitted", "implementation"]);
             } else {
                 print("[code_writer] Observing (confidence:", confidence, ")");
             };

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -131,7 +131,7 @@ fn tick(reason: string) -> void {
     } else {
         if confidence >= 0.6 {
             emit("implementation:mr_ready", plan);
-            learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "success", ["emitted", "implementation"]);
+            learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["emitted", "implementation"]);
         } else {
             print("[commit_composer] Observing (confidence:", confidence, ")");
         };

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -29,9 +29,9 @@ type MRPlan {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("commit_composer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh merge-requests --state merged";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
 }
 
 fn get_confidence() -> float {
@@ -60,7 +60,7 @@ fn tick(reason: string) -> void {
 
         if len(mr_ids) > 0 {
             let mr_iid = get(mr_ids, 0);
-            let commits_cmd = "./scripts/gitlab-api.sh mr-commits " + to_string(mr_iid);
+            let commits_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-commits " + to_string(mr_iid);
             let commits_raw = try { exec sh commits_cmd; } catch e { "[]"; };
 
             if len(commits_raw) > 10 {
@@ -74,8 +74,8 @@ fn tick(reason: string) -> void {
                         "commit_compose",
                         "MR " + to_string(mr_iid) + " (" + to_string(style.commits_seen) + " commits)",
                         "format: " + style.format + " | grouping: " + style.grouping + " | prefixes: " + style.prefixes,
-                        "observed",
-                        "implementation"
+                        "success",
+                        ["observed", "implementation"]
                     );
                     print("[commit_composer] Learned from", style.commits_seen, "commits in MR", mr_iid);
                 };
@@ -117,7 +117,7 @@ fn tick(reason: string) -> void {
 
     if confidence >= 0.85 {
         // Create the MR
-        let mr_cmd = "./scripts/gitlab-api.sh create-mr --source " + shell_escape(plan.branch_name) + " --title " + shell_escape(plan.mr_title) + " --description " + shell_escape(plan.mr_description);
+        let mr_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-mr --source " + shell_escape(plan.branch_name) + " --title " + shell_escape(plan.mr_title) + " --description " + shell_escape(plan.mr_description);
         let mr_result = try { exec sh mr_cmd; } catch e {
             print("[commit_composer] MR creation failed:", e);
             "";
@@ -126,12 +126,12 @@ fn tick(reason: string) -> void {
         if len(mr_result) > 0 {
             print("[commit_composer] Created MR for issue", plan.issue_id);
             emit("implementation:mr_ready", plan);
-            learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "acted", "implementation");
+            learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "success", ["acted", "implementation"]);
         };
     } else {
         if confidence >= 0.6 {
             emit("implementation:mr_ready", plan);
-            learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "emitted", "implementation");
+            learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "success", ["emitted", "implementation"]);
         } else {
             print("[commit_composer] Observing (confidence:", confidence, ")");
         };

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -25,9 +25,9 @@ type RefactorSuggestion {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("refactorer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh merge-requests --state merged";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
 }
 
 fn get_confidence() -> float {
@@ -56,11 +56,11 @@ fn tick(reason: string) -> void {
 
         if len(mr_ids) > 0 {
             let mr_iid = get(mr_ids, 0);
-            let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+            let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
             if len(changes_raw) > 10 {
-                let commits_cmd = "./scripts/gitlab-api.sh mr-commits " + to_string(mr_iid);
+                let commits_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-commits " + to_string(mr_iid);
                 let commits_raw = try { exec sh commits_cmd; } catch e { "[]"; };
 
                 let patterns = prompt(
@@ -73,8 +73,8 @@ fn tick(reason: string) -> void {
                         "refactor",
                         "MR " + to_string(mr_iid),
                         "smells: " + patterns.smells_fixed + " | techniques: " + patterns.techniques,
-                        "observed",
-                        "implementation"
+                        "success",
+                        ["observed", "implementation"]
                     );
                     print("[refactorer] Learned refactoring patterns from MR", mr_iid);
                 };
@@ -107,7 +107,7 @@ fn tick(reason: string) -> void {
                 refactor_context
             ) -> string;
             // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-            let commit_cmd = "./scripts/gitlab-api.sh commit-files --branch " + shell_escape(branch) + " --message " + shell_escape("refactor: apply improvements for #" + to_string(suggestion.issue_id)) + " --actions " + shell_escape(actions_json);
+            let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(branch) + " --message " + shell_escape("refactor: apply improvements for #" + to_string(suggestion.issue_id)) + " --actions " + shell_escape(actions_json);
             let commit_result = try { exec sh commit_cmd; } catch e {
                 print("[refactorer] Commit failed:", e);
                 "";
@@ -115,12 +115,12 @@ fn tick(reason: string) -> void {
             if len(commit_result) > 0 {
                 print("[refactorer] Committed refactoring to", branch);
                 emit("implementation:refactor_suggestions", suggestion);
-                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "acted", "implementation");
+                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "success", ["acted", "implementation"]);
             };
         } else {
             if confidence >= 0.6 {
                 emit("implementation:refactor_suggestions", suggestion);
-                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "emitted", "implementation");
+                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "success", ["emitted", "implementation"]);
             } else {
                 print("[refactorer] Observing (confidence:", confidence, ")");
             };

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -120,7 +120,7 @@ fn tick(reason: string) -> void {
         } else {
             if confidence >= 0.6 {
                 emit("implementation:refactor_suggestions", suggestion);
-                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "success", ["emitted", "implementation"]);
+                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["emitted", "implementation"]);
             } else {
                 print("[refactorer] Observing (confidence:", confidence, ")");
             };

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -121,7 +121,7 @@ fn tick(reason: string) -> void {
         } else {
             if confidence >= 0.6 {
                 emit("implementation:test_draft", tests);
-                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "success", ["emitted", "implementation"]);
+                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["emitted", "implementation"]);
             } else {
                 print("[test_writer] Observing (confidence:", confidence, ")");
             };

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -27,9 +27,9 @@ type TestDraft {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("test_writer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh merge-requests --state merged";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
 }
 
 fn get_confidence() -> float {
@@ -58,7 +58,7 @@ fn tick(reason: string) -> void {
 
         if len(mr_ids) > 0 {
             let mr_iid = get(mr_ids, 0);
-            let changes_cmd = "./scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+            let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
             if len(changes_raw) > 10 {
@@ -72,8 +72,8 @@ fn tick(reason: string) -> void {
                         "test_write",
                         "MR " + to_string(mr_iid) + " (" + to_string(patterns.test_files_seen) + " test files)",
                         "structure: " + patterns.structure + " | assertions: " + patterns.assertion_style + " | fixtures: " + patterns.fixture_patterns,
-                        "observed",
-                        "implementation"
+                        "success",
+                        ["observed", "implementation"]
                     );
                     print("[test_writer] Learned from", patterns.test_files_seen, "test files in MR", mr_iid);
                 };
@@ -107,7 +107,7 @@ fn tick(reason: string) -> void {
             ) -> string;
 
             // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-            let commit_cmd = "./scripts/gitlab-api.sh commit-files --branch " + shell_escape(tests.branch_name) + " --message " + shell_escape("test: add tests for #" + to_string(tests.issue_id)) + " --actions " + shell_escape(actions_json);
+            let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(tests.branch_name) + " --message " + shell_escape("test: add tests for #" + to_string(tests.issue_id)) + " --actions " + shell_escape(actions_json);
             let commit_result = try { exec sh commit_cmd; } catch e {
                 print("[test_writer] Commit failed:", e);
                 "";
@@ -116,12 +116,12 @@ fn tick(reason: string) -> void {
             if len(commit_result) > 0 {
                 print("[test_writer] Committed tests to", tests.branch_name);
                 emit("implementation:test_draft", tests);
-                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "acted", "implementation");
+                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "success", ["acted", "implementation"]);
             };
         } else {
             if confidence >= 0.6 {
                 emit("implementation:test_draft", tests);
-                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "emitted", "implementation");
+                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "success", ["emitted", "implementation"]);
             } else {
                 print("[test_writer] Observing (confidence:", confidence, ")");
             };

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -182,7 +182,12 @@ if [ -d "$AGENTIS_DIR" ]; then
     # install.sh is idempotent and never clobbers operator-tuned values.
     #
     #   daemon.tick_interval_ms     — matches --tick-interval 60000 in
-    #                                 start-colony.sh; without it the
+    #                                 start-colony.sh. start-colony.sh
+    #                                 already overrides via CLI; this
+    #                                 config entry is defense-in-depth
+    #                                 for operators who launch a daemon
+    #                                 directly (e.g. debug sessions),
+    #                                 where without the config key the
     #                                 watchdog uses the 1 s default.
     #   daemon.heartbeat_interval_ms — 3× tick is long enough for a
     #                                  Claude CLI cold start (typ. 5-30 s).
@@ -202,28 +207,33 @@ if [ -d "$AGENTIS_DIR" ]; then
     #                                 authenticates against the instance
     #                                 configured by start-colony.sh).
     AGENTIS_CONFIG="$AGENTIS_DIR/config"
-    if [ -f "$AGENTIS_CONFIG" ]; then
-        write_key() {
-            local key="$1"
-            local value="$2"
-            # Escape dots in the key for grep
-            local grep_key
-            grep_key=$(printf '%s' "$key" | sed 's/\./\\./g')
-            if ! grep -q "^${grep_key}\s*=" "$AGENTIS_CONFIG" 2>/dev/null; then
-                printf '%s = %s\n' "$key" "$value" >> "$AGENTIS_CONFIG"
-                ok "$key = $value"
-            else
-                info "$key already configured"
-            fi
-        }
-        write_key 'federation.enabled'           'true'
-        write_key 'knowledge.federation_enabled' 'true'
-        write_key 'daemon.tick_interval_ms'      '60000'
-        write_key 'daemon.heartbeat_interval_ms' '180000'
-        write_key 'daemon.cb_per_tick'           '2000'
-        write_key 'experience.enabled'           'true'
-        write_key 'exec.env_passthrough'         'COLONY_DIR,GITLAB_*'
+    # Agentis init should have created this; create it explicitly so the
+    # key-writing below is not silently skipped if init was interrupted.
+    if [ ! -f "$AGENTIS_CONFIG" ]; then
+        touch "$AGENTIS_CONFIG"
+        info "created $AGENTIS_CONFIG"
     fi
+    write_key() {
+        local key="$1"
+        local value="$2"
+        # Escape dots in the key for grep. POSIX [[:space:]] keeps this
+        # portable to BSD grep (macOS) where \s is not supported.
+        local grep_key
+        grep_key=$(printf '%s' "$key" | sed 's/\./\\./g')
+        if ! grep -q "^${grep_key}[[:space:]]*=" "$AGENTIS_CONFIG" 2>/dev/null; then
+            printf '%s = %s\n' "$key" "$value" >> "$AGENTIS_CONFIG"
+            ok "$key = $value"
+        else
+            info "$key already configured"
+        fi
+    }
+    write_key 'federation.enabled'           'true'
+    write_key 'knowledge.federation_enabled' 'true'
+    write_key 'daemon.tick_interval_ms'      '60000'
+    write_key 'daemon.heartbeat_interval_ms' '180000'
+    write_key 'daemon.cb_per_tick'           '2000'
+    write_key 'experience.enabled'           'true'
+    write_key 'exec.env_passthrough'         'COLONY_DIR,GITLAB_*'
 fi
 
 # Create per-colony .agentis symlinks so commands run from a colony dir
@@ -233,7 +243,11 @@ if [ -d "$AGENTIS_DIR" ]; then
     FED_AGENTIS_ABS="$(cd "$AGENTIS_DIR" && pwd)"
     for colony in "${COLONIES[@]}"; do
         COLONY_AGENTIS="$SCRIPT_DIR/$colony/.agentis"
-        if [ -L "$COLONY_AGENTIS" ]; then
+        if [ -L "$COLONY_AGENTIS" ] && [ ! -e "$COLONY_AGENTIS" ]; then
+            # Dangling symlink (target moved or removed). Re-point it.
+            ln -sfn "$FED_AGENTIS_ABS" "$COLONY_AGENTIS"
+            ok "$colony/.agentis -> $FED_AGENTIS_ABS (repaired dangling symlink)"
+        elif [ -L "$COLONY_AGENTIS" ]; then
             info "$colony/.agentis symlink already present"
         elif [ -e "$COLONY_AGENTIS" ]; then
             # Real directory found — likely a divergent empty .agentis from

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -151,23 +151,29 @@ PY
 done
 
 # --- 4. Initialize agentis (if not already done) ---
+#
+# Always run `agentis init` from the federation root (parent of SCRIPT_DIR),
+# not from the operator's cwd. If we used cwd, `bash /path/to/install.sh`
+# invoked from anywhere outside the federation would create a new empty
+# `.agentis/` next to the caller (e.g. in $HOME), and the lifecycle +
+# config-writing blocks below would then configure *that* directory
+# instead of the federation's.
+
+FED_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 echo ""
-if [ -d "$SCRIPT_DIR/../.agentis" ] || [ -d ".agentis" ]; then
+if [ -d "$FED_ROOT/.agentis" ]; then
     info "agentis already initialized"
 else
     echo "Initializing agentis..."
-    agentis init 2>/dev/null || true
+    (cd "$FED_ROOT" && agentis init 2>/dev/null) || true
     ok "agentis init"
 fi
 
-# Enable lifecycle tracking (required for colony health/ps)
-AGENTIS_DIR="${SCRIPT_DIR}/../.agentis"
-if [ -d "$AGENTIS_DIR" ]; then
-    AGENTIS_DIR="$AGENTIS_DIR"
-elif [ -d ".agentis" ]; then
-    AGENTIS_DIR=".agentis"
-fi
+# Enable lifecycle tracking (required for colony health/ps). Resolve
+# AGENTIS_DIR to an absolute path so downstream blocks (symlink target,
+# config path) never depend on the invoker's cwd.
+AGENTIS_DIR="$FED_ROOT/.agentis"
 
 if [ -d "$AGENTIS_DIR" ]; then
     mkdir -p "$AGENTIS_DIR/lifecycle"
@@ -216,8 +222,15 @@ if [ -d "$AGENTIS_DIR" ]; then
     write_key() {
         local key="$1"
         local value="$2"
-        # Escape dots in the key for grep. POSIX [[:space:]] keeps this
-        # portable to BSD grep (macOS) where \s is not supported.
+        # Idempotent upsert of `<key> = <value>` in `<AGENTIS_CONFIG>`.
+        # The grep pattern `^<escaped-key>[[:space:]]*=` requires a
+        # whitespace-or-equals boundary right after the key, so keys that
+        # are proper prefixes of other keys (e.g. `daemon.tick_interval`
+        # vs `daemon.tick_interval_ms`) do not collide: the `_` in
+        # `_ms = ...` is neither whitespace nor `=`. If a future key is
+        # added whose name ends in `[[:space:]=]`, revisit this guarantee.
+        # POSIX `[[:space:]]` keeps the pattern portable to BSD grep
+        # (macOS) where `\s` is treated as a literal `s`.
         local grep_key
         grep_key=$(printf '%s' "$key" | sed 's/\./\\./g')
         if ! grep -q "^${grep_key}[[:space:]]*=" "$AGENTIS_CONFIG" 2>/dev/null; then
@@ -240,13 +253,12 @@ fi
 # (e.g. `agentis doctor`) find the federation's .agentis instead of
 # spawning a divergent empty one in cwd (see issue #88 body, part 2).
 if [ -d "$AGENTIS_DIR" ]; then
-    FED_AGENTIS_ABS="$(cd "$AGENTIS_DIR" && pwd)"
     for colony in "${COLONIES[@]}"; do
         COLONY_AGENTIS="$SCRIPT_DIR/$colony/.agentis"
         if [ -L "$COLONY_AGENTIS" ] && [ ! -e "$COLONY_AGENTIS" ]; then
             # Dangling symlink (target moved or removed). Re-point it.
-            ln -sfn "$FED_AGENTIS_ABS" "$COLONY_AGENTIS"
-            ok "$colony/.agentis -> $FED_AGENTIS_ABS (repaired dangling symlink)"
+            ln -sfn "$AGENTIS_DIR" "$COLONY_AGENTIS"
+            ok "$colony/.agentis -> $AGENTIS_DIR (repaired dangling symlink)"
         elif [ -L "$COLONY_AGENTIS" ]; then
             info "$colony/.agentis symlink already present"
         elif [ -e "$COLONY_AGENTIS" ]; then
@@ -255,8 +267,8 @@ if [ -d "$AGENTIS_DIR" ]; then
             # should inspect and remove manually.
             fail "$colony/.agentis exists and is not a symlink — skipping (remove manually if empty)"
         else
-            ln -s "$FED_AGENTIS_ABS" "$COLONY_AGENTIS"
-            ok "$colony/.agentis -> $FED_AGENTIS_ABS"
+            ln -s "$AGENTIS_DIR" "$COLONY_AGENTIS"
+            ok "$colony/.agentis -> $AGENTIS_DIR"
         fi
     done
 fi

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -173,22 +173,78 @@ if [ -d "$AGENTIS_DIR" ]; then
     mkdir -p "$AGENTIS_DIR/lifecycle"
     ok "lifecycle tracking enabled"
 
-    # Enable federation monitoring and cross-colony knowledge sharing
+    # Write the defaults that every colony in this federation needs.
+    #
+    # These keys are not set by `agentis init`; without them a fresh checkout
+    # of dev-apprenticeship cannot complete a single tick on a real LLM
+    # backend (see Replikanti/agentis-colonies#88 for the full debug
+    # transcript). Each key is only written if missing so re-running
+    # install.sh is idempotent and never clobbers operator-tuned values.
+    #
+    #   daemon.tick_interval_ms     — matches --tick-interval 60000 in
+    #                                 start-colony.sh; without it the
+    #                                 watchdog uses the 1 s default.
+    #   daemon.heartbeat_interval_ms — 3× tick is long enough for a
+    #                                  Claude CLI cold start (typ. 5-30 s).
+    #                                  Default 2× tick is fine for mock,
+    #                                  but kills real-LLM agents mid-tick.
+    #   daemon.cb_per_tick          — 2000 covers ~40 prompt() calls per
+    #                                 tick. Default 100 overflows on the
+    #                                 first prompt (50 CB each) and makes
+    #                                 the agent look unhealthy from tick 1.
+    #   experience.enabled          — learn() is a no-op without this;
+    #                                 daemons throw "experience not
+    #                                 enabled" on every tick.
+    #   exec.env_passthrough        — agentis strips the env before running
+    #                                 `exec sh`. Agents need COLONY_DIR
+    #                                 (to resolve $COLONY_DIR/scripts/...
+    #                                 paths) and GITLAB_* (so gitlab-api.sh
+    #                                 authenticates against the instance
+    #                                 configured by start-colony.sh).
     AGENTIS_CONFIG="$AGENTIS_DIR/config"
     if [ -f "$AGENTIS_CONFIG" ]; then
-        if ! grep -q 'federation.enabled' "$AGENTIS_CONFIG" 2>/dev/null; then
-            printf '\nfederation.enabled = true\n' >> "$AGENTIS_CONFIG"
-            ok "federation monitoring enabled"
-        else
-            info "federation monitoring already configured"
-        fi
-        if ! grep -q 'knowledge.federation_enabled' "$AGENTIS_CONFIG" 2>/dev/null; then
-            printf 'knowledge.federation_enabled = true\n' >> "$AGENTIS_CONFIG"
-            ok "cross-colony knowledge sharing enabled"
-        else
-            info "cross-colony knowledge sharing already configured"
-        fi
+        write_key() {
+            local key="$1"
+            local value="$2"
+            # Escape dots in the key for grep
+            local grep_key
+            grep_key=$(printf '%s' "$key" | sed 's/\./\\./g')
+            if ! grep -q "^${grep_key}\s*=" "$AGENTIS_CONFIG" 2>/dev/null; then
+                printf '%s = %s\n' "$key" "$value" >> "$AGENTIS_CONFIG"
+                ok "$key = $value"
+            else
+                info "$key already configured"
+            fi
+        }
+        write_key 'federation.enabled'           'true'
+        write_key 'knowledge.federation_enabled' 'true'
+        write_key 'daemon.tick_interval_ms'      '60000'
+        write_key 'daemon.heartbeat_interval_ms' '180000'
+        write_key 'daemon.cb_per_tick'           '2000'
+        write_key 'experience.enabled'           'true'
+        write_key 'exec.env_passthrough'         'COLONY_DIR,GITLAB_*'
     fi
+fi
+
+# Create per-colony .agentis symlinks so commands run from a colony dir
+# (e.g. `agentis doctor`) find the federation's .agentis instead of
+# spawning a divergent empty one in cwd (see issue #88 body, part 2).
+if [ -d "$AGENTIS_DIR" ]; then
+    FED_AGENTIS_ABS="$(cd "$AGENTIS_DIR" && pwd)"
+    for colony in "${COLONIES[@]}"; do
+        COLONY_AGENTIS="$SCRIPT_DIR/$colony/.agentis"
+        if [ -L "$COLONY_AGENTIS" ]; then
+            info "$colony/.agentis symlink already present"
+        elif [ -e "$COLONY_AGENTIS" ]; then
+            # Real directory found — likely a divergent empty .agentis from
+            # a past `agentis doctor` run in cwd. Leave it alone; operator
+            # should inspect and remove manually.
+            fail "$colony/.agentis exists and is not a symlink — skipping (remove manually if empty)"
+        else
+            ln -s "$FED_AGENTIS_ABS" "$COLONY_AGENTIS"
+            ok "$colony/.agentis -> $FED_AGENTIS_ABS"
+        fi
+    done
 fi
 
 # --- 5. Seed confidence ---

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -144,7 +144,7 @@ fn tick(reason: string) -> void {
                 "review_plan",
                 "issue " + to_string(draft.issue_id),
                 "emitted: score=" + to_string(draft.review_score),
-                "success",
+                "partial",
                 ["emitted", "planning"]
             );
             print("[plan_reviewer] Emitted draft plan for issue", draft.issue_id);

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -75,7 +75,7 @@ fn tick(reason: string) -> void {
     // 3. Pick the newest unplanned issue and see if we have all three
     //    slots filled for it. If not, keep waiting.
     let issues_raw = try {
-        exec sh "./scripts/gitlab-api.sh issues --needs-planning";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning";
     } catch e {
         print("[plan_reviewer] GitLab unplanned-issue poll failed:", e);
         "";
@@ -125,7 +125,7 @@ fn tick(reason: string) -> void {
     print("[plan_reviewer] Issue", draft.issue_id, "-> review_score:", draft.review_score);
 
     if confidence >= 0.85 {
-        let post_cmd = "./scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft.plan);
+        let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft.plan);
         try { exec sh post_cmd; } catch e {
             print("[plan_reviewer] Failed to post note:", e);
         };
@@ -133,8 +133,8 @@ fn tick(reason: string) -> void {
             "review_plan",
             "issue " + to_string(draft.issue_id),
             "posted: score=" + to_string(draft.review_score),
-            "acted",
-            "planning"
+            "success",
+            ["acted", "planning"]
         );
         print("[plan_reviewer] Posted plan to issue", draft.issue_id);
     } else {
@@ -144,8 +144,8 @@ fn tick(reason: string) -> void {
                 "review_plan",
                 "issue " + to_string(draft.issue_id),
                 "emitted: score=" + to_string(draft.review_score),
-                "emitted",
-                "planning"
+                "success",
+                ["emitted", "planning"]
             );
             print("[plan_reviewer] Emitted draft plan for issue", draft.issue_id);
         } else {

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -25,9 +25,9 @@ type IncidentPatterns {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("risk_assessor:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh issues --needs-planning";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning";
 }
 
 fn get_confidence() -> float {
@@ -41,7 +41,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Observe: pull recent opened issues and skim for incident-style patterns
     let recent_raw = try {
-        exec sh "./scripts/gitlab-api.sh issues";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues";
     } catch e {
         print("[risk_assessor] GitLab issues poll failed:", e);
         "";
@@ -58,8 +58,8 @@ fn tick(reason: string) -> void {
                 "risk_assessment",
                 "batch of " + to_string(patterns.observed_count) + " incident-style issues",
                 patterns.recurring_themes,
-                "observed",
-                "planning"
+                "success",
+                ["observed", "planning"]
             );
             print("[risk_assessor] Observed", patterns.observed_count, "incident-style issues");
         };
@@ -96,8 +96,8 @@ fn tick(reason: string) -> void {
             "risk_assessment",
             "issue " + to_string(assessment.issue_id),
             assessment.severity + ": " + assessment.risks,
-            "emitted",
-            "planning"
+            "success",
+            ["emitted", "planning"]
         );
     } else {
         print("[risk_assessor] Observing (confidence:", confidence, ")");

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -96,7 +96,7 @@ fn tick(reason: string) -> void {
             "risk_assessment",
             "issue " + to_string(assessment.issue_id),
             assessment.severity + ": " + assessment.risks,
-            "success",
+            "partial",
             ["emitted", "planning"]
         );
     } else {

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -97,7 +97,7 @@ fn tick(reason: string) -> void {
             "scope_estimate",
             "issue " + to_string(estimate.issue_id),
             to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
-            "success",
+            "partial",
             ["emitted", "planning"]
         );
     } else {

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -26,9 +26,9 @@ type CalibrationSummary {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("scope_estimator:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh issues --needs-planning";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning";
 }
 
 fn get_confidence() -> float {
@@ -42,7 +42,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Observe: pull recent merged MRs and learn calibration
     let merged_raw = try {
-        exec sh "./scripts/gitlab-api.sh merge-requests --state merged";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
     } catch e {
         print("[scope_estimator] GitLab merged-MR poll failed:", e);
         "";
@@ -59,8 +59,8 @@ fn tick(reason: string) -> void {
                 "scope_estimate",
                 "batch of " + to_string(summary.observed_pairs) + " shipped MRs",
                 "ratio: " + summary.ratio_hint + " | " + summary.tendencies,
-                "observed",
-                "planning"
+                "success",
+                ["observed", "planning"]
             );
             print("[scope_estimator] Observed", summary.observed_pairs, "shipped pairs");
         };
@@ -97,8 +97,8 @@ fn tick(reason: string) -> void {
             "scope_estimate",
             "issue " + to_string(estimate.issue_id),
             to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
-            "emitted",
-            "planning"
+            "success",
+            ["emitted", "planning"]
         );
     } else {
         print("[scope_estimator] Observing (confidence:", confidence, ")");

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -97,7 +97,7 @@ fn tick(reason: string) -> void {
             "task_decomposition",
             "issue " + to_string(breakdown.issue_id),
             to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
-            "success",
+            "partial",
             ["emitted", "planning"]
         );
     } else {

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -26,9 +26,9 @@ type DecompositionPatterns {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("task_decomposer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh issues --needs-planning";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning";
 }
 
 fn get_confidence() -> float {
@@ -42,7 +42,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Observe: analyze recent issues to infer decomposition style
     let recent_raw = try {
-        exec sh "./scripts/gitlab-api.sh issues";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues";
     } catch e {
         print("[task_decomposer] GitLab issues poll failed:", e);
         "";
@@ -59,8 +59,8 @@ fn tick(reason: string) -> void {
                 "task_decomposition",
                 "batch of " + to_string(patterns.epics_seen) + " epics",
                 "avg " + to_string(patterns.avg_subtasks) + " subtasks | " + patterns.style,
-                "observed",
-                "planning"
+                "success",
+                ["observed", "planning"]
             );
             print("[task_decomposer] Observed", patterns.epics_seen, "epics, avg", patterns.avg_subtasks, "subtasks");
         };
@@ -97,8 +97,8 @@ fn tick(reason: string) -> void {
             "task_decomposition",
             "issue " + to_string(breakdown.issue_id),
             to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
-            "emitted",
-            "planning"
+            "success",
+            ["emitted", "planning"]
         );
     } else {
         print("[task_decomposer] Observing (confidence:", confidence, ")");

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -36,7 +36,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Learn changelog style from past releases
     let releases_raw = try {
-        exec sh "./scripts/gitlab-api.sh releases --per-page 10";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 10";
     } catch e {
         print("[changelog_writer] GitLab releases poll failed:", e);
         "";
@@ -53,8 +53,8 @@ fn tick(reason: string) -> void {
                 "changelog_write",
                 "batch of " + to_string(style.releases_seen) + " releases",
                 "grouping: " + style.grouping + " | tone: " + style.tone + " | include: " + style.inclusions + " | exclude: " + style.exclusions,
-                "observed",
-                "release"
+                "success",
+                ["observed", "release"]
             );
             print("[changelog_writer] Learned from", style.releases_seen, "past release notes");
         };
@@ -89,7 +89,7 @@ fn tick(reason: string) -> void {
 
     // Get the latest release tag to find MRs merged since then
     let latest_release = try {
-        exec sh "./scripts/gitlab-api.sh releases --per-page 1";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 1";
     } catch e { "[]"; };
 
     let since_date = prompt(
@@ -98,7 +98,7 @@ fn tick(reason: string) -> void {
     ) -> string;
 
     // Fetch MRs merged since last release
-    let mrs_cmd = "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date);
+    let mrs_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date);
     let mrs_raw = try { exec sh mrs_cmd; } catch e {
         print("[changelog_writer] MR fetch failed:", e);
         "";
@@ -117,21 +117,21 @@ fn tick(reason: string) -> void {
         print("[changelog_writer] Drafted changelog for", draft.version, "(", draft.mr_count, "MRs, confidence:", confidence, ")");
 
         if confidence >= 0.85 {
-            let mr_raw = try { exec sh "./scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+            let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
             let mr_iid = prompt("Extract the iid integer of the first MR from this JSON array. If empty, return 0.", mr_raw) -> int;
             if mr_iid > 0 {
                 let note = "**Release Notes Draft** (automated)\n\n" + draft.changelog;
-                let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
                 try { exec sh post_cmd; } catch e {
                     print("[changelog_writer] Failed to post note:", e);
                 };
             };
             emit("release:changelog_draft", draft);
-            learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "acted", "release");
+            learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "success", ["acted", "release"]);
         } else {
             if confidence >= 0.6 {
                 emit("release:changelog_draft", draft);
-                learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "emitted", "release");
+                learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "success", ["emitted", "release"]);
             } else {
                 print("[changelog_writer] Observing (confidence:", confidence, ")");
             };

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -131,7 +131,7 @@ fn tick(reason: string) -> void {
         } else {
             if confidence >= 0.6 {
                 emit("release:changelog_draft", draft);
-                learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "success", ["emitted", "release"]);
+                learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["emitted", "release"]);
             } else {
                 print("[changelog_writer] Observing (confidence:", confidence, ")");
             };

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -101,7 +101,7 @@ fn tick(reason: string) -> void {
             } else {
                 if confidence >= 0.6 {
                     emit("release:check_result", result);
-                    learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "success", ["emitted", "release"]);
+                    learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["emitted", "release"]);
                 } else {
                     print("[release_checker] Observing (confidence:", confidence, ")");
                 };
@@ -120,7 +120,7 @@ fn tick(reason: string) -> void {
             } else {
                 if confidence >= 0.6 {
                     emit("release:check_result", result);
-                    learn("release_check", "periodic check", result.ci_status, "success", ["emitted", "release"]);
+                    learn("release_check", "periodic check", result.ci_status, "partial", ["emitted", "release"]);
                 };
             };
         };

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -37,7 +37,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Learn from past releases and their pipeline outcomes
     let releases_raw = try {
-        exec sh "./scripts/gitlab-api.sh releases --per-page 10";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 10";
     } catch e {
         print("[release_checker] GitLab releases poll failed:", e);
         "";
@@ -54,8 +54,8 @@ fn tick(reason: string) -> void {
                 "release_check",
                 "batch of " + to_string(patterns.releases_seen) + " releases",
                 "ci_gates: " + patterns.ci_gates + " | validation: " + patterns.validation_steps + " | failures: " + patterns.failure_patterns,
-                "observed",
-                "release"
+                "success",
+                ["observed", "release"]
             );
             print("[release_checker] Learned from", patterns.releases_seen, "past releases");
         };
@@ -67,7 +67,7 @@ fn tick(reason: string) -> void {
 
     // Also check the default branch pipeline status
     let pipeline_raw = try {
-        exec sh "./scripts/gitlab-api.sh pipelines --ref main";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh pipelines --ref main";
     } catch e {
         print("[release_checker] Pipeline poll failed:", e);
         "";
@@ -91,17 +91,17 @@ fn tick(reason: string) -> void {
                 let mr_iid = prompt("Extract the iid or issue_id integer from this MR data. Return just the integer. If not found, return 0.", mr_str) -> int;
                 if mr_iid > 0 {
                     let note = "**Pre-release Check** (automated): " + result.ci_status + "\n\nIssues: " + result.issues_found;
-                    let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                    let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
                     try { exec sh post_cmd; } catch e {
                         print("[release_checker] Failed to post note:", e);
                     };
                 };
                 emit("release:check_result", result);
-                learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "acted", "release");
+                learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "success", ["acted", "release"]);
             } else {
                 if confidence >= 0.6 {
                     emit("release:check_result", result);
-                    learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "emitted", "release");
+                    learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "success", ["emitted", "release"]);
                 } else {
                     print("[release_checker] Observing (confidence:", confidence, ")");
                 };
@@ -116,11 +116,11 @@ fn tick(reason: string) -> void {
             let confidence = get_confidence();
             if confidence >= 0.85 {
                 emit("release:check_result", result);
-                learn("release_check", "periodic check", result.ci_status, "acted", "release");
+                learn("release_check", "periodic check", result.ci_status, "success", ["acted", "release"]);
             } else {
                 if confidence >= 0.6 {
                     emit("release:check_result", result);
-                    learn("release_check", "periodic check", result.ci_status, "emitted", "release");
+                    learn("release_check", "periodic check", result.ci_status, "success", ["emitted", "release"]);
                 };
             };
         };

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -100,7 +100,7 @@ fn tick(reason: string) -> void {
     } else {
         if confidence >= 0.6 {
             emit("release:ship_decision", decision);
-            learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "success", ["emitted", "release"]);
+            learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["emitted", "release"]);
         } else {
             print("[ship_decider] Observing (confidence:", confidence, ")");
         };

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -34,7 +34,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Learn release patterns from history
     let releases_raw = try {
-        exec sh "./scripts/gitlab-api.sh releases --per-page 20";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 20";
     } catch e {
         print("[ship_decider] GitLab releases poll failed:", e);
         "";
@@ -42,7 +42,7 @@ fn tick(reason: string) -> void {
 
     if len(releases_raw) > 10 {
         let tags_raw = try {
-            exec sh "./scripts/gitlab-api.sh tags --per-page 20";
+            exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 20";
         } catch e { "[]"; };
 
         let patterns = prompt(
@@ -55,8 +55,8 @@ fn tick(reason: string) -> void {
                 "ship_decide",
                 "batch of " + to_string(patterns.releases_seen) + " releases",
                 "cadence: " + patterns.cadence + " | blockers: " + patterns.blocker_types + " | risk: " + patterns.risk_tolerance,
-                "observed",
-                "release"
+                "success",
+                ["observed", "release"]
             );
             print("[ship_decider] Learned from", patterns.releases_seen, "past releases");
         };
@@ -86,21 +86,21 @@ fn tick(reason: string) -> void {
     print("[ship_decider] Decision:", decision.decision, "(confidence:", confidence, ")");
 
     if confidence >= 0.85 {
-        let mr_raw = try { exec sh "./scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+        let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
         let mr_iid = prompt("Extract the iid integer of the first MR from this JSON array. If empty, return 0.", mr_raw) -> int;
         if mr_iid > 0 {
             let note = "**Ship Decision** (automated): " + decision.decision + "\n\n" + decision.reasoning;
-            let post_cmd = "./scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
             try { exec sh post_cmd; } catch e {
                 print("[ship_decider] Failed to post note:", e);
             };
         };
         emit("release:ship_decision", decision);
-        learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "acted", "release");
+        learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "success", ["acted", "release"]);
     } else {
         if confidence >= 0.6 {
             emit("release:ship_decision", decision);
-            learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "emitted", "release");
+            learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "success", ["emitted", "release"]);
         } else {
             print("[ship_decider] Observing (confidence:", confidence, ")");
         };

--- a/dev-apprenticeship/release/agents/version_bumper.ag
+++ b/dev-apprenticeship/release/agents/version_bumper.ag
@@ -152,7 +152,7 @@ fn tick(reason: string) -> void {
     } else {
         if confidence >= 0.6 {
             emit("release:version_bumped", bump);
-            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "success", ["emitted", "release"]);
+            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["emitted", "release"]);
         } else {
             print("[version_bumper] Observing (confidence:", confidence, ")");
         };

--- a/dev-apprenticeship/release/agents/version_bumper.ag
+++ b/dev-apprenticeship/release/agents/version_bumper.ag
@@ -36,7 +36,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Learn versioning patterns from tags
     let tags_raw = try {
-        exec sh "./scripts/gitlab-api.sh tags --per-page 20";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 20";
     } catch e {
         print("[version_bumper] GitLab tags poll failed:", e);
         "";
@@ -53,8 +53,8 @@ fn tick(reason: string) -> void {
                 "version_bump",
                 "batch of " + to_string(patterns.tags_seen) + " version tags",
                 "format: " + patterns.format + " | strategy: " + patterns.bump_strategy + " | prerelease: " + patterns.prerelease,
-                "observed",
-                "release"
+                "success",
+                ["observed", "release"]
             );
             print("[version_bumper] Learned from", patterns.tags_seen, "version tags");
         };
@@ -93,12 +93,12 @@ fn tick(reason: string) -> void {
 
     // Get latest tags for current version context
     let latest_tags = try {
-        exec sh "./scripts/gitlab-api.sh tags --per-page 5";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 5";
     } catch e { "[]"; };
 
     // Fetch merged MRs since last release for bump analysis
     let latest_release = try {
-        exec sh "./scripts/gitlab-api.sh releases --per-page 1";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 1";
     } catch e { "[]"; };
 
     let since_date = prompt(
@@ -106,7 +106,7 @@ fn tick(reason: string) -> void {
         latest_release
     ) -> string;
 
-    let mrs_cmd = "./scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date);
+    let mrs_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date);
     let mrs_raw = try { exec sh mrs_cmd; } catch e { "[]"; };
 
     let rec = recommend("version_bump", ["accuracy"]);
@@ -123,7 +123,7 @@ fn tick(reason: string) -> void {
     if confidence >= 0.85 {
         // Create the tag
         // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-        let tag_cmd = "./scripts/gitlab-api.sh create-tag --name " + shell_escape(bump.next) + " --ref main --message " + shell_escape("Release " + bump.next);
+        let tag_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-tag --name " + shell_escape(bump.next) + " --ref main --message " + shell_escape("Release " + bump.next);
         let tag_result = try { exec sh tag_cmd; } catch e {
             print("[version_bumper] Tag creation failed:", e);
             "";
@@ -136,7 +136,7 @@ fn tick(reason: string) -> void {
             let release_desc = changelog_str + bump.reasoning;
 
             // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-            let release_cmd = "./scripts/gitlab-api.sh create-release --tag " + shell_escape(bump.next) + " --name " + shell_escape("Release " + bump.next) + " --description " + shell_escape(release_desc);
+            let release_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-release --tag " + shell_escape(bump.next) + " --name " + shell_escape("Release " + bump.next) + " --description " + shell_escape(release_desc);
             let release_result = try { exec sh release_cmd; } catch e {
                 print("[version_bumper] Release creation failed:", e);
                 "";
@@ -147,12 +147,12 @@ fn tick(reason: string) -> void {
             };
 
             emit("release:version_bumped", bump);
-            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "acted", "release");
+            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "success", ["acted", "release"]);
         };
     } else {
         if confidence >= 0.6 {
             emit("release:version_bumped", bump);
-            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "emitted", "release");
+            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "success", ["emitted", "release"]);
         } else {
             print("[version_bumper] Observing (confidence:", confidence, ")");
         };

--- a/dev-apprenticeship/triage/agents/issue_creator.ag
+++ b/dev-apprenticeship/triage/agents/issue_creator.ag
@@ -24,9 +24,9 @@ type ObservationSummary {
 fn issues_cmd() -> string {
     let ts = recall_latest("issue_creator:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh issues";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues";
 }
 
 fn get_confidence() -> float {
@@ -61,8 +61,8 @@ fn tick(reason: string) -> void {
             "create_issue",
             "batch of " + to_string(summary.count) + " issues",
             summary.patterns,
-            "observed",
-            "triage"
+            "success",
+            ["observed", "triage"]
         );
         print("[issue_creator] Observed", summary.count, "human-created issues");
     };
@@ -81,7 +81,7 @@ fn tick(reason: string) -> void {
         ) -> DraftIssue;
 
         if confidence >= 0.85 {
-            let create_cmd = "./scripts/gitlab-api.sh create-issue --title " + shell_escape(draft.title) + " --description " + shell_escape(draft.description) + " --labels " + shell_escape(draft.suggested_labels);
+            let create_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-issue --title " + shell_escape(draft.title) + " --description " + shell_escape(draft.description) + " --labels " + shell_escape(draft.suggested_labels);
             let result = try {
                 exec sh create_cmd;
             } catch e {

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -25,9 +25,9 @@ type LabelAction {
 fn issues_cmd() -> string {
     let ts = recall_latest("labeler:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh issues";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues";
 }
 
 fn get_confidence() -> float {
@@ -62,8 +62,8 @@ fn tick(reason: string) -> void {
             "label",
             "batch of " + to_string(analysis.labeled_count) + " labeled issues",
             analysis.patterns,
-            "observed",
-            "triage"
+            "success",
+            ["observed", "triage"]
         );
         print("[labeler] Observed", analysis.labeled_count, "labeled issues");
     };
@@ -72,7 +72,7 @@ fn tick(reason: string) -> void {
     if analysis.unlabeled_count > 0 {
         let confidence = get_confidence();
         let rec = recommend("label", ["accuracy"]);
-        let labels_raw = try { exec sh "./scripts/gitlab-api.sh labels"; } catch e { "[]"; };
+        let labels_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh labels"; } catch e { "[]"; };
         let context = "Unlabeled issues: " + analysis.unlabeled_issues + "\nAvailable labels: " + labels_raw + "\nPast learning: " + to_string(rec);
 
         let action = prompt(
@@ -81,14 +81,14 @@ fn tick(reason: string) -> void {
         ) -> LabelAction;
 
         if confidence >= 0.85 {
-            let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.labels);
+            let update_cmd = "$COLONY_DIR/scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.labels);
             let result = try { exec sh update_cmd; } catch e {
                 print("[labeler] Failed to apply labels:", e);
                 "";
             };
             if len(result) > 0 {
                 print("[labeler] Applied labels to issue", action.issue_id, ":", action.labels);
-                learn("label", "issue " + to_string(action.issue_id), action.labels, "acted", "triage");
+                learn("label", "issue " + to_string(action.issue_id), action.labels, "success", ["acted", "triage"]);
             };
         } else {
             if confidence >= 0.6 {

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -25,9 +25,9 @@ type PriorityAction {
 fn issues_cmd() -> string {
     let ts = recall_latest("prioritizer:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh issues";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues";
 }
 
 fn get_confidence() -> float {
@@ -62,8 +62,8 @@ fn tick(reason: string) -> void {
             "prioritize",
             "batch of " + to_string(analysis.prioritized_count) + " prioritized issues",
             analysis.patterns,
-            "observed",
-            "triage"
+            "success",
+            ["observed", "triage"]
         );
         print("[prioritizer] Observed", analysis.prioritized_count, "priority assignments");
     };
@@ -80,14 +80,14 @@ fn tick(reason: string) -> void {
         ) -> PriorityAction;
 
         if confidence >= 0.85 {
-            let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.priority);
+            let update_cmd = "$COLONY_DIR/scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.priority);
             let result = try { exec sh update_cmd; } catch e {
                 print("[prioritizer] Failed to set priority:", e);
                 "";
             };
             if len(result) > 0 {
                 print("[prioritizer] Set priority on issue", action.issue_id, ":", action.priority);
-                learn("prioritize", "issue " + to_string(action.issue_id), action.priority, "acted", "triage");
+                learn("prioritize", "issue " + to_string(action.issue_id), action.priority, "success", ["acted", "triage"]);
             };
         } else {
             if confidence >= 0.6 {

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -25,9 +25,9 @@ type RouteAction {
 fn issues_cmd() -> string {
     let ts = recall_latest("router:last_check");
     if len(ts) > 0 {
-        return "./scripts/gitlab-api.sh issues --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts);
     };
-    return "./scripts/gitlab-api.sh issues";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues";
 }
 
 fn get_confidence() -> float {
@@ -52,7 +52,7 @@ fn tick(reason: string) -> void {
     };
 
     // Get team members
-    let members_raw = try { exec sh "./scripts/gitlab-api.sh members"; } catch e { "[]"; };
+    let members_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh members"; } catch e { "[]"; };
 
     // Analyze: find assigned and unassigned issues
     let analysis = prompt(
@@ -65,8 +65,8 @@ fn tick(reason: string) -> void {
             "route",
             "batch of " + to_string(analysis.assigned_count) + " assigned issues",
             analysis.patterns,
-            "observed",
-            "triage"
+            "success",
+            ["observed", "triage"]
         );
         print("[router] Observed", analysis.assigned_count, "assignment patterns");
     };
@@ -83,14 +83,14 @@ fn tick(reason: string) -> void {
         ) -> RouteAction;
 
         if confidence >= 0.85 {
-            let update_cmd = "./scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --assignee " + shell_escape(action.assignee);
+            let update_cmd = "$COLONY_DIR/scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --assignee " + shell_escape(action.assignee);
             let result = try { exec sh update_cmd; } catch e {
                 print("[router] Failed to assign:", e);
                 "";
             };
             if len(result) > 0 {
                 print("[router] Assigned issue", action.issue_id, "to", action.assignee);
-                learn("route", "issue " + to_string(action.issue_id), action.assignee, "acted", "triage");
+                learn("route", "issue " + to_string(action.issue_id), action.assignee, "success", ["acted", "triage"]);
             };
         } else {
             if confidence >= 0.6 {


### PR DESCRIPTION
Closes #88.

## Summary

- **install.sh**: write seven runtime config keys that every colony in this federation needs but that `agentis init` does not set — `daemon.tick_interval_ms`, `daemon.heartbeat_interval_ms`, `daemon.cb_per_tick`, `experience.enabled`, `exec.env_passthrough`, plus the existing `federation.enabled` / `knowledge.federation_enabled`. All through a single idempotent helper. Without these, a fresh checkout on a real LLM backend (Claude CLI) cannot complete a single tick (see the #88 debug transcript).
- **install.sh**: create per-colony `.agentis` symlinks so `agentis doctor` or any cwd-local agentis command run from inside a colony dir doesn't silently spawn a divergent empty `.agentis` in that folder.
- **All 21 .ag files**: replace `./scripts/gitlab-api.sh ...` with `$COLONY_DIR/scripts/gitlab-api.sh ...`. `agentis daemon` runs `exec sh` with cwd set to `.agentis/sandbox/`, so the old relative paths never resolved.
- **All 21 .ag files**: rewrite `learn()` outcomes. The old `"observed"` / `"acted"` / `"emitted"` are not valid agentis outcomes (only `success/failure/partial/timeout/error` are accepted), so every `learn()` call raised `invalid outcome` and aborted the tick before `memo_write`. New form: `"success"` outcome + tag list `["observed"/"acted"/"emitted", colony]` preserves the semantic distinction. Also fixes a latent adjacent bug — `learn()` wants `Vec<String>` for tags and silently dropped the single string the .ag files were passing before.

## What's already done elsewhere

Bugs 8 (`messaging = allow`) and 9 (`exec_foreign = allow`) from the #88 comment were resolved by the agentis >= v1.1.6 bump in #89 via the new `--enable-exec` / `--enable-messaging` daemon flags.

## Test plan

- [x] `cargo build --release` of agentis-core, then `agentis commit` on each of the 21 rewritten `.ag` files — all parse
- [x] `./tools/colony-lint.sh` — 45 passed, 0 failed, 5 skipped (baseline)
- [x] `bash -n dev-apprenticeship/install.sh` — OK
- [x] Dry-run of the `write_key` helper: all seven keys written on pass 1, all recognized as "already configured" on pass 2 (idempotent)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)