### PR TITLE
feat(#256)!: rate-limit primitive + retire legacy [gitlab] (PR 7 of 7, MAJOR)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -255,8 +255,64 @@ is asserted until multi-version CI is in place.
   `github-api.sh` and `gitlab-api.sh` for the `release-summary`,
   `tag-summary`, `pipeline-summary`, and `release-mr` views.
   [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
+- **Forge rate-limit primitive (PR 7 of 7 for #256).** Every per-colony
+  forge wrapper now supports a `rate-limit-status` subcommand that
+  emits a uniform `{"remaining": <int|null>, "limit": <int|null>,
+  "reset_at": <ISO-8601 UTC|null>}` JSON object. Both backends share
+  the same output contract; the source differs. GitHub reads
+  `/rate_limit` (an uncounted endpoint so operators can poll without
+  burning budget). GitLab reads `RateLimit-*` response headers off a
+  cheap `GET /api/v4/version` call — self-hosted GitLab instances
+  without rate-limiting configured (the common case) return no
+  headers; the arm forwards `null`s and exits 0 rather than
+  hard-failing, so operator dashboards can distinguish
+  "not-configured" from "over-budget" without a wrapper error.
+  Transport failure on GitHub propagates the non-zero `gh_call` exit;
+  transport failure on GitLab still yields exit 0 with nulls (the
+  absence of a `RateLimit-Remaining` header is identical to a DNS-less
+  self-hosted instance, by design). Dashboard consumption is
+  deliberately deferred to a separate `federation-dashboard` release so
+  a UI churn does not gate the federation's v1.0.0. New test:
+  `tools/test-rate-limit-status.sh` (25 assertions: 5 colonies × 3
+  GitLab modes + 5 colonies × 2 GitHub modes).
+  [#256](https://github.com/Replikanti/agentis-colonies/issues/256)
 
 ### Changed
+
+- **BREAKING (MAJOR, v1.0.0) — legacy top-level `[gitlab]` config
+  section retired federation-wide (#256 PR 7).** The transitional
+  dual-read behavior introduced in PR 1 has ended. All 5
+  `colony.example.toml` templates now ship `[forge.gitlab]` only (no
+  top-level `[gitlab]`). All 5 `scripts/start-colony.sh` scripts read
+  from `[forge.gitlab]` / `[forge.github]` and emit an explicit
+  "Required: url, token, project under [forge.gitlab]" error when the
+  section is missing — the pre-PR-7 fallback to a bare `[gitlab]`
+  section has been removed. `install.sh` no longer writes into the
+  legacy section. `tools/colony-lint.sh` gains a guard that flags a
+  top-level `[gitlab]` in any `colony.example.toml` as a retirement
+  regression. **Operator migration:** edit each `colony.toml`, rename
+  `[gitlab]` → `[forge.gitlab]`, and add a top-level `[forge]` block
+  with `type = "gitlab"` (see `colony.example.toml` for the exact
+  shape). The `me` / `default_branch` keys move with the section.
+  Pre-#256 installs that cannot migrate should stay on
+  `dev-apprenticeship v0.3.3` (the last release carrying the
+  dual-read fallback).
+- **BREAKING (MAJOR, v1.0.0) — install.sh GitHub credential prompting
+  (#256 PR 7).** The "GitHub scaffolding is partial, continue anyway?"
+  abort gate that guarded pre-PR-6 installs has been removed — both
+  backends are first-class after PR 6. Credential prompting now branches
+  on `FORGE_TYPE`: `gitlab` prompts for url/project/PAT/me and writes
+  `[forge.gitlab]` (identical semantics to v0.3.x); `github` prompts for
+  owner/repo/PAT plus optional Enterprise URL and optional `me`,
+  uncomments the `[forge.github]` template block in `colony.toml`, and
+  writes the credentials into it. `FEDERATION_FORGE_TYPE=github
+  ./install.sh` is now a supported unattended flow.
+- `.dashboard-version` floor bumped to 0.2.0. The new dashboard release
+  delegates agent restarts through `start-colony.sh --restart-agent`
+  instead of parsing `[gitlab]` from `colony.toml` — pairing a 0.1.0
+  dashboard with a 1.x federation is still safe (the dashboard
+  gracefully logs `start-colony.sh exit 2: unknown flag`), but the
+  recommended floor matches the pair tested together.
 
 - `.dashboard-version` floor bumped to 0.2.0. The new dashboard release
   delegates agent restarts through `start-colony.sh --restart-agent`

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -307,20 +307,6 @@ is asserted until multi-version CI is in place.
   uncomments the `[forge.github]` template block in `colony.toml`, and
   writes the credentials into it. `FEDERATION_FORGE_TYPE=github
   ./install.sh` is now a supported unattended flow.
-- `.dashboard-version` floor bumped to 0.2.0. The new dashboard release
-  delegates agent restarts through `start-colony.sh --restart-agent`
-  instead of parsing `[gitlab]` from `colony.toml` — pairing a 0.1.0
-  dashboard with a 1.x federation is still safe (the dashboard
-  gracefully logs `start-colony.sh exit 2: unknown flag`), but the
-  recommended floor matches the pair tested together.
-
-- `.dashboard-version` floor bumped to 0.2.0. The new dashboard release
-  delegates agent restarts through `start-colony.sh --restart-agent`
-  instead of parsing `[gitlab]` from `colony.toml` — pairing a 0.1.0
-  dashboard with a 1.x federation is still safe (the dashboard
-  gracefully logs `start-colony.sh exit 2: unknown flag`), but the
-  recommended floor matches the pair tested together.
-
 ### Deprecated
 
 ### Removed

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -306,7 +306,7 @@ Cross-colony wiring: Triage routes issues to Implementation. Implementation sign
 
 Every `learn()` call in the federation's agents tags entries with one of `observed` (shadow tier: passive learning from GitLab activity), `emitted` (propose tier: suggestion logged with draft external write), `review-gated` (review-gated tier: direct non-terminal external write under the review gate), or `acted` (autonomous tier: terminal external write with no second gate) plus the colony name (`triage`, `code-review`, `planning`, `implementation`, `release`). See [`doc/auto-promote.md#classification`](../doc/auto-promote.md#classification) for how the auto-promote heuristic consumes these tags.
 
-**Personal vs team (`#104`).** If you set your GitLab username during `./install.sh` (or in `colony.toml` under `[gitlab] me = "..."`), three agents additionally tag their `learn()` calls as either `personal` (the issue/MR author matches your username) or `team` (anyone else):
+**Personal vs team (`#104`).** If you set your forge username during `./install.sh` (or in `colony.toml` under `[forge.gitlab] me = "..."` / `[forge.github] me = "..."`), three agents additionally tag their `learn()` calls as either `personal` (the issue/MR author matches your username) or `team` (anyone else):
 
 - `labeler` — tags every tier's entries
 - `prioritizer` — tags every tier's entries

--- a/dev-apprenticeship/code-review/README.md
+++ b/dev-apprenticeship/code-review/README.md
@@ -47,8 +47,8 @@ When a new merge request appears, all four reviewers analyze it in parallel, eac
 
 `logic_reviewer`, `style_reviewer`, `security_reviewer`, and `approval_decider` follow the federation's **delta-check + early-exit** convention so a quiet repo costs ~0 LLM calls/h:
 
-- **MR reviewers** (`logic`, `style`, `security`): a single `gitlab-api.sh merge-requests --since <last_check> --view reviewer` call filters server-side. An empty response (`[]`) → refresh `last_check` and `return` before any `prompt()`.
-- **Approval decider**: has no GitLab poll. It listens on four bus topics (`review:{style,logic,security,test}_findings`); when all four `listen()` calls return Void (the empty inbox case), `return` before any `prompt()`. `last_check` is still refreshed on the early-exit path so operators can distinguish "nothing to do" from "daemon stalled".
+- **MR reviewers** (`logic`, `style`, `security`): a single `forge-api.sh merge-requests --since <last_check> --view reviewer` call filters server-side. An empty response (`[]`) → refresh `last_check` and `return` before any `prompt()`.
+- **Approval decider**: has no forge poll. It listens on four bus topics (`review:{style,logic,security,test}_findings`); when all four `listen()` calls return Void (the empty inbox case), `return` before any `prompt()`. `last_check` is still refreshed on the early-exit path so operators can distinguish "nothing to do" from "daemon stalled".
 
 See `agents/logic_reviewer.ag` for the canonical MR-reviewer shape and `agents/approval_decider.ag` for the event-driven variant.
 
@@ -59,13 +59,17 @@ See `agents/logic_reviewer.ag` for the canonical MR-reviewer shape and `agents/a
    cp config/colony.example.toml config/colony.toml
    ```
 
-2. Configure your GitLab connection:
+2. Configure your forge connection. For GitLab:
    ```toml
-   [gitlab]
-   url = "https://gitlab.example.com"
-   token = "glpat-..."
+   [forge]
+   type = "gitlab"
+
+   [forge.gitlab]
+   url     = "https://gitlab.example.com"
+   token   = "glpat-..."
    project = "your-org/your-project"
    ```
+   For GitHub, set `[forge].type = "github"` and populate `[forge.github]` (see `colony.example.toml`).
 
 3. Configure the LLM backend:
    ```toml
@@ -112,7 +116,8 @@ agentis knowledge list --tags acted         # autonomous terminal writes
 
 # style_reviewer additionally tags its direct-write (review-gated + acted)
 # branches with `personal` or `team` based on the MR author (requires
-# `[gitlab] me = "..."` in colony.toml — see dev-apprenticeship/README.md).
+# `[forge.gitlab] me = "..."` / `[forge.github] me = "..."` in colony.toml
+# — see dev-apprenticeship/README.md).
 agentis knowledge list --tags personal      # style_reviewer on your MRs
 agentis knowledge list --tags team          # style_reviewer on others' MRs
 

--- a/dev-apprenticeship/code-review/config/colony.example.toml
+++ b/dev-apprenticeship/code-review/config/colony.example.toml
@@ -22,6 +22,7 @@ project = "your-org/your-project"
 me      = ""  # your GitLab username (optional, enables personal/team tagging)
 
 # [forge.github]
+# url   = "https://api.github.com"  # optional; override for GitHub Enterprise
 # owner = "your-org-or-user"
 # repo  = "your-repo"
 # token = "ghp_your-token-here"

--- a/dev-apprenticeship/code-review/config/colony.example.toml
+++ b/dev-apprenticeship/code-review/config/colony.example.toml
@@ -9,9 +9,9 @@ tick_interval_ms = 60000
 
 # Forge backend selection (ADR-0002, #256). `type` picks which of the
 # per-backend blocks below is active. Legal values: "gitlab", "github".
-# The top-level [gitlab] section below is retained for backwards
-# compatibility during the migration window — one release of overlap.
-# It is retired in the final PR of the port (PR 7 of #256).
+# The legacy top-level [gitlab] section was retired in PR 7 of #256
+# (MAJOR bump). Operators on pre-#256 configs: move your url/token/
+# project/me keys into [forge.gitlab] and set [forge].type = "gitlab".
 [forge]
 type = "gitlab"
 
@@ -26,12 +26,6 @@ me      = ""  # your GitLab username (optional, enables personal/team tagging)
 # repo  = "your-repo"
 # token = "ghp_your-token-here"
 # me    = ""  # your GitHub username (optional)
-
-[gitlab]
-url = "https://gitlab.example.com"
-token = "glpat-your-token-here"
-project = "your-org/your-project"
-me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.

--- a/dev-apprenticeship/code-review/scripts/github-api.sh
+++ b/dev-apprenticeship/code-review/scripts/github-api.sh
@@ -439,6 +439,31 @@ PY
         gh_post "$API/pulls/$NUM/reviews" '{"event":"APPROVE"}'
         ;;
 
+    rate-limit-status)
+        # GitHub's /rate_limit endpoint does NOT count against the
+        # authenticated REST budget, so dashboards can poll this freely.
+        # Normalize the "core" resource (the same bucket REST reads draw
+        # from) to the GitLab-shape {remaining, limit, reset_at} contract.
+        # ADR-0002 PR 7 of 7 for #256.
+        resp="$(gh_get "$GITHUB_URL/rate_limit")" || exit $?
+        RATE_RESP="$resp" python3 <<'PY'
+import os, json, datetime
+try:
+    d = json.loads(os.environ["RATE_RESP"])
+except Exception:
+    print(json.dumps({"remaining": None, "limit": None, "reset_at": None}))
+    raise SystemExit(0)
+# Prefer resources.core (matches what REST reads draw from); fall back
+# to the top-level rate summary for old GHE instances that omit it.
+core = (d.get("resources") or {}).get("core") or d.get("rate") or {}
+reset = core.get("reset")
+reset_at = None
+if isinstance(reset, (int, float)):
+    reset_at = datetime.datetime.fromtimestamp(int(reset), tz=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+print(json.dumps({"remaining": core.get("remaining"), "limit": core.get("limit"), "reset_at": reset_at}))
+PY
+        ;;
+
     *)
         emit_error "unknown command: $CMD"
         exit 1

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -290,6 +290,50 @@ case "$CMD" in
         gl_post "$API/merge_requests/$IID/approve" "{}"
         ;;
 
+    rate-limit-status)
+        # GitLab does NOT have a dedicated rate-limit endpoint. We trigger
+        # a lightweight /version call and extract RateLimit-* response
+        # headers (documented at GitLab "User and IP rate limits"). Self-
+        # hosted instances with rate limiting disabled return no such
+        # headers; we forward nulls in that case so the dashboard tile
+        # renders "—" instead of a spurious "0 remaining".
+        # ADR-0002 PR 7 of 7 for #256.
+        hdr_file="$(mktemp)"
+        # /version is the cheapest authenticated endpoint. -D dumps
+        # response headers; -o discards body; || : keeps a transport
+        # failure from killing the script (nulls forwarded in that case).
+        curl -sS -D "$hdr_file" -o /dev/null \
+            --max-time "${GITLAB_CURL_MAX_TIME:-30}" \
+            -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+            "$GITLAB_URL/api/v4/version" 2>/dev/null || :
+        HDR_FILE="$hdr_file" python3 <<'PY'
+import os, json, datetime, re
+try:
+    with open(os.environ["HDR_FILE"], "r", errors="replace") as f:
+        lines = f.readlines()
+except Exception:
+    lines = []
+hdrs = {}
+for ln in lines:
+    m = re.match(r"([^:]+):\s*(.+?)\s*$", ln)
+    if m:
+        hdrs[m.group(1).lower()] = m.group(2)
+def _int(s):
+    try:
+        return int(s) if s is not None else None
+    except Exception:
+        return None
+remaining = _int(hdrs.get("ratelimit-remaining"))
+limit = _int(hdrs.get("ratelimit-limit"))
+reset = _int(hdrs.get("ratelimit-reset"))
+reset_at = None
+if reset is not None:
+    reset_at = datetime.datetime.fromtimestamp(reset, tz=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+print(json.dumps({"remaining": remaining, "limit": limit, "reset_at": reset_at}))
+PY
+        rm -f "$hdr_file"
+        ;;
+
     *)
         emit_error "unknown command: $CMD"
         exit 1

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -67,30 +67,26 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 . "$REPO_ROOT/tools/parse-toml.sh"
 
 # #256: forge backend selection. `[forge].type` picks which backend
-# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
-# configs keep working unchanged. PR 5 of #256 ships the code-review
-# colony's github-api.sh, so FORGE_TYPE=github is now live for
-# code-review (the release colony still returns exit 99 "not
-# implemented" until PR 6 lands).
+# wrapper forge-api.sh dispatches to. Legal values: "gitlab", "github".
+# PR 7 of #256 (MAJOR bump) made `[forge]` authoritative and retired
+# the legacy top-level `[gitlab]` section. `parse_toml forge type`
+# defaults to "gitlab" when unset so a fresh colony.toml that lists
+# only `[forge.gitlab]` without the selector still launches cleanly.
 FORGE_TYPE=$(parse_toml forge type)
 FORGE_TYPE="${FORGE_TYPE:-gitlab}"
 
 case "$FORGE_TYPE" in
     gitlab)
-        # Prefer [forge.gitlab] (ADR-0002) if present; fall back to legacy
-        # [gitlab] so pre-#256 configs keep working during the overlap window.
+        # PR 7 of #256 (MAJOR bump) made [forge.gitlab] authoritative.
+        # The legacy top-level [gitlab] fallback branches retired here.
         GITLAB_URL=$(parse_toml forge.gitlab url)
-        [ -z "$GITLAB_URL" ] && GITLAB_URL=$(parse_toml gitlab url)
         GITLAB_TOKEN=$(parse_toml forge.gitlab token)
-        [ -z "$GITLAB_TOKEN" ] && GITLAB_TOKEN=$(parse_toml gitlab token)
         GITLAB_PROJECT_RAW=$(parse_toml forge.gitlab project)
-        [ -z "$GITLAB_PROJECT_RAW" ] && GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
         GITLAB_ME=$(parse_toml forge.gitlab me)
-        [ -z "$GITLAB_ME" ] && GITLAB_ME=$(parse_toml gitlab me)
 
         if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
             echo "Error: GitLab config incomplete in $CONFIG"
-            echo "Required: url, token, project under [forge.gitlab] (or legacy [gitlab])"
+            echo "Required: url, token, project under [forge.gitlab]"
             exit 1
         fi
 

--- a/dev-apprenticeship/implementation/README.md
+++ b/dev-apprenticeship/implementation/README.md
@@ -49,7 +49,7 @@ When an issue is assigned, the Code Writer produces an implementation draft. The
 
 3. (Optional) Override `[implementation] trigger_label` if your project uses a label other than `implementation` to signal an issue is ready for implementation work. Scoped labels (`DEV::in progress`) and labels with spaces are supported — `--data-urlencode` handles the encoding (#225).
 
-4. (Optional) Override `[gitlab] default_branch` if your project's primary branch is not `main` (e.g. `master`, `develop`, `trunk`). `code_writer` uses this as the MR target branch when opening merge requests (#224).
+4. (Optional) Override `[forge.gitlab] default_branch` (or `[forge.github] default_branch`) if your project's primary branch is not `main` (e.g. `master`, `develop`, `trunk`). `code_writer` uses this as the MR/PR target branch when opening merge/pull requests (#224).
 
 5. Start the colony:
    ```bash

--- a/dev-apprenticeship/implementation/config/colony.example.toml
+++ b/dev-apprenticeship/implementation/config/colony.example.toml
@@ -23,6 +23,7 @@ me             = ""      # your GitLab username (optional)
 default_branch = "main"  # primary branch (#224)
 
 # [forge.github]
+# url            = "https://api.github.com"  # optional; override for GitHub Enterprise
 # owner          = "your-org-or-user"
 # repo           = "your-repo"
 # token          = "ghp_your-token-here"

--- a/dev-apprenticeship/implementation/config/colony.example.toml
+++ b/dev-apprenticeship/implementation/config/colony.example.toml
@@ -9,9 +9,9 @@ tick_interval_ms = 60000
 
 # Forge backend selection (ADR-0002, #256). `type` picks which of the
 # per-backend blocks below is active. Legal values: "gitlab", "github".
-# The top-level [gitlab] section below is retained for backwards
-# compatibility during the migration window — one release of overlap.
-# It is retired in the final PR of the port (PR 7 of #256).
+# The legacy top-level [gitlab] section was retired in PR 7 of #256
+# (MAJOR bump). Operators on pre-#256 configs: move your url/token/
+# project/me keys into [forge.gitlab] and set [forge].type = "gitlab".
 [forge]
 type = "gitlab"
 
@@ -28,13 +28,6 @@ default_branch = "main"  # primary branch (#224)
 # token          = "ghp_your-token-here"
 # me             = ""      # your GitHub username (optional)
 # default_branch = "main"  # primary branch
-
-[gitlab]
-url = "https://gitlab.example.com"
-token = "glpat-your-token-here"
-project = "your-org/your-project"
-me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
-default_branch = "main"  # primary branch — override for projects using "master", "develop", "trunk", etc. (#224)
 
 [implementation]
 # GitLab label used to filter issues that are ready for implementation work.

--- a/dev-apprenticeship/implementation/scripts/github-api.sh
+++ b/dev-apprenticeship/implementation/scripts/github-api.sh
@@ -13,9 +13,11 @@
 #                                 "implementation", parity with gitlab-api.sh)
 #   GITLAB_DEFAULT_BRANCH         base/target branch for create-branch +
 #                                 create-mr (default "main"). The name is
-#                                 a GitLab holdover — ADR-0002 keeps it for
-#                                 backend-agnostic dispatch; PR 7 may rename
-#                                 when [gitlab] retires.
+#                                 a GitLab holdover kept for backend-agnostic
+#                                 dispatch (ADR-0002); renaming the env var
+#                                 was deferred past #256 to avoid an extra
+#                                 cross-colony churn — operators still set
+#                                 the value via [forge.<backend>] default_branch.
 #   GITHUB_ME                     authenticated-user login (optional, used
 #                                 to scope assigned-issues)
 #   GITHUB_CURL_MAX_TIME          per-attempt --max-time seconds (default 90)
@@ -872,6 +874,31 @@ PY
         esac
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
         gh_post "$API/issues/$IID/comments" "$JSON_BODY"
+        ;;
+
+    rate-limit-status)
+        # GitHub's /rate_limit endpoint does NOT count against the
+        # authenticated REST budget, so dashboards can poll this freely.
+        # Normalize the "core" resource (the same bucket REST reads draw
+        # from) to the GitLab-shape {remaining, limit, reset_at} contract.
+        # ADR-0002 PR 7 of 7 for #256.
+        resp="$(gh_get "$GITHUB_URL/rate_limit")" || exit $?
+        RATE_RESP="$resp" python3 <<'PY'
+import os, json, datetime
+try:
+    d = json.loads(os.environ["RATE_RESP"])
+except Exception:
+    print(json.dumps({"remaining": None, "limit": None, "reset_at": None}))
+    raise SystemExit(0)
+# Prefer resources.core (matches what REST reads draw from); fall back
+# to the top-level rate summary for old GHE instances that omit it.
+core = (d.get("resources") or {}).get("core") or d.get("rate") or {}
+reset = core.get("reset")
+reset_at = None
+if isinstance(reset, (int, float)):
+    reset_at = datetime.datetime.fromtimestamp(int(reset), tz=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+print(json.dumps({"remaining": core.get("remaining"), "limit": core.get("limit"), "reset_at": reset_at}))
+PY
         ;;
 
     *)

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -605,6 +605,50 @@ PY
         gl_post "$API/merge_requests/$IID/notes" "$JSON_BODY"
         ;;
 
+    rate-limit-status)
+        # GitLab does NOT have a dedicated rate-limit endpoint. We trigger
+        # a lightweight /version call and extract RateLimit-* response
+        # headers (documented at GitLab "User and IP rate limits"). Self-
+        # hosted instances with rate limiting disabled return no such
+        # headers; we forward nulls in that case so the dashboard tile
+        # renders "—" instead of a spurious "0 remaining".
+        # ADR-0002 PR 7 of 7 for #256.
+        hdr_file="$(mktemp)"
+        # /version is the cheapest authenticated endpoint. -D dumps
+        # response headers; -o discards body; || : keeps a transport
+        # failure from killing the script (nulls forwarded in that case).
+        curl -sS -D "$hdr_file" -o /dev/null \
+            --max-time "${GITLAB_CURL_MAX_TIME:-30}" \
+            -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+            "$GITLAB_URL/api/v4/version" 2>/dev/null || :
+        HDR_FILE="$hdr_file" python3 <<'PY'
+import os, json, datetime, re
+try:
+    with open(os.environ["HDR_FILE"], "r", errors="replace") as f:
+        lines = f.readlines()
+except Exception:
+    lines = []
+hdrs = {}
+for ln in lines:
+    m = re.match(r"([^:]+):\s*(.+?)\s*$", ln)
+    if m:
+        hdrs[m.group(1).lower()] = m.group(2)
+def _int(s):
+    try:
+        return int(s) if s is not None else None
+    except Exception:
+        return None
+remaining = _int(hdrs.get("ratelimit-remaining"))
+limit = _int(hdrs.get("ratelimit-limit"))
+reset = _int(hdrs.get("ratelimit-reset"))
+reset_at = None
+if reset is not None:
+    reset_at = datetime.datetime.fromtimestamp(reset, tz=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+print(json.dumps({"remaining": remaining, "limit": limit, "reset_at": reset_at}))
+PY
+        rm -f "$hdr_file"
+        ;;
+
     *)
         emit_error "unknown command: $CMD"
         exit 1

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -67,30 +67,26 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 . "$REPO_ROOT/tools/parse-toml.sh"
 
 # #256: forge backend selection. `[forge].type` picks which backend
-# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
-# configs keep working unchanged. PR 4 of #256 ships the implementation
-# colony's github-api.sh, so FORGE_TYPE=github is now live for
-# implementation (other colonies still return exit 99 "not implemented"
-# until their respective PRs land).
+# wrapper forge-api.sh dispatches to. Legal values: "gitlab", "github".
+# PR 7 of #256 (MAJOR bump) made `[forge]` authoritative and retired
+# the legacy top-level `[gitlab]` section. `parse_toml forge type`
+# defaults to "gitlab" when unset so a fresh colony.toml that lists
+# only `[forge.gitlab]` without the selector still launches cleanly.
 FORGE_TYPE=$(parse_toml forge type)
 FORGE_TYPE="${FORGE_TYPE:-gitlab}"
 
 case "$FORGE_TYPE" in
     gitlab)
-        # Prefer [forge.gitlab] (ADR-0002) if present; fall back to legacy
-        # [gitlab] so pre-#256 configs keep working during the overlap window.
+        # PR 7 of #256 (MAJOR bump) made [forge.gitlab] authoritative.
+        # The legacy top-level [gitlab] fallback branches retired here.
         GITLAB_URL=$(parse_toml forge.gitlab url)
-        [ -z "$GITLAB_URL" ] && GITLAB_URL=$(parse_toml gitlab url)
         GITLAB_TOKEN=$(parse_toml forge.gitlab token)
-        [ -z "$GITLAB_TOKEN" ] && GITLAB_TOKEN=$(parse_toml gitlab token)
         GITLAB_PROJECT_RAW=$(parse_toml forge.gitlab project)
-        [ -z "$GITLAB_PROJECT_RAW" ] && GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
         GITLAB_ME=$(parse_toml forge.gitlab me)
-        [ -z "$GITLAB_ME" ] && GITLAB_ME=$(parse_toml gitlab me)
 
         if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
             echo "Error: GitLab config incomplete in $CONFIG"
-            echo "Required: url, token, project under [forge.gitlab] (or legacy [gitlab])"
+            echo "Required: url, token, project under [forge.gitlab]"
             exit 1
         fi
 
@@ -139,14 +135,11 @@ esac
 # consume IMPLEMENTATION_TRIGGER_LABEL identically.
 IMPLEMENTATION_TRIGGER_LABEL=$(parse_toml implementation trigger_label)
 
-# #224: primary branch name. Prefer the ADR-0002 sections first so
-# operators who move everything under [forge.*] aren't silently ignored,
-# then fall back to the legacy [gitlab].default_branch for pre-#256
-# configs. All three forms yield the same GITLAB_DEFAULT_BRANCH env var
-# that both backend wrappers consume (${GITLAB_DEFAULT_BRANCH:-main}).
-# The env var name is kept as GITLAB_DEFAULT_BRANCH for cross-backend
-# parity; PR 7 of #256 may rename it when the legacy [gitlab] section
-# retires.
+# #224: primary branch name. Read from whichever of [forge.gitlab] or
+# [forge.github] the operator selected via [forge].type. The env var
+# is kept as GITLAB_DEFAULT_BRANCH for cross-backend parity (both
+# backend wrappers consume ${GITLAB_DEFAULT_BRANCH:-main}). PR 7 of
+# #256 retired the legacy top-level [gitlab].default_branch fallback.
 case "$FORGE_TYPE" in
     github)
         GITLAB_DEFAULT_BRANCH=$(parse_toml forge.github default_branch)
@@ -155,7 +148,6 @@ case "$FORGE_TYPE" in
         GITLAB_DEFAULT_BRANCH=$(parse_toml forge.gitlab default_branch)
         ;;
 esac
-[ -z "$GITLAB_DEFAULT_BRANCH" ] && GITLAB_DEFAULT_BRANCH=$(parse_toml gitlab default_branch)
 
 export FORGE_TYPE
 export IMPLEMENTATION_TRIGGER_LABEL

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -184,12 +184,9 @@ if [ -n "${FEDERATION_FORGE_TYPE:-}" ]; then
             ;;
     esac
 else
-    # Interactive prompt; default is "gitlab" for PR 1 parity with pre-#256
-    # installs. The full GitHub backend (per-colony github-api.sh wrappers,
-    # .ag agent audits) ships across PRs 2-6 of #256. Selecting "github"
-    # now is supported for config scaffolding; at runtime forge-api.sh
-    # returns exit 99 with a clear pointer to the ADR until the per-colony
-    # wrappers land.
+    # Both backends are first-class since #256 completion. Default is
+    # "gitlab" to keep interactive behavior stable for pre-#256 operators
+    # re-running install.sh; pressing Enter preserves the pre-#256 choice.
     ask "Forge backend [1] GitLab (default)  [2] GitHub:"
     read -r FORGE_CHOICE
     case "$FORGE_CHOICE" in
@@ -198,37 +195,16 @@ else
     esac
 fi
 
-if [ "$FORGE_TYPE" = "github" ]; then
-    echo ""
-    fail "GitHub backend selected."
-    info "Foundation (ADR-0002 + config schema + forge-api.sh dispatcher)"
-    info "is available from PR 1 of issue #256. Per-colony github-api.sh"
-    info "wrappers ship in PRs 2-6; at runtime, forge-api.sh currently"
-    info "exits 99 for FORGE_TYPE=github. Track progress at:"
-    info "  https://github.com/Replikanti/agentis-colonies/issues/256"
-    echo ""
-    if [ -n "${FEDERATION_FORGE_TYPE:-}" ]; then
-        # Env var already acts as explicit confirmation — skip interactive
-        # gate so unattended installs don't block on stdin.
-        info "FEDERATION_FORGE_TYPE=github → treating as confirmation, proceeding."
-    else
-        ask "Continue with GitHub scaffolding anyway? [y/N]:"
-        read -r CONTINUE_GITHUB
-        case "$CONTINUE_GITHUB" in
-            y|Y|yes|YES) info "Proceeding with GitHub scaffolding." ;;
-            *)
-                info "Aborting install. Re-run and select GitLab, or wait for PRs 2-6 of #256."
-                exit 0
-                ;;
-        esac
-    fi
-fi
-
-# --- 3. GitLab credentials ---
+# --- 3. Forge credentials ---
 
 echo ""
