### PR TITLE
fix: bash 3.2 compat — replace declare -A with case statement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ colony-name/
 
 ## Script conventions
 
-- `start-colony.sh`: symlink-safe `$0` resolution via python3, sources `tools/parse-toml.sh`, exports `GITLAB_URL`/`GITLAB_TOKEN`/`GITLAB_PROJECT`, launches daemons with `--colony <name> --tick-interval "$interval"` where `interval` is looked up per-agent in a local `TICK_INTERVALS` map (fallback 60000ms). Reactive colonies (release, code-review) run at 300000ms, triage's router/prioritizer at 180000ms, everything else at 60000ms. See #146 for rationale.
+- `start-colony.sh`: symlink-safe `$0` resolution via python3, sources `tools/parse-toml.sh`, exports `GITLAB_URL`/`GITLAB_TOKEN`/`GITLAB_PROJECT`, launches daemons with `--colony <name> --tick-interval "$interval"` where `interval` is looked up per-agent via a local `tick_interval_for()` case function (fallback 60000ms). Reactive colonies (release, code-review) run at 300000ms, triage's router/prioritizer at 180000ms, everything else at 60000ms. See #146 for rationale.
 - `gitlab-api.sh`: `emit_error()` for all error messages, `exit 2` for unknown flags, `python3 json.dumps` for all POST/PUT body construction. Read endpoints use `gl_get`/`gl_get_q`, write endpoints use `gl_post`/`gl_put`.
 
 ## Federation event wiring
@@ -100,7 +100,7 @@ release:changelog_draft      -> version_bumper
 | `federation-dashboard.sh` | Generic web dashboard for any federation (auto-discovers colonies/agents, kill switch, phase ETA) |
 | `auto-promote.sh` | Layer 1 auto-promote/auto-evolve cron script — evaluates per-agent fitness, promotes or evolves (#148) |
 | `auto-promote-config.yaml` | Decision rules for auto-promote (thresholds, promote steps, evolve triggers, dry_run flag) |
-| `resolve-tick-interval.py` | Shared helper: reads TICK_INTERVALS from start-colony.sh for a given agent+colony (used by dashboard + auto-promote) |
+| `resolve-tick-interval.py` | Shared helper: reads `tick_interval_for()` case statement (or legacy `TICK_INTERVALS`) from start-colony.sh for a given agent+colony (used by dashboard + auto-promote) |
 
 ## End-user scripts (in dev-apprenticeship/)
 

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -87,19 +87,18 @@ cd "$COLONY_DIR"
 # ticks are no-ops. 5-min cadence matches the natural rhythm of merge
 # requests in a small team and cuts idle LLM spend ~5×. Fallback is 60000ms
 # for any agent not listed.
-declare -A TICK_INTERVALS=(
-    ["style_reviewer"]=300000
-    ["logic_reviewer"]=300000
-    ["security_reviewer"]=300000
-    ["test_reviewer"]=300000
-    ["approval_decider"]=300000
-)
+tick_interval_for() {
+    case "$1" in
+        style_reviewer|logic_reviewer|security_reviewer|test_reviewer|approval_decider) echo 300000 ;;
+        *) echo 60000 ;;
+    esac
+}
 
 echo "Starting Code Review colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
-    interval="${TICK_INTERVALS[$agent]:-60000}"
+    interval=$(tick_interval_for "$agent")
     echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony code-review \

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -83,18 +83,17 @@ fi
 # run against the current working tree and produce output every tick once
 # fed by upstream route_suggestion events. 60s keeps the write-test-commit
 # pipeline responsive. Fallback is 60000ms.
-declare -A TICK_INTERVALS=(
-    ["code_writer"]=60000
-    ["test_writer"]=60000
-    ["refactorer"]=60000
-    ["commit_composer"]=60000
-)
+tick_interval_for() {
+    case "$1" in
+        *) echo 60000 ;;
+    esac
+}
 
 echo "Starting Implementation colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
-    interval="${TICK_INTERVALS[$agent]:-60000}"
+    interval=$(tick_interval_for "$agent")
     echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony implementation \

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -84,18 +84,17 @@ fi
 # cadence preserves throughput. The map is kept for consistency with the
 # reactive colonies and to make future overrides obvious. Fallback is
 # 60000ms.
-declare -A TICK_INTERVALS=(
-    ["scope_estimator"]=60000
-    ["risk_assessor"]=60000
-    ["task_decomposer"]=60000
-    ["plan_reviewer"]=60000
-)
+tick_interval_for() {
+    case "$1" in
+        *) echo 60000 ;;
+    esac
+}
 
 echo "Starting Planning colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
-    interval="${TICK_INTERVALS[$agent]:-60000}"
+    interval=$(tick_interval_for "$agent")
     echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony planning \

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -85,18 +85,18 @@ fi
 # polling spends LLM budget on no-op ticks. 5-min cadence is operationally
 # indistinguishable from 1-min here. Fallback is 60000ms for any agent not
 # listed (e.g. if a new active agent is added later).
