### PR TITLE
dashboard: calibrate evolve flat-slope threshold from production data (#163)

### DIFF
--- a/tools/federation-dashboard.html.template
+++ b/tools/federation-dashboard.html.template
@@ -647,6 +647,17 @@ const TIMELINE_AUTO_HIDE_STALE_KEY = 'dashboard.timeline.autoHideStale.' + FED_N
 const TIMELINE_STALE_WINDOW_MS = 3600 * 1000;
 // #167: every class the timeline emits, in render order.
 const TIMELINE_CLASSES = ['emit', 'recv', 'suggest', 'error', 'action', 'finding'];
+// #163: magnitude below which the fitness slope over the last 100 experience
+// entries is treated as flat and evolve is disabled as an Opus plateau. Raised
+// from the original 1e-6 guess to 1e-4 after production calibration against
+// dev-apprenticeship on v1.4.3 with populated fitness_delta values: the
+// observed per-agent |slope| distribution splits cleanly into a true-plateau
+// cluster at |slope| <= 1e-5 (code_writer, commit_composer, router,
+// prioritizer — the canonical "evolve is pointless" cases the gate is meant
+// to catch) and an oscillation cluster at |slope| in [1e-4, 3e-3], with no
+// data in the gap between. 1e-4 is the natural separator — full snapshot
+// tables are on the issue.
+const SLOPE_FLAT_THRESHOLD = 1e-4;
 
 function tlReadJSON(key, fallback) {
   try {
@@ -1423,10 +1434,10 @@ function actionGate(a, type, target) {
         evidence: f
       };
     }
-    if (Math.abs(f.slope) < 1e-6) {
+    if (Math.abs(f.slope) < SLOPE_FLAT_THRESHOLD) {
       return {
         enabled: false, ruleType: 'flat-slope',
-        reason: 'Fitness slope flat over the last ' + f.window + ' entries (likely Opus plateau) \u2014 evolve unlikely to find improvement.',
+        reason: 'Fitness slope flat over the last ' + f.window + ' entries (|slope| < ' + SLOPE_FLAT_THRESHOLD.toExponential(0) + ', likely Opus plateau) \u2014 evolve unlikely to find improvement.',
         evidence: f
       };
     }

--- a/tools/test-timeline-rendering.sh
+++ b/tools/test-timeline-rendering.sh
@@ -429,6 +429,33 @@ else
     fail "19: heredoc detected — extract content to a standalone file (see #172)"
 fi
 
+# --- #163: evolve flat-slope threshold is named, reachable, and calibrated.
+#     Guards against reverting to the pre-calibration 1e-6 guess or silently
+#     orphaning the constant (declared but never used). The production
+#     calibration in #163 picked 1e-4 as the natural separator between the
+#     true-plateau cluster (|slope| <= 1e-5) and the oscillation cluster
+#     (|slope| >= 1e-4). ---
+if python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
+import sys, re
+with open(sys.argv[1]) as f:
+    src = f.read()
+m = re.search(r'const\s+SLOPE_FLAT_THRESHOLD\s*=\s*([0-9eE.+\-]+)\s*;', src)
+if not m: sys.exit(1)
+value = float(m.group(1))
+# Must equal the calibrated value (not the pre-calibration 1e-6).
+if abs(value - 1e-4) > 1e-12: sys.exit(2)
+# Must actually be referenced (no orphaned constant).
+if 'SLOPE_FLAT_THRESHOLD' not in src[m.end():]: sys.exit(3)
+# Legacy literal must no longer guard the flat-slope branch.
+if re.search(r'Math\.abs\(\s*f\.slope\s*\)\s*<\s*1e-6\b', src): sys.exit(4)
+sys.exit(0)
+PY
+then
+    pass "20: SLOPE_FLAT_THRESHOLD defined as 1e-4, referenced, no leftover 1e-6 guard (#163)"
+else
+    fail "20: SLOPE_FLAT_THRESHOLD missing, wrong value, orphaned, or 1e-6 guard survived (#163)"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Bump `SLOPE_FLAT_THRESHOLD` in `tools/federation-dashboard.html.template` from the pre-calibration `1e-6` guess to the production-calibrated `1e-4`.
- Promote the magic number to a named const so future re-calibrations are a one-line tweak and the value is discoverable.
- The evolve gate's `flat-slope` reason string now surfaces the threshold so operators can read the calibration from the UI.

## Calibration source

Data snapshot posted on #163: 23 agents across two federations (`dev-apprenticeship` on `X/Y1`, `dev-apprenticeship-app` on `X/Y2`) on `agentis v1.4.3` with `fitness_delta` populated per outcome (post-core-PR-#542).

Per-agent `|slope|` distribution over the last 100 experience entries splits cleanly into:

| cluster | range | agents |
|---|---|---|
| true plateau | `|slope| <= 1e-5` | `code_writer`, `commit_composer`, `router`, `prioritizer` |
| oscillation | `|slope|` in `[1e-4, 3e-3]` | most everything else |
| gap | `(1e-5, 1e-4)` | **empty** |

`1e-4` sits inside the gap — it catches every cluster-1 plateau without false positives from cluster 2. `1e-3` would also lump in oscillating agents like `logic_reviewer` and `test_reviewer`, so it was rejected as too aggressive.

Full tables (including Y1 / app breakdowns and threshold-sensitivity analysis) are in the #163 comment.

## Test plan

- [x] `tools/test-timeline-rendering.sh` — new test 20 guards against reverting to `1e-6`, orphaning the constant, or the flat-slope branch bypassing it. 20/20 pass.
- [x] `./tools/colony-lint.sh` — 80 passed, 0 failed, 5 skipped.

## Out of scope

- `auto-promote-config.yaml`'s `delta_slope_min` / `delta_slope_negative_for` are semantically orthogonal (promote prereq / evolve trigger, not the evolve flat-slope gate). No change proposed there — the recommendation on the issue was explicit about only the dashboard threshold.
- Re-snapshot in 2–4 weeks once the pre-v1.4.1 zero-prefix ages out of the `last100` window for the seven agents still carrying it (see caveats on the issue). If the plateau cluster shifts, the one-line `SLOPE_FLAT_THRESHOLD = …` can be retuned without touching the gate logic.

Fixes #163