### PR TITLE
fix(dev-apprenticeship): downselect GitLab JSON via --view (#119)

### DIFF
--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -44,7 +44,7 @@ fn tick(reason: string) -> void {
     };
 
     // Learn from past human approval/rejection patterns
-    let mr_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
+    let mr_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view reviewer";
     let recent_merged = try { exec sh mr_cmd; } catch e { "[]"; };
 
     let approval_patterns = prompt(

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -24,9 +24,9 @@ type LogicReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("logic_reviewer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --view reviewer";
 }
 
 fn get_confidence() -> float {

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -25,9 +25,9 @@ type SecurityReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("security_reviewer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --view reviewer";
 }
 
 fn get_confidence() -> float {

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -24,9 +24,9 @@ type StyleReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("style_reviewer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --view reviewer";
 }
 
 fn get_confidence() -> float {

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -24,9 +24,9 @@ type TestReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("test_reviewer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --view reviewer";
 }
 
 fn get_confidence() -> float {

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -8,13 +8,19 @@
 #   GITLAB_PROJECT - URL-encoded project path
 #
 # Usage:
-#   gitlab-api.sh merge-requests [--since ISO8601] [--state opened|merged|all]
+#   gitlab-api.sh merge-requests [--since ISO8601] [--state opened|merged|all] [--view <name>]
 #   gitlab-api.sh mr-changes <iid>
 #   gitlab-api.sh mr-notes <iid>
 #   gitlab-api.sh post-note <iid> --body <text>
 #   gitlab-api.sh approve <iid>
 #
-# Returns JSON to stdout. Exit code 0 on success, 1 on error, 2 on unknown flag.
+# Views (opt-in projection; default is full JSON):
+#   merge-requests --view reviewer  [{iid, state, title, labels,
+#                                     source_branch, target_branch, draft}]
+#   merge-requests --view raw       explicit pass-through (same as no flag)
+#   GITLAB_VIEW_MODE=raw            env-override that forces pass-through globally.
+#
+# Returns JSON to stdout. Exit code 0 on success, 1 on error, 2 on unknown flag/view.
 
 set -e
 
@@ -26,6 +32,44 @@ set -e
 # Does NOT exit. The caller controls the exit code.
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+# project_json <view-name>
+# Reads full GitLab JSON from stdin, writes a downselected projection to
+# stdout. See the triage colony's gitlab-api.sh for the full design note;
+# the short version is that each view keeps only the fields a downstream
+# agent's prompt() actually needs, and GITLAB_VIEW_MODE=raw lets operators
+# roll back to full payloads without editing .ag sources.
+project_json() {
+    local view="$1"
+    if [ "${GITLAB_VIEW_MODE:-}" = "raw" ]; then
+        cat
+        return 0
+    fi
+    # Capture stdin once: python3 below reads the projection script from a
+    # `<<'PY'` heredoc (which occupies python's stdin), so the payload has
+    # to travel via env var rather than a pipe.
+    local DATA
+    DATA="$(cat)"
+    case "$view" in
+        raw)
+            printf '%s' "$DATA"
+            ;;
+        reviewer)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "state": x.get("state"), "title": x.get("title"),
+        "labels": x.get("labels", []), "source_branch": x.get("source_branch"),
+        "target_branch": x.get("target_branch"), "draft": x.get("draft")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        *)
+            emit_error "unknown view: $view"
+            exit 2
+            ;;
+    esac
 }
 
 if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
@@ -175,10 +219,12 @@ case "$CMD" in
     merge-requests)
         SINCE=""
         STATE="opened"
+        VIEW=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 --since) SINCE="$2"; shift 2 ;;
                 --state) STATE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
@@ -191,7 +237,11 @@ case "$CMD" in
         if [ -n "$SINCE" ]; then
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get_q "$API/merge_requests" "${ARGS[@]}"
+        if [ -n "$VIEW" ]; then
+            gl_get_q "$API/merge_requests" "${ARGS[@]}" | project_json "$VIEW"
+        else
+            gl_get_q "$API/merge_requests" "${ARGS[@]}"
+        fi
         ;;
 
     mr-changes)

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -238,7 +238,12 @@ case "$CMD" in
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
         if [ -n "$VIEW" ]; then
-            gl_get_q "$API/merge_requests" "${ARGS[@]}" | project_json "$VIEW"
+            # Two-step so gl_call's non-zero exit (auth/429/5xx/transport)
+            # survives the projection pipe. A bare `gl_get_q ... | project_json`
+            # would let python3 (or `cat` when GITLAB_VIEW_MODE=raw) override
+            # the meaningful exit code with 0 or 1, masking the real failure.
+            body="$(gl_get_q "$API/merge_requests" "${ARGS[@]}")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/merge_requests" "${ARGS[@]}"
         fi

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -27,9 +27,9 @@ type CodeDraft {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("code_writer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view impl";
 }
 
 fn get_confidence() -> float {
@@ -80,7 +80,7 @@ fn tick(reason: string) -> void {
     };
 
     // 2. Check for assigned issues needing implementation
-    let issues_cmd = "$COLONY_DIR/scripts/gitlab-api.sh assigned-issues";
+    let issues_cmd = "$COLONY_DIR/scripts/gitlab-api.sh assigned-issues --view assigned";
     let issues_raw = try {
         exec sh issues_cmd;
     } catch e {

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -29,9 +29,9 @@ type MRPlan {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("commit_composer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view impl";
 }
 
 fn get_confidence() -> float {

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -25,9 +25,9 @@ type RefactorSuggestion {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("refactorer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view impl";
 }
 
 fn get_confidence() -> float {

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -27,9 +27,9 @@ type TestDraft {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("test_writer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view impl";
 }
 
 fn get_confidence() -> float {

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -254,7 +254,12 @@ case "$CMD" in
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
         if [ -n "$VIEW" ]; then
-            gl_get_q "$API/merge_requests" "${ARGS[@]}" | project_json "$VIEW"
+            # Two-step so gl_call's non-zero exit (auth/429/5xx/transport)
+            # survives the projection pipe. A bare `gl_get_q ... | project_json`
+            # would let python3 (or `cat` when GITLAB_VIEW_MODE=raw) override
+            # the meaningful exit code with 0 or 1, masking the real failure.
+            body="$(gl_get_q "$API/merge_requests" "${ARGS[@]}")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/merge_requests" "${ARGS[@]}"
         fi
@@ -297,7 +302,10 @@ case "$CMD" in
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
         if [ -n "$VIEW" ]; then
-            gl_get_q "$API/issues" "${ARGS[@]}" | project_json "$VIEW"
+            # Two-step pipe so gl_call's non-zero exit survives projection (see
+            # merge-requests branch above).
+            body="$(gl_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/issues" "${ARGS[@]}"
         fi

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -8,15 +8,22 @@
 #   GITLAB_PROJECT - URL-encoded project path (e.g. your-org%2Fyour-project)
 #
 # Usage:
-#   gitlab-api.sh merge-requests [--state merged] [--since ISO8601]
+#   gitlab-api.sh merge-requests [--state merged] [--since ISO8601] [--view <name>]
 #   gitlab-api.sh mr-changes <iid>
 #   gitlab-api.sh mr-commits <iid>
 #   gitlab-api.sh issue <iid>
-#   gitlab-api.sh assigned-issues [--since ISO8601]
+#   gitlab-api.sh assigned-issues [--since ISO8601] [--view <name>]
 #   gitlab-api.sh create-branch --name <name> --ref <ref>
 #   gitlab-api.sh commit-files --branch <b> --message <m> --actions <json>
 #   gitlab-api.sh create-mr --source <branch> --title <title> [--description <d>]
 #   gitlab-api.sh post-note <iid> --body <text>
+#
+# Views (opt-in projection; default is full JSON):
+#   merge-requests  --view impl       [{iid, title, merged_at, target_branch}]
+#   assigned-issues --view assigned   [{iid, title, description, labels,
+#                                       assignees:[{username}], priority}]
+#   <cmd>           --view raw        explicit pass-through (same as no flag)
+#   GITLAB_VIEW_MODE=raw              env-override that forces pass-through globally.
 #
 # Implementation colony both reads from and writes to GitLab: it creates
 # branches, commits code, and opens merge requests. All write endpoints
@@ -34,6 +41,51 @@ set -e
 # Does NOT exit. The caller controls the exit code.
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+# project_json <view-name>
+# Reads full GitLab JSON from stdin, writes a downselected projection to
+# stdout. See the triage colony's gitlab-api.sh for the full design note.
+project_json() {
+    local view="$1"
+    if [ "${GITLAB_VIEW_MODE:-}" = "raw" ]; then
+        cat
+        return 0
+    fi
+    # Capture stdin once: python3 below reads the projection script from a
+    # `<<'PY'` heredoc (which occupies python's stdin), so the payload has
+    # to travel via env var rather than a pipe.
+    local DATA
+    DATA="$(cat)"
+    case "$view" in
+        raw)
+            printf '%s' "$DATA"
+            ;;
+        impl)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"),
+        "merged_at": x.get("merged_at"), "target_branch": x.get("target_branch")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        assigned)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
+        "labels": x.get("labels", []),
+        "assignees": [{"username": a.get("username")} for a in x.get("assignees", [])],
+        "priority": x.get("priority")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        *)
+            emit_error "unknown view: $view"
+            exit 2
+            ;;
+    esac
 }
 
 if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
@@ -183,10 +235,12 @@ case "$CMD" in
     merge-requests)
         STATE="opened"
         SINCE=""
+        VIEW=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 --state) STATE="$2"; shift 2 ;;
                 --since) SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
@@ -199,7 +253,11 @@ case "$CMD" in
         if [ -n "$SINCE" ]; then
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get_q "$API/merge_requests" "${ARGS[@]}"
+        if [ -n "$VIEW" ]; then
+            gl_get_q "$API/merge_requests" "${ARGS[@]}" | project_json "$VIEW"
+        else
+            gl_get_q "$API/merge_requests" "${ARGS[@]}"
+        fi
         ;;
 
     mr-changes)
@@ -219,9 +277,11 @@ case "$CMD" in
 
     assigned-issues)
         SINCE=""
