### PR TITLE
fix(tools): make colony-lint.sh runnable on bash 3.2 / macOS (#121)

### DIFF
--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -1,10 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # colony-lint.sh: validates colony structure, config, and scripts
 #
 # Autodiscovers federations and colonies in the repo.
-# Exit code 0 = all checks pass, 1 = one or more failures.
+# Exit code 0 = all checks pass, 1 = one or more failures, 2 = unmet prerequisites.
 #
 # Usage: ./tools/colony-lint.sh [path-to-repo-root]
+#
+# Runs on bash 3.2+ (stock macOS /bin/bash) and bash 4+. Avoid bash-4-only
+# constructs below (associative arrays, ${var^^}, mapfile, backslash-newline
+# inside case-pattern labels — see #121 for that last one).
 
 set -euo pipefail
 
@@ -181,11 +185,11 @@ if errors:
                     if ($0 !~ /\\[[:space:]]*$/) { in_cmd = 0 }
                 }
             ' "$start_script" | while read -r flag; do
+                # Pattern is deliberately on one line: bash 3.2 (stock macOS)
+                # miscompiles backslash-newline inside case-pattern labels
+                # (#121). Keep all alternatives on a single line.
                 case "$flag" in
-                    --tick-interval|--cb-per-tick|--colony|--deadline|--priority|\
-                    --enable-migration|--enable-replication|--allow-replica-replication|\
-                    --enable-exec|--enable-messaging|--deny-exec|\
-                    --help|-h) ;;
+                    --tick-interval|--cb-per-tick|--colony|--deadline|--priority|--enable-migration|--enable-replication|--allow-replica-replication|--enable-exec|--enable-messaging|--deny-exec|--help|-h) ;;
                     *) echo "$flag" ;;
                 esac
             done)


### PR DESCRIPTION
## Summary

- Collapse the daemon-flag-allowlist `case` label to a single line so stock macOS `/bin/bash` (3.2) parses it (the backslash-newline-inside-case-pattern pattern added in #71 made the whole script unparseable on any Mac without brew-bash earlier on PATH).
- Switch shebang to `/usr/bin/env bash` so brew-installed bash 4+ is picked up automatically.
- Document the bash-3.2-compat baseline in the header so future edits avoid `${var^^}`, `mapfile`, associative arrays, and the same backslash-newline trap.

No logic change — the allowlist still enforces exactly the same 11 flags as before.

## Test plan

- [x] `bash -n tools/colony-lint.sh` — clean
- [x] `bash tools/colony-lint.sh` on dev-apprenticeship — 45 passed, 0 failed, 5 skipped (identical to pre-change)
- [x] No other `|\\$` backslash-continuations elsewhere in `tools/`
- [ ] CI shellcheck + test-*.sh unit tests green

Closes #121