### PR TITLE
feat(#256): planning colony GitHub backend (PR 3 of 7)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -97,6 +97,39 @@ is asserted until multi-version CI is in place.
   `gitlab-api.sh` (drift detector for the duplicated projection
   function).
   [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
+- **Planning colony GitHub backend (PR 3 of 7 for #256).**
+  `dev-apprenticeship/planning/scripts/github-api.sh` implements the
+  planning contract against the GitHub REST API v3 (5 subcommands:
+  `issues`, `issues-by-label-events`, `issue-label-events`, `add-note`,
+  `merge-requests`). Two GitHub-specific endpoint collapses that are not
+  a concern for triage: `/issues/{n}/timeline` replaces GitLab's
+  `/resource_label_events` (filtered to `event in ("labeled",
+  "unlabeled")`, mapped `labeled` → "add" / `unlabeled` → "remove");
+  `/pulls` replaces `/merge_requests` and has no distinct "merged"
+  state, so `--state merged` collapses to `state=closed` plus a
+  client-side `merged_at != null` filter. GitHub's `/pulls` also omits
+  `changed_files` on the list endpoint — the normalizer forwards `null`,
+  and `scope_estimator` already tolerates missing complexity scores.
+  All 16 `exec sh` call sites across `scope_estimator`, `risk_assessor`,
+  `task_decomposer`, and `plan_reviewer` were rewritten from
+  `scripts/gitlab-api.sh` to `scripts/forge-api.sh` (required so
+  `check-forge-dispatch.sh` stays green once the concrete
+  `github-api.sh` lands). `planning/scripts/start-colony.sh` now
+  branches on `FORGE_TYPE` identically to triage: exports
+  `GITHUB_URL` / `GITHUB_OWNER` / `GITHUB_REPO` / `GITHUB_TOKEN` /
+  `GITHUB_ME` from `[forge.github]` when `type = "github"`, reads
+  `[forge.gitlab]` with `[gitlab]` legacy fallback otherwise; the
+  `PLANNING_TRIGGER_LABEL` export is backend-agnostic and unchanged.
+  Two new tests: `tools/test-github-planning-normalize.sh` (32
+  assertions covering `normalize_issues` PR-filter + field mapping,
+  `normalize_pulls` state collapse + target_branch/source_branch/
+  changes_count handling, `normalize_timeline` label/since filters + add/
+  remove mapping, end-to-end pipes through `planning` and `planning-mr`
+  views); and a planning-colony extension to `tools/test-gitlab-views.sh`
+  asserting byte-identical `project_json` output between
+  `github-api.sh` and `gitlab-api.sh` for the `planning` and
+  `planning-mr` views.
+  [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
 
 ### Changed
 

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -81,9 +81,9 @@ fn tick(reason: string) -> void {
     // state snapshot on first tick (byte-identical to pre-#235 boot).
     let prev_check = recall_latest("plan_reviewer:last_check");
     let issues_cmd = if len(prev_check) > 0 {
-        "$COLONY_DIR/scripts/gitlab-api.sh issues-by-label-events --since " + shell_escape(prev_check) + " --view planning";
+        "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(prev_check) + " --view planning";
     } else {
-        "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
+        "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning";
     };
     let issues_raw = try {
         exec sh issues_cmd;
@@ -166,7 +166,7 @@ fn tick(reason: string) -> void {
 
     if my_tier == "autonomous" {
         // Direct external write: post the plan as an issue note.
-        let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft.plan);
+        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft.plan);
         let post_result = try { exec sh post_cmd; } catch e {
             print("[plan_reviewer] Failed to post note:", e);
             "";
@@ -200,7 +200,7 @@ fn tick(reason: string) -> void {
             // Draft external write: post with [draft-plan] prefix so a human
             // reviewer can promote or discard it.
             let draft_body = "[draft-plan] **Plan Review** (automated, pending approval)\n\n" + draft.plan;
-            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft_body);
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft_body);
             let draft_result = try { exec sh post_cmd; } catch e {
                 print("[plan_reviewer] Failed to post draft note:", e);
                 "";

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -30,11 +30,11 @@ fn unplanned_cmd() -> string {
         // the trigger label was added at any point in [ts, now] per
         // resource_label_events. Catches transitions we'd miss between
         // 60 s polls with a pure current-state snapshot.
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
+        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
     };
     // First-tick fallback: no prior window to diff against; the snapshot
     // preserves pre-#235 boot behavior byte-identically.
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
+    return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning";
 }
 
 fn get_confidence() -> float {
@@ -71,7 +71,7 @@ fn tick(reason: string) -> void {
     // 1. Observe: pull recent opened issues and skim for incident-style patterns
     if observe_stale == 1 {
         let recent_raw = try {
-            exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --view planning";
+            exec sh "$COLONY_DIR/scripts/forge-api.sh issues --view planning";
         } catch e {
             print("[risk_assessor] GitLab issues poll failed:", e);
             "";
@@ -156,7 +156,7 @@ fn tick(reason: string) -> void {
         // Direct external write: post the risk assessment as an issue note.
         emit("planning:risks", assessment);
         let note = "**Risk Assessment** (automated): " + assessment.severity + "\n\n" + assessment.risks;
-        let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(assessment.issue_id) + " --body " + shell_escape(note);
+        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(assessment.issue_id) + " --body " + shell_escape(note);
         let post_result = try { exec sh post_cmd; } catch e {
             print("[risk_assessor] Failed to post note:", e);
             "";

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -27,10 +27,10 @@ fn unplanned_cmd() -> string {
     let ts = recall_latest("scope_estimator:last_check");
     if len(ts) > 0 {
         // #235: events-aware query — see risk_assessor.ag for rationale.
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
+        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
     };
     // First-tick fallback: no prior window; snapshot preserves pre-#235 boot behavior.
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
+    return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning";
 }
 
 fn get_confidence() -> float {
@@ -64,7 +64,7 @@ fn tick(reason: string) -> void {
     // 1. Observe: pull recent merged MRs and learn calibration
     if observe_stale == 1 {
         let merged_raw = try {
-            exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view planning-mr";
+            exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view planning-mr";
         } catch e {
             print("[scope_estimator] GitLab merged-MR poll failed:", e);
             "";
@@ -130,7 +130,7 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         emit("planning:scope_estimate", estimate);
         let note = "**Scope Estimate** (automated): " + to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points\n\n" + estimate.reasoning;
-        let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(estimate.issue_id) + " --body " + shell_escape(note);
+        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(estimate.issue_id) + " --body " + shell_escape(note);
         let post_result = try { exec sh post_cmd; } catch e {
             print("[scope_estimator] Failed to post note:", e);
             "";

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -27,10 +27,10 @@ fn unplanned_cmd() -> string {
     let ts = recall_latest("task_decomposer:last_check");
     if len(ts) > 0 {
         // #235: events-aware query — see risk_assessor.ag for rationale.
-        return "$COLONY_DIR/scripts/gitlab-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
+        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
     };
     // First-tick fallback: no prior window; snapshot preserves pre-#235 boot behavior.
-    return "$COLONY_DIR/scripts/gitlab-api.sh issues --needs-planning --view planning";
+    return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning";
 }
 
 fn get_confidence() -> float {
@@ -64,7 +64,7 @@ fn tick(reason: string) -> void {
     // 1. Observe: analyze recent issues to infer decomposition style
     if observe_stale == 1 {
         let recent_raw = try {
-            exec sh "$COLONY_DIR/scripts/gitlab-api.sh issues --view planning";
+            exec sh "$COLONY_DIR/scripts/forge-api.sh issues --view planning";
         } catch e {
             print("[task_decomposer] GitLab issues poll failed:", e);
             "";
@@ -143,7 +143,7 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         emit("planning:breakdown", breakdown);
         let note = "**Task Breakdown** (automated): " + to_string(breakdown.count) + " subtasks\n\n" + breakdown.subtasks;
-        let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(breakdown.issue_id) + " --body " + shell_escape(note);
+        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(breakdown.issue_id) + " --body " + shell_escape(note);
         let post_result = try { exec sh post_cmd; } catch e {
             print("[task_decomposer] Failed to post note:", e);
             "";

--- a/dev-apprenticeship/planning/scripts/forge-api.sh
+++ b/dev-apprenticeship/planning/scripts/forge-api.sh
@@ -35,20 +35,13 @@ case "$FORGE_TYPE" in
 esac
 
 if [ ! -x "$backend" ]; then
-    case "$FORGE_TYPE" in
-        github)
-            # Skeleton state: dispatcher exists but the per-colony wrapper is not yet
-            # shipped. Lands across PRs 2-6 of #256.
-            echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the planning colony." >&2
-            echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
-            ;;
-        *)
-            # Broken install — gitlab-api.sh should always be present alongside
-            # forge-api.sh in a valid federation checkout.
-            echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
-            echo "forge-api.sh: this indicates a broken install — re-copy the planning colony scripts/ directory." >&2
-            ;;
-    esac
+    # PR 3 of #256 ships github-api.sh for planning, so a missing github backend
+    # here means either a broken install (deleted / chmod -x'd post-install)
+    # or — if this dispatcher was copied to another colony pre-PR-3 — that
+    # colony's github-api.sh has not landed yet. Emit a uniform "missing or
+    # not executable" message and point at the ADR for the rollout state.
+    echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
+    echo "forge-api.sh: re-copy the colony scripts/ directory, or — if upgrading from pre-#256 — see doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6) for the GitHub-backend rollout status." >&2
     exit 99
 fi
 

--- a/dev-apprenticeship/planning/scripts/github-api.sh
+++ b/dev-apprenticeship/planning/scripts/github-api.sh
@@ -1,0 +1,599 @@
+#!/bin/bash
+# GitHub API wrapper for planning colony agents (ADR-0002, #256 PR 3 of 7).
+# Called by .ag agents via forge-api.sh dispatch when FORGE_TYPE=github.
+#
+# Required env vars (set by start-colony.sh from [forge.github] in colony.toml):
+#   GITHUB_URL    - API base (default https://api.github.com; override for GHE)
+#   GITHUB_TOKEN  - personal access token (classic or fine-grained)
+#   GITHUB_OWNER  - repo owner (user or org)
+#   GITHUB_REPO   - repo name
+#
+# Optional env vars (same as gitlab-api.sh):
+#   PLANNING_TRIGGER_LABEL   label used by --needs-planning (default "needs-planning")
+#   GITHUB_CURL_MAX_TIME     per-attempt --max-time seconds (default 90)
+#   GITHUB_CURL_RETRIES      retry budget for 5xx/timeouts/429 (default 3)
+#
+# Usage (identical contract to gitlab-api.sh):
+#   github-api.sh issues [--needs-planning] [--since ISO8601] [--view <name>]
+#   github-api.sh issues-by-label-events --since ISO8601 [--view <name>]
+#   github-api.sh issue-label-events <number> [--since ISO8601] [--label NAME]
+#   github-api.sh add-note <number> --body <text>
+#   github-api.sh merge-requests [--state opened|merged|all] [--since ISO8601]
+#                                [--per-page N] [--view <name>]
+#
+# Views and JSON shape are GitLab-normalized (iid <- number, author.username,
+# labels-as-strings, state "open"->"opened", target_branch <- base.ref). See
+# ADR-0002 §Shape. Planning only reads + posts comments; no write surface.
+#
+# Exit codes:
+#   0  ok (2xx)
+#   1  usage error (required flag missing, backend rejection)
+#   2  unknown flag / view / auth failure (4xx 401/403)
+#   3  rate limited (429 or secondary rate-limit, after retries)
+#   4  other 4xx client error
+#   5  5xx server error OR transport failure
+
+set -e
+
+# emit_error <message>
+# Matches gitlab-api.sh emit_error contract: JSON error object to stderr.
+emit_error() {
+    printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+# normalize_issues
+# Reads GitHub issues-list JSON from stdin, writes GitLab-shape JSON to stdout.
+# Shape contract (fields planning views + agents consume):
+#   iid (<- number), title, description (<- body), state (open->opened),
+#   labels: ["name", ...] (accept both [{name, ...}] and bare strings for GHE),
+#   assignees: [{username}, ...], author: {username}, created_at, updated_at,
+#   user_notes_count (<- comments).
+# Filters out pull_request entries — GitHub's /issues mixes PRs with issues,
+# but planning only cares about issues for triage-time fields.
+normalize_issues() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for x in data:
+    if "pull_request" in x:
+        continue
+    out.append({
+        "iid": x.get("number"),
+        "title": x.get("title"),
+        "description": x.get("body"),
+        "state": "opened" if x.get("state") == "open" else x.get("state"),
+        "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
+        "assignees": [{"username": a.get("login")} for a in (x.get("assignees") or [])],
+        "author": {"username": (x.get("user") or {}).get("login")},
+        "created_at": x.get("created_at"),
+        "updated_at": x.get("updated_at"),
+        "user_notes_count": x.get("comments", 0),
+    })
+print(json.dumps(out))
+PY
+}
+
+# normalize_issue
+# Single-issue variant. Used by issues-by-label-events when re-fetching a
+# full issue body after a timeline hit.
+normalize_issue() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+x = json.loads(os.environ["DATA"])
+print(json.dumps({
+    "iid": x.get("number"),
+    "title": x.get("title"),
+    "description": x.get("body"),
+    "state": "opened" if x.get("state") == "open" else x.get("state"),
+    "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
+    "assignees": [{"username": a.get("login")} for a in (x.get("assignees") or [])],
+    "author": {"username": (x.get("user") or {}).get("login")},
+    "created_at": x.get("created_at"),
+    "updated_at": x.get("updated_at"),
+    "user_notes_count": x.get("comments", 0),
+}))
+PY
+}
+
+# normalize_pulls
+# Reads GitHub pulls-list JSON, writes GitLab-MR-shape JSON. Field mapping:
+#   iid         <- number
+#   title, description (<- body)
+#   state       GitHub open -> opened; GitHub closed with merged_at != null -> merged
+#   labels      flattened to strings (dict|str tolerant for GHE)
+#   target_branch <- base.ref
+#   merged_at   direct
+#   changes_count GitHub /pulls list does NOT include changed_files; forwarded
+#                 as None (planning-mr view consumers — scope_estimator — tolerate
+#                 null; they only use it when present for complexity scoring)
+#   user_notes_count <- comments (issue-style comments; GitHub also has
+#                 review_comments separately but comments is the closest analog
+#                 to GitLab's user_notes_count on MRs)
+normalize_pulls() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for x in data:
+    st = x.get("state")
+    if st == "open":
+        st = "opened"
+    elif st == "closed" and x.get("merged_at"):
+        st = "merged"
+    out.append({
+        "iid": x.get("number"),
+        "title": x.get("title"),
+        "description": x.get("body"),
+        "state": st,
+        "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
+        "author": {"username": (x.get("user") or {}).get("login")},
+        "target_branch": (x.get("base") or {}).get("ref"),
+        "source_branch": (x.get("head") or {}).get("ref"),
+        "merged_at": x.get("merged_at"),
+        "created_at": x.get("created_at"),
+        "updated_at": x.get("updated_at"),
+        "changes_count": x.get("changed_files"),
+        "user_notes_count": x.get("comments", 0),
+    })
+print(json.dumps(out))
+PY
+}
+
+# normalize_timeline <label_filter> <since_filter>
+# Reads GitHub /issues/{n}/timeline JSON, writes GitLab resource_label_events
+# shape: [{ts, action, label, user}]. GitHub event names:
+#   labeled   -> action "add"
+#   unlabeled -> action "remove"
+# Other timeline events (committed, reviewed, merged, cross-referenced, ...)
+# are dropped. Matches gitlab-api.sh's client-side since/label filtering so
+# the .ag consumer code is backend-agnostic.
+normalize_timeline() {
+    local label_filter="$1" since_filter="$2"
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" LABEL="$label_filter" SINCE="$since_filter" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+label = os.environ.get("LABEL", "")
+since = os.environ.get("SINCE", "")
+out = []
+for ev in data:
+    kind = ev.get("event")
+    if kind not in ("labeled", "unlabeled"):
+        continue
+    ev_label = (ev.get("label") or {}).get("name")
+    ev_ts = ev.get("created_at") or ""
+    if since and ev_ts < since:
+        continue
+    if label and ev_label != label:
+        continue
+    out.append({
+        "ts": ev_ts,
+        "action": "add" if kind == "labeled" else "remove",
+        "label": ev_label,
+        "user": (ev.get("actor") or {}).get("login"),
+    })
+print(json.dumps(out))
+PY
+}
+
+# project_json <view-name>
+# Same contract as gitlab-api.sh project_json: read normalized GitLab-shape
+# JSON from stdin, write downselected projection to stdout. Duplicated here
+# byte-identically so test-gitlab-views.sh's parity block catches drift.
+project_json() {
+    local view="$1"
+    if [ "${GITLAB_VIEW_MODE:-}" = "raw" ]; then
+        cat
+        return 0
+    fi
+    local DATA
+    DATA="$(cat)"
+    case "$view" in
+        raw)
+            printf '%s' "$DATA"
+            ;;
+        planning)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
+        "labels": x.get("labels", []),
+        "author": {"username": (x.get("author") or {}).get("username")},
+        "created_at": x.get("created_at")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        planning-mr)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
+        "labels": x.get("labels", []), "changes_count": x.get("changes_count"),
+        "user_notes_count": x.get("user_notes_count"),
+        "merged_at": x.get("merged_at"), "target_branch": x.get("target_branch")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        *)
+            emit_error "unknown view: $view"
+            exit 2
+            ;;
+    esac
+}
+
+if [ -z "${GITHUB_TOKEN:-}" ] || [ -z "${GITHUB_OWNER:-}" ] || [ -z "${GITHUB_REPO:-}" ]; then
+    emit_error "GITHUB_TOKEN, GITHUB_OWNER, and GITHUB_REPO must be set"
+    exit 1
+fi
+
+GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+API="$GITHUB_URL/repos/$GITHUB_OWNER/$GITHUB_REPO"
+
+# gh_call <method> <url> [curl-args...]
+#
+# Mirror of gitlab-api.sh gl_call (and triage github-api.sh gh_call): retry on
+# 429/5xx/timeout, no-retry on 401/403, 403-secondary-rate detection via body,
+# bounded curl --max-time, structured exit codes.
+gh_call() {
+    local method="$1" url="$2"
+    shift 2
+    local max_time="${GITHUB_CURL_MAX_TIME:-90}"
+    local max_retries="${GITHUB_CURL_RETRIES:-3}"
+    local attempt=0 delay=3 rc code snippet body_file
+    body_file="$(mktemp)"
+    trap 'rm -f "$body_file"; trap - RETURN' RETURN
+
+    while :; do
+        attempt=$((attempt + 1))
+        code=""
+        rc=0
+        code="$(curl -sS -w '%{http_code}' -o "$body_file" \
+            --max-time "$max_time" \
+            -X "$method" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$@" \
+            "$url" 2>/dev/null)" || rc=$?
+
+        if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
+            if [ "$attempt" -le "$max_retries" ]; then
+                sleep "$delay"
+                delay=$((delay * 2))
+                continue
+            fi
+            emit_error "curl transport failure (exit $rc) after $attempt attempts: $method $url"
+            return 5
+        fi
+
+        case "$code" in
+            2*)
+                cat "$body_file"
+                return 0
+                ;;
+            401|403)
+                snippet="$(head -c 200 "$body_file")"
+                case "$snippet" in
+                    *"rate limit"*|*"abuse"*|*"secondary rate"*)
+                        if [ "$attempt" -le "$max_retries" ]; then
+                            sleep "$delay"
+                            delay=$((delay * 2))
+                            continue
+                        fi
+                        emit_error "rate limited (HTTP $code secondary) after $attempt attempts on $method $url"
+                        return 3
+                        ;;
+                    *)
+                        emit_error "auth failure (HTTP $code) on $method $url: $snippet — check PAT scope/expiry"
+                        return 2
+                        ;;
+                esac
+                ;;
+            429)
+                if [ "$attempt" -le "$max_retries" ]; then
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                    continue
+                fi
+                emit_error "rate limited (HTTP 429) after $attempt attempts on $method $url"
+                return 3
+                ;;
+            5*)
+                if [ "$attempt" -le "$max_retries" ]; then
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                    continue
+                fi
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "server error (HTTP $code) after $attempt attempts: $snippet"
+                return 5
+                ;;
+            4*)
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "client error (HTTP $code) on $method $url: $snippet"
+                return 4
+                ;;
+            *)
+                emit_error "unexpected HTTP $code on $method $url"
+                return 4
+                ;;
+        esac
+    done
+}
+
+gh_get() {
+    gh_call GET "$1"
+}
+
+gh_get_q() {
+    local url="$1"
+    shift
+    gh_call GET "$url" -G "$@"
+}
+
+gh_post() {
+    gh_call POST "$1" -H "Content-Type: application/json" -d "$2"
+}
+
+CMD="${1:?Usage: github-api.sh <command> [args...]}"
+shift
+
+case "$CMD" in
+    issues)
+        SINCE=""
+        NEEDS_PLANNING=0
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) SINCE="$2"; shift 2 ;;
+                --needs-planning) NEEDS_PLANNING=1; shift ;;
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        ARGS=(
+            --data-urlencode "state=open"
+            --data-urlencode "per_page=20"
+            --data-urlencode "sort=updated"
+            --data-urlencode "direction=desc"
+        )
+        if [ "$NEEDS_PLANNING" -eq 1 ]; then
+            # GitHub /issues accepts a comma-separated labels filter — same semantic
+            # as GitLab's ?labels=. Scoped labels (::) and spaces pass through
+            # --data-urlencode cleanly.
+            ARGS+=(--data-urlencode "labels=${PLANNING_TRIGGER_LABEL:-needs-planning}")
+        fi
+        if [ -n "$SINCE" ]; then
+            # GitHub uses `since` (not `updated_after` like GitLab).
+            ARGS+=(--data-urlencode "since=$SINCE")
+        fi
+        body="$(gh_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_issues)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$normalized" | project_json "$VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    add-note)
+        ID="${1:?Usage: github-api.sh add-note <number> --body <text>}"
+        shift
+        BODY=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --body) BODY="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$BODY" ]; then
+            emit_error "--body is required"
+            exit 1
+        fi
+        case "$ID" in
+            ''|*[!0-9]*) emit_error "issue number must be numeric: $ID"; exit 2 ;;
+        esac
+        JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
+        gh_post "$API/issues/$ID/comments" "$JSON_BODY"
+        ;;
+
+    issue-label-events)
+        # GitHub's equivalent of GitLab /issues/{iid}/resource_label_events is
+        # /issues/{n}/timeline filtered to event in ("labeled", "unlabeled").
+        # Timeline has no --since query; we filter client-side (same as
+        # gitlab-api.sh does for parity).
+        IID="${1:?Usage: github-api.sh issue-label-events <number> [--since ISO8601] [--label NAME]}"
+        shift
+        EV_SINCE=""
+        EV_LABEL=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) EV_SINCE="$2"; shift 2 ;;
+                --label) EV_LABEL="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$IID" in
+            ''|*[!0-9]*) emit_error "issue number must be numeric: $IID"; exit 2 ;;
+        esac
+        body="$(gh_get_q "$API/issues/$IID/timeline" --data-urlencode "per_page=100")" || exit $?
+        printf '%s' "$body" | normalize_timeline "$EV_LABEL" "$EV_SINCE"
+        ;;
+
+    issues-by-label-events)
+        # Composite trigger query (parity with gitlab-api.sh issues-by-label-events).
+        # Returns the union of:
+        #   (a) open issues that currently carry $PLANNING_TRIGGER_LABEL, and
+        #   (b) open issues that had that label added at any point in
+        #       [--since, now] per the /timeline endpoint.
+        # Closes the same short-lived-trigger-label observability gap as the
+        # GitLab variant — the current-state snapshot misses issues where the
+        # label was added and removed between two 60s polls.
+        EV_SINCE=""
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) EV_SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$EV_SINCE" ]; then
+            emit_error "--since is required for issues-by-label-events"
+            exit 2
+        fi
+        LABEL="${PLANNING_TRIGGER_LABEL:-needs-planning}"
+        BASE_ARGS=(
+            --data-urlencode "state=open"
+            --data-urlencode "per_page=20"
+            --data-urlencode "sort=updated"
+            --data-urlencode "direction=desc"
+            --data-urlencode "since=$EV_SINCE"
+        )
+        recent_raw="$(gh_get_q "$API/issues" "${BASE_ARGS[@]}")" || exit $?
+        recent="$(printf '%s' "$recent_raw" | normalize_issues)"
+        # Split: currently-labeled (direct include) vs. needs timeline check.
+        split="$(RECENT="$recent" LABEL="$LABEL" python3 <<'PY'
+import os, json
+items = json.loads(os.environ["RECENT"])
+label = os.environ["LABEL"]
+current = [x for x in items if label in (x.get("labels") or [])]
+to_check = [x["iid"] for x in items if label not in (x.get("labels") or [])]
+print(json.dumps({"current": current, "to_check": to_check}))
+PY
+)" || exit $?
+        current_list="$(printf '%s' "$split" | python3 -c 'import sys,json;print(json.dumps(json.load(sys.stdin)["current"]))')"
+        iids_to_check="$(printf '%s' "$split" | python3 -c 'import sys,json;print(" ".join(str(i) for i in json.load(sys.stdin)["to_check"]))')"
+        matched="[]"
+        for IID in $iids_to_check; do
+            tl_body="$(gh_get_q "$API/issues/$IID/timeline" --data-urlencode "per_page=100")" || continue
+            hit="$(TLBODY="$tl_body" LABEL="$LABEL" EV_SINCE="$EV_SINCE" python3 <<'PY'
+import os, json
+events = json.loads(os.environ["TLBODY"])
+label = os.environ["LABEL"]
+since = os.environ["EV_SINCE"]
+for ev in events:
+    if ev.get("event") != "labeled":
+        continue
+    ev_label = (ev.get("label") or {}).get("name")
+    ev_ts = ev.get("created_at") or ""
+    if ev_label == label and ev_ts >= since:
+        print("1"); break
+else:
+    print("")
+PY
+)"
+            if [ -n "$hit" ]; then
+                issue_raw="$(gh_get "$API/issues/$IID")" || continue
+                issue_norm="$(printf '%s' "$issue_raw" | normalize_issue)"
+                matched="$(MATCHED="$matched" ISSUE="$issue_norm" python3 <<'PY'
+import os, json
+acc = json.loads(os.environ["MATCHED"])
+acc.append(json.loads(os.environ["ISSUE"]))
+print(json.dumps(acc))
+PY
+)"
+            fi
+        done
+        final="$(CUR="$current_list" MATCHED="$matched" python3 <<'PY'
+import os, json
+a = json.loads(os.environ["CUR"])
+b = json.loads(os.environ["MATCHED"])
+seen = set()
+out = []
+for x in a + b:
+    iid = x.get("iid")
+    if iid in seen:
+        continue
+    seen.add(iid)
+    out.append(x)
+print(json.dumps(out))
+PY
+)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$final" | project_json "$VIEW"
+        else
+            printf '%s' "$final"
+        fi
+        ;;
+
+    merge-requests)
+        # GitHub has /pulls (pull requests). Semantic collapses:
+        #   --state opened -> GitHub `open`
+        #   --state merged -> GitHub `closed` + local filter on merged_at != null
+        #                     (GitHub's /pulls has no "merged" state)
+        #   --state all    -> GitHub `all`
+        # GitHub /pulls does NOT accept `since` directly; we fetch sort=updated
+        # desc + filter client-side. `per_page` bounds the response so this is
+        # deterministic for the scope_estimator's "recent MRs" window.
+        STATE="opened"
+        SINCE=""
+        VIEW=""
+        PER_PAGE=20
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --state) STATE="$2"; shift 2 ;;
+                --since) SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                --per-page) PER_PAGE="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
+        MERGED_FILTER=0
+        case "$STATE" in
+            opened|open) GH_STATE="open" ;;
+            closed)      GH_STATE="closed" ;;
+            merged)      GH_STATE="closed"; MERGED_FILTER=1 ;;
+            all)         GH_STATE="all" ;;
+            *) emit_error "unknown --state: $STATE (expected opened|merged|closed|all)"; exit 2 ;;
+        esac
+        ARGS=(
+            --data-urlencode "state=$GH_STATE"
+            --data-urlencode "per_page=$PER_PAGE"
+            --data-urlencode "sort=updated"
+            --data-urlencode "direction=desc"
+        )
+        body="$(gh_get_q "$API/pulls" "${ARGS[@]}")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_pulls)"
+        if [ "$MERGED_FILTER" -eq 1 ] || [ -n "$SINCE" ]; then
+            normalized="$(NORM="$normalized" SINCE="$SINCE" MERGED="$MERGED_FILTER" python3 <<'PY'
+import os, json
+items = json.loads(os.environ["NORM"])
+since = os.environ.get("SINCE", "")
+merged_only = os.environ.get("MERGED", "0") == "1"
+out = []
+for x in items:
+    if merged_only and not x.get("merged_at"):
+        continue
+    if since:
+        ts = x.get("updated_at") or ""
+        if ts < since:
+            continue
+    out.append(x)
+print(json.dumps(out))
+PY
+)"
+        fi
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$normalized" | project_json "$VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    *)
+        emit_error "unknown command: $CMD"
+        exit 1
+        ;;
+esac

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -66,45 +66,82 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # shellcheck disable=SC1091  # colony-lint runs shellcheck without -x
 . "$REPO_ROOT/tools/parse-toml.sh"
 
