### PR TITLE
observability: events-aware label-transition detection (#235)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,26 @@ is asserted until multi-version CI is in place.
 
 ### Added
 
+- **Events-aware label observability for trigger-label agents**
+  ([#235](https://github.com/Replikanti/agentis-colonies/issues/235)).
+  Planning and implementation colonies now detect short-lived trigger
+  labels that are added and removed between two 60 s polls. Two new
+  `gitlab-api.sh` commands wrap GitLab's `resource_label_events`
+  endpoint:
+    - `issues-by-label-events --since <ISO8601> [--view <name>]` (planning) —
+      union of currently-labeled open issues and issues where
+      `$PLANNING_TRIGGER_LABEL` was added in [since, now].
+    - `assigned-issues-by-label-events --since <ISO8601> [--view <name>]`
+      (implementation) — same, but assignee-scoped and uses
+      `$IMPLEMENTATION_TRIGGER_LABEL`.
+    - `issue-label-events <iid> [--since ISO8601] [--label NAME]` —
+      primitive events reader, available from both colonies.
+  `risk_assessor.ag`, `scope_estimator.ag`, `task_decomposer.ag`,
+  `plan_reviewer.ag`, and `code_writer.ag` now call the events-aware
+  variant whenever their `last_check` memo is populated; first tick
+  still issues the pre-#235 current-state snapshot, so boot behavior is
+  byte-identical.
+
 ### Changed
 
 ### Deprecated

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -20,8 +20,8 @@ is asserted until multi-version CI is in place.
 - **Events-aware label observability for trigger-label agents**
   ([#235](https://github.com/Replikanti/agentis-colonies/issues/235)).
   Planning and implementation colonies now detect short-lived trigger
-  labels that are added and removed between two 60 s polls. Two new
-  `gitlab-api.sh` commands wrap GitLab's `resource_label_events`
+  labels that are added and removed between two 60 s polls. Three new
+  `gitlab-api.sh` sub-commands wrap GitLab's `resource_label_events`
   endpoint:
     - `issues-by-label-events --since <ISO8601> [--view <name>]` (planning) —
       union of currently-labeled open issues and issues where

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -106,8 +106,17 @@ fn tick(reason: string) -> void {
         };
     };
 
-    // 2. Check for assigned issues needing implementation
-    let issues_cmd = "$COLONY_DIR/scripts/gitlab-api.sh assigned-issues --view assigned";
+    // 2. Check for assigned issues needing implementation.
+    // #235: use events-aware query when we have a prior window so short-
+    // lived trigger labels (e.g. "DEV::not started" transitioning through
+    // scoped states in seconds) aren't missed. The first tick falls back
+    // to the current-state snapshot — byte-identical to pre-#235 boot.
+    let prev_check = recall_latest("code_writer:last_check");
+    let issues_cmd = if len(prev_check) > 0 {
+        "$COLONY_DIR/scripts/gitlab-api.sh assigned-issues-by-label-events --since " + shell_escape(prev_check) + " --view assigned";
+    } else {
+        "$COLONY_DIR/scripts/gitlab-api.sh assigned-issues --view assigned";
+    };
     let issues_raw = try {
         exec sh issues_cmd;
     } catch e {

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -343,9 +343,13 @@ case "$CMD" in
             esac
         done
         body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || exit $?
-        printf '%s' "$body" | EV_SINCE="$EV_SINCE" EV_LABEL="$EV_LABEL" python3 <<'PY'
-import os, sys, json
-events = json.load(sys.stdin)
+        # Pass body via env (BODY=) rather than stdin because the heredoc
+        # (<<'PY') would otherwise override the piped input — shellcheck
+        # SC2259. Same idiom as the split / hit / matched / final blocks
+        # below in assigned-issues-by-label-events.
+        BODY="$body" EV_SINCE="$EV_SINCE" EV_LABEL="$EV_LABEL" python3 <<'PY'
+import os, json
+events = json.loads(os.environ["BODY"])
 since = os.environ.get("EV_SINCE", "")
 label = os.environ.get("EV_LABEL", "")
 out = []

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -20,6 +20,8 @@
 #   gitlab-api.sh mr-commits <iid>
 #   gitlab-api.sh issue <iid>
 #   gitlab-api.sh assigned-issues [--since ISO8601] [--view <name>]
+#   gitlab-api.sh assigned-issues-by-label-events --since ISO8601 [--view <name>]
+#   gitlab-api.sh issue-label-events <iid> [--since ISO8601] [--label NAME]
 #   gitlab-api.sh create-branch --name <name> --ref <ref>
 #   gitlab-api.sh commit-files --branch <b> --message <m> --actions <json>
 #   gitlab-api.sh create-mr --source <branch> --title <title> [--description <d>]
@@ -320,6 +322,144 @@ case "$CMD" in
             printf '%s' "$body" | project_json "$VIEW"
         else
             gl_get_q "$API/issues" "${ARGS[@]}"
+        fi
+        ;;
+
+    issue-label-events)
+        # #235: expose GitLab resource_label_events for a single issue, with
+        # optional client-side filter by label name and/or since timestamp.
+        # Projection: [{ts, action, label, user}] — stable shape independent
+        # of GitLab schema drift. The endpoint itself has no --since query
+        # param (unlike /issues), so the filter runs client-side.
+        IID="${1:?Usage: gitlab-api.sh issue-label-events <iid> [--since ISO8601] [--label NAME]}"
+        shift
+        EV_SINCE=""
+        EV_LABEL=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) EV_SINCE="$2"; shift 2 ;;
+                --label) EV_LABEL="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || exit $?
+        printf '%s' "$body" | EV_SINCE="$EV_SINCE" EV_LABEL="$EV_LABEL" python3 <<'PY'
+import os, sys, json
+events = json.load(sys.stdin)
+since = os.environ.get("EV_SINCE", "")
+label = os.environ.get("EV_LABEL", "")
+out = []
+for ev in events:
+    ev_label = (ev.get("label") or {}).get("name")
+    ev_ts = ev.get("created_at") or ""
+    if since and ev_ts < since:
+        continue
+    if label and ev_label != label:
+        continue
+    out.append({
+        "ts": ev_ts,
+        "action": ev.get("action"),
+        "label": ev_label,
+        "user": (ev.get("user") or {}).get("username"),
+    })
+print(json.dumps(out))
+PY
+        ;;
+
+    assigned-issues-by-label-events)
+        # #235: events-aware trigger query for implementation colony. Returns
+        # the union of
+        #   (a) open issues currently assigned to anyone and carrying
+        #       $IMPLEMENTATION_TRIGGER_LABEL, and
+        #   (b) open assigned issues that had the label added at any point
+        #       in [--since, now] per resource_label_events.
+        # Closes the observability gap where a short-lived trigger label
+        # is added and removed between two 60 s polls. Mirrors the planning
+        # colony's issues-by-label-events (#235) but keeps the assignee_id
+        # filter that assigned-issues uses.
+        EV_SINCE=""
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) EV_SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$EV_SINCE" ]; then
+            emit_error "--since is required for assigned-issues-by-label-events"
+            exit 2
+        fi
+        LABEL="${IMPLEMENTATION_TRIGGER_LABEL:-implementation}"
+        # Fetch recent open assigned issues with no label filter so we catch
+        # those that had the trigger label briefly and lost it again.
+        BASE_ARGS=(
+            --data-urlencode "state=opened"
+            --data-urlencode "assignee_id=Any"
+            --data-urlencode "per_page=20"
+            --data-urlencode "order_by=updated_at"
+            --data-urlencode "sort=desc"
+            --data-urlencode "updated_after=$EV_SINCE"
+        )
+        recent="$(gl_get_q "$API/issues" "${BASE_ARGS[@]}")" || exit $?
+        split="$(RECENT="$recent" LABEL="$LABEL" python3 <<'PY'
+import os, json
+items = json.loads(os.environ["RECENT"])
+label = os.environ["LABEL"]
+current = [x for x in items if label in (x.get("labels") or [])]
+to_check = [x["iid"] for x in items if label not in (x.get("labels") or [])]
+print(json.dumps({"current": current, "to_check": to_check}))
+PY
+)" || exit $?
+        current_list="$(printf '%s' "$split" | python3 -c 'import sys,json;print(json.dumps(json.load(sys.stdin)["current"]))')"
+        iids_to_check="$(printf '%s' "$split" | python3 -c 'import sys,json;print(" ".join(str(i) for i in json.load(sys.stdin)["to_check"]))')"
+        matched="[]"
+        for IID in $iids_to_check; do
+            ev_body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || continue
+            hit="$(EVBODY="$ev_body" LABEL="$LABEL" EV_SINCE="$EV_SINCE" python3 <<'PY'
+import os, json
+events = json.loads(os.environ["EVBODY"])
+label = os.environ["LABEL"]
+since = os.environ["EV_SINCE"]
+for ev in events:
+    ev_label = (ev.get("label") or {}).get("name")
+    ev_ts = ev.get("created_at") or ""
+    if ev_label == label and ev.get("action") == "add" and ev_ts >= since:
+        print("1"); break
+else:
+    print("")
+PY
+)"
+            if [ -n "$hit" ]; then
+                issue_body="$(gl_get "$API/issues/$IID")" || continue
+                matched="$(MATCHED="$matched" ISSUE="$issue_body" python3 <<'PY'
+import os, json
+acc = json.loads(os.environ["MATCHED"])
+acc.append(json.loads(os.environ["ISSUE"]))
+print(json.dumps(acc))
+PY
+)"
+            fi
+        done
+        final="$(CUR="$current_list" MATCHED="$matched" python3 <<'PY'
+import os, json
+a = json.loads(os.environ["CUR"])
+b = json.loads(os.environ["MATCHED"])
+seen = set()
+out = []
+for x in a + b:
+    iid = x.get("iid")
+    if iid in seen:
+        continue
+    seen.add(iid)
+    out.append(x)
+print(json.dumps(out))
+PY
+)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$final" | project_json "$VIEW"
+        else
+            printf '%s' "$final"
         fi
         ;;
 

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -72,12 +72,21 @@ fn tick(reason: string) -> void {
 
     // 3. Pick the newest unplanned issue and see if we have all three
     //    slots filled for it. If not, keep waiting.
-    // #147: cheap delta-check. `issues --needs-planning` returns `[]`
-    // when every open issue already has a plan, so we early-exit
-    // before the assembly prompt(). last_check is refreshed so the
-    // agent's liveness signal advances on quiet projects.
+    // #147: cheap delta-check. The query returns `[]` when every open
+    // issue already has a plan, so we early-exit before the assembly
+    // prompt(). last_check is refreshed so the agent's liveness signal
+    // advances on quiet projects.
+    // #235: use issues-by-label-events when we have a prior window so
+    // short-lived trigger labels aren't missed; fall back to the current-
+    // state snapshot on first tick (byte-identical to pre-#235 boot).
+    let prev_check = recall_latest("plan_reviewer:last_check");
+    let issues_cmd = if len(prev_check) > 0 {
+        "$COLONY_DIR/scripts/gitlab-api.sh issues-by-label-events --since " + shell_escape(prev_check) + " --view planning";
+    } else {
+        "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
+    };
     let issues_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
+        exec sh issues_cmd;
     } catch e {
         print("[plan_reviewer] GitLab unplanned-issue poll failed:", e);
         "";

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -25,8 +25,15 @@ type IncidentPatterns {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("risk_assessor:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts) + " --view planning";
+        // #235: events-aware query closes the short-lived-label gap.
+        // issues-by-label-events unions currently-labeled + issues where
+        // the trigger label was added at any point in [ts, now] per
+        // resource_label_events. Catches transitions we'd miss between
+        // 60 s polls with a pure current-state snapshot.
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
     };
+    // First-tick fallback: no prior window to diff against; the snapshot
+    // preserves pre-#235 boot behavior byte-identically.
     return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
 }
 

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -26,8 +26,10 @@ type CalibrationSummary {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("scope_estimator:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts) + " --view planning";
+        // #235: events-aware query — see risk_assessor.ag for rationale.
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
     };
+    // First-tick fallback: no prior window; snapshot preserves pre-#235 boot behavior.
     return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
 }
 

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -26,8 +26,10 @@ type DecompositionPatterns {
 fn unplanned_cmd() -> string {
     let ts = recall_latest("task_decomposer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --since " + shell_escape(ts) + " --view planning";
+        // #235: events-aware query — see risk_assessor.ag for rationale.
+        return "$COLONY_DIR/scripts/gitlab-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
     };
+    // First-tick fallback: no prior window; snapshot preserves pre-#235 boot behavior.
     return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
 }
 

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -321,9 +321,13 @@ case "$CMD" in
             esac
         done
         body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || exit $?
-        printf '%s' "$body" | EV_SINCE="$EV_SINCE" EV_LABEL="$EV_LABEL" python3 <<'PY'
-import os, sys, json
-events = json.load(sys.stdin)
+        # Pass body via env (BODY=) rather than stdin because the heredoc
+        # (<<'PY') would otherwise override the piped input — shellcheck
+        # SC2259. Same idiom as the split / hit / matched / final blocks
+        # below in issues-by-label-events.
+        BODY="$body" EV_SINCE="$EV_SINCE" EV_LABEL="$EV_LABEL" python3 <<'PY'
+import os, json
+events = json.loads(os.environ["BODY"])
 since = os.environ.get("EV_SINCE", "")
 label = os.environ.get("EV_LABEL", "")
 out = []

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -19,6 +19,8 @@
 #
 # Usage:
 #   gitlab-api.sh issues --needs-planning [--since ISO8601] [--view <name>]
+#   gitlab-api.sh issues-by-label-events --since ISO8601 [--view <name>]
+#   gitlab-api.sh issue-label-events <iid> [--since ISO8601] [--label NAME]
 #   gitlab-api.sh add-note <iid> --body <text>
 #   gitlab-api.sh merge-requests [--state merged] [--since ISO8601] [--per-page N] [--view <name>]
 #
@@ -299,6 +301,143 @@ case "$CMD" in
         # chars are all escaped correctly and markdown formatting is preserved.
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
         gl_post "$API/issues/$ID/notes" "$JSON_BODY"
+        ;;
+
+    issue-label-events)
+        # #235: expose GitLab resource_label_events for a single issue, with
+        # optional client-side filter by label name and/or since timestamp.
+        # Projection: [{ts, action, label, user}] — stable shape independent
+        # of GitLab schema drift. The endpoint itself has no --since query
+        # param (unlike /issues), so the filter runs client-side.
+        IID="${1:?Usage: gitlab-api.sh issue-label-events <iid> [--since ISO8601] [--label NAME]}"
+        shift
+        EV_SINCE=""
+        EV_LABEL=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) EV_SINCE="$2"; shift 2 ;;
+                --label) EV_LABEL="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || exit $?
+        printf '%s' "$body" | EV_SINCE="$EV_SINCE" EV_LABEL="$EV_LABEL" python3 <<'PY'
+import os, sys, json
+events = json.load(sys.stdin)
+since = os.environ.get("EV_SINCE", "")
+label = os.environ.get("EV_LABEL", "")
+out = []
+for ev in events:
+    ev_label = (ev.get("label") or {}).get("name")
+    ev_ts = ev.get("created_at") or ""
+    if since and ev_ts < since:
+        continue
+    if label and ev_label != label:
+        continue
+    out.append({
+        "ts": ev_ts,
+        "action": ev.get("action"),
+        "label": ev_label,
+        "user": (ev.get("user") or {}).get("username"),
+    })
+print(json.dumps(out))
+PY
+        ;;
+
+    issues-by-label-events)
+        # #235: events-aware trigger query. Returns the union of
+        #   (a) open issues that currently carry $PLANNING_TRIGGER_LABEL, and
+        #   (b) open issues that had the label added at any point in
+        #       [--since, now] per resource_label_events.
+        # Closes the observability gap where a short-lived trigger label
+        # (e.g. "DEV::not started" on projects that transition it in
+        # seconds) is added and removed between two 60 s polls and the
+        # current-state snapshot misses it entirely.
+        EV_SINCE=""
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) EV_SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$EV_SINCE" ]; then
+            emit_error "--since is required for issues-by-label-events"
+            exit 2
+        fi
+        LABEL="${PLANNING_TRIGGER_LABEL:-needs-planning}"
+        # Fetch recent open issues with no label filter so we catch those
+        # that had the trigger label briefly and lost it again.
+        BASE_ARGS=(
+            --data-urlencode "state=opened"
+            --data-urlencode "per_page=20"
+            --data-urlencode "order_by=updated_at"
+            --data-urlencode "sort=desc"
+            --data-urlencode "updated_after=$EV_SINCE"
+        )
+        recent="$(gl_get_q "$API/issues" "${BASE_ARGS[@]}")" || exit $?
+        # Split into currently-labeled (include directly) and need-events-check.
+        split="$(RECENT="$recent" LABEL="$LABEL" python3 <<'PY'
+import os, json
+items = json.loads(os.environ["RECENT"])
+label = os.environ["LABEL"]
+current = [x for x in items if label in (x.get("labels") or [])]
+to_check = [x["iid"] for x in items if label not in (x.get("labels") or [])]
+print(json.dumps({"current": current, "to_check": to_check}))
+PY
+)" || exit $?
+        current_list="$(printf '%s' "$split" | python3 -c 'import sys,json;print(json.dumps(json.load(sys.stdin)["current"]))')"
+        iids_to_check="$(printf '%s' "$split" | python3 -c 'import sys,json;print(" ".join(str(i) for i in json.load(sys.stdin)["to_check"]))')"
+        matched="[]"
+        for IID in $iids_to_check; do
+            ev_body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || continue
+            hit="$(EVBODY="$ev_body" LABEL="$LABEL" EV_SINCE="$EV_SINCE" python3 <<'PY'
+import os, json
+events = json.loads(os.environ["EVBODY"])
+label = os.environ["LABEL"]
+since = os.environ["EV_SINCE"]
+for ev in events:
+    ev_label = (ev.get("label") or {}).get("name")
+    ev_ts = ev.get("created_at") or ""
+    if ev_label == label and ev.get("action") == "add" and ev_ts >= since:
+        print("1"); break
+else:
+    print("")
+PY
+)"
+            if [ -n "$hit" ]; then
+                issue_body="$(gl_get "$API/issues/$IID")" || continue
+                matched="$(MATCHED="$matched" ISSUE="$issue_body" python3 <<'PY'
+import os, json
+acc = json.loads(os.environ["MATCHED"])
+acc.append(json.loads(os.environ["ISSUE"]))
+print(json.dumps(acc))
+PY
+)"
+            fi
+        done
+        # Union current + matched, dedup by iid, preserve current-first ordering.
+        final="$(CUR="$current_list" MATCHED="$matched" python3 <<'PY'
+import os, json
+a = json.loads(os.environ["CUR"])
+b = json.loads(os.environ["MATCHED"])
+seen = set()
+out = []
+for x in a + b:
+    iid = x.get("iid")
+    if iid in seen:
+        continue
+    seen.add(iid)
+    out.append(x)
+print(json.dumps(out))
+PY
+)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$final" | project_json "$VIEW"
+        else
+            printf '%s' "$final"
+        fi
         ;;
 
     merge-requests)


