### PR TITLE
fix(planning): rate-limit observe step to 30 min to cut LLM waste (#187)

### DIFF
--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -50,8 +50,14 @@ fn tick(reason: string) -> void {
     let last_obs = recall_latest("risk_assessor:observe_last_ts");
     let observe_stale = if len(last_obs) > 0 {
         if len(now_epoch) > 0 {
+            // Negative delta (operator ran `date -s <past>` or similar
+            // wall-clock regression) — treat as stale and re-observe
+            // rather than skipping forever on a clock that never catches
+            // up.
             let delta = parse_int(now_epoch) - parse_int(last_obs);
-            if delta < 1800 { 0; } else { 1; };
+            if delta >= 0 {
+                if delta < 1800 { 0; } else { 1; };
+            } else { 1; };
         } else { 1; };
     } else { 1; };
 

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -39,29 +39,50 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
+    // Staleness gate for the observe step (#187): the pattern library
+    // only feeds `recommend()` inside the act branch below, which rarely
+    // fires on low-activity projects. Re-running the observe prompt on
+    // every 60 s tick burns ~1 440 LLM calls/day for a library that may
+    // never be read. Skip the observe prompt unless the last successful
+    // observe was >= OBSERVE_MIN_INTERVAL_SEC ago. 1 800 s (30 min) keeps
+    // the library fresh without the heartbeat-LLM pathology.
+    let now_epoch = try { exec sh "date -u +%s"; } catch e { ""; };
+    let last_obs = recall_latest("risk_assessor:observe_last_ts");
+    let observe_stale = if len(last_obs) > 0 {
+        if len(now_epoch) > 0 {
+            let delta = parse_int(now_epoch) - parse_int(last_obs);
+            if delta < 1800 { 0; } else { 1; };
+        } else { 1; };
+    } else { 1; };
+
     // 1. Observe: pull recent opened issues and skim for incident-style patterns
-    let recent_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --view planning";
-    } catch e {
-        print("[risk_assessor] GitLab issues poll failed:", e);
-        "";
-    };
+    if observe_stale == 1 {
+        let recent_raw = try {
+            exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --view planning";
+        } catch e {
+            print("[risk_assessor] GitLab issues poll failed:", e);
+            "";
+        };
 
-    if len(recent_raw) > 10 {
-        let patterns = prompt(
-            "Analyze this recent GitLab issues JSON. Focus on issues labeled 'incident', 'bug', or 'blocker'. What recurring themes appear (dependency surprises, integration gotchas, flaky services)? Return JSON: observed_count (int, how many incident-style issues you saw), recurring_themes (string, one short paragraph).",
-            recent_raw
-        ) -> IncidentPatterns;
+        if len(recent_raw) > 10 {
+            let patterns = prompt(
+                "Analyze this recent GitLab issues JSON. Focus on issues labeled 'incident', 'bug', or 'blocker'. What recurring themes appear (dependency surprises, integration gotchas, flaky services)? Return JSON: observed_count (int, how many incident-style issues you saw), recurring_themes (string, one short paragraph).",
+                recent_raw
+            ) -> IncidentPatterns;
 
-        if patterns.observed_count > 0 {
-            learn(
-                "risk_assessment",
-                "batch of " + to_string(patterns.observed_count) + " incident-style issues",
-                patterns.recurring_themes,
-                "success",
-                ["observed", "planning"]
-            );
-            print("[risk_assessor] Observed", patterns.observed_count, "incident-style issues");
+            if patterns.observed_count > 0 {
+                learn(
+                    "risk_assessment",
+                    "batch of " + to_string(patterns.observed_count) + " incident-style issues",
+                    patterns.recurring_themes,
+                    "success",
+                    ["observed", "planning"]
+                );
+                if len(now_epoch) > 0 {
+                    memo_write("risk_assessor:observe_last_ts", now_epoch);
+                };
+                print("[risk_assessor] Observed", patterns.observed_count, "incident-style issues");
+            };
         };
     };
 

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -40,29 +40,47 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
+    // Staleness gate for the observe step (#187). See risk_assessor.ag
+    // for rationale. 1 800 s = 30 min between observe prompts keeps
+    // calibration fresh without a heartbeat-LLM pathology on idle
+    // projects where the act branch rarely fires.
+    let now_epoch = try { exec sh "date -u +%s"; } catch e { ""; };
+    let last_obs = recall_latest("scope_estimator:observe_last_ts");
+    let observe_stale = if len(last_obs) > 0 {
+        if len(now_epoch) > 0 {
+            let delta = parse_int(now_epoch) - parse_int(last_obs);
+            if delta < 1800 { 0; } else { 1; };
+        } else { 1; };
+    } else { 1; };
+
     // 1. Observe: pull recent merged MRs and learn calibration
-    let merged_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view planning-mr";
-    } catch e {
-        print("[scope_estimator] GitLab merged-MR poll failed:", e);
-        "";
-    };
+    if observe_stale == 1 {
+        let merged_raw = try {
+            exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view planning-mr";
+        } catch e {
+            print("[scope_estimator] GitLab merged-MR poll failed:", e);
+            "";
+        };
 
-    if len(merged_raw) > 10 {
-        let summary = prompt(
-            "Analyze these recently merged GitLab MRs. For each MR that closes an issue, compare the issue body's implied scope (phases, story points, or rough size) to the actual diff size and number of files touched. Summarize patterns (tendencies), give a rough over/under ratio hint (ratio_hint), and count the pairs you could compare (observed_pairs). Return JSON: observed_pairs (int), ratio_hint (string), tendencies (string).",
-            merged_raw
-        ) -> CalibrationSummary;
+        if len(merged_raw) > 10 {
+            let summary = prompt(
+                "Analyze these recently merged GitLab MRs. For each MR that closes an issue, compare the issue body's implied scope (phases, story points, or rough size) to the actual diff size and number of files touched. Summarize patterns (tendencies), give a rough over/under ratio hint (ratio_hint), and count the pairs you could compare (observed_pairs). Return JSON: observed_pairs (int), ratio_hint (string), tendencies (string).",
+                merged_raw
+            ) -> CalibrationSummary;
 
-        if summary.observed_pairs > 0 {
-            learn(
-                "scope_estimate",
-                "batch of " + to_string(summary.observed_pairs) + " shipped MRs",
-                "ratio: " + summary.ratio_hint + " | " + summary.tendencies,
-                "success",
-                ["observed", "planning"]
-            );
-            print("[scope_estimator] Observed", summary.observed_pairs, "shipped pairs");
+            if summary.observed_pairs > 0 {
+                learn(
+                    "scope_estimate",
+                    "batch of " + to_string(summary.observed_pairs) + " shipped MRs",
+                    "ratio: " + summary.ratio_hint + " | " + summary.tendencies,
+                    "success",
+                    ["observed", "planning"]
+                );
+                if len(now_epoch) > 0 {
+                    memo_write("scope_estimator:observe_last_ts", now_epoch);
+                };
+                print("[scope_estimator] Observed", summary.observed_pairs, "shipped pairs");
+            };
         };
     };
 

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -48,8 +48,14 @@ fn tick(reason: string) -> void {
     let last_obs = recall_latest("scope_estimator:observe_last_ts");
     let observe_stale = if len(last_obs) > 0 {
         if len(now_epoch) > 0 {
+            // Negative delta (operator ran `date -s <past>` or similar
+            // wall-clock regression) — treat as stale and re-observe
+            // rather than skipping forever on a clock that never catches
+            // up.
             let delta = parse_int(now_epoch) - parse_int(last_obs);
-            if delta < 1800 { 0; } else { 1; };
+            if delta >= 0 {
+                if delta < 1800 { 0; } else { 1; };
+            } else { 1; };
         } else { 1; };
     } else { 1; };
 

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -48,8 +48,14 @@ fn tick(reason: string) -> void {
     let last_obs = recall_latest("task_decomposer:observe_last_ts");
     let observe_stale = if len(last_obs) > 0 {
         if len(now_epoch) > 0 {
+            // Negative delta (operator ran `date -s <past>` or similar
+            // wall-clock regression) — treat as stale and re-observe
+            // rather than skipping forever on a clock that never catches
+            // up.
             let delta = parse_int(now_epoch) - parse_int(last_obs);
-            if delta < 1800 { 0; } else { 1; };
+            if delta >= 0 {
+                if delta < 1800 { 0; } else { 1; };
+            } else { 1; };
         } else { 1; };
     } else { 1; };
 

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -40,29 +40,47 @@ fn get_confidence() -> float {
 }
 
 fn tick(reason: string) -> void {
+    // Staleness gate for the observe step (#187). See risk_assessor.ag
+    // for rationale. 1 800 s = 30 min between observe prompts keeps
+    // the decomposition-pattern library fresh without a heartbeat-LLM
+    // pathology on idle projects where the act branch rarely fires.
+    let now_epoch = try { exec sh "date -u +%s"; } catch e { ""; };
+    let last_obs = recall_latest("task_decomposer:observe_last_ts");
+    let observe_stale = if len(last_obs) > 0 {
+        if len(now_epoch) > 0 {
+            let delta = parse_int(now_epoch) - parse_int(last_obs);
+            if delta < 1800 { 0; } else { 1; };
+        } else { 1; };
+    } else { 1; };
+
     // 1. Observe: analyze recent issues to infer decomposition style
-    let recent_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --view planning";
-    } catch e {
-        print("[task_decomposer] GitLab issues poll failed:", e);
-        "";
-    };
+    if observe_stale == 1 {
+        let recent_raw = try {
+            exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --view planning";
+        } catch e {
+            print("[task_decomposer] GitLab issues poll failed:", e);
+            "";
+        };
 
-    if len(recent_raw) > 10 {
-        let patterns = prompt(
-            "Analyze this recent GitLab issues JSON. Identify epics (issues labeled 'epic' or with subtask-like child references in the description). For each epic you can see, estimate how many subtasks were created. Summarize the decomposition style (checklist vs linked issues, granularity). Return JSON: epics_seen (int), avg_subtasks (int), style (string, one short sentence).",
-            recent_raw
-        ) -> DecompositionPatterns;
+        if len(recent_raw) > 10 {
+            let patterns = prompt(
+                "Analyze this recent GitLab issues JSON. Identify epics (issues labeled 'epic' or with subtask-like child references in the description). For each epic you can see, estimate how many subtasks were created. Summarize the decomposition style (checklist vs linked issues, granularity). Return JSON: epics_seen (int), avg_subtasks (int), style (string, one short sentence).",
+                recent_raw
+            ) -> DecompositionPatterns;
 
-        if patterns.epics_seen > 0 {
-            learn(
-                "task_decomposition",
-                "batch of " + to_string(patterns.epics_seen) + " epics",
-                "avg " + to_string(patterns.avg_subtasks) + " subtasks | " + patterns.style,
-                "success",
-                ["observed", "planning"]
-            );
-            print("[task_decomposer] Observed", patterns.epics_seen, "epics, avg", patterns.avg_subtasks, "subtasks");
+            if patterns.epics_seen > 0 {
+                learn(
+                    "task_decomposition",
+                    "batch of " + to_string(patterns.epics_seen) + " epics",
+                    "avg " + to_string(patterns.avg_subtasks) + " subtasks | " + patterns.style,
+                    "success",
+                    ["observed", "planning"]
+                );
+                if len(now_epoch) > 0 {
+                    memo_write("task_decomposer:observe_last_ts", now_epoch);
+                };
+                print("[task_decomposer] Observed", patterns.epics_seen, "epics, avg", patterns.avg_subtasks, "subtasks");
+            };
         };
     };
 


### PR DESCRIPTION
## Summary

- The three planning agents (`risk_assessor`, `scope_estimator`, `task_decomposer`) used to run an **unconditional `prompt()` observe step every tick** — ~1 440 LLM calls per agent per day at the default 60 s tick interval. The pattern library they built only feeds `recommend()` inside the act branch, which rarely fires on low-activity projects, so the work went almost entirely unused (see issue evidence: 425/288/426 observed rows with 0 emitted/review-gated/acted rows).
- Adds a **30-min staleness gate** on the observe step in each of the three `.ag` files. The observe prompt runs only when `now - last_observe_ts >= 1800 s`; otherwise the tick proceeds straight to the act branch. Fresh observes stamp `memo_write("<agent>:observe_last_ts", now_epoch)`.
- **Fail-open** by design: if `date -u +%s` fails, `last_obs` is empty, or the observe produces zero patterns, the next tick re-runs observe — no starvation of the pattern library.

## Expected impact

| Metric                                        | Before                 | After                 |
|-----------------------------------------------|------------------------|-----------------------|
| Observe LLM calls / agent / day               | 1 440                  | ~48                   |
| Across the planning trio / day                | ~4 320                 | ~144                  |
| Reduction                                     | —                      | **~97 %**             |

Act-branch cadence is unchanged — still gated on `len(issues_raw) >= 3`. The fix is purely about stopping heartbeat-rate observe prompts on idle projects.

Fixes #187.

## Test plan

- [x] `./tools/colony-lint.sh` — 71 passed, 0 failed, 5 skipped.
- [x] `agentis commit <agent>.ag` — all three agents parse cleanly (syntax validated individually).
- [ ] Live verification on dev-apprenticeship next time the federation is running: confirm the `:observe_last_ts` memo lands on the first observed tick and that subsequent ticks within 30 min skip the observe prompt.

## Design notes

- `let observe_stale = if len(last_obs) > 0 { ... } else { 1; };` — `.ag` has immutable `let` bindings, so the gate is an if-expression rather than a mutable flag. Each branch terminates its last expression with `;` per `.ag` block syntax.
- Interval is hardcoded to 1800 s rather than read from colony.toml. The issue lists configurability as "(configurable)" but a hardcoded sensible default is enough to resolve the waste; a future PR can promote it to a knob if operators want to tune it.
- No change to the act-branch shape. No change to tier gating. No change to event wiring.