### PR TITLE
feat(#256): forge abstraction foundation — ADR-0002 + [forge] schema + dispatcher (PR 1 of 7)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -40,11 +40,16 @@ is asserted until multi-version CI is in place.
   `FEDERATION_FORGE_TYPE=gitlab|github` env short-circuit for
   unattended installs, an interactive prompt defaulting to gitlab,
   a clear warning when github is chosen before PRs 2-6 land, and a
-  `_set_forge_type()` helper that rewrites `[forge].type` in the
-  generated `colony.toml`. The top-level `[gitlab]` section is
-  retained for one release of migration overlap (retired in PR 7 of
-  #256). New lint gate: `tools/test-forge-config.sh` (8 invariants ×
-  5 colonies + 4 global = 35 sub-tests). See
+  section-scoped rewrite that sets `[forge].type` in the generated
+  `colony.toml`. The `[forge].type` rewrite runs unconditionally (even
+  when the operator re-runs `install.sh` purely to switch forge and
+  declines to update credentials), and both the GitHub-confirm and
+  credential-update prompts short-circuit when `FEDERATION_FORGE_TYPE`
+  is set — unattended `FEDERATION_FORGE_TYPE=github ./install.sh`
+  installs no longer block on stdin. The top-level `[gitlab]` section
+  is retained for one release of migration overlap (retired in PR 7 of
+  #256). New lint gate: `tools/test-forge-config.sh` (6 per-colony
+  checks × 5 colonies + 7 install.sh + ADR checks = 37 sub-tests). See
   `doc/adr/ADR-0002-forge-abstraction.md` for the full contract.
   [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
 

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -26,6 +26,27 @@ is asserted until multi-version CI is in place.
   pre-#257 callers. Enables the dashboard-side decoupling in
   `federation-dashboard` 0.2.0.
   [#257](https://github.com/Replikanti/agentis-colonies/issues/257)
+- **Forge abstraction foundation (ADR-0002, PR 1 of 7 for #256).** Every
+  colony's `colony.example.toml` now carries a `[forge]` section with
+  `type = "gitlab"` plus `[forge.gitlab]` and a commented-out
+  `[forge.github]` template. Each colony ships a thin
+  `scripts/forge-api.sh` dispatcher that reads `$FORGE_TYPE` and execs
+  the right per-colony wrapper (`gitlab-api.sh` today, `github-api.sh`
+  in PRs 2-6). Unknown `FORGE_TYPE` → exit 2; `FORGE_TYPE=github` with
+  no wrapper yet → exit 99 with an ADR pointer. `start-colony.sh`
+  parses `[forge].type`, defaults to `"gitlab"` (pre-#256 configs keep
+  working verbatim), and exports `FORGE_TYPE`. `install.sh` gained a
+  new "3a. Forge backend selection" section with a
+  `FEDERATION_FORGE_TYPE=gitlab|github` env short-circuit for
+  unattended installs, an interactive prompt defaulting to gitlab,
+  a clear warning when github is chosen before PRs 2-6 land, and a
+  `_set_forge_type()` helper that rewrites `[forge].type` in the
+  generated `colony.toml`. The top-level `[gitlab]` section is
+  retained for one release of migration overlap (retired in PR 7 of
+  #256). New lint gate: `tools/test-forge-config.sh` (8 invariants ×
+  5 colonies + 4 global = 35 sub-tests). See
+  `doc/adr/ADR-0002-forge-abstraction.md` for the full contract.
+  [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
 
 ### Changed
 

--- a/dev-apprenticeship/code-review/config/colony.example.toml
+++ b/dev-apprenticeship/code-review/config/colony.example.toml
@@ -7,6 +7,26 @@
 name = "code-review"
 tick_interval_ms = 60000
 
+# Forge backend selection (ADR-0002, #256). `type` picks which of the
+# per-backend blocks below is active. Legal values: "gitlab", "github".
+# The top-level [gitlab] section below is retained for backwards
+# compatibility during the migration window — one release of overlap.
+# It is retired in the final PR of the port (PR 7 of #256).
+[forge]
+type = "gitlab"
+
+[forge.gitlab]
+url     = "https://gitlab.example.com"
+token   = "glpat-your-token-here"
+project = "your-org/your-project"
+me      = ""  # your GitLab username (optional, enables personal/team tagging)
+
+# [forge.github]
+# owner = "your-org-or-user"
+# repo  = "your-repo"
+# token = "ghp_your-token-here"
+# me    = ""  # your GitHub username (optional)
+
 [gitlab]
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"

--- a/dev-apprenticeship/code-review/scripts/forge-api.sh
+++ b/dev-apprenticeship/code-review/scripts/forge-api.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Forge dispatcher for the code-review colony (ADR-0002, #256).
+#
+# Agents call this script via exec sh instead of the backend-specific
+# wrappers (gitlab-api.sh, github-api.sh). The dispatcher reads the
+# FORGE_TYPE env var (exported by start-colony.sh from the [forge].type
+# config key) and forwards argv verbatim to the matching backend wrapper.
+#
+# Agents receive identical normalized JSON regardless of backend. See
+# doc/adr/ADR-0002-forge-abstraction.md for the shape contract.
+#
+# Exit codes:
+#   0   success (from the underlying wrapper)
+#   1   backend wrapper failure (from the underlying wrapper)
+#   2   unknown flag / usage error
+#   99  requested FORGE_TYPE has no backend wrapper yet (see #256 PRs 2-6)
+
+set -e
+
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+case "$FORGE_TYPE" in
+    gitlab)
+        backend="$SCRIPT_DIR/gitlab-api.sh"
+        ;;
+    github)
+        backend="$SCRIPT_DIR/github-api.sh"
+        ;;
+    *)
+        echo "forge-api.sh: unknown FORGE_TYPE '$FORGE_TYPE' (expected: gitlab|github)" >&2
+        exit 2
+        ;;
+esac
+
+if [ ! -x "$backend" ]; then
+    echo "forge-api.sh: backend wrapper not available: $backend" >&2
+    echo "forge-api.sh: FORGE_TYPE=$FORGE_TYPE is not yet implemented for the code-review colony." >&2
+    echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256." >&2
+    exit 99
+fi
+
+exec "$backend" "$@"

--- a/dev-apprenticeship/code-review/scripts/forge-api.sh
+++ b/dev-apprenticeship/code-review/scripts/forge-api.sh
@@ -35,9 +35,20 @@ case "$FORGE_TYPE" in
 esac
 
 if [ ! -x "$backend" ]; then
-    echo "forge-api.sh: backend wrapper not available: $backend" >&2
-    echo "forge-api.sh: FORGE_TYPE=$FORGE_TYPE is not yet implemented for the code-review colony." >&2
-    echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256." >&2
+    case "$FORGE_TYPE" in
+        github)
+            # Skeleton state: dispatcher exists but the per-colony wrapper is not yet
+            # shipped. Lands across PRs 2-6 of #256.
+            echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the code-review colony." >&2
+            echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
+            ;;
+        *)
+            # Broken install — gitlab-api.sh should always be present alongside
+            # forge-api.sh in a valid federation checkout.
+            echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
+            echo "forge-api.sh: this indicates a broken install — re-copy the code-review colony scripts/ directory." >&2
+            ;;
+    esac
     exit 99
 fi
 

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -90,6 +90,16 @@ export GITLAB_PROJECT
 export GITLAB_ME
 export COLONY_DIR
 
+# #256: forge backend selection. `[forge].type` picks which backend
+# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
+# configs keep working unchanged. The github backend is skeleton-only
+# until PRs 2-6 of #256 land their per-colony github-api.sh wrappers;
+# until then, FORGE_TYPE=github yields exit 99 "not implemented" from
+# forge-api.sh.
+FORGE_TYPE=$(parse_toml forge type)
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+export FORGE_TYPE
+
 AGENTS=(
     style_reviewer
     logic_reviewer

--- a/dev-apprenticeship/implementation/config/colony.example.toml
+++ b/dev-apprenticeship/implementation/config/colony.example.toml
@@ -7,6 +7,28 @@
 name = "implementation"
 tick_interval_ms = 60000
 
+# Forge backend selection (ADR-0002, #256). `type` picks which of the
+# per-backend blocks below is active. Legal values: "gitlab", "github".
+# The top-level [gitlab] section below is retained for backwards
+# compatibility during the migration window — one release of overlap.
+# It is retired in the final PR of the port (PR 7 of #256).
+[forge]
+type = "gitlab"
+
+[forge.gitlab]
+url            = "https://gitlab.example.com"
+token          = "glpat-your-token-here"
+project        = "your-org/your-project"
+me             = ""      # your GitLab username (optional)
+default_branch = "main"  # primary branch (#224)
+
+# [forge.github]
+# owner          = "your-org-or-user"
+# repo           = "your-repo"
+# token          = "ghp_your-token-here"
+# me             = ""      # your GitHub username (optional)
+# default_branch = "main"  # primary branch
+
 [gitlab]
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"

--- a/dev-apprenticeship/implementation/scripts/forge-api.sh
+++ b/dev-apprenticeship/implementation/scripts/forge-api.sh
@@ -35,9 +35,20 @@ case "$FORGE_TYPE" in
 esac
 
 if [ ! -x "$backend" ]; then
-    echo "forge-api.sh: backend wrapper not available: $backend" >&2
-    echo "forge-api.sh: FORGE_TYPE=$FORGE_TYPE is not yet implemented for the implementation colony." >&2
-    echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256." >&2
+    case "$FORGE_TYPE" in
+        github)
+            # Skeleton state: dispatcher exists but the per-colony wrapper is not yet
+            # shipped. Lands across PRs 2-6 of #256.
+            echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the implementation colony." >&2
+            echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
+            ;;
+        *)
+            # Broken install — gitlab-api.sh should always be present alongside
+            # forge-api.sh in a valid federation checkout.
+            echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
+            echo "forge-api.sh: this indicates a broken install — re-copy the implementation colony scripts/ directory." >&2
+            ;;
+    esac
     exit 99
 fi
 

