### PR TITLE
planning: idempotency guards for 3 peer agents (#227)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -47,6 +47,20 @@ is asserted until multi-version CI is in place.
   promotion isn't blocked by a stale marker).
   ([#223](https://github.com/Replikanti/agentis-colonies/issues/223))
 
+- **Planning peers now short-circuit re-posting to long-lived labeled issues**
+  ([#227](https://github.com/Replikanti/agentis-colonies/issues/227)) —
+  `risk_assessor`, `scope_estimator`, and `task_decomposer` each gain a
+  per-agent `<agent>:<iid>:posted` memo marker written only after a
+  successful `add-note` call. Prior to this fix, an issue carrying a
+  long-lived workflow label (e.g. `DEV::not started`) would be re-prompted
+  and re-posted every autonomous-tier tick for as long as the label
+  remained. Follow-up to
+  [#223](https://github.com/Replikanti/agentis-colonies/issues/223) which
+  applied the same pattern to `plan_reviewer`. The marker is gated on
+  non-empty `exec sh` output, so auth/rate-limit/5xx/transport failures
+  leave the marker unset and the next tick retries (matches
+  `version_bumper.ag`'s tag/release idiom).
+
 ### Security
 
 ## [0.1.1] — 2026-04-19

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -105,6 +105,21 @@ fn tick(reason: string) -> void {
         return;
     };
 
+    // #227: idempotency guard. Long-lived workflow labels (e.g.
+    // "DEV::not started" on projects using scoped-label taxonomies)
+    // persist across human-gated transitions, so without this marker
+    // the act branch would re-prompt() + re-add-note() every tick.
+    // target_iid via json_get (mechanical JSON read, 0 LLM calls) —
+    // same idiom as plan_reviewer after #147.
+    let target_iid = parse_int(to_string(json_get(issues_raw, "[0].iid")));
+    if target_iid <= 0 {
+        return;
+    };
+    let posted_key = "risk_assessor:" + to_string(target_iid) + ":posted";
+    if len(recall_latest(posted_key)) > 0 {
+        return;
+    };
+
     let rec = recommend("risk_assessment", ["accuracy", "safety"]);
     let context = "Unplanned issues (newest first): " + issues_raw + "\nPast incident patterns: " + to_string(rec);
 
@@ -122,16 +137,32 @@ fn tick(reason: string) -> void {
         emit("planning:risks", assessment);
         let note = "**Risk Assessment** (automated): " + assessment.severity + "\n\n" + assessment.risks;
         let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(assessment.issue_id) + " --body " + shell_escape(note);
-        try { exec sh post_cmd; } catch e {
+        let post_result = try { exec sh post_cmd; } catch e {
             print("[risk_assessor] Failed to post note:", e);
+            "";
         };
-        learn(
-            "risk_assessment",
-            "issue " + to_string(assessment.issue_id),
-            assessment.severity + ": " + assessment.risks,
-            "success",
-            ["acted", "planning"]
-        );
+        // #227: only mark posted (and learn() success) when the GitLab
+        // call actually returned a body. On failure (auth/429/5xx/
+        // transport) leave the marker unset so the next tick retries
+        // instead of silently consuming the issue.
+        if len(post_result) > 0 {
+            memo_write(posted_key, "1");
+            learn(
+                "risk_assessment",
+                "issue " + to_string(assessment.issue_id),
+                assessment.severity + ": " + assessment.risks,
+                "success",
+                ["acted", "planning"]
+            );
+        } else {
+            learn(
+                "risk_assessment",
+                "issue " + to_string(assessment.issue_id),
+                "post-failed: " + assessment.severity,
+                "fail",
+                ["acted", "planning"]
+            );
+        };
     } else {
         if my_tier == "review-gated" {
             // Draft external write: stash in plan_reviewer's memo slot so

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -103,6 +103,16 @@ fn tick(reason: string) -> void {
         return;
     };
 
+    // #227: idempotency guard — see risk_assessor.ag for rationale.
+    let target_iid = parse_int(to_string(json_get(issues_raw, "[0].iid")));
+    if target_iid <= 0 {
+        return;
+    };
+    let posted_key = "scope_estimator:" + to_string(target_iid) + ":posted";
+    if len(recall_latest(posted_key)) > 0 {
+        return;
+    };
+
     let rec = recommend("scope_estimate", ["accuracy"]);
     let context = "Unplanned issues (newest first): " + issues_raw + "\nPast calibration: " + to_string(rec);
 
@@ -119,16 +129,29 @@ fn tick(reason: string) -> void {
         emit("planning:scope_estimate", estimate);
         let note = "**Scope Estimate** (automated): " + to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points\n\n" + estimate.reasoning;
         let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(estimate.issue_id) + " --body " + shell_escape(note);
-        try { exec sh post_cmd; } catch e {
+        let post_result = try { exec sh post_cmd; } catch e {
             print("[scope_estimator] Failed to post note:", e);
+            "";
         };
-        learn(
-            "scope_estimate",
-            "issue " + to_string(estimate.issue_id),
-            to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
-            "success",
-            ["acted", "planning"]
-        );
+        // #227: gate marker + success learn on non-empty post result.
+        if len(post_result) > 0 {
+            memo_write(posted_key, "1");
+            learn(
+                "scope_estimate",
+                "issue " + to_string(estimate.issue_id),
+                to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                "success",
+                ["acted", "planning"]
+            );
+        } else {
+            learn(
+                "scope_estimate",
+                "issue " + to_string(estimate.issue_id),
+                "post-failed: " + to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points",
+                "fail",
+                ["acted", "planning"]
+            );
+        };
     } else {
         if my_tier == "review-gated" {
             emit("planning:scope_estimate", estimate);

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -103,6 +103,16 @@ fn tick(reason: string) -> void {
         return;
     };
 
+    // #227: idempotency guard — see risk_assessor.ag for rationale.
+    let target_iid = parse_int(to_string(json_get(issues_raw, "[0].iid")));
+    if target_iid <= 0 {
+        return;
+    };
+    let posted_key = "task_decomposer:" + to_string(target_iid) + ":posted";
+    if len(recall_latest(posted_key)) > 0 {
+        return;
+    };
+
     let rec = recommend("task_decomposition", ["accuracy"]);
     let context = "Unplanned issues (newest first): " + issues_raw + "\nPast decomposition patterns: " + to_string(rec);
 
@@ -119,16 +129,29 @@ fn tick(reason: string) -> void {
         emit("planning:breakdown", breakdown);
         let note = "**Task Breakdown** (automated): " + to_string(breakdown.count) + " subtasks\n\n" + breakdown.subtasks;
         let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(breakdown.issue_id) + " --body " + shell_escape(note);
-        try { exec sh post_cmd; } catch e {
+        let post_result = try { exec sh post_cmd; } catch e {
             print("[task_decomposer] Failed to post note:", e);
+            "";
         };
-        learn(
-            "task_decomposition",
-            "issue " + to_string(breakdown.issue_id),
-            to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
-            "success",
-            ["acted", "planning"]
-        );
+        // #227: gate marker + success learn on non-empty post result.
+        if len(post_result) > 0 {
+            memo_write(posted_key, "1");
+            learn(
+                "task_decomposition",
+                "issue " + to_string(breakdown.issue_id),
+                to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                "success",
+                ["acted", "planning"]
+            );
+        } else {
+            learn(
+                "task_decomposition",
+                "issue " + to_string(breakdown.issue_id),
+                "post-failed: " + to_string(breakdown.count) + " subtasks",
+                "fail",
+                ["acted", "planning"]
+            );
+        };
     } else {
         if my_tier == "review-gated" {
             emit("planning:breakdown", breakdown);


### PR DESCRIPTION
Closes #227. Follow-up to #223 (which landed the same pattern for `plan_reviewer`); this PR applies it to the remaining three planning peers that also call `gitlab-api.sh add-note` from the autonomous branch.

## Summary

- `risk_assessor.ag`, `scope_estimator.ag`, `task_decomposer.ag` each gain:
  - A pre-prompt `target_iid` extraction via `json_get` (mechanical JSON read, 0 LLM calls — same idiom as `plan_reviewer` after #147).
  - A pre-prompt short-circuit on `recall_latest("<agent>:<iid>:posted")`.
  - An `exec sh` capture + gated marker write: marker + success `learn()` run only when the GitLab call returned a body; on auth/429/5xx/transport failure, a `fail` `learn()` row is emitted and the marker is left unset so the next tick retries.
- No change to `review-gated` / `propose` / `shadow` branches — none of them call `add-note`, so no marker is written (same shape as `plan_reviewer` from #223).
- `observe_last_ts` retained untouched. It rate-limits the shadow-tier observe prompt (30 min); `:posted` is a per-issue one-shot for the act prompt. Different signals, different cadences — merging them would break observe-branch rate limiting.

## Why not fold into #223

Different files, same pattern. Separate PR makes each diff a single-concern review, and keeps blast radius for any regression small. Per the plan's rationale (and #227's own acceptance criteria).

## Test plan

- [x] `./tools/colony-lint.sh` — 80 passed / 0 failed / 5 skipped (shellcheck/agentis not on this host).
- [x] `check-prompt-gate` passes on all 3 peers — new `recall_latest(posted_key)` is accepted as the gate for each `prompt()`.
- [x] CHANGELOG `### Fixed` bullet under `[Unreleased]`, references #227. VERSION unchanged (correct — release PR territory).
- [x] Memo-key hygiene: each peer uses its own prefix (`risk_assessor:`, `scope_estimator:`, `task_decomposer:`) — no cross-agent collision.
- [ ] Human smoke test: autonomous-tier peer against a still-labeled issue — 1st tick posts + sets marker, 2nd tick short-circuits before `prompt()`.

## Semver

**PATCH** — bug fix, no config schema or bus event contract change.

## Files touched

- `dev-apprenticeship/planning/agents/risk_assessor.ag`
- `dev-apprenticeship/planning/agents/scope_estimator.ag`
- `dev-apprenticeship/planning/agents/task_decomposer.ag`
- `dev-apprenticeship/CHANGELOG.md`