### PR DESCRIPTION
## Summary

Closes #235. Planning and implementation colonies now see short-lived trigger-label transitions — an issue that had `needs-planning` / `implementation` added and removed between two 60 s polls is no longer silently missed.

The fix wraps GitLab's `resource_label_events` endpoint in two new `gitlab-api.sh` commands per colony script, then threads them through the 5 ticking agents that poll for new trigger-labeled issues. Each agent keeps its existing first-tick fallback to the current-state snapshot, so pre-#235 boot behavior is byte-identical.

## Changes

### New `gitlab-api.sh` commands

**planning/scripts/gitlab-api.sh**
- `issues-by-label-events --since <ISO8601> [--view <name>]` — union of currently-labeled open issues and issues where `$PLANNING_TRIGGER_LABEL` was added at any point in `[since, now]`.
- `issue-label-events <iid> [--since ISO8601] [--label NAME]` — primitive events reader with optional client-side filters.

**implementation/scripts/gitlab-api.sh**
- `assigned-issues-by-label-events --since <ISO8601> [--view <name>]` — same union pattern, assignee-scoped, uses `$IMPLEMENTATION_TRIGGER_LABEL`.
- `issue-label-events <iid> [--since ISO8601] [--label NAME]`.

### Agent wiring (5 agents)

