### PR TITLE
feat(colony-lint): warn on unguarded prompt() in implementation/agents (#205)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Pre-built agent colonies for the [Agentis](https://github.com/Replikanti/agentis
 bash -n scripts/gitlab-api.sh   # Bash syntax check on any script
 ```
 
-Colony lint must pass with 0 failures before merge. Current CI baseline: 38 passed, 0 failed, 1 skipped (agentis binary not installed on runners). Local runs add ~42 per-agent `.ag` syntax + tier-branch passes when `agentis` is installed, and 5 skips when `shellcheck` is not.
+Colony lint must pass with 0 failures before merge. Current CI baseline: 40 passed, 0 failed, 1 skipped (agentis binary not installed on runners). Local runs add ~42 per-agent `.ag` syntax + tier-branch passes when `agentis` is installed, and 5 skips when `shellcheck` is not.
 
 ## Colony structure
 
@@ -124,6 +124,7 @@ release:changelog_draft      -> version_bumper
 | `colony-lint.sh` | Full federation lint (structure, config, .ag syntax, exec-sh safety, daemon flag allowlist, markdown links) |
 | `new-colony.sh` | Scaffold a new colony (creates dirs, example config, starter scripts) |
 | `check-exec-sh.sh` | Grep-based check for unsafe string concat into `exec sh`. See `check-exec-sh.md` for known limitations. |
+| `check-impl-prompt-gate.sh` | Grep/awk-based check that every `prompt()` in `implementation/agents/*.ag` is preceded within the same fn by a `recall_latest()` read or a gate-fn call ([#200](https://github.com/Replikanti/agentis-colonies/issues/200), [#205](https://github.com/Replikanti/agentis-colonies/issues/205)). Annotate a cold-path prompt with `// colony-lint: impl-prompt-gate-ok` to suppress. |
 | `parse-toml.sh` | Shared TOML parser sourced by all start-colony.sh scripts |
 | `federation-dashboard.sh` | Generic web dashboard for any federation — auto-discovers colonies/agents, serves operator controls (promote, demote, evolve, restart, kill). Thin shell; orchestrates the four Python helpers + HTML template below. **Never inline heredocs here** (macOS bash parser bug; `test-timeline-rendering.sh` tests 13–19 enforce). Full reference: [`doc/federation-dashboard.md`](./doc/federation-dashboard.md). |
 | `federation-dashboard-collector.py` | Per-agent data collector (experience stats, `.ag` descriptions, log lines, PID liveness, timeline, confidence history). Called by `federation-dashboard.sh` once per regen. See [`doc/federation-dashboard.md`](./doc/federation-dashboard.md#architecture). |

--- a/tools/check-impl-prompt-gate.sh
+++ b/tools/check-impl-prompt-gate.sh
@@ -28,9 +28,15 @@
 #     suppression comment if you hit this deliberately; fix the code
 #     otherwise.
 #   - `/* */` block comments are not recognised (no .ag file uses them).
-#   - Braces inside string literals (e.g., `"{ foo }"`) are ignored by
-#     stripping `//` line comments only; none of the current .ag files
-#     exercises that pattern.
+#     `//` line comments are stripped before matching, so neither
+#     `prompt(` nor `recall_latest(` nor a gate-fn name inside a `//`
+#     comment triggers the checker.
+#   - Same-line ordering is respected: if a gate call appears AFTER a
+#     `prompt(` on the same physical line, it does NOT cover that
+#     prompt (only triggers on subsequent lines).
+#   - Braces or `prompt(` tokens inside string literals are not
+#     specially handled (comments are, string literals are not) — none
+#     of the current .ag files exercises that pattern.
 #
 # Usage: ./tools/check-impl-prompt-gate.sh [path]
 # Exit 0 if no unguarded prompts, 1 if one or more findings, 2 on usage error.
@@ -52,30 +58,33 @@ check_file() {
     local ag_file="$1"
 
     # Pass 1: collect gate function names — fns whose body contains
-    # `recall_latest(`. Output: one name per line.
+    # `recall_latest(` (outside of a `//` line comment). Output: one
+    # name per line.
     local gate_fns
     gate_fns="$(awk '
         BEGIN { depth = 0; in_fn = 0; fn_name = ""; gate_seen = 0 }
 
         {
+            # `clean` is the line with any `//` line-comment stripped,
+            # so comments cannot trigger gate detection or brace counting.
+            clean = $0
+            sub(/\/\/.*$/, "", clean)
+
             # Detect top-level `fn NAME(` when not already inside one.
-            if (!in_fn && depth == 0 && match($0, /^[[:space:]]*fn[[:space:]]+[a-zA-Z_][a-zA-Z_0-9]*/)) {
-                s = substr($0, RSTART, RLENGTH)
+            if (!in_fn && depth == 0 && match(clean, /^[[:space:]]*fn[[:space:]]+[a-zA-Z_][a-zA-Z_0-9]*/)) {
+                s = substr(clean, RSTART, RLENGTH)
                 sub(/^[[:space:]]*fn[[:space:]]+/, "", s)
                 fn_name = s
                 in_fn = 1
                 gate_seen = 0
             }
 
-            if (in_fn && $0 ~ /recall_latest[[:space:]]*\(/) {
+            if (in_fn && clean ~ /recall_latest[[:space:]]*\(/) {
                 gate_seen = 1
             }
 
-            # Update brace depth using a copy with line-comments stripped.
-            line = $0
-            sub(/\/\/.*$/, "", line)
-            opens = gsub(/\{/, "", line)
-            closes = gsub(/\}/, "", line)
+            opens = gsub(/\{/, "", clean)
+            closes = gsub(/\}/, "", clean)
             depth += opens - closes
 
             if (in_fn && depth <= 0) {
@@ -98,13 +107,29 @@ check_file() {
                 if (arr[i] != "") gate_fns[arr[i]] = 1
             }
             depth = 0; in_fn = 0; fn_name = ""; gate_seen = 0
-            prev_line = ""
+            prev_clean = ""
+        }
+
+        # is_gated(text): return 1 if `text` contains a gate trigger.
+        function is_gated(text,    g, pat) {
+            if (text ~ /recall_latest[[:space:]]*\(/) return 1
+            for (g in gate_fns) {
+                pat = "(^|[^a-zA-Z_0-9])" g "[[:space:]]*\\("
+                if (text ~ pat) return 1
+            }
+            return 0
         }
 
         {
+            # Strip `//` line-comments before any matching so that
+            # `prompt(`, `recall_latest(`, and gate-fn names inside a
+            # comment are ignored.
+            clean = $0
+            sub(/\/\/.*$/, "", clean)
+
             entered_fn_this_line = 0
-            if (!in_fn && depth == 0 && match($0, /^[[:space:]]*fn[[:space:]]+[a-zA-Z_][a-zA-Z_0-9]*/)) {
-                s = substr($0, RSTART, RLENGTH)
+            if (!in_fn && depth == 0 && match(clean, /^[[:space:]]*fn[[:space:]]+[a-zA-Z_][a-zA-Z_0-9]*/)) {
+                s = substr(clean, RSTART, RLENGTH)
                 sub(/^[[:space:]]*fn[[:space:]]+/, "", s)
                 fn_name = s
                 in_fn = 1
@@ -112,43 +137,37 @@ check_file() {
                 entered_fn_this_line = 1
             }
 
-            if (in_fn) {
-                # Rule 1: recall_latest() in same fn.
-                if ($0 ~ /recall_latest[[:space:]]*\(/) gate_seen = 1
+            if (in_fn && !entered_fn_this_line) {
+                # Check for a `prompt(` on this line first, so that a
+                # gate call that appears AFTER the prompt on the same
+                # physical line does not retroactively "cover" it.
+                pp = match(clean, /prompt[[:space:]]*\(/)
+                if (pp > 0) {
+                    # Only the portion of the line BEFORE the `prompt(`
+                    # counts as a preceding gate for this specific prompt.
+                    left = substr(clean, 1, pp - 1)
+                    local_gate = gate_seen
+                    if (!local_gate && is_gated(left)) local_gate = 1
 
-                # Rule 2: call to a known gate function in same fn.
-                if (!gate_seen) {
-                    for (g in gate_fns) {
-                        # `g(` where `g` is a whole-word identifier.
-                        # [^a-zA-Z_0-9] ensures we do not match a prefix
-                        # of another name.
-                        pat = "(^|[^a-zA-Z_0-9])" g "[[:space:]]*\\("
-                        if ($0 ~ pat) { gate_seen = 1; break }
+                    suppressed = 0
+                    # Suppression comment check uses the ORIGINAL line so
+                    # `// colony-lint: impl-prompt-gate-ok` is visible.
+                    if ($0 ~ /colony-lint:[[:space:]]*impl-prompt-gate-ok/) suppressed = 1
+                    else if (prev_original ~ /colony-lint:[[:space:]]*impl-prompt-gate-ok/) suppressed = 1
+
+                    if (!suppressed && !local_gate) {
+                        printf "[UNGATED] %s:%d: prompt() in fn `%s` is not preceded by recall_latest() or a gate-fn call (add a memo gate or annotate with `// colony-lint: impl-prompt-gate-ok`)\n", file, NR, fn_name
                     }
                 }
 
-                # Check for `prompt(` on this line — but only flag if this
-                # is not the `fn prompt(` definition line itself (defensive;
-                # agentis has no user-defined prompt function but belt-and-braces).
-                if (!entered_fn_this_line && $0 ~ /prompt[[:space:]]*\(/) {
-                    # Exclude the standalone `fn prompt(` definition case.
-                    if ($0 !~ /^[[:space:]]*fn[[:space:]]+prompt[[:space:]]*\(/) {
-                        suppressed = 0
-                        if ($0 ~ /colony-lint:[[:space:]]*impl-prompt-gate-ok/) suppressed = 1
-                        else if (prev_line ~ /colony-lint:[[:space:]]*impl-prompt-gate-ok/) suppressed = 1
-
-                        if (!suppressed && !gate_seen) {
-                            printf "[UNGATED] %s:%d: prompt() in fn `%s` is not preceded by recall_latest() or a gate-fn call (add a memo gate or annotate with `// colony-lint: impl-prompt-gate-ok`)\n", file, NR, fn_name
-                        }
-                    }
-                }
+                # Update gate_seen from the whole cleaned line AFTER the
+                # prompt check so that gate triggers carry forward to
+                # subsequent lines.
+                if (!gate_seen && is_gated(clean)) gate_seen = 1
             }
 
-            # Update brace depth for next iteration.
-            line = $0
-            sub(/\/\/.*$/, "", line)
-            opens = gsub(/\{/, "", line)
-            closes = gsub(/\}/, "", line)
+            opens = gsub(/\{/, "", clean)
+            closes = gsub(/\}/, "", clean)
             depth += opens - closes
 
             if (in_fn && depth <= 0) {
@@ -158,7 +177,7 @@ check_file() {
                 if (depth < 0) depth = 0
             }
 
-            prev_line = $0
+            prev_original = $0
         }
     ' "$ag_file")"
 

--- a/tools/check-impl-prompt-gate.sh
+++ b/tools/check-impl-prompt-gate.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# tools/check-impl-prompt-gate.sh: Flag unguarded `prompt()` calls in implementation/agents/*.ag.
+#
+# The implementation colony is wired to run many times per minute against a
+# GitLab project. If an `implementation/` agent calls `prompt()` without a
+# memo-based staleness gate, a single stuck issue or stuck MR can drive
+# ~60 LLM calls per hour per agent. Issue #200 / PR #204 fixed the three
+# ticking agents; this lint prevents a future implementation/ agent from
+# silently re-introducing the same drift.
+#
+# Rule: every `prompt(...)` call in a `*.ag` file under
+# `*/implementation/agents/` must be preceded within the same function by
+# either:
+#   1. a `recall_latest(...)` read, or
+#   2. a call to a "gate function" — a free function defined in the same
+#      file whose body contains `recall_latest(...)`.
+#
+# Authors can suppress a false positive on a specific line by adding
+# `// colony-lint: impl-prompt-gate-ok` to the `prompt(` line itself or to
+# the preceding line. Prefer a real memo gate; use the suppression only
+# when the prompt is on a proven cold-path (e.g., guarded by upstream
+# emitters that already carry memo gates).
+#
+# This is a grep/awk-level check, not a full parser. Known caveats:
+#   - Gate check is textual within-function. If `recall_latest()` appears
+#     in one branch of an `if/else` and `prompt()` in a sibling branch,
+#     the check passes but the prompt is in fact unguarded. Use the
+#     suppression comment if you hit this deliberately; fix the code
+#     otherwise.
+#   - `/* */` block comments are not recognised (no .ag file uses them).
+#   - Braces inside string literals (e.g., `"{ foo }"`) are ignored by
+#     stripping `//` line comments only; none of the current .ag files
+#     exercises that pattern.
+#
+# Usage: ./tools/check-impl-prompt-gate.sh [path]
+# Exit 0 if no unguarded prompts, 1 if one or more findings, 2 on usage error.
+
+set -euo pipefail
+
+SCAN_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+if [ ! -e "$SCAN_ROOT" ]; then
+    echo "check-impl-prompt-gate: scan root does not exist: $SCAN_ROOT" >&2
+    exit 2
+fi
+
+FAIL=0
+
+# check_file <path>
+# Scan one .ag file. Prints findings to stdout. Updates global FAIL.
+check_file() {
+    local ag_file="$1"
+
+    # Pass 1: collect gate function names — fns whose body contains
+    # `recall_latest(`. Output: one name per line.
+    local gate_fns
+    gate_fns="$(awk '
+        BEGIN { depth = 0; in_fn = 0; fn_name = ""; gate_seen = 0 }
+
+        {
+            # Detect top-level `fn NAME(` when not already inside one.
+            if (!in_fn && depth == 0 && match($0, /^[[:space:]]*fn[[:space:]]+[a-zA-Z_][a-zA-Z_0-9]*/)) {
+                s = substr($0, RSTART, RLENGTH)
+                sub(/^[[:space:]]*fn[[:space:]]+/, "", s)
+                fn_name = s
+                in_fn = 1
+                gate_seen = 0
+            }
+
+            if (in_fn && $0 ~ /recall_latest[[:space:]]*\(/) {
+                gate_seen = 1
+            }
+
+            # Update brace depth using a copy with line-comments stripped.
+            line = $0
+            sub(/\/\/.*$/, "", line)
+            opens = gsub(/\{/, "", line)
+            closes = gsub(/\}/, "", line)
+            depth += opens - closes
+
+            if (in_fn && depth <= 0) {
+                if (gate_seen && fn_name != "") print fn_name
+                in_fn = 0
+                fn_name = ""
+                gate_seen = 0
+                if (depth < 0) depth = 0
+            }
+        }
+    ' "$ag_file" | sort -u)"
+
+    # Pass 2: flag each `prompt(` call inside a fn that was not preceded
+    # within the same fn by `recall_latest(` or a gate-fn call.
+    local findings
+    findings="$(awk -v gate_fns_str="$gate_fns" -v file="$ag_file" '
+        BEGIN {
+            n = split(gate_fns_str, arr, "\n")
+            for (i = 1; i <= n; i++) {
+                if (arr[i] != "") gate_fns[arr[i]] = 1
+            }
+            depth = 0; in_fn = 0; fn_name = ""; gate_seen = 0
+            prev_line = ""
+        }
+
+        {
+            entered_fn_this_line = 0
+            if (!in_fn && depth == 0 && match($0, /^[[:space:]]*fn[[:space:]]+[a-zA-Z_][a-zA-Z_0-9]*/)) {
+                s = substr($0, RSTART, RLENGTH)
+                sub(/^[[:space:]]*fn[[:space:]]+/, "", s)
+                fn_name = s
+                in_fn = 1
+                gate_seen = 0
+                entered_fn_this_line = 1
+            }
+
+            if (in_fn) {
+                # Rule 1: recall_latest() in same fn.
+                if ($0 ~ /recall_latest[[:space:]]*\(/) gate_seen = 1
+
+                # Rule 2: call to a known gate function in same fn.
+                if (!gate_seen) {
+                    for (g in gate_fns) {
+                        # `g(` where `g` is a whole-word identifier.
+                        # [^a-zA-Z_0-9] ensures we do not match a prefix
+                        # of another name.
+                        pat = "(^|[^a-zA-Z_0-9])" g "[[:space:]]*\\("
+                        if ($0 ~ pat) { gate_seen = 1; break }
+                    }
+                }
+
+                # Check for `prompt(` on this line — but only flag if this
+                # is not the `fn prompt(` definition line itself (defensive;
+                # agentis has no user-defined prompt function but belt-and-braces).
+                if (!entered_fn_this_line && $0 ~ /prompt[[:space:]]*\(/) {
+                    # Exclude the standalone `fn prompt(` definition case.
+                    if ($0 !~ /^[[:space:]]*fn[[:space:]]+prompt[[:space:]]*\(/) {
+                        suppressed = 0
+                        if ($0 ~ /colony-lint:[[:space:]]*impl-prompt-gate-ok/) suppressed = 1
+                        else if (prev_line ~ /colony-lint:[[:space:]]*impl-prompt-gate-ok/) suppressed = 1
+
+                        if (!suppressed && !gate_seen) {
+                            printf "[UNGATED] %s:%d: prompt() in fn `%s` is not preceded by recall_latest() or a gate-fn call (add a memo gate or annotate with `// colony-lint: impl-prompt-gate-ok`)\n", file, NR, fn_name
+                        }
+                    }
+                }
+            }
+
+            # Update brace depth for next iteration.
+            line = $0
+            sub(/\/\/.*$/, "", line)
+            opens = gsub(/\{/, "", line)
+            closes = gsub(/\}/, "", line)
+            depth += opens - closes
+
+            if (in_fn && depth <= 0) {
+                in_fn = 0
+                fn_name = ""
+                gate_seen = 0
+                if (depth < 0) depth = 0
+            }
+
+            prev_line = $0
+        }
+    ' "$ag_file")"
+
+    if [ -n "$findings" ]; then
+        printf '%s\n' "$findings"
+        local count
+        count="$(printf '%s\n' "$findings" | grep -c '^\[UNGATED\]' || true)"
+        FAIL=$((FAIL + count))
+    fi
+}
+
+# Main: walk only implementation/agents/*.ag files under SCAN_ROOT.
+if [ -f "$SCAN_ROOT" ]; then
+    # Single-file mode: scan regardless of path (useful for testing).
+    check_file "$SCAN_ROOT"
+else
+    while IFS= read -r -d '' f; do
+        check_file "$f"
+    done < <(find "$SCAN_ROOT" -type f -path '*/implementation/agents/*.ag' -print0)
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "check-impl-prompt-gate: $FAIL unguarded prompt() finding(s)"
+    exit 1
+fi
+
+exit 0

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -444,6 +444,22 @@ if [ -x "$REPO_ROOT/tools/check-exec-sh.sh" ]; then
     fi
 fi
 
+# --- Check implementation/agents/ for unguarded prompt() (#200 / #205) ---
+# The implementation colony ticks frequently; a `prompt()` that is not
+# gated on a memo-based staleness check drives ~60 LLM calls/hour per
+# stuck issue. This grep-level check fails the lint if any
+# `implementation/agents/*.ag` file has a `prompt()` not preceded (within
+# the same function) by `recall_latest()` or a call to a gate fn.
+if [ -x "$REPO_ROOT/tools/check-impl-prompt-gate.sh" ]; then
+    check_out="$("$REPO_ROOT/tools/check-impl-prompt-gate.sh" "$REPO_ROOT" 2>&1)" && check_rc=0 || check_rc=$?
+    if [ "$check_rc" -eq 0 ]; then
+        pass "check-impl-prompt-gate: all implementation prompts memo-gated"
+    else
+        fail "check-impl-prompt-gate: unguarded prompt() in implementation/agents"
+        printf '%s\n' "$check_out"
+    fi
+fi
+
 # --- Lint tools themselves ---
 if command -v shellcheck &>/dev/null; then
     tools_dir="$REPO_ROOT/tools"

--- a/tools/test-check-impl-prompt-gate.sh
+++ b/tools/test-check-impl-prompt-gate.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+# tools/test-check-impl-prompt-gate.sh: unit tests for tools/check-impl-prompt-gate.sh.
+#
+# Self-contained. Creates temporary .ag fixture files, runs the checker
+# against them, asserts exit code + output pattern. Cleans up on exit.
+#
+# Usage: ./tools/test-check-impl-prompt-gate.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECKER="$SCRIPT_DIR/check-impl-prompt-gate.sh"
+
+if [ ! -x "$CHECKER" ]; then
+    echo "[FAIL] checker not found or not executable: $CHECKER"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# write_fixture <name> <content>
+# Returns: path to the fixture file via stdout.
+write_fixture() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name.ag"
+    printf '%s' "$content" > "$path"
+    printf '%s' "$path"
+}
+
+# run_checker <fixture-path>
+# Captures stdout+stderr in $out, exit code in $rc.
+run_checker() {
+    set +e
+    out="$("$CHECKER" "$1" 2>&1)"
+    rc=$?
+    set -e
+}
+
+# --- Test 1: prompt gated by recall_latest in same fn ---
+f="$(write_fixture "gated-via-recall" '
+fn tick(reason: string) -> void {
+    let ts = recall_latest("agent:last_check");
+    let classification = prompt("classify", "x") -> string;
+    print(classification);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "gated-via-recall: prompt after recall_latest not flagged"
+else
+    fail "gated-via-recall" "rc=$rc out=$out"
+fi
+
+# --- Test 2: prompt gated by call to a gate fn ---
+f="$(write_fixture "gated-via-fn" '
+fn should_act() -> bool {
+    let last = recall_latest("agent:last_check");
+    return len(last) > 0;
+}
+
+fn tick(reason: string) -> void {
+    if should_act() {
+        let classification = prompt("classify", "x") -> string;
+        print(classification);
+    };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "gated-via-fn: prompt after gate-fn call not flagged"
+else
+    fail "gated-via-fn" "rc=$rc out=$out"
+fi
+
+# --- Test 3: bare prompt with no gate is flagged ---
+f="$(write_fixture "ungated-bare" '
+fn tick(reason: string) -> void {
+    let classification = prompt("classify", "x") -> string;
+    print(classification);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "\[UNGATED\]" && printf '%s' "$out" | grep -q "tick"; then
+    pass "ungated-bare: flagged"
+else
+    fail "ungated-bare" "rc=$rc out=$out"
+fi
+
+# --- Test 4: suppression comment on same line ---
+f="$(write_fixture "suppressed-same-line" '
+fn tick(reason: string) -> void {
+    let classification = prompt("classify", "x") -> string; // colony-lint: impl-prompt-gate-ok
+    print(classification);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "suppressed-same-line: not flagged"
+else
+    fail "suppressed-same-line" "rc=$rc out=$out"
+fi
+
+# --- Test 5: suppression comment on preceding line ---
+f="$(write_fixture "suppressed-preceding" '
+fn tick(reason: string) -> void {
+    // colony-lint: impl-prompt-gate-ok
+    let classification = prompt("classify", "x") -> string;
+    print(classification);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "suppressed-preceding: not flagged"
+else
+    fail "suppressed-preceding" "rc=$rc out=$out"
+fi
+
+# --- Test 6: non-gate fn (no recall_latest in body) does not launder a prompt ---
+f="$(write_fixture "fake-gate-fn" '
+fn not_a_gate() -> string {
+    return "hello";
+}
+
+fn tick(reason: string) -> void {
+    let x = not_a_gate();
+    let classification = prompt("classify", "x") -> string;
+    print(classification);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "\[UNGATED\]"; then
+    pass "fake-gate-fn: prompt after call to non-gate fn still flagged"
+else
+    fail "fake-gate-fn" "rc=$rc out=$out"
+fi
+
+# --- Test 7: recall_latest in a sibling fn does not count ---
+f="$(write_fixture "recall-in-other-fn" '
+fn get_confidence() -> float {
+    let raw = recall_latest("agent:confidence");
+    return parse_float(raw);
+}
+
+fn tick(reason: string) -> void {
+    let classification = prompt("classify", "x") -> string;
+    print(classification);
+}
+')"
+run_checker "$f"
+# get_confidence IS a gate fn (it reads recall_latest), but tick() does
+# not call it before the prompt, so the prompt must still be flagged.
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "\[UNGATED\]"; then
+    pass "recall-in-other-fn: uncalled gate-fn does not count"
+else
+    fail "recall-in-other-fn" "rc=$rc out=$out"
+fi
+
+# --- Test 8: multiple prompts in one fn, all after a gate, all clean ---
+f="$(write_fixture "multi-prompt-after-gate" '
+fn should_act(iid: string) -> bool {
+    let last = recall_latest("agent:last_iid");
+    return last != iid;
+}
+
+fn tick(reason: string) -> void {
+    if should_act("42") {
+        let a = prompt("first", "x") -> string;
+        let b = prompt("second", a) -> string;
+        let c = prompt("third", b) -> string;
+        print(a, b, c);
+    };
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "multi-prompt-after-gate: all cleared by a single preceding gate call"
+else
+    fail "multi-prompt-after-gate" "rc=$rc out=$out"
+fi
+
+# --- Test 9: fn boundary resets gate state ---
+f="$(write_fixture "boundary-reset" '
+fn one() -> void {
+    let ts = recall_latest("agent:a");
+    let x = prompt("ok here", ts) -> string;
+}
+
+fn two() -> void {
+    let y = prompt("but not here", "x") -> string;
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "\[UNGATED\]" && printf '%s' "$out" | grep -q "two"; then
+    pass "boundary-reset: prompt in second fn flagged, first fn clean"
+else
+    fail "boundary-reset" "rc=$rc out=$out"
+fi
+
+# --- Test 10: regression — current dev-apprenticeship/implementation/agents must pass ---
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+run_checker "$REPO_ROOT/dev-apprenticeship"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "regression: current implementation/agents clean"
+else
+    fail "regression: current implementation/agents" "rc=$rc out=$out"
+fi
+
+# --- Test 11: directory with no implementation/agents is clean ---
+empty_dir="$TMPDIR_TEST/empty-fed"
+mkdir -p "$empty_dir/other-colony/agents"
+cat > "$empty_dir/other-colony/agents/x.ag" <<'AGEOF'
+fn tick(reason: string) -> void {
+    let y = prompt("x", "y") -> string;
+}
+AGEOF
+run_checker "$empty_dir"
+# This file is NOT under */implementation/agents/*, so it must not be scanned.
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "non-implementation-path: not scanned"
+else
+    fail "non-implementation-path" "rc=$rc out=$out"
+fi
+
+# --- Test 12: nonexistent path exits 2 ---
+run_checker "$TMPDIR_TEST/does-not-exist"
+if [ "$rc" -eq 2 ]; then
+    pass "nonexistent: exit code 2"
+else
+    fail "nonexistent" "rc=$rc out=$out"
+fi
+
+# --- Test 13: prompt gated via nested gate fn (gate-fn calls another gate-fn) ---
+# We do not do transitive analysis; a gate-fn is defined strictly as a fn
+# that contains `recall_latest(` in its own body. Verify this is NOT
+# laundered through a wrapper.
+f="$(write_fixture "transitive-gate" '
+fn inner() -> string {
+    let x = recall_latest("agent:a");
+    return x;
+}
+
+fn wrapper() -> string {
+    return inner();
+}
+
+fn tick(reason: string) -> void {
+    let x = wrapper();
+    let y = prompt("q", x) -> string;
+}
+')"
+run_checker "$f"
+# `wrapper` is NOT a gate fn (its body has no recall_latest) — by design,
+# this must fail so that authors are forced to make the memo read visible.
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "\[UNGATED\]"; then
+    pass "transitive-gate: wrapper call does NOT launder (by design)"
+else
+    fail "transitive-gate" "rc=$rc out=$out"
+fi
+
+# --- Test 14: prompt on gate line + multi-line prompt body ---
+f="$(write_fixture "multiline-prompt" '
+fn tick(reason: string) -> void {
+    let ts = recall_latest("agent:last_check");
+    let result = prompt(
+        "long prompt here",
+        ts
+    ) -> string;
+    print(result);
+}
+')"
+run_checker "$f"
+# The `prompt(` token is on its own line. Gate was set above. Must pass.
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "multiline-prompt: gate on earlier line covers multi-line prompt()"
+else
+    fail "multiline-prompt" "rc=$rc out=$out"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-check-impl-prompt-gate.sh
+++ b/tools/test-check-impl-prompt-gate.sh
@@ -284,6 +284,67 @@ else
     fail "multiline-prompt" "rc=$rc out=$out"
 fi
 
+# --- Test 15: `prompt(` token inside a `//` line comment is ignored ---
+f="$(write_fixture "prompt-in-comment" '
+fn tick(reason: string) -> void {
+    // once called prompt() here but no longer
+    let y = 42;
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass 'prompt-in-comment: prompt( in // comment not flagged'
+else
+    fail "prompt-in-comment" "rc=$rc out=$out"
+fi
+
+# --- Test 16: gate call AFTER prompt on same physical line does NOT cover it ---
+f="$(write_fixture "same-line-order" '
+fn tick(reason: string) -> void {
+    let y = prompt("bare", "x") -> string; let z = recall_latest("k");
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "\[UNGATED\]"; then
+    pass "same-line-order: gate after prompt on same line does not cover it"
+else
+    fail "same-line-order" "rc=$rc out=$out"
+fi
+
+# --- Test 17: gate call BEFORE prompt on same physical line DOES cover it ---
+f="$(write_fixture "same-line-gate-first" '
+fn tick(reason: string) -> void {
+    let x = recall_latest("k"); let y = prompt("ok", x) -> string;
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "same-line-gate-first: gate before prompt on same line covers it"
+else
+    fail "same-line-gate-first" "rc=$rc out=$out"
+fi
+
+# --- Test 18: commented-out `recall_latest` in a fn does NOT make it a gate fn ---
+f="$(write_fixture "commented-recall" '
+fn fake_gate() -> string {
+    // recall_latest("agent:x")
+    return "y";
+}
+
+fn tick(reason: string) -> void {
+    let x = fake_gate();
+    let y = prompt("bare", x) -> string;
+}
+')"
+run_checker "$f"
+# fake_gate is NOT a gate fn because its real body has no recall_latest —
+# the match is only inside a `//` line comment, which pass 1 strips.
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "\[UNGATED\]"; then
+    pass "commented-recall: // recall_latest in fn body does not make it a gate fn"
+else
+    fail "commented-recall" "rc=$rc out=$out"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds `tools/check-impl-prompt-gate.sh` — a grep/awk-based colony-lint check that fails if any `prompt()` call inside a file under `*/implementation/agents/` is not preceded (within the same function scope) by either a `recall_latest()` read or a call to a **gate function** (a free fn in the same file whose body contains `recall_latest(...)`).

Motivation: the implementation colony ticks frequently against GitLab, and an unguarded `prompt()` call burns ~60 LLM calls per hour per stuck issue (the bug that #200 / PR #204 fixed in the three current ticking agents). This lint guards against a future `implementation/` agent silently re-introducing the same waste.

Matches the grep-level design pattern of `tools/check-exec-sh.sh` — integrated into `colony-lint.sh` the same way, picked up automatically by the existing `test-*.sh` unit-test loop and by the `shellcheck` sweep.

Closes #205.

## Rule

For every `prompt(...)` call in a `.ag` file under `*/implementation/agents/`, the same function must contain **before** the prompt either:

1. A `recall_latest(...)` read, **or**
2. A call to a gate function — a free fn defined in the same file whose body contains `recall_latest(...)`.

Suppress a false positive (e.g., a proven cold-path prompt whose upstream emitters carry memo gates) with `// colony-lint: impl-prompt-gate-ok` on the `prompt(` line itself or the preceding line.

### Current agents all pass

The 4 existing `implementation/agents/*.ag` files satisfy rule (2) via `merged_mr_cmd()` (pattern-learning branch) and/or `should_*` helpers (draft branch); the regression test in `test-check-impl-prompt-gate.sh` pins that.

## Design

Two-pass awk over each `.ag` file:

- **Pass 1** — identify gate functions: fn whose body contains `recall_latest(...)`. Brace-depth tracking with `//` comments stripped.
- **Pass 2** — for each `prompt(...)` inside a fn, require the same-function prefix to contain a `recall_latest(` call OR a call to a gate function from pass 1. Respect suppression comment on the prompt line or the preceding line.

Intentionally **does not** do transitive analysis (a wrapper fn that calls a gate fn is not itself a gate) — forces the memo read to stay visible where the prompt lives. See test 13 `transitive-gate`.

Known caveats documented in the file header.

## Tests

14 unit tests in `tools/test-check-impl-prompt-gate.sh`, all passing:

- `gated-via-recall` / `gated-via-fn` / `multi-prompt-after-gate` / `multiline-prompt` — positive cases, must not flag
- `ungated-bare` / `fake-gate-fn` / `recall-in-other-fn` / `boundary-reset` / `transitive-gate` — negative cases, must flag
- `suppressed-same-line` / `suppressed-preceding` — suppression semantics
- `non-implementation-path` — only scans `*/implementation/agents/*.ag`
- `nonexistent` — exit 2 on usage error
- `regression` — real `dev-apprenticeship/` codebase must pass

## Acceptance checklist (from #205)

- [x] Running `tools/colony-lint.sh` on a synthetic `implementation/` agent with a bare `prompt()` fails — covered by `ungated-bare` test.
- [x] Running it on the 4 current `implementation/` agents passes — covered by `regression` test + full colony-lint run.
- [x] Added to CI coverage counts — baseline bumped CI 38→40, local 74→76 (+1 check pass, +1 unit-test pass).

## Test plan

- [x] `./tools/check-impl-prompt-gate.sh dev-apprenticeship` → rc=0
- [x] `./tools/test-check-impl-prompt-gate.sh` → 14 passed, 0 failed
- [x] `./tools/colony-lint.sh` → 76/0/5 (local)
- [ ] CI `colony-lint.sh` → 40/0/1