### PR TITLE
fix(code-review): staleness gate for pattern-learning prompts (#201)

### DIFF
--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -70,17 +70,38 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    // Learn from human logic-related comments
-    let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
-    let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
+    // #201: staleness gate for the human-pattern-learning prompt. The
+    // outer #147 delta-check only catches no-activity ticks; when our
+    // own review post bumps the MR updated_at, the next tick re-enters
+    // this block and re-summarizes identical notes. Gate the observe
+    // prompt on a 1800s window aligned with the #187 planning gate.
+    let now_epoch_s = try { exec sh "date -u +%s"; } catch e { ""; };
+    let last_learn = recall_latest("logic_reviewer:last_pattern_learn_ts");
+    let should_learn = if len(last_learn) > 0 {
+        if len(now_epoch_s) > 0 {
+            let delta = parse_int(now_epoch_s) - parse_int(last_learn);
+            if delta >= 0 {
+                if delta < 1800 { 0; } else { 1; };
+            } else { 1; };
+        } else { 1; };
+    } else { 1; };
 
-    let human_patterns = prompt(
-        "Analyze these MR review comments. Find comments about logic bugs: edge cases, off-by-one, null/nil handling, race conditions, incorrect assumptions, missing error handling. Summarize the patterns. If no logic-related comments, return 'none'.",
-        notes_raw
-    ) -> string;
+    if should_learn == 1 {
+        // Learn from human logic-related comments
+        let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+        let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
-    if len(human_patterns) > 5 {
-        learn("logic_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+        let human_patterns = prompt(
+            "Analyze these MR review comments. Find comments about logic bugs: edge cases, off-by-one, null/nil handling, race conditions, incorrect assumptions, missing error handling. Summarize the patterns. If no logic-related comments, return 'none'.",
+            notes_raw
+        ) -> string;
+
+        if len(human_patterns) > 5 {
+            learn("logic_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            if len(now_epoch_s) > 0 {
+                memo_write("logic_reviewer:last_pattern_learn_ts", now_epoch_s);
+            };
+        };
     };
 
     // Perform logic review

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -71,17 +71,38 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    // Learn from human security-related comments
-    let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
-    let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
+    // #201: staleness gate for the human-pattern-learning prompt. The
+    // outer #147 delta-check only catches no-activity ticks; when our
+    // own review post bumps the MR updated_at, the next tick re-enters
+    // this block and re-summarizes identical notes. Gate the observe
+    // prompt on a 1800s window aligned with the #187 planning gate.
+    let now_epoch_s = try { exec sh "date -u +%s"; } catch e { ""; };
+    let last_learn = recall_latest("security_reviewer:last_pattern_learn_ts");
+    let should_learn = if len(last_learn) > 0 {
+        if len(now_epoch_s) > 0 {
+            let delta = parse_int(now_epoch_s) - parse_int(last_learn);
+            if delta >= 0 {
+                if delta < 1800 { 0; } else { 1; };
+            } else { 1; };
+        } else { 1; };
+    } else { 1; };
 
-    let human_patterns = prompt(
-        "Analyze these MR review comments. Find comments about security: injection, XSS, CSRF, auth, secrets, credentials, dependencies, permissions, input validation. Summarize. If none, return 'none'.",
-        notes_raw
-    ) -> string;
+    if should_learn == 1 {
+        // Learn from human security-related comments
+        let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+        let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
-    if len(human_patterns) > 5 {
-        learn("security_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+        let human_patterns = prompt(
+            "Analyze these MR review comments. Find comments about security: injection, XSS, CSRF, auth, secrets, credentials, dependencies, permissions, input validation. Summarize. If none, return 'none'.",
+            notes_raw
+        ) -> string;
+
+        if len(human_patterns) > 5 {
+            learn("security_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            if len(now_epoch_s) > 0 {
+                memo_write("security_reviewer:last_pattern_learn_ts", now_epoch_s);
+            };
+        };
     };
 
     // Perform security review

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -95,18 +95,39 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    // Check for existing human review comments to learn from
-    let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
-    let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
+    // #201: staleness gate for the human-pattern-learning prompt. The
+    // outer #147 delta-check only catches no-activity ticks; when our
+    // own review post bumps the MR updated_at, the next tick re-enters
+    // this block and re-summarizes identical notes. Gate the observe
+    // prompt on a 1800s window aligned with the #187 planning gate.
+    let now_epoch_s = try { exec sh "date -u +%s"; } catch e { ""; };
+    let last_learn = recall_latest("style_reviewer:last_pattern_learn_ts");
+    let should_learn = if len(last_learn) > 0 {
+        if len(now_epoch_s) > 0 {
+            let delta = parse_int(now_epoch_s) - parse_int(last_learn);
+            if delta >= 0 {
+                if delta < 1800 { 0; } else { 1; };
+            } else { 1; };
+        } else { 1; };
+    } else { 1; };
 
-    // Learn from human style comments
-    let human_patterns = prompt(
-        "Analyze these MR review comments. Find comments about style issues (naming, formatting, imports, whitespace, conventions). Summarize the patterns and preferences expressed. If no style-related comments, return 'none'.",
-        notes_raw
-    ) -> string;
+    if should_learn == 1 {
+        // Check for existing human review comments to learn from
+        let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+        let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
-    if len(human_patterns) > 5 {
-        learn("style_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+        // Learn from human style comments
+        let human_patterns = prompt(
+            "Analyze these MR review comments. Find comments about style issues (naming, formatting, imports, whitespace, conventions). Summarize the patterns and preferences expressed. If no style-related comments, return 'none'.",
+            notes_raw
+        ) -> string;
+
+        if len(human_patterns) > 5 {
+            learn("style_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            if len(now_epoch_s) > 0 {
+                memo_write("style_reviewer:last_pattern_learn_ts", now_epoch_s);
+            };
+        };
     };
 
     // Perform style review on the diff

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -62,17 +62,39 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    // Learn from human test-related comments
-    let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
-    let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
+    // #201: staleness gate for the human-pattern-learning prompt. The
+    // outer #147-style delta-check only catches no-activity ticks; when
+    // our own review post bumps the MR updated_at, the next tick
+    // re-enters this block and re-summarizes identical notes. Gate the
+    // observe prompt on a 1800s window aligned with the #187 planning
+    // gate.
+    let now_epoch_s = try { exec sh "date -u +%s"; } catch e { ""; };
+    let last_learn = recall_latest("test_reviewer:last_pattern_learn_ts");
+    let should_learn = if len(last_learn) > 0 {
+        if len(now_epoch_s) > 0 {
+            let delta = parse_int(now_epoch_s) - parse_int(last_learn);
+            if delta >= 0 {
+                if delta < 1800 { 0; } else { 1; };
+            } else { 1; };
+        } else { 1; };
+    } else { 1; };
 
-    let human_patterns = prompt(
-        "Analyze these MR review comments. Find comments about testing: missing tests, coverage gaps, test quality, assertion issues, edge case tests, flaky tests, test structure. Summarize. If none, return 'none'.",
-        notes_raw
-    ) -> string;
+    if should_learn == 1 {
+        // Learn from human test-related comments
+        let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+        let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
-    if len(human_patterns) > 5 {
-        learn("test_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+        let human_patterns = prompt(
+            "Analyze these MR review comments. Find comments about testing: missing tests, coverage gaps, test quality, assertion issues, edge case tests, flaky tests, test structure. Summarize. If none, return 'none'.",
+            notes_raw
+        ) -> string;
+
+        if len(human_patterns) > 5 {
+            learn("test_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            if len(now_epoch_s) > 0 {
+                memo_write("test_reviewer:last_pattern_learn_ts", now_epoch_s);
+            };
+        };
     };
 
     // Perform test review


### PR DESCRIPTION
## Summary

Closes #201. The four code-review agents (`style_reviewer`, `logic_reviewer`, `security_reviewer`, `test_reviewer`) each run a \"learn from human review comments\" \`prompt()\` on every tick where the outer \`--since\` filter returns any MR activity. When the agent's own review post bumps the MR \`updated_at\`, the next tick re-enters that block and re-summarizes the same notes. Gate the observe prompt on a 1800s (30 min) per-agent memo window, aligned with the #187 precedent in the planning colony.

**Scope reduction.** Issue #201 listed 7 agents. After audit, the 3 planning observers already have this gate from #187 (memo `<agent>:observe_last_ts`, 1800s window). The fix is only needed on the 4 code-review agents.

## Changes

Per agent (`style_reviewer`, `logic_reviewer`, `security_reviewer`, `test_reviewer`):

1. Compute \`now_epoch_s\` once via \`exec sh \"date -u +%s\"\`.
2. Read memo \`<agent>:last_pattern_learn_ts\`.
3. Compute \`should_learn\` — \`1\` on empty memo, on missing \`now_epoch_s\` (fail-open), on negative delta (wall-clock regression — re-observe rather than skip forever), or when \`delta >= 1800\`. Otherwise \`0\`.
4. Wrap the \`mr-notes\` fetch + \`human_patterns\` prompt + subsequent \`learn()\` in \`if should_learn == 1 { ... }\`. On successful \`learn()\`, write \`memo_write(\"<agent>:last_pattern_learn_ts\", now_epoch_s)\`.

Pattern is identical across the 4 files; minor differences are in prompt text and topic strings.

## Design decisions

- **Memo key differs from #187 planning** (`last_pattern_learn_ts` vs `observe_last_ts`). Chose the #201 spec name. Both refer to the same concept conceptually; can be unified later if needed, but mixing them now would churn the planning colony for no behavior change.
- **1800s window**, not the 3600s default from #201's prompt, to stay consistent with the #187 gate already running in planning.
- **Notes API call moved inside the gate** so we don't burn GitLab network traffic on a prompt we won't fire.
- **Did not touch planning** — already gated. Kept out of the diff to avoid unrelated changes.

## Test plan

- [x] \`./tools/colony-lint.sh\` — 74 passed / 0 failed / 5 skipped
- [x] \`.ag\` syntax + tier-branch checks pass for all four modified files
- [x] exec-sh safety check passes (no new dynamic-value concatenations)
- [ ] Production smoke — verify over a full tick cycle that a single review post doesn't retrigger \`human_patterns\` prompt on subsequent ticks within 30 min

## Estimated LLM savings

Per #201: ~5–10 prompt calls/day on a quiet project, tens/day on an active project. Small against the #200 savings but strictly avoidable. Combined with #200 (merged in #204), the idle-state LLM floor is now effectively zero.

## Out of scope / follow-up

- \`test_reviewer.ag\` has no \`last_check\` refresh in the early-exit branch (other reviewers do per #147). That's a pre-existing tiny-window-of-re-scanning issue, not addressed here.
- \`#205\` tracks the optional colony-lint rule to prevent regression of this and #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)