-GITLAB_URL=$(parse_toml gitlab url)
-GITLAB_TOKEN=$(parse_toml gitlab token)
-GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
-
-if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
-    echo "Error: GitLab config incomplete in $CONFIG"
-    echo "Required: url, token, project under [gitlab]"
-    exit 1
-fi
-
-# URL-encode the project path (replace / with %2F)
-GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
-
-# #104: operator identity. Empty if not configured (pre-#104 setups or
-# operators who skipped the install.sh prompt); agents fall back to
-# memo gitlab:me and tag everything as team when both are empty.
-GITLAB_ME=$(parse_toml gitlab me)
-
-# #223: operator-configurable trigger label. Empty if the config
-# predates #223 (no [planning] section); gitlab-api.sh falls back to
-# "needs-planning" in that case, preserving pre-#223 behavior.
-PLANNING_TRIGGER_LABEL=$(parse_toml planning trigger_label)
-
-export GITLAB_URL
-export GITLAB_TOKEN
-export GITLAB_PROJECT
-export GITLAB_ME
-export PLANNING_TRIGGER_LABEL
-export COLONY_DIR
-
 # #256: forge backend selection. `[forge].type` picks which backend
 # wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
-# configs keep working unchanged. The github backend is skeleton-only
-# until PRs 2-6 of #256 land their per-colony github-api.sh wrappers;
-# until then, FORGE_TYPE=github yields exit 99 "not implemented" from
-# forge-api.sh.
+# configs keep working unchanged. PR 3 of #256 ships the planning colony's
+# github-api.sh, so FORGE_TYPE=github is now live for planning (other
+# colonies still return exit 99 "not implemented" until their respective
+# PRs land).
 FORGE_TYPE=$(parse_toml forge type)
 FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+
