### PR TITLE
planning+triage: configurable prompt vocabulary (#226)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -25,6 +25,17 @@ is asserted until multi-version CI is in place.
   pre-#223 behavior. `--data-urlencode` handles scoped labels and spaces
   at the API layer, no new encoding logic required.
   ([#223](https://github.com/Replikanti/agentis-colonies/issues/223))
+- **Configurable prompt vocabulary** — new `[planning.labels]` section
+  (`incident`, `epic` keys) and `[triage.labels]` section (`priority`
+  key) in the respective `colony.example.toml` files. `start-colony.sh`
+  seeds these values into memo (`planning:labels:incident`,
+  `planning:labels:epic`, `triage:labels:priority`) on every restart;
+  `risk_assessor`, `task_decomposer`, and `prioritizer` prompts splice
+  the memo value into the prompt string via `recall_latest()` with a
+  hardcoded-default fallback. Values are free-text so operators can list
+  label names or describe non-label patterns (e.g. `"umbrella-issue
+  pattern"`). Unset keys preserve pre-#226 prompts byte-identically.
+  ([#226](https://github.com/Replikanti/agentis-colonies/issues/226))
 
 ### Changed
 

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -30,11 +30,15 @@ is asserted until multi-version CI is in place.
   key) in the respective `colony.example.toml` files. `start-colony.sh`
   seeds these values into memo (`planning:labels:incident`,
   `planning:labels:epic`, `triage:labels:priority`) on every restart;
-  `risk_assessor`, `task_decomposer`, and `prioritizer` prompts splice
-  the memo value into the prompt string via `recall_latest()` with a
-  hardcoded-default fallback. Values are free-text so operators can list
-  label names or describe non-label patterns (e.g. `"umbrella-issue
-  pattern"`). Unset keys preserve pre-#226 prompts byte-identically.
+  `risk_assessor`, `task_decomposer`, and `prioritizer` inject the
+  vocabulary into their `prompt()` context arg via `recall_latest()`
+  with a hardcoded-default fallback. The agentis parser requires a
+  string literal for the prompt instruction arg, so vocabulary flows
+  through `context`; instruction strings were rephrased to reference
+  the context ("focus on the vocabulary above"). Values are free-text
+  so operators can list label names or describe non-label patterns
+  (e.g. `"umbrella-issue pattern"`). Unset keys preserve the pre-#226
+  vocabulary verbatim — LLM behaviour is semantically equivalent.
   ([#226](https://github.com/Replikanti/agentis-colonies/issues/226))
 
 ### Changed

--- a/dev-apprenticeship/planning/README.md
+++ b/dev-apprenticeship/planning/README.md
@@ -59,7 +59,9 @@ When a new issue needs planning, the Scope Estimator, Risk Assessor, and Task De
 
 3. (Optional) Override `[planning] trigger_label` if your project uses a label other than `needs-planning` to signal an issue is ready for planning. Scoped labels (`DEV::not started`) and labels with spaces are supported — `--data-urlencode` handles the encoding (#223).
 
-4. Start the colony:
+4. (Optional) Retune `[planning.labels]` if your project uses a different label taxonomy for incidents and epics (#226). Values are free-text and injected verbatim into the `risk_assessor` and `task_decomposer` prompt context, so operators can list comma-separated label names or describe non-label patterns (e.g. `epic = "umbrella-issue pattern, parent/child references in description"`). Defaults preserve pre-#226 vocabulary (`incident, bug, blocker` / `epic`).
+
+5. Start the colony:
    ```bash
    ./scripts/start-colony.sh
    ```

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -71,9 +71,22 @@ fn tick(reason: string) -> void {
         };
 
         if len(recent_raw) > 10 {
+            // #226: operator-configurable label vocabulary. The agentis
+            // parser requires a string literal for the `prompt()`
+            // instruction arg, so the vocabulary is spliced into the
+            // `context` arg instead. Unseeded memo returns "" → the
+            // hardcoded fallback below is used, byte-identical to
+            // pre-#226 for configs that don't set `[planning.labels]`.
+            let incident_vocab = recall_latest("planning:labels:incident");
+            let vocab_line = if len(incident_vocab) > 0 {
+                "Label vocabulary (focus on these): " + incident_vocab;
+            } else {
+                "Label vocabulary (focus on these): incident, bug, blocker";
+            };
+            let observe_ctx = vocab_line + "\n\nRecent GitLab issues JSON:\n" + recent_raw;
             let patterns = prompt(
-                "Analyze this recent GitLab issues JSON. Focus on issues labeled 'incident', 'bug', or 'blocker'. What recurring themes appear (dependency surprises, integration gotchas, flaky services)? Return JSON: observed_count (int, how many incident-style issues you saw), recurring_themes (string, one short paragraph).",
-                recent_raw
+                "Analyze the GitLab issues JSON in the context. Focus on issues matching the label vocabulary listed above. What recurring themes appear (dependency surprises, integration gotchas, flaky services)? Return JSON: observed_count (int, how many issues you saw matching the vocabulary), recurring_themes (string, one short paragraph).",
+                observe_ctx
             ) -> IncidentPatterns;
 
             if patterns.observed_count > 0 {

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -69,9 +69,22 @@ fn tick(reason: string) -> void {
         };
 
         if len(recent_raw) > 10 {
+            // #226: operator-configurable label vocabulary. The agentis
+            // parser requires a string literal for the `prompt()`
+            // instruction arg, so the vocabulary is spliced into the
+            // `context` arg instead. Unseeded memo returns "" → the
+            // hardcoded fallback below is used, byte-identical to
+            // pre-#226 for configs that don't set `[planning.labels]`.
+            let epic_vocab = recall_latest("planning:labels:epic");
+            let vocab_line = if len(epic_vocab) > 0 {
+                "Epic vocabulary (match these): " + epic_vocab;
+            } else {
+                "Epic vocabulary (match these): epic-labeled issues, or issues with subtask-like child references in the description";
+            };
+            let observe_ctx = vocab_line + "\n\nRecent GitLab issues JSON:\n" + recent_raw;
             let patterns = prompt(
-                "Analyze this recent GitLab issues JSON. Identify epics (issues labeled 'epic' or with subtask-like child references in the description). For each epic you can see, estimate how many subtasks were created. Summarize the decomposition style (checklist vs linked issues, granularity). Return JSON: epics_seen (int), avg_subtasks (int), style (string, one short sentence).",
-                recent_raw
+                "Analyze the GitLab issues JSON in the context. Identify epics matching the epic vocabulary listed above. For each epic you can see, estimate how many subtasks were created. Summarize the decomposition style (checklist vs linked issues, granularity). Return JSON: epics_seen (int), avg_subtasks (int), style (string, one short sentence).",
+                observe_ctx
             ) -> DecompositionPatterns;
 
             if patterns.epics_seen > 0 {

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -16,6 +16,16 @@ tick_interval_ms = 60000
 # encoding at the API layer.
 trigger_label = "needs-planning"
 
+# #226: label vocabulary injected into risk_assessor and task_decomposer
+# prompts. Free-text; the agents splice the value into their prompt
+# verbatim so operators can list comma-separated label names or describe
+# non-label patterns (e.g. `"umbrella-issue pattern, parent/child refs"`).
+# Leave unset to keep the pre-#226 hardcoded defaults
+# ('incident, bug, blocker' and 'epic').
+[planning.labels]
+incident = "incident, bug, blocker"   # labels risk_assessor treats as incident-class
+epic = "epic"                          # labels/patterns task_decomposer treats as epic-class
+
 [gitlab]
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -63,6 +63,22 @@ AGENTS=(
     plan_reviewer
 )
 
+# #226: vocabulary memo seeding. Operator-tuned label vocabulary overrides
+# the hardcoded defaults baked into risk_assessor / task_decomposer
+# prompts. Read from colony.toml on every restart so config edits take
+# effect on the next start-colony cycle (no install.sh re-run). Failures
+# are non-fatal: agents fall back to the pre-#226 hardcoded strings via
+# the `recall_latest() / if len() > 0` pattern.
+INCIDENT_LABELS=$(parse_toml planning.labels incident)
+EPIC_LABELS=$(parse_toml planning.labels epic)
+FED_ROOT="$(cd "$REPO_ROOT/dev-apprenticeship" && pwd)"
+if [ -n "$INCIDENT_LABELS" ]; then
+    (cd "$FED_ROOT" && agentis memo set planning:labels:incident "$INCIDENT_LABELS" >/dev/null 2>&1) || true
+fi
+if [ -n "$EPIC_LABELS" ]; then
+    (cd "$FED_ROOT" && agentis memo set planning:labels:epic "$EPIC_LABELS" >/dev/null 2>&1) || true
+fi
+
 # Opt-in log truncation. Off by default so operators who rely on log
 # history across restarts are not surprised. Set TRUNCATE_LOGS=1 in
 # the environment (or via start-federation.sh) to bound disk use

--- a/dev-apprenticeship/triage/README.md
+++ b/dev-apprenticeship/triage/README.md
@@ -60,7 +60,9 @@ The last-check refresh inside the early-exit branch is load-bearing — otherwis
 
 2. Configure your GitLab connection in `colony.toml`.
 
-3. Start the colony:
+3. (Optional) Retune `[triage.labels] priority` if your project uses a different priority-label taxonomy (#226). The value is free-text and injected verbatim into the `prioritizer` prompt context, so operators can list comma-separated label names (e.g. `"P0, P1, P2, P3"`, or `"severity::1, severity::2, severity::3"`). Default preserves pre-#226 vocabulary (`priority::critical/high/medium/low, P1-P4, urgent`).
+
+4. Start the colony:
    ```bash
    ./scripts/start-colony.sh
    ```

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -73,10 +73,26 @@ fn tick(reason: string) -> void {
         return;
     };
 
+    // #226: operator-configurable priority label vocabulary. The agentis
+    // parser requires a string literal for `prompt()` instruction args,
+    // so the vocabulary is spliced into the `context` arg instead. One
+    // `recall`, two uses (the analyze context here and the suggest
+    // context further down). Unseeded memo returns "" → the hardcoded
+    // fallback is used, byte-identical to pre-#226 for configs that
+    // don't set `[triage.labels].priority`.
+    let priority_vocab = recall_latest("triage:labels:priority");
+    let priority_example = if len(priority_vocab) > 0 {
+        priority_vocab;
+    } else {
+        "priority::critical, priority::high, priority::medium, priority::low, P1, P2, P3, P4, urgent";
+    };
+    let vocab_line = "Priority label vocabulary: " + priority_example;
+
     // Analyze: find prioritized and unprioritized issues
+    let analyze_ctx = vocab_line + "\n\nIssues JSON:\n" + raw;
     let analysis = prompt(
-        "Analyze this GitLab issues JSON. Count issues with priority labels like priority::critical/high/medium/low, P1-P4, urgent (prioritized_count) and those without (unprioritized_count). Summarize patterns (patterns). List unprioritized issue IDs, titles, labels (unprioritized_issues). Return JSON: prioritized_count (int), unprioritized_count (int), patterns (string), unprioritized_issues (string).",
-        raw
+        "Analyze the GitLab issues JSON in the context. Count issues with priority labels from the vocabulary above (prioritized_count) and those without (unprioritized_count). Summarize patterns (patterns). List unprioritized issue IDs, titles, labels (unprioritized_issues). Return JSON: prioritized_count (int), unprioritized_count (int), patterns (string), unprioritized_issues (string).",
+        analyze_ctx
     ) -> PriorityAnalysis;
 
     if analysis.prioritized_count > 0 {
@@ -94,10 +110,10 @@ fn tick(reason: string) -> void {
     if analysis.unprioritized_count > 0 {
         let my_tier = tier("prioritizer");
         let rec = recommend("prioritize", ["accuracy"]);
-        let context = "Unprioritized issues: " + analysis.unprioritized_issues + "\nPast learning: " + to_string(rec);
+        let context = vocab_line + "\nUnprioritized issues: " + analysis.unprioritized_issues + "\nPast learning: " + to_string(rec);
 
         let action = prompt(
-            "You are a prioritization agent. Suggest priority for the most important unprioritized issue. Return JSON: issue_id (int), priority (string, e.g. priority::high), reasoning (string), author (string, the GitLab username from the issue's author.username field in the context — empty string if absent), confidence (float 0-1).",
+            "You are a prioritization agent. Suggest priority for the most important unprioritized issue from the context. The priority value MUST be one label from the priority vocabulary listed above. Return JSON: issue_id (int), priority (string, from the vocabulary above), reasoning (string), author (string, the GitLab username from the issue's author.username field in the context — empty string if absent), confidence (float 0-1).",
             context
         ) -> PriorityAction;
 

--- a/dev-apprenticeship/triage/config/colony.example.toml
+++ b/dev-apprenticeship/triage/config/colony.example.toml
@@ -17,6 +17,14 @@ me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
 backend = "cli"
 
+# #226: label vocabulary injected into the prioritizer prompts. Free-text;
+# the agent splices the value into the prompt verbatim so operators can
+# list comma-separated label names or describe non-label patterns. Leave
+# unset to keep the pre-#226 hardcoded defaults
+# ('priority::critical/high/medium/low, P1-P4, urgent').
+[triage.labels]
+priority = "priority::critical, priority::high, priority::medium, priority::low, P1, P2, P3, P4, urgent"
+
 # Auto-confidence knobs (#106). These are informational in the current
 # Phase 1 shipment: the agents hard-code the defaults (match +0.02,
 # partial +0.005, mismatch -0.01, timeout 86400s, autonomy_cap 0.85) and

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -57,6 +57,18 @@ AGENTS=(
     router
 )
 
+# #226: vocabulary memo seeding. Operator-tuned priority label vocabulary
+# overrides the hardcoded defaults baked into the prioritizer prompts.
+# Read from colony.toml on every restart so config edits take effect on
+# the next start-colony cycle (no install.sh re-run). Failures are
+# non-fatal: the agent falls back to the pre-#226 hardcoded strings via
+# the `recall_latest() / if len() > 0` pattern.
+PRIORITY_LABELS=$(parse_toml triage.labels priority)
+FED_ROOT="$(cd "$REPO_ROOT/dev-apprenticeship" && pwd)"
+if [ -n "$PRIORITY_LABELS" ]; then
+    (cd "$FED_ROOT" && agentis memo set triage:labels:priority "$PRIORITY_LABELS" >/dev/null 2>&1) || true
+fi
+
 # Opt-in log truncation. Off by default so operators who rely on log
 # history across restarts are not surprised. Set TRUNCATE_LOGS=1 in
 # the environment (or via start-federation.sh) to bound disk use

--- a/tools/test-parse-toml.sh
+++ b/tools/test-parse-toml.sh
@@ -167,6 +167,25 @@ url = "llm-url"
 assert_eq "gitlab.url resolves to gitlab section" "gitlab-url" "$(parse_toml gitlab url)"
 assert_eq "llm.url resolves to llm section" "llm-url" "$(parse_toml llm url)"
 
+# --- Test 12: #226 — dotted sub-table header ---
+fixture "sub-table" '[planning]
+trigger_label = "needs-planning"
+
+[planning.labels]
+incident = "incident, bug, blocker"
+epic = "epic"
+
+[triage.labels]
+priority = "P1, P2, P3, P4"
+'
+assert_eq "#226: planning.labels.incident" "incident, bug, blocker" "$(parse_toml planning.labels incident)"
+assert_eq "#226: planning.labels.epic" "epic" "$(parse_toml planning.labels epic)"
+assert_eq "#226: triage.labels.priority" "P1, P2, P3, P4" "$(parse_toml triage.labels priority)"
+# Parent section does not leak into sub-table scope and vice versa.
+assert_eq "#226: parent planning.trigger_label unaffected" "needs-planning" "$(parse_toml planning trigger_label)"
+assert_eq "#226: parent does not see sub-table key" "" "$(parse_toml planning incident)"
+assert_eq "#226: sub-table does not see parent key" "" "$(parse_toml planning.labels trigger_label)"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #226.

## Summary

Three agents (`planning/risk_assessor`, `planning/task_decomposer`, `triage/prioritizer`) previously anchored their prompts on generic-OSS label names — `incident`/`bug`/`blocker`, `epic`, `priority::critical`/`high`/.../`P1-P4`/`urgent`. Operators on projects with different taxonomies (scoped labels, severity-prefix conventions, umbrella-issue patterns) had to fork agent source to retune vocabulary. This PR makes it declarative.

## What changed

### New config sections

```toml
# dev-apprenticeship/planning/config/colony.example.toml
[planning.labels]
incident = "incident, bug, blocker"
epic     = "epic"

# dev-apprenticeship/triage/config/colony.example.toml
[triage.labels]
priority = "priority::critical, priority::high, priority::medium, priority::low, P1, P2, P3, P4, urgent"
```

Values are free-text and injected verbatim, so operators can list label names or describe non-label patterns (e.g. `epic = "umbrella-issue pattern, parent/child references in description"`).

### start-colony.sh seeds memo

Both `planning/scripts/start-colony.sh` and `triage/scripts/start-colony.sh` gain a memo-seed block (same pattern as `gitlab:me` from #104). Each restart re-seeds from the current config — no `install.sh` re-run required. Failures are non-fatal: agents fall back to hardcoded defaults via `recall_latest() == ""`.

### Agent prompt rewrites

`risk_assessor.ag`, `task_decomposer.ag`, `prioritizer.ag` splice the vocabulary into the `context` arg of `prompt()`, not the instruction string. The agentis parser requires a string literal for the instruction arg (verified by `agentis commit` — `prompt()` concat on arg 1 emits `expected string literal for prompt instruction`), so the dynamic vocabulary is passed via context instead. Each prompt's instruction text references "the vocabulary above" / "from the vocabulary" to anchor the LLM on the context-provided list.

### parse-toml.sh

No change required. The existing `sect_name == section` comparison matches any bracketed header verbatim, including dots — `[planning.labels]` → `sect_name = "planning.labels"` → compares equal to `"planning.labels"`. Verified:

```
$ CONFIG=.../planning/config/colony.example.toml bash -c 'source tools/parse-toml.sh && parse_toml planning.labels incident'
incident, bug, blocker
```

## Backward compatibility

- Pre-#226 configs (no `[*.labels]` sections): `parse_toml` returns empty → memo never seeded → `recall_latest()` returns empty → fallback branch fires → byte-identical prompt to today.
- No memo-namespace collision: keys live under `planning:labels:*` / `triage:labels:*`, which don't collide with the existing per-agent prefixes (`risk_assessor:`, `prioritizer:`, etc.).

## Test plan

- [x] `./tools/colony-lint.sh` — 80 passed / 0 failed / 5 skipped.
- [x] `agentis commit` parses all 3 modified `.ag` files clean.
- [x] `parse_toml planning.labels incident` / `planning.labels epic` / `triage.labels priority` all return expected values against the example configs.
- [x] CHANGELOG `### Added` bullet under `[Unreleased]` cross-references #226. VERSION unchanged (release-PR territory).
- [ ] Human smoke test: seed custom vocabulary, start planning colony, verify `dev-apprenticeship/.agentis/logs/risk_assessor.log` shows the custom vocabulary line in prompt context (requires live GitLab project + observed-tier).

## Semver

**MINOR** — net-new optional config keys. Zero behaviour change for unset configs. No existing key removed/renamed, no bus event changed, no agent removed. Per CLAUDE.md semver rules, a new optional config key is MINOR.

## Out of scope (follow-up)

- Option (2) from the plan: shadow-tier vocabulary learning (agents infer the project's taxonomy by observing existing labels and update the vocabulary autonomously). Worth its own issue once #226 ships and we see whether operators actually edit the new keys. Flagged in plan-226.md.
- Other prompt vocabulary biases beyond the three sites the issue identifies (e.g. severity / type taxonomies in `code_writer`, `labeler`). Out of scope here; follow-up ticket if useful.

## Relationship to other PRs in flight

- This PR touches `planning/` and `triage/`. No file overlap with the implementation colony (#230/#231) or release colony.
- CHANGELOG uses `### Added` under `[Unreleased]`. Will rebase cleanly against #230 (also `### Added`) once one merges first.

## Files touched

- `dev-apprenticeship/planning/config/colony.example.toml`
- `dev-apprenticeship/triage/config/colony.example.toml`
- `dev-apprenticeship/planning/scripts/start-colony.sh`
- `dev-apprenticeship/triage/scripts/start-colony.sh`
- `dev-apprenticeship/planning/agents/risk_assessor.ag`
- `dev-apprenticeship/planning/agents/task_decomposer.ag`
- `dev-apprenticeship/triage/agents/prioritizer.ag`
- `dev-apprenticeship/CHANGELOG.md`