### PR TITLE
feat(#256): release colony GitHub backend (PR 6 of 7)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -207,6 +207,54 @@ is asserted until multi-version CI is in place.
   `project_json` output between `github-api.sh` and `gitlab-api.sh`
   for the `reviewer` view.
   [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
+- **Release colony GitHub backend (PR 6 of 7 for #256).**
+  `dev-apprenticeship/release/scripts/github-api.sh` implements the
+  release contract against the GitHub REST API v3 (7 subcommands:
+  `releases`, `tags`, `pipelines`, `merge-requests`, `create-tag`,
+  `create-release`, `post-note`). Three release-specific endpoint
+  collapses: `normalize_tags` forwards `message` and
+  `commit.created_at` as `null` rather than doing the per-tag
+  `/git/refs/tags` + `/git/tags` + `/git/commits` round-trip (~20
+  extra API calls per `tags` list read — the one consumer,
+  release_checker's `tag-summary` view, only needs `name` +
+  `commit.short_id` for prompt context, and `short_id` is derived as
+  `sha[:8]` locally). `normalize_pipelines` unwraps GitHub's
+  `{total_count, workflow_runs: [...]}` envelope and collapses the
+  2-axis `(status, conclusion)` matrix to GitLab's single-field
+  `status`: `completed + success|skipped|neutral` → `success`,
+  `completed + failure|cancelled|timed_out|action_required|stale` →
+  `failed`, `in_progress` → `running`, `queued|requested|waiting|
+  pending` → `pending`. `normalize_releases` maps `body` →
+  `description`, `published_at` → `released_at`, `author.login` →
+  `author.username`; the `commit` object is forwarded as `null` (not
+  carried inline by GitHub's `/releases` — changelog_writer reads it
+  from `tags` instead). `create-tag` implements the 3-step annotated-
+  tag dance (`GET /git/refs` to resolve the ref → `POST /git/tags` →
+  `POST /git/refs` to advance `refs/tags/{name}`); without a
+  `--message` it short-circuits to a single `POST /git/refs` for a
+  lightweight tag. `create-release` posts to `/releases` with
+  `{tag_name, name, body}` and normalizes the response.
+  `post-note <num>` on the release colony (used by ship_decider and
+  changelog_writer for MR comments) goes through
+  `/issues/{n}/comments`, same endpoint as code-review's. All 29
+  `exec sh` call sites across `version_bumper`, `ship_decider`,
+  `release_checker`, and `changelog_writer` were rewritten from
+  `scripts/gitlab-api.sh` to `scripts/forge-api.sh`.
+  `release/scripts/start-colony.sh` now branches on `FORGE_TYPE`
+  identically to triage/planning/implementation/code-review, and —
+  as a bonus fix deferred from PR 4 QA finding F1 — now honors
+  `[forge.gitlab].default_branch` and `[forge.github].default_branch`
+  (pre-PR 6 release silently ignored both, falling back only to
+  legacy `[gitlab].default_branch`). Two new tests:
+  `tools/test-github-release-normalize.sh` (47 assertions covering
+  all four normalizers with the full status/conclusion matrix,
+  annotated-vs-lightweight tag fixtures, the envelope-unwrap
+  fallback, and end-to-end pipes through all four release views);
+  and a release-colony extension to `tools/test-gitlab-views.sh`
+  asserting byte-identical `project_json` output between
+  `github-api.sh` and `gitlab-api.sh` for the `release-summary`,
+  `tag-summary`, `pipeline-summary`, and `release-mr` views.
+  [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
 
 ### Changed
 

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -52,7 +52,7 @@ fn tick(reason: string) -> void {
     // 1. Learn changelog style from past releases (only when we're
     //    actually about to write one — gated by the delta-check above).
     let releases_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 10 --view release-summary";
+        exec sh "$COLONY_DIR/scripts/forge-api.sh releases --per-page 10 --view release-summary";
     } catch e {
         print("[changelog_writer] GitLab releases poll failed:", e);
         "";
@@ -93,7 +93,7 @@ fn tick(reason: string) -> void {
 
     // Get the latest release tag to find MRs merged since then
     let latest_release = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 1 --view release-summary";
+        exec sh "$COLONY_DIR/scripts/forge-api.sh releases --per-page 1 --view release-summary";
     } catch e { "[]"; };
 
     let since_date = prompt(
@@ -102,7 +102,7 @@ fn tick(reason: string) -> void {
     ) -> string;
 
     // Fetch MRs merged since last release
-    let mrs_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date) + " --view release-mr";
+    let mrs_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(since_date) + " --view release-mr";
     let mrs_raw = try { exec sh mrs_cmd; } catch e {
         print("[changelog_writer] MR fetch failed:", e);
         "";
@@ -124,11 +124,11 @@ fn tick(reason: string) -> void {
         // external write. The terminal action (create-release / create-tag)
         // belongs to version_bumper and is gated on autonomous there.
         if my_tier == "autonomous" {
-            let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+            let mr_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
             let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
             if mr_iid > 0 {
                 let note = "**Release Notes Draft** (automated)\n\n" + draft.changelog;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
                 try { exec sh post_cmd; } catch e {
                     print("[changelog_writer] Failed to post note:", e);
                 };
@@ -137,11 +137,11 @@ fn tick(reason: string) -> void {
             learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "success", ["acted", "release"]);
         } else {
             if my_tier == "review-gated" {
-                let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+                let mr_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
                 let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
                 if mr_iid > 0 {
                     let note = "[draft-changelog] **Release Notes Draft** (automated, pending approval)\n\n" + draft.changelog;
-                    let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
                     try { exec sh post_cmd; } catch e {
                         print("[changelog_writer] Failed to post draft note:", e);
                     };

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -38,9 +38,9 @@ fn get_confidence() -> float {
 // the tick's pre-prompt delta-check.
 fn mr_delta_cmd_for(ts: string) -> string {
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --per-page 1";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --per-page 1";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --per-page 1";
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --per-page 1";
 }
 
 fn tick(reason: string) -> void {
@@ -70,7 +70,7 @@ fn tick(reason: string) -> void {
     // 1. Learn from past releases and their pipeline outcomes (only when
     //    there IS new work — gated by the delta-check above).
     let releases_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 10 --view release-summary";
+        exec sh "$COLONY_DIR/scripts/forge-api.sh releases --per-page 10 --view release-summary";
     } catch e {
         print("[release_checker] GitLab releases poll failed:", e);
         "";
@@ -98,7 +98,7 @@ fn tick(reason: string) -> void {
 
     // Also check the default branch pipeline status
     let pipeline_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh pipelines --ref main --view pipeline-summary";
+        exec sh "$COLONY_DIR/scripts/forge-api.sh pipelines --ref main --view pipeline-summary";
     } catch e {
         print("[release_checker] Pipeline poll failed:", e);
         "";
@@ -127,7 +127,7 @@ fn tick(reason: string) -> void {
                 let mr_iid = mr_ready.issue_id;
                 if mr_iid > 0 {
                     let note = "**Pre-release Check** (automated): " + result.ci_status + "\n\nIssues: " + result.issues_found;
-                    let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
                     try { exec sh post_cmd; } catch e {
                         print("[release_checker] Failed to post note:", e);
                     };
@@ -139,7 +139,7 @@ fn tick(reason: string) -> void {
                     let mr_iid = mr_ready.issue_id;
                     if mr_iid > 0 {
                         let note = "[draft-check] **Pre-release Check** (automated, pending approval): " + result.ci_status + "\n\nIssues: " + result.issues_found;
-                        let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
                         try { exec sh post_cmd; } catch e {
                             print("[release_checker] Failed to post draft note:", e);
                         };

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -36,9 +36,9 @@ fn get_confidence() -> float {
 // work has landed since the last tick.
 fn mr_delta_cmd_for(ts: string) -> string {
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --per-page 1";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --per-page 1";
     };
-    return "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --per-page 1";
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --per-page 1";
 }
 
 fn tick(reason: string) -> void {
@@ -67,7 +67,7 @@ fn tick(reason: string) -> void {
 
     // 1. Learn release patterns from history (only when there IS new work)
     let releases_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 20 --view release-summary";
+        exec sh "$COLONY_DIR/scripts/forge-api.sh releases --per-page 20 --view release-summary";
     } catch e {
         print("[ship_decider] GitLab releases poll failed:", e);
         "";
@@ -75,7 +75,7 @@ fn tick(reason: string) -> void {
 
     if len(releases_raw) > 10 {
         let tags_raw = try {
-            exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 20 --view tag-summary";
+            exec sh "$COLONY_DIR/scripts/forge-api.sh tags --per-page 20 --view tag-summary";
         } catch e { "[]"; };
 
         let patterns = prompt(
@@ -122,11 +122,11 @@ fn tick(reason: string) -> void {
     // review-gated = post draft-flagged note + emit. propose = emit only.
     // shadow/dormant = observe.
     if my_tier == "autonomous" {
-        let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+        let mr_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
         let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
         if mr_iid > 0 {
             let note = "**Ship Decision** (automated): " + decision.decision + "\n\n" + decision.reasoning;
-            let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
             try { exec sh post_cmd; } catch e {
                 print("[ship_decider] Failed to post note:", e);
             };
@@ -135,11 +135,11 @@ fn tick(reason: string) -> void {
         learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "success", ["acted", "release"]);
     } else {
         if my_tier == "review-gated" {
-            let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+            let mr_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
             let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
             if mr_iid > 0 {
                 let note = "[draft-ship] **Ship Decision** (automated, pending approval): " + decision.decision + "\n\n" + decision.reasoning;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
                 try { exec sh post_cmd; } catch e {
                     print("[ship_decider] Failed to post draft note:", e);
                 };

--- a/dev-apprenticeship/release/agents/version_bumper.ag
+++ b/dev-apprenticeship/release/agents/version_bumper.ag
@@ -53,7 +53,7 @@ fn tick(reason: string) -> void {
     // 1. Learn versioning patterns from tags (only when we're actually
     //    about to bump — gated by the delta-check above).
     let tags_raw = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 20 --view tag-summary";
+        exec sh "$COLONY_DIR/scripts/forge-api.sh tags --per-page 20 --view tag-summary";
     } catch e {
         print("[version_bumper] GitLab tags poll failed:", e);
         "";
@@ -98,12 +98,12 @@ fn tick(reason: string) -> void {
 
     // Get latest tags for current version context
     let latest_tags = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh tags --per-page 5 --view tag-summary";
+        exec sh "$COLONY_DIR/scripts/forge-api.sh tags --per-page 5 --view tag-summary";
     } catch e { "[]"; };
 
     // Fetch merged MRs since last release for bump analysis
     let latest_release = try {
-        exec sh "$COLONY_DIR/scripts/gitlab-api.sh releases --per-page 1 --view release-summary";
+        exec sh "$COLONY_DIR/scripts/forge-api.sh releases --per-page 1 --view release-summary";
     } catch e { "[]"; };
 
     let since_date = prompt(
@@ -111,7 +111,7 @@ fn tick(reason: string) -> void {
         latest_release
     ) -> string;
 
-    let mrs_cmd = "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --state merged --since " + shell_escape(since_date) + " --view release-mr";
+    let mrs_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(since_date) + " --view release-mr";
     let mrs_raw = try { exec sh mrs_cmd; } catch e { "[]"; };
 
     let rec = recommend("version_bump", ["accuracy"]);
@@ -131,7 +131,7 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         // Create the tag
         // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-        let tag_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-tag --name " + shell_escape(bump.next) + " --ref main --message " + shell_escape("Release " + bump.next);
+        let tag_cmd = "$COLONY_DIR/scripts/forge-api.sh create-tag --name " + shell_escape(bump.next) + " --ref main --message " + shell_escape("Release " + bump.next);
         let tag_result = try { exec sh tag_cmd; } catch e {
             print("[version_bumper] Tag creation failed:", e);
             "";
@@ -144,7 +144,7 @@ fn tick(reason: string) -> void {
             let release_desc = changelog_str + bump.reasoning;
 
             // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-            let release_cmd = "$COLONY_DIR/scripts/gitlab-api.sh create-release --tag " + shell_escape(bump.next) + " --name " + shell_escape("Release " + bump.next) + " --description " + shell_escape(release_desc);
+            let release_cmd = "$COLONY_DIR/scripts/forge-api.sh create-release --tag " + shell_escape(bump.next) + " --name " + shell_escape("Release " + bump.next) + " --description " + shell_escape(release_desc);
             let release_result = try { exec sh release_cmd; } catch e {
                 print("[version_bumper] Release creation failed:", e);
                 "";
@@ -162,11 +162,11 @@ fn tick(reason: string) -> void {
             // Non-terminal proposal: post a draft note on the latest MR flagged as
             // a pending bump so a human can approve before we tag. No tag/release
             // is created at this tier.
-            let mr_raw = try { exec sh "$COLONY_DIR/scripts/gitlab-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+            let mr_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
             let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
             if mr_iid > 0 {
                 let note = "[draft-bump] **Version Bump Proposal** (automated, pending approval): " + bump.current + " -> " + bump.next + " (" + bump.bump_type + ")\n\n" + bump.reasoning;
-                let post_cmd = "$COLONY_DIR/scripts/gitlab-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
                 try { exec sh post_cmd; } catch e {
                     print("[version_bumper] Failed to post draft bump note:", e);
                 };

--- a/dev-apprenticeship/release/scripts/forge-api.sh
+++ b/dev-apprenticeship/release/scripts/forge-api.sh
@@ -35,20 +35,8 @@ case "$FORGE_TYPE" in
 esac
 
 if [ ! -x "$backend" ]; then
-    case "$FORGE_TYPE" in
-        github)
-            # Skeleton state: dispatcher exists but the per-colony wrapper is not yet
-            # shipped. Lands across PRs 2-6 of #256.
-            echo "forge-api.sh: FORGE_TYPE=github is not yet implemented for the release colony." >&2
-            echo "forge-api.sh: See doc/adr/ADR-0002-forge-abstraction.md and https://github.com/Replikanti/agentis-colonies/issues/256 (PRs 2-6)." >&2
-            ;;
-        *)
-            # Broken install — gitlab-api.sh should always be present alongside
-            # forge-api.sh in a valid federation checkout.
-            echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
-            echo "forge-api.sh: this indicates a broken install — re-copy the release colony scripts/ directory." >&2
-            ;;
-    esac
+    echo "forge-api.sh: backend wrapper missing or not executable: $backend" >&2
+    echo "forge-api.sh: this indicates a broken install — re-copy the release colony scripts/ directory." >&2
     exit 99
 fi
 

--- a/dev-apprenticeship/release/scripts/github-api.sh
+++ b/dev-apprenticeship/release/scripts/github-api.sh
@@ -1,0 +1,706 @@
+#!/bin/bash
+# GitHub API wrapper for release colony agents (ADR-0002, #256 PR 6 of 7).
+# Called by .ag agents via forge-api.sh dispatch when FORGE_TYPE=github.
+#
+# Required env vars (set by start-colony.sh from [forge.github] in colony.toml):
+#   GITHUB_URL    - API base (default https://api.github.com; override for GHE)
+#   GITHUB_TOKEN  - personal access token (classic or fine-grained)
+#   GITHUB_OWNER  - repo owner (user or org)
+#   GITHUB_REPO   - repo name
+#
+# Optional env vars:
+#   GITLAB_DEFAULT_BRANCH base/target branch for create-tag (default "main").
+#                         The env-var name is a GitLab holdover — ADR-0002
+#                         keeps it for backend-agnostic dispatch; PR 7 may
+#                         rename when [gitlab] retires.
+#   GITHUB_ME             authenticated-user login (optional; used as the
+#                         `tagger.name` fallback when creating annotated tags)
+#   GITHUB_CURL_MAX_TIME  per-attempt --max-time seconds (default 90)
+#   GITHUB_CURL_RETRIES   retry budget for 5xx/timeouts/429 (default 3)
+#
+# Usage (identical contract to gitlab-api.sh):
+#   github-api.sh releases [--per-page N] [--view <name>]
+#   github-api.sh tags [--per-page N] [--view <name>]
+#   github-api.sh pipelines --ref <branch> [--per-page N] [--view <name>]
+#   github-api.sh merge-requests [--state opened|merged|closed|all]
+#                                [--since ISO8601] [--per-page N] [--view <name>]
+#   github-api.sh create-tag --name <name> [--ref <ref>] [--message <m>]
+#   github-api.sh create-release --tag <tag> --name <name> --description <d>
+#   github-api.sh post-note <number> --body <text>
+#
+# Views (opt-in projection; byte-identical to gitlab-api.sh):
+#   releases       --view release-summary  [{tag_name, name, released_at, description}]
+#   tags           --view tag-summary      [{name, message, commit:{short_id, created_at}}]
+#   pipelines      --view pipeline-summary [{id, status, ref, sha, created_at, web_url}]
+#   merge-requests --view release-mr       [{iid, title, description, merged_at, labels, target_branch}]
+#   <cmd>          --view raw              explicit pass-through (same as no flag)
+#   GITLAB_VIEW_MODE=raw                   env-override that forces pass-through globally.
+#
+# Semantic collapses vs GitLab:
+#   /releases                replaces /releases; description <- body,
+#                            released_at <- published_at. `commit` is not
+#                            returned by GitHub in the list response — forward
+#                            as null (version_bumper/changelog_writer tolerate).
+#   /tags                    replaces /repository/tags. GitHub's /tags omits
+#                            tag-object message and commit.created_at; the
+#                            normalizer forwards both as null (would require
+#                            N+1 per-tag calls to /git/tags and /git/commits
+#                            to recover them). tag-summary consumers use this
+#                            for prompt context only — not branching signal.
+#   /actions/runs            replaces /pipelines. Wrapped response `{workflow_runs:
+#                            [...]}` is unpacked; status/conclusion collapse:
+#                            completed+success -> "success"; completed+failure/
+#                            cancelled/timed_out -> "failed"; in_progress ->
+#                            "running"; queued/requested/waiting/pending ->
+#                            "pending". GitLab's "skipped" is mapped similarly
+#                            (conclusion=skipped -> "success", since a skipped
+#                            job is not a failure signal).
+#   /pulls                   replaces /merge_requests; state merged -> closed +
+#                            client-side merged_at!=null filter; no `since`
+#                            query param, --since is client-side on updated_at.
+#   /issues/{n}/comments     replaces /merge_requests/{iid}/notes for post-note
+#                            (GitHub unifies PR conversation with issue
+#                            comments; same endpoint used by code-review's
+#                            post-note and triage/planning/impl's add-note).
+#   /git/refs + /git/tags    replaces POST /repository/tags. Annotated tags
+#                            (non-empty --message) need the 3-step dance:
+#                            resolve ref -> POST /git/tags -> POST /git/refs.
+#                            Lightweight tags (empty --message) short-circuit
+#                            to a single POST /git/refs after ref resolution.
+#
+# Exit codes:
+#   0  ok (2xx)
+#   1  usage error (required flag missing, backend rejection)
+#   2  unknown flag / view / auth failure (4xx 401/403)
+#   3  rate limited (429 or secondary rate-limit, after retries)
+#   4  other 4xx client error
+#   5  5xx server error OR transport failure
+
+set -e
+
+# emit_error <message>
+# Matches gitlab-api.sh emit_error contract: JSON error object to stderr.
+emit_error() {
+    printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps({"error": sys.stdin.read()}), file=sys.stderr)'
+}
+
+# normalize_releases
+# Reads GitHub /releases JSON, writes GitLab-releases-shape JSON. Shape is a
+# superset of what the release-summary view consumes (tag_name, name,
+# released_at, description) plus the fields changelog_writer reads from the
+# raw output (author, created_at) when prompted for release-note context.
+normalize_releases() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{
+    "tag_name": x.get("tag_name"),
+    "name": x.get("name"),
+    "description": x.get("body"),
+    "created_at": x.get("created_at"),
+    "released_at": x.get("published_at"),
+    "author": {"username": (x.get("author") or {}).get("login")} if x.get("author") else None,
+    # /releases list response doesn't embed the underlying commit; forward as
+    # null so downstream consumers don't trip on a missing key.
+    "commit": None,
+} for x in data]
+print(json.dumps(out))
+PY
+}
+
+# normalize_tags
+# Reads GitHub /tags JSON, writes GitLab-tags-shape JSON. GitHub's /tags
+# payload is much thinner: no tag-object `message`, no commit `created_at`.
+# Both are forwarded as null. tag-summary consumers (version_bumper, ship_decider,
+# changelog_writer) use these fields for prompt context only — missing values
+# degrade prompt quality but do not break branching.
+normalize_tags() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for x in data:
+    commit = x.get("commit") or {}
+    sha = commit.get("sha")
+    out.append({
+        "name": x.get("name"),
+        # Tag-object message lives behind a separate GET /git/tags/{sha} call
+        # for annotated tags; lightweight tags have none. Null is correct for
+        # both cases without N+1 calls.
+        "message": None,
+        "target": sha,
+        "commit": {
+            "id": sha,
+            # GitLab emits 8-char short_id; match that so tag-summary renders
+            # identically across backends.
+            "short_id": sha[:8] if sha else None,
+            # commit.created_at requires a second GET /git/commits/{sha};
+            # forward null to keep this a single round-trip.
+            "created_at": None,
+        },
+    })
+print(json.dumps(out))
+PY
+}
+
+# normalize_pipelines
+# Reads GitHub /actions/runs JSON (envelope with workflow_runs[]), writes
+# GitLab-pipelines-shape JSON. Status collapse mirrors the agentis-colonies
+# shape contract in ADR-0002 §"Semantic collapses".
+normalize_pipelines() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+envelope = json.loads(os.environ["DATA"])
+# GitHub wraps the list in {total_count, workflow_runs: [...]}; other endpoints
+# return a bare array. Accept both so ad-hoc callers piping raw responses work.
+if isinstance(envelope, dict):
+    runs = envelope.get("workflow_runs") or []
+else:
+    runs = envelope
+out = []
+for r in runs:
+    status = r.get("status") or ""
+    conclusion = r.get("conclusion") or ""
+    if status == "completed":
+        if conclusion in ("success", "skipped", "neutral"):
+            gl_status = "success"
+        elif conclusion in ("failure", "cancelled", "timed_out", "action_required", "stale"):
+            gl_status = "failed"
+        else:
+            # unknown conclusion on completed — treat as failed to avoid
+            # falsely reporting success; ship_decider branches on "success".
+            gl_status = "failed"
+    elif status == "in_progress":
+        gl_status = "running"
+    elif status in ("queued", "requested", "waiting", "pending"):
+        gl_status = "pending"
+    else:
+        # unknown status — leave as-is so it's visible rather than masked.
+        gl_status = status
+    out.append({
+        "id": r.get("id"),
+        "status": gl_status,
+        "ref": r.get("head_branch"),
+        "sha": r.get("head_sha"),
+        "created_at": r.get("created_at"),
+        "updated_at": r.get("updated_at"),
+        "web_url": r.get("html_url"),
+    })
+print(json.dumps(out))
+PY
+}
+
+# normalize_pulls
+# Same shape as planning/implementation normalize_pulls — no `draft` field
+# (release's release-mr view doesn't expose it; code-review's reviewer view
+# does). State collapse: open -> opened; closed + merged_at -> merged;
+# closed + no merged_at stays closed.
+normalize_pulls() {
+    local DATA
+    DATA="$(cat)"
+    DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = []
+for x in data:
+    st = x.get("state")
+    if st == "open":
+        st = "opened"
+    elif st == "closed" and x.get("merged_at"):
+        st = "merged"
+    out.append({
+        "iid": x.get("number"),
+        "title": x.get("title"),
+        "description": x.get("body"),
+        "state": st,
+        "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
+        "author": {"username": (x.get("user") or {}).get("login")},
+        "target_branch": (x.get("base") or {}).get("ref"),
+        "source_branch": (x.get("head") or {}).get("ref"),
+        "merged_at": x.get("merged_at"),
+        "created_at": x.get("created_at"),
+        "updated_at": x.get("updated_at"),
+        "changes_count": x.get("changed_files"),
+        "user_notes_count": x.get("comments", 0),
+    })
+print(json.dumps(out))
+PY
+}
+
+# project_json <view-name>
+# Byte-identical to gitlab-api.sh project_json; test-gitlab-views.sh enforces
+# parity for all four release views.
+project_json() {
+    local view="$1"
+    if [ "${GITLAB_VIEW_MODE:-}" = "raw" ]; then
+        cat
+        return 0
+    fi
+    local DATA
+    DATA="$(cat)"
+    case "$view" in
+        raw)
+            printf '%s' "$DATA"
+            ;;
+        release-summary)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"tag_name": x.get("tag_name"), "name": x.get("name"),
+        "released_at": x.get("released_at"), "description": x.get("description")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        tag-summary)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"name": x.get("name"), "message": x.get("message"),
+        "commit": {"short_id": (x.get("commit") or {}).get("short_id"),
+                   "created_at": (x.get("commit") or {}).get("created_at")}} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        pipeline-summary)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"id": x.get("id"), "status": x.get("status"), "ref": x.get("ref"),
+        "sha": x.get("sha"), "created_at": x.get("created_at"),
+        "web_url": x.get("web_url")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        release-mr)
+            DATA="$DATA" python3 <<'PY'
+import os, json
+data = json.loads(os.environ["DATA"])
+out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
+        "merged_at": x.get("merged_at"),
+        "labels": x.get("labels", []), "target_branch": x.get("target_branch")} for x in data]
+print(json.dumps(out))
+PY
+            ;;
+        *)
+            emit_error "unknown view: $view"
+            exit 2
+            ;;
+    esac
+}
+
+if [ -z "${GITHUB_TOKEN:-}" ] || [ -z "${GITHUB_OWNER:-}" ] || [ -z "${GITHUB_REPO:-}" ]; then
+    emit_error "GITHUB_TOKEN, GITHUB_OWNER, and GITHUB_REPO must be set"
+    exit 1
+fi
+
+GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+API="$GITHUB_URL/repos/$GITHUB_OWNER/$GITHUB_REPO"
+
+# gh_call <method> <url> [curl-args...]
+# Mirrors every other github-api.sh gh_call: retry on 429/5xx/timeout, no-retry
+# on 401/403 non-rate-limit, 403-secondary-rate detection via body snippet,
+# bounded curl --max-time. Exit codes 0/2/3/4/5 match gl_call.
+gh_call() {
+    local method="$1" url="$2"
+    shift 2
+    local max_time="${GITHUB_CURL_MAX_TIME:-90}"
+    local max_retries="${GITHUB_CURL_RETRIES:-3}"
+    local attempt=0 delay=3 rc code snippet body_file
+    body_file="$(mktemp)"
+    trap 'rm -f "$body_file"; trap - RETURN' RETURN
+
+    while :; do
+        attempt=$((attempt + 1))
+        code=""
+        rc=0
+        code="$(curl -sS -w '%{http_code}' -o "$body_file" \
+            --max-time "$max_time" \
+            -X "$method" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$@" \
+            "$url" 2>/dev/null)" || rc=$?
+
+        if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
+            if [ "$attempt" -le "$max_retries" ]; then
+                sleep "$delay"
+                delay=$((delay * 2))
+                continue
+            fi
+            emit_error "curl transport failure (exit $rc) after $attempt attempts: $method $url"
+            return 5
+        fi
+
+        case "$code" in
+            2*)
+                cat "$body_file"
+                return 0
+                ;;
+            401)
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "auth failure (HTTP 401) on $method $url: $snippet — check PAT scope/expiry"
+                return 2
+                ;;
+            403)
+                snippet="$(head -c 400 "$body_file")"
+                if printf '%s' "$snippet" | grep -qiE 'rate limit|abuse|secondary rate'; then
+                    if [ "$attempt" -le "$max_retries" ]; then
+                        sleep "$delay"
+                        delay=$((delay * 2))
+                        continue
+                    fi
+                    emit_error "secondary rate limit (HTTP 403) after $attempt attempts: $snippet"
+                    return 3
+                fi
+                emit_error "auth/permission failure (HTTP 403) on $method $url: $snippet — check PAT scope"
+                return 2
+                ;;
+            429)
+                if [ "$attempt" -le "$max_retries" ]; then
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                    continue
+                fi
+                emit_error "rate limited (HTTP 429) after $attempt attempts on $method $url"
+                return 3
+                ;;
+            5*)
+                if [ "$attempt" -le "$max_retries" ]; then
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                    continue
+                fi
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "server error (HTTP $code) after $attempt attempts: $snippet"
+                return 5
+                ;;
+            4*)
+                snippet="$(head -c 200 "$body_file")"
+                emit_error "client error (HTTP $code) on $method $url: $snippet"
+                return 4
+                ;;
+            *)
+                emit_error "unexpected HTTP $code on $method $url"
+                return 4
+                ;;
+        esac
+    done
+}
+
+gh_get() {
+    gh_call GET "$1"
+}
+
+gh_get_q() {
+    local url="$1"
+    shift
+    gh_call GET "$url" -G "$@"
+}
+
+gh_post() {
+    gh_call POST "$1" -H "Content-Type: application/json" -d "$2"
+}
+
+CMD="${1:?Usage: github-api.sh <command> [args...]}"
+shift
+
+case "$CMD" in
+    releases)
+        PER_PAGE="20"
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --per-page) PER_PAGE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
+        # GitHub's /releases list is sorted by created_at desc by default —
+        # matches GitLab's order_by=released_at sort=desc for the common case.
+        body="$(gh_get_q "$API/releases" --data-urlencode "per_page=$PER_PAGE")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_releases)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$normalized" | project_json "$VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    tags)
+        PER_PAGE="20"
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --per-page) PER_PAGE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
+        body="$(gh_get_q "$API/tags" --data-urlencode "per_page=$PER_PAGE")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_tags)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$normalized" | project_json "$VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    pipelines)
+        REF=""
+        PER_PAGE="5"
+        VIEW=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --ref) REF="$2"; shift 2 ;;
+                --per-page) PER_PAGE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$REF" ]; then
+            emit_error "--ref is required"
+            exit 1
+        fi
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
+        # GitHub's /actions/runs uses `branch` (not `ref`) for branch-scoped
+        # filtering. Translate the arg name at the boundary to keep the
+        # .ag-layer contract identical.
+        body="$(gh_get_q "$API/actions/runs" \
+            --data-urlencode "branch=$REF" \
+            --data-urlencode "per_page=$PER_PAGE")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_pipelines)"
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$normalized" | project_json "$VIEW"
+        else
+            printf '%s' "$normalized"
+        fi
+        ;;
+
+    merge-requests)
+        STATE="opened"
+        SINCE=""
+        VIEW=""
+        PER_PAGE=100
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --state) STATE="$2"; shift 2 ;;
+                --since) SINCE="$2"; shift 2 ;;
+                --view) VIEW="$2"; shift 2 ;;
+                --per-page) PER_PAGE="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$PER_PAGE" in
+            ''|*[!0-9]*) emit_error "invalid --per-page: $PER_PAGE (integer required)"; exit 2 ;;
+        esac
+        case "$STATE" in
+            opened) GH_STATE="open" ;;
+            closed) GH_STATE="closed" ;;
+            all)    GH_STATE="all" ;;
+            merged) GH_STATE="closed" ;;
+            *) emit_error "invalid --state: $STATE (expected opened|closed|merged|all)"; exit 2 ;;
+        esac
+        ARGS=(
+            --data-urlencode "state=$GH_STATE"
+            --data-urlencode "per_page=$PER_PAGE"
+            --data-urlencode "sort=updated"
+            --data-urlencode "direction=desc"
+        )
+        body="$(gh_get_q "$API/pulls" "${ARGS[@]}")" || exit $?
+        normalized="$(printf '%s' "$body" | normalize_pulls)"
+        # Client-side --state merged and --since filters (GitHub's /pulls has
+        # no `since` query param and no distinct "merged" state; see ADR-0002
+        # §"PR 3 additions" and §"PR 4 additions").
+        filtered="$(STATE="$STATE" SINCE="$SINCE" DATA="$normalized" python3 <<'PY'
+import os, json
+items = json.loads(os.environ["DATA"])
+state = os.environ.get("STATE", "")
+since = os.environ.get("SINCE", "")
+out = []
+for x in items:
+    if state == "merged" and x.get("state") != "merged":
+        continue
+    if since and (x.get("updated_at") or "") < since:
+        continue
+    out.append(x)
+print(json.dumps(out))
+PY
+)" || exit $?
+        if [ -n "$VIEW" ]; then
+            printf '%s' "$filtered" | project_json "$VIEW"
+        else
+            printf '%s' "$filtered"
+        fi
+        ;;
+
+    create-tag)
+        NAME=""
+        # Honour operator-configured default branch (#224); fall back to
+        # "main" when unset.
+        REF="${GITLAB_DEFAULT_BRANCH:-main}"
+        MESSAGE=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --name) NAME="$2"; shift 2 ;;
+                --ref) REF="$2"; shift 2 ;;
+                --message) MESSAGE="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$NAME" ]; then
+            emit_error "--name is required"
+            exit 1
+        fi
+        # Step 1: resolve ref to a commit SHA. Short-circuit on 40-hex.
+        if [ "${#REF}" -eq 40 ] && printf '%s' "$REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
+            REF_SHA="$REF"
+        else
+            ref_body="$(gh_get "$API/git/refs/heads/$REF")" || exit $?
+            REF_SHA="$(REF_BODY="$ref_body" python3 -c 'import os,json;print((json.loads(os.environ["REF_BODY"]).get("object") or {}).get("sha") or "")')"
+            if [ -z "$REF_SHA" ]; then
+                emit_error "could not resolve ref '$REF' to a commit SHA"
+                exit 1
+            fi
+        fi
+
+        if [ -n "$MESSAGE" ]; then
+            # Annotated tag: 3-step dance (resolve above + create tag obj +
+            # create ref). Tagger identity prefers GITHUB_ME; falls back to a
+            # bot label so repos without a configured `me` still succeed.
+            TAGGER_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+            TAG_JSON=$(NAME="$NAME" MESSAGE="$MESSAGE" SHA="$REF_SHA" \
+                       ME="${GITHUB_ME:-}" DATE="$TAGGER_DATE" python3 - <<'PY'
+import os, json
+me = os.environ.get("ME") or "agentis-bot"
+# noreply email keeps GitHub happy without exposing a real address; the
+# domain is the standard GitHub noreply host.
+email = me + "@users.noreply.github.com" if me != "agentis-bot" else "agentis-bot@users.noreply.github.com"
+print(json.dumps({
+    "tag": os.environ["NAME"],
+    "message": os.environ["MESSAGE"],
+    "object": os.environ["SHA"],
+    "type": "commit",
+    "tagger": {"name": me, "email": email, "date": os.environ["DATE"]},
+}))
+PY
+)
+            tag_resp="$(gh_post "$API/git/tags" "$TAG_JSON")" || exit $?
+            TAG_SHA="$(TAG_RESP="$tag_resp" python3 -c 'import os,json;print(json.loads(os.environ["TAG_RESP"]).get("sha") or "")')"
+            if [ -z "$TAG_SHA" ]; then
+                emit_error "tag-object creation returned no sha; cannot create ref"
+                exit 1
+            fi
+            REF_TARGET_SHA="$TAG_SHA"
+        else
+            # Lightweight tag: skip /git/tags, point the ref straight at the
+            # commit SHA. Matches GitLab create-tag without --message.
+            REF_TARGET_SHA="$REF_SHA"
+        fi
+
+        REF_JSON=$(NAME="$NAME" SHA="$REF_TARGET_SHA" python3 - <<'PY'
+import os, json
+print(json.dumps({"ref": "refs/tags/" + os.environ["NAME"], "sha": os.environ["SHA"]}))
+PY
+)
+        # Create the ref; we don't use the response body — we synthesize the
+        # GitLab-shape reply below from the inputs we already have. shellcheck
+        # SC2034 disable needed because the capture is only for exit-code
+        # forwarding via `|| exit $?`.
+        # shellcheck disable=SC2034
+        ref_resp="$(gh_post "$API/git/refs" "$REF_JSON")" || exit $?
+
+        # Emit a GitLab-tag-shape response so version_bumper's `len > 0`
+        # truthy check stays happy and downstream normalize_tags-style
+        # consumers don't choke on an unfamiliar envelope.
+        NAME="$NAME" MESSAGE="$MESSAGE" COMMIT_SHA="$REF_SHA" REF_TARGET="$REF_TARGET_SHA" python3 <<'PY'
+import os, json
+sha = os.environ["COMMIT_SHA"]
+print(json.dumps({
+    "name": os.environ["NAME"],
+    "message": os.environ.get("MESSAGE") or None,
+    "target": os.environ["REF_TARGET"],
+    "commit": {
+        "id": sha,
+        "short_id": sha[:8] if sha else None,
+        "created_at": None,
+    },
+    "release": None,
+}))
+PY
+        ;;
+
+    create-release)
+        TAG=""
+        NAME=""
+        DESC=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --tag) TAG="$2"; shift 2 ;;
+                --name) NAME="$2"; shift 2 ;;
+                --description) DESC="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$TAG" ] || [ -z "$NAME" ]; then
+            emit_error "--tag and --name are required"
+            exit 1
+        fi
+        JSON_BODY=$(TAG="$TAG" NAME="$NAME" DESC="$DESC" python3 - <<'PY'
+import os, json
+body = {"tag_name": os.environ["TAG"], "name": os.environ["NAME"]}
+if os.environ.get("DESC"):
+    body["body"] = os.environ["DESC"]
+print(json.dumps(body))
+PY
+)
+        resp="$(gh_post "$API/releases" "$JSON_BODY")" || exit $?
+        # Normalize single-item response to GitLab-release shape so the
+        # downstream .ag `len > 0` check works identically and any future
+        # JSON-field reader gets the expected keys.
+        printf '%s' "[$resp]" | normalize_releases | python3 -c 'import sys,json; items=json.load(sys.stdin); print(json.dumps(items[0] if items else {}))'
+        ;;
+
+    post-note)
+        NUM="${1:?Usage: github-api.sh post-note <number> --body <text>}"
+        shift
+        BODY=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --body) BODY="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$BODY" ]; then
+            emit_error "--body is required"
+            exit 1
+        fi
+        case "$NUM" in
+            ''|*[!0-9]*) emit_error "pr/issue number must be numeric: $NUM"; exit 2 ;;
+        esac
+        # Same /issues/{n}/comments endpoint as code-review's post-note and
+        # triage/planning/impl's add-note — GitHub unifies issue and PR
+        # conversation comments.
+        JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
+        gh_post "$API/issues/$NUM/comments" "$JSON_BODY"
+        ;;
+
+    *)
+        emit_error "unknown command: $CMD"
+        exit 1
+        ;;
+esac

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -60,51 +60,86 @@ if [ ! -f "$CONFIG" ]; then
     exit 1
 fi
 
