### PR TITLE
fix(agents): drop prompt() round-trip for confidence parsing (#125)

### DIFF
--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -20,7 +20,7 @@ type ReviewDecision {
 fn get_confidence() -> float {
     let raw = recall_latest("approval_decider:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -32,7 +32,7 @@ fn mr_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("logic_reviewer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -33,7 +33,7 @@ fn mr_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("security_reviewer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -32,7 +32,7 @@ fn mr_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("style_reviewer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -32,7 +32,7 @@ fn mr_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("test_reviewer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -35,7 +35,7 @@ fn merged_mr_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("code_writer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -37,7 +37,7 @@ fn merged_mr_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("commit_composer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -33,7 +33,7 @@ fn merged_mr_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("refactorer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -35,7 +35,7 @@ fn merged_mr_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("test_writer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -25,7 +25,7 @@ type DraftPlan {
 fn get_confidence() -> float {
     let raw = recall_latest("plan_reviewer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -33,7 +33,7 @@ fn unplanned_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("risk_assessor:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -34,7 +34,7 @@ fn unplanned_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("scope_estimator:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -34,7 +34,7 @@ fn unplanned_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("task_decomposer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -28,7 +28,7 @@ type ChangelogDraft {
 fn get_confidence() -> float {
     let raw = recall_latest("changelog_writer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -29,7 +29,7 @@ type CheckResult {
 fn get_confidence() -> float {
     let raw = recall_latest("release_checker:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -26,7 +26,7 @@ type ShipDecision {
 fn get_confidence() -> float {
     let raw = recall_latest("ship_decider:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/release/agents/version_bumper.ag
+++ b/dev-apprenticeship/release/agents/version_bumper.ag
@@ -28,7 +28,7 @@ type VersionBump {
 fn get_confidence() -> float {
     let raw = recall_latest("version_bumper:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/triage/agents/issue_creator.ag
+++ b/dev-apprenticeship/triage/agents/issue_creator.ag
@@ -32,7 +32,7 @@ fn issues_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("issue_creator:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -33,7 +33,7 @@ fn issues_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("labeler:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -33,7 +33,7 @@ fn issues_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("prioritizer:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -33,7 +33,7 @@ fn issues_cmd() -> string {
 fn get_confidence() -> float {
     let raw = recall_latest("router:confidence");
     if len(raw) > 0 {
-        return prompt("Return this number as a decimal. Nothing else.", raw) -> float;
+        return parse_float(raw);
     };
     return 0.0;
 }


### PR DESCRIPTION
## Summary

Every one of the 21 \`dev-apprenticeship\` agents was calling

\`\`\`ag
prompt(\"Return this number as a decimal. Nothing else.\", raw) -> float
\`\`\`

once per tick to turn its own stored \`*:confidence\` memo (e.g. \"0.85\") back into a float. That was **~1260 wasted LLM round-trips per hour** on a fully populated colony — purely because \`.ag\` had no native string-to-float parser.

agentis v1.2.0 (#506) added \`parse_float\`. This PR replaces the prompt call with the native builtin in every \`get_confidence\` function.

### Scope

Intentionally **confidence-only** — the highest-frequency, lowest-risk migration. The remaining \`prompt(\"Extract the iid ...\")\` / \`prompt(\"Return just the string ...\")\` calls in \`changelog_writer\`, \`ship_decider\`, \`release_checker\`, \`refactorer\`, and \`plan_reviewer\` are separate migrations that need Void-handling in \`.ag\` — will be tracked as follow-ups after this lands.

### Behavior

No change. \`parse_float\` returns 0.0 on parse failure (trim-tolerant, accepts scientific notation per #510 tests), matching the previous LLM fallback path where a malformed memo would have been coerced to the type's zero value.

## Test plan

- [x] Each of the 21 \`.ag\` files parses cleanly with the v1.2.0 binary (\`agentis commit <file>\` — exit 0)
- [x] Diff is mechanical — 21 files, 1 line each

## Impact

Rough estimate:
- Before: 21 agents × 60 ticks/hr = **1260 LLM calls/hr** for confidence parses alone
- After: **0 LLM calls** for the same work — just a native \`f64::from_str\`

Closes #125 (confidence-parse scope; remaining JSON-extraction work tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)