+        VIEW=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 --since) SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
@@ -236,7 +296,11 @@ case "$CMD" in
         if [ -n "$SINCE" ]; then
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get_q "$API/issues" "${ARGS[@]}"
+        if [ -n "$VIEW" ]; then
+            gl_get_q "$API/issues" "${ARGS[@]}" | project_json "$VIEW"
+        else
+            gl_get_q "$API/issues" "${ARGS[@]}"
+        fi
         ;;
 
     create-branch)

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -75,7 +75,7 @@ fn tick(reason: string) -> void {
     // 3. Pick the newest unplanned issue and see if we have all three
     //    slots filled for it. If not, keep waiting.
     let issues_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
     } catch e {
         print("[plan_reviewer] GitLab unplanned-issue poll failed:", e);
         "";

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -25,9 +25,9 @@ type IncidentPatterns {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("risk_assessor:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts) + " --view planning";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
 }
 
 fn get_confidence() -> float {
@@ -41,7 +41,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Observe: pull recent opened issues and skim for incident-style patterns
     let recent_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --view planning";
     } catch e {
         print("[risk_assessor] GitLab issues poll failed:", e);
         "";

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -26,9 +26,9 @@ type CalibrationSummary {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("scope_estimator:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts) + " --view planning";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
 }
 
 fn get_confidence() -> float {
@@ -42,7 +42,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Observe: pull recent merged MRs and learn calibration
     let merged_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view planning-mr";
     } catch e {
         print("[scope_estimator] GitLab merged-MR poll failed:", e);
         "";

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -26,9 +26,9 @@ type DecompositionPatterns {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("task_decomposer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts) + " --view planning";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
 }
 
 fn get_confidence() -> float {
@@ -42,7 +42,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Observe: analyze recent issues to infer decomposition style
     let recent_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --view planning";
     } catch e {
         print("[task_decomposer] GitLab issues poll failed:", e);
         "";

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -256,7 +256,12 @@ case "$CMD" in
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
         if [ -n "$VIEW" ]; then
-            gl_get_q "$API/issues" "${ARGS[@]}" | project_json "$VIEW"
+            # Two-step so gl_call's non-zero exit (auth/429/5xx/transport)
+            # survives the projection pipe. A bare `gl_get_q ... | project_json`
+            # would let python3 (or `cat` when GITLAB_VIEW_MODE=raw) override
+            # the meaningful exit code with 0 or 1, masking the real failure.
+            body="$(gl_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/issues" "${ARGS[@]}"
         fi
@@ -304,7 +309,10 @@ case "$CMD" in
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
         if [ -n "$VIEW" ]; then
-            gl_get_q "$API/merge_requests" "${ARGS[@]}" | project_json "$VIEW"
+            # Two-step pipe so gl_call's non-zero exit survives projection (see
+            # issues branch above).
+            body="$(gl_get_q "$API/merge_requests" "${ARGS[@]}")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/merge_requests" "${ARGS[@]}"
         fi

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -8,16 +8,25 @@
 #   GITLAB_PROJECT - URL-encoded project path (e.g. your-org%2Fyour-project)
 #
 # Usage:
-#   gitlab-api.sh issues --needs-planning [--since ISO8601]
+#   gitlab-api.sh issues --needs-planning [--since ISO8601] [--view <name>]
 #   gitlab-api.sh add-note <iid> --body <text>
-#   gitlab-api.sh merge-requests [--state merged] [--since ISO8601]
+#   gitlab-api.sh merge-requests [--state merged] [--since ISO8601] [--view <name>]
+#
+# Views (opt-in projection; default is full JSON):
+#   issues         --view planning     [{iid, title, description, labels,
+#                                        author:{username}, created_at}]
+#   merge-requests --view planning-mr  [{iid, title, description, labels,
+#                                        changes_count, user_notes_count,
+#                                        merged_at, target_branch}]
+#   <cmd>          --view raw          explicit pass-through (same as no flag)
+#   GITLAB_VIEW_MODE=raw               env-override that forces pass-through globally.
 #
 # Planning only reads from GitLab and posts comments. It never changes labels,
 # approves, assigns, or merges. That surface lives in triage / code-review /
 # release colonies. If you are tempted to add a write endpoint here, it
 # probably belongs in a different colony.
 #
-# Returns JSON to stdout. Exit code 0 on success, 1 on error, 2 on unknown flag.
+# Returns JSON to stdout. Exit code 0 on success, 1 on error, 2 on unknown flag/view.
 
 set -e
 
@@ -29,6 +38,53 @@ set -e
 # Does NOT exit. The caller controls the exit code.
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+# project_json <view-name>
+# Reads full GitLab JSON from stdin, writes a downselected projection to
+# stdout. See the triage colony's gitlab-api.sh for the full design note.
+project_json() {
+    local view="$1"
+    if [ "${GITLAB_VIEW_MODE:-}" = "raw" ]; then
+        cat
+        return 0
+    fi
+    # Capture stdin once: python3 below reads the projection script from a
+    # `<<'PY'` heredoc (which occupies python's stdin), so the payload has
+    # to travel via env var rather than a pipe.
+    local DATA
+    DATA="$(cat)"
+    case "$view" in
+        raw)
+            printf '%s' "$DATA"
+            ;;
+        planning)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
+        "labels": x.get("labels", []),
+        "author": {"username": (x.get("author") or {}).get("username")},
+        "created_at": x.get("created_at")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        planning-mr)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
+        "labels": x.get("labels", []), "changes_count": x.get("changes_count"),
+        "user_notes_count": x.get("user_notes_count"),
+        "merged_at": x.get("merged_at"), "target_branch": x.get("target_branch")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        *)
+            emit_error "unknown view: $view"
+            exit 2
+            ;;
+    esac
 }
 
 if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
@@ -178,10 +234,12 @@ case "$CMD" in
     issues)
         SINCE=""
         NEEDS_PLANNING=0
+        VIEW=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 --since) SINCE="$2"; shift 2 ;;
                 --needs-planning) NEEDS_PLANNING=1; shift ;;
+                --view) VIEW="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
@@ -197,7 +255,11 @@ case "$CMD" in
         if [ -n "$SINCE" ]; then
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get_q "$API/issues" "${ARGS[@]}"
+        if [ -n "$VIEW" ]; then
+            gl_get_q "$API/issues" "${ARGS[@]}" | project_json "$VIEW"
+        else
+            gl_get_q "$API/issues" "${ARGS[@]}"
+        fi
         ;;
 
     add-note)
@@ -223,10 +285,12 @@ case "$CMD" in
     merge-requests)
         STATE="opened"
         SINCE=""
+        VIEW=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 --state) STATE="$2"; shift 2 ;;
                 --since) SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
