### PR TITLE
fix(implementation): gate sticky-work LLM re-burns (#200)

### DIFF
--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -40,6 +40,28 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
+// #200: skip the LLM draft when the top assigned issue hasn't changed
+// since our last run. `assigned-issues` has no --since filter server-side,
+// so without this gate the draft prompt re-fires every tick as long as
+// any issue remains assigned, re-paying the LLM cost for identical
+// input. Gate on (iid, updated_at) so that issue edits (title,
+// description, labels — anything that bumps updated_at) trigger a
+// fresh draft.
+fn should_draft_code(iid_str: string, upd: string) -> bool {
+    let last_iid = recall_latest("code_writer:last_drafted_iid");
+    if len(last_iid) == 0 {
+        return true;
+    };
+    if iid_str != last_iid {
+        return true;
+    };
+    let last_upd = recall_latest("code_writer:last_drafted_updated_at");
+    if upd != last_upd {
+        return true;
+    };
+    return false;
+}
+
 fn tick(reason: string) -> void {
     // 1. Learn from recently merged MRs
     let cmd = merged_mr_cmd();
@@ -85,68 +107,79 @@ fn tick(reason: string) -> void {
     };
 
     if len(issues_raw) > 10 {
-        let rec = recommend("code_write", ["accuracy"]);
-        let context = "Assigned issues: " + issues_raw + "\nLearned code patterns: " + to_string(rec);
+        // #200: early-out when the top assigned issue is the same one we
+        // already drafted and its `updated_at` is unchanged. The iid /
+        // updated_at pair is stashed at the start of a fresh draft so
+        // subsequent ticks on a sticky assignment short-circuit before
+        // the `draft = prompt(...)` call below.
+        let first_iid_str = to_string(json_get(issues_raw, "[0].iid"));
+        let first_upd = to_string(json_get(issues_raw, "[0].updated_at"));
+        if should_draft_code(first_iid_str, first_upd) {
+            memo_write("code_writer:last_drafted_iid", first_iid_str);
+            memo_write("code_writer:last_drafted_updated_at", first_upd);
+            let rec = recommend("code_write", ["accuracy"]);
+            let context = "Assigned issues: " + issues_raw + "\nLearned code patterns: " + to_string(rec);
 
-        let draft = prompt(
-            "You are a code writer agent. Pick the highest-priority assigned issue and draft an implementation plan. Propose a branch name (kebab-case, prefixed with feat/ or fix/), list the files to create or modify with brief descriptions, and summarize the approach. Return JSON: issue_id (int), branch_name (string), files (string, markdown list of file paths and what each does), summary (string, 2-3 sentences), confidence (float 0-1). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
-            context
-        ) -> CodeDraft;
+            let draft = prompt(
+                "You are a code writer agent. Pick the highest-priority assigned issue and draft an implementation plan. Propose a branch name (kebab-case, prefixed with feat/ or fix/), list the files to create or modify with brief descriptions, and summarize the approach. Return JSON: issue_id (int), branch_name (string), files (string, markdown list of file paths and what each does), summary (string, 2-3 sentences), confidence (float 0-1). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
+                context
+            ) -> CodeDraft;
 
-        let my_tier = tier("code_writer");
-        print("[code_writer] Drafted code for issue", draft.issue_id, "(tier:", my_tier, ")");
+            let my_tier = tier("code_writer");
+            print("[code_writer] Drafted code for issue", draft.issue_id, "(tier:", my_tier, ")");
 
-        if my_tier == "autonomous" {
-            // Create branch
-            let branch_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-branch --name " + shell_escape(draft.branch_name) + " --ref main";
-            let branch_result = try { exec sh branch_cmd; } catch e {
-                print("[code_writer] Branch creation failed:", e);
-                "";
-            };
-
-            if len(branch_result) > 0 {
-                // Generate actual code and commit it to the branch
-                let issue_cmd = "$COLONY_DIR/scripts/gitlab-api.sh issue " + to_string(draft.issue_id);
-                let issue_detail = try { exec sh issue_cmd; } catch e { ""; };
-                let code_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec);
-
-                let actions_json = prompt(
-                    "You are a code writer. Generate the actual file contents for this implementation plan. Return a JSON array of objects, each with: action (string, 'create' or 'update'), file_path (string), content (string, the full file content). Follow the learned naming and structure patterns. Only return the JSON array, nothing else.",
-                    code_context
-                ) -> string;
-
-                // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-                let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json);
-                let commit_result = try { exec sh commit_cmd; } catch e {
-                    print("[code_writer] Commit failed:", e);
+            if my_tier == "autonomous" {
+                // Create branch
+                let branch_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-branch --name " + shell_escape(draft.branch_name) + " --ref main";
+                let branch_result = try { exec sh branch_cmd; } catch e {
+                    print("[code_writer] Branch creation failed:", e);
                     "";
                 };
 
-                if len(commit_result) > 0 {
-                    print("[code_writer] Committed code to", draft.branch_name);
-                    emit("implementation:code_draft", draft);
-                    learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation"]);
+                if len(branch_result) > 0 {
+                    // Generate actual code and commit it to the branch
+                    let issue_cmd = "$COLONY_DIR/scripts/gitlab-api.sh issue " + to_string(draft.issue_id);
+                    let issue_detail = try { exec sh issue_cmd; } catch e { ""; };
+                    let code_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec);
+
+                    let actions_json = prompt(
+                        "You are a code writer. Generate the actual file contents for this implementation plan. Return a JSON array of objects, each with: action (string, 'create' or 'update'), file_path (string), content (string, the full file content). Follow the learned naming and structure patterns. Only return the JSON array, nothing else.",
+                        code_context
+                    ) -> string;
+
+                    // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
+                    let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json);
+                    let commit_result = try { exec sh commit_cmd; } catch e {
+                        print("[code_writer] Commit failed:", e);
+                        "";
+                    };
+
+                    if len(commit_result) > 0 {
+                        print("[code_writer] Committed code to", draft.branch_name);
+                        emit("implementation:code_draft", draft);
+                        learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation"]);
+                    };
                 };
-            };
-        } else {
-            if my_tier == "review-gated" {
-                // Non-terminal draft: post the implementation plan as a comment
-                // on the issue so a human can approve before we create a branch
-                // and commit code. No branch or commit at this tier.
-                let note = "[draft-impl] **Implementation Plan** (automated, pending approval)\n\nBranch: `" + draft.branch_name + "`\n\n" + draft.summary + "\n\nFiles:\n" + draft.files;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(note);
-                try { exec sh post_cmd; } catch e {
-                    print("[code_writer] Failed to post draft plan:", e);
-                };
-                emit("implementation:code_draft", draft);
-                learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["implementation", "review-gated"]);
             } else {
-                if my_tier == "propose" {
+                if my_tier == "review-gated" {
+                    // Non-terminal draft: post the implementation plan as a comment
+                    // on the issue so a human can approve before we create a branch
+                    // and commit code. No branch or commit at this tier.
+                    let note = "[draft-impl] **Implementation Plan** (automated, pending approval)\n\nBranch: `" + draft.branch_name + "`\n\n" + draft.summary + "\n\nFiles:\n" + draft.files;
+                    let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(note);
+                    try { exec sh post_cmd; } catch e {
+                        print("[code_writer] Failed to post draft plan:", e);
+                    };
                     emit("implementation:code_draft", draft);
-                    learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["emitted", "implementation"]);
+                    learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["implementation", "review-gated"]);
                 } else {
-                    print("[code_writer] Observing (tier:", my_tier, ")");
-                    learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["observed", "implementation"]);
+                    if my_tier == "propose" {
+                        emit("implementation:code_draft", draft);
+                        learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["emitted", "implementation"]);
+                    } else {
+                        print("[code_writer] Observing (tier:", my_tier, ")");
+                        learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["observed", "implementation"]);
+                    };
                 };
             };
         };

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -48,6 +48,15 @@ fn get_confidence() -> float {
 // description, labels — anything that bumps updated_at) trigger a
 // fresh draft.
 fn should_draft_code(iid_str: string, upd: string) -> bool {
+    // Malformed GitLab payload (missing iid) would otherwise collapse
+    // all drafts into the shared "void" memo slot. Skip entirely — we
+    // have nothing to gate on, and the next tick will re-poll.
+    if iid_str == "void" {
+        return false;
+    };
+    if len(iid_str) == 0 {
+        return false;
+    };
     let last_iid = recall_latest("code_writer:last_drafted_iid");
     if len(last_iid) == 0 {
         return true;

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -45,6 +45,15 @@ fn get_confidence() -> float {
 // cost. Cooldown expires so a genuine new draft for the same issue
 // after an edit eventually passes.
 fn should_handle_refactor(iid_str: string) -> bool {
+    // Malformed bus payload (missing issue_id) would otherwise collapse
+    // all drafts into the shared "void" memo slot. Skip — we have
+    // nothing to gate on.
+    if iid_str == "void" {
+        return false;
+    };
+    if len(iid_str) == 0 {
+        return false;
+    };
     let last_iid = recall_latest("refactorer:last_handled_iid");
     if len(last_iid) == 0 {
         return true;
@@ -62,7 +71,7 @@ fn should_handle_refactor(iid_str: string) -> bool {
     };
     let now_epoch = parse_int(now_str);
     let last_epoch = parse_int(last_ts_str);
-    if now_epoch - last_epoch > 300 {
+    if now_epoch - last_epoch >= 300 {
         return true;
     };
     return false;

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -38,6 +38,36 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
+// #200: suppress repeated refactor suggestions for the same `issue_id`
+// within a 300s cooldown window (5× the 60s tick interval).
+// Defense-in-depth: code_writer has its own (iid, updated_at) gate so
+// the bus shouldn't see dupes, but if it does we don't re-pay the LLM
+// cost. Cooldown expires so a genuine new draft for the same issue
+// after an edit eventually passes.
+fn should_handle_refactor(iid_str: string) -> bool {
+    let last_iid = recall_latest("refactorer:last_handled_iid");
+    if len(last_iid) == 0 {
+        return true;
+    };
+    if iid_str != last_iid {
+        return true;
+    };
+    let last_ts_str = recall_latest("refactorer:last_handled_ts");
+    if len(last_ts_str) == 0 {
+        return true;
+    };
+    let now_str = try { exec sh "date +%s"; } catch e { ""; };
+    if len(now_str) == 0 {
+        return true;
+    };
+    let now_epoch = parse_int(now_str);
+    let last_epoch = parse_int(last_ts_str);
+    if now_epoch - last_epoch > 300 {
+        return true;
+    };
+    return false;
+}
+
 fn tick(reason: string) -> void {
     // 1. Learn from refactoring patterns in merged MRs
     let cmd = merged_mr_cmd();
@@ -83,57 +113,69 @@ fn tick(reason: string) -> void {
     let draft_str = to_string(draft);
 
     if len(draft_str) > 5 {
-        let rec = recommend("refactor", ["accuracy"]);
-        let context = "Code draft to review: " + draft_str + "\nLearned refactoring patterns: " + to_string(rec);
-
-        let suggestion = prompt(
-            "You are a refactoring agent. A code draft has been produced for an issue. Review it against learned refactoring patterns and suggest improvements. Focus on: naming consistency, duplication, overly complex conditionals, missing error handling, extract/inline opportunities. Return JSON: issue_id (int, from the draft), suggestions (string, markdown list of specific improvements), priority (string, 'high' if structural issues or 'low' if cosmetic only), confidence (float 0-1). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
-            context
-        ) -> RefactorSuggestion;
-
-        let my_tier = tier("refactorer");
-        print("[refactorer] Reviewed draft for issue", suggestion.issue_id, "(tier:", my_tier, ")");
-
-        if my_tier == "autonomous" {
-            // Generate refactored code and commit to branch.
-            // #131: read branch_name via field access on the bus-delivered
-            // record instead of stringifying + re-prompting.
-            let branch = draft.branch_name;
-            let refactor_context = "Code draft: " + draft_str + "\nSuggestions: " + suggestion.suggestions + "\nPatterns: " + to_string(rec);
-            let actions_json = prompt(
-                "You are a refactorer. Apply these refactoring suggestions to the code draft. Return a JSON array of objects, each with: action (string, 'update'), file_path (string), content (string, the refactored file content). Only return the JSON array, nothing else.",
-                refactor_context
-            ) -> string;
-            // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-            let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(branch) + " --message " + shell_escape("refactor: apply improvements for #" + to_string(suggestion.issue_id)) + " --actions " + shell_escape(actions_json);
-            let commit_result = try { exec sh commit_cmd; } catch e {
-                print("[refactorer] Commit failed:", e);
-                "";
+        // #200: extract issue_id directly from the bus payload JSON and
+        // gate on (iid, 300s cooldown) before paying for the review LLM
+        // call. Stash the memos *before* prompt() so downstream failures
+        // don't force re-burn.
+        let incoming_iid = to_string(json_get(draft_str, "issue_id"));
+        if should_handle_refactor(incoming_iid) {
+            memo_write("refactorer:last_handled_iid", incoming_iid);
+            let ts_now = try { exec sh "date +%s"; } catch e { ""; };
+            if len(ts_now) > 0 {
+                memo_write("refactorer:last_handled_ts", ts_now);
             };
-            if len(commit_result) > 0 {
-                print("[refactorer] Committed refactoring to", branch);
-                emit("implementation:refactor_suggestions", suggestion);
-                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "success", ["acted", "implementation"]);
-            };
-        } else {
-            if my_tier == "review-gated" {
-                // Non-terminal draft: post the refactoring suggestions as a
-                // comment on the issue so a human can approve before we
-                // commit refactored files. No commit at this tier.
-                let note = "[draft-refactor] **Refactoring Suggestions** (automated, pending approval) — priority: " + suggestion.priority + "\n\n" + suggestion.suggestions;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(suggestion.issue_id) + " --body " + shell_escape(note);
-                try { exec sh post_cmd; } catch e {
-                    print("[refactorer] Failed to post draft note:", e);
+            let rec = recommend("refactor", ["accuracy"]);
+            let context = "Code draft to review: " + draft_str + "\nLearned refactoring patterns: " + to_string(rec);
+
+            let suggestion = prompt(
+                "You are a refactoring agent. A code draft has been produced for an issue. Review it against learned refactoring patterns and suggest improvements. Focus on: naming consistency, duplication, overly complex conditionals, missing error handling, extract/inline opportunities. Return JSON: issue_id (int, from the draft), suggestions (string, markdown list of specific improvements), priority (string, 'high' if structural issues or 'low' if cosmetic only), confidence (float 0-1). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
+                context
+            ) -> RefactorSuggestion;
+
+            let my_tier = tier("refactorer");
+            print("[refactorer] Reviewed draft for issue", suggestion.issue_id, "(tier:", my_tier, ")");
+
+            if my_tier == "autonomous" {
+                // Generate refactored code and commit to branch.
+                // #131: read branch_name via field access on the bus-delivered
+                // record instead of stringifying + re-prompting.
+                let branch = draft.branch_name;
+                let refactor_context = "Code draft: " + draft_str + "\nSuggestions: " + suggestion.suggestions + "\nPatterns: " + to_string(rec);
+                let actions_json = prompt(
+                    "You are a refactorer. Apply these refactoring suggestions to the code draft. Return a JSON array of objects, each with: action (string, 'update'), file_path (string), content (string, the refactored file content). Only return the JSON array, nothing else.",
+                    refactor_context
+                ) -> string;
+                // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
+                let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(branch) + " --message " + shell_escape("refactor: apply improvements for #" + to_string(suggestion.issue_id)) + " --actions " + shell_escape(actions_json);
+                let commit_result = try { exec sh commit_cmd; } catch e {
+                    print("[refactorer] Commit failed:", e);
+                    "";
                 };
-                emit("implementation:refactor_suggestions", suggestion);
-                learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["implementation", "review-gated"]);
-            } else {
-                if my_tier == "propose" {
+                if len(commit_result) > 0 {
+                    print("[refactorer] Committed refactoring to", branch);
                     emit("implementation:refactor_suggestions", suggestion);
-                    learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["emitted", "implementation"]);
+                    learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "success", ["acted", "implementation"]);
+                };
+            } else {
+                if my_tier == "review-gated" {
+                    // Non-terminal draft: post the refactoring suggestions as a
+                    // comment on the issue so a human can approve before we
+                    // commit refactored files. No commit at this tier.
+                    let note = "[draft-refactor] **Refactoring Suggestions** (automated, pending approval) — priority: " + suggestion.priority + "\n\n" + suggestion.suggestions;
+                    let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(suggestion.issue_id) + " --body " + shell_escape(note);
+                    try { exec sh post_cmd; } catch e {
+                        print("[refactorer] Failed to post draft note:", e);
+                    };
+                    emit("implementation:refactor_suggestions", suggestion);
+                    learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["implementation", "review-gated"]);
                 } else {
-                    print("[refactorer] Observing (tier:", my_tier, ")");
-                    learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["observed", "implementation"]);
+                    if my_tier == "propose" {
+                        emit("implementation:refactor_suggestions", suggestion);
+                        learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["emitted", "implementation"]);
+                    } else {
+                        print("[refactorer] Observing (tier:", my_tier, ")");
+                        learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["observed", "implementation"]);
+                    };
                 };
             };
         };

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -40,6 +40,36 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
+// #200: suppress repeated test drafts for the same `issue_id` within a
+// 300s cooldown window (5× the 60s tick interval). Defense-in-depth
+// against upstream re-emits: code_writer has its own (iid, updated_at)
+// gate so the bus shouldn't see dupes, but if it does we don't re-pay
+// the LLM cost for generating identical tests. Cooldown expires so a
+// genuine new draft for the same issue after an edit eventually passes.
+fn should_handle_test_draft(iid_str: string) -> bool {
+    let last_iid = recall_latest("test_writer:last_handled_iid");
+    if len(last_iid) == 0 {
+        return true;
+    };
+    if iid_str != last_iid {
+        return true;
+    };
+    let last_ts_str = recall_latest("test_writer:last_handled_ts");
+    if len(last_ts_str) == 0 {
+        return true;
+    };
+    let now_str = try { exec sh "date +%s"; } catch e { ""; };
+    if len(now_str) == 0 {
+        return true;
+    };
+    let now_epoch = parse_int(now_str);
+    let last_epoch = parse_int(last_ts_str);
+    if now_epoch - last_epoch > 300 {
+        return true;
+    };
+    return false;
+}
+
 fn tick(reason: string) -> void {
     // 1. Learn from test files in recently merged MRs
     let cmd = merged_mr_cmd();
@@ -82,56 +112,68 @@ fn tick(reason: string) -> void {
     let draft_str = to_string(draft);
 
     if len(draft_str) > 5 {
-        let rec = recommend("test_write", ["accuracy"]);
-        let context = "Code draft: " + draft_str + "\nLearned test patterns: " + to_string(rec);
-
-        let tests = prompt(
-            "You are a test writer agent. A code draft has been produced for an issue. Generate matching tests that follow the learned test patterns (structure, assertion style, fixtures). Return JSON: issue_id (int, from the draft), branch_name (string, same branch as the draft), test_files (string, markdown list of test file paths with brief description of what each tests), summary (string), confidence (float 0-1). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
-            context
-        ) -> TestDraft;
-
-        let my_tier = tier("test_writer");
-        print("[test_writer] Drafted tests for issue", tests.issue_id, "(tier:", my_tier, ")");
-
-        if my_tier == "autonomous" {
-            // Generate actual test file contents and commit to the branch
-            let test_context = "Code draft: " + draft_str + "\nTest plan: " + tests.test_files + "\nPatterns: " + to_string(rec);
-
-            let actions_json = prompt(
-                "You are a test writer. Generate the actual test file contents for this test plan. Return a JSON array of objects, each with: action (string, 'create' or 'update'), file_path (string), content (string, the full test file content). Follow the learned test structure and assertion patterns. Only return the JSON array, nothing else.",
-                test_context
-            ) -> string;
-
-            // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-            let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(tests.branch_name) + " --message " + shell_escape("test: add tests for #" + to_string(tests.issue_id)) + " --actions " + shell_escape(actions_json);
-            let commit_result = try { exec sh commit_cmd; } catch e {
-                print("[test_writer] Commit failed:", e);
-                "";
+        // #200: extract issue_id directly from the bus payload JSON and
+        // gate on (iid, 300s cooldown) before paying for the test-draft
+        // LLM call. Stash the memos *before* prompt() so downstream
+        // failures don't force re-burn.
+        let incoming_iid = to_string(json_get(draft_str, "issue_id"));
+        if should_handle_test_draft(incoming_iid) {
+            memo_write("test_writer:last_handled_iid", incoming_iid);
+            let ts_now = try { exec sh "date +%s"; } catch e { ""; };
+            if len(ts_now) > 0 {
+                memo_write("test_writer:last_handled_ts", ts_now);
             };
+            let rec = recommend("test_write", ["accuracy"]);
+            let context = "Code draft: " + draft_str + "\nLearned test patterns: " + to_string(rec);
 
-            if len(commit_result) > 0 {
-                print("[test_writer] Committed tests to", tests.branch_name);
-                emit("implementation:test_draft", tests);
-                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "success", ["acted", "implementation"]);
-            };
-        } else {
-            if my_tier == "review-gated" {
-                // Non-terminal draft: post the test plan as a comment on the
-                // issue so a human can approve before we commit test files.
-                let note = "[draft-tests] **Test Plan** (automated, pending approval)\n\nBranch: `" + tests.branch_name + "`\n\n" + tests.summary + "\n\nTest files:\n" + tests.test_files;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(tests.issue_id) + " --body " + shell_escape(note);
-                try { exec sh post_cmd; } catch e {
-                    print("[test_writer] Failed to post draft note:", e);
+            let tests = prompt(
+                "You are a test writer agent. A code draft has been produced for an issue. Generate matching tests that follow the learned test patterns (structure, assertion style, fixtures). Return JSON: issue_id (int, from the draft), branch_name (string, same branch as the draft), test_files (string, markdown list of test file paths with brief description of what each tests), summary (string), confidence (float 0-1). Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",
+                context
+            ) -> TestDraft;
+
+            let my_tier = tier("test_writer");
+            print("[test_writer] Drafted tests for issue", tests.issue_id, "(tier:", my_tier, ")");
+
+            if my_tier == "autonomous" {
+                // Generate actual test file contents and commit to the branch
+                let test_context = "Code draft: " + draft_str + "\nTest plan: " + tests.test_files + "\nPatterns: " + to_string(rec);
+
+                let actions_json = prompt(
+                    "You are a test writer. Generate the actual test file contents for this test plan. Return a JSON array of objects, each with: action (string, 'create' or 'update'), file_path (string), content (string, the full test file content). Follow the learned test structure and assertion patterns. Only return the JSON array, nothing else.",
+                    test_context
+                ) -> string;
+
+                // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
+                let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(tests.branch_name) + " --message " + shell_escape("test: add tests for #" + to_string(tests.issue_id)) + " --actions " + shell_escape(actions_json);
+                let commit_result = try { exec sh commit_cmd; } catch e {
+                    print("[test_writer] Commit failed:", e);
+                    "";
                 };
-                emit("implementation:test_draft", tests);
-                learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["implementation", "review-gated"]);
-            } else {
-                if my_tier == "propose" {
+
+                if len(commit_result) > 0 {
+                    print("[test_writer] Committed tests to", tests.branch_name);
                     emit("implementation:test_draft", tests);
-                    learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["emitted", "implementation"]);
+                    learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "success", ["acted", "implementation"]);
+                };
+            } else {
+                if my_tier == "review-gated" {
+                    // Non-terminal draft: post the test plan as a comment on the
+                    // issue so a human can approve before we commit test files.
+                    let note = "[draft-tests] **Test Plan** (automated, pending approval)\n\nBranch: `" + tests.branch_name + "`\n\n" + tests.summary + "\n\nTest files:\n" + tests.test_files;
+                    let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(tests.issue_id) + " --body " + shell_escape(note);
+                    try { exec sh post_cmd; } catch e {
+                        print("[test_writer] Failed to post draft note:", e);
+                    };
+                    emit("implementation:test_draft", tests);
+                    learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["implementation", "review-gated"]);
                 } else {
-                    print("[test_writer] Observing (tier:", my_tier, ")");
-                    learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["observed", "implementation"]);
+                    if my_tier == "propose" {
+                        emit("implementation:test_draft", tests);
+                        learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["emitted", "implementation"]);
+                    } else {
+                        print("[test_writer] Observing (tier:", my_tier, ")");
+                        learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["observed", "implementation"]);
+                    };
                 };
             };
         };

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -47,6 +47,15 @@ fn get_confidence() -> float {
 // the LLM cost for generating identical tests. Cooldown expires so a
 // genuine new draft for the same issue after an edit eventually passes.
 fn should_handle_test_draft(iid_str: string) -> bool {
+    // Malformed bus payload (missing issue_id) would otherwise collapse
+    // all drafts into the shared "void" memo slot. Skip — we have
+    // nothing to gate on.
+    if iid_str == "void" {
+        return false;
+    };
+    if len(iid_str) == 0 {
+        return false;
+    };
     let last_iid = recall_latest("test_writer:last_handled_iid");
     if len(last_iid) == 0 {
         return true;
@@ -64,7 +73,7 @@ fn should_handle_test_draft(iid_str: string) -> bool {
     };
     let now_epoch = parse_int(now_str);
     let last_epoch = parse_int(last_ts_str);
-    if now_epoch - last_epoch > 300 {
+    if now_epoch - last_epoch >= 300 {
         return true;
     };
     return false;


### PR DESCRIPTION
## Summary

Closes #200. Eliminates the biggest remaining LLM-waste source in the federation: the implementation colony re-drafting the *same* issue every tick.

**Root cause.** `scripts/gitlab-api.sh assigned-issues` has no server-side `--since` filter, so `code_writer.ag` would re-prompt for a draft every 60 s as long as any issue stayed assigned. Downstream, `test_writer` / `refactorer` `listen()` on `implementation:code_draft`, and whenever the bus re-emitted they also re-drafted.

Estimated savings on a federation with one stuck assignment: **~180 prompt calls/hour** (60 each for code_writer + test_writer + refactorer) collapse to **~0** until the issue is edited (`updated_at` bump) or 300 s elapses.

## Changes

**`implementation/agents/code_writer.ag`** — upstream gate
- New `should_draft_code(iid_str, upd) -> bool` helper.
- Memos: `code_writer:last_drafted_iid`, `code_writer:last_drafted_updated_at`.
- Wraps the `if len(issues_raw) > 10 { ... }` body with the gate so `prompt(...)` never fires for an (iid, updated_at) pair we've already drafted.
- Memos written **before** `prompt()` so downstream commit / note-post failures don't force a re-burn; recovery via issue-edit bumping `updated_at`.

**`implementation/agents/test_writer.ag`** — downstream defense-in-depth
- New `should_handle_test_draft(iid_str) -> bool` helper.
- Memos: `test_writer:last_handled_iid`, `test_writer:last_handled_ts` (epoch seconds).
- Extracts `issue_id` from the bus payload via `json_get(draft_str, "issue_id")` without a prompt.
- Gate on (iid, 300 s cooldown = 5× tick interval).

**`implementation/agents/refactorer.ag`** — same downstream pattern
- `should_handle_refactor(iid_str) -> bool`, `refactorer:last_handled_iid` + `refactorer:last_handled_ts`.

## Design decisions

- **Upstream keys on `updated_at`**, downstream on a **time window**. Upstream sees the authoritative GitLab timestamp; downstream only sees the bus payload, which doesn't carry an update cursor, so a time window is the simplest total recovery signal.
- **Memo-before-prompt.** The alternative (memo-after-success) keeps retrying on downstream failure — but each retry costs a full LLM draft. Since the input hasn't changed, the retry will produce the same draft anyway. Trade: lose transient-failure auto-retry; save ~60 LLM calls/hour per stuck issue.
- **No config knob.** 300 s is hard-coded. If users need a different cadence, the 60 s tick interval and 5× multiplier are both explicit in the code and easy to change. Premature abstraction otherwise.

## Test plan

- [x] `./tools/colony-lint.sh` — 74 passed / 0 failed / 5 skipped (shellcheck-adjacent skips)
- [x] `.ag` syntax + tier-branch checks pass for all three modified files
- [x] exec-sh safety check passes (all dynamic values wrapped in `shell_escape`)
- [ ] Production smoke — waiting for federation restart; log grep `\[code_writer\] Drafted code for issue <X>` should appear once per (iid, updated_at), not every 60 s.

## Follow-up / out of scope

None — #200 was scoped to just the implementation colony. For the other drift source identified in the same survey, see #201 (staleness gate for reviewer + planning pattern-learning prompts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)