### PR TITLE
feat(start-colony): per-agent tick-interval override; reactive agents to 5m (#146)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ colony-name/
 
 ## Script conventions
 
-- `start-colony.sh`: symlink-safe `$0` resolution via python3, sources `tools/parse-toml.sh`, exports `GITLAB_URL`/`GITLAB_TOKEN`/`GITLAB_PROJECT`, launches daemons with `--colony <name> --tick-interval 60000`.
+- `start-colony.sh`: symlink-safe `$0` resolution via python3, sources `tools/parse-toml.sh`, exports `GITLAB_URL`/`GITLAB_TOKEN`/`GITLAB_PROJECT`, launches daemons with `--colony <name> --tick-interval "$interval"` where `interval` is looked up per-agent in a local `TICK_INTERVALS` map (fallback 60000ms). Reactive colonies (release, code-review) run at 300000ms, triage's router/prioritizer at 180000ms, everything else at 60000ms. See #146 for rationale.
 - `gitlab-api.sh`: `emit_error()` for all error messages, `exit 2` for unknown flags, `python3 json.dumps` for all POST/PUT body construction. Read endpoints use `gl_get`/`gl_get_q`, write endpoints use `gl_post`/`gl_put`.
 
 ## Federation event wiring

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -81,16 +81,31 @@ cd "$COLONY_DIR"
 # `--enable-exec` is required since agentis v1.1.6 (exec sh is opt-in; see #484/#489).
 # `--enable-messaging` is required for cross-agent emit/listen (#484, v1.1.6+).
 
+# Per-agent tick-interval override (#146). Every agent in this colony is
+# reactive: the four reviewers wait on implementation:mr_ready events, and
+# approval_decider waits on their findings. When no MR is in flight the
+# ticks are no-ops. 5-min cadence matches the natural rhythm of merge
+# requests in a small team and cuts idle LLM spend ~5×. Fallback is 60000ms
+# for any agent not listed.
+declare -A TICK_INTERVALS=(
+    ["style_reviewer"]=300000
+    ["logic_reviewer"]=300000
+    ["security_reviewer"]=300000
+    ["test_reviewer"]=300000
+    ["approval_decider"]=300000
+)
+
 echo "Starting Code Review colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
-    echo "  Starting $agent..."
+    interval="${TICK_INTERVALS[$agent]:-60000}"
+    echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony code-review \
         --enable-exec \
         --enable-messaging \
-        --tick-interval 60000 &
+        --tick-interval "$interval" &
     sleep 2  # stagger starts to reduce API contention
 done
 

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -78,16 +78,29 @@ fi
 # `--enable-exec` is required since agentis v1.1.6 (exec sh is opt-in; see #484/#489).
 # `--enable-messaging` is required for cross-agent emit/listen (#484, v1.1.6+).
 
+# Per-agent tick-interval override (#146). All implementation agents are
+# active: code_writer, test_writer, refactorer and commit_composer each
+# run against the current working tree and produce output every tick once
+# fed by upstream route_suggestion events. 60s keeps the write-test-commit
+# pipeline responsive. Fallback is 60000ms.
+declare -A TICK_INTERVALS=(
+    ["code_writer"]=60000
+    ["test_writer"]=60000
+    ["refactorer"]=60000
+    ["commit_composer"]=60000
+)
+
 echo "Starting Implementation colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
-    echo "  Starting $agent..."
+    interval="${TICK_INTERVALS[$agent]:-60000}"
+    echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony implementation \
         --enable-exec \
         --enable-messaging \
-        --tick-interval 60000 &
+        --tick-interval "$interval" &
     sleep 2  # stagger starts to reduce API contention
 done
 

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -278,14 +278,16 @@ if [ -d "$AGENTIS_DIR" ]; then
     # transcript). Each key is only written if missing so re-running
     # install.sh is idempotent and never clobbers operator-tuned values.
     #
-    #   daemon.tick_interval_ms     — matches --tick-interval 60000 in
-    #                                 start-colony.sh. start-colony.sh
-    #                                 already overrides via CLI; this
-    #                                 config entry is defense-in-depth
+    #   daemon.tick_interval_ms     — 60000ms safe default. start-colony.sh
+    #                                 now sets per-agent intervals via CLI
+    #                                 (#146: reactive agents at 180000-
+    #                                 300000ms, active agents keep 60000),
+    #                                 so the CLI flag always wins at startup.
+    #                                 This config entry is defense-in-depth
     #                                 for operators who launch a daemon
-    #                                 directly (e.g. debug sessions),
-    #                                 where without the config key the
-    #                                 watchdog uses the 1 s default.
+    #                                 directly (e.g. debug sessions), where
+    #                                 without the config key the watchdog
+    #                                 uses the 1 s default.
     #   daemon.heartbeat_interval_ms — 3× tick is long enough for a
     #                                  Claude CLI cold start (typ. 5-30 s).
     #                                  Default 2× tick is fine for mock,

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -78,16 +78,30 @@ fi
 # `--enable-exec` is required since agentis v1.1.6 (exec sh is opt-in; see #484/#489).
 # `--enable-messaging` is required for cross-agent emit/listen (#484, v1.1.6+).
 
+# Per-agent tick-interval override (#146). All planning agents are active:
+# scope_estimator, risk_assessor, task_decomposer and plan_reviewer each
+# produce work whenever an issue reaches triage:route_suggestion, so 60s
+# cadence preserves throughput. The map is kept for consistency with the
+# reactive colonies and to make future overrides obvious. Fallback is
+# 60000ms.
+declare -A TICK_INTERVALS=(
+    ["scope_estimator"]=60000
+    ["risk_assessor"]=60000
+    ["task_decomposer"]=60000
+    ["plan_reviewer"]=60000
+)
+
 echo "Starting Planning colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
-    echo "  Starting $agent..."
+    interval="${TICK_INTERVALS[$agent]:-60000}"
+    echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony planning \
         --enable-exec \
         --enable-messaging \
-        --tick-interval 60000 &
+        --tick-interval "$interval" &
     sleep 2  # stagger starts to reduce API contention
 done
 

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -78,16 +78,31 @@ fi
 # `--enable-exec` is required since agentis v1.1.6 (exec sh is opt-in; see #484/#489).
 # `--enable-messaging` is required for cross-agent emit/listen (#484, v1.1.6+).
 
+# Per-agent tick-interval override (#146). Every agent in this colony is
+# reactive: release_checker polls GitLab for fresh tags, ship_decider/
+# version_bumper/changelog_writer wait on upstream MR-merge events. These
+# signals don't arrive more than a few times per hour, so minute-grained
+# polling spends LLM budget on no-op ticks. 5-min cadence is operationally
+# indistinguishable from 1-min here. Fallback is 60000ms for any agent not
+# listed (e.g. if a new active agent is added later).
+declare -A TICK_INTERVALS=(
+    ["release_checker"]=300000
+    ["ship_decider"]=300000
+    ["changelog_writer"]=300000
+    ["version_bumper"]=300000
+)
+
 echo "Starting Release colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
-    echo "  Starting $agent..."
+    interval="${TICK_INTERVALS[$agent]:-60000}"
+    echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony release \
         --enable-exec \
         --enable-messaging \
-        --tick-interval 60000 &
+        --tick-interval "$interval" &
     sleep 2  # stagger starts to reduce API contention
 done
 

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -78,16 +78,30 @@ fi
 # `--enable-exec` is required since agentis v1.1.6 (exec sh is opt-in; see #484/#489).
 # `--enable-messaging` is required for cross-agent emit/listen (#484, v1.1.6+).
 
+# Per-agent tick-interval override (#146). Mixed colony: issue_creator and
+# labeler are active (they produce work on every tick driven by incoming
+# issues) and stay on the 60s default; router and prioritizer are reactive
+# (periodic routing sweeps, re-ranking) and run at 3-min cadence since
+# minute-grained latency on priority changes is not observable. Fallback is
+# 60000ms.
+declare -A TICK_INTERVALS=(
+    ["issue_creator"]=60000
+    ["labeler"]=60000
+    ["prioritizer"]=180000
+    ["router"]=180000
+)
+
 echo "Starting Triage colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
-    echo "  Starting $agent..."
+    interval="${TICK_INTERVALS[$agent]:-60000}"
+    echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony triage \
         --enable-exec \
         --enable-messaging \
-        --tick-interval 60000 &
+        --tick-interval "$interval" &
     sleep 2  # stagger starts to reduce API contention
 done
 

--- a/tools/new-colony.sh
+++ b/tools/new-colony.sh
@@ -149,11 +149,20 @@ echo "Starting NAME_PLACEHOLDER colony (${#AGENTS[@]} agents)..."
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.
 
+# Per-agent tick-interval override (#146). Add entries here only for agents
+# whose natural cadence differs from 60s. Reactive agents (those that poll
+# for infrequent upstream events) typically go to 180000-300000ms; active
+# agents producing work every tick stay at the 60000ms fallback.
+declare -A TICK_INTERVALS=(
+    # ["example_reactive_agent"]=300000
+)
+
 for agent in "${AGENTS[@]}"; do
-    echo "  Starting $agent..."
+    interval="${TICK_INTERVALS[$agent]:-60000}"
+    echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony COLONY_ID_PLACEHOLDER \
-        --tick-interval 60000 &
+        --tick-interval "$interval" &
     sleep 2  # stagger starts to reduce API contention
 done
 


### PR DESCRIPTION
## Summary
- Restructures each colony's `start-colony.sh` around a local `TICK_INTERVALS` assoc array keyed by agent name (fallback 60000ms).
- Bumps reactive agents: release colony and code-review colony to 300s; triage router/prioritizer to 180s. Active agents (planning, implementation, triage issue_creator/labeler) keep 60s.
- Updates `CLAUDE.md`, `tools/new-colony.sh` scaffolder, and `dev-apprenticeship/install.sh` comment to reflect the new pattern.
- No `.ag` changes — companion early-exit work stays in #147.

## Rationale
Per #146: of 21 federation agents, 11 were reactive and spent one `claude` CLI invocation per minute producing no observable work. Releasing to 5-min cadence on release/code-review and 3-min on triage router/prioritizer cuts federation idle LLM calls from ~1260/hr to ~770/hr (~38%) without touching agentis-core.

## Per-colony intervals
| colony | agent | interval |
|---|---|---|
| release | release_checker, ship_decider, changelog_writer, version_bumper | 300000ms |
| code-review | style_reviewer, logic_reviewer, security_reviewer, test_reviewer, approval_decider | 300000ms |
| triage | router, prioritizer | 180000ms |
| triage | issue_creator, labeler | 60000ms |
| planning | scope_estimator, risk_assessor, task_decomposer, plan_reviewer | 60000ms |
| implementation | code_writer, test_writer, refactorer, commit_composer | 60000ms |

## Test plan
- [x] `bash -n` passes on every modified script.
- [x] `./tools/colony-lint.sh` → 46 passed, 0 failed, 5 skipped (shellcheck not installed locally).
- [x] Dry-run interval lookup verified against each script's `TICK_INTERVALS` + `AGENTS` arrays — every agent resolves to the expected value listed in #146.
- [ ] Live run with a real colony (requires GitLab config + LLM backend; not attempted from the worktree).

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)