@@ -239,7 +303,11 @@ case "$CMD" in
         if [ -n "$SINCE" ]; then
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get_q "$API/merge_requests" "${ARGS[@]}"
+        if [ -n "$VIEW" ]; then
+            gl_get_q "$API/merge_requests" "${ARGS[@]}" | project_json "$VIEW"
+        else
+            gl_get_q "$API/merge_requests" "${ARGS[@]}"
+        fi
         ;;
 
     *)

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -36,7 +36,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Learn changelog style from past releases
     let releases_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 10";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 10 --view release-summary";
     } catch e {
         print("[changelog_writer] GitLab releases poll failed:", e);
         "";
@@ -89,7 +89,7 @@ fn tick(reason: string) -> void {
 
     // Get the latest release tag to find MRs merged since then
     let latest_release = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 1";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 1 --view release-summary";
     } catch e { "[]"; };
 
     let since_date = prompt(
@@ -98,7 +98,7 @@ fn tick(reason: string) -> void {
     ) -> string;
 
     // Fetch MRs merged since last release
-    let mrs_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date);
+    let mrs_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date) + " --view release-mr";
     let mrs_raw = try { exec sh mrs_cmd; } catch e {
         print("[changelog_writer] MR fetch failed:", e);
         "";

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -37,7 +37,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Learn from past releases and their pipeline outcomes
     let releases_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 10";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 10 --view release-summary";
     } catch e {
         print("[release_checker] GitLab releases poll failed:", e);
         "";
@@ -67,7 +67,7 @@ fn tick(reason: string) -> void {
 
     // Also check the default branch pipeline status
     let pipeline_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh pipelines --ref main";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh pipelines --ref main --view pipeline-summary";
     } catch e {
         print("[release_checker] Pipeline poll failed:", e);
         "";

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -34,7 +34,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Learn release patterns from history
     let releases_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 20";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 20 --view release-summary";
     } catch e {
         print("[ship_decider] GitLab releases poll failed:", e);
         "";
@@ -42,7 +42,7 @@ fn tick(reason: string) -> void {
 
     if len(releases_raw) > 10 {
         let tags_raw = try {
-            exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 20";
+            exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 20 --view tag-summary";
         } catch e { "[]"; };
 
         let patterns = prompt(

--- a/dev-apprenticeship/release/agents/version_bumper.ag
+++ b/dev-apprenticeship/release/agents/version_bumper.ag
@@ -36,7 +36,7 @@ fn get_confidence() -> float {
 fn tick(reason: string) -> void {
     // 1. Learn versioning patterns from tags
     let tags_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 20";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 20 --view tag-summary";
     } catch e {
         print("[version_bumper] GitLab tags poll failed:", e);
         "";
@@ -93,12 +93,12 @@ fn tick(reason: string) -> void {
 
     // Get latest tags for current version context
     let latest_tags = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 5";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 5 --view tag-summary";
     } catch e { "[]"; };
 
     // Fetch merged MRs since last release for bump analysis
     let latest_release = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 1";
+        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 1 --view release-summary";
     } catch e { "[]"; };
 
     let since_date = prompt(
@@ -106,7 +106,7 @@ fn tick(reason: string) -> void {
         latest_release
     ) -> string;
 
-    let mrs_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date);
+    let mrs_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date) + " --view release-mr";
     let mrs_raw = try { exec sh mrs_cmd; } catch e { "[]"; };
 
     let rec = recommend("version_bump", ["accuracy"]);

--- a/dev-apprenticeship/release/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/release/scripts/gitlab-api.sh
@@ -8,14 +8,22 @@
 #   GITLAB_PROJECT - URL-encoded project path (e.g. your-org%2Fyour-project)
 #
 # Usage:
-#   gitlab-api.sh releases [--per-page N]
-#   gitlab-api.sh tags [--per-page N]
-#   gitlab-api.sh pipelines --ref <branch> [--per-page N]
-#   gitlab-api.sh merge-requests --state merged [--since ISO8601]
+#   gitlab-api.sh releases [--per-page N] [--view <name>]
+#   gitlab-api.sh tags [--per-page N] [--view <name>]
+#   gitlab-api.sh pipelines --ref <branch> [--per-page N] [--view <name>]
+#   gitlab-api.sh merge-requests --state merged [--since ISO8601] [--view <name>]
 #   gitlab-api.sh mr-commits <iid>
 #   gitlab-api.sh create-tag --name <name> --ref <ref> [--message <m>]
 #   gitlab-api.sh create-release --tag <tag> --name <name> --description <d>
 #   gitlab-api.sh post-note <iid> --body <text>
+#
+# Views (opt-in projection; default is full JSON):
+#   releases       --view release-summary  [{tag_name, name, released_at, description}]
+#   tags           --view tag-summary      [{name, message, commit:{short_id, created_at}}]
+#   pipelines      --view pipeline-summary [{id, status, ref, sha, created_at, web_url}]
+#   merge-requests --view release-mr       [{iid, title, merged_at, labels, target_branch}]
+#   <cmd>          --view raw              explicit pass-through (same as no flag)
+#   GITLAB_VIEW_MODE=raw                   env-override that forces pass-through globally.
 #
 # The release colony reads release history, CI status, and merged MRs to learn
 # shipping patterns. Write endpoints create tags and releases. All write
@@ -33,6 +41,69 @@ set -e
 # Does NOT exit. The caller controls the exit code.
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+# project_json <view-name>
+# Reads full GitLab JSON from stdin, writes a downselected projection to
+# stdout. See the triage colony's gitlab-api.sh for the full design note.
+project_json() {
+    local view="$1"
+    if [ "${GITLAB_VIEW_MODE:-}" = "raw" ]; then
+        cat
+        return 0
+    fi
+    # Capture stdin once: python3 below reads the projection script from a
+    # `<<'PY'` heredoc (which occupies python's stdin), so the payload has
+    # to travel via env var rather than a pipe.
+    local DATA
+    DATA="$(cat)"
+    case "$view" in
+        raw)
+            printf '%s' "$DATA"
+            ;;
+        release-summary)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"tag_name": x.get("tag_name"), "name": x.get("name"),
+        "released_at": x.get("released_at"), "description": x.get("description")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        tag-summary)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"name": x.get("name"), "message": x.get("message"),
+        "commit": {"short_id": (x.get("commit") or {}).get("short_id"),
+                   "created_at": (x.get("commit") or {}).get("created_at")}} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        pipeline-summary)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"id": x.get("id"), "status": x.get("status"), "ref": x.get("ref"),
+        "sha": x.get("sha"), "created_at": x.get("created_at"),
+        "web_url": x.get("web_url")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        release-mr)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "merged_at": x.get("merged_at"),
+        "labels": x.get("labels", []), "target_branch": x.get("target_branch")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        *)
+            emit_error "unknown view: $view"
+            exit 2
+            ;;
+    esac
 }
 
 if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
@@ -181,39 +252,59 @@ shift
 case "$CMD" in
     releases)
         PER_PAGE="20"
+        VIEW=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 --per-page) PER_PAGE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
-        gl_get_q "$API/releases" \
-            --data-urlencode "per_page=$PER_PAGE" \
-            --data-urlencode "order_by=released_at" \
-            --data-urlencode "sort=desc"
+        if [ -n "$VIEW" ]; then
+            gl_get_q "$API/releases" \
+                --data-urlencode "per_page=$PER_PAGE" \
+                --data-urlencode "order_by=released_at" \
+                --data-urlencode "sort=desc" | project_json "$VIEW"
+        else
+            gl_get_q "$API/releases" \
+                --data-urlencode "per_page=$PER_PAGE" \
+                --data-urlencode "order_by=released_at" \
+                --data-urlencode "sort=desc"
+        fi
         ;;
 
     tags)
         PER_PAGE="20"
+        VIEW=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 --per-page) PER_PAGE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
-        gl_get_q "$API/repository/tags" \
-            --data-urlencode "per_page=$PER_PAGE" \
-            --data-urlencode "order_by=updated" \
-            --data-urlencode "sort=desc"
+        if [ -n "$VIEW" ]; then
+            gl_get_q "$API/repository/tags" \
+                --data-urlencode "per_page=$PER_PAGE" \
+                --data-urlencode "order_by=updated" \
+                --data-urlencode "sort=desc" | project_json "$VIEW"
+        else
+            gl_get_q "$API/repository/tags" \
+                --data-urlencode "per_page=$PER_PAGE" \
+                --data-urlencode "order_by=updated" \
+                --data-urlencode "sort=desc"
+        fi
         ;;
 
     pipelines)
         REF=""
         PER_PAGE="5"
+        VIEW=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 --ref) REF="$2"; shift 2 ;;
                 --per-page) PER_PAGE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
@@ -221,20 +312,30 @@ case "$CMD" in
             emit_error "--ref is required"
             exit 1
         fi
-        gl_get_q "$API/pipelines" \
-            --data-urlencode "ref=$REF" \
-            --data-urlencode "per_page=$PER_PAGE" \
-            --data-urlencode "order_by=updated_at" \
-            --data-urlencode "sort=desc"
+        if [ -n "$VIEW" ]; then
+            gl_get_q "$API/pipelines" \
+                --data-urlencode "ref=$REF" \
+                --data-urlencode "per_page=$PER_PAGE" \
+                --data-urlencode "order_by=updated_at" \
+                --data-urlencode "sort=desc" | project_json "$VIEW"
+        else
+            gl_get_q "$API/pipelines" \
+                --data-urlencode "ref=$REF" \
+                --data-urlencode "per_page=$PER_PAGE" \
+                --data-urlencode "order_by=updated_at" \
+                --data-urlencode "sort=desc"
+        fi
         ;;
 
     merge-requests)
         STATE="opened"
         SINCE=""
