### PR TITLE
feat(dashboard): restart-required toast after confidence write (#137)

### DIFF
--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -693,13 +693,23 @@ function setConfidence(agent, value) {
     headers: {'Content-Type': 'application/x-www-form-urlencoded'},
     body: body,
   })
-    .then(r => r.text().then(t => ({ok: r.ok, text: t})))
-    .then(({ok, text}) => {
-      if (!ok) {
-        alert('Set failed: ' + text);
+    .then(r => {
+      // 200 returns application/json; 4xx/5xx return text/plain. Parse per branch.
+      if (r.ok) return r.json().then(data => ({ok: true, data}));
+      return r.text().then(text => ({ok: false, text}));
+    })
+    .then(result => {
+      if (!result.ok) {
+        alert('Set failed: ' + result.text);
         return;
       }
-      showRestartToast(agent, value);
+      // The page has <meta http-equiv="refresh" content="60"> in <head>. Without
+      // removing it, a pending browser-level refresh can fire inside the 12 s
+      // toast window and destroy the toast before the operator finishes reading
+      // — same reason the kill-switch handler removes it on success.
+      const m = document.querySelector('meta[http-equiv="refresh"]');
+      if (m) m.remove();
+      showRestartToast(agent, value, result.data);
       // Defer the static-HTML regen + reload so the toast stays readable.
       // Without the delay location.reload() destroys the toast before the
       // operator can see the restart command.
@@ -710,12 +720,16 @@ function setConfidence(agent, value) {
     .catch(e => alert('Set failed: ' + e));
 }
 
-function showRestartToast(agent, value) {
+function showRestartToast(agent, value, data) {
   const el = document.createElement('div');
   el.className = 'toast';
   el.setAttribute('role', 'status');
   el.setAttribute('aria-live', 'polite');
-  const v = (typeof value === 'number') ? value.toFixed(2) : String(value);
+  // Prefer the server's authoritative value (it's what actually landed on
+  // disk via `agentis memo set`) and fall back to the click-site value.
+  const serverValue = data && typeof data.value === 'string' ? parseFloat(data.value) : NaN;
+  const shown = Number.isFinite(serverValue) ? serverValue : value;
+  const v = (typeof shown === 'number') ? shown.toFixed(2) : String(shown);
   const head = document.createElement('div');
   head.className = 'toast-head';
   head.textContent = 'Memo written — daemon restart required';
@@ -731,7 +745,12 @@ function showRestartToast(agent, value) {
   pre.textContent = 'agentis daemon stop --all && ./start-federation.sh';
   const foot = document.createElement('div');
   foot.className = 'toast-foot';
-  foot.textContent = 'Audit: appended to .dashboard/confidence-log.jsonl — click to dismiss';
+  // audit_logged comes from the backend; missing/undefined means legacy
+  // response — fall back to the optimistic wording rather than a false claim.
+  const auditOk = !data || data.audit_logged !== false;
+  foot.textContent = auditOk
+    ? 'Audit: appended to .dashboard/confidence-log.jsonl — click to dismiss'
+    : 'Audit write failed — restart still required. Click to dismiss.';
   el.appendChild(head);
   el.appendChild(line1);
   el.appendChild(line2);

--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -461,6 +461,32 @@ HEADEOF
     0%, 100% { box-shadow: 0 0 10px rgba(255,0,255,0.3); }
     50% { box-shadow: 0 0 25px rgba(255,0,255,0.6); }
   }
+  .toast {
+    position: fixed; right: 16px; bottom: 16px; z-index: 9999;
+    max-width: 420px; padding: 12px 14px 12px 16px;
+    background: var(--surface); border: 1px solid var(--yellow);
+    border-radius: 4px; color: var(--text);
+    font-family: 'Share Tech Mono', 'Courier New', monospace;
+    font-size: 12px; line-height: 1.6;
+    box-shadow: 0 0 20px rgba(255,255,0,0.35);
+    cursor: pointer;
+    animation: toast-in 0.25s ease-out;
+  }
+  .toast .toast-head {
+    color: var(--yellow); font-size: 11px; letter-spacing: 2px;
+    text-transform: uppercase; margin-bottom: 6px;
+    text-shadow: 0 0 6px rgba(255,255,0,0.4);
+  }
+  .toast pre {
+    margin: 6px 0; padding: 6px 8px; background: rgba(0,255,255,0.05);
+    border-left: 2px solid var(--cyan); color: var(--cyan);
+    font-size: 11px; white-space: pre-wrap; word-break: break-all;
+  }
+  .toast .toast-foot { color: var(--muted); font-size: 10px; margin-top: 6px; }
+  @keyframes toast-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
   ::-webkit-scrollbar { width: 4px; }
   ::-webkit-scrollbar-track { background: transparent; }
   ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
@@ -673,11 +699,47 @@ function setConfidence(agent, value) {
         alert('Set failed: ' + text);
         return;
       }
-      // Regenerate the static HTML so the reloaded page reflects the new
-      // memo value immediately instead of waiting for the 60 s background loop.
-      fetch('/refresh', { method: 'POST' }).catch(() => {}).finally(() => location.reload());
+      showRestartToast(agent, value);
+      // Defer the static-HTML regen + reload so the toast stays readable.
+      // Without the delay location.reload() destroys the toast before the
+      // operator can see the restart command.
+      setTimeout(() => {
+        fetch('/refresh', { method: 'POST' }).catch(() => {}).finally(() => location.reload());
+      }, 12000);
     })
     .catch(e => alert('Set failed: ' + e));
+}
+
+function showRestartToast(agent, value) {
+  const el = document.createElement('div');
+  el.className = 'toast';
+  el.setAttribute('role', 'status');
+  el.setAttribute('aria-live', 'polite');
+  const v = (typeof value === 'number') ? value.toFixed(2) : String(value);
+  const head = document.createElement('div');
+  head.className = 'toast-head';
+  head.textContent = 'Memo written — daemon restart required';
+  const line1 = document.createElement('div');
+  line1.textContent = agent + ':confidence set to ';
+  const b = document.createElement('b');
+  b.textContent = v;
+  line1.appendChild(b);
+  line1.appendChild(document.createTextNode(' on disk.'));
+  const line2 = document.createElement('div');
+  line2.textContent = 'The running daemon will keep using its in-flight value until its next tick (up to ~60 s) and spawn-time decisions will not reload. For immediate, guaranteed effect run:';
+  const pre = document.createElement('pre');
+  pre.textContent = 'agentis daemon stop --all && ./start-federation.sh';
+  const foot = document.createElement('div');
+  foot.className = 'toast-foot';
+  foot.textContent = 'Audit: appended to .dashboard/confidence-log.jsonl — click to dismiss';
+  el.appendChild(head);
+  el.appendChild(line1);
+  el.appendChild(line2);
+  el.appendChild(pre);
+  el.appendChild(foot);
+  el.addEventListener('click', () => el.remove());
+  document.body.appendChild(el);
+  setTimeout(() => { if (el.parentNode) el.remove(); }, 12000);
 }
 
 (function() {
@@ -1016,6 +1078,7 @@ class Handler(SimpleHTTPRequestHandler):
             # Audit log: append a JSONL row per change. .dashboard/ is
             # already operator-visible (index.html, history.json live here)
             # so this keeps all per-federation dashboard state colocated.
+            audit_ok = False
             try:
                 with open(confidence_log, 'a') as f:
                     f.write(json.dumps({
@@ -1024,13 +1087,20 @@ class Handler(SimpleHTTPRequestHandler):
                         'value': value,
                         'remote': self.client_address[0],
                     }) + '\n')
+                audit_ok = True
             except OSError:
                 # Audit write failure must not mask the successful memo set.
                 pass
             self.send_response(200)
-            self.send_header('Content-Type', 'text/plain')
+            self.send_header('Content-Type', 'application/json')
             self.end_headers()
-            self.wfile.write(f'{agent}:confidence set to {value:.3f}'.encode())
+            self.wfile.write(json.dumps({
+                'agent': agent,
+                'value': f'{value:.3f}',
+                'memo_written': True,
+                'audit_logged': audit_ok,
+                'restart_required': True,
+            }).encode())
             return
         if self.path == '/kill':
             # Run from fed_dir, not .dashboard. The actual fix for #91 is


### PR DESCRIPTION
## Summary

Closes #137. After a successful `/confidence` write from the ▲/▼ buttons, show a CSS-animated DOM toast reminding the operator that the running daemon keeps using its in-flight value until its next tick (~60 s) and spawn-time decisions do not reload — so `agentis daemon stop --all && ./start-federation.sh` is required for immediate, guaranteed effect.

- **CSS** (`tools/federation-dashboard.sh` inside `<style>`): `.toast` + `.toast-head` + `.toast pre` + `.toast-foot` + `@keyframes toast-in`, using the dashboard's existing `--yellow` / `--cyan` vocabulary and `Share Tech Mono`.
- **JS** `setConfidence` / new `showRestartToast`: fires the toast on HTTP 200 regardless of direction (promote **and** demote — demote is safety-critical, operator trying to *stop* an autonomous agent), defers `location.reload()` by 12 s so the toast stays readable. Toast is built via `createElement`/`textContent` (no `innerHTML` from inputs), exposes `role="status"` + `aria-live="polite"` for screen readers, click-dismiss, 12 s auto-dismiss. `confirm()` preamble for `value >= 0.85` and the error path are unchanged.
- **Backend** `/confidence`: switched from `text/plain` to `application/json` with `memo_written` / `audit_logged` / `restart_required` fields. No external consumers of the response body exist today (only the inline browser JS), so this is safe.

Wording intentionally says "**requires restart to take immediate effect**" — strictly true given `recall_latest` is file-fresh each tick, unlike the stronger "never applies" claim in the original ticket. Rationale recorded in the planning comment on #137.

## Implementation notes

- No shell control flow altered — `colony-lint.sh` passes 46/0/5 (shellcheck skipped: not installed locally, unchanged from baseline).
- `bash -n tools/federation-dashboard.sh` clean.
- `dev-apprenticeship/dashboard.sh` wrapper unchanged per plan.
- Plan link: https://github.com/Replikanti/agentis-colonies/issues/137#issuecomment-4252129573

## Test plan

Backend curl regressions (can run automated):

- [ ] `curl -sS -X POST http://localhost:8420/confidence -d 'agent=router&value=0.6'` → HTTP 200, JSON body with `memo_written: true`, `restart_required: true`.
- [ ] `curl -sS -X POST http://localhost:8420/confidence -d 'agent=bogus&value=0.6'` → HTTP 400 `unknown agent: 'bogus'`.
- [ ] `curl -sS -X POST http://localhost:8420/confidence -d 'agent=router&value=1.5'` → HTTP 400 `value out of [0,1]: 1.5`.

Manual browser tests (§6 of the plan — **not executed by the implementation agent; reviewer / operator needed**):

- [ ] **M1** — Click ▲ on agent at 0.50 (→ 0.60). No `confirm()`. Toast appears bottom-right with yellow border. Reloads after ~12 s. Log row appended to `.dashboard/confidence-log.jsonl`.
- [ ] **M2** — Click ▲ on agent at 0.60 (→ 0.85). `confirm()` first; accept. Toast fires. Reloads after ~12 s.
- [ ] **M2b** — Same as M2 but cancel `confirm()`. No POST, no toast, no reload.
- [ ] **M3** — Click ▼ (demote 0.85 → 0.60). No `confirm()`. Toast fires (symmetric rule — demoting an autonomous agent is safety-critical).
- [ ] **M4** — Click ▲ on two agents within a second. Two toasts stack; each dismisses independently.
- [ ] **M5** — Click toast body. Disappears immediately; reload still fires at t=12 s.
- [ ] **M6** — Simulate backend error (e.g. temporarily block `agentis` on PATH) and click ▲. `alert('Set failed: ...')` appears; no toast; no reload.
- [ ] **M7** — Keyboard-only navigation with a screen reader. Toast is announced via `aria-live="polite"` without stealing focus from the buttons.
- [ ] **M8** — After toast fires, run `agentis daemon stop --all && ./start-federation.sh`, then `agentis memo get <agent>:confidence`. Value matches what the toast announced — proves the recommended command works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)