### PR TITLE
feat(triage): auto-confidence from operator feedback (#106)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -208,7 +208,26 @@ Out-of-scope (not implemented): integration with a system secret store (Secret S
 
 **Week 1-2**: Knowledge entries accumulate from your GitLab activity. Run `agentis knowledge list` to inspect.
 
-**After promotion**: Suggestions appear in logs (0.6) or directly on GitLab (0.85). Knowledge keeps growing with every tick. Promotion is not automatic — no agent ever updates its own `<agent>:confidence` memo, so the observe → suggest → act transition happens exactly when you run `agentis memo set <agent>:confidence …`. The runtime does slowly decay the per-entry confidence score that `learn()` attaches to each unvalidated knowledge row (`knowledge.confidence_decay_rate`, default 0.01/hr, floor `knowledge.confidence_decay_min` 0.05; validated entries are left alone), which is a separate dial from the per-agent promotion level you control — it affects how much weight an old entry carries inside an agent, not which behavior gradient the agent is running at.
+**After promotion**: Suggestions appear in logs (0.6) or directly on GitLab (0.85). Knowledge keeps growing with every tick. The runtime slowly decays the per-entry confidence score that `learn()` attaches to each unvalidated knowledge row (`knowledge.confidence_decay_rate`, default 0.01/hr, floor `knowledge.confidence_decay_min` 0.05; validated entries are left alone), which is a separate dial from the per-agent promotion level — it affects how much weight an old entry carries inside an agent, not which behavior gradient the agent is running at.
+
+## Auto-confidence from feedback (#106)
+
+Suggestions don't just sit in logs — participating agents score themselves against what you actually did. The loop is:
+
+1. Agent emits a suggestion at confidence 0.6–0.84 (SUGGEST mode) and stashes a "pending verdict" — issue/MR id plus the payload it proposed.
+2. On a later tick, agent fetches the current GitLab state of the artifact and compares.
+3. Exact match → confidence `+0.02`. Partial match → `+0.005`. Mismatch → `-0.01`. Still no operator action → leave pending, re-check next tick.
+4. Verdicts that age past 24 h without operator action are dropped without scoring — absence is not evidence of wrong suggestion.
+
+**Autonomy cap**. Auto-promotion stops at **0.85**. Positive deltas above the cap are clipped; the agent has to earn *suggestion trust* automatically, but you still have to manually bump it from 0.85 (via the dashboard ▲ button or `agentis memo set <agent>:confidence 0.85`) before it starts writing to GitLab. This is deliberate — the auto-loop earns suggestion trust from matching your style; autonomy is your call. Negative deltas are not capped, so a confident agent that goes off the rails can still be pulled back down.
+
+**Phase 1 scope** (what ships today). The feedback loop is wired into the `labeler` agent as the reference implementation. Suggested labels are compared against the labels you actually apply to the issue (set overlap). The remaining four reference agents — `style_reviewer`, `plan_reviewer`, `code_writer`, `version_bumper` — will follow in separate PRs using the same pattern. Each needs its own matcher (did the MR get merged? was the plan followed? was the version tagged?) but the infrastructure (`clamp_auto`, `signal_to_delta`, `apply_feedback`, `record_*_verdict`, `evaluate_*_verdict`, `get-issue` gitlab-api subcommand) is in place.
+
+**Config knobs** live in each colony's `config/colony.toml` under `[feedback]`. The current shipment reads the defaults directly from the agent source (`match_rate = 0.02`, `partial_rate = 0.005`, `mismatch_rate = 0.01`, `timeout_s = 86400`, `autonomy_cap = 0.85`). The TOML section is declared so you can see where runtime-configurable knobs will land without a future config rewrite being disruptive.
+
+**Observability**. Every delta prints one line to the agent's log: `[labeler] feedback delta 0.02 confidence 0.62 -> 0.64`. Grep that prefix to audit every confidence change the agent made to itself. The dashboard's per-agent confidence bar reflects the current memo value regardless of how it moved.
+
+**Why not promote straight through to 0.85**. The cap makes the honest claim match the observed behavior: *agents learn to suggest well*. Promoting them past that line ought to be an explicit operator decision, not a drift that happened while you weren't looking.
 
 ## Colonies
 

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -52,7 +52,122 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
+// #106: Auto-confidence from feedback.
+//
+// Each time labeler emits a suggestion at 0.6-0.84, it stashes a "pending
+// verdict" memo with the issue iid and the labels it proposed. On each
+// subsequent tick, before doing new work, we check whether the operator
+// has since applied labels to that issue on GitLab. Exact-set match
+// (every suggested label is present) → +0.02. Any-overlap → +0.005.
+// No-overlap (and the issue now has *some* label, so we have signal) →
+// -0.01. Verdicts that age past 24 h without operator action are dropped
+// without scoring — absence of action is not evidence of a wrong
+// suggestion.
+//
+// Auto-promotion is capped at 0.85 (the autonomy threshold). Positive
+// deltas stop at 0.85; operators must manually bump past that via the
+// dashboard or CLI, since at 0.85 the agent starts writing to GitLab
+// directly and the operator should explicitly sign off on autonomy.
+
+fn clamp_auto(cur: float, delta: float) -> float {
+    let cap = 0.85;
+    if delta > 0.0 {
+        if cur >= cap {
+            return cur;
+        };
+        if (cur + delta) > cap {
+            return cap;
+        };
+        return cur + delta;
+    };
+    if (cur + delta) < 0.0 {
+        return 0.0;
+    };
+    return cur + delta;
+}
+
+fn signal_to_delta(signal: int) -> float {
+    if signal == 1 {
+        return 0.02;
+    };
+    if signal == 2 {
+        return 0.005;
+    };
+    if signal == 3 {
+        return 0.0 - 0.01;
+    };
+    return 0.0;
+}
+
+fn apply_feedback(delta: float) -> void {
+    let cur = get_confidence();
+    let target = clamp_auto(cur, delta);
+    memo_write("labeler:confidence", to_string(target));
+    print("[labeler] feedback delta", delta, "confidence", cur, "->", target);
+}
+
+// Record a pending verdict. Stored as JSON array [t, iid, "labels_csv"] —
+// the three fields are ASCII-safe (epoch int, iid int, label names have
+// no quotes/newlines/backslashes in practice on GitLab) so naive
+// concatenation is sufficient and we skip a JSON encoder.
+fn record_label_verdict(issue_id: int, labels_csv: string) -> void {
+    let ts_raw = try { exec sh "date +%s"; } catch e { "0"; };
+    let blob = "[" + ts_raw + "," + to_string(issue_id) + ",\"" + labels_csv + "\"]";
+    memo_write("labeler:pending_verdict", blob);
+    print("[labeler] verdict recorded: issue", issue_id, "suggested", labels_csv);
+}
+
+fn verdict_age_seconds(blob: string) -> int {
+    let emit_ts = parse_int(to_string(json_get(blob, "[0]")));
+    let now_raw = try { exec sh "date +%s"; } catch e { "0"; };
+    let now = parse_int(now_raw);
+    return now - emit_ts;
+}
+
+// Score the current pending verdict against what the operator actually
+// did on GitLab. Returns early (leaves verdict pending) when no verdict
+// exists or the issue still has no labels (no signal yet). Clears the
+// verdict when scored or aged out (> 24h).
+fn evaluate_label_verdict() -> void {
+    let blob = recall_latest("labeler:pending_verdict");
+    if len(blob) < 3 {
+        return;
+    };
+    let timeout_s = 86400;
+    if verdict_age_seconds(blob) > timeout_s {
+        print("[labeler] verdict aged out without signal");
+        memo_write("labeler:pending_verdict", "");
+        return;
+    };
+    let issue_id = parse_int(to_string(json_get(blob, "[1]")));
+    let suggested = to_string(json_get(blob, "[2]"));
+    let cur_cmd = "$COLONY_DIR/scripts/gitlab-api.sh get-issue " + to_string(issue_id) + " --view feedback-issue";
+    let cur_raw = try { exec sh cur_cmd; } catch e { ""; };
+    if len(cur_raw) < 3 {
+        return;
+    };
+    // Deterministic overlap check in python (cheap, reproducible) rather
+    // than a prompt() round-trip. json_get() returns Void for array leaves,
+    // so extract `labels` inside python instead of via a second json_get.
+    // Output: 0 = no signal (no labels yet), 1 = full match (every suggested
+    // label present), 2 = partial overlap, 3 = mismatch (operator labeled
+    // but none of ours matched).
+    let match_cmd = "SUGGESTED=" + shell_escape(suggested) + " RAW=" + shell_escape(cur_raw) + " python3 -c 'import os, json; sug={s.strip() for s in os.environ[\"SUGGESTED\"].split(\",\") if s.strip()}; act=set(json.loads(os.environ[\"RAW\"]).get(\"labels\", [])); print(0 if not act else (1 if sug and sug.issubset(act) else (2 if sug & act else 3)))'";
+    let signal_raw = try { exec sh match_cmd; } catch e { "0"; };
+    let signal = parse_int(signal_raw);
+    if signal == 0 {
+        return;
+    };
+    apply_feedback(signal_to_delta(signal));
+    memo_write("labeler:pending_verdict", "");
+}
+
 fn tick(reason: string) -> void {
+    // #106: Check any pending verdict from a previous tick before doing
+    // new work. The matcher is cheap when there's nothing pending, and
+    // this placement means a verdict recorded at tick N is evaluated at
+    // tick N+1 onwards (matching the "subsequent tick" semantic).
+    evaluate_label_verdict();
     let cmd = issues_cmd();
     let raw = try {
         exec sh cmd;
@@ -110,6 +225,12 @@ fn tick(reason: string) -> void {
             if confidence >= 0.6 {
                 print("[labeler] Suggesting labels for issue", action.issue_id, ":", action.labels);
                 emit("triage:label_suggestion", action);
+                // #106: stash the verdict so next tick can score this
+                // suggestion against whatever the operator actually does
+                // to the issue. Only records at SUGGEST level — at ACT
+                // (>= 0.85) the agent writes its own labels, so there's
+                // no separable operator signal to score against.
+                record_label_verdict(action.issue_id, action.labels);
             } else {
                 print("[labeler] Observing (confidence:", confidence, ")");
             };

--- a/dev-apprenticeship/triage/config/colony.example.toml
+++ b/dev-apprenticeship/triage/config/colony.example.toml
@@ -17,6 +17,20 @@ me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
 backend = "cli"
 
+# Auto-confidence knobs (#106). These are informational in the current
+# Phase 1 shipment: the agents hard-code the defaults (match +0.02,
+# partial +0.005, mismatch -0.01, timeout 86400s, autonomy_cap 0.85) and
+# read them directly rather than through the TOML layer. The section is
+# declared here so operators know where the future runtime-configurable
+# knobs will live and so editing this file now won't be disruptive later.
+[feedback]
+enabled = true
+match_rate = 0.02
+partial_rate = 0.005
+mismatch_rate = 0.01
+timeout_s = 86400
+autonomy_cap = 0.85
+
 # Agent definitions
 # Each agent runs as a separate agentis daemon process.
 # They discover each other via colony UDP and communicate over TCP emit/listen.

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -119,6 +119,18 @@ data = json.loads(os.environ["DATA"])
 print(json.dumps([{"name": x.get("name"), "description": x.get("description"), "color": x.get("color")} for x in data]))
 PY
             ;;
+        feedback-issue)
+            # #106: minimal per-issue projection used by the labeler's
+            # verdict matcher to compare suggested labels against what the
+            # operator actually applied. Keeping the view tiny keeps the
+            # round-trip body size (and therefore the agent's input token
+            # budget if it ever feeds this back into a prompt) small.
+            DATA="$DATA" python3 <<'PY'
+import os, json
+x = json.loads(os.environ["DATA"])
+print(json.dumps({"iid": x.get("iid"), "state": x.get("state"), "labels": x.get("labels", [])}))
+PY
+            ;;
         *)
             emit_error "unknown view: $view"
             exit 2
@@ -438,6 +450,34 @@ PY
             printf '%s' "$body" | project_json "$INTERNAL_VIEW"
         else
             gl_get "$API/members/all?per_page=100"
+        fi
+        ;;
+
+    get-issue)
+        # #106: single-issue fetch for the feedback matcher. Arg is the
+        # issue iid (the project-local number, not GitLab's global id).
+        # Supports --view feedback-issue to downselect to {iid, state, labels}.
+        if [ $# -lt 1 ]; then
+            emit_error "Usage: gitlab-api.sh get-issue <iid> [--view <name>]"
+            exit 2
+        fi
+        IID="$1"
+        shift
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$IID" in
+            ''|*[!0-9]*) emit_error "iid must be numeric: $IID"; exit 2 ;;
+        esac
+        if [ -n "$VIEW" ]; then
+            body="$(gl_get "$API/issues/$IID")" || exit $?
+            printf '%s' "$body" | project_json "$VIEW"
+        else
+            gl_get "$API/issues/$IID"
         fi
         ;;
 


### PR DESCRIPTION
## Summary

- The labeler agent now scores its own SUGGEST-mode label proposals against what the operator actually applies on GitLab, and bumps `labeler:confidence` accordingly. Exact match `+0.02`, partial overlap `+0.005`, mismatch `-0.01`, no-signal/aged-out leave the verdict pending.
- Auto-promotion is hard-capped at **0.85** (autonomy threshold). The cap makes the honest claim match observed behavior — *agents learn to suggest well*; promoting past that line is an explicit operator action, not a drift.
- Adds `gitlab-api.sh get-issue <iid> [--view feedback-issue]` for the matcher to fetch a single issue cheaply.
- Adds `[feedback]` TOML section as informational scaffolding (defaults are still read from source); future PRs flip the runtime to read TOML.

Phase 1 ships with the labeler as the reference implementation. The four remaining feedback-eligible agents (`style_reviewer`, `plan_reviewer`, `code_writer`, `version_bumper`) will follow in separate PRs using the same helpers — each needs its own matcher.

Closes Replikanti/agentis-colonies#106.

## Test plan

- [x] `bash tools/colony-lint.sh` — 46 passed, 0 failed, 5 skipped (labeler.ag syntax OK)
- [x] `bash tools/test-gitlab-views.sh` — 48 passed, 0 failed (feedback-issue view round-trips)
- [x] Unit: `clamp_auto` + `signal_to_delta` — 12 cases including cap-clipping and floor
- [x] Unit: python matcher — 8 cases (exact/subset/partial/no-overlap/empty/whitespace)
- [x] End-to-end: stubbed `gitlab-api.sh`, seeded `pending_verdict` memo, ran `evaluate_label_verdict()` with 4 mocked GitLab responses → signals 1/2/3/0 produced conf 0.62/0.605/0.59/0.6 from a 0.6 baseline
- [ ] CI: colony-lint passes on PR

## Notes

- `json_get` returns `Void` for array leaves, so the matcher can't extract `labels` via a second `json_get(cur_raw, "labels")`. Instead the python one-liner receives the raw issue JSON via `$RAW` and extracts `labels` itself. This is documented in a comment in the agent source.
- The matcher uses `python3` and is gated by `exec.env_passthrough` — the parent shell forwards `COLONY_DIR` (set by `start-colony.sh`) but not `SUGGESTED`/`RAW`, which sh sets inline before exec'ing python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)