+        VIEW=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 --state) STATE="$2"; shift 2 ;;
                 --since) SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
@@ -247,7 +348,11 @@ case "$CMD" in
         if [ -n "$SINCE" ]; then
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get_q "$API/merge_requests" "${ARGS[@]}"
+        if [ -n "$VIEW" ]; then
+            gl_get_q "$API/merge_requests" "${ARGS[@]}" | project_json "$VIEW"
+        else
+            gl_get_q "$API/merge_requests" "${ARGS[@]}"
+        fi
         ;;
 
     mr-commits)

--- a/dev-apprenticeship/release/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/release/scripts/gitlab-api.sh
@@ -21,7 +21,7 @@
 #   releases       --view release-summary  [{tag_name, name, released_at, description}]
 #   tags           --view tag-summary      [{name, message, commit:{short_id, created_at}}]
 #   pipelines      --view pipeline-summary [{id, status, ref, sha, created_at, web_url}]
-#   merge-requests --view release-mr       [{iid, title, merged_at, labels, target_branch}]
+#   merge-requests --view release-mr       [{iid, title, description, merged_at, labels, target_branch}]
 #   <cmd>          --view raw              explicit pass-through (same as no flag)
 #   GITLAB_VIEW_MODE=raw                   env-override that forces pass-through globally.
 #
@@ -91,10 +91,15 @@ print(json.dumps(out))
 PY
             ;;
         release-mr)
+            # Keep `description` so version_bumper / changelog_writer can see
+            # `BREAKING CHANGE:` footers and release-note prose. Title + labels
+            # cover the common cases, but the major-bump signal lives in the
+            # description body.
             DATA="$DATA" python3 <<'PY'
 import os, json
 data = json.loads(os.environ["DATA"])
-out = [{"iid": x.get("iid"), "title": x.get("title"), "merged_at": x.get("merged_at"),
+out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
+        "merged_at": x.get("merged_at"),
         "labels": x.get("labels", []), "target_branch": x.get("target_branch")} for x in data]
 print(json.dumps(out))
 PY
@@ -261,10 +266,15 @@ case "$CMD" in
             esac
         done
         if [ -n "$VIEW" ]; then
-            gl_get_q "$API/releases" \
+            # Two-step so gl_call's non-zero exit (auth/429/5xx/transport)
+            # survives the projection pipe. A bare `gl_get_q ... | project_json`
+            # would let python3 (or `cat` when GITLAB_VIEW_MODE=raw) override
+            # the meaningful exit code with 0 or 1, masking the real failure.
+            body="$(gl_get_q "$API/releases" \
                 --data-urlencode "per_page=$PER_PAGE" \
                 --data-urlencode "order_by=released_at" \
-                --data-urlencode "sort=desc" | project_json "$VIEW"
+                --data-urlencode "sort=desc")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/releases" \
                 --data-urlencode "per_page=$PER_PAGE" \
@@ -284,10 +294,13 @@ case "$CMD" in
             esac
         done
         if [ -n "$VIEW" ]; then
-            gl_get_q "$API/repository/tags" \
+            # Two-step pipe so gl_call's non-zero exit survives projection (see
+            # releases branch above).
+            body="$(gl_get_q "$API/repository/tags" \
                 --data-urlencode "per_page=$PER_PAGE" \
                 --data-urlencode "order_by=updated" \
-                --data-urlencode "sort=desc" | project_json "$VIEW"
+                --data-urlencode "sort=desc")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/repository/tags" \
                 --data-urlencode "per_page=$PER_PAGE" \
@@ -313,11 +326,14 @@ case "$CMD" in
             exit 1
         fi
         if [ -n "$VIEW" ]; then
-            gl_get_q "$API/pipelines" \
+            # Two-step pipe so gl_call's non-zero exit survives projection (see
+            # releases branch above).
+            body="$(gl_get_q "$API/pipelines" \
                 --data-urlencode "ref=$REF" \
                 --data-urlencode "per_page=$PER_PAGE" \
                 --data-urlencode "order_by=updated_at" \
-                --data-urlencode "sort=desc" | project_json "$VIEW"
+                --data-urlencode "sort=desc")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/pipelines" \
                 --data-urlencode "ref=$REF" \
@@ -349,7 +365,10 @@ case "$CMD" in
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
         if [ -n "$VIEW" ]; then
-            gl_get_q "$API/merge_requests" "${ARGS[@]}" | project_json "$VIEW"
+            # Two-step pipe so gl_call's non-zero exit survives projection (see
+            # releases branch above).
+            body="$(gl_get_q "$API/merge_requests" "${ARGS[@]}")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/merge_requests" "${ARGS[@]}"
         fi

