### PR TITLE
feat(#256): triage colony GitHub backend (PR 2 of 7)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -52,6 +52,32 @@ is asserted until multi-version CI is in place.
   checks × 5 colonies + 7 install.sh + ADR checks = 37 sub-tests). See
   `doc/adr/ADR-0002-forge-abstraction.md` for the full contract.
   [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
+- **Triage colony GitHub backend (PR 2 of 7 for #256).**
+  `dev-apprenticeship/triage/scripts/github-api.sh` implements the full
+  triage contract against the GitHub REST API v3 (7 subcommands: `issues`,
+  `create-issue`, `update-issue`, `members`, `get-issue`, `labels`,
+  `add-note`). Responses are normalized to GitLab shape (iid ← number,
+  author.username ← user.login, assignees[].username ← login, labels as
+  strings, state "open" → "opened", `pull_request`-bearing entries
+  filtered out) so the existing 8 views and all triage `.ag` agents work
+  unchanged. GitHub-specific error handling distinguishes HTTP 403 auth
+  failures from secondary rate-limit 403s (retryable) via response-body
+  inspection. The `--priority` flag rejects loud with guidance to use
+  `--add-labels "priority::<level>"` (GitHub has no native priority
+  field). `triage/scripts/start-colony.sh` now branches on `FORGE_TYPE`:
+  exports `GITHUB_URL` / `GITHUB_OWNER` / `GITHUB_REPO` / `GITHUB_TOKEN`
+  / `GITHUB_ME` from `[forge.github]` when `type = "github"`, reads
+  `[forge.gitlab]` with `[gitlab]` legacy fallback otherwise. Back-ports
+  missing `add-note` subcommand into `triage/scripts/gitlab-api.sh`
+  (closes a silent bug where labeler/prioritizer/router review-gated
+  comment-posting calls were swallowed by the `.ag` try/catch). Two new
+  tests: `tools/test-github-triage-normalize.sh` (25 assertions covering
+  shape, PR filtering, empty-list handling, and end-to-end pipe through
+  a view); extended `tools/test-gitlab-views.sh` with a 6-case parity
+  block that asserts byte-identical `project_json` output between
+  `github-api.sh` and `gitlab-api.sh` (drift detector for the
+  duplicated projection function).
+  [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
 
 ### Changed
 

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -58,25 +58,44 @@ is asserted until multi-version CI is in place.
   `create-issue`, `update-issue`, `members`, `get-issue`, `labels`,
   `add-note`). Responses are normalized to GitLab shape (iid ← number,
   author.username ← user.login, assignees[].username ← login, labels as
-  strings, state "open" → "opened", `pull_request`-bearing entries
-  filtered out) so the existing 8 views and all triage `.ag` agents work
-  unchanged. GitHub-specific error handling distinguishes HTTP 403 auth
-  failures from secondary rate-limit 403s (retryable) via response-body
-  inspection. The `--priority` flag rejects loud with guidance to use
+  strings — both object-form `[{"name": ...}]` and bare-string form are
+  accepted for GitHub Enterprise compatibility — state "open" → "opened",
+  `pull_request`-bearing entries filtered out) so the existing 8 views
+  and the triage `.ag` agents keep parsing identical JSON across
+  backends. Every triage `.ag` `exec sh` call site was rewritten from
+  `scripts/gitlab-api.sh` to `scripts/forge-api.sh` (19 call sites
+  across `issue_creator`, `labeler`, `prioritizer`, `router`) — without
+  this, `FORGE_TYPE=github` silently fails because `start-colony.sh`
+  exports only the `GITHUB_*` env, `gitlab-api.sh` trips its env check,
+  and the `.ag` try/catch swallows the error. A new lint rule
+  `tools/check-forge-dispatch.sh` (wired into `colony-lint.sh`) now
+  fails CI whenever any `.ag` in a colony shipping `github-api.sh`
+  references a concrete backend wrapper directly. GitHub-specific error
+  handling distinguishes HTTP 403 auth failures from secondary
+  rate-limit 403s (retryable) via response-body inspection. The
+  `--priority` flag rejects loud with guidance to use
   `--add-labels "priority::<level>"` (GitHub has no native priority
-  field). `triage/scripts/start-colony.sh` now branches on `FORGE_TYPE`:
-  exports `GITHUB_URL` / `GITHUB_OWNER` / `GITHUB_REPO` / `GITHUB_TOKEN`
-  / `GITHUB_ME` from `[forge.github]` when `type = "github"`, reads
-  `[forge.gitlab]` with `[gitlab]` legacy fallback otherwise. Back-ports
-  missing `add-note` subcommand into `triage/scripts/gitlab-api.sh`
-  (closes a silent bug where labeler/prioritizer/router review-gated
-  comment-posting calls were swallowed by the `.ag` try/catch). Two new
-  tests: `tools/test-github-triage-normalize.sh` (25 assertions covering
+  field). `--remove-labels` treats 404 as no-op for idempotency parity
+  with GitLab. `triage/scripts/start-colony.sh` now branches on
+  `FORGE_TYPE`: exports `GITHUB_URL` / `GITHUB_OWNER` / `GITHUB_REPO` /
+  `GITHUB_TOKEN` / `GITHUB_ME` from `[forge.github]` when
+  `type = "github"`, reads `[forge.gitlab]` with `[gitlab]` legacy
+  fallback otherwise. `[forge.github].url` is optional (defaults to
+  `https://api.github.com`) and exists solely to point the wrapper at a
+  GitHub Enterprise Server instance. Back-ports missing `add-note`
+  subcommand into `triage/scripts/gitlab-api.sh` with a numeric-iid
+  guard (closes a silent bug where labeler/prioritizer/router
+  review-gated comment-posting calls were swallowed by the `.ag`
+  try/catch). Four new tests:
+  `tools/test-github-triage-normalize.sh` (25 assertions covering
   shape, PR filtering, empty-list handling, and end-to-end pipe through
-  a view); extended `tools/test-gitlab-views.sh` with a 6-case parity
-  block that asserts byte-identical `project_json` output between
-  `github-api.sh` and `gitlab-api.sh` (drift detector for the
-  duplicated projection function).
+  a view); `tools/test-check-forge-dispatch.sh` (6 assertions);
+  `tools/test-gitlab-add-note.sh` (4 assertions for arg parsing and the
+  happy path via a curl shim); and an extension to
+  `tools/test-gitlab-views.sh` with a 6-case parity block asserting
+  byte-identical `project_json` output between `github-api.sh` and
+  `gitlab-api.sh` (drift detector for the duplicated projection
+  function).
   [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
 
 ### Changed

--- a/dev-apprenticeship/triage/agents/issue_creator.ag
+++ b/dev-apprenticeship/triage/agents/issue_creator.ag
@@ -24,9 +24,9 @@ type ObservationSummary {
 fn issues_cmd() -> string {
     let ts = recall_latest("issue_creator:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts) + " --view issue_creator";
+        return "$COLONY_DIR/scripts/forge-api.sh issues --since " + shell_escape(ts) + " --view issue_creator";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues --view issue_creator";
+    return "$COLONY_DIR/scripts/forge-api.sh issues --view issue_creator";
 }
 
 fn get_confidence() -> float {
@@ -81,7 +81,7 @@ fn tick(reason: string) -> void {
         ) -> DraftIssue;
 
         if my_tier == "autonomous" {
-            let create_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-issue --title " + shell_escape(draft.title) + " --description " + shell_escape(draft.description) + " --labels " + shell_escape(draft.suggested_labels);
+            let create_cmd = "$COLONY_DIR/scripts/forge-api.sh create-issue --title " + shell_escape(draft.title) + " --description " + shell_escape(draft.description) + " --labels " + shell_escape(draft.suggested_labels);
             let result = try {
                 exec sh create_cmd;
             } catch e {

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -39,9 +39,9 @@ fn scope_for_author(author: string) -> string {
 fn issues_cmd() -> string {
     let ts = recall_latest("labeler:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts) + " --view labeler";
+        return "$COLONY_DIR/scripts/forge-api.sh issues --since " + shell_escape(ts) + " --view labeler";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues --view labeler";
+    return "$COLONY_DIR/scripts/forge-api.sh issues --view labeler";
 }
 
 fn get_confidence() -> float {
@@ -154,7 +154,7 @@ fn evaluate_label_verdict() -> void {
     };
     let issue_id = parse_int(to_string(json_get(blob, "[1]")));
     let suggested = to_string(json_get(blob, "[2]"));
-    let cur_cmd = "$COLONY_DIR/scripts/gitlab-api.sh get-issue " + to_string(issue_id) + " --view feedback-issue";
+    let cur_cmd = "$COLONY_DIR/scripts/forge-api.sh get-issue " + to_string(issue_id) + " --view feedback-issue";
     let cur_raw = try { exec sh cur_cmd; } catch e { ""; };
     if len(cur_raw) < 3 {
         return;
@@ -287,7 +287,7 @@ fn score_one_autonomous(issue_id: int) -> string {
         return "drop";
     };
     let suggested = to_string(json_get(blob, "[2]"));
-    let cur_cmd = "$COLONY_DIR/scripts/gitlab-api.sh get-issue " + to_string(issue_id) + " --view feedback-issue";
+    let cur_cmd = "$COLONY_DIR/scripts/forge-api.sh get-issue " + to_string(issue_id) + " --view feedback-issue";
     let cur_raw = try { exec sh cur_cmd; } catch e { ""; };
     if len(cur_raw) < 3 {
         // GitLab query failed (network blip, issue deleted, etc.).
@@ -410,7 +410,7 @@ fn tick(reason: string) -> void {
     if analysis.unlabeled_count > 0 {
         let my_tier = tier("labeler");
         let rec = recommend("label", ["accuracy"]);
-        let labels_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh labels --view summary"; } catch e { "[]"; };
+        let labels_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh labels --view summary"; } catch e { "[]"; };
         let context = "Unlabeled issues: " + analysis.unlabeled_issues + "\nAvailable labels: " + labels_raw + "\nPast learning: " + to_string(rec);
 
         let action = prompt(
@@ -419,7 +419,7 @@ fn tick(reason: string) -> void {
         ) -> LabelAction;
 
         if my_tier == "autonomous" {
-            let update_cmd = "$COLONY_DIR/scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.labels);
+            let update_cmd = "$COLONY_DIR/scripts/forge-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.labels);
             let result = try { exec sh update_cmd; } catch e {
                 print("[labeler] Failed to apply labels:", e);
                 "";
@@ -442,7 +442,7 @@ fn tick(reason: string) -> void {
         } else {
             if my_tier == "review-gated" {
                 let note = "[draft-labels] **Label Suggestion** (automated, pending approval): " + action.labels + "\n\n" + action.reasoning;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(action.issue_id) + " --body " + shell_escape(note);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(action.issue_id) + " --body " + shell_escape(note);
                 try { exec sh post_cmd; } catch e {
                     print("[labeler] Failed to post draft note:", e);
                 };

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -39,9 +39,9 @@ fn scope_for_author(author: string) -> string {
 fn issues_cmd() -> string {
     let ts = recall_latest("prioritizer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts) + " --view prioritizer";
+        return "$COLONY_DIR/scripts/forge-api.sh issues --since " + shell_escape(ts) + " --view prioritizer";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues --view prioritizer";
+    return "$COLONY_DIR/scripts/forge-api.sh issues --view prioritizer";
 }
 
 fn get_confidence() -> float {
@@ -118,7 +118,7 @@ fn tick(reason: string) -> void {
         ) -> PriorityAction;
 
         if my_tier == "autonomous" {
-            let update_cmd = "$COLONY_DIR/scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.priority);
+            let update_cmd = "$COLONY_DIR/scripts/forge-api.sh update-issue " + to_string(action.issue_id) + " --add-labels " + shell_escape(action.priority);
             let result = try { exec sh update_cmd; } catch e {
                 print("[prioritizer] Failed to set priority:", e);
                 "";
@@ -133,7 +133,7 @@ fn tick(reason: string) -> void {
         } else {
             if my_tier == "review-gated" {
                 let note = "[draft-priority] **Priority Suggestion** (automated, pending approval): " + action.priority + "\n\n" + action.reasoning;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(action.issue_id) + " --body " + shell_escape(note);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(action.issue_id) + " --body " + shell_escape(note);
                 try { exec sh post_cmd; } catch e {
                     print("[prioritizer] Failed to post draft note:", e);
                 };

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -25,9 +25,9 @@ type RouteAction {
 fn issues_cmd() -> string {
     let ts = recall_latest("router:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues --since " + shell_escape(ts) + " --view router";
+        return "$COLONY_DIR/scripts/forge-api.sh issues --since " + shell_escape(ts) + " --view router";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues --view router";
+    return "$COLONY_DIR/scripts/forge-api.sh issues --view router";
 }
 
 fn get_confidence() -> float {
@@ -62,7 +62,7 @@ fn tick(reason: string) -> void {
     };
 
     // Get team members
-    let members_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh members --view summary"; } catch e { "[]"; };
+    let members_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh members --view summary"; } catch e { "[]"; };
 
     // Analyze: find assigned and unassigned issues
     let analysis = prompt(
@@ -93,7 +93,7 @@ fn tick(reason: string) -> void {
         ) -> RouteAction;
 
         if my_tier == "autonomous" {
-            let update_cmd = "$COLONY_DIR/scripts/gitlab-api.sh update-issue " + to_string(action.issue_id) + " --assignee " + shell_escape(action.assignee);
+            let update_cmd = "$COLONY_DIR/scripts/forge-api.sh update-issue " + to_string(action.issue_id) + " --assignee " + shell_escape(action.assignee);
             let result = try { exec sh update_cmd; } catch e {
                 print("[router] Failed to assign:", e);
                 "";
@@ -108,7 +108,7 @@ fn tick(reason: string) -> void {
                 // Non-terminal draft: emit the suggestion and post an issue note
                 // flagged for human approval instead of directly assigning.
                 let note = "[draft-route] **Routing Suggestion** (automated, pending approval): assign to @" + action.assignee + "\n\n" + action.reasoning;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(action.issue_id) + " --body " + shell_escape(note);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(action.issue_id) + " --body " + shell_escape(note);
                 try { exec sh post_cmd; } catch e {
                     print("[router] Failed to post draft note:", e);
                 };

--- a/dev-apprenticeship/triage/config/colony.example.toml
+++ b/dev-apprenticeship/triage/config/colony.example.toml
@@ -22,6 +22,7 @@ project = "your-org/your-project"
 me      = ""  # your GitLab username (optional, enables personal/team tagging)
 
 # [forge.github]
+# url   = "https://api.github.com"  # optional; override for GitHub Enterprise
 # owner = "your-org-or-user"
 # repo  = "your-repo"
 # token = "ghp_your-token-here"

--- a/dev-apprenticeship/triage/scripts/forge-api.sh
+++ b/dev-apprenticeship/triage/scripts/forge-api.sh
@@ -35,21 +35,13 @@ case "$FORGE_TYPE" in
 esac
 
 if [ ! -x "$backend" ]; then
-    case "$FORGE_TYPE" in
-        github)
-            # PR 2 of #256 ships github-api.sh for triage, so this branch now
-            # fires only if github-api.sh was deleted or chmod -x'd post-install.
-            # Keep the "not yet implemented" wording because it still applies
-            # verbatim to the other four colonies' forge-api.sh files (same
-            # template, copied pre-PR-2).
-            echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the triage colony." >&2
-            echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
-            ;;
-        *)
-            echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
-            echo "forge-api.sh: this indicates a broken install — re-copy the triage colony scripts/ directory." >&2
-            ;;
-    esac
+    # PR 2 of #256 ships github-api.sh for triage, so a missing github backend
+    # here means either a broken install (deleted / chmod -x'd post-install)
+    # or — if this dispatcher was copied to another colony pre-PR-2 — that
+    # colony's github-api.sh has not landed yet. Emit a uniform "missing or
+    # not executable" message and point at the ADR for the rollout state.
+    echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
+    echo "forge-api.sh: re-copy the colony scripts/ directory, or — if upgrading from pre-#256 — see doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6) for the GitHub-backend rollout status." >&2
     exit 99
 fi
 

--- a/dev-apprenticeship/triage/scripts/forge-api.sh
+++ b/dev-apprenticeship/triage/scripts/forge-api.sh
@@ -37,14 +37,15 @@ esac
 if [ ! -x "$backend" ]; then
     case "$FORGE_TYPE" in
         github)
-            # Skeleton state: dispatcher exists but the per-colony wrapper is not yet
-            # shipped. Lands across PRs 2-6 of #256.
+            # PR 2 of #256 ships github-api.sh for triage, so this branch now
+            # fires only if github-api.sh was deleted or chmod -x'd post-install.
+            # Keep the "not yet implemented" wording because it still applies
+            # verbatim to the other four colonies' forge-api.sh files (same
+            # template, copied pre-PR-2).
             echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the triage colony." >&2
             echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
             ;;
         *)
-            # Broken install — gitlab-api.sh should always be present alongside
-            # forge-api.sh in a valid federation checkout.
             echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
             echo "forge-api.sh: this indicates a broken install — re-copy the triage colony scripts/ directory." >&2
             ;;

--- a/dev-apprenticeship/triage/scripts/github-api.sh
+++ b/dev-apprenticeship/triage/scripts/github-api.sh
@@ -1,0 +1,608 @@
+#!/bin/bash
+# GitHub API wrapper for triage colony agents (ADR-0002, #256 PR 2 of 7).
+# Called by .ag agents via forge-api.sh dispatch when FORGE_TYPE=github.
+#
+# Required env vars (set by start-colony.sh from [forge.github] in colony.toml):
+#   GITHUB_URL    - API base (default https://api.github.com; override for GHE)
+#   GITHUB_TOKEN  - personal access token (classic or fine-grained)
+#   GITHUB_OWNER  - repo owner (user or org)
+#   GITHUB_REPO   - repo name
+#
+# Usage (identical contract to gitlab-api.sh):
+#   github-api.sh issues [--since ISO8601] [--state open|closed|all] [--view <name>]
+#   github-api.sh create-issue --title <t> --description <d> [--labels l1,l2]
+#   github-api.sh update-issue <number> [--add-labels l1,l2] [--remove-labels l1,l2] [--assignee login]
+#   github-api.sh members [--view <name>]
+#   github-api.sh get-issue <number> [--view <name>]
+#   github-api.sh labels  [--view <name>]
+#   github-api.sh add-note <number> --body <text>
+#
+# Views and JSON shape are GitLab-normalized (author.username, labels-as-strings,
+# assignees[].username, iid=number, state=opened/closed). See ADR-0002 §Shape.
+#
+# Exit codes:
+#   0  ok (2xx)
+#   1  usage error (required flag missing, backend rejection)
+#   2  unknown flag / view / auth failure (4xx 401/403)
+#   3  rate limited (429 or secondary rate-limit, after retries)
+#   4  other 4xx client error
+#   5  5xx server error OR transport failure
+
+set -e
+
+# emit_error <message>
+# Matches gitlab-api.sh emit_error contract: JSON error object to stderr.
+emit_error() {
+    printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+# normalize_issues
+# Reads GitHub issues-list JSON from stdin, writes GitLab-shape JSON to stdout.
+# Shape contract (fields triage views consume):
+#   iid (<- number), title, description (<- body), state (open->opened),
+#   labels: ["name", ...] (GitHub returns [{name, ...}]; flatten to strings),
+#   assignees: [{username}, ...] (GitHub field: login -> username),
+#   author: {username} (GitHub field: user.login -> username),
+#   created_at, updated_at, user_notes_count (<- comments).
+# Also filters out pull_request entries — GitHub's /issues endpoint mixes PRs
+# with issues, but the triage colony only cares about issues.
+normalize_issues() {
+    # stdin travels via env var because python3's <<'PY' heredoc already
+    # occupies python's stdin — same idiom as project_json below.
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for x in data:
+    if "pull_request" in x:  # skip PRs
+        continue
+    out.append({
+        "iid": x.get("number"),
+        "title": x.get("title"),
+        "description": x.get("body"),
+        "state": "opened" if x.get("state") == "open" else x.get("state"),
+        "labels": [lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, dict)],
+        "assignees": [{"username": a.get("login")} for a in (x.get("assignees") or [])],
+        "author": {"username": (x.get("user") or {}).get("login")},
+        "created_at": x.get("created_at"),
+        "updated_at": x.get("updated_at"),
+        "user_notes_count": x.get("comments", 0),
+    })
+print(json.dumps(out))
+PY
+}
+
+# normalize_issue
+# Single-issue variant of normalize_issues. Outputs a single object (not array).
+normalize_issue() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+x = json.loads(os.environ["DATA"])
+print(json.dumps({
+    "iid": x.get("number"),
+    "title": x.get("title"),
+    "description": x.get("body"),
+    "state": "opened" if x.get("state") == "open" else x.get("state"),
+    "labels": [lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, dict)],
+    "assignees": [{"username": a.get("login")} for a in (x.get("assignees") or [])],
+    "author": {"username": (x.get("user") or {}).get("login")},
+    "created_at": x.get("created_at"),
+    "updated_at": x.get("updated_at"),
+    "user_notes_count": x.get("comments", 0),
+}))
+PY
+}
+
+# normalize_members
+# Reads GitHub collaborators JSON, writes GitLab-shape members JSON.
+# GitLab `name` is a real display name; GitHub's /collaborators endpoint
+# returns `login` only (no `name` field). Fall back to login so the shape
+# has no nulls — the router agent uses `username` for mechanical assignment,
+# `name` is only for display and null-vs-login doesn't matter operationally.
+normalize_members() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for x in data:
+    login = x.get("login")
+    out.append({
+        "id": x.get("id"),
+        "username": login,
+        "name": login,  # fallback; GitHub /collaborators doesn't return name
+    })
+print(json.dumps(out))
+PY
+}
+
+# normalize_labels
+# GitHub labels are close to GitLab's but have slightly different field set
+# (no text_color, no *_count fields). We forward name/description/color which
+# is what the labels-summary view keeps anyway.
+normalize_labels() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{
+    "name": x.get("name"),
+    "description": x.get("description"),
+    "color": "#" + x.get("color", "").lstrip("#"),
+} for x in data]
+print(json.dumps(out))
+PY
+}
+
+# project_json <view-name>
+# Same contract as gitlab-api.sh project_json: read normalized GitLab-shape
+# JSON from stdin, write downselected projection to stdout. Duplicated here
+# (not sourced from gitlab-api.sh) so github-api.sh has no runtime coupling.
+# Kept byte-identical to the gitlab-api.sh version; drift is checked by
+# tools/test-gitlab-views.sh which runs both implementations against the
+# same fixtures.
+project_json() {
+    local view="$1"
+    if [ "${GITLAB_VIEW_MODE:-}" = "raw" ]; then
+        cat
+        return 0
+    fi
+    local DATA
+    DATA="$(cat)"
+    case "$view" in
+        raw)
+            printf '%s' "$DATA"
+            ;;
+        labeler)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+print(json.dumps([{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", []),
+                   "author": {"username": (x.get("author") or {}).get("username")}} for x in data]))
+PY
+            ;;
+        router)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", []),
+        "assignees": [{"username": a.get("username")} for a in x.get("assignees", [])]} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        prioritizer)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+print(json.dumps([{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", []),
+                   "author": {"username": (x.get("author") or {}).get("username")}} for x in data]))
+PY
+            ;;
+        issue_creator)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
+        "labels": x.get("labels", []),
+        "author": {"username": (x.get("author") or {}).get("username")}} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        members-summary)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+print(json.dumps([{"id": x.get("id"), "username": x.get("username"), "name": x.get("name")} for x in data]))
+PY
+            ;;
+        labels-summary)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+print(json.dumps([{"name": x.get("name"), "description": x.get("description"), "color": x.get("color")} for x in data]))
+PY
+            ;;
+        feedback-issue)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+x = json.loads(os.environ["DATA"])
+print(json.dumps({"iid": x.get("iid"), "state": x.get("state"), "labels": x.get("labels", [])}))
+PY
+            ;;
+        *)
+            emit_error "unknown view: $view"
+            exit 2
+            ;;
+    esac
+}
+
+if [ -z "${GITHUB_TOKEN:-}" ] || [ -z "${GITHUB_OWNER:-}" ] || [ -z "${GITHUB_REPO:-}" ]; then
+    emit_error "GITHUB_TOKEN, GITHUB_OWNER, and GITHUB_REPO must be set"
+    exit 1
+fi
+
+GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+API="$GITHUB_URL/repos/$GITHUB_OWNER/$GITHUB_REPO"
+
+# gh_call <method> <url> [curl-args...]
+#
+# Mirror of gitlab-api.sh gl_call: transport retry on 429/5xx/timeout, no-retry
+# on 401/403, actionable auth error, bounded curl --max-time, structured exit
+# codes. GitHub-specific: Authorization: Bearer, Accept: application/vnd.github+json,
+# and the X-GitHub-Api-Version: 2022-11-28 header (pinned so server-side default
+# flips don't silently change the response shape).
+#
+# Env knobs (same defaults as gl_call):
+#   GITHUB_CURL_MAX_TIME  per-attempt --max-time seconds (default 90)
+#   GITHUB_CURL_RETRIES   retry budget for 5xx/timeouts/429 (default 3)
+gh_call() {
+    local method="$1" url="$2"
+    shift 2
+    local max_time="${GITHUB_CURL_MAX_TIME:-90}"
+    local max_retries="${GITHUB_CURL_RETRIES:-3}"
+    local attempt=0 delay=3 rc code snippet body_file
+    body_file="$(mktemp)"
+    trap 'rm -f "$body_file"; trap - RETURN' RETURN
+
+    while :; do
+        attempt=$((attempt + 1))
+        code=""
+        rc=0
+        code="$(curl -sS -w '%{http_code}' -o "$body_file" \
+            --max-time "$max_time" \
+            -X "$method" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$@" \
+            "$url" 2>/dev/null)" || rc=$?
+
+        if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
+            if [ "$attempt" -le "$max_retries" ]; then
+                sleep "$delay"
+                delay=$((delay * 2))
+                continue
+            fi
+            emit_error "curl transport failure (exit $rc) after $attempt attempts: $method $url"
+            return 5
+        fi
+
+        case "$code" in
+            2*)
+                cat "$body_file"
+                return 0
+                ;;
+            401|403)
+                # GitHub returns 403 both for auth and for secondary rate limits.
+                # Distinguish via response body: "rate limit" / "abuse" => retryable,
+                # otherwise auth. This avoids hard-failing a transient throttle as
+                # an unrecoverable auth error.
+                snippet="$(head -c 200 "$body_file")"
+                case "$snippet" in
+                    *"rate limit"*|*"abuse"*|*"secondary rate"*)
+                        if [ "$attempt" -le "$max_retries" ]; then
+                            sleep "$delay"
+                            delay=$((delay * 2))
+                            continue
+                        fi
+                        emit_error "rate limited (HTTP $code secondary) after $attempt attempts on $method $url"
+                        return 3
+                        ;;
+                    *)
+                        emit_error "auth failure (HTTP $code) on $method $url: $snippet — check PAT scope/expiry"
+                        return 2
+                        ;;
+                esac
+                ;;
+            429)
+                if [ "$attempt" -le "$max_retries" ]; then
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                    continue
+                fi
+                emit_error "rate limited (HTTP 429) after $attempt attempts on $method $url"
+                return 3
+                ;;
+            5*)
+                if [ "$attempt" -le "$max_retries" ]; then
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                    continue
+                fi
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "server error (HTTP $code) after $attempt attempts: $snippet"
+                return 5
+                ;;
+            4*)
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "client error (HTTP $code) on $method $url: $snippet"
+                return 4
+                ;;
+            *)
+                emit_error "unexpected HTTP $code on $method $url"
+                return 4
+                ;;
+        esac
+    done
+}
+
+gh_get() {
+    gh_call GET "$1"
+}
+
+gh_get_q() {
+    local url="$1"
+    shift
+    gh_call GET "$url" -G "$@"
+}
+
+gh_post() {
+    gh_call POST "$1" -H "Content-Type: application/json" -d "$2"
+}
+
+gh_patch() {
+    gh_call PATCH "$1" -H "Content-Type: application/json" -d "$2"
+}
+
+CMD="${1:?Usage: github-api.sh <command> [args...]}"
+shift
+
+case "$CMD" in
+    issues)
+        SINCE=""
+        STATE="open"
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                # GitLab uses "opened" in the state filter; GitHub uses "open".
+                # Translate the GitLab spelling so forge-api.sh callers don't need
+                # per-backend state vocabulary.
+                --since) SINCE="$2"; shift 2 ;;
+                --state)
+                    case "$2" in
+                        opened|open) STATE="open" ;;
+                        closed)      STATE="closed" ;;
+                        all)         STATE="all" ;;
+                        *) emit_error "unknown state: $2 (expected open|closed|all)"; exit 2 ;;
+                    esac
+                    shift 2
+                    ;;
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        ARGS=(
+            --data-urlencode "state=$STATE"
+            --data-urlencode "per_page=20"
+            --data-urlencode "sort=updated"
+            --data-urlencode "direction=desc"
+        )
+        if [ -n "$SINCE" ]; then
+            ARGS+=(--data-urlencode "since=$SINCE")
+        fi
+        # Two-step so gh_call's non-zero exit survives the normalize/project pipe
+        # (same reason as gitlab-api.sh's body=... || exit $? pattern).
+        body="$(gh_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_issues)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$normalized" | project_json "$VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    create-issue)
+        TITLE=""
+        DESC=""
+        LABELS=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --title) TITLE="$2"; shift 2 ;;
+                --description) DESC="$2"; shift 2 ;;
+                --labels) LABELS="$2"; shift 2 ;;
+                # Priority is expressed via labels on GitHub — there is no
+                # priority field on the issue. Rejecting loud instead of
+                # silent-drop so any caller passing --priority gets an
+                # actionable message (they should use --labels "priority::X").
+                --priority)
+                    emit_error "--priority is not supported on GitHub; use --labels \"priority::<level>\" instead"
+                    exit 2
+                    ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$TITLE" ]; then
+            emit_error "--title is required"
+            exit 1
+        fi
+        # Build JSON body via python3 json.dumps so titles and descriptions
+        # containing quotes, backslashes, newlines, or control chars are
+        # escaped correctly. GitHub accepts `labels` as an array of strings
+        # (which is where GitLab's comma-separated string differs).
+        JSON_BODY=$(TITLE="$TITLE" DESC="$DESC" LABELS="$LABELS" python3 - <<'PY'
+import os, json
+body = {"title": os.environ["TITLE"]}
+if os.environ.get("DESC"):
+    body["body"] = os.environ["DESC"]
+if os.environ.get("LABELS"):
+    body["labels"] = [s.strip() for s in os.environ["LABELS"].split(",") if s.strip()]
+print(json.dumps(body))
+PY
+)
+        body="$(gh_post "$API/issues" "$JSON_BODY")" || exit $?
+        # Normalize the returned issue to GitLab shape so callers can consume
+        # the iid field from the response without branching on backend.
+        printf '%s' "$body" | normalize_issue
+        ;;
+
+    update-issue)
+        ID="${1:?Usage: github-api.sh update-issue <number> [--add-labels ...] ...}"
+        shift
+        ADD_LABELS=""
+        REMOVE_LABELS=""
+        ASSIGNEE=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --add-labels) ADD_LABELS="$2"; shift 2 ;;
+                --remove-labels) REMOVE_LABELS="$2"; shift 2 ;;
+                --assignee) ASSIGNEE="$2"; shift 2 ;;
+                --priority)
+                    emit_error "--priority is not supported on GitHub; use --add-labels \"priority::<level>\" instead"
+                    exit 2
+                    ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        # Fail fast if no modifying flags were passed (mirror of gitlab-api.sh).
+        if [ -z "$ADD_LABELS" ] && [ -z "$REMOVE_LABELS" ] && [ -z "$ASSIGNEE" ]; then
+            emit_error "update-issue requires at least one of --add-labels, --remove-labels, --assignee"
+            exit 1
+        fi
+        case "$ID" in
+            ''|*[!0-9]*) emit_error "issue number must be numeric: $ID"; exit 2 ;;
+        esac
+        # Add-labels: POST /issues/{n}/labels with {"labels": [...]} — GitHub
+        # supports this natively (appends, no PATCH needed).
+        if [ -n "$ADD_LABELS" ]; then
+            ADD_JSON=$(LABELS="$ADD_LABELS" python3 -c 'import os, json; print(json.dumps({"labels": [s.strip() for s in os.environ["LABELS"].split(",") if s.strip()]}))')
+            gh_post "$API/issues/$ID/labels" "$ADD_JSON" >/dev/null || exit $?
+        fi
+        # Remove-labels: DELETE /issues/{n}/labels/{name} per label. GitHub has
+        # no bulk remove endpoint — loop. URL-encode via python3 so label names
+        # containing '/', ' ', '::' etc. survive.
+        if [ -n "$REMOVE_LABELS" ]; then
+            IFS=',' read -r -a _RM <<< "$REMOVE_LABELS"
+            for lab in "${_RM[@]}"; do
+                lab_trimmed="$(printf '%s' "$lab" | python3 -c 'import sys; print(sys.stdin.read().strip())')"
+                [ -z "$lab_trimmed" ] && continue
+                enc="$(printf '%s' "$lab_trimmed" | python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read(), safe=""))')"
+                gh_call DELETE "$API/issues/$ID/labels/$enc" >/dev/null || exit $?
+            done
+        fi
+        # Assignee: POST /issues/{n}/assignees with {"assignees": [login]}.
+        # GitHub silently drops unknown or non-collaborator assignees with a
+        # 201 — validate by re-reading the issue and asserting the login is
+        # present, so "unknown user" fails loud (matching gitlab-api.sh).
+        if [ -n "$ASSIGNEE" ]; then
+            ASSIGN_JSON=$(LOGIN="$ASSIGNEE" python3 -c 'import os, json; print(json.dumps({"assignees": [os.environ["LOGIN"]]}))')
+            gh_post "$API/issues/$ID/assignees" "$ASSIGN_JSON" >/dev/null || exit $?
+            check="$(gh_get "$API/issues/$ID")" || exit $?
+            present=$(LOGIN="$ASSIGNEE" CHECK="$check" python3 <<'PY'
+import os, json
+x = json.loads(os.environ["CHECK"])
+login = os.environ["LOGIN"]
+print("1" if any((a or {}).get("login") == login for a in (x.get("assignees") or [])) else "0")
+PY
+)
+            if [ "$present" != "1" ]; then
+                emit_error "update-issue: unknown user: $ASSIGNEE (GitHub silently drops non-collaborator assignees)"
+                exit 1
+            fi
+        fi
+        # Return the updated issue so callers have a consistent response shape.
+        body="$(gh_get "$API/issues/$ID")" || exit $?
+        printf '%s' "$body" | normalize_issue
+        ;;
+
+    members)
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        body="$(gh_get "$API/collaborators?per_page=100")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_members)"
+        if [ -n "$VIEW" ]; then
+            case "$VIEW" in
+                summary) INTERNAL_VIEW="members-summary" ;;
+                raw) INTERNAL_VIEW="raw" ;;
+                *) emit_error "unknown view: $VIEW"; exit 2 ;;
+            esac
+            printf '%s' "$normalized" | project_json "$INTERNAL_VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    get-issue)
+        if [ $# -lt 1 ]; then
+            emit_error "Usage: github-api.sh get-issue <number> [--view <name>]"
+            exit 2
+        fi
+        ID="$1"
+        shift
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$ID" in
+            ''|*[!0-9]*) emit_error "issue number must be numeric: $ID"; exit 2 ;;
+        esac
+        body="$(gh_get "$API/issues/$ID")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_issue)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$normalized" | project_json "$VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    labels)
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        body="$(gh_get "$API/labels?per_page=100")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_labels)"
+        if [ -n "$VIEW" ]; then
+            case "$VIEW" in
+                summary) INTERNAL_VIEW="labels-summary" ;;
+                raw) INTERNAL_VIEW="raw" ;;
+                *) emit_error "unknown view: $VIEW"; exit 2 ;;
+            esac
+            printf '%s' "$normalized" | project_json "$INTERNAL_VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    add-note)
+        ID="${1:?Usage: github-api.sh add-note <number> --body <text>}"
+        shift
+        BODY=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --body) BODY="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$BODY" ]; then
+            emit_error "--body is required"
+            exit 1
+        fi
+        case "$ID" in
+            ''|*[!0-9]*) emit_error "issue number must be numeric: $ID"; exit 2 ;;
+        esac
+        JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
+        gh_post "$API/issues/$ID/comments" "$JSON_BODY"
+        ;;
+
+    *)
+        emit_error "unknown command: $CMD"
+        exit 1
+        ;;
+esac