+case "$FORGE_TYPE" in
+    gitlab)
+        # Prefer [forge.gitlab] (ADR-0002) if present; fall back to legacy
+        # [gitlab] so pre-#256 configs keep working during the overlap window.
+        GITLAB_URL=$(parse_toml forge.gitlab url)
+        [ -z "$GITLAB_URL" ] && GITLAB_URL=$(parse_toml gitlab url)
+        GITLAB_TOKEN=$(parse_toml forge.gitlab token)
+        [ -z "$GITLAB_TOKEN" ] && GITLAB_TOKEN=$(parse_toml gitlab token)
+        GITLAB_PROJECT_RAW=$(parse_toml forge.gitlab project)
+        [ -z "$GITLAB_PROJECT_RAW" ] && GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
+        GITLAB_ME=$(parse_toml forge.gitlab me)
+        [ -z "$GITLAB_ME" ] && GITLAB_ME=$(parse_toml gitlab me)
+
+        if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
+            echo "Error: GitLab config incomplete in $CONFIG"
+            echo "Required: url, token, project under [forge.gitlab] (or legacy [gitlab])"
+            exit 1
+        fi
+
+        # URL-encode the project path (replace / with %2F)
+        GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
+
+        export GITLAB_URL
+        export GITLAB_TOKEN
+        export GITLAB_PROJECT
+        export GITLAB_ME
+        ;;
+    github)
+        GITHUB_URL=$(parse_toml forge.github url)
+        GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+        GITHUB_OWNER=$(parse_toml forge.github owner)
+        GITHUB_REPO=$(parse_toml forge.github repo)
+        GITHUB_TOKEN=$(parse_toml forge.github token)
+        GITHUB_ME=$(parse_toml forge.github me)
+
+        if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
+            echo "Error: GitHub config incomplete in $CONFIG"
+            echo "Required: owner, repo, token under [forge.github]"
+            exit 1
+        fi
+
+        # Use the project-raw variable name for the summary echo below so
+        # both branches can share one format string. Value is informational.
+        GITLAB_PROJECT_RAW="$GITHUB_OWNER/$GITHUB_REPO"
+
+        export GITHUB_URL
+        export GITHUB_OWNER
+        export GITHUB_REPO
+        export GITHUB_TOKEN
+        export GITHUB_ME
+        ;;
+    *)
+        echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2
+        exit 1
+        ;;
+esac
+
+# #223: operator-configurable trigger label. Empty if the config
+# predates #223 (no [planning] section); forge-api.sh falls back to
+# "needs-planning" in that case, preserving pre-#223 behavior. The label
+# itself is backend-agnostic — both gitlab-api.sh and github-api.sh
+# consume PLANNING_TRIGGER_LABEL identically.
+PLANNING_TRIGGER_LABEL=$(parse_toml planning trigger_label)
+
 export FORGE_TYPE
