### PR TITLE
refactor: migrate 21 dev-apprenticeship agents to tier() gating (M4, #176)

### DIFF
--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -75,11 +75,11 @@ fn tick(reason: string) -> void {
         all_findings
     ) -> ReviewDecision;
 
-    let confidence = get_confidence();
+    let my_tier = tier("approval_decider");
 
     print("[approval_decider] MR", decision.mr_iid, "-> action:", decision.action, "(", decision.total_findings, "findings,", decision.critical_count, "critical)");
 
-    if confidence >= 0.85 {
+    if my_tier == "autonomous" {
         if decision.action == "approve" {
             let approve_cmd = "$COLONY_DIR/scripts/gitlab-api.sh approve " + to_string(decision.mr_iid);
             try { exec sh approve_cmd; } catch e {
@@ -101,11 +101,26 @@ fn tick(reason: string) -> void {
             };
         };
     } else {
-        if confidence >= 0.6 {
-            print("[approval_decider] Suggesting:", decision.action, "for MR", decision.mr_iid);
+        if my_tier == "review-gated" {
+            // Non-terminal draft: post a draft-flagged summary on the MR so
+            // a human can promote the approve / request_changes action instead
+            // of acting directly.
+            let comment = "[draft-review-decision] **Review Summary** (automated, pending approval): suggested action `" + decision.action + "`\n\n" + decision.reasoning + "\n\nFindings: " + to_string(decision.total_findings) + " total, " + to_string(decision.critical_count) + " critical";
+            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment);
+            try { exec sh post_cmd; } catch e {
+                print("[approval_decider] Failed to post draft summary:", e);
+            };
             emit("review:decision_suggestion", decision);
+            learn("approval_decision", "MR " + to_string(decision.mr_iid), "drafted: " + decision.action + " — " + decision.reasoning, "partial", ["code-review", "review-gated"]);
         } else {
-            print("[approval_decider] Observing (confidence:", confidence, ")");
+            if my_tier == "propose" {
+                print("[approval_decider] Suggesting:", decision.action, "for MR", decision.mr_iid);
+                emit("review:decision_suggestion", decision);
+                learn("approval_decision", "MR " + to_string(decision.mr_iid), "suggested: " + decision.action + " — " + decision.reasoning, "partial", ["emitted", "code-review"]);
+            } else {
+                print("[approval_decider] Observing (tier:", my_tier, ")");
+                learn("approval_decision", "MR " + to_string(decision.mr_iid), "observed: " + decision.action + " — " + decision.reasoning, "partial", ["observed", "code-review"]);
+            };
         };
     };
 

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -92,22 +92,55 @@ fn tick(reason: string) -> void {
         context
     ) -> LogicReview;
 
-    let confidence = get_confidence();
+    let my_tier = tier("logic_reviewer");
 
     if len(review.findings) > 0 {
-        emit("review:logic_findings", review);
         print("[logic_reviewer] MR", mr_iid, ":", len(review.findings), "logic findings");
 
-        if confidence >= 0.85 {
+        if my_tier == "autonomous" {
+            emit("review:logic_findings", review);
             let comment = "**Logic Review** (automated)\n\n" + review.summary;
             let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             try { exec sh post_cmd; } catch e {
                 print("[logic_reviewer] Failed to post comment:", e);
             };
+            learn("logic_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted"]);
+        } else {
+            if my_tier == "review-gated" {
+                emit("review:logic_findings", review);
+                let comment = "[draft-review] **Logic Review** (automated, pending approval)\n\n" + review.summary;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                let result = try { exec sh post_cmd; } catch e {
+                    print("[logic_reviewer] Failed to post draft comment:", e);
+                    "";
+                };
+                if len(result) > 0 {
+                    memo_write("logic_reviewer:approved:" + to_string(mr_iid), "drafted");
+                    learn("logic_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated"]);
+                };
+            } else {
+                if my_tier == "propose" {
+                    emit("review:logic_findings", review);
+                    learn("logic_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                } else {
+                    print("[logic_reviewer] MR", mr_iid, ": observing (tier:", my_tier, ")");
+                    learn("logic_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                };
+            };
         };
     } else {
         print("[logic_reviewer] MR", mr_iid, ": clean");
-        emit("review:logic_findings", review);
+        if my_tier == "autonomous" {
+            emit("review:logic_findings", review);
+        } else {
+            if my_tier == "review-gated" {
+                emit("review:logic_findings", review);
+            } else {
+                if my_tier == "propose" {
+                    emit("review:logic_findings", review);
+                };
+            };
+        };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -93,22 +93,55 @@ fn tick(reason: string) -> void {
         context
     ) -> SecurityReview;
 
-    let confidence = get_confidence();
+    let my_tier = tier("security_reviewer");
 
     if len(review.findings) > 0 {
-        emit("review:security_findings", review);
         print("[security_reviewer] MR", mr_iid, ":", len(review.findings), "security findings");
 
-        if confidence >= 0.85 {
+        if my_tier == "autonomous" {
+            emit("review:security_findings", review);
             let comment = "**Security Review** (automated)\n\n" + review.summary;
             let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             try { exec sh post_cmd; } catch e {
                 print("[security_reviewer] Failed to post comment:", e);
             };
+            learn("security_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted"]);
+        } else {
+            if my_tier == "review-gated" {
+                emit("review:security_findings", review);
+                let comment = "[draft-review] **Security Review** (automated, pending approval)\n\n" + review.summary;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                let result = try { exec sh post_cmd; } catch e {
+                    print("[security_reviewer] Failed to post draft comment:", e);
+                    "";
+                };
+                if len(result) > 0 {
+                    memo_write("security_reviewer:approved:" + to_string(mr_iid), "drafted");
+                    learn("security_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated"]);
+                };
+            } else {
+                if my_tier == "propose" {
+                    emit("review:security_findings", review);
+                    learn("security_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                } else {
+                    print("[security_reviewer] MR", mr_iid, ": observing (tier:", my_tier, ")");
+                    learn("security_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                };
+            };
         };
     } else {
         print("[security_reviewer] MR", mr_iid, ": clean");
-        emit("review:security_findings", review);
+        if my_tier == "autonomous" {
+            emit("review:security_findings", review);
+        } else {
+            if my_tier == "review-gated" {
+                emit("review:security_findings", review);
+            } else {
+                if my_tier == "propose" {
+                    emit("review:security_findings", review);
+                };
+            };
+        };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -123,15 +123,14 @@ fn tick(reason: string) -> void {
         "MR author: " + mr_author + "\n" + context
     ) -> StyleReview;
 
-    let confidence = get_confidence();
+    let my_tier = tier("style_reviewer");
 
     if len(review.findings) > 0 {
-        // Emit findings to colony bus for approval_decider
-        emit("review:style_findings", review);
         print("[style_reviewer] MR", mr_iid, ":", len(review.findings), "style findings");
 
-        if confidence >= 0.85 {
-            // Post review comment directly
+        if my_tier == "autonomous" {
+            // Post review comment directly (terminal voice on the MR).
+            emit("review:style_findings", review);
             let comment = "**Style Review** (automated)\n\n" + review.summary;
             let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             let result = try { exec sh post_cmd; } catch e {
@@ -144,11 +143,48 @@ fn tick(reason: string) -> void {
                 learn("style_review", "posted on MR " + to_string(mr_iid), review.summary, "success", [scope, "code-review", "acted"]);
             };
         } else {
-            print("[style_reviewer] Confidence:", confidence, "- findings emitted to bus only");
+            if my_tier == "review-gated" {
+                // Draft external write: post with a [draft-review] prefix and
+                // record an approval marker so downstream promotion can pick it up.
+                emit("review:style_findings", review);
+                let comment = "[draft-review] **Style Review** (automated, pending approval)\n\n" + review.summary;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                let result = try { exec sh post_cmd; } catch e {
+                    print("[style_reviewer] Failed to post draft comment:", e);
+                    "";
+                };
+                if len(result) > 0 {
+                    memo_write("style_reviewer:approved:" + to_string(mr_iid), "drafted");
+                    let scope = scope_for_author(review.author);
+                    learn("style_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", [scope, "code-review", "review-gated"]);
+                };
+            } else {
+                if my_tier == "propose" {
+                    // Emit on bus for approval_decider; no external write.
+                    emit("review:style_findings", review);
+                    learn("style_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                } else {
+                    // shadow / dormant: observe only, no emit, no external write.
+                    print("[style_reviewer] MR", mr_iid, ": observing (tier:", my_tier, ")");
+                    learn("style_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                };
+            };
         };
     } else {
         print("[style_reviewer] MR", mr_iid, ": clean");
-        emit("review:style_findings", review);
+        // Emit the clean signal to the bus for all tiers that may contribute
+        // to downstream consumers (approval_decider). shadow/dormant stay silent.
+        if my_tier == "autonomous" {
+            emit("review:style_findings", review);
+        } else {
+            if my_tier == "review-gated" {
+                emit("review:style_findings", review);
+            } else {
+                if my_tier == "propose" {
+                    emit("review:style_findings", review);
+                };
+            };
+        };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -84,22 +84,55 @@ fn tick(reason: string) -> void {
         context
     ) -> TestReview;
 
-    let confidence = get_confidence();
+    let my_tier = tier("test_reviewer");
 
     if len(review.findings) > 0 {
-        emit("review:test_findings", review);
         print("[test_reviewer] MR", mr_iid, ":", len(review.findings), "test findings");
 
-        if confidence >= 0.85 {
+        if my_tier == "autonomous" {
+            emit("review:test_findings", review);
             let comment = "**Test Review** (automated)\n\n" + review.summary;
             let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             try { exec sh post_cmd; } catch e {
                 print("[test_reviewer] Failed to post comment:", e);
             };
+            learn("test_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted"]);
+        } else {
+            if my_tier == "review-gated" {
+                emit("review:test_findings", review);
+                let comment = "[draft-review] **Test Review** (automated, pending approval)\n\n" + review.summary;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                let result = try { exec sh post_cmd; } catch e {
+                    print("[test_reviewer] Failed to post draft comment:", e);
+                    "";
+                };
+                if len(result) > 0 {
+                    memo_write("test_reviewer:approved:" + to_string(mr_iid), "drafted");
+                    learn("test_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated"]);
+                };
+            } else {
+                if my_tier == "propose" {
+                    emit("review:test_findings", review);
+                    learn("test_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                } else {
+                    print("[test_reviewer] MR", mr_iid, ": observing (tier:", my_tier, ")");
+                    learn("test_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                };
+            };
         };
     } else {
         print("[test_reviewer] MR", mr_iid, ": adequate");
-        emit("review:test_findings", review);
+        if my_tier == "autonomous" {
+            emit("review:test_findings", review);
+        } else {
+            if my_tier == "review-gated" {
+                emit("review:test_findings", review);
+            } else {
+                if my_tier == "propose" {
+                    emit("review:test_findings", review);
+                };
+            };
+        };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -93,10 +93,10 @@ fn tick(reason: string) -> void {
             context
         ) -> CodeDraft;
 
-        let confidence = get_confidence();
-        print("[code_writer] Drafted code for issue", draft.issue_id, "(confidence:", confidence, ")");
+        let my_tier = tier("code_writer");
+        print("[code_writer] Drafted code for issue", draft.issue_id, "(tier:", my_tier, ")");
 
-        if confidence >= 0.85 {
+        if my_tier == "autonomous" {
             // Create branch
             let branch_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-branch --name " + shell_escape(draft.branch_name) + " --ref main";
             let branch_result = try { exec sh branch_cmd; } catch e {
@@ -129,11 +129,25 @@ fn tick(reason: string) -> void {
                 };
             };
         } else {
-            if confidence >= 0.6 {
+            if my_tier == "review-gated" {
+                // Non-terminal draft: post the implementation plan as a comment
+                // on the issue so a human can approve before we create a branch
+                // and commit code. No branch or commit at this tier.
+                let note = "[draft-impl] **Implementation Plan** (automated, pending approval)\n\nBranch: `" + draft.branch_name + "`\n\n" + draft.summary + "\n\nFiles:\n" + draft.files;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(note);
+                try { exec sh post_cmd; } catch e {
+                    print("[code_writer] Failed to post draft plan:", e);
+                };
                 emit("implementation:code_draft", draft);
-                learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["emitted", "implementation"]);
+                learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["implementation", "review-gated"]);
             } else {
-                print("[code_writer] Observing (confidence:", confidence, ")");
+                if my_tier == "propose" {
+                    emit("implementation:code_draft", draft);
+                    learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["emitted", "implementation"]);
+                } else {
+                    print("[code_writer] Observing (tier:", my_tier, ")");
+                    learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["observed", "implementation"]);
+                };
             };
         };
     };

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -108,10 +108,10 @@ fn tick(reason: string) -> void {
         context
     ) -> MRPlan;
 
-    let confidence = get_confidence();
-    print("[commit_composer] Composed MR plan for issue", plan.issue_id, "(confidence:", confidence, ")");
+    let my_tier = tier("commit_composer");
+    print("[commit_composer] Composed MR plan for issue", plan.issue_id, "(tier:", my_tier, ")");
 
-    if confidence >= 0.85 {
+    if my_tier == "autonomous" {
         // Create the MR
         let mr_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-mr --source " + shell_escape(plan.branch_name) + " --title " + shell_escape(plan.mr_title) + " --description " + shell_escape(plan.mr_description);
         let mr_result = try { exec sh mr_cmd; } catch e {
@@ -125,11 +125,24 @@ fn tick(reason: string) -> void {
             learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "success", ["acted", "implementation"]);
         };
     } else {
-        if confidence >= 0.6 {
+        if my_tier == "review-gated" {
+            // Non-terminal draft: post the MR plan as a comment on the issue
+            // so a human can approve before we actually open a non-draft MR.
+            let note = "[draft-mr] **Merge Request Plan** (automated, pending approval)\n\nBranch: `" + plan.branch_name + "`\nTitle: " + plan.mr_title + "\n\n" + plan.mr_description + "\n\nCommits:\n" + plan.commits;
+            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(plan.issue_id) + " --body " + shell_escape(note);
+            try { exec sh post_cmd; } catch e {
+                print("[commit_composer] Failed to post draft plan:", e);
+            };
             emit("implementation:mr_ready", plan);
-            learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["emitted", "implementation"]);
+            learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["implementation", "review-gated"]);
         } else {
-            print("[commit_composer] Observing (confidence:", confidence, ")");
+            if my_tier == "propose" {
+                emit("implementation:mr_ready", plan);
+                learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["emitted", "implementation"]);
+            } else {
+                print("[commit_composer] Observing (tier:", my_tier, ")");
+                learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["observed", "implementation"]);
+            };
         };
     };
 

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -91,10 +91,10 @@ fn tick(reason: string) -> void {
             context
         ) -> RefactorSuggestion;
 
-        let confidence = get_confidence();
-        print("[refactorer] Reviewed draft for issue", suggestion.issue_id, "(confidence:", confidence, ")");
+        let my_tier = tier("refactorer");
+        print("[refactorer] Reviewed draft for issue", suggestion.issue_id, "(tier:", my_tier, ")");
 
-        if confidence >= 0.85 {
+        if my_tier == "autonomous" {
             // Generate refactored code and commit to branch.
             // #131: read branch_name via field access on the bus-delivered
             // record instead of stringifying + re-prompting.
@@ -116,11 +116,25 @@ fn tick(reason: string) -> void {
                 learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "success", ["acted", "implementation"]);
             };
         } else {
-            if confidence >= 0.6 {
+            if my_tier == "review-gated" {
+                // Non-terminal draft: post the refactoring suggestions as a
+                // comment on the issue so a human can approve before we
+                // commit refactored files. No commit at this tier.
+                let note = "[draft-refactor] **Refactoring Suggestions** (automated, pending approval) — priority: " + suggestion.priority + "\n\n" + suggestion.suggestions;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(suggestion.issue_id) + " --body " + shell_escape(note);
+                try { exec sh post_cmd; } catch e {
+                    print("[refactorer] Failed to post draft note:", e);
+                };
                 emit("implementation:refactor_suggestions", suggestion);
-                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["emitted", "implementation"]);
+                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["implementation", "review-gated"]);
             } else {
-                print("[refactorer] Observing (confidence:", confidence, ")");
+                if my_tier == "propose" {
+                    emit("implementation:refactor_suggestions", suggestion);
+                    learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["emitted", "implementation"]);
+                } else {
+                    print("[refactorer] Observing (tier:", my_tier, ")");
+                    learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["observed", "implementation"]);
+                };
             };
         };
     };

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -90,10 +90,10 @@ fn tick(reason: string) -> void {
             context
         ) -> TestDraft;
 
-        let confidence = get_confidence();
-        print("[test_writer] Drafted tests for issue", tests.issue_id, "(confidence:", confidence, ")");
+        let my_tier = tier("test_writer");
+        print("[test_writer] Drafted tests for issue", tests.issue_id, "(tier:", my_tier, ")");
 
-        if confidence >= 0.85 {
+        if my_tier == "autonomous" {
             // Generate actual test file contents and commit to the branch
             let test_context = "Code draft: " + draft_str + "\nTest plan: " + tests.test_files + "\nPatterns: " + to_string(rec);
 
@@ -115,11 +115,24 @@ fn tick(reason: string) -> void {
                 learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "success", ["acted", "implementation"]);
             };
         } else {
-            if confidence >= 0.6 {
+            if my_tier == "review-gated" {
+                // Non-terminal draft: post the test plan as a comment on the
+                // issue so a human can approve before we commit test files.
+                let note = "[draft-tests] **Test Plan** (automated, pending approval)\n\nBranch: `" + tests.branch_name + "`\n\n" + tests.summary + "\n\nTest files:\n" + tests.test_files;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(tests.issue_id) + " --body " + shell_escape(note);
+                try { exec sh post_cmd; } catch e {
+                    print("[test_writer] Failed to post draft note:", e);
+                };
                 emit("implementation:test_draft", tests);
-                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["emitted", "implementation"]);
+                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["implementation", "review-gated"]);
             } else {
-                print("[test_writer] Observing (confidence:", confidence, ")");
+                if my_tier == "propose" {
+                    emit("implementation:test_draft", tests);
+                    learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["emitted", "implementation"]);
+                } else {
+                    print("[test_writer] Observing (tier:", my_tier, ")");
+                    learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["observed", "implementation"]);
+                };
             };
         };
     };

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -420,17 +420,18 @@ fi
 echo ""
 echo "Agent confidence seeding"
 echo ""
-echo "Agents start silent (confidence = 0.0). You choose the starting level:"
+echo "Agents start silent (confidence = 0.0). You choose the starting tier:"
 echo ""
-echo "  0.5  - Observe only (recommended for first run)"
-echo "  0.6  - Observe + emit suggestions for your review"
-echo "  0.85 - Full autonomy (agents act on their own)"
+echo "  0.4  - shadow (recommended, observe-only; see ADR-0001)"
+echo "  0.6  - propose (emit suggestions on the bus)"
+echo "  0.8  - review-gated (draft external writes under human review)"
+echo "  0.95 - autonomous (terminal writes without a second gate)"
 echo "  skip - Do not seed, configure manually later"
 echo ""
 
-ask "Starting confidence [0.5]:"
+ask "Starting confidence [0.4]:"
 read -r CONFIDENCE
-CONFIDENCE="${CONFIDENCE:-0.5}"
+CONFIDENCE="${CONFIDENCE:-0.4}"
 
 if [ "$CONFIDENCE" != "skip" ]; then
     # Validate: must be a number between 0.0 and 1.0
@@ -440,17 +441,36 @@ if [ "$CONFIDENCE" != "skip" ]; then
     fi
     echo ""
     echo "Seeding all 21 agents at $CONFIDENCE..."
+    # #173 / #176: idempotent seeding. Never downgrade an existing memo
+    # value — an operator may have deliberately promoted an agent before
+    # re-running install.sh. Only write when the memo is missing or its
+    # value is strictly below the new seed.
     SEED_FAILED=0
+    SEED_KEPT=0
+    SEED_WROTE=0
     for agent in "${ALL_AGENTS[@]}"; do
-        if ! agentis memo set "${agent}:confidence" "$CONFIDENCE" 2>/dev/null; then
-            fail "Failed to seed ${agent}:confidence"
-            SEED_FAILED=1
+        existing="$(agentis memo get "${agent}:confidence" 2>/dev/null || true)"
+        keep=0
+        if [ -n "$existing" ]; then
+            if python3 -c "import sys; sys.exit(0 if float(sys.argv[1]) >= float(sys.argv[2]) else 1)" "$existing" "$CONFIDENCE" 2>/dev/null; then
+                keep=1
+            fi
+        fi
+        if [ "$keep" -eq 1 ]; then
+            SEED_KEPT=$((SEED_KEPT + 1))
+        else
+            if ! agentis memo set "${agent}:confidence" "$CONFIDENCE" 2>/dev/null; then
+                fail "Failed to seed ${agent}:confidence"
+                SEED_FAILED=1
+            else
+                SEED_WROTE=$((SEED_WROTE + 1))
+            fi
         fi
     done
     if [ "$SEED_FAILED" -eq 1 ]; then
         fail "Some seeds failed. Is agentis initialized? Try: agentis init"
     else
-        ok "All agents seeded at $CONFIDENCE"
+        ok "Seeded $SEED_WROTE agents at $CONFIDENCE (kept $SEED_KEPT already at or above)"
     fi
 fi
 

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -134,11 +134,12 @@ fn tick(reason: string) -> void {
         context
     ) -> DraftPlan;
 
-    let confidence = get_confidence();
+    let my_tier = tier("plan_reviewer");
 
     print("[plan_reviewer] Issue", draft.issue_id, "-> review_score:", draft.review_score);
 
-    if confidence >= 0.85 {
+    if my_tier == "autonomous" {
+        // Direct external write: post the plan as an issue note.
         let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft.plan);
         try { exec sh post_cmd; } catch e {
             print("[plan_reviewer] Failed to post note:", e);
@@ -152,18 +153,43 @@ fn tick(reason: string) -> void {
         );
         print("[plan_reviewer] Posted plan to issue", draft.issue_id);
     } else {
-        if confidence >= 0.6 {
-            emit("planning:draft_plan", draft);
+        if my_tier == "review-gated" {
+            // Draft external write: post with [draft-plan] prefix so a human
+            // reviewer can promote or discard it.
+            let draft_body = "[draft-plan] **Plan Review** (automated, pending approval)\n\n" + draft.plan;
+            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft_body);
+            try { exec sh post_cmd; } catch e {
+                print("[plan_reviewer] Failed to post draft note:", e);
+            };
             learn(
                 "review_plan",
                 "issue " + to_string(draft.issue_id),
-                "emitted: score=" + to_string(draft.review_score),
+                "drafted: score=" + to_string(draft.review_score),
                 "partial",
-                ["emitted", "planning"]
+                ["planning", "review-gated"]
             );
-            print("[plan_reviewer] Emitted draft plan for issue", draft.issue_id);
+            print("[plan_reviewer] Drafted plan for issue", draft.issue_id);
         } else {
-            print("[plan_reviewer] Observing (confidence:", confidence, ")");
+            if my_tier == "propose" {
+                emit("planning:draft_plan", draft);
+                learn(
+                    "review_plan",
+                    "issue " + to_string(draft.issue_id),
+                    "emitted: score=" + to_string(draft.review_score),
+                    "partial",
+                    ["emitted", "planning"]
+                );
+                print("[plan_reviewer] Emitted draft plan for issue", draft.issue_id);
+            } else {
+                print("[plan_reviewer] Observing (tier:", my_tier, ")");
+                learn(
+                    "review_plan",
+                    "issue " + to_string(draft.issue_id),
+                    "observed: score=" + to_string(draft.review_score),
+                    "partial",
+                    ["observed", "planning"]
+                );
+            };
         };
     };
 

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -86,21 +86,59 @@ fn tick(reason: string) -> void {
         context
     ) -> RiskAssessment;
 
-    let confidence = get_confidence();
+    let my_tier = tier("risk_assessor");
 
     print("[risk_assessor] Issue", assessment.issue_id, "-> severity:", assessment.severity);
 
-    if confidence >= 0.6 {
+    if my_tier == "autonomous" {
+        // Direct external write: post the risk assessment as an issue note.
         emit("planning:risks", assessment);
+        let note = "**Risk Assessment** (automated): " + assessment.severity + "\n\n" + assessment.risks;
+        let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(assessment.issue_id) + " --body " + shell_escape(note);
+        try { exec sh post_cmd; } catch e {
+            print("[risk_assessor] Failed to post note:", e);
+        };
         learn(
             "risk_assessment",
             "issue " + to_string(assessment.issue_id),
             assessment.severity + ": " + assessment.risks,
-            "partial",
-            ["emitted", "planning"]
+            "success",
+            ["acted", "planning"]
         );
     } else {
-        print("[risk_assessor] Observing (confidence:", confidence, ")");
+        if my_tier == "review-gated" {
+            // Draft external write: stash in plan_reviewer's memo slot so
+            // plan_reviewer can pick it up and optionally promote to a real post.
+            emit("planning:risks", assessment);
+            memo_write("plan_reviewer:" + to_string(assessment.issue_id) + ":risks_drafted", "true");
+            learn(
+                "risk_assessment",
+                "issue " + to_string(assessment.issue_id),
+                assessment.severity + ": " + assessment.risks,
+                "partial",
+                ["planning", "review-gated"]
+            );
+        } else {
+            if my_tier == "propose" {
+                emit("planning:risks", assessment);
+                learn(
+                    "risk_assessment",
+                    "issue " + to_string(assessment.issue_id),
+                    assessment.severity + ": " + assessment.risks,
+                    "partial",
+                    ["emitted", "planning"]
+                );
+            } else {
+                print("[risk_assessor] Observing (tier:", my_tier, ")");
+                learn(
+                    "risk_assessment",
+                    "issue " + to_string(assessment.issue_id),
+                    assessment.severity + ": " + assessment.risks,
+                    "partial",
+                    ["observed", "planning"]
+                );
+            };
+        };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -87,21 +87,56 @@ fn tick(reason: string) -> void {
         context
     ) -> ScopeEstimate;
 
-    let confidence = get_confidence();
+    let my_tier = tier("scope_estimator");
 
     print("[scope_estimator] Issue", estimate.issue_id, "->", estimate.phases, "phases,", estimate.points, "points");
 
-    if confidence >= 0.6 {
+    if my_tier == "autonomous" {
         emit("planning:scope_estimate", estimate);
+        let note = "**Scope Estimate** (automated): " + to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points\n\n" + estimate.reasoning;
+        let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(estimate.issue_id) + " --body " + shell_escape(note);
+        try { exec sh post_cmd; } catch e {
+            print("[scope_estimator] Failed to post note:", e);
+        };
         learn(
             "scope_estimate",
             "issue " + to_string(estimate.issue_id),
             to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
-            "partial",
-            ["emitted", "planning"]
+            "success",
+            ["acted", "planning"]
         );
     } else {
-        print("[scope_estimator] Observing (confidence:", confidence, ")");
+        if my_tier == "review-gated" {
+            emit("planning:scope_estimate", estimate);
+            memo_write("plan_reviewer:" + to_string(estimate.issue_id) + ":scope_drafted", "true");
+            learn(
+                "scope_estimate",
+                "issue " + to_string(estimate.issue_id),
+                to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                "partial",
+                ["planning", "review-gated"]
+            );
+        } else {
+            if my_tier == "propose" {
+                emit("planning:scope_estimate", estimate);
+                learn(
+                    "scope_estimate",
+                    "issue " + to_string(estimate.issue_id),
+                    to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                    "partial",
+                    ["emitted", "planning"]
+                );
+            } else {
+                print("[scope_estimator] Observing (tier:", my_tier, ")");
+                learn(
+                    "scope_estimate",
+                    "issue " + to_string(estimate.issue_id),
+                    to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                    "partial",
+                    ["observed", "planning"]
+                );
+            };
+        };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -87,21 +87,56 @@ fn tick(reason: string) -> void {
         context
     ) -> TaskBreakdown;
 
-    let confidence = get_confidence();
+    let my_tier = tier("task_decomposer");
 
     print("[task_decomposer] Issue", breakdown.issue_id, "->", breakdown.count, "subtasks");
 
-    if confidence >= 0.6 {
+    if my_tier == "autonomous" {
         emit("planning:breakdown", breakdown);
+        let note = "**Task Breakdown** (automated): " + to_string(breakdown.count) + " subtasks\n\n" + breakdown.subtasks;
+        let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(breakdown.issue_id) + " --body " + shell_escape(note);
+        try { exec sh post_cmd; } catch e {
+            print("[task_decomposer] Failed to post note:", e);
+        };
         learn(
             "task_decomposition",
             "issue " + to_string(breakdown.issue_id),
             to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
-            "partial",
-            ["emitted", "planning"]
+            "success",
+            ["acted", "planning"]
         );
     } else {
-        print("[task_decomposer] Observing (confidence:", confidence, ")");
+        if my_tier == "review-gated" {
+            emit("planning:breakdown", breakdown);
+            memo_write("plan_reviewer:" + to_string(breakdown.issue_id) + ":breakdown_drafted", "true");
+            learn(
+                "task_decomposition",
+                "issue " + to_string(breakdown.issue_id),
+                to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                "partial",
+                ["planning", "review-gated"]
+            );
+        } else {
+            if my_tier == "propose" {
+                emit("planning:breakdown", breakdown);
+                learn(
+                    "task_decomposition",
+                    "issue " + to_string(breakdown.issue_id),
+                    to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                    "partial",
+                    ["emitted", "planning"]
+                );
+            } else {
+                print("[task_decomposer] Observing (tier:", my_tier, ")");
+                learn(
+                    "task_decomposition",
+                    "issue " + to_string(breakdown.issue_id),
+                    to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                    "partial",
+                    ["observed", "planning"]
+                );
+            };
+        };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -117,10 +117,13 @@ fn tick(reason: string) -> void {
             context
         ) -> ChangelogDraft;
 
-        let confidence = get_confidence();
-        print("[changelog_writer] Drafted changelog for", draft.version, "(", draft.mr_count, "MRs, confidence:", confidence, ")");
+        let my_tier = tier("changelog_writer");
+        print("[changelog_writer] Drafted changelog for", draft.version, "(", draft.mr_count, "MRs, tier:", my_tier, ")");
 
-        if confidence >= 0.85 {
+        // Posting a release-notes draft as a note on the MR is a non-terminal
+        // external write. The terminal action (create-release / create-tag)
+        // belongs to version_bumper and is gated on autonomous there.
+        if my_tier == "autonomous" {
             let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
             let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
             if mr_iid > 0 {
@@ -133,11 +136,26 @@ fn tick(reason: string) -> void {
             emit("release:changelog_draft", draft);
             learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "success", ["acted", "release"]);
         } else {
-            if confidence >= 0.6 {
+            if my_tier == "review-gated" {
+                let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+                let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
+                if mr_iid > 0 {
+                    let note = "[draft-changelog] **Release Notes Draft** (automated, pending approval)\n\n" + draft.changelog;
+                    let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                    try { exec sh post_cmd; } catch e {
+                        print("[changelog_writer] Failed to post draft note:", e);
+                    };
+                };
                 emit("release:changelog_draft", draft);
-                learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["emitted", "release"]);
+                learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["release", "review-gated"]);
             } else {
-                print("[changelog_writer] Observing (confidence:", confidence, ")");
+                if my_tier == "propose" {
+                    emit("release:changelog_draft", draft);
+                    learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["emitted", "release"]);
+                } else {
+                    print("[changelog_writer] Observing (tier:", my_tier, ")");
+                    learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["observed", "release"]);
+                };
             };
         };
     };

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -115,10 +115,12 @@ fn tick(reason: string) -> void {
                 context_full
             ) -> CheckResult;
 
-            let confidence = get_confidence();
-            print("[release_checker] Checked main pipeline:", result.ci_status, "(confidence:", confidence, ")");
+            let my_tier = tier("release_checker");
+            print("[release_checker] Checked main pipeline:", result.ci_status, "(tier:", my_tier, ")");
 
-            if confidence >= 0.85 {
+            // release_checker produces a non-terminal diagnostic: posting a
+            // check-result note on the MR is never a release-terminal action.
+            if my_tier == "autonomous" {
                 // #131: mr_ready is emitted by commit_composer as an
                 // MRPlan record whose issue_id is the GitLab iid — read
                 // via field access instead of prompting.
@@ -133,11 +135,25 @@ fn tick(reason: string) -> void {
                 emit("release:check_result", result);
                 learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "success", ["acted", "release"]);
             } else {
-                if confidence >= 0.6 {
+                if my_tier == "review-gated" {
+                    let mr_iid = mr_ready.issue_id;
+                    if mr_iid > 0 {
+                        let note = "[draft-check] **Pre-release Check** (automated, pending approval): " + result.ci_status + "\n\nIssues: " + result.issues_found;
+                        let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                        try { exec sh post_cmd; } catch e {
+                            print("[release_checker] Failed to post draft note:", e);
+                        };
+                    };
                     emit("release:check_result", result);
-                    learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["emitted", "release"]);
+                    learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["release", "review-gated"]);
                 } else {
-                    print("[release_checker] Observing (confidence:", confidence, ")");
+                    if my_tier == "propose" {
+                        emit("release:check_result", result);
+                        learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["emitted", "release"]);
+                    } else {
+                        print("[release_checker] Observing (tier:", my_tier, ")");
+                        learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["observed", "release"]);
+                    };
                 };
             };
         } else {
@@ -147,14 +163,21 @@ fn tick(reason: string) -> void {
                 context
             ) -> CheckResult;
 
-            let confidence = get_confidence();
-            if confidence >= 0.85 {
+            let my_tier = tier("release_checker");
+            if my_tier == "autonomous" {
                 emit("release:check_result", result);
                 learn("release_check", "periodic check", result.ci_status, "success", ["acted", "release"]);
             } else {
-                if confidence >= 0.6 {
+                if my_tier == "review-gated" {
                     emit("release:check_result", result);
-                    learn("release_check", "periodic check", result.ci_status, "partial", ["emitted", "release"]);
+                    learn("release_check", "periodic check", result.ci_status, "partial", ["release", "review-gated"]);
+                } else {
+                    if my_tier == "propose" {
+                        emit("release:check_result", result);
+                        learn("release_check", "periodic check", result.ci_status, "partial", ["emitted", "release"]);
+                    } else {
+                        learn("release_check", "periodic check", result.ci_status, "partial", ["observed", "release"]);
+                    };
                 };
             };
         };

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -114,10 +114,14 @@ fn tick(reason: string) -> void {
         context
     ) -> ShipDecision;
 
-    let confidence = get_confidence();
-    print("[ship_decider] Decision:", decision.decision, "(confidence:", confidence, ")");
+    let my_tier = tier("ship_decider");
+    print("[ship_decider] Decision:", decision.decision, "(tier:", my_tier, ")");
 
-    if confidence >= 0.85 {
+    // ship_decider produces a non-terminal signal — it never tags, merges,
+    // or publishes. autonomous = post directly to the MR + emit on bus.
+    // review-gated = post draft-flagged note + emit. propose = emit only.
+    // shadow/dormant = observe.
+    if my_tier == "autonomous" {
         let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
         let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
         if mr_iid > 0 {
@@ -130,11 +134,26 @@ fn tick(reason: string) -> void {
         emit("release:ship_decision", decision);
         learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "success", ["acted", "release"]);
     } else {
-        if confidence >= 0.6 {
+        if my_tier == "review-gated" {
+            let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+            let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
+            if mr_iid > 0 {
+                let note = "[draft-ship] **Ship Decision** (automated, pending approval): " + decision.decision + "\n\n" + decision.reasoning;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                try { exec sh post_cmd; } catch e {
+                    print("[ship_decider] Failed to post draft note:", e);
+                };
+            };
             emit("release:ship_decision", decision);
-            learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["emitted", "release"]);
+            learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["release", "review-gated"]);
         } else {
-            print("[ship_decider] Observing (confidence:", confidence, ")");
+            if my_tier == "propose" {
+                emit("release:ship_decision", decision);
+                learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["emitted", "release"]);
+            } else {
+                print("[ship_decider] Observing (tier:", my_tier, ")");
+                learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["observed", "release"]);
+            };
         };
     };
 

--- a/dev-apprenticeship/release/agents/version_bumper.ag
+++ b/dev-apprenticeship/release/agents/version_bumper.ag
@@ -122,10 +122,13 @@ fn tick(reason: string) -> void {
         context
     ) -> VersionBump;
 
-    let confidence = get_confidence();
-    print("[version_bumper] Version bump:", bump.current, "->", bump.next, "(", bump.bump_type, ", confidence:", confidence, ")");
+    let my_tier = tier("version_bumper");
+    print("[version_bumper] Version bump:", bump.current, "->", bump.next, "(", bump.bump_type, ", tier:", my_tier, ")");
 
-    if confidence >= 0.85 {
+    // create-tag + create-release are TERMINAL actions (cannot be withdrawn
+    // by a subsequent automated step). Per ADR-0001 terminal actions require
+    // the `autonomous` tier. review-gated may only produce a draft/proposal.
+    if my_tier == "autonomous" {
         // Create the tag
         // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
         let tag_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-tag --name " + shell_escape(bump.next) + " --ref main --message " + shell_escape("Release " + bump.next);
@@ -155,11 +158,29 @@ fn tick(reason: string) -> void {
             learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "success", ["acted", "release"]);
         };
     } else {
-        if confidence >= 0.6 {
+        if my_tier == "review-gated" {
+            // Non-terminal proposal: post a draft note on the latest MR flagged as
+            // a pending bump so a human can approve before we tag. No tag/release
+            // is created at this tier.
+            let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+            let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
+            if mr_iid > 0 {
+                let note = "[draft-bump] **Version Bump Proposal** (automated, pending approval): " + bump.current + " -> " + bump.next + " (" + bump.bump_type + ")\n\n" + bump.reasoning;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                try { exec sh post_cmd; } catch e {
+                    print("[version_bumper] Failed to post draft bump note:", e);
+                };
+            };
             emit("release:version_bumped", bump);
-            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["emitted", "release"]);
+            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["release", "review-gated"]);
         } else {
-            print("[version_bumper] Observing (confidence:", confidence, ")");
+            if my_tier == "propose" {
+                emit("release:version_bumped", bump);
+                learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["emitted", "release"]);
+            } else {
+                print("[version_bumper] Observing (tier:", my_tier, ")");
+                learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["observed", "release"]);
+            };
         };
     };
 

--- a/dev-apprenticeship/triage/agents/issue_creator.ag
+++ b/dev-apprenticeship/triage/agents/issue_creator.ag
@@ -71,7 +71,7 @@ fn tick(reason: string) -> void {
     let inbox = try { poll_inbox(); } catch e { ""; };
 
     if len(to_string(inbox)) > 5 {
-        let confidence = get_confidence();
+        let my_tier = tier("issue_creator");
         let rec = recommend("create_issue", ["accuracy", "style"]);
         let context = "Event: " + to_string(inbox) + "\nPast learning: " + to_string(rec);
 
@@ -80,7 +80,7 @@ fn tick(reason: string) -> void {
             context
         ) -> DraftIssue;
 
-        if confidence >= 0.85 {
+        if my_tier == "autonomous" {
             let create_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-issue --title " + shell_escape(draft.title) + " --description " + shell_escape(draft.description) + " --labels " + shell_escape(draft.suggested_labels);
             let result = try {
                 exec sh create_cmd;
@@ -91,13 +91,25 @@ fn tick(reason: string) -> void {
             if len(result) > 0 {
                 print("[issue_creator] Created issue:", draft.title);
                 emit("triage:new_issue", draft);
+                learn("create_issue", "created", draft.title, "success", ["acted", "triage"]);
             };
         } else {
-            if confidence >= 0.6 {
-                print("[issue_creator] Suggesting issue:", draft.title);
+            if my_tier == "review-gated" {
+                // Non-terminal draft: emit the draft on the bus. A human
+                // reviewer can promote it; the actual `create-issue` call
+                // stays behind the autonomous branch.
+                print("[issue_creator] Drafted issue (pending approval):", draft.title);
                 emit("triage:new_issue", draft);
+                learn("create_issue", "drafted", draft.title, "partial", ["triage", "review-gated"]);
             } else {
-                print("[issue_creator] Observing (confidence:", confidence, ")");
+                if my_tier == "propose" {
+                    print("[issue_creator] Suggesting issue:", draft.title);
+                    emit("triage:new_issue", draft);
+                    learn("create_issue", "suggested", draft.title, "partial", ["emitted", "triage"]);
+                } else {
+                    print("[issue_creator] Observing (tier:", my_tier, ")");
+                    learn("create_issue", "observed", draft.title, "partial", ["observed", "triage"]);
+                };
             };
         };
     };

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -199,7 +199,7 @@ fn tick(reason: string) -> void {
 
     // Suggest/apply labels for unlabeled issues
     if analysis.unlabeled_count > 0 {
-        let confidence = get_confidence();
+        let my_tier = tier("labeler");
         let rec = recommend("label", ["accuracy"]);
         let labels_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh labels --view summary"; } catch e { "[]"; };
         let context = "Unlabeled issues: " + analysis.unlabeled_issues + "\nAvailable labels: " + labels_raw + "\nPast learning: " + to_string(rec);
@@ -209,7 +209,7 @@ fn tick(reason: string) -> void {
             context
         ) -> LabelAction;
 
-        if confidence >= 0.85 {
+        if my_tier == "autonomous" {
             let update_cmd = "$COLONY_DIR/scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.labels);
             let result = try { exec sh update_cmd; } catch e {
                 print("[labeler] Failed to apply labels:", e);
@@ -219,20 +219,40 @@ fn tick(reason: string) -> void {
                 print("[labeler] Applied labels to issue", action.issue_id, ":", action.labels);
                 // #104: tag knowledge as personal (operator's issue) vs team.
                 let scope = scope_for_author(action.author);
+                emit("triage:label_suggestion", action);
                 learn("label", "issue " + to_string(action.issue_id), action.labels, "success", [scope, "triage", "acted"]);
             };
         } else {
-            if confidence >= 0.6 {
-                print("[labeler] Suggesting labels for issue", action.issue_id, ":", action.labels);
+            if my_tier == "review-gated" {
+                let note = "[draft-labels] **Label Suggestion** (automated, pending approval): " + action.labels + "\n\n" + action.reasoning;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(action.issue_id) + " --body " + shell_escape(note);
+                try { exec sh post_cmd; } catch e {
+                    print("[labeler] Failed to post draft note:", e);
+                };
                 emit("triage:label_suggestion", action);
-                // #106: stash the verdict so next tick can score this
-                // suggestion against whatever the operator actually does
-                // to the issue. Only records at SUGGEST level — at ACT
-                // (>= 0.85) the agent writes its own labels, so there's
-                // no separable operator signal to score against.
+                // #106: stash the verdict so the next tick can score this
+                // suggestion against whatever the operator eventually applies
+                // to the issue.
                 record_label_verdict(action.issue_id, action.labels);
+                let scope = scope_for_author(action.author);
+                learn("label", "issue " + to_string(action.issue_id), action.labels, "partial", [scope, "triage", "review-gated"]);
             } else {
-                print("[labeler] Observing (confidence:", confidence, ")");
+                if my_tier == "propose" {
+                    print("[labeler] Suggesting labels for issue", action.issue_id, ":", action.labels);
+                    emit("triage:label_suggestion", action);
+                    // #106: stash the verdict so next tick can score this
+                    // suggestion against whatever the operator actually does
+                    // to the issue. Only records at propose/review-gated level —
+                    // at autonomous the agent writes its own labels, so there's
+                    // no separable operator signal to score against.
+                    record_label_verdict(action.issue_id, action.labels);
+                    let scope = scope_for_author(action.author);
+                    learn("label", "issue " + to_string(action.issue_id), action.labels, "partial", [scope, "triage", "emitted"]);
+                } else {
+                    print("[labeler] Observing (tier:", my_tier, ")");
+                    let scope = scope_for_author(action.author);
+                    learn("label", "issue " + to_string(action.issue_id), action.labels, "partial", [scope, "triage", "observed"]);
+                };
             };
         };
     };

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -92,7 +92,7 @@ fn tick(reason: string) -> void {
 
     // Suggest/apply priority for unprioritized issues
     if analysis.unprioritized_count > 0 {
-        let confidence = get_confidence();
+        let my_tier = tier("prioritizer");
         let rec = recommend("prioritize", ["accuracy"]);
         let context = "Unprioritized issues: " + analysis.unprioritized_issues + "\nPast learning: " + to_string(rec);
 
@@ -101,7 +101,7 @@ fn tick(reason: string) -> void {
             context
         ) -> PriorityAction;
 
-        if confidence >= 0.85 {
+        if my_tier == "autonomous" {
             let update_cmd = "$COLONY_DIR/scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.priority);
             let result = try { exec sh update_cmd; } catch e {
                 print("[prioritizer] Failed to set priority:", e);
@@ -111,14 +111,30 @@ fn tick(reason: string) -> void {
                 print("[prioritizer] Set priority on issue", action.issue_id, ":", action.priority);
                 // #104: tag knowledge as personal vs team.
                 let scope = scope_for_author(action.author);
+                emit("triage:priority_suggestion", action);
                 learn("prioritize", "issue " + to_string(action.issue_id), action.priority, "success", [scope, "triage", "acted"]);
             };
         } else {
-            if confidence >= 0.6 {
-                print("[prioritizer] Suggesting priority for issue", action.issue_id, ":", action.priority);
+            if my_tier == "review-gated" {
+                let note = "[draft-priority] **Priority Suggestion** (automated, pending approval): " + action.priority + "\n\n" + action.reasoning;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(action.issue_id) + " --body " + shell_escape(note);
+                try { exec sh post_cmd; } catch e {
+                    print("[prioritizer] Failed to post draft note:", e);
+                };
                 emit("triage:priority_suggestion", action);
+                let scope = scope_for_author(action.author);
+                learn("prioritize", "issue " + to_string(action.issue_id), action.priority, "partial", [scope, "triage", "review-gated"]);
             } else {
-                print("[prioritizer] Observing (confidence:", confidence, ")");
+                if my_tier == "propose" {
+                    print("[prioritizer] Suggesting priority for issue", action.issue_id, ":", action.priority);
+                    emit("triage:priority_suggestion", action);
+                    let scope = scope_for_author(action.author);
+                    learn("prioritize", "issue " + to_string(action.issue_id), action.priority, "partial", [scope, "triage", "emitted"]);
+                } else {
+                    print("[prioritizer] Observing (tier:", my_tier, ")");
+                    let scope = scope_for_author(action.author);
+                    learn("prioritize", "issue " + to_string(action.issue_id), action.priority, "partial", [scope, "triage", "observed"]);
+                };
             };
         };
     };

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -83,7 +83,7 @@ fn tick(reason: string) -> void {
 
     // Suggest/apply routing for unassigned issues
     if analysis.unassigned_count > 0 {
-        let confidence = get_confidence();
+        let my_tier = tier("router");
         let rec = recommend("route", ["accuracy"]);
         let context = "Unassigned issues: " + analysis.unassigned_issues + "\nTeam members: " + members_raw + "\nPast learning: " + to_string(rec);
 
@@ -92,7 +92,7 @@ fn tick(reason: string) -> void {
             context
         ) -> RouteAction;
 
-        if confidence >= 0.85 {
+        if my_tier == "autonomous" {
             let update_cmd = "$COLONY_DIR/scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --assignee " + shell_escape(action.assignee);
             let result = try { exec sh update_cmd; } catch e {
                 print("[router] Failed to assign:", e);
@@ -100,14 +100,29 @@ fn tick(reason: string) -> void {
             };
             if len(result) > 0 {
                 print("[router] Assigned issue", action.issue_id, "to", action.assignee);
+                emit("triage:route_suggestion", action);
                 learn("route", "issue " + to_string(action.issue_id), action.assignee, "success", ["acted", "triage"]);
             };
         } else {
-            if confidence >= 0.6 {
-                print("[router] Suggesting assignee for issue", action.issue_id, ":", action.assignee);
+            if my_tier == "review-gated" {
+                // Non-terminal draft: emit the suggestion and post an issue note
+                // flagged for human approval instead of directly assigning.
+                let note = "[draft-route] **Routing Suggestion** (automated, pending approval): assign to @" + action.assignee + "\n\n" + action.reasoning;
+                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(action.issue_id) + " --body " + shell_escape(note);
+                try { exec sh post_cmd; } catch e {
+                    print("[router] Failed to post draft note:", e);
+                };
                 emit("triage:route_suggestion", action);
+                learn("route", "issue " + to_string(action.issue_id), action.assignee, "partial", ["triage", "review-gated"]);
             } else {
-                print("[router] Observing (confidence:", confidence, ")");
+                if my_tier == "propose" {
+                    print("[router] Suggesting assignee for issue", action.issue_id, ":", action.assignee);
+                    emit("triage:route_suggestion", action);
+                    learn("route", "issue " + to_string(action.issue_id), action.assignee, "partial", ["emitted", "triage"]);
+                } else {
+                    print("[router] Observing (tier:", my_tier, ")");
+                    learn("route", "issue " + to_string(action.issue_id), action.assignee, "partial", ["observed", "triage"]);
+                };
             };
         };
     };

--- a/tools/federation-dashboard-collector.py
+++ b/tools/federation-dashboard-collector.py
@@ -130,10 +130,24 @@ for agent in all_agents:
                 break
         rec['description'] = '\n'.join(desc_lines)
 
-        # #160: extract `if confidence >= X` gates with line numbers, plus
-        # clamp_auto cap idiom (currently only labeler.ag, gates promote at 0.85).
+        # #160 + #176: extract confidence gates. After M4 (#176) agents branch on
+        # tier("<name>") == "<tier>" instead of raw confidence literals. Map
+        # each tier-branch back to its numeric lower bound so downstream tooling
+        # (dashboard promote/demote buttons, auto-promote.sh) keeps working.
+        # Fall back to the pre-M4 `if confidence >= X` form if the agent has
+        # not been migrated yet. clamp_auto cap idiom is unchanged.
+        TIER_LEVELS = {
+            'shadow': 0.4,
+            'propose': 0.6,
+            'review-gated': 0.8,
+            'autonomous': 0.95,
+        }
         gates = []
         for lineno, line in enumerate(ag_lines, 1):
+            m_tier = re.search(r'my_tier\s*==\s*"(shadow|propose|review-gated|autonomous)"', line)
+            if m_tier:
+                gates.append({'level': TIER_LEVELS[m_tier.group(1)], 'line': lineno, 'tier': m_tier.group(1)})
+                continue
             m = re.search(r'\bif\s+confidence\s+>=\s+([0-9]+(?:\.[0-9]+)?)', line)
             if m:
                 gates.append({'level': float(m.group(1)), 'line': lineno})

--- a/tools/test-dashboard-gates.sh
+++ b/tools/test-dashboard-gates.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 # tools/test-dashboard-gates.sh: smoke test for the confidence_gates / cap
-# parser used by the federation dashboard (#160).
+# parser used by the federation dashboard (#160, retargeted for #176).
 #
-# Runs the same regex the dashboard uses against every .ag file in
-# dev-apprenticeship/ and asserts the extracted set of gate levels matches the
-# manually-curated table in #160. Catches two regressions:
-#   - someone changes the regex in federation-dashboard.sh and forgets here
-#   - someone edits an .ag file and removes / adds a gate the table assumes
+# After M4 (#176) all 21 dev-apprenticeship agents branch on
+# `tier("<agent>") == "<tier_name>"` instead of raw `confidence >= X`
+# literals. This test runs the same regex the dashboard uses against
+# every .ag file in dev-apprenticeship/ and asserts the extracted set
+# of tier-branches matches the expected set per agent. Catches two
+# regressions:
+#   - someone changes the regex in federation-dashboard-collector.py and
+#     forgets here
+#   - someone edits an .ag file and removes / adds a tier branch the
+#     table assumes
 #
 # Self-contained, no external deps beyond python3. Exits 0 on full pass.
 
@@ -26,40 +31,41 @@ import os, re, sys
 
 fed_dir = sys.argv[1]
 
-# Manually curated from issue #160. Each entry: (gates, cap)
-# Mirrors the "Observed capability gaps" table in the issue body.
+# Expected tier-branches per agent after #176. Every agent is required
+# to have all four tiers (shadow, propose, review-gated, autonomous) as
+# per ADR-0001 — the canonical 4-branch pattern. labeler.ag still has
+# the clamp_auto cap at 0.85.
+FOUR_TIERS = ['autonomous', 'propose', 'review-gated', 'shadow']
 EXPECTED = {
-    # planning observers — only suggest gate, no act-level
-    'risk_assessor':     ([0.6],         None),
-    'task_decomposer':   ([0.6],         None),
-    'scope_estimator':   ([0.6],         None),
-    # planning writer
-    'plan_reviewer':     ([0.6, 0.85],   None),
-    # code-review (5 agents) — act-only gates
-    'logic_reviewer':    ([0.85],        None),
-    'security_reviewer': ([0.85],        None),
-    'style_reviewer':    ([0.85],        None),
-    'test_reviewer':     ([0.85],        None),
-    'approval_decider':  ([0.6, 0.85],   None),
-    # triage (4 agents)
-    'router':            ([0.6, 0.85],   None),
-    'prioritizer':       ([0.6, 0.85],   None),
-    'labeler':           ([0.6, 0.85],   0.85),  # has clamp_auto cap
-    'issue_creator':     ([0.6, 0.85],   None),
-    # implementation (4 agents)
-    'code_writer':       ([0.6, 0.85],   None),
-    'test_writer':       ([0.6, 0.85],   None),
-    'refactorer':        ([0.6, 0.85],   None),
-    'commit_composer':   ([0.6, 0.85],   None),
-    # release (4 agents)
-    'release_checker':   ([0.6, 0.85],   None),
-    'ship_decider':      ([0.6, 0.85],   None),
-    'changelog_writer':  ([0.6, 0.85],   None),
-    'version_bumper':    ([0.6, 0.85],   None),
+    'risk_assessor':     (FOUR_TIERS, None),
+    'task_decomposer':   (FOUR_TIERS, None),
+    'scope_estimator':   (FOUR_TIERS, None),
+    'plan_reviewer':     (FOUR_TIERS, None),
+    'logic_reviewer':    (FOUR_TIERS, None),
+    'security_reviewer': (FOUR_TIERS, None),
+    'style_reviewer':    (FOUR_TIERS, None),
+    'test_reviewer':     (FOUR_TIERS, None),
+    'approval_decider':  (FOUR_TIERS, None),
+    'router':            (FOUR_TIERS, None),
+    'prioritizer':       (FOUR_TIERS, None),
+    'labeler':           (FOUR_TIERS, 0.85),
+    'issue_creator':     (FOUR_TIERS, None),
+    'code_writer':       (FOUR_TIERS, None),
+    'test_writer':       (FOUR_TIERS, None),
+    'refactorer':        (FOUR_TIERS, None),
+    'commit_composer':   (FOUR_TIERS, None),
+    'release_checker':   (FOUR_TIERS, None),
+    'ship_decider':      (FOUR_TIERS, None),
+    'changelog_writer':  (FOUR_TIERS, None),
+    'version_bumper':    (FOUR_TIERS, None),
 }
 
-# Same regex as federation-dashboard.sh
-GATE_RE = re.compile(r'\bif\s+confidence\s+>=\s+([0-9]+(?:\.[0-9]+)?)')
+# Same regex as federation-dashboard-collector.py after #176: match every
+# tier-branch comparison in the agent. We look for any occurrence of
+# `== "<tier_name>"` that follows a `my_tier` identifier, gathering the
+# set of tier names that the agent branches on.
+TIER_CALL_RE = re.compile(r'\btier\s*\(\s*"([^"]+)"\s*\)')
+TIER_BRANCH_RE = re.compile(r'my_tier\s*==\s*"(shadow|propose|review-gated|autonomous|dormant)"')
 CLAMP_RE = re.compile(r'\bfn\s+clamp_auto\s*\(')
 CAP_RE = re.compile(r'\blet\s+cap\s*=\s*([0-9]+(?:\.[0-9]+)?)')
 
@@ -78,7 +84,17 @@ for colony in sorted(os.listdir(fed_dir)):
         seen.add(agent)
         with open(os.path.join(ag_dir, fn)) as f:
             text = f.read()
-        gates_set = sorted({float(m) for m in GATE_RE.findall(text)})
+        tier_calls = TIER_CALL_RE.findall(text)
+        branches = sorted(set(TIER_BRANCH_RE.findall(text)))
+        # The shadow tier is expressed as the else-fallthrough (no explicit
+        # `my_tier == "shadow"` comparison) since the dormant-as-shadow
+        # collapse is the canonical pattern from CLAUDE.md. Treat the
+        # presence of a `tier(...)` call + at least the 3 non-shadow
+        # branches as implicitly covering shadow.
+        non_shadow = [b for b in branches if b != 'shadow']
+        has_tier_call = len(tier_calls) > 0
+        if has_tier_call and set(non_shadow) >= {'autonomous', 'review-gated', 'propose'}:
+            branches = sorted(set(branches) | {'shadow'})
         cap = None
         if CLAMP_RE.search(text):
             cm = CAP_RE.search(text)
@@ -88,16 +104,16 @@ for colony in sorted(os.listdir(fed_dir)):
             print(f'[FAIL] {agent}: not in expected table — add it or remove the .ag')
             failed += 1
             continue
-        exp_gates, exp_cap = EXPECTED[agent]
-        if gates_set != sorted(exp_gates):
-            print(f'[FAIL] {agent}: gates={gates_set!r} expected {sorted(exp_gates)!r}')
+        exp_branches, exp_cap = EXPECTED[agent]
+        if branches != sorted(exp_branches):
+            print(f'[FAIL] {agent}: branches={branches!r} expected {sorted(exp_branches)!r}')
             failed += 1
             continue
         if cap != exp_cap:
             print(f'[FAIL] {agent}: cap={cap!r} expected {exp_cap!r}')
             failed += 1
             continue
-        print(f'[PASS] {agent} gates={gates_set} cap={cap}')
+        print(f'[PASS] {agent} branches={branches} cap={cap}')
         passed += 1
 
 missing = set(EXPECTED) - seen


### PR DESCRIPTION
## Summary

Milestone **M4** of the four-tier confidence gating rollout (parent
issue #173). Migrates all 21 `dev-apprenticeship` agents from raw
`confidence >= 0.X` threshold checks to the new `tier("<agent_name>")`
runtime builtin from agentis-core (#537). Every agent now follows the
canonical four-branch pattern defined in CLAUDE.md and normatively
specified in [`doc/adr/ADR-0001-confidence-tiers.md`](doc/adr/ADR-0001-confidence-tiers.md):

| Tier           | Range         | Behaviour |
|----------------|---------------|-----------|
| `shadow`       | `[0.4, 0.6)`  | LLM + memo, no emit, no external write |
| `propose`      | `[0.6, 0.8)`  | + emit on bus + draft external writes |
| `review-gated` | `[0.8, 0.95)` | + direct external writes (non-terminal) |
| `autonomous`   | `[0.95, 1.0]` | + terminal writes (merge, tag, publish) |

`install.sh` default seed was lowered from `0.5` to `0.4` (shadow) and
seeding is now idempotent — it never downgrades an agent that is
already at or above the new default.

## What changed

- **21 `.ag` agents** migrated across all 5 colonies:
  - `code-review/`: style_reviewer, logic_reviewer, security_reviewer, test_reviewer, approval_decider
  - `planning/`: risk_assessor, scope_estimator, task_decomposer, plan_reviewer
  - `release/`: version_bumper, ship_decider, release_checker, changelog_writer
  - `triage/`: router, prioritizer, labeler, issue_creator
  - `implementation/`: code_writer, test_writer, refactorer, commit_composer
- **`install.sh`**: default 0.5 -> 0.4 shadow, idempotent seed, new tier labels in prompt.
- **`tools/test-dashboard-gates.sh`**: expected-gate table replaced with the four named tiers per agent; `TIER_BRANCH_RE` matches `my_tier == "<tier>"`. Shadow treated as implicit (fall-through else branch).
- **`tools/federation-dashboard-collector.py`**: gate regex now recognizes both `confidence >= X` and `my_tier == "<tier>"`, mapping tier names to numeric levels so dashboards keep rendering during/after the migration.

## Baseline

- `grep -nR "confidence >= 0" dev-apprenticeship/` -> **0** hits
- `grep -cR "tier(" dev-apprenticeship/agents/*.ag` -> **22** tier() calls across **21** files (release_checker.ag has two independent tick branches)
- `./tools/colony-lint.sh` -> **50 passed, 0 failed, 5 skipped** (matches pre-migration baseline)
- Diff: **24 files changed, 711 insertions(+), 179 deletions(-)**

## Terminal vs non-terminal write discipline

Per ADR-0001, terminal writes (merge, tag, publish) stay strictly behind
`autonomous`. Non-terminal writes (comments, draft MR, assign) are
allowed at `review-gated`. Concretely:

- `version_bumper`: only `autonomous` calls `create-tag` + `create-release`; `review-gated` posts a `[draft-bump]` proposal note.
- `approval_decider`: only `autonomous` posts the final approval verdict; `review-gated` posts `[draft-review-decision]` summary.
- `code_writer` / `test_writer` / `refactorer` / `commit_composer`: branch/commit/MR creation only at `autonomous`; `review-gated` posts a `[draft-*]` plan as an issue comment.
- 4 reviewers + `router` / `plan_reviewer`: `review-gated` posts `[draft-*]` prefixed comments + writes an `<agent>:approved:<id>` memo marker so a human can promote.

## Test plan

- [x] Per-tier smoke test (using agentis-core #537 binary) on `style_reviewer`:
  - `c=0.30 -> dormant`
  - `c=0.50 -> shadow`
  - `c=0.70 -> propose`
  - `c=0.85 -> review-gated`
  - `c=0.96 -> autonomous`
- [x] `./tools/colony-lint.sh` passes at 50/0/5 baseline.
- [x] `grep -nR "confidence >= 0" dev-apprenticeship/` returns 0 hits.
- [x] Every `.ag` file parses via `agentis commit <file>` in a temp repo (verified per-file during migration).
- [ ] Dry-run `install.sh` on a fresh repo and one already at 0.95 to verify idempotent seed (manual, not run on CI).

Closes #176.