### PR TITLE
fix(implementation): gate MR-learning loop per iid (#239)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -25,6 +25,26 @@ is asserted until multi-version CI is in place.
 
 ### Fixed
 
+- **Implementation agents: MR-level idempotency gate on the learning path**
+  ([#239](https://github.com/Replikanti/agentis-colonies/issues/239)).
+  `code_writer`, `test_writer`, `refactorer`, and `commit_composer` each
+  gain a `should_learn_from_mr(mr_iid)` gate that memoizes the last MR
+  iid learned from and short-circuits before the `mr-changes` /
+  `mr-commits` subprocess, the LLM `prompt()`, and the `learn()` call
+  when the same MR is seen again. Without the gate, `merge-requests
+  --since <last_check>` kept returning the same MR at index `[0]` as
+  long as its `updated_at` kept getting bumped (new comment, pipeline
+  event, label change) — at the implementation colony's `cb_budget`
+  (600 – 2000 per agent), that produces hundreds of duplicate `Learned
+  from MR <N>` entries per hour on a long-lived issue and the memory
+  load that precedes the silent agent-daemon deaths described in the
+  issue. Memo keys: `<agent>:last_learned_mr_iid`. Single-key, no TTL —
+  we want at-most-once per distinct MR iid per daemon lifetime.
+  Upstream concerns (terminal `daemon.stopped` on SIGKILL-by-OS,
+  per-agent RSS instrumentation, watchdog auto-restart on silent death)
+  remain open in `agentis-core`; this colony-side fix removes the load
+  that triggers the class of runtime failure.
+
 ### Security
 
 ## [0.3.0] — 2026-04-20

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -71,6 +71,29 @@ fn should_draft_code(iid_str: string, upd: string) -> bool {
     return false;
 }
 
+// #239: learn from each merged MR at most once per daemon lifetime.
+// Without this gate, the `merge-requests --since <last_check>` query
+// keeps returning the same MR at index [0] as long as its `updated_at`
+// keeps getting bumped (new comments, pipeline events, label changes),
+// so the learning-path prompt re-fires every tick at cb_budget 2000 —
+// hundreds of duplicate `Learned from MR <N>` log entries and an
+// OOM-class load on long-lived MRs. Single-key memo, no TTL: we want
+// at-most-once per distinct MR iid.
+fn should_learn_from_mr(mr_iid: int) -> bool {
+    if mr_iid <= 0 {
+        return false;
+    };
+    let iid_str = to_string(mr_iid);
+    let last_iid = recall_latest("code_writer:last_learned_mr_iid");
+    if len(last_iid) == 0 {
+        return true;
+    };
+    if iid_str != last_iid {
+        return true;
+    };
+    return false;
+}
+
 fn tick(reason: string) -> void {
     // 1. Learn from recently merged MRs
     let cmd = merged_mr_cmd();
@@ -84,7 +107,8 @@ fn tick(reason: string) -> void {
     if len(raw) > 10 {
         let mr_iid = parse_int(to_string(json_get(raw, "[0].iid")));
 
-        if mr_iid > 0 {
+        if should_learn_from_mr(mr_iid) {
+            memo_write("code_writer:last_learned_mr_iid", to_string(mr_iid));
             let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -42,6 +42,27 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
+// #239: learn from each merged MR at most once per daemon lifetime.
+// Without this gate, the `merge-requests --since <last_check>` query
+// keeps returning the same MR at index [0] as long as its `updated_at`
+// keeps getting bumped, so the learning-path prompt re-fires every
+// tick at cb_budget 600. Single-key memo, no TTL: at-most-once per
+// distinct MR iid.
+fn should_learn_from_mr(mr_iid: int) -> bool {
+    if mr_iid <= 0 {
+        return false;
+    };
+    let iid_str = to_string(mr_iid);
+    let last_iid = recall_latest("commit_composer:last_learned_mr_iid");
+    if len(last_iid) == 0 {
+        return true;
+    };
+    if iid_str != last_iid {
+        return true;
+    };
+    return false;
+}
+
 fn tick(reason: string) -> void {
     // 1. Learn commit conventions from recently merged MRs
     let cmd = merged_mr_cmd();
@@ -55,7 +76,8 @@ fn tick(reason: string) -> void {
     if len(raw) > 10 {
         let mr_iid = parse_int(to_string(json_get(raw, "[0].iid")));
 
-        if mr_iid > 0 {
+        if should_learn_from_mr(mr_iid) {
+            memo_write("commit_composer:last_learned_mr_iid", to_string(mr_iid));
             let commits_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-commits " + to_string(mr_iid);
             let commits_raw = try { exec sh commits_cmd; } catch e { "[]"; };
 

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -77,6 +77,27 @@ fn should_handle_refactor(iid_str: string) -> bool {
     return false;
 }
 
+// #239: learn from each merged MR at most once per daemon lifetime.
+// Without this gate, the `merge-requests --since <last_check>` query
+// keeps returning the same MR at index [0] as long as its `updated_at`
+// keeps getting bumped, so the learning-path prompt re-fires every
+// tick at cb_budget 1000. Single-key memo, no TTL: at-most-once per
+// distinct MR iid.
+fn should_learn_from_mr(mr_iid: int) -> bool {
+    if mr_iid <= 0 {
+        return false;
+    };
+    let iid_str = to_string(mr_iid);
+    let last_iid = recall_latest("refactorer:last_learned_mr_iid");
+    if len(last_iid) == 0 {
+        return true;
+    };
+    if iid_str != last_iid {
+        return true;
+    };
+    return false;
+}
+
 fn tick(reason: string) -> void {
     // 1. Learn from refactoring patterns in merged MRs
     let cmd = merged_mr_cmd();
@@ -90,7 +111,8 @@ fn tick(reason: string) -> void {
     if len(raw) > 10 {
         let mr_iid = parse_int(to_string(json_get(raw, "[0].iid")));
 
-        if mr_iid > 0 {
+        if should_learn_from_mr(mr_iid) {
+            memo_write("refactorer:last_learned_mr_iid", to_string(mr_iid));
             let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -79,6 +79,27 @@ fn should_handle_test_draft(iid_str: string) -> bool {
     return false;
 }
 
+// #239: learn from each merged MR at most once per daemon lifetime.
+// Without this gate, the `merge-requests --since <last_check>` query
+// keeps returning the same MR at index [0] as long as its `updated_at`
+// keeps getting bumped, so the learning-path prompt re-fires every
+// tick at cb_budget 1500. Single-key memo, no TTL: at-most-once per
+// distinct MR iid.
+fn should_learn_from_mr(mr_iid: int) -> bool {
+    if mr_iid <= 0 {
+        return false;
+    };
+    let iid_str = to_string(mr_iid);
+    let last_iid = recall_latest("test_writer:last_learned_mr_iid");
+    if len(last_iid) == 0 {
+        return true;
+    };
+    if iid_str != last_iid {
+        return true;
+    };
+    return false;
+}
+
 fn tick(reason: string) -> void {
     // 1. Learn from test files in recently merged MRs
     let cmd = merged_mr_cmd();
@@ -92,7 +113,8 @@ fn tick(reason: string) -> void {
     if len(raw) > 10 {
         let mr_iid = parse_int(to_string(json_get(raw, "[0].iid")));
 
-        if mr_iid > 0 {
+        if should_learn_from_mr(mr_iid) {
+            memo_write("test_writer:last_learned_mr_iid", to_string(mr_iid));
             let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 

--- a/tools/test-learn-idempotency.sh
+++ b/tools/test-learn-idempotency.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# test-learn-idempotency.sh -- Verify the #239 MR-learning idempotency gate
+#
+# Every implementation-colony agent that learns from merged MRs must:
+#   1. Define `fn should_learn_from_mr(mr_iid: int) -> bool` following the
+#      single-key-memo idiom established by the #200 gates.
+#   2. Call it from `fn tick` immediately after extracting the top MR iid,
+#      gating the mr-changes / mr-commits + prompt + learn block.
+#   3. Write `<agent>:last_learned_mr_iid` inside the gate body before any
+#      downstream work, so a subsequent prompt/commit failure does not
+#      re-burn the LLM budget on the same MR next tick.
+#
+# Without this, the `merge-requests --since <last_check>` query keeps
+# returning the same MR at index [0] as long as its updated_at keeps
+# getting bumped, and the learning path prompt re-fires every tick —
+# the tight-loop-of-duplicate-learns signature from issue #239.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AGENTS_DIR="$REPO_ROOT/dev-apprenticeship/implementation/agents"
+
+pass=0
+fail=0
+
+ok()   { echo "  ok — $1"; pass=$((pass + 1)); }
+bad()  { echo "  FAIL — $1"; fail=$((fail + 1)); }
+
+check_agent() {
+    local agent="$1"
+    local file="$AGENTS_DIR/${agent}.ag"
+    echo "[$agent]"
+
+    if [ ! -f "$file" ]; then
+        bad "missing file: $file"
+        return
+    fi
+
+    if grep -Fq "fn should_learn_from_mr(mr_iid: int) -> bool {" "$file"; then
+        ok "gate function defined"
+    else
+        bad "gate function missing"
+    fi
+
+    if grep -Fq "recall_latest(\"${agent}:last_learned_mr_iid\")" "$file"; then
+        ok "gate reads ${agent}:last_learned_mr_iid"
+    else
+        bad "gate does not recall ${agent}:last_learned_mr_iid"
+    fi
+
+    if grep -Fq "if should_learn_from_mr(mr_iid) {" "$file"; then
+        ok "tick() calls gate"
+    else
+        bad "tick() does not call should_learn_from_mr(mr_iid)"
+    fi
+
+    if grep -Fq "memo_write(\"${agent}:last_learned_mr_iid\", to_string(mr_iid));" "$file"; then
+        ok "memo_write stashes iid"
+    else
+        bad "memo_write for ${agent}:last_learned_mr_iid missing"
+    fi
+
+    # Defense-in-depth: the pre-gate `if mr_iid > 0 {` was removed (the
+    # gate function already handles mr_iid <= 0). A lingering copy would
+    # re-nest the learn block and is likely a merge mistake.
+    if grep -Fq "if mr_iid > 0 {" "$file"; then
+        bad "stale 'if mr_iid > 0' left in place — should be replaced by should_learn_from_mr call"
+    else
+        ok "no stale 'if mr_iid > 0' gate"
+    fi
+}
+
+for agent in code_writer test_writer refactorer commit_composer; do
+    check_agent "$agent"
+done
+
+echo
+echo "learn-idempotency: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tools/test-learn-idempotency.sh
+++ b/tools/test-learn-idempotency.sh
@@ -37,7 +37,10 @@ check_agent() {
         return
     fi
 
-    if grep -Fq "fn should_learn_from_mr(mr_iid: int) -> bool {" "$file"; then
+    # Loose signature check (QA #7): match the function by name + open paren
+    # only, not the full `(mr_iid: int) -> bool` signature — a harmless
+    # parameter rename should not false-fail this test.
+    if grep -Eq "^fn should_learn_from_mr\(" "$file"; then
         ok "gate function defined"
     else
         bad "gate function missing"
@@ -49,16 +52,32 @@ check_agent() {
         bad "gate does not recall ${agent}:last_learned_mr_iid"
     fi
 
-    if grep -Fq "if should_learn_from_mr(mr_iid) {" "$file"; then
+    if grep -Fq "if should_learn_from_mr(" "$file"; then
         ok "tick() calls gate"
     else
-        bad "tick() does not call should_learn_from_mr(mr_iid)"
+        bad "tick() does not call should_learn_from_mr"
     fi
 
-    if grep -Fq "memo_write(\"${agent}:last_learned_mr_iid\", to_string(mr_iid));" "$file"; then
+    if grep -Fq "memo_write(\"${agent}:last_learned_mr_iid\"," "$file"; then
         ok "memo_write stashes iid"
     else
         bad "memo_write for ${agent}:last_learned_mr_iid missing"
+    fi
+
+    # Ordering invariant (QA #6): memo_write MUST appear before the first
+    # prompt() call that follows the `if should_learn_from_mr(...) {` line.
+    # The at-most-once-per-iid semantics depend on the memo being stamped
+    # before the prompt fires — a future refactor that moves the memo-write
+    # after prompt() re-opens the re-burn window on prompt failures.
+    local gate_line memo_line prompt_line
+    gate_line="$(grep -n "if should_learn_from_mr(" "$file" | head -1 | cut -d: -f1 || true)"
+    memo_line="$(grep -n "memo_write(\"${agent}:last_learned_mr_iid\"," "$file" | head -1 | cut -d: -f1 || true)"
+    prompt_line="$(awk -v g="${gate_line:-0}" 'NR>g && /prompt\(/ {print NR; exit}' "$file")"
+    if [ -n "$gate_line" ] && [ -n "$memo_line" ] && [ -n "$prompt_line" ] \
+       && [ "$memo_line" -gt "$gate_line" ] && [ "$memo_line" -lt "$prompt_line" ]; then
+        ok "memo_write before first prompt() inside gate body (lines ${gate_line} < ${memo_line} < ${prompt_line})"
+    else
+        bad "ordering broken: gate=${gate_line:-?} memo=${memo_line:-?} prompt=${prompt_line:-?} — memo_write must be between gate and first prompt()"
     fi
 
     # Defense-in-depth: the pre-gate `if mr_iid > 0 {` was removed (the


### PR DESCRIPTION
## Summary

- Adds `should_learn_from_mr(mr_iid)` to each of the four implementation-colony agents (`code_writer`, `test_writer`, `refactorer`, `commit_composer`). Single-key memo per agent (`<agent>:last_learned_mr_iid`), no TTL — each distinct merged MR is learned from at most once per daemon lifetime.
- Adds `tools/test-learn-idempotency.sh` as an auto-discovered colony-lint regression test (20 grep-based checks across the 4 agents).
- CHANGELOG `### Fixed` entry for #239 under `[Unreleased]`.

Plan was [posted on the issue](https://github.com/Replikanti/agentis-colonies/issues/239#issuecomment-4284791110) and approved before coding.

## Root cause (short version)

`merge-requests --since <last_check>` with GitLab's `updated_after` filter keeps returning the same MR at index `[0]` as long as that MR's `updated_at` keeps getting bumped (new comment, pipeline event, label change). Every tick re-entered the learn-path prompt at `cb_budget` 600–2000 per agent, producing hundreds of duplicate `Learned from MR <N>` log entries per hour on a real long-lived trigger-labeled issue. That load is what precedes the silent agent-daemon deaths described in the issue.

Pattern follows the existing `should_draft_code` (#200) idiom: `recall_latest` → compare iid → return bool, with `memo_write` stashed inside the gate body before any downstream subprocess / prompt / commit so failures don't re-burn the LLM budget.

## Out of scope (upstream in agentis-core)

Runtime-layer concerns from the issue's *What would help* section stay upstream and will be filed separately:

1. Terminal `daemon.stopped` event on SIGKILL-by-OS.
2. Per-agent RSS / heap instrumentation surfaced via `agentis daemon list --json`.
3. Watchdog auto-restart when pidfile goes stale without a graceful stop.

This colony-side fix removes the load that triggers the class of runtime failure. The upstream items make future load problems visible and recoverable.

## Verification

Run locally in the worktree:

```
./tools/test-learn-idempotency.sh   # 20/0
./tools/colony-lint.sh              # 81/0 (was 80, +1 new auto-discovered test)
```

## Test plan

- [ ] CI green (colony-lint passes, new test picked up by its tools/ test-*.sh loop)
- [ ] Spawn `agentis-qa-agent` once CI is green
- [ ] On approval: merge, then file the three upstream concerns as separate agentis-core issues

Closes #239.