### PR TITLE
feat(reactive-agents): delta-check + early-exit before prompt() in 11 agents (#147)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ colony-name/
 - All dynamic values in `exec sh` calls must be wrapped in `shell_escape()`.
 - If the grep-based linter cannot see through nested `shell_escape()`, add `// colony-lint: safe-exec-concat` on the line above.
 - Emit events use `"<colony_name>:<event_name>"` format.
-- For mechanical JSON field extraction from `exec sh` output, prefer `parse_int(to_string(json_get(raw, "[0].iid")))` over `prompt(...) -> list<T>` / `-> map<K,V>`. The idiom is total on every failure mode (`Void → "void" → 0`) and saves one LLM round-trip per tick. Precedent: `release/agents/ship_decider.ag:89-91`, `release/agents/changelog_writer.ag:120-122`, every `implementation/agents/*.ag` and `code-review/agents/{logic,test,security,style}_reviewer.ag` after #138.
+- For mechanical JSON field extraction from `exec sh` output, prefer `parse_int(to_string(json_get(raw, "[0].iid")))` over `prompt(...) -> list<T>` / `-> map<K,V>`. The idiom is total on every failure mode (`Void → "void" → 0`) and saves one LLM round-trip per tick. Precedent: the `post-note` branches in `release/agents/ship_decider.ag` and `release/agents/changelog_writer.ag`, every `implementation/agents/*.ag`, `code-review/agents/{logic,test,security,style}_reviewer.ag` after #138, and `planning/agents/plan_reviewer.ag` after #147.
 
 ## Script conventions
 

--- a/dev-apprenticeship/code-review/README.md
+++ b/dev-apprenticeship/code-review/README.md
@@ -43,6 +43,15 @@ graph LR
 
 When a new merge request appears, all four reviewers analyze it in parallel, each from their own perspective. They publish findings to the colony bus. The Approval Decider aggregates those findings, weighs severity, and produces the final review action: approve, request changes, or escalate to the human.
 
+## Early-exit on quiet ticks (#147)
+
+`logic_reviewer`, `style_reviewer`, `security_reviewer`, and `approval_decider` follow the federation's **delta-check + early-exit** convention so a quiet repo costs ~0 LLM calls/h:
+
+- **MR reviewers** (`logic`, `style`, `security`): a single `gitlab-api.sh merge-requests --since <last_check> --view reviewer` call filters server-side. An empty response (`[]`) → refresh `last_check` and `return` before any `prompt()`.
+- **Approval decider**: has no GitLab poll. It listens on four bus topics (`review:{style,logic,security,test}_findings`); when all four `listen()` calls return Void (the empty inbox case), `return` before any `prompt()`. `last_check` is still refreshed on the early-exit path so operators can distinguish "nothing to do" from "daemon stalled".
+
+See `agents/logic_reviewer.ag` for the canonical MR-reviewer shape and `agents/approval_decider.ag` for the event-driven variant.
+
 ## Setup
 
 1. Copy and edit the config:

--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -26,7 +26,13 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
-    // Collect findings from all reviewers
+    // #147: cheap delta-check. approval_decider has no GitLab poll —
+    // its input is the colony bus. If no reviewer emitted findings
+    // since the last tick (all four `listen()` calls returned Void —
+    // to_string "void" = 4 chars, so 4*4 = 16 < 24), early-exit
+    // before any prompt(). `last_check` is refreshed so operators can
+    // see the agent is alive (and so downstream tooling can tell an
+    // empty-inbox tick from a stalled daemon).
     let style = listen("review:style_findings", 500);
     let logic = listen("review:logic_findings", 500);
     let security = listen("review:security_findings", 500);
@@ -40,6 +46,10 @@ fn tick(reason: string) -> void {
     // Only proceed if at least one reviewer reported
     let total_len = len(style_str) + len(logic_str) + len(security_str) + len(tests_str);
     if total_len < 24 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("approval_decider:last_check", now_e);
+        };
         return;
     };
 
