### PR TITLE
feat(dashboard): timeline Clear button + human-readable timestamps (#158)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Pre-built agent colonies for the [Agentis](https://github.com/Replikanti/agentis
 bash -n scripts/gitlab-api.sh   # Bash syntax check on any script
 ```
 
-Colony lint must pass with 0 failures before merge. Current baseline: 49 passed, 5 skipped (shellcheck not installed).
+Colony lint must pass with 0 failures before merge. Current baseline: 50 passed, 5 skipped (shellcheck not installed).
 
 ## Colony structure
 
@@ -97,7 +97,7 @@ release:changelog_draft      -> version_bumper
 | `new-colony.sh` | Scaffold a new colony (creates dirs, example config, starter scripts) |
 | `check-exec-sh.sh` | Grep-based check for unsafe string concat into `exec sh`. See `check-exec-sh.md` for known limitations. |
 | `parse-toml.sh` | Shared TOML parser sourced by all start-colony.sh scripts |
-| `federation-dashboard.sh` | Generic web dashboard for any federation (auto-discovers colonies/agents, kill switch, phase ETA). Promote/demote/evolve buttons gate on per-agent `.ag` `confidence_gates` + fitness signal (#160) — disabled buttons open a "Why" sidebar with evidence + remediation. Kill button invokes tools/kill-federation.sh --json and surfaces failures in a persistent notification region rather than overwriting the button label (#161). |
+| `federation-dashboard.sh` | Generic web dashboard for any federation (auto-discovers colonies/agents, kill switch, phase ETA). Promote/demote/evolve buttons gate on per-agent `.ag` `confidence_gates` + fitness signal (#160) — disabled buttons open a "Why" sidebar with evidence + remediation. Kill button invokes tools/kill-federation.sh --json and surfaces failures in a persistent notification region rather than overwriting the button label (#161). Timeline parses raw epoch-ms log lines, renders human-readable timestamps with ISO+relative tooltip, and supports per-federation Clear cursor (#158). |
 | `auto-promote.sh` | Layer 1 auto-promote/auto-evolve cron script — evaluates per-agent fitness, promotes or evolves (#148) |
 | `auto-promote-config.yaml` | Decision rules for auto-promote (thresholds, promote steps, evolve triggers, dry_run flag) |
 | `resolve-tick-interval.py` | Shared helper: reads `tick_interval_for()` case statement (or legacy `TICK_INTERVALS`) from start-colony.sh for a given agent+colony (used by dashboard + auto-promote) |

--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -37,6 +37,9 @@ fi
 
 PORT="${2:-8420}"
 FED_NAME="$(basename "$FED_DIR")"
+# JSON-escaped form for safe embedding in JS string literal (handles
+# federation directories containing " or \).
+FED_NAME_JS="$(printf '%s' "$FED_NAME" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')"
 DASH_DIR="$FED_DIR/.dashboard"
 HTML_FILE="$DASH_DIR/index.html"
 HISTORY_FILE="$DASH_DIR/history.json"
@@ -1051,7 +1054,7 @@ const colonyList = ${COLONY_LIST_JS};
 const nowEpoch = ${EPOCH};
 const timestamp = "${TIMESTAMP}";
 const totalAgents = ${AGENT_COUNT};
-const FED_NAME = "${FED_NAME}";
+const FED_NAME = ${FED_NAME_JS};
 DATAEOF
 
     cat <<'JSEOF'
@@ -1845,6 +1848,9 @@ function openDetail(agentName) {
   if (a.recent_experience && a.recent_experience.length > 0) {
     html += '<div class="exp-table"><table><tr><th>Time</th><th>Action</th><th>In</th><th>Outcome</th><th>Delta</th></tr>';
     a.recent_experience.slice().reverse().forEach(e => {
+      // recent_experience[].ts is epoch-SECONDS (written by agentis-core
+      // experience JSONL). Distinct from events[].ts which is epoch-ms
+      // after the #158 wire-shape change. Do not pre-divide here.
       const ts = e.ts ? relTime(e.ts) : '';
       const action = esc(String(e.action || '').slice(0, 30));
       const inp = esc(String(e.in || '').slice(0, 40));

--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -119,7 +119,7 @@ generate() {
     # confidence change history. Outputs a single JSON blob consumed by JS.
     local COLLECTOR_JSON
     COLLECTOR_JSON="$(python3 - "$DAEMONS" "$AGENT_COLONY_MAP" "$FED_DIR" "$EPOCH" "$EXPERIENCE_DIR" "$LOG_DIR" "$DASH_DIR" "$COLONY_LIST_PY" <<'PY' "${ALL_AGENTS[@]}"
-import sys, os, json, time, re
+import sys, os, json, time, re, datetime
 
 daemons_json   = sys.argv[1]
 agent_map_json = sys.argv[2]
@@ -335,13 +335,30 @@ if os.path.isdir(log_dir):
                     line = line.strip()
                     if not line:
                         continue
-                    # Try to extract timestamp from line start
-                    ts_match = re.match(r'^\[?(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})\]?\s*(.*)', line)
-                    ts_str = ''
+                    # Try to extract timestamp from line start. Two formats
+                    # supported: (1) raw 13-digit epoch-ms produced by the
+                    # agentis daemon (the actual production format), (2)
+                    # bracketed/ISO YYYY-MM-DD[T ]HH:MM:SS (kept as a
+                    # fallback for older logs and external producers; do
+                    # NOT remove without auditing every log emitter).
+                    ts_ms_match = re.match(r'^(\d{13})\s+(.*)', line)
+                    ts_iso_match = re.match(r'^\[?(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})\]?\s*(.*)', line)
+                    ts = 0
                     content = line
-                    if ts_match:
-                        ts_str = ts_match.group(1)
-                        content = ts_match.group(2)
+                    if ts_ms_match:
+                        try:
+                            ts = int(ts_ms_match.group(1))
+                            content = ts_ms_match.group(2)
+                        except ValueError:
+                            ts = 0
+                    elif ts_iso_match:
+                        iso = ts_iso_match.group(1).replace(' ', 'T')
+                        try:
+                            ts = int(datetime.datetime.fromisoformat(iso).timestamp() * 1000)
+                            content = ts_iso_match.group(2)
+                        except (ValueError, OSError):
+                            ts = 0
+                            content = ts_iso_match.group(2)
                     # Classify event type (word-boundary match to avoid
                     # false positives like "react"→action, "referred"→error)
                     etype = 'log'
@@ -361,7 +378,7 @@ if os.path.isdir(log_dir):
                     # Only include interesting events in timeline
                     if etype != 'log':
                         events.append({
-                            'ts': ts_str,
+                            'ts': ts,
                             'agent': role,
                             'type': etype,
                             'content': content[:200],
@@ -370,8 +387,9 @@ if os.path.isdir(log_dir):
                 pass
     except OSError:
         pass
-# Sort by timestamp descending, limit to 100
-events.sort(key=lambda e: e.get('ts', ''), reverse=True)
+# Sort by timestamp descending, limit to 100. ts is integer epoch-ms; entries
+# with ts == 0 (unparseable) sort to the end.
+events.sort(key=lambda e: e.get('ts', 0), reverse=True)
 events = events[:100]
 
 # --- Confidence change log ---
@@ -631,10 +649,30 @@ HEADEOF
   .promote-suggest { color: var(--yellow); font-size: 11px; }
 
   /* --- Event Timeline --- */
-  .timeline { max-height: 300px; overflow-y: auto; font-size: 11px; line-height: 1.8; }
-  .timeline-entry { padding: 3px 0; border-bottom: 1px solid var(--border2); display: flex; gap: 8px; }
+  .timeline-header { display: flex; justify-content: space-between; align-items: center; }
+  .timeline-clear-btn {
+    background: transparent; border: 1px solid var(--border);
+    color: var(--muted); font-family: 'Share Tech Mono', monospace;
+    font-size: 10px; padding: 3px 8px; cursor: pointer;
+    text-transform: uppercase; letter-spacing: 1px;
+    border-radius: 2px; transition: all 0.15s;
+  }
+  .timeline-clear-btn:hover { color: var(--text); border-color: var(--text); }
+  .timeline-banner {
+    padding: 6px 10px; background: rgba(255,255,255,0.04);
+    border-left: 2px solid var(--muted); font-size: 11px;
+    color: var(--muted); margin-bottom: 6px;
+  }
+  .timeline-banner-show-all {
+    background: transparent; border: none; color: var(--muted);
+    font-family: 'Share Tech Mono', monospace; font-size: 11px;
+    cursor: pointer; padding: 0; text-decoration: none;
+  }
+  .timeline-banner-show-all:hover { text-decoration: underline; color: var(--text); }
+  .timeline { max-height: 300px; overflow-y: auto; overflow-x: visible; font-size: 11px; line-height: 1.8; }
+  .timeline-entry { padding: 3px 0; border-bottom: 1px solid var(--border2); display: flex; gap: 8px; overflow: visible; }
   .timeline-entry:hover { background: rgba(0,255,255,0.03); }
-  .timeline-ts { color: var(--muted); width: 65px; flex-shrink: 0; }
+  .timeline-ts { color: var(--muted); width: 145px; flex-shrink: 0; }
   .timeline-agent { color: var(--cyan); width: 130px; flex-shrink: 0; }
   .timeline-type { width: 60px; flex-shrink: 0; font-size: 10px; text-transform: uppercase; letter-spacing: 1px; }
   .timeline-type.emit { color: var(--green); }
@@ -967,7 +1005,11 @@ HEADEREOF
 </div>
 
 <div class="card full">
-<h2>Event Timeline</h2>
+<div class="timeline-header">
+  <h2>Event Timeline</h2>
+  <button class="timeline-clear-btn" id="timeline-clear-btn">Clear</button>
+</div>
+<div class="timeline-banner" id="timeline-banner" hidden></div>
 <div id="event-timeline" class="timeline"></div>
 </div>
 
@@ -1009,6 +1051,7 @@ const colonyList = ${COLONY_LIST_JS};
 const nowEpoch = ${EPOCH};
 const timestamp = "${TIMESTAMP}";
 const totalAgents = ${AGENT_COUNT};
+const FED_NAME = "${FED_NAME}";
 DATAEOF
 
     cat <<'JSEOF'
@@ -1031,6 +1074,16 @@ function relTime(ts) {
   if (diff < 86400) return Math.floor(diff/3600) + 'h ago';
   return Math.floor(diff/86400) + 'd ago';
 }
+
+function formatTimestamp(ms) {
+  if (!ms) return '';
+  const d = new Date(ms);
+  const pad = n => String(n).padStart(2, '0');
+  return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate())
+       + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds());
+}
+
+const TIMELINE_CURSOR_KEY = 'dashboard.timeline.cursorMs.' + FED_NAME;
 
 // --- Refresh countdown ---
 (function() {
@@ -1377,21 +1430,68 @@ renderAgentTable();
 // --- Event Timeline ---
 (function() {
   const el = document.getElementById('event-timeline');
-  if (!events.length) {
-    el.innerHTML = '<span class="empty">No inter-agent events captured yet.</span>';
-    return;
+  const banner = document.getElementById('timeline-banner');
+  const cursor = parseInt(localStorage.getItem(TIMELINE_CURSOR_KEY) || '0', 10);
+  // Filter rule: entries with ts === 0 (no parseable timestamp) always pass
+  // through so the operator can still see them; entries with ts >= cursor
+  // pass; older entries are hidden until "Show all" is clicked.
+  const filtered = events.filter(e => !cursor || !e.ts || e.ts >= cursor);
+  const hidden = events.length - filtered.length;
+
+  if (banner) {
+    if (hidden > 0) {
+      banner.hidden = false;
+      banner.innerHTML = 'Hidden ' + hidden + ' entries before ' +
+        esc(formatTimestamp(cursor)) +
+        ' &mdash; <button type="button" class="timeline-banner-show-all" id="timeline-show-all">Show all</button>';
+      const showAll = document.getElementById('timeline-show-all');
+      if (showAll) {
+        showAll.addEventListener('click', () => {
+          localStorage.removeItem(TIMELINE_CURSOR_KEY);
+          location.reload();
+        });
+      }
+    } else {
+      banner.hidden = true;
+      banner.innerHTML = '';
+    }
   }
-  let html = '';
-  events.forEach(e => {
-    const tsDisplay = e.ts ? e.ts.split(/[T ]/)[1] || e.ts : '';
-    html += '<div class="timeline-entry">' +
-      '<span class="timeline-ts">' + esc(tsDisplay) + '</span>' +
-      '<span class="timeline-agent">' + esc(e.agent) + '</span>' +
-      '<span class="timeline-type ' + e.type + '">' + esc(e.type) + '</span>' +
-      '<span class="timeline-content">' + esc(e.content) + '</span>' +
-      '</div>';
-  });
-  el.innerHTML = html;
+
+  if (!filtered.length) {
+    el.innerHTML = '<span class="empty">No inter-agent events captured yet.</span>';
+  } else {
+    let html = '';
+    filtered.forEach(e => {
+      const tsDisplay = formatTimestamp(e.ts) || '?';
+      let tip;
+      if (e.ts) {
+        try { tip = new Date(e.ts).toISOString() + '\n' + relTime(e.ts / 1000); }
+        catch (err) { tip = String(e.ts); }
+      } else {
+        tip = 'no timestamp parsed from log line';
+      }
+      html += '<div class="timeline-entry">' +
+        '<span class="timeline-ts tooltip">' + esc(tsDisplay) +
+          '<span class="tip-text">' + esc(tip) + '</span>' +
+        '</span>' +
+        '<span class="timeline-agent">' + esc(e.agent) + '</span>' +
+        '<span class="timeline-type ' + e.type + '">' + esc(e.type) + '</span>' +
+        '<span class="timeline-content">' + esc(e.content) + '</span>' +
+        '</div>';
+    });
+    el.innerHTML = html;
+  }
+
+  // Wire Clear: stamp the cursor at "now" and reload (the dashboard's
+  // existing meta-refresh idiom — see <meta http-equiv="refresh"> at top).
+  const clearBtn = document.getElementById('timeline-clear-btn');
+  if (clearBtn) {
+    // TODO(#167): selective-clear in v2 — see issue
+    clearBtn.addEventListener('click', () => {
+      localStorage.setItem(TIMELINE_CURSOR_KEY, String(Date.now()));
+      location.reload();
+    });
+  }
 })();
 
 // --- Experience Growth Chart ---

--- a/tools/federation-dashboard.sh
+++ b/tools/federation-dashboard.sh
@@ -1866,7 +1866,19 @@ function openDetail(agentName) {
   if (a.recent_logs && a.recent_logs.length > 0) {
     html += '<div class="log-feed">';
     a.recent_logs.forEach(l => {
-      html += '<div>' + esc(l) + '</div>';
+      // #158: replace leading raw 13-digit epoch-ms (agentis 1.3.0 log
+      // format) with human-readable timestamp so the modal does not show
+      // "1776250011452 tick manual" verbatim. Tooltip preserves the raw ms
+      // and ISO-UTC for audit copy-paste.
+      const m = String(l).match(/^(\d{13})\s+(.*)$/);
+      if (m) {
+        const ms = parseInt(m[1], 10);
+        const iso = new Date(ms).toISOString();
+        const human = formatTimestamp(ms);
+        html += '<div><span class="tooltip">' + esc(human) + '<span class="tip-text">' + esc(iso) + '\n' + esc(m[1]) + '</span></span> ' + esc(m[2]) + '</div>';
+      } else {
+        html += '<div>' + esc(l) + '</div>';
+      }
     });
     html += '</div>';
   } else {

--- a/tools/test-timeline-rendering.sh
+++ b/tools/test-timeline-rendering.sh
@@ -217,6 +217,38 @@ else
     fail "7: /kill regression — response missing 'ok' key" "body: $(head -c 400 "$RESP_FILE" 2>/dev/null)"
 fi
 
+# --- Test 8: unit-mismatch guard. relTime() expects epoch-SECONDS. The
+#     timeline IIFE works in epoch-ms (post-#158) and must divide by 1000
+#     before passing to relTime. Recent Experience modal works in epoch-
+#     seconds and must NOT divide. Lock both in to prevent the next
+#     refactor from mixing units. ---
+if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
+import sys, re
+with open(sys.argv[1]) as f:
+    html = f.read()
+# Timeline IIFE must call relTime(e.ts / 1000) (or e.ts/1000) somewhere.
+m = re.search(r'// --- Event Timeline ---(.*?)// --- ', html, re.DOTALL)
+if not m:
+    sys.exit(1)
+timeline_body = m.group(1)
+if not re.search(r'relTime\(\s*e\.ts\s*/\s*1000\s*\)', timeline_body):
+    sys.exit(1)
+# Recent Experience modal must call relTime(e.ts) — no division. Locate
+# the modal block by its header marker.
+m2 = re.search(r'Recent Experience.*?(relTime\([^)]*\))', html, re.DOTALL)
+if not m2:
+    sys.exit(1)
+call = m2.group(1)
+if '/' in call or '* 1000' in call:
+    sys.exit(1)
+sys.exit(0)
+PY
+then
+    pass "8: unit contract — timeline divides ts/1000, recent_experience does not"
+else
+    fail "8: unit-mismatch guard tripped (relTime call shape changed)"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-timeline-rendering.sh
+++ b/tools/test-timeline-rendering.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+# tools/test-timeline-rendering.sh: structural test for the Event Timeline
+# panel in federation-dashboard.sh (issue #158). Boots the dashboard against
+# a fixture .agentis/logs/ directory containing log lines in BOTH the raw
+# 13-digit epoch-ms format (the real agentis daemon production format) and
+# the legacy ISO/bracketed format, plus one corrupted line, then asserts
+# the served HTML renders all three events with human-readable timestamps,
+# wires the per-federation Clear button + cursor, and does NOT leak raw
+# 13-digit ms into the rendered timeline rows. Also smokes /kill so we
+# don't regress #161.
+#
+# Usage: ./tools/test-timeline-rendering.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DASHBOARD_SH="$SCRIPT_DIR/federation-dashboard.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+DASH_PID=""
+
+cleanup() {
+    if [ -n "$DASH_PID" ]; then
+        kill -TERM "-$DASH_PID" 2>/dev/null || kill -TERM "$DASH_PID" 2>/dev/null || true
+        sleep 1
+        kill -KILL "-$DASH_PID" 2>/dev/null || kill -KILL "$DASH_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# Sanity: dashboard script exists and is executable.
+if [ ! -x "$DASHBOARD_SH" ]; then
+    fail "0: dashboard script missing or not executable" "$DASHBOARD_SH"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# --- Fixture: federation directory with a single colony stub and a logs
+#     dir containing three crafted lines exercising each timestamp path.
+#     The dashboard reads logs from "$FED_DIR/../.agentis/logs", so the
+#     logs live at $TMPDIR_TEST/.agentis/logs/ (one level above FED_DIR). ---
+FED_DIR="$TMPDIR_TEST/fed"
+mkdir -p "$FED_DIR/.agentis/daemon" \
+         "$TMPDIR_TEST/.agentis/logs" \
+         "$FED_DIR/stub-colony/agents" \
+         "$FED_DIR/stub-colony/config"
+
+cat > "$FED_DIR/stub-colony/config/colony.toml" <<'TOML'
+[colony]
+name = "stub-colony"
+TOML
+
+cat > "$FED_DIR/stub-colony/agents/stub_agent.ag" <<'AG'
+cb 100;
+fn tick() { return Void; }
+AG
+
+# Three log lines:
+# 1. Raw 13-digit epoch-ms format (the real agentis daemon production
+#    format) with the 'emit' keyword so it hits the timeline.
+# 2. Legacy bracketed ISO format (kept as a fallback for older logs and
+#    external producers) with the 'error' keyword.
+# 3. Corrupted line with no parseable timestamp; the 'action' keyword
+#    keeps it in the timeline so the ts==0 fallback path is exercised.
+cat > "$TMPDIR_TEST/.agentis/logs/stub_agent.log" <<'LOG'
+1776250011452 emit test:event from stub
+[2026-04-15 13:23:58] error something failed
+corrupted line with no timestamp action draft
+LOG
+
+# --- Pick a free port ---
+PORT="$(python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); p=s.getsockname()[1]; s.close(); print(p)")"
+if [ -z "$PORT" ]; then
+    fail "1: free-port discovery failed"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# --- Boot the dashboard. setsid -> own process group for clean teardown. ---
+LOG_FILE="$TMPDIR_TEST/dashboard.log"
+setsid bash "$DASHBOARD_SH" "$FED_DIR" "$PORT" >"$LOG_FILE" 2>&1 &
+DASH_PID=$!
+
+# Wait for readiness.
+ready=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -f -s -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null; then
+        ready=1
+        break
+    fi
+    sleep 0.5
+done
+if [ "$ready" -ne 1 ]; then
+    fail "0: dashboard never became ready" "log tail: $(tail -10 "$LOG_FILE" 2>/dev/null | tr '\n' ' ')"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+HTML_FILE="$TMPDIR_TEST/index.html"
+curl -s "http://127.0.0.1:$PORT/" -o "$HTML_FILE" || true
+
+if [ ! -s "$HTML_FILE" ]; then
+    fail "0: GET / returned empty body"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# --- Test 1: timeline JSON injection contains all three events. ---
+t1_ok=1
+if ! grep -q 'test:event' "$HTML_FILE"; then echo "  missing 'test:event'"; t1_ok=0; fi
+if ! grep -q 'something failed' "$HTML_FILE"; then echo "  missing 'something failed'"; t1_ok=0; fi
+if ! grep -q 'corrupted line' "$HTML_FILE"; then echo "  missing 'corrupted line'"; t1_ok=0; fi
+if [ "$t1_ok" -eq 1 ]; then
+    pass "1: timeline ingests both raw-ms and ISO formats plus the no-timestamp fallback"
+else
+    fail "1: timeline missing one or more crafted events"
+fi
+
+# --- Test 2: formatTimestamp helper present in served HTML. ---
+if grep -q 'function formatTimestamp' "$HTML_FILE"; then
+    pass "2: formatTimestamp helper present in served HTML"
+else
+    fail "2: formatTimestamp helper missing"
+fi
+
+# --- Test 3: TIMELINE_CURSOR_KEY namespaced via FED_NAME concat. The
+#     trailing dot proves the FED_NAME suffix is appended (vs. a bare
+#     constant that would collide across federations). ---
+if grep -q 'dashboard.timeline.cursorMs\.' "$HTML_FILE"; then
+    pass "3: TIMELINE_CURSOR_KEY is namespaced with FED_NAME suffix"
+else
+    fail "3: TIMELINE_CURSOR_KEY namespacing missing"
+fi
+
+# --- Test 4: Clear button structurally present. ---
+if grep -q 'id="timeline-clear-btn"' "$HTML_FILE"; then
+    pass "4: timeline Clear button present in HTML"
+else
+    fail "4: #timeline-clear-btn missing"
+fi
+
+# --- Test 5: Tooltip wired — at least one tip-text near a timeline-ts. ---
+if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
+import sys, re
+with open(sys.argv[1]) as f:
+    html = f.read()
+# Look for 'tip-text' within ~200 chars after any 'timeline-ts' occurrence
+# inside the JS source (the IIFE constructs the row template).
+ok = False
+for m in re.finditer(r'timeline-ts', html):
+    window = html[m.start(): m.start() + 400]
+    if 'tip-text' in window:
+        ok = True
+        break
+sys.exit(0 if ok else 1)
+PY
+then
+    pass "5: tooltip (tip-text) wired adjacent to timeline-ts in row template"
+else
+    fail "5: tip-text not found near timeline-ts"
+fi
+
+# --- Test 6: no raw 13-digit ms leaks into rendered timeline rows. The
+#     events array literal in the JS source legitimately contains the raw
+#     ms values (that's the JSON payload), so we restrict the check to
+#     the JS that builds the row HTML — i.e. the timeline IIFE body and
+#     the format helpers must not contain a 13-digit standalone literal
+#     in a way that would render in the row. We instead assert that the
+#     row template uses formatTimestamp(e.ts), not bare e.ts string
+#     concatenation. ---
+if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
+import sys, re
+with open(sys.argv[1]) as f:
+    html = f.read()
+# Locate the timeline IIFE: from "// --- Event Timeline ---" to the next
+# "// --- " marker.
+m = re.search(r'// --- Event Timeline ---(.*?)// --- ', html, re.DOTALL)
+if not m:
+    sys.exit(1)
+body = m.group(1)
+# Must reference formatTimestamp on e.ts; must NOT concat e.ts directly
+# into a span without going through formatTimestamp/esc/Date.
+if 'formatTimestamp(e.ts)' not in body:
+    sys.exit(1)
+# Defensive: ensure no naked '+ e.ts +' that would dump a 13-digit number.
+if re.search(r'\+\s*e\.ts\s*\+', body):
+    sys.exit(1)
+sys.exit(0)
+PY
+then
+    pass "6: timeline row template renders e.ts via formatTimestamp, no raw-ms leak"
+else
+    fail "6: rendered timeline row template still references e.ts directly"
+fi
+
+# --- Test 7: /kill regression smoke (issue #161). ---
+RESP_FILE="$TMPDIR_TEST/kill.json"
+curl -s -X POST -H 'Content-Type: application/json' \
+    -d '{}' "http://127.0.0.1:$PORT/kill" -o "$RESP_FILE" || true
+if python3 - "$RESP_FILE" <<'PY' 2>/dev/null
+import sys, json
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+assert isinstance(data, dict)
+assert 'ok' in data
+PY
+then
+    pass "7: /kill endpoint still returns JSON with 'ok' key"
+else
+    fail "7: /kill regression — response missing 'ok' key" "body: $(head -c 400 "$RESP_FILE" 2>/dev/null)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes #158. Two paper cuts on the federation dashboard's Event Timeline + Recent Logs panels:

1. **Raw 13-digit Unix ms timestamps** rendered verbatim (`1776250011452 tick manual`) instead of human-readable form. Operator manually converted each entry to figure out "is this from today?".
2. **No way to clear** historical errors from a known-fixed period. Today after agentis 1.3.0 fixes landed, the timeline still showed hundreds of pre-1.3.0 error lines mixed with current state.

## Wire-shape change (important)

The original audit assumed `events[].ts` was a parsed string. Verified against a real agentis 1.3.0 log file (`1776250011452 tick manual`): the actual production format is **raw 13-digit epoch-ms prefix**, which the existing server regex (line ~339) was missing entirely. The PR therefore:

- **Server**: extends the regex to recognise BOTH formats (raw `^\d{13}\s+...` AND legacy `[YYYY-MM-DD HH:MM:SS] ...`); changes `events[].ts` from string → integer epoch-ms (uniform numeric contract).
- **Client**: new `formatTimestamp(ms)` helper renders `YYYY-MM-DD HH:MM:SS` (locale-free, deterministic). Tooltip exposes ISO-UTC + relative ("2h ago"). Reuses existing `.tooltip` CSS infra.
- **`recent_experience[].ts` is left as epoch-seconds** (different producer, different units). New inline comment + Test 8 lock the unit contract on both sides.
- **Recent Logs modal** also gets the formatTimestamp treatment for raw-ms log lines so the bug stops appearing in two places.

## Clear button + cursor

- New `<button id="timeline-clear-btn">Clear</button>` in the Event Timeline panel header.
- Click stores `Date.now()` in `localStorage` under key `dashboard.timeline.cursorMs.<FED_NAME>` (per-federation namespacing — two dashboards on different ports keep independent cursors). Page reloads to apply.
- Banner above the timeline: `Hidden N entries before HH:MM:SS — [Show all]` when cursor is set. Show all clears the cursor and reloads.
- Entries with unparseable timestamps (`ts === 0`) always pass the cursor filter — preserves visibility of malformed lines.

## Out of scope (deferred to #167)

- Selective clear ("Clear errors from agents that have ticked cleanly for >1h") — needs server-side `agent_last_ok_ts` aggregation.
- Per-row dismiss `×`.
- Severity / class filter (`tick:error` vs `LLM transport` vs `capability denied`).
- Absolute ↔ relative toggle button (tooltip already provides both).

`// TODO(#167): selective-clear in v2` comment placed at the v1 Clear button click handler.

## Files

- **EDIT** `tools/federation-dashboard.sh`: server regex + JSON shape (string → int epoch-ms), CSS for `.timeline-header`/`.timeline-clear-btn`/`.timeline-banner`, `formatTimestamp` helper, FED_NAME JSON-escape, IIFE rewrite (cursor filter + banner + tooltip), Recent Logs modal raw-ms formatting, recent_experience unit comment.
- **NEW** `tools/test-timeline-rendering.sh` (~225 lines, 8 assertions, auto-discovered by `colony-lint.sh`): spawns dashboard against `mktemp` fixture with three crafted log lines (raw-ms, ISO, no-timestamp), asserts wire-shape change works, Clear button structurally present, tooltip wired, no raw-ms leak in rendered rows, /kill regression smoke, unit contract guard for `relTime` units.
- **EDIT** `CLAUDE.md`: Tools row updated; baseline 49 → 50.

## Test plan

- [x] `tools/test-timeline-rendering.sh` — 8/8 pass (incl. unit-contract guard added in defensive commit)
- [x] `tools/test-kill-endpoint.sh` — 5/5 pass (regression #161)
- [x] `tools/test-kill-federation.sh` — 8/8 pass (regression #162)
- [x] `tools/test-dashboard-gates.sh` — 21/21 pass (regression #160)
- [x] `tools/colony-lint.sh` — `50 passed, 0 failed, 5 skipped`
- [x] `bash -n` clean
- [x] Manual JSON shape spot-check: `events[].ts` is bare integer in served HTML (`"ts": 1776250011452`, `"ts": 1776252238000`, `"ts": 0` for unparseable), no string timestamps remain
- [ ] End-to-end browser smoke (no headless infra; structural assertions cover the regression surface)

## Review trail

PR-reviewer agent ran locally before push. Verdict initially flagged `tools/federation-dashboard.sh:1848` as a BLOCKER (suspected unit mismatch on `recent_experience[].ts`). Verified the suspicion was a false alarm: `recent_experience[].ts` is epoch-seconds (written by agentis-core JSONL — confirmed by `e.get('ts') > epoch - 3600` comparison at line 275-276 where `epoch` is `date +%s`), distinct producer from the changed `events[].ts`. Added a defensive commit (`d0b0586`) covering: FED_NAME JSON-escape, inline unit comment, and a new Test 8 that structurally asserts the unit contract on both sides — so future refactors can't silently mix epoch-ms and epoch-seconds.

Closes #158
Follow-up: #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)