### PR TITLE
chore: bump agentis MIN_VERSION to v1.3.0

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -1,6 +1,6 @@
 # Dev Apprenticeship
 
-![Agentis >= v1.2.3](https://img.shields.io/badge/agentis-%3E%3D%20v1.2.3-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
+![Agentis >= v1.3.0](https://img.shields.io/badge/agentis-%3E%3D%20v1.3.0-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
 
 A federation of 21 agents that learns how you work by watching your GitLab activity. It observes how you triage issues, review merge requests, plan features, write code, and ship releases. Over time it takes over the mechanical parts, while you keep control over the decisions that matter.
 
@@ -35,7 +35,7 @@ graph LR
 
 ## What you need
 
-- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.2.3**
+- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.3.0**
 - An LLM backend (Claude CLI, Ollama, or any OpenAI-compatible API)
 - GitLab instance with API access (personal access token with `api` scope)
 - Python 3 and git

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -19,7 +19,7 @@ ALL_AGENTS=(
     code_writer test_writer refactorer commit_composer
     ship_decider changelog_writer version_bumper release_checker
 )
-MIN_VERSION="1.2.3"
+MIN_VERSION="1.3.0"
 
 # --- Helpers ---
 
@@ -116,7 +116,7 @@ AGENTIS_VERSION=$(agentis --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9
 info "agentis version: $AGENTIS_VERSION (minimum: $MIN_VERSION)"
 
 if ! version_gte "$AGENTIS_VERSION" "$MIN_VERSION"; then
-    fail "agentis >= $MIN_VERSION required (--enable-exec/--enable-messaging flags, #492 quarantine fix, #499 watchdog heartbeat fix, #107 daemon PII grant + exec.default_timeout_ms, #123 tick-success health, #125 parse_float/parse_int/json_get, #518 zombie daemon registry prune, #519 adaptive-engine fail-loud gate). Please update."
+    fail "agentis >= $MIN_VERSION required (#530 idle-skip, #523 bounded daemon stop, #524 daemon list confidence). Please update."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Bump `MIN_VERSION` in `install.sh` from 1.2.3 to 1.3.0
- Update README badges and requirements to v1.3.0
- Simplify version-gate error message (#530 idle-skip, #523 bounded stop, #524 list confidence)

Depends on Replikanti/agentis-core#532 (v1.3.0 tag).