### PR TITLE
feat(tools): auto-promote/auto-evolve cron script, layer 1 (#148)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ release:changelog_draft      -> version_bumper
 | `check-exec-sh.sh` | Grep-based check for unsafe string concat into `exec sh`. See `check-exec-sh.md` for known limitations. |
 | `parse-toml.sh` | Shared TOML parser sourced by all start-colony.sh scripts |
 | `federation-dashboard.sh` | Generic web dashboard for any federation (auto-discovers colonies/agents, kill switch, phase ETA) |
+| `auto-promote.sh` | Layer 1 auto-promote/auto-evolve cron script — evaluates per-agent fitness, promotes or evolves (#148) |
+| `auto-promote-config.yaml` | Decision rules for auto-promote (thresholds, promote steps, evolve triggers, dry_run flag) |
 
 ## End-user scripts (in dev-apprenticeship/)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ release:changelog_draft      -> version_bumper
 | `federation-dashboard.sh` | Generic web dashboard for any federation (auto-discovers colonies/agents, kill switch, phase ETA) |
 | `auto-promote.sh` | Layer 1 auto-promote/auto-evolve cron script — evaluates per-agent fitness, promotes or evolves (#148) |
 | `auto-promote-config.yaml` | Decision rules for auto-promote (thresholds, promote steps, evolve triggers, dry_run flag) |
+| `resolve-tick-interval.py` | Shared helper: reads TICK_INTERVALS from start-colony.sh for a given agent+colony (used by dashboard + auto-promote) |
 
 ## End-user scripts (in dev-apprenticeship/)
 

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -285,3 +285,56 @@ Terminal colony bus events with no internal listener, meant for external consump
 | `review:escalation` | approval_decider | Confidence >= 0.85: MR requires human attention |
 | `planning:draft_plan` | plan_reviewer | Confidence 0.6-0.84: assembled plan for human review |
 | `release:version_bumped` | version_bumper | After tag/release creation or version bump suggestion |
+
+## Auto-promote / auto-evolve (#148)
+
+An external cron script that evaluates per-agent fitness from experience data and decides when to promote (raise confidence) or evolve (mutate `.ag` source). Runs outside the federation, reads state via `agentis daemon list --json` and experience JSONL files.
+
+### Quick start
+
+```bash
+# Dry-run (default) — log what would happen, take no action:
+./tools/auto-promote.sh dev-apprenticeship
+
+# Live mode — actually promote/evolve:
+./tools/auto-promote.sh dev-apprenticeship --live
+
+# Cron entry (every 30 minutes):
+# */30 * * * * cd /path/to/agentis-colonies && ./tools/auto-promote.sh dev-apprenticeship >> /var/log/auto-promote.log 2>&1
+```
+
+Configuration lives in `tools/auto-promote-config.yaml`. Decisions are journaled to `tools/auto-promote-journal.jsonl` (append-only, one JSON line per decision).
+
+### Decision rules
+
+**Promote** (confidence step-up, e.g. 0.5 → 0.6 → 0.85):
+- Minimum 200 experience entries
+- At least 48 hours of runtime
+- Reject rate below 5%
+- Delta slope non-negative over last 100 entries
+
+**Evolve** (`.ag` source mutation via `agentis evolve`):
+- Negative delta slope sustained over 1000 entries, OR
+- Reject rate above 20%
+
+### Safety guards
+
+1. **Federation check**: exits cleanly when `agentis daemon list --json` returns empty
+2. **Lock file**: `tools/.auto-promote.lock` prevents overlapping cron runs
+3. **Confidence seeded**: skips agents where `recall_latest` returns null
+4. **PID liveness**: `kill -0` check before acting on a daemon
+5. **Dry-run default**: all actions are logged but not executed until you flip `dry_run: false` in the config
+
+### Roadmap: 3 layers of self-governance
+
+| Layer | Where | Status |
+|-------|-------|--------|
+| **1 — External cron** | `tools/auto-promote.sh` | Shipped (#148) |
+| **2 — Supervisor agent** | `meta/agents/conductor.ag` | Planned (separate ticket) |
+| **3 — Daemon self-decide** | agentis-core | Long-horizon (needs months of L1+L2 data) |
+
+**Layer 1** (this) runs as a dumb cron job. It cannot observe the federation in real time — it snapshots state once per invocation, evaluates rules, and exits. Good enough for 30-minute decision cadence.
+
+**Layer 2** lifts the same logic into a native `.ag` agent (`conductor.ag`) running inside a new `meta` colony. The supervisor ticks every 5 minutes, reads other agents' state via the agentis API, and emits structured `promote`/`evolve` events. The federation learns how to manage itself — and you can evolve the supervisor too. Requires agentis-core support for cross-agent state reads (currently sandboxed).
+
+**Layer 3** gives each daemon a self-governance loop: track own metrics, decide when to self-promote, write memo, signal restart. Most invasive design with open questions about uncontrolled escalation. Out of scope until layers 1+2 have run for months and we have data on whether self-promote is desirable.

--- a/tools/auto-promote-config.yaml
+++ b/tools/auto-promote-config.yaml
@@ -1,0 +1,32 @@
+# auto-promote-config.yaml — Decision rules for auto-promote / auto-evolve
+#
+# Used by tools/auto-promote.sh. See issue #148 for rationale.
+#
+# All thresholds are per-agent: the script evaluates each running agent
+# independently against these rules.
+
+promote:
+  prerequisites:
+    min_entries: 200             # minimum experience entries before considering
+    min_runtime_hours: 48        # don't promote in the first 2 days
+    reject_rate_threshold: 0.05  # reject_rate must be < 5%
+    delta_slope_window: 100      # compute slope over last N entries
+    delta_slope_min: 0           # average delta must be non-negative
+  steps:
+    - from: 0.5
+      to: 0.6
+    - from: 0.6
+      to: 0.85
+
+evolve:
+  trigger:
+    delta_slope_negative_for: 1000  # negative slope sustained over N entries
+    reject_rate_above: 0.20         # OR reject_rate > 20%
+  config:
+    generations: 3
+    population: 4
+    weights: "cb,val,exp"
+
+# dry_run: true means all actions are logged but not executed.
+# Default is true — flip to false only after reviewing the journal.
+dry_run: true

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -51,24 +51,14 @@ CONFIG_FILE="$SCRIPT_DIR/auto-promote-config.yaml"
 JOURNAL_FILE="$SCRIPT_DIR/auto-promote-journal.jsonl"
 LOCK_FILE="$SCRIPT_DIR/.auto-promote.lock"
 
-# --- Safety guard 2: Lock file ---
+# --- Safety guard 2: Lock file (flock, atomic) ---
 
-cleanup_lock() {
-    rm -f "$LOCK_FILE"
-}
-
-if [ -f "$LOCK_FILE" ]; then
-    LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
-    if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
-        echo "Another auto-promote instance is running (pid $LOCK_PID). Exiting."
-        exit 0
-    fi
-    # Stale lock — previous run crashed. Clean up and proceed.
-    rm -f "$LOCK_FILE"
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+    echo "Another auto-promote instance is running. Exiting."
+    exit 0
 fi
-
-echo $$ > "$LOCK_FILE"
-trap cleanup_lock EXIT
+# fd 200 is held until the process exits — no cleanup trap needed.
 
 # --- Logging + journal helpers ---
 
@@ -77,9 +67,11 @@ log() {
 }
 
 # Append a structured JSON line to the journal.
-# Args: agent, decision, detail_json
+# Args: agent, decision, evidence_json [, from, to]
+# Matches the spec format from #148: top-level from/to + evidence object.
 journal_append() {
-    local agent="$1" decision="$2" detail_json="$3"
+    local agent="$1" decision="$2" evidence_json="$3"
+    local step_from="${4:-}" step_to="${5:-}"
     python3 -c "
 import json, sys, time
 entry = {
@@ -88,10 +80,16 @@ entry = {
     'agent': sys.argv[1],
     'decision': sys.argv[2],
     'dry_run': sys.argv[3] == 'true',
-    'detail': json.loads(sys.argv[4]),
+    'evidence': json.loads(sys.argv[4]),
 }
+if sys.argv[5]:
+    try: entry['from'] = float(sys.argv[5])
+    except ValueError: pass
+if sys.argv[6]:
+    try: entry['to'] = float(sys.argv[6])
+    except ValueError: pass
 print(json.dumps(entry))
-" "$agent" "$decision" "$DRY_RUN" "$detail_json" >> "$JOURNAL_FILE"
+" "$agent" "$decision" "$DRY_RUN" "$evidence_json" "$step_from" "$step_to" >> "$JOURNAL_FILE"
 }
 
 # --- Parse config ---
@@ -546,7 +544,8 @@ while IFS='|' read -r decision agent colony step_from step_to reason evidence_js
                 log "  [dry-run] Would run: agentis memo set ${agent}:confidence $step_to"
                 log "  [dry-run] Would restart daemon for $agent"
                 journal_append "$agent" "promote" \
-                    "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['action']='dry-run'; print(json.dumps(e))" "$evidence_json")"
+                    "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='dry-run'; print(json.dumps(e))" "$evidence_json")" \
+                    "$step_from" "$step_to"
             else
                 # Write new confidence to memo (cwd=FED_DIR for .agentis/ resolution)
                 log "  Writing confidence: agentis memo set ${agent}:confidence $step_to"
@@ -555,7 +554,8 @@ while IFS='|' read -r decision agent colony step_from step_to reason evidence_js
                 else
                     log "  WARNING: memo set failed for $agent"
                     journal_append "$agent" "promote-failed" \
-                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['error']='memo_set_failed'; print(json.dumps(e))" "$evidence_json")"
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['error']='memo_set_failed'; print(json.dumps(e))" "$evidence_json")" \
+                        "$step_from" "$step_to"
                     continue
                 fi
 
@@ -578,7 +578,8 @@ while IFS='|' read -r decision agent colony step_from step_to reason evidence_js
                 if [ -z "$AGENT_AG_FILE" ]; then
                     log "  WARNING: could not find .ag file for $agent, skipping restart"
                     journal_append "$agent" "promote-partial" \
-                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['action']='memo-only'; e['warning']='ag_file_not_found'; print(json.dumps(e))" "$evidence_json")"
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='memo-only'; e['warning']='ag_file_not_found'; print(json.dumps(e))" "$evidence_json")" \
+                        "$step_from" "$step_to"
                     continue
                 fi
 
@@ -628,7 +629,8 @@ else:
                 if [ "$SPAWN_ENV" = "__INCOMPLETE__" ] || [ -z "$SPAWN_ENV" ]; then
                     log "  WARNING: incomplete [gitlab] in $COLONY_TOML, skipping restart"
                     journal_append "$agent" "promote-partial" \
-                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['action']='memo-only'; e['warning']='incomplete_colony_toml'; print(json.dumps(e))" "$evidence_json")"
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='memo-only'; e['warning']='incomplete_colony_toml'; print(json.dumps(e))" "$evidence_json")" \
+                        "$step_from" "$step_to"
                     continue
                 fi
 
@@ -663,7 +665,8 @@ for d in daemons:
                 log "  Daemon respawned for $agent"
 
                 journal_append "$agent" "promote" \
-                    "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['action']='executed'; print(json.dumps(e))" "$evidence_json")"
+                    "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='executed'; print(json.dumps(e))" "$evidence_json")" \
+                    "$step_from" "$step_to"
             fi
             PROMOTE_COUNT=$((PROMOTE_COUNT + 1))
             ;;

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -72,11 +72,8 @@ trap cleanup_lock EXIT
 
 # --- Logging + journal helpers ---
 
-TS_EPOCH=$(date +%s)
-TS_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
 log() {
-    echo "[$TS_ISO] auto-promote: $*"
+    echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] auto-promote: $*"
 }
 
 # Append a structured JSON line to the journal.
