### PR TITLE
feat: ship tools/kill-federation.sh — reliable OS-level federation shutdown (#162)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Pre-built agent colonies for the [Agentis](https://github.com/Replikanti/agentis
 bash -n scripts/gitlab-api.sh   # Bash syntax check on any script
 ```
 
-Colony lint must pass with 0 failures before merge. Current baseline: 47 passed, 5 skipped (shellcheck not installed).
+Colony lint must pass with 0 failures before merge. Current baseline: 48 passed, 5 skipped (shellcheck not installed).
 
 ## Colony structure
 
@@ -101,6 +101,7 @@ release:changelog_draft      -> version_bumper
 | `auto-promote.sh` | Layer 1 auto-promote/auto-evolve cron script — evaluates per-agent fitness, promotes or evolves (#148) |
 | `auto-promote-config.yaml` | Decision rules for auto-promote (thresholds, promote steps, evolve triggers, dry_run flag) |
 | `resolve-tick-interval.py` | Shared helper: reads `tick_interval_for()` case statement (or legacy `TICK_INTERVALS`) from start-colony.sh for a given agent+colony (used by dashboard + auto-promote) |
+| `kill-federation.sh` | OS-level reliable shutdown of a federation (agents + dashboard + registry sidecar files + backup). Bypasses `agentis daemon stop` bugs by using SIGTERM/SIGKILL with verification. Supports `--dry-run` and `--json` for dashboard kill-button integration (#162) |
 
 ## End-user scripts (in dev-apprenticeship/)
 
@@ -110,3 +111,4 @@ release:changelog_draft      -> version_bumper
 | `start-federation.sh` | Starts all 5 colonies (launches 21 daemon processes) |
 | `watch-suggestions.sh` | Live feed of agent suggestions from all 21 logs (for suggest mode, confidence 0.6-0.84) |
 | `dashboard.sh` | Web dashboard (wrapper around `tools/federation-dashboard.sh`, includes kill switch) |
+| `kill-federation.sh` | Reliably stop the federation (wrapper around `tools/kill-federation.sh`, federation-scoped via `--fed-dir`) |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ graph TD
 - An LLM backend (Claude CLI, Ollama, or any OpenAI-compatible API)
 - GitLab instance with API access
 
+## Operator scripts
+
+When you need to reliably stop a federation — agents, dashboard, registry sidecar files, with a backup tarball before cleanup — use [`tools/kill-federation.sh`](./tools/kill-federation.sh) (or its per-federation wrapper, e.g. `dev-apprenticeship/kill-federation.sh`). It bypasses the `agentis` CLI and uses OS signals with post-kill verification, so it works even when `agentis daemon stop --all` reports false success or false failure. Run with `--help` for options including `--dry-run` and `--json`.
+
 ## License
 
 Apache 2.0. See [LICENSE](./LICENSE).

--- a/dev-apprenticeship/kill-federation.sh
+++ b/dev-apprenticeship/kill-federation.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# kill-federation.sh - Reliably stop the Dev Apprenticeship federation
+#
+# Thin wrapper around the generic tools/kill-federation.sh. Stops every
+# agentis daemon, the dashboard (if running), and cleans the registry
+# sidecar files. See tools/kill-federation.sh --help for full options.
+#
+# Usage: ./kill-federation.sh [OPTIONS]
+#        ./kill-federation.sh                # kill this federation
+#        ./kill-federation.sh --dry-run      # preview, do nothing
+#        ./kill-federation.sh --help         # full option list
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+
+exec "$SCRIPT_DIR/../tools/kill-federation.sh" --fed-dir "$SCRIPT_DIR" "$@"

--- a/tools/kill-federation.sh
+++ b/tools/kill-federation.sh
@@ -79,6 +79,11 @@ Exit codes:
   0   federation fully stopped (or dry-run completed)
   1   at least one process survived SIGKILL / not fully clean
   2   invalid flag, missing federation dir, or other bad invocation
+
+Notes:
+  Port 8420 is verified with `lsof` if available, falling back to `ss`
+  (iproute2). On minimal images without either, the port check is
+  skipped and reported as "unknown" (treated as clean).
 EOF
 }
 
@@ -228,10 +233,18 @@ _walk_safety=0
 while [ -n "$_walk_pid" ] && [ "$_walk_pid" != "0" ] && [ "$_walk_pid" != "1" ] && [ "$_walk_safety" -lt 32 ]; do
     EXCLUDE_PIDS="$EXCLUDE_PIDS $_walk_pid"
     # `ps -o ppid=` works on every POSIX ps; trim handles macOS leading spaces.
-    _walk_pid="$(ps -o ppid= -p "$_walk_pid" 2>/dev/null | tr -d ' ' || echo '')"
+    _next_pid="$(ps -o ppid= -p "$_walk_pid" 2>/dev/null | tr -d ' ' || echo '')"
+    if [ -z "$_next_pid" ] && [ "$_walk_pid" != "1" ]; then
+        # Rare race: an ancestor exited mid-walk so `ps` returned nothing
+        # before we reached PID 1. Higher ancestors are now un-excludable;
+        # log a hint so operators can correlate if the script ever flags
+        # one of them as a kill target.
+        warn "ancestor walk: ps returned empty ppid for PID $_walk_pid before reaching 1; higher ancestors not excluded"
+    fi
+    _walk_pid="$_next_pid"
     _walk_safety=$((_walk_safety + 1))
 done
-unset _walk_pid _walk_safety
+unset _walk_pid _walk_safety _next_pid
 SCRIPT_BASENAME="$(basename "$SCRIPT_PATH")"
 filter_self() {
     local input="$1"
@@ -258,6 +271,11 @@ filter_self() {
         local cmd
         cmd="$(ps -o command= -p "$p" 2>/dev/null || echo '')"
         case "$cmd" in
+            # Exclude pgrep itself: on slow runners or under strace, the
+            # verifying `pgrep -f PATTERN` process can outlive its own
+            # exec window long enough to appear in its own results
+            # (its argv contains PATTERN as a literal substring).
+            pgrep*) skip=1 ;;
             *"$SCRIPT_BASENAME"*) skip=1 ;;
         esac
         [ "$skip" -eq 1 ] && continue
@@ -396,16 +414,32 @@ step "Cleaning stale registry"
 BACKUP_PATH=""
 if [ -n "$AGENTIS_DIR" ] && [ -d "$AGENTIS_DIR/daemon" ]; then
     if [ "$NO_BACKUP" -eq 0 ]; then
-        TS=$(date +%Y%m%d-%H%M%S)
-        BACKUP_DIR="$AGENTIS_DIR/backups"
-        mkdir -p "$BACKUP_DIR" 2>/dev/null || true
-        BACKUP_PATH="$BACKUP_DIR/agentis-daemon-registry-backup-$TS.tar.gz"
-        if tar czf "$BACKUP_PATH" -C "$AGENTIS_DIR" daemon 2>/dev/null; then
-            ok "backup: $BACKUP_PATH"
-        else
-            warn "backup failed (continuing): $BACKUP_PATH"
-            BACKUP_PATH=""
+        # n1: skip the backup entirely if `daemon/` has no regular files
+        # (only inbox/ subdirs or it's empty). Avoids leaving a ~100-byte
+        # empty tarball behind on every nothing-to-clean run.
+        _has_files=0
+        if find "$AGENTIS_DIR/daemon" -maxdepth 1 -type f -print -quit 2>/dev/null | grep -q .; then
+            _has_files=1
         fi
+        if [ "$_has_files" -eq 0 ]; then
+            ok "no registry files to back up — skipping tarball"
+        else
+            TS=$(date +%Y%m%d-%H%M%S)
+            BACKUP_DIR="$AGENTIS_DIR/backups"
+            mkdir -p "$BACKUP_DIR" 2>/dev/null || true
+            # Append PID as a suffix so two operators running this script
+            # in the same wall-clock second don't clobber each other's
+            # backup tarball. PID is preferred over `mktemp` to avoid
+            # adding a dependency we don't already require.
+            BACKUP_PATH="$BACKUP_DIR/agentis-daemon-registry-backup-$TS-$$.tar.gz"
+            if tar czf "$BACKUP_PATH" -C "$AGENTIS_DIR" daemon 2>/dev/null; then
+                ok "backup: $BACKUP_PATH"
+            else
+                warn "backup failed (continuing): $BACKUP_PATH"
+                BACKUP_PATH=""
+            fi
+        fi
+        unset _has_files
     else
         ok "backup skipped (--no-backup)"
     fi
@@ -415,7 +449,13 @@ if [ -n "$AGENTIS_DIR" ] && [ -d "$AGENTIS_DIR/daemon" ]; then
     for ext in pid watchdog.pid colony heartbeat status stop; do
         find "$AGENTIS_DIR/daemon" -maxdepth 1 -name "*.$ext" -type f -delete 2>/dev/null || true
     done
-    REMAINING_FILES=$(find "$AGENTIS_DIR/daemon" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    # Use `find -printf '.'` rather than `wc -l` so a filename containing
+    # a literal newline doesn't inflate the count. Fall back to `wc -l` if
+    # `find -printf` is unavailable (e.g. BSD/macOS find).
+    REMAINING_FILES=$(find "$AGENTIS_DIR/daemon" -maxdepth 1 -type f -printf '.' 2>/dev/null | wc -c | tr -d ' ')
+    if [ -z "$REMAINING_FILES" ]; then
+        REMAINING_FILES=$(find "$AGENTIS_DIR/daemon" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    fi
     ok "registry sidecar files removed (${REMAINING_FILES} regular files remain — inbox/ subdirs kept)"
 else
     warn "no $AGENTIS_DIR/daemon — skipping registry cleanup"
@@ -427,19 +467,30 @@ step "Verification"
 FINAL_AGENTIS=$(count_pids "$(filter_self "$(pgrep -f "$DAEMON_MATCH" 2>/dev/null | sort -u || true)")")
 FINAL_DASH=$(count_pids "$(filter_self "$(pgrep -f "$DASHBOARD_MATCH" 2>/dev/null | sort -u || true)")")
 
-# lsof is not installed everywhere (minimal containers, busybox). Warn
-# and skip the port check rather than failing the whole sweep.
+# lsof is not installed everywhere (minimal containers, busybox). Try
+# `ss` (iproute2, universal on Linux including Alpine) before falling
+# back to "unknown" so the port check still works on minimal images.
 if command -v lsof >/dev/null 2>&1; then
     FINAL_PORT=$(lsof -iTCP:8420 -sTCP:LISTEN -P 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')
     FINAL_PORT=${FINAL_PORT:-0}
+elif command -v ss >/dev/null 2>&1; then
+    # `ss -ltn 'sport = :8420'` lists only listeners on TCP port 8420 in
+    # numeric form. Header is one line; subtract it via `tail -n +2`.
+    FINAL_PORT=$(ss -ltn 'sport = :8420' 2>/dev/null | tail -n +2 | grep -c .)
+    FINAL_PORT=${FINAL_PORT:-0}
 else
-    warn "lsof not installed — skipping port 8420 check"
+    warn "neither lsof nor ss installed — skipping port 8420 check"
     FINAL_PORT="unknown"
 fi
 
 REGISTRY_REMAINING=0
 if [ -n "$AGENTIS_DIR" ] && [ -d "$AGENTIS_DIR/daemon" ]; then
-    REGISTRY_REMAINING=$(find "$AGENTIS_DIR/daemon" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    # See the matching `find -printf '.'` block above for why we don't pipe
+    # to `wc -l` here — newlines in filenames would inflate the count.
+    REGISTRY_REMAINING=$(find "$AGENTIS_DIR/daemon" -maxdepth 1 -type f -printf '.' 2>/dev/null | wc -c | tr -d ' ')
+    if [ -z "$REGISTRY_REMAINING" ]; then
+        REGISTRY_REMAINING=$(find "$AGENTIS_DIR/daemon" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    fi
 fi
 
 echo "  matching processes: $FINAL_AGENTIS" >&2

--- a/tools/kill-federation.sh
+++ b/tools/kill-federation.sh
@@ -1,0 +1,482 @@
+#!/usr/bin/env bash
+# kill-federation.sh — reliable full shutdown of an agentis federation.
+#
+# Works around upstream bugs where `agentis daemon stop --all` and per-agent
+# `agentis daemon stop <id>` can report failure while daemons actually die,
+# or report success while they linger. This script uses OS-level signals
+# (TERM then KILL with timeout), verifies every PID is actually gone, and
+# cleans the stale registry sidecar files afterwards.
+#
+# Safe to run:
+#   - when the federation is fully running
+#   - when it's partially running (some daemons dead, some alive)
+#   - when it's already stopped (no-op, registry cleanup only)
+#   - when the dashboard is running (stops it too)
+#
+# Exit codes:
+#   0  all agentis processes dead, registry clean, dashboard stopped
+#   1  at least one process survived SIGKILL / federation not fully clean
+#   2  invalid invocation / missing federation dir / bad flag
+#
+# Why `set -u` only (no `-e`/`-o pipefail`):
+#   This script is defence-in-depth. Each step (signal, sweep, cleanup,
+#   verify) must be allowed to soft-fail without aborting the next step,
+#   so that a partial failure still results in maximum cleanup. The final
+#   verification block returns the authoritative exit code. Do NOT add
+#   `set -e` here — future reviewers, please leave this as-is.
+set -u
+
+# --- Self-resolution (matches install.sh / start-federation.sh idiom) ---
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+TOOL_DIR="$(dirname "$SCRIPT_PATH")"
+: "$TOOL_DIR"  # silence "unused" — kept for parity with sibling tools
+
+# --- Defaults (overridable via flags) ---
+FED_DIR=""
+DRY_RUN=0
+JSON_MODE=0
+NO_BACKUP=0
+# Default daemon match pattern. Narrowed from the original draft's bare
+# 'agentis' to 'agentis daemon' to avoid self-killing the running script,
+# sibling clones of agentis-colonies, the operator's editor titles, and
+# `tail -f .agentis/logs/...` sessions. Residual risk: a custom wrapper
+# that launches daemons with a different argv0 will be missed — the
+# `--match-pattern` test hook below exists to validate that path.
+DAEMON_MATCH='agentis daemon'
+# Dashboard pattern: federation-dashboard.sh wrapper + any dashboard.sh
+# shell processes. Separate from DAEMON_MATCH so the test harness can
+# point it at a fixture tag without touching real dashboards.
+DASHBOARD_MATCH='federation-dashboard|dashboard\.sh'
+# Dashboard Python server pattern: the `python3 -m http.server` child of
+# the dashboard wrapper. Overridable for the same reason as above.
+DASH_PY_MATCH='Python.*dashboard|Python.*\.dashboard'
+
+usage() {
+    cat <<'EOF'
+Usage: kill-federation.sh [OPTIONS] [FEDERATION-DIR]
+
+Reliably stop an agentis federation: agents, dashboard, registry sidecar
+files, and a backup tarball before cleanup. Bypasses the agentis CLI and
+uses OS signals so it works even when `agentis daemon stop --all` lies.
+
+Positional:
+  FEDERATION-DIR     Directory containing .agentis/ state (default: $(pwd)).
+                     Overridden by --fed-dir if both are given.
+
+Options:
+  -h, --help         Show this help and exit (0).
+  --dry-run          List target PIDs and registry files but do not signal
+                     or delete. Always exits 0 unless invocation is bad.
+  --json             Emit a single trailing JSON line on stdout for machine
+                     consumers (e.g. dashboard kill button). Human-readable
+                     coloured prose still goes to stderr.
+  --no-backup        Skip the tar.gz backup of .agentis/daemon/. Used by
+                     CI / tests where the registry is fixture data.
+  --fed-dir DIR      Federation dir (overrides positional argument). Used
+                     by the dev-apprenticeship/kill-federation.sh wrapper.
+
+Exit codes:
+  0   federation fully stopped (or dry-run completed)
+  1   at least one process survived SIGKILL / not fully clean
+  2   invalid flag, missing federation dir, or other bad invocation
+EOF
+}
+
+# --- Argument parsing ---
+# Hidden flag --match-pattern PATTERN: substitutes the daemon match string
+# so the test harness (tools/test-kill-federation.sh) can exercise the
+# kill machinery against fixture processes without touching real agentis
+# daemons. Kept undocumented in --help by design; do NOT remove during
+# future cleanups — see the note in tools/test-kill-federation.sh.
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --json)
+            JSON_MODE=1
+            shift
+            ;;
+        --no-backup)
+            NO_BACKUP=1
+            shift
+            ;;
+        --fed-dir)
+            if [ $# -lt 2 ]; then
+                echo "kill-federation.sh: --fed-dir requires an argument" >&2
+                exit 2
+            fi
+            FED_DIR="$2"
+            shift 2
+            ;;
+        --match-pattern)
+            if [ $# -lt 2 ]; then
+                echo "kill-federation.sh: --match-pattern requires an argument" >&2
+                exit 2
+            fi
+            DAEMON_MATCH="$2"
+            shift 2
+            ;;
+        --dashboard-pattern)
+            # Hidden test hook: substitutes the dashboard match pattern
+            # so tests don't accidentally signal a real dashboard.sh
+            # running on the operator's machine. See
+            # tools/test-kill-federation.sh.
+            if [ $# -lt 2 ]; then
+                echo "kill-federation.sh: --dashboard-pattern requires an argument" >&2
+                exit 2
+            fi
+            DASHBOARD_MATCH="$2"
+            shift 2
+            ;;
+        --dashboard-py-pattern)
+            # Hidden test hook: substitutes the dashboard-python server
+            # match pattern. Same rationale as --dashboard-pattern.
+            if [ $# -lt 2 ]; then
+                echo "kill-federation.sh: --dashboard-py-pattern requires an argument" >&2
+                exit 2
+            fi
+            DASH_PY_MATCH="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "kill-federation.sh: unknown flag: $1" >&2
+            echo "Try --help for usage." >&2
+            exit 2
+            ;;
+        *)
+            if [ -z "$FED_DIR" ]; then
+                FED_DIR="$1"
+            else
+                echo "kill-federation.sh: unexpected argument: $1" >&2
+                exit 2
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$FED_DIR" ]; then
+    FED_DIR="$(pwd)"
+fi
+
+# --- Output helpers ---
+# Human-readable prose goes to stderr so --json can keep stdout clean
+# for the single trailing JSON line.
+step() { printf '\n\033[1;36m== %s ==\033[0m\n' "$*" >&2; }
+ok()   { printf '  \033[1;32mok\033[0m %s\n' "$*" >&2; }
+warn() { printf '  \033[1;33m!\033[0m %s\n' "$*" >&2; }
+fail() { printf '  \033[1;31mFAIL\033[0m %s\n' "$*" >&2; }
+
+# --- Resolve federation ---
+step "Resolving federation"
+
+if [ ! -d "$FED_DIR" ]; then
+    fail "Federation dir missing: $FED_DIR"
+    exit 2
+fi
+AGENTIS_DIR="$FED_DIR/.agentis"
+if [ ! -d "$AGENTIS_DIR" ]; then
+    # Fallback: maybe FED_DIR is a colony inside a federation; walk up one.
+    if [ -d "$FED_DIR/../.agentis" ]; then
+        AGENTIS_DIR="$FED_DIR/../.agentis"
+    else
+        warn "No .agentis dir under $FED_DIR; assuming standalone mode"
+        AGENTIS_DIR=""
+    fi
+fi
+ok "federation dir = $FED_DIR"
+[ -n "$AGENTIS_DIR" ] && ok "agentis state  = $AGENTIS_DIR"
+[ "$DRY_RUN" -eq 1 ] && warn "DRY-RUN: no signals will be sent, no files deleted"
+
+# --- Collect PIDs (once, up front, with precise patterns) ---
+step "Collecting target PIDs"
+
+# Use newline separation internally so we can count without word-splitting
+# surprises. Convert to space-separated lists for the signal loops.
+AGENTIS_PIDS_NL="$(pgrep -f "$DAEMON_MATCH" 2>/dev/null | sort -u || true)"
+DASHBOARD_PIDS_NL="$(pgrep -f "$DASHBOARD_MATCH" 2>/dev/null | sort -u || true)"
+DASH_PY_PIDS_NL="$(pgrep -f "$DASH_PY_MATCH" 2>/dev/null | sort -u || true)"
+
+# Don't ever signal ourselves — exclude this script's PID, our parent
+# shell, AND our grandparent from every PID list and every pkill sweep.
+# Why all three: pgrep -f matches against the FULL command line, and
+# any test harness or wrapper that invokes us with a flag value like
+# `--match-pattern foo` will appear in pgrep results because `foo` is
+# a substring of *its own* argv. Excluding the ancestor chain prevents
+# this from killing the caller (e.g. the test runner shell, the
+# operator's terminal, a CI runner). The lifetime of these ancestors
+# is by definition longer than the script's, so they are never
+# legitimate kill targets.
+SELF_PID=$$
+# Walk the full parent chain back to PID 1 — pgrep -f matches the entire
+# command line of every process, and any ancestor invoking us with our
+# pattern as a flag value will appear in the results. Stop at PID 1 (init)
+# because it's never a kill target anyway.
+EXCLUDE_PIDS="$SELF_PID"
+_walk_pid="$PPID"
+_walk_safety=0
+while [ -n "$_walk_pid" ] && [ "$_walk_pid" != "0" ] && [ "$_walk_pid" != "1" ] && [ "$_walk_safety" -lt 32 ]; do
+    EXCLUDE_PIDS="$EXCLUDE_PIDS $_walk_pid"
+    # `ps -o ppid=` works on every POSIX ps; trim handles macOS leading spaces.
+    _walk_pid="$(ps -o ppid= -p "$_walk_pid" 2>/dev/null | tr -d ' ' || echo '')"
+    _walk_safety=$((_walk_safety + 1))
+done
+unset _walk_pid _walk_safety
+SCRIPT_BASENAME="$(basename "$SCRIPT_PATH")"
+filter_self() {
+    local input="$1"
+    [ -z "$input" ] && return 0
+    printf '%s\n' "$input" | while IFS= read -r p; do
+        [ -z "$p" ] && continue
+        local skip=0
+        for ex in $EXCLUDE_PIDS; do
+            [ "$p" = "$ex" ] && skip=1 && break
+        done
+        [ "$skip" -eq 1 ] && continue
+        # If the process is already gone (e.g. a transient `$()` subshell
+        # that was captured by pgrep and died before we could re-check),
+        # drop it — it's not a kill target.
+        if ! kill -0 "$p" 2>/dev/null; then
+            continue
+        fi
+        # Also skip any process whose own argv mentions this script's
+        # basename — covers the transient `$()` bash subshells spawned by
+        # this very script (whose argv is the parent script's argv, and
+        # therefore contains the user-supplied PATTERN as a flag value).
+        # Without this, pgrep -f PATTERN matches our own subshells and
+        # the verification step reports phantom "live processes".
+        local cmd
+        cmd="$(ps -o command= -p "$p" 2>/dev/null || echo '')"
+        case "$cmd" in
+            *"$SCRIPT_BASENAME"*) skip=1 ;;
+        esac
+        [ "$skip" -eq 1 ] && continue
+        printf '%s\n' "$p"
+    done
+}
+AGENTIS_PIDS_NL="$(filter_self "$AGENTIS_PIDS_NL")"
+DASHBOARD_PIDS_NL="$(filter_self "$DASHBOARD_PIDS_NL")"
+DASH_PY_PIDS_NL="$(filter_self "$DASH_PY_PIDS_NL")"
+
+# Safe alternative to `pkill -SIG -f PATTERN`: pgrep matches, filter
+# self/ancestors, then send the signal manually. Used by the sweep step
+# below — pkill itself has no exclusion mechanism.
+safe_killall() {
+    local sig="$1" pattern="$2"
+    local pids
+    pids="$(pgrep -f "$pattern" 2>/dev/null | sort -u || true)"
+    pids="$(filter_self "$pids")"
+    [ -z "$pids" ] && return 0
+    while IFS= read -r p; do
+        [ -z "$p" ] && continue
+        kill "-$sig" "$p" 2>/dev/null || true
+    done <<< "$pids"
+}
+
+AGENTIS_PIDS="$(printf '%s' "$AGENTIS_PIDS_NL" | tr '\n' ' ')"
+DASHBOARD_PIDS="$(printf '%s' "$DASHBOARD_PIDS_NL" | tr '\n' ' ')"
+DASH_PY_PIDS="$(printf '%s' "$DASH_PY_PIDS_NL" | tr '\n' ' ')"
+
+count_pids() {
+    [ -z "$1" ] && { echo 0; return; }
+    printf '%s\n' "$1" | grep -c .
+}
+AGENTIS_COUNT=$(count_pids "$AGENTIS_PIDS_NL")
+DASHBOARD_COUNT=$(count_pids "$DASHBOARD_PIDS_NL")
+DASH_PY_COUNT=$(count_pids "$DASH_PY_PIDS_NL")
+
+echo "  agentis daemon PIDs ($AGENTIS_COUNT): ${AGENTIS_PIDS:-(none)}" >&2
+echo "  dashboard PIDs      ($DASHBOARD_COUNT): ${DASHBOARD_PIDS:-(none)}" >&2
+echo "  dashboard python    ($DASH_PY_COUNT): ${DASH_PY_PIDS:-(none)}" >&2
+
+ALL_PIDS_NL="$(printf '%s\n%s\n%s\n' "$AGENTIS_PIDS_NL" "$DASHBOARD_PIDS_NL" "$DASH_PY_PIDS_NL" | grep -v '^$' | sort -u || true)"
+ALL_PIDS="$(printf '%s' "$ALL_PIDS_NL" | tr '\n' ' ')"
+ALL_COUNT=$(count_pids "$ALL_PIDS_NL")
+
+# --- Dry-run shortcut ---
+if [ "$DRY_RUN" -eq 1 ]; then
+    step "Dry-run: registry files that would be removed"
+    REG_FILES_LIST=""
+    if [ -n "$AGENTIS_DIR" ] && [ -d "$AGENTIS_DIR/daemon" ]; then
+        for ext in pid watchdog.pid colony heartbeat status stop; do
+            while IFS= read -r f; do
+                [ -z "$f" ] && continue
+                echo "  would remove: $f" >&2
+                REG_FILES_LIST="$REG_FILES_LIST$f"$'\n'
+            done < <(find "$AGENTIS_DIR/daemon" -maxdepth 1 -name "*.$ext" -type f 2>/dev/null)
+        done
+    fi
+    REG_COUNT=$(printf '%s' "$REG_FILES_LIST" | grep -c . || true)
+    ok "dry-run complete: $ALL_COUNT process(es), $REG_COUNT registry file(s) would be touched"
+    if [ "$JSON_MODE" -eq 1 ]; then
+        printf '{"dry_run":true,"agentis":%d,"dashboard":%d,"dashboard_python":%d,"total_processes":%d,"registry_files":%d,"backup":null,"exit":0}\n' \
+            "$AGENTIS_COUNT" "$DASHBOARD_COUNT" "$DASH_PY_COUNT" "$ALL_COUNT" "$REG_COUNT"
+    fi
+    exit 0
+fi
+
+# --- SIGTERM (graceful) ---
+step "SIGTERM everything (graceful)"
+
+if [ "$ALL_COUNT" -gt 0 ]; then
+    # Word-split intentional: ALL_PIDS is a controlled space-separated PID list.
+    # shellcheck disable=SC2086
+    for pid in $ALL_PIDS; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -TERM "$pid" 2>/dev/null && ok "TERM $pid"
+        fi
+    done
+    sleep 3
+else
+    ok "no live processes to signal"
+fi
+
+# --- SIGKILL survivors ---
+step "SIGKILL any survivors"
+
+SURVIVORS_NL=""
+# shellcheck disable=SC2086  # see SIGTERM loop
+for pid in $ALL_PIDS; do
+    if kill -0 "$pid" 2>/dev/null; then
+        SURVIVORS_NL="$SURVIVORS_NL$pid"$'\n'
+    fi
+done
+SURVIVORS_NL="$(printf '%s' "$SURVIVORS_NL" | grep -v '^$' || true)"
+SURVIVOR_COUNT=$(count_pids "$SURVIVORS_NL")
+
+if [ "$SURVIVOR_COUNT" -gt 0 ]; then
+    SURVIVORS="$(printf '%s' "$SURVIVORS_NL" | tr '\n' ' ')"
+    warn "survived SIGTERM: $SURVIVORS — escalating to SIGKILL"
+    # shellcheck disable=SC2086  # controlled PID list
+    for pid in $SURVIVORS; do
+        kill -KILL "$pid" 2>/dev/null && ok "KILL $pid"
+    done
+    sleep 1
+else
+    ok "all processes exited on SIGTERM"
+fi
+
+# --- Sweep stragglers (narrow pattern) ---
+step "Sweep stragglers matching '$DAEMON_MATCH'"
+
+# We re-use the precise DAEMON_MATCH pattern (default 'agentis daemon')
+# rather than bare 'agentis' to avoid matching this script's own argv,
+# sibling clones, or unrelated agentis-* processes. Residual risk: a
+# stray daemon launched with a wrapper that mangled argv0 won't be
+# caught — covered by the verification block below which surfaces it.
+safe_killall TERM "$DAEMON_MATCH"
+sleep 1
+safe_killall KILL "$DAEMON_MATCH"
+sleep 1
+
+REMAINING_NL="$(filter_self "$(pgrep -f "$DAEMON_MATCH" 2>/dev/null | sort -u || true)")"
+REMAINING=$(count_pids "$REMAINING_NL")
+if [ "$REMAINING" -gt 0 ]; then
+    fail "$REMAINING process(es) matching '$DAEMON_MATCH' still alive after KILL"
+    while IFS= read -r p; do
+        [ -z "$p" ] && continue
+        ps -o pid=,command= -p "$p" >&2 2>/dev/null || true
+    done <<< "$REMAINING_NL"
+fi
+[ "$REMAINING" -eq 0 ] && ok "no processes matching '$DAEMON_MATCH' alive"
+
+# --- Registry cleanup ---
+step "Cleaning stale registry"
+
+BACKUP_PATH=""
+if [ -n "$AGENTIS_DIR" ] && [ -d "$AGENTIS_DIR/daemon" ]; then
+    if [ "$NO_BACKUP" -eq 0 ]; then
+        TS=$(date +%Y%m%d-%H%M%S)
+        BACKUP_DIR="$AGENTIS_DIR/backups"
+        mkdir -p "$BACKUP_DIR" 2>/dev/null || true
+        BACKUP_PATH="$BACKUP_DIR/agentis-daemon-registry-backup-$TS.tar.gz"
+        if tar czf "$BACKUP_PATH" -C "$AGENTIS_DIR" daemon 2>/dev/null; then
+            ok "backup: $BACKUP_PATH"
+        else
+            warn "backup failed (continuing): $BACKUP_PATH"
+            BACKUP_PATH=""
+        fi
+    else
+        ok "backup skipped (--no-backup)"
+    fi
+
+    # Use find -delete (not shell globs) — avoids 'no match' failures on
+    # bash 3.2 / zsh when a registry happens to be empty.
+    for ext in pid watchdog.pid colony heartbeat status stop; do
+        find "$AGENTIS_DIR/daemon" -maxdepth 1 -name "*.$ext" -type f -delete 2>/dev/null || true
+    done
+    REMAINING_FILES=$(find "$AGENTIS_DIR/daemon" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    ok "registry sidecar files removed (${REMAINING_FILES} regular files remain — inbox/ subdirs kept)"
+else
+    warn "no $AGENTIS_DIR/daemon — skipping registry cleanup"
+fi
+
+# --- Verification ---
+step "Verification"
+
+FINAL_AGENTIS=$(count_pids "$(filter_self "$(pgrep -f "$DAEMON_MATCH" 2>/dev/null | sort -u || true)")")
+FINAL_DASH=$(count_pids "$(filter_self "$(pgrep -f "$DASHBOARD_MATCH" 2>/dev/null | sort -u || true)")")
+
+# lsof is not installed everywhere (minimal containers, busybox). Warn
+# and skip the port check rather than failing the whole sweep.
+if command -v lsof >/dev/null 2>&1; then
+    FINAL_PORT=$(lsof -iTCP:8420 -sTCP:LISTEN -P 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')
+    FINAL_PORT=${FINAL_PORT:-0}
+else
+    warn "lsof not installed — skipping port 8420 check"
+    FINAL_PORT="unknown"
+fi
+
+REGISTRY_REMAINING=0
+if [ -n "$AGENTIS_DIR" ] && [ -d "$AGENTIS_DIR/daemon" ]; then
+    REGISTRY_REMAINING=$(find "$AGENTIS_DIR/daemon" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+fi
+
+echo "  matching processes: $FINAL_AGENTIS" >&2
+echo "  dashboard processes: $FINAL_DASH" >&2
+echo "  port 8420 listen:    $FINAL_PORT" >&2
+echo "  registry files:      $REGISTRY_REMAINING" >&2
+
+EXIT_CODE=0
+PORT_OK=1
+case "$FINAL_PORT" in
+    0|unknown) PORT_OK=1 ;;
+    *) PORT_OK=0 ;;
+esac
+
+if [ "$FINAL_AGENTIS" -eq 0 ] && [ "$FINAL_DASH" -eq 0 ] && [ "$PORT_OK" -eq 1 ]; then
+    ok "federation fully stopped"
+    EXIT_CODE=0
+else
+    fail "not fully clean — see counters above"
+    EXIT_CODE=1
+fi
+
+if [ "$JSON_MODE" -eq 1 ]; then
+    # Emit BACKUP_PATH as null (not empty string) when not produced, so
+    # JSON consumers can `if data["backup"] is None: ...` cleanly.
+    if [ -n "$BACKUP_PATH" ]; then
+        BACKUP_JSON="\"$BACKUP_PATH\""
+    else
+        BACKUP_JSON="null"
+    fi
+    if [ "$FINAL_PORT" = "unknown" ]; then
+        PORT_JSON="null"
+    else
+        PORT_JSON="$FINAL_PORT"
+    fi
+    printf '{"dry_run":false,"agentis":%d,"dashboard":%d,"port_8420":%s,"registry_remaining":%d,"backup":%s,"exit":%d}\n' \
+        "$FINAL_AGENTIS" "$FINAL_DASH" "$PORT_JSON" "$REGISTRY_REMAINING" "$BACKUP_JSON" "$EXIT_CODE"
+fi
+
+exit "$EXIT_CODE"

--- a/tools/test-kill-federation.sh
+++ b/tools/test-kill-federation.sh
@@ -125,11 +125,14 @@ sleep 1
 if ! kill -0 "$DUMMY_PID" 2>/dev/null; then
     fail "5: spawn dummy" "PID $DUMMY_PID not alive after spawn"
 else
+    # Run with --json so we exercise the real-execution JSON code path
+    # (the dry-run JSON path is already covered by Test 6). Capture
+    # stdout — the trailing line should be the JSON document.
     set +e
-    "$KILL_SH" --fed-dir "$FIX3" --no-backup \
+    json_stdout="$("$KILL_SH" --json --fed-dir "$FIX3" --no-backup \
         --match-pattern "$FIXTURE_TAG" \
         --dashboard-pattern "kill-fed-test-no-such-dash-$$" \
-        --dashboard-py-pattern "kill-fed-test-no-such-dashpy-$$" >/dev/null 2>&1
+        --dashboard-py-pattern "kill-fed-test-no-such-dashpy-$$" 2>/dev/null)"
     rc=$?
     set -e
     sleep 1
@@ -138,10 +141,26 @@ else
         kill -KILL "$DUMMY_PID" 2>/dev/null || true
     else
         registry_left=$(find "$FIX3/.agentis/daemon" -maxdepth 1 -type f | wc -l | tr -d ' ')
-        if [ "$rc" -eq 0 ] && [ "$registry_left" -eq 0 ]; then
-            pass "5: real kill terminates fixture process and clears registry"
+        # Validate the trailing JSON line shape: real-execution path
+        # must include port_8420 and registry_remaining keys, dry_run
+        # must be false, and exit must be 0.
+        json_ok=0
+        if printf '%s' "$json_stdout" | python3 -c "
+import sys, json
+lines = sys.stdin.read().splitlines()
+assert lines, 'no stdout from --json'
+data = json.loads(lines[-1])
+assert data['exit'] == 0, 'exit != 0'
+assert data['dry_run'] is False, 'dry_run not False on real-kill path'
+assert 'port_8420' in data, 'missing port_8420 key'
+assert 'registry_remaining' in data, 'missing registry_remaining key'
+" 2>/dev/null; then
+            json_ok=1
+        fi
+        if [ "$rc" -eq 0 ] && [ "$registry_left" -eq 0 ] && [ "$json_ok" -eq 1 ]; then
+            pass "5: real kill terminates fixture, clears registry, emits valid real-path --json"
         else
-            fail "5: real kill" "rc=$rc registry_left=$registry_left"
+            fail "5: real kill" "rc=$rc registry_left=$registry_left json_ok=$json_ok"
         fi
     fi
 fi

--- a/tools/test-kill-federation.sh
+++ b/tools/test-kill-federation.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# tools/test-kill-federation.sh: unit tests for tools/kill-federation.sh.
+#
+# Self-contained — only bash, python3, and standard Unix tools. Spawns
+# a synthetic long-running process labelled with a per-test argv0 so the
+# kill machinery can be exercised without ever touching a real agentis
+# daemon. Cleans up on every exit path via trap.
+#
+# Usage: ./tools/test-kill-federation.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+KILL_SH="$SCRIPT_DIR/kill-federation.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+SPAWNED_PIDS=()
+
+cleanup() {
+    # Best-effort: kill any dummy process the tests left behind.
+    for p in "${SPAWNED_PIDS[@]:-}"; do
+        [ -z "$p" ] && continue
+        kill -KILL "$p" 2>/dev/null || true
+    done
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+assert_exit_eq() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        pass "$name"
+    else
+        fail "$name" "expected exit=$expected, got exit=$actual"
+    fi
+}
+
+# --- Test 1: --help exits 0, prints Usage ---
+set +e
+out="$("$KILL_SH" --help 2>&1)"
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "Usage"; then
+    pass "1: --help exits 0 with Usage"
+else
+    fail "1: --help" "rc=$rc, out missing 'Usage'"
+fi
+
+# --- Test 2: --unknown-flag exits 2 with stderr message ---
+set +e
+err="$("$KILL_SH" --unknown-flag 2>&1 >/dev/null)"
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && [ -n "$err" ]; then
+    pass "2: bad flag exits 2 with stderr"
+else
+    fail "2: bad flag" "rc=$rc err=$err"
+fi
+
+# --- Test 3: empty fixture, no live processes, exit 0 ---
+FIX1="$TMPDIR_TEST/fix1"
+mkdir -p "$FIX1/.agentis/daemon"
+# Use a unique pattern that matches nothing in the test runner's process
+# table to guarantee a clean run.
+NOPATTERN="kill-fed-test-no-such-pattern-$$-empty"
+set +e
+out="$("$KILL_SH" --fed-dir "$FIX1" --no-backup \
+    --match-pattern "$NOPATTERN" \
+    --dashboard-pattern "$NOPATTERN" \
+    --dashboard-py-pattern "$NOPATTERN" 2>&1)"
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "no live processes"; then
+    pass "3: empty fixture exits 0 with 'no live processes'"
+else
+    fail "3: empty fixture" "rc=$rc out=$out"
+fi
+
+# --- Test 4: dry-run with fixture files preserves them, exit 0 ---
+FIX2="$TMPDIR_TEST/fix2"
+mkdir -p "$FIX2/.agentis/daemon"
+touch "$FIX2/.agentis/daemon/foo.pid" \
+      "$FIX2/.agentis/daemon/bar.heartbeat" \
+      "$FIX2/.agentis/daemon/baz.colony" \
+      "$FIX2/.agentis/daemon/qux.watchdog.pid"
+NOPATTERN2="kill-fed-test-no-such-pattern-$$-dryrun"
+set +e
+"$KILL_SH" --dry-run --fed-dir "$FIX2" \
+    --match-pattern "$NOPATTERN2" \
+    --dashboard-pattern "$NOPATTERN2" \
+    --dashboard-py-pattern "$NOPATTERN2" >/dev/null 2>&1
+rc=$?
+set -e
+files_after=$(find "$FIX2/.agentis/daemon" -type f | wc -l | tr -d ' ')
+if [ "$rc" -eq 0 ] && [ "$files_after" -eq 4 ]; then
+    pass "4: --dry-run leaves fixture files intact"
+else
+    fail "4: --dry-run" "rc=$rc files_after=$files_after (expected 4)"
+fi
+
+# --- Test 5: real kill against fixture process; registry cleaned; exit 0 ---
+FIX3="$TMPDIR_TEST/fix3"
+mkdir -p "$FIX3/.agentis/daemon"
+touch "$FIX3/.agentis/daemon/agent1.pid" \
+      "$FIX3/.agentis/daemon/agent1.heartbeat" \
+      "$FIX3/.agentis/daemon/agent1.colony"
+
+# Spawn a dummy long-running process with a unique argv0. We use
+# `exec -a` so pgrep -f sees the renamed argv. Sleep 600s (10 min) is
+# more than enough — the test will signal it within seconds.
+FIXTURE_TAG="agentis-daemon-test-fixture-$$"
+bash -c "exec -a '$FIXTURE_TAG' sleep 600" &
+DUMMY_PID=$!
+SPAWNED_PIDS+=("$DUMMY_PID")
+
+# Give the kernel a beat to settle the renamed argv into /proc/PID/cmdline.
+sleep 1
+
+if ! kill -0 "$DUMMY_PID" 2>/dev/null; then
+    fail "5: spawn dummy" "PID $DUMMY_PID not alive after spawn"
+else
+    set +e
+    "$KILL_SH" --fed-dir "$FIX3" --no-backup \
+        --match-pattern "$FIXTURE_TAG" \
+        --dashboard-pattern "kill-fed-test-no-such-dash-$$" \
+        --dashboard-py-pattern "kill-fed-test-no-such-dashpy-$$" >/dev/null 2>&1
+    rc=$?
+    set -e
+    sleep 1
+    if kill -0 "$DUMMY_PID" 2>/dev/null; then
+        fail "5: real kill" "dummy PID $DUMMY_PID still alive after kill (rc=$rc)"
+        kill -KILL "$DUMMY_PID" 2>/dev/null || true
+    else
+        registry_left=$(find "$FIX3/.agentis/daemon" -maxdepth 1 -type f | wc -l | tr -d ' ')
+        if [ "$rc" -eq 0 ] && [ "$registry_left" -eq 0 ]; then
+            pass "5: real kill terminates fixture process and clears registry"
+        else
+            fail "5: real kill" "rc=$rc registry_left=$registry_left"
+        fi
+    fi
+fi
+
+# --- Test 6: --json emits valid JSON on stdout (dry-run path) ---
+FIX4="$TMPDIR_TEST/fix4"
+mkdir -p "$FIX4/.agentis/daemon"
+touch "$FIX4/.agentis/daemon/x.pid"
+NOPATTERN3="kill-fed-test-no-such-pattern-$$-json"
+set +e
+stdout="$("$KILL_SH" --json --dry-run --fed-dir "$FIX4" \
+    --match-pattern "$NOPATTERN3" \
+    --dashboard-pattern "$NOPATTERN3" \
+    --dashboard-py-pattern "$NOPATTERN3" 2>/dev/null)"
+rc=$?
+set -e
+last_line="$(printf '%s' "$stdout" | tail -n 1)"
+if [ "$rc" -eq 0 ] && printf '%s' "$last_line" | python3 -c "
+import sys, json
+data = json.loads(sys.stdin.read())
+assert 'exit' in data, 'missing exit key'
+assert 'dry_run' in data, 'missing dry_run key'
+assert data['dry_run'] is True, 'dry_run not True'
+" 2>/dev/null; then
+    pass "6: --json --dry-run emits valid JSON trailing line"
+else
+    fail "6: --json" "rc=$rc last_line=$last_line"
+fi
+
+# --- Test 7: --fed-dir on non-existent path exits 2 ---
+set +e
+"$KILL_SH" --fed-dir "$TMPDIR_TEST/does-not-exist" --dry-run >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit_eq "7: missing --fed-dir exits 2" "2" "$rc"
+
+# --- Test 8: backup is created in $AGENTIS_DIR/backups when not --no-backup ---
+FIX5="$TMPDIR_TEST/fix5"
+mkdir -p "$FIX5/.agentis/daemon"
+touch "$FIX5/.agentis/daemon/agent.pid"
+NOPATTERN4="kill-fed-test-no-such-pattern-$$-backup"
+set +e
+"$KILL_SH" --fed-dir "$FIX5" \
+    --match-pattern "$NOPATTERN4" \
+    --dashboard-pattern "$NOPATTERN4" \
+    --dashboard-py-pattern "$NOPATTERN4" >/dev/null 2>&1
+rc=$?
+set -e
+backups_count=$(find "$FIX5/.agentis/backups" -name 'agentis-daemon-registry-backup-*.tar.gz' 2>/dev/null | wc -l | tr -d ' ')
+# Parent dir must NOT be polluted with backup tarballs.
+parent_pollution=$(find "$FIX5/.." -maxdepth 1 -name 'agentis-daemon-registry-backup-*.tar.gz' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$rc" -eq 0 ] && [ "$backups_count" -eq 1 ] && [ "$parent_pollution" -eq 0 ]; then
+    pass "8: backup written to .agentis/backups/, parent dir untouched"
+else
+    fail "8: backup location" "rc=$rc in_backups=$backups_count parent=$parent_pollution"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Ships `tools/kill-federation.sh` per #162: SIGTERM → SIGKILL → registry cleanup → backup, idempotent, with operator-facing wrapper at `dev-apprenticeship/kill-federation.sh`.

The script will be invoked by the dashboard's "Kill federation" button once the UX in #161 lands — the `--json` mode is ready for that integration.

## Hardening over the issue's draft

- **`pkill -f 'agentis'` narrowed to `pkill -f 'agentis daemon'`** — the bare pattern would self-kill the script, sibling clones, `tail -f .agentis/logs/...`, etc.
- **`safe_killall` helper replaces `pkill`** — collects PIDs, walks ancestor chain to PID 1, excludes script + `pgrep` itself, signals only survivors with `kill -0` liveness re-check.
- **Hidden test hooks** (`--match-pattern`, `--dashboard-pattern`, `--dashboard-py-pattern`) so the test harness exercises kill machinery against synthetic `sleep` fixtures without touching real daemons.
- **`stdout`/`stderr` split**: human prose to stderr; single trailing JSON line to stdout when `--json` passed.
- **Backup federation-scoped**: `$AGENTIS_DIR/backups/agentis-daemon-registry-backup-$TS-$$.tar.gz` (PID suffix avoids same-second collision).
- **`lsof` → `ss -ltn` → "unknown" fallback chain** for port verification (covers Alpine / minimal containers).

## Files

- **NEW** `tools/kill-federation.sh` (533 lines)
- **NEW** `tools/test-kill-federation.sh` (223 lines, 8 assertions, auto-discovered by `colony-lint.sh`)
- **NEW** `dev-apprenticeship/kill-federation.sh` (16-line operator wrapper, mirrors `dashboard.sh` pattern)
- **EDIT** `CLAUDE.md` (Tools row + end-user scripts row + lint baseline 47 → 48)
- **EDIT** `README.md` (operator scripts pointer)

## Out of scope (explicitly deferred)

- **Dashboard kill button → script wiring**: #161
- **Polling loop instead of fixed `sleep 3` / `sleep 1`**: cosmetic, deferred
- **Watchdog respawn race during PID collection**: rare, sweep-stragglers covers daemon respawns; defer until/unless it bites

## Test plan

- [x] `bash -n` clean on all three new scripts
- [x] `tools/test-kill-federation.sh` — 8/8 pass (fixture spawn + real kill + dry-run + JSON shape both code paths)
- [x] `tools/colony-lint.sh` — `48 passed, 0 failed, 5 skipped` (shellcheck not installed)
- [x] `--help` documents exit-code contract + `lsof`/`ss` fallback
- [x] Real-execution `--json` shape parsed by the test (`exit`, `port_8420`, `registry_remaining`, `dry_run` keys)
- [x] Idempotent — second run on already-stopped federation exits 0
- [ ] Dashboard integration smoke (deferred to #161)

## Review thread

PR-reviewer agent ran locally before push. Findings: 1 MAJOR (M1 — `pgrep` self-match on slow runners) + 6 MINOR (m1, m2, m5, m6, m7, n1) all addressed in commit `c0a15ff`. m3 (polling) and m4 (respawn race) deferred with rationale in the commit body.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)