@@ -103,5 +113,10 @@ fn tick(reason: string) -> void {
     let impl_mr = listen("implementation:mr_ready", 100);
     if len(to_string(impl_mr)) > 5 {
         print("[approval_decider] Implementation colony created a new MR, reviewers will pick it up on next tick");
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("approval_decider:last_check", now);
     };
 }

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -38,6 +38,10 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
+    // #147: cheap delta-check. `mr_cmd()` filters --since last_check;
+    // an empty `[]` response means no MR updates since last tick and we
+    // early-exit before any prompt(). last_check is refreshed so the
+    // --since window advances on quiet projects.
     let cmd = mr_cmd();
     let raw = try {
         exec sh cmd;
@@ -47,6 +51,10 @@ fn tick(reason: string) -> void {
     };
 
     if len(raw) < 3 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("logic_reviewer:last_check", now_e);
+        };
         return;
     };
 

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -39,6 +39,10 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
+    // #147: cheap delta-check. `mr_cmd()` filters --since last_check; an
+    // empty `[]` response means no MR updates since last tick and we
+    // early-exit before any prompt(). last_check is refreshed so the
+    // --since window advances on quiet projects.
     let cmd = mr_cmd();
     let raw = try {
         exec sh cmd;
@@ -48,6 +52,10 @@ fn tick(reason: string) -> void {
     };
 
     if len(raw) < 3 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("security_reviewer:last_check", now_e);
+        };
         return;
     };
 

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -62,6 +62,10 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
+    // #147: cheap delta-check. `mr_cmd()` filters --since last_check;
+    // an empty `[]` response means no MR updates since last tick and we
+    // early-exit before any prompt(). last_check is refreshed so the
+    // --since window advances on quiet projects.
     let cmd = mr_cmd();
     let raw = try {
         exec sh cmd;
@@ -71,6 +75,10 @@ fn tick(reason: string) -> void {
     };
 
     if len(raw) < 3 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("style_reviewer:last_check", now_e);
+        };
         return;
     };
 

--- a/dev-apprenticeship/planning/README.md
+++ b/dev-apprenticeship/planning/README.md
@@ -39,6 +39,15 @@ graph LR
 
 When a new issue needs planning, the Scope Estimator, Risk Assessor, and Task Decomposer each analyze it from their perspective. Their outputs flow to the Plan Reviewer, which evaluates the combined plan against learned standards and either publishes it or flags it for human review.
 
+## Early-exit on quiet ticks (#147)
+
+`plan_reviewer` follows the federation's **delta-check + early-exit** convention so ticks on a quiet project cost ~0 LLM calls:
+
+1. Peer outputs (`planning:scope_estimate`, `planning:risks`, `planning:breakdown`) are listened for and stashed per-issue.
+2. A single cheap `exec sh` call to `gitlab-api.sh issues --needs-planning --view planning` tells us whether any open issue still lacks a plan. An empty response (`[]`) means everything is already planned.
+3. On empty: refresh `plan_reviewer:last_check` and `return` **before** any `prompt()` — no Claude invocation.
+4. The newest-issue iid is extracted with `json_get` (mechanical JSON read, zero LLM cost) instead of a `prompt()`; the assembly prompt only runs once all three peer slots are filled for the target issue.
+
 ## Setup
 
 1. Copy and edit the config:

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -72,6 +72,10 @@ fn tick(reason: string) -> void {
 
     // 3. Pick the newest unplanned issue and see if we have all three
     //    slots filled for it. If not, keep waiting.
+    // #147: cheap delta-check. `issues --needs-planning` returns `[]`
+    // when every open issue already has a plan, so we early-exit
+    // before the assembly prompt(). last_check is refreshed so the
+    // agent's liveness signal advances on quiet projects.
     let issues_raw = try {
         exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
     } catch e {
@@ -80,13 +84,21 @@ fn tick(reason: string) -> void {
     };
 
     if len(issues_raw) < 3 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("plan_reviewer:last_check", now_e);
+        };
         return;
     };
 
-    let target_iid = prompt(
-        "Return just the issue_id integer of the newest issue in this JSON array. Nothing else.",
-        issues_raw
-    ) -> int;
+    // #147: extract target_iid via json_get instead of prompt() — avoids
+    // an LLM round-trip on a purely mechanical JSON extraction (matches
+    // CLAUDE.md "prefer json_get" convention, same idiom as the MR
+    // reviewers).
+    let target_iid = parse_int(to_string(json_get(issues_raw, "[0].iid")));
+    if target_iid <= 0 {
+        return;
+    };
 
     let s = recall_latest("plan_reviewer:" + to_string(target_iid) + ":scope");
     let r = recall_latest("plan_reviewer:" + to_string(target_iid) + ":risks");
@@ -149,5 +161,10 @@ fn tick(reason: string) -> void {
         } else {
             print("[plan_reviewer] Observing (confidence:", confidence, ")");
         };
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("plan_reviewer:last_check", now);
     };
 }

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -97,6 +97,10 @@ fn tick(reason: string) -> void {
     // reviewers).
     let target_iid = parse_int(to_string(json_get(issues_raw, "[0].iid")));
     if target_iid <= 0 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("plan_reviewer:last_check", now_e);
+        };
         return;
     };
 