--- a/dev-apprenticeship/implementation/scripts/forge-api.sh
+++ b/dev-apprenticeship/implementation/scripts/forge-api.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Forge dispatcher for the implementation colony (ADR-0002, #256).
+#
+# Agents call this script via exec sh instead of the backend-specific
+# wrappers (gitlab-api.sh, github-api.sh). The dispatcher reads the
+# FORGE_TYPE env var (exported by start-colony.sh from the [forge].type
+# config key) and forwards argv verbatim to the matching backend wrapper.
+#
+# Agents receive identical normalized JSON regardless of backend. See
+# doc/adr/ADR-0002-forge-abstraction.md for the shape contract.
+#
+# Exit codes:
+#   0   success (from the underlying wrapper)
+#   1   backend wrapper failure (from the underlying wrapper)
+#   2   unknown flag / usage error
+#   99  requested FORGE_TYPE has no backend wrapper yet (see #256 PRs 2-6)
+
+set -e
+
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+case "$FORGE_TYPE" in
+    gitlab)
+        backend="$SCRIPT_DIR/gitlab-api.sh"
+        ;;
+    github)
+        backend="$SCRIPT_DIR/github-api.sh"
+        ;;
+    *)
+        echo "forge-api.sh: unknown FORGE_TYPE '$FORGE_TYPE' (expected: gitlab|github)" >&2
+        exit 2
+        ;;
+esac
+
+if [ ! -x "$backend" ]; then
+    echo "forge-api.sh: backend wrapper not available: $backend" >&2
+    echo "forge-api.sh: FORGE_TYPE=$FORGE_TYPE is not yet implemented for the implementation colony." >&2
+    echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256." >&2
+    exit 99
+fi
+
+exec "$backend" "$@"

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -102,6 +102,16 @@ export IMPLEMENTATION_TRIGGER_LABEL
 export GITLAB_DEFAULT_BRANCH
 export COLONY_DIR
 
+# #256: forge backend selection. `[forge].type` picks which backend
+# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
+# configs keep working unchanged. The github backend is skeleton-only
+# until PRs 2-6 of #256 land their per-colony github-api.sh wrappers;
+# until then, FORGE_TYPE=github yields exit 99 "not implemented" from
+# forge-api.sh.
+FORGE_TYPE=$(parse_toml forge type)
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+export FORGE_TYPE
+
 AGENTS=(
     code_writer
     test_writer

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -162,6 +162,62 @@ if [ "$CONFIGS_EXISTED" -eq 5 ]; then
     fi
 fi
 
+# --- 3a. Forge backend selection (ADR-0002, #256) ---
+
+echo ""
+echo "Forge backend"
+echo "============="
+echo "All 5 colonies connect to the same forge (GitLab or GitHub)."
+echo ""
+
+# FEDERATION_FORGE_TYPE env var short-circuits the prompt for unattended
+# installs. Anything other than "gitlab" / "github" is rejected.
+if [ -n "${FEDERATION_FORGE_TYPE:-}" ]; then
+    case "$FEDERATION_FORGE_TYPE" in
+        gitlab|github)
+            FORGE_TYPE="$FEDERATION_FORGE_TYPE"
+            info "FEDERATION_FORGE_TYPE=$FORGE_TYPE (unattended selection)"
+            ;;
+        *)
+            fail "FEDERATION_FORGE_TYPE must be 'gitlab' or 'github' (got '$FEDERATION_FORGE_TYPE')"
+            exit 1
+            ;;
+    esac
+else
+    # Interactive prompt; default is "gitlab" for PR 1 parity with pre-#256
+    # installs. The full GitHub backend (per-colony github-api.sh wrappers,
+    # .ag agent audits) ships across PRs 2-6 of #256. Selecting "github"
+    # now is supported for config scaffolding; at runtime forge-api.sh
+    # returns exit 99 with a clear pointer to the ADR until the per-colony
+    # wrappers land.
+    ask "Forge backend [1] GitLab (default)  [2] GitHub:"
+    read -r FORGE_CHOICE
+    case "$FORGE_CHOICE" in
+        2|github|GitHub|GITHUB) FORGE_TYPE="github" ;;
+        *)                       FORGE_TYPE="gitlab" ;;
+    esac
+fi
+
+if [ "$FORGE_TYPE" = "github" ]; then
+    echo ""
+    fail "GitHub backend selected."
+    info "Foundation (ADR-0002 + config schema + forge-api.sh dispatcher)"
+    info "is available from PR 1 of issue #256. Per-colony github-api.sh"
+    info "wrappers ship in PRs 2-6; at runtime, forge-api.sh currently"
+    info "exits 99 for FORGE_TYPE=github. Track progress at:"
+    info "  https://github.com/Replikanti/agentis-colonies/issues/256"
+    echo ""
+    ask "Continue with GitHub scaffolding anyway? [y/N]:"
+    read -r CONTINUE_GITHUB
+    case "$CONTINUE_GITHUB" in
+        y|Y|yes|YES) info "Proceeding with GitHub scaffolding." ;;
+        *)
+            info "Aborting install. Re-run and select GitLab, or wait for PRs 2-6 of #256."
+            exit 0
+            ;;
+    esac
+fi
+
 # --- 3. GitLab credentials ---
 
 echo ""
@@ -229,10 +285,12 @@ if [ "$WRITE_CREDS" -eq 1 ]; then
 
     for colony in "${COLONIES[@]}"; do
         CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
-        # Write credentials by matching TOML keys (works on both fresh and existing configs)
-        python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" "$GITLAB_ME" <<'PY'
+        # Write credentials by matching TOML keys (works on both fresh and existing configs).
+        # The credential substitutions also hit the [forge.gitlab] block (same key names)
+        # so [gitlab] and [forge.gitlab] stay in sync during the migration overlap.
+        python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" "$GITLAB_ME" "$FORGE_TYPE" <<'PY'
 import sys, re
-path, url, token, project, me = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
+path, url, token, project, me, forge_type = sys.argv[1:7]
 with open(path) as f:
     content = f.read()
 content = re.sub(r'(url\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + url + '"', content)
@@ -243,6 +301,24 @@ content = re.sub(r'(project\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + projec
 # it manually if they want personal/team tagging). Anchor with ^ +
 # line flag so `name = ` / `some = ` don't match.
 content = re.sub(r'(?m)^(me\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + me + '"', content)
+# #256: [forge].type selects the active backend. Section-scoped rewrite
+# so the literal key `type = "..."` inside [forge] is the only one
+# touched (there is no ambiguity today, but future sections may reuse
+# the word `type` and we want to fail loudly if that ever happens).
+def _set_forge_type(content, value):
+    lines = content.splitlines(keepends=True)
+    in_forge = False
+    out = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith('[') and stripped.endswith(']'):
+            sect = stripped[1:-1].strip()
+            in_forge = (sect == 'forge')
+        if in_forge and re.match(r'\s*type\s*=\s*"[^"]*"', line):
+            line = re.sub(r'(type\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + value + '"', line, count=1)
+        out.append(line)
+    return ''.join(out)
+content = _set_forge_type(content, forge_type)
 with open(path, 'w') as f:
     f.write(content)
 PY

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -207,15 +207,21 @@ if [ "$FORGE_TYPE" = "github" ]; then
     info "exits 99 for FORGE_TYPE=github. Track progress at:"
     info "  https://github.com/Replikanti/agentis-colonies/issues/256"
     echo ""
-    ask "Continue with GitHub scaffolding anyway? [y/N]:"
-    read -r CONTINUE_GITHUB
-    case "$CONTINUE_GITHUB" in
-        y|Y|yes|YES) info "Proceeding with GitHub scaffolding." ;;
-        *)
-            info "Aborting install. Re-run and select GitLab, or wait for PRs 2-6 of #256."
-            exit 0
-            ;;
-    esac
+    if [ -n "${FEDERATION_FORGE_TYPE:-}" ]; then
+        # Env var already acts as explicit confirmation — skip interactive
+        # gate so unattended installs don't block on stdin.
+        info "FEDERATION_FORGE_TYPE=github → treating as confirmation, proceeding."
+    else
+        ask "Continue with GitHub scaffolding anyway? [y/N]:"
+        read -r CONTINUE_GITHUB
+        case "$CONTINUE_GITHUB" in
+            y|Y|yes|YES) info "Proceeding with GitHub scaffolding." ;;
+            *)
+                info "Aborting install. Re-run and select GitLab, or wait for PRs 2-6 of #256."
+                exit 0
+                ;;
+        esac
+    fi
 fi
 
 # --- 3. GitLab credentials ---
@@ -234,14 +240,23 @@ echo ""
 # redoing the install. See #116 gap 5.
 WRITE_CREDS=1
 if [ "$CONFIGS_EXISTED" -eq 5 ]; then
-    ask "Update GitLab credentials in existing configs? [Y/n]:"
-    read -r UPDATE_CREDS
-    case "$UPDATE_CREDS" in
-        n|N)
-            WRITE_CREDS=0
-            info "Keeping existing GitLab credentials. Skipping prompts."
-            ;;
-    esac
+    if [ -n "${FEDERATION_FORGE_TYPE:-}" ]; then
+        # Unattended re-install purely to switch forge (or reaffirm it).
+        # Don't block on stdin and don't silently overwrite existing
+        # credentials — the operator set the env var to pick the forge,
+        # not to rotate credentials.
+        WRITE_CREDS=0
+        info "FEDERATION_FORGE_TYPE set and configs exist → keeping existing credentials (forge type will still be updated below)."
+    else
+        ask "Update GitLab credentials in existing configs? [Y/n]:"
+        read -r UPDATE_CREDS
+        case "$UPDATE_CREDS" in
+            n|N)
+                WRITE_CREDS=0
+                info "Keeping existing GitLab credentials. Skipping prompts."
+                ;;
+        esac
+    fi
 fi
 
 if [ "$WRITE_CREDS" -eq 1 ]; then
