### PR TITLE
fix(dashboard): manual refresh regenerates HTML server-side (#98)

### DIFF
--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -93,6 +93,11 @@ generate() {
     TIMESTAMP="$(date '+%Y-%m-%d %H:%M:%S')"
     local EPOCH
     EPOCH="$(date '+%s')"
+    # Per-PID temp file so concurrent generate() invocations (60 s background
+    # loop + POST /refresh subprocess, see #98) don't stomp on each other or
+    # let a SimpleHTTPRequestHandler read a half-written index.html. Final
+    # `mv` below is atomic on the same filesystem.
+    local HTML_TMP="$HTML_FILE.tmp.$$"
 
     local DAEMONS
     DAEMONS="$(agentis daemon list --json 2>/dev/null || echo '[]')"
@@ -153,7 +158,7 @@ print(json.dumps(lines))
 
     # Append to history
     python3 - "$HISTORY_FILE" "$EPOCH" "$KNOWLEDGE_COUNTS" "$CONFIDENCES" "$AGENT_COLONY_MAP" <<'PY'
-import sys, json
+import sys, os, json
 def _safe_json(s, default, label):
     try:
         return json.loads(s)
@@ -190,8 +195,12 @@ entry = {"t": epoch, "knowledge": kc, "confidence": avg_conf}
 history.append(entry)
 cutoff = epoch - 7 * 86400
 history = [h for h in history if h["t"] > cutoff]
-with open(path, "w") as f:
+# Per-PID temp + os.replace: atomic on the same filesystem so concurrent
+# generate() writers don't leave a partially-written history.json readable.
+tmp = f"{path}.tmp.{os.getpid()}"
+with open(tmp, "w") as f:
     json.dump(history, f)
+os.replace(tmp, path)
 PY
 
     local HISTORY
@@ -368,7 +377,7 @@ HEADEOF
 </head>
 <body>
 HTMLEOF
-    } > "$HTML_FILE"
+    } > "$HTML_TMP"
 
     {
     cat <<HEADEREOF
@@ -694,7 +703,11 @@ function killSwitch() {
 </body>
 </html>
 JSEOF
-    } >> "$HTML_FILE"
+    } >> "$HTML_TMP"
+    # Atomic publish: mv(2) on the same filesystem replaces the inode in a
+    # single syscall, so any HTTP reader sees either the old or the new file
+    # in full — never a truncated-in-progress state.
+    mv "$HTML_TMP" "$HTML_FILE"
 }
 
 # --- Regen-only mode ---

--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -471,8 +471,14 @@ document.getElementById('clock').textContent = timestamp;
 function manualRefresh() {
   const btn = document.getElementById('refresh-btn');
   if (btn) btn.classList.add('spinning');
-  // Short delay so the spin is visible even on near-instant reloads.
-  setTimeout(() => location.reload(), 150);
+  // #98: ask the server to regenerate the static HTML snapshot before we
+  // reload. The background loop only runs every 60 s, so without this POST
+  // a manual refresh would just re-render the stale on-disk file. Errors
+  // are swallowed — reload anyway so the operator sees *something* rather
+  // than a wedged spinner.
+  fetch('/refresh', { method: 'POST' })
+    .catch(() => {})
+    .finally(() => location.reload());
 }
 
 document.addEventListener('keydown', (e) => {
@@ -691,6 +697,16 @@ JSEOF
     } >> "$HTML_FILE"
 }
 
+# --- Regen-only mode ---
+# When invoked by POST /refresh from the running dashboard server (see the
+# PYSERVER block below), re-execute generate and exit. The active server
+# process keeps serving; only the static HTML snapshot is refreshed.
+# Without this, manual refresh just reloads the stale on-disk HTML — see #98.
+if [ "${DASHBOARD_REGEN_ONLY:-0}" = "1" ]; then
+    generate
+    exit 0
+fi
+
 # --- Main ---
 
 echo "Starting web server on http://localhost:$PORT"
@@ -709,12 +725,14 @@ generate
 REGEN_PID=$!
 trap 'kill $REGEN_PID 2>/dev/null; exit 0' INT TERM
 
