### PR TITLE
docs(adr): align ADR-0001 tag convention with 21-agent implementation (#193)

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -254,9 +254,9 @@ Cross-colony wiring: Triage routes issues to Implementation. Implementation sign
 
 ## Knowledge portability
 
-Every `learn()` call in the federation's agents tags entries with one of `observed` (shadow tier: passive learning from GitLab activity), `emitted` (propose tier: suggestion logged with draft external write), or `acted` (review-gated / autonomous tier: direct external write) plus the colony name (`triage`, `code-review`, `planning`, `implementation`, `release`).
+Every `learn()` call in the federation's agents tags entries with one of `observed` (shadow tier: passive learning from GitLab activity), `emitted` (propose tier: suggestion logged with draft external write), `review-gated` (review-gated tier: direct non-terminal external write under the review gate), or `acted` (autonomous tier: terminal external write with no second gate) plus the colony name (`triage`, `code-review`, `planning`, `implementation`, `release`). See [`doc/auto-promote.md#classification`](../doc/auto-promote.md#classification) for how the auto-promote heuristic consumes these tags.
 
-**Personal vs team (`#104`).** If you set your GitLab username during `./install.sh` (or in `colony.toml` under `[gitlab] me = "..."`), three agents (`labeler`, `prioritizer`, `style_reviewer`) additionally tag their `acted` learn calls as either `personal` (the issue/MR author matches your username) or `team` (anyone else). The remaining agents still tag only `observed|emitted|acted` + colony; widening coverage is tracked as future work. If you leave the username empty, every entry keeps the legacy `team` tag so exports stay stable.
+**Personal vs team (`#104`).** If you set your GitLab username during `./install.sh` (or in `colony.toml` under `[gitlab] me = "..."`), three agents (`labeler`, `prioritizer`, `style_reviewer`) additionally tag their `learn()` calls as either `personal` (the issue/MR author matches your username) or `team` (anyone else). `labeler` and `prioritizer` tag every tier's entries; `style_reviewer` tags only its direct-write (`review-gated` and `acted`) branches. The remaining agents still tag only the tier name + colony; widening coverage is tracked as future work. If you leave the username empty, every entry keeps the legacy `team` tag so exports stay stable.
 
 Bulk export/import is available at the runtime level and will carry all entries as-is:
 
@@ -266,7 +266,7 @@ agentis knowledge export --tags personal > my-preferences.json  # carry just you
 agentis knowledge import fed-knowledge.json --merge
 ```
 
-Filtering by `--tags observed`, `--tags emitted`, `--tags acted`, `--tags <colony>`, `--tags personal`, or `--tags team` works once the matching agents have acted at least once with the relevant author context.
+Filtering by `--tags observed`, `--tags emitted`, `--tags review-gated`, `--tags acted`, `--tags <colony>`, `--tags personal`, or `--tags team` works once the matching agents have acted at least once with the relevant author context.
 
 ## Troubleshooting
 

--- a/dev-apprenticeship/code-review/README.md
+++ b/dev-apprenticeship/code-review/README.md
@@ -105,11 +105,18 @@ agentis knowledge list
 
 # Filter by real tags this colony emits
 agentis knowledge list --tags code-review
-agentis knowledge list --tags acted         # entries from autonomous actions
-agentis knowledge list --tags emitted       # entries from suggestions
+agentis knowledge list --tags observed      # shadow-tier passive learning
+agentis knowledge list --tags emitted       # propose-tier suggestions
+agentis knowledge list --tags review-gated  # review-gated direct non-terminal writes
+agentis knowledge list --tags acted         # autonomous terminal writes
 
-# Bulk export/import (carries every entry as-is — there is no
-# "personal" tag today, so --tags personal would return [])
+# style_reviewer additionally tags its direct-write (review-gated + acted)
+# branches with `personal` or `team` based on the MR author (requires
+# `[gitlab] me = "..."` in colony.toml — see dev-apprenticeship/README.md).
+agentis knowledge list --tags personal      # style_reviewer on your MRs
+agentis knowledge list --tags team          # style_reviewer on others' MRs
+
+# Bulk export/import (carries every entry as-is)
 agentis knowledge export > review-knowledge.json
 agentis knowledge import review-knowledge.json --merge
 ```

--- a/doc/adr/ADR-0001-confidence-tiers.md
+++ b/doc/adr/ADR-0001-confidence-tiers.md
@@ -129,7 +129,7 @@ for itself and for evolution, and nothing else.
 - **MAY:** perform LLM calls; write memos, including experience
   records tagged `observed`; read the bus.
 - **MUST NOT:** emit on the bus; perform any external write, draft
-  or direct; call `learn(..., tags=["emitted"|"acted"])`.
+  or direct; call `learn(..., tags=["emitted"|"review-gated"|"acted"])`.
 
 ### `propose` — `[0.6, 0.8)`
 
@@ -151,7 +151,7 @@ gate.
 
 - **MAY:** everything allowed at `propose`; create **direct**
   external writes (post a real review comment, open a non-draft MR,
-  publish a non-tag artefact); call `learn(..., tags=["acted"])`.
+  publish a non-tag artefact); call `learn(..., tags=["review-gated"])`.
 - **MUST NOT:** take any action that is terminal for a release
   artefact without a separate approver — specifically: merging an
   MR, pushing a release tag, promoting a package in the registry,
