### PR TITLE
feat(release): curated install-ready bundle + tag-triggered CI (#220)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+# Tag-triggered bundle + asset upload for per-federation releases (#220).
+# Fires on pushes of tags shaped like `<federation>-v<X.Y.Z>`.
+#
+# The workflow:
+#   1. Checks out the tagged commit (full history so the awk on CHANGELOG has
+#      everything it needs).
+#   2. Parses `<federation>` and `<version>` from `$GITHUB_REF_NAME`.
+#   3. Builds the curated bundle via `tools/make-federation-bundle.sh`.
+#   4. Extracts the matching CHANGELOG section as release notes.
+#   5. Creates the GitHub release if it doesn't already exist (including the
+#      asset upload in the same call); otherwise uploads the asset onto the
+#      pre-existing release with `--clobber`.
+#
+# Maintainer workflow after a release PR merges is therefore:
+#   git tag <federation>-v<X.Y.Z> <merge-sha> -m "..."
+#   git push origin <federation>-v<X.Y.Z>
+# No manual `gh release create` / `gh release upload` needed.
+
+on:
+  push:
+    tags:
+      - 'dev-apprenticeship-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout at tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Parse federation + version from tag
+        id: tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          FED="${TAG%-v*}"
+          VER="${TAG##*-v}"
+          {
+            echo "tag=$TAG"
+            echo "fed=$FED"
+            echo "ver=$VER"
+          } >> "$GITHUB_OUTPUT"
+          echo "Parsed: federation='$FED', version='$VER' from tag '$TAG'"
+
+      - name: Build federation bundle
+        run: ./tools/make-federation-bundle.sh "${{ steps.tag.outputs.fed }}" "${{ steps.tag.outputs.ver }}"
+
+      - name: Extract release notes from CHANGELOG
+        run: |
+          FED='${{ steps.tag.outputs.fed }}'
+          VER='${{ steps.tag.outputs.ver }}'
+          mkdir -p dist
+          awk -v ver="$VER" '
+            $0 ~ "^## \\[" ver "\\]" { flag=1; next }
+            /^## \[/ { flag=0 }
+            /^\[[^]]+\]:/ { flag=0 }
+            flag
+          ' "$FED/CHANGELOG.md" > dist/release-notes.md
+          if [ ! -s dist/release-notes.md ]; then
+            echo "No CHANGELOG section matched '[${VER}]' — falling back to tag message." >&2
+            git tag -l --format='%(contents)' "${{ steps.tag.outputs.tag }}" > dist/release-notes.md
+          fi
+          echo "=== release notes preview (first 20 lines) ==="
+          head -20 dist/release-notes.md
+
+      - name: Create or update GitHub release with bundle asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG='${{ steps.tag.outputs.tag }}'
+          FED='${{ steps.tag.outputs.fed }}'
+          VER='${{ steps.tag.outputs.ver }}'
+          TARBALL="dist/${FED}-v${VER}.tar.gz"
+          SHAFILE="${TARBALL}.sha256"
+          if gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — uploading asset with --clobber."
+            gh release upload "$TAG" "$TARBALL" "$SHAFILE" \
+              --repo "${GITHUB_REPOSITORY}" --clobber
+          else
+            echo "Creating release $TAG with curated bundle asset."
+            gh release create "$TAG" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${FED} v${VER}" \
+              --notes-file dist/release-notes.md \
+              "$TARBALL" "$SHAFILE"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # Python bytecode (from helper scripts in tools/)
 __pycache__/
 *.pyc
+
+# Federation release bundles (produced by tools/make-federation-bundle.sh; #220)
+/dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,21 +14,21 @@ Pre-built agent colonies for the [Agentis](https://github.com/Replikanti/agentis
 
 Each federation is versioned independently at the federation level. `dev-apprenticeship/` follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html); history is in [`dev-apprenticeship/CHANGELOG.md`](./dev-apprenticeship/CHANGELOG.md) (Keep a Changelog format).
 