@@ -84,17 +81,17 @@ log() {
 journal_append() {
     local agent="$1" decision="$2" detail_json="$3"
     python3 -c "
-import json, sys
+import json, sys, time
 entry = {
-    'ts': $TS_EPOCH,
-    'ts_iso': '$TS_ISO',
+    'ts': int(time.time()),
+    'ts_iso': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
     'agent': sys.argv[1],
     'decision': sys.argv[2],
-    'dry_run': $( [ "$DRY_RUN" = "true" ] && echo "True" || echo "False" ),
-    'detail': json.loads(sys.argv[3]),
+    'dry_run': sys.argv[3] == 'true',
+    'detail': json.loads(sys.argv[4]),
 }
 print(json.dumps(entry))
-" "$agent" "$decision" "$detail_json" >> "$JOURNAL_FILE"
+" "$agent" "$decision" "$DRY_RUN" "$detail_json" >> "$JOURNAL_FILE"
 }
 
 # --- Parse config ---
@@ -247,7 +244,10 @@ log "Starting (dry_run=$DRY_RUN, fed=$FED_DIR)"
 
 # --- Safety guard 1: Federation running check ---
 
-DAEMONS_JSON=$(agentis daemon list --json 2>/dev/null || echo "[]")
+# All agentis CLI commands must run from $FED_DIR so the CLI finds
+# .agentis/ (daemon registry, memo store, experience). Matches the
+# cwd=fed_dir pattern in federation-dashboard.sh.
+DAEMONS_JSON=$(cd "$FED_DIR" && agentis daemon list --json 2>/dev/null || echo "[]")
 DAEMON_COUNT=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); print(len(d))" "$DAEMONS_JSON")
 
 if [ "$DAEMON_COUNT" -eq 0 ]; then
@@ -497,21 +497,10 @@ PROMOTE_COUNT=0
 EVOLVE_COUNT=0
 SKIP_COUNT=0
 
-# Parse decisions and act on each
-python3 -c "
-import json, sys
-decisions = json.loads(sys.argv[1])
-for d in decisions:
-    # Output one line per decision: decision|agent|colony|from|to|reason|evidence_json
-    decision = d.get('decision', 'skip')
-    agent = d.get('agent', '')
-    colony = d.get('colony', '')
-    step_from = d.get('from', '')
-    step_to = d.get('to', '')
-    reason = d.get('reason', '')
-    evidence = json.dumps(d.get('evidence', d))
-    print(f'{decision}|{agent}|{colony}|{step_from}|{step_to}|{reason}|{evidence}')
-" "$DECISIONS_JSON" | while IFS='|' read -r decision agent colony step_from step_to reason evidence_json; do
+# Parse decisions and act on each.
+# Process substitution (< <(...)) instead of pipe so the while loop runs
+# in the current shell — counter variables survive after the loop.
+while IFS='|' read -r decision agent colony step_from step_to reason evidence_json; do
 
     case "$decision" in
         skip)