+export PLANNING_TRIGGER_LABEL
+export COLONY_DIR
 
 AGENTS=(
     scope_estimator
@@ -204,7 +241,10 @@ if [ -n "$RESTART_AGENT" ]; then
 fi
 
 echo "Starting Planning colony (${#AGENTS[@]} agents)..."
-echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
+case "$FORGE_TYPE" in
+    gitlab) echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)" ;;
+    github) echo "  GitHub: $GITHUB_URL ($GITHUB_OWNER/$GITHUB_REPO)" ;;
+esac
 
 for agent in "${AGENTS[@]}"; do
     interval=$(tick_interval_for "$agent")

--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -107,14 +107,18 @@ authoritative contract; `test-forge-api.sh` enforces byte-identical
 output for matching fixtures across both backends.
 
 **Per-PR rollout.** PR 1 shipped the dispatcher skeleton and config
-schema only. PR 2 (the current PR as of this writing) ships the triage
-colony's `github-api.sh` with 7 subcommands (`issues`, `create-issue`,
-`update-issue`, `members`, `get-issue`, `labels`, `add-note`) plus the
-`[forge.github]` env-export branch in `triage/scripts/start-colony.sh`.
-The remaining colonies' wrappers land across PRs 3-6 in the order
-planning → implementation → code-review → release. `rate-limit-status`
-and the dashboard tile ship in PR 7 alongside the legacy
-`[gitlab]`-section retirement.
+schema only. PR 2 shipped the triage colony's `github-api.sh` with 7
+subcommands (`issues`, `create-issue`, `update-issue`, `members`,
+`get-issue`, `labels`, `add-note`) plus the `[forge.github]` env-export
+branch in `triage/scripts/start-colony.sh`. PR 3 (the current PR as of
+this writing) ships the planning colony's `github-api.sh` with 5
+subcommands (`issues`, `issues-by-label-events`, `issue-label-events`,
+`add-note`, `merge-requests`) plus the matching `[forge.github]`
+env-export branch and `.ag` dispatcher migration. The remaining
+colonies' wrappers land across PRs 4-6 in the order
+implementation → code-review → release. `rate-limit-status` and the
+dashboard tile ship in PR 7 alongside the legacy `[gitlab]`-section
+retirement.
 
 **`.ag` migration is in-scope for every per-colony PR.** Each
 per-colony PR (PRs 2-6) MUST rewrite every `exec sh` call site in that
