### PR TITLE
fix(dashboard): handle fresh federation without running daemons (#96)

### DIFF
--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -123,14 +123,16 @@ print(json.dumps(counts))
     REMEDIATION="$(agentis remediation history --limit 5 --json 2>/dev/null || echo '[]')"
 
     # Confidence values. `agentis memo get` on a missing key exits 0 with
-    # empty stdout (not non-zero), so `|| echo '0.0'` never fires — the
-    # shell substitution default on the next line is what actually catches
-    # a fresh federation where no memos have been written yet (#96).
+    # empty stdout (not non-zero), so `|| echo ''` is not what catches the
+    # missing-key case — the `${conf:-0.0}` default on the next line is
+    # (#96). But the `|| echo ''` is still needed to keep the script
+    # running under `set -e` (L17) if `agentis` itself exits non-zero
+    # (binary missing, store lock contention, etc.).
     local CONFIDENCES=""
     for i in "${!ALL_AGENTS[@]}"; do
         local agent="${ALL_AGENTS[$i]}"
         local conf
-        conf="$(agentis memo get "${agent}:confidence" 2>/dev/null)"
+        conf="$(agentis memo get "${agent}:confidence" 2>/dev/null || echo '')"
         CONFIDENCES="${CONFIDENCES}${conf:-0.0},"
     done
     CONFIDENCES="[${CONFIDENCES%,}]"
@@ -152,19 +154,25 @@ print(json.dumps(lines))
     # Append to history
     python3 - "$HISTORY_FILE" "$EPOCH" "$KNOWLEDGE_COUNTS" "$CONFIDENCES" "$AGENT_COLONY_MAP" <<'PY'
 import sys, json
-def _safe_json(s, default):
+def _safe_json(s, default, label):
     try:
         return json.loads(s)
-    except (json.JSONDecodeError, TypeError, ValueError):
+    except (json.JSONDecodeError, TypeError, ValueError) as e:
+        # Surface real breakages (daemon crash, store corruption) rather
+        # than silently rendering "0 entries" forever. On a fresh
+        # federation the inputs are legitimately empty strings and
+        # `json.loads("")` fails — that is expected and noisy but
+        # short-lived (one tick per agent until memos are seeded).
+        sys.stderr.write(f"[dashboard] {label} parse failed: {e}; using default\n")
         return default
 path, epoch = sys.argv[1], int(sys.argv[2])
 # Defensive parse: on a fresh federation any of these shell-assembled JSON
 # blobs may be malformed (see #96). Fall back to empty structures so the
 # dashboard still renders — the resulting history entry just has empty
 # `knowledge` / `confidence` fields for this tick.
-kc = _safe_json(sys.argv[3], {"total": 0})
-conf_vals = _safe_json(sys.argv[4], [])
-agent_map = _safe_json(sys.argv[5], [])
+kc = _safe_json(sys.argv[3], {"total": 0}, "knowledge_counts")
+conf_vals = _safe_json(sys.argv[4], [], "confidences")
+agent_map = _safe_json(sys.argv[5], [], "agent_colony_map")
 try:
     with open(path) as f:
         history = json.load(f)

--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -122,13 +122,16 @@ print(json.dumps(counts))
     local REMEDIATION
     REMEDIATION="$(agentis remediation history --limit 5 --json 2>/dev/null || echo '[]')"
 
-    # Confidence values
+    # Confidence values. `agentis memo get` on a missing key exits 0 with
+    # empty stdout (not non-zero), so `|| echo '0.0'` never fires — the
+    # shell substitution default on the next line is what actually catches
+    # a fresh federation where no memos have been written yet (#96).
     local CONFIDENCES=""
     for i in "${!ALL_AGENTS[@]}"; do
         local agent="${ALL_AGENTS[$i]}"
         local conf
-        conf="$(agentis memo get "${agent}:confidence" 2>/dev/null || echo '0.0')"
-        CONFIDENCES="${CONFIDENCES}${conf},"
+        conf="$(agentis memo get "${agent}:confidence" 2>/dev/null)"
+        CONFIDENCES="${CONFIDENCES}${conf:-0.0},"
     done
     CONFIDENCES="[${CONFIDENCES%,}]"
 
@@ -149,10 +152,19 @@ print(json.dumps(lines))
     # Append to history
     python3 - "$HISTORY_FILE" "$EPOCH" "$KNOWLEDGE_COUNTS" "$CONFIDENCES" "$AGENT_COLONY_MAP" <<'PY'
 import sys, json
+def _safe_json(s, default):
+    try:
+        return json.loads(s)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return default
 path, epoch = sys.argv[1], int(sys.argv[2])
-kc = json.loads(sys.argv[3])
-conf_vals = json.loads(sys.argv[4])
-agent_map = json.loads(sys.argv[5])
+# Defensive parse: on a fresh federation any of these shell-assembled JSON
+# blobs may be malformed (see #96). Fall back to empty structures so the
+# dashboard still renders — the resulting history entry just has empty
+# `knowledge` / `confidence` fields for this tick.
+kc = _safe_json(sys.argv[3], {"total": 0})
+conf_vals = _safe_json(sys.argv[4], [])
+agent_map = _safe_json(sys.argv[5], [])
 try:
     with open(path) as f:
         history = json.load(f)


### PR DESCRIPTION
## Summary

Two compounding bugs crashed `dashboard.sh` on a freshly installed federation before the first `start-federation.sh`:

1. **Shell-side root cause**: `agentis memo get <agent>:confidence` exits 0 with empty stdout on a missing key, so the `|| echo '0.0'` fallback never fires. The shell assembled `CONFIDENCES="[,,,,...]"` — valid array brackets around comma-separated empty strings — which is not valid JSON. Fix: use `${conf:-0.0}` parameter expansion which catches both unset and empty.
2. **Python-side defense**: `json.loads(sys.argv[3..5])` in the history-append heredoc had no try/except, while only the history file read was guarded. Introduce a small `_safe_json(s, default)` helper so a malformed argv degrades to empty structures instead of crashing `generate()`. The history entry ends up with empty `knowledge` / `confidence` fields for that tick, but `index.html` renders.

## E2E verification (the unchecked box from PR #95 is finally ticked)

```bash
mkdir -p /tmp/smoke/fed/colony1/agents /tmp/smoke/fed/colony2/agents
touch /tmp/smoke/fed/{colony1,colony2}/agents/agent_{a,b}.ag
cd /tmp/smoke && agentis init
timeout 6 bash tools/federation-dashboard.sh fed 18424
# Before this PR: crashes with JSONDecodeError, no index.html
# After this PR: index.html written, history.json written, HTTP server starts
```

Subsequent runs append valid entries to `history.json`:
```json
[
    {"t": 1776117534, "knowledge": {"colony1": 0, "colony2": 0, "total": 0},
     "confidence": {"colony1": 0.0, "colony2": 0.0}},
    {"t": 1776117644, ...}
]
```

## Test plan

- [x] `bash -n tools/federation-dashboard.sh` passes
- [x] Both embedded Python heredocs (history-append, PYSERVER) still `compile()` cleanly
- [x] E2E: fresh `agentis init`'d federation → `index.html` + `history.json` generated on first run
- [x] E2E: second dashboard run appends a well-formed entry to `history.json` (verified via `python3 -m json.tool`)
- [x] Countdown / refresh-btn markers from PR #95 still present in the rendered HTML

## Out of scope

- `agentis remediation history --json` returns `{"history":[],...}` while the shell fallback emits `[]` (mismatched shape). Separate display bug; not triggered by this PR's scenario.
- Rewriting shell-driven JSON assembly into a single Python pass. Real long-term fix but 10× the diff.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)