### PR TITLE
docs(CLAUDE.md): refresh colony-lint baseline count (#194 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Pre-built agent colonies for the [Agentis](https://github.com/Replikanti/agentis
 bash -n scripts/gitlab-api.sh   # Bash syntax check on any script
 ```
 
-Colony lint must pass with 0 failures before merge. Current baseline: 50 passed, 5 skipped (shellcheck not installed).
+Colony lint must pass with 0 failures before merge. Current CI baseline: 38 passed, 0 failed, 1 skipped (agentis binary not installed on runners). Local runs add ~42 per-agent `.ag` syntax + tier-branch passes when `agentis` is installed, and 5 skips when `shellcheck` is not.
 
 ## Colony structure
 


### PR DESCRIPTION
## Summary

`CLAUDE.md:20` held a stale baseline — "50 passed, 5 skipped" — that pre-dated several recent additions (`#186` auto-promote tag classification, `#194` CLAUDE.md/doc/ link checks, new unit-test harnesses). The QA audit on PR #197 flagged it as a non-blocking observation; fixing it here to keep the number honest.

### Actual current counts

| Environment | Passed | Failed | Skipped | Gap explanation |
|---|---|---|---|---|
| CI (shellcheck installed, no agentis) | 38 | 0 | 1 | skip = agentis binary |
| Local (agentis installed, no shellcheck) | 74 | 0 | 5 | +42 passes = 21 agents × (`.ag` syntax + tier-branch); skips = 5 per-colony shellcheck slots |

CI numbers are the authoritative baseline. The local addendum explains the ~42-pass gap so a developer running the lint locally knows what they're looking at.

## Test plan

- [x] `./tools/colony-lint.sh` passes locally (74 / 0 / 5) — numbers match the new text
- [x] CI will run colony-lint and produce the 38 / 0 / 1 numbers quoted — green CI confirms

## Related

- Observation raised in [#197 QA comment](https://github.com/Replikanti/agentis-colonies/pull/197#issuecomment-4274647585)
- #194 added the CLAUDE.md + doc/ link checks that bumped the count

🤖 Generated with [Claude Code](https://claude.com/claude-code)