--- a/dev-apprenticeship/release/README.md
+++ b/dev-apprenticeship/release/README.md
@@ -38,6 +38,15 @@ graph LR
 
 When a release candidate is ready, the Release Checker runs pre-release validation (CI status, dependency audit, migration safety). The Ship Decider weighs the results against learned thresholds and makes a ship/no-ship call. If shipping, the Changelog Writer compiles the release notes and the Version Bumper determines the correct version number, both following conventions learned from past releases.
 
+## Early-exit on quiet ticks (#147)
+
+All four release agents follow the federation's **delta-check + early-exit** convention so ticks on a quiet repo cost ~0 LLM calls/h:
+
+- **`ship_decider`** / **`release_checker`**: a cheap `gitlab-api.sh merge-requests --state merged --since <last_check> --per-page 1` query answers "has anything release-worthy landed?" in one HTTP call. Combined with a `listen()` on the relevant event (`release:check_result` for ship_decider, `implementation:mr_ready` for release_checker), if both signals are empty the tick refreshes `last_check` and `return`s **before** any `prompt()` — including the release-pattern learning prompt that used to run every tick.
+- **`version_bumper`** / **`changelog_writer`**: pure event-driven. Each listens for `release:ship_decision`; empty inbox → refresh `last_check` and `return` before the tag/release-style learning prompt. The learn-from-history prompts only run on ticks where a ship decision actually arrived.
+
+The learn-on-demand shape is intentional: past releases don't change between ticks, so re-analyzing them every minute wastes Claude calls. Gating pattern learning behind the delta-check keeps the cost proportional to real activity.
+
 ## Setup
 
 1. Copy and edit the config:

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -34,7 +34,23 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
-    // 1. Learn changelog style from past releases
+    // #147: changelog_writer is pure event-driven. It reacts to a
+    // `release:ship_decision` emit from ship_decider. If the inbox is
+    // empty, early-exit before any prompt() (including the release-
+    // note style-learning one, which used to run every tick).
+    let ship_decision = listen("release:ship_decision", 100);
+    let decision_str = to_string(ship_decision);
+
+    if len(decision_str) < 5 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("changelog_writer:last_check", now_e);
+        };
+        return;
+    };
+
+    // 1. Learn changelog style from past releases (only when we're
+    //    actually about to write one — gated by the delta-check above).
     let releases_raw = try {
         exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 10 --view release-summary";
     } catch e {
@@ -58,18 +74,6 @@ fn tick(reason: string) -> void {
             );
             print("[changelog_writer] Learned from", style.releases_seen, "past release notes");
         };
