### PR TITLE
feat(dev-apprenticeship): per-operator personal knowledge tag (#104)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -222,16 +222,19 @@ Cross-colony wiring: Triage routes issues to Implementation. Implementation sign
 
 ## Knowledge portability
 
-Every `learn()` call in the federation's agents tags entries with one of `observed` (passive learning from GitLab activity), `emitted` (suggestion logged at confidence 0.6-0.84), or `acted` (autonomous action taken at ≥ 0.85) plus the colony name (`triage`, `code-review`, `planning`, `implementation`, `release`). There is no built-in distinction between "your preferences" and "codebase-specific" knowledge — agents see the full GitLab project activity without any concept of who `you` are, so everything learned is effectively project-scoped.
+Every `learn()` call in the federation's agents tags entries with one of `observed` (passive learning from GitLab activity), `emitted` (suggestion logged at confidence 0.6-0.84), or `acted` (autonomous action taken at ≥ 0.85) plus the colony name (`triage`, `code-review`, `planning`, `implementation`, `release`).
+
+**Personal vs team (`#104`).** If you set your GitLab username during `./install.sh` (or in `colony.toml` under `[gitlab] me = "..."`), three agents (`labeler`, `prioritizer`, `style_reviewer`) additionally tag their `acted` learn calls as either `personal` (the issue/MR author matches your username) or `team` (anyone else). The remaining agents still tag only `observed|emitted|acted` + colony; widening coverage is tracked as future work. If you leave the username empty, every entry keeps the legacy `team` tag so exports stay stable.
 
 Bulk export/import is available at the runtime level and will carry all entries as-is:
 
 ```bash
 agentis knowledge export > fed-knowledge.json
+agentis knowledge export --tags personal > my-preferences.json  # carry just your style
 agentis knowledge import fed-knowledge.json --merge
 ```
 
-Filtering by `--tags observed`, `--tags emitted`, `--tags acted`, or `--tags <colony>` works (those are real tags the agents emit), but there is no `personal` or `project:<name>` tag today — if you try `--tags personal` you will get an empty array.
+Filtering by `--tags observed`, `--tags emitted`, `--tags acted`, `--tags <colony>`, `--tags personal`, or `--tags team` works once the matching agents have acted at least once with the relevant author context.
 
 ## Troubleshooting
 

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -18,7 +18,31 @@ type StyleFinding {
 type StyleReview {
     mr_iid: int,
     findings: list<StyleFinding>,
-    summary: string
+    summary: string,
+    author: string
+}
+
+// #104: Returns "personal" if the given author matches the operator's
+// GitLab username (memo `gitlab:me`, seeded by install.sh); "team"
+// otherwise. Empty memo = pre-#104 behavior (everyone is team).
+fn scope_for_author(author: string) -> string {
+    let me = recall_latest("gitlab:me");
+    if len(me) > 0 {
+        if author == me {
+            return "personal";
+        };
+    };
+    return "team";
+}
+
+// #104: json_get on a miss returns Void, whose to_string renders as
+// "void". Collapse that to empty so downstream consumers (prompt
+// context, scope_for_author) don't get the sentinel word.
+fn sanitize_author(s: string) -> string {
+    if s == "void" {
+        return "";
+    };
+    return s;
 }
 
 fn mr_cmd() -> string {
@@ -87,9 +111,14 @@ fn tick(reason: string) -> void {
     let rec = recommend("style_review", ["accuracy"]);
     let context = "MR diff:\n" + changes_raw + "\n\nLearned preferences: " + to_string(rec);
 
+    // #104: Extract author from the MR listing so the review prompt
+    // has access to it. `raw` holds the first-page MR JSON; json_get
+    // on a missing key returns Void whose to_string is "void" — collapse
+    // that to "" so the prompt context stays clean.
+    let mr_author = sanitize_author(to_string(json_get(raw, "[0].author.username")));
     let review = prompt(
-        "You are a style reviewer. Analyze this merge request diff for style issues: naming conventions, formatting, import ordering, whitespace, code organization. Return JSON: mr_iid (int), findings (array of objects with file, issue, severity, suggestion), summary (string). Only flag real style issues, not logic or security. If clean, return empty findings array. Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
-        context
+        "You are a style reviewer. Analyze this merge request diff for style issues: naming conventions, formatting, import ordering, whitespace, code organization. Return JSON: mr_iid (int), findings (array of objects with file, issue, severity, suggestion), summary (string), author (string, echo back the MR author username if provided below). Only flag real style issues, not logic or security. If clean, return empty findings array. Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
+        "MR author: " + mr_author + "\n" + context
     ) -> StyleReview;
 
     let confidence = get_confidence();
@@ -108,7 +137,9 @@ fn tick(reason: string) -> void {
                 "";
             };
             if len(result) > 0 {
-                learn("style_review", "posted on MR " + to_string(mr_iid), review.summary, "success", ["acted", "code-review"]);
+                // #104: tag knowledge as personal (operator's own MR) vs team.
+                let scope = scope_for_author(review.author);
+                learn("style_review", "posted on MR " + to_string(mr_iid), review.summary, "success", [scope, "code-review", "acted"]);
             };
         } else {
             print("[style_reviewer] Confidence:", confidence, "- findings emitted to bus only");

--- a/dev-apprenticeship/code-review/config/colony.example.toml
+++ b/dev-apprenticeship/code-review/config/colony.example.toml
@@ -11,6 +11,7 @@ tick_interval_ms = 60000
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"
 project = "your-org/your-project"
+me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -59,9 +59,12 @@ project_json() {
             DATA="$DATA" python3 <<'PY'
 import os, json
 data = json.loads(os.environ["DATA"])
+# #104: include author.username so style_reviewer can tag knowledge
+# as personal (operator's own MR) vs team.
 out = [{"iid": x.get("iid"), "state": x.get("state"), "title": x.get("title"),
         "labels": x.get("labels", []), "source_branch": x.get("source_branch"),
-        "target_branch": x.get("target_branch"), "draft": x.get("draft")} for x in data]
+        "target_branch": x.get("target_branch"), "draft": x.get("draft"),
+        "author": {"username": (x.get("author") or {}).get("username")}} for x in data]
 print(json.dumps(out))
 PY
             ;;

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -39,9 +39,15 @@ fi
 # URL-encode the project path (replace / with %2F)
 GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
 
+# #104: operator identity. Empty if not configured (pre-#104 setups or
+# operators who skipped the install.sh prompt); agents fall back to
+# memo gitlab:me and tag everything as team when both are empty.
+GITLAB_ME=$(parse_toml gitlab me)
+
 export GITLAB_URL
 export GITLAB_TOKEN
 export GITLAB_PROJECT
+export GITLAB_ME
 export COLONY_DIR
 
 AGENTS=(

--- a/dev-apprenticeship/implementation/config/colony.example.toml
+++ b/dev-apprenticeship/implementation/config/colony.example.toml
@@ -11,6 +11,7 @@ tick_interval_ms = 60000
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"
 project = "your-org/your-project"
+me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -39,9 +39,15 @@ fi
 # URL-encode the project path (replace / with %2F)
 GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
 
+# #104: operator identity. Empty if not configured (pre-#104 setups or
+# operators who skipped the install.sh prompt); agents fall back to
+# memo gitlab:me and tag everything as team when both are empty.
+GITLAB_ME=$(parse_toml gitlab me)
+
 export GITLAB_URL
 export GITLAB_TOKEN
 export GITLAB_PROJECT
+export GITLAB_ME
 export COLONY_DIR
 
 AGENTS=(

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -192,20 +192,36 @@ if [ "$WRITE_CREDS" -eq 1 ]; then
         "Must start with 'glpat-' followed by the token body." \
         --secret
 
+    # #104: operator GitLab username for personal/team knowledge
+    # tagging. Optional — if left blank, agents tag everything as
+    # "team" (pre-#104 behavior). The regex matches GitLab's username
+    # rules (alphanumeric, dots, dashes, underscores, minimum 2 chars).
+    ask "Your GitLab username for personal/team knowledge tagging (optional, press Enter to skip):"
+    read -r GITLAB_ME
+    if [ -n "$GITLAB_ME" ] && ! [[ "$GITLAB_ME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]+$ ]]; then
+        fail "Invalid GitLab username. Must be alphanumeric with . _ - (no leading special char)."
+        GITLAB_ME=""
+    fi
+
     echo ""
     echo "Writing credentials to colony configs..."
 
     for colony in "${COLONIES[@]}"; do
         CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
         # Write credentials by matching TOML keys (works on both fresh and existing configs)
-        python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" <<'PY'
+        python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" "$GITLAB_ME" <<'PY'
 import sys, re
-path, url, token, project = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+path, url, token, project, me = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
 with open(path) as f:
     content = f.read()
 content = re.sub(r'(url\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + url + '"', content)
 content = re.sub(r'(token\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + token + '"', content)
 content = re.sub(r'(project\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + project + '"', content)
+# #104: `me` key. Only update if the template declared one; do not
+# inject into existing configs that predate #104 (operator can add
+# it manually if they want personal/team tagging). Anchor with ^ +
+# line flag so `name = ` / `some = ` don't match.
+content = re.sub(r'(?m)^(me\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + me + '"', content)
 with open(path, 'w') as f:
     f.write(content)
 PY
@@ -424,6 +440,19 @@ if [ "$CONFIDENCE" != "skip" ]; then
     else
         ok "All agents seeded at $CONFIDENCE"
     fi
+fi
+
+# --- 5b. Seed operator identity for personal/team tagging (#104) ---
+#
+# Agents read `gitlab:me` via recall_latest() to classify learned
+# activity as `personal` (operator's own) vs `team`. Seeding here
+# (rather than requiring a memo set step post-install) keeps all
+# identity wiring in one place.
+if [ -n "${GITLAB_ME:-}" ]; then
+    echo ""
+    (cd "$FED_ROOT" && agentis memo set gitlab:me "$GITLAB_ME" 2>/dev/null) \
+        && ok "Seeded gitlab:me = $GITLAB_ME" \
+        || fail "Failed to seed gitlab:me (agents will tag everything as 'team')"
 fi
 
 # --- 6. LLM backend ---

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -11,6 +11,7 @@ tick_interval_ms = 60000
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"
 project = "your-org/your-project"
+me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -39,9 +39,15 @@ fi
 # URL-encode the project path (replace / with %2F)
 GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
 
+# #104: operator identity. Empty if not configured (pre-#104 setups or
+# operators who skipped the install.sh prompt); agents fall back to
+# memo gitlab:me and tag everything as team when both are empty.
+GITLAB_ME=$(parse_toml gitlab me)
+
 export GITLAB_URL
 export GITLAB_TOKEN
 export GITLAB_PROJECT
+export GITLAB_ME
 export COLONY_DIR
 
 AGENTS=(

--- a/dev-apprenticeship/release/config/colony.example.toml
+++ b/dev-apprenticeship/release/config/colony.example.toml
@@ -11,6 +11,7 @@ tick_interval_ms = 60000
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"
 project = "your-org/your-project"
+me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -39,9 +39,15 @@ fi
 # URL-encode the project path (replace / with %2F)
 GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
 
+# #104: operator identity. Empty if not configured (pre-#104 setups or
+# operators who skipped the install.sh prompt); agents fall back to
+# memo gitlab:me and tag everything as team when both are empty.
+GITLAB_ME=$(parse_toml gitlab me)
+
 export GITLAB_URL
 export GITLAB_TOKEN
 export GITLAB_PROJECT
+export GITLAB_ME
 export COLONY_DIR
 
 AGENTS=(

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -19,7 +19,21 @@ type LabelAction {
     issue_id: int,
     labels: string,
     reasoning: string,
+    author: string,
     confidence: float
+}
+
+// #104: Returns "personal" if the given author matches the operator's
+// GitLab username (memo `gitlab:me`, seeded by install.sh); "team"
+// otherwise. Empty memo = pre-#104 behavior (everyone is team).
+fn scope_for_author(author: string) -> string {
+    let me = recall_latest("gitlab:me");
+    if len(me) > 0 {
+        if author == me {
+            return "personal";
+        };
+    };
+    return "team";
 }
 
 fn issues_cmd() -> string {
@@ -76,7 +90,7 @@ fn tick(reason: string) -> void {
         let context = "Unlabeled issues: " + analysis.unlabeled_issues + "\nAvailable labels: " + labels_raw + "\nPast learning: " + to_string(rec);
 
         let action = prompt(
-            "You are a labeling agent. Suggest labels for the most important unlabeled issue. Return JSON: issue_id (int), labels (comma-separated string), reasoning (string), confidence (float 0-1).",
+            "You are a labeling agent. Suggest labels for the most important unlabeled issue. Return JSON: issue_id (int), labels (comma-separated string), reasoning (string), author (string, the GitLab username from the issue's author.username field in the context — empty string if absent), confidence (float 0-1).",
             context
         ) -> LabelAction;
 
@@ -88,7 +102,9 @@ fn tick(reason: string) -> void {
             };
             if len(result) > 0 {
                 print("[labeler] Applied labels to issue", action.issue_id, ":", action.labels);
-                learn("label", "issue " + to_string(action.issue_id), action.labels, "success", ["acted", "triage"]);
+                // #104: tag knowledge as personal (operator's issue) vs team.
+                let scope = scope_for_author(action.author);
+                learn("label", "issue " + to_string(action.issue_id), action.labels, "success", [scope, "triage", "acted"]);
             };
         } else {
             if confidence >= 0.6 {

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -19,7 +19,21 @@ type PriorityAction {
     issue_id: int,
     priority: string,
     reasoning: string,
+    author: string,
     confidence: float
+}
+
+// #104: Returns "personal" if the given author matches the operator's
+// GitLab username (memo `gitlab:me`, seeded by install.sh); "team"
+// otherwise. Empty memo = pre-#104 behavior (everyone is team).
+fn scope_for_author(author: string) -> string {
+    let me = recall_latest("gitlab:me");
+    if len(me) > 0 {
+        if author == me {
+            return "personal";
+        };
+    };
+    return "team";
 }
 
 fn issues_cmd() -> string {
@@ -75,7 +89,7 @@ fn tick(reason: string) -> void {
         let context = "Unprioritized issues: " + analysis.unprioritized_issues + "\nPast learning: " + to_string(rec);
 
         let action = prompt(
-            "You are a prioritization agent. Suggest priority for the most important unprioritized issue. Return JSON: issue_id (int), priority (string, e.g. priority::high), reasoning (string), confidence (float 0-1).",
+            "You are a prioritization agent. Suggest priority for the most important unprioritized issue. Return JSON: issue_id (int), priority (string, e.g. priority::high), reasoning (string), author (string, the GitLab username from the issue's author.username field in the context — empty string if absent), confidence (float 0-1).",
             context
         ) -> PriorityAction;
 
@@ -87,7 +101,9 @@ fn tick(reason: string) -> void {
             };
             if len(result) > 0 {
                 print("[prioritizer] Set priority on issue", action.issue_id, ":", action.priority);
-                learn("prioritize", "issue " + to_string(action.issue_id), action.priority, "success", ["acted", "triage"]);
+                // #104: tag knowledge as personal vs team.
+                let scope = scope_for_author(action.author);
+                learn("prioritize", "issue " + to_string(action.issue_id), action.priority, "success", [scope, "triage", "acted"]);
             };
         } else {
             if confidence >= 0.6 {

--- a/dev-apprenticeship/triage/config/colony.example.toml
+++ b/dev-apprenticeship/triage/config/colony.example.toml
@@ -11,6 +11,7 @@ tick_interval_ms = 60000
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"
 project = "your-org/your-project"
+me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -71,7 +71,10 @@ project_json() {
             DATA="$DATA" python3 <<'PY'
 import os, json
 data = json.loads(os.environ["DATA"])
-print(json.dumps([{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", [])} for x in data]))
+# #104: include author.username so labeler can tag knowledge as
+# personal (operator's own issue) vs team.
+print(json.dumps([{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", []),
+                   "author": {"username": (x.get("author") or {}).get("username")}} for x in data]))
 PY
             ;;
         router)
@@ -87,7 +90,9 @@ PY
             DATA="$DATA" python3 <<'PY'
 import os, json
 data = json.loads(os.environ["DATA"])
-print(json.dumps([{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", [])} for x in data]))
+# #104: include author.username for personal/team tagging.
+print(json.dumps([{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", []),
+                   "author": {"username": (x.get("author") or {}).get("username")}} for x in data]))
 PY
             ;;
         issue_creator)

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -39,9 +39,15 @@ fi
 # URL-encode the project path (replace / with %2F)
 GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
 
+# #104: operator identity. Empty if not configured (pre-#104 setups or
+# operators who skipped the install.sh prompt); agents fall back to
+# memo gitlab:me and tag everything as team when both are empty.
+GITLAB_ME=$(parse_toml gitlab me)
+
 export GITLAB_URL
 export GITLAB_TOKEN
 export GITLAB_PROJECT
+export GITLAB_ME
 export COLONY_DIR
 
 AGENTS=(

--- a/tools/test-gitlab-views.sh
+++ b/tools/test-gitlab-views.sh
@@ -173,15 +173,19 @@ test_view() {
 }
 
 # --- Triage ---
-test_view "triage" "labeler"        "iid,title,labels"                                  "$FIXTURE_ISSUES"
+# #104: labeler/prioritizer/reviewer now include `author` so the agents
+# can tag knowledge as personal vs team. The expected key sets here track
+# that addition; if you remove the personal/team plumbing, drop `author`
+# back out of these three rows.
+test_view "triage" "labeler"        "iid,title,labels,author"                           "$FIXTURE_ISSUES"
 test_view "triage" "router"         "iid,title,labels,assignees"                        "$FIXTURE_ISSUES"
-test_view "triage" "prioritizer"    "iid,title,labels"                                  "$FIXTURE_ISSUES"
+test_view "triage" "prioritizer"    "iid,title,labels,author"                           "$FIXTURE_ISSUES"
 test_view "triage" "issue_creator"  "iid,title,description,labels,author"               "$FIXTURE_ISSUES"
 test_view "triage" "members-summary" "id,username,name"                                  "$FIXTURE_MEMBERS"
 test_view "triage" "labels-summary"  "name,description,color"                            "$FIXTURE_LABELS"
 
 # --- Code-review ---
-test_view "code-review" "reviewer" "iid,state,title,labels,source_branch,target_branch,draft" "$FIXTURE_MRS"
+test_view "code-review" "reviewer" "iid,state,title,labels,source_branch,target_branch,draft,author" "$FIXTURE_MRS"
 
 # --- Planning ---
 test_view "planning" "planning"    "iid,title,description,labels,author,created_at"                    "$FIXTURE_ISSUES"


### PR DESCRIPTION
## Summary
Closes #104. Completes Option B from #99 by making `personal` vs `team` knowledge tags real.

**Identity wiring**
- `install.sh` — optional new prompt for GitLab username; writes to all 5 `colony.toml` as `[gitlab] me = "..."` and seeds memo `gitlab:me`
- 5× `colony.example.toml` — new `me = ""` placeholder under `[gitlab]`
- 5× `start-colony.sh` — parse + export `GITLAB_ME` (covered by the existing `GITLAB_*` glob in `exec.env_passthrough`)

**Data surfacing**
- `triage/scripts/gitlab-api.sh` — `labeler` + `prioritizer` views now include `author.username`
- `code-review/scripts/gitlab-api.sh` — `reviewer` view now includes `author.username`

**Author-aware tagging (3 agents, per issue acceptance criteria)**
- `labeler.ag`, `prioritizer.ag`, `style_reviewer.ag` — new `scope_for_author()` helper reads memo `gitlab:me`, returns `personal` on match else `team`; `acted` `learn()` calls now use this scope

**Docs**
- `dev-apprenticeship/README.md` — rewrote "Knowledge portability" section to document the new tagging and `agentis knowledge export --tags personal` usage

Empty username = legacy behavior (everyone tagged `team`), so fresh upgrades don't need reconfiguration.

## Test plan
- [x] All 3 modified `.ag` files parse (`agentis commit` v1.2.0) clean
- [x] `bash -n install.sh` / `bash -n start-colony.sh` clean
- [x] `colony-lint.sh dev-apprenticeship` passes (1 passed, 5 skipped by tool design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)