### PR TITLE
fix(dev-apprenticeship): tighten prompts to reject markdown-wrapped JSON

### DIFF
--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -61,7 +61,7 @@ fn tick(reason: string) -> void {
     let all_findings = "Style findings: " + style_str + "\nLogic findings: " + logic_str + "\nSecurity findings: " + security_str + "\nTest findings: " + tests_str + "\nPast approval patterns: " + to_string(rec);
 
     let decision = prompt(
-        "You are the approval decider. Based on findings from style, logic, security, and test reviewers, decide the review outcome. Rules: any critical security finding = request changes. Multiple high-severity logic findings = request changes. Style-only findings = approve with comments. No findings = approve. Return JSON: mr_iid (int, from the findings), action (string: 'approve', 'request_changes', or 'escalate'), reasoning (string), critical_count (int), total_findings (int).",
+        "You are the approval decider. Based on findings from style, logic, security, and test reviewers, decide the review outcome. Rules: any critical security finding = request changes. Multiple high-severity logic findings = request changes. Style-only findings = approve with comments. No findings = approve. Return JSON: mr_iid (int, from the findings), action (string: 'approve', 'request_changes', or 'escalate'), reasoning (string), critical_count (int), total_findings (int). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
         all_findings
     ) -> ReviewDecision;
 

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -51,7 +51,7 @@ fn tick(reason: string) -> void {
     };
 
     let mr_ids = prompt(
-        "Extract all merge request IIDs from this GitLab JSON array. Only opened MRs. Return JSON array of integers.",
+        "Extract all merge request IIDs from this GitLab JSON array. Only opened MRs. Return ONLY a raw JSON array of integers — no markdown code fences, no ```json wrapper, no prose. Just the array.",
         raw
     ) -> list<int>;
 
@@ -85,7 +85,7 @@ fn tick(reason: string) -> void {
     let context = "MR diff:\n" + changes_raw + "\n\nLearned patterns: " + to_string(rec);
 
     let review = prompt(
-        "You are a logic reviewer. Analyze this merge request diff for logic bugs: off-by-one errors, null/nil dereferences, unhandled edge cases, race conditions, incorrect boundary checks, resource leaks, wrong operator usage. Focus only on correctness, not style. Return JSON: mr_iid (int), findings (array with file, issue, severity, explanation), summary (string). If clean, return empty findings.",
+        "You are a logic reviewer. Analyze this merge request diff for logic bugs: off-by-one errors, null/nil dereferences, unhandled edge cases, race conditions, incorrect boundary checks, resource leaks, wrong operator usage. Focus only on correctness, not style. Return JSON: mr_iid (int), findings (array with file, issue, severity, explanation), summary (string). If clean, return empty findings. Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
         context
     ) -> LogicReview;
 

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -52,7 +52,7 @@ fn tick(reason: string) -> void {
     };
 
     let mr_ids = prompt(
-        "Extract all merge request IIDs from this GitLab JSON array. Only opened MRs. Return JSON array of integers.",
+        "Extract all merge request IIDs from this GitLab JSON array. Only opened MRs. Return ONLY a raw JSON array of integers — no markdown code fences, no ```json wrapper, no prose. Just the array.",
         raw
     ) -> list<int>;
 
@@ -86,7 +86,7 @@ fn tick(reason: string) -> void {
     let context = "MR diff:\n" + changes_raw + "\n\nLearned patterns: " + to_string(rec);
 
     let review = prompt(
-        "You are a security reviewer. Analyze this merge request diff for security vulnerabilities: SQL/command injection, XSS, CSRF, hardcoded secrets, insecure auth, path traversal, SSRF, insecure deserialization, dependency issues. Include CWE IDs where applicable. Return JSON: mr_iid (int), findings (array with file, issue, severity, cwe, remediation), summary (string). If clean, return empty findings.",
+        "You are a security reviewer. Analyze this merge request diff for security vulnerabilities: SQL/command injection, XSS, CSRF, hardcoded secrets, insecure auth, path traversal, SSRF, insecure deserialization, dependency issues. Include CWE IDs where applicable. Return JSON: mr_iid (int), findings (array with file, issue, severity, cwe, remediation), summary (string). If clean, return empty findings. Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
         context
     ) -> SecurityReview;
 

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -52,7 +52,7 @@ fn tick(reason: string) -> void {
 
     // Find MRs to review
     let mr_ids = prompt(
-        "Extract all merge request IIDs from this GitLab JSON array. Return a JSON array of integers. Only include MRs in 'opened' state. If empty, return [].",
+        "Extract all merge request IIDs from this GitLab JSON array. Only include MRs in 'opened' state. If empty, return []. Return ONLY a raw JSON array of integers — no markdown code fences, no ```json wrapper, no prose. Just the array.",
         raw
     ) -> list<int>;
 
@@ -88,7 +88,7 @@ fn tick(reason: string) -> void {
     let context = "MR diff:\n" + changes_raw + "\n\nLearned preferences: " + to_string(rec);
 
     let review = prompt(
-        "You are a style reviewer. Analyze this merge request diff for style issues: naming conventions, formatting, import ordering, whitespace, code organization. Return JSON: mr_iid (int), findings (array of objects with file, issue, severity, suggestion), summary (string). Only flag real style issues, not logic or security. If clean, return empty findings array.",
+        "You are a style reviewer. Analyze this merge request diff for style issues: naming conventions, formatting, import ordering, whitespace, code organization. Return JSON: mr_iid (int), findings (array of objects with file, issue, severity, suggestion), summary (string). Only flag real style issues, not logic or security. If clean, return empty findings array. Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
         context
     ) -> StyleReview;
 

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -51,7 +51,7 @@ fn tick(reason: string) -> void {
     };
 
     let mr_ids = prompt(
-        "Extract all merge request IIDs from this GitLab JSON array. Only opened MRs. Return JSON array of integers.",
+        "Extract all merge request IIDs from this GitLab JSON array. Only opened MRs. Return ONLY a raw JSON array of integers — no markdown code fences, no ```json wrapper, no prose. Just the array.",
         raw
     ) -> list<int>;
 
@@ -85,7 +85,7 @@ fn tick(reason: string) -> void {
     let context = "MR diff:\n" + changes_raw + "\n\nLearned patterns: " + to_string(rec);
 
     let review = prompt(
-        "You are a test reviewer. Analyze this merge request diff for test quality: missing tests for new code, untested edge cases, weak assertions (only checking happy path), missing error path tests, test duplication, flaky patterns (timing, ordering). Return JSON: mr_iid (int), findings (array with file, issue, severity, suggestion), summary (string). If tests are adequate, return empty findings.",
+        "You are a test reviewer. Analyze this merge request diff for test quality: missing tests for new code, untested edge cases, weak assertions (only checking happy path), missing error path tests, test duplication, flaky patterns (timing, ordering). Return JSON: mr_iid (int), findings (array with file, issue, severity, suggestion), summary (string). If tests are adequate, return empty findings. Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
         context
     ) -> TestReview;
 

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -52,7 +52,7 @@ fn tick(reason: string) -> void {
 
     if len(raw) > 10 {
         let mr_ids = prompt(
-            "Extract all merge request IIDs from this GitLab JSON array. Return JSON array of integers.",
+            "Extract all merge request IIDs from this GitLab JSON array. Return ONLY a raw JSON array of integers — no markdown code fences, no ```json wrapper, no prose. Just the array.",
             raw
         ) -> list<int>;
 
@@ -63,7 +63,7 @@ fn tick(reason: string) -> void {
 
             if len(changes_raw) > 10 {
                 let patterns = prompt(
-                    "Analyze this MR diff JSON. Identify: naming conventions (variable/function names, casing), code structure (module organization, import style), error handling patterns (try/catch, Result types, guard clauses). Return JSON: mr_count (int, always 1), naming (string), structure (string), error_handling (string).",
+                    "Analyze this MR diff JSON. Identify: naming conventions (variable/function names, casing), code structure (module organization, import style), error handling patterns (try/catch, Result types, guard clauses). Return JSON: mr_count (int, always 1), naming (string), structure (string), error_handling (string). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
                     changes_raw
                 ) -> CodePatterns;
 
@@ -93,7 +93,7 @@ fn tick(reason: string) -> void {
         let context = "Assigned issues: " + issues_raw + "\nLearned code patterns: " + to_string(rec);
 
         let draft = prompt(
-            "You are a code writer agent. Pick the highest-priority assigned issue and draft an implementation plan. Propose a branch name (kebab-case, prefixed with feat/ or fix/), list the files to create or modify with brief descriptions, and summarize the approach. Return JSON: issue_id (int), branch_name (string), files (string, markdown list of file paths and what each does), summary (string, 2-3 sentences), confidence (float 0-1).",
+            "You are a code writer agent. Pick the highest-priority assigned issue and draft an implementation plan. Propose a branch name (kebab-case, prefixed with feat/ or fix/), list the files to create or modify with brief descriptions, and summarize the approach. Return JSON: issue_id (int), branch_name (string), files (string, markdown list of file paths and what each does), summary (string, 2-3 sentences), confidence (float 0-1). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
             context
         ) -> CodeDraft;
 

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -54,7 +54,7 @@ fn tick(reason: string) -> void {
 
     if len(raw) > 10 {
         let mr_ids = prompt(
-            "Extract all merge request IIDs from this GitLab JSON array. Return JSON array of integers.",
+            "Extract all merge request IIDs from this GitLab JSON array. Return ONLY a raw JSON array of integers — no markdown code fences, no ```json wrapper, no prose. Just the array.",
             raw
         ) -> list<int>;
 
@@ -65,7 +65,7 @@ fn tick(reason: string) -> void {
 
             if len(commits_raw) > 10 {
                 let style = prompt(
-                    "Analyze these commit messages from a merged MR. Identify: how many commits (commits_seen), message format (conventional commits, imperative mood, ticket references), change grouping strategy (one big commit, logical splits, separate refactoring commits), common prefixes (feat:, fix:, chore:, refactor:). Return JSON: commits_seen (int), format (string), grouping (string), prefixes (string).",
+                    "Analyze these commit messages from a merged MR. Identify: how many commits (commits_seen), message format (conventional commits, imperative mood, ticket references), change grouping strategy (one big commit, logical splits, separate refactoring commits), common prefixes (feat:, fix:, chore:, refactor:). Return JSON: commits_seen (int), format (string), grouping (string), prefixes (string). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
                     commits_raw
                 ) -> CommitStyle;
 
@@ -108,7 +108,7 @@ fn tick(reason: string) -> void {
     let context = all_input + "\nLearned commit conventions: " + to_string(rec);
 
     let plan = prompt(
-        "You are a commit composer agent. You received a code draft, possibly tests, and possibly refactoring suggestions for an issue. Compose a structured commit plan following learned conventions. Decide how to split changes into commits (code, tests, refactoring as separate commits or combined, based on learned grouping style). Write commit messages in the learned format. Propose an MR title and description. Return JSON: issue_id (int), branch_name (string, from the code draft), commits (string, markdown numbered list of commit messages), mr_title (string), mr_description (string, brief summary), confidence (float 0-1).",
+        "You are a commit composer agent. You received a code draft, possibly tests, and possibly refactoring suggestions for an issue. Compose a structured commit plan following learned conventions. Decide how to split changes into commits (code, tests, refactoring as separate commits or combined, based on learned grouping style). Write commit messages in the learned format. Propose an MR title and description. Return JSON: issue_id (int), branch_name (string, from the code draft), commits (string, markdown numbered list of commit messages), mr_title (string), mr_description (string, brief summary), confidence (float 0-1). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
         context
     ) -> MRPlan;
 

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -50,7 +50,7 @@ fn tick(reason: string) -> void {
 
     if len(raw) > 10 {
         let mr_ids = prompt(
-            "Extract all merge request IIDs from this GitLab JSON array. Return JSON array of integers.",
+            "Extract all merge request IIDs from this GitLab JSON array. Return ONLY a raw JSON array of integers — no markdown code fences, no ```json wrapper, no prose. Just the array.",
             raw
         ) -> list<int>;
 
@@ -64,7 +64,7 @@ fn tick(reason: string) -> void {
                 let commits_raw = try { exec sh commits_cmd; } catch e { "[]"; };
 
                 let patterns = prompt(
-                    "Analyze this MR diff and commit messages. Identify refactoring activity: code smells that were fixed (duplication, long methods, dead code, naming), techniques used (extract method, inline variable, move to module, simplify conditional). If the MR is purely new features with no refactoring, set refactor_mrs to 0. Return JSON: refactor_mrs (int, 0 or 1), smells_fixed (string), techniques (string).",
+                    "Analyze this MR diff and commit messages. Identify refactoring activity: code smells that were fixed (duplication, long methods, dead code, naming), techniques used (extract method, inline variable, move to module, simplify conditional). If the MR is purely new features with no refactoring, set refactor_mrs to 0. Return JSON: refactor_mrs (int, 0 or 1), smells_fixed (string), techniques (string). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
                     changes_raw + "\n\nCommit messages: " + commits_raw
                 ) -> RefactorPatterns;
 
@@ -91,7 +91,7 @@ fn tick(reason: string) -> void {
         let context = "Code draft to review: " + draft_str + "\nLearned refactoring patterns: " + to_string(rec);
 
         let suggestion = prompt(
-            "You are a refactoring agent. A code draft has been produced for an issue. Review it against learned refactoring patterns and suggest improvements. Focus on: naming consistency, duplication, overly complex conditionals, missing error handling, extract/inline opportunities. Return JSON: issue_id (int, from the draft), suggestions (string, markdown list of specific improvements), priority (string, 'high' if structural issues or 'low' if cosmetic only), confidence (float 0-1).",
+            "You are a refactoring agent. A code draft has been produced for an issue. Review it against learned refactoring patterns and suggest improvements. Focus on: naming consistency, duplication, overly complex conditionals, missing error handling, extract/inline opportunities. Return JSON: issue_id (int, from the draft), suggestions (string, markdown list of specific improvements), priority (string, 'high' if structural issues or 'low' if cosmetic only), confidence (float 0-1). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
             context
         ) -> RefactorSuggestion;
 

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -52,7 +52,7 @@ fn tick(reason: string) -> void {
 
     if len(raw) > 10 {
         let mr_ids = prompt(
-            "Extract all merge request IIDs from this GitLab JSON array. Return JSON array of integers.",
+            "Extract all merge request IIDs from this GitLab JSON array. Return ONLY a raw JSON array of integers — no markdown code fences, no ```json wrapper, no prose. Just the array.",
             raw
         ) -> list<int>;
 
@@ -63,7 +63,7 @@ fn tick(reason: string) -> void {
 
             if len(changes_raw) > 10 {
                 let patterns = prompt(
-                    "Analyze this MR diff JSON. Focus only on test files (files matching *_test.*, test_*, tests/, spec/). Identify: how many test files were changed (test_files_seen), test structure (describe/it, test functions, test classes), assertion style (assert, expect, should), fixture patterns (setup/teardown, before/after, test helpers). If no test files in this diff, set test_files_seen to 0. Return JSON: test_files_seen (int), structure (string), assertion_style (string), fixture_patterns (string).",
+                    "Analyze this MR diff JSON. Focus only on test files (files matching *_test.*, test_*, tests/, spec/). Identify: how many test files were changed (test_files_seen), test structure (describe/it, test functions, test classes), assertion style (assert, expect, should), fixture patterns (setup/teardown, before/after, test helpers). If no test files in this diff, set test_files_seen to 0. Return JSON: test_files_seen (int), structure (string), assertion_style (string), fixture_patterns (string). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
                     changes_raw
                 ) -> TestPatterns;
 
@@ -90,7 +90,7 @@ fn tick(reason: string) -> void {
         let context = "Code draft: " + draft_str + "\nLearned test patterns: " + to_string(rec);
 
         let tests = prompt(
-            "You are a test writer agent. A code draft has been produced for an issue. Generate matching tests that follow the learned test patterns (structure, assertion style, fixtures). Return JSON: issue_id (int, from the draft), branch_name (string, same branch as the draft), test_files (string, markdown list of test file paths with brief description of what each tests), summary (string), confidence (float 0-1).",
+            "You are a test writer agent. A code draft has been produced for an issue. Generate matching tests that follow the learned test patterns (structure, assertion style, fixtures). Return JSON: issue_id (int, from the draft), branch_name (string, same branch as the draft), test_files (string, markdown list of test file paths with brief description of what each tests), summary (string), confidence (float 0-1). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
             context
         ) -> TestDraft;
 


### PR DESCRIPTION
## Summary

Claude (via `llm.backend = cli`) frequently wraps JSON output in markdown code fences instead of the bare array/object the prompt requests. The agentis runtime's response decoder then sees a string where `-> list<int>` (or `-> <SomeStruct>`) expects a JSON array/object, and aborts the tick with:

```
type error: expected list or map, got string
```

Every subsequent tick re-issues the same prompt and gets the same wrapped-JSON, so the loop is permanent. On a real GitLab project this breaks **9/21 agents** — all 5 code-review agents (`style_reviewer`, `logic_reviewer`, `security_reviewer`, `test_reviewer`, `approval_decider`) and all 4 implementation agents (`code_writer`, `test_writer`, `refactorer`, `commit_composer`). Those colonies are entirely dead.

## What this changes

Appends an explicit anti-markdown directive to every prompt in those 9 files whose `-> T` is a list or struct type:

> "Return ONLY a raw JSON array/object — no markdown code fences, no \`\`\`json wrapper, no prose. Just the &lt;shape&gt;."

**21 sites across 9 files.** Each file:
- 1× `-> list<int>` (GitLab MR IID extraction)
- 1-2× `-> <SomeStruct>` (pattern analysis / review JSON)

No prompt returning `-> string`, `-> float`, or `-> int` is touched — those types parse fine even when wrapped in markdown, and the `"Return this number as a decimal. Nothing else."` sites are already explicit.

## Why this repo, not agentis-core

This is Option A from the issue — agent-side, shippable today, no upstream dependency. Option B (agentis-core strips markdown fences before decoding, which would fix every `.ag` program in the wild) is a real product change that deserves its own design discussion and doesn't have to block this.

Fixes Replikanti/agentis-colonies#109

## Test plan

- [ ] `agentis commit` parses all 9 edited files (verified locally — both representative files parsed clean).
- [ ] On a real GitLab project with ≥ 1 opened MR, code-review and implementation agents complete at least one tick without the `expected list or map, got string` error.
- [ ] No regression in the 12 agents not touched by this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)