@@ -528,9 +517,9 @@ for d in decisions:
                 journal_append "$agent" "promote" \
                     "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['action']='dry-run'; print(json.dumps(e))" "$evidence_json")"
             else
-                # Write new confidence to memo
+                # Write new confidence to memo (cwd=FED_DIR for .agentis/ resolution)
                 log "  Writing confidence: agentis memo set ${agent}:confidence $step_to"
-                if agentis memo set "${agent}:confidence" "$step_to" 2>&1; then
+                if (cd "$FED_DIR" && agentis memo set "${agent}:confidence" "$step_to") 2>&1; then
                     log "  Memo written successfully"
                 else
                     log "  WARNING: memo set failed for $agent"
@@ -541,13 +530,16 @@ for d in decisions:
 
                 # Restart the daemon so it picks up the new confidence.
                 # Use the same stop+respawn pattern as the dashboard (#137).
+                # The respawn must export GITLAB_* env vars from colony.toml
+                # (the cron environment won't have them).
                 log "  Restarting daemon for $agent..."
                 AGENT_AG_FILE=""
-                for colony_dir in "$FED_DIR"/*/; do
-                    candidate="${colony_dir}agents/${agent}.ag"
+                AGENT_COLONY_DIR=""
+                for cdir in "$FED_DIR"/*/; do
+                    candidate="${cdir}agents/${agent}.ag"
                     if [ -f "$candidate" ]; then
                         AGENT_AG_FILE="$candidate"
-                        AGENT_COLONY_DIR="$colony_dir"
+                        AGENT_COLONY_DIR="$cdir"
                         break
                     fi
                 done
@@ -556,6 +548,56 @@ for d in decisions:
                     log "  WARNING: could not find .ag file for $agent, skipping restart"
                     journal_append "$agent" "promote-partial" \
                         "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['action']='memo-only'; e['warning']='ag_file_not_found'; print(json.dumps(e))" "$evidence_json")"