-# Parse GitLab config from TOML via the shared helper.
+# Parse forge config from TOML via the shared helper.
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # shellcheck source=../../../tools/parse-toml.sh
 # shellcheck disable=SC1091  # colony-lint runs shellcheck without -x
 . "$REPO_ROOT/tools/parse-toml.sh"
 
-GITLAB_URL=$(parse_toml gitlab url)
-GITLAB_TOKEN=$(parse_toml gitlab token)
-GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
-
-if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
-    echo "Error: GitLab config incomplete in $CONFIG"
-    echo "Required: url, token, project under [gitlab]"
-    exit 1
-fi
-
-# URL-encode the project path (replace / with %2F)
-GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
-
-# #104: operator identity. Empty if not configured (pre-#104 setups or
-# operators who skipped the install.sh prompt); agents fall back to
-# memo gitlab:me and tag everything as team when both are empty.
-GITLAB_ME=$(parse_toml gitlab me)
-
-# #224: primary branch name. Empty if not configured (pre-#224 setups);
-# gitlab-api.sh falls back to the hardcoded default "main" via
-# ${GITLAB_DEFAULT_BRANCH:-main}.
-GITLAB_DEFAULT_BRANCH=$(parse_toml gitlab default_branch)
-
-export GITLAB_URL
-export GITLAB_TOKEN
-export GITLAB_PROJECT
-export GITLAB_ME
-export GITLAB_DEFAULT_BRANCH
-export COLONY_DIR
-
 # #256: forge backend selection. `[forge].type` picks which backend
 # wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
