### PR TITLE
docs: polish top-level README for discoverability + onboarding (#212)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Open-source agent colonies built on the [Agentis](https://github.com/Replikanti/agentis) runtime.
 
-**Agentis** is a proprietary AI-native platform for agent emergence. It provides the runtime, language, evolution engine, and distributed infrastructure. **Colonies** (this repo) are open-source (Apache 2.0) configurations of agents that solve real-world problems using that runtime.
+**Agentis** is a proprietary AI-native platform for agent emergence (runtime, language, evolution engine, distributed infrastructure). **Colonies** (this repo) are Apache 2.0 configurations of agents that solve real-world problems on that runtime.
+
+**What makes this repo distinctive:** every agent runs in `shadow` (observe-only) mode by default. It graduates up a four-tier confidence ladder — `shadow` → `propose` → `review-gated` → `autonomous` — based on measured experience, not hand-tuned thresholds. An agent only acts on your project once it has earned the tier. See [`doc/adr/ADR-0001-confidence-tiers.md`](./doc/adr/ADR-0001-confidence-tiers.md).
 
 ## Colonies and Federations
 
@@ -34,6 +36,8 @@ graph TD
     C3 --> A6
 ```
 
+[`dev-apprenticeship/`](./dev-apprenticeship/) is one concrete instance: 5 colonies, 21 agents covering triage, planning, implementation, code review, and release.
+
 ## Federations
 
 | Federation | Description | Agents | Status |
@@ -49,15 +53,47 @@ graph TD
 | **Alpha** | Core agents work. Some features incomplete or untested. |
 | **Planned** | Design exists, implementation not started. |
 
+## Quickstart
+
+```bash
+git clone https://github.com/Replikanti/agentis-colonies
+cd agentis-colonies/dev-apprenticeship
+./install.sh           # interactive: prereqs, config, GitLab creds, confidence seed
+./start-federation.sh  # launches 21 daemons
+```
+
+You now have 21 agents in `shadow` mode observing your GitLab project. Watch their reasoning via `./watch-suggestions.sh` or the web dashboard via `./dashboard.sh`.
+
+Need the runtime first? See [Replikanti/agentis](https://github.com/Replikanti/agentis).
+
 ## Prerequisites
 
 - [Agentis](https://github.com/Replikanti/agentis) runtime
 - An LLM backend (Claude CLI, Ollama, or any OpenAI-compatible API)
 - GitLab instance with API access
 
+## Repository structure
+
+```
+dev-apprenticeship/   # Federation: GitLab dev workflow (21 agents, Beta)
+tools/                # Shared federation tooling (lint, dashboard, auto-promote, kill)
+doc/                  # Reference docs (auto-promote, federation-dashboard)
+doc/adr/              # Architecture Decision Records (normative cross-repo contracts)
+```
+
 ## Operator scripts
 
-When you need to reliably stop a federation — agents, dashboard, registry sidecar files, with a backup tarball before cleanup — use [`tools/kill-federation.sh`](./tools/kill-federation.sh) (or its per-federation wrapper, e.g. `dev-apprenticeship/kill-federation.sh`). It bypasses the `agentis` CLI and uses OS signals with post-kill verification, so it works even when `agentis daemon stop --all` reports false success or false failure. Run with `--help` for options including `--dry-run` and `--json`.
+End-user scripts live inside each federation. For `dev-apprenticeship/`:
+
+| Script | Purpose |
+|--------|---------|
+| [`install.sh`](./dev-apprenticeship/install.sh) | Interactive setup: prerequisites, config, GitLab creds, confidence seed |
+| [`start-federation.sh`](./dev-apprenticeship/start-federation.sh) | Launch all 5 colonies (21 daemons) |
+| [`watch-suggestions.sh`](./dev-apprenticeship/watch-suggestions.sh) | Live feed of agent suggestions from all 21 logs |
+| [`dashboard.sh`](./dev-apprenticeship/dashboard.sh) | Web dashboard with operator controls (promote, demote, evolve, restart, kill). Full reference: [`doc/federation-dashboard.md`](./doc/federation-dashboard.md) |
+| [`kill-federation.sh`](./dev-apprenticeship/kill-federation.sh) | Reliable shutdown (wraps [`tools/kill-federation.sh`](./tools/kill-federation.sh) with `--fed-dir` scoping) |
+
+`kill-federation.sh` bypasses the `agentis` CLI and uses OS signals with post-kill verification, so it works even when `agentis daemon stop --all` reports false success or false failure. Run with `--help` for options including `--dry-run` and `--json`.
 
 ## Tiers
 


### PR DESCRIPTION
Closes #212.

## Summary

Adds the pieces a first-time visitor needs from the top-level README: quickstart, repo map, full operator-script table, and a concrete "why" hook. All changes contained in `README.md` — no CLAUDE.md, no ADR, no agent files.

## Changes

- **Intro**: sharpened with a "what makes this repo distinctive" paragraph centred on the observe-before-act tier ladder (normative per ADR-0001; no new claim).
- **Quickstart**: new section with the 3-command happy path (`clone → install.sh → start-federation.sh`), positioned so the reader sees the payoff before the checklist.
- **Repository structure**: one-line descriptions of `dev-apprenticeship/`, `tools/`, `doc/`, `doc/adr/`.
- **Operator scripts**: expanded from a single-paragraph kill-federation note to a full table of all 5 end-user scripts (install, start, watch-suggestions, dashboard, kill); kill-federation rationale preserved as a trailing paragraph.
- **Dashboard mention**: one-line pointer to `doc/federation-dashboard.md` from the operator-scripts table.
- **Mermaid note**: single line below the abstract diagram noting `dev-apprenticeship/` as a concrete instance (cheapest fix for the "abstract-only" criticism without redrawing).

## Test plan

- [x] `./tools/colony-lint.sh` → 76 passed, 0 failed, 5 skipped (markdown-link check included).
- [x] All 13 relative links in README verified to resolve via `grep + -e` check.
- [x] Line count: 89 → 125 (under 150 budget).
- [x] CI → 40 passed, 0 failed, 1 skipped (baseline preserved, same as #211).

## Out of scope

- `dev-apprenticeship/README.md` polish (separate candidate, Option B).
- Per-colony README consistency pass (separate candidate, Option D).
- Screenshots, CI/license badges, no new artifacts.
- No CLAUDE.md / ADR changes.