### PR TITLE
chore: require agentis >= v1.1.7 (#499 watchdog heartbeat fix)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -1,6 +1,6 @@
 # Dev Apprenticeship
 
-![Agentis >= v1.1.6](https://img.shields.io/badge/agentis-%3E%3D%20v1.1.6-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
+![Agentis >= v1.1.7](https://img.shields.io/badge/agentis-%3E%3D%20v1.1.7-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
 
 A federation of 21 agents that learns how you work by watching your GitLab activity. It observes how you triage issues, review merge requests, plan features, write code, and ship releases. Over time it takes over the mechanical parts, while you keep control over the decisions that matter.
 
@@ -35,7 +35,7 @@ graph LR
 
 ## What you need
 
-- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.1.6**
+- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.1.7**
 - An LLM backend (Claude CLI, Ollama, or any OpenAI-compatible API)
 - GitLab instance with API access (personal access token with `api` scope)
 - Python 3 and git

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -19,7 +19,7 @@ ALL_AGENTS=(
     code_writer test_writer refactorer commit_composer
     ship_decider changelog_writer version_bumper release_checker
 )
-MIN_VERSION="1.1.6"
+MIN_VERSION="1.1.7"
 
 # --- Helpers ---
 
@@ -65,17 +65,18 @@ if [ "$MISSING" -eq 1 ]; then
     exit 1
 fi
 
-# Check agentis version. v1.1.6 is the first release with `--enable-exec` and
-# `--enable-messaging` daemon flags (required by start-colony.sh) and the
-# quarantine oscillation fix (#492), which previously caused silent capability
-# revocations mid-federation. Older builds will appear to start but all agents
-# either fail with `capability denied: exec_foreign` or never receive
-# emit/listen messages.
+# Check agentis version. v1.1.6 added `--enable-exec` / `--enable-messaging`
+# (required by start-colony.sh) and the #492 quarantine oscillation fix.
+# v1.1.7 then fixed #499 (agentis_root walk-up), without which the watchdog
+# silently falls back to a 2000 ms heartbeat timeout and kills any agent
+# whose prompts take longer — on a cold Claude CLI that is every agent.
+# Older builds either fail with `capability denied: exec_foreign`, never
+# receive emit/listen, or get killed by the watchdog every tick.
 AGENTIS_VERSION=$(agentis --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
 info "agentis version: $AGENTIS_VERSION (minimum: $MIN_VERSION)"
 
 if ! version_gte "$AGENTIS_VERSION" "$MIN_VERSION"; then
-    fail "agentis >= $MIN_VERSION required (--enable-exec / --enable-messaging daemon flags, #492 quarantine fix). Please update."
+    fail "agentis >= $MIN_VERSION required (--enable-exec/--enable-messaging flags, #492 quarantine fix, #499 watchdog heartbeat fix). Please update."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Bump `MIN_VERSION` in `install.sh` from 1.1.6 to 1.1.7
- Bump badge and prerequisite line in `dev-apprenticeship/README.md`
- Expand the explanatory comment in `install.sh` to mention #499 alongside #492

## Why

Agentis v1.1.7 ships the #499 fix: `agentis_root()` now walks up ancestor directories looking for `.agentis/objects/`. On v1.1.6, running `start-federation.sh` from the `dev-apprenticeship/` directory (which has no `.agentis/` of its own — the federation's `.agentis/` lives one level up in `agentis-colonies/`) meant `Config::load` silently returned empty defaults, `daemon.heartbeat_interval_ms` was ignored, and the watchdog fell back to a 2000 ms timeout. That kills every agent whose prompt takes longer, which on a cold Claude CLI is every agent.

## Test plan

- [x] `MIN_VERSION="1.1.7"` enforced before any config is written
- [x] README badge and "What you need" section both show v1.1.7
- [x] `install.sh` comment no longer misleads about #492 being the only critical fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)