Each agent issues the events-aware variant whenever its `<agent>:last_check` memo is populated; first tick still hits the pre-#235 current-state snapshot.

- `planning/agents/risk_assessor.ag` — `unplanned_cmd()`
- `planning/agents/scope_estimator.ag` — `unplanned_cmd()`
- `planning/agents/task_decomposer.ag` — `unplanned_cmd()`
- `planning/agents/plan_reviewer.ag` — inline at cheap delta-check
- `implementation/agents/code_writer.ag` — inline at `issues_cmd`

### Out of scope

- **Triage labeler** — #235 marked it as Optional. It fires on issue-creation hooks, not label-state polling, so it's already events-aware for its domain.

## Algorithm

`issues-by-label-events` / `assigned-issues-by-label-events`:

1. Fetch open issues with `state=opened + updated_after=since` (no label filter) so any recently-active issue is picked up.
2. Split client-side: `current` (has label now) vs `to_check` (iids to query events for).
3. Per `to_check` iid, fetch `resource_label_events?per_page=100`, match on `action==add && label==$LABEL && ts>=since` with early-exit.
4. On match, fetch the full issue body and append.
5. Union current + matched, dedup by iid, optionally project via the existing `--view` mechanism.

## Test plan

- [ ] `./tools/colony-lint.sh` — 80 passed, 0 failed, 5 skipped
- [ ] Bash syntax check on both `gitlab-api.sh` scripts
- [ ] `bash -n` on all 5 modified `.ag` files via colony-lint's agentis-syntax pass
- [ ] QA agent spawn (substantive PR)

## Semver

MINOR — new observability feature + 4 new `gitlab-api.sh` sub-commands. No breaking changes, no schema changes. Runtime floor unchanged.