### PR TITLE
fix(planning): configurable trigger label + plan_reviewer idempotency guard (#223)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,15 @@ is asserted until multi-version CI is in place.
 
 ### Added
 
+- **Configurable planning trigger label** — new `[planning] trigger_label`
+  key in `planning/config/colony.example.toml`. Operators on projects
+  that don't use a flat `needs-planning` label (e.g. scoped-label
+  taxonomies like `DEV::not started`) can point the planning colony at
+  the local label without edits to the 4 agent files. Default preserves
+  pre-#223 behavior. `--data-urlencode` handles scoped labels and spaces
+  at the API layer, no new encoding logic required.
+  ([#223](https://github.com/Replikanti/agentis-colonies/issues/223))
+
 ### Changed
 
 ### Deprecated
@@ -24,6 +33,15 @@ is asserted until multi-version CI is in place.
 ### Removed
 
 ### Fixed
+
+- **`plan_reviewer` idempotency guard** — new `plan_reviewer:<iid>:posted`
+  memo marker short-circuits the `prompt()` + `add-note` path once a
+  plan has been posted for an issue. Long-lived workflow labels (e.g.
+  `DEV::not started` that persists for days until a human starts work)
+  previously drove re-assembly and re-posting every 60s for the same
+  still-labeled issue. Marker is written in the `autonomous` and
+  `review-gated` branches only; `propose`/`shadow` don't post.
+  ([#223](https://github.com/Replikanti/agentis-colonies/issues/223))
 
 ### Security
 

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -36,11 +36,15 @@ is asserted until multi-version CI is in place.
 
 - **`plan_reviewer` idempotency guard** — new `plan_reviewer:<iid>:posted`
   memo marker short-circuits the `prompt()` + `add-note` path once a
-  plan has been posted for an issue. Long-lived workflow labels (e.g.
-  `DEV::not started` that persists for days until a human starts work)
-  previously drove re-assembly and re-posting every 60s for the same
-  still-labeled issue. Marker is written in the `autonomous` and
-  `review-gated` branches only; `propose`/`shadow` don't post.
+  plan has been successfully posted for an issue at `autonomous` or
+  `review-gated` tier. Long-lived workflow labels (e.g. `DEV::not started`
+  that persists for days until a human starts work) previously drove
+  per-tick re-posting on the same still-labeled issue. The marker is
+  written **only** when the GitLab call returns a non-empty body, so
+  failed posts (auth/rate-limit/5xx/transport) are retried on the next
+  tick instead of silently consumed. `propose`/`shadow` tiers do no
+  external write and remain unmarked by design (so a future tier
+  promotion isn't blocked by a stale marker).
   ([#223](https://github.com/Replikanti/agentis-colonies/issues/223))
 
 ### Security

--- a/dev-apprenticeship/planning/README.md
+++ b/dev-apprenticeship/planning/README.md
@@ -57,7 +57,9 @@ When a new issue needs planning, the Scope Estimator, Risk Assessor, and Task De
 
 2. Configure your GitLab connection in `colony.toml`.
 
-3. Start the colony:
+3. (Optional) Override `[planning] trigger_label` if your project uses a label other than `needs-planning` to signal an issue is ready for planning. Scoped labels (`DEV::not started`) and labels with spaces are supported — `--data-urlencode` handles the encoding (#223).
+
+4. Start the colony:
    ```bash
    ./scripts/start-colony.sh
    ```

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -104,6 +104,23 @@ fn tick(reason: string) -> void {
         return;
     };
 
+    // #223: idempotency guard. Long-lived workflow labels (e.g.
+    // "DEV::not started" on projects using scoped-label taxonomies)
+    // persist across human-gated transitions, so without this marker
+    // the reviewer would re-prompt() and re-add-note() every tick for
+    // days on end. Marker is written only in the branches that actually
+    // post a GitLab note (autonomous + review-gated); propose/shadow do
+    // no external write, so leaving them unmarked is correct.
+    let iid_str = to_string(target_iid);
+    let posted_key = "plan_reviewer:" + iid_str + ":posted";
+    if len(recall_latest(posted_key)) > 0 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("plan_reviewer:last_check", now_e);
+        };
+        return;
+    };
+
     let s = recall_latest("plan_reviewer:" + to_string(target_iid) + ":scope");
     let r = recall_latest("plan_reviewer:" + to_string(target_iid) + ":risks");
     let b = recall_latest("plan_reviewer:" + to_string(target_iid) + ":breakdown");
@@ -144,6 +161,9 @@ fn tick(reason: string) -> void {
         try { exec sh post_cmd; } catch e {
             print("[plan_reviewer] Failed to post note:", e);
         };
+        // #223: mark as posted so subsequent ticks short-circuit before
+        // the prompt()/add-note path even if the trigger label persists.
+        memo_write(posted_key, "1");
         learn(
             "review_plan",
             "issue " + to_string(draft.issue_id),
@@ -161,6 +181,10 @@ fn tick(reason: string) -> void {
             try { exec sh post_cmd; } catch e {
                 print("[plan_reviewer] Failed to post draft note:", e);
             };
+            // #223: same marker as autonomous. A draft post is still a
+            // GitLab note whose body doesn't change tick-to-tick; we
+            // only want it once per issue.
+            memo_write(posted_key, "1");
             learn(
                 "review_plan",
                 "issue " + to_string(draft.issue_id),

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -158,41 +158,65 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         // Direct external write: post the plan as an issue note.
         let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft.plan);
-        try { exec sh post_cmd; } catch e {
+        let post_result = try { exec sh post_cmd; } catch e {
             print("[plan_reviewer] Failed to post note:", e);
+            "";
         };
-        // #223: mark as posted so subsequent ticks short-circuit before
-        // the prompt()/add-note path even if the trigger label persists.
-        memo_write(posted_key, "1");
-        learn(
-            "review_plan",
-            "issue " + to_string(draft.issue_id),
-            "posted: score=" + to_string(draft.review_score),
-            "success",
-            ["acted", "planning"]
-        );
-        print("[plan_reviewer] Posted plan to issue", draft.issue_id);
+        // #223: only mark posted (and learn() success) when the GitLab
+        // call actually returned a body. Same shape as
+        // version_bumper.ag's tag/release pattern. On failure
+        // (auth/429/5xx/transport) we leave the marker unset so the
+        // next tick retries instead of silently consuming the issue.
+        if len(post_result) > 0 {
+            memo_write(posted_key, "1");
+            learn(
+                "review_plan",
+                "issue " + to_string(draft.issue_id),
+                "posted: score=" + to_string(draft.review_score),
+                "success",
+                ["acted", "planning"]
+            );
+            print("[plan_reviewer] Posted plan to issue", draft.issue_id);
+        } else {
+            learn(
+                "review_plan",
+                "issue " + to_string(draft.issue_id),
+                "post-failed: score=" + to_string(draft.review_score),
+                "fail",
+                ["acted", "planning"]
+            );
+        };
     } else {
         if my_tier == "review-gated" {
             // Draft external write: post with [draft-plan] prefix so a human
             // reviewer can promote or discard it.
             let draft_body = "[draft-plan] **Plan Review** (automated, pending approval)\n\n" + draft.plan;
             let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft_body);
-            try { exec sh post_cmd; } catch e {
+            let draft_result = try { exec sh post_cmd; } catch e {
                 print("[plan_reviewer] Failed to post draft note:", e);
+                "";
             };
-            // #223: same marker as autonomous. A draft post is still a
-            // GitLab note whose body doesn't change tick-to-tick; we
-            // only want it once per issue.
-            memo_write(posted_key, "1");
-            learn(
-                "review_plan",
-                "issue " + to_string(draft.issue_id),
-                "drafted: score=" + to_string(draft.review_score),
-                "partial",
-                ["planning", "review-gated"]
-            );
-            print("[plan_reviewer] Drafted plan for issue", draft.issue_id);
+            // #223: same gating as autonomous — only mark posted when
+            // the GitLab call actually succeeded.
+            if len(draft_result) > 0 {
+                memo_write(posted_key, "1");
+                learn(
+                    "review_plan",
+                    "issue " + to_string(draft.issue_id),
+                    "drafted: score=" + to_string(draft.review_score),
+                    "partial",
+                    ["planning", "review-gated"]
+                );
+                print("[plan_reviewer] Drafted plan for issue", draft.issue_id);
+            } else {
+                learn(
+                    "review_plan",
+                    "issue " + to_string(draft.issue_id),
+                    "draft-post-failed: score=" + to_string(draft.review_score),
+                    "fail",
+                    ["planning", "review-gated"]
+                );
+            };
         } else {
             if my_tier == "propose" {
                 emit("planning:draft_plan", draft);

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -7,6 +7,15 @@
 name = "planning"
 tick_interval_ms = 60000
 
+[planning]
+# GitLab label that marks an issue as ready for planning. The 4 planning
+# agents only look at issues carrying this label. Default preserves the
+# pre-#223 behavior; override to match the target project's workflow
+# taxonomy (e.g. "DEV::not started" on projects using scoped labels).
+# Scoped labels and spaces are supported — `--data-urlencode` handles
+# encoding at the API layer.
+trigger_label = "needs-planning"
+
 [gitlab]
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -7,6 +7,16 @@
 #   GITLAB_TOKEN   - Personal access token or project token
 #   GITLAB_PROJECT - URL-encoded project path (e.g. your-org%2Fyour-project)
 #
+# Optional env vars:
+#   PLANNING_TRIGGER_LABEL - label matched by --needs-planning
+#                            (default: "needs-planning"). Override via
+#                            the [planning] trigger_label key in
+#                            colony.toml to match project-local
+#                            taxonomies (e.g. "DEV::not started").
+#                            Scoped labels with `::` and spaces are
+#                            supported — `--data-urlencode` handles
+#                            the encoding.
+#
 # Usage:
 #   gitlab-api.sh issues --needs-planning [--since ISO8601] [--view <name>]
 #   gitlab-api.sh add-note <iid> --body <text>
@@ -250,7 +260,11 @@ case "$CMD" in
             --data-urlencode "sort=desc"
         )
         if [ "$NEEDS_PLANNING" -eq 1 ]; then
-            ARGS+=(--data-urlencode "labels=needs-planning")
+            # #223: label read from env var (seeded by start-colony.sh
+            # from colony.toml [planning] trigger_label). Default
+            # "needs-planning" preserves pre-#223 behavior for configs
+            # that lack the key.
+            ARGS+=(--data-urlencode "labels=${PLANNING_TRIGGER_LABEL:-needs-planning}")
         fi
         if [ -n "$SINCE" ]; then
             ARGS+=(--data-urlencode "updated_after=$SINCE")

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -44,10 +44,16 @@ GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
 # memo gitlab:me and tag everything as team when both are empty.
 GITLAB_ME=$(parse_toml gitlab me)
 
+# #223: operator-configurable trigger label. Empty if the config
+# predates #223 (no [planning] section); gitlab-api.sh falls back to
+# "needs-planning" in that case, preserving pre-#223 behavior.
+PLANNING_TRIGGER_LABEL=$(parse_toml planning trigger_label)
+
 export GITLAB_URL
 export GITLAB_TOKEN
 export GITLAB_PROJECT
 export GITLAB_ME
+export PLANNING_TRIGGER_LABEL
 export COLONY_DIR
 
 AGENTS=(


### PR DESCRIPTION
## Summary

Closes #223. Ships the two coupled changes the issue proposes:

1. **Configurable planning trigger label** — new `[planning] trigger_label` key in `planning/config/colony.example.toml`. Default preserves pre-#223 behavior; operators on projects using scoped labels (e.g. `DEV::not started`) can point the planning colony at the local label without touching agent code.
2. **`plan_reviewer` idempotency guard** — new `plan_reviewer:<iid>:posted` memo marker short-circuits `prompt()` + `add-note` once the plan is posted for an issue.

Peer-agent idempotency (`risk_assessor`/`scope_estimator`/`task_decomposer`) is **out of scope** here — that's the #227 follow-up, shipped separately per the issue's "why not fold" rationale.

## Design notes

- **Script-layer, not agent-layer**: the trigger-label substitution lives in `gitlab-api.sh` (`labels=${PLANNING_TRIGGER_LABEL:-needs-planning}`). All 4 planning agents keep calling `--needs-planning` verbatim, so zero `.ag` diff for the label decoupling. `--data-urlencode` already handles scoped labels and spaces.
- **Marker only in posting branches**: the idempotency guard writes the marker in the `autonomous` and `review-gated` branches (both post a GitLab note). `propose` emits on the bus and `shadow` only `learn()`s — those don't post, so marking them would prevent legitimate future posts if the agent is promoted.
- **Satisfies `check-prompt-gate`** — the new `recall_latest(posted_key)` is a memo gate directly covering the `prompt()` on its hot path.

## Backward compatibility

- Configs without `[planning] trigger_label`: `parse_toml` returns empty → `${:-needs-planning}` fallback → byte-identical to today.
- Agents keep the literal `--needs-planning` flag. No migration for callers.
- New memo key (`plan_reviewer:<iid>:posted`) — no collision with existing keys.

## Semver

**MINOR** — new optional config key per CLAUDE.md classification.

## Test plan

- [x] `./tools/colony-lint.sh` — 80 passed, 0 failed, 5 skipped (`shellcheck` / `agentis` unavailable on this host).
- [x] `bash -n` on both modified scripts.
- [ ] Live smoke test (post-merge): point a staging planning colony at a GitLab project with a scoped trigger label and verify (a) issues flow through, (b) second tick short-circuits before `prompt()` after the plan is posted.

## Files touched

- `dev-apprenticeship/planning/config/colony.example.toml` — new `[planning]` section with `trigger_label` key.
- `dev-apprenticeship/planning/scripts/start-colony.sh` — parse + export `PLANNING_TRIGGER_LABEL`.
- `dev-apprenticeship/planning/scripts/gitlab-api.sh` — env-var resolved default in `--needs-planning` branch; header doc updated.
- `dev-apprenticeship/planning/agents/plan_reviewer.ag` — idempotency guard before prompt; marker write in both posting branches.
- `dev-apprenticeship/CHANGELOG.md` — `### Added` entry for the config key, `### Fixed` entry for the guard.

Plan: https://github.com/Replikanti/agentis-colonies/issues/223#issuecomment-4279905868

🤖 Generated with [Claude Code](https://claude.com/claude-code)