### PR TITLE
feat(#256): implementation colony GitHub backend (PR 4 of 7)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -130,6 +130,46 @@ is asserted until multi-version CI is in place.
   `github-api.sh` and `gitlab-api.sh` for the `planning` and
   `planning-mr` views.
   [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
+- **Implementation colony GitHub backend (PR 4 of 7 for #256).**
+  `dev-apprenticeship/implementation/scripts/github-api.sh` implements
+  the implementation contract against the GitHub REST API v3 (11
+  subcommands: `merge-requests`, `mr-changes`, `mr-commits`, `issue`,
+  `assigned-issues`, `issue-label-events`,
+  `assigned-issues-by-label-events`, `create-branch`, `commit-files`,
+  `create-mr`, `add-note`). The write-path subcommands — `create-branch`,
+  `commit-files`, `create-mr` — carry the main GitHub-vs-GitLab
+  asymmetry: GitHub has no single-call multi-file commit endpoint, so
+  `commit-files` implements the 5-step Git Database API dance (resolve
+  HEAD ref → fetch base tree → `POST /git/trees` with per-file action
+  list → `POST /git/commits` → `PATCH /git/refs/heads/{branch}`).
+  Supported actions are `create`/`update`/`delete`; `move`/`chmod` are
+  rejected up-front with exit 1 (GitLab-only semantics). `mr-changes`
+  maps `/pulls/{n}/files` into the GitLab
+  `{"changes": [{old_path, new_path, diff, new_file, deleted_file,
+  renamed_file}]}` shape; `mr-commits` flattens
+  `commit.author.{name,date}` into the GitLab-flat
+  `{author_name, created_at}` shape. All 25 `exec sh` call sites across
+  `code_writer`, `test_writer`, `refactorer`, and `commit_composer`
+  were rewritten from `scripts/gitlab-api.sh` to `scripts/forge-api.sh`.
+  `implementation/scripts/start-colony.sh` now branches on `FORGE_TYPE`
+  identically to triage and planning; the `IMPLEMENTATION_TRIGGER_LABEL`
+  and `GITLAB_DEFAULT_BRANCH` exports are backend-agnostic and
+  unchanged. Back-port fix: `implementation/scripts/gitlab-api.sh`
+  gains an `add-note` subcommand targeting `/issues/{iid}/notes`; all
+  four implementation agents call `add-note` on their review-gated
+  branches but it never existed on the GitLab side (the existing
+  `post-note` arm targets MRs). Calls were silently failing through
+  `.ag` try/catch — same pattern that PR 2 fixed for triage. Two new
+  tests: `tools/test-github-implementation-normalize.sh` (50 assertions
+  covering `normalize_issues` PR-filter, `normalize_pulls` state
+  collapse, new `normalize_mr_changes` wrap-and-flag mapping, new
+  `normalize_mr_commits` author flattening, `normalize_timeline`
+  label/since filters, end-to-end pipes through `impl` and `assigned`
+  views); and an implementation-colony extension to
+  `tools/test-gitlab-views.sh` asserting byte-identical `project_json`
+  output between `github-api.sh` and `gitlab-api.sh` for the `impl`
+  and `assigned` views.
+  [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
 
 ### Changed
 

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -27,9 +27,9 @@ type CodeDraft {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("code_writer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view impl";
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl";
 }
 
 fn get_confidence() -> float {
@@ -109,7 +109,7 @@ fn tick(reason: string) -> void {
 
         if should_learn_from_mr(mr_iid) {
             memo_write("code_writer:last_learned_mr_iid", to_string(mr_iid));
-            let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+            let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
             if len(changes_raw) > 10 {
@@ -137,9 +137,9 @@ fn tick(reason: string) -> void {
     // to the current-state snapshot — byte-identical to pre-#235 boot.
     let prev_check = recall_latest("code_writer:last_check");
     let issues_cmd = if len(prev_check) > 0 {
-        "$COLONY_DIR/scripts/gitlab-api.sh assigned-issues-by-label-events --since " + shell_escape(prev_check) + " --view assigned";
+        "$COLONY_DIR/scripts/forge-api.sh assigned-issues-by-label-events --since " + shell_escape(prev_check) + " --view assigned";
     } else {
-        "$COLONY_DIR/scripts/gitlab-api.sh assigned-issues --view assigned";
+        "$COLONY_DIR/scripts/forge-api.sh assigned-issues --view assigned";
     };
     let issues_raw = try {
         exec sh issues_cmd;
@@ -172,7 +172,7 @@ fn tick(reason: string) -> void {
 
             if my_tier == "autonomous" {
                 // Create branch
-                let branch_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-branch --name " + shell_escape(draft.branch_name) + " --ref main";
+                let branch_cmd = "$COLONY_DIR/scripts/forge-api.sh create-branch --name " + shell_escape(draft.branch_name) + " --ref main";
                 let branch_result = try { exec sh branch_cmd; } catch e {
                     print("[code_writer] Branch creation failed:", e);
                     "";
@@ -180,7 +180,7 @@ fn tick(reason: string) -> void {
 
                 if len(branch_result) > 0 {
                     // Generate actual code and commit it to the branch
-                    let issue_cmd = "$COLONY_DIR/scripts/gitlab-api.sh issue " + to_string(draft.issue_id);
+                    let issue_cmd = "$COLONY_DIR/scripts/forge-api.sh issue " + to_string(draft.issue_id);
                     let issue_detail = try { exec sh issue_cmd; } catch e { ""; };
                     let code_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec);
 
@@ -190,7 +190,7 @@ fn tick(reason: string) -> void {
                     ) -> string;
 
                     // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-                    let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json);
+                    let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json);
                     let commit_result = try { exec sh commit_cmd; } catch e {
                         print("[code_writer] Commit failed:", e);
                         "";
@@ -208,7 +208,7 @@ fn tick(reason: string) -> void {
                     // on the issue so a human can approve before we create a branch
                     // and commit code. No branch or commit at this tier.
                     let note = "[draft-impl] **Implementation Plan** (automated, pending approval)\n\nBranch: `" + draft.branch_name + "`\n\n" + draft.summary + "\n\nFiles:\n" + draft.files;
-                    let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(note);
+                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(note);
                     try { exec sh post_cmd; } catch e {
                         print("[code_writer] Failed to post draft plan:", e);
                     };

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -29,9 +29,9 @@ type MRPlan {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("commit_composer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view impl";
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl";
 }
 
 fn get_confidence() -> float {
@@ -78,7 +78,7 @@ fn tick(reason: string) -> void {
 
         if should_learn_from_mr(mr_iid) {
             memo_write("commit_composer:last_learned_mr_iid", to_string(mr_iid));
-            let commits_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-commits " + to_string(mr_iid);
+            let commits_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-commits " + to_string(mr_iid);
             let commits_raw = try { exec sh commits_cmd; } catch e { "[]"; };
 
             if len(commits_raw) > 10 {
@@ -135,7 +135,7 @@ fn tick(reason: string) -> void {
 
     if my_tier == "autonomous" {
         // Create the MR
-        let mr_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-mr --source " + shell_escape(plan.branch_name) + " --title " + shell_escape(plan.mr_title) + " --description " + shell_escape(plan.mr_description);
+        let mr_cmd = "$COLONY_DIR/scripts/forge-api.sh create-mr --source " + shell_escape(plan.branch_name) + " --title " + shell_escape(plan.mr_title) + " --description " + shell_escape(plan.mr_description);
         let mr_result = try { exec sh mr_cmd; } catch e {
             print("[commit_composer] MR creation failed:", e);
             "";
@@ -151,7 +151,7 @@ fn tick(reason: string) -> void {
             // Non-terminal draft: post the MR plan as a comment on the issue
             // so a human can approve before we actually open a non-draft MR.
             let note = "[draft-mr] **Merge Request Plan** (automated, pending approval)\n\nBranch: `" + plan.branch_name + "`\nTitle: " + plan.mr_title + "\n\n" + plan.mr_description + "\n\nCommits:\n" + plan.commits;
-            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(plan.issue_id) + " --body " + shell_escape(note);
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(plan.issue_id) + " --body " + shell_escape(note);
             try { exec sh post_cmd; } catch e {
                 print("[commit_composer] Failed to post draft plan:", e);
             };

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -25,9 +25,9 @@ type RefactorSuggestion {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("refactorer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view impl";
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl";
 }
 
 fn get_confidence() -> float {
@@ -113,11 +113,11 @@ fn tick(reason: string) -> void {
 
         if should_learn_from_mr(mr_iid) {
             memo_write("refactorer:last_learned_mr_iid", to_string(mr_iid));
-            let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+            let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
             if len(changes_raw) > 10 {
-                let commits_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-commits " + to_string(mr_iid);
+                let commits_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-commits " + to_string(mr_iid);
                 let commits_raw = try { exec sh commits_cmd; } catch e { "[]"; };
 
                 let patterns = prompt(
@@ -177,7 +177,7 @@ fn tick(reason: string) -> void {
                     refactor_context
                 ) -> string;
                 // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-                let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(branch) + " --message " + shell_escape("refactor: apply improvements for #" + to_string(suggestion.issue_id)) + " --actions " + shell_escape(actions_json);
+                let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(branch) + " --message " + shell_escape("refactor: apply improvements for #" + to_string(suggestion.issue_id)) + " --actions " + shell_escape(actions_json);
                 let commit_result = try { exec sh commit_cmd; } catch e {
                     print("[refactorer] Commit failed:", e);
                     "";
@@ -193,7 +193,7 @@ fn tick(reason: string) -> void {
                     // comment on the issue so a human can approve before we
                     // commit refactored files. No commit at this tier.
                     let note = "[draft-refactor] **Refactoring Suggestions** (automated, pending approval) — priority: " + suggestion.priority + "\n\n" + suggestion.suggestions;
-                    let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(suggestion.issue_id) + " --body " + shell_escape(note);
+                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(suggestion.issue_id) + " --body " + shell_escape(note);
                     try { exec sh post_cmd; } catch e {
                         print("[refactorer] Failed to post draft note:", e);
                     };

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -27,9 +27,9 @@ type TestDraft {
 fn merged_mr_cmd() -> string {
     let ts = recall_latest("test_writer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view impl";
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl";
 }
 
 fn get_confidence() -> float {
@@ -115,7 +115,7 @@ fn tick(reason: string) -> void {
 
         if should_learn_from_mr(mr_iid) {
             memo_write("test_writer:last_learned_mr_iid", to_string(mr_iid));
-            let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+            let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
             if len(changes_raw) > 10 {
@@ -175,7 +175,7 @@ fn tick(reason: string) -> void {
                 ) -> string;
 
                 // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-                let commit_cmd = "$COLONY_DIR/scripts/gitlab-api.sh commit-files --branch " + shell_escape(tests.branch_name) + " --message " + shell_escape("test: add tests for #" + to_string(tests.issue_id)) + " --actions " + shell_escape(actions_json);
+                let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(tests.branch_name) + " --message " + shell_escape("test: add tests for #" + to_string(tests.issue_id)) + " --actions " + shell_escape(actions_json);
                 let commit_result = try { exec sh commit_cmd; } catch e {
                     print("[test_writer] Commit failed:", e);
                     "";
@@ -191,7 +191,7 @@ fn tick(reason: string) -> void {
                     // Non-terminal draft: post the test plan as a comment on the
                     // issue so a human can approve before we commit test files.
                     let note = "[draft-tests] **Test Plan** (automated, pending approval)\n\nBranch: `" + tests.branch_name + "`\n\n" + tests.summary + "\n\nTest files:\n" + tests.test_files;
-                    let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh add-note " + to_string(tests.issue_id) + " --body " + shell_escape(note);
+                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(tests.issue_id) + " --body " + shell_escape(note);
                     try { exec sh post_cmd; } catch e {
                         print("[test_writer] Failed to post draft note:", e);
                     };

--- a/dev-apprenticeship/implementation/scripts/forge-api.sh
+++ b/dev-apprenticeship/implementation/scripts/forge-api.sh
@@ -35,20 +35,8 @@ case "$FORGE_TYPE" in
 esac
 
 if [ ! -x "$backend" ]; then
-    case "$FORGE_TYPE" in
-        github)
-            # Skeleton state: dispatcher exists but the per-colony wrapper is not yet
-            # shipped. Lands across PRs 2-6 of #256.
-            echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the implementation colony." >&2
-            echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
-            ;;
-        *)
-            # Broken install — gitlab-api.sh should always be present alongside
-            # forge-api.sh in a valid federation checkout.
-            echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
-            echo "forge-api.sh: this indicates a broken install — re-copy the implementation colony scripts/ directory." >&2
-            ;;
-    esac
+    echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
+    echo "forge-api.sh: this indicates a broken install — re-copy the implementation colony scripts/ directory." >&2
     exit 99
 fi
 

--- a/dev-apprenticeship/implementation/scripts/github-api.sh
+++ b/dev-apprenticeship/implementation/scripts/github-api.sh
@@ -1,0 +1,881 @@
+#!/bin/bash
+# GitHub API wrapper for implementation colony agents (ADR-0002, #256 PR 4 of 7).
+# Called by .ag agents via forge-api.sh dispatch when FORGE_TYPE=github.
+#
+# Required env vars (set by start-colony.sh from [forge.github] in colony.toml):
+#   GITHUB_URL    - API base (default https://api.github.com; override for GHE)
+#   GITHUB_TOKEN  - personal access token (classic or fine-grained)
+#   GITHUB_OWNER  - repo owner (user or org)
+#   GITHUB_REPO   - repo name
+#
+# Optional env vars:
+#   IMPLEMENTATION_TRIGGER_LABEL  label used by assigned-issues (default
+#                                 "implementation", parity with gitlab-api.sh)
+#   GITLAB_DEFAULT_BRANCH         base/target branch for create-branch +
+#                                 create-mr (default "main"). The name is
+#                                 a GitLab holdover — ADR-0002 keeps it for
+#                                 backend-agnostic dispatch; PR 7 may rename
+#                                 when [gitlab] retires.
+#   GITHUB_ME                     authenticated-user login (optional, used
+#                                 to scope assigned-issues)
+#   GITHUB_CURL_MAX_TIME          per-attempt --max-time seconds (default 90)
+#   GITHUB_CURL_RETRIES           retry budget for 5xx/timeouts/429 (default 3)
+#
+# Usage (identical contract to gitlab-api.sh):
+#   github-api.sh merge-requests [--state opened|merged|closed|all] [--since ISO8601]
+#                                [--per-page N] [--view <name>]
+#   github-api.sh mr-changes <number>
+#   github-api.sh mr-commits <number>
+#   github-api.sh issue <number>
+#   github-api.sh assigned-issues [--since ISO8601] [--view <name>]
+#   github-api.sh assigned-issues-by-label-events --since ISO8601 [--view <name>]
+#   github-api.sh issue-label-events <number> [--since ISO8601] [--label NAME]
+#   github-api.sh create-branch --name <name> [--ref <ref>]
+#   github-api.sh commit-files --branch <b> --message <m> --actions <json>
+#   github-api.sh create-mr --source <branch> --title <title> [--description <d>]
+#   github-api.sh add-note <number> --body <text>
+#
+# Views (opt-in projection; byte-identical to gitlab-api.sh):
+#   merge-requests  --view impl       [{iid, title, merged_at, target_branch}]
+#   assigned-issues --view assigned   [{iid, title, description, labels,
+#                                       assignees:[{username}], priority}]
+#   <cmd>           --view raw        explicit pass-through (same as no flag)
+#   GITLAB_VIEW_MODE=raw              env-override that forces pass-through.
+#
+# Semantic collapses vs GitLab:
+#   /pulls               replaces /merge_requests; state merged -> closed +
+#                        client-side merged_at!=null filter; no `since`
+#                        query param, --since is client-side on updated_at.
+#   /pulls/{n}/files     replaces /merge_requests/{iid}/changes; per-file
+#                        entries are wrapped into {"changes": [...]} for
+#                        shape parity with the GitLab MR-changes response.
+#   /pulls/{n}/commits   replaces /merge_requests/{iid}/commits; author
+#                        data lifted from commit.author into GitLab-style
+#                        {id, title, message, author_name, created_at}.
+#   /issues/{n}/timeline replaces /resource_label_events (PR 3 parity).
+#   /git/refs + /git/trees + /git/commits
+#                        implement commit-files via the 5-step Git DB dance,
+#                        since GitHub has no one-shot multi-file commit endpoint.
+#
+# Exit codes:
+#   0  ok (2xx)
+#   1  usage error (required flag missing, backend rejection, unsupported action)
+#   2  unknown flag / view / auth failure (4xx 401/403)
+#   3  rate limited (429 or secondary rate-limit, after retries)
+#   4  other 4xx client error
+#   5  5xx server error OR transport failure
+
+set -e
+
+# emit_error <message>
+# Matches gitlab-api.sh emit_error contract: JSON error object to stderr.
+emit_error() {
+    printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+# normalize_issues
+# Reads GitHub issues-list JSON from stdin, writes GitLab-shape JSON.
+# Filters pull_request entries (GitHub /issues mixes PRs with issues).
+normalize_issues() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for x in data:
+    if "pull_request" in x:
+        continue
+    out.append({
+        "iid": x.get("number"),
+        "title": x.get("title"),
+        "description": x.get("body"),
+        "state": "opened" if x.get("state") == "open" else x.get("state"),
+        "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
+        "assignees": [{"username": a.get("login")} for a in (x.get("assignees") or [])],
+        "author": {"username": (x.get("user") or {}).get("login")},
+        "created_at": x.get("created_at"),
+        "updated_at": x.get("updated_at"),
+        "user_notes_count": x.get("comments", 0),
+        # GitHub has no "priority" field; leave null so the assigned view's
+        # priority key resolves consistently (None, not missing).
+        "priority": None,
+    })
+print(json.dumps(out))
+PY
+}
+
+# normalize_issue
+# Single-issue variant (used by `issue <n>` and by assigned-issues-by-label-events
+# after a timeline hit).
+normalize_issue() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+x = json.loads(os.environ["DATA"])
+print(json.dumps({
+    "iid": x.get("number"),
+    "title": x.get("title"),
+    "description": x.get("body"),
+    "state": "opened" if x.get("state") == "open" else x.get("state"),
+    "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
+    "assignees": [{"username": a.get("login")} for a in (x.get("assignees") or [])],
+    "author": {"username": (x.get("user") or {}).get("login")},
+    "created_at": x.get("created_at"),
+    "updated_at": x.get("updated_at"),
+    "user_notes_count": x.get("comments", 0),
+    "priority": None,
+}))
+PY
+}
+
+# normalize_pulls
+# Reads GitHub pulls-list JSON, writes GitLab-MR-shape JSON.
+normalize_pulls() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for x in data:
+    st = x.get("state")
+    if st == "open":
+        st = "opened"
+    elif st == "closed" and x.get("merged_at"):
+        st = "merged"
+    out.append({
+        "iid": x.get("number"),
+        "title": x.get("title"),
+        "description": x.get("body"),
+        "state": st,
+        "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
+        "author": {"username": (x.get("user") or {}).get("login")},
+        "target_branch": (x.get("base") or {}).get("ref"),
+        "source_branch": (x.get("head") or {}).get("ref"),
+        "merged_at": x.get("merged_at"),
+        "created_at": x.get("created_at"),
+        "updated_at": x.get("updated_at"),
+        # /pulls list endpoint omits changed_files (only on single-PR fetch);
+        # forward as null. Consumers tolerate null.
+        "changes_count": x.get("changed_files"),
+        "user_notes_count": x.get("comments", 0),
+    })
+print(json.dumps(out))
+PY
+}
+
+# normalize_mr_changes
+# Reads GitHub /pulls/{n}/files JSON, writes a GitLab-mr-changes-shape JSON
+# object: {"changes": [{"old_path", "new_path", "diff", "new_file",
+# "deleted_file", "renamed_file"}, ...]}. Matches the subset that the
+# implementation .ag agents feed to prompt() when learning from prior MRs.
+# GitHub's "status" field drives new_file/deleted_file/renamed_file; "patch"
+# is the unified-diff text (may be absent on binary files).
+normalize_mr_changes() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for f in data:
+    status = f.get("status") or ""
+    path = f.get("filename") or ""
+    prev = f.get("previous_filename") or path
+    out.append({
+        "old_path": prev,
+        "new_path": path,
+        "diff": f.get("patch") or "",
+        "new_file": status == "added",
+        "deleted_file": status == "removed",
+        "renamed_file": status == "renamed",
+    })
+print(json.dumps({"changes": out}))
+PY
+}
+
+# normalize_mr_commits
+# Reads GitHub /pulls/{n}/commits JSON, writes a GitLab-mr-commits-shape
+# JSON array: [{"id", "title", "message", "author_name", "created_at"}, ...].
+# GitHub's `commit.author` carries {name, email, date}; we lift `name` into
+# the flat author_name field for prompt-friendliness. "title" is the first
+# line of the commit message (same as GitLab's behavior).
+normalize_mr_commits() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for c in data:
+    commit = c.get("commit") or {}
+    author = commit.get("author") or {}
+    msg = commit.get("message") or ""
+    title = msg.split("\n", 1)[0] if msg else ""
+    out.append({
+        "id": c.get("sha"),
+        "title": title,
+        "message": msg,
+        "author_name": author.get("name"),
+        "created_at": author.get("date"),
+    })
+print(json.dumps(out))
+PY
+}
+
+# normalize_timeline <label_filter> <since_filter>
+# Reads GitHub /issues/{n}/timeline JSON, writes GitLab resource_label_events
+# shape: [{ts, action, label, user}]. Same logic as the planning wrapper —
+# duplicated rather than sourced so the two scripts have no runtime coupling.
+normalize_timeline() {
+    local label_filter="$1" since_filter="$2"
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" LABEL="$label_filter" SINCE="$since_filter" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+label = os.environ.get("LABEL", "")
+since = os.environ.get("SINCE", "")
+out = []
+for ev in data:
+    kind = ev.get("event")
+    if kind not in ("labeled", "unlabeled"):
+        continue
+    ev_label = (ev.get("label") or {}).get("name")
+    ev_ts = ev.get("created_at") or ""
+    if since and ev_ts < since:
+        continue
+    if label and ev_label != label:
+        continue
+    out.append({
+        "ts": ev_ts,
+        "action": "add" if kind == "labeled" else "remove",
+        "label": ev_label,
+        "user": (ev.get("actor") or {}).get("login"),
+    })
+print(json.dumps(out))
+PY
+}
+
+# project_json <view-name>
+# Byte-identical to gitlab-api.sh project_json; test-gitlab-views.sh enforces
+# parity. Two views (impl, assigned) plus raw pass-throughs.
+project_json() {
+    local view="$1"
+    if [ "${GITLAB_VIEW_MODE:-}" = "raw" ]; then
+        cat
+        return 0
+    fi
+    local DATA
+    DATA="$(cat)"
+    case "$view" in
+        raw)
+            printf '%s' "$DATA"
+            ;;
+        impl)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"),
+        "merged_at": x.get("merged_at"), "target_branch": x.get("target_branch")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        assigned)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
+        "labels": x.get("labels", []),
+        "assignees": [{"username": a.get("username")} for a in x.get("assignees", [])],
+        "priority": x.get("priority")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        *)
+            emit_error "unknown view: $view"
+            exit 2
+            ;;
+    esac
+}
+
+if [ -z "${GITHUB_TOKEN:-}" ] || [ -z "${GITHUB_OWNER:-}" ] || [ -z "${GITHUB_REPO:-}" ]; then
+    emit_error "GITHUB_TOKEN, GITHUB_OWNER, and GITHUB_REPO must be set"
+    exit 1
+fi
+
+GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+API="$GITHUB_URL/repos/$GITHUB_OWNER/$GITHUB_REPO"
+
+# gh_call <method> <url> [curl-args...]
+# Mirrors planning/triage gh_call: retry on 429/5xx/timeout, no-retry on
+# 401/403 non-rate-limit, 403-secondary-rate detection via body snippet,
+# bounded curl --max-time.
+gh_call() {
+    local method="$1" url="$2"
+    shift 2
+    local max_time="${GITHUB_CURL_MAX_TIME:-90}"
+    local max_retries="${GITHUB_CURL_RETRIES:-3}"
+    local attempt=0 delay=3 rc code snippet body_file
+    body_file="$(mktemp)"
+    trap 'rm -f "$body_file"; trap - RETURN' RETURN
+
+    while :; do
+        attempt=$((attempt + 1))
+        code=""
+        rc=0
+        code="$(curl -sS -w '%{http_code}' -o "$body_file" \
+            --max-time "$max_time" \
+            -X "$method" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$@" \
+            "$url" 2>/dev/null)" || rc=$?
+
+        if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
+            if [ "$attempt" -le "$max_retries" ]; then
+                sleep "$delay"
+                delay=$((delay * 2))
+                continue
+            fi
+            emit_error "curl transport failure (exit $rc) after $attempt attempts: $method $url"
+            return 5
+        fi
+
+        case "$code" in
+            2*)
+                cat "$body_file"
+                return 0
+                ;;
+            401|403)
+                snippet="$(head -c 200 "$body_file")"
+                case "$snippet" in
+                    *"rate limit"*|*"abuse"*|*"secondary rate"*)
+                        if [ "$attempt" -le "$max_retries" ]; then
+                            sleep "$delay"
+                            delay=$((delay * 2))
+                            continue
+                        fi
+                        emit_error "rate limited (HTTP $code secondary) after $attempt attempts on $method $url"
+                        return 3
+                        ;;
+                    *)
+                        emit_error "auth failure (HTTP $code) on $method $url: $snippet — check PAT scope/expiry"
+                        return 2
+                        ;;
+                esac
+                ;;
+            429)
+                if [ "$attempt" -le "$max_retries" ]; then
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                    continue
+                fi
+                emit_error "rate limited (HTTP 429) after $attempt attempts on $method $url"
+                return 3
+                ;;
+            5*)
+                if [ "$attempt" -le "$max_retries" ]; then
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                    continue
+                fi
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "server error (HTTP $code) after $attempt attempts: $snippet"
+                return 5
+                ;;
+            4*)
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "client error (HTTP $code) on $method $url: $snippet"
+                return 4
+                ;;
+            *)
+                emit_error "unexpected HTTP $code on $method $url"
+                return 4
+                ;;
+        esac
+    done
+}
+
+gh_get() {
+    gh_call GET "$1"
+}
+
+gh_get_q() {
+    local url="$1"
+    shift
+    gh_call GET "$url" -G "$@"
+}
+
+gh_post() {
+    gh_call POST "$1" -H "Content-Type: application/json" -d "$2"
+}
+
+gh_patch() {
+    gh_call PATCH "$1" -H "Content-Type: application/json" -d "$2"
+}
+
+CMD="${1:?Usage: github-api.sh <command> [args...]}"
+shift
+
+case "$CMD" in
+    merge-requests)
+        # Same as planning's merge-requests arm: state collapse + client-side
+        # --since filter (GitHub /pulls has no `since` query param).
+        STATE="opened"
+        SINCE=""
+        VIEW=""
+        PER_PAGE=20
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --state) STATE="$2"; shift 2 ;;
+                --since) SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                --per-page) PER_PAGE="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
+        MERGED_FILTER=0
+        case "$STATE" in
+            opened|open) GH_STATE="open" ;;
+            closed)      GH_STATE="closed" ;;
+            merged)      GH_STATE="closed"; MERGED_FILTER=1 ;;
+            all)         GH_STATE="all" ;;
+            *) emit_error "unknown --state: $STATE (expected opened|merged|closed|all)"; exit 2 ;;
+        esac
+        ARGS=(
+            --data-urlencode "state=$GH_STATE"
+            --data-urlencode "per_page=$PER_PAGE"
+            --data-urlencode "sort=updated"
+            --data-urlencode "direction=desc"
+        )
+        body="$(gh_get_q "$API/pulls" "${ARGS[@]}")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_pulls)"
+        if [ "$MERGED_FILTER" -eq 1 ] || [ -n "$SINCE" ]; then
+            normalized="$(NORM="$normalized" SINCE="$SINCE" MERGED="$MERGED_FILTER" python3 <<'PY'
+import os, json
+items = json.loads(os.environ["NORM"])
+since = os.environ.get("SINCE", "")
+merged_only = os.environ.get("MERGED", "0") == "1"
+out = []
+for x in items:
+    if merged_only and not x.get("merged_at"):
+        continue
+    if since:
+        ts = x.get("updated_at") or ""
+        if ts < since:
+            continue
+    out.append(x)
+print(json.dumps(out))
+PY
+)"
+        fi
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$normalized" | project_json "$VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    mr-changes)
+        IID="${1:?Usage: github-api.sh mr-changes <number>}"
+        case "$IID" in
+            ''|*[!0-9]*) emit_error "PR number must be numeric: $IID"; exit 2 ;;
+        esac
+        body="$(gh_get_q "$API/pulls/$IID/files" --data-urlencode "per_page=100")" || exit $?
+        printf '%s' "$body" | normalize_mr_changes
+        ;;
+
+    mr-commits)
+        IID="${1:?Usage: github-api.sh mr-commits <number>}"
+        case "$IID" in
+            ''|*[!0-9]*) emit_error "PR number must be numeric: $IID"; exit 2 ;;
+        esac
+        body="$(gh_get_q "$API/pulls/$IID/commits" --data-urlencode "per_page=100")" || exit $?
+        printf '%s' "$body" | normalize_mr_commits
+        ;;
+
+    issue)
+        IID="${1:?Usage: github-api.sh issue <number>}"
+        case "$IID" in
+            ''|*[!0-9]*) emit_error "issue number must be numeric: $IID"; exit 2 ;;
+        esac
+        body="$(gh_get "$API/issues/$IID")" || exit $?
+        printf '%s' "$body" | normalize_issue
+        ;;
+
+    assigned-issues)
+        SINCE=""
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        # GitLab uses assignee_id=Any to match any assignee. GitHub's /issues
+        # endpoint accepts assignee=* with the same "assigned to any user"
+        # semantic. When GITHUB_ME is set, narrow to that operator so the
+        # colony doesn't process work assigned to teammates.
+        ASSIGNEE="${GITHUB_ME:-*}"
+        ARGS=(
+            --data-urlencode "state=open"
+            --data-urlencode "assignee=$ASSIGNEE"
+            --data-urlencode "labels=${IMPLEMENTATION_TRIGGER_LABEL:-implementation}"
+            --data-urlencode "per_page=20"
+            --data-urlencode "sort=updated"
+            --data-urlencode "direction=desc"
+        )
+        if [ -n "$SINCE" ]; then
+            ARGS+=(--data-urlencode "since=$SINCE")
+        fi
+        body="$(gh_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_issues)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$normalized" | project_json "$VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    issue-label-events)
+        IID="${1:?Usage: github-api.sh issue-label-events <number> [--since ISO8601] [--label NAME]}"
+        shift
+        EV_SINCE=""
+        EV_LABEL=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) EV_SINCE="$2"; shift 2 ;;
+                --label) EV_LABEL="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$IID" in
+            ''|*[!0-9]*) emit_error "issue number must be numeric: $IID"; exit 2 ;;
+        esac
+        body="$(gh_get_q "$API/issues/$IID/timeline" --data-urlencode "per_page=100")" || exit $?
+        printf '%s' "$body" | normalize_timeline "$EV_LABEL" "$EV_SINCE"
+        ;;
+
+    assigned-issues-by-label-events)
+        # Composite parity query: currently-assigned+labeled ∪ timeline-added-
+        # in-window for the same assignee. Same structure as planning's
+        # issues-by-label-events but with the assignee filter.
+        EV_SINCE=""
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --since) EV_SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$EV_SINCE" ]; then
+            emit_error "--since is required for assigned-issues-by-label-events"
+            exit 2
+        fi
+        LABEL="${IMPLEMENTATION_TRIGGER_LABEL:-implementation}"
+        ASSIGNEE="${GITHUB_ME:-*}"
+        BASE_ARGS=(
+            --data-urlencode "state=open"
+            --data-urlencode "assignee=$ASSIGNEE"
+            --data-urlencode "per_page=20"
+            --data-urlencode "sort=updated"
+            --data-urlencode "direction=desc"
+            --data-urlencode "since=$EV_SINCE"
+        )
+        recent_raw="$(gh_get_q "$API/issues" "${BASE_ARGS[@]}")" || exit $?
+        recent="$(printf '%s' "$recent_raw" | normalize_issues)"
+        split="$(RECENT="$recent" LABEL="$LABEL" python3 <<'PY'
+import os, json
+items = json.loads(os.environ["RECENT"])
+label = os.environ["LABEL"]
+current = [x for x in items if label in (x.get("labels") or [])]
+to_check = [x["iid"] for x in items if label not in (x.get("labels") or [])]
+print(json.dumps({"current": current, "to_check": to_check}))
+PY
+)" || exit $?
+        current_list="$(printf '%s' "$split" | python3 -c 'import sys,json;print(json.dumps(json.load(sys.stdin)["current"]))')"
+        iids_to_check="$(printf '%s' "$split" | python3 -c 'import sys,json;print(" ".join(str(i) for i in json.load(sys.stdin)["to_check"]))')"
+        matched="[]"
+        for IID in $iids_to_check; do
+            tl_body="$(gh_get_q "$API/issues/$IID/timeline" --data-urlencode "per_page=100")" || continue
+            hit="$(TLBODY="$tl_body" LABEL="$LABEL" EV_SINCE="$EV_SINCE" python3 <<'PY'
+import os, json
+events = json.loads(os.environ["TLBODY"])
+label = os.environ["LABEL"]
+since = os.environ["EV_SINCE"]
+for ev in events:
+    if ev.get("event") != "labeled":
+        continue
+    ev_label = (ev.get("label") or {}).get("name")
+    ev_ts = ev.get("created_at") or ""
+    if ev_label == label and ev_ts >= since:
+        print("1"); break
+else:
+    print("")
+PY
+)"
+            if [ -n "$hit" ]; then
+                issue_raw="$(gh_get "$API/issues/$IID")" || continue
+                issue_norm="$(printf '%s' "$issue_raw" | normalize_issue)"
+                matched="$(MATCHED="$matched" ISSUE="$issue_norm" python3 <<'PY'
+import os, json
+acc = json.loads(os.environ["MATCHED"])
+acc.append(json.loads(os.environ["ISSUE"]))
+print(json.dumps(acc))
+PY
+)"
+            fi
+        done
+        final="$(CUR="$current_list" MATCHED="$matched" python3 <<'PY'
+import os, json
+a = json.loads(os.environ["CUR"])
+b = json.loads(os.environ["MATCHED"])
+seen = set()
+out = []
+for x in a + b:
+    iid = x.get("iid")
+    if iid in seen:
+        continue
+    seen.add(iid)
+    out.append(x)
+print(json.dumps(out))
+PY
+)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$final" | project_json "$VIEW"
+        else
+            printf '%s' "$final"
+        fi
+        ;;
+
+    create-branch)
+        # GitLab has POST /repository/branches {branch, ref}. GitHub needs
+        # two steps: resolve `ref` (branch name) to its head SHA, then
+        # POST /git/refs {ref: "refs/heads/<name>", sha: <head_sha>}.
+        NAME=""
+        REF="${GITLAB_DEFAULT_BRANCH:-main}"
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --name) NAME="$2"; shift 2 ;;
+                --ref) REF="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$NAME" ]; then
+            emit_error "--name is required"
+            exit 1
+        fi
+        # Step 1: resolve ref to SHA. If REF looks like a bare SHA (40 hex
+        # chars), skip the ref resolution entirely — GitHub also accepts a
+        # tag or a full ref path but those aren't used by the .ag code today.
+        case "$REF" in
+            *[!0-9a-fA-F]*|"")
+                ref_body="$(gh_get "$API/git/refs/heads/$REF")" || exit $?
+                REF_SHA="$(REF_BODY="$ref_body" python3 -c 'import os,json;print((json.loads(os.environ["REF_BODY"]).get("object") or {}).get("sha") or "")')"
+                if [ -z "$REF_SHA" ]; then
+                    emit_error "could not resolve ref '$REF' to a commit SHA"
+                    exit 1
+                fi
+                ;;
+            *)
+                # 40-hex sha — short-circuit.
+                if [ "${#REF}" -eq 40 ]; then
+                    REF_SHA="$REF"
+                else
+                    ref_body="$(gh_get "$API/git/refs/heads/$REF")" || exit $?
+                    REF_SHA="$(REF_BODY="$ref_body" python3 -c 'import os,json;print((json.loads(os.environ["REF_BODY"]).get("object") or {}).get("sha") or "")')"
+                fi
+                ;;
+        esac
+        # Step 2: create the new ref.
+        JSON_BODY=$(NAME="$NAME" SHA="$REF_SHA" python3 - <<'PY'
+import os, json
+print(json.dumps({"ref": "refs/heads/" + os.environ["NAME"], "sha": os.environ["SHA"]}))
+PY
+)
+        gh_post "$API/git/refs" "$JSON_BODY"
+        ;;
+
+    commit-files)
+        # GitLab ships a single POST /repository/commits with an actions
+        # array. GitHub has no equivalent one-shot endpoint, so we drive
+        # the Git Database API through 5 calls:
+        #   1. GET /git/refs/heads/{branch}       -> head commit SHA
+        #   2. GET /git/commits/{head_sha}        -> base tree SHA
+        #   3. POST /git/trees {base_tree, tree}  -> new tree SHA
+        #   4. POST /git/commits {message, tree, parents} -> new commit SHA
+        #   5. PATCH /git/refs/heads/{branch} {sha} -> ref updated
+        # Actions supported: create, update (both map to tree entry with
+        # content), delete (tree entry with sha:null). move/chmod are not
+        # emitted by any current .ag agent; we fail loud rather than silently
+        # mishandle them.
+        BRANCH=""
+        MESSAGE=""
+        ACTIONS=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --branch) BRANCH="$2"; shift 2 ;;
+                --message) MESSAGE="$2"; shift 2 ;;
+                --actions) ACTIONS="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$BRANCH" ] || [ -z "$MESSAGE" ] || [ -z "$ACTIONS" ]; then
+            emit_error "--branch, --message, and --actions are all required"
+            exit 1
+        fi
+        # Validate actions JSON up front so a malformed payload fails before
+        # we spend an HTTP call. Rejects move/chmod loudly.
+        ACTIONS="$ACTIONS" python3 - <<'PY' >/dev/null
+import os, json, sys
+try:
+    a = json.loads(os.environ["ACTIONS"])
+except Exception as e:
+    print(json.dumps({"error": f"invalid --actions JSON: {e}"}), file=sys.stderr)
+    sys.exit(1)
+if not isinstance(a, list):
+    print(json.dumps({"error": "--actions must be a JSON array"}), file=sys.stderr)
+    sys.exit(1)
+for entry in a:
+    if not isinstance(entry, dict):
+        print(json.dumps({"error": "each action must be a JSON object"}), file=sys.stderr)
+        sys.exit(1)
+    action = entry.get("action")
+    if action not in ("create", "update", "delete"):
+        print(json.dumps({"error": f"unsupported action '{action}' (supported on GitHub: create, update, delete)"}), file=sys.stderr)
+        sys.exit(1)
+    if not entry.get("file_path"):
+        print(json.dumps({"error": "each action requires file_path"}), file=sys.stderr)
+        sys.exit(1)
+    if action in ("create", "update") and entry.get("content") is None:
+        print(json.dumps({"error": f"action '{action}' requires content"}), file=sys.stderr)
+        sys.exit(1)
+PY
+        # Step 1: branch head SHA.
+        ref_body="$(gh_get "$API/git/refs/heads/$BRANCH")" || exit $?
+        HEAD_SHA="$(REF_BODY="$ref_body" python3 -c 'import os,json;print((json.loads(os.environ["REF_BODY"]).get("object") or {}).get("sha") or "")')"
+        if [ -z "$HEAD_SHA" ]; then
+            emit_error "could not resolve head SHA for branch '$BRANCH'"
+            exit 1
+        fi
+        # Step 2: base tree SHA.
+        commit_body="$(gh_get "$API/git/commits/$HEAD_SHA")" || exit $?
+        BASE_TREE_SHA="$(COMMIT_BODY="$commit_body" python3 -c 'import os,json;print((json.loads(os.environ["COMMIT_BODY"]).get("tree") or {}).get("sha") or "")')"
+        if [ -z "$BASE_TREE_SHA" ]; then
+            emit_error "could not resolve base tree SHA for commit $HEAD_SHA"
+            exit 1
+        fi
+        # Step 3: build tree. For delete, tree entry carries sha:null so
+        # GitHub removes the path. For create/update, carry content inline.
+        TREE_BODY=$(ACTIONS="$ACTIONS" BASE_TREE="$BASE_TREE_SHA" python3 - <<'PY'
+import os, json
+actions = json.loads(os.environ["ACTIONS"])
+tree = []
+for a in actions:
+    path = a["file_path"]
+    if a["action"] == "delete":
+        tree.append({"path": path, "mode": "100644", "type": "blob", "sha": None})
+    else:
+        tree.append({"path": path, "mode": "100644", "type": "blob", "content": a["content"]})
+print(json.dumps({"base_tree": os.environ["BASE_TREE"], "tree": tree}))
+PY
+)
+        tree_resp="$(gh_post "$API/git/trees" "$TREE_BODY")" || exit $?
+        NEW_TREE_SHA="$(TREE_RESP="$tree_resp" python3 -c 'import os,json;print(json.loads(os.environ["TREE_RESP"]).get("sha") or "")')"
+        if [ -z "$NEW_TREE_SHA" ]; then
+            emit_error "tree creation returned no sha"
+            exit 1
+        fi
+        # Step 4: create commit on the new tree.
+        COMMIT_POST_BODY=$(MESSAGE="$MESSAGE" TREE="$NEW_TREE_SHA" PARENT="$HEAD_SHA" python3 - <<'PY'
+import os, json
+print(json.dumps({
+    "message": os.environ["MESSAGE"],
+    "tree": os.environ["TREE"],
+    "parents": [os.environ["PARENT"]],
+}))
+PY
+)
+        commit_resp="$(gh_post "$API/git/commits" "$COMMIT_POST_BODY")" || exit $?
+        NEW_COMMIT_SHA="$(COMMIT_RESP="$commit_resp" python3 -c 'import os,json;print(json.loads(os.environ["COMMIT_RESP"]).get("sha") or "")')"
+        if [ -z "$NEW_COMMIT_SHA" ]; then
+            emit_error "commit creation returned no sha"
+            exit 1
+        fi
+        # Step 5: fast-forward the branch ref. Final response echoes the ref
+        # object — callers treat truthy output as success.
+        REF_PATCH_BODY=$(SHA="$NEW_COMMIT_SHA" python3 - <<'PY'
+import os, json
+print(json.dumps({"sha": os.environ["SHA"]}))
+PY
+)
+        gh_patch "$API/git/refs/heads/$BRANCH" "$REF_PATCH_BODY"
+        ;;
+
+    create-mr)
+        SOURCE=""
+        TITLE=""
+        DESC=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --source) SOURCE="$2"; shift 2 ;;
+                --title) TITLE="$2"; shift 2 ;;
+                --description) DESC="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$SOURCE" ] || [ -z "$TITLE" ]; then
+            emit_error "--source and --title are required"
+            exit 1
+        fi
+        JSON_BODY=$(SOURCE="$SOURCE" TITLE="$TITLE" DESC="$DESC" \
+            DEFAULT_BRANCH="${GITLAB_DEFAULT_BRANCH:-main}" python3 - <<'PY'
+import os, json
+body = {
+    "head": os.environ["SOURCE"],
+    "base": os.environ["DEFAULT_BRANCH"],
+    "title": os.environ["TITLE"],
+}
+if os.environ.get("DESC"):
+    body["body"] = os.environ["DESC"]
+print(json.dumps(body))
+PY
+)
+        gh_post "$API/pulls" "$JSON_BODY"
+        ;;
+
+    add-note)
+        IID="${1:?Usage: github-api.sh add-note <number> --body <text>}"
+        shift
+        BODY=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --body) BODY="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$BODY" ]; then
+            emit_error "--body is required"
+            exit 1
+        fi
+        case "$IID" in
+            ''|*[!0-9]*) emit_error "issue number must be numeric: $IID"; exit 2 ;;
+        esac
+        JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
+        gh_post "$API/issues/$IID/comments" "$JSON_BODY"
+        ;;
+
+    *)
+        emit_error "unknown command: $CMD"
+        exit 1
+        ;;
+esac

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -25,6 +25,7 @@
 #   gitlab-api.sh create-branch --name <name> --ref <ref>
 #   gitlab-api.sh commit-files --branch <b> --message <m> --actions <json>
 #   gitlab-api.sh create-mr --source <branch> --title <title> [--description <d>]
