### PR TITLE
fix(dev-apprenticeship): operational-readiness bundle (#116, #118)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -186,6 +186,20 @@ agentis memo set labeler:confidence 0.85
 
 You can always demote an agent back: `agentis memo set labeler:confidence 0.5`
 
+## Security
+
+Your GitLab personal access token is stored in plaintext in 5 files:
+
+```
+<colony>/config/colony.toml     # token = "glpat-..."
+```
+
+`install.sh` sets these to mode 0600 (owner-only). If you move a federation directory to a multi-user system or copy configs manually, re-run `chmod 600 <colony>/config/colony.toml` on each.
+
+Rotate tokens periodically via GitLab (User Settings -> Access Tokens). Re-run `./install.sh` and answer `Y` to the "Update GitLab credentials" prompt — it accepts a new token without rewriting the colony templates.
+
+Out-of-scope (not implemented): integration with a system secret store (Secret Service, macOS Keychain, `pass`). If you need that today, replace `token = "..."` with a reference your shell evaluates before starting the federation.
+
 ## What to expect
 
 **Day 1**: Nothing visible. Agents are silent at 0.5. Check `agentis daemon list` and logs to confirm they are polling.
@@ -231,7 +245,9 @@ Filtering by `--tags observed`, `--tags emitted`, `--tags acted`, or `--tags <co
 
 **Agents not learning**: Run `agentis knowledge list`. If empty after several ticks, verify the GitLab project has recent activity.
 
-**Log growth**: Logs go to `.agentis/logs/<agent>.log` with no built-in rotation. Volume is low (a few lines per tick per agent), but with 21 agents running continuously you should set up `logrotate` or equivalent.
+**Log growth**: Logs go to `.agentis/logs/<agent>.log` with no built-in rotation. Volume is low (a few lines per tick per agent), but with 21 agents running continuously and occasional error loops (e.g. a bad GitLab token causing one log line per retry × 6 retries × per tick) individual logs can reach tens of megabytes per day. A sample logrotate config lives at `ops/logrotate.conf` — copy it into `/etc/logrotate.d/` (requires sudo) and adjust the path to your federation root, or adapt it for a user-level cron if you prefer not to touch system logrotate.
+
+As a zero-config fallback, `start-federation.sh` can be asked to truncate logs on start by setting `TRUNCATE_LOGS=1` in the environment. This keeps disk usage bounded between manual restarts but loses history — use logrotate for long-running federations.
 
 ## Extension points
 

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -52,6 +52,21 @@ AGENTS=(
     approval_decider
 )
 
+# Opt-in log truncation. Off by default so operators who rely on log
+# history across restarts are not surprised. Set TRUNCATE_LOGS=1 in
+# the environment (or via start-federation.sh) to bound disk use
+# between manual restarts. Real log rotation should use the
+# logrotate.conf sample in ops/ instead; this is the zero-config
+# fallback for laptops that do not have logrotate configured.
+if [ "${TRUNCATE_LOGS:-0}" = "1" ]; then
+    AGENTIS_LOGS="$REPO_ROOT/dev-apprenticeship/.agentis/logs"
+    if [ -d "$AGENTIS_LOGS" ]; then
+        for agent in "${AGENTS[@]}"; do
+            : > "$AGENTIS_LOGS/${agent}.log" 2>/dev/null || true
+        done
+    fi
+fi
+
 cd "$COLONY_DIR"
 
 # Note: LLM backend is read by agentis daemon from the llm.backend key in

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -51,6 +51,21 @@ AGENTS=(
     commit_composer
 )
 
+# Opt-in log truncation. Off by default so operators who rely on log
+# history across restarts are not surprised. Set TRUNCATE_LOGS=1 in
+# the environment (or via start-federation.sh) to bound disk use
+# between manual restarts. Real log rotation should use the
+# logrotate.conf sample in ops/ instead; this is the zero-config
+# fallback for laptops that do not have logrotate configured.
+if [ "${TRUNCATE_LOGS:-0}" = "1" ]; then
+    AGENTIS_LOGS="$REPO_ROOT/dev-apprenticeship/.agentis/logs"
+    if [ -d "$AGENTIS_LOGS" ]; then
+        for agent in "${AGENTS[@]}"; do
+            : > "$AGENTIS_LOGS/${agent}.log" 2>/dev/null || true
+        done
+    fi
+fi
+
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -168,15 +168,23 @@ if [ "$CONFIGS_EXISTED" -eq 5 ]; then
 fi
 
 if [ "$WRITE_CREDS" -eq 1 ]; then
+    # URL char class includes `_` because corporate self-hosted DNS
+    # routinely uses underscores in hostnames (RFC-noncompliant but
+    # widespread) — rejecting them was a regression in PR #122 v1.
     prompt_validated GITLAB_URL \
         "GitLab URL (e.g. https://gitlab.com):" \
-        '^https?://[A-Za-z0-9.-]+(:[0-9]+)?(/.*)?$' \
+        '^https?://[A-Za-z0-9._-]+(:[0-9]+)?(/.*)?$' \
         "Must start with http:// or https://"
 
+    # Project regex accepts group/project AND subgroup nesting
+    # (group/subgroup/.../project) because GitLab Premium lets you
+    # nest groups and start-colony.sh already URL-encodes the whole
+    # path to %2F before calling the API. The earlier "exactly two
+    # segments" form in PR #122 v1 rejected valid GitLab paths.
     prompt_validated GITLAB_PROJECT \
-        "GitLab project path (e.g. my-org/my-project):" \
-        '^[^/[:space:]]+/[^/[:space:]]+$' \
-        "Must be exactly two segments separated by /, no extra slashes or spaces."
+        "GitLab project path (e.g. my-org/my-project or group/subgroup/project):" \
+        '^[^/[:space:]]+(/[^/[:space:]]+)+$' \
+        "Must be at least group/project, segments separated by / with no whitespace or empty segments."
 
     prompt_validated GITLAB_TOKEN \
         "GitLab personal access token (glpat-...):" \

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -28,6 +28,31 @@ ok()    { printf '  [ok] %s\n' "$*"; }
 fail()  { printf '  [!!] %s\n' "$*"; }
 ask()   { printf '\n  %s ' "$1"; }
 
+# Read a prompt line, validate against a regex, re-prompt on failure.
+# Usage: prompt_validated VAR_NAME "Prompt:" '^regex$' "hint shown on reject" [--secret]
+prompt_validated() {
+    local __var="$1" __prompt="$2" __re="$3" __hint="$4" __secret="$5"
+    local __val
+    while true; do
+        ask "$__prompt"
+        if [ "$__secret" = "--secret" ]; then
+            read -rs __val
+            echo ""
+        else
+            read -r __val
+        fi
+        if [ -z "$__val" ]; then
+            fail "Value is required. $__hint"
+            continue
+        fi
+        if [[ "$__val" =~ $__re ]]; then
+            printf -v "$__var" '%s' "$__val"
+            return 0
+        fi
+        fail "Invalid format. $__hint"
+    done
+}
+
 check_cmd() {
     if command -v "$1" >/dev/null 2>&1; then
         ok "$1 found ($(command -v "$1"))"
@@ -123,26 +148,49 @@ echo "GitLab configuration"
 echo "All 5 colonies connect to the same GitLab project."
 echo ""
 
-ask "GitLab URL (e.g. https://gitlab.com):"
-read -r GITLAB_URL
-ask "GitLab project path (e.g. my-org/my-project):"
-read -r GITLAB_PROJECT
-ask "GitLab personal access token (glpat-...):"
-read -rs GITLAB_TOKEN
-echo ""
-
-if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_PROJECT" ] || [ -z "$GITLAB_TOKEN" ]; then
-    fail "All three fields are required."
-    exit 1
+# Separate prompt for credentials. The existing "overwrite templates"
+# prompt only controls colony.example.toml -> colony.toml copies; it
+# does not gate credential writes. If the operator re-runs install.sh
+# purely to rotate the PAT (or to update url/project), we must still
+# prompt before silently overwriting — otherwise a typo at the URL
+# prompt corrupts 5 working configs with no recovery path other than
+# redoing the install. See #116 gap 5.
+WRITE_CREDS=1
+if [ "$CONFIGS_EXISTED" -eq 5 ]; then
+    ask "Update GitLab credentials in existing configs? [Y/n]:"
+    read -r UPDATE_CREDS
+    case "$UPDATE_CREDS" in
+        n|N)
+            WRITE_CREDS=0
+            info "Keeping existing GitLab credentials. Skipping prompts."
+            ;;
+    esac
 fi
 
-echo ""
-echo "Writing credentials to colony configs..."
+if [ "$WRITE_CREDS" -eq 1 ]; then
+    prompt_validated GITLAB_URL \
+        "GitLab URL (e.g. https://gitlab.com):" \
+        '^https?://[A-Za-z0-9.-]+(:[0-9]+)?(/.*)?$' \
+        "Must start with http:// or https://"
 
-for colony in "${COLONIES[@]}"; do
-    CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
-    # Write credentials by matching TOML keys (works on both fresh and existing configs)
-    python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" <<'PY'
+    prompt_validated GITLAB_PROJECT \
+        "GitLab project path (e.g. my-org/my-project):" \
+        '^[^/[:space:]]+/[^/[:space:]]+$' \
+        "Must be exactly two segments separated by /, no extra slashes or spaces."
+
+    prompt_validated GITLAB_TOKEN \
+        "GitLab personal access token (glpat-...):" \
+        '^glpat-[A-Za-z0-9_-]+$' \
+        "Must start with 'glpat-' followed by the token body." \
+        --secret
+
+    echo ""
+    echo "Writing credentials to colony configs..."
+
+    for colony in "${COLONIES[@]}"; do
+        CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
+        # Write credentials by matching TOML keys (works on both fresh and existing configs)
+        python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" <<'PY'
 import sys, re
 path, url, token, project = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 with open(path) as f:
@@ -153,8 +201,11 @@ content = re.sub(r'(project\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + projec
 with open(path, 'w') as f:
     f.write(content)
 PY
-    ok "$colony"
-done
+        ok "$colony"
+        chmod 600 "$CONFIG" 2>/dev/null || \
+            info "$colony: could not chmod 600 $CONFIG (filesystem may not support it)"
+    done
+fi
 
 # --- 4. Initialize agentis (if not already done) ---
 #
@@ -297,6 +348,11 @@ if [ -d "$AGENTIS_DIR" ]; then
     write_key 'pii_transmit'                 'allow'
     write_key 'knowledge.enabled'            'true'
     write_key 'learning.enabled'             'true'
+
+    # Lock down the federation config alongside colony.toml. No secrets
+    # are written here today, but llm.* keys operators add manually may
+    # include api-key env names or inline tokens.
+    chmod 600 "$AGENTIS_CONFIG" 2>/dev/null || true
 fi
 
 # Create per-colony .agentis symlinks so commands run from a colony dir

--- a/dev-apprenticeship/ops/logrotate.conf
+++ b/dev-apprenticeship/ops/logrotate.conf
@@ -1,0 +1,19 @@
+# Sample logrotate config for the Dev Apprenticeship federation.
+# Copy to /etc/logrotate.d/dev-apprenticeship (requires sudo) and
+# replace /PATH/TO/dev-apprenticeship with your federation root.
+#
+# Cadence: daily, with a 10 MB early-rotate trigger so runaway
+# error loops (e.g. a bad GitLab token producing 6 retry lines per
+# tick per agent) do not fill the disk between daily passes.
+# Keep 7 rotations (~1 week) and compress older ones.
+
+/PATH/TO/dev-apprenticeship/.agentis/logs/*.log {
+    daily
+    size 10M
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -51,6 +51,21 @@ AGENTS=(
     plan_reviewer
 )
 
+# Opt-in log truncation. Off by default so operators who rely on log
+# history across restarts are not surprised. Set TRUNCATE_LOGS=1 in
+# the environment (or via start-federation.sh) to bound disk use
+# between manual restarts. Real log rotation should use the
+# logrotate.conf sample in ops/ instead; this is the zero-config
+# fallback for laptops that do not have logrotate configured.
+if [ "${TRUNCATE_LOGS:-0}" = "1" ]; then
+    AGENTIS_LOGS="$REPO_ROOT/dev-apprenticeship/.agentis/logs"
+    if [ -d "$AGENTIS_LOGS" ]; then
+        for agent in "${AGENTS[@]}"; do
+            : > "$AGENTIS_LOGS/${agent}.log" 2>/dev/null || true
+        done
+    fi
+fi
+
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -51,6 +51,21 @@ AGENTS=(
     version_bumper
 )
 
+# Opt-in log truncation. Off by default so operators who rely on log
+# history across restarts are not surprised. Set TRUNCATE_LOGS=1 in
+# the environment (or via start-federation.sh) to bound disk use
+# between manual restarts. Real log rotation should use the
+# logrotate.conf sample in ops/ instead; this is the zero-config
+# fallback for laptops that do not have logrotate configured.
+if [ "${TRUNCATE_LOGS:-0}" = "1" ]; then
+    AGENTIS_LOGS="$REPO_ROOT/dev-apprenticeship/.agentis/logs"
+    if [ -d "$AGENTIS_LOGS" ]; then
+        for agent in "${AGENTS[@]}"; do
+            : > "$AGENTIS_LOGS/${agent}.log" 2>/dev/null || true
+        done
+    fi
+fi
+
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.

--- a/dev-apprenticeship/start-federation.sh
+++ b/dev-apprenticeship/start-federation.sh
@@ -20,6 +20,18 @@ echo "Dev Apprenticeship Federation"
 echo "============================="
 echo ""
 
+# Refuse to start if any agentis daemon is already running under this
+# federation root. A second invocation would spawn 21 more daemons
+# racing the first set for the same GitLab project (dup labels, dup
+# comments, dup MRs) and there is no safe way to untangle them after
+# the fact — stop-all hits both generations equally.
+if agentis daemon list 2>/dev/null | grep -Eq '(^|[[:space:]])running([[:space:]]|$)'; then
+    echo "[!!] A federation is already running under this directory."
+    echo "     Stop it first:  agentis daemon stop --all"
+    echo "     Inspect it:     agentis daemon list"
+    exit 1
+fi
+
 # Pre-flight: check all configs exist
 for colony in "${COLONIES[@]}"; do
     CONFIG="$FED_DIR/$colony/config/colony.toml"
@@ -29,6 +41,17 @@ for colony in "${COLONIES[@]}"; do
         exit 1
     fi
 done
+
+# After laptop sleep/reboot, heartbeat files under .agentis/daemon/
+# retain the pre-sleep mtime and the watchdog reads them as "last
+# heartbeat was N hours ago", killing every fresh child on its first
+# tick. Wipe them before any child writes a fresh one. Safe because
+# the double-start guard above proved there is no live federation to
+# disrupt.
+FED_AGENTIS_DIR="$FED_DIR/.agentis/daemon"
+if [ -d "$FED_AGENTIS_DIR" ]; then
+    rm -f "$FED_AGENTIS_DIR"/*.heartbeat 2>/dev/null || true
+fi
 
 # Start each colony
 TOTAL_AGENTS=0

--- a/dev-apprenticeship/start-federation.sh
+++ b/dev-apprenticeship/start-federation.sh
@@ -6,6 +6,12 @@
 #
 # Usage: ./start-federation.sh [path/to/federation-dir]
 #        ./start-federation.sh              # uses script's own directory
+#
+# Env vars (forwarded to start-colony.sh):
+#   TRUNCATE_LOGS=1   zero out .agentis/logs/*.log at spawn time.
+#                     Zero-config fallback for boxes without logrotate;
+#                     loses history between restarts. For long-running
+#                     federations, use ops/logrotate.conf instead.
 
 set -e
 
@@ -25,7 +31,13 @@ echo ""
 # racing the first set for the same GitLab project (dup labels, dup
 # comments, dup MRs) and there is no safe way to untangle them after
 # the fact — stop-all hits both generations equally.
-if agentis daemon list 2>/dev/null | grep -Eq '(^|[[:space:]])running([[:space:]]|$)'; then
+#
+# NB: `agentis daemon list` writes the human-readable table to stderr
+# (eprintln! in agentis-core src/cli/daemon.rs), so the previous
+# version of this guard grepped empty stdout and never matched.
+# `--json` goes to stdout and is table-layout-stable, so we key on
+# the structured field instead of the table row.
+if agentis daemon list --json 2>/dev/null | grep -Fq '"state":"running"'; then
     echo "[!!] A federation is already running under this directory."
     echo "     Stop it first:  agentis daemon stop --all"
     echo "     Inspect it:     agentis daemon list"
@@ -50,7 +62,13 @@ done
 # disrupt.
 FED_AGENTIS_DIR="$FED_DIR/.agentis/daemon"
 if [ -d "$FED_AGENTIS_DIR" ]; then
-    rm -f "$FED_AGENTIS_DIR"/*.heartbeat 2>/dev/null || true
+    # *.pid / *.status / *.watchdog.pid go stale on the same axis as
+    # *.heartbeat — on wake they point at PIDs from the previous boot
+    # which may now belong to an unrelated process. Sweep them all.
+    rm -f "$FED_AGENTIS_DIR"/*.heartbeat \
+          "$FED_AGENTIS_DIR"/*.pid \
+          "$FED_AGENTIS_DIR"/*.status \
+          "$FED_AGENTIS_DIR"/*.watchdog.pid 2>/dev/null || true
 fi
 
 # Start each colony

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -51,6 +51,21 @@ AGENTS=(
     router
 )
 
+# Opt-in log truncation. Off by default so operators who rely on log
+# history across restarts are not surprised. Set TRUNCATE_LOGS=1 in
+# the environment (or via start-federation.sh) to bound disk use
+# between manual restarts. Real log rotation should use the
+# logrotate.conf sample in ops/ instead; this is the zero-config
+# fallback for laptops that do not have logrotate configured.
+if [ "${TRUNCATE_LOGS:-0}" = "1" ]; then
+    AGENTIS_LOGS="$REPO_ROOT/dev-apprenticeship/.agentis/logs"
+    if [ -d "$AGENTIS_LOGS" ]; then
+        for agent in "${AGENTS[@]}"; do
+            : > "$AGENTIS_LOGS/${agent}.log" 2>/dev/null || true
+        done
+    fi
+fi
+
 # Note: LLM backend is read by agentis daemon from the llm.backend key in
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.


### PR DESCRIPTION
## Summary

Bundles fixes for #116 (5 operational-readiness gaps) and #118 (PAT world-readable in `colony.toml`) into one scoped sweep of the `dev-apprenticeship/` scaffold.

- `start-federation.sh`: refuse to start if a federation is already running (#116 gap 3); wipe stale heartbeats before spawn so post-sleep/reboot restarts don't have the watchdog killing fresh children (#116 gap 1). Guard ordered **before** wipe so a double-invocation cannot clobber a live federation.
- `install.sh`: `prompt_validated` helper + regex-validated prompts for URL / project / token with re-prompt on invalid (#116 gap 4); separate Y/N gate on credential overwrite when 5 `colony.toml` files already exist, so answering `N` to the templates prompt no longer silently rewrites creds (#116 gap 5); `chmod 600` on every `colony.toml` and `.agentis/config` after write (#118).
- `start-colony.sh` (×5): opt-in log truncation via `TRUNCATE_LOGS=1` (#116 gap 2 zero-config fallback).
- `dev-apprenticeship/ops/logrotate.conf`: new sample config (daily, 10 M early-rotate, 7 copies, `copytruncate`) for operators who want proper rotation.
- `README.md`: Security section documenting plaintext token storage and the rotation workflow (#118); expanded log-growth paragraph pointing at the sample logrotate config and `TRUNCATE_LOGS=1`.

## Ordering notes

Within `start-federation.sh`, the double-start guard (#116 gap 3) is placed **above** the heartbeat wipe (#116 gap 1), because the wipe is only safe when no federation is running — the guard proves that precondition.

The existing "Overwrite with fresh templates? [y/N]" prompt historically controlled only the `.example.toml -> .toml` copy. Rather than changing its semantics (which would surprise operators who have been relying on "N = keep templates, rewrite creds"), this PR adds a **second, explicit** prompt for credentials. First-time installs never see it.

The `TRUNCATE_LOGS=1` block was moved from the plan's suggested spot (before the agents array) to immediately after the `AGENTS=(...)` declaration, because the block iterates `"${AGENTS[@]}"` — inserting before the array would make the loop a no-op. All 5 copies consistent.

## Test plan

- [ ] **Gap 3 — double-start guard**: `./start-federation.sh`; immediately `./start-federation.sh` → second invocation exits 1 with actionable message; no extra daemons in `agentis daemon list`.
- [ ] **Gap 1 — heartbeat wipe**: `stop-all`, `touch -d '2 hours ago' .agentis/daemon/*.heartbeat`, `./start-federation.sh` → heartbeats wiped before spawn, no watchdog kills in the first two ticks.
- [ ] **Gap 4 — validation**: fresh `./install.sh` rejects empty URL, bad scheme, single-segment project, non-`glpat-` token; accepts good values on retry.
- [ ] **Gap 5 — re-run cred prompt**: `./install.sh` again, answer N to templates + N to credentials → 5 `colony.toml` files unchanged; N + Y prompts for new creds only.
- [ ] **#118 — chmod 600**: `ls -l */config/colony.toml` after install → all 5 are `-rw-------`; `.agentis/config` also `-rw-------`.
- [ ] **Gap 2 — log truncate**: `TRUNCATE_LOGS=1 ./start-federation.sh` zeroes logs at spawn; plain invocation does not. `logrotate -f ops/logrotate.conf` (with path adjusted) rotates cleanly via `copytruncate`.

## Out of scope (tracked separately)

- Secret store integration (Keychain / Secret Service / `pass` / 1Password CLI).
- Token-rotation automation beyond the `install.sh` re-run flow.
- Auto-install of system logrotate (requires sudo; intentionally manual — single-user apprenticeship scaffold).
- Daemon-side stale-heartbeat detection; belongs in `agentis-core`, not here.

Closes #116. Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)