### PR TITLE
docs: adopt tier() convention for .ag confidence gating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,36 @@ colony-name/
 ## Agent conventions (.ag files)
 
 - `cb <N>;` at the top must match the `cb_budget` in colony.example.toml.
-- `get_confidence()` reads from `recall_latest("<agent_name>:confidence")`.
-- Confidence gradient: < 0.6 observe only, >= 0.6 emit suggestions, >= 0.85 act autonomously.
-- The four-tier confidence contract (`shadow` / `propose` / `review-gated` / `autonomous`) defined in [`doc/adr/ADR-0001-confidence-tiers.md`](./doc/adr/ADR-0001-confidence-tiers.md) is **normative** for all `.ag` scenarios in this repo. Forthcoming milestones of issue #173 replace the raw-threshold gradient above with `tier("<agent_name>")` branches.
+- **Gate behaviour on tiers, not raw thresholds.** Call `tier("<agent_name>")` (agentis-core builtin) and compare against one of the five name strings; never inline `confidence >= 0.X` literals. `colony-lint` enforces this.
+- The four-tier confidence contract defined in [`doc/adr/ADR-0001-confidence-tiers.md`](./doc/adr/ADR-0001-confidence-tiers.md) is **normative** for every `.ag` scenario in this repo.
+
+  | Tier           | Range         | Behaviour |
+  |----------------|---------------|-----------|
+  | `shadow`       | `[0.4, 0.6)`  | LLM + memo, no emit, no external write |
+  | `propose`      | `[0.6, 0.8)`  | + emit on bus + draft external writes |
+  | `review-gated` | `[0.8, 0.95)` | + direct external writes (non-terminal) |
+  | `autonomous`   | `[0.95, 1.0]` | + terminal writes (merge, tag, publish) |
+
+  Below `0.4` = `dormant`. The runtime also returns `"dormant"` when the memo is missing, so authors must handle it (typically collapsed into the `shadow` branch).
+
+  Canonical pattern (one `tier()` call per tick, branch once, fall through to `shadow`/`dormant`):
+
+  ```
+  fn tick(rec: string) -> void {
+      let my_tier = tier("style_reviewer");
+      if my_tier == "autonomous" {
+          // direct external write + learn(..., tags=[..., "acted"])
+      } else if my_tier == "review-gated" {
+          // draft external write pending approval + learn(..., tags=[..., "review-gated"])
+      } else if my_tier == "propose" {
+          // emit on bus + learn(..., tags=[..., "emitted"])
+      } else {
+          // shadow / dormant: observe only + learn(..., tags=[..., "observed"])
+      }
+  }
+  ```
+
+- `get_confidence()` reads from `recall_latest("<agent_name>:confidence")`. Use it for diagnostics or logging — not for branching.
 - `learn()` topic must match the topic in `recommend()` within the same agent.
 - `memo_write("<agent_name>:last_check", now)` at the end of every tick.
 - All dynamic values in `exec sh` calls must be wrapped in `shell_escape()`.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ graph TD
 
 When you need to reliably stop a federation — agents, dashboard, registry sidecar files, with a backup tarball before cleanup — use [`tools/kill-federation.sh`](./tools/kill-federation.sh) (or its per-federation wrapper, e.g. `dev-apprenticeship/kill-federation.sh`). It bypasses the `agentis` CLI and uses OS signals with post-kill verification, so it works even when `agentis daemon stop --all` reports false success or false failure. Run with `--help` for options including `--dry-run` and `--json`.
 
+## Tiers
+
+Every agent in this repo gates its behaviour on one of four named confidence tiers, not on raw numeric thresholds. Authors of `.ag` scenarios call the `tier("<agent_name>")` runtime builtin and compare against the tier name:
+
+| Tier           | Range         | What the agent may do |
+|----------------|---------------|-----------------------|
+| `shadow`       | `[0.4, 0.6)`  | LLM calls + memo writes; no emit, no external write |
+| `propose`      | `[0.6, 0.8)`  | ...plus emit on bus + draft external writes |
+| `review-gated` | `[0.8, 0.95)` | ...plus direct external writes (non-terminal) |
+| `autonomous`   | `[0.95, 1.0]` | ...plus terminal writes (merge, tag, publish) |
+
+Below `0.4` the agent is `dormant`. The full normative contract — per-tier action classes, migration rules, alternatives considered — lives in [`doc/adr/ADR-0001-confidence-tiers.md`](./doc/adr/ADR-0001-confidence-tiers.md).
+
 ## Design decisions
 
 Normative design decisions for this repository are recorded as Architecture Decision Records under [`doc/adr/`](./doc/adr/README.md). External authors of `.ag` federations should treat the ADRs as the source of truth for cross-repo contracts such as the confidence-tier ladder.


### PR DESCRIPTION
Closes #175.

## Summary

- `CLAUDE.md` "Agent conventions": replace the old `< 0.6 / >= 0.6 / >= 0.85` gradient rule with a normative `tier("<agent>")` rule + inline 4-tier table + canonical tick pattern. `get_confidence()` retained for diagnostics only.
- `README.md`: new "Tiers" section near the top (before "Design decisions") with a compact 4-row table and cross-link to `doc/adr/ADR-0001-confidence-tiers.md`.

M3 of the four-tier confidence gating work (#173). Depends on #179 (ADR-0001 landed) and Replikanti/agentis-core#537 (`tier()` builtin landed in core via Replikanti/agentis-core#539).

## Scope

Documentation only. No `.ag` file changes in this PR — M4 (#176) will migrate all 21 agents. `colony-lint` enforcement of the new rule lands in M5.

## Baseline (for M4 verification)

```
$ grep -r "confidence >= 0" dev-apprenticeship/ -l | wc -l
21
$ grep -r 'tier("' dev-apprenticeship/ -l | wc -l
0
```

M4 will drive the first to 0 and the second to ≥21.

## Test plan

- [x] `./tools/colony-lint.sh` → 50 passed, 0 failed, 5 skipped
- [x] Markdown renders correctly (tables, code block, links)
- [x] Cross-link `doc/adr/ADR-0001-confidence-tiers.md` resolves (file exists, landed in #180)