+#   gitlab-api.sh add-note <iid> --body <text>
 #   gitlab-api.sh post-note <iid> --body <text>
 #
 # Views (opt-in projection; default is full JSON):
@@ -556,6 +557,34 @@ print(json.dumps(body))
 PY
 )
         gl_post "$API/merge_requests" "$JSON_BODY"
+        ;;
+
+    add-note)
+        # Back-ported from triage/scripts/gitlab-api.sh (#256 PR 4). All four
+        # implementation agents (code_writer, test_writer, refactorer,
+        # commit_composer) shell out to `gitlab-api.sh add-note <iid> --body …`
+        # on their review-gated branches; prior to this PR the call silently
+        # failed with "unknown command: add-note" (caught by the .ag try/catch
+        # so no operator noticed). Mirrors the github-api.sh add-note arm so
+        # the contract is symmetric across backends.
+        ID="${1:?Usage: gitlab-api.sh add-note <iid> --body <text>}"
+        shift
+        BODY=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --body) BODY="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$BODY" ]; then
+            emit_error "--body is required"
+            exit 1
+        fi
+        case "$ID" in
+            ''|*[!0-9]*) emit_error "issue iid must be numeric: $ID"; exit 2 ;;
+        esac
+        JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
+        gl_post "$API/issues/$ID/notes" "$JSON_BODY"
         ;;
 
     post-note)

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -60,57 +60,96 @@ if [ ! -f "$CONFIG" ]; then
     exit 1
 fi
 