@@ -138,6 +142,21 @@ not in the original ADR table; it is added here and back-ported to
 `triage/scripts/gitlab-api.sh` to match (the `.ag` agents were calling
 it against a non-existent gitlab-api.sh arm before PR 2, silently
 swallowed by `try/catch`).
+
+**PR 3 additions.** The planning contract layers two subcommands on
+top of the triage surface: `merge-requests` (maps to GitHub `/pulls`
+with `state=open|closed|all`, `--state merged` collapsing to
+`closed + merged_at != null` since GitHub has no separate "merged"
+state) and `issue-label-events` (maps to GitHub `/issues/{n}/timeline`
+filtered to `event in ("labeled", "unlabeled")`, since GitHub has no
+dedicated `resource_label_events` endpoint). `issues-by-label-events`
+(the composite the planning agents use to catch short-lived trigger
+labels) is shared contract for PRs 3-6 — any colony that ingests
+label-event-driven triggers uses the same shape. GitHub's `/pulls`
+list endpoint omits `changed_files`; the normalizer forwards `null`,
+and scope_estimator tolerates it (complexity scoring is best-effort).
+GitHub's `/pulls` has no `since` query param, so `--since` is filtered
+client-side against `updated_at`.
 
 | Subcommand           | Normalized output |
 |----------------------|-------------------|

