### PR TITLE
feat(dashboard): live refresh countdown + manual refresh button (#92)

### DIFF
--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -360,7 +360,7 @@ HTMLEOF
   <div class="header-right" style="display:flex;align-items:center;gap:16px;">
     <div>
       <div class="time" id="clock"></div>
-      <div><span id="countdown">auto-refresh in 60s</span> <button class="refresh-btn" id="refresh-btn" onclick="manualRefresh()" title="Refresh now (press 'r')">&#x21bb;</button></div>
+      <div><span id="countdown">auto-refresh in 60s</span> <button class="refresh-btn" id="refresh-btn" onclick="manualRefresh()" title="Refresh now (press 'r')" aria-label="Refresh now">&#x21bb;</button></div>
     </div>
     <button class="kill-btn" id="kill-btn" onclick="killSwitch()">Kill Federation</button>
   </div>
@@ -456,7 +456,10 @@ function manualRefresh() {
 }
 
 document.addEventListener('keydown', (e) => {
-  if (e.key === 'r' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+  // Ignore Ctrl/Meta/Alt/Shift combinations (browser reserves Ctrl-R,
+  // Shift-R is a legitimate uppercase R the operator may type elsewhere)
+  // and held-down repeats so a single press only fires one reload.
+  if (e.key === 'r' && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && !e.repeat) {
     const tag = (e.target && e.target.tagName) || '';
     // Don't steal 'r' from text fields or contenteditable regions.
     if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target && e.target.isContentEditable)) return;

--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -313,6 +313,18 @@ HEADEOF
   }
   .stat-value { font-size: 28px; color: var(--cyan); text-shadow: 0 0 15px rgba(0,255,255,0.4); }
   .stat-label { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 2px; margin-top: 4px; }
+  .refresh-btn {
+    background: transparent; border: 1px solid var(--border);
+    color: var(--muted); font-family: inherit; font-size: 12px;
+    padding: 0 6px; cursor: pointer; border-radius: 2px;
+    line-height: 1.4; vertical-align: middle;
+    transition: color 0.15s, border-color 0.15s, transform 0.15s;
+  }
+  .refresh-btn:hover { color: var(--cyan); border-color: var(--cyan); }
+  .refresh-btn.spinning { animation: spin 0.6s linear infinite; }
+  @keyframes spin {
+    from { transform: rotate(0deg); } to { transform: rotate(360deg); }
+  }
   .kill-btn {
     background: transparent; border: 2px solid var(--red);
     color: var(--red); font-family: 'Share Tech Mono', monospace;
@@ -348,7 +360,7 @@ HTMLEOF
   <div class="header-right" style="display:flex;align-items:center;gap:16px;">
     <div>
       <div class="time" id="clock"></div>
-      <div>auto-refresh 60s</div>
+      <div><span id="countdown">auto-refresh in 60s</span> <button class="refresh-btn" id="refresh-btn" onclick="manualRefresh()" title="Refresh now (press 'r')">&#x21bb;</button></div>
     </div>
     <button class="kill-btn" id="kill-btn" onclick="killSwitch()">Kill Federation</button>
   </div>
@@ -417,6 +429,41 @@ const colonyColors = {};
 colonyList.forEach((c, i) => colonyColors[c] = palette[i % palette.length]);
 
 document.getElementById('clock').textContent = timestamp;
+
+// --- Refresh countdown ---
+// The meta-refresh fires 60 s after the page loads. Mirror that here so
+// the operator always knows when the next reload happens and can trigger
+// one manually (button or 'r' key).
+(function() {
+  const REFRESH_MS = 60000;
+  const el = document.getElementById('countdown');
+  if (!el) return;
+  const loadedAt = Date.now();
+  function tick() {
+    const remaining = Math.max(0, REFRESH_MS - (Date.now() - loadedAt));
+    const s = Math.ceil(remaining / 1000);
+    el.textContent = 'auto-refresh in ' + String(Math.floor(s/60)).padStart(2,'0') + ':' + String(s%60).padStart(2,'0');
+  }
+  tick();
+  setInterval(tick, 1000);
+})();
+
+function manualRefresh() {
+  const btn = document.getElementById('refresh-btn');
+  if (btn) btn.classList.add('spinning');
+  // Short delay so the spin is visible even on near-instant reloads.
+  setTimeout(() => location.reload(), 150);
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'r' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+    const tag = (e.target && e.target.tagName) || '';
+    // Don't steal 'r' from text fields or contenteditable regions.
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target && e.target.isContentEditable)) return;
+    e.preventDefault();
+    manualRefresh();
+  }
+});
 
 // --- Stats row ---
 (function() {


### PR DESCRIPTION
## Summary

- **Live countdown:** replaces the static "auto-refresh 60s" text with a ticking "auto-refresh in MM:SS" that updates every second. Mirrors the meta-refresh timer (page load + 60 s), so it always agrees with when the reload actually fires.
- **Manual refresh button:** small circular `&#x21bb;` button next to the countdown, reloads the page immediately. Spins briefly so the click is visibly registered even on near-instant reloads.
- **Keyboard shortcut:** pressing `r` triggers the same manual refresh. Scoped so inputs/textareas/contenteditable don't get their keystrokes stolen.

## Why

Per #92: dashboard is designed to be left open on a second monitor. The previous static "auto-refresh 60s" gave no signal that the page was alive or how old the numbers were. Countdown addresses both; manual refresh lets the operator see the effect of a just-issued command (e.g. `agentis memo set ...:confidence`) without waiting out the 60 s tick.

## Test plan

- [x] `bash -n tools/federation-dashboard.sh` passes (shell syntax OK)
- [x] Embedded Python heredoc still compiles (PYSERVER block extracted + `compile()` check)
- [x] Static HTML markers present: `id="countdown"`, `class="refresh-btn"`, `.refresh-btn.spinning` CSS, `function manualRefresh`, `e.key === 'r'`
- [ ] End-to-end browser verification — **blocked on a pre-existing bug** in `generate()`: on a fresh federation with no daemons/knowledge entries, one of the `json.loads()` calls in the Python history-append block fails with `Expecting value: line 1 column 2 (char 1)`. Reproduces on main **before** this PR, so unrelated to #92. Worth a separate issue; not blocking.
- [x] Visual design: countdown sits where the "auto-refresh 60s" was, refresh button uses muted/cyan theme colors consistent with the existing palette.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)