-    };
-
-    // 2. Listen for ship decision and compile changelog
-    let ship_decision = listen("release:ship_decision", 100);
-    let decision_str = to_string(ship_decision);
-
-    if len(decision_str) < 5 {
-        let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
-        if len(now) > 0 {
-            memo_write("changelog_writer:last_check", now);
-        };
-        return;
     };
 
     // Only proceed if the decision is "ship"

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -34,8 +34,41 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
+// #147: build the merged-MR delta query with optional --since. Used by
+// the tick's pre-prompt delta-check.
+fn mr_delta_cmd_for(ts: string) -> string {
+    if len(ts) > 0 {
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --per-page 1";
+    };
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --per-page 1";
+}
+
 fn tick(reason: string) -> void {
-    // 1. Learn from past releases and their pipeline outcomes
+    // #147: cheap delta-check BEFORE any prompt(). release_checker's
+    // real work is driven by two signals: `implementation:mr_ready`
+    // (a new MR needs a pre-release check) and newly-merged MRs (re-
+    // learn pipeline-gate patterns). If neither is present since the
+    // last tick, we early-exit without a Claude call.
+    let mr_ready = listen("implementation:mr_ready", 100);
+    let mr_str = to_string(mr_ready);
+    let has_event = len(mr_str) >= 5;
+
+    let mr_delta_cmd = mr_delta_cmd_for(recall_latest("release_checker:last_check"));
+    let mr_delta = try { exec sh mr_delta_cmd; } catch e { "[]"; };
+    let has_new_mr = len(mr_delta) >= 3;
+
+    if !has_event {
+        if !has_new_mr {
+            let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_e) > 0 {
+                memo_write("release_checker:last_check", now_e);
+            };
+            return;
+        };
+    };
+
+    // 1. Learn from past releases and their pipeline outcomes (only when
+    //    there IS new work — gated by the delta-check above).
     let releases_raw = try {
         exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 10 --view release-summary";
     } catch e {
@@ -61,9 +94,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    // 2. Check for pending release candidates (listen from implementation colony)
-    let mr_ready = listen("implementation:mr_ready", 100);
-    let mr_str = to_string(mr_ready);
+    // 2. Check pipeline state for the pending MR (or periodic check).
 
     // Also check the default branch pipeline status
     let pipeline_raw = try {

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -31,8 +31,41 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
+// #147: build the merged-MR delta query with optional --since. Used by
+// the tick's pre-prompt delta-check to tell whether any release-relevant
+// work has landed since the last tick.
+fn mr_delta_cmd_for(ts: string) -> string {
+    if len(ts) > 0 {
+        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --per-page 1";
+    };
+    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --per-page 1";
+}
+
 fn tick(reason: string) -> void {
-    // 1. Learn release patterns from history
+    // #147: cheap delta-check BEFORE any prompt(). ship_decider's work
+    // is reactive: decide ship/no-ship when `release:check_result`
+    // arrives, and re-learn release cadence when new merged MRs show
+    // up. If neither signal is present since the last tick, early-exit
+    // — no Claude call at all.
+    let check_result = listen("release:check_result", 100);
+    let check_str = to_string(check_result);
+    let has_event = len(check_str) >= 5;
+
+    let mr_delta_cmd = mr_delta_cmd_for(recall_latest("ship_decider:last_check"));
+    let mr_delta = try { exec sh mr_delta_cmd; } catch e { "[]"; };
+    let has_new_mr = len(mr_delta) >= 3;
+
+    if !has_event {
+        if !has_new_mr {
+            let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_e) > 0 {
+                memo_write("ship_decider:last_check", now_e);
+            };
+            return;
+        };
+    };
+
+    // 1. Learn release patterns from history (only when there IS new work)
     let releases_raw = try {
         exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 20 --view release-summary";
     } catch e {
@@ -62,14 +95,13 @@ fn tick(reason: string) -> void {
         };
     };
 
-    // 2. Listen for check results and make ship/no-ship decision
-    let check_result = listen("release:check_result", 100);
-    let check_str = to_string(check_result);
-
-    if len(check_str) < 5 {
-        let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
-        if len(now) > 0 {
-            memo_write("ship_decider:last_check", now);
+    // 2. Make ship/no-ship decision — only if a check_result arrived
+    //    this tick (the MR-delta branch re-learns patterns but has no
+    //    pending check to decide on).
+    if !has_event {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("ship_decider:last_check", now_e);
         };
         return;
     };

--- a/dev-apprenticeship/release/agents/version_bumper.ag
+++ b/dev-apprenticeship/release/agents/version_bumper.ag
@@ -34,7 +34,24 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
-    // 1. Learn versioning patterns from tags
+    // #147: version_bumper is pure event-driven. It reacts to a
+    // `release:ship_decision` emit from ship_decider — no GitLab poll
+    // is needed to decide whether to do work. If the inbox is empty,
+    // early-exit before any prompt() (including the tag-pattern
+    // learning one, which used to run every tick).
+    let ship_decision = listen("release:ship_decision", 100);
+    let decision_str = to_string(ship_decision);
+
+    if len(decision_str) < 5 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("version_bumper:last_check", now_e);
+        };
+        return;
+    };
+
+    // 1. Learn versioning patterns from tags (only when we're actually
+    //    about to bump — gated by the delta-check above).
     let tags_raw = try {
         exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 20 --view tag-summary";
     } catch e {
@@ -58,18 +75,6 @@ fn tick(reason: string) -> void {
             );
             print("[version_bumper] Learned from", patterns.tags_seen, "version tags");
         };
-    };
-
-    // 2. Listen for ship decision and determine next version
-    let ship_decision = listen("release:ship_decision", 100);
-    let decision_str = to_string(ship_decision);
-
-    if len(decision_str) < 5 {
-        let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
-        if len(now) > 0 {
-            memo_write("version_bumper:last_check", now);
-        };
-        return;
     };
 
     // Only proceed if the decision is "ship"

--- a/dev-apprenticeship/triage/README.md
+++ b/dev-apprenticeship/triage/README.md
@@ -40,6 +40,17 @@ graph LR
 
 When a new event arrives (bug report, support ticket, alert), the Issue Creator drafts the issue with learned title and description conventions. The Labeler, Prioritizer, and Router each add their metadata (labels, priority level, and assignee) based on patterns learned from past decisions.
 