-# Parse GitLab config from TOML via the shared helper.
+# Parse forge config from TOML via the shared helper.
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # shellcheck source=../../../tools/parse-toml.sh
 # shellcheck disable=SC1091  # colony-lint runs shellcheck without -x
 . "$REPO_ROOT/tools/parse-toml.sh"
 
-GITLAB_URL=$(parse_toml gitlab url)
-GITLAB_TOKEN=$(parse_toml gitlab token)
-GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
+# #256: forge backend selection. `[forge].type` picks which backend
+# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
+# configs keep working unchanged. PR 4 of #256 ships the implementation
+# colony's github-api.sh, so FORGE_TYPE=github is now live for
+# implementation (other colonies still return exit 99 "not implemented"
+# until their respective PRs land).
+FORGE_TYPE=$(parse_toml forge type)
+FORGE_TYPE="${FORGE_TYPE:-gitlab}"
 
-if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
-    echo "Error: GitLab config incomplete in $CONFIG"
-    echo "Required: url, token, project under [gitlab]"
-    exit 1
-fi
+case "$FORGE_TYPE" in
+    gitlab)
+        # Prefer [forge.gitlab] (ADR-0002) if present; fall back to legacy
+        # [gitlab] so pre-#256 configs keep working during the overlap window.
+        GITLAB_URL=$(parse_toml forge.gitlab url)
+        [ -z "$GITLAB_URL" ] && GITLAB_URL=$(parse_toml gitlab url)
+        GITLAB_TOKEN=$(parse_toml forge.gitlab token)
+        [ -z "$GITLAB_TOKEN" ] && GITLAB_TOKEN=$(parse_toml gitlab token)
+        GITLAB_PROJECT_RAW=$(parse_toml forge.gitlab project)
+        [ -z "$GITLAB_PROJECT_RAW" ] && GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
+        GITLAB_ME=$(parse_toml forge.gitlab me)
+        [ -z "$GITLAB_ME" ] && GITLAB_ME=$(parse_toml gitlab me)
 