-# configs keep working unchanged. The github backend is skeleton-only
-# until PRs 2-6 of #256 land their per-colony github-api.sh wrappers;
-# until then, FORGE_TYPE=github yields exit 99 "not implemented" from
-# forge-api.sh.
+# configs keep working unchanged. PR 6 of #256 ships the release
+# colony's github-api.sh, so FORGE_TYPE=github is now live for release.
 FORGE_TYPE=$(parse_toml forge type)
 FORGE_TYPE="${FORGE_TYPE:-gitlab}"
+
+case "$FORGE_TYPE" in
+    gitlab)
+        # Prefer [forge.gitlab] (ADR-0002) if present; fall back to legacy
+        # [gitlab] so pre-#256 configs keep working during the overlap window.
+        GITLAB_URL=$(parse_toml forge.gitlab url)
+        [ -z "$GITLAB_URL" ] && GITLAB_URL=$(parse_toml gitlab url)
+        GITLAB_TOKEN=$(parse_toml forge.gitlab token)
+        [ -z "$GITLAB_TOKEN" ] && GITLAB_TOKEN=$(parse_toml gitlab token)
+        GITLAB_PROJECT_RAW=$(parse_toml forge.gitlab project)
+        [ -z "$GITLAB_PROJECT_RAW" ] && GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
+        GITLAB_ME=$(parse_toml forge.gitlab me)
+        [ -z "$GITLAB_ME" ] && GITLAB_ME=$(parse_toml gitlab me)
+        # FORGE_TYPE-aware default_branch (was silently ignoring [forge.gitlab]
+        # and [forge.github] default_branch keys pre-PR 6; see the identical
+        # fix in implementation/scripts/start-colony.sh shipped in PR 4).
+        GITLAB_DEFAULT_BRANCH=$(parse_toml forge.gitlab default_branch)
+        [ -z "$GITLAB_DEFAULT_BRANCH" ] && GITLAB_DEFAULT_BRANCH=$(parse_toml gitlab default_branch)
+
+        if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
+            echo "Error: GitLab config incomplete in $CONFIG"
+            echo "Required: url, token, project under [forge.gitlab] (or legacy [gitlab])"
+            exit 1
+        fi
+
+        # URL-encode the project path (replace / with %2F)
+        GITLAB_PROJECT="${GITLAB_PROJECT_RAW//\//%2F}"
+
+        export GITLAB_URL
+        export GITLAB_TOKEN
+        export GITLAB_PROJECT
+        export GITLAB_ME
+        ;;
+    github)
+        GITHUB_URL=$(parse_toml forge.github url)
+        GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+        GITHUB_OWNER=$(parse_toml forge.github owner)
+        GITHUB_REPO=$(parse_toml forge.github repo)
+        GITHUB_TOKEN=$(parse_toml forge.github token)
+        GITHUB_ME=$(parse_toml forge.github me)
+        # default_branch used by create-tag (--ref default). Forward via the
+        # legacy GITLAB_DEFAULT_BRANCH env name — ADR-0002 keeps that name for
+        # backend-agnostic dispatch; PR 7 may rename when [gitlab] retires.
+        GITLAB_DEFAULT_BRANCH=$(parse_toml forge.github default_branch)
+
+        if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
+            echo "Error: GitHub config incomplete in $CONFIG"
+            echo "Required: owner, repo, token under [forge.github]"
+            exit 1
+        fi
+
+        GITLAB_PROJECT_RAW="$GITHUB_OWNER/$GITHUB_REPO"
+
+        export GITHUB_URL
+        export GITHUB_OWNER
+        export GITHUB_REPO
+        export GITHUB_TOKEN
+        export GITHUB_ME
+        ;;
+    *)
+        echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2
+        exit 1
+        ;;
+esac
+
+export GITLAB_DEFAULT_BRANCH
 export FORGE_TYPE
