### PR TITLE
implementation: configurable trigger label (#225)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -26,6 +26,21 @@ is asserted until multi-version CI is in place.
   at the API layer, no new encoding logic required.
   ([#223](https://github.com/Replikanti/agentis-colonies/issues/223))
 
+- **Configurable implementation trigger label**
+  ([#225](https://github.com/Replikanti/agentis-colonies/issues/225)) — new
+  optional `[implementation] trigger_label` key in
+  `implementation/config/colony.toml` lets operators override the
+  hard-coded `implementation` label used by
+  `gitlab-api.sh assigned-issues` so projects whose workflow taxonomy
+  uses a different or scoped label (e.g. `DEV::in progress`) no longer
+  have to rename their GitLab labels to match the colony. Scoped labels
+  and labels containing spaces are handled safely via
+  `--data-urlencode`. Unset configs fall back to `implementation`
+  verbatim — fully backward compatible with pre-#225 setups. Mirrors
+  the [#223](https://github.com/Replikanti/agentis-colonies/issues/223)
+  pattern for the planning colony's `needs-planning` label; agent
+  files are unchanged (no `.ag` diff).
+
 ### Changed
 
 ### Deprecated

--- a/dev-apprenticeship/implementation/README.md
+++ b/dev-apprenticeship/implementation/README.md
@@ -47,7 +47,9 @@ When an issue is assigned, the Code Writer produces an implementation draft. The
 
 2. Configure your GitLab connection in `colony.toml`.
 
-3. Start the colony:
+3. (Optional) Override `[implementation] trigger_label` if your project uses a label other than `implementation` to signal an issue is ready for implementation work. Scoped labels (`DEV::in progress`) and labels with spaces are supported — `--data-urlencode` handles the encoding (#225).
+
+4. Start the colony:
    ```bash
    ./scripts/start-colony.sh
    ```

--- a/dev-apprenticeship/implementation/config/colony.example.toml
+++ b/dev-apprenticeship/implementation/config/colony.example.toml
@@ -13,6 +13,14 @@ token = "glpat-your-token-here"
 project = "your-org/your-project"
 me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
 
+[implementation]
+# GitLab label used to filter issues that are ready for implementation work.
+# Leave unset (or as default) to use "implementation". Override when your
+# project's workflow taxonomy uses a different or scoped label, e.g.
+# "DEV::in progress". Scoped labels and labels with spaces are handled
+# via --data-urlencode at the gitlab-api.sh layer. (#225)
+trigger_label = "implementation"
+
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
 backend = "cli"

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -3,9 +3,12 @@
 # Called by .ag agents via exec sh.
 #
 # Required env vars (set by start-colony.sh from colony.toml):
-#   GITLAB_URL     - GitLab instance URL (e.g. https://gitlab.example.com)
-#   GITLAB_TOKEN   - Personal access token or project token
-#   GITLAB_PROJECT - URL-encoded project path (e.g. your-org%2Fyour-project)
+#   GITLAB_URL                     - GitLab instance URL (e.g. https://gitlab.example.com)
+#   GITLAB_TOKEN                   - Personal access token or project token
+#   GITLAB_PROJECT                 - URL-encoded project path (e.g. your-org%2Fyour-project)
+#   IMPLEMENTATION_TRIGGER_LABEL   - (optional, #225) label name used by
+#                                    `assigned-issues` filter. Defaults to
+#                                    "implementation" when unset.
 #
 # Usage:
 #   gitlab-api.sh merge-requests [--state merged] [--since ISO8601] [--per-page N] [--view <name>]
@@ -298,7 +301,7 @@ case "$CMD" in
         ARGS=(
             --data-urlencode "state=opened"
             --data-urlencode "assignee_id=Any"
-            --data-urlencode "labels=implementation"
+            --data-urlencode "labels=${IMPLEMENTATION_TRIGGER_LABEL:-implementation}"
             --data-urlencode "per_page=20"
             --data-urlencode "order_by=updated_at"
             --data-urlencode "sort=desc"

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -44,10 +44,16 @@ GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
 # memo gitlab:me and tag everything as team when both are empty.
 GITLAB_ME=$(parse_toml gitlab me)
 
+# #225: configurable trigger label for assigned-issues filter. Empty if
+# not configured (pre-#225 setups); gitlab-api.sh falls back to the
+# hardcoded default "implementation" via ${VAR:-implementation}.
+IMPLEMENTATION_TRIGGER_LABEL=$(parse_toml implementation trigger_label)
+
 export GITLAB_URL
 export GITLAB_TOKEN
 export GITLAB_PROJECT
 export GITLAB_ME
+export IMPLEMENTATION_TRIGGER_LABEL
 export COLONY_DIR
 
 AGENTS=(


### PR DESCRIPTION
Closes #225.

## Summary

Mirror of the #223 script-layer fix but for the implementation colony. New optional `[implementation] trigger_label` key in `colony.toml` decouples the GitLab label used by `assigned-issues` from the hardcoded `implementation`. Operators can override to match project-local taxonomy (e.g. `DEV::in progress`). Unset configs keep the pre-#225 behaviour byte-for-byte.

## What changed

- `implementation/config/colony.example.toml` — new `[implementation]` section with `trigger_label = "implementation"` default and an inline doc block.
- `implementation/scripts/start-colony.sh` — parse + export `IMPLEMENTATION_TRIGGER_LABEL` next to the `GITLAB_ME` block.
- `implementation/scripts/gitlab-api.sh` — line 301 now reads `${IMPLEMENTATION_TRIGGER_LABEL:-implementation}`; header env-var doc updated.
- `implementation/README.md` — §Setup gains a bullet describing the new knob and scoped-label support.
- `CHANGELOG.md` — `### Added` entry under `[Unreleased]`, references #225.

## Backward compatibility

- Configs with no `[implementation]` section: `parse_toml` returns empty → `${:-implementation}` fallback → `labels=implementation` on wire, byte-identical to pre-#225.
- Scoped labels encoded safely: `DEV::in progress` → `labels=DEV%3A%3Ain+progress` (verified via `python3 urllib.parse.quote_plus`).
- Zero `.ag` diff. All four agents continue calling `assigned-issues --view assigned` verbatim.

## Test plan

- [x] `./tools/colony-lint.sh` → 80 passed / 0 failed / 5 skipped.
- [x] `bash -n` on both modified scripts → OK.
- [x] `urllib.parse.quote_plus` roundtrip for scoped label and default → matches expectation.
- [x] CHANGELOG bullet references #225 and explains the fix accurately.
- [ ] Human smoke test: configure `trigger_label = "DEV::in progress"` on a local project, verify `gitlab-api.sh assigned-issues --view assigned` returns issues carrying that scoped label.

## Semver

**MINOR** — new optional config key with backward-compatible default (per CLAUDE.md semver rules).

## Relationship to other PRs in flight

- #228 (planning trigger label + plan_reviewer idempotency) is the sibling for the planning colony. Same script-layer approach.
- #229 (planning peers idempotency) is independent — planning-only.
- This PR touches only the implementation colony. No shared files. Can land in any order relative to #228 / #229.

The "federation-level parse helper" refactor the issue mentions as a follow-up is intentionally deferred to a separate PR once #223 + #225 have proven the per-colony copy-paste shape in practice.