--- a/dev-apprenticeship/triage/scripts/github-api.sh
+++ b/dev-apprenticeship/triage/scripts/github-api.sh
@@ -477,29 +477,31 @@ PY
         # no bulk remove endpoint — loop. URL-encode via python3 so label names
         # containing '/', ' ', '::' etc. survive. Idempotency parity with
         # gitlab-api.sh: a 404 (label already absent) is a no-op, not an error.
+        # Use gh_call so 429 + 5xx retry, secondary-rate-limit 403 detection,
+        # and the transport-failure handling all work identically to every
+        # other verb. gh_call emits to stderr + returns 4 on any 4xx; capture
+        # stderr, and if it reports HTTP 404 specifically, swallow silently.
         if [ -n "$REMOVE_LABELS" ]; then
             IFS=',' read -r -a _RM <<< "$REMOVE_LABELS"
             for lab in "${_RM[@]}"; do
                 lab_trimmed="$(printf '%s' "$lab" | python3 -c 'import sys; print(sys.stdin.read().strip())')"
                 [ -z "$lab_trimmed" ] && continue
                 enc="$(printf '%s' "$lab_trimmed" | python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read(), safe=""))')"
-                del_code=$(curl -sS -o /dev/null -w '%{http_code}' \
-                    --max-time "${GITHUB_CURL_MAX_TIME:-90}" \
-                    -X DELETE \
-                    -H "Authorization: Bearer $GITHUB_TOKEN" \
-                    -H "Accept: application/vnd.github+json" \
-                    -H "X-GitHub-Api-Version: 2022-11-28" \
-                    "$API/issues/$ID/labels/$enc" 2>/dev/null) || {
-                    emit_error "curl transport failure on DELETE label '$lab_trimmed'"
-                    exit 5
-                }
-                case "$del_code" in
-                    2*|404) ;;  # success or already absent — no-op
-                    401|403)   emit_error "auth failure (HTTP $del_code) removing label '$lab_trimmed'"; exit 2 ;;
-                    429)       emit_error "rate limited (HTTP 429) removing label '$lab_trimmed'"; exit 3 ;;
-                    5*)        emit_error "server error (HTTP $del_code) removing label '$lab_trimmed'"; exit 5 ;;
-                    *)         emit_error "client error (HTTP $del_code) removing label '$lab_trimmed'"; exit 4 ;;
-                esac
+                del_err="$(mktemp)"
+                set +e
+                gh_call DELETE "$API/issues/$ID/labels/$enc" >/dev/null 2> "$del_err"
+                del_rc=$?
+                set -e
+                if [ "$del_rc" -eq 4 ] && grep -q 'HTTP 404' "$del_err"; then
+                    rm -f "$del_err"
+                    continue  # label already absent — no-op
+                fi
+                if [ "$del_rc" -ne 0 ]; then
+                    cat "$del_err" >&2
+                    rm -f "$del_err"
+                    exit "$del_rc"
+                fi
+                rm -f "$del_err"
             done
         fi
         # Assignee: POST /issues/{n}/assignees with {"assignees": [login]}.

