### PR TITLE
docs(dev-apprenticeship): drop false auto-confidence claim (#100)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -4,7 +4,7 @@
 
 A federation of 21 agents that learns how you work by watching your GitLab activity. It observes how you triage issues, review merge requests, plan features, write code, and ship releases. Over time it takes over the mechanical parts, while you keep control over the decisions that matter.
 
-The federation starts silent. Agents only watch. As they build confidence from your patterns, you progressively unlock autonomy: first suggestions, then full automation. You can always veto.
+The federation starts silent. Agents only watch. As you see what they are learning in the logs and trust what they would do, you progressively unlock autonomy by raising each agent's confidence memo — first suggestions (≥ 0.6), then full automation (≥ 0.85). Agents do not promote themselves; the gradient is operator-controlled. You can always veto or demote.
 
 As knowledge accumulates, agents rely more on stored patterns and less on LLM inference. Early ticks are LLM-heavy (learning your style, generating summaries). Mature agents resolve most decisions from knowledge recall alone, falling back to the LLM only for novel situations.
 
@@ -192,7 +192,7 @@ You can always demote an agent back: `agentis memo set labeler:confidence 0.5`
 
 **Week 1-2**: Knowledge entries accumulate from your GitLab activity. Run `agentis knowledge list` to inspect.
 
-**After promotion**: Suggestions appear in logs (0.6) or directly on GitLab (0.85). Knowledge grows with every tick. Agents that predict correctly gain confidence. Stale knowledge decays. The system improves as long as you keep working on the project.
+**After promotion**: Suggestions appear in logs (0.6) or directly on GitLab (0.85). Knowledge keeps growing with every tick. Promotion is not automatic — no agent ever updates its own `<agent>:confidence` memo, so the observe → suggest → act transition happens exactly when you run `agentis memo set <agent>:confidence …`. The runtime does slowly decay the per-entry confidence score that `learn()` attaches to each knowledge row (`knowledge.confidence_decay_rate`, default 0.01/hr, floor `knowledge.confidence_decay_min` 0.05), which is a separate dial from the per-agent promotion level you control — it affects how much weight an old entry carries inside an agent, not which behavior gradient the agent is running at.
 
 ## Colonies
 

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -192,7 +192,7 @@ You can always demote an agent back: `agentis memo set labeler:confidence 0.5`
 
 **Week 1-2**: Knowledge entries accumulate from your GitLab activity. Run `agentis knowledge list` to inspect.
 
-**After promotion**: Suggestions appear in logs (0.6) or directly on GitLab (0.85). Knowledge keeps growing with every tick. Promotion is not automatic — no agent ever updates its own `<agent>:confidence` memo, so the observe → suggest → act transition happens exactly when you run `agentis memo set <agent>:confidence …`. The runtime does slowly decay the per-entry confidence score that `learn()` attaches to each knowledge row (`knowledge.confidence_decay_rate`, default 0.01/hr, floor `knowledge.confidence_decay_min` 0.05), which is a separate dial from the per-agent promotion level you control — it affects how much weight an old entry carries inside an agent, not which behavior gradient the agent is running at.
+**After promotion**: Suggestions appear in logs (0.6) or directly on GitLab (0.85). Knowledge keeps growing with every tick. Promotion is not automatic — no agent ever updates its own `<agent>:confidence` memo, so the observe → suggest → act transition happens exactly when you run `agentis memo set <agent>:confidence …`. The runtime does slowly decay the per-entry confidence score that `learn()` attaches to each unvalidated knowledge row (`knowledge.confidence_decay_rate`, default 0.01/hr, floor `knowledge.confidence_decay_min` 0.05; validated entries are left alone), which is a separate dial from the per-agent promotion level you control — it affects how much weight an old entry carries inside an agent, not which behavior gradient the agent is running at.
 
 ## Colonies
 


### PR DESCRIPTION
## Summary

Fixes #100. The README promised agents would "build confidence from your patterns" and "predict correctly [to] gain confidence". In reality no `.ag` file ever writes to `<agent>:confidence` — confirmed by `grep -rn memo_write.*confidence dev-apprenticeship/*/agents/*.ag` returning zero matches. The gradient only moves when the operator runs `agentis memo set`.

Also corrected the sister claim "Stale knowledge decays": there IS runtime-side decay via `ConfidenceDecayEngine` (wired at the daemon level, default `knowledge.confidence_decay_rate=0.01/hr`, floor 0.05), but it decays *per-entry* confidence scores inside the knowledge base — not the per-agent promotion memo. Old wording conflated the two.

Two paragraphs changed:
- Top-of-README intro: "As they build confidence…" → "As you see what they are learning in the logs…"
- "After promotion" bullet: dropped "Agents that predict correctly gain confidence. Stale knowledge decays." and replaced with accurate description of both dials.

## Test plan

- [x] Claim verified: `grep -rn "memo_write.*confidence" dev-apprenticeship/*/agents/*.ag` returns no matches on `main`
- [x] Every agent only *reads* via `get_confidence()` (shown by grep in branch setup)
- [x] Runtime-side decay claim: `src/experience/knowledge.rs` defines `ConfidenceDecayEngine`; `src/daemon/config.rs:666-673` reads `knowledge.confidence_decay_rate` (default 0.01) and `knowledge.confidence_decay_min` (default 0.05); `src/cli/daemon.rs:1139-1143` wires it into the evaluator
- [ ] Independent read-through of the new wording — unchecked until reviewer confirms it's accurate and doesn't introduce new false promises

🤖 Generated with [Claude Code](https://claude.com/claude-code)