--- a/dev-apprenticeship/triage/agents/issue_creator.ag
+++ b/dev-apprenticeship/triage/agents/issue_creator.ag
@@ -24,9 +24,9 @@ type ObservationSummary {
 fn issues_cmd() -> string {
     let ts = recall_latest("issue_creator:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts) + " --view issue_creator";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues --view issue_creator";
 }
 
 fn get_confidence() -> float {

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -25,9 +25,9 @@ type LabelAction {
 fn issues_cmd() -> string {
     let ts = recall_latest("labeler:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts) + " --view labeler";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues --view labeler";
 }
 
 fn get_confidence() -> float {
@@ -72,7 +72,7 @@ fn tick(reason: string) -> void {
     if analysis.unlabeled_count > 0 {
         let confidence = get_confidence();
         let rec = recommend("label", ["accuracy"]);
-        let labels_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh labels"; } catch e { "[]"; };
+        let labels_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh labels --view summary"; } catch e { "[]"; };
         let context = "Unlabeled issues: " + analysis.unlabeled_issues + "\nAvailable labels: " + labels_raw + "\nPast learning: " + to_string(rec);
 
         let action = prompt(

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -25,9 +25,9 @@ type PriorityAction {
 fn issues_cmd() -> string {
     let ts = recall_latest("prioritizer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts) + " --view prioritizer";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues --view prioritizer";
 }
 
 fn get_confidence() -> float {

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -25,9 +25,9 @@ type RouteAction {
 fn issues_cmd() -> string {
     let ts = recall_latest("router:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts);
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts) + " --view router";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues";
+    return "$COLONY_DIR/scripts/gitlab-api.sh issues --view router";
 }
 
 fn get_confidence() -> float {
@@ -52,7 +52,7 @@ fn tick(reason: string) -> void {
     };
 
     // Get team members
-    let members_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh members"; } catch e { "[]"; };
+    let members_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh members --view summary"; } catch e { "[]"; };
 
     // Analyze: find assigned and unassigned issues
     let analysis = prompt(

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -291,7 +291,12 @@ case "$CMD" in
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
         if [ -n "$VIEW" ]; then
-            gl_get_q "$API/issues" "${ARGS[@]}" | project_json "$VIEW"
+            # Two-step so gl_call's non-zero exit (auth/429/5xx/transport)
+            # survives the projection pipe. A bare `gl_get_q ... | project_json`
+            # would let python3 (or `cat` when GITLAB_VIEW_MODE=raw) override
+            # the meaningful exit code with 0 or 1, masking the real failure.
+            body="$(gl_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/issues" "${ARGS[@]}"
         fi
@@ -411,13 +416,21 @@ PY
             # User-facing `--view summary` maps to the internal
             # `members-summary` projection to avoid name collision with
             # the `labels --view summary` projection, which keeps a
-            # different set of fields.
+            # different set of fields. Unknown names must fail loudly here
+            # — falling through would let e.g. `members --view labeler`
+            # silently produce a rc=0 bogus projection, inconsistent with
+            # the "unknown view exits 2" contract elsewhere.
             case "$VIEW" in
                 summary) INTERNAL_VIEW="members-summary" ;;
                 raw) INTERNAL_VIEW="raw" ;;
-                *) INTERNAL_VIEW="$VIEW" ;;
+                *) emit_error "unknown view: $VIEW"; exit 2 ;;
             esac
-            gl_get "$API/members/all?per_page=100" | project_json "$INTERNAL_VIEW"
+            # Two-step so gl_call's non-zero exit (auth/429/5xx/transport)
+            # survives the projection pipe. A bare `gl_get ... | project_json`
+            # would let python3 (or `cat` when GITLAB_VIEW_MODE=raw) override
+            # the meaningful exit code with 0 or 1, masking the real failure.
+            body="$(gl_get "$API/members/all?per_page=100")" || exit $?
+            printf '%s' "$body" | project_json "$INTERNAL_VIEW"
         else
             gl_get "$API/members/all?per_page=100"
         fi
@@ -432,12 +445,17 @@ PY
             esac
         done
         if [ -n "$VIEW" ]; then
+            # Unknown names fail here so `labels --view prioritizer` doesn't
+            # silently produce a bogus projection (see members branch above).
             case "$VIEW" in
                 summary) INTERNAL_VIEW="labels-summary" ;;
                 raw) INTERNAL_VIEW="raw" ;;
-                *) INTERNAL_VIEW="$VIEW" ;;
+                *) emit_error "unknown view: $VIEW"; exit 2 ;;
             esac
-            gl_get "$API/labels?per_page=100" | project_json "$INTERNAL_VIEW"
+            # Two-step pipe so gl_call's non-zero exit survives projection (see
+            # members branch above).
+            body="$(gl_get "$API/labels?per_page=100")" || exit $?
+            printf '%s' "$body" | project_json "$INTERNAL_VIEW"
         else
             gl_get "$API/labels?per_page=100"
         fi

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -8,13 +8,23 @@
 #   GITLAB_PROJECT - URL-encoded project path (e.g. your-org%2Fyour-project)
 #
 # Usage:
-#   gitlab-api.sh issues [--since ISO8601] [--state opened|closed|all]
+#   gitlab-api.sh issues [--since ISO8601] [--state opened|closed|all] [--view <name>]
 #   gitlab-api.sh create-issue --title <t> --description <d> [--labels l1,l2] [--priority p]
 #   gitlab-api.sh update-issue <id> [--add-labels l1,l2] [--remove-labels l1,l2] [--priority p] [--assignee username]
-#   gitlab-api.sh members
-#   gitlab-api.sh labels
+#   gitlab-api.sh members [--view <name>]
+#   gitlab-api.sh labels  [--view <name>]
 #
-# Returns JSON to stdout. Exit code 0 on success, 1 on error, 2 on unknown flag.
+# Views (opt-in projection; default is full JSON):
+#   issues  --view labeler        [{iid, title, labels}]
+#   issues  --view router         [{iid, title, labels, assignees:[{username}]}]
+#   issues  --view prioritizer    [{iid, title, labels}]
+#   issues  --view issue_creator  [{iid, title, description, labels, author:{username}}]
+#   members --view summary        [{id, username, name}]
+#   labels  --view summary        [{name, description, color}]
+#   <cmd>   --view raw            explicit pass-through (same as no flag)
+#   GITLAB_VIEW_MODE=raw          env-override that forces pass-through globally.
+#
+# Returns JSON to stdout. Exit code 0 on success, 1 on error, 2 on unknown flag/view.
 
 set -e
 
@@ -26,6 +36,89 @@ set -e
 # Does NOT exit. The caller controls the exit code.
 emit_error() {
     printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+# project_json <view-name>
+# Reads full GitLab JSON from stdin, writes a downselected projection to
+# stdout. Views keep only the fields that the downstream .ag agent's
+# prompt() actually needs, shrinking payloads ~10x and cutting LLM cost.
+#
+# Views are defined inline in a single python case-dispatch below. Each
+# projection stays under 10 lines. Unknown views exit 2 via emit_error
+# (matching the rest of the script's "unknown flag" contract).
+#
+# Env override: GITLAB_VIEW_MODE=raw short-circuits to cat, giving
+# operators a one-var rollback if a projection drops a field an agent
+# silently depended on.
+project_json() {
+    local view="$1"
+    if [ "${GITLAB_VIEW_MODE:-}" = "raw" ]; then
+        cat
+        return 0
+    fi
+    # Capture stdin once. python3 below reads the projection script from a
+    # `<<'PY'` heredoc (which ties up python's stdin), so the payload has to
+    # travel via env var instead of a pipe. json.loads is cheap enough here
+    # that the extra round-trip through memory is invisible next to the
+    # LLM cost we're trying to avoid.
+    local DATA
+    DATA="$(cat)"
+    case "$view" in
+        raw)
+            printf '%s' "$DATA"
+            ;;
+        labeler)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+print(json.dumps([{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", [])} for x in data]))
+PY
+            ;;
+        router)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", []),
+        "assignees": [{"username": a.get("username")} for a in x.get("assignees", [])]} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        prioritizer)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+print(json.dumps([{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", [])} for x in data]))
+PY
+            ;;
+        issue_creator)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
+        "labels": x.get("labels", []),
+        "author": {"username": (x.get("author") or {}).get("username")}} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        members-summary)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+print(json.dumps([{"id": x.get("id"), "username": x.get("username"), "name": x.get("name")} for x in data]))
+PY
+            ;;
+        labels-summary)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+print(json.dumps([{"name": x.get("name"), "description": x.get("description"), "color": x.get("color")} for x in data]))
+PY
+            ;;
+        *)
+            emit_error "unknown view: $view"
+            exit 2
+            ;;
+    esac
 }
 
 if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT" ]; then
@@ -179,10 +272,12 @@ case "$CMD" in
     issues)
         SINCE=""
         STATE="opened"
+        VIEW=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 --since) SINCE="$2"; shift 2 ;;
                 --state) STATE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
@@ -195,7 +290,11 @@ case "$CMD" in
         if [ -n "$SINCE" ]; then
             ARGS+=(--data-urlencode "updated_after=$SINCE")
         fi
-        gl_get_q "$API/issues" "${ARGS[@]}"
+        if [ -n "$VIEW" ]; then
+            gl_get_q "$API/issues" "${ARGS[@]}" | project_json "$VIEW"
+        else
+            gl_get_q "$API/issues" "${ARGS[@]}"
+        fi
         ;;
 
     create-issue)
@@ -301,11 +400,47 @@ PY
         ;;
 
     members)
-        gl_get "$API/members/all?per_page=100"
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -n "$VIEW" ]; then
+            # User-facing `--view summary` maps to the internal
+            # `members-summary` projection to avoid name collision with
+            # the `labels --view summary` projection, which keeps a
+            # different set of fields.
+            case "$VIEW" in
+                summary) INTERNAL_VIEW="members-summary" ;;
+                raw) INTERNAL_VIEW="raw" ;;
+                *) INTERNAL_VIEW="$VIEW" ;;
+            esac
+            gl_get "$API/members/all?per_page=100" | project_json "$INTERNAL_VIEW"
+        else
+            gl_get "$API/members/all?per_page=100"
+        fi
         ;;
 
     labels)
-        gl_get "$API/labels?per_page=100"
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -n "$VIEW" ]; then
+            case "$VIEW" in
+                summary) INTERNAL_VIEW="labels-summary" ;;
+                raw) INTERNAL_VIEW="raw" ;;
+                *) INTERNAL_VIEW="$VIEW" ;;
+            esac
+            gl_get "$API/labels?per_page=100" | project_json "$INTERNAL_VIEW"
+        else
+            gl_get "$API/labels?per_page=100"
+        fi
         ;;
 
     *)