--- a/dev-apprenticeship/triage/scripts/github-api.sh
+++ b/dev-apprenticeship/triage/scripts/github-api.sh
@@ -63,7 +63,7 @@ for x in data:
         "title": x.get("title"),
         "description": x.get("body"),
         "state": "opened" if x.get("state") == "open" else x.get("state"),
-        "labels": [lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, dict)],
+        "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
         "assignees": [{"username": a.get("login")} for a in (x.get("assignees") or [])],
         "author": {"username": (x.get("user") or {}).get("login")},
         "created_at": x.get("created_at"),
@@ -87,7 +87,7 @@ print(json.dumps({
     "title": x.get("title"),
     "description": x.get("body"),
     "state": "opened" if x.get("state") == "open" else x.get("state"),
-    "labels": [lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, dict)],
+    "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
     "assignees": [{"username": a.get("login")} for a in (x.get("assignees") or [])],
     "author": {"username": (x.get("user") or {}).get("login")},
     "created_at": x.get("created_at"),
@@ -475,14 +475,31 @@ PY
         fi
         # Remove-labels: DELETE /issues/{n}/labels/{name} per label. GitHub has
         # no bulk remove endpoint — loop. URL-encode via python3 so label names
-        # containing '/', ' ', '::' etc. survive.
+        # containing '/', ' ', '::' etc. survive. Idempotency parity with
+        # gitlab-api.sh: a 404 (label already absent) is a no-op, not an error.
         if [ -n "$REMOVE_LABELS" ]; then
             IFS=',' read -r -a _RM <<< "$REMOVE_LABELS"
             for lab in "${_RM[@]}"; do
                 lab_trimmed="$(printf '%s' "$lab" | python3 -c 'import sys; print(sys.stdin.read().strip())')"
                 [ -z "$lab_trimmed" ] && continue
                 enc="$(printf '%s' "$lab_trimmed" | python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read(), safe=""))')"
-                gh_call DELETE "$API/issues/$ID/labels/$enc" >/dev/null || exit $?
+                del_code=$(curl -sS -o /dev/null -w '%{http_code}' \
+                    --max-time "${GITHUB_CURL_MAX_TIME:-90}" \
+                    -X DELETE \
+                    -H "Authorization: Bearer $GITHUB_TOKEN" \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    "$API/issues/$ID/labels/$enc" 2>/dev/null) || {
+                    emit_error "curl transport failure on DELETE label '$lab_trimmed'"
+                    exit 5
+                }
+                case "$del_code" in
+                    2*|404) ;;  # success or already absent — no-op
+                    401|403)   emit_error "auth failure (HTTP $del_code) removing label '$lab_trimmed'"; exit 2 ;;
+                    429)       emit_error "rate limited (HTTP 429) removing label '$lab_trimmed'"; exit 3 ;;
+                    5*)        emit_error "server error (HTTP $del_code) removing label '$lab_trimmed'"; exit 5 ;;
+                    *)         emit_error "client error (HTTP $del_code) removing label '$lab_trimmed'"; exit 4 ;;
+                esac
             done
         fi
         # Assignee: POST /issues/{n}/assignees with {"assignees": [login]}.

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -528,6 +528,9 @@ PY
             emit_error "--body is required"
             exit 1
         fi
