### PR TITLE
chore: bump MIN_VERSION to 1.2.0

### DIFF
--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -19,7 +19,7 @@ ALL_AGENTS=(
     code_writer test_writer refactorer commit_composer
     ship_decider changelog_writer version_bumper release_checker
 )
-MIN_VERSION="1.1.8"
+MIN_VERSION="1.2.0"
 
 # --- Helpers ---
 
@@ -106,7 +106,7 @@ AGENTIS_VERSION=$(agentis --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9
 info "agentis version: $AGENTIS_VERSION (minimum: $MIN_VERSION)"
 
 if ! version_gte "$AGENTIS_VERSION" "$MIN_VERSION"; then
-    fail "agentis >= $MIN_VERSION required (--enable-exec/--enable-messaging flags, #492 quarantine fix, #499 watchdog heartbeat fix, #107 daemon PII grant + exec.default_timeout_ms). Please update."
+    fail "agentis >= $MIN_VERSION required (--enable-exec/--enable-messaging flags, #492 quarantine fix, #499 watchdog heartbeat fix, #107 daemon PII grant + exec.default_timeout_ms, #123 tick-success health, #125 parse_float/parse_int/json_get). Please update."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Core v1.2.0 was tagged today. This bumps the install.sh MIN_VERSION floor
from 1.1.8 → 1.2.0 so that fresh colony installs get the runtime features
the agents already rely on:

- **#123** — tick-success-rate health signal (daemon list no longer reports
  0%-tick-success agents as `healthy`)
- **#125** — native `parse_float`, `parse_int`, `json_get` builtins (halves
  the prompt budget for agents that were calling `prompt() → int`)

## Test plan

- [x] `bash -n install.sh` — syntactic check passes
- [ ] Ran `install.sh` against a 1.1.8 binary — confirmed fail message shows new floor
- [ ] Ran `install.sh` against a 1.2.0 binary — passes the version gate

## Follow-up

Migrating existing `.ag` agents to use `parse_float` / `parse_int` / `json_get`
(instead of the current `prompt() → int` pattern) is tracked separately in
Replikanti/agentis-colonies#125 and will land as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)