@@ -285,40 +300,41 @@ if [ "$WRITE_CREDS" -eq 1 ]; then
 
     for colony in "${COLONIES[@]}"; do
         CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
-        # Write credentials by matching TOML keys (works on both fresh and existing configs).
-        # The credential substitutions also hit the [forge.gitlab] block (same key names)
-        # so [gitlab] and [forge.gitlab] stay in sync during the migration overlap.
-        python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" "$GITLAB_ME" "$FORGE_TYPE" <<'PY'
+        # Rewrite credentials in both [gitlab] and [forge.gitlab]. Section-
+        # scoped so an operator who uncommented [forge.github] (and perhaps
+        # dropped a ghp_* PAT there) does not see their GitHub token
+        # clobbered by the glpat rewrite.
+        python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" "$GITLAB_ME" <<'PY'
 import sys, re
-path, url, token, project, me, forge_type = sys.argv[1:7]
+path, url, token, project, me = sys.argv[1:6]
 with open(path) as f:
     content = f.read()
-content = re.sub(r'(url\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + url + '"', content)
-content = re.sub(r'(token\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + token + '"', content)
-content = re.sub(r'(project\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + project + '"', content)
-# #104: `me` key. Only update if the template declared one; do not
-# inject into existing configs that predate #104 (operator can add
-# it manually if they want personal/team tagging). Anchor with ^ +
-# line flag so `name = ` / `some = ` don't match.
-content = re.sub(r'(?m)^(me\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + me + '"', content)
-# #256: [forge].type selects the active backend. Section-scoped rewrite
-# so the literal key `type = "..."` inside [forge] is the only one
-# touched (there is no ambiguity today, but future sections may reuse
-# the word `type` and we want to fail loudly if that ever happens).
-def _set_forge_type(content, value):
+
+def _rewrite_in_sections(content, targets, rewrites):
     lines = content.splitlines(keepends=True)
-    in_forge = False
+    section = None
     out = []
     for line in lines:
         stripped = line.strip()
         if stripped.startswith('[') and stripped.endswith(']'):
-            sect = stripped[1:-1].strip()
-            in_forge = (sect == 'forge')
-        if in_forge and re.match(r'\s*type\s*=\s*"[^"]*"', line):
-            line = re.sub(r'(type\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + value + '"', line, count=1)
+            section = stripped[1:-1].strip()
+        if section in targets:
+            for pat, sub in rewrites:
+                line = re.sub(pat, sub, line)
         out.append(line)
     return ''.join(out)
-content = _set_forge_type(content, forge_type)
+
+cred_sections = {'gitlab', 'forge.gitlab'}
+rewrites = [
+    (r'(url\s*=\s*)"[^"]*"',     lambda m: m.group(1) + '"' + url + '"'),
+    (r'(token\s*=\s*)"[^"]*"',   lambda m: m.group(1) + '"' + token + '"'),
+    (r'(project\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + project + '"'),
+    # #104: `me` is optional; only rewrite if the template declared one
+    # (operator on a pre-#104 config can add it manually).
+    (r'(me\s*=\s*)"[^"]*"',      lambda m: m.group(1) + '"' + me + '"'),
+]
+content = _rewrite_in_sections(content, cred_sections, rewrites)
+
 with open(path, 'w') as f:
     f.write(content)
 PY
@@ -327,6 +343,50 @@ PY
             info "$colony: could not chmod 600 $CONFIG (filesystem may not support it)"
     done
 fi
+
+# #256: rewrite [forge].type unconditionally — runs even when WRITE_CREDS=0
+# (e.g. operator re-ran install.sh purely to switch forge via
+# FEDERATION_FORGE_TYPE, or answered "n" to the credential-update prompt).
+# Section-scoped so the literal key `type = "..."` inside [forge] is the
+# only one touched. Prints "no-forge-section" on stdout when the config
+# predates #256 and lacks a [forge] block — the outer loop flags that
+# visibly so the operator knows to re-copy colony.example.toml.
+echo ""
+echo "Setting [forge].type = \"$FORGE_TYPE\" in all colony configs..."
+for colony in "${COLONIES[@]}"; do
+    CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
+    RESULT=$(python3 - "$CONFIG" "$FORGE_TYPE" <<'PY'
+import sys, re
+path, forge_type = sys.argv[1:3]
+with open(path) as f:
+    content = f.read()
+lines = content.splitlines(keepends=True)
+in_forge = False
+rewrote = False
+out = []
+for line in lines:
+    stripped = line.strip()
+    if stripped.startswith('[') and stripped.endswith(']'):
+        sect = stripped[1:-1].strip()
+        in_forge = (sect == 'forge')
+    if in_forge and re.match(r'\s*type\s*=\s*"[^"]*"', line):
+        line = re.sub(r'(type\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + forge_type + '"', line, count=1)
+        rewrote = True
+    out.append(line)
+if rewrote:
+    with open(path, 'w') as f:
+        f.write(''.join(out))
+    print("ok")
+else:
+    print("no-forge-section")
+PY
+)
+    case "$RESULT" in
+        ok)               ok "$colony: [forge].type = \"$FORGE_TYPE\"" ;;
+        no-forge-section) fail "$colony: no [forge] section in colony.toml (config predates #256). Re-copy from colony.example.toml or add [forge] manually." ;;
+        *)                fail "$colony: unexpected result from [forge].type rewrite: $RESULT" ;;
+    esac
+done
 
 # --- 4. Initialize agentis (if not already done) ---
 #

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -26,6 +26,26 @@ trigger_label = "needs-planning"
 incident = "incident, bug, blocker"   # labels risk_assessor treats as incident-class
 epic = "epic"                          # labels/patterns task_decomposer treats as epic-class
 
+# Forge backend selection (ADR-0002, #256). `type` picks which of the
+# per-backend blocks below is active. Legal values: "gitlab", "github".
+# The top-level [gitlab] section below is retained for backwards
+# compatibility during the migration window — one release of overlap.
+# It is retired in the final PR of the port (PR 7 of #256).
+[forge]
+type = "gitlab"
+
+[forge.gitlab]
+url     = "https://gitlab.example.com"
+token   = "glpat-your-token-here"
+project = "your-org/your-project"
+me      = ""  # your GitLab username (optional, enables personal/team tagging)
+
+# [forge.github]
+# owner = "your-org-or-user"
+# repo  = "your-repo"
+# token = "ghp_your-token-here"
+# me    = ""  # your GitHub username (optional)
+
 [gitlab]
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"

--- a/dev-apprenticeship/planning/scripts/forge-api.sh
+++ b/dev-apprenticeship/planning/scripts/forge-api.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Forge dispatcher for the planning colony (ADR-0002, #256).
+#
+# Agents call this script via exec sh instead of the backend-specific
+# wrappers (gitlab-api.sh, github-api.sh). The dispatcher reads the
+# FORGE_TYPE env var (exported by start-colony.sh from the [forge].type
+# config key) and forwards argv verbatim to the matching backend wrapper.
+#
+# Agents receive identical normalized JSON regardless of backend. See
+# doc/adr/ADR-0002-forge-abstraction.md for the shape contract.
+#
+# Exit codes:
+#   0   success (from the underlying wrapper)
+#   1   backend wrapper failure (from the underlying wrapper)
+#   2   unknown flag / usage error
+#   99  requested FORGE_TYPE has no backend wrapper yet (see #256 PRs 2-6)
+
+set -e
+
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+case "$FORGE_TYPE" in
+    gitlab)
+        backend="$SCRIPT_DIR/gitlab-api.sh"
+        ;;
+    github)
+        backend="$SCRIPT_DIR/github-api.sh"
+        ;;
+    *)
+        echo "forge-api.sh: unknown FORGE_TYPE '$FORGE_TYPE' (expected: gitlab|github)" >&2
+        exit 2
+        ;;
+esac
+
+if [ ! -x "$backend" ]; then
+    echo "forge-api.sh: backend wrapper not available: $backend" >&2
+    echo "forge-api.sh: FORGE_TYPE=$FORGE_TYPE is not yet implemented for the planning colony." >&2
+    echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256." >&2
+    exit 99
+fi
+
+exec "$backend" "$@"

--- a/dev-apprenticeship/planning/scripts/forge-api.sh
+++ b/dev-apprenticeship/planning/scripts/forge-api.sh
@@ -35,9 +35,20 @@ case "$FORGE_TYPE" in
 esac
 
 if [ ! -x "$backend" ]; then
-    echo "forge-api.sh: backend wrapper not available: $backend" >&2
-    echo "forge-api.sh: FORGE_TYPE=$FORGE_TYPE is not yet implemented for the planning colony." >&2
-    echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256." >&2
+    case "$FORGE_TYPE" in
+        github)
+            # Skeleton state: dispatcher exists but the per-colony wrapper is not yet
+            # shipped. Lands across PRs 2-6 of #256.
+            echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the planning colony." >&2
+            echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
+            ;;
+        *)
+            # Broken install — gitlab-api.sh should always be present alongside
+            # forge-api.sh in a valid federation checkout.
+            echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
+            echo "forge-api.sh: this indicates a broken install — re-copy the planning colony scripts/ directory." >&2
+            ;;
+    esac
     exit 99
 fi
 

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -96,6 +96,16 @@ export GITLAB_ME
 export PLANNING_TRIGGER_LABEL
 export COLONY_DIR
 
