### PR TITLE
fix(dev-apprenticeship): pin agentis >= v1.1.8 + write #107 defaults

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -1,6 +1,6 @@
 # Dev Apprenticeship
 
-![Agentis >= v1.1.7](https://img.shields.io/badge/agentis-%3E%3D%20v1.1.7-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
+![Agentis >= v1.1.8](https://img.shields.io/badge/agentis-%3E%3D%20v1.1.8-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
 
 A federation of 21 agents that learns how you work by watching your GitLab activity. It observes how you triage issues, review merge requests, plan features, write code, and ship releases. Over time it takes over the mechanical parts, while you keep control over the decisions that matter.
 
@@ -35,7 +35,7 @@ graph LR
 
 ## What you need
 
-- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.1.7**
+- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.1.8**
 - An LLM backend (Claude CLI, Ollama, or any OpenAI-compatible API)
 - GitLab instance with API access (personal access token with `api` scope)
 - Python 3 and git

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -19,7 +19,7 @@ ALL_AGENTS=(
     code_writer test_writer refactorer commit_composer
     ship_decider changelog_writer version_bumper release_checker
 )
-MIN_VERSION="1.1.7"
+MIN_VERSION="1.1.8"
 
 # --- Helpers ---
 
@@ -70,13 +70,18 @@ fi
 # v1.1.7 then fixed #499 (agentis_root walk-up), without which the watchdog
 # silently falls back to a 2000 ms heartbeat timeout and kills any agent
 # whose prompts take longer — on a cold Claude CLI that is every agent.
-# Older builds either fail with `capability denied: exec_foreign`, never
-# receive emit/listen, or get killed by the watchdog every tick.
+# v1.1.8 made the daemon honor `pii_transmit = allow` from config and
+# added `exec.default_timeout_ms`; before that, the federation could not
+# complete a single tick on any real GitLab project (issue #107) because
+# every prompt containing author emails was denied and every curl past
+# 10 s timed out. Older builds either fail with `capability denied:
+# exec_foreign`, never receive emit/listen, get killed by the watchdog
+# every tick, or fail every single tick on PII + ExecTimeout.
 AGENTIS_VERSION=$(agentis --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
 info "agentis version: $AGENTIS_VERSION (minimum: $MIN_VERSION)"
 
 if ! version_gte "$AGENTIS_VERSION" "$MIN_VERSION"; then
-    fail "agentis >= $MIN_VERSION required (--enable-exec/--enable-messaging flags, #492 quarantine fix, #499 watchdog heartbeat fix). Please update."
+    fail "agentis >= $MIN_VERSION required (--enable-exec/--enable-messaging flags, #492 quarantine fix, #499 watchdog heartbeat fix, #107 daemon PII grant + exec.default_timeout_ms). Please update."
     exit 1
 fi
 
@@ -213,6 +218,21 @@ if [ -d "$AGENTIS_DIR" ]; then
     #                                 paths) and GITLAB_* (so gitlab-api.sh
     #                                 authenticates against the instance
     #                                 configured by start-colony.sh).
+    #   exec.default_timeout_ms     — gitlab-api.sh calls curl with
+    #                                 `--max-time 30`. The agentis-default
+    #                                 10 s `exec sh` timeout preempts
+    #                                 curl mid-response on real projects
+    #                                 (issue #107). 45 s gives curl its
+    #                                 30 s budget plus 15 s of process
+    #                                 spawn/JSON-parse headroom.
+    #   pii_transmit                — GitLab API payloads always contain
+    #                                 author/assignee emails and phone-
+    #                                 shaped numbers in descriptions.
+    #                                 Without this grant the PII guard
+    #                                 denies every prompt() on the first
+    #                                 tick and the federation never makes
+    #                                 progress. Only honored by the daemon
+    #                                 path from agentis v1.1.8 onward.
     AGENTIS_CONFIG="$AGENTIS_DIR/config"
     # Agentis init should have created this; create it explicitly so the
     # key-writing below is not silently skipped if init was interrupted.
@@ -248,6 +268,8 @@ if [ -d "$AGENTIS_DIR" ]; then
     write_key 'daemon.cb_per_tick'           '2000'
     write_key 'experience.enabled'           'true'
     write_key 'exec.env_passthrough'         'COLONY_DIR,GITLAB_*'
+    write_key 'exec.default_timeout_ms'      '45000'
+    write_key 'pii_transmit'                 'allow'
 fi
 
 # Create per-colony .agentis symlinks so commands run from a colony dir


### PR DESCRIPTION
## Summary

- Bumps `MIN_VERSION` in `dev-apprenticeship/install.sh` from `1.1.7` to `1.1.8` and updates the README badge / requirement line accordingly.
- Adds two new `write_key` calls so fresh installs get the two config keys that Replikanti/agentis-core v1.1.8 introduced for #107:
  - `exec.default_timeout_ms = 45000` — gitlab-api.sh calls `curl --max-time 30`; the daemon-default 10s `exec sh` timeout was preempting curl mid-response on real projects. 45s gives curl its 30s budget plus 15s of process spawn / JSON-parse headroom.
  - `pii_transmit = allow` — GitLab API payloads always contain author / assignee emails (and phone-shaped numbers in descriptions). Without this grant the PII guard denied every `prompt()` on the first tick. v1.1.8 is the first release where the daemon path actually honors the config key.
- Updates the long version-check comment to document why v1.1.8 is the new floor.

## Why now

Without this commit, even on agentis v1.1.8 a fresh `./install.sh` would still produce a federation that fails every tick on a real GitLab project — the runtime fix shipped in core, but operators would never write the new keys. Closes the loop on the issue.

Fixes Replikanti/agentis-colonies#107

## Test plan

- [ ] `./install.sh` on a fresh checkout writes both new keys into `.agentis/config`.
- [ ] Re-running `./install.sh` is still idempotent (does not duplicate the keys).
- [ ] Version gate rejects agentis < 1.1.8 with the updated error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)