-# URL-encode the project path (replace / with %2F)
-GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
+        if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
+            echo "Error: GitLab config incomplete in $CONFIG"
+            echo "Required: url, token, project under [forge.gitlab] (or legacy [gitlab])"
+            exit 1
+        fi
 
-# #104: operator identity. Empty if not configured (pre-#104 setups or
-# operators who skipped the install.sh prompt); agents fall back to
-# memo gitlab:me and tag everything as team when both are empty.
-GITLAB_ME=$(parse_toml gitlab me)
+        # URL-encode the project path (replace / with %2F)
+        GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
+
+        export GITLAB_URL
+        export GITLAB_TOKEN
+        export GITLAB_PROJECT
+        export GITLAB_ME
+        ;;
+    github)
+        GITHUB_URL=$(parse_toml forge.github url)
+        GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+        GITHUB_OWNER=$(parse_toml forge.github owner)
+        GITHUB_REPO=$(parse_toml forge.github repo)
+        GITHUB_TOKEN=$(parse_toml forge.github token)
+        GITHUB_ME=$(parse_toml forge.github me)
+
+        if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
+            echo "Error: GitHub config incomplete in $CONFIG"
+            echo "Required: owner, repo, token under [forge.github]"
+            exit 1
+        fi
+
+        # Use the project-raw variable name for the summary echo below so
+        # both branches can share one format string. Value is informational.
+        GITLAB_PROJECT_RAW="$GITHUB_OWNER/$GITHUB_REPO"
+
+        export GITHUB_URL
+        export GITHUB_OWNER
+        export GITHUB_REPO
+        export GITHUB_TOKEN
+        export GITHUB_ME
+        ;;
+    *)
+        echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2
+        exit 1
+        ;;
+esac
 
 # #225: configurable trigger label for assigned-issues filter. Empty if