+# #256: forge backend selection. `[forge].type` picks which backend
+# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
+# configs keep working unchanged. The github backend is skeleton-only
+# until PRs 2-6 of #256 land their per-colony github-api.sh wrappers;
+# until then, FORGE_TYPE=github yields exit 99 "not implemented" from
+# forge-api.sh.
+FORGE_TYPE=$(parse_toml forge type)
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+export FORGE_TYPE
+
 AGENTS=(
     scope_estimator
     risk_assessor

--- a/dev-apprenticeship/release/config/colony.example.toml
+++ b/dev-apprenticeship/release/config/colony.example.toml
@@ -7,6 +7,28 @@
 name = "release"
 tick_interval_ms = 60000
 
+# Forge backend selection (ADR-0002, #256). `type` picks which of the
+# per-backend blocks below is active. Legal values: "gitlab", "github".
+# The top-level [gitlab] section below is retained for backwards
+# compatibility during the migration window — one release of overlap.
+# It is retired in the final PR of the port (PR 7 of #256).
+[forge]
+type = "gitlab"
+
+[forge.gitlab]
+url            = "https://gitlab.example.com"
+token          = "glpat-your-token-here"
+project        = "your-org/your-project"
+me             = ""      # your GitLab username (optional)
+default_branch = "main"  # primary branch (#224)
+
+# [forge.github]
+# owner          = "your-org-or-user"
+# repo           = "your-repo"
+# token          = "ghp_your-token-here"
+# me             = ""      # your GitHub username (optional)
+# default_branch = "main"  # primary branch
+
 [gitlab]
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"

--- a/dev-apprenticeship/release/scripts/forge-api.sh
+++ b/dev-apprenticeship/release/scripts/forge-api.sh
@@ -35,9 +35,20 @@ case "$FORGE_TYPE" in
 esac
 
 if [ ! -x "$backend" ]; then
-    echo "forge-api.sh: backend wrapper not available: $backend" >&2
-    echo "forge-api.sh: FORGE_TYPE=$FORGE_TYPE is not yet implemented for the release colony." >&2
-    echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256." >&2
+    case "$FORGE_TYPE" in
+        github)
+            # Skeleton state: dispatcher exists but the per-colony wrapper is not yet
+            # shipped. Lands across PRs 2-6 of #256.
+            echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the release colony." >&2
+            echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
+            ;;
+        *)
+            # Broken install — gitlab-api.sh should always be present alongside
+            # forge-api.sh in a valid federation checkout.
+            echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
+            echo "forge-api.sh: this indicates a broken install — re-copy the release colony scripts/ directory." >&2
+            ;;
+    esac
     exit 99
 fi
 

--- a/dev-apprenticeship/release/scripts/forge-api.sh
+++ b/dev-apprenticeship/release/scripts/forge-api.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Forge dispatcher for the release colony (ADR-0002, #256).
+#
+# Agents call this script via exec sh instead of the backend-specific
+# wrappers (gitlab-api.sh, github-api.sh). The dispatcher reads the
+# FORGE_TYPE env var (exported by start-colony.sh from the [forge].type
+# config key) and forwards argv verbatim to the matching backend wrapper.
+#
+# Agents receive identical normalized JSON regardless of backend. See
+# doc/adr/ADR-0002-forge-abstraction.md for the shape contract.
+#
+# Exit codes:
+#   0   success (from the underlying wrapper)
+#   1   backend wrapper failure (from the underlying wrapper)
+#   2   unknown flag / usage error
+#   99  requested FORGE_TYPE has no backend wrapper yet (see #256 PRs 2-6)
+
+set -e
+
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+case "$FORGE_TYPE" in
+    gitlab)
+        backend="$SCRIPT_DIR/gitlab-api.sh"
+        ;;
+    github)
+        backend="$SCRIPT_DIR/github-api.sh"
+        ;;
+    *)
+        echo "forge-api.sh: unknown FORGE_TYPE '$FORGE_TYPE' (expected: gitlab|github)" >&2
+        exit 2
+        ;;
+esac
+
+if [ ! -x "$backend" ]; then
+    echo "forge-api.sh: backend wrapper not available: $backend" >&2
+    echo "forge-api.sh: FORGE_TYPE=$FORGE_TYPE is not yet implemented for the release colony." >&2
+    echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256." >&2
+    exit 99
+fi
+
+exec "$backend" "$@"

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -96,6 +96,16 @@ export GITLAB_ME
 export GITLAB_DEFAULT_BRANCH
 export COLONY_DIR
 
+# #256: forge backend selection. `[forge].type` picks which backend
+# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
+# configs keep working unchanged. The github backend is skeleton-only
+# until PRs 2-6 of #256 land their per-colony github-api.sh wrappers;
+# until then, FORGE_TYPE=github yields exit 99 "not implemented" from
+# forge-api.sh.
+FORGE_TYPE=$(parse_toml forge type)
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+export FORGE_TYPE
+
 AGENTS=(
     release_checker
     ship_decider

--- a/dev-apprenticeship/triage/config/colony.example.toml
+++ b/dev-apprenticeship/triage/config/colony.example.toml
@@ -7,6 +7,26 @@
 name = "triage"
 tick_interval_ms = 60000
 
+# Forge backend selection (ADR-0002, #256). `type` picks which of the
+# per-backend blocks below is active. Legal values: "gitlab", "github".
+# The top-level [gitlab] section below is retained for backwards
+# compatibility during the migration window — one release of overlap.
+# It is retired in the final PR of the port (PR 7 of #256).
+[forge]
+type = "gitlab"
+
+[forge.gitlab]
+url     = "https://gitlab.example.com"
+token   = "glpat-your-token-here"
+project = "your-org/your-project"
+me      = ""  # your GitLab username (optional, enables personal/team tagging)
+
+# [forge.github]
+# owner = "your-org-or-user"
+# repo  = "your-repo"
+# token = "ghp_your-token-here"
+# me    = ""  # your GitHub username (optional)
+
 [gitlab]
 url = "https://gitlab.example.com"
 token = "glpat-your-token-here"

--- a/dev-apprenticeship/triage/scripts/forge-api.sh
+++ b/dev-apprenticeship/triage/scripts/forge-api.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Forge dispatcher for the triage colony (ADR-0002, #256).
+#
+# Agents call this script via exec sh instead of the backend-specific
+# wrappers (gitlab-api.sh, github-api.sh). The dispatcher reads the
+# FORGE_TYPE env var (exported by start-colony.sh from the [forge].type
+# config key) and forwards argv verbatim to the matching backend wrapper.
+#
+# Agents receive identical normalized JSON regardless of backend. See
+# doc/adr/ADR-0002-forge-abstraction.md for the shape contract.
+#
+# Exit codes:
+#   0   success (from the underlying wrapper)
+#   1   backend wrapper failure (from the underlying wrapper)
+#   2   unknown flag / usage error
+#   99  requested FORGE_TYPE has no backend wrapper yet (see #256 PRs 2-6)
+
+set -e
+
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+case "$FORGE_TYPE" in
+    gitlab)
+        backend="$SCRIPT_DIR/gitlab-api.sh"
+        ;;
+    github)
+        backend="$SCRIPT_DIR/github-api.sh"
+        ;;
+    *)
+        echo "forge-api.sh: unknown FORGE_TYPE '$FORGE_TYPE' (expected: gitlab|github)" >&2
+        exit 2
+        ;;
+esac
+
+if [ ! -x "$backend" ]; then
+    echo "forge-api.sh: backend wrapper not available: $backend" >&2
+    echo "forge-api.sh: FORGE_TYPE=$FORGE_TYPE is not yet implemented for the triage colony." >&2
+    echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256." >&2
+    exit 99
+fi
+
+exec "$backend" "$@"

--- a/dev-apprenticeship/triage/scripts/forge-api.sh
+++ b/dev-apprenticeship/triage/scripts/forge-api.sh
@@ -35,9 +35,20 @@ case "$FORGE_TYPE" in
 esac
 
 if [ ! -x "$backend" ]; then
-    echo "forge-api.sh: backend wrapper not available: $backend" >&2
-    echo "forge-api.sh: FORGE_TYPE=$FORGE_TYPE is not yet implemented for the triage colony." >&2
-    echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256." >&2
+    case "$FORGE_TYPE" in
+        github)
+            # Skeleton state: dispatcher exists but the per-colony wrapper is not yet
+            # shipped. Lands across PRs 2-6 of #256.
+            echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the triage colony." >&2
+            echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
+            ;;
+        *)
+            # Broken install — gitlab-api.sh should always be present alongside
+            # forge-api.sh in a valid federation checkout.
+            echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
+            echo "forge-api.sh: this indicates a broken install — re-copy the triage colony scripts/ directory." >&2
+            ;;
+    esac
     exit 99
 fi
 

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -90,6 +90,16 @@ export GITLAB_PROJECT
 export GITLAB_ME
 export COLONY_DIR
 