--- a/tools/test-gitlab-views.sh
+++ b/tools/test-gitlab-views.sh
@@ -228,10 +228,10 @@ run_view_env() {
     local prelude
     prelude=$(mktemp)
     build_prelude "$script" "$prelude"
-    # shellcheck disable=SC1090,SC2016
-    # SC2016: the $1/$2/$3 below are deliberately inner-shell positional args
+    # $1/$2/$3 below are deliberately inner-shell positional args
     # (bash -c's own argv), not outer-scope variables — same pattern as
     # run_view above.
+    # shellcheck disable=SC1090,SC2016
     env "$env_kv" GITLAB_URL=http://x GITLAB_TOKEN=y GITLAB_PROJECT=z bash -c '
         source "$1"
         printf "%s" "$2" | project_json "$3"

--- a/tools/test-gitlab-views.sh
+++ b/tools/test-gitlab-views.sh
@@ -195,7 +195,85 @@ test_view "implementation" "assigned" "iid,title,description,labels,assignees,pr
 test_view "release" "release-summary"  "tag_name,name,released_at,description" "$FIXTURE_RELEASES"
 test_view "release" "tag-summary"      "name,message,commit"                   "$FIXTURE_TAGS"
 test_view "release" "pipeline-summary" "id,status,ref,sha,created_at,web_url"  "$FIXTURE_PIPELINES"
-test_view "release" "release-mr"       "iid,title,merged_at,labels,target_branch" "$FIXTURE_MRS"
+test_view "release" "release-mr"       "iid,title,description,merged_at,labels,target_branch" "$FIXTURE_MRS"
+
+# --- Rollback / error paths (review #126) ---
+# The previous block exercises every declared view. These three extra cases
+# lock down the three "escape hatches" around projection so they can't
+# regress silently:
+#   1. GITLAB_VIEW_MODE=raw env override  -> project_json is a `cat`
+#   2. unknown view name                  -> exit 2, no stdout
+#   3. explicit `--view raw` argument     -> short-circuit to printf stdin
+#
+# Any one of these breaking would silently degrade the rollback story:
+# operators set GITLAB_VIEW_MODE=raw to undo a bad projection without editing
+# .ag sources, and the typo-loud behaviour for unknown views prevents cases
+# like `--view labler` silently matching a `*)` wildcard.
+
+# check_equals <expected> <actual> <label>
+check_equals() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$expected" = "$actual" ]; then
+        pass "$label: output matches input"
+    else
+        fail "$label: output does NOT match input"
+    fi
+}
+
+# run_view_env <env-assignment> <script> <view> <fixture>
+# Variant of run_view that injects an extra env var (e.g. GITLAB_VIEW_MODE=raw)
+# into the inner shell. Kept small and inline to match the existing style.
+run_view_env() {
+    local env_kv="$1" script="$2" view="$3" fixture="$4"
+    local prelude
+    prelude=$(mktemp)
+    build_prelude "$script" "$prelude"
+    # shellcheck disable=SC1090,SC2016
+    # SC2016: the $1/$2/$3 below are deliberately inner-shell positional args
+    # (bash -c's own argv), not outer-scope variables — same pattern as
+    # run_view above.
+    env "$env_kv" GITLAB_URL=http://x GITLAB_TOKEN=y GITLAB_PROJECT=z bash -c '
+        source "$1"
+        printf "%s" "$2" | project_json "$3"
+    ' _ "$prelude" "$fixture" "$view"
+    local rc=$?
+    rm -f "$prelude"
+    return $rc
+}
+
+# Case 1: GITLAB_VIEW_MODE=raw short-circuits even on a normally-valid view.
+# Triage's `labeler` exists; with the env override set, project_json must
+# return the input byte-for-byte (cat path).
+RAW_OUT=$(run_view_env "GITLAB_VIEW_MODE=raw" \
+    "$REPO_ROOT/dev-apprenticeship/triage/scripts/gitlab-api.sh" \
+    "labeler" "$FIXTURE_ISSUES")
+check_equals "$FIXTURE_ISSUES" "$RAW_OUT" "triage/labeler (GITLAB_VIEW_MODE=raw)"
+
+# Case 2: unknown view must exit 2 and not produce a bogus projection.
+# We call project_json directly via the prelude-bash wrapper and capture rc.
+PRELUDE=$(mktemp)
+build_prelude "$REPO_ROOT/dev-apprenticeship/triage/scripts/gitlab-api.sh" "$PRELUDE"
+# shellcheck disable=SC1090,SC2016
+# SC2016: $1/$2/$3 below are the inner bash -c's positional args.
+UNKNOWN_OUT=$(GITLAB_URL=http://x GITLAB_TOKEN=y GITLAB_PROJECT=z bash -c '
+    source "$1"
+    printf "%s" "$2" | project_json "$3"
+' _ "$PRELUDE" "$FIXTURE_ISSUES" "definitely-not-a-view" 2>/dev/null)
+UNKNOWN_RC=$?
+rm -f "$PRELUDE"
+if [ "$UNKNOWN_RC" -eq 2 ] && [ -z "$UNKNOWN_OUT" ]; then
+    pass "triage: unknown view exits 2 with empty stdout"
+else
+    fail "triage: unknown view: rc=$UNKNOWN_RC, stdout='$UNKNOWN_OUT' (want rc=2, empty stdout)"
+fi
+
+# Case 3: explicit `--view raw` arg is a pass-through (no env override set).
+# Same byte-for-byte equality as case 1, but driven by the `raw) printf...`
+# case arm instead of the GITLAB_VIEW_MODE short-circuit.
+RAW_ARG_OUT=$(run_view \
+    "$REPO_ROOT/dev-apprenticeship/triage/scripts/gitlab-api.sh" \
+    "raw" "$FIXTURE_ISSUES")
+check_equals "$FIXTURE_ISSUES" "$RAW_ARG_OUT" "triage: --view raw pass-through"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tools/test-gitlab-views.sh
+++ b/tools/test-gitlab-views.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# test-gitlab-views.sh: unit-test the project_json view projections defined in
+# each colony's scripts/gitlab-api.sh (issue #119).
+#
+# For every (colony, view) pair we care about, this test:
+#   1. Sources the colony's gitlab-api.sh (via a "prelude" that stops right
+#      before the CLI case statement, so the script never tries to hit
+#      $GITLAB_URL) and invokes project_json directly with a fixture on stdin.
+#   2. Checks the output parses as JSON (python3 json.load — no jq).
+#   3. Checks every top-level array element contains EXACTLY the expected
+#      set of keys (no extras — that's the whole point of the projection).
+#   4. Checks the output is <= 30% the size of the input (the downselection
+#      objective from #119; projections that don't clear this bar have
+#      drifted and need a look).
+#
+# Runs under bash 3.2 (stock macOS) and bash 4+. No associative arrays, no
+# mapfile, no ${var^^}, no backslash-newline inside case-pattern labels — same
+# discipline as tools/colony-lint.sh so the macOS CI path stays green (#121).
+#
+# Exit 0 all-pass, 1 any-fail.
+
+set -u  # `set -e` would fire on the first assertion miss; we want to run all
+        # cases and report totals, so errors are checked explicitly.
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+# Canned GitLab JSON fixtures. Each one is deliberately noisy — has fields
+# beyond what any view needs — so a projection that leaks a field by accident
+# shows up as an assertion miss in check_keys. Not checked into tests/ per the
+# spec; kept inline so the fixture travels with the test.
+#
+# The noise fields (description_html, avatar_url, _links, time_stats, etc.)
+# are also what dominates real GitLab payload size — keep them beefy so the
+# 30% size assertion reflects the real-world compression ratio, not a fixture
+# artifact. Build_noise() gives each fixture element a chunky HTML blob to
+# approximate GitLab's actual description_html bloat.
+NOISE='<div class=\"note\"><p>Long description that GitLab renders server-side into bulky HTML with lots of classes and attributes, representing the realistic payload size that drives #119 LLM cost: <a href=\"https://example.gitlab/group/project/-/blob/main/docs/huge-reference-link.md\" class=\"gfm gfm-project_member\" data-reference-type=\"project_member\">reference</a> plus some <code>inline code</code> and <strong>bold text</strong> and more prose that mimics a real issue body after GitLab Markdown pipeline rendering.</p></div>'
+
+FIXTURE_ISSUES='[{"id":100,"iid":1,"project_id":42,"title":"First","description":"desc-1","description_html":"'"$NOISE"'","state":"opened","labels":["bug","priority::high"],"author":{"id":7,"username":"alice","name":"Alice","email":"alice@example.com","avatar_url":"https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?s=80&d=identicon"},"assignees":[{"id":8,"username":"bob","name":"Bob","avatar_url":"https://secure.gravatar.com/avatar/fedcba9876543210fedcba9876543210?s=80&d=identicon"},{"id":9,"username":"carol","avatar_url":"https://secure.gravatar.com/avatar/1111222233334444aaaabbbbccccdddd?s=80&d=identicon"}],"created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-02T10:00:00Z","weight":null,"user_notes_count":3,"upvotes":1,"downvotes":0,"milestone":null,"web_url":"https://example.gitlab/group/project/-/issues/1","priority":"high","_links":{"self":"https://example.gitlab/api/v4/projects/42/issues/1","notes":"https://example.gitlab/api/v4/projects/42/issues/1/notes","award_emoji":"https://example.gitlab/api/v4/projects/42/issues/1/award_emoji"}},{"id":101,"iid":2,"project_id":42,"title":"Second","description":"desc-2","description_html":"'"$NOISE"'","state":"opened","labels":[],"author":{"id":7,"username":"alice","name":"Alice","email":"alice@example.com","avatar_url":"https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?s=80&d=identicon"},"assignees":[],"created_at":"2026-04-03T10:00:00Z","updated_at":"2026-04-04T10:00:00Z","weight":null,"user_notes_count":0,"upvotes":0,"downvotes":0,"milestone":null,"web_url":"https://example.gitlab/group/project/-/issues/2","priority":null,"_links":{"self":"https://example.gitlab/api/v4/projects/42/issues/2","notes":"https://example.gitlab/api/v4/projects/42/issues/2/notes","award_emoji":"https://example.gitlab/api/v4/projects/42/issues/2/award_emoji"}}]'
+
+FIXTURE_MRS='[{"id":500,"iid":10,"project_id":42,"title":"MR-1","description":"mr-desc","description_html":"'"$NOISE"'","state":"opened","labels":["feature"],"source_branch":"feat/x","target_branch":"main","draft":false,"author":{"id":7,"username":"alice","name":"Alice","avatar_url":"https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?s=80&d=identicon"},"assignee":null,"merge_status":"can_be_merged","merged_at":null,"changes_count":"5","user_notes_count":2,"web_url":"https://example.gitlab/group/project/-/merge_requests/10","pipeline":{"id":999,"status":"success","web_url":"https://example.gitlab/group/project/-/pipelines/999","ref":"feat/x","sha":"abcdef1234567890abcdef1234567890abcdef12"},"head_pipeline":{"id":999,"status":"success","web_url":"https://example.gitlab/group/project/-/pipelines/999","ref":"feat/x","sha":"abcdef1234567890abcdef1234567890abcdef12"},"milestone":null,"time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null}},{"id":501,"iid":11,"project_id":42,"title":"MR-2","description":"mr-desc-2","description_html":"'"$NOISE"'","state":"merged","labels":["fix","release-note"],"source_branch":"fix/y","target_branch":"main","draft":true,"author":{"id":7,"username":"alice","name":"Alice","avatar_url":"https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?s=80&d=identicon"},"assignee":null,"merge_status":"merged","merged_at":"2026-04-05T12:00:00Z","changes_count":"2","user_notes_count":0,"web_url":"https://example.gitlab/group/project/-/merge_requests/11","pipeline":{"id":1000,"status":"success","web_url":"https://example.gitlab/group/project/-/pipelines/1000","ref":"fix/y","sha":"ffffff1234567890abcdef1234567890abcdef12"},"head_pipeline":{"id":1000,"status":"success","web_url":"https://example.gitlab/group/project/-/pipelines/1000","ref":"fix/y","sha":"ffffff1234567890abcdef1234567890abcdef12"},"milestone":null,"time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null}}]'
+
+FIXTURE_MEMBERS='[{"id":7,"username":"alice","name":"Alice","state":"active","avatar_url":"https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?s=80&d=identicon","web_url":"https://example.gitlab/alice","access_level":50,"expires_at":null,"email":"alice@example.com","created_at":"2024-01-01T00:00:00Z","created_by":{"id":1,"username":"root","name":"Administrator"}},{"id":8,"username":"bob","name":"Bob","state":"active","avatar_url":"https://secure.gravatar.com/avatar/fedcba9876543210fedcba9876543210?s=80&d=identicon","web_url":"https://example.gitlab/bob","access_level":30,"expires_at":null,"email":"bob@example.com","created_at":"2024-02-01T00:00:00Z","created_by":{"id":1,"username":"root","name":"Administrator"}}]'
+
+FIXTURE_LABELS='[{"id":1,"name":"bug","description":"Something is broken","description_html":"'"$NOISE"'","text_color":"#ffffff","color":"#ff0000","subscribed":false,"priority":null,"is_project_label":true,"open_issues_count":12,"closed_issues_count":40,"open_merge_requests_count":3},{"id":2,"name":"feature","description":"New functionality","description_html":"'"$NOISE"'","text_color":"#000000","color":"#00ff00","subscribed":false,"priority":null,"is_project_label":true,"open_issues_count":5,"closed_issues_count":20,"open_merge_requests_count":2}]'
+
+FIXTURE_RELEASES='[{"tag_name":"v1.2.3","name":"Release 1.2.3","description":"- fix: a bug\n- feat: a thing","description_html":"'"$NOISE"'","created_at":"2026-03-01T10:00:00Z","released_at":"2026-03-01T12:00:00Z","author":{"id":7,"username":"alice","avatar_url":"https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?s=80&d=identicon","web_url":"https://example.gitlab/alice"},"commit":{"id":"abc123def456abc123def456abc123def456abcd","short_id":"abc123d","title":"Release 1.2.3","parent_ids":["parent1","parent2"],"created_at":"2026-03-01T10:00:00Z","author_name":"Alice","author_email":"alice@example.com","authored_date":"2026-03-01T10:00:00Z","committer_name":"Alice","committer_email":"alice@example.com","committed_date":"2026-03-01T10:00:00Z"},"assets":{"count":0,"sources":[],"links":[]},"evidences":[{"sha":"abcdef1234567890abcdef1234567890abcdef12","filepath":"https://example.gitlab/group/project/-/releases/v1.2.3/evidences/1.json","collected_at":"2026-03-01T12:00:00Z"}]},{"tag_name":"v1.2.2","name":"Release 1.2.2","description":"- fix: something","description_html":"'"$NOISE"'","created_at":"2026-02-15T10:00:00Z","released_at":"2026-02-15T12:00:00Z","author":{"id":7,"username":"alice","avatar_url":"https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?s=80&d=identicon","web_url":"https://example.gitlab/alice"},"commit":{"id":"fff111aaa222fff111aaa222fff111aaa222fff1","short_id":"fff111a","title":"Release 1.2.2","parent_ids":["parent3","parent4"],"created_at":"2026-02-15T10:00:00Z","author_name":"Alice","author_email":"alice@example.com","authored_date":"2026-02-15T10:00:00Z","committer_name":"Alice","committer_email":"alice@example.com","committed_date":"2026-02-15T10:00:00Z"},"assets":{"count":0,"sources":[],"links":[]},"evidences":[{"sha":"1234567890abcdef1234567890abcdef12345678","filepath":"https://example.gitlab/group/project/-/releases/v1.2.2/evidences/1.json","collected_at":"2026-02-15T12:00:00Z"}]}]'
+
+FIXTURE_TAGS='[{"name":"v1.2.3","message":"Release 1.2.3","target":"abc123def456abc123def456abc123def456abcd","commit":{"id":"abc123def456abc123def456abc123def456abcd","short_id":"abc123d","created_at":"2026-03-01T10:00:00Z","parent_ids":["ppp1ppp1ppp1ppp1ppp1ppp1ppp1ppp1ppp1ppp1"],"title":"chore: bump","message":"chore: bump to 1.2.3","author_name":"Alice","author_email":"alice@example.com","authored_date":"2026-03-01T10:00:00Z","committer_name":"Alice","committer_email":"alice@example.com","committed_date":"2026-03-01T10:00:00Z","web_url":"https://example.gitlab/group/project/-/commit/abc123def456abc123def456abc123def456abcd"},"release":null,"protected":false},{"name":"v1.2.2","message":"","target":"fff111aaa222fff111aaa222fff111aaa222fff1","commit":{"id":"fff111aaa222fff111aaa222fff111aaa222fff1","short_id":"fff111a","created_at":"2026-02-15T10:00:00Z","parent_ids":["ppp2ppp2ppp2ppp2ppp2ppp2ppp2ppp2ppp2ppp2"],"title":"chore: bump","message":"chore: bump to 1.2.2","author_name":"Alice","author_email":"alice@example.com","authored_date":"2026-02-15T10:00:00Z","committer_name":"Alice","committer_email":"alice@example.com","committed_date":"2026-02-15T10:00:00Z","web_url":"https://example.gitlab/group/project/-/commit/fff111aaa222fff111aaa222fff111aaa222fff1"},"release":null,"protected":false}]'
+
+FIXTURE_PIPELINES='[{"id":9001,"project_id":42,"status":"success","ref":"main","sha":"abc123def456abc123def456abc123def456abcd","created_at":"2026-04-06T10:00:00Z","updated_at":"2026-04-06T10:15:00Z","web_url":"https://example.gitlab/group/project/-/pipelines/9001","iid":"9001","name":"main","source":"push","before_sha":"parent1parent1parent1parent1parent1parent","tag":false,"yaml_errors":null,"user":{"id":7,"username":"alice","avatar_url":"https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?s=80&d=identicon","web_url":"https://example.gitlab/alice"},"detailed_status":{"icon":"status_success","text":"passed","label":"passed","group":"success","tooltip":"passed","has_details":true,"details_path":"https://example.gitlab/group/project/-/pipelines/9001","favicon":"favicon.png"}},{"id":9000,"project_id":42,"status":"failed","ref":"main","sha":"123456abcdef123456abcdef123456abcdef1234","created_at":"2026-04-05T10:00:00Z","updated_at":"2026-04-05T10:15:00Z","web_url":"https://example.gitlab/group/project/-/pipelines/9000","iid":"9000","name":"main","source":"push","before_sha":"parent2parent2parent2parent2parent2parent","tag":false,"yaml_errors":null,"user":{"id":7,"username":"alice","avatar_url":"https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?s=80&d=identicon","web_url":"https://example.gitlab/alice"},"detailed_status":{"icon":"status_failed","text":"failed","label":"failed","group":"failed","tooltip":"failed","has_details":true,"details_path":"https://example.gitlab/group/project/-/pipelines/9000","favicon":"favicon.png"}}]'
+
+# Build the sourceable "prelude" for a script. Every gitlab-api.sh ends its
+# function block with `CMD=...` and then the big CLI case. We stop at that
+# CMD= line so we get just the function defs — no env check explosions, no
+# command dispatch, no curl calls. Temp prelude file gets cleaned up in main.
+build_prelude() {
+    local script="$1"
+    local out="$2"
+    awk '/^CMD=/{exit} {print}' "$script" > "$out"
+}
+
+# run_view <script-path> <internal-view-name> <fixture-json>
+# Streams the fixture through project_json and prints the projection.
+# Uses dummy GITLAB_URL/TOKEN/PROJECT so the env check passes. Echoes via
+# printf to avoid echo's platform quirks (Linux-bash prints -e as literal).
+run_view() {
+    local script="$1" view="$2" fixture="$3"
+    local prelude
+    prelude=$(mktemp)
+    build_prelude "$script" "$prelude"
+    # shellcheck disable=SC1090
+    GITLAB_URL=http://x GITLAB_TOKEN=y GITLAB_PROJECT=z bash -c '
+        source "$1"
+        printf "%s" "$2" | project_json "$3"
+    ' _ "$prelude" "$fixture" "$view"
+    local rc=$?
+    rm -f "$prelude"
+    return $rc
+}
+
+# check_is_json <json-text> <label>
+check_is_json() {
+    local text="$1" label="$2"
+    if printf '%s' "$text" | python3 -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+        pass "$label: output is valid JSON"
+    else
+        fail "$label: output is NOT valid JSON"
+    fi
+}
+
+# check_keys <json-text> <expected-csv> <label>
+# Asserts every array element has EXACTLY the expected set of top-level keys.
+# Extras (or missing required keys) fail. Uses python3 symmetric difference.
+# DATA travels via env var because the heredoc is already tying up python's
+# stdin — same pattern as project_json inside the gitlab-api.sh scripts.
+check_keys() {
+    local text="$1" expected="$2" label="$3"
+    local result
+    result=$(DATA="$text" EXPECTED="$expected" python3 <<'PY'
+import os, json
+try:
+    data = json.loads(os.environ["DATA"])
+except Exception as e:
+    print("PARSE_ERR:" + str(e))
+    raise SystemExit(0)
+expected = set(x.strip() for x in os.environ["EXPECTED"].split(",") if x.strip())
+if not isinstance(data, list):
+    print("NOT_LIST")
+    raise SystemExit(0)
+if not data:
+    print("EMPTY")
+    raise SystemExit(0)
+for i, elem in enumerate(data):
+    if not isinstance(elem, dict):
+        print("NOT_DICT:" + str(i))
+        raise SystemExit(0)
+    got = set(elem.keys())
+    extra = got - expected
+    missing = expected - got
+    if extra or missing:
+        print("KEYS_MISMATCH:" + str(i) + " extra=" + ",".join(sorted(extra)) + " missing=" + ",".join(sorted(missing)))
+        raise SystemExit(0)
+print("OK")
+PY
+)
+    if [ "$result" = "OK" ]; then
+        pass "$label: top-level keys match {$expected}"
+    else
+        fail "$label: key check failed: $result"
+    fi
+}
+
+# check_size <input-text> <output-text> <label>
+# Requires output <= 30% of input. We're aiming for ~10x shrinkage in
+# realistic payloads; 30% is a loose bar so small fixtures with limited
+# field-count-to-value-size ratios don't falsely trip the test.
+check_size() {
+    local input="$1" output="$2" label="$3"
+    local in_size out_size
+    in_size=${#input}
+    out_size=${#output}
+    local threshold=$(( in_size * 30 / 100 ))
+    if [ "$out_size" -le "$threshold" ]; then
+        pass "$label: size $out_size <= 30% of $in_size (threshold $threshold)"
+    else
+        fail "$label: size $out_size > 30% of $in_size (threshold $threshold)"
+    fi
+}
+
+# Runs the full test triplet (valid-json + keys + size) for one view.
+#
+# Args: colony_label internal_view_name expected_csv fixture
+# Resolves script path from colony_label -> dev-apprenticeship/<label>/...
+test_view() {
+    local colony="$1" view="$2" keys="$3" fixture="$4"
+    local label="$colony/$view"
+    local script="$REPO_ROOT/dev-apprenticeship/$colony/scripts/gitlab-api.sh"
+    if [ ! -f "$script" ]; then
+        fail "$label: script not found at $script"
+        return
+    fi
+    local out
+    out=$(run_view "$script" "$view" "$fixture")
+    check_is_json "$out" "$label"
+    check_keys "$out" "$keys" "$label"
+    check_size "$fixture" "$out" "$label"
+}
+
+# --- Triage ---
+test_view "triage" "labeler"        "iid,title,labels"                                  "$FIXTURE_ISSUES"
+test_view "triage" "router"         "iid,title,labels,assignees"                        "$FIXTURE_ISSUES"
+test_view "triage" "prioritizer"    "iid,title,labels"                                  "$FIXTURE_ISSUES"
+test_view "triage" "issue_creator"  "iid,title,description,labels,author"               "$FIXTURE_ISSUES"
+test_view "triage" "members-summary" "id,username,name"                                  "$FIXTURE_MEMBERS"
+test_view "triage" "labels-summary"  "name,description,color"                            "$FIXTURE_LABELS"
+
+# --- Code-review ---
+test_view "code-review" "reviewer" "iid,state,title,labels,source_branch,target_branch,draft" "$FIXTURE_MRS"
+
+# --- Planning ---
+test_view "planning" "planning"    "iid,title,description,labels,author,created_at"                    "$FIXTURE_ISSUES"
+test_view "planning" "planning-mr" "iid,title,description,labels,changes_count,user_notes_count,merged_at,target_branch" "$FIXTURE_MRS"
+
+# --- Implementation ---
+test_view "implementation" "impl"     "iid,title,merged_at,target_branch"                      "$FIXTURE_MRS"
+test_view "implementation" "assigned" "iid,title,description,labels,assignees,priority"        "$FIXTURE_ISSUES"
+
+# --- Release ---
+test_view "release" "release-summary"  "tag_name,name,released_at,description" "$FIXTURE_RELEASES"
+test_view "release" "tag-summary"      "name,message,commit"                   "$FIXTURE_TAGS"
+test_view "release" "pipeline-summary" "id,status,ref,sha,created_at,web_url"  "$FIXTURE_PIPELINES"
+test_view "release" "release-mr"       "iid,title,merged_at,labels,target_branch" "$FIXTURE_MRS"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Add opt-in named `--view` flag to list endpoints in every colony's `scripts/gitlab-api.sh` (triage, code-review, planning, implementation, release). Each view is a `python3` projection (no `jq` dependency) defined inline in a `project_json` function at the top of the script. Default behavior unchanged — omitting `--view` returns today's full payload.
- Add 14 views across the 5 scripts, shrinking payloads ~10x for the agent's `prompt()` call (issue #119 goal). See commit body for the full list.
- Thread `--view <name>` through every matching `exec sh .../gitlab-api.sh` call site in `dev-apprenticeship/*/agents/*.ag`. Detail endpoints (`issue/<iid>`, `mr-changes`, `mr-commits`, `mr-notes`) are deliberately left unchanged — those agents genuinely need the full payload.
- `GITLAB_VIEW_MODE=raw` env-var escape hatch forces every view back to pass-through globally — one-var rollback for operators if a projection drops a field an agent silently depended on.
- Unknown view exits 2 via `emit_error`, matching the existing "unknown flag" contract.
- New `tools/test-gitlab-views.sh`: 45 assertions covering every (colony, view) pair against inline noisy GitLab fixtures. Verifies (a) valid JSON, (b) exact top-level key set per array element, (c) output <= 30% of input size. Picked up automatically by `colony-lint.sh`'s `test-*.sh` discovery.
- Bash 3.2 compatible throughout (issue #121 baseline): no `mapfile`, no associative arrays, no `${var^^}`, no backslash-newline inside case labels.

## Test plan

- [x] `bash tools/colony-lint.sh` → 46 passed / 0 failed (was 45 / 0)
- [x] `bash tools/test-gitlab-views.sh` → 45 passed / 0 failed
- [x] `bash -n` on all 5 modified `gitlab-api.sh` scripts
- [x] `bash -n` on new `tools/test-gitlab-views.sh`
- [x] All 21 `.ag` files still parse via `agentis commit` (lint-step in colony-lint)
- [x] `--view raw` and `GITLAB_VIEW_MODE=raw` both produce pass-through output
- [x] Unknown view (`--view bogus`) exits 2 with JSON error on stderr
- [ ] CI shellcheck clean on the modified scripts (runs in GH Actions; skipped locally)

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)