### PR TITLE
chore: bump agentis MIN_VERSION to v1.2.2

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -1,6 +1,6 @@
 # Dev Apprenticeship
 
-![Agentis >= v1.1.8](https://img.shields.io/badge/agentis-%3E%3D%20v1.1.8-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
+![Agentis >= v1.2.2](https://img.shields.io/badge/agentis-%3E%3D%20v1.2.2-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
 
 A federation of 21 agents that learns how you work by watching your GitLab activity. It observes how you triage issues, review merge requests, plan features, write code, and ship releases. Over time it takes over the mechanical parts, while you keep control over the decisions that matter.
 
@@ -35,7 +35,7 @@ graph LR
 
 ## What you need
 
-- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.1.8**
+- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.2.2**
 - An LLM backend (Claude CLI, Ollama, or any OpenAI-compatible API)
 - GitLab instance with API access (personal access token with `api` scope)
 - Python 3 and git

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -19,7 +19,7 @@ ALL_AGENTS=(
     code_writer test_writer refactorer commit_composer
     ship_decider changelog_writer version_bumper release_checker
 )
-MIN_VERSION="1.2.0"
+MIN_VERSION="1.2.2"
 
 # --- Helpers ---
 
@@ -99,14 +99,24 @@ fi
 # added `exec.default_timeout_ms`; before that, the federation could not
 # complete a single tick on any real GitLab project (issue #107) because
 # every prompt containing author emails was denied and every curl past
-# 10 s timed out. Older builds either fail with `capability denied:
+# 10 s timed out. v1.2.2 adds `agentis daemon prune` + `effective_state`
+# zombie-registry reconciliation (#518), without which an in-place binary
+# upgrade SIGKILLs every watchdog and leaves the federation in a state
+# where `daemon list` keeps reporting "running" for processes that no
+# longer exist. v1.2.2 also fails loud at spawn when a program uses
+# `recommend`/`adapt`/`score_options`/`recommend_federated`/
+# `score_options_federated` without `learning.enabled = true` (#519) —
+# every agent in this federation calls `recommend(...)`, so older
+# builds would silently tick-error-loop forever when the three learning
+# keys were not all set. Older builds either fail with `capability denied:
 # exec_foreign`, never receive emit/listen, get killed by the watchdog
-# every tick, or fail every single tick on PII + ExecTimeout.
+# every tick, fail every single tick on PII + ExecTimeout, leak zombie
+# daemons after every upgrade, or silently tick-error on adaptive calls.
 AGENTIS_VERSION=$(agentis --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
 info "agentis version: $AGENTIS_VERSION (minimum: $MIN_VERSION)"
 
 if ! version_gte "$AGENTIS_VERSION" "$MIN_VERSION"; then
-    fail "agentis >= $MIN_VERSION required (--enable-exec/--enable-messaging flags, #492 quarantine fix, #499 watchdog heartbeat fix, #107 daemon PII grant + exec.default_timeout_ms, #123 tick-success health, #125 parse_float/parse_int/json_get). Please update."
+    fail "agentis >= $MIN_VERSION required (--enable-exec/--enable-messaging flags, #492 quarantine fix, #499 watchdog heartbeat fix, #107 daemon PII grant + exec.default_timeout_ms, #123 tick-success health, #125 parse_float/parse_int/json_get, #518 zombie daemon registry prune, #519 adaptive-engine fail-loud gate). Please update."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Bumps the dev-apprenticeship federation's agentis runtime floor from **v1.2.0 → v1.2.2**. Two fixes just shipped in agentis-core that this federation materially depends on:

- **[Replikanti/agentis-core#518](https://github.com/Replikanti/agentis-core/issues/518)** — zombie daemon registry reconciliation. `install.sh` rerun SIGKILLs every watchdog; pre-v1.2.2 this leaves `.pid` / `.status` / `.heartbeat` claiming `running` for a dead PID, so `daemon list` / `daemon stop --all` can't clean up. v1.2.2 adds `agentis daemon prune [--json] [--dry-run]` and `DaemonInfo::effective_state()` reconciling `(alive, state)` into `zombie`. `stop <id>` and `stop --all` auto-prune; `--force` preserves the legacy blind stop-file behavior.
- **[Replikanti/agentis-core#519](https://github.com/Replikanti/agentis-core/issues/519)** — adaptive-engine fail-loud gate. Every one of the 20 agents here calls `recommend(...)`. Pre-v1.2.2 ran an `EvalError("adaptive engine not enabled")` on every tick when `learning.enabled` was off, producing a silent tick-error loop. v1.2.2 statically scans the AST at spawn (`agentis daemon` / `run` / `go` / `daemon restart` / `resume`) and fails loud with the offending builtin names + exact three config keys to set.

`install.sh` already writes `learning.enabled = true`, `experience.enabled = true`, `knowledge.enabled = true` on fresh setups, so the gate is trivially satisfied — but the preflight version check needs to refuse older binaries, otherwise operators on <1.2.2 hit the silent tick-loop regardless.

## Changes

- `dev-apprenticeship/install.sh`: `MIN_VERSION="1.2.0"` → `"1.2.2"`; extend the preflight rationale comment with #518 + #519 context; extend the failure message with `#518 zombie daemon registry prune, #519 adaptive-engine fail-loud gate`.
- `dev-apprenticeship/README.md`: badge and "What you need" requirement both bumped to `>= v1.2.2`.

Historical "since v1.1.6" / "from v1.1.8 onward" context comments in `start-colony.sh`, `federation-dashboard.sh`, `colony-lint.sh`, and `install.sh:327` are left untouched — they document *when a feature was introduced*, not the current floor.

## Test plan

- [x] `grep -rn '1\.1\.\|1\.2\.0' dev-apprenticeship/` shows only historical-context references, no remaining version gates on old floors.
- [x] On a host with agentis v1.2.0 or v1.2.1 installed, running `./install.sh` exits with `agentis >= 1.2.2 required (…, #518 zombie daemon registry prune, #519 adaptive-engine fail-loud gate). Please update.` exit code 1.
- [x] On a host with agentis v1.2.2 installed, `./install.sh` passes the preflight and proceeds to config writing (no functional change to the config-write path).
- [x] README badge renders with the updated version pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)