+export COLONY_DIR
 
 AGENTS=(
     release_checker
@@ -186,7 +221,10 @@ if [ -n "$RESTART_AGENT" ]; then
 fi
 
 echo "Starting Release colony (${#AGENTS[@]} agents)..."
-echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)"
+case "$FORGE_TYPE" in
+    gitlab) echo "  GitLab: $GITLAB_URL ($GITLAB_PROJECT_RAW)" ;;
+    github) echo "  GitHub: $GITHUB_URL ($GITHUB_OWNER/$GITHUB_REPO)" ;;
+esac
 
 for agent in "${AGENTS[@]}"; do
     interval=$(tick_interval_for "$agent")

--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -125,9 +125,13 @@ agents. PR 5 (the current PR as of this writing) ships the code-review
 colony's `github-api.sh` with 5 subcommands (`merge-requests`,
 `mr-changes`, `mr-notes`, `post-note`, `approve`) plus the matching
 `[forge.github]` env-export branch and 28 `.ag` call-site migrations
-across the five code-review agents. The remaining colony wrapper
-(release) lands in PR 6. `rate-limit-status` and the dashboard tile
-ship in PR 7 alongside the legacy `[gitlab]`-section retirement.
+across the five code-review agents. PR 6 (the current PR as of this
+writing) ships the release colony's `github-api.sh` with 7 subcommands
+(`releases`, `tags`, `pipelines`, `merge-requests`, `create-tag`,
+`create-release`, `post-note`) plus the matching `[forge.github]`
+env-export branch and 29 `.ag` call-site migrations across the four
+release agents. `rate-limit-status` and the dashboard tile ship in PR 7
+alongside the legacy `[gitlab]`-section retirement.
 
 **`.ag` migration is in-scope for every per-colony PR.** Each
 per-colony PR (PRs 2-6) MUST rewrite every `exec sh` call site in that