+# #256: forge backend selection. `[forge].type` picks which backend
+# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
+# configs keep working unchanged. The github backend is skeleton-only
+# until PRs 2-6 of #256 land their per-colony github-api.sh wrappers;
+# until then, FORGE_TYPE=github yields exit 99 "not implemented" from
+# forge-api.sh.
+FORGE_TYPE=$(parse_toml forge type)
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+export FORGE_TYPE
+
 AGENTS=(
     issue_creator
     labeler

--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -78,13 +78,21 @@ type = "github"               # or "gitlab"
 [forge.github]
 owner = "me"
 repo  = "myrepo"
-token = "${GITHUB_TOKEN}"
+token = "ghp_your-token-here"
 
 [forge.gitlab]
 url     = "https://gitlab.com"
-project = 123
-token   = "${GITLAB_TOKEN}"
+project = "your-org/your-project"
+token   = "glpat-your-token-here"
 ```
+
+Values are literal strings. `parse-toml.sh` does not expand `${VAR}`
+references — tokens are stored verbatim in `colony.toml` (which is
+`chmod 600`) and `install.sh` writes the literal operator-supplied
+token, not an env-var reference. The `project` field is a path string
+(`owner/repo` or `group/subgroup/project`), matching the existing
+`[gitlab].project` convention; `gitlab-api.sh` URL-encodes it to
+`%2F`-separated form before calling the API.
 
 `start-colony.sh` reads `[forge].type`, exports `FORGE_TYPE`, and
 continues to export the legacy `GITLAB_*` env for backwards
@@ -97,6 +105,14 @@ retired and `[forge.*]` is authoritative.
 Every subcommand emits a fixed JSON shape. The following table is the
 authoritative contract; `test-forge-api.sh` enforces byte-identical
 output for matching fixtures across both backends.
+
+**Per-PR rollout.** PR 1 (this PR) ships only the dispatcher skeleton
+and config schema — none of the subcommands below are newly
+implemented in PR 1. Per-colony `github-api.sh` wrappers that
+implement the subcommands land across PRs 2-6 in the order triage
+→ planning → implementation → code-review → release. `rate-limit-status`
+and the dashboard tile ship in PR 7 alongside the legacy
+`[gitlab]`-section retirement.
 
 | Subcommand           | Normalized output |
 |----------------------|-------------------|

--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -1,0 +1,296 @@
+---
+id: ADR-0002
+title: Forge abstraction — normalized wrapper dispatch for multi-forge federations
+status: Proposed
+date: 2026-04-23
+authors: [ylohnitram]
+supersedes: (none)
+superseded-by: (none)
+tags: [portability, forge, gitlab, github, dev-apprenticeship]
+---
+
+# ADR-0002: Forge abstraction — normalized wrapper dispatch for multi-forge federations
+
+## Context
+
+`dev-apprenticeship` is currently 100% GitLab-coupled. A grep across the
+21 `.ag` agents surfaces 144 `gitlab` / `GITLAB` references. Each of the
+five colonies ships its own `gitlab-api.sh` wrapper (~500 LOC each). The
+JSON shape consumed by agents mirrors GitLab's REST responses verbatim
+(`iid`, `merge_requests`, `approvals` fields, `/resource_label_events`
+timeline).
+
+`agentis-colonies` itself ships as a GitHub repository. Every potential
+contributor or operator who runs `dev-apprenticeship` against GitHub
+bounces off `install.sh` step 1. The portability gap is the most
+visible adoption blocker in the project today.
+
+Partial groundwork already exists. #223–#226 introduced env-driven
+label vocabulary (`PLANNING_TRIGGER_LABEL`, `IMPLEMENTATION_TRIGGER_LABEL`),
+a forge-agnostic default-branch knob (`GITLAB_DEFAULT_BRANCH`, name
+notwithstanding), and memo-seeded prompt vocabulary. The confidence-tier
+contract from ADR-0001, the auto-promote sidecar, the dashboard, and
+the experience store are already forge-agnostic by construction. The
+remaining coupling is in the API-call layer — the `gitlab-api.sh`
+wrappers and the JSON shape agents parse from them.
+
+The intent of this ADR is **not** a thin-slice GitHub PoC or a second
+federation fork. One federation, one install, one CHANGELOG — forge
+choice is a configuration toggle. #257 removed the last forge coupling
+from the federation-dashboard side (restart delegates to
+`start-colony.sh`, which owns env wiring), so the remaining surface is
+exactly the colony `.ag` → wrapper → REST path.
+
+## Decision
+
+Adopt **wrapper dispatch with normalized JSON** as the forge
+abstraction boundary.
+
+```
+.ag agent
+  │
+  ▼
+exec sh "$COLONY_DIR/scripts/forge-api.sh <subcommand> <args>"
+  │
+  ▼                (new thin dispatcher; reads $FORGE_TYPE)
+forge-api.sh
+  │
+  ├──> gitlab-api.sh <subcommand> <args>     (existing, modified to
+  │                                           emit normalized JSON)
+  └──> github-api.sh <subcommand> <args>     (new, emits the same
+                                              normalized JSON)
+```
+
+Agents keep calling the `exec sh` subcommand interface they already
+use. They receive an identical JSON shape regardless of backend. The
+translation from backend-specific REST to the normalized shape happens
+in exactly one place per subcommand: inside the backend's
+`<backend>-api.sh` wrapper, with help from shared normalization
+helpers in `tools/forge-normalize.sh`.
+
+### Configuration
+
+```toml
+# colony.toml
+[forge]
+type = "github"               # or "gitlab"
+
+[forge.github]
+owner = "me"
+repo  = "myrepo"
+token = "${GITHUB_TOKEN}"
+
+[forge.gitlab]
+url     = "https://gitlab.com"
+project = 123
+token   = "${GITLAB_TOKEN}"
+```
+
+`start-colony.sh` reads `[forge].type`, exports `FORGE_TYPE`, and
+continues to export the legacy `GITLAB_*` env for backwards
+compatibility during the migration window (one release). After the
+release PR at the end of the port, the top-level `[gitlab]` section is
+retired and `[forge.*]` is authoritative.
+
+### Normalized shape contract (normative)
+
+Every subcommand emits a fixed JSON shape. The following table is the
+authoritative contract; `test-forge-api.sh` enforces byte-identical
+output for matching fixtures across both backends.
+
+| Subcommand           | Normalized output |
+|----------------------|-------------------|
+| `get-issue <n>`      | `{"number", "title", "description", "labels": [...], "state", "assignees": [...], "author", "web_url"}` |
+| `list-open-issues`   | `[{...get-issue shape...}, ...]` |
+| `create-issue`       | `{...get-issue shape of the created issue...}` |
+| `update-issue`       | `{...get-issue shape after update...}` |
+| `merge-requests`     | `[{"number", "title", "state", "draft": bool, "labels", "source_branch", "target_branch", "author", "web_url"}, ...]` |
+| `mr-changes <n>`     | `[{"path", "diff"}, ...]` |
+| `mr-commits <n>`     | `[{"sha", "title", "author", "created_at"}, ...]` |
+| `mr-notes <n>`       | `[{"author", "body", "created_at", "system": bool}, ...]` |
+| `post-note <n> <body>` | `{"id", "author", "created_at"}` |
+| `create-mr`          | `{...merge-requests shape of the created MR/PR...}` |
+| `create-branch`      | `{"name", "sha"}` |
+| `commit-files`       | `{"sha", "branch"}` |
+| `approvals <n>`      | `{"approved": bool, "approvers": [...], "required": N}` |
+| `approve <n>`        | `{"approved": bool, "approvers": [...]}` |
+| `labels`             | `[{"name", "color", "description"}, ...]` |
+| `members`            | `[{"username", "name", "access_level": "maintainer\|developer\|reporter"}, ...]` |
+| `label-events <n>`   | `[{"action": "added\|removed", "label", "user", "created_at"}, ...]` |
+| `issues-by-label-events <labels>` | `[{"issue": {...get-issue...}, "events": [...label-events...]}, ...]` |
+| `assigned-issues`    | `[{...get-issue shape...}, ...]` |
+| `issue-label-events` | alias of `label-events` for issue-scoped consumption |
+| `assigned-issues-by-label-events <labels>` | `[{...}, ...]` composed from the two above |
+| `pipeline-status <sha>` | `{"status": "success\|failed\|running\|pending", "web_url"}` |
+| `releases`           | `[{"tag", "name", "created_at", "body"}, ...]` |
+| `tags`               | `[{"name", "sha", "created_at"}, ...]` |
+| `create-tag`         | `{"name", "sha"}` |
+| `create-release`     | `{"tag", "name", "web_url"}` |
+| `rate-limit-status`  | `{"remaining", "limit", "reset_at"}` |
+
+Agents never see REST responses directly. Anywhere agents currently
+read `.iid`, they read `.number`. Anywhere they currently pattern-match
+on `state == "opened"`, the wrapper normalizes to `"open"`.
+
+### Semantic collapses (where shape loses fidelity)
+
+Several asymmetries cannot be papered over; the wrapper resolves them
+by collapsing to the simpler semantic and documenting the collapse
+here.
+
+| Concept | GitLab | GitHub | Collapse |
+|---------|--------|--------|----------|
+| Issue/MR ID | `iid` (per-project) | `number` (per-repo) | Always emit `number`. |
+| Approvals | Threshold-based boolean + approver list | Review state machine (`APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED` / `PENDING`) | Emit `{approved: bool, approvers: [...]}`. Rule: count latest non-dismissed review per reviewer with state `APPROVED`; `approved = (count >= required)` where `required` comes from the ruleset / branch protection. `CHANGES_REQUESTED` collapses to "not approved"; agents do not see the negative-review signal in this normalized shape. |
+| Pipeline / CI | `/projects/:id/pipelines/:sha` | `/repos/:o/:r/actions/runs?head_sha=:sha` (iterate workflow runs, aggregate) | Emit `{status: success \| failed \| running \| pending}`. Multiple GitHub workflow runs for the same SHA aggregate as: any failed → `failed`; any running/queued and none failed → `running`; all success → `success`; else `pending`. |
+| Label events | `/resource_label_events` (one event type) | `/issues/:n/timeline` (20+ event types) | Filter timeline to `labeled` / `unlabeled`; drop everything else. |
+| Draft | Title prefix `Draft:` / `WIP:` | `draft: true` boolean | Always emit `draft: bool`. The GitLab wrapper parses the title prefix. |
+| Pagination | `X-Next-Page` header | `Link: <...>; rel="next"` | Both wrappers implement an internal paginator and emit a single flat JSON array. No cursor / next-page surface is exposed to agents. |
+| Atomic multi-file commit | Single API call | Four-step tree/blob/commit/ref update | `commit-files` is transactional on GitLab, best-effort on GitHub. Retry: up to 3 fast-forward retries if the branch tip advances mid-operation. On persistent conflict the wrapper surfaces a non-zero exit with a structured error JSON (`{error: "branch_advanced", attempts: 3}`) rather than silently force-pushing. |
+
+Where a collapse loses useful signal, the rationale and the reverse
+direction (how an agent can still inspect the lost detail, typically
+via a follow-up subcommand) are called out in the per-PR CHANGELOG
+entry for the affected colony.
+
+### Non-goals
+
+- **Gitea, Forgejo, Bitbucket**. The ADR deliberately scopes the shape
+  contract to exactly GitLab + GitHub. A future ADR may extend the
+  `FORGE_TYPE` enum once the shape has been stable for one release.
+- **Polyglot federations**. One federation = one forge. `FORGE_TYPE`
+  is a single value, not a list. A user who wants to mirror a
+  federation onto a second forge runs a second install.
+- **Keeping the top-level `[gitlab]` config section past the final
+  release of the port.** One release of overlap, then retire.
+- **Agent-layer knowledge of forge semantics.** Agents may branch on
+  `$FORGE_TYPE` only for prompt-vocabulary tweaks ("pull request" vs
+  "merge request"); they must never embed forge-specific API logic or
+  parse forge-specific JSON.
+
+## Consequences
+
+### Migration of existing `.ag` scenarios
+
+Every `gitlab`-ism in the 21 agents is an edit point:
+
+- `parse_int(to_string(json_get(raw, "[0].iid")))` → `[0].number`.
+- Prompt strings mentioning "GitLab" / "MR" get the `$FORGE_TYPE`-aware
+  treatment (either a generic term like "pull request" or a
+  conditional phrasing).
+- `shell_escape("$COLONY_DIR/scripts/gitlab-api.sh …")` →
+  `forge-api.sh`. `colony-lint` gains a rule that `.ag` files must not
+  reference `gitlab-api.sh` or `github-api.sh` directly.
+
+Per-colony edits land in the colony-port PRs (PRs 2–6 of #256).
+
+### Runtime changes
+
+- `start-colony.sh` across all 5 colonies reads `[forge].type` and
+  exports `FORGE_TYPE`. Existing `GITLAB_*` exports are kept for one
+  release of overlap.
+- `tools/forge-normalize.sh` (new) ships shared helpers: pagination
+  walker, label-event filter, draft-flag inferrer, approvals collapse.
+- `install.sh` gains a forge-choice prompt, defaulting to GitLab for
+  one release then "ask" (no default) at the end of the port.
+  `FEDERATION_FORGE_TYPE=github|gitlab` env var short-circuits prompts
+  for unattended installs.
+
+### Rate limits
+
+GitHub authenticated: 5000 req/h per token. Worst-case projection with
+current tick intervals:
+
+- triage (60s) × 4 agents × ~3 req/tick = 720/h
+- planning (60s) × 4 × ~3 = 720
+- implementation (60s) × 4 × ~3 = 720
+- code-review (300s) × 5 × ~3 = 180
+- release (300s) × 4 × ~3 = 144
+- **Total: ~2500 req/h** — comfortably under the limit.
+
+`rate-limit-status` subcommand + a dashboard tile are added in PR 7 of
+#256 so operators see a live remaining/limit counter. If a real install
+trips, the fix is per-agent tick-interval tuning, not a change to this
+ADR.
+
+### Testing
+
+- `tools/test-forge-api.sh` (new) — fixture-based replay harness.
+  Recorded GitLab + GitHub JSON blobs for every subcommand; wrappers
+  run against the fixtures via an HTTP-shim; output compared
+  byte-for-byte against the normalized contract.
+- `tools/test-forge-normalize.sh` (new) — unit tests for the
+  translation helpers.
+- `colony-lint.sh` — new rule: `.ag` files must use `forge-api.sh`,
+  never the backend-specific wrappers.
+
+### Versioning
+
+The final release PR of #256 (PR 7) is a **MAJOR** `dev-apprenticeship`
+bump — `[forge]` is a new config-schema key and the top-level
+`[gitlab]` section is retired, both of which are breaking changes per
+the release-process rules in `CLAUDE.md`.
+
+Foundation PRs (PR 1 of this series, which introduces the ADR + config
+schema + dispatcher skeleton under the default `FORGE_TYPE=gitlab`) are
+**MINOR**: additive config, no break.
+
+## Alternatives considered
+
+### Second federation fork (dev-apprenticeship-github)
+
+Copy the whole federation into a second tree with GitLab wrappers
+replaced by GitHub wrappers. Rejected because (a) every bugfix would
+land twice, (b) the `.ag` agents diverge on shape, which undermines
+the single-source-of-truth guarantee, and (c) the user has explicitly
+scoped the issue: "No thin-slice PoC, no second federation fork. One
+federation, one install."
+
+### Runtime-layer forge abstraction in `agentis-core`
+
+Move the forge adapter into `agentis-core` as a first-class concept.
+Rejected because it would require a `agentis-core` release and a cross-
+repo coordination step every time we extend the shape. The
+subcommand-level interface is already where every `.ag` crosses the
+forge boundary; promoting it to a runtime concern would ossify it
+without removing any duplication. If the adapter ends up stable for
+three releases, future work may propose a runtime-level home for it.
+
+### GraphQL-only wrapper (GitHub)
+
+Use GitHub's GraphQL endpoint exclusively; avoid the shape asymmetry
+by letting each subcommand ask for exactly the normalized shape.
+Rejected because (a) GitHub's GraphQL surface does not cover
+`actions/runs` cleanly (pipeline status stays REST), (b) GitLab has no
+equivalent GraphQL coverage for the write subcommands (`commit-files`,
+`create-release`), so the overall wrapper can't be GraphQL-uniform
+anyway, and (c) REST has better debuggability for operators (curl-
+ability). The REST-per-backend + normalization approach keeps the
+reasoning local.
+
+### Forge-adapter as a runtime plugin loaded by the daemon
+
+Pass a `--forge <name>` flag to `agentis daemon` and have the runtime
+load a shared library. Rejected for the same reason as the runtime-
+layer option above — premature coupling. The `exec sh` subcommand
+abstraction already works; we're not adding a new boundary, just
+honouring the one we have.
+
+## References
+
+- GitHub issue: Replikanti/agentis-colonies#256 (motivates this ADR,
+  contains the 7-PR breakdown the colony ports follow).
+- Replikanti/agentis-colonies#257 — dashboard decoupling, the prior
+  restart-path fix that removed the last forge coupling on the
+  dashboard side.
+- Replikanti/agentis-colonies#223, #224, #225, #226 — env-driven label
+  vocabulary and default-branch knob that prepared the ground for this
+  ADR.
+- `doc/adr/ADR-0001-confidence-tiers.md` — tier contract is already
+  forge-agnostic; no changes required.
+- `CLAUDE.md` — release-process rules (MAJOR vs MINOR) and federation
+  conventions for `.ag` scenarios.
+
+## Supersedes
+
+(none)

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -15,3 +15,4 @@ not rewrite decisions.
 ## Index
 
 - [ADR-0001: Confidence tiers for autonomous agent behaviour](./ADR-0001-confidence-tiers.md) — Proposed, 2026-04-17
+- [ADR-0002: Forge abstraction — normalized wrapper dispatch for multi-forge federations](./ADR-0002-forge-abstraction.md) — Proposed, 2026-04-23

--- a/tools/test-forge-config.sh
+++ b/tools/test-forge-config.sh
@@ -89,7 +89,10 @@ for colony in $COLONIES; do
         fail "$colony: forge-api.sh does not reference FORGE_TYPE"
         continue
     fi
-    if ! grep -q 'case "\$FORGE_TYPE"' "$disp"; then
+    # grep -F to treat `$FORGE_TYPE` as a literal string (shellcheck SC2016
+    # flags escaped-$ in single-quoted patterns; -F sidesteps the ambiguity
+    # and matches the dispatcher's literal `case "$FORGE_TYPE"` line).
+    if ! grep -qF 'case "$FORGE_TYPE"' "$disp"; then
         fail "$colony: forge-api.sh missing FORGE_TYPE case dispatch"
         continue
     fi
@@ -193,11 +196,14 @@ done
 # -----------------------------------------------------------------------------
 for colony in $COLONIES; do
     start="$REPO_ROOT/dev-apprenticeship/$colony/scripts/start-colony.sh"
-    if ! grep -qE 'FORGE_TYPE=\$\(parse_toml forge type\)' "$start"; then
+    # grep -F to match literal `$()` / `${}` shell syntax in the script
+    # (shellcheck SC2016 flags escaped-$ in single-quoted regex patterns;
+    # -F sidesteps it by treating the whole pattern as a fixed string).
+    if ! grep -qF 'FORGE_TYPE=$(parse_toml forge type)' "$start"; then
         fail "$colony: start-colony.sh does not parse [forge].type via parse_toml"
         continue
     fi
-    if ! grep -qE 'FORGE_TYPE="\$\{FORGE_TYPE:-gitlab\}"' "$start"; then
+    if ! grep -qF 'FORGE_TYPE="${FORGE_TYPE:-gitlab}"' "$start"; then
         fail "$colony: start-colony.sh does not default FORGE_TYPE to \"gitlab\""
         continue
     fi

--- a/tools/test-forge-config.sh
+++ b/tools/test-forge-config.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+# tools/test-forge-config.sh: verify the #256 forge-abstraction foundation.
+#
+# PR 1 of #256 adds:
+#  - [forge] section (with type, [forge.gitlab], commented [forge.github]) to
+#    every colony.example.toml
+#  - per-colony scripts/forge-api.sh dispatcher that reads $FORGE_TYPE
+#  - start-colony.sh exports FORGE_TYPE from [forge].type (default "gitlab")
+#
+# This test locks all three invariants in place before PRs 2-6 land the
+# per-colony github-api.sh wrappers.
+#
+# Usage: ./tools/test-forge-config.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+COLONIES="triage planning implementation code-review release"
+
+# -----------------------------------------------------------------------------
+# Test 1: every colony.example.toml has [forge] with type = "gitlab" default
+# -----------------------------------------------------------------------------
+for colony in $COLONIES; do
+    cfg="$REPO_ROOT/dev-apprenticeship/$colony/config/colony.example.toml"
+    if [ ! -f "$cfg" ]; then
+        fail "$colony: colony.example.toml missing"
+        continue
+    fi
+    if ! grep -qE '^\[forge\]$' "$cfg"; then
+        fail "$colony: [forge] section missing from colony.example.toml"
+        continue
+    fi
+    if ! grep -qE '^type = "gitlab"$' "$cfg"; then
+        fail "$colony: [forge].type must default to \"gitlab\""
+        continue
+    fi
+    if ! grep -qE '^\[forge\.gitlab\]$' "$cfg"; then
+        fail "$colony: [forge.gitlab] block missing"
+        continue
+    fi
+    if ! grep -qE '^# \[forge\.github\]$' "$cfg"; then
+        fail "$colony: commented-out [forge.github] block missing (operators need a template to uncomment)"
+        continue
+    fi
+    pass "$colony: [forge] + [forge.gitlab] + commented [forge.github] present in colony.example.toml"
+done
+
+# -----------------------------------------------------------------------------
+# Test 2: dispatcher exists, is executable, forwards to gitlab-api.sh by default
+# -----------------------------------------------------------------------------
+for colony in $COLONIES; do
+    disp="$REPO_ROOT/dev-apprenticeship/$colony/scripts/forge-api.sh"
+    if [ ! -x "$disp" ]; then
+        fail "$colony: forge-api.sh missing or not executable" "$disp"
+        continue
+    fi
+    if ! grep -q 'FORGE_TYPE=' "$disp"; then
+        fail "$colony: forge-api.sh does not reference FORGE_TYPE"
+        continue
+    fi
+    if ! grep -q 'case "\$FORGE_TYPE"' "$disp"; then
+        fail "$colony: forge-api.sh missing FORGE_TYPE case dispatch"
+        continue
+    fi
+    if ! grep -q 'gitlab-api.sh' "$disp"; then
+        fail "$colony: forge-api.sh does not reference gitlab-api.sh backend"
+        continue
+    fi
+    if ! grep -q 'github-api.sh' "$disp"; then
+        fail "$colony: forge-api.sh does not reference github-api.sh backend (needed for #256 PRs 2-6)"
+        continue
+    fi
+    pass "$colony: forge-api.sh dispatcher present and references both backends"
+done
+
+# -----------------------------------------------------------------------------
+# Test 3: dispatcher returns exit 99 for github (not implemented yet)
+# -----------------------------------------------------------------------------
+for colony in $COLONIES; do
+    disp="$REPO_ROOT/dev-apprenticeship/$colony/scripts/forge-api.sh"
+    out="$TMPDIR_TEST/$colony.github.log"
+    set +e
+    FORGE_TYPE=github bash "$disp" any-command >"$out" 2>&1
+    rc=$?
+    set -e
+    if [ "$rc" = "99" ] && grep -q "not yet implemented" "$out"; then
+        pass "$colony: FORGE_TYPE=github returns exit 99 with ADR pointer"
+    else
+        fail "$colony: FORGE_TYPE=github should exit 99 with clear message" "rc=$rc body=$(head -c 200 "$out")"
+    fi
+done
+
+# -----------------------------------------------------------------------------
+# Test 4: dispatcher returns exit 2 for unknown FORGE_TYPE
+# -----------------------------------------------------------------------------
+for colony in $COLONIES; do
+    disp="$REPO_ROOT/dev-apprenticeship/$colony/scripts/forge-api.sh"
+    out="$TMPDIR_TEST/$colony.unknown.log"
+    set +e
+    FORGE_TYPE=bogus bash "$disp" any-command >"$out" 2>&1
+    rc=$?
+    set -e
+    if [ "$rc" = "2" ] && grep -q "unknown FORGE_TYPE" "$out"; then
+        pass "$colony: unknown FORGE_TYPE returns exit 2 with clear message"
+    else
+        fail "$colony: unknown FORGE_TYPE should exit 2 with clear message" "rc=$rc body=$(head -c 200 "$out")"
+    fi
+done
+
+# -----------------------------------------------------------------------------
+# Test 5: dispatcher forwards to gitlab-api.sh with argv preserved
+# -----------------------------------------------------------------------------
+# Shim gitlab-api.sh via PATH isn't enough because forge-api.sh resolves it
+# from $SCRIPT_DIR, not PATH. Instead we shim by renaming the colony's real
+# gitlab-api.sh aside for the duration of the test.
+for colony in $COLONIES; do
+    sd="$REPO_ROOT/dev-apprenticeship/$colony/scripts"
+    real="$sd/gitlab-api.sh"
+    if [ ! -f "$real" ]; then
+        fail "$colony: gitlab-api.sh missing in scripts/" "$real"
+        continue
+    fi
+    backup="$TMPDIR_TEST/gitlab-api.sh.$colony.bak"
+    cp "$real" "$backup"
+    cat > "$real" <<'SHIM'
+#!/bin/bash
+printf 'gitlab-shim argv=%s\n' "$*"
+exit 77
+SHIM
+    chmod +x "$real"
+
+    out="$TMPDIR_TEST/$colony.forward.log"
+    set +e
+    FORGE_TYPE=gitlab bash "$sd/forge-api.sh" first-arg --flag value >"$out" 2>&1
+    rc=$?
+    set -e
+
+    # Restore real gitlab-api.sh regardless of test outcome.
+    cp "$backup" "$real"
+    chmod +x "$real"
+
+    if [ "$rc" = "77" ] && grep -q 'gitlab-shim argv=first-arg --flag value' "$out"; then
+        pass "$colony: FORGE_TYPE=gitlab forwards argv verbatim to gitlab-api.sh"
+    else
+        fail "$colony: dispatch to gitlab-api.sh broken" "rc=$rc body=$(head -c 200 "$out")"
+    fi
+done
+
+# -----------------------------------------------------------------------------
+# Test 6: start-colony.sh exports FORGE_TYPE with default "gitlab"
+# -----------------------------------------------------------------------------
+for colony in $COLONIES; do
+    start="$REPO_ROOT/dev-apprenticeship/$colony/scripts/start-colony.sh"
+    if ! grep -qE 'FORGE_TYPE=\$\(parse_toml forge type\)' "$start"; then
+        fail "$colony: start-colony.sh does not parse [forge].type via parse_toml"
+        continue
+    fi
+    if ! grep -qE 'FORGE_TYPE="\$\{FORGE_TYPE:-gitlab\}"' "$start"; then
+        fail "$colony: start-colony.sh does not default FORGE_TYPE to \"gitlab\""
+        continue
+    fi
+    if ! grep -qE '^export FORGE_TYPE$' "$start"; then
+        fail "$colony: start-colony.sh does not export FORGE_TYPE"
+        continue
+    fi
+    pass "$colony: start-colony.sh parses + defaults + exports FORGE_TYPE"
+done
+
+# -----------------------------------------------------------------------------
+# Test 7: install.sh forge-choice prompt + FEDERATION_FORGE_TYPE env short-circuit
+# -----------------------------------------------------------------------------
+install="$REPO_ROOT/dev-apprenticeship/install.sh"
+if ! grep -q 'FEDERATION_FORGE_TYPE' "$install"; then
+    fail "install.sh: FEDERATION_FORGE_TYPE env short-circuit missing"
+else
+    pass "install.sh: FEDERATION_FORGE_TYPE env short-circuit present"
+fi
+if ! grep -q 'Forge backend' "$install"; then
+    fail "install.sh: 'Forge backend' prompt section missing"
+else
+    pass "install.sh: interactive forge-choice prompt present"
+fi
+if ! grep -q '_set_forge_type' "$install"; then
+    fail "install.sh: [forge].type rewrite helper missing — operator's forge selection would not persist to colony.toml"
+else
+    pass "install.sh: [forge].type rewrite helper present"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 8: ADR-0002 exists and is indexed
+# -----------------------------------------------------------------------------
+adr="$REPO_ROOT/doc/adr/ADR-0002-forge-abstraction.md"
+if [ ! -f "$adr" ]; then
+    fail "ADR-0002 missing at $adr"
+else
+    pass "ADR-0002 present"
+fi
+if ! grep -q 'ADR-0002-forge-abstraction.md' "$REPO_ROOT/doc/adr/README.md"; then
+    fail "ADR-0002 not indexed in doc/adr/README.md"
+else
+    pass "ADR-0002 indexed in doc/adr/README.md"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-forge-config.sh
+++ b/tools/test-forge-config.sh
@@ -21,7 +21,27 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PASS=0
 FAIL=0
 TMPDIR_TEST="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Test 5 swaps each colony's real gitlab-api.sh with a printf shim so
+# the dispatcher-forwarding assertion does not require a real GitLab.
+# We *must* restore the originals no matter how this script exits —
+# a Ctrl+C / OOM / set -e abort that leaves the shim in place turns
+# every colony's committed gitlab-api.sh into a 3-line stub. Track the
+# backup pairs in an array and restore in the EXIT trap.
+declare -a SHIMMED_REALS=()
+declare -a SHIMMED_BACKUPS=()
+restore_shims() {
+    local i
+    for i in "${!SHIMMED_REALS[@]}"; do
+        local real="${SHIMMED_REALS[$i]}"
+        local backup="${SHIMMED_BACKUPS[$i]}"
+        if [ -f "$backup" ] && [ -f "$real" ]; then
+            cp -f "$backup" "$real" 2>/dev/null || true
+            chmod +x "$real" 2>/dev/null || true
+        fi
+    done
+}
+trap 'restore_shims; rm -rf "$TMPDIR_TEST"' EXIT INT TERM
 
 pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
 fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
@@ -94,10 +114,13 @@ for colony in $COLONIES; do
     FORGE_TYPE=github bash "$disp" any-command >"$out" 2>&1
     rc=$?
     set -e
-    if [ "$rc" = "99" ] && grep -q "not yet implemented" "$out"; then
-        pass "$colony: FORGE_TYPE=github returns exit 99 with ADR pointer"
+    if [ "$rc" = "99" ] \
+       && grep -q "not yet implemented" "$out" \
+       && grep -q "ADR-0002" "$out" \
+       && grep -q "issues/256" "$out"; then
+        pass "$colony: FORGE_TYPE=github returns exit 99 with ADR + issue pointers"
     else
-        fail "$colony: FORGE_TYPE=github should exit 99 with clear message" "rc=$rc body=$(head -c 200 "$out")"
+        fail "$colony: FORGE_TYPE=github should exit 99 with clear message + ADR + issue pointers" "rc=$rc body=$(head -c 300 "$out")"
     fi
 done
 
@@ -122,8 +145,11 @@ done
 # Test 5: dispatcher forwards to gitlab-api.sh with argv preserved
 # -----------------------------------------------------------------------------
 # Shim gitlab-api.sh via PATH isn't enough because forge-api.sh resolves it
-# from $SCRIPT_DIR, not PATH. Instead we shim by renaming the colony's real
-# gitlab-api.sh aside for the duration of the test.
+# from $SCRIPT_DIR, not PATH. Instead we shim by copying a stub over each
+# colony's real gitlab-api.sh for the duration of the test. Backups are
+# tracked in SHIMMED_REALS/SHIMMED_BACKUPS so the EXIT trap restores the
+# originals even on Ctrl+C / set -e abort (otherwise a fatal mid-loop leaves
+# the repo with stubs in place of the committed gitlab-api.sh files).
 for colony in $COLONIES; do
     sd="$REPO_ROOT/dev-apprenticeship/$colony/scripts"
     real="$sd/gitlab-api.sh"
@@ -133,6 +159,10 @@ for colony in $COLONIES; do
     fi
     backup="$TMPDIR_TEST/gitlab-api.sh.$colony.bak"
     cp "$real" "$backup"
+    # Register for trap-based restore BEFORE writing the shim so a crash
+    # between cp+register and the shim install still restores correctly.
+    SHIMMED_REALS+=("$real")
+    SHIMMED_BACKUPS+=("$backup")
     cat > "$real" <<'SHIM'
 #!/bin/bash
 printf 'gitlab-shim argv=%s\n' "$*"
@@ -146,7 +176,8 @@ SHIM
     rc=$?
     set -e
 
-    # Restore real gitlab-api.sh regardless of test outcome.
+    # Synchronous restore (in addition to the EXIT trap) so subsequent
+    # tests see the real gitlab-api.sh rather than the shim.
     cp "$backup" "$real"
     chmod +x "$real"
 
@@ -191,10 +222,29 @@ if ! grep -q 'Forge backend' "$install"; then
 else
     pass "install.sh: interactive forge-choice prompt present"
 fi
-if ! grep -q '_set_forge_type' "$install"; then
-    fail "install.sh: [forge].type rewrite helper missing — operator's forge selection would not persist to colony.toml"
+# The [forge].type rewrite must run UNCONDITIONALLY (outside the WRITE_CREDS
+# branch) — otherwise an operator re-running install.sh purely to switch
+# forge (or answering "n" to the credential-update prompt) never has their
+# selection persisted. We assert this by pattern-matching the section
+# header that introduces the unconditional rewrite.
+if ! grep -q 'Setting \[forge\].type = ' "$install"; then
+    fail "install.sh: unconditional [forge].type rewrite missing — forge selection would not persist when WRITE_CREDS=0"
 else
-    pass "install.sh: [forge].type rewrite helper present"
+    pass "install.sh: unconditional [forge].type rewrite present"
+fi
+# The unattended-install short-circuit must also skip the two interactive
+# gates: (a) the "Continue with GitHub scaffolding anyway?" prompt when
+# FEDERATION_FORGE_TYPE=github; (b) the "Update GitLab credentials?" prompt
+# when configs already exist. Pattern-match the two short-circuit comments.
+if ! grep -q 'treating as confirmation, proceeding' "$install"; then
+    fail "install.sh: FEDERATION_FORGE_TYPE does not short-circuit the GitHub-confirm prompt"
+else
+    pass "install.sh: FEDERATION_FORGE_TYPE short-circuits the GitHub-confirm prompt"
+fi
+if ! grep -q 'FEDERATION_FORGE_TYPE set and configs exist' "$install"; then
+    fail "install.sh: FEDERATION_FORGE_TYPE does not short-circuit the credential-update prompt for existing configs"
+else
+    pass "install.sh: FEDERATION_FORGE_TYPE short-circuits the credential-update prompt"
 fi
 
 # -----------------------------------------------------------------------------

--- a/tools/test-forge-config.sh
+++ b/tools/test-forge-config.sh
@@ -89,9 +89,9 @@ for colony in $COLONIES; do
         fail "$colony: forge-api.sh does not reference FORGE_TYPE"
         continue
     fi
-    # grep -F to treat `$FORGE_TYPE` as a literal string (shellcheck SC2016
-    # flags escaped-$ in single-quoted patterns; -F sidesteps the ambiguity
-    # and matches the dispatcher's literal `case "$FORGE_TYPE"` line).
+    # Single-quoted pattern is intentional — we want to match the literal
+    # text `case "$FORGE_TYPE"` inside the dispatcher, not shell-expand it.
+    # shellcheck disable=SC2016
     if ! grep -qF 'case "$FORGE_TYPE"' "$disp"; then
         fail "$colony: forge-api.sh missing FORGE_TYPE case dispatch"
         continue
@@ -196,13 +196,15 @@ done
 # -----------------------------------------------------------------------------
 for colony in $COLONIES; do
     start="$REPO_ROOT/dev-apprenticeship/$colony/scripts/start-colony.sh"
-    # grep -F to match literal `$()` / `${}` shell syntax in the script
-    # (shellcheck SC2016 flags escaped-$ in single-quoted regex patterns;
-    # -F sidesteps it by treating the whole pattern as a fixed string).
+    # Single-quoted patterns are intentional — we want to match literal
+    # `$(...)` and `${...}` shell syntax in the target script, not
+    # shell-expand them here.
+    # shellcheck disable=SC2016
     if ! grep -qF 'FORGE_TYPE=$(parse_toml forge type)' "$start"; then
         fail "$colony: start-colony.sh does not parse [forge].type via parse_toml"
         continue
     fi
+    # shellcheck disable=SC2016
     if ! grep -qF 'FORGE_TYPE="${FORGE_TYPE:-gitlab}"' "$start"; then
         fail "$colony: start-colony.sh does not default FORGE_TYPE to \"gitlab\""
         continue


### PR DESCRIPTION
## Summary

PR 1 of 7 for [#256](https://github.com/Replikanti/agentis-colonies/issues/256). Lays the foundation every subsequent PR builds on — ADR, config schema, dispatcher skeleton — **without changing runtime behaviour on GitLab**.

- `doc/adr/ADR-0002-forge-abstraction.md`: full ADR with normalized subcommand → JSON contract, semantic-collapse table, non-goals, consequences, alternatives. Indexed in `doc/adr/README.md`.
- Every colony's `config/colony.example.toml` gains `[forge]` with `type = "gitlab"` default, plus `[forge.gitlab]` and a commented `[forge.github]` template. Legacy `[gitlab]` stays — one release of migration overlap, retired in PR 7.
- Every colony's `scripts/forge-api.sh` dispatcher reads `$FORGE_TYPE`, execs `gitlab-api.sh` today, `github-api.sh` when PRs 2-6 land per-colony wrappers. Unknown `FORGE_TYPE` → exit 2; `FORGE_TYPE=github` before a wrapper exists → exit 99 with ADR pointer.
- Every colony's `scripts/start-colony.sh` parses `[forge].type`, defaults to `"gitlab"`, exports `FORGE_TYPE`.
- `dev-apprenticeship/install.sh` §3a "Forge backend selection": `FEDERATION_FORGE_TYPE=gitlab|github` env short-circuit for unattended installs, interactive prompt (default gitlab), warning if github is picked before PRs 2-6, `_set_forge_type()` rewrites `[forge].type` in the generated `colony.toml`.
- `tools/test-forge-config.sh`: 8 invariants × 5 colonies + 4 global = 35 sub-tests, wired into `colony-lint.sh`.

Pre-#256 configs keep working verbatim. `github` backend stays skeleton-only until PRs 2-6.

## Follow-ups (tracked by the #256 plan)

- PRs 2-6: port each colony in turn — add `scripts/github-api.sh` wrapper for triage → planning → implementation → code-review → release.
- PR 7: retire legacy `[gitlab]` section from `colony.example.toml`, soak-test federation on GitHub, add rate-limit tile to the dashboard, MAJOR bump.

## Test plan

- [x] `bash tools/test-forge-config.sh` → 35 passed, 0 failed
- [x] `bash tools/colony-lint.sh` → 87 passed, 0 failed, 6 skipped
- [x] Manual: `FORGE_TYPE=bogus bash <colony>/scripts/forge-api.sh anything` → exit 2 with message
- [x] Manual: `FORGE_TYPE=github bash <colony>/scripts/forge-api.sh anything` → exit 99 with ADR pointer
- [x] Manual: `FORGE_TYPE=gitlab bash <colony>/scripts/forge-api.sh --help` forwards to real `gitlab-api.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)