+        case "$ID" in
+            ''|*[!0-9]*) emit_error "issue iid must be numeric: $ID"; exit 2 ;;
+        esac
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
         gl_post "$API/issues/$ID/notes" "$JSON_BODY"
         ;;

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -13,6 +13,7 @@
 #   gitlab-api.sh update-issue <id> [--add-labels l1,l2] [--remove-labels l1,l2] [--priority p] [--assignee username]
 #   gitlab-api.sh members [--view <name>]
 #   gitlab-api.sh labels  [--view <name>]
+#   gitlab-api.sh add-note <iid> --body <text>
 #
 # Views (opt-in projection; default is full JSON):
 #   issues  --view labeler        [{iid, title, labels}]
@@ -504,6 +505,31 @@ PY
         else
             gl_get "$API/labels?per_page=100"
         fi
+        ;;
+
+    add-note)
+        # Back-ported from planning/scripts/gitlab-api.sh (#256 PR 2). The
+        # labeler, prioritizer, and router agents' review-gated branches
+        # shell out to `gitlab-api.sh add-note <iid> --body ...` to post
+        # draft suggestions as comments; prior to this PR the call silently
+        # failed with "unknown command: add-note" (caught by the .ag try/catch
+        # so no operator noticed). Mirrors the github-api.sh add-note arm so
+        # the contract is symmetric across backends.
+        ID="${1:?Usage: gitlab-api.sh add-note <iid> --body <text>}"
+        shift
+        BODY=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --body) BODY="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$BODY" ]; then
+            emit_error "--body is required"
+            exit 1
+        fi
+        JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
+        gl_post "$API/issues/$ID/notes" "$JSON_BODY"
         ;;
 
     *)

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -66,39 +66,73 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # shellcheck disable=SC1091  # colony-lint runs shellcheck without -x
 . "$REPO_ROOT/tools/parse-toml.sh"
 