-# not configured (pre-#225 setups); gitlab-api.sh falls back to the
-# hardcoded default "implementation" via ${VAR:-implementation}.
+# not configured (pre-#225 setups); the backend wrapper falls back to the
+# hardcoded default "implementation" via ${VAR:-implementation}. The label
+# itself is backend-agnostic — both gitlab-api.sh and github-api.sh
+# consume IMPLEMENTATION_TRIGGER_LABEL identically.
 IMPLEMENTATION_TRIGGER_LABEL=$(parse_toml implementation trigger_label)
 
 # #224: primary branch name. Empty if not configured (pre-#224 setups);
-# gitlab-api.sh falls back to the hardcoded default "main" via
-# ${GITLAB_DEFAULT_BRANCH:-main}.
+# the backend wrapper falls back to the hardcoded default "main" via
+# ${GITLAB_DEFAULT_BRANCH:-main}. The env var name is kept as
+# GITLAB_DEFAULT_BRANCH for cross-backend parity; PR 7 of #256 may rename
+# it when the legacy [gitlab] section retires.
 GITLAB_DEFAULT_BRANCH=$(parse_toml gitlab default_branch)
 
-export GITLAB_URL
-export GITLAB_TOKEN
-export GITLAB_PROJECT
-export GITLAB_ME
+export FORGE_TYPE
 export IMPLEMENTATION_TRIGGER_LABEL
 export GITLAB_DEFAULT_BRANCH
 export COLONY_DIR
-
-# #256: forge backend selection. `[forge].type` picks which backend
-# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
-# configs keep working unchanged. The github backend is skeleton-only
-# until PRs 2-6 of #256 land their per-colony github-api.sh wrappers;
-# until then, FORGE_TYPE=github yields exit 99 "not implemented" from
-# forge-api.sh.
-FORGE_TYPE=$(parse_toml forge type)
-FORGE_TYPE="${FORGE_TYPE:-gitlab}"
-export FORGE_TYPE
 
 AGENTS=(
     code_writer
@@ -189,7 +228,10 @@ if [ -n "$RESTART_AGENT" ]; then
 fi
 
 echo "Starting Implementation colony (${#AGENTS[@]} agents)..."
-echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
+case "$FORGE_TYPE" in
+    gitlab) echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)" ;;
+    github) echo "  GitHub: $GITHUB_URL ($GITHUB_OWNER/$GITHUB_REPO)" ;;
+esac
 
 for agent in "${AGENTS[@]}"; do
     interval=$(tick_interval_for "$agent")

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -139,12 +139,23 @@ esac
 # consume IMPLEMENTATION_TRIGGER_LABEL identically.
 IMPLEMENTATION_TRIGGER_LABEL=$(parse_toml implementation trigger_label)
 
