### PR TITLE
implementation+release: configurable default branch (#224)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -40,6 +40,19 @@ is asserted until multi-version CI is in place.
   the [#223](https://github.com/Replikanti/agentis-colonies/issues/223)
   pattern for the planning colony's `needs-planning` label; agent
   files are unchanged (no `.ag` diff).
+- **Configurable primary branch for implementation + release colonies**
+  ([#224](https://github.com/Replikanti/agentis-colonies/issues/224)) — new
+  optional `[gitlab] default_branch` key in the implementation and
+  release colony configs replaces three hard-coded `"main"` references
+  in `gitlab-api.sh`: the default `--ref` for `create-branch`, the
+  `target_branch` body field on `create-mr` (implementation colony),
+  and the default `--ref` for `create-tag` (release colony). Projects
+  whose primary branch is `master`, `develop`, `trunk`, or any custom
+  name can now configure that once in `colony.toml` instead of
+  per-call `--ref` flags. Unset configs fall back to `"main"` — fully
+  backward compatible with pre-#224 setups. Explicit-config approach
+  chosen over API auto-detect (fails closed when PAT lacks
+  project-read scope; zero extra request per colony boot).
 
 ### Changed
 

--- a/dev-apprenticeship/implementation/config/colony.example.toml
+++ b/dev-apprenticeship/implementation/config/colony.example.toml
@@ -12,6 +12,7 @@ url = "https://gitlab.example.com"
 token = "glpat-your-token-here"
 project = "your-org/your-project"
 me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
+default_branch = "main"  # primary branch — override for projects using "master", "develop", "trunk", etc. (#224)
 
 [implementation]
 # GitLab label used to filter issues that are ready for implementation work.

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -9,6 +9,10 @@
 #   IMPLEMENTATION_TRIGGER_LABEL   - (optional, #225) label name used by
 #                                    `assigned-issues` filter. Defaults to
 #                                    "implementation" when unset.
+#   GITLAB_DEFAULT_BRANCH          - (optional, #224) primary branch name used as the
+#                                    default --ref for create-branch and the
+#                                    target_branch for create-mr. Defaults to "main"
+#                                    when unset.
 #
 # Usage:
 #   gitlab-api.sh merge-requests [--state merged] [--since ISO8601] [--per-page N] [--view <name>]
@@ -321,7 +325,9 @@ case "$CMD" in
 
     create-branch)
         NAME=""
-        REF="main"
+        # #224: honour operator-configured default branch; fall back to "main"
+        # for pre-#224 setups where the env var is unset.
+        REF="${GITLAB_DEFAULT_BRANCH:-main}"
         while [ $# -gt 0 ]; do
             case "$1" in
                 --name) NAME="$2"; shift 2 ;;
@@ -389,11 +395,15 @@ PY
             emit_error "--source and --title are required"
             exit 1
         fi
-        JSON_BODY=$(SOURCE="$SOURCE" TITLE="$TITLE" DESC="$DESC" python3 - <<'PY'
+        # #224: target_branch reads from operator-configured default branch;
+        # env var passed through to the heredoc since python3 cannot see the
+        # ${VAR:-fallback} expansion in the bash context.
+        JSON_BODY=$(SOURCE="$SOURCE" TITLE="$TITLE" DESC="$DESC" \
+            DEFAULT_BRANCH="${GITLAB_DEFAULT_BRANCH:-main}" python3 - <<'PY'
 import os, json
 body = {
     "source_branch": os.environ["SOURCE"],
-    "target_branch": "main",
+    "target_branch": os.environ["DEFAULT_BRANCH"],
     "title": os.environ["TITLE"],
 }
 if os.environ.get("DESC"):

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -49,11 +49,17 @@ GITLAB_ME=$(parse_toml gitlab me)
 # hardcoded default "implementation" via ${VAR:-implementation}.
 IMPLEMENTATION_TRIGGER_LABEL=$(parse_toml implementation trigger_label)
 
+# #224: primary branch name. Empty if not configured (pre-#224 setups);
+# gitlab-api.sh falls back to the hardcoded default "main" via
+# ${GITLAB_DEFAULT_BRANCH:-main}.
+GITLAB_DEFAULT_BRANCH=$(parse_toml gitlab default_branch)
+
 export GITLAB_URL
 export GITLAB_TOKEN
 export GITLAB_PROJECT
 export GITLAB_ME
 export IMPLEMENTATION_TRIGGER_LABEL
+export GITLAB_DEFAULT_BRANCH
 export COLONY_DIR
 
 AGENTS=(

--- a/dev-apprenticeship/release/config/colony.example.toml
+++ b/dev-apprenticeship/release/config/colony.example.toml
@@ -12,6 +12,7 @@ url = "https://gitlab.example.com"
 token = "glpat-your-token-here"
 project = "your-org/your-project"
 me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
+default_branch = "main"  # primary branch — override for projects using "master", "develop", "trunk", etc. (#224)
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.

--- a/dev-apprenticeship/release/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/release/scripts/gitlab-api.sh
@@ -3,9 +3,12 @@
 # Called by .ag agents via exec sh.
 #
 # Required env vars (set by start-colony.sh from colony.toml):
-#   GITLAB_URL     - GitLab instance URL (e.g. https://gitlab.example.com)
-#   GITLAB_TOKEN   - Personal access token or project token
-#   GITLAB_PROJECT - URL-encoded project path (e.g. your-org%2Fyour-project)
+#   GITLAB_URL             - GitLab instance URL (e.g. https://gitlab.example.com)
+#   GITLAB_TOKEN           - Personal access token or project token
+#   GITLAB_PROJECT         - URL-encoded project path (e.g. your-org%2Fyour-project)
+#   GITLAB_DEFAULT_BRANCH  - (optional, #224) primary branch name used as the
+#                            default --ref for create-tag. Defaults to "main"
+#                            when unset.
 #
 # Usage:
 #   gitlab-api.sh releases [--per-page N] [--view <name>]
@@ -386,7 +389,9 @@ case "$CMD" in
 
     create-tag)
         NAME=""
-        REF="main"
+        # #224: honour operator-configured default branch; fall back to "main"
+        # for pre-#224 setups where the env var is unset.
+        REF="${GITLAB_DEFAULT_BRANCH:-main}"
         MESSAGE=""
         while [ $# -gt 0 ]; do
             case "$1" in

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -44,10 +44,16 @@ GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
 # memo gitlab:me and tag everything as team when both are empty.
 GITLAB_ME=$(parse_toml gitlab me)
 
+# #224: primary branch name. Empty if not configured (pre-#224 setups);
+# gitlab-api.sh falls back to the hardcoded default "main" via
+# ${GITLAB_DEFAULT_BRANCH:-main}.
+GITLAB_DEFAULT_BRANCH=$(parse_toml gitlab default_branch)
+
 export GITLAB_URL
 export GITLAB_TOKEN
 export GITLAB_PROJECT
 export GITLAB_ME
+export GITLAB_DEFAULT_BRANCH
 export COLONY_DIR
 
 AGENTS=(


### PR DESCRIPTION
Closes #224.

## Summary

Replace three hardcoded `"main"` references in `gitlab-api.sh` (across implementation + release colonies) with a new optional `[gitlab] default_branch` config key. Projects using `master` / `develop` / `trunk` / any custom primary branch can now configure it once in `colony.toml` instead of forcing per-call `--ref` overrides.

## Call sites replaced

- `implementation/scripts/gitlab-api.sh:321` — `create-branch` default `REF`.
- `implementation/scripts/gitlab-api.sh:393` — `create-mr` `target_branch` body field. `DEFAULT_BRANCH` env var now passed through the `python3` heredoc (env vars are the only way the heredoc can see a bash `${VAR:-fallback}` expansion).
- `release/scripts/gitlab-api.sh:389` — `create-tag` default `REF`.

Each site reads `${GITLAB_DEFAULT_BRANCH:-main}`, preserving byte-identical behaviour for pre-#224 configs.

## Config schema

- `implementation/config/colony.example.toml` — `[gitlab] default_branch = "main"` + doc comment.
- `release/config/colony.example.toml` — same.

Key placed under `[gitlab]` (parallel to `url`, `token`, `project`, `me`) because it's a connection/project-level setting, not a per-colony workflow knob. `triage`, `code-review`, and `planning` don't touch repo refs so they don't need the key.

## Env var plumbing

Both `implementation/scripts/start-colony.sh` and `release/scripts/start-colony.sh` parse and export `GITLAB_DEFAULT_BRANCH` next to the existing `GITLAB_ME` block. Empty export when the key is missing → `${VAR:-main}` fallback in the scripts → pre-#224 behaviour preserved.

Script headers document the new env var.

## Backward compatibility

- Configs without `[gitlab] default_branch`: `parse_toml` returns empty → `${:-main}` fallback → identical wire format to today.
- Callers passing `--ref` / `--source` explicitly are unaffected (the default applies only when the flag is omitted).
- Zero `.ag` agent diff.

## Why not auto-detect via `GET /projects/:id`

Fails closed when the PAT lacks project-read scope, with no retry path. Also adds one extra API round-trip per colony boot. Explicit config is safer and free. Noted in the plan as deferred.

## Test plan

- [x] `./tools/colony-lint.sh` → 80 passed / 0 failed / 5 skipped.
- [x] `bash -n` on all four modified scripts → OK.
- [ ] Human smoke: set `default_branch = "master"` on a test config, invoke `gitlab-api.sh create-branch --name test-branch` → verify the JSON body carries `"ref": "master"`.

## Semver

**MINOR** — new optional config key with backward-compatible default.

## Files

- `dev-apprenticeship/implementation/config/colony.example.toml`
- `dev-apprenticeship/release/config/colony.example.toml`
- `dev-apprenticeship/implementation/scripts/start-colony.sh`
- `dev-apprenticeship/release/scripts/start-colony.sh`
- `dev-apprenticeship/implementation/scripts/gitlab-api.sh`
- `dev-apprenticeship/release/scripts/gitlab-api.sh`
- `dev-apprenticeship/CHANGELOG.md`