@@ -221,6 +225,45 @@ it to skip draft PRs, which GitHub (unlike GitLab) exposes natively
 on the list response. As in PRs 3-4, `--state merged` collapses to
 `state=closed + merged_at != null` client-side and `--since` is a
 client-side filter on `updated_at`.
+
+**PR 6 additions.** The release contract adds the tag/release/pipeline
+read + write surface the four release agents depend on: `releases`,
+`tags`, `pipelines`, `create-tag`, `create-release`, plus the shared
+`merge-requests` and `post-note` already contracted in PRs 3-5.
+`normalize_releases` maps `body` → `description`, `published_at` →
+`released_at`, and `author.login` → `author.username`; the `commit`
+object is forwarded as `null` because GitHub's `/releases` response
+does not carry the tag's target commit inline (changelog_writer reads
+it from `tags` instead, which is the only consumer that needs it).
+`normalize_tags` forwards `message` and `commit.created_at` as `null`
+rather than doing the per-tag `GET /git/refs/tags/{name}` +
+`GET /git/tags/{sha}` + `GET /git/commits/{sha}` round-trip — for the
+release colony's list reads this would be ~20 extra API calls per
+`tags` fetch, and the one consumer (tag-summary view in
+release_checker) only needs `name` + `short_id` for prompt context.
+`commit.short_id` is derived as `sha[:8]` locally.
+`normalize_pipelines` unwraps GitHub's `{total_count, workflow_runs:
+[...]}` envelope (also tolerates a bare array for defensive test
+input) and collapses the 2-axis `(status, conclusion)` matrix to
+GitLab's single-field `status`: `completed + success|skipped|neutral`
+→ `success`, `completed + failure|cancelled|timed_out|action_required|
+stale` → `failed`, `in_progress` → `running`, `queued|requested|
+waiting|pending` → `pending`. `create-tag` implements the 3-step
+annotated-tag dance (`GET /git/refs` to resolve the ref, `POST
+/git/tags` to create the tag object, `POST /git/refs` to point
+`refs/tags/{name}` at the new tag SHA); when no `--message` is
+supplied it short-circuits to a single `POST /git/refs` for a
+lightweight tag. `create-release` posts to `/releases` with
+`{tag_name, name, body}` and normalizes the response through
+`normalize_releases` so the calling agent sees the same shape regardless
+of backend. `post-note` on the release colony (used by ship_decider
+and changelog_writer to post on MRs) goes through
+`/issues/{n}/comments`, same as code-review's. PR 6 also back-ports
+the `[forge.gitlab]`/`[forge.github]`-aware `default_branch` fix
+first called out in PR 4 QA into `release/scripts/start-colony.sh`
+(pre-PR 6 the release colony's gitlab arm silently ignored both
+`[forge.gitlab].default_branch` and `[forge.github].default_branch`,
+falling back to legacy `[gitlab].default_branch` only).
 
 | Subcommand           | Normalized output |
 |----------------------|-------------------|

--- a/tools/test-github-release-normalize.sh
+++ b/tools/test-github-release-normalize.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# test-github-release-normalize.sh: unit-test the GitHub -> GitLab-shape
+# normalizers in dev-apprenticeship/release/scripts/github-api.sh
+# (ADR-0002, #256 PR 6).
+#
+# The release colony's surface is broader than code-review's: four normalizers
+# (releases, tags, pipelines, pulls) and four views (release-summary,
+# tag-summary, pipeline-summary, release-mr). Two of the normalizers forward
+# nulls where GitHub's list responses lack the GitLab-equivalent field:
+#   normalize_tags  — message, commit.created_at (require N+1 per-tag calls
+#                     to /git/tags and /git/commits to recover)
+#   normalize_releases — commit (not embedded in the /releases list response)
+# normalize_pipelines has the heaviest collapse logic — two GitHub fields
+# (status, conclusion) → one GitLab field (status) — and this test locks down
+# every branch so ship_decider's `status == "success"` check stays accurate.
+#
+# Style matches test-github-triage/planning/implementation/code-review-normalize.sh
+# (bash 3.2, python3 for JSON, build_prelude pattern for sourcing the
+# script under test).
+#
+# Exit 0 all-pass, 1 any-fail.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT="$REPO_ROOT/dev-apprenticeship/release/scripts/github-api.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+# --- Fixtures ---
+
+# GitHub /releases list response. `body` (GitLab `description`), `published_at`
+# (GitLab `released_at`), and author:{login} are the three renames. `commit` is
+# intentionally absent from GitHub's list response (available via per-release
+# /releases/{id} + /git/refs/tags/{tag} dance — not worth N+1 calls for prompt
+# context); the normalizer forwards commit: null.
+FIXTURE_RELEASES='[
+  {"id":501,"tag_name":"v1.2.3","name":"Release 1.2.3",
+   "body":"- fix: bug A\n- feat: thing B","draft":false,"prerelease":false,
+   "created_at":"2026-03-01T10:00:00Z","published_at":"2026-03-01T12:00:00Z",
+   "author":{"login":"alice","id":7},
+   "html_url":"https://github.com/o/r/releases/tag/v1.2.3"},
+  {"id":502,"tag_name":"v1.2.2","name":"Release 1.2.2",
+   "body":"- fix: something","draft":false,"prerelease":false,
+   "created_at":"2026-02-15T10:00:00Z","published_at":"2026-02-15T12:00:00Z",
+   "author":{"login":"bob","id":8},
+   "html_url":"https://github.com/o/r/releases/tag/v1.2.2"}
+]'
+
+# GitHub /tags list response. Thin payload — no tag-object message (annotated
+# tag metadata lives behind per-tag /git/tags/{sha}) and no commit.created_at
+# (lives behind /git/commits/{sha}). short_id is derived from the first 8 sha
+# characters to match GitLab's output.
+FIXTURE_TAGS='[
+  {"name":"v1.2.3","commit":{"sha":"abc123def456abc123def456abc123def456abcd",
+                             "url":"https://api.github.com/repos/o/r/commits/abc123d"},
+   "zipball_url":"https://github.com/o/r/zipball/v1.2.3",
+   "tarball_url":"https://github.com/o/r/tarball/v1.2.3",
+   "node_id":"MDIwOlRhZ1YxLjIuMw=="},
+  {"name":"v1.2.2","commit":{"sha":"fff111aaa222fff111aaa222fff111aaa222fff1",
+                             "url":"https://api.github.com/repos/o/r/commits/fff111a"},
+   "zipball_url":"https://github.com/o/r/zipball/v1.2.2",
+   "tarball_url":"https://github.com/o/r/tarball/v1.2.2",
+   "node_id":"MDIwOlRhZ1YxLjIuMg=="}
+]'
+
+# GitHub /actions/runs response. Envelope-wrapped {total_count, workflow_runs}.
+# The five distinct status/conclusion combinations below are the full state
+# machine ship_decider and release_checker need to reason about.
+FIXTURE_PIPELINES='{"total_count":5,"workflow_runs":[
+  {"id":9001,"name":"CI","head_branch":"main","head_sha":"abc123def456abc123def456abc123def456abcd",
+   "status":"completed","conclusion":"success",
+   "created_at":"2026-04-06T10:00:00Z","updated_at":"2026-04-06T10:15:00Z",
+   "html_url":"https://github.com/o/r/actions/runs/9001"},
+  {"id":9002,"name":"CI","head_branch":"main","head_sha":"def456abc123def456abc123def456abc123def4",
+   "status":"completed","conclusion":"failure",
+   "created_at":"2026-04-06T09:00:00Z","updated_at":"2026-04-06T09:10:00Z",
+   "html_url":"https://github.com/o/r/actions/runs/9002"},
+  {"id":9003,"name":"CI","head_branch":"main","head_sha":"111222333444111222333444111222333444aaaa",
+   "status":"in_progress","conclusion":null,
+   "created_at":"2026-04-06T11:00:00Z","updated_at":"2026-04-06T11:00:00Z",
+   "html_url":"https://github.com/o/r/actions/runs/9003"},
+  {"id":9004,"name":"CI","head_branch":"main","head_sha":"555666777888555666777888555666777888bbbb",
+   "status":"queued","conclusion":null,
+   "created_at":"2026-04-06T11:05:00Z","updated_at":"2026-04-06T11:05:00Z",
+   "html_url":"https://github.com/o/r/actions/runs/9004"},
+  {"id":9005,"name":"CI","head_branch":"main","head_sha":"999aaaabbbbccccdddd999aaaabbbbccccdddd00",
+   "status":"completed","conclusion":"cancelled",
+   "created_at":"2026-04-05T20:00:00Z","updated_at":"2026-04-05T20:05:00Z",
+   "html_url":"https://github.com/o/r/actions/runs/9005"}
+]}'
+
+# GitHub /pulls list response (same shape as code-review/planning/implementation
+# fixtures, no `draft` need here — release-mr view doesnt consume it). The
+# state collapse coverage (open -> opened; closed + merged_at -> merged;
+# closed + null -> closed) is repeated per-colony on purpose: each github-api.sh
+# ships its own normalize_pulls copy and this test certifies *this* copy.
+FIXTURE_PULLS='[
+  {"number":20,"title":"Open PR","body":"desc-20","state":"open","merged_at":null,
+   "labels":[{"name":"release-note"}],"user":{"login":"alice"},
+   "base":{"ref":"main"},"head":{"ref":"feat/x"},
+   "created_at":"2026-04-01T10:00:00Z","updated_at":"2026-04-02T10:00:00Z",
+   "comments":1,"changed_files":3},
+  {"number":21,"title":"Merged PR","body":"desc-21","state":"closed",
+   "merged_at":"2026-04-05T12:00:00Z",
+   "labels":[{"name":"bug"}],"user":{"login":"bob"},
+   "base":{"ref":"main"},"head":{"ref":"fix/y"},
+   "created_at":"2026-04-03T10:00:00Z","updated_at":"2026-04-05T12:00:00Z",
+   "comments":2,"changed_files":5},
+  {"number":22,"title":"Closed No-Merge","body":"desc-22","state":"closed",
+   "merged_at":null,
+   "labels":[],"user":{"login":"carol"},
+   "base":{"ref":"main"},"head":{"ref":"wip/z"},
+   "created_at":"2026-04-04T10:00:00Z","updated_at":"2026-04-04T12:00:00Z",
+   "comments":0}
+]'
+
+# --- Plumbing: source just the function defs (stop before CMD dispatcher) ---
+build_prelude() {
+    awk '/^CMD=/{exit} {print}' "$SCRIPT" > "$1"
+}
+
+run_fn() {
+    local fn="$1" input="$2"
+    shift 2
+    local prelude
+    prelude=$(mktemp)
+    build_prelude "$prelude"
+    # shellcheck disable=SC1090,SC2016
+    GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+        source "$1"
+        input="$2"
+        fn="$3"
+        shift 3
+        printf "%s" "$input" | "$fn" "$@"
+    ' _ "$prelude" "$input" "$fn" "$@"
+    local rc=$?
+    rm -f "$prelude"
+    return $rc
+}
+
+json_extract() {
+    DATA="$1" python3 -c "
+import os, json
+data = json.loads(os.environ['DATA'])
+print($2)
+"
+}
+
+assert_eq() {
+    if [ "$1" = "$2" ]; then
+        pass "$3"
+    else
+        fail "$3: expected='$1' actual='$2'"
+    fi
+}
+
+# --- normalize_releases ---
+RELEASES_OUT=$(run_fn normalize_releases "$FIXTURE_RELEASES")
+R_COUNT=$(json_extract "$RELEASES_OUT" "len(data)")
+assert_eq "2" "$R_COUNT" "normalize_releases: two entries"
+
+R0_TAG=$(json_extract "$RELEASES_OUT" "data[0]['tag_name']")
+R0_NAME=$(json_extract "$RELEASES_OUT" "data[0]['name']")
+R0_DESC=$(json_extract "$RELEASES_OUT" "data[0]['description']")
+R0_RELEASED=$(json_extract "$RELEASES_OUT" "data[0]['released_at']")
+R0_CREATED=$(json_extract "$RELEASES_OUT" "data[0]['created_at']")
+R0_AUTHOR=$(json_extract "$RELEASES_OUT" "data[0]['author']['username']")
+R0_COMMIT=$(json_extract "$RELEASES_OUT" "repr(data[0]['commit'])")
+assert_eq "v1.2.3" "$R0_TAG" "normalize_releases: tag_name preserved"
+assert_eq "Release 1.2.3" "$R0_NAME" "normalize_releases: name preserved"
+assert_eq "- fix: bug A
+- feat: thing B" "$R0_DESC" "normalize_releases: description <- body"
+assert_eq "2026-03-01T12:00:00Z" "$R0_RELEASED" "normalize_releases: released_at <- published_at"
+assert_eq "2026-03-01T10:00:00Z" "$R0_CREATED" "normalize_releases: created_at preserved"
+assert_eq "alice" "$R0_AUTHOR" "normalize_releases: author.username <- author.login"
+assert_eq "None" "$R0_COMMIT" "normalize_releases: commit forwarded null"
+
+# --- normalize_tags ---
+TAGS_OUT=$(run_fn normalize_tags "$FIXTURE_TAGS")
+T_COUNT=$(json_extract "$TAGS_OUT" "len(data)")
+assert_eq "2" "$T_COUNT" "normalize_tags: two entries"
+
+T0_NAME=$(json_extract "$TAGS_OUT" "data[0]['name']")
+T0_MSG=$(json_extract "$TAGS_OUT" "repr(data[0]['message'])")
+T0_TARGET=$(json_extract "$TAGS_OUT" "data[0]['target']")
+T0_COMMIT_ID=$(json_extract "$TAGS_OUT" "data[0]['commit']['id']")
+T0_COMMIT_SHORT=$(json_extract "$TAGS_OUT" "data[0]['commit']['short_id']")
+T0_COMMIT_CREATED=$(json_extract "$TAGS_OUT" "repr(data[0]['commit']['created_at'])")
+assert_eq "v1.2.3" "$T0_NAME" "normalize_tags: name preserved"
+assert_eq "None" "$T0_MSG" "normalize_tags: message forwarded null (no /git/tags round-trip)"
+assert_eq "abc123def456abc123def456abc123def456abcd" "$T0_TARGET" "normalize_tags: target <- commit.sha"
+assert_eq "abc123def456abc123def456abc123def456abcd" "$T0_COMMIT_ID" "normalize_tags: commit.id <- commit.sha"
+assert_eq "abc123de" "$T0_COMMIT_SHORT" "normalize_tags: commit.short_id = sha[:8]"
+assert_eq "None" "$T0_COMMIT_CREATED" "normalize_tags: commit.created_at forwarded null"
+
+# --- normalize_pipelines: status/conclusion collapse is the critical one ---
+PIPE_OUT=$(run_fn normalize_pipelines "$FIXTURE_PIPELINES")
+P_COUNT=$(json_extract "$PIPE_OUT" "len(data)")
+assert_eq "5" "$P_COUNT" "normalize_pipelines: envelope unwrapped to 5 entries"
+
+P0_STATUS=$(json_extract "$PIPE_OUT" "data[0]['status']")
+P1_STATUS=$(json_extract "$PIPE_OUT" "data[1]['status']")
+P2_STATUS=$(json_extract "$PIPE_OUT" "data[2]['status']")
+P3_STATUS=$(json_extract "$PIPE_OUT" "data[3]['status']")
+P4_STATUS=$(json_extract "$PIPE_OUT" "data[4]['status']")
+assert_eq "success" "$P0_STATUS" "normalize_pipelines: completed+success -> success"
+assert_eq "failed"  "$P1_STATUS" "normalize_pipelines: completed+failure -> failed"
+assert_eq "running" "$P2_STATUS" "normalize_pipelines: in_progress -> running"
+assert_eq "pending" "$P3_STATUS" "normalize_pipelines: queued -> pending"
+assert_eq "failed"  "$P4_STATUS" "normalize_pipelines: completed+cancelled -> failed"
+
+P0_ID=$(json_extract "$PIPE_OUT" "data[0]['id']")
+P0_REF=$(json_extract "$PIPE_OUT" "data[0]['ref']")
+P0_SHA=$(json_extract "$PIPE_OUT" "data[0]['sha']")
+P0_CREATED=$(json_extract "$PIPE_OUT" "data[0]['created_at']")
+P0_WEB=$(json_extract "$PIPE_OUT" "data[0]['web_url']")
+assert_eq "9001" "$P0_ID" "normalize_pipelines: id preserved"
+assert_eq "main" "$P0_REF" "normalize_pipelines: ref <- head_branch"
+assert_eq "abc123def456abc123def456abc123def456abcd" "$P0_SHA" "normalize_pipelines: sha <- head_sha"
+assert_eq "2026-04-06T10:00:00Z" "$P0_CREATED" "normalize_pipelines: created_at preserved"
+assert_eq "https://github.com/o/r/actions/runs/9001" "$P0_WEB" "normalize_pipelines: web_url <- html_url"
+
+# Bare-array fallback: /actions/runs normally returns {workflow_runs:[...]}
+# but the normalizer also accepts a raw array so ad-hoc callers (e.g. piping
+# a pre-unwrapped JSON) dont need to re-wrap.
+BARE_PIPE='[{"id":1,"name":"x","head_branch":"main","head_sha":"0000","status":"completed","conclusion":"success","created_at":"2026-01-01T00:00:00Z","html_url":"https://github.com/o/r/actions/runs/1"}]'
+BARE_OUT=$(run_fn normalize_pipelines "$BARE_PIPE")
+BARE_COUNT=$(json_extract "$BARE_OUT" "len(data)")
+BARE_STATUS=$(json_extract "$BARE_OUT" "data[0]['status']")
+assert_eq "1" "$BARE_COUNT" "normalize_pipelines: bare-array input also accepted"
+assert_eq "success" "$BARE_STATUS" "normalize_pipelines: bare-array status collapse still works"
+
+# --- normalize_pulls: state collapse + MR-shape (release-mr-consuming fields) ---
+PULLS_OUT=$(run_fn normalize_pulls "$FIXTURE_PULLS")
+PL_COUNT=$(json_extract "$PULLS_OUT" "len(data)")
+assert_eq "3" "$PL_COUNT" "normalize_pulls: three entries"
+
+PL0_STATE=$(json_extract "$PULLS_OUT" "data[0]['state']")
+PL1_STATE=$(json_extract "$PULLS_OUT" "data[1]['state']")
+PL2_STATE=$(json_extract "$PULLS_OUT" "data[2]['state']")
+assert_eq "opened" "$PL0_STATE" "normalize_pulls: open -> opened"
+assert_eq "merged" "$PL1_STATE" "normalize_pulls: closed + merged_at -> merged"
+assert_eq "closed" "$PL2_STATE" "normalize_pulls: closed + null merged_at stays closed"
+
+PL1_IID=$(json_extract "$PULLS_OUT" "data[1]['iid']")
+PL1_DESC=$(json_extract "$PULLS_OUT" "data[1]['description']")
+PL1_MERGED=$(json_extract "$PULLS_OUT" "data[1]['merged_at']")
+PL1_TGT=$(json_extract "$PULLS_OUT" "data[1]['target_branch']")
+PL1_LABELS=$(json_extract "$PULLS_OUT" "','.join(data[1]['labels'])")
+assert_eq "21" "$PL1_IID" "normalize_pulls: iid <- number"
+assert_eq "desc-21" "$PL1_DESC" "normalize_pulls: description <- body"
+assert_eq "2026-04-05T12:00:00Z" "$PL1_MERGED" "normalize_pulls: merged_at preserved"
+assert_eq "main" "$PL1_TGT" "normalize_pulls: target_branch <- base.ref"
+assert_eq "bug" "$PL1_LABELS" "normalize_pulls: labels flattened to strings"
+
+# --- End-to-end: project_json views consume normalized output ---
+# release-summary: 4 keys (tag_name, name, released_at, description)
+E2E_RS=$(
+    PRELUDE=$(mktemp)
+    build_prelude "$PRELUDE"
+    # shellcheck disable=SC1090,SC2016
+    GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+        source "$1"
+        printf "%s" "$2" | normalize_releases | project_json release-summary
+    ' _ "$PRELUDE" "$FIXTURE_RELEASES"
+    rm -f "$PRELUDE"
+)
+E2E_RS_KEYS=$(json_extract "$E2E_RS" "','.join(sorted(data[0].keys()))")
+E2E_RS_TAG=$(json_extract "$E2E_RS" "data[0]['tag_name']")
+assert_eq "description,name,released_at,tag_name" "$E2E_RS_KEYS" "e2e release-summary: view keys match gitlab"
+assert_eq "v1.2.3" "$E2E_RS_TAG" "e2e release-summary: tag_name through pipe"
+
+# tag-summary: 3 top-level keys (name, message, commit); commit has short_id, created_at
+E2E_TS=$(
+    PRELUDE=$(mktemp)
+    build_prelude "$PRELUDE"
+    # shellcheck disable=SC1090,SC2016
+    GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+        source "$1"
+        printf "%s" "$2" | normalize_tags | project_json tag-summary
+    ' _ "$PRELUDE" "$FIXTURE_TAGS"
+    rm -f "$PRELUDE"
+)
+E2E_TS_KEYS=$(json_extract "$E2E_TS" "','.join(sorted(data[0].keys()))")
+E2E_TS_COMMIT_KEYS=$(json_extract "$E2E_TS" "','.join(sorted(data[0]['commit'].keys()))")
+E2E_TS_SHORT=$(json_extract "$E2E_TS" "data[0]['commit']['short_id']")
+assert_eq "commit,message,name" "$E2E_TS_KEYS" "e2e tag-summary: top-level keys match gitlab"
+assert_eq "created_at,short_id" "$E2E_TS_COMMIT_KEYS" "e2e tag-summary: commit keys match gitlab"
+assert_eq "abc123de" "$E2E_TS_SHORT" "e2e tag-summary: short_id through pipe"
+
+# pipeline-summary: 6 keys (id, status, ref, sha, created_at, web_url)
+E2E_PS=$(
+    PRELUDE=$(mktemp)
+    build_prelude "$PRELUDE"
+    # shellcheck disable=SC1090,SC2016
+    GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+        source "$1"
+        printf "%s" "$2" | normalize_pipelines | project_json pipeline-summary
+    ' _ "$PRELUDE" "$FIXTURE_PIPELINES"
+    rm -f "$PRELUDE"
+)
+E2E_PS_KEYS=$(json_extract "$E2E_PS" "','.join(sorted(data[0].keys()))")
+E2E_PS_STATUS=$(json_extract "$E2E_PS" "data[0]['status']")
+assert_eq "created_at,id,ref,sha,status,web_url" "$E2E_PS_KEYS" "e2e pipeline-summary: view keys match gitlab"
+assert_eq "success" "$E2E_PS_STATUS" "e2e pipeline-summary: status through pipe"
+
+# release-mr: 6 keys (iid, title, description, merged_at, labels, target_branch)
+E2E_MR=$(
+    PRELUDE=$(mktemp)
+    build_prelude "$PRELUDE"
+    # shellcheck disable=SC1090,SC2016
+    GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+        source "$1"
+        printf "%s" "$2" | normalize_pulls | project_json release-mr
+    ' _ "$PRELUDE" "$FIXTURE_PULLS"
+    rm -f "$PRELUDE"
+)
+E2E_MR_KEYS=$(json_extract "$E2E_MR" "','.join(sorted(data[0].keys()))")
+E2E_MR_IID=$(json_extract "$E2E_MR" "data[1]['iid']")
+E2E_MR_STATE_MERGED=$(json_extract "$E2E_MR" "data[1]['merged_at']")
+assert_eq "description,iid,labels,merged_at,target_branch,title" "$E2E_MR_KEYS" "e2e release-mr: view keys match gitlab"
+assert_eq "21" "$E2E_MR_IID" "e2e release-mr: iid through pipe"
+assert_eq "2026-04-05T12:00:00Z" "$E2E_MR_STATE_MERGED" "e2e release-mr: merged_at through pipe"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-gitlab-views.sh
+++ b/tools/test-gitlab-views.sh
@@ -390,6 +390,33 @@ if [ -f "$GH_CODE_REVIEW_SCRIPT" ]; then
     fi
 fi
 
+# --- release github-api.sh project_json parity (#256 PR 6) ---
+# release/scripts/github-api.sh duplicates project_json rather than sourcing
+# gitlab-api.sh. The release-specific views are `release-summary`,
+# `tag-summary`, `pipeline-summary`, and `release-mr`; all must emit
+# byte-identical JSON to their gitlab twin when fed an already-GitLab-shape
+# fixture. Drift here means a view in github-api.sh silently ships a
+# different projection than its gitlab twin.
+GH_RELEASE_SCRIPT="$REPO_ROOT/dev-apprenticeship/release/scripts/github-api.sh"
+if [ -f "$GH_RELEASE_SCRIPT" ]; then
+    for pair in \
+        "release-summary:$FIXTURE_RELEASES" \
+        "tag-summary:$FIXTURE_TAGS" \
+        "pipeline-summary:$FIXTURE_PIPELINES" \
+        "release-mr:$FIXTURE_MRS"
+    do
+        view="${pair%%:*}"
+        fixture="${pair#*:}"
+        gl_out=$(run_view "$REPO_ROOT/dev-apprenticeship/release/scripts/gitlab-api.sh" "$view" "$fixture")
+        gh_out=$(run_view_github "$GH_RELEASE_SCRIPT" "$view" "$fixture")
+        if [ "$gl_out" = "$gh_out" ]; then
+            pass "release github-api.sh project_json parity: $view"
+        else
+            fail "release github-api.sh project_json drifted from gitlab-api.sh: $view"
+        fi
+    done
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

PR 6 of 7 for [#256](https://github.com/Replikanti/agentis-colonies/issues/256) (forge abstraction). Ships the release colony's `github-api.sh` against GitHub REST API v3, normalizing to GitLab shape so the four release agents see identical JSON across backends.

**7 subcommands:** `releases`, `tags`, `pipelines`, `merge-requests`, `create-tag`, `create-release`, `post-note`.

**Three release-specific semantic collapses:**

- **`normalize_tags` forwards `message` + `commit.created_at` as `null`** rather than doing per-tag `/git/refs/tags` + `/git/tags` + `/git/commits` round-trips (~20 extra API calls per `tags` list read). The one consumer — release_checker's `tag-summary` view — only needs `name` + `commit.short_id` for prompt context, and `short_id` is derived as `sha[:8]` locally.
- **`normalize_pipelines` unwraps `{total_count, workflow_runs: [...]}`** and collapses the 2-axis `(status, conclusion)` matrix to GitLab's single-field `status`: `completed+success/skipped/neutral` → `success`, `completed+failure/cancelled/timed_out/action_required/stale` → `failed`, `in_progress` → `running`, `queued/requested/waiting/pending` → `pending`.
- **`normalize_releases` maps `body` → `description`, `published_at` → `released_at`, `author.login` → `author.username`**; `commit` forwarded as `null` (not carried inline by GitHub `/releases` — changelog_writer reads it from `tags` instead).

**`create-tag` implements the 3-step annotated-tag dance** (resolve ref → `POST /git/tags` → `POST /git/refs`). Short-circuits to a single `POST /git/refs` for lightweight tags when no `--message`.

**29 `.ag` call sites migrated** across `version_bumper`, `ship_decider`, `release_checker`, `changelog_writer` from `scripts/gitlab-api.sh` to `scripts/forge-api.sh`.

**Bonus fix (PR 4 QA F1):** `release/scripts/start-colony.sh` now honors `[forge.gitlab].default_branch` and `[forge.github].default_branch`; pre-PR 6 it silently fell back only to legacy `[gitlab].default_branch`.

## Tests

- **`tools/test-github-release-normalize.sh`** (new) — 47 assertions covering all four normalizers with the full status/conclusion matrix, annotated-vs-lightweight tag fixtures, the envelope-unwrap fallback, and end-to-end pipes through all four release views.
- **`tools/test-gitlab-views.sh`** — extended with release parity block: byte-identical `project_json` output for `release-summary`, `tag-summary`, `pipeline-summary`, `release-mr` across `github-api.sh` / `gitlab-api.sh`.
- **`colony-lint.sh`**: 101 passed, 0 failed, 1 skipped (baseline 100 + 1 new test).

## Test plan

- [x] `./tools/test-github-release-normalize.sh` — 47/47 pass
- [x] `./tools/test-gitlab-views.sh` — 63/63 pass (59 baseline + 4 release parity)
- [x] `./tools/colony-lint.sh` — 101 passed, 0 failed, 1 skipped
- [x] `check-forge-dispatch` green (release no longer references `gitlab-api.sh` directly)
- [ ] Post-merge: 1 PR remaining (PR 7: rate-limit-status + dashboard tile + retire legacy `[gitlab]` section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)