-# #224: primary branch name. Empty if not configured (pre-#224 setups);
-# the backend wrapper falls back to the hardcoded default "main" via
-# ${GITLAB_DEFAULT_BRANCH:-main}. The env var name is kept as
-# GITLAB_DEFAULT_BRANCH for cross-backend parity; PR 7 of #256 may rename
-# it when the legacy [gitlab] section retires.
-GITLAB_DEFAULT_BRANCH=$(parse_toml gitlab default_branch)
+# #224: primary branch name. Prefer the ADR-0002 sections first so
+# operators who move everything under [forge.*] aren't silently ignored,
+# then fall back to the legacy [gitlab].default_branch for pre-#256
+# configs. All three forms yield the same GITLAB_DEFAULT_BRANCH env var
+# that both backend wrappers consume (${GITLAB_DEFAULT_BRANCH:-main}).
+# The env var name is kept as GITLAB_DEFAULT_BRANCH for cross-backend
+# parity; PR 7 of #256 may rename it when the legacy [gitlab] section
+# retires.
+case "$FORGE_TYPE" in
+    github)
+        GITLAB_DEFAULT_BRANCH=$(parse_toml forge.github default_branch)
+        ;;
+    *)
+        GITLAB_DEFAULT_BRANCH=$(parse_toml forge.gitlab default_branch)
+        ;;
+esac
+[ -z "$GITLAB_DEFAULT_BRANCH" ] && GITLAB_DEFAULT_BRANCH=$(parse_toml gitlab default_branch)
 
 export FORGE_TYPE
 export IMPLEMENTATION_TRIGGER_LABEL

--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -110,15 +110,20 @@ output for matching fixtures across both backends.
 schema only. PR 2 shipped the triage colony's `github-api.sh` with 7
 subcommands (`issues`, `create-issue`, `update-issue`, `members`,
 `get-issue`, `labels`, `add-note`) plus the `[forge.github]` env-export
-branch in `triage/scripts/start-colony.sh`. PR 3 (the current PR as of
-this writing) ships the planning colony's `github-api.sh` with 5
-subcommands (`issues`, `issues-by-label-events`, `issue-label-events`,
-`add-note`, `merge-requests`) plus the matching `[forge.github]`
-env-export branch and `.ag` dispatcher migration. The remaining
-colonies' wrappers land across PRs 4-6 in the order
-implementation → code-review → release. `rate-limit-status` and the
-dashboard tile ship in PR 7 alongside the legacy `[gitlab]`-section
-retirement.
+branch in `triage/scripts/start-colony.sh`. PR 3 shipped the planning
+colony's `github-api.sh` with 5 subcommands (`issues`,
+`issues-by-label-events`, `issue-label-events`, `add-note`,
+`merge-requests`) plus the matching `[forge.github]` env-export branch
+and `.ag` dispatcher migration. PR 4 (the current PR as of this
+writing) ships the implementation colony's `github-api.sh` with 11
+subcommands (`merge-requests`, `mr-changes`, `mr-commits`, `issue`,
+`assigned-issues`, `issue-label-events`,
+`assigned-issues-by-label-events`, `create-branch`, `commit-files`,
+`create-mr`, `add-note`) plus the matching `[forge.github]` env-export
+branch and 25 `.ag` call-site migrations across the four implementation
+agents. The remaining colonies' wrappers land across PRs 5-6 in the
+order code-review → release. `rate-limit-status` and the dashboard tile
+ship in PR 7 alongside the legacy `[gitlab]`-section retirement.
 
 **`.ag` migration is in-scope for every per-colony PR.** Each
 per-colony PR (PRs 2-6) MUST rewrite every `exec sh` call site in that
@@ -157,6 +162,36 @@ list endpoint omits `changed_files`; the normalizer forwards `null`,
 and scope_estimator tolerates it (complexity scoring is best-effort).
 GitHub's `/pulls` has no `since` query param, so `--since` is filtered
 client-side against `updated_at`.
+
+**PR 4 additions.** The implementation contract adds the write-path
+subcommands: `create-branch`, `commit-files`, `create-mr`, plus the
+two MR-detail readers `mr-changes` and `mr-commits`. GitHub has no
+single-call multi-file commit endpoint (unlike GitLab's
+`POST /repository/commits`); `commit-files` implements the 5-step Git
+Database API dance — `GET /git/refs/heads/{branch}` to resolve HEAD,
+`GET /git/commits/{sha}` to fetch the base tree, `POST /git/trees`
+with the per-file action list (supported: `create`/`update`/`delete`;
+`move`/`chmod` are rejected up-front with exit 1), `POST /git/commits`
+to create the commit object, then `PATCH /git/refs/heads/{branch}` to
+advance the ref. Failure at any step surfaces as a normal `gh_call`
+non-zero exit and the `.ag` try/catch rolls back. `create-branch`
+mirrors `/git/refs` — when `--ref` is a 40-hex SHA we short-circuit
+the ref resolution and POST directly; otherwise we resolve via
+`/git/refs/heads/{ref}` first. `mr-changes` maps GitHub's
+`/pulls/{n}/files` into the GitLab `{"changes": [{old_path, new_path,
+diff, new_file, deleted_file, renamed_file}]}` shape; the per-file
+`status` drives the three boolean flags, `previous_filename` (when
+present) drives `old_path`. `mr-commits` flattens
+`commit.author.{name,date}` into the GitLab-flat
+`{author_name, created_at}` shape. As in PR 3, GitHub's `/pulls` has
+no `since` query param, so `--since` is client-side on `updated_at`
+and the list response omits `changed_files` (forwarded as `null`).
+`add-note` is the `.ag`-layer call target for implementation agents'
+review-gated comment posts; it was silently failing against both
+backends before this PR (the implementation `gitlab-api.sh` exposed
+only `post-note` targeting MRs), same failure pattern PR 2 fixed for
+triage. The back-port of `add-note` into the implementation
+`gitlab-api.sh` is in-scope for this PR.
 
 | Subcommand           | Normalized output |
 |----------------------|-------------------|

