### PR TITLE
fix(dev-apprenticeship): migrate remaining prompt extractions (#131)

### DIFF
--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -99,8 +99,10 @@ fn tick(reason: string) -> void {
         print("[refactorer] Reviewed draft for issue", suggestion.issue_id, "(confidence:", confidence, ")");
 
         if confidence >= 0.85 {
-            // Generate refactored code and commit to branch
-            let branch = prompt("Extract the branch_name from this code draft record. Return just the string, nothing else.", draft_str) -> string;
+            // Generate refactored code and commit to branch.
+            // #131: read branch_name via field access on the bus-delivered
+            // record instead of stringifying + re-prompting.
+            let branch = draft.branch_name;
             let refactor_context = "Code draft: " + draft_str + "\nSuggestions: " + suggestion.suggestions + "\nPatterns: " + to_string(rec);
             let actions_json = prompt(
                 "You are a refactorer. Apply these refactoring suggestions to the code draft. Return a JSON array of objects, each with: action (string, 'update'), file_path (string), content (string, the refactored file content). Only return the JSON array, nothing else.",

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -56,20 +56,18 @@ fn tick(reason: string) -> void {
     let breakdown_str = to_string(breakdown);
 
     // 2. Stash each partial under the issue id it belongs to.
-    // Peer outputs arrive as struct Display format (not JSON), but the
-    // issue_id field is rendered verbatim either way, so we let the LLM
-    // extract it once per non-void bucket.
+    // #131: listen() returns the emitted record directly; we read
+    // `issue_id` via field access (0 LLM calls) instead of stringifying
+    // and re-prompting. The stash body keeps the Display repr because
+    // the downstream assembly prompt consumes that.
     if received(scope_str) {
-        let scope_iid = prompt("Return just the issue_id integer from this record. Nothing else.", scope_str) -> int;
-        stash("scope", scope_iid, scope_str);
+        stash("scope", scope.issue_id, scope_str);
     };
     if received(risks_str) {
-        let risks_iid = prompt("Return just the issue_id integer from this record. Nothing else.", risks_str) -> int;
-        stash("risks", risks_iid, risks_str);
+        stash("risks", risks.issue_id, risks_str);
     };
     if received(breakdown_str) {
-        let bd_iid = prompt("Return just the issue_id integer from this record. Nothing else.", breakdown_str) -> int;
-        stash("breakdown", bd_iid, breakdown_str);
+        stash("breakdown", breakdown.issue_id, breakdown_str);
     };
 
     // 3. Pick the newest unplanned issue and see if we have all three

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -118,7 +118,7 @@ fn tick(reason: string) -> void {
 
         if confidence >= 0.85 {
             let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
-            let mr_iid = prompt("Extract the iid integer of the first MR from this JSON array. If empty, return 0.", mr_raw) -> int;
+            let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
             if mr_iid > 0 {
                 let note = "**Release Notes Draft** (automated)\n\n" + draft.changelog;
                 let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -88,7 +88,10 @@ fn tick(reason: string) -> void {
             print("[release_checker] Checked main pipeline:", result.ci_status, "(confidence:", confidence, ")");
 
             if confidence >= 0.85 {
-                let mr_iid = prompt("Extract the iid or issue_id integer from this MR data. Return just the integer. If not found, return 0.", mr_str) -> int;
+                // #131: mr_ready is emitted by commit_composer as an
+                // MRPlan record whose issue_id is the GitLab iid — read
+                // via field access instead of prompting.
+                let mr_iid = mr_ready.issue_id;
                 if mr_iid > 0 {
                     let note = "**Pre-release Check** (automated): " + result.ci_status + "\n\nIssues: " + result.issues_found;
                     let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -87,7 +87,7 @@ fn tick(reason: string) -> void {
 
     if confidence >= 0.85 {
         let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
-        let mr_iid = prompt("Extract the iid integer of the first MR from this JSON array. If empty, return 0.", mr_raw) -> int;
+        let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
         if mr_iid > 0 {
             let note = "**Ship Decision** (automated): " + decision.decision + "\n\n" + decision.reasoning;
             let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);


### PR DESCRIPTION
## Summary
Closes #131.

**Group A — JSON extraction (2× prompts → json_get)**
- `release/agents/changelog_writer.ag` — iid of first MR via `json_get(mr_raw, \"[0].iid\")`
- `release/agents/ship_decider.ag` — same shape

Pattern: \`parse_int(to_string(json_get(raw, \"[0].iid\")))\`. The Void-on-miss case resolves to \`parse_int(\"void\")\` → 0, matching the old prompt's "If empty, return 0." contract.

**Group B — record field access (5× prompts → direct field access)**
Verified \`listen()\` returns the live record and the \`.\` accessor works on the result. No core language changes needed.

- \`planning/agents/plan_reviewer.ag\` (3×) — \`scope.issue_id\` / \`risks.issue_id\` / \`breakdown.issue_id\`
- \`implementation/agents/refactorer.ag\` — \`draft.branch_name\`
- \`release/agents/release_checker.ag\` — \`mr_ready.issue_id\`

## Impact
~7 prompt roundtrips per tick removed across planning, implementation, and release colonies. Combined with PR #130's 21× confidence parse removal, \`#125\` extraction cleanup is complete.

## Test plan
- [x] \`agentis commit\` (v1.2.0 local binary) parses all 5 modified files clean
- [x] Typechecker accepts \`.field\` access on \`listen()\` result (verified via minimal repro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)