### PR TITLE
feat(#256): code-review colony GitHub backend (PR 5 of 7)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -170,6 +170,43 @@ is asserted until multi-version CI is in place.
   output between `github-api.sh` and `gitlab-api.sh` for the `impl`
   and `assigned` views.
   [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
+- **Code-review colony GitHub backend (PR 5 of 7 for #256).**
+  `dev-apprenticeship/code-review/scripts/github-api.sh` implements the
+  code-review contract against the GitHub REST API v3 (5 subcommands:
+  `merge-requests`, `mr-changes`, `mr-notes`, `post-note`, `approve`).
+  Two endpoint collapses unique to the review surface: GitHub unifies
+  issue and PR conversations under `/issues/{n}/comments`, so both
+  `mr-notes` and `post-note` target that endpoint (same one the
+  triage/planning/implementation `add-note` subcommands already hit);
+  `approve` maps GitLab's idempotent
+  `POST /merge_requests/{iid}/approve` to GitHub's non-idempotent
+  `POST /pulls/{n}/reviews` with `{"event": "APPROVE"}` (extra calls
+  from the same reviewer stack as additional APPROVED review events
+  but don't break the approvals collapse, since the approved-count
+  logic counts latest-per-reviewer). `normalize_pulls` adds a native
+  `draft` boolean from GitHub's `draft` field (consumed by the
+  `reviewer` view to skip draft PRs); GitHub has no `system` flag on
+  comments, so `normalize_notes` stamps `system: false` on every row
+  (correct because `/issues/{n}/comments` only surfaces human comments,
+  unlike GitLab's `/notes` which mixes in timeline events). As in
+  PRs 3-4, `--state merged` collapses to
+  `state=closed + merged_at != null` client-side and `--since` filters
+  client-side on `updated_at` (GitHub's `/pulls` has no `since` param).
+  All 28 `exec sh` call sites across `approval_decider`, `logic_reviewer`,
+  `security_reviewer`, `style_reviewer`, and `test_reviewer` were
+  rewritten from `scripts/gitlab-api.sh` to `scripts/forge-api.sh`.
+  `code-review/scripts/start-colony.sh` now branches on `FORGE_TYPE`
+  identically to triage/planning/implementation; no colony-specific
+  env additions (code-review agents don't create branches or issues).
+  Two new tests: `tools/test-github-code-review-normalize.sh` (32
+  assertions covering `normalize_pulls` state collapse + `draft` field
+  passthrough, `normalize_mr_changes` status → new_file/deleted_file/
+  renamed_file mapping, `normalize_notes` `system: false` invariant,
+  end-to-end pipe through the `reviewer` view); and a code-review-colony
+  extension to `tools/test-gitlab-views.sh` asserting byte-identical
+  `project_json` output between `github-api.sh` and `gitlab-api.sh`
+  for the `reviewer` view.
+  [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
 
 ### Changed
 

--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -54,7 +54,7 @@ fn tick(reason: string) -> void {
     };
 
     // Learn from past human approval/rejection patterns
-    let mr_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --view reviewer";
+    let mr_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view reviewer";
     let recent_merged = try { exec sh mr_cmd; } catch e { "[]"; };
 
     // Cold-path via upstream rate-limit: the bus-load early-exit above
@@ -88,7 +88,7 @@ fn tick(reason: string) -> void {
 
     if my_tier == "autonomous" {
         if decision.action == "approve" {
-            let approve_cmd = "$COLONY_DIR/scripts/gitlab-api.sh approve " + to_string(decision.mr_iid);
+            let approve_cmd = "$COLONY_DIR/scripts/forge-api.sh approve " + to_string(decision.mr_iid);
             try { exec sh approve_cmd; } catch e {
                 print("[approval_decider] Failed to approve:", e);
             };
@@ -97,7 +97,7 @@ fn tick(reason: string) -> void {
         } else {
             if decision.action == "request_changes" {
                 let comment = "**Review Summary** (automated)\n\n" + decision.reasoning + "\n\nFindings: " + to_string(decision.total_findings) + " total, " + to_string(decision.critical_count) + " critical";
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment);
                 try { exec sh post_cmd; } catch e {
                     print("[approval_decider] Failed to post:", e);
                 };
@@ -113,7 +113,7 @@ fn tick(reason: string) -> void {
             // a human can promote the approve / request_changes action instead
             // of acting directly.
             let comment = "[draft-review-decision] **Review Summary** (automated, pending approval): suggested action `" + decision.action + "`\n\n" + decision.reasoning + "\n\nFindings: " + to_string(decision.total_findings) + " total, " + to_string(decision.critical_count) + " critical";
-            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment);
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment);
             try { exec sh post_cmd; } catch e {
                 print("[approval_decider] Failed to post draft summary:", e);
             };

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -24,9 +24,9 @@ type LogicReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("logic_reviewer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --view reviewer";
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer";
 }
 
 fn get_confidence() -> float {
@@ -63,7 +63,7 @@ fn tick(reason: string) -> void {
     if mr_iid <= 0 {
         return;
     };
-    let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -88,7 +88,7 @@ fn tick(reason: string) -> void {
 
     if should_learn == 1 {
         // Learn from human logic-related comments
-        let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid);
         let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
         let human_patterns = prompt(
@@ -121,7 +121,7 @@ fn tick(reason: string) -> void {
         if my_tier == "autonomous" {
             emit("review:logic_findings", review);
             let comment = "**Logic Review** (automated)\n\n" + review.summary;
-            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             try { exec sh post_cmd; } catch e {
                 print("[logic_reviewer] Failed to post comment:", e);
             };
@@ -130,7 +130,7 @@ fn tick(reason: string) -> void {
             if my_tier == "review-gated" {
                 emit("review:logic_findings", review);
                 let comment = "[draft-review] **Logic Review** (automated, pending approval)\n\n" + review.summary;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
                 let result = try { exec sh post_cmd; } catch e {
                     print("[logic_reviewer] Failed to post draft comment:", e);
                     "";

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -25,9 +25,9 @@ type SecurityReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("security_reviewer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --view reviewer";
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer";
 }
 
 fn get_confidence() -> float {
@@ -64,7 +64,7 @@ fn tick(reason: string) -> void {
     if mr_iid <= 0 {
         return;
     };
-    let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -89,7 +89,7 @@ fn tick(reason: string) -> void {
 
     if should_learn == 1 {
         // Learn from human security-related comments
-        let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid);
         let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
         let human_patterns = prompt(
@@ -122,7 +122,7 @@ fn tick(reason: string) -> void {
         if my_tier == "autonomous" {
             emit("review:security_findings", review);
             let comment = "**Security Review** (automated)\n\n" + review.summary;
-            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             try { exec sh post_cmd; } catch e {
                 print("[security_reviewer] Failed to post comment:", e);
             };
@@ -131,7 +131,7 @@ fn tick(reason: string) -> void {
             if my_tier == "review-gated" {
                 emit("review:security_findings", review);
                 let comment = "[draft-review] **Security Review** (automated, pending approval)\n\n" + review.summary;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
                 let result = try { exec sh post_cmd; } catch e {
                     print("[security_reviewer] Failed to post draft comment:", e);
                     "";

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -48,9 +48,9 @@ fn sanitize_author(s: string) -> string {
 fn mr_cmd() -> string {
     let ts = recall_latest("style_reviewer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --view reviewer";
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer";
 }
 
 fn get_confidence() -> float {
@@ -88,7 +88,7 @@ fn tick(reason: string) -> void {
     if mr_iid <= 0 {
         return;
     };
-    let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -113,7 +113,7 @@ fn tick(reason: string) -> void {
 
     if should_learn == 1 {
         // Check for existing human review comments to learn from
-        let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid);
         let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
         // Learn from human style comments
@@ -153,7 +153,7 @@ fn tick(reason: string) -> void {
             // Post review comment directly (terminal voice on the MR).
             emit("review:style_findings", review);
             let comment = "**Style Review** (automated)\n\n" + review.summary;
-            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             let result = try { exec sh post_cmd; } catch e {
                 print("[style_reviewer] Failed to post comment:", e);
                 "";
@@ -169,7 +169,7 @@ fn tick(reason: string) -> void {
                 // record an approval marker so downstream promotion can pick it up.
                 emit("review:style_findings", review);
                 let comment = "[draft-review] **Style Review** (automated, pending approval)\n\n" + review.summary;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
                 let result = try { exec sh post_cmd; } catch e {
                     print("[style_reviewer] Failed to post draft comment:", e);
                     "";

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -24,9 +24,9 @@ type TestReview {
 fn mr_cmd() -> string {
     let ts = recall_latest("test_reviewer:last_check");
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --view reviewer";
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer";
 }
 
 fn get_confidence() -> float {
@@ -55,7 +55,7 @@ fn tick(reason: string) -> void {
     if mr_iid <= 0 {
         return;
     };
-    let changes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-changes " + to_string(mr_iid);
+    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -81,7 +81,7 @@ fn tick(reason: string) -> void {
 
     if should_learn == 1 {
         // Learn from human test-related comments
-        let notes_cmd = "$COLONY_DIR/scripts/gitlab-api.sh mr-notes " + to_string(mr_iid);
+        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid);
         let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
         let human_patterns = prompt(
@@ -114,7 +114,7 @@ fn tick(reason: string) -> void {
         if my_tier == "autonomous" {
             emit("review:test_findings", review);
             let comment = "**Test Review** (automated)\n\n" + review.summary;
-            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
             try { exec sh post_cmd; } catch e {
                 print("[test_reviewer] Failed to post comment:", e);
             };
@@ -123,7 +123,7 @@ fn tick(reason: string) -> void {
             if my_tier == "review-gated" {
                 emit("review:test_findings", review);
                 let comment = "[draft-review] **Test Review** (automated, pending approval)\n\n" + review.summary;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
                 let result = try { exec sh post_cmd; } catch e {
                     print("[test_reviewer] Failed to post draft comment:", e);
                     "";

--- a/dev-apprenticeship/code-review/scripts/forge-api.sh
+++ b/dev-apprenticeship/code-review/scripts/forge-api.sh
@@ -35,20 +35,8 @@ case "$FORGE_TYPE" in
 esac
 
 if [ ! -x "$backend" ]; then
-    case "$FORGE_TYPE" in
-        github)
-            # Skeleton state: dispatcher exists but the per-colony wrapper is not yet
-            # shipped. Lands across PRs 2-6 of #256.
-            echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the code-review colony." >&2
-            echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
-            ;;
-        *)
-            # Broken install — gitlab-api.sh should always be present alongside
-            # forge-api.sh in a valid federation checkout.
-            echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
-            echo "forge-api.sh: this indicates a broken install — re-copy the code-review colony scripts/ directory." >&2
-            ;;
-    esac
+    echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
+    echo "forge-api.sh: this indicates a broken install — re-copy the code-review colony scripts/ directory." >&2
     exit 99
 fi
 

--- a/dev-apprenticeship/code-review/scripts/github-api.sh
+++ b/dev-apprenticeship/code-review/scripts/github-api.sh
@@ -1,0 +1,446 @@
+#!/bin/bash
+# GitHub API wrapper for code-review colony agents (ADR-0002, #256 PR 5 of 7).
+# Called by .ag agents via forge-api.sh dispatch when FORGE_TYPE=github.
+#
+# Required env vars (set by start-colony.sh from [forge.github] in colony.toml):
+#   GITHUB_URL    - API base (default https://api.github.com; override for GHE)
+#   GITHUB_TOKEN  - personal access token (classic or fine-grained)
+#   GITHUB_OWNER  - repo owner (user or org)
+#   GITHUB_REPO   - repo name
+#
+# Optional env vars:
+#   GITHUB_ME             authenticated-user login (optional, for personal
+#                         vs team tagging via style_reviewer etc.)
+#   GITHUB_CURL_MAX_TIME  per-attempt --max-time seconds (default 90)
+#   GITHUB_CURL_RETRIES   retry budget for 5xx/timeouts/429 (default 3)
+#
+# Usage (identical contract to gitlab-api.sh):
+#   github-api.sh merge-requests [--state opened|merged|closed|all] [--since ISO8601]
+#                                [--per-page N] [--view <name>]
+#   github-api.sh mr-changes <number>
+#   github-api.sh mr-notes <number>
+#   github-api.sh post-note <number> --body <text>
+#   github-api.sh approve <number>
+#
+# Views (opt-in projection; byte-identical to gitlab-api.sh):
+#   merge-requests --view reviewer  [{iid, state, title, labels,
+#                                     source_branch, target_branch, draft,
+#                                     author:{username}}]
+#   <cmd>          --view raw       explicit pass-through (same as no flag)
+#   GITLAB_VIEW_MODE=raw            env-override that forces pass-through.
+#
+# Semantic collapses vs GitLab:
+#   /pulls                   replaces /merge_requests; state merged -> closed +
+#                            client-side merged_at!=null filter; no `since`
+#                            query param, --since is client-side on updated_at.
+#                            Carries `draft` natively — the only normalize_pulls
+#                            addition vs the implementation colony's shape.
+#   /pulls/{n}/files         replaces /merge_requests/{iid}/changes; per-file
+#                            entries are wrapped into {"changes": [...]} for
+#                            shape parity with the GitLab MR-changes response.
+#   /issues/{n}/comments     replaces /merge_requests/{iid}/notes. Every GitHub
+#                            PR is also an issue (same number), and PR
+#                            conversation comments land in the issues-comments
+#                            endpoint. System events (merged/labeled/...) live
+#                            in /issues/{n}/timeline and are intentionally
+#                            excluded from mr-notes (agents only read human
+#                            discussion). The normalizer emits system: false
+#                            on every row so downstream shape stays stable.
+#   /pulls/{n}/reviews       replaces /merge_requests/{iid}/approve; POST with
+#                            {"event": "APPROVE"} creates an approving review.
+#                            Unlike GitLab, GitHub has no idempotent /approve
+#                            endpoint — calling this twice creates two reviews
+#                            (approval_decider guards on its own decide-once
+#                            memo; double-approve is inert but visible).
+#
+# Exit codes:
+#   0  ok (2xx)
+#   1  usage error (required flag missing, backend rejection)
+#   2  unknown flag / view / auth failure (4xx 401/403)
+#   3  rate limited (429 or secondary rate-limit, after retries)
+#   4  other 4xx client error
+#   5  5xx server error OR transport failure
+
+set -e
+
+# emit_error <message>
+# Matches gitlab-api.sh emit_error contract: JSON error object to stderr.
+emit_error() {
+    printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+# normalize_pulls
+# Reads GitHub pulls-list JSON, writes GitLab-MR-shape JSON. Superset of the
+# planning/implementation normalize_pulls: adds `draft` (needed by the
+# reviewer view). Duplicated rather than sourced for script-independence per
+# ADR-0002. State collapse: open -> opened; closed + merged_at -> merged;
+# closed + no merged_at stays closed.
+normalize_pulls() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for x in data:
+    st = x.get("state")
+    if st == "open":
+        st = "opened"
+    elif st == "closed" and x.get("merged_at"):
+        st = "merged"
+    out.append({
+        "iid": x.get("number"),
+        "title": x.get("title"),
+        "description": x.get("body"),
+        "state": st,
+        "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
+        "author": {"username": (x.get("user") or {}).get("login")},
+        "target_branch": (x.get("base") or {}).get("ref"),
+        "source_branch": (x.get("head") or {}).get("ref"),
+        # `draft` is native on GitHub PRs. The reviewer view passes this
+        # through so style/logic/security/test reviewers can skip drafts.
+        "draft": bool(x.get("draft")),
+        "merged_at": x.get("merged_at"),
+        "created_at": x.get("created_at"),
+        "updated_at": x.get("updated_at"),
+        # /pulls list endpoint omits changed_files; forward as null.
+        "changes_count": x.get("changed_files"),
+        "user_notes_count": x.get("comments", 0),
+    })
+print(json.dumps(out))
+PY
+}
+
+# normalize_mr_changes
+# Reads GitHub /pulls/{n}/files JSON, writes a GitLab-mr-changes-shape JSON
+# object: {"changes": [{"old_path", "new_path", "diff", "new_file",
+# "deleted_file", "renamed_file"}, ...]}. The reviewers feed `diff` (unified
+# patch text) straight into prompt() so drift in this shape breaks all four
+# finding streams silently.
+normalize_mr_changes() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for f in data:
+    status = f.get("status") or ""
+    path = f.get("filename") or ""
+    prev = f.get("previous_filename") or path
+    out.append({
+        "old_path": prev,
+        "new_path": path,
+        "diff": f.get("patch") or "",
+        "new_file": status == "added",
+        "deleted_file": status == "removed",
+        "renamed_file": status == "renamed",
+    })
+print(json.dumps({"changes": out}))
+PY
+}
+
+# normalize_notes
+# Reads GitHub /issues/{n}/comments JSON, writes GitLab /notes-shape:
+# [{id, body, author:{username}, created_at, system}]. GitHub's issue-comments
+# endpoint returns only human discussion — state-change / label / review
+# system events live in /issues/{n}/timeline. We stamp system: false on every
+# row so the GitLab-shape filter (`if not system`) that reviewers apply over
+# mr-notes continues to work.
+normalize_notes() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{
+    "id": c.get("id"),
+    "body": c.get("body"),
+    "author": {"username": (c.get("user") or {}).get("login")},
+    "created_at": c.get("created_at"),
+    "updated_at": c.get("updated_at"),
+    "system": False,
+} for c in data]
+print(json.dumps(out))
+PY
+}
+
+# project_json <view-name>
+# Byte-identical to gitlab-api.sh project_json; test-gitlab-views.sh enforces
+# parity. One view (reviewer) plus raw pass-through.
+project_json() {
+    local view="$1"
+    if [ "${GITLAB_VIEW_MODE:-}" = "raw" ]; then
+        cat
+        return 0
+    fi
+    local DATA
+    DATA="$(cat)"
+    case "$view" in
+        raw)
+            printf '%s' "$DATA"
+            ;;
+        reviewer)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+# #104 parity: keep author.username so style_reviewer tags personal vs team.
+out = [{"iid": x.get("iid"), "state": x.get("state"), "title": x.get("title"),
+        "labels": x.get("labels", []), "source_branch": x.get("source_branch"),
+        "target_branch": x.get("target_branch"), "draft": x.get("draft"),
+        "author": {"username": (x.get("author") or {}).get("username")}} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        *)
+            emit_error "unknown view: $view"
+            exit 2
+            ;;
+    esac
+}
+
+if [ -z "${GITHUB_TOKEN:-}" ] || [ -z "${GITHUB_OWNER:-}" ] || [ -z "${GITHUB_REPO:-}" ]; then
+    emit_error "GITHUB_TOKEN, GITHUB_OWNER, and GITHUB_REPO must be set"
+    exit 1
+fi
+
+GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+API="$GITHUB_URL/repos/$GITHUB_OWNER/$GITHUB_REPO"
+
+# gh_call <method> <url> [curl-args...]
+# Mirrors planning/triage/implementation gh_call: retry on 429/5xx/timeout,
+# no-retry on 401/403 non-rate-limit, 403-secondary-rate detection via body
+# snippet, bounded curl --max-time. Exit codes 0/2/3/4/5 match gl_call.
+gh_call() {
+    local method="$1" url="$2"
+    shift 2
+    local max_time="${GITHUB_CURL_MAX_TIME:-90}"
+    local max_retries="${GITHUB_CURL_RETRIES:-3}"
+    local attempt=0 delay=3 rc code snippet body_file
+    body_file="$(mktemp)"
+    trap 'rm -f "$body_file"; trap - RETURN' RETURN
+
+    while :; do
+        attempt=$((attempt + 1))
+        code=""
+        rc=0
+        code="$(curl -sS -w '%{http_code}' -o "$body_file" \
+            --max-time "$max_time" \
+            -X "$method" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$@" \
+            "$url" 2>/dev/null)" || rc=$?
+
+        if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
+            if [ "$attempt" -le "$max_retries" ]; then
+                sleep "$delay"
+                delay=$((delay * 2))
+                continue
+            fi
+            emit_error "curl transport failure (exit $rc) after $attempt attempts: $method $url"
+            return 5
+        fi
+
+        case "$code" in
+            2*)
+                cat "$body_file"
+                return 0
+                ;;
+            401)
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "auth failure (HTTP 401) on $method $url: $snippet — check PAT scope/expiry"
+                return 2
+                ;;
+            403)
+                # GitHub overloads 403: could be missing scope (permanent) or
+                # secondary rate-limit / abuse-detection (transient). Heuristic
+                # on the error body — matches the triage/planning/impl wrappers.
+                snippet="$(head -c 400 "$body_file")"
+                if printf '%s' "$snippet" | grep -qiE 'rate limit|abuse|secondary rate'; then
+                    if [ "$attempt" -le "$max_retries" ]; then
+                        sleep "$delay"
+                        delay=$((delay * 2))
+                        continue
+                    fi
+                    emit_error "secondary rate limit (HTTP 403) after $attempt attempts: $snippet"
+                    return 3
+                fi
+                emit_error "auth/permission failure (HTTP 403) on $method $url: $snippet — check PAT scope"
+                return 2
+                ;;
+            429)
+                if [ "$attempt" -le "$max_retries" ]; then
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                    continue
+                fi
+                emit_error "rate limited (HTTP 429) after $attempt attempts on $method $url"
+                return 3
+                ;;
+            5*)
+                if [ "$attempt" -le "$max_retries" ]; then
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                    continue
+                fi
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "server error (HTTP $code) after $attempt attempts: $snippet"
+                return 5
+                ;;
+            4*)
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "client error (HTTP $code) on $method $url: $snippet"
+                return 4
+                ;;
+            *)
+                emit_error "unexpected HTTP $code on $method $url"
+                return 4
+                ;;
+        esac
+    done
+}
+
+gh_get() {
+    gh_call GET "$1"
+}
+
+gh_get_q() {
+    local url="$1"
+    shift
+    gh_call GET "$url" -G "$@"
+}
+
+gh_post() {
+    gh_call POST "$1" -H "Content-Type: application/json" -d "$2"
+}
+
+CMD="${1:?Usage: github-api.sh <command> [args...]}"
+shift
+
+case "$CMD" in
+    merge-requests)
+        STATE="opened"
+        SINCE=""
+        VIEW=""
+        PER_PAGE=20
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --state) STATE="$2"; shift 2 ;;
+                --since) SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                --per-page) PER_PAGE="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
+        # GitLab state semantics -> GitHub /pulls state:
+        #   opened -> open, closed -> closed, all -> all,
+        #   merged -> closed + client-side merged_at!=null filter.
+        case "$STATE" in
+            opened) GH_STATE="open" ;;
+            closed) GH_STATE="closed" ;;
+            all)    GH_STATE="all" ;;
+            merged) GH_STATE="closed" ;;
+            *) emit_error "invalid --state: $STATE (expected opened|closed|merged|all)"; exit 2 ;;
+        esac
+        ARGS=(
+            --data-urlencode "state=$GH_STATE"
+            --data-urlencode "per_page=$PER_PAGE"
+            --data-urlencode "sort=updated"
+            --data-urlencode "direction=desc"
+        )
+        body="$(gh_get_q "$API/pulls" "${ARGS[@]}")" || exit $?
+        # Normalize first, then apply client-side filters (--state merged /
+        # --since), then optionally project.
+        normalized="$(printf '%s' "$body" | normalize_pulls)"
+        filtered="$(STATE="$STATE" SINCE="$SINCE" DATA="$normalized" python3 <<'PY'
+import os, json
+items = json.loads(os.environ["DATA"])
+state = os.environ.get("STATE", "")
+since = os.environ.get("SINCE", "")
+out = []
+for x in items:
+    if state == "merged" and x.get("state") != "merged":
+        continue
+    if since and (x.get("updated_at") or "") < since:
+        continue
+    out.append(x)
+print(json.dumps(out))
+PY
+)" || exit $?
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$filtered" | project_json "$VIEW"
+        else
+            printf '%s' "$filtered"
+        fi
+        ;;
+
+    mr-changes)
+        NUM="${1:?Usage: github-api.sh mr-changes <number>}"
+        case "$NUM" in
+            ''|*[!0-9]*) emit_error "pr number must be numeric: $NUM"; exit 2 ;;
+        esac
+        body="$(gh_get_q "$API/pulls/$NUM/files" --data-urlencode "per_page=100")" || exit $?
+        printf '%s' "$body" | normalize_mr_changes
+        ;;
+
+    mr-notes)
+        NUM="${1:?Usage: github-api.sh mr-notes <number>}"
+        case "$NUM" in
+            ''|*[!0-9]*) emit_error "pr number must be numeric: $NUM"; exit 2 ;;
+        esac
+        # GitHub PR conversation comments live under the issues endpoint
+        # (same number). Inline review comments at /pulls/{n}/comments are
+        # a separate stream reviewers don't currently ingest; adding them
+        # later would be additive in this endpoint.
+        body="$(gh_get_q "$API/issues/$NUM/comments" \
+            --data-urlencode "per_page=100" \
+            --data-urlencode "sort=created" \
+            --data-urlencode "direction=desc")" || exit $?
+        printf '%s' "$body" | normalize_notes
+        ;;
+
+    post-note)
+        NUM="${1:?Usage: github-api.sh post-note <number> --body <text>}"
+        shift
+        BODY=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --body) BODY="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$BODY" ]; then
+            emit_error "--body is required"
+            exit 1
+        fi
+        case "$NUM" in
+            ''|*[!0-9]*) emit_error "pr number must be numeric: $NUM"; exit 2 ;;
+        esac
+        # Same /issues/{n}/comments endpoint as implementation's add-note —
+        # GitHub doesn't split issue-notes from MR-notes the way GitLab does.
+        JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
+        gh_post "$API/issues/$NUM/comments" "$JSON_BODY"
+        ;;
+
+    approve)
+        NUM="${1:?Usage: github-api.sh approve <number>}"
+        case "$NUM" in
+            ''|*[!0-9]*) emit_error "pr number must be numeric: $NUM"; exit 2 ;;
+        esac
+        # POST /pulls/{n}/reviews with event=APPROVE. Unlike GitLab's
+        # idempotent /approve, GitHub creates a new review object every call;
+        # approval_decider already guards via its decide-once memo so double
+        # invocations here would only waste a round-trip and a review row.
+        gh_post "$API/pulls/$NUM/reviews" '{"event":"APPROVE"}'
+        ;;
+
+    *)
+        emit_error "unknown command: $CMD"
+        exit 1
+        ;;
+esac

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -60,45 +60,78 @@ if [ ! -f "$CONFIG" ]; then
     exit 1
 fi
 
-# Parse GitLab config from TOML via the shared helper.
+# Parse forge config from TOML via the shared helper.
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # shellcheck source=../../../tools/parse-toml.sh
 # shellcheck disable=SC1091  # colony-lint runs shellcheck without -x
 . "$REPO_ROOT/tools/parse-toml.sh"
 
-GITLAB_URL=$(parse_toml gitlab url)
-GITLAB_TOKEN=$(parse_toml gitlab token)
-GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
-
-if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
-    echo "Error: GitLab config incomplete in $CONFIG"
-    echo "Required: url, token, project under [gitlab]"
-    exit 1
-fi
-
-# URL-encode the project path (replace / with %2F)
-GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
-
-# #104: operator identity. Empty if not configured (pre-#104 setups or
-# operators who skipped the install.sh prompt); agents fall back to
-# memo gitlab:me and tag everything as team when both are empty.
-GITLAB_ME=$(parse_toml gitlab me)
-
-export GITLAB_URL
-export GITLAB_TOKEN
-export GITLAB_PROJECT
-export GITLAB_ME
-export COLONY_DIR
-
 # #256: forge backend selection. `[forge].type` picks which backend
 # wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
-# configs keep working unchanged. The github backend is skeleton-only
-# until PRs 2-6 of #256 land their per-colony github-api.sh wrappers;
-# until then, FORGE_TYPE=github yields exit 99 "not implemented" from
-# forge-api.sh.
+# configs keep working unchanged. PR 5 of #256 ships the code-review
+# colony's github-api.sh, so FORGE_TYPE=github is now live for
+# code-review (the release colony still returns exit 99 "not
+# implemented" until PR 6 lands).
 FORGE_TYPE=$(parse_toml forge type)
 FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+
+case "$FORGE_TYPE" in
+    gitlab)
+        # Prefer [forge.gitlab] (ADR-0002) if present; fall back to legacy
+        # [gitlab] so pre-#256 configs keep working during the overlap window.
+        GITLAB_URL=$(parse_toml forge.gitlab url)
+        [ -z "$GITLAB_URL" ] && GITLAB_URL=$(parse_toml gitlab url)
+        GITLAB_TOKEN=$(parse_toml forge.gitlab token)
+        [ -z "$GITLAB_TOKEN" ] && GITLAB_TOKEN=$(parse_toml gitlab token)
+        GITLAB_PROJECT_RAW=$(parse_toml forge.gitlab project)
+        [ -z "$GITLAB_PROJECT_RAW" ] && GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
+        GITLAB_ME=$(parse_toml forge.gitlab me)
+        [ -z "$GITLAB_ME" ] && GITLAB_ME=$(parse_toml gitlab me)
+
+        if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
+            echo "Error: GitLab config incomplete in $CONFIG"
+            echo "Required: url, token, project under [forge.gitlab] (or legacy [gitlab])"
+            exit 1
+        fi
+
+        # URL-encode the project path (replace / with %2F)
+        GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
+
+        export GITLAB_URL
+        export GITLAB_TOKEN
+        export GITLAB_PROJECT
+        export GITLAB_ME
+        ;;
+    github)
+        GITHUB_URL=$(parse_toml forge.github url)
+        GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+        GITHUB_OWNER=$(parse_toml forge.github owner)
+        GITHUB_REPO=$(parse_toml forge.github repo)
+        GITHUB_TOKEN=$(parse_toml forge.github token)
+        GITHUB_ME=$(parse_toml forge.github me)
+
+        if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
+            echo "Error: GitHub config incomplete in $CONFIG"
+            echo "Required: owner, repo, token under [forge.github]"
+            exit 1
+        fi
+
+        GITLAB_PROJECT_RAW="$GITHUB_OWNER/$GITHUB_REPO"
+
+        export GITHUB_URL
+        export GITHUB_OWNER
+        export GITHUB_REPO
+        export GITHUB_TOKEN
+        export GITHUB_ME
+        ;;
+    *)
+        echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2
+        exit 1
+        ;;
+esac
+
 export FORGE_TYPE
+export COLONY_DIR
 
 AGENTS=(
     style_reviewer
@@ -183,7 +216,10 @@ if [ -n "$RESTART_AGENT" ]; then
 fi
 
 echo "Starting Code Review colony (${#AGENTS[@]} agents)..."
-echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
+case "$FORGE_TYPE" in
+    gitlab) echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)" ;;
+    github) echo "  GitHub: $GITHUB_URL ($GITHUB_OWNER/$GITHUB_REPO)" ;;
+esac
 
 for agent in "${AGENTS[@]}"; do
     interval=$(tick_interval_for "$agent")

--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -121,8 +121,12 @@ subcommands (`merge-requests`, `mr-changes`, `mr-commits`, `issue`,
 `assigned-issues-by-label-events`, `create-branch`, `commit-files`,
 `create-mr`, `add-note`) plus the matching `[forge.github]` env-export
 branch and 25 `.ag` call-site migrations across the four implementation
-agents. The remaining colonies' wrappers land across PRs 5-6 in the
-order code-review → release. `rate-limit-status` and the dashboard tile
+agents. PR 5 (the current PR as of this writing) ships the code-review
+colony's `github-api.sh` with 5 subcommands (`merge-requests`,
+`mr-changes`, `mr-notes`, `post-note`, `approve`) plus the matching
+`[forge.github]` env-export branch and 28 `.ag` call-site migrations
+across the five code-review agents. The remaining colony wrapper
+(release) lands in PR 6. `rate-limit-status` and the dashboard tile
 ship in PR 7 alongside the legacy `[gitlab]`-section retirement.
 
 **`.ag` migration is in-scope for every per-colony PR.** Each
@@ -192,6 +196,31 @@ backends before this PR (the implementation `gitlab-api.sh` exposed
 only `post-note` targeting MRs), same failure pattern PR 2 fixed for
 triage. The back-port of `add-note` into the implementation
 `gitlab-api.sh` is in-scope for this PR.
+
+**PR 5 additions.** The code-review contract adds the comment-path
+subcommands agents use to leave findings and approve merges:
+`mr-notes`, `post-note`, and `approve`. GitHub unifies issue and PR
+conversations under `/issues/{n}/comments` — the same endpoint
+triage/planning/implementation already hit via `add-note` — so
+code-review's `mr-notes` reads from `/issues/{n}/comments` and
+`post-note` writes to it. There is no `system` flag on GitHub
+comments (GitLab uses it to mark timeline-event notes like
+`assigned user`, which the reviewer agents filter out to avoid
+echo-chamber loops); the normalizer stamps `system: false` on every
+row unconditionally, which is correct because `/issues/{n}/comments`
+only surfaces human-authored comments. `approve` maps GitLab's
+idempotent `POST /merge_requests/{iid}/approve` to GitHub's
+non-idempotent `POST /pulls/{n}/reviews` with
+`{"event": "APPROVE"}`; calling it twice creates two APPROVED review
+events on GitHub (the approvals collapse from the table above still
+holds — `approved = (count of latest-per-reviewer APPROVED reviews
+>= required)`, so extra approves from the same reviewer don't break
+the count). `normalize_pulls` adds a native `draft` boolean pulled
+from GitHub's `draft` field — code-review's `reviewer` view consumes
+it to skip draft PRs, which GitHub (unlike GitLab) exposes natively
+on the list response. As in PRs 3-4, `--state merged` collapses to
+`state=closed + merged_at != null` client-side and `--since` is a
+client-side filter on `updated_at`.
 
 | Subcommand           | Normalized output |
 |----------------------|-------------------|

--- a/tools/test-github-code-review-normalize.sh
+++ b/tools/test-github-code-review-normalize.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# test-github-code-review-normalize.sh: unit-test the GitHub -> GitLab-shape
+# normalizers in dev-apprenticeship/code-review/scripts/github-api.sh
+# (ADR-0002, #256 PR 5).
+#
+# Code-review's normalizer surface overlaps partially with implementation's
+# but adds `draft` to normalize_pulls (reviewer view needs it) and drops
+# normalize_mr_commits (reviewers never consume commit-list data). One new
+# normalizer — normalize_notes, mapping /issues/{n}/comments into the
+# GitLab-MR-notes shape with system: false stamped on every row.
+#
+# Style matches test-github-triage/planning/implementation-normalize.sh
+# (bash 3.2, python3 for JSON, build_prelude pattern for sourcing the
+# script under test).
+#
+# Exit 0 all-pass, 1 any-fail.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT="$REPO_ROOT/dev-apprenticeship/code-review/scripts/github-api.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+# --- Fixtures ---
+
+# GitHub /pulls fixture with `draft` flags so the reviewer view's draft
+# passthrough gets exercised. The state collapse (open -> opened, closed +
+# merged_at -> merged, closed + null merged_at -> closed) is the same
+# invariant as planning/implementation but re-asserted here because the
+# code-review normalize_pulls is a separate function (duplicated by design
+# per ADR-0002 for script independence).
+FIXTURE_PULLS='[
+  {"url":"https://api.github.com/repos/o/r/pulls/10","number":10,"title":"Draft PR",
+   "body":"pr-10","state":"open","draft":true,"merged_at":null,
+   "labels":[{"id":1,"name":"feature"}],
+   "user":{"login":"alice"},"base":{"ref":"main"},"head":{"ref":"feat/x"},
+   "created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-02T10:00:00Z",
+   "comments":1},
+  {"url":"https://api.github.com/repos/o/r/pulls/11","number":11,"title":"Ready PR",
+   "body":"pr-11","state":"open","draft":false,"merged_at":null,
+   "labels":[{"id":2,"name":"bugfix"}],
+   "user":{"login":"alice"},"base":{"ref":"main"},"head":{"ref":"fix/y"},
+   "created_at":"2026-04-03T10:00:00Z","updated_at":"2026-04-05T12:00:00Z",
+   "comments":4,"changed_files":7},
+  {"url":"https://api.github.com/repos/o/r/pulls/12","number":12,"title":"Merged PR",
+   "body":"pr-12","state":"closed","draft":false,"merged_at":"2026-04-06T12:00:00Z",
+   "labels":[],
+   "user":{"login":"carol"},"base":{"ref":"main"},"head":{"ref":"wip/z"},
+   "created_at":"2026-04-04T10:00:00Z","updated_at":"2026-04-06T12:00:00Z",
+   "comments":0}
+]'
+
+FIXTURE_PULL_FILES='[
+  {"filename":"src/lib/new_feature.py","status":"added",
+   "additions":42,"deletions":0,"changes":42,
+   "patch":"@@ -0,0 +1,42 @@\n+def foo():\n+    pass\n"},
+  {"filename":"src/lib/old_name.py","status":"renamed",
+   "previous_filename":"src/lib/really_old_name.py",
+   "additions":1,"deletions":1,"changes":2,
+   "patch":"@@ -1,1 +1,1 @@\n-# old\n+# new\n"},
+  {"filename":"src/lib/gone.py","status":"removed",
+   "additions":0,"deletions":10,"changes":10,
+   "patch":"@@ -1,10 +0,0 @@\n-line1\n-line2\n"}
+]'
+
+# GitHub /issues/{n}/comments fixture. Only human discussion comes through
+# this endpoint — system events (labeled/merged/...) live in /issues/{n}/timeline
+# and are intentionally excluded from mr-notes. The normalizer stamps
+# system: false on every row so the GitLab-shape filter continues to hold.
+FIXTURE_NOTES='[
+  {"id":1001,"body":"LGTM, minor nit inline",
+   "user":{"login":"alice","id":7},
+   "created_at":"2026-04-10T10:00:00Z","updated_at":"2026-04-10T10:00:00Z"},
+  {"id":1002,"body":"Fixed the nit, please re-review",
+   "user":{"login":"bob","id":8},
+   "created_at":"2026-04-10T11:00:00Z","updated_at":"2026-04-10T11:00:00Z"},
+  {"id":1003,"body":"Thanks!",
+   "user":{"login":"alice","id":7},
+   "created_at":"2026-04-10T11:30:00Z","updated_at":"2026-04-10T11:30:00Z"}
+]'
+
+# --- Plumbing: source just the function defs (stop before CMD dispatcher) ---
+build_prelude() {
+    awk '/^CMD=/{exit} {print}' "$SCRIPT" > "$1"
+}
+
+run_fn() {
+    local fn="$1" input="$2"
+    shift 2
+    local prelude
+    prelude=$(mktemp)
+    build_prelude "$prelude"
+    # shellcheck disable=SC1090,SC2016
+    GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+        source "$1"
+        input="$2"
+        fn="$3"
+        shift 3
+        printf "%s" "$input" | "$fn" "$@"
+    ' _ "$prelude" "$input" "$fn" "$@"
+    local rc=$?
+    rm -f "$prelude"
+    return $rc
+}
+
+json_extract() {
+    DATA="$1" python3 -c "
+import os, json
+data = json.loads(os.environ['DATA'])
+print($2)
+"
+}
+
+assert_eq() {
+    if [ "$1" = "$2" ]; then
+        pass "$3"
+    else
+        fail "$3: expected='$1' actual='$2'"
+    fi
+}
+
+# --- normalize_pulls: state collapse + draft field + MR-shape ---
+PULLS_OUT=$(run_fn normalize_pulls "$FIXTURE_PULLS")
+P_COUNT=$(json_extract "$PULLS_OUT" "len(data)")
+assert_eq "3" "$P_COUNT" "normalize_pulls: three entries"
+
+P0_STATE=$(json_extract "$PULLS_OUT" "data[0]['state']")
+P1_STATE=$(json_extract "$PULLS_OUT" "data[1]['state']")
+P2_STATE=$(json_extract "$PULLS_OUT" "data[2]['state']")
+assert_eq "opened" "$P0_STATE" "normalize_pulls: open -> opened"
+assert_eq "opened" "$P1_STATE" "normalize_pulls: open (non-draft) -> opened"
+assert_eq "merged" "$P2_STATE" "normalize_pulls: closed + merged_at -> merged"
+
+P0_DRAFT=$(json_extract "$PULLS_OUT" "data[0]['draft']")
+P1_DRAFT=$(json_extract "$PULLS_OUT" "data[1]['draft']")
+P2_DRAFT=$(json_extract "$PULLS_OUT" "data[2]['draft']")
+assert_eq "True" "$P0_DRAFT" "normalize_pulls: draft:true preserved"
+assert_eq "False" "$P1_DRAFT" "normalize_pulls: draft:false preserved"
+assert_eq "False" "$P2_DRAFT" "normalize_pulls: closed-merged draft defaults false"
+
+P1_TGT=$(json_extract "$PULLS_OUT" "data[1]['target_branch']")
+P1_SRC=$(json_extract "$PULLS_OUT" "data[1]['source_branch']")
+P1_AUTHOR=$(json_extract "$PULLS_OUT" "data[1]['author']['username']")
+P1_LABELS=$(json_extract "$PULLS_OUT" "','.join(data[1]['labels'])")
+assert_eq "main" "$P1_TGT" "normalize_pulls: target_branch <- base.ref"
+assert_eq "fix/y" "$P1_SRC" "normalize_pulls: source_branch <- head.ref"
+assert_eq "alice" "$P1_AUTHOR" "normalize_pulls: author.username <- user.login"
+assert_eq "bugfix" "$P1_LABELS" "normalize_pulls: labels flattened to strings"
+
+P0_CHANGES=$(json_extract "$PULLS_OUT" "repr(data[0]['changes_count'])")
+P1_CHANGES=$(json_extract "$PULLS_OUT" "data[1]['changes_count']")
+assert_eq "None" "$P0_CHANGES" "normalize_pulls: missing changed_files -> null"
+assert_eq "7" "$P1_CHANGES" "normalize_pulls: changes_count <- changed_files"
+
+# --- normalize_mr_changes: /pulls/{n}/files -> {changes: [...]} ---
+CHANGES_OUT=$(run_fn normalize_mr_changes "$FIXTURE_PULL_FILES")
+CH_TOP_KEYS=$(json_extract "$CHANGES_OUT" "','.join(sorted(data.keys()))")
+assert_eq "changes" "$CH_TOP_KEYS" "normalize_mr_changes: wraps into {changes: [...]}"
+
+CH_COUNT=$(json_extract "$CHANGES_OUT" "len(data['changes'])")
+assert_eq "3" "$CH_COUNT" "normalize_mr_changes: three entries"
+
+CH0_NEW=$(json_extract "$CHANGES_OUT" "data['changes'][0]['new_file']")
+CH0_DIFF=$(json_extract "$CHANGES_OUT" "'def foo' in data['changes'][0]['diff']")
+assert_eq "True" "$CH0_NEW" "normalize_mr_changes: status added -> new_file=true"
+assert_eq "True" "$CH0_DIFF" "normalize_mr_changes: diff <- patch (carries through)"
+
+CH1_RENAMED=$(json_extract "$CHANGES_OUT" "data['changes'][1]['renamed_file']")
+CH1_OLD_PATH=$(json_extract "$CHANGES_OUT" "data['changes'][1]['old_path']")
+CH1_NEW_PATH=$(json_extract "$CHANGES_OUT" "data['changes'][1]['new_path']")
+assert_eq "True" "$CH1_RENAMED" "normalize_mr_changes: status renamed -> renamed_file=true"
+assert_eq "src/lib/really_old_name.py" "$CH1_OLD_PATH" "normalize_mr_changes: renamed old_path <- previous_filename"
+assert_eq "src/lib/old_name.py" "$CH1_NEW_PATH" "normalize_mr_changes: renamed new_path <- filename"
+
+CH2_DELETED=$(json_extract "$CHANGES_OUT" "data['changes'][2]['deleted_file']")
+assert_eq "True" "$CH2_DELETED" "normalize_mr_changes: status removed -> deleted_file=true"
+
+# --- normalize_notes: /issues/{n}/comments -> GitLab /notes shape ---
+NOTES_OUT=$(run_fn normalize_notes "$FIXTURE_NOTES")
+N_COUNT=$(json_extract "$NOTES_OUT" "len(data)")
+assert_eq "3" "$N_COUNT" "normalize_notes: three entries"
+
+N0_ID=$(json_extract "$NOTES_OUT" "data[0]['id']")
+N0_BODY=$(json_extract "$NOTES_OUT" "data[0]['body']")
+N0_AUTHOR=$(json_extract "$NOTES_OUT" "data[0]['author']['username']")
+N0_SYSTEM=$(json_extract "$NOTES_OUT" "data[0]['system']")
+assert_eq "1001" "$N0_ID" "normalize_notes: id preserved"
+assert_eq "LGTM, minor nit inline" "$N0_BODY" "normalize_notes: body preserved"
+assert_eq "alice" "$N0_AUTHOR" "normalize_notes: author.username <- user.login"
+assert_eq "False" "$N0_SYSTEM" "normalize_notes: system: false stamped on every row"
+
+# Iterate: all three rows must have system:false (invariant, not per-entry).
+ALL_FALSE=$(json_extract "$NOTES_OUT" "all(not n['system'] for n in data)")
+assert_eq "True" "$ALL_FALSE" "normalize_notes: system:false invariant holds for all rows"
+
+# --- End-to-end: normalize_pulls -> project_json reviewer ---
+# The four reviewer agents (style/logic/security/test) + approval_decider
+# consume `merge-requests --view reviewer` on every tick. The view keys
+# must stay locked to {iid, state, title, labels, source_branch,
+# target_branch, draft, author}.
+PIPE_PRELUDE=$(mktemp)
+build_prelude "$PIPE_PRELUDE"
+# shellcheck disable=SC1090,SC2016
+E2E_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    printf "%s" "$2" | normalize_pulls | project_json reviewer
+' _ "$PIPE_PRELUDE" "$FIXTURE_PULLS")
+rm -f "$PIPE_PRELUDE"
+
+E2E_COUNT=$(json_extract "$E2E_OUT" "len(data)")
+E2E_KEYS=$(json_extract "$E2E_OUT" "','.join(sorted(data[0].keys()))")
+E2E_IID=$(json_extract "$E2E_OUT" "data[0]['iid']")
+E2E_DRAFT=$(json_extract "$E2E_OUT" "data[0]['draft']")
+E2E_AUTHOR=$(json_extract "$E2E_OUT" "data[0]['author']['username']")
+assert_eq "3" "$E2E_COUNT" "e2e reviewer: normalize | reviewer view emits 3 items"
+assert_eq "author,draft,iid,labels,source_branch,state,target_branch,title" "$E2E_KEYS" "e2e reviewer: view keys match gitlab reviewer shape"
+assert_eq "10" "$E2E_IID" "e2e reviewer: view carries iid through pipe"
+assert_eq "True" "$E2E_DRAFT" "e2e reviewer: draft flows through pipe"
+assert_eq "alice" "$E2E_AUTHOR" "e2e reviewer: author.username preserved"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-gitlab-views.sh
+++ b/tools/test-gitlab-views.sh
@@ -369,6 +369,27 @@ if [ -f "$GH_IMPL_SCRIPT" ]; then
     done
 fi
 
+# --- code-review github-api.sh project_json parity (#256 PR 5) ---
+# code-review/scripts/github-api.sh duplicates project_json rather than
+# sourcing gitlab-api.sh. The code-review-specific view is `reviewer` (MR
+# list for the four reviewers + approval_decider); it must emit byte-identical
+# JSON to its gitlab twin when fed an already-GitLab-shape fixture.
+GH_CODE_REVIEW_SCRIPT="$REPO_ROOT/dev-apprenticeship/code-review/scripts/github-api.sh"
+if [ -f "$GH_CODE_REVIEW_SCRIPT" ]; then
+    # code-review only exposes one list view (`reviewer`); no for-loop over
+    # view:fixture pairs here (shellcheck SC2066 fires on a single-element
+    # for — the existing triage/planning/implementation blocks all have ≥2
+    # views so they're fine). If a second view lands, switch back to the
+    # for-pair idiom used above.
+    gl_out=$(run_view "$REPO_ROOT/dev-apprenticeship/code-review/scripts/gitlab-api.sh" "reviewer" "$FIXTURE_MRS")
+    gh_out=$(run_view_github "$GH_CODE_REVIEW_SCRIPT" "reviewer" "$FIXTURE_MRS")
+    if [ "$gl_out" = "$gh_out" ]; then
+        pass "code-review github-api.sh project_json parity: reviewer"
+    else
+        fail "code-review github-api.sh project_json drifted from gitlab-api.sh: reviewer"
+    fi
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- **code-review/scripts/github-api.sh** — 5 subcommands (`merge-requests`, `mr-changes`, `mr-notes`, `post-note`, `approve`) emitting normalized GitLab shape so the four reviewers + `approval_decider` parse identical JSON across backends.
- **Endpoint collapses unique to code-review:** `/issues/{n}/comments` replaces `/merge_requests/{iid}/notes` (GitHub unifies issue + PR conversations; same endpoint `add-note` already hits in triage/planning/implementation). `POST /pulls/{n}/reviews` with `{"event": "APPROVE"}` replaces the idempotent `/approve` endpoint — extra approves from the same reviewer stack as additional APPROVED review events but don't break the latest-per-reviewer approved-count.
- **Normalizer additions:** `normalize_pulls` carries native `draft` from GitHub (consumed by the `reviewer` view to skip draft PRs). `normalize_notes` stamps `system: false` on every row unconditionally — correct because `/issues/{n}/comments` only surfaces human-authored comments (GitLab's `/notes` mixes timeline events).
- **28 `.ag` call-site migrations** across `approval_decider`, `logic_reviewer`, `security_reviewer`, `style_reviewer`, `test_reviewer` from `scripts/gitlab-api.sh` → `scripts/forge-api.sh`. Required so `check-forge-dispatch` stays green once `github-api.sh` ships.
- **`code-review/scripts/start-colony.sh`** now branches on `FORGE_TYPE` identically to triage/planning/implementation; gitlab arm keeps `[forge.gitlab]` + legacy `[gitlab]` fallback.
- **ADR-0002** updated: Per-PR rollout marks PR 5 shipped, PR 5 additions paragraph documents all four collapses.
- **CHANGELOG** Unreleased entry.

## Test plan

- [x] `tools/test-github-code-review-normalize.sh` — 32 assertions pass (normalize_pulls state + draft, normalize_mr_changes status mapping, normalize_notes system:false invariant, e2e reviewer view pipe)
- [x] `tools/test-gitlab-views.sh` — 59 passed, 0 failed (includes new code-review `reviewer` parity row)
- [x] `tools/colony-lint.sh` — 100 passed, 0 failed, 1 skipped (baseline 99 + 1 new test)
- [ ] QA via `agentis-qa-agent` — findings report posted as PR comment before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)