-echo "GitLab configuration"
-echo "All 5 colonies connect to the same GitLab project."
+if [ "$FORGE_TYPE" = "github" ]; then
+    echo "GitHub configuration"
+    echo "All 5 colonies connect to the same GitHub repository."
+else
+    echo "GitLab configuration"
+    echo "All 5 colonies connect to the same GitLab project."
+fi
 echo ""
 
 # Separate prompt for credentials. The existing "overwrite templates"
@@ -248,18 +224,18 @@ if [ "$CONFIGS_EXISTED" -eq 5 ]; then
         WRITE_CREDS=0
         info "FEDERATION_FORGE_TYPE set and configs exist → keeping existing credentials (forge type will still be updated below)."
     else
-        ask "Update GitLab credentials in existing configs? [Y/n]:"
+        ask "Update $FORGE_TYPE credentials in existing configs? [Y/n]:"
         read -r UPDATE_CREDS
         case "$UPDATE_CREDS" in
             n|N)
                 WRITE_CREDS=0
-                info "Keeping existing GitLab credentials. Skipping prompts."
+                info "Keeping existing $FORGE_TYPE credentials. Skipping prompts."
                 ;;
         esac
     fi
 fi
 
-if [ "$WRITE_CREDS" -eq 1 ]; then
+if [ "$WRITE_CREDS" -eq 1 ] && [ "$FORGE_TYPE" = "gitlab" ]; then
     # URL char class includes `_` because corporate self-hosted DNS
     # routinely uses underscores in hostnames (RFC-noncompliant but
     # widespread) — rejecting them was a regression in PR #122 v1.