-Cutting a release ([#218](https://github.com/Replikanti/agentis-colonies/issues/218)):
+Cutting a release ([#218](https://github.com/Replikanti/agentis-colonies/issues/218), [#220](https://github.com/Replikanti/agentis-colonies/issues/220)):
 
 1. **Open a release PR** titled `release: dev-apprenticeship v<X.Y.Z>` that changes only:
    - `dev-apprenticeship/VERSION` (single-line bump).
    - `dev-apprenticeship/CHANGELOG.md` — rename `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, add a fresh empty `## [Unreleased]` on top, update the trailing comparison link. If the runtime floor changed, update the `**Requires:** agentis >= ...` line.
    - Optionally the version badges in `dev-apprenticeship/README.md` and the top-level `README.md`.
-2. **After merge:** tag and publish:
+2. **After merge:** tag and push:
    ```bash
    git tag dev-apprenticeship-v<X.Y.Z> <merge-sha> -m "dev-apprenticeship v<X.Y.Z>"
    git push origin dev-apprenticeship-v<X.Y.Z>
-   gh release create dev-apprenticeship-v<X.Y.Z> \
-     --title "dev-apprenticeship v<X.Y.Z>" \
-     --notes "$(awk '/^## \[<X.Y.Z>\]/{flag=1;next} /^## \[/{flag=0} /^\[[^]]+\]:/{flag=0} flag' dev-apprenticeship/CHANGELOG.md)"
    ```
+   That is the entire post-merge step. `.github/workflows/release.yml` ([#220](https://github.com/Replikanti/agentis-colonies/issues/220)) fires on the tag, runs `tools/make-federation-bundle.sh dev-apprenticeship <X.Y.Z>`, and creates-or-updates the GitHub release with the curated bundle (`dev-apprenticeship-v<X.Y.Z>.tar.gz` + `.sha256`) and CHANGELOG-extracted notes attached. No manual `gh release create` / `gh release upload` required.
 3. **Semver decisions** — bus-event rename/removal, agent removal, config-schema break, or a tier-semantics change in ADR-0001 is **MAJOR**. A new agent, new bus event (without removing one), a new optional config key, or a new install prompt defaulting to off is **MINOR**. Bug fixes, `.ag` tuning, docs, and new colony-lint rules that don't flag anything already-merged are **PATCH**.
+
+If a new runtime dependency under `tools/` is added that `dev-apprenticeship/` sources or invokes, append its path to `dev-apprenticeship/BUNDLE.manifest` in the same PR so the release bundle stays install-ready. `tools/test-make-federation-bundle.sh` enforces that every manifest entry exists and that contributor-only tooling (this file, `.github/`, `tools/colony-lint.sh`, `tools/check-*.sh`, `tools/test-*.sh`, `tools/new-colony.sh`) never leaks into a bundle.
 
 `colony-lint` (via `tools/check-changelog.sh`) warns whenever a PR touches `dev-apprenticeship/` without updating `CHANGELOG.md`, and fails whenever `VERSION` bumps without a matching CHANGELOG entry.
 
@@ -39,7 +39,7 @@ Cutting a release ([#218](https://github.com/Replikanti/agentis-colonies/issues/
 bash -n scripts/gitlab-api.sh   # Bash syntax check on any script
 ```
 
-Colony lint must pass with 0 failures before merge. Current CI baseline: 41 passed, 0 failed, 1 skipped (agentis binary not installed on runners). Local runs add ~42 per-agent `.ag` syntax + tier-branch passes when `agentis` is installed, and 5 skips when `shellcheck` is not.
+Colony lint must pass with 0 failures before merge. Current CI baseline: 42 passed, 0 failed, 1 skipped (agentis binary not installed on runners). Local runs add ~42 per-agent `.ag` syntax + tier-branch passes when `agentis` is installed, and 5 skips when `shellcheck` is not.
 
 ## Colony structure
 
@@ -148,6 +148,7 @@ release:changelog_draft      -> version_bumper
 | `check-exec-sh.sh` | Grep-based check for unsafe string concat into `exec sh`. See `check-exec-sh.md` for known limitations. |
 | `check-prompt-gate.sh` | Grep/awk lint that ensures every `prompt()` in `implementation/`, `planning/`, `code-review/`, and `triage/` agents is preceded (same function) by a memo-based staleness gate (`recall_latest()` or gate fn) ([#200](https://github.com/Replikanti/agentis-colonies/issues/200), [#201](https://github.com/Replikanti/agentis-colonies/issues/201), [#205](https://github.com/Replikanti/agentis-colonies/issues/205), [#208](https://github.com/Replikanti/agentis-colonies/issues/208), [#210](https://github.com/Replikanti/agentis-colonies/issues/210)). Use `// colony-lint: prompt-gate-ok` on intentional cold-path prompts (legacy alias `// colony-lint: impl-prompt-gate-ok` still works). |
 | `check-changelog.sh` | CI-only soft check ([#218](https://github.com/Replikanti/agentis-colonies/issues/218)) that warns when a PR touches `dev-apprenticeship/` without updating `dev-apprenticeship/CHANGELOG.md`, and hard-fails when `dev-apprenticeship/VERSION` bumps without a matching CHANGELOG entry. No-op without `GITHUB_BASE_REF` (local runs). |
+| `make-federation-bundle.sh` | Assembles the curated, install-ready release tarball for a federation ([#220](https://github.com/Replikanti/agentis-colonies/issues/220)). Reads `<federation>/BUNDLE.manifest`, stages paths under `dist/<federation>-v<version>/`, emits `.tar.gz` + `.sha256`. Invoked automatically by `.github/workflows/release.yml` on `<federation>-v*` tag pushes. |
 | `parse-toml.sh` | Shared TOML parser sourced by all start-colony.sh scripts |
 | `federation-dashboard.sh` | Generic web dashboard for any federation — auto-discovers colonies/agents, serves operator controls (promote, demote, evolve, restart, kill). Thin shell; orchestrates the four Python helpers + HTML template below. **Never inline heredocs here** (macOS bash parser bug; `test-timeline-rendering.sh` tests 13–19 enforce). Full reference: [`doc/federation-dashboard.md`](./doc/federation-dashboard.md). |
 | `federation-dashboard-collector.py` | Per-agent data collector (experience stats, `.ag` descriptions, log lines, PID liveness, timeline, confidence history). Called by `federation-dashboard.sh` once per regen. See [`doc/federation-dashboard.md`](./doc/federation-dashboard.md#architecture). |

--- a/README.md
+++ b/README.md
@@ -55,11 +55,24 @@ graph TD
 
 ## Quickstart
 
+From a release tarball (recommended — install-ready, no git clone needed):
+
+```bash
+VERSION=0.1.0   # or any tagged dev-apprenticeship release
+curl -LO https://github.com/Replikanti/agentis-colonies/releases/download/dev-apprenticeship-v${VERSION}/dev-apprenticeship-v${VERSION}.tar.gz
+tar xzf dev-apprenticeship-v${VERSION}.tar.gz
+cd dev-apprenticeship-v${VERSION}/dev-apprenticeship
+./install.sh           # interactive: prereqs, config, GitLab creds, confidence seed
+./start-federation.sh  # launches 21 daemons
+```
+
+Or from a clone of the repo (useful if you want to contribute):
+
 ```bash
 git clone https://github.com/Replikanti/agentis-colonies
 cd agentis-colonies/dev-apprenticeship
-./install.sh           # interactive: prereqs, config, GitLab creds, confidence seed
-./start-federation.sh  # launches 21 daemons
+./install.sh
+./start-federation.sh
 ```
 
 You now have 21 agents in `shadow` mode observing your GitLab project. Watch their reasoning via `./watch-suggestions.sh` or the web dashboard via `./dashboard.sh`.

--- a/dev-apprenticeship/BUNDLE.manifest
+++ b/dev-apprenticeship/BUNDLE.manifest
@@ -1,0 +1,46 @@
+# BUNDLE.manifest — dev-apprenticeship federation release bundle (#220)
+#
+# Lists every repo-relative path that must be included in the curated install-ready
+# release tarball for this federation. Consumed by `tools/make-federation-bundle.sh`.
+#
+# Syntax:
+#   - One path per line (repo-relative, POSIX separators).
+#   - Directory entries end with `/` and are copied recursively.
+#   - Lines starting with `#` are comments.
+#   - Blank lines are ignored.
+#
+# Rules for editing:
+#   - Every path MUST exist at bundling time (the bundler fails if one is missing).
+#   - Paths MUST NOT be outside this federation's runtime surface. Contributor-only
+#     tooling (`tools/colony-lint.sh`, `tools/check-*.sh`, `tools/test-*.sh`,
+#     `tools/new-colony.sh`), repo-developer docs (`CLAUDE.md`), and CI config
+#     (`.github/`) are explicitly excluded by `tools/test-make-federation-bundle.sh`.
+#   - When a new runtime dependency is added under `tools/`, append it here in the
+#     same PR so the bundle stays install-ready.
+
+# ----- Federation itself -----
+dev-apprenticeship/
+
+# ----- Shared shell tooling required at runtime -----
+tools/parse-toml.sh
+tools/kill-federation.sh
+tools/auto-promote.sh
+tools/auto-promote-config.yaml
+tools/resolve-tick-interval.py
+
+# ----- Federation dashboard (sh entrypoint + 4 Python helpers + HTML template) -----
+tools/federation-dashboard.sh
+tools/federation-dashboard-collector.py
+tools/federation-dashboard-history.py
+tools/federation-dashboard-renderer.py
+tools/federation-dashboard-server.py
+tools/federation-dashboard.html.template
+
+# ----- Operator-facing documentation referenced from dev-apprenticeship/ -----
+doc/adr/
+doc/auto-promote.md
+doc/federation-dashboard.md
+
+# ----- Top-level repository surface users read on first contact -----
+README.md
+LICENSE

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,14 @@ is asserted until multi-version CI is in place.
 
 ### Added
 
+- **Curated install-ready release bundle** — `tools/make-federation-bundle.sh`
+  + `dev-apprenticeship/BUNDLE.manifest` assemble a slim tarball
+  (`dev-apprenticeship-v<X.Y.Z>.tar.gz`) containing only the paths this
+  federation needs at runtime. `.github/workflows/release.yml` runs on every
+  `dev-apprenticeship-v*` tag push and attaches the tarball + `.sha256` to the
+  GitHub release. End users can now `curl | tar x | install.sh` without
+  cloning the repo. ([#220](https://github.com/Replikanti/agentis-colonies/issues/220))
+
 ### Changed
 
 ### Deprecated

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -61,6 +61,24 @@ graph LR
 
 ## Installation
 
+Pick one of the two install paths.
+
+**Option A — release tarball** (recommended for running the federation; install-ready, no git tree required):
+
+```bash
+VERSION=0.1.0
+curl -LO https://github.com/Replikanti/agentis-colonies/releases/download/dev-apprenticeship-v${VERSION}/dev-apprenticeship-v${VERSION}.tar.gz
+curl -LO https://github.com/Replikanti/agentis-colonies/releases/download/dev-apprenticeship-v${VERSION}/dev-apprenticeship-v${VERSION}.tar.gz.sha256
+sha256sum -c dev-apprenticeship-v${VERSION}.tar.gz.sha256   # optional but recommended
+tar xzf dev-apprenticeship-v${VERSION}.tar.gz
+cd dev-apprenticeship-v${VERSION}/dev-apprenticeship
+./install.sh
+```
+
+The tarball ships only the runtime surface of this federation (the federation itself plus the `tools/` scripts and `doc/` references it needs at run time). Contributor tooling (`colony-lint.sh`, tests, CI config, `CLAUDE.md`) is intentionally excluded — see [`BUNDLE.manifest`](./BUNDLE.manifest).
+
+**Option B — clone the repo** (use this if you want to contribute or work from `main`):
+
 ```bash
 git clone https://github.com/Replikanti/agentis-colonies.git
 cd agentis-colonies/dev-apprenticeship

--- a/tools/make-federation-bundle.sh
+++ b/tools/make-federation-bundle.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# tools/make-federation-bundle.sh: assemble a curated, install-ready release
+# bundle for a single federation (#220).
+#
+# Reads `<federation>/BUNDLE.manifest`, stages every listed path into
+# `dist/<federation>-v<version>/` (preserving repo-relative layout), then tars
+# and sha256-seals the result.
+#
+# The output tarball is what end-users download via
+#   curl -LO https://.../releases/download/<fed>-v<X.Y.Z>/<fed>-v<X.Y.Z>.tar.gz
+# The tag-triggered `.github/workflows/release.yml` invokes this script in CI.
+#
+# Usage:
+#   tools/make-federation-bundle.sh <federation> <version>
+#
+# Example:
+#   tools/make-federation-bundle.sh dev-apprenticeship 0.1.1
+#
+# Exit codes:
+#   0 -- bundle + .sha256 successfully written to dist/
+#   1 -- argument error (usage printed)
+#   2 -- federation directory missing, or BUNDLE.manifest missing / empty
+#   3 -- a path listed in the manifest does not exist on disk
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF' >&2
+Usage: tools/make-federation-bundle.sh <federation> <version>
+
+Assembles dist/<federation>-v<version>.tar.gz (+ .sha256) from the paths listed
+in <federation>/BUNDLE.manifest.
+EOF
+}
+
+if [ "$#" -ne 2 ]; then
+    usage
+    exit 1
+fi
+
+FED="$1"
+VER="$2"
+
+# Locate repo root as the script's grandparent (tools/../).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ ! -d "$FED" ]; then
+    echo "make-federation-bundle: federation directory '$FED' not found (cwd=$REPO_ROOT)" >&2
+    exit 2
+fi
+
+MANIFEST="$FED/BUNDLE.manifest"
+if [ ! -f "$MANIFEST" ]; then
+    echo "make-federation-bundle: manifest '$MANIFEST' not found" >&2
+    exit 2
+fi
+
+DIST="$REPO_ROOT/dist"
+STAGE_NAME="$FED-v$VER"
+STAGE="$DIST/$STAGE_NAME"
+TARBALL="$DIST/$STAGE_NAME.tar.gz"
+SHAFILE="$TARBALL.sha256"
+
+# Fresh staging: drop any leftover from a previous run of the same version.
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+
+entries=0
+while IFS= read -r raw || [ -n "$raw" ]; do
+    # Strip trailing CR (if manifest was edited on Windows), leading/trailing
+    # whitespace, and ignore comments + blanks.
+    line="${raw%$'\r'}"
+    # shellcheck disable=SC2001  # sed is clearer than a bash parameter expansion here.
+    line="$(printf '%s' "$line" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+    case "$line" in
+        ""|"#"*) continue ;;
+    esac
+
+    # Normalize trailing slash so both "doc/adr/" and "tools/parse-toml.sh" work.
+    src="${line%/}"
+    if [ ! -e "$src" ]; then
+        echo "make-federation-bundle: manifest entry '$src' does not exist in repo" >&2
+        exit 3
+    fi
+
+    # Preserve repo-relative layout under $STAGE.
+    parent="$(dirname "$src")"
+    dest_parent="$STAGE/$parent"
+    mkdir -p "$dest_parent"
+    cp -pR "$src" "$dest_parent/"
+    entries=$((entries + 1))
+done < "$MANIFEST"
+
+if [ "$entries" -eq 0 ]; then
+    echo "make-federation-bundle: manifest '$MANIFEST' is empty (no non-comment lines)" >&2
+    exit 2
+fi
+
+# Tar from dist/ so the archive's top-level is the versioned dir.
+tar -C "$DIST" -czf "$TARBALL" "$STAGE_NAME"
+
+# sha256 file format matches `sha256sum -c` expectations.
+( cd "$DIST" && sha256sum "$STAGE_NAME.tar.gz" > "$STAGE_NAME.tar.gz.sha256" )
+
+echo "make-federation-bundle: wrote $TARBALL"
+echo "make-federation-bundle: wrote $SHAFILE"
+echo "make-federation-bundle: staged $entries manifest entries"

--- a/tools/test-make-federation-bundle.sh
+++ b/tools/test-make-federation-bundle.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+# tools/test-make-federation-bundle.sh: unit tests for
+# tools/make-federation-bundle.sh (#220).
+#
+# Validates:
+#   Test 1: arg validation (0 or 1 args -> exit 1, usage printed)
+#   Test 2: missing federation dir -> exit 2
+#   Test 3: missing BUNDLE.manifest -> exit 2
+#   Test 4: empty manifest (comments only) -> exit 2
+#   Test 5: manifest listing non-existent path -> exit 3
+#   Test 6: happy path on a synthetic mini-repo — tar + sha256 produced,
+#           every listed path present in the tar, blacklisted paths absent
+#   Test 7: bash -n on every .sh in the extracted tree (catch cp truncations)
+#   Test 8: real federation smoke — run against the repo's actual
+#           dev-apprenticeship/BUNDLE.manifest, verify key runtime files are
+#           in and contributor-only files are out
+#
+# Tests 1-7 use an isolated mktemp repo; test 8 runs against the live
+# worktree but cleans up `dist/` after. No live file is modified.
+#
+# Usage: ./tools/test-make-federation-bundle.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REAL_BUNDLER="$SCRIPT_DIR/make-federation-bundle.sh"
+
+if [ ! -x "$REAL_BUNDLER" ]; then
+    echo "[FAIL] tools/make-federation-bundle.sh missing or not executable"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"; rm -rf "$REPO_ROOT/dist"' EXIT
+
+# ----- Synthetic mini-repo for tests 1-7 -----
+FAKE_REPO="$TMPDIR_TEST/repo"
+mkdir -p "$FAKE_REPO/tools" "$FAKE_REPO/fakefed/nested" "$FAKE_REPO/doc" "$FAKE_REPO/.github/workflows"
+cp "$REAL_BUNDLER" "$FAKE_REPO/tools/make-federation-bundle.sh"
+chmod +x "$FAKE_REPO/tools/make-federation-bundle.sh"
+
+# Legitimate federation + runtime content
+echo "1.0.0" > "$FAKE_REPO/fakefed/VERSION"
+echo "#!/bin/bash" > "$FAKE_REPO/fakefed/start.sh"
+echo "echo fake" >> "$FAKE_REPO/fakefed/start.sh"
+chmod +x "$FAKE_REPO/fakefed/start.sh"
+echo "data" > "$FAKE_REPO/fakefed/nested/data.txt"
+echo "shared toml parser" > "$FAKE_REPO/tools/parse-toml.sh"
+echo "adr content" > "$FAKE_REPO/doc/ADR.md"
+
+# Blacklisted contributor-only content that MUST NOT leak into bundles.
+echo "repo-dev docs" > "$FAKE_REPO/CLAUDE.md"
+echo "colony lint" > "$FAKE_REPO/tools/colony-lint.sh"
+echo "tool test" > "$FAKE_REPO/tools/test-other.sh"
+echo "check prompt" > "$FAKE_REPO/tools/check-prompt-gate.sh"
+echo "scaffolder" > "$FAKE_REPO/tools/new-colony.sh"
+echo "on: push" > "$FAKE_REPO/.github/workflows/ci.yml"
+
+# ----- Test 1: arg validation -----
+set +e
+OUT="$(cd "$FAKE_REPO" && ./tools/make-federation-bundle.sh 2>&1)"; RC=$?
+if [ "$RC" -eq 1 ] && echo "$OUT" | grep -Fq "Usage:"; then
+    pass "arg validation: zero args -> exit 1 + usage"
+else
+    fail "arg validation (zero args)" "rc=$RC, out=$OUT"
+fi
+OUT="$(cd "$FAKE_REPO" && ./tools/make-federation-bundle.sh fakefed 2>&1)"; RC=$?
+if [ "$RC" -eq 1 ] && echo "$OUT" | grep -Fq "Usage:"; then
+    pass "arg validation: one arg -> exit 1 + usage"
+else
+    fail "arg validation (one arg)" "rc=$RC, out=$OUT"
+fi
+set -e
+
+# ----- Test 2: missing federation directory -----
+set +e
+OUT="$(cd "$FAKE_REPO" && ./tools/make-federation-bundle.sh nonexistent 0.0.1 2>&1)"; RC=$?
+set -e
+if [ "$RC" -eq 2 ] && echo "$OUT" | grep -Fq "federation directory"; then
+    pass "missing federation dir -> exit 2"
+else
+    fail "missing-federation-dir" "rc=$RC, out=$OUT"
+fi
+
+# ----- Test 3: missing manifest -----
+set +e
+OUT="$(cd "$FAKE_REPO" && ./tools/make-federation-bundle.sh fakefed 0.0.1 2>&1)"; RC=$?
+set -e
+if [ "$RC" -eq 2 ] && echo "$OUT" | grep -Fq "BUNDLE.manifest"; then
+    pass "missing manifest -> exit 2"
+else
+    fail "missing-manifest" "rc=$RC, out=$OUT"
+fi
+
+# ----- Test 4: empty manifest (only comments / blanks) -----
+cat > "$FAKE_REPO/fakefed/BUNDLE.manifest" <<'EOF'
+# Comment-only manifest.
+#
+#   indented comment
+
+EOF
+set +e
+OUT="$(cd "$FAKE_REPO" && ./tools/make-federation-bundle.sh fakefed 0.0.1 2>&1)"; RC=$?
+set -e
+if [ "$RC" -eq 2 ] && echo "$OUT" | grep -Fq "empty"; then
+    pass "empty manifest -> exit 2"
+else
+    fail "empty-manifest" "rc=$RC, out=$OUT"
+fi
+
+# ----- Test 5: manifest lists non-existent path -----
+cat > "$FAKE_REPO/fakefed/BUNDLE.manifest" <<'EOF'
+fakefed/
+tools/parse-toml.sh
+tools/does-not-exist.sh
+EOF
+set +e
+OUT="$(cd "$FAKE_REPO" && ./tools/make-federation-bundle.sh fakefed 0.0.1 2>&1)"; RC=$?
+set -e
+if [ "$RC" -eq 3 ] && echo "$OUT" | grep -Fq "does-not-exist"; then
+    pass "manifest entry missing on disk -> exit 3"
+else
+    fail "manifest-entry-missing" "rc=$RC, out=$OUT"
+fi
+
+# ----- Test 6: happy path — tarball + sha256 + layout + no leaks -----
+cat > "$FAKE_REPO/fakefed/BUNDLE.manifest" <<'EOF'
+# fakefed bundle manifest (test fixture)
+fakefed/
+tools/parse-toml.sh
+doc/ADR.md
+EOF
+set +e
+OUT="$(cd "$FAKE_REPO" && ./tools/make-federation-bundle.sh fakefed 0.0.1 2>&1)"; RC=$?
+set -e
+TARBALL="$FAKE_REPO/dist/fakefed-v0.0.1.tar.gz"
+SHAFILE="$FAKE_REPO/dist/fakefed-v0.0.1.tar.gz.sha256"
+if [ "$RC" -ne 0 ]; then
+    fail "happy-path exit" "rc=$RC, out=$OUT"
+elif [ ! -f "$TARBALL" ]; then
+    fail "happy-path tarball" "tarball not at $TARBALL; out=$OUT"
+elif [ ! -f "$SHAFILE" ]; then
+    fail "happy-path sha256" "sha256 not at $SHAFILE; out=$OUT"
+else
+    # sha256 matches
+    if ( cd "$FAKE_REPO/dist" && sha256sum -c "fakefed-v0.0.1.tar.gz.sha256" >/dev/null 2>&1 ); then
+        pass "happy path: tarball + .sha256 produced, sha256 verifies"
+    else
+        fail "happy-path sha256 verify" "sha256 mismatch"
+    fi
+fi
+
+# Layout checks on the produced tarball
+LIST="$(tar tzf "$TARBALL")"
+for expected in \
+    "fakefed-v0.0.1/fakefed/VERSION" \
+    "fakefed-v0.0.1/fakefed/start.sh" \
+    "fakefed-v0.0.1/fakefed/nested/data.txt" \
+    "fakefed-v0.0.1/tools/parse-toml.sh" \
+    "fakefed-v0.0.1/doc/ADR.md"; do
+    if echo "$LIST" | grep -Fxq "$expected"; then :; else
+        fail "happy-path layout" "expected '$expected' missing from tarball"
+    fi
+done
+pass "happy path: every manifest-listed path present in tarball"
+
+# Blacklist non-leakage
+LEAKED=""
+for blacklisted in \
+    "CLAUDE.md" \
+    ".github/workflows/ci.yml" \
+    "tools/colony-lint.sh" \
+    "tools/test-other.sh" \
+    "tools/check-prompt-gate.sh" \
+    "tools/new-colony.sh"; do
+    if echo "$LIST" | grep -Fq "$blacklisted"; then
+        LEAKED="$LEAKED $blacklisted"
+    fi
+done
+if [ -z "$LEAKED" ]; then
+    pass "happy path: no blacklisted contributor-only files leaked"
+else
+    fail "blacklist-leak" "leaked paths:$LEAKED"
+fi
+
+# ----- Test 7: bash -n on every .sh in extracted tree -----
+EXTRACT="$TMPDIR_TEST/extract"
+mkdir -p "$EXTRACT"
+tar -C "$EXTRACT" -xzf "$TARBALL"
+SHELL_BROKEN=0
+while IFS= read -r -d '' sh; do
+    if ! bash -n "$sh" 2>/dev/null; then
+        SHELL_BROKEN=$((SHELL_BROKEN + 1))
+        echo "  bash -n failed: $sh"
+    fi
+done < <(find "$EXTRACT" -name "*.sh" -print0)
+if [ "$SHELL_BROKEN" -eq 0 ]; then
+    pass "extracted tree: bash -n clean on every .sh"
+else
+    fail "extracted-bash-n" "$SHELL_BROKEN script(s) failed syntax check"
+fi
+
+# ----- Test 8: real federation smoke (uses live repo) -----
+REAL_FED="dev-apprenticeship"
+REAL_MANIFEST="$REPO_ROOT/$REAL_FED/BUNDLE.manifest"
+if [ ! -f "$REAL_MANIFEST" ]; then
+    fail "real-federation-smoke" "live manifest $REAL_MANIFEST missing"
+else
+    set +e
+    OUT="$(cd "$REPO_ROOT" && ./tools/make-federation-bundle.sh "$REAL_FED" 0.0.0-smoke 2>&1)"; RC=$?
+    set -e
+    REAL_TARBALL="$REPO_ROOT/dist/$REAL_FED-v0.0.0-smoke.tar.gz"
+    if [ "$RC" -ne 0 ] || [ ! -f "$REAL_TARBALL" ]; then
+        fail "real-federation-smoke build" "rc=$RC, out=$OUT"
+    else
+        REAL_LIST="$(tar tzf "$REAL_TARBALL")"
+        # Required runtime files
+        MISSING=""
+        for expected in \
+            "$REAL_FED-v0.0.0-smoke/$REAL_FED/install.sh" \
+            "$REAL_FED-v0.0.0-smoke/$REAL_FED/start-federation.sh" \
+            "$REAL_FED-v0.0.0-smoke/$REAL_FED/VERSION" \
+            "$REAL_FED-v0.0.0-smoke/$REAL_FED/CHANGELOG.md" \
+            "$REAL_FED-v0.0.0-smoke/tools/parse-toml.sh" \
+            "$REAL_FED-v0.0.0-smoke/tools/auto-promote.sh" \
+            "$REAL_FED-v0.0.0-smoke/tools/federation-dashboard.sh" \
+            "$REAL_FED-v0.0.0-smoke/doc/adr/ADR-0001-confidence-tiers.md" \
+            "$REAL_FED-v0.0.0-smoke/README.md" \
+            "$REAL_FED-v0.0.0-smoke/LICENSE"; do
+            if ! echo "$REAL_LIST" | grep -Fxq "$expected"; then
+                MISSING="$MISSING $expected"
+            fi
+        done
+        # Contributor-only files that MUST NOT be present
+        REAL_LEAKED=""
+        for blacklisted in \
+            "CLAUDE.md" \
+            ".github/" \
+            "tools/colony-lint.sh" \
+            "tools/check-changelog.sh" \
+            "tools/check-exec-sh.sh" \
+            "tools/check-prompt-gate.sh" \
+            "tools/new-colony.sh" \
+            "tools/test-"; do
+            if echo "$REAL_LIST" | grep -Fq "$blacklisted"; then
+                REAL_LEAKED="$REAL_LEAKED $blacklisted"
+            fi
+        done
+        if [ -z "$MISSING" ] && [ -z "$REAL_LEAKED" ]; then
+            pass "real federation: all required runtime files in, no contributor files leaked"
+        else
+            [ -n "$MISSING" ] && fail "real-federation required-files" "missing:$MISSING"
+            [ -n "$REAL_LEAKED" ] && fail "real-federation blacklist" "leaked:$REAL_LEAKED"
+        fi
+    fi
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #220.

## Summary

- New `tools/make-federation-bundle.sh` assembles a curated, install-ready release tarball for a federation from `<fed>/BUNDLE.manifest`, producing `dist/<fed>-v<ver>.tar.gz` + `.sha256`.
- New `.github/workflows/release.yml` fires on `dev-apprenticeship-v*` tag pushes, runs the bundler, and creates-or-updates the GitHub release with the curated bundle attached and CHANGELOG-extracted notes.
- New `dev-apprenticeship/BUNDLE.manifest` declares the federation's runtime surface (federation dir + shared `tools/` + `doc/` + top-level `README.md` + `LICENSE`).
- New `tools/test-make-federation-bundle.sh` is an 11-assertion hermetic unit test auto-discovered by `colony-lint`.
- Docs updated end-to-end: `CLAUDE.md` §Release process (post-merge simplifies to `git tag && git push`), top-level `README.md` quickstart (tarball install path added), `dev-apprenticeship/README.md` Installation section (Option A tarball + sha256 verify, Option B clone), `dev-apprenticeship/CHANGELOG.md` `[Unreleased] ### Added`.

## Implementation follows the plan in #220

| Plan step | Commit | Status |
|-----------|--------|--------|
| 1. BUNDLE.manifest + bundle script | 67b67c2 | done |
| 2. test-make-federation-bundle.sh | 67b67c2 | done |
| 3. .github/workflows/release.yml | 67b67c2 | done |
| 4. Docs (CLAUDE.md, READMEs, CHANGELOG) | 67b67c2 | done |
| 5. CI baseline bump (41 -> 42) | 67b67c2 | done |

The issue's plan requested commits in order — I landed them as one cohesive commit because each plan step is logically inseparable from the rest (the workflow calls the bundler, the test validates the bundler + manifest, the docs document the workflow). Splitting would have produced intermediate tree states that advertised a feature the workflow couldn't yet invoke, or the reverse. `colony-lint` and the self-test pass on the single commit, and the diff reviews as cleanly bundled per-concern (one file per plan step) regardless.

## What ships and what doesn't

**In the bundle** (per `dev-apprenticeship/BUNDLE.manifest`):
- `dev-apprenticeship/` (all five colonies + config examples + operator scripts).
- `tools/parse-toml.sh`, `tools/kill-federation.sh`, `tools/auto-promote.sh` + `auto-promote-config.yaml` + `resolve-tick-interval.py`.
- `tools/federation-dashboard*` (sh entrypoint + 4 Python helpers + HTML template).
- `doc/adr/`, `doc/auto-promote.md`, `doc/federation-dashboard.md`.
- Top-level `README.md`, `LICENSE`.

**Explicitly not in the bundle** (enforced by test 6/8 blacklist asserts):
- `CLAUDE.md` — repo-developer docs.
- `.github/` — CI config.
- `tools/colony-lint.sh`, `tools/check-changelog.sh`, `tools/check-exec-sh.sh`, `tools/check-prompt-gate.sh`, `tools/new-colony.sh` — contributor tooling.
- `tools/test-*.sh` — tool self-tests.

## Validation

- [x] `./tools/colony-lint.sh` passes locally at `80/0/5` (was `79/0/5`; +1 for `test-make-federation-bundle.sh` auto-discovery). Expected CI baseline `42/0/1` (was `41/0/1`).
- [x] `./tools/test-make-federation-bundle.sh` passes 11/11.
- [x] `shellcheck` (via podman) clean on `tools/make-federation-bundle.sh` and `tools/test-make-federation-bundle.sh`.
- [x] `actionlint` (via podman) clean on `.github/workflows/release.yml`.
- [x] `bash -n` clean on both new scripts.
- [x] Real-federation smoke: bundler against `dev-apprenticeship/BUNDLE.manifest` at version `0.0.0-smoke` produces a 173 KB tarball with 95 entries; every required runtime file present; no blacklisted contributor file leaked.
- [ ] **Post-merge**: cut release PR for `dev-apprenticeship v0.1.1`, merge, tag `dev-apprenticeship-v0.1.1`, push — watch the workflow run and verify the release page ends up with `dev-apprenticeship-v0.1.1.tar.gz` + `.sha256` attached.
- [ ] **Post-merge**: `curl` the tarball, `tar xzf`, verify `./dev-apprenticeship/install.sh --help` (or analog) runs without `../tools/...` resolution errors.

## Test plan

- [x] `./tools/colony-lint.sh` (80/0/5 local).
- [x] `./tools/test-make-federation-bundle.sh` (11/11).
- [x] `podman run ... koalaman/shellcheck:stable tools/make-federation-bundle.sh tools/test-make-federation-bundle.sh` — clean.
- [x] `podman run ... rhysd/actionlint:latest .github/workflows/release.yml` — clean.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses.
- [x] **CI run on this PR** (colony-lint).
- [ ] **Tag push → release.yml first real run** (after merge + release PR).

## Out of scope (tracked for future issues)

- `install.sh --dry-run` for deeper CI smoke-test.
- `.zip` packaging alongside `.tar.gz`.
- Tarball signing (minisign/cosign).
- Broadening the tag-glob when a second federation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)