### PR TITLE
feedback-loop: extend reality-check to autonomous-tier writes (#203)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,29 @@ is asserted until multi-version CI is in place.
 
 ### Added
 
+- **Labeler autonomous-tier reality check (pilot)**
+  ([#203](https://github.com/Replikanti/agentis-colonies/issues/203)).
+  Extends the #195 reality-check pattern to the labeler's autonomous
+  branch, where the agent writes labels to GitLab directly and the
+  ground-truth signal is "did the operator revert the write?" rather
+  than "did the operator apply our suggestion?". New memo schema is
+  multi-slot per-iid (`labeler:autonomous_verdict:<iid>` + an index
+  CSV `labeler:autonomous_verdict_index`) so multiple in-flight writes
+  can soak in parallel; the single-slot propose-path idiom remains
+  untouched. Soak window 30 min, ageout 48 h (longer than the propose
+  path's 24 h to match the slower human-response horizon on an
+  already-applied label). Two-row pattern per autonomous action:
+  at-write `learn("success", ..., "acted")` preserves the existing
+  acting-path fitness signal for #186, post-soak
+  `learn(<outcome>, ..., "acted")` lands in the same tag bucket and
+  averages in — so a consistently-reverted agent sees its acting
+  fitness drift down despite at-write optimism. Full pattern
+  documented in
+  [`doc/feedback-loop.md`](../doc/feedback-loop.md#autonomous-tier-extension-203-labeler-pilot);
+  structural regression in `tools/test-labeler-autonomous-verdict.sh`.
+  Fan-out to the other 20 agents is tracked per-agent in follow-up
+  tickets.
+
 ### Changed
 
 ### Deprecated

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -193,12 +193,183 @@ fn evaluate_label_verdict() -> void {
     memo_write("labeler:pending_verdict", "");
 }
 
+// #203: longer-horizon reality check for autonomous-tier writes.
+//
+// The propose / review-gated path above uses a single-slot
+// `labeler:pending_verdict` blob that the next tick overwrites. That
+// shape is fine there because the signal we want ("did the operator
+// apply our suggestion?") settles in minutes and a stale entry is
+// never wrong for long.
+//
+// Autonomous is different. The agent writes labels directly to GitLab,
+// and the ground-truth signal is "did the operator REVERT my write?"
+// — a question that only makes sense after the operator has had time
+// to notice and react. We soak each autonomous write for at least 30
+// minutes before scoring, and accept the verdict as stale ("aged out
+// without signal") after 48 hours. During that window the agent may
+// emit further autonomous writes for other issues, so we need one
+// slot per iid, not the single-slot idiom the propose path uses.
+//
+// Memo schema:
+//   labeler:autonomous_verdict:<iid>  -> "[ts, iid, \"labels_csv\"]"
+//   labeler:autonomous_verdict_index  -> CSV of iids with pending blobs
+//
+// The index is the only structure the per-tick scanner reads to
+// decide which iids to check. Blobs are read per-iid inside the
+// scanner, and a missing blob (drift) triggers a self-heal that drops
+// the iid from the index without emitting a learn row.
+
+// Append an iid to the autonomous-verdict index, deduping so the same
+// iid never appears twice. We store the freshest occurrence at the
+// tail (matches the "latest write wins" semantic for repeated writes
+// on the same issue).
+fn append_autonomous_index(iid: int) -> void {
+    let existing = recall_latest("labeler:autonomous_verdict_index");
+    let iid_str = to_string(iid);
+    let append_cmd = "EX=" + shell_escape(existing) + " N=" + shell_escape(iid_str) +
+        " python3 -c 'import os; ex=os.environ[\"EX\"]; n=os.environ[\"N\"]; parts=[p for p in ex.split(\",\") if p.strip() and p.strip()!=n]; parts.append(n); print(\",\".join(parts))'";
+    let next = try { exec sh append_cmd; } catch e { iid_str; };
+    memo_write("labeler:autonomous_verdict_index", next);
+}
+
+// Record a pending autonomous verdict for a specific iid. Called
+// immediately after a successful `update-issue --add-labels` in the
+// autonomous branch. Writing the blob BEFORE the at-write `learn()`
+// (see tick()) means a `learn()` failure does not leave a phantom iid
+// in the index; an `append_autonomous_index` failure means the blob
+// is unreachable from the scanner and gets GC'd on drift-cleanup when
+// it eventually expires.
+fn record_autonomous_verdict(issue_id: int, labels_csv: string) -> void {
+    let ts_raw = try { exec sh "date +%s"; } catch e { "0"; };
+    let blob = "[" + ts_raw + "," + to_string(issue_id) + ",\"" + labels_csv + "\"]";
+    memo_write("labeler:autonomous_verdict:" + to_string(issue_id), blob);
+    append_autonomous_index(issue_id);
+    print("[labeler] autonomous verdict recorded: issue", issue_id, "labels", labels_csv);
+}
+
+// Score a single pending autonomous verdict. Returns "keep" when the
+// verdict is still soaking (< 30 min) and should remain in the index
+// for a future tick; returns "drop" when the verdict is scored,
+// aged out (> 48 h), or was drift-orphaned (blob missing). Only the
+// scored-and-emitted path appends to the experience store.
+fn score_one_autonomous(issue_id: int) -> string {
+    let key = "labeler:autonomous_verdict:" + to_string(issue_id);
+    let blob = recall_latest(key);
+    if len(blob) < 3 {
+        // Drift: index references a blob that was already cleared or
+        // never written (the `record` path writes blob first, then
+        // appends to index — if `append` failed the blob exists but
+        // the index never held this iid; if we got here, the index
+        // did hold it, so the blob was cleared by an earlier scan).
+        return "drop";
+    };
+    let age = verdict_age_seconds(blob);
+    let soak_s = 1800;
+    if age < soak_s {
+        // Still soaking — operator hasn't had time to react. Leave
+        // the blob and keep the iid in the index for the next tick.
+        return "keep";
+    };
+    let ageout_s = 172800;
+    if age > ageout_s {
+        // Aged out without signal. Absence of action is not evidence
+        // of a wrong write — drop silently, no learn() row (matches
+        // the propose path's 24 h ageout semantic at line 150).
+        print("[labeler] autonomous verdict aged out: issue", issue_id);
+        memo_write(key, "");
+        return "drop";
+    };
+    let suggested = to_string(json_get(blob, "[2]"));
+    let cur_cmd = "$COLONY_DIR/scripts/gitlab-api.sh get-issue " + to_string(issue_id) + " --view feedback-issue";
+    let cur_raw = try { exec sh cur_cmd; } catch e { ""; };
+    if len(cur_raw) < 3 {
+        // GitLab query failed (network blip, issue deleted, etc.).
+        // Keep the iid in flight — next tick retries. Repeated
+        // failures will eventually hit the ageout and drop silently.
+        return "keep";
+    };
+    // Autonomous compare is different from the propose path: we WROTE
+    // the labels, so "act empty" is a reversal signal (signal 3, fail),
+    // not a "no signal yet" (which in propose we would leave pending).
+    // Output: 1 = full match (none removed), 2 = partial erosion,
+    // 3 = full reversal (none of ours remain).
+    let match_cmd = "SUGGESTED=" + shell_escape(suggested) + " RAW=" + shell_escape(cur_raw) + " python3 -c 'import os, json; sug={s.strip() for s in os.environ[\"SUGGESTED\"].split(\",\") if s.strip()}; act=set(json.loads(os.environ[\"RAW\"]).get(\"labels\", [])); print(1 if sug and sug.issubset(act) else (2 if sug & act else 3))'";
+    let signal_raw = try { exec sh match_cmd; } catch e { "3"; };
+    let signal = parse_int(signal_raw);
+    let outcome = signal_to_outcome(signal);
+    let cur_author = to_string(json_get(cur_raw, "author.username"));
+    let scope = scope_for_author(cur_author);
+    learn(
+        "label",
+        "issue " + to_string(issue_id) + " autonomous-revert-check",
+        "written: " + suggested + " | signal: " + to_string(signal),
+        outcome,
+        [scope, "triage", "acted"]
+    );
+    print("[labeler] autonomous reality-check: issue", issue_id, "signal", signal, "->", outcome);
+    memo_write(key, "");
+    return "drop";
+}
+
+// CSV accumulator helper — appends `iid_raw` to `acc` with a comma
+// separator, or returns `iid_raw` when `acc` is empty. Split out of
+// the recursive iterator so the control flow stays linear.
+fn append_csv(acc: string, iid_raw: string) -> string {
+    if len(acc) > 0 {
+        return acc + "," + iid_raw;
+    };
+    return iid_raw;
+}
+
+// Recursive iterator over `index_csv`. `.ag` has no loops, so we
+// substitute a tail-recursive function per the runtime convention
+// (agentis-core src/runtime.rs:2077 "Use recursive function as loop
+// substitute"). Each call reads one iid at position `pos`, scores it,
+// and appends to `acc` only when `score_one_autonomous` returned
+// "keep" (iid still soaking — carry forward to next tick).
+//
+// The CB budget per tick (400) bounds the recursion depth implicitly:
+// each hop costs ~50 CB (one exec sh + one memo read + optional
+// GitLab query + optional learn()). At worst ~8 iids evaluated per
+// tick; the rest stay in the carried-over index and get picked up on
+// subsequent ticks.
+fn eval_autonomous_at(index_csv: string, pos: int, acc: string) -> string {
+    let iid_raw = try {
+        exec sh "CSV=" + shell_escape(index_csv) + " POS=" + to_string(pos) +
+            " python3 -c 'import os; parts=[p for p in os.environ[\"CSV\"].split(\",\") if p.strip()]; p=int(os.environ[\"POS\"]); print(parts[p] if 0<=p<len(parts) else \"\")'";
+    } catch e { ""; };
+    if len(iid_raw) < 1 {
+        return acc;
+    };
+    let iid = parse_int(iid_raw);
+    let verdict = score_one_autonomous(iid);
+    if verdict == "keep" {
+        return eval_autonomous_at(index_csv, pos + 1, append_csv(acc, iid_raw));
+    };
+    return eval_autonomous_at(index_csv, pos + 1, acc);
+}
+
+// Entry point: scan the autonomous-verdict index, score every iid,
+// rewrite the index with the survivors (still-soaking ones). Cheap
+// no-op when the index is empty (the common case before the agent
+// reaches autonomous tier).
+fn evaluate_autonomous_verdicts() -> void {
+    let index_csv = recall_latest("labeler:autonomous_verdict_index");
+    if len(index_csv) < 1 {
+        return;
+    };
+    let new_index = eval_autonomous_at(index_csv, 0, "");
+    memo_write("labeler:autonomous_verdict_index", new_index);
+}
+
 fn tick(reason: string) -> void {
-    // #106: Check any pending verdict from a previous tick before doing
-    // new work. The matcher is cheap when there's nothing pending, and
-    // this placement means a verdict recorded at tick N is evaluated at
-    // tick N+1 onwards (matching the "subsequent tick" semantic).
+    // #106: Check any pending propose / review-gated verdict from a
+    // previous tick before doing new work. Cheap when nothing pending.
     evaluate_label_verdict();
+    // #203: Score any pending autonomous-tier verdicts. Multi-slot,
+    // keyed per-iid; the scanner drops scored/aged iids and keeps
+    // still-soaking ones for the next tick.
+    evaluate_autonomous_verdicts();
     let cmd = issues_cmd();
     let raw = try {
         exec sh cmd;
@@ -251,6 +422,14 @@ fn tick(reason: string) -> void {
                 // #104: tag knowledge as personal (operator's issue) vs team.
                 let scope = scope_for_author(action.author);
                 emit("triage:label_suggestion", action);
+                // #203: stash the write for the per-iid autonomous-tier
+                // reality check. Must precede the bare `learn("success")`:
+                // the two-row pattern is at-write optimism + post-soak
+                // honesty. If `record_autonomous_verdict` fails the `learn()`
+                // row still lands (acceptable asymmetry — a missing soak
+                // row means no reality-check adjustment for this iid, not a
+                // phantom success).
+                record_autonomous_verdict(action.issue_id, action.labels);
                 learn("label", "issue " + to_string(action.issue_id), action.labels, "success", [scope, "triage", "acted"]);
             };
         } else {

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -228,7 +228,14 @@ fn append_autonomous_index(iid: int) -> void {
     let iid_str = to_string(iid);
     let append_cmd = "EX=" + shell_escape(existing) + " N=" + shell_escape(iid_str) +
         " python3 -c 'import os; ex=os.environ[\"EX\"]; n=os.environ[\"N\"]; parts=[p for p in ex.split(\",\") if p.strip() and p.strip()!=n]; parts.append(n); print(\",\".join(parts))'";
-    let next = try { exec sh append_cmd; } catch e { iid_str; };
+    // Catch-branch fallback preserves previously-queued peers: if the
+    // dedup+append subprocess itself fails (python3 missing, OOM,
+    // exec_foreign revoked mid-tick), we still want the current iid in
+    // the index, but falling back to `iid_str` alone would silently
+    // drop any peer iids that were already soaking. `append_csv`
+    // tolerates an already-present iid (the next successful scan
+    // naturally normalizes a brief duplicate on the next tick).
+    let next = try { exec sh append_cmd; } catch e { append_csv(existing, iid_str); };
     memo_write("labeler:autonomous_verdict_index", next);
 }
 
@@ -256,11 +263,11 @@ fn score_one_autonomous(issue_id: int) -> string {
     let key = "labeler:autonomous_verdict:" + to_string(issue_id);
     let blob = recall_latest(key);
     if len(blob) < 3 {
-        // Drift: index references a blob that was already cleared or
-        // never written (the `record` path writes blob first, then
-        // appends to index — if `append` failed the blob exists but
-        // the index never held this iid; if we got here, the index
-        // did hold it, so the blob was cleared by an earlier scan).
+        // Unexpected drift: index held the iid but the blob is gone.
+        // Possible causes: external memo clear, scanner/record race
+        // (not expected in single-threaded daemons), or a prior scan
+        // that cleared the blob but failed to rewrite the index.
+        // Self-heal by dropping from the index on this scan.
         return "drop";
     };
     let age = verdict_age_seconds(blob);

--- a/doc/feedback-loop.md
+++ b/doc/feedback-loop.md
@@ -237,15 +237,93 @@ a fresh agent is not penalised for having no reality-check rows yet.
   `delta_slope_negative_for` or `evolve.trigger.reject_rate_above`
   need re-calibration once real reject rows flow, that is a follow-up
   (see [#163](https://github.com/Replikanti/agentis-colonies/issues/163)).
-- **Autonomous-tier agents that write GitLab state directly.** When
-  the agent is the one writing the label / comment / tag, there is no
-  separable operator signal to score against. The pilot's
-  `record_label_verdict()` is called only in the propose and
-  review-gated branches for that reason. Future work may introduce a
-  longer-horizon check (e.g. does the operator *revert* the
-  autonomous write within N days?) but that is a separate pattern.
 - **Fan-out to the other 20 agents.** One follow-up per colony or per
   agent; the pilot validates the shape, subsequent tickets copy it.
+  Autonomous-tier coverage is tracked separately (see below).
+
+## Autonomous-tier extension (#203, labeler pilot)
+
+The propose / review-gated pattern above hinges on a separable
+operator signal: the agent suggests, the operator reacts, and the
+reaction is the ground truth. Autonomous-tier agents don't have that
+shape — the agent *is* the writer, so "did the operator apply our
+suggestion?" collapses into "yes, we did." The longer-horizon
+question that still makes sense is "**did the operator revert the
+autonomous write?**" — and that takes time to settle, so a
+single-slot `pending_verdict` idiom won't work.
+
+### Memo schema
+
+The autonomous path uses one blob per in-flight iid plus a separate
+index to make them iterable:
+
+```
+labeler:autonomous_verdict:<iid>  -> "[ts, iid, \"labels_csv\"]"
+labeler:autonomous_verdict_index  -> CSV of iids with pending blobs
+```
+
+The index is the only structure the per-tick scanner reads to decide
+which iids to check. Blobs are read per-iid inside the scanner, and
+a missing blob (index drift) triggers a self-heal that drops the iid
+from the index without emitting a learn row.
+
+### Soak and ageout
+
+- **Soak: 30 min (1800 s).** An autonomous write is scored no earlier
+  than 30 minutes after it lands. That gives the operator time to
+  notice and react before the agent decides "no revert = success."
+  Too short and the system converges on false positives; too long and
+  the feedback loop stalls.
+- **Ageout: 48 h (172 800 s).** After 48 hours the blob is dropped
+  without emitting a learn row. Absence of action is not evidence of
+  a wrong write (same rationale as the propose path's 24 h ageout at
+  line 150 of `labeler.ag`). The longer window reflects the longer
+  human-response horizon — operators notice a misapplied label within
+  a working day or two, not within a lunch hour.
+
+Both windows are intentionally `.ag` literals rather than config
+knobs; if they need tuning once signal flows, the next iteration
+lifts them into a memo or config file (same posture as propose-path
+`delta` values).
+
+### Two-row pattern at autonomous tier
+
+Autonomous writes emit **two** `learn()` rows per action, not one:
+
+| When               | Row                                                                             | Outcome    | Tag bucket  |
+|--------------------|---------------------------------------------------------------------------------|------------|-------------|
+| At write           | `learn("label", "issue <iid>", <labels>, "success", [scope, "triage", "acted"])` | success    | acted       |
+| After 30 min soak  | `learn("label", "issue <iid> autonomous-revert-check", ..., <outcome>, [scope, "triage", "acted"])` | success / partial / fail | acted       |
+
+The at-write row preserves the acting-path fitness signal the
+existing `#186` aggregation consumes. The post-soak row lands in the
+same tag bucket and averages in — so if operators consistently revert
+an autonomous write, the acting fitness for that agent drifts down
+despite the at-write optimism. One correctly-kept write plus one
+reverted write nets to ~0.0 fitness delta, which is the honest answer.
+
+### Signal interpretation
+
+The compare step in `score_one_autonomous()` differs from the propose
+path because we wrote the labels ourselves. There is no "no signal
+yet" case (signal 0 doesn't exist here) — if the operator has cleared
+our labels entirely, that is a reversal, not silence. The python3
+output is strict:
+
+- **1 — full match:** every suggested label still present → `success`
+- **2 — partial erosion:** some labels removed → `partial`
+- **3 — full reversal:** none of our labels remain → `fail`
+
+### Ordering invariant
+
+`record_autonomous_verdict` is called **before** the at-write
+`learn("success")` in the autonomous branch. If the memo write
+succeeds but `learn()` fails, we have a soak row coming but no
+at-write row — acceptable asymmetry (the soak row is the honest one).
+If `learn()` succeeds but the memo write fails, we have an at-write
+row with no future reality-check — acceptable asymmetry (the acting
+fitness is at worst slightly optimistic, which is the bias the
+two-row pattern is designed to correct over time).
 
 ## Related
 
@@ -253,5 +331,5 @@ a fresh agent is not penalised for having no reality-check rows yet.
 - [`auto-promote.md`](./auto-promote.md) — consumer of the honest signal.
 - [#106](https://github.com/Replikanti/agentis-colonies/issues/106) — auto-confidence from feedback (per-agent memo track).
 - [#186](https://github.com/Replikanti/agentis-colonies/issues/186) / [#192](https://github.com/Replikanti/agentis-colonies/pull/192) — tag classification that makes the honest signal consumable.
-- [#195](https://github.com/Replikanti/agentis-colonies/issues/195) — this pattern's parent issue.
-- [#163](https://github.com/Replikanti/agentis-colonies/issues/163) — follow-up calibration once signal flows.
+- [#195](https://github.com/Replikanti/agentis-colonies/issues/195) — this pattern's parent issue (propose / review-gated).
+- [#203](https://github.com/Replikanti/agentis-colonies/issues/203) — autonomous-tier extension documented in the section above.

--- a/tools/test-labeler-autonomous-verdict.sh
+++ b/tools/test-labeler-autonomous-verdict.sh
@@ -167,6 +167,27 @@ else
     bad "propose-path timeout_s != 86400 s — #106/#195 spec drift"
 fi
 
+# -- (8) hardening asserts (QA PR #243 round 2) ------------------------------
+
+# Append catch-branch must preserve peer iids when the subprocess fails.
+# A refactor that falls back to plain `iid_str` (or `""`) silently discards
+# any previously-queued autonomous writes.
+if awk '/^fn append_autonomous_index\(/,/^}/' "$LABELER" | grep -Eq "catch e \{ append_csv\(existing, iid_str\); \}"; then
+    ok "append_autonomous_index catch-branch preserves peers via append_csv(existing, iid_str)"
+else
+    bad "append_autonomous_index catch-branch does NOT preserve peers — silently clobbers the index on subprocess failure"
+fi
+
+# End-of-scan index rewrite: evaluate_autonomous_verdicts MUST write the
+# surviving index at the end of the scan. A refactor that moves this into
+# eval_autonomous_at or drops it turns the scanner into a no-op after the
+# first still-soaking iid.
+if awk '/^fn evaluate_autonomous_verdicts\(/,/^}/' "$LABELER" | grep -Fq 'memo_write("labeler:autonomous_verdict_index",'; then
+    ok "evaluate_autonomous_verdicts rewrites the index at end of scan"
+else
+    bad "evaluate_autonomous_verdicts does NOT rewrite the index — scanner is a no-op after first keep"
+fi
+
 echo
 echo "labeler-autonomous-verdict: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tools/test-labeler-autonomous-verdict.sh
+++ b/tools/test-labeler-autonomous-verdict.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# test-labeler-autonomous-verdict.sh -- #203 structural regression test
+#
+# Verifies the autonomous-tier reality-check pattern in triage/labeler.ag:
+#
+#   1. Per-iid memo schema (multi-slot), not single-slot like the propose path.
+#      Keys: `labeler:autonomous_verdict:<iid>` + `labeler:autonomous_verdict_index`
+#   2. Entry points defined: record / score-one / iterator / scanner.
+#   3. Scanner wired into tick() alongside the existing propose-path
+#      evaluate_label_verdict() call.
+#   4. Autonomous branch records the verdict BEFORE emitting the at-write
+#      `learn("success", ..., "acted")` row — the two-row-per-action
+#      ordering is what preserves the honest reality-check signal (soak
+#      row is the truthful one; at-write row is the optimistic one).
+#   5. Propose-path single-slot `labeler:pending_verdict` idiom is still
+#      in place — this ticket extends the pattern, it does not replace
+#      the #106/#195 path.
+#   6. Signal compare in score_one_autonomous() has no signal==0 arm
+#      (autonomous WROTE the labels; "act empty" = reversal, not silence).
+#   7. Soak and ageout windows are the documented 1800 s / 172 800 s.
+#
+# Grep-based rather than dynamic because the runtime end-to-end path
+# (tier=autonomous + GitLab write + 30 min soak + reality-check tick)
+# would require a daemon + a mock GitLab API; the structural invariants
+# above are the regression surface a future refactor is most likely to
+# quietly break.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LABELER="$REPO_ROOT/dev-apprenticeship/triage/agents/labeler.ag"
+
+pass=0
+fail=0
+
+ok()  { echo "  ok — $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL — $1"; fail=$((fail + 1)); }
+
+echo "[labeler.ag]"
+
+if [ ! -f "$LABELER" ]; then
+    bad "missing file: $LABELER"
+    echo
+    echo "labeler-autonomous-verdict: $pass passed, $fail failed"
+    exit 1
+fi
+
+# -- (2) entry points --------------------------------------------------------
+for fn in record_autonomous_verdict score_one_autonomous eval_autonomous_at evaluate_autonomous_verdicts append_autonomous_index; do
+    if grep -Eq "^fn ${fn}\(" "$LABELER"; then
+        ok "fn ${fn}() defined"
+    else
+        bad "fn ${fn}() missing"
+    fi
+done
+
+# -- (1) multi-slot memo schema ----------------------------------------------
+if grep -Fq 'memo_write("labeler:autonomous_verdict:"' "$LABELER"; then
+    ok "multi-slot blob key memo_write(\"labeler:autonomous_verdict:\" + ...)"
+else
+    bad "multi-slot blob key memo_write missing"
+fi
+
+if grep -Fq 'recall_latest("labeler:autonomous_verdict_index")' "$LABELER"; then
+    ok "index recall_latest(\"labeler:autonomous_verdict_index\")"
+else
+    bad "index recall_latest missing"
+fi
+
+if grep -Fq 'memo_write("labeler:autonomous_verdict_index",' "$LABELER"; then
+    ok "index memo_write(\"labeler:autonomous_verdict_index\", ...)"
+else
+    bad "index memo_write missing"
+fi
+
+# -- (3) scanner wired into tick() -------------------------------------------
+# evaluate_autonomous_verdicts() must be called from tick(); paired with
+# evaluate_label_verdict() so both reality checks run before new work each
+# tick.
+tick_line="$(grep -n '^fn tick(' "$LABELER" | head -1 | cut -d: -f1 || true)"
+if [ -z "$tick_line" ]; then
+    bad "fn tick() not found — cannot verify scanner wiring"
+else
+    scanner_line="$(awk -v t="$tick_line" 'NR>t && /evaluate_autonomous_verdicts\(\)/ {print NR; exit}' "$LABELER")"
+    propose_line="$(awk -v t="$tick_line" 'NR>t && /evaluate_label_verdict\(\)/ {print NR; exit}' "$LABELER")"
+    if [ -n "$scanner_line" ]; then
+        ok "evaluate_autonomous_verdicts() called from tick() (line $scanner_line)"
+    else
+        bad "evaluate_autonomous_verdicts() NOT called from tick() — scanner is dead code"
+    fi
+    if [ -n "$propose_line" ]; then
+        ok "evaluate_label_verdict() still called from tick() (line $propose_line) — propose path not broken"
+    else
+        bad "evaluate_label_verdict() no longer called from tick() — #106/#195 propose path regressed"
+    fi
+fi
+
+# -- (4) ordering invariant: record_autonomous_verdict BEFORE at-write learn -
+# Inside the `if my_tier == "autonomous"` branch, record_autonomous_verdict()
+# MUST appear before the bare learn("label", ..., "success", [..., "acted"]).
+# If this ordering flips, a prompt/learn failure could leave a row in the
+# experience store with no future reality-check to correct it.
+auto_line="$(grep -n 'if my_tier == "autonomous"' "$LABELER" | head -1 | cut -d: -f1 || true)"
+if [ -z "$auto_line" ]; then
+    bad "autonomous branch not found"
+else
+    record_line="$(awk -v a="$auto_line" 'NR>a && /record_autonomous_verdict\(/ {print NR; exit}' "$LABELER")"
+    learn_line="$(awk -v a="$auto_line" 'NR>a && /learn\("label"/ && /"success"/ && /"acted"/ {print NR; exit}' "$LABELER")"
+    if [ -n "$record_line" ] && [ -n "$learn_line" ] && [ "$record_line" -gt "$auto_line" ] && [ "$record_line" -lt "$learn_line" ]; then
+        ok "record_autonomous_verdict() before at-write learn() inside autonomous branch (lines $auto_line < $record_line < $learn_line)"
+    else
+        bad "ordering broken: autonomous=$auto_line record=${record_line:-?} learn=${learn_line:-?} — record must be between branch opener and first at-write learn()"
+    fi
+fi
+
+# -- (5) propose-path single-slot path intact --------------------------------
+if grep -Fq 'memo_write("labeler:pending_verdict"' "$LABELER"; then
+    ok "propose-path labeler:pending_verdict memo_write still present"
+else
+    bad "propose-path labeler:pending_verdict memo_write removed — #106/#195 regressed"
+fi
+if grep -Fq 'recall_latest("labeler:pending_verdict")' "$LABELER"; then
+    ok "propose-path labeler:pending_verdict recall_latest still present"
+else
+    bad "propose-path labeler:pending_verdict recall_latest removed — #106/#195 regressed"
+fi
+
+# -- (6) autonomous compare has no signal==0 arm -----------------------------
+# Compare the two compare_cmd python3 inline scripts: propose has signal 0,
+# autonomous must not. Grep for the two-arm ternary that starts at `print(1
+# if sug and sug.issubset(act)` — the propose variant prepends a
+# `0 if not act else` guard; the autonomous variant does not.
+if grep -Fq "print(0 if not act else" "$LABELER"; then
+    ok "propose compare still has signal==0 guard (0 if not act else ...)"
+else
+    bad "propose compare signal==0 guard missing — #195 regressed"
+fi
+
+# Look for an autonomous-specific compare that does NOT have the `0 if not act`
+# prefix. The pattern must be: `print(1 if sug and sug.issubset(act) else (2`
+# WITHOUT a leading `0 if not act else`.
+if awk '/SUGGESTED=/ && /RAW=/ && /python3/ {print}' "$LABELER" | grep -vq "0 if not act else"; then
+    ok "at least one compare call is autonomous-style (no signal==0 arm)"
+else
+    bad "every compare call still has signal==0 arm — autonomous-compare variant missing"
+fi
+
+# -- (7) soak and ageout constants -------------------------------------------
+if grep -Eq "let soak_s = 1800" "$LABELER"; then
+    ok "soak window = 1800 s (30 min)"
+else
+    bad "soak window != 1800 s — spec drift"
+fi
+
+if grep -Eq "let ageout_s = 172800" "$LABELER"; then
+    ok "autonomous ageout window = 172800 s (48 h)"
+else
+    bad "autonomous ageout window != 172800 s — spec drift"
+fi
+
+# Propose-path ageout must stay at 86400 — this test doubles as a regression
+# guard against accidentally unifying the two windows.
+if grep -Eq "let timeout_s = 86400" "$LABELER"; then
+    ok "propose-path timeout_s = 86400 s (24 h) preserved"
+else
+    bad "propose-path timeout_s != 86400 s — #106/#195 spec drift"
+fi
+
+echo
+echo "labeler-autonomous-verdict: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Extends the [#195](https://github.com/Replikanti/agentis-colonies/issues/195) reality-check pattern to the labeler's **autonomous** branch. Closes #203 as a labeler-pilot — fan-out to the other 20 agents is tracked in follow-ups per agent (each needs its own ground-truth signal defined).

## What's different from the propose path

The propose / review-gated path scores against *"did the operator apply our suggestion?"* — signal is separable because the operator's reaction happens *after* the agent's suggestion. Autonomous is different: the agent *is* the writer, so the separable signal becomes *"did the operator revert the write?"* — and that takes time to settle.

- **Multi-slot memo** (one blob per in-flight iid + an index CSV) instead of single-slot, so multiple parallel autonomous writes can soak simultaneously.
- **Soak window: 30 min.** An autonomous write is scored no earlier than 30 minutes after it lands.
- **Ageout: 48 h.** Longer than the propose-path 24 h to match the slower operator-response horizon on already-applied labels.
- **Compare has no signal==0 arm.** We wrote the labels, so empty label set = reversal, not silence. Strict 1/2/3 output.
- **Two-row pattern per autonomous action.** At-write `learn("success", ..., "acted")` preserves the acting-path fitness signal [#186](https://github.com/Replikanti/agentis-colonies/issues/186) already consumes; post-soak `learn(<outcome>, ..., "acted")` lands in the same tag bucket and averages in — so a consistently-reverted agent sees its acting fitness drift down despite at-write optimism.

## Ordering invariant

`record_autonomous_verdict(...)` is called **before** the bare at-write `learn("success", ..., "acted")`. If the memo write fails, the `learn()` still lands (acceptable asymmetry — slightly optimistic fitness, which the overall two-row pattern is designed to correct over time). If `learn()` fails after a successful memo write, we get the soak row with no at-write row (also fine — soak row is the honest one).

Enforced by `tools/test-labeler-autonomous-verdict.sh` (awk line-ordering check between `if my_tier == \"autonomous\"` and the first matching `learn()`).

## Memo schema

```
labeler:autonomous_verdict:<iid>  -> "[ts, iid, \"labels_csv\"]"
labeler:autonomous_verdict_index  -> CSV of iids with pending blobs
```

Index is the only structure the scanner reads; blobs are read per-iid. A missing blob (index drift) triggers a self-heal that drops the iid from the index without emitting a learn row.

## Changes

- `dev-apprenticeship/triage/agents/labeler.ag` — 6 new functions (`append_autonomous_index`, `record_autonomous_verdict`, `score_one_autonomous`, `append_csv`, `eval_autonomous_at`, `evaluate_autonomous_verdicts`). Scanner wired into `tick()` next to the existing `evaluate_label_verdict()`. Autonomous branch records the verdict before the at-write `learn()`. Iterates via tail recursion (runtime convention — `.ag` has no loops).
- `doc/feedback-loop.md` — remove the old "autonomous out of scope" bullet, add a full autonomous-tier-extension section covering memo schema, soak / ageout rationale, two-row pattern, signal interpretation, and the ordering invariant.
- `tools/test-labeler-autonomous-verdict.sh` — structural regression (18 assertions: entry points, memo keys, tick() wiring, ordering invariant, propose path intact, signal==0 arm absent in autonomous compare, soak / ageout constants).
- `dev-apprenticeship/CHANGELOG.md` — entry under `[Unreleased]`.

## Test plan

- [x] `./tools/colony-lint.sh` — 83 passed, 0 failed, 5 skipped (shellcheck skips; CI runs it)
- [x] `./tools/test-labeler-autonomous-verdict.sh` — 18 / 18
- [x] Existing `test-learn-idempotency.sh` / `test-dashboard-*` / `test-kill-*` — all green (untouched surface)
- [x] CI green across all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)