--- a/tools/test-github-planning-normalize.sh
+++ b/tools/test-github-planning-normalize.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# test-github-planning-normalize.sh: unit-test the GitHub -> GitLab-shape
+# normalizers in dev-apprenticeship/planning/scripts/github-api.sh
+# (ADR-0002, #256 PR 3).
+#
+# Planning's normalizer surface differs from triage's: no members/labels
+# enumeration (planning doesn't assign), but two planning-specific
+# normalizers — normalize_pulls (for `merge-requests` command) and
+# normalize_timeline (for `issue-label-events`) — covering the GitHub
+# /pulls and /issues/{n}/timeline endpoints respectively.
+#
+# Matches the style of test-github-triage-normalize.sh (bash 3.2, python3
+# for JSON, build_prelude pattern for sourcing the script under test).
+#
+# Exit 0 all-pass, 1 any-fail.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT="$REPO_ROOT/dev-apprenticeship/planning/scripts/github-api.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+# GitHub /issues fixture: two real issues plus one pull_request-bearing entry
+# that must be filtered out. Mirrors the triage fixture so parity bugs in
+# normalize_issues show up on either side.
+FIXTURE_ISSUES='[
+  {"url":"https://api.github.com/repos/o/r/issues/1","number":1,"title":"Plan me",
+   "body":"epic-desc","state":"open","labels":[{"id":1,"name":"needs-planning"},
+   {"id":2,"name":"epic"}],
+   "user":{"login":"alice","id":7,"type":"User"},
+   "assignees":[{"login":"bob","id":8}],
+   "created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-02T10:00:00Z",
+   "comments":2,"author_association":"MEMBER"},
+  {"url":"https://api.github.com/repos/o/r/issues/2","number":2,"title":"Another",
+   "body":"desc-2","state":"open","labels":[],
+   "user":{"login":"alice","id":7,"type":"User"},
+   "assignees":[],"created_at":"2026-04-03T10:00:00Z","updated_at":"2026-04-04T10:00:00Z",
+   "comments":0,"author_association":"MEMBER"},
+  {"url":"https://api.github.com/repos/o/r/issues/3","number":3,"title":"I-am-a-PR",
+   "body":"pr-body","state":"open","labels":[{"id":3,"name":"needs-planning"}],
+   "user":{"login":"alice","id":7,"type":"User"},"assignees":[],
+   "created_at":"2026-04-05T10:00:00Z","updated_at":"2026-04-06T10:00:00Z","comments":1,
+   "pull_request":{"url":"https://api.github.com/repos/o/r/pulls/3"}}
+]'
+
+FIXTURE_SINGLE_ISSUE='{"url":"https://api.github.com/repos/o/r/issues/42","number":42,
+  "title":"Single","body":"single-desc","state":"closed",
+  "labels":[{"id":99,"name":"epic"}],
+  "user":{"login":"alice","id":7},"assignees":[{"login":"bob","id":8}],
+  "created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-10T10:00:00Z","comments":5}'
+
+# GitHub /pulls fixture. scope_estimator reads `merge-requests --state merged
+# --view planning-mr`, so the normalizer must:
+#   (1) state open -> opened
+#   (2) state closed with merged_at != null -> merged
+#   (3) state closed with merged_at == null -> closed (rejected PR)
+#   (4) target_branch <- base.ref, source_branch <- head.ref
+#   (5) user_notes_count <- comments
+#   (6) changes_count <- changed_files (often absent on list endpoint — null ok)
+FIXTURE_PULLS='[
+  {"url":"https://api.github.com/repos/o/r/pulls/10","number":10,"title":"Open PR",
+   "body":"pr-10","state":"open","merged_at":null,
+   "labels":[{"id":1,"name":"feature"}],
+   "user":{"login":"alice"},"base":{"ref":"main"},"head":{"ref":"feat/x"},
+   "created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-02T10:00:00Z",
+   "comments":1},
+  {"url":"https://api.github.com/repos/o/r/pulls/11","number":11,"title":"Merged PR",
+   "body":"pr-11","state":"closed","merged_at":"2026-04-05T12:00:00Z",
+   "labels":[{"id":2,"name":"bugfix"}],
+   "user":{"login":"alice"},"base":{"ref":"main"},"head":{"ref":"fix/y"},
+   "created_at":"2026-04-03T10:00:00Z","updated_at":"2026-04-05T12:00:00Z",
+   "comments":4,"changed_files":7},
+  {"url":"https://api.github.com/repos/o/r/pulls/12","number":12,"title":"Rejected PR",
+   "body":"pr-12","state":"closed","merged_at":null,
+   "labels":[],
+   "user":{"login":"carol"},"base":{"ref":"main"},"head":{"ref":"wip/z"},
+   "created_at":"2026-04-04T10:00:00Z","updated_at":"2026-04-06T10:00:00Z",
+   "comments":0}
+]'
+
+# GitHub /issues/{n}/timeline fixture. Per the GitHub REST API, events vary
+# wildly — `labeled` / `unlabeled` carry a `label: {name, color}` object, and
+# most other event kinds (`committed`, `reviewed`, `cross-referenced`, ...)
+# should be ignored. The normalizer's job is to drop non-label events and map
+# labeled -> "add", unlabeled -> "remove".
+FIXTURE_TIMELINE='[
+  {"id":1,"event":"labeled","created_at":"2026-04-10T10:00:00Z",
+   "actor":{"login":"alice"},"label":{"name":"needs-planning","color":"ff0000"}},
+  {"id":2,"event":"cross-referenced","created_at":"2026-04-10T10:01:00Z",
+   "actor":{"login":"bob"}},
+  {"id":3,"event":"unlabeled","created_at":"2026-04-11T09:00:00Z",
+   "actor":{"login":"alice"},"label":{"name":"needs-planning","color":"ff0000"}},
+  {"id":4,"event":"labeled","created_at":"2026-04-12T09:00:00Z",
+   "actor":{"login":"alice"},"label":{"name":"epic","color":"00ff00"}},
+  {"id":5,"event":"committed","created_at":"2026-04-12T09:30:00Z"}
+]'
+
+# Source just the function defs. Same awk-stop trick as test-github-triage.
+build_prelude() {
+    awk '/^CMD=/{exit} {print}' "$SCRIPT" > "$1"
+}
+
+# run_fn <fn-name> <input-json> [args...]
+# Pipes the fixture through the named normalize fn with optional args.
+# Dummy GITHUB_* env satisfies the env-check block that fires at source time.
+run_fn() {
+    local fn="$1" input="$2"
+    shift 2
+    local prelude
+    prelude=$(mktemp)
+    build_prelude "$prelude"
+    # shellcheck disable=SC1090,SC2016
+    GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+        source "$1"
+        input="$2"
+        fn="$3"
+        shift 3
+        printf "%s" "$input" | "$fn" "$@"
+    ' _ "$prelude" "$input" "$fn" "$@"
+    local rc=$?
+    rm -f "$prelude"
+    return $rc
+}
+
+json_extract() {
+    DATA="$1" python3 -c "
+import os, json
+data = json.loads(os.environ['DATA'])
+print($2)
+"
+}
+
+assert_eq() {
+    if [ "$1" = "$2" ]; then
+        pass "$3"
+    else
+        fail "$3: expected='$1' actual='$2'"
+    fi
+}
+
+# --- normalize_issues: PR filter + shape ---
+ISSUES_OUT=$(run_fn normalize_issues "$FIXTURE_ISSUES")
+
+COUNT=$(json_extract "$ISSUES_OUT" "len(data)")
+assert_eq "2" "$COUNT" "normalize_issues: pull_request entries filtered out"
+
+IID0=$(json_extract "$ISSUES_OUT" "data[0]['iid']")
+assert_eq "1" "$IID0" "normalize_issues: iid == number"
+
+STATE0=$(json_extract "$ISSUES_OUT" "data[0]['state']")
+assert_eq "opened" "$STATE0" "normalize_issues: state open -> opened"
+
+LABELS0=$(json_extract "$ISSUES_OUT" "','.join(data[0]['labels'])")
+assert_eq "needs-planning,epic" "$LABELS0" "normalize_issues: labels flattened to strings"
+
+AUTHOR0=$(json_extract "$ISSUES_OUT" "data[0]['author']['username']")
+assert_eq "alice" "$AUTHOR0" "normalize_issues: author.username == user.login"
+
+# --- normalize_issue (single-issue variant) ---
+SINGLE_OUT=$(run_fn normalize_issue "$FIXTURE_SINGLE_ISSUE")
+SINGLE_IID=$(DATA="$SINGLE_OUT" python3 -c "import os, json; print(json.loads(os.environ['DATA'])['iid'])")
+SINGLE_STATE=$(DATA="$SINGLE_OUT" python3 -c "import os, json; print(json.loads(os.environ['DATA'])['state'])")
+assert_eq "42" "$SINGLE_IID" "normalize_issue: iid == number"
+assert_eq "closed" "$SINGLE_STATE" "normalize_issue: state closed stays closed"
+
+# --- normalize_pulls: state collapse + MR-shape ---
+PULLS_OUT=$(run_fn normalize_pulls "$FIXTURE_PULLS")
+P_COUNT=$(json_extract "$PULLS_OUT" "len(data)")
+assert_eq "3" "$P_COUNT" "normalize_pulls: three entries"
+
+P0_STATE=$(json_extract "$PULLS_OUT" "data[0]['state']")
+P1_STATE=$(json_extract "$PULLS_OUT" "data[1]['state']")
+P2_STATE=$(json_extract "$PULLS_OUT" "data[2]['state']")
+assert_eq "opened" "$P0_STATE" "normalize_pulls: open -> opened"
+assert_eq "merged" "$P1_STATE" "normalize_pulls: closed + merged_at -> merged"
+assert_eq "closed" "$P2_STATE" "normalize_pulls: closed + no merged_at -> closed"
+
+P1_TGT=$(json_extract "$PULLS_OUT" "data[1]['target_branch']")
+P1_SRC=$(json_extract "$PULLS_OUT" "data[1]['source_branch']")
+P1_MERGED=$(json_extract "$PULLS_OUT" "data[1]['merged_at']")
+P1_CHANGES=$(json_extract "$PULLS_OUT" "data[1]['changes_count']")
+P1_NOTES=$(json_extract "$PULLS_OUT" "data[1]['user_notes_count']")
+assert_eq "main" "$P1_TGT" "normalize_pulls: target_branch <- base.ref"
+assert_eq "fix/y" "$P1_SRC" "normalize_pulls: source_branch <- head.ref"
+assert_eq "2026-04-05T12:00:00Z" "$P1_MERGED" "normalize_pulls: merged_at preserved"
+assert_eq "7" "$P1_CHANGES" "normalize_pulls: changes_count <- changed_files"
+assert_eq "4" "$P1_NOTES" "normalize_pulls: user_notes_count <- comments"
+
+# Open PR has no changed_files in list endpoint — forwarded as null, not missing.
+P0_CHANGES=$(json_extract "$PULLS_OUT" "repr(data[0]['changes_count'])")
+assert_eq "None" "$P0_CHANGES" "normalize_pulls: missing changed_files -> null"
+
+# --- normalize_timeline: label events only + add/remove mapping ---
+TIMELINE_OUT=$(run_fn normalize_timeline "$FIXTURE_TIMELINE" "" "")
+T_COUNT=$(json_extract "$TIMELINE_OUT" "len(data)")
+assert_eq "3" "$T_COUNT" "normalize_timeline: non-label events dropped (committed/cross-referenced)"
+
+T0_ACTION=$(json_extract "$TIMELINE_OUT" "data[0]['action']")
+T0_LABEL=$(json_extract "$TIMELINE_OUT" "data[0]['label']")
+T0_USER=$(json_extract "$TIMELINE_OUT" "data[0]['user']")
+assert_eq "add" "$T0_ACTION" "normalize_timeline: labeled -> add"
+assert_eq "needs-planning" "$T0_LABEL" "normalize_timeline: label.name preserved"
+assert_eq "alice" "$T0_USER" "normalize_timeline: actor.login -> user"
+
+T1_ACTION=$(json_extract "$TIMELINE_OUT" "data[1]['action']")
+assert_eq "remove" "$T1_ACTION" "normalize_timeline: unlabeled -> remove"
+
+# --- normalize_timeline: label filter ---
+TL_LABEL_ONLY=$(run_fn normalize_timeline "$FIXTURE_TIMELINE" "needs-planning" "")
+TL_LABEL_COUNT=$(json_extract "$TL_LABEL_ONLY" "len(data)")
+assert_eq "2" "$TL_LABEL_COUNT" "normalize_timeline: label filter narrows to 'needs-planning' events"
+
+# --- normalize_timeline: since filter ---
+TL_SINCE=$(run_fn normalize_timeline "$FIXTURE_TIMELINE" "" "2026-04-11T00:00:00Z")
+TL_SINCE_COUNT=$(json_extract "$TL_SINCE" "len(data)")
+assert_eq "2" "$TL_SINCE_COUNT" "normalize_timeline: since filter drops pre-cutoff events"
+
+# --- End-to-end: normalize_issues -> project_json planning ---
+# Ensures the view keys stay locked to {iid, title, description, labels,
+# author, created_at} — scope_estimator/risk_assessor/task_decomposer all
+# read this projection and drift would silently misfeed their prompts.
+PIPE_PRELUDE=$(mktemp)
+build_prelude "$PIPE_PRELUDE"
+# shellcheck disable=SC1090,SC2016
+E2E_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    printf "%s" "$2" | normalize_issues | project_json planning
+' _ "$PIPE_PRELUDE" "$FIXTURE_ISSUES")
+rm -f "$PIPE_PRELUDE"
+
+E2E_COUNT=$(json_extract "$E2E_OUT" "len(data)")
+E2E_KEYS=$(json_extract "$E2E_OUT" "','.join(sorted(data[0].keys()))")
+E2E_IID=$(json_extract "$E2E_OUT" "data[0]['iid']")
+E2E_AUTHOR=$(json_extract "$E2E_OUT" "data[0]['author']['username']")
+assert_eq "2" "$E2E_COUNT" "e2e planning: normalize | planning view emits 2 items (PR filtered)"
+assert_eq "author,created_at,description,iid,labels,title" "$E2E_KEYS" "e2e planning: view keys match gitlab shape"
+assert_eq "1" "$E2E_IID" "e2e planning: view carries iid through pipe"
+assert_eq "alice" "$E2E_AUTHOR" "e2e planning: view carries author.username through pipe"
+
+# --- End-to-end: normalize_pulls -> project_json planning-mr ---
+PIPE_PRELUDE2=$(mktemp)
+build_prelude "$PIPE_PRELUDE2"
+# shellcheck disable=SC1090,SC2016
+E2E_MR_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    printf "%s" "$2" | normalize_pulls | project_json planning-mr
+' _ "$PIPE_PRELUDE2" "$FIXTURE_PULLS")
+rm -f "$PIPE_PRELUDE2"
+
+E2E_MR_COUNT=$(json_extract "$E2E_MR_OUT" "len(data)")
+E2E_MR_KEYS=$(json_extract "$E2E_MR_OUT" "','.join(sorted(data[0].keys()))")
+E2E_MR_MERGED=$(json_extract "$E2E_MR_OUT" "data[1]['merged_at']")
+E2E_MR_TGT=$(json_extract "$E2E_MR_OUT" "data[1]['target_branch']")
+assert_eq "3" "$E2E_MR_COUNT" "e2e planning-mr: normalize | planning-mr view emits 3 items"
+assert_eq "changes_count,description,iid,labels,merged_at,target_branch,title,user_notes_count" "$E2E_MR_KEYS" "e2e planning-mr: view keys match gitlab-mr shape"
+assert_eq "2026-04-05T12:00:00Z" "$E2E_MR_MERGED" "e2e planning-mr: merged_at carried through"
+assert_eq "main" "$E2E_MR_TGT" "e2e planning-mr: target_branch carried through"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-gitlab-views.sh
+++ b/tools/test-gitlab-views.sh
@@ -323,6 +323,29 @@ if [ -f "$GH_SCRIPT" ]; then
     done
 fi
 