--- a/tools/test-github-implementation-normalize.sh
+++ b/tools/test-github-implementation-normalize.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# test-github-implementation-normalize.sh: unit-test the GitHub -> GitLab-shape
+# normalizers in dev-apprenticeship/implementation/scripts/github-api.sh
+# (ADR-0002, #256 PR 4).
+#
+# Implementation's normalizer surface adds two endpoints planning did not need:
+#   normalize_mr_changes   for `mr-changes` command (/pulls/{n}/files)
+#   normalize_mr_commits   for `mr-commits` command (/pulls/{n}/commits)
+# The other normalizers (normalize_issues, normalize_issue, normalize_pulls,
+# normalize_timeline) are duplicated from the planning wrapper by design —
+# intentional copy to keep the two scripts runtime-independent. This test
+# re-asserts their shape so drift on either side fails loudly.
+#
+# Matches the style of test-github-triage-normalize.sh and
+# test-github-planning-normalize.sh (bash 3.2, python3 for JSON, build_prelude
+# pattern for sourcing the script under test).
+#
+# Exit 0 all-pass, 1 any-fail.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT="$REPO_ROOT/dev-apprenticeship/implementation/scripts/github-api.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+# --- Fixtures ---
+
+# GitHub /issues fixture: two real issues plus one pull_request-bearing entry
+# (must be filtered out).
+FIXTURE_ISSUES='[
+  {"url":"https://api.github.com/repos/o/r/issues/1","number":1,"title":"Impl me",
+   "body":"impl-desc","state":"open","labels":[{"id":1,"name":"implementation"},
+   {"id":2,"name":"priority:high"}],
+   "user":{"login":"alice","id":7,"type":"User"},
+   "assignees":[{"login":"bob","id":8}],
+   "created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-02T10:00:00Z",
+   "comments":2,"author_association":"MEMBER"},
+  {"url":"https://api.github.com/repos/o/r/issues/2","number":2,"title":"Another",
+   "body":"desc-2","state":"open","labels":[],
+   "user":{"login":"alice","id":7,"type":"User"},
+   "assignees":[],"created_at":"2026-04-03T10:00:00Z","updated_at":"2026-04-04T10:00:00Z",
+   "comments":0,"author_association":"MEMBER"},
+  {"url":"https://api.github.com/repos/o/r/issues/3","number":3,"title":"I-am-a-PR",
+   "body":"pr-body","state":"open","labels":[{"id":3,"name":"implementation"}],
+   "user":{"login":"alice","id":7,"type":"User"},"assignees":[],
+   "created_at":"2026-04-05T10:00:00Z","updated_at":"2026-04-06T10:00:00Z","comments":1,
+   "pull_request":{"url":"https://api.github.com/repos/o/r/pulls/3"}}
+]'
+
+FIXTURE_SINGLE_ISSUE='{"url":"https://api.github.com/repos/o/r/issues/42","number":42,
+  "title":"Single","body":"single-desc","state":"closed",
+  "labels":[{"id":99,"name":"implementation"}],
+  "user":{"login":"alice","id":7},"assignees":[{"login":"bob","id":8}],
+  "created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-10T10:00:00Z","comments":5}'
+
+# GitHub /pulls fixture. The `impl` view extracts {iid, title, merged_at,
+# target_branch} — commit_composer reads --state merged --view impl to learn
+# from prior MRs.
+FIXTURE_PULLS='[
+  {"url":"https://api.github.com/repos/o/r/pulls/10","number":10,"title":"Open PR",
+   "body":"pr-10","state":"open","merged_at":null,
+   "labels":[{"id":1,"name":"feature"}],
+   "user":{"login":"alice"},"base":{"ref":"main"},"head":{"ref":"feat/x"},
+   "created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-02T10:00:00Z",
+   "comments":1},
+  {"url":"https://api.github.com/repos/o/r/pulls/11","number":11,"title":"Merged PR",
+   "body":"pr-11","state":"closed","merged_at":"2026-04-05T12:00:00Z",
+   "labels":[{"id":2,"name":"bugfix"}],
+   "user":{"login":"alice"},"base":{"ref":"main"},"head":{"ref":"fix/y"},
+   "created_at":"2026-04-03T10:00:00Z","updated_at":"2026-04-05T12:00:00Z",
+   "comments":4,"changed_files":7},
+  {"url":"https://api.github.com/repos/o/r/pulls/12","number":12,"title":"Rejected PR",
+   "body":"pr-12","state":"closed","merged_at":null,
+   "labels":[],
+   "user":{"login":"carol"},"base":{"ref":"main"},"head":{"ref":"wip/z"},
+   "created_at":"2026-04-04T10:00:00Z","updated_at":"2026-04-06T10:00:00Z",
+   "comments":0}
+]'
+
+# GitHub /pulls/{n}/files fixture. Status drives new_file/deleted_file/renamed_file;
+# patch carries the unified diff (absent on binary files — forwarded as empty
+# string, not null, to match the subset gitlab-api.sh emits).
+FIXTURE_PULL_FILES='[
+  {"filename":"src/lib/new_feature.py","status":"added",
+   "additions":42,"deletions":0,"changes":42,
+   "patch":"@@ -0,0 +1,42 @@\n+def foo():\n+    pass\n"},
+  {"filename":"src/lib/old_name.py","status":"renamed",
+   "previous_filename":"src/lib/really_old_name.py",
+   "additions":1,"deletions":1,"changes":2,
+   "patch":"@@ -1,1 +1,1 @@\n-# old\n+# new\n"},
+  {"filename":"src/lib/gone.py","status":"removed",
+   "additions":0,"deletions":10,"changes":10,
+   "patch":"@@ -1,10 +0,0 @@\n-line1\n-line2\n"},
+  {"filename":"assets/logo.png","status":"modified","additions":0,"deletions":0,"changes":0}
+]'
+
+# GitHub /pulls/{n}/commits fixture. commit.author carries {name, email, date};
+# the normalizer flattens it into {author_name, created_at} and derives title
+# from the first line of message.
+FIXTURE_PULL_COMMITS='[
+  {"sha":"abc123","commit":{
+     "author":{"name":"Alice Example","email":"alice@example.com",
+               "date":"2026-04-01T10:00:00Z"},
+     "message":"feat: add foo\n\nLonger body\nwith details."}},
+  {"sha":"def456","commit":{
+     "author":{"name":"Bob Example","email":"bob@example.com",
+               "date":"2026-04-02T11:00:00Z"},
+     "message":"fix: bar"}}
+]'
+
+# GitHub /issues/{n}/timeline fixture. Only labeled/unlabeled should survive
+# normalize_timeline; the rest (committed, cross-referenced, ...) drop out.
+FIXTURE_TIMELINE='[
+  {"id":1,"event":"labeled","created_at":"2026-04-10T10:00:00Z",
+   "actor":{"login":"alice"},"label":{"name":"implementation","color":"ff0000"}},
+  {"id":2,"event":"cross-referenced","created_at":"2026-04-10T10:01:00Z",
+   "actor":{"login":"bob"}},
+  {"id":3,"event":"unlabeled","created_at":"2026-04-11T09:00:00Z",
+   "actor":{"login":"alice"},"label":{"name":"implementation","color":"ff0000"}},
+  {"id":4,"event":"labeled","created_at":"2026-04-12T09:00:00Z",
+   "actor":{"login":"alice"},"label":{"name":"priority:high","color":"00ff00"}},
+  {"id":5,"event":"committed","created_at":"2026-04-12T09:30:00Z"}
+]'
+
+# --- Plumbing: source just the function defs (stop before the CMD dispatcher) ---
+build_prelude() {
+    awk '/^CMD=/{exit} {print}' "$SCRIPT" > "$1"
+}
+
+# run_fn <fn-name> <input-json> [args...]
+run_fn() {
+    local fn="$1" input="$2"
+    shift 2
+    local prelude
+    prelude=$(mktemp)
+    build_prelude "$prelude"
+    # shellcheck disable=SC1090,SC2016
+    GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+        source "$1"
+        input="$2"
+        fn="$3"
+        shift 3
+        printf "%s" "$input" | "$fn" "$@"
+    ' _ "$prelude" "$input" "$fn" "$@"
+    local rc=$?
+    rm -f "$prelude"
+    return $rc
+}
+
+json_extract() {
+    DATA="$1" python3 -c "
+import os, json
+data = json.loads(os.environ['DATA'])
+print($2)
+"
+}
+
+assert_eq() {
+    if [ "$1" = "$2" ]; then
+        pass "$3"
+    else
+        fail "$3: expected='$1' actual='$2'"
+    fi
+}
+
+# --- normalize_issues: PR filter + shape ---
+ISSUES_OUT=$(run_fn normalize_issues "$FIXTURE_ISSUES")
+
+COUNT=$(json_extract "$ISSUES_OUT" "len(data)")
+assert_eq "2" "$COUNT" "normalize_issues: pull_request entries filtered out"
+
+IID0=$(json_extract "$ISSUES_OUT" "data[0]['iid']")
+assert_eq "1" "$IID0" "normalize_issues: iid == number"
+
+STATE0=$(json_extract "$ISSUES_OUT" "data[0]['state']")
+assert_eq "opened" "$STATE0" "normalize_issues: state open -> opened"
+
+LABELS0=$(json_extract "$ISSUES_OUT" "','.join(data[0]['labels'])")
+assert_eq "implementation,priority:high" "$LABELS0" "normalize_issues: labels flattened to strings"
+
+AUTHOR0=$(json_extract "$ISSUES_OUT" "data[0]['author']['username']")
+assert_eq "alice" "$AUTHOR0" "normalize_issues: author.username == user.login"
+
+ASSIGNEE0=$(json_extract "$ISSUES_OUT" "data[0]['assignees'][0]['username']")
+assert_eq "bob" "$ASSIGNEE0" "normalize_issues: assignees[].username <- login"
+
+# --- normalize_issue (single-issue variant) ---
+SINGLE_OUT=$(run_fn normalize_issue "$FIXTURE_SINGLE_ISSUE")
+SINGLE_IID=$(json_extract "$SINGLE_OUT" "data['iid']")
+SINGLE_STATE=$(json_extract "$SINGLE_OUT" "data['state']")
+SINGLE_ASSIGNEE=$(json_extract "$SINGLE_OUT" "data['assignees'][0]['username']")
+assert_eq "42" "$SINGLE_IID" "normalize_issue: iid == number"
+assert_eq "closed" "$SINGLE_STATE" "normalize_issue: state closed stays closed"
+assert_eq "bob" "$SINGLE_ASSIGNEE" "normalize_issue: single-issue assignees preserved"
+
+# --- normalize_pulls: state collapse + MR-shape ---
+PULLS_OUT=$(run_fn normalize_pulls "$FIXTURE_PULLS")
+P_COUNT=$(json_extract "$PULLS_OUT" "len(data)")
+assert_eq "3" "$P_COUNT" "normalize_pulls: three entries"
+
+P0_STATE=$(json_extract "$PULLS_OUT" "data[0]['state']")
+P1_STATE=$(json_extract "$PULLS_OUT" "data[1]['state']")
+P2_STATE=$(json_extract "$PULLS_OUT" "data[2]['state']")
+assert_eq "opened" "$P0_STATE" "normalize_pulls: open -> opened"
+assert_eq "merged" "$P1_STATE" "normalize_pulls: closed + merged_at -> merged"
+assert_eq "closed" "$P2_STATE" "normalize_pulls: closed + no merged_at -> closed"
+
+P1_TGT=$(json_extract "$PULLS_OUT" "data[1]['target_branch']")
+P1_SRC=$(json_extract "$PULLS_OUT" "data[1]['source_branch']")
+P1_MERGED=$(json_extract "$PULLS_OUT" "data[1]['merged_at']")
+P1_CHANGES=$(json_extract "$PULLS_OUT" "data[1]['changes_count']")
+P1_NOTES=$(json_extract "$PULLS_OUT" "data[1]['user_notes_count']")
+assert_eq "main" "$P1_TGT" "normalize_pulls: target_branch <- base.ref"
+assert_eq "fix/y" "$P1_SRC" "normalize_pulls: source_branch <- head.ref"
+assert_eq "2026-04-05T12:00:00Z" "$P1_MERGED" "normalize_pulls: merged_at preserved"
+assert_eq "7" "$P1_CHANGES" "normalize_pulls: changes_count <- changed_files"
+assert_eq "4" "$P1_NOTES" "normalize_pulls: user_notes_count <- comments"
+
+P0_CHANGES=$(json_extract "$PULLS_OUT" "repr(data[0]['changes_count'])")
+assert_eq "None" "$P0_CHANGES" "normalize_pulls: missing changed_files -> null"
+
+# --- normalize_mr_changes: /pulls/{n}/files -> {changes: [...]} ---
+CHANGES_OUT=$(run_fn normalize_mr_changes "$FIXTURE_PULL_FILES")
+CH_TOP_KEYS=$(json_extract "$CHANGES_OUT" "','.join(sorted(data.keys()))")
+assert_eq "changes" "$CH_TOP_KEYS" "normalize_mr_changes: wraps into {changes: [...]}"
+
+CH_COUNT=$(json_extract "$CHANGES_OUT" "len(data['changes'])")
+assert_eq "4" "$CH_COUNT" "normalize_mr_changes: four entries"
+
+CH0_NEW=$(json_extract "$CHANGES_OUT" "data['changes'][0]['new_file']")
+CH0_OLD_PATH=$(json_extract "$CHANGES_OUT" "data['changes'][0]['old_path']")
+CH0_NEW_PATH=$(json_extract "$CHANGES_OUT" "data['changes'][0]['new_path']")
+assert_eq "True" "$CH0_NEW" "normalize_mr_changes: status added -> new_file=true"
+assert_eq "src/lib/new_feature.py" "$CH0_OLD_PATH" "normalize_mr_changes: added file old_path == new_path"
+assert_eq "src/lib/new_feature.py" "$CH0_NEW_PATH" "normalize_mr_changes: added file new_path preserved"
+
+CH1_RENAMED=$(json_extract "$CHANGES_OUT" "data['changes'][1]['renamed_file']")
+CH1_OLD_PATH=$(json_extract "$CHANGES_OUT" "data['changes'][1]['old_path']")
+CH1_NEW_PATH=$(json_extract "$CHANGES_OUT" "data['changes'][1]['new_path']")
+assert_eq "True" "$CH1_RENAMED" "normalize_mr_changes: status renamed -> renamed_file=true"
+assert_eq "src/lib/really_old_name.py" "$CH1_OLD_PATH" "normalize_mr_changes: renamed old_path <- previous_filename"
+assert_eq "src/lib/old_name.py" "$CH1_NEW_PATH" "normalize_mr_changes: renamed new_path <- filename"
+
+CH2_DELETED=$(json_extract "$CHANGES_OUT" "data['changes'][2]['deleted_file']")
+assert_eq "True" "$CH2_DELETED" "normalize_mr_changes: status removed -> deleted_file=true"
+
+# Binary file with no patch — diff should be empty string, not missing.
+CH3_DIFF=$(json_extract "$CHANGES_OUT" "repr(data['changes'][3]['diff'])")
+assert_eq "''" "$CH3_DIFF" "normalize_mr_changes: binary (no patch) -> diff=''"
+
+# --- normalize_mr_commits: /pulls/{n}/commits -> [{id, title, message, author_name, created_at}] ---
+COMMITS_OUT=$(run_fn normalize_mr_commits "$FIXTURE_PULL_COMMITS")
+C_COUNT=$(json_extract "$COMMITS_OUT" "len(data)")
+assert_eq "2" "$C_COUNT" "normalize_mr_commits: two entries"
+
+C0_ID=$(json_extract "$COMMITS_OUT" "data[0]['id']")
+C0_TITLE=$(json_extract "$COMMITS_OUT" "data[0]['title']")
+C0_AUTHOR=$(json_extract "$COMMITS_OUT" "data[0]['author_name']")
+C0_DATE=$(json_extract "$COMMITS_OUT" "data[0]['created_at']")
+assert_eq "abc123" "$C0_ID" "normalize_mr_commits: id <- sha"
+assert_eq "feat: add foo" "$C0_TITLE" "normalize_mr_commits: title is first line of message"
+assert_eq "Alice Example" "$C0_AUTHOR" "normalize_mr_commits: author_name <- commit.author.name"
+assert_eq "2026-04-01T10:00:00Z" "$C0_DATE" "normalize_mr_commits: created_at <- commit.author.date"
+
+# --- normalize_timeline: label events only + add/remove mapping ---
+TIMELINE_OUT=$(run_fn normalize_timeline "$FIXTURE_TIMELINE" "" "")
+T_COUNT=$(json_extract "$TIMELINE_OUT" "len(data)")
+assert_eq "3" "$T_COUNT" "normalize_timeline: non-label events dropped (committed/cross-referenced)"
+
+T0_ACTION=$(json_extract "$TIMELINE_OUT" "data[0]['action']")
+T0_LABEL=$(json_extract "$TIMELINE_OUT" "data[0]['label']")
+T0_USER=$(json_extract "$TIMELINE_OUT" "data[0]['user']")
+assert_eq "add" "$T0_ACTION" "normalize_timeline: labeled -> add"
+assert_eq "implementation" "$T0_LABEL" "normalize_timeline: label.name preserved"
+assert_eq "alice" "$T0_USER" "normalize_timeline: actor.login -> user"
+
+T1_ACTION=$(json_extract "$TIMELINE_OUT" "data[1]['action']")
+assert_eq "remove" "$T1_ACTION" "normalize_timeline: unlabeled -> remove"
+
+TL_LABEL_ONLY=$(run_fn normalize_timeline "$FIXTURE_TIMELINE" "implementation" "")
+TL_LABEL_COUNT=$(json_extract "$TL_LABEL_ONLY" "len(data)")
+assert_eq "2" "$TL_LABEL_COUNT" "normalize_timeline: label filter narrows to 'implementation' events"
+
+TL_SINCE=$(run_fn normalize_timeline "$FIXTURE_TIMELINE" "" "2026-04-11T00:00:00Z")
+TL_SINCE_COUNT=$(json_extract "$TL_SINCE" "len(data)")
+assert_eq "2" "$TL_SINCE_COUNT" "normalize_timeline: since filter drops pre-cutoff events"
+
+# --- End-to-end: normalize_issues -> project_json assigned ---
+# code_writer reads `assigned-issues --view assigned` for trigger detection.
+# The view keys must stay locked to {iid, title, description, labels,
+# assignees, priority} — drift would silently misfeed prompts.
+PIPE_PRELUDE=$(mktemp)
+build_prelude "$PIPE_PRELUDE"
+# shellcheck disable=SC1090,SC2016
+E2E_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    printf "%s" "$2" | normalize_issues | project_json assigned
+' _ "$PIPE_PRELUDE" "$FIXTURE_ISSUES")
+rm -f "$PIPE_PRELUDE"
+
+E2E_COUNT=$(json_extract "$E2E_OUT" "len(data)")
+E2E_KEYS=$(json_extract "$E2E_OUT" "','.join(sorted(data[0].keys()))")
+E2E_IID=$(json_extract "$E2E_OUT" "data[0]['iid']")
+E2E_ASSIGNEE=$(json_extract "$E2E_OUT" "data[0]['assignees'][0]['username']")
+E2E_PRIORITY=$(json_extract "$E2E_OUT" "repr(data[0]['priority'])")
+assert_eq "2" "$E2E_COUNT" "e2e assigned: normalize | assigned view emits 2 items (PR filtered)"
+assert_eq "assignees,description,iid,labels,priority,title" "$E2E_KEYS" "e2e assigned: view keys match gitlab shape"
+assert_eq "1" "$E2E_IID" "e2e assigned: view carries iid through pipe"
+assert_eq "bob" "$E2E_ASSIGNEE" "e2e assigned: view carries assignees[].username through pipe"
+assert_eq "None" "$E2E_PRIORITY" "e2e assigned: GitHub issue -> priority null"
+
+# --- End-to-end: normalize_pulls -> project_json impl ---
+# commit_composer reads `merge-requests --state merged --view impl` to learn
+# merge cadence. View keys must be {iid, title, merged_at, target_branch}.
+PIPE_PRELUDE2=$(mktemp)
+build_prelude "$PIPE_PRELUDE2"
+# shellcheck disable=SC1090,SC2016
+E2E_MR_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    printf "%s" "$2" | normalize_pulls | project_json impl
+' _ "$PIPE_PRELUDE2" "$FIXTURE_PULLS")
+rm -f "$PIPE_PRELUDE2"
+
+E2E_MR_COUNT=$(json_extract "$E2E_MR_OUT" "len(data)")
+E2E_MR_KEYS=$(json_extract "$E2E_MR_OUT" "','.join(sorted(data[0].keys()))")
+E2E_MR_MERGED=$(json_extract "$E2E_MR_OUT" "data[1]['merged_at']")
+E2E_MR_TGT=$(json_extract "$E2E_MR_OUT" "data[1]['target_branch']")
+assert_eq "3" "$E2E_MR_COUNT" "e2e impl: normalize | impl view emits 3 items"
+assert_eq "iid,merged_at,target_branch,title" "$E2E_MR_KEYS" "e2e impl: view keys match gitlab impl shape"
+assert_eq "2026-04-05T12:00:00Z" "$E2E_MR_MERGED" "e2e impl: merged_at carried through"
+assert_eq "main" "$E2E_MR_TGT" "e2e impl: target_branch carried through"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-gitlab-views.sh
+++ b/tools/test-gitlab-views.sh
@@ -346,6 +346,29 @@ if [ -f "$GH_PLANNING_SCRIPT" ]; then
     done
 fi
 
