### PR TITLE
docs(dev-apprenticeship): drop non-existent personal/project: tag framing (#99)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -208,12 +208,16 @@ Cross-colony wiring: Triage routes issues to Implementation. Implementation sign
 
 ## Knowledge portability
 
-Knowledge is tagged by scope: `personal` (your preferences, portable across projects) and `project:<name>` (codebase-specific, stays with the project).
+Every `learn()` call in the federation's agents tags entries with `observed` or `acted` plus the colony name (`triage`, `code-review`, `planning`, `implementation`, `release`). There is no built-in distinction between "your preferences" and "codebase-specific" knowledge — agents see the full GitLab project activity without any concept of who `you` are, so everything learned is effectively project-scoped.
+
+Bulk export/import is available at the runtime level and will carry all entries as-is:
 
 ```bash
-agentis knowledge export --tags personal > my-preferences.json   # carry to new project
-agentis knowledge import my-preferences.json --merge
+agentis knowledge export > fed-knowledge.json
+agentis knowledge import fed-knowledge.json --merge
 ```
+
+Filtering by `--tags acted` or `--tags <colony>` works (those are real tags the agents emit), but there is no `personal` or `project:<name>` tag today — if you try `--tags personal` you will get an empty array.
 
 ## Troubleshooting
 

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -208,7 +208,7 @@ Cross-colony wiring: Triage routes issues to Implementation. Implementation sign
 
 ## Knowledge portability
 
-Every `learn()` call in the federation's agents tags entries with `observed` or `acted` plus the colony name (`triage`, `code-review`, `planning`, `implementation`, `release`). There is no built-in distinction between "your preferences" and "codebase-specific" knowledge — agents see the full GitLab project activity without any concept of who `you` are, so everything learned is effectively project-scoped.
+Every `learn()` call in the federation's agents tags entries with one of `observed` (passive learning from GitLab activity), `emitted` (suggestion logged at confidence 0.6-0.84), or `acted` (autonomous action taken at ≥ 0.85) plus the colony name (`triage`, `code-review`, `planning`, `implementation`, `release`). There is no built-in distinction between "your preferences" and "codebase-specific" knowledge — agents see the full GitLab project activity without any concept of who `you` are, so everything learned is effectively project-scoped.
 
 Bulk export/import is available at the runtime level and will carry all entries as-is:
 
@@ -217,7 +217,7 @@ agentis knowledge export > fed-knowledge.json
 agentis knowledge import fed-knowledge.json --merge
 ```
 
-Filtering by `--tags acted` or `--tags <colony>` works (those are real tags the agents emit), but there is no `personal` or `project:<name>` tag today — if you try `--tags personal` you will get an empty array.
+Filtering by `--tags observed`, `--tags emitted`, `--tags acted`, or `--tags <colony>` works (those are real tags the agents emit), but there is no `personal` or `project:<name>` tag today — if you try `--tags personal` you will get an empty array.
 
 ## Troubleshooting
 

--- a/dev-apprenticeship/code-review/README.md
+++ b/dev-apprenticeship/code-review/README.md
@@ -94,9 +94,13 @@ After running for a while, inspect what the colony has learned:
 # List all knowledge entries
 agentis knowledge list
 
-# Export personal knowledge (portable to other projects)
-agentis knowledge export --tags personal > my-preferences.json
+# Filter by real tags this colony emits
+agentis knowledge list --tags code-review
+agentis knowledge list --tags acted         # entries from autonomous actions
+agentis knowledge list --tags emitted       # entries from suggestions
 
-# Import on a new project
-agentis knowledge import my-preferences.json --merge
+# Bulk export/import (carries every entry as-is — there is no
+# "personal" tag today, so --tags personal would return [])
+agentis knowledge export > review-knowledge.json
+agentis knowledge import review-knowledge.json --merge
 ```


### PR DESCRIPTION
## Summary

Fixes #99. The README promised `personal` and `project:<name>` knowledge tag scopes, but no agent ever emits those tags — every `learn()` call uses `[observed|acted, <colony>]`. The documented `agentis knowledge export --tags personal` command silently returns `[]`.

Rewrote the Knowledge portability section to describe the real tag scheme and note that:
- Bulk `export` / `import` work for all entries
- `--tags acted` / `--tags <colony>` are real, useful filters
- `--tags personal` returns `[]` today — there's no operator-identity concept

Option B from #99 (author-aware tagging) can follow as a separate issue/MR. This PR just stops the README from lying.

## Test plan

- [x] Claim verified: `grep -rn '"personal"\|"project:"' dev-apprenticeship/ tools/` returns no matches on `main`
- [x] Claim verified: `agentis knowledge export --tags personal` returns `[]`
- [x] Agents use `[observed|acted, <colony>]` tags (grep of `*/agents/*.ag` confirms)
- [ ] Independent read-through of the new wording — unchecked until reviewer confirms it's clear and doesn't introduce new false promises

🤖 Generated with [Claude Code](https://claude.com/claude-code)