-GITLAB_URL=$(parse_toml gitlab url)
-GITLAB_TOKEN=$(parse_toml gitlab token)
-GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
-
-if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
-    echo "Error: GitLab config incomplete in $CONFIG"
-    echo "Required: url, token, project under [gitlab]"
-    exit 1
-fi
-
-# URL-encode the project path (replace / with %2F)
-GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
-
-# #104: operator identity. Empty if not configured (pre-#104 setups or
-# operators who skipped the install.sh prompt); agents fall back to
-# memo gitlab:me and tag everything as team when both are empty.
-GITLAB_ME=$(parse_toml gitlab me)
-
-export GITLAB_URL
-export GITLAB_TOKEN
-export GITLAB_PROJECT
-export GITLAB_ME
-export COLONY_DIR
-
 # #256: forge backend selection. `[forge].type` picks which backend
 # wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
-# configs keep working unchanged. The github backend is skeleton-only
-# until PRs 2-6 of #256 land their per-colony github-api.sh wrappers;
-# until then, FORGE_TYPE=github yields exit 99 "not implemented" from
-# forge-api.sh.
+# configs keep working unchanged. PR 2 of #256 ships the triage colony's
+# github-api.sh, so FORGE_TYPE=github is now live for triage (other colonies
+# still return exit 99 "not implemented" until their respective PRs land).
 FORGE_TYPE=$(parse_toml forge type)
 FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+
+case "$FORGE_TYPE" in
+    gitlab)
+        # Prefer [forge.gitlab] (ADR-0002) if present; fall back to legacy
+        # [gitlab] so pre-#256 configs keep working during the overlap window.
+        GITLAB_URL=$(parse_toml forge.gitlab url)
+        [ -z "$GITLAB_URL" ] && GITLAB_URL=$(parse_toml gitlab url)
+        GITLAB_TOKEN=$(parse_toml forge.gitlab token)
+        [ -z "$GITLAB_TOKEN" ] && GITLAB_TOKEN=$(parse_toml gitlab token)
+        GITLAB_PROJECT_RAW=$(parse_toml forge.gitlab project)
+        [ -z "$GITLAB_PROJECT_RAW" ] && GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
+        GITLAB_ME=$(parse_toml forge.gitlab me)
+        [ -z "$GITLAB_ME" ] && GITLAB_ME=$(parse_toml gitlab me)
+
+        if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
+            echo "Error: GitLab config incomplete in $CONFIG"
+            echo "Required: url, token, project under [forge.gitlab] (or legacy [gitlab])"
+            exit 1
+        fi
+
+        # URL-encode the project path (replace / with %2F)
+        GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
+
+        export GITLAB_URL
+        export GITLAB_TOKEN
+        export GITLAB_PROJECT
+        export GITLAB_ME
+        ;;
+    github)
+        GITHUB_URL=$(parse_toml forge.github url)
+        GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+        GITHUB_OWNER=$(parse_toml forge.github owner)
+        GITHUB_REPO=$(parse_toml forge.github repo)
+        GITHUB_TOKEN=$(parse_toml forge.github token)
+        GITHUB_ME=$(parse_toml forge.github me)
+
+        if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
+            echo "Error: GitHub config incomplete in $CONFIG"
+            echo "Required: owner, repo, token under [forge.github]"
+            exit 1
+        fi
+
+        # Use the project-raw variable name for the summary echo below so
+        # both branches can share one format string. Value is informational.
+        GITLAB_PROJECT_RAW="$GITHUB_OWNER/$GITHUB_REPO"
+
+        export GITHUB_URL
+        export GITHUB_OWNER
+        export GITHUB_REPO
+        export GITHUB_TOKEN
+        export GITHUB_ME
+        ;;
+    *)
+        echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2
+        exit 1
+        ;;
+esac
+
 export FORGE_TYPE
+export COLONY_DIR
 
 AGENTS=(
     issue_creator
@@ -195,7 +229,10 @@ if [ -n "$RESTART_AGENT" ]; then
 fi
 
 echo "Starting Triage colony (${#AGENTS[@]} agents)..."
-echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
+case "$FORGE_TYPE" in
+    gitlab) echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)" ;;
+    github) echo "  GitHub: $GITHUB_URL ($GITHUB_OWNER/$GITHUB_REPO)" ;;
+esac
 
 for agent in "${AGENTS[@]}"; do
     interval=$(tick_interval_for "$agent")

--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -116,6 +116,17 @@ planning → implementation → code-review → release. `rate-limit-status`
 and the dashboard tile ship in PR 7 alongside the legacy
 `[gitlab]`-section retirement.
 
+**`.ag` migration is in-scope for every per-colony PR.** Each
+per-colony PR (PRs 2-6) MUST rewrite every `exec sh` call site in that
+colony's `.ag` agents from `scripts/gitlab-api.sh` to
+`scripts/forge-api.sh`. A colony that only ships `github-api.sh`
+without rewriting its `.ag` files is a silent-failure landmine: under
+`FORGE_TYPE=github`, `start-colony.sh` exports only `GITHUB_*` env, the
+direct `gitlab-api.sh` call trips its env check and exits 1, and the
+`.ag` try/catch swallows the error — the colony ticks doing zero work.
+The `check-forge-dispatch.sh` lint fires per-colony (once that colony
+ships a concrete `github-api.sh`), so forgetting this step breaks CI.
+
 **PR 2 deviations from the table below.** The triage contract in PR 2
 is a subset of the "full" shape listed here, because triage agents only
 consume issue + member + label data and only need the seven subcommands

--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -106,13 +106,27 @@ Every subcommand emits a fixed JSON shape. The following table is the
 authoritative contract; `test-forge-api.sh` enforces byte-identical
 output for matching fixtures across both backends.
 
-**Per-PR rollout.** PR 1 (this PR) ships only the dispatcher skeleton
-and config schema — none of the subcommands below are newly
-implemented in PR 1. Per-colony `github-api.sh` wrappers that
-implement the subcommands land across PRs 2-6 in the order triage
-→ planning → implementation → code-review → release. `rate-limit-status`
+**Per-PR rollout.** PR 1 shipped the dispatcher skeleton and config
+schema only. PR 2 (the current PR as of this writing) ships the triage
+colony's `github-api.sh` with 7 subcommands (`issues`, `create-issue`,
+`update-issue`, `members`, `get-issue`, `labels`, `add-note`) plus the
+`[forge.github]` env-export branch in `triage/scripts/start-colony.sh`.
+The remaining colonies' wrappers land across PRs 3-6 in the order
+planning → implementation → code-review → release. `rate-limit-status`
 and the dashboard tile ship in PR 7 alongside the legacy
 `[gitlab]`-section retirement.
+
+**PR 2 deviations from the table below.** The triage contract in PR 2
+is a subset of the "full" shape listed here, because triage agents only
+consume issue + member + label data and only need the seven subcommands
+enumerated above — there are no `merge-requests`, `mr-*`, or
+`rate-limit-status` calls in any triage `.ag` agent. That part of the
+contract will be implemented incrementally as PRs 3-6 wire it into the
+colonies that actually need it. Triage's `add-note` is a new subcommand
+not in the original ADR table; it is added here and back-ported to
+`triage/scripts/gitlab-api.sh` to match (the `.ag` agents were calling
+it against a non-existent gitlab-api.sh arm before PR 2, silently
+swallowed by `try/catch`).
 
 | Subcommand           | Normalized output |
 |----------------------|-------------------|

