### PR TITLE
docs: add dashboard version badges to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Federation-agnostic components are versioned and released independently so fixes
 From a release tarball (recommended — install-ready, no git clone needed):
 
 ```bash
-VERSION=0.1.0   # or any tagged dev-apprenticeship release
+VERSION=0.3.3   # or any tagged dev-apprenticeship release
 curl -LO https://github.com/Replikanti/agentis-colonies/releases/download/dev-apprenticeship-v${VERSION}/dev-apprenticeship-v${VERSION}.tar.gz
 tar xzf dev-apprenticeship-v${VERSION}.tar.gz
 cd dev-apprenticeship-v${VERSION}/dev-apprenticeship

--- a/README.md
+++ b/README.md
@@ -40,9 +40,17 @@ graph TD
 
 ## Federations
 
-| Federation | Description | Agents | Status |
-|------------|-------------|--------|--------|
-| [dev-apprenticeship](./dev-apprenticeship/) | Learns a developer's complete workflow by observing how you work on GitLab. Covers triage, code review, planning, implementation, and release. | 21 | Beta |
+| Federation | Version | Description | Agents | Status |
+|------------|---------|-------------|--------|--------|
+| [dev-apprenticeship](./dev-apprenticeship/) | [`0.3.3`](https://github.com/Replikanti/agentis-colonies/releases/tag/dev-apprenticeship-v0.3.3) | Learns a developer's complete workflow by observing how you work on GitLab. Covers triage, code review, planning, implementation, and release. | 21 | Beta |
+
+## Components
+
+Federation-agnostic components are versioned and released independently so fixes ship without forcing a federation re-release.
+
+| Component | Version | Description |
+|-----------|---------|-------------|
+| [federation-dashboard](./federation-dashboard/) | [`0.1.0`](https://github.com/Replikanti/agentis-colonies/releases/tag/federation-dashboard-v0.1.0) | Generic web dashboard with operator controls (promote / demote / evolve / restart / kill). Auto-discovers colonies + agents from any federation directory. |
 
 ### Status
 

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -106,6 +106,8 @@ agentis daemon stop --all       # Stop everything
 
 A web dashboard that shows agent health, confidence levels, phase readiness with ETA, knowledge growth trends, remediation history, and a live suggestion feed. Auto-refreshes every 60 seconds. Includes a kill switch (two-click safety) to stop the entire federation from the browser.
 
+The dashboard is a [separately-versioned standalone component](../federation-dashboard/) ([#252](https://github.com/Replikanti/agentis-colonies/issues/252)). This federation recommends `federation-dashboard >= 0.1.0` (pinned in [`.dashboard-version`](./.dashboard-version)); `install.sh` step 8 offers to install it for you, and `./dashboard.sh` is a thin resolver that finds the installed binary.
+
 Per-agent **confidence bump** controls (▲▼) in the Confidence Levels card walk each agent through the canonical tier ladder: `shadow` (0.4) → `propose` (0.6) → `review-gated` (0.8) → `autonomous` (0.95). Promotions to `autonomous` trigger a confirmation dialog since at that level the agent performs terminal external writes (merge, tag, publish) without a second gate. Every change is appended to `.dashboard/confidence-log.jsonl` for audit. The CLI path (`agentis memo set <agent>:confidence <value>`) still works and is equivalent.
 
 ```bash

--- a/federation-dashboard/README.md
+++ b/federation-dashboard/README.md
@@ -1,5 +1,9 @@
 # federation-dashboard
 
+![Version: 0.1.0](https://img.shields.io/badge/version-0.1.0-blue) ![Standalone component](https://img.shields.io/badge/component-standalone-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
+
+**Version:** `0.1.0` · [Changelog](./CHANGELOG.md) · **Recommended for:** dev-apprenticeship >= `0.3.3`
+
 Generic web dashboard for any [Agentis](https://github.com/Replikanti/agentis)
 federation. Auto-discovers colonies and agents from the federation directory,
 collects per-agent data from the `agentis` CLI, regenerates a static HTML


### PR DESCRIPTION
## Summary
- `federation-dashboard/README.md`: version/component/status badges + `**Version:** 0.1.0` line at top, matching the pattern used in `dev-apprenticeship/README.md`.
- Top-level `README.md`: add a Components table with the `federation-dashboard` entry (linked to the tagged release); add a Version column to the Federations table.
- `dev-apprenticeship/README.md`: one-paragraph note in the Dashboard section calling out that the dashboard is a separately-versioned standalone component and pointing at `.dashboard-version`.

Follow-up to #252 — every README now surfaces the standalone component's version alongside the federation it serves.

## Test plan
- [x] `git diff` — only documentation hunks, no code or workflow changes.
- [x] Colony-lint clean on the three edited files (CI).
- [x] Rendered badges load correctly (shields.io).