+                    continue
+                fi
+
+                # Read gitlab config from colony.toml (mirrors dashboard restart_daemon)
+                COLONY_TOML="${AGENT_COLONY_DIR}config/colony.toml"
+                SPAWN_ENV=$(python3 -c "
+import sys, os
+toml_path = sys.argv[1]
+colony_dir = sys.argv[2]
+# Minimal TOML [gitlab] section reader (same approach as federation-dashboard.sh)
+vals = {}
+in_section = False
+try:
+    with open(toml_path) as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith('#'):
+                continue
+            if line.startswith('[') and line.endswith(']'):
+                in_section = (line[1:-1].strip() == 'gitlab')
+                continue
+            if not in_section or '=' not in line:
+                continue
+            k, _, v = line.partition('=')
+            k = k.strip()
+            v = v.strip().strip('\"').strip(\"'\")
+            vals[k] = v
+except OSError:
+    pass
+url = vals.get('url', '')
+token = vals.get('token', '')
+project_raw = vals.get('project', '')
+me = vals.get('me', '')
+if not url or not token or not project_raw:
+    print('__INCOMPLETE__')
+else:
+    project = project_raw.replace('/', '%2F')
+    # Shell-safe export statements
+    import shlex
+    print(f'export GITLAB_URL={shlex.quote(url)}')
+    print(f'export GITLAB_TOKEN={shlex.quote(token)}')
+    print(f'export GITLAB_PROJECT={shlex.quote(project)}')
+    print(f'export GITLAB_ME={shlex.quote(me)}')
+    print(f'export COLONY_DIR={shlex.quote(colony_dir)}')
+" "$COLONY_TOML" "$AGENT_COLONY_DIR" 2>/dev/null)
+
+                if [ "$SPAWN_ENV" = "__INCOMPLETE__" ] || [ -z "$SPAWN_ENV" ]; then
+                    log "  WARNING: incomplete [gitlab] in $COLONY_TOML, skipping restart"
+                    journal_append "$agent" "promote-partial" \
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['action']='memo-only'; e['warning']='incomplete_colony_toml'; print(json.dumps(e))" "$evidence_json")"
                     continue
                 fi
 
@@ -571,14 +613,15 @@ for d in daemons:
         break
 " "$DAEMONS_JSON" "$agent")
 
-                # Stop the daemon
+                # Stop the daemon (cwd=FED_DIR for .agentis/ resolution)
                 if [ -n "$AGENT_ID" ]; then
-                    agentis daemon stop "$AGENT_ID" 2>&1 || true
+                    (cd "$FED_DIR" && agentis daemon stop "$AGENT_ID") 2>&1 || true
                     sleep 3
                 fi
 
-                # Respawn
+                # Respawn with GITLAB_* env vars from colony.toml
                 (
+                    eval "$SPAWN_ENV"
                     cd "$AGENT_COLONY_DIR"
                     agentis daemon "$AGENT_AG_FILE" \
                         --colony "$colony" \
@@ -603,8 +646,8 @@ for d in daemons:
             else
                 # Find the .ag file for the agent
                 AGENT_AG_FILE=""
-                for colony_dir in "$FED_DIR"/*/; do
-                    candidate="${colony_dir}agents/${agent}.ag"
+                for cdir in "$FED_DIR"/*/; do
+                    candidate="${cdir}agents/${agent}.ag"
                     if [ -f "$candidate" ]; then
                         AGENT_AG_FILE="$candidate"
                         break
@@ -619,7 +662,7 @@ for d in daemons:
                 fi
 
                 log "  Running: agentis evolve $AGENT_AG_FILE"
-                EVOLVE_OUTPUT=$(agentis evolve "$AGENT_AG_FILE" \
+                EVOLVE_OUTPUT=$(cd "$FED_DIR" && agentis evolve "$AGENT_AG_FILE" \
                     --generations "$CFG_EVOLVE_GENERATIONS" \
                     --population "$CFG_EVOLVE_POPULATION" \
                     --weights "$CFG_EVOLVE_WEIGHTS" 2>&1) || true
@@ -631,6 +674,18 @@ for d in daemons:
             EVOLVE_COUNT=$((EVOLVE_COUNT + 1))
             ;;
     esac
-done
+done < <(python3 -c "
+import json, sys
+decisions = json.loads(sys.argv[1])
+for d in decisions:
+    decision = d.get('decision', 'skip')
+    agent = d.get('agent', '')
+    colony = d.get('colony', '')
+    step_from = d.get('from', '')
+    step_to = d.get('to', '')
+    reason = d.get('reason', '')
+    evidence = json.dumps(d.get('evidence', d))
+    print(f'{decision}|{agent}|{colony}|{step_from}|{step_to}|{reason}|{evidence}')
+" "$DECISIONS_JSON")
 
 log "Done. Promotes=$PROMOTE_COUNT, Evolves=$EVOLVE_COUNT, Skips=$SKIP_COUNT"

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -653,7 +653,8 @@ for d in daemons:
                 fi
 
                 # Resolve per-agent tick interval from start-colony.sh (#155)
-                TICK_INTERVAL=$(python3 "$SCRIPT_DIR/resolve-tick-interval.py" "$agent" "$AGENT_COLONY_DIR")
+                TICK_INTERVAL=$(python3 "$SCRIPT_DIR/resolve-tick-interval.py" "$agent" "$AGENT_COLONY_DIR" 2>/dev/null) || true
+                TICK_INTERVAL="${TICK_INTERVAL:-60000}"
 
                 # Respawn with GITLAB_* env vars from colony.toml
                 (

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -1,0 +1,636 @@
+#!/bin/bash
+# auto-promote.sh — Layer 1 auto-promote / auto-evolve cron script
+#
+# Reads experience + memo + daemon state, evaluates per-agent fitness
+# rules from auto-promote-config.yaml, and promotes or evolves agents
+# whose metrics meet the thresholds.
+#
+# Intended to be invoked by cron (e.g. */30 * * * *). Safe to run when
+# the federation is stopped — exits 0 with a no-op log line.
+#
+# All actions default to --dry-run (config: dry_run: true). Flip to
+# false in auto-promote-config.yaml only after reviewing the journal.
+#
+# Usage: ./tools/auto-promote.sh <federation-dir>
+#        ./tools/auto-promote.sh dev-apprenticeship
+#        ./tools/auto-promote.sh dev-apprenticeship --live   # override dry_run
+#
+# Prerequisites: agentis, python3 (with PyYAML or a fallback parser)
+#
+# Layer 1 of the auto-governance roadmap (#148). See README for layers 2+3.
+
+set -euo pipefail
+
+# --- Path resolution ---
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <federation-dir> [--live]"
+    echo "Example: $0 dev-apprenticeship"
+    exit 1
+fi
+
+FED_DIR="$REPO_ROOT/$1"
+if [ ! -d "$FED_DIR" ]; then
+    FED_DIR="$1"  # try as absolute/relative path
+fi
+if [ ! -d "$FED_DIR" ]; then
+    echo "Federation directory not found: $1"
+    exit 1
+fi
+
+LIVE_OVERRIDE=false
+if [ "${2:-}" = "--live" ]; then
+    LIVE_OVERRIDE=true
+fi
+
+CONFIG_FILE="$SCRIPT_DIR/auto-promote-config.yaml"
+JOURNAL_FILE="$SCRIPT_DIR/auto-promote-journal.jsonl"
+LOCK_FILE="$SCRIPT_DIR/.auto-promote.lock"
+
+# --- Safety guard 2: Lock file ---
+
+cleanup_lock() {
+    rm -f "$LOCK_FILE"
+}
+
+if [ -f "$LOCK_FILE" ]; then
+    LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
+        echo "Another auto-promote instance is running (pid $LOCK_PID). Exiting."
+        exit 0
+    fi
+    # Stale lock — previous run crashed. Clean up and proceed.
+    rm -f "$LOCK_FILE"
+fi
+
+echo $$ > "$LOCK_FILE"
+trap cleanup_lock EXIT
+
+# --- Logging + journal helpers ---
+
+TS_EPOCH=$(date +%s)
+TS_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+log() {
+    echo "[$TS_ISO] auto-promote: $*"
+}
+
+# Append a structured JSON line to the journal.
+# Args: agent, decision, detail_json
+journal_append() {
+    local agent="$1" decision="$2" detail_json="$3"
+    python3 -c "
+import json, sys
+entry = {
+    'ts': $TS_EPOCH,
+    'ts_iso': '$TS_ISO',
+    'agent': sys.argv[1],
+    'decision': sys.argv[2],
+    'dry_run': $( [ "$DRY_RUN" = "true" ] && echo "True" || echo "False" ),
+    'detail': json.loads(sys.argv[3]),
+}
+print(json.dumps(entry))
+" "$agent" "$decision" "$detail_json" >> "$JOURNAL_FILE"
+}
+
+# --- Parse config ---
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    log "Config not found: $CONFIG_FILE"
+    exit 1
+fi
+
+# Parse YAML config into shell variables via python3. We try PyYAML first,
+# fall back to a minimal regex parser for the flat structure we need.
+eval "$(python3 - "$CONFIG_FILE" <<'PYCONFIG'
+import sys, json
+
+config_path = sys.argv[1]
+
+def parse_yaml_simple(path):
+    """Minimal YAML parser for our flat config structure.
+    Handles only scalar values and simple lists (- from/to pairs)."""
+    cfg = {}
+    with open(path) as f:
+        lines = f.readlines()
+
+    current_path = []
+    indent_stack = [(-1, cfg)]
+
+    for raw in lines:
+        line = raw.rstrip('\n')
+        stripped = line.lstrip()
+
+        # Skip blanks and comments
+        if not stripped or stripped.startswith('#'):
+            continue
+
+        indent = len(line) - len(stripped)
+
+        # Pop indent stack to current level
+        while len(indent_stack) > 1 and indent_stack[-1][0] >= indent:
+            indent_stack.pop()
+
+        parent = indent_stack[-1][1]
+
+        # List item
+        if stripped.startswith('- '):
+            item_content = stripped[2:].strip()
+            if ':' in item_content:
+                # e.g. "- from: 0.5"
+                k, _, v = item_content.partition(':')
+                k = k.strip()
+                v = v.strip()
+                if not isinstance(parent, list):
+                    continue
+                if not parent or not isinstance(parent[-1], dict) or k in parent[-1]:
+                    parent.append({})
+                parent[-1][k] = _parse_value(v)
+            else:
+                if isinstance(parent, list):
+                    parent.append(_parse_value(item_content))
+            continue
+
+        if ':' not in stripped:
+            continue
+
+        k, _, v = stripped.partition(':')
+        k = k.strip()
+        v = v.strip()
+
+        if not v:
+            # Section header — create nested dict or list
+            # Peek ahead to see if children are list items
+            is_list = False
+            for upcoming in lines[lines.index(raw)+1:]:
+                us = upcoming.lstrip()
+                if not us or us.startswith('#'):
+                    continue
+                if us.startswith('- '):
+                    is_list = True
+                break
+
+            child = [] if is_list else {}
+            if isinstance(parent, dict):
+                parent[k] = child
+            indent_stack.append((indent, child))
+        else:
+            if isinstance(parent, dict):
+                parent[k] = _parse_value(v)
+
+    return cfg
+
+def _parse_value(v):
+    if v.startswith('"') and v.endswith('"'):
+        return v[1:-1]
+    if v.startswith("'") and v.endswith("'"):
+        return v[1:-1]
+    if v == 'true':
+        return True
+    if v == 'false':
+        return False
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        pass
+    return v
+
+try:
+    import yaml
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+except ImportError:
+    cfg = parse_yaml_simple(config_path)
+
+p = cfg.get('promote', {}).get('prerequisites', {})
+print(f"CFG_MIN_ENTRIES={p.get('min_entries', 200)}")
+print(f"CFG_MIN_RUNTIME_HOURS={p.get('min_runtime_hours', 48)}")
+print(f"CFG_REJECT_RATE_THRESHOLD={p.get('reject_rate_threshold', 0.05)}")
+print(f"CFG_DELTA_SLOPE_WINDOW={p.get('delta_slope_window', 100)}")
+print(f"CFG_DELTA_SLOPE_MIN={p.get('delta_slope_min', 0)}")
+
+steps = cfg.get('promote', {}).get('steps', [])
+step_pairs = ' '.join(f"{s['from']}:{s['to']}" for s in steps if 'from' in s and 'to' in s)
+print(f"CFG_PROMOTE_STEPS='{step_pairs}'")
+
+e = cfg.get('evolve', {}).get('trigger', {})
+print(f"CFG_EVOLVE_SLOPE_NEG_FOR={e.get('delta_slope_negative_for', 1000)}")
+print(f"CFG_EVOLVE_REJECT_ABOVE={e.get('reject_rate_above', 0.20)}")
+
+ec = cfg.get('evolve', {}).get('config', {})
+print(f"CFG_EVOLVE_GENERATIONS={ec.get('generations', 3)}")
+print(f"CFG_EVOLVE_POPULATION={ec.get('population', 4)}")
+print(f"CFG_EVOLVE_WEIGHTS='{ec.get('weights', 'cb,val,exp')}'")
+
+dr = cfg.get('dry_run', True)
+dr_str = 'true' if dr else 'false'
+print(f"CFG_DRY_RUN={dr_str}")
+PYCONFIG
+)"
+
+# --live flag overrides config dry_run
+if [ "$LIVE_OVERRIDE" = "true" ]; then
+    DRY_RUN="false"
+else
+    DRY_RUN="$CFG_DRY_RUN"
+fi
+
+log "Starting (dry_run=$DRY_RUN, fed=$FED_DIR)"
+
+# --- Safety guard 1: Federation running check ---
+
+DAEMONS_JSON=$(agentis daemon list --json 2>/dev/null || echo "[]")
+DAEMON_COUNT=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); print(len(d))" "$DAEMONS_JSON")
+
+if [ "$DAEMON_COUNT" -eq 0 ]; then
+    log "Federation not running, no-op"
+    journal_append "_system" "no-op" '{"reason": "federation not running"}'
+    exit 0
+fi
+
+log "Found $DAEMON_COUNT daemon(s) running"
+
+# --- Build per-agent state ---
+# For each running daemon, collect: agent name, colony, pid, confidence,
+# experience entry count, reject rate, delta slope.
+
+DECISIONS_JSON=$(python3 - "$DAEMONS_JSON" "$FED_DIR" \
+    "$CFG_MIN_ENTRIES" "$CFG_MIN_RUNTIME_HOURS" "$CFG_REJECT_RATE_THRESHOLD" \
+    "$CFG_DELTA_SLOPE_WINDOW" "$CFG_DELTA_SLOPE_MIN" "$CFG_PROMOTE_STEPS" \
+    "$CFG_EVOLVE_SLOPE_NEG_FOR" "$CFG_EVOLVE_REJECT_ABOVE" <<'PYEVAL'
+import json, sys, os, time, subprocess, glob
+
+daemons = json.loads(sys.argv[1])
+fed_dir = sys.argv[2]
+min_entries = int(sys.argv[3])
+min_runtime_hours = float(sys.argv[4])
+reject_rate_threshold = float(sys.argv[5])
+delta_slope_window = int(sys.argv[6])
+delta_slope_min = float(sys.argv[7])
+promote_steps_raw = sys.argv[8]
+evolve_slope_neg_for = int(sys.argv[9])
+evolve_reject_above = float(sys.argv[10])
+
+# Parse promote steps
+promote_steps = []
+for pair in promote_steps_raw.split():
+    parts = pair.split(':')
+    if len(parts) == 2:
+        promote_steps.append((float(parts[0]), float(parts[1])))
+
+now = time.time()
+decisions = []
+
+for d in daemons:
+    source = d.get('source', '')
+    if not source:
+        continue
+    agent_name = os.path.basename(source)
+    if agent_name.endswith('.ag'):
+        agent_name = agent_name[:-3]
+
+    pid = d.get('pid', 0)
+    state = d.get('state', '')
+    agent_id = d.get('agent_id', '')
+    colony = d.get('colony', '')
+    started_at = d.get('started_at', 0)
+    confidence = d.get('confidence')
+
+    # Safety guard 3: Per-agent confidence existence check
+    # If confidence is None, agent has never been seeded — skip
+    if confidence is None:
+        decisions.append({
+            'agent': agent_name,
+            'colony': colony,
+            'decision': 'skip',
+            'reason': 'confidence not seeded (recall_latest returned null)',
+            'pid': pid,
+        })
+        continue
+
+    # Safety guard 4: PID liveness check
+    if pid and pid > 0:
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            decisions.append({
+                'agent': agent_name,
+                'colony': colony,
+                'decision': 'skip',
+                'reason': f'pid {pid} not alive',
+                'pid': pid,
+                'confidence': confidence,
+            })
+            continue
+
+    # Compute runtime hours
+    runtime_hours = (now - started_at) / 3600 if started_at else 0
+
+    # Find experience file: .agentis/experience/<agent_id>.jsonl
+    # Try both agent_id-based and agent_name-based paths
+    exp_file = None
+    exp_entries = []
+    for pattern in [
+        os.path.join(fed_dir, '.agentis', 'experience', f'{agent_id}.jsonl'),
+        os.path.join(fed_dir, '.agentis', 'experience', f'{agent_name}.jsonl'),
+    ]:
+        if os.path.isfile(pattern):
+            exp_file = pattern
+            break
+
+    if exp_file:
+        try:
+            with open(exp_file) as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        try:
+                            exp_entries.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            pass
+        except OSError:
+            pass
+
+    entry_count = len(exp_entries)
+
+    # Compute reject_rate from experience entries
+    reject_count = sum(1 for e in exp_entries if e.get('verdict') == 'reject'
+                       or e.get('outcome') == 'reject'
+                       or e.get('rejected', False))
+    reject_rate = reject_count / entry_count if entry_count > 0 else 0.0
+
+    # Compute delta slope over the last N entries (linear regression on delta field)
+    window = exp_entries[-delta_slope_window:] if len(exp_entries) >= delta_slope_window else exp_entries
+    deltas = []
+    for e in window:
+        delta = e.get('delta')
+        if delta is not None:
+            try:
+                deltas.append(float(delta))
+            except (ValueError, TypeError):
+                pass
+
+    delta_slope = 0.0
+    if len(deltas) >= 2:
+        n = len(deltas)
+        sx = sum(range(n))
+        sy = sum(deltas)
+        sxy = sum(i * d for i, d in enumerate(deltas))
+        sx2 = sum(i * i for i in range(n))
+        denom = n * sx2 - sx * sx
+        if denom != 0:
+            delta_slope = (n * sxy - sx * sy) / denom
+
+    # Compute delta slope over the evolve window (longer)
+    evolve_window = exp_entries[-evolve_slope_neg_for:] if len(exp_entries) >= evolve_slope_neg_for else exp_entries
+    evolve_deltas = []
+    for e in evolve_window:
+        delta = e.get('delta')
+        if delta is not None:
+            try:
+                evolve_deltas.append(float(delta))
+            except (ValueError, TypeError):
+                pass
+
+    evolve_slope = 0.0
+    if len(evolve_deltas) >= 2:
+        n = len(evolve_deltas)
+        sx = sum(range(n))
+        sy = sum(evolve_deltas)
+        sxy = sum(i * d for i, d in enumerate(evolve_deltas))
+        sx2 = sum(i * i for i in range(n))
+        denom = n * sx2 - sx * sx
+        if denom != 0:
+            evolve_slope = (n * sxy - sx * sy) / denom
+
+    evidence = {
+        'entries': entry_count,
+        'runtime_hours': round(runtime_hours, 1),
+        'reject_rate': round(reject_rate, 4),
+        'delta_slope': round(delta_slope, 6),
+        'evolve_slope': round(evolve_slope, 6),
+        'confidence': confidence,
+        'pid': pid,
+    }
+
+    # --- Evolve check (takes priority if agent is degrading) ---
+    evolve_triggered = False
+    if len(exp_entries) >= evolve_slope_neg_for and evolve_slope < 0:
+        evolve_triggered = True
+    if entry_count > 0 and reject_rate > evolve_reject_above:
+        evolve_triggered = True
+
+    if evolve_triggered:
+        decisions.append({
+            'agent': agent_name,
+            'colony': colony,
+            'decision': 'evolve',
+            'reason': f'evolve triggered (slope={evolve_slope:.6f}, reject_rate={reject_rate:.4f})',
+            'evidence': evidence,
+        })
+        continue
+
+    # --- Promote check ---
+    # Find applicable step for current confidence
+    target_step = None
+    for step_from, step_to in promote_steps:
+        if abs(confidence - step_from) < 0.001:
+            target_step = (step_from, step_to)
+            break
+
+    if target_step is None:
+        decisions.append({
+            'agent': agent_name,
+            'colony': colony,
+            'decision': 'skip',
+            'reason': f'no applicable promote step for confidence={confidence}',
+            'evidence': evidence,
+        })
+        continue
+
+    # Check all prerequisites
+    fails = []
+    if entry_count < min_entries:
+        fails.append(f'entries={entry_count} < {min_entries}')
+    if runtime_hours < min_runtime_hours:
+        fails.append(f'runtime={runtime_hours:.1f}h < {min_runtime_hours}h')
+    if reject_rate >= reject_rate_threshold:
+        fails.append(f'reject_rate={reject_rate:.4f} >= {reject_rate_threshold}')
+    if delta_slope < delta_slope_min:
+        fails.append(f'delta_slope={delta_slope:.6f} < {delta_slope_min}')
+
+    if fails:
+        decisions.append({
+            'agent': agent_name,
+            'colony': colony,
+            'decision': 'skip',
+            'reason': 'prerequisites not met: ' + '; '.join(fails),
+            'evidence': evidence,
+        })
+        continue
+
+    # All prerequisites passed — promote
+    decisions.append({
+        'agent': agent_name,
+        'colony': colony,
+        'decision': 'promote',
+        'from': target_step[0],
+        'to': target_step[1],
+        'evidence': evidence,
+    })
+
+print(json.dumps(decisions))
+PYEVAL
+)
+
+# --- Execute decisions ---
+
+PROMOTE_COUNT=0
+EVOLVE_COUNT=0
+SKIP_COUNT=0
+
+# Parse decisions and act on each
+python3 -c "
+import json, sys
+decisions = json.loads(sys.argv[1])
+for d in decisions:
+    # Output one line per decision: decision|agent|colony|from|to|reason|evidence_json
+    decision = d.get('decision', 'skip')
+    agent = d.get('agent', '')
+    colony = d.get('colony', '')
+    step_from = d.get('from', '')
+    step_to = d.get('to', '')
+    reason = d.get('reason', '')
+    evidence = json.dumps(d.get('evidence', d))
+    print(f'{decision}|{agent}|{colony}|{step_from}|{step_to}|{reason}|{evidence}')
+" "$DECISIONS_JSON" | while IFS='|' read -r decision agent colony step_from step_to reason evidence_json; do
+
+    case "$decision" in
+        skip)
+            log "SKIP $agent ($colony): $reason"
+            journal_append "$agent" "skip" "$evidence_json"
+            SKIP_COUNT=$((SKIP_COUNT + 1))
+            ;;
+
+        promote)
+            log "PROMOTE $agent ($colony): $step_from -> $step_to"
+            if [ "$DRY_RUN" = "true" ]; then
+                log "  [dry-run] Would run: agentis memo set ${agent}:confidence $step_to"
+                log "  [dry-run] Would restart daemon for $agent"
+                journal_append "$agent" "promote" \
+                    "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['action']='dry-run'; print(json.dumps(e))" "$evidence_json")"
+            else
+                # Write new confidence to memo
+                log "  Writing confidence: agentis memo set ${agent}:confidence $step_to"
+                if agentis memo set "${agent}:confidence" "$step_to" 2>&1; then
+                    log "  Memo written successfully"
+                else
+                    log "  WARNING: memo set failed for $agent"
+                    journal_append "$agent" "promote-failed" \
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['error']='memo_set_failed'; print(json.dumps(e))" "$evidence_json")"
+                    continue
+                fi
+
+                # Restart the daemon so it picks up the new confidence.
+                # Use the same stop+respawn pattern as the dashboard (#137).
+                log "  Restarting daemon for $agent..."
+                AGENT_AG_FILE=""
+                for colony_dir in "$FED_DIR"/*/; do
+                    candidate="${colony_dir}agents/${agent}.ag"
+                    if [ -f "$candidate" ]; then
+                        AGENT_AG_FILE="$candidate"
+                        AGENT_COLONY_DIR="$colony_dir"
+                        break
+                    fi
+                done
+
+                if [ -z "$AGENT_AG_FILE" ]; then
+                    log "  WARNING: could not find .ag file for $agent, skipping restart"
+                    journal_append "$agent" "promote-partial" \
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['action']='memo-only'; e['warning']='ag_file_not_found'; print(json.dumps(e))" "$evidence_json")"
+                    continue
+                fi
+
+                # Find agent_id from daemon list
+                AGENT_ID=$(python3 -c "
+import json, sys, os
+daemons = json.loads(sys.argv[1])
+agent = sys.argv[2]
+for d in daemons:
+    src = d.get('source', '')
+    if os.path.basename(src) == agent + '.ag':
+        print(d.get('agent_id', ''))
+        break
+" "$DAEMONS_JSON" "$agent")
+
+                # Stop the daemon
+                if [ -n "$AGENT_ID" ]; then
+                    agentis daemon stop "$AGENT_ID" 2>&1 || true
+                    sleep 3
+                fi
+
+                # Respawn
+                (
+                    cd "$AGENT_COLONY_DIR"
+                    agentis daemon "$AGENT_AG_FILE" \
+                        --colony "$colony" \
+                        --enable-exec \
+                        --enable-messaging \
+                        --tick-interval 60000 &
+                )
+                log "  Daemon respawned for $agent"
+
+                journal_append "$agent" "promote" \
+                    "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['from']=$step_from; e['to']=$step_to; e['action']='executed'; print(json.dumps(e))" "$evidence_json")"
+            fi
+            PROMOTE_COUNT=$((PROMOTE_COUNT + 1))
+            ;;
+
+        evolve)
+            log "EVOLVE $agent ($colony): $reason"
+            if [ "$DRY_RUN" = "true" ]; then
+                log "  [dry-run] Would run: agentis evolve $agent.ag (generations=$CFG_EVOLVE_GENERATIONS, population=$CFG_EVOLVE_POPULATION)"
+                journal_append "$agent" "evolve" \
+                    "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='dry-run'; print(json.dumps(e))" "$evidence_json")"
+            else
+                # Find the .ag file for the agent
+                AGENT_AG_FILE=""
+                for colony_dir in "$FED_DIR"/*/; do
+                    candidate="${colony_dir}agents/${agent}.ag"
+                    if [ -f "$candidate" ]; then
+                        AGENT_AG_FILE="$candidate"
+                        break
+                    fi
+                done
+
+                if [ -z "$AGENT_AG_FILE" ]; then
+                    log "  WARNING: could not find .ag file for $agent, skipping evolve"
+                    journal_append "$agent" "evolve-failed" \
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['error']='ag_file_not_found'; print(json.dumps(e))" "$evidence_json")"
+                    continue
+                fi
+
+                log "  Running: agentis evolve $AGENT_AG_FILE"
+                EVOLVE_OUTPUT=$(agentis evolve "$AGENT_AG_FILE" \
+                    --generations "$CFG_EVOLVE_GENERATIONS" \
+                    --population "$CFG_EVOLVE_POPULATION" \
+                    --weights "$CFG_EVOLVE_WEIGHTS" 2>&1) || true
+                log "  Evolve output: $EVOLVE_OUTPUT"
+
+                journal_append "$agent" "evolve" \
+                    "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='executed'; e['evolve_output']=sys.argv[2][:500]; print(json.dumps(e))" "$evidence_json" "$EVOLVE_OUTPUT")"
+            fi
+            EVOLVE_COUNT=$((EVOLVE_COUNT + 1))
+            ;;
+    esac
+done
+
+log "Done. Promotes=$PROMOTE_COUNT, Evolves=$EVOLVE_COUNT, Skips=$SKIP_COUNT"

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -108,21 +108,57 @@ import sys, json
 
 config_path = sys.argv[1]
 