-# Serve with kill switch endpoint
-python3 - "$DASH_DIR" "$PORT" <<'PYSERVER'
+# Serve with kill switch + refresh endpoints. SCRIPT_PATH and FED_DIR are
+# passed through so POST /refresh can re-exec this script in regen-only mode.
+python3 - "$DASH_DIR" "$PORT" "$SCRIPT_PATH" "$FED_DIR" <<'PYSERVER'
 import sys, os, subprocess
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 
 serve_dir, port = sys.argv[1], int(sys.argv[2])
+script_path, fed_dir_arg = sys.argv[3], sys.argv[4]
 # serve_dir is $FED_DIR/.dashboard; the federation root (parent of serve_dir)
 # is the cwd we want agentis to resolve .agentis/ from. We still os.chdir to
 # serve_dir so SimpleHTTPRequestHandler serves index.html from here.
@@ -723,6 +741,37 @@ fed_dir = os.path.dirname(serve_dir)
 
 class Handler(SimpleHTTPRequestHandler):
     def do_POST(self):
+        if self.path == '/refresh':
+            # #98: regenerate the static HTML snapshot on operator request.
+            # The background loop only regenerates every 60 s; without this
+            # endpoint the ↻ button and `r` key just reload the stale file.
+            env = dict(os.environ)
+            env['DASHBOARD_REGEN_ONLY'] = '1'
+            try:
+                result = subprocess.run(
+                    ['bash', script_path, fed_dir_arg],
+                    capture_output=True, text=True,
+                    env=env,
+                    timeout=30,
+                )
+            except (OSError, subprocess.SubprocessError) as e:
+                self.send_response(500)
+                self.send_header('Content-Type', 'text/plain')
+                self.end_headers()
+                self.wfile.write(f'regen failed: {e}'.encode())
+                return
+            if result.returncode != 0:
+                self.send_response(500)
+                self.send_header('Content-Type', 'text/plain')
+                self.end_headers()
+                msg = (result.stderr or result.stdout or 'regen failed').strip()
+                self.wfile.write(msg.encode() or b'regen failed')
+                return
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'ok')
+            return
         if self.path == '/kill':
             # Run from fed_dir, not .dashboard. The actual fix for #91 is
             # the v1.1.7 walk-up in agentis_root() (Replikanti/agentis-core#499)


### PR DESCRIPTION
## Summary

Fixes #98. Manual refresh (↻ button + `r` key) now asks the server to regenerate `index.html` before reloading the page.

- Shell: `DASHBOARD_REGEN_ONLY=1` short-circuit — run `discover` + `generate`, exit 0, no server startup.
- Python server: new `POST /refresh` handler re-execs the script via `subprocess.run(['bash', SCRIPT_PATH, FED_DIR], env={'DASHBOARD_REGEN_ONLY':'1', ...})`, 30 s timeout, 200 on success / 500 on failure with stderr body.
- JS: `manualRefresh()` fetches `/refresh` before `location.reload()`. Errors are swallowed so the button never wedges.
- Concurrency (addressing review feedback in 451ea0e): `generate` now writes to `$HTML_FILE.tmp.$$` and `mv`s atomically; history append uses `{path}.tmp.{pid}` + `os.replace`. Readers never see a torn file.

The background 60 s loop is untouched — it still regenerates for passive viewers.

## Test plan

- [x] `bash -n` passes
- [x] Both Python heredocs (`PY`, `PYSERVER`) compile
- [x] E2E in `/tmp/smoke-98` (fresh federation, 2 colonies, 2 stub agents):
  - POST `/refresh` returns HTTP 200 body `ok`
  - `index.html` mtime advances on POST
  - `history.json` appends a new entry
- [x] Standalone `DASHBOARD_REGEN_ONLY=1 bash federation-dashboard.sh <fed>` runs to completion, writes HTML, appends history
- [x] `/kill` endpoint still works (regression): verified 200 `0 daemon(s) stopped\nNo running daemons to stop.` on empty fed in `/tmp/smoke-98c`
- [x] Concurrent stress: 5 parallel POST /refresh all 200, HTML stays valid (open+close tags, 23 KB), history.json parses with all entries, no `.tmp.*` leftovers
- [x] `/unknown` → 404, `GET /` → 200 (router unchanged)
- [ ] End-to-end browser verification (kill federation → refresh → dashboard reflects real state within seconds, not 60 s) — unchecked until independently browser-tested in a real browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)