### PR TITLE
feat(tooling): retarget auto-promote/dashboard/lint to four-tier gating (M5, #177)

### DIFF
--- a/tools/auto-promote-config.yaml
+++ b/tools/auto-promote-config.yaml
@@ -12,11 +12,18 @@ promote:
     reject_rate_threshold: 0.05  # reject_rate must be < 5%
     delta_slope_window: 100      # compute slope over last N entries
     delta_slope_min: 0           # average delta must be non-negative
+  # Three-step ladder aligned with the four-tier confidence contract
+  # (ADR-0001, issue #177). Each step promotes the agent across one
+  # behavioural tier boundary: shadow -> propose -> review-gated ->
+  # autonomous. Numeric anchors match the tier lower bounds defined in
+  # ADR-0001; do not adjust independently.
   steps:
-    - from: 0.5
-      to: 0.6
-    - from: 0.6
-      to: 0.85
+    - from: 0.4   # shadow seed
+      to: 0.6     # promote to propose (emit + draft external writes)
+    - from: 0.6   # propose
+      to: 0.8     # promote to review-gated (direct non-terminal writes)
+    - from: 0.8   # review-gated
+      to: 0.95    # promote to autonomous (terminal writes)
 
 evolve:
   trigger:

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -11,6 +11,11 @@
 # All actions default to --dry-run (config: dry_run: true). Flip to
 # false in auto-promote-config.yaml only after reviewing the journal.
 #
+# Promote ladder (four-tier, ADR-0001 / #177): the steps list in
+# auto-promote-config.yaml drives progression shadow(0.4) -> propose(0.6)
+# -> review-gated(0.8) -> autonomous(0.95). This script is fully
+# YAML-driven — no numeric thresholds are hardcoded here.
+#
 # Usage: ./tools/auto-promote.sh <federation-dir>
 #        ./tools/auto-promote.sh dev-apprenticeship
 #        ./tools/auto-promote.sh dev-apprenticeship --live   # override dry_run
@@ -150,7 +155,7 @@ def parse_yaml_simple(path):
 
     indent_stack = [(-1, cfg)]
     # Track the last dict appended to a list so continuation keys
-    # (e.g. "to: 0.6" indented under "- from: 0.5") can be added.
+    # (e.g. "to: 0.6" indented under "- from: 0.4") can be added.
     last_list_dict = None
 
     for idx, raw in enumerate(lines):
@@ -214,7 +219,7 @@ def parse_yaml_simple(path):
                 parent[k] = _parse_value(v)
             elif isinstance(parent, list) and last_list_dict is not None:
                 # Continuation key for the last list-item dict
-                # e.g. "to: 0.6" after "- from: 0.5"
+                # e.g. "to: 0.6" after "- from: 0.4"
                 last_list_dict[k] = _parse_value(v)
 
     return cfg

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -275,8 +275,10 @@ DAEMONS_JSON=$(cd "$FED_DIR" && agentis daemon list --json 2>/dev/null || echo "
 DAEMON_COUNT=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); print(len(d))" "$DAEMONS_JSON")
 
 if [ "$DAEMON_COUNT" -eq 0 ]; then
+    # #177: no journal row for federation-down — otherwise a weekend with
+    # the federation stopped accumulates ~96 identical _system no-op rows
+    # (cron runs every 30 min). The tick log still records the no-op.
     log "Federation not running, no-op"
-    journal_append "_system" "no-op" '{"reason": "federation not running"}'
     exit 0
 fi
 

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -270,6 +270,26 @@ if command -v agentis &>/dev/null; then
     trap 'rm -rf "$lint_tmp"' EXIT
     (cd "$lint_tmp" && agentis init &>/dev/null) || true
 
+    # --- Capability probe: tier() builtin (#177) ---
+    # The tier-branch lint below requires the `tier()` builtin shipped by
+    # Replikanti/agentis-core#537. Version-string parsing is brittle because
+    # the release carrying tier() has not been tagged at the time this code
+    # ships — so probe the capability directly by evaluating a minimal .ag
+    # that calls tier(). If the probe fails we skip the tier-branch check
+    # and surface a clear error instead of crashing every agent check.
+    tier_probe_ok=false
+    probe_tmp=$(mktemp -d)
+    (cd "$probe_tmp" && agentis init &>/dev/null) || true
+    printf 'fn tick(r:string)->void{print(tier("x"));}\n' > "$probe_tmp/_probe.ag"
+    if (cd "$probe_tmp" && agentis go "_probe.ag") &>/dev/null; then
+        tier_probe_ok=true
+    fi
+    rm -rf "$probe_tmp"
+
+    if ! $tier_probe_ok; then
+        fail "agentis binary does not support tier() builtin (#177 requires Replikanti/agentis-core#537); upgrade agentis before running tier-branch lint"
+    fi
+
     for fed in "${federations[@]}"; do
         for dir in "$REPO_ROOT/$fed"/*/; do
             [ -d "$dir/config" ] || continue
@@ -285,6 +305,68 @@ if command -v agentis &>/dev/null; then
                         pass "$fed/$colony: $(basename "$ag") syntax OK"
                     else
                         fail "$fed/$colony: $(basename "$ag") syntax error"
+                    fi
+
+                    # --- Tier-branch convention (#177) ---
+                    # For every agent that defines fn tick(...), enforce the
+                    # four-tier contract from ADR-0001:
+                    #   1. at least one tier("...") call
+                    #   2. all four tiers covered: shadow / propose /
+                    #      review-gated / autonomous. The canonical pattern
+                    #      from CLAUDE.md collapses shadow (and dormant)
+                    #      into the else-fallthrough, so the literal
+                    #      "shadow" may be absent — when the other three
+                    #      non-shadow tiers are present AND a tier() call
+                    #      exists, shadow is treated as implicitly covered.
+                    #   3. no raw `confidence >= <number>` literals
+                    # Escape hatch: a line `// tiers: partial` in the file
+                    # skips rule #2 but never rule #1 or #3.
+                    if $tier_probe_ok && grep -qE '^\s*fn\s+tick\s*\(' "$ag"; then
+                        ag_rel="$fed/$colony/$(basename "$ag")"
+                        tier_ok=true
+
+                        if grep -qE 'tier\s*\(\s*"[^"]+"\s*\)' "$ag"; then
+                            has_tier_call=true
+                        else
+                            has_tier_call=false
+                            fail "$ag_rel: missing tier(\"...\") call (required by ADR-0001)"
+                            tier_ok=false
+                        fi
+
+                        if grep -qE '^\s*//\s*tiers:\s*partial' "$ag"; then
+                            partial_ok=true
+                        else
+                            partial_ok=false
+                        fi
+
+                        if ! $partial_ok; then
+                            missing_explicit=""
+                            for tier_name in propose review-gated autonomous; do
+                                if ! grep -qE "\"$tier_name\"" "$ag"; then
+                                    missing_explicit="$missing_explicit $tier_name"
+                                fi
+                            done
+                            has_shadow_literal=false
+                            if grep -qE '"shadow"' "$ag"; then
+                                has_shadow_literal=true
+                            fi
+                            if [ -n "$missing_explicit" ]; then
+                                fail "$ag_rel: missing tier literal(s):$missing_explicit"
+                                tier_ok=false
+                            elif ! $has_shadow_literal && ! $has_tier_call; then
+                                fail "$ag_rel: missing tier literal(s): shadow (no tier() call to imply else-fallthrough)"
+                                tier_ok=false
+                            fi
+                        fi
+
+                        if grep -nE '\bconfidence\s*>=\s*[0-9]+(\.[0-9]+)?' "$ag" >/dev/null; then
+                            fail "$ag_rel: raw confidence >= <number> literal (use tier() per ADR-0001)"
+                            tier_ok=false
+                        fi
+
+                        if $tier_ok; then
+                            pass "$ag_rel: tier-branch convention OK"
+                        fi
                     fi
                 done
             fi

--- a/tools/federation-dashboard-collector.py
+++ b/tools/federation-dashboard-collector.py
@@ -137,6 +137,7 @@ for agent in all_agents:
         # Fall back to the pre-M4 `if confidence >= X` form if the agent has
         # not been migrated yet. clamp_auto cap idiom is unchanged.
         TIER_LEVELS = {
+            'dormant': 0.0,
             'shadow': 0.4,
             'propose': 0.6,
             'review-gated': 0.8,
@@ -144,7 +145,7 @@ for agent in all_agents:
         }
         gates = []
         for lineno, line in enumerate(ag_lines, 1):
-            m_tier = re.search(r'my_tier\s*==\s*"(shadow|propose|review-gated|autonomous)"', line)
+            m_tier = re.search(r'my_tier\s*==\s*"(dormant|shadow|propose|review-gated|autonomous)"', line)
             if m_tier:
                 gates.append({'level': TIER_LEVELS[m_tier.group(1)], 'line': lineno, 'tier': m_tier.group(1)})
                 continue

--- a/tools/federation-dashboard.html.template
+++ b/tools/federation-dashboard.html.template
@@ -118,9 +118,15 @@
   .badge-error { border: 1px solid var(--red); color: var(--red); }
   .badge-critical { border: 1px solid var(--red); color: var(--red); text-shadow: 0 0 6px rgba(255,68,68,0.4); }
   .badge-quarantine { border: 1px solid var(--magenta); color: var(--magenta); text-shadow: 0 0 6px rgba(255,0,255,0.3); }
-  .badge-observe { border: 1px solid var(--muted); color: var(--muted); }
-  .badge-suggest { border: 1px solid var(--yellow); color: var(--yellow); text-shadow: 0 0 6px rgba(255,255,0,0.3); }
-  .badge-act { border: 1px solid var(--green); color: var(--green); text-shadow: 0 0 6px rgba(0,255,0,0.3); }
+  /* #177: four-tier badge colours matching ADR-0001.
+     Each tier gets a distinct visual so operators can tell review-gated
+     (direct non-terminal writes, needs approval) and autonomous (terminal
+     writes OK) apart at a glance. dormant is below the 0.4 seed floor. */
+  .badge-dormant { border: 1px solid var(--red); color: var(--red); background: rgba(255,68,68,0.08); }
+  .badge-shadow { border: 1px solid var(--muted); color: var(--muted); }
+  .badge-propose { border: 1px solid var(--yellow); color: var(--yellow); text-shadow: 0 0 6px rgba(255,255,0,0.3); }
+  .badge-review-gated { border: 1px solid var(--orange); color: var(--orange); text-shadow: 0 0 6px rgba(255,136,0,0.3); }
+  .badge-autonomous { border: 1px solid var(--green); color: var(--green); text-shadow: 0 0 6px rgba(0,255,0,0.3); }
   .badge-na { border: 1px solid var(--muted); color: var(--muted); }
   .badge-dead { border: 1px solid var(--red); color: var(--red); background: rgba(255,68,68,0.1); }
   .agent-name { color: var(--cyan); text-shadow: 0 0 6px rgba(0,255,255,0.2); }
@@ -792,12 +798,12 @@ function renderAgentTable() {
     if (a.confidence == null) {
       confHtml = '<span class="badge badge-na">\u2014</span>';
     } else {
-      // #177: tier names from ADR-0001. CSS classes kept as act/suggest/observe
-      // for backwards compatibility with the existing stylesheet.
-      const phase = a.confidence >= 0.95 ? 'act'
-        : a.confidence >= 0.8 ? 'act'
-        : a.confidence >= 0.6 ? 'suggest'
-        : 'observe';
+      // #177: four-tier badges matching ADR-0001 — each tier distinct.
+      const phase = a.confidence >= 0.95 ? 'autonomous'
+        : a.confidence >= 0.8 ? 'review-gated'
+        : a.confidence >= 0.6 ? 'propose'
+        : a.confidence >= 0.4 ? 'shadow'
+        : 'dormant';
       confHtml = '<span class="badge badge-' + phase + '">' + a.confidence.toFixed(2) + '</span>';
       // #145: tooltip with generation + written_at
       if (a.confidence_generation != null || a.confidence_written_at) {
@@ -981,6 +987,17 @@ renderAgentTable();
     // Skip silently: no entries AND not running. Stats row already surfaces
     // these as inactive — listing them as "skipped" is just noise.
     if (f.count === 0 && a.state !== 'running') return;
+
+    // #177: unseeded confidence — skip with explicit reason rather than
+    // silently proposing "promote to propose 0.60" for an agent that
+    // doesn't even have a shadow-tier memo yet. Matches auto-promote.sh
+    // Python behaviour which skips when confidence is null.
+    if (a.confidence == null) {
+      skippedHtml += '<div class="skipped-row"><span class="agent-name">' + esc(a.name) + '</span>';
+      skippedHtml += '<span>\u2014 confidence not seeded (run install.sh or set memo)</span></div>';
+      skippedCount++;
+      return;
+    }
 
     if (!fitnessOK) {
       let reason;
@@ -1435,7 +1452,7 @@ const WHY_FIX_HINT = {
     return 'Raise the cap inside `clamp_auto` in ' + a.name + '.ag (currently ' + ev.cap.toFixed(2) + '), or use a different agent that does not clamp.';
   },
   'few-entries': function(a, ev) {
-    return 'Let the agent run longer in suggest mode \u2014 evolve needs at least 100 experience entries (currently ' + ev.count + ').';
+    return 'Let the agent run longer in its current tier \u2014 evolve needs at least 100 experience entries (currently ' + ev.count + ').';
   },
   'no-variance': function(a) {
     return 'Vary the agent\u2019s inputs or recover non-zero `delta` values from `experience` \u2014 evolve needs measurable fitness differences.';

--- a/tools/federation-dashboard.html.template
+++ b/tools/federation-dashboard.html.template
@@ -709,8 +709,18 @@ const confChanges = data.confidence_changes || [];
   agents.forEach(a => { if (a.confidence != null) { sum += a.confidence; n += 1; } });
   const avgConf = n ? sum / n : 0;
   // #144: consistent NO DATA label when all agents are null
-  const phase = n === 0 ? 'NO DATA' : avgConf >= 0.85 ? 'AUTONOMOUS' : avgConf >= 0.6 ? 'SUGGEST' : 'OBSERVE';
-  const avgColor = n === 0 ? 'var(--muted)' : avgConf >= 0.85 ? 'var(--green)' : avgConf >= 0.6 ? 'var(--yellow)' : 'var(--cyan)';
+  // #177: tier names from ADR-0001 four-tier contract.
+  const phase = n === 0 ? 'NO DATA'
+    : avgConf >= 0.95 ? 'AUTONOMOUS'
+    : avgConf >= 0.8  ? 'REVIEW-GATED'
+    : avgConf >= 0.6  ? 'PROPOSE'
+    : avgConf >= 0.4  ? 'SHADOW'
+    : 'DORMANT';
+  const avgColor = n === 0 ? 'var(--muted)'
+    : avgConf >= 0.95 ? 'var(--green)'
+    : avgConf >= 0.8  ? 'var(--yellow)'
+    : avgConf >= 0.6  ? 'var(--cyan)'
+    : 'var(--muted)';
   const avgLabel = n === 0 ? '\u2014' : avgConf.toFixed(2);
   const quarantined = agents.filter(a => a.quarantine === 'yes').length;
   const deadPids = agents.filter(a => a.state === 'running' && a.pid > 0 && !a.pid_alive).length;
@@ -782,7 +792,12 @@ function renderAgentTable() {
     if (a.confidence == null) {
       confHtml = '<span class="badge badge-na">\u2014</span>';
     } else {
-      const phase = a.confidence >= 0.85 ? 'act' : a.confidence >= 0.6 ? 'suggest' : 'observe';
+      // #177: tier names from ADR-0001. CSS classes kept as act/suggest/observe
+      // for backwards compatibility with the existing stylesheet.
+      const phase = a.confidence >= 0.95 ? 'act'
+        : a.confidence >= 0.8 ? 'act'
+        : a.confidence >= 0.6 ? 'suggest'
+        : 'observe';
       confHtml = '<span class="badge badge-' + phase + '">' + a.confidence.toFixed(2) + '</span>';
       // #145: tooltip with generation + written_at
       if (a.confidence_generation != null || a.confidence_written_at) {
@@ -881,9 +896,15 @@ renderAgentTable();
 
   function estimateEta(colony, cur, hasData) {
     if (!hasData) return { text: '\u2014', color: 'var(--muted)' };
-    if (cur >= 0.85) return { text: 'AUTONOMOUS', color: 'var(--green)' };
-    const target = cur < 0.6 ? 0.6 : 0.85;
-    const label = target === 0.6 ? 'SUGGEST' : 'AUTONOMOUS';
+    // #177: four-tier ladder from ADR-0001. Target is the next-higher tier
+    // boundary; label matches the tier name reached once the boundary
+    // is crossed.
+    if (cur >= 0.95) return { text: 'AUTONOMOUS', color: 'var(--green)' };
+    let target;
+    let label;
+    if (cur < 0.6) { target = 0.6; label = 'PROPOSE'; }
+    else if (cur < 0.8) { target = 0.8; label = 'REVIEW-GATED'; }
+    else { target = 0.95; label = 'AUTONOMOUS'; }
     if (history.length < 120) return { text: 'collecting data...', color: 'var(--muted)' };
     const dayAgo = nowEpoch - 86400;
     // #143: filter stale zeros from regression — old history entries may
@@ -912,8 +933,10 @@ renderAgentTable();
     const eta = estimateEta(col, v, hasData);
     html += '<div class="phase-row"><span class="phase-colony">' + esc(col) + '</span>';
     html += '<div class="phase-bar-outer">';
-    html += '<div class="phase-marker" style="left:60%"><span class="phase-marker-label">0.6 suggest</span></div>';
-    html += '<div class="phase-marker" style="left:85%"><span class="phase-marker-label">0.85 autonomous</span></div>';
+    html += '<div class="phase-marker" style="left:40%"><span class="phase-marker-label">0.4 shadow</span></div>';
+    html += '<div class="phase-marker" style="left:60%"><span class="phase-marker-label">0.6 propose</span></div>';
+    html += '<div class="phase-marker" style="left:80%"><span class="phase-marker-label">0.8 review-gated</span></div>';
+    html += '<div class="phase-marker" style="left:95%"><span class="phase-marker-label">0.95 autonomous</span></div>';
     if (hasData) {
       html += '<div class="phase-bar-inner" style="width:' + pct + '%;background:' + color + ';box-shadow:0 0 10px ' + color + '50;color:#000">' + v.toFixed(2) + '</div>';
     } else {
@@ -936,11 +959,20 @@ renderAgentTable();
 // into a collapsed "Skipped candidates" section with the reason + Why button.
 (function() {
   const el = document.getElementById('promote-candidates');
-  const SUGGEST_TARGET = 0.85;
+  // #177: walk the four-tier ladder (shadow 0.4 -> propose 0.6 ->
+  // review-gated 0.8 -> autonomous 0.95). The candidate list proposes
+  // the next-higher tier for each agent based on its current confidence.
   let actionableHtml = '';
   let skippedHtml = '';
   let actionableCount = 0;
   let skippedCount = 0;
+
+  function nextTierTarget(cur) {
+    if (cur == null || cur < 0.6) return { value: 0.6, label: 'propose' };
+    if (cur < 0.8) return { value: 0.8, label: 'review-gated' };
+    if (cur < 0.95) return { value: 0.95, label: 'autonomous' };
+    return null;
+  }
 
   agents.forEach(a => {
     const f = computeFitness(a);
@@ -961,12 +993,21 @@ renderAgentTable();
       return;
     }
 
-    // Fitness passed — does the agent's source actually support promote-to-suggest?
-    const promoteGate = actionGate(a, 'promote', SUGGEST_TARGET);
+    const next = nextTierTarget(a.confidence);
+    if (!next) {
+      skippedHtml += '<div class="skipped-row"><span class="agent-name">' + esc(a.name) + '</span>';
+      skippedHtml += '<span>\u2014 already autonomous (no higher tier)</span></div>';
+      skippedCount++;
+      return;
+    }
+
+    // Fitness passed — does the agent's source actually support promoting
+    // across the next tier boundary?
+    const promoteGate = actionGate(a, 'promote', next.value);
     if (!promoteGate.enabled) {
       registerWhy(a.name, 'rec-promote', promoteGate);
       skippedHtml += '<div class="skipped-row"><span class="agent-name">' + esc(a.name) + '</span>';
-      skippedHtml += '<span>\u2014 promote to ' + SUGGEST_TARGET.toFixed(2) + ' would be a no-op</span>';
+      skippedHtml += '<span>\u2014 promote to ' + next.label + ' (' + next.value.toFixed(2) + ') would be a no-op</span>';
       skippedHtml += '<span class="skipped-info" onclick="showWhy(\'' + esc(a.name) + '\',\'rec-promote\')">why?</span></div>';
       skippedCount++;
       return;
@@ -978,7 +1019,7 @@ renderAgentTable();
     actionableHtml += f.count + ' entries, ' + Math.round(f.successRate * 100) + '% success, ';
     actionableHtml += (f.slope >= 0 ? '+' : '') + f.slope.toFixed(3) + ' slope';
     if (a.confidence != null) actionableHtml += ', on ' + a.confidence.toFixed(2);
-    actionableHtml += ' <span class="promote-suggest">\u2192 suggest ' + SUGGEST_TARGET.toFixed(2) + '</span>';
+    actionableHtml += ' <span class="promote-suggest">\u2192 ' + next.label + ' ' + next.value.toFixed(2) + '</span>';
     actionableHtml += '</div>';
   });
 
@@ -1246,11 +1287,15 @@ renderAgentTable();
     svg += '<line x1="'+PAD+'" y1="'+y+'" x2="'+W+'" y2="'+y+'" stroke="rgba(0,255,255,0.06)" />';
     svg += '<text x="'+(PAD-4)+'" y="'+(y+3)+'" fill="var(--muted)" font-family="Share Tech Mono,monospace" font-size="8" text-anchor="end">'+label+'</text>';
   }
-  // Phase markers
-  const suggestY = 10+(H-10)*(1-0.6);
-  const actY = 10+(H-10)*(1-0.85);
-  svg += '<line x1="'+PAD+'" y1="'+suggestY+'" x2="'+W+'" y2="'+suggestY+'" stroke="rgba(255,255,0,0.15)" stroke-dasharray="4,4" />';
-  svg += '<line x1="'+PAD+'" y1="'+actY+'" x2="'+W+'" y2="'+actY+'" stroke="rgba(0,255,0,0.15)" stroke-dasharray="4,4" />';
+  // Phase markers — #177: four tier boundaries from ADR-0001.
+  const shadowY = 10+(H-10)*(1-0.4);
+  const proposeY = 10+(H-10)*(1-0.6);
+  const reviewY = 10+(H-10)*(1-0.8);
+  const autoY = 10+(H-10)*(1-0.95);
+  svg += '<line x1="'+PAD+'" y1="'+shadowY+'" x2="'+W+'" y2="'+shadowY+'" stroke="rgba(0,255,255,0.10)" stroke-dasharray="2,4" />';
+  svg += '<line x1="'+PAD+'" y1="'+proposeY+'" x2="'+W+'" y2="'+proposeY+'" stroke="rgba(255,255,0,0.15)" stroke-dasharray="4,4" />';
+  svg += '<line x1="'+PAD+'" y1="'+reviewY+'" x2="'+W+'" y2="'+reviewY+'" stroke="rgba(255,170,0,0.15)" stroke-dasharray="4,4" />';
+  svg += '<line x1="'+PAD+'" y1="'+autoY+'" x2="'+W+'" y2="'+autoY+'" stroke="rgba(0,255,0,0.15)" stroke-dasharray="4,4" />';
   svg += '<line x1="'+PAD+'" y1="'+H+'" x2="'+W+'" y2="'+H+'" stroke="var(--border)" />';
   svg += '<text x="'+PAD+'" y="'+(H+14)+'" fill="var(--muted)" font-family="Share Tech Mono,monospace" font-size="9">'+new Date(tMin*1000).toLocaleDateString()+'</text>';
   svg += '<text x="'+W+'" y="'+(H+14)+'" fill="var(--muted)" font-family="Share Tech Mono,monospace" font-size="9" text-anchor="end">'+new Date(tMax*1000).toLocaleDateString()+'</text>';
@@ -1322,7 +1367,7 @@ function actionGate(a, type, target) {
       const dirWord = type === 'promote' ? 'Promoting' : 'Demoting';
       return {
         enabled: false, ruleType: 'no-branch',
-        reason: dirWord + ' to ' + target.toFixed(2) + ' would not cross any `if confidence >= X` gate in ' + a.name + '.ag — agent stays in the same behavioural tier.',
+        reason: dirWord + ' to ' + target.toFixed(2) + ' would not cross any tier() branch in ' + a.name + '.ag — agent stays in the same behavioural tier.',
         evidence: { gates: gates, current: cur, target: target, tier: curTier }
       };
     }
@@ -1379,8 +1424,12 @@ function actionGate(a, type, target) {
 const WHY_FIX_HINT = {
   'no-branch': function(a, ev) {
     const existing = (ev.gates && ev.gates.length) ? ev.gates.map(g => g.toFixed(2)).join(', ') : 'none';
-    return 'Add `if confidence >= ' + ev.target.toFixed(2) + ' { ... }` branch to ' +
-      a.name + '.ag (current gates: ' + existing + ') and respawn the daemon.';
+    // #177: migrated agents branch on tier("...") == "<tier>". Point the
+    // operator at the canonical pattern rather than the legacy raw literal.
+    const TIER_FOR = { 0.4: 'shadow', 0.6: 'propose', 0.8: 'review-gated', 0.95: 'autonomous' };
+    const tierName = TIER_FOR[ev.target] || 'tier for ' + ev.target.toFixed(2);
+    return 'Add `my_tier == "' + tierName + '"` branch to ' +
+      a.name + '.ag (current tier gates: ' + existing + ') and respawn the daemon.';
   },
   'capped': function(a, ev) {
     return 'Raise the cap inside `clamp_auto` in ' + a.name + '.ag (currently ' + ev.cap.toFixed(2) + '), or use a different agent that does not clamp.';
@@ -1395,7 +1444,7 @@ const WHY_FIX_HINT = {
     return 'Wait for fitness signal to move, or accept the plateau \u2014 evolve cannot improve a flat surface.';
   },
   'no-step': function() {
-    return 'No further confidence step in this direction. Confidence steps are 0.5 / 0.6 / 0.85.';
+    return 'No further confidence step in this direction. Tier steps are shadow 0.4 / propose 0.6 / review-gated 0.8 / autonomous 0.95.';
   }
 };
 
@@ -1502,8 +1551,14 @@ function openDetail(agentName) {
     const tMin=confPts[0].t, tMax=confPts[confPts.length-1].t, tR=Math.max(tMax-tMin,1);
     let svg = '<svg width="100%" viewBox="0 0 '+W+' '+H+'">';
     svg += '<line x1="'+PAD+'" y1="'+(H-5)+'" x2="'+W+'" y2="'+(H-5)+'" stroke="var(--border)" />';
-    const sY=10+(H-15)*(1-0.6), aY=10+(H-15)*(1-0.85);
-    svg += '<line x1="'+PAD+'" y1="'+sY+'" x2="'+W+'" y2="'+sY+'" stroke="rgba(255,255,0,0.2)" stroke-dasharray="3,3" />';
+    // #177: four-tier boundaries from ADR-0001 (shadow / propose / review-gated / autonomous).
+    const shY=10+(H-15)*(1-0.4);
+    const pY=10+(H-15)*(1-0.6);
+    const rY=10+(H-15)*(1-0.8);
+    const aY=10+(H-15)*(1-0.95);
+    svg += '<line x1="'+PAD+'" y1="'+shY+'" x2="'+W+'" y2="'+shY+'" stroke="rgba(0,255,255,0.15)" stroke-dasharray="2,3" />';
+    svg += '<line x1="'+PAD+'" y1="'+pY+'" x2="'+W+'" y2="'+pY+'" stroke="rgba(255,255,0,0.2)" stroke-dasharray="3,3" />';
+    svg += '<line x1="'+PAD+'" y1="'+rY+'" x2="'+W+'" y2="'+rY+'" stroke="rgba(255,170,0,0.2)" stroke-dasharray="3,3" />';
     svg += '<line x1="'+PAD+'" y1="'+aY+'" x2="'+W+'" y2="'+aY+'" stroke="rgba(0,255,0,0.2)" stroke-dasharray="3,3" />';
     const points = confPts.map(h => {
       const x = PAD+((h.t-tMin)/tR)*(W-PAD);
@@ -1649,7 +1704,9 @@ document.getElementById('detail-modal').addEventListener('click', function(e) {
 });
 
 // --- Confidence set with auto-restart (#137 Option 2) ---
-const CONF_STEPS = [0.5, 0.6, 0.85];
+// #177: four-tier ladder from ADR-0001. Steps walk shadow -> propose ->
+// review-gated -> autonomous boundaries.
+const CONF_STEPS = [0.4, 0.6, 0.8, 0.95];
 function nextStep(cur, dir) {
   let idx = 0, best = Math.abs(cur - CONF_STEPS[0]);
   for (let i = 1; i < CONF_STEPS.length; i++) {
@@ -1662,8 +1719,11 @@ function nextStep(cur, dir) {
 }
 
 function setConfidence(agent, value) {
-  if (value >= 0.85) {
-    if (!confirm('Promote ' + agent + ' to ' + value.toFixed(2) + ' (AUTONOMOUS)?\n\nAt this level the agent will act directly on GitLab \u2014 posting comments, applying labels, opening MRs, approving reviews. Proceed?')) {
+  // #177: confirm only at the autonomous boundary (terminal writes such
+  // as merge / tag / publish). Review-gated (0.8) still allows direct
+  // non-terminal writes, which are individually auditable.
+  if (value >= 0.95) {
+    if (!confirm('Promote ' + agent + ' to ' + value.toFixed(2) + ' (AUTONOMOUS)?\n\nAt this level the agent will perform terminal writes on GitLab \u2014 merging MRs, tagging releases, publishing. Proceed?')) {
       return;
     }
   }

--- a/tools/test-dashboard-gates.sh
+++ b/tools/test-dashboard-gates.sh
@@ -142,6 +142,48 @@ for colony in sorted(os.listdir(fed_dir)):
             print(f'[FAIL] {agent}: found `cap` near confidence without clamp_auto \u2014 extend the dashboard parser to recognise the new capping idiom')
             failed += 1
 
+# --- #177: collector regex fixture ---
+# Synthesise a minimal .ag snippet with a tier("foo") == "<tier>" branch
+# for each of the four tier names and confirm the collector regex + level
+# map in federation-dashboard-collector.py produces the expected levels.
+# Catches regressions where someone tightens the regex and drops a tier.
+COLLECTOR_TIER_RE = re.compile(r'my_tier\s*==\s*"(dormant|shadow|propose|review-gated|autonomous)"')
+COLLECTOR_LEVELS = {
+    'dormant': 0.0,
+    'shadow': 0.4,
+    'propose': 0.6,
+    'review-gated': 0.8,
+    'autonomous': 0.95,
+}
+FIXTURE = '''
+fn tick(rec: string) -> void {
+    let my_tier = tier("foo");
+    if my_tier == "autonomous" { print("a"); }
+    else if my_tier == "review-gated" { print("r"); }
+    else if my_tier == "propose" { print("p"); }
+    else if my_tier == "shadow" { print("s"); }
+    else if my_tier == "dormant" { print("d"); }
+}
+'''
+hits = []
+for line in FIXTURE.splitlines():
+    m = COLLECTOR_TIER_RE.search(line)
+    if m:
+        hits.append((m.group(1), COLLECTOR_LEVELS[m.group(1)]))
+expected = [
+    ('autonomous', 0.95),
+    ('review-gated', 0.8),
+    ('propose', 0.6),
+    ('shadow', 0.4),
+    ('dormant', 0.0),
+]
+if hits == expected:
+    print(f'[PASS] collector-regex fixture: all {len(expected)} tier branches detected')
+    passed += 1
+else:
+    print(f'[FAIL] collector-regex fixture: got {hits!r} expected {expected!r}')
+    failed += 1
+
 print(f'\nResults: {passed} passed, {failed} failed')
 sys.exit(0 if failed == 0 else 1)
 PY


### PR DESCRIPTION
## Summary

M5 of the four-tier confidence gating rollout (#173). Ships the tooling
that consumes the tier() convention introduced in M3 (#175) and migrated
in M4 (#176).

- Auto-promote ladder retargeted to 3 steps: shadow(0.4) -> propose(0.6)
  -> review-gated(0.8) -> autonomous(0.95). `tools/auto-promote.sh` is
  already fully YAML-driven, so only the config + docstrings change.
- `tools/colony-lint.sh` gains a tier-branch check: every `fn tick(...)`
  agent must have at least one `tier("...")` call, cover the four tier
  strings (shadow-as-else-fallthrough permitted when the call is
  present), and must NOT contain raw `confidence >= <number>` literals.
  Gated behind a capability probe rather than version-string parsing
  because the release carrying `tier()` (agentis-core#537) is not yet
  tagged.
- `federation-dashboard.html.template` swaps numeric labels for tier
  names and gains **five distinct tier badge classes** (see "QA
  findings fixed inline" below): stats-row phase, phase-readiness bars,
  promote-candidates panel, confidence trend + detail-modal charts,
  CONF_STEPS button ladder, AUTONOMOUS confirm dialog (triggers at
  0.95 / terminal writes, not 0.85), and the Why-panel `no-branch`
  remediation text.
- `federation-dashboard-collector.py` regex adds the `"dormant"` case
  (maps to 0.0) so hand-written dormant branches aren't silently
  dropped from `confidence_gates`.
- `federation-dashboard-renderer.py` left untouched — it only pipes JSON.
- `tools/test-dashboard-gates.sh` gains a collector-regex fixture test
  asserting all five tier labels (including dormant) are recognised.

### QA findings fixed inline (commit `3ae6b32`)

All four findings from the QA review were fixed in this PR rather than
deferred to a follow-up:

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | MEDIUM | `badge-act` conflated `autonomous` + `review-gated` into one green colour | Split into 5 distinct badge classes matching ADR-0001: `badge-dormant` (red), `badge-shadow` (muted), `badge-propose` (yellow), `badge-review-gated` (orange, new intermediate), `badge-autonomous` (green). Phase assignment expanded to 5 arms with explicit `dormant` for `< 0.4`. |
| 2 | LOW | Stale "suggest mode" string in `WHY_FIX_HINT['few-entries']` | "suggest mode" → "its current tier". |
| 3 | LOW | `auto-promote.sh` wrote a `_system no-op` journal row on every federation-down run (~96 rows over a weekend with cron at */30) | Drop the `journal_append` on the federation-not-running branch; the log line still records the no-op. Pre-existing behaviour from `main`; folded in here since the PR already retargets the script. |
| 4 | LOW | `nextTierTarget(null)` edge case — unseeded agents with enough experience could land in the promote-candidates panel without an "on X.XX" anchor | Skip unseeded agents up front with "confidence not seeded (run install.sh or set memo)" reason, matching the auto-promote.sh Python skip behaviour. |

### M4 tooling overlap already on main

- `312056f` added the `my_tier == "<tier>"` regex branch to
  `federation-dashboard-collector.py` and the tier-aware fixture table
  to `test-dashboard-gates.sh`. This PR extends both to include
  `dormant` and adds the collector-regex synthetic fixture that was
  still missing.
- The collector + test already treat the canonical
  `let my_tier = tier("...")` + `my_tier == "<tier>"` pattern as
  normative; M5 keeps that anchor (not the literal `tier("...") ==`
  form) because it's what every migrated agent actually uses.

### Colony-lint baseline

Before M5: `50 passed, 0 failed, 5 skipped`.
After M5: `71 passed, 0 failed, 5 skipped` (50 baseline + 21 new
tier-branch PASSes on the migrated dev-apprenticeship agents).

### Negative-case verification

A synthetic `.ag` fixture with a raw `confidence >= 0.6` literal and
otherwise-valid tier branches was run through `colony-lint.sh`. It
correctly fails with:

```
[FAIL] fedfixture/fakecolony/bad_agent.ag: raw confidence >= <number> literal (use tier() per ADR-0001)
```

Fixture was temp-only; not committed.

### #163 note

Evolve flat-slope calibration (#163) was NOT folded in — empirical
slope data is not yet available and the issue explicitly allows
deferring to a follow-up one-liner.

### Out of scope

Live dashboard smoke test on `:8420` was skipped — no live federation
is running. The next operator that boots the dashboard should eyeball
the promote/demote button labels, the phase-readiness markers, and the
new orange `review-gated` badge (Finding 1 above).

## Test plan

- [x] `./tools/colony-lint.sh` — 71 passed, 0 failed, 5 skipped
- [x] `./tools/test-dashboard-gates.sh` — 22 passed, 0 failed
      (21 migrated agents + collector-regex fixture)
- [x] `./tools/test-timeline-rendering.sh` — 19 passed, 0 failed
      (all template sentinels + heredoc guards intact)
- [x] `./tools/auto-promote.sh dev-apprenticeship` — dry-run no-op
      (federation not running); config parses as 3 steps
      (0.4->0.6, 0.6->0.8, 0.8->0.95); **no journal row written**
      (Finding 3 fix verified)
- [x] Negative-case fixture: raw `confidence >= 0.6` literal correctly
      rejected by new lint rule
- [x] All 4 QA findings fixed inline (see table above)

Closes #177.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