+def _strip_inline_comment(s):
+    """Strip YAML inline comments (# ...) respecting quoted strings."""
+    quote = None
+    for i, ch in enumerate(s):
+        if quote:
+            if ch == '\\' and i + 1 < len(s):
+                continue  # skip escaped char
+            if ch == quote:
+                quote = None
+            continue
+        if ch in ('"', "'"):
+            quote = ch
+            continue
+        if ch == '#':
+            return s[:i].rstrip()
+    return s
+
+def _parse_value(v):
+    v = _strip_inline_comment(v)
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in ('"', "'"):
+        return v[1:-1]
+    if v == 'true':
+        return True
+    if v == 'false':
+        return False
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        pass
+    return v
+
 def parse_yaml_simple(path):
     """Minimal YAML parser for our flat config structure.
-    Handles only scalar values and simple lists (- from/to pairs)."""
+    Handles scalar values and simple lists (- from/to pairs)."""
     cfg = {}
     with open(path) as f:
         lines = f.readlines()
 
-    current_path = []
     indent_stack = [(-1, cfg)]
+    # Track the last dict appended to a list so continuation keys
+    # (e.g. "to: 0.6" indented under "- from: 0.5") can be added.
+    last_list_dict = None
 
-    for raw in lines:
+    for idx, raw in enumerate(lines):
         line = raw.rstrip('\n')
         stripped = line.lstrip()
 
-        # Skip blanks and comments
         if not stripped or stripped.startswith('#'):
             continue
 
@@ -138,18 +174,18 @@ def parse_yaml_simple(path):
         if stripped.startswith('- '):
             item_content = stripped[2:].strip()
             if ':' in item_content:
-                # e.g. "- from: 0.5"
                 k, _, v = item_content.partition(':')
                 k = k.strip()
                 v = v.strip()
                 if not isinstance(parent, list):
                     continue
-                if not parent or not isinstance(parent[-1], dict) or k in parent[-1]:
-                    parent.append({})
-                parent[-1][k] = _parse_value(v)
+                new_dict = {k: _parse_value(v)}
+                parent.append(new_dict)
+                last_list_dict = new_dict
             else:
                 if isinstance(parent, list):
                     parent.append(_parse_value(item_content))
+                    last_list_dict = None
             continue
 
         if ':' not in stripped:
@@ -160,10 +196,9 @@ def parse_yaml_simple(path):
         v = v.strip()
 
         if not v:
-            # Section header — create nested dict or list
-            # Peek ahead to see if children are list items
+            # Section header
             is_list = False
-            for upcoming in lines[lines.index(raw)+1:]:
+            for upcoming in lines[idx+1:]:
                 us = upcoming.lstrip()
                 if not us or us.startswith('#'):
                     continue
@@ -175,30 +210,16 @@ def parse_yaml_simple(path):
             if isinstance(parent, dict):
                 parent[k] = child
             indent_stack.append((indent, child))
+            last_list_dict = None
         else:
             if isinstance(parent, dict):
                 parent[k] = _parse_value(v)
+            elif isinstance(parent, list) and last_list_dict is not None:
+                # Continuation key for the last list-item dict
+                # e.g. "to: 0.6" after "- from: 0.5"
+                last_list_dict[k] = _parse_value(v)
 
     return cfg
-
-def _parse_value(v):
-    if v.startswith('"') and v.endswith('"'):
-        return v[1:-1]
-    if v.startswith("'") and v.endswith("'"):
-        return v[1:-1]
-    if v == 'true':
-        return True
-    if v == 'false':
-        return False
-    try:
-        return int(v)
-    except ValueError:
-        pass
-    try:
-        return float(v)
-    except ValueError:
-        pass
-    return v
 
 try:
     import yaml
@@ -266,7 +287,7 @@ DECISIONS_JSON=$(python3 - "$DAEMONS_JSON" "$FED_DIR" \
     "$CFG_MIN_ENTRIES" "$CFG_MIN_RUNTIME_HOURS" "$CFG_REJECT_RATE_THRESHOLD" \
     "$CFG_DELTA_SLOPE_WINDOW" "$CFG_DELTA_SLOPE_MIN" "$CFG_PROMOTE_STEPS" \
     "$CFG_EVOLVE_SLOPE_NEG_FOR" "$CFG_EVOLVE_REJECT_ABOVE" <<'PYEVAL'
-import json, sys, os, time, subprocess, glob
+import json, sys, os, time
 
 daemons = json.loads(sys.argv[1])
 fed_dir = sys.argv[2]
@@ -317,19 +338,29 @@ for d in daemons:
         continue
 
     # Safety guard 4: PID liveness check
-    if pid and pid > 0:
-        try:
-            os.kill(pid, 0)
-        except OSError:
-            decisions.append({
-                'agent': agent_name,
-                'colony': colony,
-                'decision': 'skip',
-                'reason': f'pid {pid} not alive',
-                'pid': pid,
-                'confidence': confidence,
-            })
-            continue
+    # If pid is missing (0) or dead, skip — we can't verify the daemon
+    # is actually running, so acting on it is unsafe.
+    if not pid or pid <= 0:
+        decisions.append({
+            'agent': agent_name,
+            'colony': colony,
+            'decision': 'skip',
+            'reason': 'no pid reported by daemon list',
+            'confidence': confidence,
+        })
+        continue
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        decisions.append({
+            'agent': agent_name,
+            'colony': colony,
+            'decision': 'skip',
+            'reason': f'pid {pid} not alive',
+            'pid': pid,
+            'confidence': confidence,
+        })
+        continue
 
     # Compute runtime hours
     runtime_hours = (now - started_at) / 3600 if started_at else 0

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -652,6 +652,9 @@ for d in daemons:
                     sleep 3
                 fi
 
+                # Resolve per-agent tick interval from start-colony.sh (#155)
+                TICK_INTERVAL=$(python3 "$SCRIPT_DIR/resolve-tick-interval.py" "$agent" "$AGENT_COLONY_DIR")
+
                 # Respawn with GITLAB_* env vars from colony.toml
                 (
                     eval "$SPAWN_ENV"
@@ -660,7 +663,7 @@ for d in daemons:
                         --colony "$colony" \
                         --enable-exec \
                         --enable-messaging \
-                        --tick-interval 60000 &
+                        --tick-interval "$TICK_INTERVAL" &
                 )
                 log "  Daemon respawned for $agent"
 

--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -1235,6 +1235,26 @@ agent_to_colony = {e.get('agent',''): e.get('colony','') for e in _map if e.get(
 os.chdir(serve_dir)
 fed_dir = os.path.dirname(serve_dir)
 confidence_log = os.path.join(serve_dir, 'confidence-log.jsonl')
+# Path to the tick-interval resolver (#155). script_path is the absolute
+# path to this federation-dashboard.sh; the resolver lives next to it.
+_tools_dir = os.path.dirname(os.path.realpath(script_path))
+_resolver_script = os.path.join(_tools_dir, 'resolve-tick-interval.py')
+
+
+def resolve_tick_interval(agent, colony_dir):
+    """Return tick interval (str, ms) for *agent* using resolve-tick-interval.py.
+
+    Falls back to '60000' if the resolver is missing or fails.
+    """
+    try:
+        r = subprocess.run(
+            [sys.executable, _resolver_script, agent, colony_dir],
+            capture_output=True, text=True, timeout=5,
+        )
+        val = r.stdout.strip()
+        return val if r.returncode == 0 and val.isdigit() else '60000'
+    except (OSError, subprocess.SubprocessError):
+        return '60000'
 
 
 def parse_toml_section(toml_path, section):
@@ -1381,6 +1401,10 @@ def build_manual_command(colony, colony_dir, agent_file):
     real GITLAB_TOKEN would leak credentials into the DOM, browser cache,
     and DevTools (QA review #1).
     """