-declare -A TICK_INTERVALS=(
-    ["release_checker"]=300000
-    ["ship_decider"]=300000
-    ["changelog_writer"]=300000
-    ["version_bumper"]=300000
-)
+tick_interval_for() {
+    case "$1" in
+        release_checker|ship_decider|changelog_writer|version_bumper) echo 300000 ;;
+        *) echo 60000 ;;
+    esac
+}
 
 echo "Starting Release colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
-    interval="${TICK_INTERVALS[$agent]:-60000}"
+    interval=$(tick_interval_for "$agent")
     echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony release \

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -84,18 +84,18 @@ fi
 # (periodic routing sweeps, re-ranking) and run at 3-min cadence since
 # minute-grained latency on priority changes is not observable. Fallback is
 # 60000ms.
-declare -A TICK_INTERVALS=(
-    ["issue_creator"]=60000
-    ["labeler"]=60000
-    ["prioritizer"]=180000
-    ["router"]=180000
-)
+tick_interval_for() {
+    case "$1" in
+        router|prioritizer) echo 180000 ;;
+        *)                  echo 60000 ;;
+    esac
+}
 
 echo "Starting Triage colony (${#AGENTS[@]} agents)..."
 echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
 
 for agent in "${AGENTS[@]}"; do
-    interval="${TICK_INTERVALS[$agent]:-60000}"
+    interval=$(tick_interval_for "$agent")
     echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony triage \

--- a/tools/new-colony.sh
+++ b/tools/new-colony.sh
@@ -149,16 +149,20 @@ echo "Starting NAME_PLACEHOLDER colony (${#AGENTS[@]} agents)..."
 # .agentis/config, not from a CLI flag. The [llm] section in colony.toml is
 # informational only. Operators should mirror it into .agentis/config.
 
-# Per-agent tick-interval override (#146). Add entries here only for agents
+# Per-agent tick-interval override (#146). Add cases here only for agents
 # whose natural cadence differs from 60s. Reactive agents (those that poll
 # for infrequent upstream events) typically go to 180000-300000ms; active
 # agents producing work every tick stay at the 60000ms fallback.
-declare -A TICK_INTERVALS=(
-    # ["example_reactive_agent"]=300000
-)
+# Uses a case statement instead of declare -A for bash 3.2 (macOS) compat.
+tick_interval_for() {
+    case "$1" in
+        # example_reactive_agent) echo 300000 ;;
+        *) echo 60000 ;;
+    esac
+}
 
 for agent in "${AGENTS[@]}"; do
-    interval="${TICK_INTERVALS[$agent]:-60000}"
+    interval=$(tick_interval_for "$agent")
     echo "  Starting $agent (tick=${interval}ms)..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony COLONY_ID_PLACEHOLDER \

--- a/tools/resolve-tick-interval.py
+++ b/tools/resolve-tick-interval.py
@@ -4,13 +4,13 @@
 Usage: resolve-tick-interval.py <agent> <colony-dir>
 Output: interval in milliseconds (default 60000)
 
-Reads the TICK_INTERVALS associative-array declaration from
+Reads tick_interval_for() case statement (or legacy declare -A) from
 <colony-dir>/scripts/start-colony.sh. This keeps start-colony.sh as
 the single source of truth — the dashboard and auto-promote script
 both call this helper instead of hardcoding 60000.
 
-See #146 for why intervals differ per colony, and #155 for why this
-helper exists.
+See #146 for why intervals differ per colony, #155 for why this
+helper exists, and #157 for the bash 3.2 migration.
 """
 import os
 import re
@@ -28,9 +28,17 @@ def resolve(agent, colony_dir):
     except OSError:
         return DEFAULT_INTERVAL
 
-    # Match:  ["agent_name"]=12345
-    pattern = rf'\["{re.escape(agent)}"\]\s*=\s*(\d+)'
-    m = re.search(pattern, content)
+    # New format (#157): case statement with pipe-separated agent names
+    #   agent_name|other_agent) echo 300000 ;;
+    escaped = re.escape(agent)
+    case_pattern = rf'\b{escaped}\b.*?\)\s+echo\s+(\d+)\s*;;'
+    m = re.search(case_pattern, content)
+    if m:
+        return int(m.group(1))
+
+    # Legacy format: declare -A  ["agent_name"]=12345
+    legacy_pattern = rf'\["{escaped}"\]\s*=\s*(\d+)'
+    m = re.search(legacy_pattern, content)
     return int(m.group(1)) if m else DEFAULT_INTERVAL
 
 


### PR DESCRIPTION
## Summary

- Replace `declare -A TICK_INTERVALS=(...)` with `tick_interval_for()` case functions in all 5 `start-colony.sh` scripts
- Update `tools/new-colony.sh` scaffold template to generate the new pattern
- Update `tools/resolve-tick-interval.py` regex to parse case format (keeps legacy fallback)

macOS ships bash 3.2 which lacks associative arrays. The federation now starts cleanly on stock macOS without `brew install bash`.

Closes #157

## Test plan

- [x] `bash -n` passes on all 5 start-colony.sh + new-colony.sh
- [x] `colony-lint.sh`: 46 passed, 0 failed
- [x] `resolve-tick-interval.py` returns correct intervals for all 21 agents
- [ ] Manual test on macOS with `/bin/bash` (3.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)