+# --- implementation github-api.sh project_json parity (#256 PR 4) ---
+# implementation/scripts/github-api.sh duplicates project_json rather than
+# sourcing gitlab-api.sh. The implementation-specific views are `impl` (MR
+# list) and `assigned` (trigger issues); both must emit byte-identical JSON
+# to their gitlab twin when fed an already-GitLab-shape fixture.
+GH_IMPL_SCRIPT="$REPO_ROOT/dev-apprenticeship/implementation/scripts/github-api.sh"
+if [ -f "$GH_IMPL_SCRIPT" ]; then
+    for pair in \
+        "impl:$FIXTURE_MRS" \
+        "assigned:$FIXTURE_ISSUES"
+    do
+        view="${pair%%:*}"
+        fixture="${pair#*:}"
+        gl_out=$(run_view "$REPO_ROOT/dev-apprenticeship/implementation/scripts/gitlab-api.sh" "$view" "$fixture")
+        gh_out=$(run_view_github "$GH_IMPL_SCRIPT" "$view" "$fixture")
+        if [ "$gl_out" = "$gh_out" ]; then
+            pass "implementation github-api.sh project_json parity: $view"
+        else
+            fail "implementation github-api.sh project_json drifted from gitlab-api.sh: $view"
+        fi
+    done
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Ship `dev-apprenticeship/implementation/scripts/github-api.sh` (11 subcommands) — the GitHub write path (`create-branch`, `commit-files`, `create-mr`) plus MR/issue readers with GitLab-shape normalization. `commit-files` implements the 5-step Git Database API dance since GitHub has no single-call multi-file commit endpoint. Supported actions are `create`/`update`/`delete`; `move`/`chmod` are rejected up-front with exit 1.
- Migrate all 25 `exec sh` call sites across `code_writer`, `test_writer`, `refactorer`, `commit_composer` from `scripts/gitlab-api.sh` to `scripts/forge-api.sh`. `start-colony.sh` branches on `FORGE_TYPE` identically to triage/planning.
- Back-port fix: `implementation/scripts/gitlab-api.sh` gains an `add-note` subcommand targeting `/issues/{iid}/notes`. All 4 implementation agents call `add-note` on review-gated branches but it never existed (only `post-note` targeted MRs). Silent failures through `.ag` try/catch — same pattern PR 2 fixed for triage.
- Two new tests: `tools/test-github-implementation-normalize.sh` (50 assertions) and an implementation-colony parity block in `tools/test-gitlab-views.sh`. `colony-lint`: 99 passed, 0 failed.

## Scope

PR 4 of 7 for #256 (forge abstraction). PRs 5-6 land the remaining colonies (code-review, release). PR 7 retires `[gitlab]` and ships `rate-limit-status`.

See ADR-0002's Per-PR rollout + PR 4 additions paragraphs for the full contract surface.

## Test plan

- [x] `./tools/colony-lint.sh` — 99 passed, 0 failed, 1 skipped
- [x] `./tools/test-github-implementation-normalize.sh` — 50/50 passed
- [x] `./tools/test-gitlab-views.sh` — 58/58 passed (includes new implementation parity block)
- [x] `bash -n` on all modified + new scripts
- [x] `check-forge-dispatch` — 0 direct `gitlab-api.sh` / `github-api.sh` refs in implementation `.ag` files
- [x] QA sweep via `agentis-qa-agent` before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)