+    agent_name = os.path.basename(agent_file)
+    if agent_name.endswith('.ag'):
+        agent_name = agent_name[:-3]
+    tick = resolve_tick_interval(agent_name, colony_dir)
     env_refs = (
         'GITLAB_URL="$GITLAB_URL" GITLAB_TOKEN="$GITLAB_TOKEN" '
         'GITLAB_PROJECT="$GITLAB_PROJECT" GITLAB_ME="$GITLAB_ME" '
@@ -1391,7 +1415,7 @@ def build_manual_command(colony, colony_dir, agent_file):
         f'{env_refs} '
         f'agentis daemon {shlex.quote(agent_file)}'
         f' --colony {shlex.quote(colony)}'
-        f' --enable-exec --enable-messaging --tick-interval 60000 &'
+        f' --enable-exec --enable-messaging --tick-interval {tick} &'
     )
 
 
@@ -1516,7 +1540,8 @@ def restart_daemon(agent):
 
     # Respawn detached so the dashboard process can die without taking
     # the fresh daemon with it.
-    rec('spawn', 'start')
+    tick = resolve_tick_interval(agent, colony_dir)
+    rec('spawn', 'start', tick_interval=tick)
     env = dict(os.environ)
     env.update(env_overrides)
     spawn_ts = int(time.time())