--- a/tools/check-forge-dispatch.sh
+++ b/tools/check-forge-dispatch.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# tools/check-forge-dispatch.sh: Flag direct backend-wrapper calls from .ag files.
+#
+# Under the forge abstraction (ADR-0002, #256), `.ag` agents must call
+# `scripts/forge-api.sh` — the per-colony dispatcher that reads
+# `$FORGE_TYPE` and forwards to the matching backend wrapper (gitlab-api.sh
+# or github-api.sh). An agent that hardcodes `scripts/gitlab-api.sh` (or
+# `scripts/github-api.sh`) silently breaks on the other backend: with
+# `FORGE_TYPE=github`, start-colony.sh exports only GITHUB_* env and the
+# gitlab-api.sh env-check fails, then .ag try/catch swallows the error.
+#
+# The check fires per-colony, and only once that colony ships a concrete
+# GitHub backend (`scripts/github-api.sh`). Colonies that still have only
+# the dispatcher skeleton (#256 PRs 3-6 pending) are exempt — an operator
+# cannot meaningfully run them on `FORGE_TYPE=github` yet, so there is
+# nothing to enforce.
+#
+# Usage: ./tools/check-forge-dispatch.sh [path]
+# Exit 0 if no findings, 1 if one or more findings, 2 on usage error.
+
+set -euo pipefail
+
+SCAN_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+if [ ! -e "$SCAN_ROOT" ]; then
+    echo "check-forge-dispatch: scan root does not exist: $SCAN_ROOT" >&2
+    exit 2
+fi
+
+FAIL=0
+
+# Discover colonies that ship a concrete GitHub backend. Those are the
+# colonies where `.ag` agents MUST route through forge-api.sh.
+while IFS= read -r github_backend; do
+    colony_dir="$(dirname "$(dirname "$github_backend")")"
+    agents_dir="$colony_dir/agents"
+    [ -d "$agents_dir" ] || continue
+
+    while IFS= read -r ag_file; do
+        [ -f "$ag_file" ] || continue
+        # Strip line comments (everything after `//`) before matching.
+        matches=$(awk '
+            {
+                line = $0
+                pos = index(line, "//")
+                if (pos > 0) line = substr(line, 1, pos - 1)
+                if (line ~ /scripts\/(gitlab|github)-api\.sh/) print NR ":" $0
+            }
+        ' "$ag_file") || true
+        if [ -n "$matches" ]; then
+            FAIL=1
+            echo "check-forge-dispatch: direct backend-wrapper call in $ag_file — use scripts/forge-api.sh"
+            printf '%s\n' "$matches" | sed 's/^/  /'
+        fi
+    done < <(find "$agents_dir" -type f -name '*.ag' 2>/dev/null)
+done < <(find "$SCAN_ROOT" -type f -path '*/scripts/github-api.sh' 2>/dev/null)
+
+exit "$FAIL"

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -444,6 +444,21 @@ if [ -x "$REPO_ROOT/tools/check-exec-sh.sh" ]; then
     fi
 fi
 
+# --- Check .ag files for direct backend-wrapper calls (ADR-0002, #256) ---
+# Colonies that ship a concrete github-api.sh MUST route .ag calls through
+# scripts/forge-api.sh — a hardcoded gitlab-api.sh / github-api.sh path
+# silently breaks on the other backend (start-colony.sh exports only the
+# env for the selected FORGE_TYPE, and .ag try/catch swallows the failure).
+if [ -x "$REPO_ROOT/tools/check-forge-dispatch.sh" ]; then
+    check_out="$("$REPO_ROOT/tools/check-forge-dispatch.sh" "$REPO_ROOT" 2>&1)" && check_rc=0 || check_rc=$?
+    if [ "$check_rc" -eq 0 ]; then
+        pass "check-forge-dispatch: .ag agents route through forge-api.sh"
+    else
+        fail "check-forge-dispatch: direct backend-wrapper call from .ag file"
+        printf '%s\n' "$check_out"
+    fi
+fi
+
 # --- Check ticking colonies for unguarded prompt() (#200 / #201 / #205 / #208 / #210) ---
 # The implementation, planning, code-review, and triage colonies tick
 # frequently; a `prompt()` that is not gated on a memo-based staleness

--- a/tools/test-check-forge-dispatch.sh
+++ b/tools/test-check-forge-dispatch.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# tools/test-check-forge-dispatch.sh: unit tests for tools/check-forge-dispatch.sh.
+#
+# Self-contained. Builds temporary colony-shaped trees and asserts exit
+# code + output. Cleans up on exit.
+#
+# Usage: ./tools/test-check-forge-dispatch.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECKER="$SCRIPT_DIR/check-forge-dispatch.sh"
+
+if [ ! -x "$CHECKER" ]; then
+    echo "[FAIL] checker not found or not executable: $CHECKER"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# make_colony <fed> <colony> <ships_github>
+# Builds a fake colony under $TMPDIR_TEST. If ships_github=1, drops a
+# github-api.sh alongside gitlab-api.sh — that turns the check on.
+make_colony() {
+    local fed="$1"
+    local colony="$2"
+    local ships_github="$3"
+    local root="$TMPDIR_TEST/$fed/$colony"
+    mkdir -p "$root/scripts" "$root/agents" "$root/config"
+    touch "$root/scripts/gitlab-api.sh"
+    touch "$root/scripts/forge-api.sh"
+    if [ "$ships_github" = "1" ]; then
+        touch "$root/scripts/github-api.sh"
+    fi
+    printf '%s' "$root"
+}
+
+run_checker() {
+    set +e
+    out="$("$CHECKER" "$TMPDIR_TEST" 2>&1)"
+    rc=$?
+    set -e
+}
+
+# --- Test 1: migrated colony with forge-api.sh call is clean ---
+root="$(make_colony fed1 triage 1)"
+cat > "$root/agents/good.ag" <<'AG'
+fn tick(rec: string) -> void {
+    let cmd = "$COLONY_DIR/scripts/forge-api.sh issues --view labeler";
+    let raw = try { exec sh cmd; } catch e { "[]"; };
+}
+AG
+run_checker
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "migrated-colony-clean: forge-api.sh call not flagged"
+else
+    fail "migrated-colony-clean" "rc=$rc out=$out"
+fi
+rm -rf "${TMPDIR_TEST:?}"/*
+
+# --- Test 2: migrated colony with hardcoded gitlab-api.sh fails ---
+root="$(make_colony fed1 triage 1)"
+cat > "$root/agents/bad.ag" <<'AG'
+fn tick(rec: string) -> void {
+    let cmd = "$COLONY_DIR/scripts/gitlab-api.sh issues --view labeler";
+    let raw = try { exec sh cmd; } catch e { "[]"; };
+}
+AG
+run_checker
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "scripts/gitlab-api.sh"; then
+    pass "migrated-colony-bad-gitlab: hardcoded gitlab-api.sh flagged"
+else
+    fail "migrated-colony-bad-gitlab" "rc=$rc out=$out"
+fi
+rm -rf "${TMPDIR_TEST:?}"/*
+
+# --- Test 3: migrated colony with hardcoded github-api.sh fails too ---
+root="$(make_colony fed1 triage 1)"
+cat > "$root/agents/bad.ag" <<'AG'
+fn tick(rec: string) -> void {
+    let cmd = "$COLONY_DIR/scripts/github-api.sh issues --view labeler";
+    let raw = try { exec sh cmd; } catch e { "[]"; };
+}
+AG
+run_checker
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "scripts/github-api.sh"; then
+    pass "migrated-colony-bad-github: hardcoded github-api.sh flagged"
+else
+    fail "migrated-colony-bad-github" "rc=$rc out=$out"
+fi
+rm -rf "${TMPDIR_TEST:?}"/*
+
+# --- Test 4: unmigrated colony (no github-api.sh) is exempt ---
+# Other colonies (planning/implementation/release/code-review) still have
+# direct gitlab-api.sh calls until their per-colony PR lands. Don't flag.
+root="$(make_colony fed1 planning 0)"
+cat > "$root/agents/legacy.ag" <<'AG'
+fn tick(rec: string) -> void {
+    let cmd = "$COLONY_DIR/scripts/gitlab-api.sh issues";
+    let raw = try { exec sh cmd; } catch e { "[]"; };
+}
+AG
+run_checker
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "unmigrated-colony-exempt: no github-api.sh, direct calls allowed"
+else
+    fail "unmigrated-colony-exempt" "rc=$rc out=$out"
+fi
+rm -rf "${TMPDIR_TEST:?}"/*
+
+# --- Test 5: comments don't count ---
+root="$(make_colony fed1 triage 1)"
+cat > "$root/agents/commented.ag" <<'AG'
+// Historically this called scripts/gitlab-api.sh directly; see #256 PR 2.
+fn tick(rec: string) -> void {
+    let cmd = "$COLONY_DIR/scripts/forge-api.sh issues";  // ex-scripts/gitlab-api.sh
+    let raw = try { exec sh cmd; } catch e { "[]"; };
+}
+AG
+run_checker
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "comment-only: references inside // comments not flagged"
+else
+    fail "comment-only" "rc=$rc out=$out"
+fi
+rm -rf "${TMPDIR_TEST:?}"/*
+
+# --- Test 6: multiple findings in one file print all lines ---
+root="$(make_colony fed1 triage 1)"
+cat > "$root/agents/bad.ag" <<'AG'
+fn fetch() -> string {
+    let cmd1 = "$COLONY_DIR/scripts/gitlab-api.sh issues --view router";
+    let cmd2 = "$COLONY_DIR/scripts/gitlab-api.sh members";
+    return try { exec sh cmd1; } catch e { "[]"; };
+}
+AG
+run_checker
+hits=$(printf '%s' "$out" | grep -c "scripts/gitlab-api.sh" || true)
+if [ "$rc" -eq 1 ] && [ "$hits" -ge 2 ]; then
+    pass "multi-findings: all offending lines reported"
+else
+    fail "multi-findings" "rc=$rc hits=$hits out=$out"
+fi
+rm -rf "${TMPDIR_TEST:?}"/*
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-forge-config.sh
+++ b/tools/test-forge-config.sh
@@ -108,22 +108,50 @@ for colony in $COLONIES; do
 done
 
 # -----------------------------------------------------------------------------
-# Test 3: dispatcher returns exit 99 for github (not implemented yet)
+# Test 3: dispatcher behaviour under FORGE_TYPE=github
 # -----------------------------------------------------------------------------
+# Two cases per colony, decided by whether github-api.sh has shipped:
+#   (a) skeleton state (no github-api.sh yet): exit 99 + ADR + issue pointers
+#       — same contract as when PR 1 landed
+#   (b) shipped (github-api.sh present): dispatcher execs the wrapper, which
+#       fails at its own env-check with rc=1 because GITHUB_TOKEN et al. are
+#       not set in the test shell. Assert that rc=1 and the error message
+#       names the three required env vars — proves routing works and surfaces
+#       an actionable message to operators who forgot to configure
+#       [forge.github].
+# This keeps the test stable as PRs 2-6 of #256 land additional wrappers.
 for colony in $COLONIES; do
     disp="$REPO_ROOT/dev-apprenticeship/$colony/scripts/forge-api.sh"
+    gh_backend="$REPO_ROOT/dev-apprenticeship/$colony/scripts/github-api.sh"
     out="$TMPDIR_TEST/$colony.github.log"
     set +e
+    # Scrub any inherited GITHUB_* env so the shipped-backend branch can
+    # deterministically trip the env-check in github-api.sh regardless of
+    # whether the operator's shell already has a PAT exported. FORGE_TYPE
+    # still takes effect (case arm below sets it explicitly).
+    unset GITHUB_TOKEN GITHUB_OWNER GITHUB_REPO GITHUB_URL GITHUB_ME 2>/dev/null || true
     FORGE_TYPE=github bash "$disp" any-command >"$out" 2>&1
     rc=$?
     set -e
-    if [ "$rc" = "99" ] \
-       && grep -q "not yet implemented" "$out" \
-       && grep -q "ADR-0002" "$out" \
-       && grep -q "issues/256" "$out"; then
-        pass "$colony: FORGE_TYPE=github returns exit 99 with ADR + issue pointers"
+    if [ -x "$gh_backend" ]; then
+        # Case (b): backend shipped. Dispatcher should exec it; the wrapper
+        # itself should fail at env-check with exit 1 naming the required vars.
+        if [ "$rc" = "1" ] && grep -q "GITHUB_TOKEN" "$out" && grep -q "GITHUB_OWNER" "$out" && grep -q "GITHUB_REPO" "$out"; then
+            pass "$colony: FORGE_TYPE=github routes to github-api.sh (env-check fires with clear message)"
+        else
+            fail "$colony: FORGE_TYPE=github routing to github-api.sh broken" "rc=$rc body=$(head -c 300 "$out")"
+        fi
     else
-        fail "$colony: FORGE_TYPE=github should exit 99 with clear message + ADR + issue pointers" "rc=$rc body=$(head -c 300 "$out")"
+        # Case (a): skeleton state. Dispatcher itself surfaces the ADR pointer
+        # and exits 99.
+        if [ "$rc" = "99" ] \
+           && grep -q "not yet implemented" "$out" \
+           && grep -q "ADR-0002" "$out" \
+           && grep -q "issues/256" "$out"; then
+            pass "$colony: FORGE_TYPE=github returns exit 99 with ADR + issue pointers (skeleton)"
+        else
+            fail "$colony: FORGE_TYPE=github should exit 99 with clear message + ADR + issue pointers" "rc=$rc body=$(head -c 300 "$out")"
+        fi
     fi
 done
 

--- a/tools/test-github-triage-normalize.sh
+++ b/tools/test-github-triage-normalize.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# test-github-triage-normalize.sh: unit-test the GitHub -> GitLab-shape
+# normalizers in dev-apprenticeship/triage/scripts/github-api.sh
+# (ADR-0002, #256 PR 2).
+#
+# GitHub API responses differ from GitLab's in field names (number vs iid,
+# user vs author, login vs username), label shape (objects vs strings),
+# state vocabulary (open vs opened), and response-body composition (issues
+# list is mixed with PRs, pull_request key must be filtered out).
+#
+# github-api.sh normalizes these before handing JSON to project_json so the
+# existing views and .ag agents can consume it unmodified. This test feeds
+# canned GitHub fixtures through each normalize_* function and asserts the
+# output is byte-correct GitLab-shape JSON.
+#
+# Matches the style of test-gitlab-views.sh (bash 3.2 discipline, python3
+# for JSON, build_prelude pattern for sourcing the script under test).
+#
+# Exit 0 all-pass, 1 any-fail.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT="$REPO_ROOT/dev-apprenticeship/triage/scripts/github-api.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+# GitHub-shape fixtures. Hand-constructed from the actual
+# https://docs.github.com/rest/issues/issues#list-repository-issues schema so
+# the normalizer sees realistic payloads including the `pull_request` key
+# (issues endpoint mixes issues and PRs), labels as objects, user vs author
+# rename, login vs username rename, state open/closed (no "opened"), and
+# `comments` as the user_notes_count equivalent.
+FIXTURE_ISSUES='[
+  {"url":"https://api.github.com/repos/o/r/issues/1","number":1,"title":"First",
+   "body":"desc-1","state":"open","labels":[{"id":1,"name":"bug","color":"ff0000"},
+   {"id":2,"name":"priority::high","color":"ff8800"}],
+   "user":{"login":"alice","id":7,"type":"User"},
+   "assignees":[{"login":"bob","id":8},{"login":"carol","id":9}],
+   "created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-02T10:00:00Z",
+   "comments":3,"author_association":"MEMBER"},
+  {"url":"https://api.github.com/repos/o/r/issues/2","number":2,"title":"Second",
+   "body":"desc-2","state":"open","labels":[],
+   "user":{"login":"alice","id":7,"type":"User"},
+   "assignees":[],"created_at":"2026-04-03T10:00:00Z","updated_at":"2026-04-04T10:00:00Z",
+   "comments":0,"author_association":"MEMBER"},
+  {"url":"https://api.github.com/repos/o/r/issues/3","number":3,"title":"PR-not-issue",
+   "body":"pr-body","state":"open","labels":[{"id":3,"name":"feature","color":"00ff00"}],
+   "user":{"login":"alice","id":7,"type":"User"},"assignees":[],
+   "created_at":"2026-04-05T10:00:00Z","updated_at":"2026-04-06T10:00:00Z","comments":1,
+   "pull_request":{"url":"https://api.github.com/repos/o/r/pulls/3",
+   "html_url":"https://github.com/o/r/pull/3","diff_url":"","patch_url":""}}
+]'
+
+FIXTURE_SINGLE_ISSUE='{"url":"https://api.github.com/repos/o/r/issues/42","number":42,
+  "title":"Single","body":"single-desc","state":"closed",
+  "labels":[{"id":99,"name":"bug","color":"ff0000"}],
+  "user":{"login":"alice","id":7},"assignees":[{"login":"bob","id":8}],
+  "created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-10T10:00:00Z","comments":5}'
+
+# GitHub /collaborators response — login only, no `name` field (that requires
+# an extra /users/{login} hop). Our normalizer falls back to login for name.
+FIXTURE_MEMBERS='[
+  {"login":"alice","id":7,"type":"User","site_admin":false,
+   "permissions":{"admin":true,"maintain":true,"push":true,"triage":true,"pull":true},
+   "role_name":"admin"},
+  {"login":"bob","id":8,"type":"User","site_admin":false,
+   "permissions":{"admin":false,"maintain":false,"push":true,"triage":true,"pull":true},
+   "role_name":"write"}
+]'
+
+# GitHub /labels response — color is a plain 6-hex-char string with no '#';
+# our normalizer prepends '#' so downstream views match the GitLab shape.
+FIXTURE_LABELS='[
+  {"id":1,"name":"bug","description":"Something is broken","color":"ff0000","default":true},
+  {"id":2,"name":"feature","description":"New functionality","color":"00ff00","default":false}
+]'
+
+# Source just the function defs from github-api.sh. Matches the pattern in
+# test-gitlab-views.sh: awk-stops at the CLI case statement (CMD=) so the
+# script never tries to hit an API. Stored in a temp file because `bash -c`
+# can only `source` a path, not a variable.
+build_prelude() {
+    awk '/^CMD=/{exit} {print}' "$SCRIPT" > "$1"
+}
+
+# run_fn <fn-name> <input-json>
+# Pipes the fixture through the named normalize function and prints stdout.
+# The GITHUB_* dummy env vars satisfy github-api.sh's top-level env-check
+# block (it fires during source-time because the check is outside a fn).
+run_fn() {
+    local fn="$1" input="$2"
+    local prelude
+    prelude=$(mktemp)
+    build_prelude "$prelude"
+    # shellcheck disable=SC1090,SC2016  # $1/$2/$3 are inner bash -c argv
+    GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+        source "$1"
+        printf "%s" "$2" | "$3"
+    ' _ "$prelude" "$input" "$fn"
+    local rc=$?
+    rm -f "$prelude"
+    return $rc
+}
+
+# json_extract <json> <python-expr>
+# Evaluates a python expression against the JSON in the DATA env var and
+# prints the result. Used in assertions to poke specific fields without
+# writing one-off jq pipelines (keeps the test bash-3.2 friendly).
+json_extract() {
+    DATA="$1" python3 -c "
+import os, json
+data = json.loads(os.environ['DATA'])
+print($2)
+"
+}
+
+# assert_eq <expected> <actual> <label>
+assert_eq() {
+    if [ "$1" = "$2" ]; then
+        pass "$3"
+    else
+        fail "$3: expected='$1' actual='$2'"
+    fi
+}
+
+# --- normalize_issues: PR filter + shape ---
+ISSUES_OUT=$(run_fn normalize_issues "$FIXTURE_ISSUES")
+
+# PR-filter: 3 items in, 2 out (issue #3 has pull_request key, must be dropped).
+COUNT=$(json_extract "$ISSUES_OUT" "len(data)")
+assert_eq "2" "$COUNT" "normalize_issues: pull_request entries filtered out"
+
+# iid <- number mapping (the crux of every view that consumes iid).
+IID0=$(json_extract "$ISSUES_OUT" "data[0]['iid']")
+IID1=$(json_extract "$ISSUES_OUT" "data[1]['iid']")
+assert_eq "1" "$IID0" "normalize_issues: issue[0].iid == number"
+assert_eq "2" "$IID1" "normalize_issues: issue[1].iid == number"
+
+# state open -> opened (matches GitLab vocabulary that .ag agents use).
+STATE0=$(json_extract "$ISSUES_OUT" "data[0]['state']")
+assert_eq "opened" "$STATE0" "normalize_issues: state open -> opened"
+
+# labels: [{name}] -> [name] (flattened to strings for the labeler view).
+LABELS0=$(json_extract "$ISSUES_OUT" "','.join(data[0]['labels'])")
+assert_eq "bug,priority::high" "$LABELS0" "normalize_issues: labels flattened to strings"
+
+# author.username <- user.login (feeds the #104 personal/team tagging path).
+AUTHOR0=$(json_extract "$ISSUES_OUT" "data[0]['author']['username']")
+assert_eq "alice" "$AUTHOR0" "normalize_issues: author.username == user.login"
+
+# assignees[].username <- login (router's assignment decisions read this).
+ASSIGNEE0_0=$(json_extract "$ISSUES_OUT" "data[0]['assignees'][0]['username']")
+ASSIGNEE0_1=$(json_extract "$ISSUES_OUT" "data[0]['assignees'][1]['username']")
+assert_eq "bob" "$ASSIGNEE0_0" "normalize_issues: assignee[0].username == login"
+assert_eq "carol" "$ASSIGNEE0_1" "normalize_issues: assignee[1].username == login"
+
+# user_notes_count <- comments (feedback-issue view can reuse this field).
+NOTES0=$(json_extract "$ISSUES_OUT" "data[0]['user_notes_count']")
+assert_eq "3" "$NOTES0" "normalize_issues: user_notes_count == comments"
+
+# Empty labels/assignees on issue[1] normalize to [], not null.
+EMPTY_LABELS=$(json_extract "$ISSUES_OUT" "data[1]['labels']")
+EMPTY_ASSIGNEES=$(json_extract "$ISSUES_OUT" "data[1]['assignees']")
+assert_eq "[]" "$EMPTY_LABELS" "normalize_issues: empty labels -> []"
+assert_eq "[]" "$EMPTY_ASSIGNEES" "normalize_issues: empty assignees -> []"
+
+# --- normalize_issue (single-issue variant) ---
+SINGLE_OUT=$(run_fn normalize_issue "$FIXTURE_SINGLE_ISSUE")
+SINGLE_IID=$(DATA="$SINGLE_OUT" python3 -c "import os, json; print(json.loads(os.environ['DATA'])['iid'])")
+SINGLE_STATE=$(DATA="$SINGLE_OUT" python3 -c "import os, json; print(json.loads(os.environ['DATA'])['state'])")
+assert_eq "42" "$SINGLE_IID" "normalize_issue: iid == number"
+# Single-issue state "closed" stays as "closed" (translation is only for "open").
+assert_eq "closed" "$SINGLE_STATE" "normalize_issue: state closed stays closed"
+
+# --- normalize_members ---
+MEMBERS_OUT=$(run_fn normalize_members "$FIXTURE_MEMBERS")
+M_COUNT=$(json_extract "$MEMBERS_OUT" "len(data)")
+M_USER0=$(json_extract "$MEMBERS_OUT" "data[0]['username']")
+M_NAME0=$(json_extract "$MEMBERS_OUT" "data[0]['name']")
+M_ID0=$(json_extract "$MEMBERS_OUT" "data[0]['id']")
+assert_eq "2" "$M_COUNT" "normalize_members: two entries"
+assert_eq "alice" "$M_USER0" "normalize_members: username == login"
+assert_eq "alice" "$M_NAME0" "normalize_members: name falls back to login"
+assert_eq "7" "$M_ID0" "normalize_members: id preserved"
+
+# --- normalize_labels ---
+LABELS_OUT=$(run_fn normalize_labels "$FIXTURE_LABELS")
+L_COUNT=$(json_extract "$LABELS_OUT" "len(data)")
+L_NAME0=$(json_extract "$LABELS_OUT" "data[0]['name']")
+L_COLOR0=$(json_extract "$LABELS_OUT" "data[0]['color']")
+L_DESC0=$(json_extract "$LABELS_OUT" "data[0]['description']")
+assert_eq "2" "$L_COUNT" "normalize_labels: two entries"
+assert_eq "bug" "$L_NAME0" "normalize_labels: name preserved"
+# GitHub returns "ff0000"; we prepend '#' so the color field matches GitLab shape.
+assert_eq "#ff0000" "$L_COLOR0" "normalize_labels: color prefixed with #"
+assert_eq "Something is broken" "$L_DESC0" "normalize_labels: description preserved"
+
+# --- End-to-end: normalize_issues -> project_json labeler ---
+# Proves the pipe agents depend on actually produces the same shape as gitlab's
+# labeler view (iid, title, labels, author). If this drifts, a github triage
+# agent running `issues --view labeler` would silently see different keys.
+PIPE_PRELUDE=$(mktemp)
+build_prelude "$PIPE_PRELUDE"
+# shellcheck disable=SC1090,SC2016
+E2E_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    printf "%s" "$2" | normalize_issues | project_json labeler
+' _ "$PIPE_PRELUDE" "$FIXTURE_ISSUES")
+rm -f "$PIPE_PRELUDE"
+
+E2E_COUNT=$(json_extract "$E2E_OUT" "len(data)")
+E2E_KEYS=$(json_extract "$E2E_OUT" "','.join(sorted(data[0].keys()))")
+E2E_IID=$(json_extract "$E2E_OUT" "data[0]['iid']")
+E2E_AUTHOR=$(json_extract "$E2E_OUT" "data[0]['author']['username']")
+assert_eq "2" "$E2E_COUNT" "e2e: normalize | labeler view emits 2 items (PR filtered)"
+assert_eq "author,iid,labels,title" "$E2E_KEYS" "e2e: labeler view keys match gitlab shape"
+assert_eq "1" "$E2E_IID" "e2e: labeler view carries iid through pipe"
+assert_eq "alice" "$E2E_AUTHOR" "e2e: labeler view carries author.username through pipe"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-gitlab-add-note.sh
+++ b/tools/test-gitlab-add-note.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# test-gitlab-add-note.sh: smoke test for the add-note back-port in the
+# triage colony's gitlab-api.sh (#256 PR 2).
+#
+# The labeler, prioritizer, and router agents' review-gated branches shell
+# out to `gitlab-api.sh add-note <iid> --body ...`. Before PR 2 the triage
+# gitlab-api.sh had no add-note arm, and the call silently failed with
+# "unknown command: add-note" under .ag try/catch.
+#
+# This test verifies:
+#   - `add-note` is a recognised subcommand
+#   - missing --body exits 1 with a clear error
+#   - unknown flag exits 2
+#   - non-numeric iid exits 2 with a clear error
+#   - happy path builds the expected JSON body and hits the expected URL
+#     (via a curl shim that echoes its invocation instead of calling out)
+#
+# Exit 0 all-pass, 1 any-fail.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/dev-apprenticeship/triage/scripts/gitlab-api.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+if [ ! -x "$SCRIPT" ]; then
+    echo "[FAIL] gitlab-api.sh not found or not executable: $SCRIPT"
+    exit 1
+fi
+
+# --- Test 1: missing --body exits 1 ---
+set +e
+out=$(GITLAB_URL=http://x GITLAB_TOKEN=y GITLAB_PROJECT=z "$SCRIPT" add-note 42 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -qi 'body is required'; then
+    pass "missing --body: exit 1 + clear error"
+else
+    fail "missing --body" "rc=$rc out=$out"
+fi
+
+# --- Test 2: unknown flag exits 2 ---
+set +e
+out=$(GITLAB_URL=http://x GITLAB_TOKEN=y GITLAB_PROJECT=z "$SCRIPT" add-note 42 --body "hi" --bogus value 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qi 'unknown flag'; then
+    pass "unknown flag: exit 2 + clear error"
+else
+    fail "unknown flag" "rc=$rc out=$out"
+fi
+
+# --- Test 3: non-numeric iid exits 2 ---
+set +e
+out=$(GITLAB_URL=http://x GITLAB_TOKEN=y GITLAB_PROJECT=z "$SCRIPT" add-note 'abc' --body "hi" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qi 'numeric'; then
+    pass "non-numeric iid: exit 2 + clear error"
+else
+    fail "non-numeric iid" "rc=$rc out=$out"
+fi
+
+# --- Test 4: happy path builds correct JSON + URL ---
+# Shim curl: prints method, URL, and stdin (the JSON body) to stdout, then
+# exits 0 with a minimal JSON response so the caller's jq/awk is happy.
+TMPDIR_SHIM="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_SHIM"' EXIT
+cat > "$TMPDIR_SHIM/curl" <<'CURL_SHIM'
+#!/usr/bin/env bash
+# Parse the last positional arg as the URL, scan for "-X <method>" and
+# "-d <body>". Emit a shim trace file the test can inspect.
+METHOD=""
+BODY=""
+URL=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -X) METHOD="$2"; shift 2 ;;
+        --data|-d) BODY="$2"; shift 2 ;;
+        -H) shift 2 ;;
+        -sS|-S|-s|-f) shift ;;
+        -w|--max-time) shift 2 ;;
+        -o)
+            # Swallow the output-file arg so we don't write curl's own -w
+            # status to the trace. Write nothing to it.
+            : > "$2"
+            shift 2
+            ;;
+        *) URL="$1"; shift ;;
+    esac
+done
+printf 'METHOD=%s\nURL=%s\nBODY=%s\n' "$METHOD" "$URL" "$BODY" > "$CURL_TRACE"
+# gl_call reads the HTTP code from `-w "%{http_code}"` stdout; emit 200.
+printf '200'
+CURL_SHIM
+chmod +x "$TMPDIR_SHIM/curl"
+export CURL_TRACE="$TMPDIR_SHIM/trace"
+
+set +e
+out=$(PATH="$TMPDIR_SHIM:$PATH" GITLAB_URL=http://example.gitlab GITLAB_TOKEN=tok GITLAB_PROJECT=42 "$SCRIPT" add-note 7 --body 'hello world' 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ] && [ -s "$CURL_TRACE" ]; then
+    trace="$(cat "$CURL_TRACE")"
+    ok=1
+    printf '%s' "$trace" | grep -q '^METHOD=POST$' || ok=0
+    printf '%s' "$trace" | grep -q '/projects/42/issues/7/notes' || ok=0
+    # JSON body should have {"body": "hello world"}.
+    if ! printf '%s' "$trace" | python3 -c '
+import sys, json, re
+t = sys.stdin.read()
+m = re.search(r"^BODY=(.*)$", t, re.M)
+assert m, "BODY= line missing in trace"
+b = json.loads(m.group(1))
+assert b == {"body": "hello world"}, f"unexpected body: {b}"
+'; then
+        ok=0
+    fi
+    if [ "$ok" -eq 1 ]; then
+        pass "happy path: POST /issues/7/notes with {body:'hello world'}"
+    else
+        fail "happy path" "trace=$trace out=$out"
+    fi
+else
+    fail "happy path" "rc=$rc out=$out trace_exists=$([ -s "$CURL_TRACE" ] && echo yes || echo no)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-gitlab-views.sh
+++ b/tools/test-gitlab-views.sh
@@ -279,6 +279,50 @@ RAW_ARG_OUT=$(run_view \
     "raw" "$FIXTURE_ISSUES")
 check_equals "$FIXTURE_ISSUES" "$RAW_ARG_OUT" "triage: --view raw pass-through"
 
+# --- github-api.sh project_json parity (#256 PR 2) ---
+# The triage colony's github-api.sh duplicates project_json rather than sourcing
+# gitlab-api.sh so the two wrappers have no runtime coupling. Duplication is
+# only safe if the behavior stays byte-identical — this block runs the same
+# fixtures (already in GitLab shape; no normalization needed) through both
+# scripts' project_json and asserts the outputs match. Drift here means a view
+# in github-api.sh silently ships a different projection than its gitlab twin.
+run_view_github() {
+    local script="$1" view="$2" fixture="$3"
+    local prelude
+    prelude=$(mktemp)
+    build_prelude "$script" "$prelude"
+    # shellcheck disable=SC1090,SC2016  # $1/$2/$3 are inner bash -c argv
+    GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+        source "$1"
+        printf "%s" "$2" | project_json "$3"
+    ' _ "$prelude" "$fixture" "$view"
+    local rc=$?
+    rm -f "$prelude"
+    return $rc
+}
+
+GH_SCRIPT="$REPO_ROOT/dev-apprenticeship/triage/scripts/github-api.sh"
+if [ -f "$GH_SCRIPT" ]; then
+    for pair in \
+        "labeler:$FIXTURE_ISSUES" \
+        "router:$FIXTURE_ISSUES" \
+        "prioritizer:$FIXTURE_ISSUES" \
+        "issue_creator:$FIXTURE_ISSUES" \
+        "members-summary:$FIXTURE_MEMBERS" \
+        "labels-summary:$FIXTURE_LABELS"
+    do
+        view="${pair%%:*}"
+        fixture="${pair#*:}"
+        gl_out=$(run_view "$REPO_ROOT/dev-apprenticeship/triage/scripts/gitlab-api.sh" "$view" "$fixture")
+        gh_out=$(run_view_github "$GH_SCRIPT" "$view" "$fixture")
+        if [ "$gl_out" = "$gh_out" ]; then
+            pass "triage github-api.sh project_json parity: $view"
+        else
+            fail "triage github-api.sh project_json drifted from gitlab-api.sh: $view"
+        fi
+    done
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

PR 2 of 7 for #256 — triage colony GitHub port, first live backend behind the forge-abstraction dispatcher that PR 1 (#260) set up.

- **`dev-apprenticeship/triage/scripts/github-api.sh`** — new, 7 subcommands against GitHub REST API v3 (`issues`, `create-issue`, `update-issue`, `members`, `get-issue`, `labels`, `add-note`). Normalizes every response to GitLab shape (`iid ← number`, `author.username ← user.login`, `assignees[].username ← login`, labels flattened to strings, state `open → opened`, `pull_request`-bearing entries filtered out) so the existing 8 views and all triage `.ag` agents work unchanged.
- **`triage/scripts/gitlab-api.sh`** — back-ports missing `add-note` subcommand. Closes a silent bug: labeler/prioritizer/router's `review-gated`-tier comment-posting calls were previously swallowed by the `.ag` `try/catch` (3 agents calling a subcommand that didn't exist).
- **`triage/scripts/start-colony.sh`** — branches on `FORGE_TYPE`: exports `GITHUB_URL` / `GITHUB_OWNER` / `GITHUB_REPO` / `GITHUB_TOKEN` / `GITHUB_ME` from `[forge.github]` when `type = "github"`; reads `[forge.gitlab]` with `[gitlab]` legacy fallback otherwise. The forge-api.sh dispatcher needs no changes — the "not yet implemented" arm just stops firing for triage because the backend is now executable.

### GitHub-specific quirks handled

- HTTP 403 split between auth failure (no retry) and secondary rate-limit (retryable, response-body heuristic `rate limit` / `abuse` / `secondary rate`).
- `--priority` rejects loud with guidance to use `--add-labels "priority::<level>"` — GitHub has no native priority field, silent-drop would surprise operators.
- `update-issue --assignee` re-reads the issue after POST `/assignees` because GitHub silently drops non-collaborator logins with 201 — matches gitlab-api.sh's loud "unknown user" failure mode.
- `--remove-labels` loops DELETE `/labels/{name}` per label because GitHub has no bulk-remove endpoint; label names URL-encoded via `python3` so `/`, spaces, `::` survive.

### Tests

1. **New** `tools/test-github-triage-normalize.sh` — 25 assertions covering `normalize_issues` (PR filter, field map, empty-list handling), `normalize_issue` (single-issue variant, state translation), `normalize_members` (login→username, name fallback), `normalize_labels` (color `#` prefix), plus end-to-end pipe `normalize_issues | project_json labeler`.
2. **Extended** `tools/test-gitlab-views.sh` with a 6-case parity block that asserts byte-identical `project_json` output between `github-api.sh` and `gitlab-api.sh` — drift detector for the duplicated projection function (intentional duplication; avoids runtime coupling between the two wrappers).
3. **Updated** `tools/test-forge-config.sh` Test 3: for colonies where `github-api.sh` has shipped, asserts exit 1 + env-check message naming `GITHUB_TOKEN` / `GITHUB_OWNER` / `GITHUB_REPO` (proves routing works); otherwise keeps the original skeleton-state exit-99 assertion. Scales as PRs 3-6 land additional wrappers.

Local: `colony-lint.sh` → 94 passed, 0 failed, 1 skipped. `shellcheck` clean on all six touched shell files.

## Test plan

- [x] `bash tools/test-github-triage-normalize.sh` → 25/25
- [x] `bash tools/test-gitlab-views.sh` → 54/54 (48 existing + 6 new parity)
- [x] `bash tools/test-forge-config.sh` → 37/37 (triage's Test 3 now exercises case (b), other 4 stay on case (a))
- [x] `bash tools/colony-lint.sh` → 94 passed, 0 failed, 1 skipped
- [x] `shellcheck` clean on github-api.sh, start-colony.sh, gitlab-api.sh, test-github-triage-normalize.sh, test-gitlab-views.sh, test-forge-config.sh

## Deferred to later PRs

- PR 3: planning colony github-api.sh (4 subcommands: `issues`, `add-note`, `issue-label-events`, `merge-requests`)
- PR 4: implementation colony (`merge-requests`, `issue-label-events`, `create-mr`)
- PR 5: code-review colony (`merge-requests`)
- PR 6: release colony (`releases`, `tags`, `pipelines`, `merge-requests`)
- PR 7: legacy `[gitlab]` retirement, `rate-limit-status` + dashboard tile, soak window, MAJOR bump

Refs #256