@@ -165,7 +165,7 @@ act as the final authority for its action class.
 
 - **MAY:** everything allowed at `review-gated`; perform terminal
   external writes (merge, tag, publish, rotate); act without a
-  second gate.
+  second gate; call `learn(..., tags=["acted"])`.
 - **MUST NOT:** escalate beyond its own action class — an
   autonomous code-review agent does not thereby acquire release
   authority. Tier is per topic, not per colony.
@@ -225,11 +225,16 @@ drifting from the ADR. The canonical way to gate behaviour is
 - Evolution gains a usable gradient in `[0.4, 0.6)` because agents
   in `shadow` emit experience records without acting.
 - The `learn(..., tags=...)` vocabulary acquires a concrete meaning:
-  `observed` at `shadow`, `emitted` at `propose`, `acted` at
-  `review-gated` and above.
+  `observed` at `shadow`, `emitted` at `propose`, `review-gated` at
+  `review-gated`, `acted` at `autonomous`. The authoritative
+  classification table consumed by the auto-promote heuristic
+  (acting vs. observe buckets) lives in
+  [`doc/auto-promote.md`](../auto-promote.md#classification); this
+  ADR governs the emission side, that document governs the
+  consumption side.
 - Downstream retrieval heuristics SHOULD prefer records tagged
-  `acted` for action recommendations and records tagged
-  `observed`/`emitted` for context-building.
+  `acted` or `review-gated` for action recommendations and records
+  tagged `observed`/`emitted` for context-building.
 
 ## Alternatives considered
 

--- a/doc/auto-promote.md
+++ b/doc/auto-promote.md
@@ -66,11 +66,11 @@ Evaluated before promote. If true, emit `evolve` and skip promote check.
 `evolve_slope` is computed like `delta_slope_acting` but over a longer
 window (default 1000 acting rows).
 
-## Classification (tag buckets)
+## Classification
 
 Every row in the experience store carries a `tags` array (see the
 canonical `.ag` pattern in [CLAUDE.md](../CLAUDE.md#agent-conventions-ag-files)).
-The cron classifies each row by its tags:
+The cron classifies each row into one of three tag buckets:
 
 | Bucket | Match | Example tag set |
 |---|---|---|


### PR DESCRIPTION
## Summary

- `doc/adr/ADR-0001-confidence-tiers.md`: canonical tag at `review-gated` changed from `["acted"]` to `["review-gated"]`; autonomous now explicitly states it emits `["acted"]`; shadow's forbidden-tag list includes `review-gated`. Tier→tag mapping sentence fixed; `doc/auto-promote.md#classification` cross-linked as the authoritative bucket table.
- `dev-apprenticeship/README.md`: knowledge-portability section lists all four tier/tag pairs (was: three, with review-gated + autonomous collapsed under `acted`). Personal/team note corrected to reflect actual asymmetric behaviour (labeler + prioritizer tag every tier; style_reviewer tags only direct-write branches). `--tags review-gated` added to the documented filter values.

## Background

Surfaced by the QA report on #192 (agentis-qa-agent finding #3). ADR-0001 assigned `acted` to review-gated, but every agent since #176/#177 emits `review-gated` there (and reserves `acted` for autonomous). The auto-promote classifier from #186/#192 happens to accept both (`ACTING_TAGS = {acted, review-gated, emitted}`), so there was no functional defect — but ADR-0001 is normative, and a future `.ag` author reading it literally would lose per-tier observability granularity.

## Separation of concerns

This PR makes the split between ADR-0001 and `doc/auto-promote.md` explicit:

- **ADR-0001** governs the **emission** side: what tag an `.ag` author SHOULD emit at each tier.
- **`doc/auto-promote.md#classification`** governs the **consumption** side: which tags the auto-promote heuristic accepts as \"acting\" vs \"observe\".

Both are now cross-linked. No overlap, no drift path.

## Test plan

- [x] `./tools/colony-lint.sh` — 72 passed, 0 failed, 5 skipped
- [x] No `.ag` change, no code change, no config change
- [x] `grep -r 'tags=\[' doc/` produces consistent vocabulary across ADR + auto-promote.md

## Checklist

- [x] Branch off `main` in a worktree
- [x] `colony-lint.sh` clean
- [x] No stale tag references remaining (grep audit performed; root README.md already correct, CLAUDE.md already correct)
- [x] Cross-links consistent

Closes #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)