@@ -1527,7 +1552,7 @@ def restart_daemon(agent):
                 '--colony', colony,
                 '--enable-exec',
                 '--enable-messaging',
-                '--tick-interval', '60000',
+                '--tick-interval', tick,
             ],
             cwd=colony_dir,
             env=env,

--- a/tools/resolve-tick-interval.py
+++ b/tools/resolve-tick-interval.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Resolve the tick interval for an agent from its colony's start-colony.sh.
+
+Usage: resolve-tick-interval.py <agent> <colony-dir>
+Output: interval in milliseconds (default 60000)
+
+Reads the TICK_INTERVALS associative-array declaration from
+<colony-dir>/scripts/start-colony.sh. This keeps start-colony.sh as
+the single source of truth — the dashboard and auto-promote script
+both call this helper instead of hardcoding 60000.
+
+See #146 for why intervals differ per colony, and #155 for why this
+helper exists.
+"""
+import os
+import re
+import sys
+
+DEFAULT_INTERVAL = 60000
+
+
+def resolve(agent, colony_dir):
+    """Return the tick interval (int, ms) for *agent* in *colony_dir*."""
+    script = os.path.join(colony_dir, 'scripts', 'start-colony.sh')
+    try:
+        with open(script, encoding='utf-8') as f:
+            content = f.read()
+    except OSError:
+        return DEFAULT_INTERVAL
+
+    # Match:  ["agent_name"]=12345
+    pattern = rf'\["{re.escape(agent)}"\]\s*=\s*(\d+)'
+    m = re.search(pattern, content)
+    return int(m.group(1)) if m else DEFAULT_INTERVAL
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print(DEFAULT_INTERVAL)
+        sys.exit(0)
+    print(resolve(sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
## Summary

- Add `tools/auto-promote.sh` — external cron script that evaluates per-agent fitness from experience data and decides when to promote (confidence step-up) or evolve (`.ag` source mutation)
- Add `tools/auto-promote-config.yaml` — configurable decision rules (promote prerequisites, evolve triggers, dry-run flag)
- All 5 safety guards from #148: federation-running check, lock file, confidence-seeded check, PID liveness, dry-run default ON

## Decision rules

**Promote** (0.5→0.6→0.85): min 200 entries, 48h runtime, reject rate <5%, non-negative delta slope.
**Evolve**: negative slope over 1000 entries OR reject rate >20%.

## Safety

1. `agentis daemon list --json` empty → exit 0
2. `tools/.auto-promote.lock` prevents overlapping cron runs
3. Per-agent confidence null check (skips unseeded agents)
4. `kill -0 PID` before acting on a daemon
5. `dry_run: true` by default — all actions logged but not executed

## Files

| File | Purpose |
|------|---------|
| `tools/auto-promote.sh` | Main script (bash, uses python3 for YAML parsing + decision evaluation) |
| `tools/auto-promote-config.yaml` | Default config with all thresholds |
| `CLAUDE.md` | Updated tools table |
| `dev-apprenticeship/README.md` | Added auto-promote section with cron sample + Layer 1→2→3 roadmap |

## Test plan

- [x] `bash -n tools/auto-promote.sh` passes
- [x] `./tools/colony-lint.sh` — 46 passed, 0 failed
- [x] Dry-run with no federation → clean exit 0 + journal line
- [x] Lock file created during run, cleaned up after exit
- [ ] Manual: start federation, run `./tools/auto-promote.sh dev-apprenticeship`, verify per-agent decisions in journal

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)