+# --- planning github-api.sh project_json parity (#256 PR 3) ---
+# Same deal as triage: planning/scripts/github-api.sh duplicates project_json
+# instead of sourcing gitlab-api.sh. The planning-specific views are `planning`
+# and `planning-mr`; both must emit byte-identical JSON to their gitlab twin
+# when fed an already-GitLab-shape fixture.
+GH_PLANNING_SCRIPT="$REPO_ROOT/dev-apprenticeship/planning/scripts/github-api.sh"
+if [ -f "$GH_PLANNING_SCRIPT" ]; then
+    for pair in \
+        "planning:$FIXTURE_ISSUES" \
+        "planning-mr:$FIXTURE_MRS"
+    do
+        view="${pair%%:*}"
+        fixture="${pair#*:}"
+        gl_out=$(run_view "$REPO_ROOT/dev-apprenticeship/planning/scripts/gitlab-api.sh" "$view" "$fixture")
+        gh_out=$(run_view_github "$GH_PLANNING_SCRIPT" "$view" "$fixture")
+        if [ "$gl_out" = "$gh_out" ]; then
+            pass "planning github-api.sh project_json parity: $view"
+        else
+            fail "planning github-api.sh project_json drifted from gitlab-api.sh: $view"
+        fi
+    done
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Third of 7 PRs in the #256 forge-abstraction rollout — ships the **planning colony's** concrete `github-api.sh`, migrates its 4 `.ag` agents to dispatch through `forge-api.sh`, and wires `start-colony.sh` to export `GITHUB_*` under `FORGE_TYPE=github`. Planning is now a working second colony on GitHub. PR 1 shipped the dispatcher skeleton + `[forge.*]` schema (4e6d20e); PR 2 shipped triage (7bee533).