+## Early-exit on quiet ticks (#147)
+
+Reactive agents (`router`, `prioritizer`) follow a **delta-check + early-exit** pattern so a quiet GitLab project costs ~0 LLM calls/h on the 60-second tick interval:
+
+1. `recall_latest("<agent>:last_check")` → an ISO-8601 timestamp (empty on first ever tick).
+2. A single cheap `exec sh` call to `gitlab-api.sh issues --since <last_check> --view <agent>` filters server-side. An empty response (`[]`, 2 chars) means "nothing new".
+3. On empty: refresh `last_check` and `return` **before** any `prompt()` — no Claude invocation at all.
+4. On non-empty: proceed to the normal learning/analysis prompts.
+
+The last-check refresh inside the early-exit branch is load-bearing — otherwise the `--since` window never advances on quiet projects and each tick would keep re-querying the same gap. This is the conventional structure for all reactive agents in this federation; see `agents/router.ag` and `agents/prioritizer.ag` for the canonical shape.
+
 ## Setup
 
 1. Copy and edit the config:

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -53,6 +53,10 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
+    // #147: cheap delta-check. `issues_cmd()` filters --since last_check
+    // server-side; an empty `[]` response means "no new issues" and we
+    // early-exit before any prompt(). last_check is refreshed so the
+    // window advances on quiet projects.
     let cmd = issues_cmd();
     let raw = try {
         exec sh cmd;
@@ -62,6 +66,10 @@ fn tick(reason: string) -> void {
     };
 
     if len(raw) < 3 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("prioritizer:last_check", now_e);
+        };
         return;
     };
 

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -39,6 +39,12 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
+    // #147: cheap delta-check. `issues_cmd()` already filters
+    // server-side via --since last_check, so an empty response
+    // (`[]`, 2 chars) means "no new issues since last tick" and we
+    // early-exit *before* any prompt(). The last_check memo is
+    // refreshed here too — otherwise the --since window would never
+    // advance on a quiet project.
     let cmd = issues_cmd();
     let raw = try {
         exec sh cmd;
@@ -48,6 +54,10 @@ fn tick(reason: string) -> void {
     };
 
     if len(raw) < 3 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("router:last_check", now_e);
+        };
         return;
     };
 


### PR DESCRIPTION
## Summary

Closes #147.

Each of the 11 reactive agents now runs a cheap `exec sh` delta-check **before** any `prompt()`. On an empty delta the tick refreshes `<agent>:last_check` and `return`s without spawning Claude — on a fully-quiet GitLab project the combined LLM cost for these agents drops from ~660 calls/h to ~0.

## Pattern per agent family

- **triage** (`router`, `prioritizer`): existing `--since last_check` filter is already server-side; the change is to refresh `last_check` on the empty-`[]` early-exit branch so the `--since` window keeps advancing on quiet repos.
- **code-review MR reviewers** (`logic_reviewer`, `style_reviewer`, `security_reviewer`): same `--since` + len-check pattern, same `last_check` fix on the empty branch.
- **code-review `approval_decider`**: event-driven on `review:{style,logic,security,test}_findings`. Empty inbox (all `listen()` → Void) → refresh `last_check` + return **before** the pattern-learn and decision prompts.
- **planning `plan_reviewer`**: `issues --needs-planning` response gates the assembly prompt. `target_iid` now comes from `json_get` instead of a prompt — matches the CLAUDE.md "prefer json_get for mechanical JSON reads" convention and saves one LLM round-trip per tick with pending work.
- **release `ship_decider`** + **`release_checker`**: cheap merged-MR delta query (`merge-requests --state merged --since last_check --per-page 1`) plus `listen()` on the relevant event (`release:check_result` / `implementation:mr_ready`). If both signals are empty, early-exit **before** the release-pattern learning prompt that used to run every tick regardless of activity.
- **release `version_bumper`** + **`changelog_writer`**: pure event-driven on `release:ship_decision`. Empty inbox → early-exit before the tag/release-style learning prompts.

## Docs

Each colony's `README.md` gets a short "Early-exit on quiet ticks (#147)" section documenting the pattern as the conventional structure, and pointing at one canonical `.ag` file per family.

## Files

- 11 `.ag` agents across `triage/`, `planning/`, `code-review/`, `release/`.
- 4 colony `README.md` files.
- No changes to `start-colony.sh` (that's #146, separate PR).
- No changes to `gitlab-api.sh` — every delta-check uses existing subcommands.

## Test plan

- [x] `./tools/colony-lint.sh` — 46 passed, 0 failed, 5 skipped (same as baseline).
- [x] `agentis commit` round-trip succeeds on each modified `.ag` (syntax OK).
- [ ] Run federation for 1h against a quiet GitLab project; verify `tick_ok` increments for all 11 agents while `claude` CLI is spawned 0 times for them (per acceptance criteria in #147). **Operator-run test — requires a live GitLab project; not exercised in this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)