### PR TITLE
chore: bump required agentis runtime to v1.4.0

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -1,6 +1,6 @@
 # Dev Apprenticeship
 
-![Agentis >= v1.3.0](https://img.shields.io/badge/agentis-%3E%3D%20v1.3.0-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
+![Agentis >= v1.4.0](https://img.shields.io/badge/agentis-%3E%3D%20v1.4.0-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
 
 A federation of 21 agents that learns how you work by watching your GitLab activity. It observes how you triage issues, review merge requests, plan features, write code, and ship releases. Over time it takes over the mechanical parts, while you keep control over the decisions that matter.
 
@@ -35,7 +35,7 @@ graph LR
 
 ## What you need
 
-- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.3.0**
+- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.4.0** (provides the `tier()` builtin required by the four-tier confidence gating in all 21 agents)
 - An LLM backend (Claude CLI, Ollama, or any OpenAI-compatible API)
 - GitLab instance with API access (personal access token with `api` scope)
 - Python 3 and git

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -19,7 +19,7 @@ ALL_AGENTS=(
     code_writer test_writer refactorer commit_composer
     ship_decider changelog_writer version_bumper release_checker
 )
-MIN_VERSION="1.3.0"
+MIN_VERSION="1.4.0"
 
 # --- Helpers ---
 
@@ -116,7 +116,7 @@ AGENTIS_VERSION=$(agentis --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9
 info "agentis version: $AGENTIS_VERSION (minimum: $MIN_VERSION)"
 
 if ! version_gte "$AGENTIS_VERSION" "$MIN_VERSION"; then
-    fail "agentis >= $MIN_VERSION required (#530 idle-skip, #523 bounded daemon stop, #524 daemon list confidence). Please update."
+    fail "agentis >= $MIN_VERSION required (tier() builtin for four-tier confidence gating, #539). Please update."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Mechanical follow-up to Replikanti/agentis#541 (v1.4.0 bump). All 21 `dev-apprenticeship/` agents call the `tier(<agent>)` evaluator builtin shipped in agentis PR #539 and tagged in agentis v1.4.0, so the minimum agentis version required by `install.sh` must be bumped accordingly.

**Blocked on:** Replikanti/agentis#541 merge + `v1.4.0` tag + binary release. Opened as draft; marked ready once the upstream release artifacts are live.

### What changed

- **`dev-apprenticeship/install.sh:22`** — `MIN_VERSION="1.3.0"` → `"1.4.0"`.
- **`dev-apprenticeship/install.sh:119`** — pre-flight fail message no longer cites the pre-v1.3.0 daemon changes; now cites `tier()` builtin (#539) as the blocking feature.
- **`dev-apprenticeship/README.md:3`** — shields.io badge `v1.3.0` → `v1.4.0`.
- **`dev-apprenticeship/README.md:38`** — "What you need" line bumped, plus short explanatory clause about `tier()`.

No `.ag` changes, no tooling changes, no config changes. `colony-lint.sh` baseline (71/0/5 after M5) unaffected.

## Test plan

- [x] `grep -n 'v1\.3\.0\|1\.3\.0' dev-apprenticeship/install.sh dev-apprenticeship/README.md` returns zero hits on the bumped branch.
- [x] `./tools/colony-lint.sh` still passes at the M5 baseline (71 passed, 0 failed, 5 skipped).
- [ ] After agentis v1.4.0 is released: `install.sh` pre-flight accepts v1.4.0 and rejects v1.3.1 with the new `#539 tier() builtin` message (manual smoke).
- [ ] QA by `agentis-qa-agent` (non-binding verification report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)