### What's in the contract

Planning's surface is smaller than triage's (no members/labels enumeration — planning doesn't assign) but adds two GitHub endpoint collapses that triage doesn't care about:

| Subcommand | GitLab → GitHub collapse |
|---|---|
| `issues [--needs-planning] [--since]` | `/repos/{o}/{r}/issues` with `labels=` + `since=` |
| `issue-label-events <n>` | `/issues/{n}/timeline` filtered to `event in ("labeled","unlabeled")`, mapped `labeled`→"add" / `unlabeled`→"remove" |
| `issues-by-label-events --since` | composite: recent open issues ∪ timeline-added-in-window, dedup by iid |
| `merge-requests [--state opened\|merged\|all] [--since]` | `/pulls` with `state=open\|closed\|all`; `--state merged` collapses to `closed + merged_at != null` (GitHub has no distinct "merged" state); `--since` is client-side on `updated_at` (GitHub `/pulls` has no `since` param) |
| `add-note <n> --body` | `/issues/{n}/comments` POST |

All responses normalized to GitLab shape (iid ← number, author.username ← user.login, labels flattened — both object + bare-string form tolerated for GHE, state open → opened, pull_request-bearing entries filtered out).

### .ag migration (non-optional)

All **16 `exec sh` call sites** across `scope_estimator`, `risk_assessor`, `task_decomposer`, `plan_reviewer` rewritten from `scripts/gitlab-api.sh` to `scripts/forge-api.sh`. Without this, `check-forge-dispatch.sh` (the PR 2 lint rule) would fail CI the moment `planning/scripts/github-api.sh` lands.

### start-colony.sh

Same `FORGE_TYPE` branch as triage: exports `GITHUB_URL`/`GITHUB_OWNER`/`GITHUB_REPO`/`GITHUB_TOKEN`/`GITHUB_ME` from `[forge.github]` under github, reads `[forge.gitlab]` with `[gitlab]` legacy fallback under gitlab. `PLANNING_TRIGGER_LABEL` is backend-agnostic and unchanged.

### Tests

- **`tools/test-github-planning-normalize.sh`** (new, 32 assertions): `normalize_issues` PR-filter + shape; `normalize_issue` (single); `normalize_pulls` state collapse + target_branch/source_branch/changes_count/merged_at handling; `normalize_timeline` label/since filters + add/remove mapping; e2e pipes through `planning` and `planning-mr` views.
- **`tools/test-gitlab-views.sh`** (extension): adds a planning parity block — asserts byte-identical `project_json` output between the duplicated `planning/scripts/github-api.sh` and `planning/scripts/gitlab-api.sh` projections for the `planning` and `planning-mr` views.

### ADR-0002

Per-PR rollout paragraph marks PR 3 shipped. Adds a "PR 3 additions" paragraph documenting the `/timeline` and `/pulls` endpoint collapses, the `changed_files`-is-null behavior on the `/pulls` list endpoint, and the client-side `since` filter.

### colony-lint

98 passed, 0 failed, 1 skipped (agentis binary not on CI runners).

## Test plan

- [x] `bash tools/test-github-planning-normalize.sh` → 32/32 passing locally
- [x] `bash tools/test-gitlab-views.sh` → 56/56 passing locally (new planning parity block included)
- [x] `bash tools/check-forge-dispatch.sh` → exit 0 (planning + triage both green under the lint rule)
- [x] `bash tools/colony-lint.sh` → 98 passed, 0 failed, 1 skipped
- [x] CI green on this branch
- [x] QA pass + findings posted as PR comment before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)