### PR TITLE
fix(dev-apprenticeship): accept --per-page on merge-requests (#127)

### DIFF
--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -8,7 +8,7 @@
 #   GITLAB_PROJECT - URL-encoded project path
 #
 # Usage:
-#   gitlab-api.sh merge-requests [--since ISO8601] [--state opened|merged|all] [--view <name>]
+#   gitlab-api.sh merge-requests [--since ISO8601] [--state opened|merged|all] [--per-page N] [--view <name>]
 #   gitlab-api.sh mr-changes <iid>
 #   gitlab-api.sh mr-notes <iid>
 #   gitlab-api.sh post-note <iid> --body <text>
@@ -220,17 +220,19 @@ case "$CMD" in
         SINCE=""
         STATE="opened"
         VIEW=""
+        PER_PAGE=20
         while [ $# -gt 0 ]; do
             case "$1" in
                 --since) SINCE="$2"; shift 2 ;;
                 --state) STATE="$2"; shift 2 ;;
                 --view) VIEW="$2"; shift 2 ;;
+                --per-page) PER_PAGE="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
         ARGS=(
             --data-urlencode "state=$STATE"
-            --data-urlencode "per_page=20"
+            --data-urlencode "per_page=$PER_PAGE"
             --data-urlencode "order_by=updated_at"
             --data-urlencode "sort=desc"
         )

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -230,6 +230,9 @@ case "$CMD" in
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
         ARGS=(
             --data-urlencode "state=$STATE"
             --data-urlencode "per_page=$PER_PAGE"

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -246,6 +246,9 @@ case "$CMD" in
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
         ARGS=(
             --data-urlencode "state=$STATE"
             --data-urlencode "per_page=$PER_PAGE"

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -8,7 +8,7 @@
 #   GITLAB_PROJECT - URL-encoded project path (e.g. your-org%2Fyour-project)
 #
 # Usage:
-#   gitlab-api.sh merge-requests [--state merged] [--since ISO8601] [--view <name>]
+#   gitlab-api.sh merge-requests [--state merged] [--since ISO8601] [--per-page N] [--view <name>]
 #   gitlab-api.sh mr-changes <iid>
 #   gitlab-api.sh mr-commits <iid>
 #   gitlab-api.sh issue <iid>
@@ -236,17 +236,19 @@ case "$CMD" in
         STATE="opened"
         SINCE=""
         VIEW=""
+        PER_PAGE=20
         while [ $# -gt 0 ]; do
             case "$1" in
                 --state) STATE="$2"; shift 2 ;;
                 --since) SINCE="$2"; shift 2 ;;
                 --view) VIEW="$2"; shift 2 ;;
+                --per-page) PER_PAGE="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
         ARGS=(
             --data-urlencode "state=$STATE"
-            --data-urlencode "per_page=20"
+            --data-urlencode "per_page=$PER_PAGE"
             --data-urlencode "order_by=updated_at"
             --data-urlencode "sort=desc"
         )

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -301,6 +301,9 @@ case "$CMD" in
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
         ARGS=(
             --data-urlencode "state=$STATE"
             --data-urlencode "per_page=$PER_PAGE"

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -10,7 +10,7 @@
 # Usage:
 #   gitlab-api.sh issues --needs-planning [--since ISO8601] [--view <name>]
 #   gitlab-api.sh add-note <iid> --body <text>
-#   gitlab-api.sh merge-requests [--state merged] [--since ISO8601] [--view <name>]
+#   gitlab-api.sh merge-requests [--state merged] [--since ISO8601] [--per-page N] [--view <name>]
 #
 # Views (opt-in projection; default is full JSON):
 #   issues         --view planning     [{iid, title, description, labels,
@@ -291,17 +291,19 @@ case "$CMD" in
         STATE="opened"
         SINCE=""
         VIEW=""
+        PER_PAGE=20
         while [ $# -gt 0 ]; do
             case "$1" in
                 --state) STATE="$2"; shift 2 ;;
                 --since) SINCE="$2"; shift 2 ;;
                 --view) VIEW="$2"; shift 2 ;;
+                --per-page) PER_PAGE="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
         ARGS=(
             --data-urlencode "state=$STATE"
-            --data-urlencode "per_page=20"
+            --data-urlencode "per_page=$PER_PAGE"
             --data-urlencode "order_by=updated_at"
             --data-urlencode "sort=desc"
         )

--- a/dev-apprenticeship/release/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/release/scripts/gitlab-api.sh
@@ -357,6 +357,9 @@ case "$CMD" in
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
         ARGS=(
             --data-urlencode "state=$STATE"
             --data-urlencode "per_page=$PER_PAGE"

--- a/dev-apprenticeship/release/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/release/scripts/gitlab-api.sh
@@ -11,7 +11,7 @@
 #   gitlab-api.sh releases [--per-page N] [--view <name>]
 #   gitlab-api.sh tags [--per-page N] [--view <name>]
 #   gitlab-api.sh pipelines --ref <branch> [--per-page N] [--view <name>]
-#   gitlab-api.sh merge-requests --state merged [--since ISO8601] [--view <name>]
+#   gitlab-api.sh merge-requests --state merged [--since ISO8601] [--per-page N] [--view <name>]
 #   gitlab-api.sh mr-commits <iid>
 #   gitlab-api.sh create-tag --name <name> --ref <ref> [--message <m>]
 #   gitlab-api.sh create-release --tag <tag> --name <name> --description <d>
@@ -347,17 +347,19 @@ case "$CMD" in
         STATE="opened"
         SINCE=""
         VIEW=""
+        PER_PAGE=100
         while [ $# -gt 0 ]; do
             case "$1" in
                 --state) STATE="$2"; shift 2 ;;
                 --since) SINCE="$2"; shift 2 ;;
                 --view) VIEW="$2"; shift 2 ;;
+                --per-page) PER_PAGE="$2"; shift 2 ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
         ARGS=(
             --data-urlencode "state=$STATE"
-            --data-urlencode "per_page=100"
+            --data-urlencode "per_page=$PER_PAGE"
             --data-urlencode "order_by=updated_at"
             --data-urlencode "sort=desc"
         )


### PR DESCRIPTION
## Summary

- **#127**: `merge-requests --per-page <N>` was silently unsupported across all four dev-apprenticeship `gitlab-api.sh` copies. Release colony's `changelog_writer.ag` and `ship_decider.ag` called it with `--per-page 1`, which tripped the `*) emit_error "unknown flag: $1"; exit 2` arm. The `try { exec sh ... } catch e { "[]" }` wrapper swallowed the failure, so `mr_iid` always extracted as `0` and the `if mr_iid > 0` note-posting branch never fired.
- Added `--per-page N` to the `merge-requests` subcommand in all four copies (code-review, implementation, planning, release), routed through a `PER_PAGE` variable.
- Preserved each file's pre-existing default: `20` for code-review/implementation/planning, `100` for release.
- Updated the `# Usage:` header in all four files.

## Test plan

- [x] `./tools/colony-lint.sh` — 46/46 pass
- [x] `bash -n` all four files
- [x] Smoke: `GITLAB_URL=http://example GITLAB_TOKEN=x GITLAB_PROJECT=x bash .../release/scripts/gitlab-api.sh merge-requests --per-page 1` — reaches the curl call (HTTP transport error) instead of failing at arg-parse with `unknown flag`.
- [ ] CI colony-lint

## Not migrated in this PR

The `prompt()`-based `mr_iid` extraction at `changelog_writer.ag:120` / `ship_decider.ag:89` is still a wasted LLM call. That belongs in the post-v1.2.0 migration to `json_get` (tracked under #125 and the pending core PR #506).

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)