@@ -300,10 +276,10 @@ if [ "$WRITE_CREDS" -eq 1 ]; then
 
     for colony in "${COLONIES[@]}"; do
         CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
-        # Rewrite credentials in both [gitlab] and [forge.gitlab]. Section-
-        # scoped so an operator who uncommented [forge.github] (and perhaps
-        # dropped a ghp_* PAT there) does not see their GitHub token
-        # clobbered by the glpat rewrite.
+        # Section-scoped rewrite into [forge.gitlab] only. The legacy
+        # top-level [gitlab] block was retired in PR 7 of #256 (MAJOR
+        # v1.0.0). Operators on pre-#256 configs must re-copy
+        # colony.example.toml; the [forge].type check below flags that.
         python3 - "$CONFIG" "$GITLAB_URL" "$GITLAB_TOKEN" "$GITLAB_PROJECT" "$GITLAB_ME" <<'PY'
 import sys, re
 path, url, token, project, me = sys.argv[1:6]
@@ -324,7 +300,7 @@ def _rewrite_in_sections(content, targets, rewrites):
         out.append(line)
     return ''.join(out)
 
-cred_sections = {'gitlab', 'forge.gitlab'}
+cred_sections = {'forge.gitlab'}
 rewrites = [
     (r'(url\s*=\s*)"[^"]*"',     lambda m: m.group(1) + '"' + url + '"'),
     (r'(token\s*=\s*)"[^"]*"',   lambda m: m.group(1) + '"' + token + '"'),
@@ -337,6 +313,104 @@ content = _rewrite_in_sections(content, cred_sections, rewrites)
 
 with open(path, 'w') as f:
     f.write(content)
+PY
+        ok "$colony"
+        chmod 600 "$CONFIG" 2>/dev/null || \
+            info "$colony: could not chmod 600 $CONFIG (filesystem may not support it)"
+    done
+fi
+
+if [ "$WRITE_CREDS" -eq 1 ] && [ "$FORGE_TYPE" = "github" ]; then
+    # GitHub owner/repo split. The per-colony forge.github section takes
+    # owner+repo as separate keys (not combined into a path) because
+    # GitHub's REST API keeps them separate at the route level; the
+    # wrappers concatenate them locally.
+    prompt_validated GITHUB_OWNER \
+        "GitHub owner (user or organization):" \
+        '^[A-Za-z0-9](-?[A-Za-z0-9]){0,38}$' \
+        "1-39 chars, alphanumeric + single hyphens (GitHub login rules)."
+
+    prompt_validated GITHUB_REPO \
+        "GitHub repository name:" \
+        '^[A-Za-z0-9._-]+$' \
+        "Alphanumeric, dot, underscore, dash only."
+
+    prompt_validated GITHUB_TOKEN \
+        "GitHub personal access token (ghp_... or github_pat_...):" \
+        '^(ghp_|github_pat_)[A-Za-z0-9_]+$' \
+        "Must start with 'ghp_' or 'github_pat_' followed by the token body." \
+        --secret
+
+    # Optional Enterprise override. github.com stays the default by
+    # leaving GITHUB_URL empty (template ships commented out).
+    ask "GitHub Enterprise API URL (optional, press Enter for github.com):"
+    read -r GITHUB_URL
+    if [ -n "$GITHUB_URL" ] && ! [[ "$GITHUB_URL" =~ ^https?://[A-Za-z0-9._-]+(:[0-9]+)?(/.*)?$ ]]; then
+        fail "Invalid URL; leaving blank (github.com will be used)."
+        GITHUB_URL=""
+    fi
+
+    ask "Your GitHub username for personal/team knowledge tagging (optional, press Enter to skip):"
+    read -r GITHUB_ME
+    if [ -n "$GITHUB_ME" ] && ! [[ "$GITHUB_ME" =~ ^[A-Za-z0-9](-?[A-Za-z0-9]){0,38}$ ]]; then
+        fail "Invalid GitHub username. 1-39 chars, alphanumeric + single hyphens."
+        GITHUB_ME=""
+    fi
+
+    echo ""
+    echo "Writing credentials to colony configs..."
+
+    for colony in "${COLONIES[@]}"; do
+        CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
+        # Two-step rewrite: (1) uncomment the [forge.github] template
+        # block if it ships commented (default in colony.example.toml),
+        # (2) section-scoped key rewrites inside [forge.github]. The
+        # [forge.gitlab] section is untouched so operators can switch
+        # back via FEDERATION_FORGE_TYPE without losing credentials.
+        python3 - "$CONFIG" "$GITHUB_URL" "$GITHUB_TOKEN" "$GITHUB_OWNER" "$GITHUB_REPO" "$GITHUB_ME" <<'PY'
+import sys, re
+path, url, token, owner, repo, me = sys.argv[1:7]
+with open(path) as f:
+    lines = f.readlines()
+
+# Step 1: uncomment [forge.github] block if it's fully commented.
+# Enter on `# [forge.github]`, stay while subsequent lines match
+# `# key = ...`, exit on the first line that doesn't (blank,
+# next section header, or anything else).
+out = []
+in_block = False
+for line in lines:
+    if re.match(r'\s*#\s*\[forge\.github\]\s*$', line):
+        in_block = True
+        out.append(re.sub(r'^(\s*)#\s?', r'\1', line))
+        continue
+    if in_block:
+        if re.match(r'\s*#\s*[A-Za-z_][\w.]*\s*=', line):
+            out.append(re.sub(r'^(\s*)#\s?', r'\1', line))
+            continue
+        in_block = False
+    out.append(line)
+
+# Step 2: rewrite keys inside the [forge.github] section.
+content = ''.join(out)
+lines = content.splitlines(keepends=True)
+section = None
+out2 = []
+for line in lines:
+    stripped = line.strip()
+    if stripped.startswith('[') and stripped.endswith(']'):
+        section = stripped[1:-1].strip()
+    if section == 'forge.github':
+        if url:
+            line = re.sub(r'(url\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + url + '"', line)
+        line = re.sub(r'(owner\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + owner + '"', line)
+        line = re.sub(r'(repo\s*=\s*)"[^"]*"',  lambda m: m.group(1) + '"' + repo  + '"', line)
+        line = re.sub(r'(token\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + token + '"', line)
+        line = re.sub(r'(me\s*=\s*)"[^"]*"',    lambda m: m.group(1) + '"' + me    + '"', line)
+    out2.append(line)
+
+with open(path, 'w') as f:
+    f.write(''.join(out2))
 PY
         ok "$colony"
         chmod 600 "$CONFIG" 2>/dev/null || \

--- a/dev-apprenticeship/planning/README.md
+++ b/dev-apprenticeship/planning/README.md
@@ -44,7 +44,7 @@ When a new issue needs planning, the Scope Estimator, Risk Assessor, and Task De
 `plan_reviewer` follows the federation's **delta-check + early-exit** convention so ticks on a quiet project cost ~0 LLM calls:
 
 1. Peer outputs (`planning:scope_estimate`, `planning:risks`, `planning:breakdown`) are listened for and stashed per-issue.
-2. A single cheap `exec sh` call to `gitlab-api.sh issues --needs-planning --view planning` tells us whether any open issue still lacks a plan. An empty response (`[]`) means everything is already planned.
+2. A single cheap `exec sh` call to `forge-api.sh issues --needs-planning --view planning` tells us whether any open issue still lacks a plan. An empty response (`[]`) means everything is already planned.
 3. On empty: refresh `plan_reviewer:last_check` and `return` **before** any `prompt()` — no Claude invocation.
 4. The newest-issue iid is extracted with `json_get` (mechanical JSON read, zero LLM cost) instead of a `prompt()`; the assembly prompt only runs once all three peer slots are filled for the target issue.
 

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -28,9 +28,9 @@ epic = "epic"                          # labels/patterns task_decomposer treats 
 
 # Forge backend selection (ADR-0002, #256). `type` picks which of the
 # per-backend blocks below is active. Legal values: "gitlab", "github".
-# The top-level [gitlab] section below is retained for backwards
-# compatibility during the migration window — one release of overlap.
-# It is retired in the final PR of the port (PR 7 of #256).
+# The legacy top-level [gitlab] section was retired in PR 7 of #256
+# (MAJOR bump). Operators on pre-#256 configs: move your url/token/
+# project/me keys into [forge.gitlab] and set [forge].type = "gitlab".
 [forge]
 type = "gitlab"
 
@@ -45,12 +45,6 @@ me      = ""  # your GitLab username (optional, enables personal/team tagging)
 # repo  = "your-repo"
 # token = "ghp_your-token-here"
 # me    = ""  # your GitHub username (optional)
-
-[gitlab]
-url = "https://gitlab.example.com"
-token = "glpat-your-token-here"
-project = "your-org/your-project"
-me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -41,6 +41,7 @@ project = "your-org/your-project"
 me      = ""  # your GitLab username (optional, enables personal/team tagging)
 
 # [forge.github]
+# url   = "https://api.github.com"  # optional; override for GitHub Enterprise
 # owner = "your-org-or-user"
 # repo  = "your-repo"
 # token = "ghp_your-token-here"

--- a/dev-apprenticeship/planning/scripts/github-api.sh
+++ b/dev-apprenticeship/planning/scripts/github-api.sh
@@ -592,6 +592,31 @@ PY
         fi
         ;;
 
+    rate-limit-status)
+        # GitHub's /rate_limit endpoint does NOT count against the
+        # authenticated REST budget, so dashboards can poll this freely.
+        # Normalize the "core" resource (the same bucket REST reads draw
+        # from) to the GitLab-shape {remaining, limit, reset_at} contract.
+        # ADR-0002 PR 7 of 7 for #256.
+        resp="$(gh_get "$GITHUB_URL/rate_limit")" || exit $?
+        RATE_RESP="$resp" python3 <<'PY'
+import os, json, datetime
+try:
+    d = json.loads(os.environ["RATE_RESP"])
+except Exception:
+    print(json.dumps({"remaining": None, "limit": None, "reset_at": None}))
+    raise SystemExit(0)
+# Prefer resources.core (matches what REST reads draw from); fall back
+# to the top-level rate summary for old GHE instances that omit it.
+core = (d.get("resources") or {}).get("core") or d.get("rate") or {}
+reset = core.get("reset")
+reset_at = None
+if isinstance(reset, (int, float)):
+    reset_at = datetime.datetime.fromtimestamp(int(reset), tz=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+print(json.dumps({"remaining": core.get("remaining"), "limit": core.get("limit"), "reset_at": reset_at}))
+PY
+        ;;
+
     *)
         emit_error "unknown command: $CMD"
         exit 1

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -480,6 +480,50 @@ PY
         fi
         ;;
 
+    rate-limit-status)
+        # GitLab does NOT have a dedicated rate-limit endpoint. We trigger
+        # a lightweight /version call and extract RateLimit-* response
+        # headers (documented at GitLab "User and IP rate limits"). Self-
+        # hosted instances with rate limiting disabled return no such
+        # headers; we forward nulls in that case so the dashboard tile
+        # renders "—" instead of a spurious "0 remaining".
+        # ADR-0002 PR 7 of 7 for #256.
+        hdr_file="$(mktemp)"
+        # /version is the cheapest authenticated endpoint. -D dumps
+        # response headers; -o discards body; || : keeps a transport
+        # failure from killing the script (nulls forwarded in that case).
+        curl -sS -D "$hdr_file" -o /dev/null \
+            --max-time "${GITLAB_CURL_MAX_TIME:-30}" \
+            -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+            "$GITLAB_URL/api/v4/version" 2>/dev/null || :
+        HDR_FILE="$hdr_file" python3 <<'PY'
+import os, json, datetime, re
+try:
+    with open(os.environ["HDR_FILE"], "r", errors="replace") as f:
+        lines = f.readlines()
+except Exception:
+    lines = []
+hdrs = {}
+for ln in lines:
+    m = re.match(r"([^:]+):\s*(.+?)\s*$", ln)
+    if m:
+        hdrs[m.group(1).lower()] = m.group(2)
+def _int(s):
+    try:
+        return int(s) if s is not None else None
+    except Exception:
+        return None
+remaining = _int(hdrs.get("ratelimit-remaining"))
+limit = _int(hdrs.get("ratelimit-limit"))
+reset = _int(hdrs.get("ratelimit-reset"))
+reset_at = None
+if reset is not None:
+    reset_at = datetime.datetime.fromtimestamp(reset, tz=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+print(json.dumps({"remaining": remaining, "limit": limit, "reset_at": reset_at}))
+PY
+        rm -f "$hdr_file"
+        ;;
+
     *)
         emit_error "unknown command: $CMD"
         exit 1

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -67,30 +67,26 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 . "$REPO_ROOT/tools/parse-toml.sh"
 
 # #256: forge backend selection. `[forge].type` picks which backend
-# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
-# configs keep working unchanged. PR 3 of #256 ships the planning colony's
-# github-api.sh, so FORGE_TYPE=github is now live for planning (other
-# colonies still return exit 99 "not implemented" until their respective
-# PRs land).
+# wrapper forge-api.sh dispatches to. Legal values: "gitlab", "github".
+# PR 7 of #256 (MAJOR bump) made `[forge]` authoritative and retired
+# the legacy top-level `[gitlab]` section. `parse_toml forge type`
+# defaults to "gitlab" when unset so a fresh colony.toml that lists
+# only `[forge.gitlab]` without the selector still launches cleanly.
 FORGE_TYPE=$(parse_toml forge type)
 FORGE_TYPE="${FORGE_TYPE:-gitlab}"
 
 case "$FORGE_TYPE" in
     gitlab)
-        # Prefer [forge.gitlab] (ADR-0002) if present; fall back to legacy
-        # [gitlab] so pre-#256 configs keep working during the overlap window.
+        # PR 7 of #256 (MAJOR bump) made [forge.gitlab] authoritative.
+        # The legacy top-level [gitlab] fallback branches retired here.
         GITLAB_URL=$(parse_toml forge.gitlab url)
-        [ -z "$GITLAB_URL" ] && GITLAB_URL=$(parse_toml gitlab url)
         GITLAB_TOKEN=$(parse_toml forge.gitlab token)
-        [ -z "$GITLAB_TOKEN" ] && GITLAB_TOKEN=$(parse_toml gitlab token)
         GITLAB_PROJECT_RAW=$(parse_toml forge.gitlab project)
-        [ -z "$GITLAB_PROJECT_RAW" ] && GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
         GITLAB_ME=$(parse_toml forge.gitlab me)
-        [ -z "$GITLAB_ME" ] && GITLAB_ME=$(parse_toml gitlab me)
 
         if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
             echo "Error: GitLab config incomplete in $CONFIG"
-            echo "Required: url, token, project under [forge.gitlab] (or legacy [gitlab])"
+            echo "Required: url, token, project under [forge.gitlab]"
             exit 1
         fi
 

--- a/dev-apprenticeship/release/README.md
+++ b/dev-apprenticeship/release/README.md
@@ -42,7 +42,7 @@ When a release candidate is ready, the Release Checker runs pre-release validati
 
 All four release agents follow the federation's **delta-check + early-exit** convention so ticks on a quiet repo cost ~0 LLM calls/h:
 
-- **`ship_decider`** / **`release_checker`**: a cheap `gitlab-api.sh merge-requests --state merged --since <last_check> --per-page 1` query answers "has anything release-worthy landed?" in one HTTP call. Combined with a `listen()` on the relevant event (`release:check_result` for ship_decider, `implementation:mr_ready` for release_checker), if both signals are empty the tick refreshes `last_check` and `return`s **before** any `prompt()` — including the release-pattern learning prompt that used to run every tick.
+- **`ship_decider`** / **`release_checker`**: a cheap `forge-api.sh merge-requests --state merged --since <last_check> --per-page 1` query answers "has anything release-worthy landed?" in one HTTP call. Combined with a `listen()` on the relevant event (`release:check_result` for ship_decider, `implementation:mr_ready` for release_checker), if both signals are empty the tick refreshes `last_check` and `return`s **before** any `prompt()` — including the release-pattern learning prompt that used to run every tick.
 - **`version_bumper`** / **`changelog_writer`**: pure event-driven. Each listens for `release:ship_decision`; empty inbox → refresh `last_check` and `return` before the tag/release-style learning prompt. The learn-from-history prompts only run on ticks where a ship decision actually arrived.
 
 The learn-on-demand shape is intentional: past releases don't change between ticks, so re-analyzing them every minute wastes Claude calls. Gating pattern learning behind the delta-check keeps the cost proportional to real activity.
@@ -56,7 +56,7 @@ The learn-on-demand shape is intentional: past releases don't change between tic
 
 2. Configure your GitLab connection in `colony.toml`.
 
-3. (Optional) Override `[gitlab] default_branch` if your project's primary branch is not `main` (e.g. `master`, `develop`, `trunk`). `version_bumper` passes this to `gitlab-api.sh create-tag` as the tag's source ref (#224).
+3. (Optional) Override `[forge.gitlab] default_branch` (or `[forge.github] default_branch`) if your project's primary branch is not `main` (e.g. `master`, `develop`, `trunk`). `version_bumper` passes this to `forge-api.sh create-tag` as the tag's source ref (#224).
 
 4. Start the colony:
    ```bash

--- a/dev-apprenticeship/release/config/colony.example.toml
+++ b/dev-apprenticeship/release/config/colony.example.toml
@@ -9,9 +9,9 @@ tick_interval_ms = 60000
 
 # Forge backend selection (ADR-0002, #256). `type` picks which of the
 # per-backend blocks below is active. Legal values: "gitlab", "github".
-# The top-level [gitlab] section below is retained for backwards
-# compatibility during the migration window — one release of overlap.
-# It is retired in the final PR of the port (PR 7 of #256).
+# The legacy top-level [gitlab] section was retired in PR 7 of #256
+# (MAJOR bump). Operators on pre-#256 configs: move your url/token/
+# project/me keys into [forge.gitlab] and set [forge].type = "gitlab".
 [forge]
 type = "gitlab"
 
@@ -28,13 +28,6 @@ default_branch = "main"  # primary branch (#224)
 # token          = "ghp_your-token-here"
 # me             = ""      # your GitHub username (optional)
 # default_branch = "main"  # primary branch
-
-[gitlab]
-url = "https://gitlab.example.com"
-token = "glpat-your-token-here"
-project = "your-org/your-project"
-me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
-default_branch = "main"  # primary branch — override for projects using "master", "develop", "trunk", etc. (#224)
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.

--- a/dev-apprenticeship/release/config/colony.example.toml
+++ b/dev-apprenticeship/release/config/colony.example.toml
@@ -23,6 +23,7 @@ me             = ""      # your GitLab username (optional)
 default_branch = "main"  # primary branch (#224)
 
 # [forge.github]
+# url            = "https://api.github.com"  # optional; override for GitHub Enterprise
 # owner          = "your-org-or-user"
 # repo           = "your-repo"
 # token          = "ghp_your-token-here"

--- a/dev-apprenticeship/release/scripts/github-api.sh
+++ b/dev-apprenticeship/release/scripts/github-api.sh
@@ -10,9 +10,11 @@
 #
 # Optional env vars:
 #   GITLAB_DEFAULT_BRANCH base/target branch for create-tag (default "main").
-#                         The env-var name is a GitLab holdover — ADR-0002
-#                         keeps it for backend-agnostic dispatch; PR 7 may
-#                         rename when [gitlab] retires.
+#                         The env-var name is a GitLab holdover kept for
+#                         backend-agnostic dispatch (ADR-0002); renaming was
+#                         deferred past #256 to avoid cross-colony churn —
+#                         operators still set the value via
+#                         [forge.<backend>] default_branch.
 #   GITHUB_ME             authenticated-user login (optional; used as the
 #                         `tagger.name` fallback when creating annotated tags)
 #   GITHUB_CURL_MAX_TIME  per-attempt --max-time seconds (default 90)
@@ -697,6 +699,31 @@ PY
         # conversation comments.
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
         gh_post "$API/issues/$NUM/comments" "$JSON_BODY"
+        ;;
+
+    rate-limit-status)
+        # GitHub's /rate_limit endpoint does NOT count against the
+        # authenticated REST budget, so dashboards can poll this freely.
+        # Normalize the "core" resource (the same bucket REST reads draw
+        # from) to the GitLab-shape {remaining, limit, reset_at} contract.
+        # ADR-0002 PR 7 of 7 for #256.
+        resp="$(gh_get "$GITHUB_URL/rate_limit")" || exit $?
+        RATE_RESP="$resp" python3 <<'PY'
+import os, json, datetime
+try:
+    d = json.loads(os.environ["RATE_RESP"])
+except Exception:
+    print(json.dumps({"remaining": None, "limit": None, "reset_at": None}))
+    raise SystemExit(0)
+# Prefer resources.core (matches what REST reads draw from); fall back
+# to the top-level rate summary for old GHE instances that omit it.
+core = (d.get("resources") or {}).get("core") or d.get("rate") or {}
+reset = core.get("reset")
+reset_at = None
+if isinstance(reset, (int, float)):
+    reset_at = datetime.datetime.fromtimestamp(int(reset), tz=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+print(json.dumps({"remaining": core.get("remaining"), "limit": core.get("limit"), "reset_at": reset_at}))
+PY
         ;;
 
     *)

--- a/dev-apprenticeship/release/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/release/scripts/gitlab-api.sh
@@ -461,6 +461,50 @@ PY
         gl_post "$API/merge_requests/$IID/notes" "$JSON_BODY"
         ;;
 
+    rate-limit-status)
+        # GitLab does NOT have a dedicated rate-limit endpoint. We trigger
+        # a lightweight /version call and extract RateLimit-* response
+        # headers (documented at GitLab "User and IP rate limits"). Self-
+        # hosted instances with rate limiting disabled return no such
+        # headers; we forward nulls in that case so the dashboard tile
+        # renders "—" instead of a spurious "0 remaining".
+        # ADR-0002 PR 7 of 7 for #256.
+        hdr_file="$(mktemp)"
+        # /version is the cheapest authenticated endpoint. -D dumps
+        # response headers; -o discards body; || : keeps a transport
+        # failure from killing the script (nulls forwarded in that case).
+        curl -sS -D "$hdr_file" -o /dev/null \
+            --max-time "${GITLAB_CURL_MAX_TIME:-30}" \
+            -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+            "$GITLAB_URL/api/v4/version" 2>/dev/null || :
+        HDR_FILE="$hdr_file" python3 <<'PY'
+import os, json, datetime, re
+try:
+    with open(os.environ["HDR_FILE"], "r", errors="replace") as f:
+        lines = f.readlines()
+except Exception:
+    lines = []
+hdrs = {}
+for ln in lines:
+    m = re.match(r"([^:]+):\s*(.+?)\s*$", ln)
+    if m:
+        hdrs[m.group(1).lower()] = m.group(2)
+def _int(s):
+    try:
+        return int(s) if s is not None else None
+    except Exception:
+        return None
+remaining = _int(hdrs.get("ratelimit-remaining"))
+limit = _int(hdrs.get("ratelimit-limit"))
+reset = _int(hdrs.get("ratelimit-reset"))
+reset_at = None
+if reset is not None:
+    reset_at = datetime.datetime.fromtimestamp(reset, tz=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+print(json.dumps({"remaining": remaining, "limit": limit, "reset_at": reset_at}))
+PY
+        rm -f "$hdr_file"
+        ;;
+
     *)
         emit_error "unknown command: $CMD"
         exit 1

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -67,33 +67,27 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 . "$REPO_ROOT/tools/parse-toml.sh"
 
 # #256: forge backend selection. `[forge].type` picks which backend
-# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
-# configs keep working unchanged. PR 6 of #256 ships the release
-# colony's github-api.sh, so FORGE_TYPE=github is now live for release.
+# wrapper forge-api.sh dispatches to. Legal values: "gitlab", "github".
+# PR 7 of #256 (MAJOR bump) made `[forge]` authoritative and retired
+# the legacy top-level `[gitlab]` section. `parse_toml forge type`
+# defaults to "gitlab" when unset so a fresh colony.toml that lists
+# only `[forge.gitlab]` without the selector still launches cleanly.
 FORGE_TYPE=$(parse_toml forge type)
 FORGE_TYPE="${FORGE_TYPE:-gitlab}"
 
 case "$FORGE_TYPE" in
     gitlab)
-        # Prefer [forge.gitlab] (ADR-0002) if present; fall back to legacy
-        # [gitlab] so pre-#256 configs keep working during the overlap window.
+        # PR 7 of #256 (MAJOR bump) made [forge.gitlab] authoritative.
+        # The legacy top-level [gitlab] fallback branches retired here.
         GITLAB_URL=$(parse_toml forge.gitlab url)
-        [ -z "$GITLAB_URL" ] && GITLAB_URL=$(parse_toml gitlab url)
         GITLAB_TOKEN=$(parse_toml forge.gitlab token)
-        [ -z "$GITLAB_TOKEN" ] && GITLAB_TOKEN=$(parse_toml gitlab token)
         GITLAB_PROJECT_RAW=$(parse_toml forge.gitlab project)
-        [ -z "$GITLAB_PROJECT_RAW" ] && GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
         GITLAB_ME=$(parse_toml forge.gitlab me)
-        [ -z "$GITLAB_ME" ] && GITLAB_ME=$(parse_toml gitlab me)
-        # FORGE_TYPE-aware default_branch (was silently ignoring [forge.gitlab]
-        # and [forge.github] default_branch keys pre-PR 6; see the identical
-        # fix in implementation/scripts/start-colony.sh shipped in PR 4).
         GITLAB_DEFAULT_BRANCH=$(parse_toml forge.gitlab default_branch)
-        [ -z "$GITLAB_DEFAULT_BRANCH" ] && GITLAB_DEFAULT_BRANCH=$(parse_toml gitlab default_branch)
 
         if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
             echo "Error: GitLab config incomplete in $CONFIG"
-            echo "Required: url, token, project under [forge.gitlab] (or legacy [gitlab])"
+            echo "Required: url, token, project under [forge.gitlab]"
             exit 1
         fi
 
@@ -112,9 +106,9 @@ case "$FORGE_TYPE" in
         GITHUB_REPO=$(parse_toml forge.github repo)
         GITHUB_TOKEN=$(parse_toml forge.github token)
         GITHUB_ME=$(parse_toml forge.github me)
-        # default_branch used by create-tag (--ref default). Forward via the
-        # legacy GITLAB_DEFAULT_BRANCH env name — ADR-0002 keeps that name for
-        # backend-agnostic dispatch; PR 7 may rename when [gitlab] retires.
+        # default_branch used by create-tag (--ref default). The env var
+        # stays named GITLAB_DEFAULT_BRANCH for backend-agnostic dispatch
+        # (same name under both forge arms).
         GITLAB_DEFAULT_BRANCH=$(parse_toml forge.github default_branch)
 
         if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then

--- a/dev-apprenticeship/triage/README.md
+++ b/dev-apprenticeship/triage/README.md
@@ -45,7 +45,7 @@ When a new event arrives (bug report, support ticket, alert), the Issue Creator 
 Reactive agents (`router`, `prioritizer`) follow a **delta-check + early-exit** pattern so a quiet GitLab project costs ~0 LLM calls/h on the 60-second tick interval:
 
 1. `recall_latest("<agent>:last_check")` → an ISO-8601 timestamp (empty on first ever tick).
-2. A single cheap `exec sh` call to `gitlab-api.sh issues --since <last_check> --view <agent>` filters server-side. An empty response (`[]`, 2 chars) means "nothing new".
+2. A single cheap `exec sh` call to `forge-api.sh issues --since <last_check> --view <agent>` filters server-side. An empty response (`[]`, 2 chars) means "nothing new".
 3. On empty: refresh `last_check` and `return` **before** any `prompt()` — no Claude invocation at all.
 4. On non-empty: proceed to the normal learning/analysis prompts.
 

--- a/dev-apprenticeship/triage/config/colony.example.toml
+++ b/dev-apprenticeship/triage/config/colony.example.toml
@@ -9,9 +9,9 @@ tick_interval_ms = 60000
 
 # Forge backend selection (ADR-0002, #256). `type` picks which of the
 # per-backend blocks below is active. Legal values: "gitlab", "github".
-# The top-level [gitlab] section below is retained for backwards
-# compatibility during the migration window — one release of overlap.
-# It is retired in the final PR of the port (PR 7 of #256).
+# The legacy top-level [gitlab] section was retired in PR 7 of #256
+# (MAJOR bump). Operators on pre-#256 configs: move your url/token/
+# project/me keys into [forge.gitlab] and set [forge].type = "gitlab".
 [forge]
 type = "gitlab"
 
@@ -27,12 +27,6 @@ me      = ""  # your GitLab username (optional, enables personal/team tagging)
 # repo  = "your-repo"
 # token = "ghp_your-token-here"
 # me    = ""  # your GitHub username (optional)
-
-[gitlab]
-url = "https://gitlab.example.com"
-token = "glpat-your-token-here"
-project = "your-org/your-project"
-me = ""  # your GitLab username, e.g. "martin.holy" (optional, enables personal/team tagging)
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.

--- a/dev-apprenticeship/triage/scripts/github-api.sh
+++ b/dev-apprenticeship/triage/scripts/github-api.sh
@@ -620,6 +620,31 @@ PY
         gh_post "$API/issues/$ID/comments" "$JSON_BODY"
         ;;
 
+    rate-limit-status)
+        # GitHub's /rate_limit endpoint does NOT count against the
+        # authenticated REST budget, so dashboards can poll this freely.
+        # Normalize the "core" resource (the same bucket REST reads draw
+        # from) to the GitLab-shape {remaining, limit, reset_at} contract.
+        # ADR-0002 PR 7 of 7 for #256.
+        resp="$(gh_get "$GITHUB_URL/rate_limit")" || exit $?
+        RATE_RESP="$resp" python3 <<'PY'
+import os, json, datetime
+try:
+    d = json.loads(os.environ["RATE_RESP"])
+except Exception:
+    print(json.dumps({"remaining": None, "limit": None, "reset_at": None}))
+    raise SystemExit(0)
+# Prefer resources.core (matches what REST reads draw from); fall back
+# to the top-level rate summary for old GHE instances that omit it.
+core = (d.get("resources") or {}).get("core") or d.get("rate") or {}
+reset = core.get("reset")
+reset_at = None
+if isinstance(reset, (int, float)):
+    reset_at = datetime.datetime.fromtimestamp(int(reset), tz=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+print(json.dumps({"remaining": core.get("remaining"), "limit": core.get("limit"), "reset_at": reset_at}))
+PY
+        ;;
+
     *)
         emit_error "unknown command: $CMD"
         exit 1

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -535,6 +535,50 @@ PY
         gl_post "$API/issues/$ID/notes" "$JSON_BODY"
         ;;
 
+    rate-limit-status)
+        # GitLab does NOT have a dedicated rate-limit endpoint. We trigger
+        # a lightweight /version call and extract RateLimit-* response
+        # headers (documented at GitLab "User and IP rate limits"). Self-
+        # hosted instances with rate limiting disabled return no such
+        # headers; we forward nulls in that case so the dashboard tile
+        # renders "—" instead of a spurious "0 remaining".
+        # ADR-0002 PR 7 of 7 for #256.
+        hdr_file="$(mktemp)"
+        # /version is the cheapest authenticated endpoint. -D dumps
+        # response headers; -o discards body; || : keeps a transport
+        # failure from killing the script (nulls forwarded in that case).
+        curl -sS -D "$hdr_file" -o /dev/null \
+            --max-time "${GITLAB_CURL_MAX_TIME:-30}" \
+            -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+            "$GITLAB_URL/api/v4/version" 2>/dev/null || :
+        HDR_FILE="$hdr_file" python3 <<'PY'
+import os, json, datetime, re
+try:
+    with open(os.environ["HDR_FILE"], "r", errors="replace") as f:
+        lines = f.readlines()
+except Exception:
+    lines = []
+hdrs = {}
+for ln in lines:
+    m = re.match(r"([^:]+):\s*(.+?)\s*$", ln)
+    if m:
+        hdrs[m.group(1).lower()] = m.group(2)
+def _int(s):
+    try:
+        return int(s) if s is not None else None
+    except Exception:
+        return None
+remaining = _int(hdrs.get("ratelimit-remaining"))
+limit = _int(hdrs.get("ratelimit-limit"))
+reset = _int(hdrs.get("ratelimit-reset"))
+reset_at = None
+if reset is not None:
+    reset_at = datetime.datetime.fromtimestamp(reset, tz=datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+print(json.dumps({"remaining": remaining, "limit": limit, "reset_at": reset_at}))
+PY
+        rm -f "$hdr_file"
+        ;;
+
     *)
         emit_error "unknown command: $CMD"
         exit 1

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -67,29 +67,26 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 . "$REPO_ROOT/tools/parse-toml.sh"
 
 # #256: forge backend selection. `[forge].type` picks which backend
-# wrapper forge-api.sh dispatches to. Defaults to "gitlab" so pre-#256
-# configs keep working unchanged. PR 2 of #256 ships the triage colony's
-# github-api.sh, so FORGE_TYPE=github is now live for triage (other colonies
-# still return exit 99 "not implemented" until their respective PRs land).
+# wrapper forge-api.sh dispatches to. Legal values: "gitlab", "github".
+# PR 7 of #256 (MAJOR bump) made `[forge]` authoritative and retired
+# the legacy top-level `[gitlab]` section. `parse_toml forge type`
+# defaults to "gitlab" when unset so a fresh colony.toml that lists
+# only `[forge.gitlab]` without the selector still launches cleanly.
 FORGE_TYPE=$(parse_toml forge type)
 FORGE_TYPE="${FORGE_TYPE:-gitlab}"
 
 case "$FORGE_TYPE" in
     gitlab)
-        # Prefer [forge.gitlab] (ADR-0002) if present; fall back to legacy
-        # [gitlab] so pre-#256 configs keep working during the overlap window.
+        # PR 7 of #256 (MAJOR bump) made [forge.gitlab] authoritative.
+        # The legacy top-level [gitlab] fallback branches retired here.
         GITLAB_URL=$(parse_toml forge.gitlab url)
-        [ -z "$GITLAB_URL" ] && GITLAB_URL=$(parse_toml gitlab url)
         GITLAB_TOKEN=$(parse_toml forge.gitlab token)
-        [ -z "$GITLAB_TOKEN" ] && GITLAB_TOKEN=$(parse_toml gitlab token)
         GITLAB_PROJECT_RAW=$(parse_toml forge.gitlab project)
-        [ -z "$GITLAB_PROJECT_RAW" ] && GITLAB_PROJECT_RAW=$(parse_toml gitlab project)
         GITLAB_ME=$(parse_toml forge.gitlab me)
-        [ -z "$GITLAB_ME" ] && GITLAB_ME=$(parse_toml gitlab me)
 
         if [ -z "$GITLAB_URL" ] || [ -z "$GITLAB_TOKEN" ] || [ -z "$GITLAB_PROJECT_RAW" ]; then
             echo "Error: GitLab config incomplete in $CONFIG"
-            echo "Required: url, token, project under [forge.gitlab] (or legacy [gitlab])"
+            echo "Required: url, token, project under [forge.gitlab]"
             exit 1
         fi
 

--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -1,8 +1,9 @@
 ---
 id: ADR-0002
 title: Forge abstraction — normalized wrapper dispatch for multi-forge federations
-status: Proposed
+status: Accepted
 date: 2026-04-23
+accepted-date: 2026-04-24
 authors: [ylohnitram]
 supersedes: (none)
 superseded-by: (none)
@@ -95,10 +96,13 @@ token, not an env-var reference. The `project` field is a path string
 `%2F`-separated form before calling the API.
 
 `start-colony.sh` reads `[forge].type`, exports `FORGE_TYPE`, and
-continues to export the legacy `GITLAB_*` env for backwards
-compatibility during the migration window (one release). After the
-release PR at the end of the port, the top-level `[gitlab]` section is
-retired and `[forge.*]` is authoritative.
+exports the legacy `GITLAB_*` env names from whichever `[forge.<type>]`
+block is active. The migration window collapsed at PR 7 (v1.0.0): the
+top-level `[gitlab]` section has been retired and `[forge.*]` is
+authoritative. Operators on pre-#256 configs must move their
+`url`/`token`/`project`/`me` keys under `[forge.gitlab]` and add
+`[forge].type = "gitlab"` — the post-PR-7 start-colony.sh rejects
+configs that lack `[forge]`.
 
 ### Normalized shape contract (normative)
 
@@ -121,7 +125,7 @@ subcommands (`merge-requests`, `mr-changes`, `mr-commits`, `issue`,
 `assigned-issues-by-label-events`, `create-branch`, `commit-files`,
 `create-mr`, `add-note`) plus the matching `[forge.github]` env-export
 branch and 25 `.ag` call-site migrations across the four implementation
-agents. PR 5 (the current PR as of this writing) ships the code-review
+agents. PR 5 ships the code-review
 colony's `github-api.sh` with 5 subcommands (`merge-requests`,
 `mr-changes`, `mr-notes`, `post-note`, `approve`) plus the matching
 `[forge.github]` env-export branch and 28 `.ag` call-site migrations
@@ -265,6 +269,35 @@ first called out in PR 4 QA into `release/scripts/start-colony.sh`
 `[forge.gitlab].default_branch` and `[forge.github].default_branch`,
 falling back to legacy `[gitlab].default_branch` only).
 
+**PR 7 additions (MAJOR, v1.0.0).** The final PR ships the
+`rate-limit-status` subcommand across all 10 per-colony wrappers (5
+GitLab, 5 GitHub) with a uniform `{"remaining", "limit", "reset_at"}`
+contract — GitHub reads `/rate_limit` (uncounted), GitLab reads
+`RateLimit-*` response headers from a cheap `/api/v4/version` call.
+GitLab behavior under a self-hosted instance without rate-limiting: the
+arm forwards `null`s and exits 0 (not-configured is common and
+non-fatal). GitHub behavior under transport failure: the arm propagates
+the non-zero `gh_call` exit so operators can distinguish "no rate-limit
+data" (never happens on github.com) from "PAT missing / API down".
+Dashboard consumption of the primitive is deliberately deferred to a
+separate `federation-dashboard` release; the rate-limit-status
+subcommand is a stable building block regardless of when the tile ships.
+The same PR retires the legacy top-level `[gitlab]` config section
+federation-wide: all 5 `colony.example.toml` templates, all 5
+`start-colony.sh` scripts, and `install.sh`'s credential-writer have
+been rewritten to read/write `[forge.<backend>]` only — the MAJOR bump
+that gates v1.0.0. Pre-#256 configs with a bare `[gitlab]` block now
+fail the `[forge]`-presence guard in `start-colony.sh` with an explicit
+retirement message pointing operators at the migration one-liner;
+`tools/colony-lint.sh` adds a matching lint rule so a regression
+re-introducing `[gitlab]` in any `colony.example.toml` fails CI.
+`install.sh` drops the PR-1-to-PR-6 "GitHub scaffolding is partial,
+continue anyway?" abort gate and splits credential prompting into
+FORGE_TYPE-conditional branches: GitLab selects the existing
+url/project/PAT/me flow; GitHub uncomments the `[forge.github]`
+template block and writes owner/repo/PAT + optional Enterprise URL +
+optional `me` into it.
+
 | Subcommand           | Normalized output |
 |----------------------|-------------------|
 | `get-issue <n>`      | `{"number", "title", "description", "labels": [...], "state", "assignees": [...], "author", "web_url"}` |
@@ -329,7 +362,8 @@ entry for the affected colony.
   is a single value, not a list. A user who wants to mirror a
   federation onto a second forge runs a second install.
 - **Keeping the top-level `[gitlab]` config section past the final
-  release of the port.** One release of overlap, then retire.
+  release of the port.** Retired in PR 7 (v1.0.0, MAJOR); operators
+  must migrate to `[forge.gitlab]`.
 - **Agent-layer knowledge of forge semantics.** Agents may branch on
   `$FORGE_TYPE` only for prompt-vocabulary tweaks ("pull request" vs
   "merge request"); they must never embed forge-specific API logic or
@@ -354,12 +388,17 @@ Per-colony edits land in the colony-port PRs (PRs 2–6 of #256).
 ### Runtime changes
 
 - `start-colony.sh` across all 5 colonies reads `[forge].type` and
-  exports `FORGE_TYPE`. Existing `GITLAB_*` exports are kept for one
-  release of overlap.
+  exports `FORGE_TYPE`. The `GITLAB_*` env-var names are kept as
+  backend-agnostic internal exports (populated from whichever
+  `[forge.<type>]` block is active); renaming to `FORGE_*` was deferred
+  past #256 to avoid a cross-colony churn that doesn't change operator
+  semantics.
 - `tools/forge-normalize.sh` (new) ships shared helpers: pagination
   walker, label-event filter, draft-flag inferrer, approvals collapse.
-- `install.sh` gains a forge-choice prompt, defaulting to GitLab for
-  one release then "ask" (no default) at the end of the port.
+- `install.sh` carries a forge-choice prompt defaulting to GitLab
+  (preserves Enter-key behavior for pre-#256 re-runs) and conditional
+  credential prompting branched on `FORGE_TYPE`. Legacy top-level
+  `[gitlab]` is never written (retired in PR 7).
   `FEDERATION_FORGE_TYPE=github|gitlab` env var short-circuits prompts
   for unattended installs.
 
@@ -375,10 +414,12 @@ current tick intervals:
 - release (300s) × 4 × ~3 = 144
 - **Total: ~2500 req/h** — comfortably under the limit.
 
-`rate-limit-status` subcommand + a dashboard tile are added in PR 7 of
-#256 so operators see a live remaining/limit counter. If a real install
-trips, the fix is per-agent tick-interval tuning, not a change to this
-ADR.
+`rate-limit-status` subcommand is shipped in PR 7 of #256 (contract:
+`{"remaining", "limit", "reset_at"}`) as the building block for an
+operator-visible counter. A dashboard tile is deliberately deferred to
+a separate `federation-dashboard` release so a UI churn does not gate
+v1.0.0 of the federation. If a real install trips the limit, the fix
+is per-agent tick-interval tuning, not a change to this ADR.
 
 ### Testing
 

--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -118,8 +118,7 @@ branch in `triage/scripts/start-colony.sh`. PR 3 shipped the planning
 colony's `github-api.sh` with 5 subcommands (`issues`,
 `issues-by-label-events`, `issue-label-events`, `add-note`,
 `merge-requests`) plus the matching `[forge.github]` env-export branch
-and `.ag` dispatcher migration. PR 4 (the current PR as of this
-writing) ships the implementation colony's `github-api.sh` with 11
+and `.ag` dispatcher migration. PR 4 ships the implementation colony's `github-api.sh` with 11
 subcommands (`merge-requests`, `mr-changes`, `mr-commits`, `issue`,
 `assigned-issues`, `issue-label-events`,
 `assigned-issues-by-label-events`, `create-branch`, `commit-files`,
@@ -129,8 +128,7 @@ agents. PR 5 ships the code-review
 colony's `github-api.sh` with 5 subcommands (`merge-requests`,
 `mr-changes`, `mr-notes`, `post-note`, `approve`) plus the matching
 `[forge.github]` env-export branch and 28 `.ag` call-site migrations
-across the five code-review agents. PR 6 (the current PR as of this
-writing) ships the release colony's `github-api.sh` with 7 subcommands
+across the five code-review agents. PR 6 ships the release colony's `github-api.sh` with 7 subcommands
 (`releases`, `tags`, `pipelines`, `merge-requests`, `create-tag`,
 `create-release`, `post-note`) plus the matching `[forge.github]`
 env-export branch and 29 `.ag` call-site migrations across the four

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -97,8 +97,18 @@ with open(sys.argv[1], 'rb') as f:
 errors = []
 if 'colony' not in data:
     errors.append('missing [colony] section')
-if 'gitlab' not in data:
-    errors.append('missing [gitlab] section')
+if 'gitlab' in data:
+    errors.append('legacy top-level [gitlab] section still present — retired in #256 PR 7 (v1.0.0). Move keys under [forge.gitlab].')
+if 'forge' not in data or not isinstance(data.get('forge'), dict):
+    errors.append('missing [forge] section (post-#256: required)')
+else:
+    forge_type = data['forge'].get('type')
+    if forge_type not in ('gitlab', 'github'):
+        errors.append(f'[forge].type must be \"gitlab\" or \"github\" (got {forge_type!r})')
+    if forge_type == 'gitlab' and 'gitlab' not in data['forge']:
+        errors.append('[forge].type = \"gitlab\" but [forge.gitlab] is missing')
+    if forge_type == 'github' and 'github' not in data['forge']:
+        errors.append('[forge].type = \"github\" but [forge.github] is missing')
 if 'llm' not in data:
     errors.append('missing [llm] section')
 if 'agents' not in data or not isinstance(data['agents'], list) or len(data['agents']) == 0:

--- a/tools/test-forge-config.sh
+++ b/tools/test-forge-config.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-# tools/test-forge-config.sh: verify the #256 forge-abstraction foundation.
+# tools/test-forge-config.sh: verify the #256 forge-abstraction end state.
 #
-# PR 1 of #256 adds:
+# #256 PR 1 (foundation) adds:
 #  - [forge] section (with type, [forge.gitlab], commented [forge.github]) to
 #    every colony.example.toml
 #  - per-colony scripts/forge-api.sh dispatcher that reads $FORGE_TYPE
 #  - start-colony.sh exports FORGE_TYPE from [forge].type (default "gitlab")
+# #256 PRs 2-6 ship the per-colony github-api.sh wrappers.
+# #256 PR 7 (MAJOR, v1.0.0) retires the legacy top-level [gitlab] section.
 #
-# This test locks all three invariants in place before PRs 2-6 land the
-# per-colony github-api.sh wrappers.
+# This test locks the full post-#256 contract in place.
 #
 # Usage: ./tools/test-forge-config.sh
 # Exit 0 if all tests pass, 1 otherwise.
@@ -268,20 +269,51 @@ if ! grep -q 'Setting \[forge\].type = ' "$install"; then
 else
     pass "install.sh: unconditional [forge].type rewrite present"
 fi
-# The unattended-install short-circuit must also skip the two interactive
-# gates: (a) the "Continue with GitHub scaffolding anyway?" prompt when
-# FEDERATION_FORGE_TYPE=github; (b) the "Update GitLab credentials?" prompt
-# when configs already exist. Pattern-match the two short-circuit comments.
-if ! grep -q 'treating as confirmation, proceeding' "$install"; then
-    fail "install.sh: FEDERATION_FORGE_TYPE does not short-circuit the GitHub-confirm prompt"
-else
-    pass "install.sh: FEDERATION_FORGE_TYPE short-circuits the GitHub-confirm prompt"
-fi
+# The FEDERATION_FORGE_TYPE short-circuit must skip the credential-update
+# prompt when configs already exist. Pattern-match the short-circuit comment.
 if ! grep -q 'FEDERATION_FORGE_TYPE set and configs exist' "$install"; then
     fail "install.sh: FEDERATION_FORGE_TYPE does not short-circuit the credential-update prompt for existing configs"
 else
     pass "install.sh: FEDERATION_FORGE_TYPE short-circuits the credential-update prompt"
 fi
+# #256 PR 7 (v1.0.0): the legacy GitHub-confirm abort gate ("Continue with
+# GitHub scaffolding anyway?" + "Aborting install. Re-run and select GitLab")
+# was removed when the per-colony github-api.sh wrappers landed — both
+# backends are first-class. Assert the gate stays gone.
+if grep -q 'Continue with GitHub scaffolding' "$install"; then
+    fail "install.sh: legacy GitHub-confirm abort gate is still present (must be removed in #256 PR 7)"
+else
+    pass "install.sh: legacy GitHub-confirm abort gate removed"
+fi
+if grep -q 'Aborting install. Re-run and select GitLab' "$install"; then
+    fail "install.sh: legacy 'Re-run and select GitLab' abort message still present (must be removed in #256 PR 7)"
+else
+    pass "install.sh: legacy abort-to-GitLab message removed"
+fi
+# #256 PR 7 (v1.0.0): install.sh must prompt for GitHub credentials when
+# FORGE_TYPE=github, and must NOT write to the retired top-level [gitlab]
+# section. Pattern-match the conditional branches and the cred_sections set.
+if ! grep -q 'FORGE_TYPE" = "github"' "$install"; then
+    fail "install.sh: FORGE_TYPE=github credential branch missing"
+else
+    pass "install.sh: FORGE_TYPE=github credential branch present"
+fi
+if ! grep -qE "cred_sections = \\{'forge\\.gitlab'\\}" "$install"; then
+    fail "install.sh: legacy [gitlab] still in cred_sections set (must be removed in PR 7)"
+else
+    pass "install.sh: cred_sections writes to [forge.gitlab] only (legacy [gitlab] retired)"
+fi
+# -----------------------------------------------------------------------------
+# Test 7b: colony.example.toml must NOT carry a top-level [gitlab] section
+# -----------------------------------------------------------------------------
+for colony in $COLONIES; do
+    cfg="$REPO_ROOT/dev-apprenticeship/$colony/config/colony.example.toml"
+    if grep -qE '^\[gitlab\]$' "$cfg"; then
+        fail "$colony: legacy top-level [gitlab] section still present in colony.example.toml (retired in #256 PR 7)"
+    else
+        pass "$colony: legacy [gitlab] section absent from colony.example.toml"
+    fi
+done
 
 # -----------------------------------------------------------------------------
 # Test 8: ADR-0002 exists and is indexed

--- a/tools/test-rate-limit-status.sh
+++ b/tools/test-rate-limit-status.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# test-rate-limit-status.sh: unit-test the `rate-limit-status` subcommand
+# shipped across all 10 per-colony forge wrappers in #256 PR 7 (v1.0.0).
+#
+# Contract: every wrapper's `rate-limit-status` subcommand prints a single
+# JSON object of shape
+#     {"remaining": <int|null>, "limit": <int|null>, "reset_at": <ISO-8601-Z|null>}
+# and exits 0 on transport success. Behavior under transport failure:
+#   GitLab: missing/absent RateLimit-* response headers → forward nulls,
+#           exit 0 (common case on self-hosted GitLab without rate-limiting)
+#   GitHub: /rate_limit failure → propagate the non-zero gh_call exit
+#
+# The backends are exercised by swapping `curl` in $PATH with a shim that
+# writes canned responses. Each wrapper is tested in isolation.
+#
+# Exit 0 all-pass, 1 any-fail.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+COLONIES="triage planning implementation code-review release"
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# Pinned reset timestamp: 1735689600 = 2025-01-01T00:00:00Z. Must round-trip
+# through the Python `datetime.fromtimestamp(..., tz=UTC).isoformat()`
+# call inside both wrapper arms to the exact string below.
+EXPECTED_RESET_AT="2025-01-01T00:00:00Z"
+
+# -----------------------------------------------------------------------------
+# Shim dir hosting fake `curl`. PATH is prepended for each invocation so the
+# real `curl` is never reached. Mode switch via CURL_SHIM_MODE env var:
+#   github_ok        — emit GitHub /rate_limit JSON body, HTTP 200
+#   gitlab_headers   — emit RateLimit-* headers to -D <file>, no body
+#   gitlab_noheaders — emit minimal HTTP status line, no RateLimit-* headers
+#   gitlab_fail      — exit 6 (DNS resolution failure) to simulate transport
+#                      failure; gitlab-api.sh's arm tolerates this with `|| :`
+#   github_fail      — exit 6 for the same reason; github-api.sh's arm must
+#                      propagate this (bubble up via `|| exit $?`)
+# -----------------------------------------------------------------------------
+SHIM_DIR="$TMPDIR_TEST/shim"
+mkdir -p "$SHIM_DIR"
+cat > "$SHIM_DIR/curl" <<'SHIM'
+#!/usr/bin/env bash
+# Fake curl. Parses -o <body_file>, -D <hdr_file>, -w <fmt> flags, emits
+# canned response based on $CURL_SHIM_MODE, returns the rc/http_code the
+# wrapper expects.
+
+body_file=""
+hdr_file=""
+want_code=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -o) body_file="$2"; shift 2 ;;
+        -D) hdr_file="$2"; shift 2 ;;
+        -w)
+            case "$2" in
+                *'%{http_code}'*) want_code=1 ;;
+            esac
+            shift 2
+            ;;
+        --max-time|-X|-H|-G|--data-urlencode|-d)
+            shift 2
+            ;;
+        -s|-sS|-S) shift ;;
+        *)         shift ;;
+    esac
+done
+
+case "${CURL_SHIM_MODE:-}" in
+    github_ok)
+        if [ -n "$body_file" ]; then
+            cat > "$body_file" <<'JSON'
+{"resources":{"core":{"limit":5000,"remaining":4321,"reset":1735689600,"used":679},
+              "search":{"limit":30,"remaining":30,"reset":1735689600,"used":0}},
+ "rate":{"limit":5000,"remaining":4321,"reset":1735689600,"used":679}}
+JSON
+        fi
+        if [ "$want_code" = "1" ]; then
+            printf '200'
+        fi
+        exit 0
+        ;;
+    github_fail)
+        exit 6
+        ;;
+    gitlab_headers)
+        if [ -n "$hdr_file" ]; then
+            cat > "$hdr_file" <<'HDR'
+HTTP/2 200
+Content-Type: application/json
+RateLimit-Remaining: 598
+RateLimit-Limit: 600
+RateLimit-Reset: 1735689600
+HDR
+        fi
+        # Body routed to /dev/null by the wrapper's -o /dev/null arg.
+        exit 0
+        ;;
+    gitlab_noheaders)
+        if [ -n "$hdr_file" ]; then
+            cat > "$hdr_file" <<'HDR'
+HTTP/2 200
+Content-Type: application/json
+HDR
+        fi
+        exit 0
+        ;;
+    gitlab_fail)
+        # Simulate transport failure (e.g. DNS). gitlab-api.sh tolerates
+        # this with `|| :` and still emits a null-valued JSON object.
+        exit 6
+        ;;
+    *)
+        echo "curl shim: unknown CURL_SHIM_MODE=${CURL_SHIM_MODE:-<unset>}" >&2
+        exit 99
+        ;;
+esac
+SHIM
+chmod +x "$SHIM_DIR/curl"
+
+# Helper: run a wrapper's rate-limit-status subcommand with the shim curl and
+# return stdout for JSON assertion.
+run_wrapper() {
+    local wrapper="$1" mode="$2"
+    shift 2
+    PATH="$SHIM_DIR:$PATH" CURL_SHIM_MODE="$mode" \
+        GITLAB_URL="https://example.invalid" \
+        GITLAB_TOKEN="fake-token" \
+        GITLAB_PROJECT="org/repo" \
+        GITHUB_URL="https://api.github.com" \
+        GITHUB_TOKEN="ghp_fake-token" \
+        GITHUB_OWNER="org" \
+        GITHUB_REPO="repo" \
+        GITHUB_CURL_RETRIES="0" \
+        GITLAB_CURL_RETRIES="0" \
+        GITLAB_CURL_MAX_TIME="5" \
+        GITHUB_CURL_MAX_TIME="5" \
+        bash "$wrapper" rate-limit-status "$@"
+}
+
+# JSON shape assertion via python3. All three keys must be present.
+assert_shape() {
+    local name="$1" json="$2" expect_remaining="$3" expect_limit="$4" expect_reset="$5"
+    local py_out
+    py_out="$(printf '%s' "$json" | python3 -c "
+import sys, json
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+except Exception as e:
+    print('INVALID_JSON:' + str(e))
+    sys.exit(1)
+need = ['remaining', 'limit', 'reset_at']
+for k in need:
+    if k not in d:
+        print('MISSING_KEY:' + k)
+        sys.exit(1)
+print(json.dumps([d.get('remaining'), d.get('limit'), d.get('reset_at')]))
+")"
+    case "$py_out" in
+        INVALID_JSON:*|MISSING_KEY:*)
+            fail "$name" "$py_out on output: $json"
+            return 1
+            ;;
+    esac
+    local expected
+    expected="$(python3 -c "import json; print(json.dumps([${expect_remaining}, ${expect_limit}, ${expect_reset}]))")"
+    if [ "$py_out" = "$expected" ]; then
+        pass "$name"
+    else
+        fail "$name" "got=$py_out want=$expected"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Test matrix — all 5 colonies, both backends, 3 modes each.
+# -----------------------------------------------------------------------------
+for colony in $COLONIES; do
+    gitlab_wrapper="$REPO_ROOT/dev-apprenticeship/$colony/scripts/gitlab-api.sh"
+    github_wrapper="$REPO_ROOT/dev-apprenticeship/$colony/scripts/github-api.sh"
+
+    # --- GitLab, headers present ---
+    out="$(run_wrapper "$gitlab_wrapper" gitlab_headers 2>/dev/null)"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        fail "$colony/gitlab: headers-present expected rc=0 got rc=$rc" "out=$(printf '%.120s' "$out")"
+    else
+        assert_shape "$colony/gitlab: rate-limit-status with headers" "$out" \
+            "598" "600" "'${EXPECTED_RESET_AT}'"
+    fi
+
+    # --- GitLab, no RateLimit-* headers (self-hosted default) ---
+    out="$(run_wrapper "$gitlab_wrapper" gitlab_noheaders 2>/dev/null)"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        fail "$colony/gitlab: no-headers expected rc=0 got rc=$rc" "out=$(printf '%.120s' "$out")"
+    else
+        assert_shape "$colony/gitlab: rate-limit-status without headers (nulls)" "$out" \
+            "None" "None" "None"
+    fi
+
+    # --- GitLab, transport failure → arm still emits nulls, exits 0 ---
+    out="$(run_wrapper "$gitlab_wrapper" gitlab_fail 2>/dev/null)"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        fail "$colony/gitlab: transport-failure expected rc=0 got rc=$rc" "out=$(printf '%.120s' "$out")"
+    else
+        assert_shape "$colony/gitlab: rate-limit-status on transport failure (nulls)" "$out" \
+            "None" "None" "None"
+    fi
+
+    # --- GitHub, /rate_limit succeeds ---
+    out="$(run_wrapper "$github_wrapper" github_ok 2>/dev/null)"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        fail "$colony/github: /rate_limit expected rc=0 got rc=$rc" "out=$(printf '%.120s' "$out")"
+    else
+        assert_shape "$colony/github: rate-limit-status parses /rate_limit" "$out" \
+            "4321" "5000" "'${EXPECTED_RESET_AT}'"
+    fi
+
+    # --- GitHub, transport failure → non-zero rc propagated ---
+    out="$(run_wrapper "$github_wrapper" github_fail 2>/dev/null)"
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        fail "$colony/github: transport-failure should propagate non-zero rc (got 0)" "out=$(printf '%.120s' "$out")"
+    else
+        pass "$colony/github: transport failure propagates non-zero exit (rc=$rc)"
+    fi
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-start-colony-restart.sh
+++ b/tools/test-start-colony-restart.sh
@@ -30,11 +30,15 @@ trap 'rm -rf "$TMPDIR_TEST"' EXIT
 pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
 fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
 
-# Each colony's start-colony.sh expects a populated [gitlab] section.
+# Each colony's start-colony.sh expects a populated [forge.gitlab] section
+# (the legacy top-level [gitlab] section was retired in #256 PR 7 / v1.0.0).
 # Shared minimal TOML for all five colonies.
 FIXTURE_TOML="$TMPDIR_TEST/colony.toml"
 cat > "$FIXTURE_TOML" <<'TOML'
-[gitlab]
+[forge]
+type = "gitlab"
+
+[forge.gitlab]
 url = "https://example.invalid"
 token = "fake"
 project = "org/repo"


### PR DESCRIPTION
## Summary

Final PR of the #256 forge-abstraction series. Closes ADR-0002 and gates
`dev-apprenticeship` **v1.0.0**.

- **Added:** `rate-limit-status` subcommand across all 10 per-colony forge
  wrappers (5 GitLab, 5 GitHub). Uniform contract:
  `{"remaining": <int|null>, "limit": <int|null>, "reset_at": <ISO-8601-Z|null>}`.
  GitHub reads `/rate_limit` (uncounted). GitLab reads `RateLimit-*` response
  headers off a cheap `GET /api/v4/version`; missing headers on self-hosted
  GitLab forward nulls + exit 0 (common, non-fatal case). Transport failure
  on GitHub propagates non-zero; on GitLab still exits 0 with nulls.
- **BREAKING — retired legacy `[gitlab]` config section federation-wide.**
  All 5 `colony.example.toml` templates ship `[forge.gitlab]` only; all 5
  `start-colony.sh` scripts reject missing `[forge]` with an explicit
  migration message. `install.sh` writes to `[forge.<backend>]` only.
  `colony-lint.sh` gains a guard that fails CI if `[gitlab]` reappears.
- **BREAKING — `install.sh` credential prompting.** The "GitHub scaffolding
  is partial, continue anyway?" abort gate is removed (both backends are
  first-class since PR 6). Credential prompts branch on `FORGE_TYPE`:
  GitLab keeps the existing url/project/PAT/me flow; GitHub prompts for
  owner/repo/PAT + optional Enterprise URL + optional `me`, uncomments
  the `[forge.github]` template block in `colony.toml`, and writes
  credentials into it. `FEDERATION_FORGE_TYPE=github ./install.sh` is now
  a supported unattended flow.

## Operator migration (pre-#256 configs)

```toml
[forge]
type = "gitlab"

[forge.gitlab]
url     = "https://gitlab.example.com"
token   = "glpat-..."
project = "your-org/your-project"
me      = ""              # optional
default_branch = "main"   # implementation/release only
```

Operators who cannot migrate should pin to `dev-apprenticeship v0.3.3` —
the last release carrying the dual-read fallback.

## Scope boundary — dashboard tile

The wrapper primitive (`rate-limit-status`) ships here as the stable v1.0.0
contract. A `federation-dashboard` consumer tile is deliberately **deferred**
to a separate dashboard release PR after v1.0.0 ships, so a UI churn does
not gate the federation bump. ADR-0002 PR 7 additions paragraph + the
CHANGELOG entry call this out explicitly.

## Validation

- `./tools/colony-lint.sh` — **102 passed, 0 failed, 1 skipped** (baseline
  after PR 6 was 101)
- `tools/test-rate-limit-status.sh` — 25/25 pass (5 colonies × 3 GitLab
  modes + 5 colonies × 2 GitHub modes via PATH-prepended curl shim)
- `tools/test-forge-config.sh` — 45/45 pass (expanded to enforce
  retirement + the FORGE_TYPE-conditional install.sh branches)
- `tools/test-start-colony-restart.sh` — fixture rewritten to
  `[forge.gitlab]`; all colonies pass

## Test plan

- [ ] Review ADR-0002 end-state reads coherently (status Accepted, no
      "as of this writing" language, PR 7 additions paragraph lands)
- [ ] Skim the 10 wrapper `rate-limit-status` arms for symmetry
- [ ] Skim `install.sh` FORGE_TYPE branches — uncomment logic for the
      `[forge.github]` block handles all 5 template shapes
- [ ] Confirm no `[gitlab]` writes anywhere in `install.sh` / `start-colony.sh`
- [ ] Check CHANGELOG BREAKING bullets are unmistakable + migration recipe is correct
- [ ] CI: colony-lint + test-forge-config + test-rate-limit-status all green

Part of #256 — final PR. A separate `release: dev-apprenticeship v1.0.0` PR
follows after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)