### PR TITLE
fix(github-api): read body via stdin to bypass MAX_ARG_STRLEN (#279)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -25,6 +25,8 @@ is asserted until multi-version CI is in place.
 
 ### Fixed
 
+- GitHub wrapper no longer fails on repos with >20 closed PRs — normalizers now read HTTP body via stdin instead of env var, bypassing `MAX_ARG_STRLEN` (#279).
+
 ### Security
 
 ## [1.1.0] — 2026-04-24

--- a/dev-apprenticeship/code-review/scripts/github-api.sh
+++ b/dev-apprenticeship/code-review/scripts/github-api.sh
@@ -76,11 +76,9 @@ emit_error() {
 # ADR-0002. State collapse: open -> opened; closed + merged_at -> merged;
 # closed + no merged_at stays closed.
 normalize_pulls() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for x in data:
     st = x.get("state")
@@ -118,11 +116,9 @@ PY
 # patch text) straight into prompt() so drift in this shape breaks all four
 # finding streams silently.
 normalize_mr_changes() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for f in data:
     status = f.get("status") or ""
@@ -148,11 +144,9 @@ PY
 # row so the GitLab-shape filter (`if not system`) that reviewers apply over
 # mr-notes continues to work.
 normalize_notes() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{
     "id": c.get("id"),
     "body": c.get("body"),
@@ -181,9 +175,9 @@ project_json() {
             printf '%s' "$DATA"
             ;;
         reviewer)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 # #104 parity: keep author.username so style_reviewer tags personal vs team.
 out = [{"iid": x.get("iid"), "state": x.get("state"), "title": x.get("title"),
         "labels": x.get("labels", []), "source_branch": x.get("source_branch"),

--- a/dev-apprenticeship/implementation/scripts/github-api.sh
+++ b/dev-apprenticeship/implementation/scripts/github-api.sh
@@ -79,11 +79,9 @@ emit_error() {
 # Reads GitHub issues-list JSON from stdin, writes GitLab-shape JSON.
 # Filters pull_request entries (GitHub /issues mixes PRs with issues).
 normalize_issues() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for x in data:
     if "pull_request" in x:
@@ -111,11 +109,9 @@ PY
 # Single-issue variant (used by `issue <n>` and by assigned-issues-by-label-events
 # after a timeline hit).
 normalize_issue() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-x = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+x = json.loads(sys.stdin.read())
 print(json.dumps({
     "iid": x.get("number"),
     "title": x.get("title"),
@@ -135,11 +131,9 @@ PY
 # normalize_pulls
 # Reads GitHub pulls-list JSON, writes GitLab-MR-shape JSON.
 normalize_pulls() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for x in data:
     st = x.get("state")
@@ -176,11 +170,9 @@ PY
 # GitHub's "status" field drives new_file/deleted_file/renamed_file; "patch"
 # is the unified-diff text (may be absent on binary files).
 normalize_mr_changes() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for f in data:
     status = f.get("status") or ""
@@ -205,11 +197,9 @@ PY
 # the flat author_name field for prompt-friendliness. "title" is the first
 # line of the commit message (same as GitLab's behavior).
 normalize_mr_commits() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for c in data:
     commit = c.get("commit") or {}
@@ -277,18 +267,18 @@ project_json() {
             printf '%s' "$DATA"
             ;;
         impl)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{"iid": x.get("iid"), "title": x.get("title"),
         "merged_at": x.get("merged_at"), "target_branch": x.get("target_branch")} for x in data]
 print(json.dumps(out))
 PY
             ;;
         assigned)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
         "labels": x.get("labels", []),
         "assignees": [{"username": a.get("username")} for a in x.get("assignees", [])],
@@ -460,9 +450,9 @@ case "$CMD" in
         body="$(gh_get_q "$API/pulls" "${ARGS[@]}")" || exit $?
         normalized="$(printf '%s' "$body" | normalize_pulls)"
         if [ "$MERGED_FILTER" -eq 1 ] || [ -n "$SINCE" ]; then
-            normalized="$(NORM="$normalized" SINCE="$SINCE" MERGED="$MERGED_FILTER" python3 <<'PY'
-import os, json
-items = json.loads(os.environ["NORM"])
+            normalized="$(printf '%s' "$normalized" | SINCE="$SINCE" MERGED="$MERGED_FILTER" python3 /dev/fd/3 3<<'PY'
+import os, sys, json
+items = json.loads(sys.stdin.read())
 since = os.environ.get("SINCE", "")
 merged_only = os.environ.get("MERGED", "0") == "1"
 out = []

--- a/dev-apprenticeship/planning/scripts/github-api.sh
+++ b/dev-apprenticeship/planning/scripts/github-api.sh
@@ -51,11 +51,9 @@ emit_error() {
 # Filters out pull_request entries — GitHub's /issues mixes PRs with issues,
 # but planning only cares about issues for triage-time fields.
 normalize_issues() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for x in data:
     if "pull_request" in x:
@@ -80,11 +78,9 @@ PY
 # Single-issue variant. Used by issues-by-label-events when re-fetching a
 # full issue body after a timeline hit.
 normalize_issue() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-x = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+x = json.loads(sys.stdin.read())
 print(json.dumps({
     "iid": x.get("number"),
     "title": x.get("title"),
@@ -115,11 +111,9 @@ PY
 #                 review_comments separately but comments is the closest analog
 #                 to GitLab's user_notes_count on MRs)
 normalize_pulls() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for x in data:
     st = x.get("state")
@@ -201,9 +195,9 @@ project_json() {
             printf '%s' "$DATA"
             ;;
         planning)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
         "labels": x.get("labels", []),
         "author": {"username": (x.get("author") or {}).get("username")},
@@ -212,9 +206,9 @@ print(json.dumps(out))
 PY
             ;;
         planning-mr)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
         "labels": x.get("labels", []), "changes_count": x.get("changes_count"),
         "user_notes_count": x.get("user_notes_count"),
@@ -567,9 +561,9 @@ PY
         body="$(gh_get_q "$API/pulls" "${ARGS[@]}")" || exit $?
         normalized="$(printf '%s' "$body" | normalize_pulls)"
         if [ "$MERGED_FILTER" -eq 1 ] || [ -n "$SINCE" ]; then
-            normalized="$(NORM="$normalized" SINCE="$SINCE" MERGED="$MERGED_FILTER" python3 <<'PY'
-import os, json
-items = json.loads(os.environ["NORM"])
+            normalized="$(printf '%s' "$normalized" | SINCE="$SINCE" MERGED="$MERGED_FILTER" python3 /dev/fd/3 3<<'PY'
+import os, sys, json
+items = json.loads(sys.stdin.read())
 since = os.environ.get("SINCE", "")
 merged_only = os.environ.get("MERGED", "0") == "1"
 out = []

--- a/dev-apprenticeship/release/scripts/github-api.sh
+++ b/dev-apprenticeship/release/scripts/github-api.sh
@@ -92,11 +92,9 @@ emit_error() {
 # released_at, description) plus the fields changelog_writer reads from the
 # raw output (author, created_at) when prompted for release-note context.
 normalize_releases() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{
     "tag_name": x.get("tag_name"),
     "name": x.get("name"),
@@ -119,11 +117,9 @@ PY
 # changelog_writer) use these fields for prompt context only — missing values
 # degrade prompt quality but do not break branching.
 normalize_tags() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for x in data:
     commit = x.get("commit") or {}
@@ -154,11 +150,9 @@ PY
 # GitLab-pipelines-shape JSON. Status collapse mirrors the agentis-colonies
 # shape contract in ADR-0002 §"Semantic collapses".
 normalize_pipelines() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-envelope = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+envelope = json.loads(sys.stdin.read())
 # GitHub wraps the list in {total_count, workflow_runs: [...]}; other endpoints
 # return a bare array. Accept both so ad-hoc callers piping raw responses work.
 if isinstance(envelope, dict):
@@ -204,11 +198,9 @@ PY
 # does). State collapse: open -> opened; closed + merged_at -> merged;
 # closed + no merged_at stays closed.
 normalize_pulls() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for x in data:
     st = x.get("state")
@@ -251,18 +243,18 @@ project_json() {
             printf '%s' "$DATA"
             ;;
         release-summary)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{"tag_name": x.get("tag_name"), "name": x.get("name"),
         "released_at": x.get("released_at"), "description": x.get("description")} for x in data]
 print(json.dumps(out))
 PY
             ;;
         tag-summary)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{"name": x.get("name"), "message": x.get("message"),
         "commit": {"short_id": (x.get("commit") or {}).get("short_id"),
                    "created_at": (x.get("commit") or {}).get("created_at")}} for x in data]
@@ -270,9 +262,9 @@ print(json.dumps(out))
 PY
             ;;
         pipeline-summary)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{"id": x.get("id"), "status": x.get("status"), "ref": x.get("ref"),
         "sha": x.get("sha"), "created_at": x.get("created_at"),
         "web_url": x.get("web_url")} for x in data]
@@ -280,9 +272,9 @@ print(json.dumps(out))
 PY
             ;;
         release-mr)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
         "merged_at": x.get("merged_at"),
         "labels": x.get("labels", []), "target_branch": x.get("target_branch")} for x in data]

--- a/dev-apprenticeship/triage/scripts/github-api.sh
+++ b/dev-apprenticeship/triage/scripts/github-api.sh
@@ -47,13 +47,9 @@ emit_error() {
 # Also filters out pull_request entries — GitHub's /issues endpoint mixes PRs
 # with issues, but the triage colony only cares about issues.
 normalize_issues() {
-    # stdin travels via env var because python3's <<'PY' heredoc already
-    # occupies python's stdin — same idiom as project_json below.
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for x in data:
     if "pull_request" in x:  # skip PRs
@@ -77,11 +73,9 @@ PY
 # normalize_issue
 # Single-issue variant of normalize_issues. Outputs a single object (not array).
 normalize_issue() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-x = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+x = json.loads(sys.stdin.read())
 print(json.dumps({
     "iid": x.get("number"),
     "title": x.get("title"),
@@ -104,11 +98,9 @@ PY
 # has no nulls — the router agent uses `username` for mechanical assignment,
 # `name` is only for display and null-vs-login doesn't matter operationally.
 normalize_members() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = []
 for x in data:
     login = x.get("login")
@@ -126,11 +118,9 @@ PY
 # (no text_color, no *_count fields). We forward name/description/color which
 # is what the labels-summary view keeps anyway.
 normalize_labels() {
-    local DATA
-    DATA="$(cat)"
-    DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{
     "name": x.get("name"),
     "description": x.get("description"),
@@ -160,34 +150,34 @@ project_json() {
             printf '%s' "$DATA"
             ;;
         labeler)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 print(json.dumps([{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", []),
                    "author": {"username": (x.get("author") or {}).get("username")}} for x in data]))
 PY
             ;;
         router)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", []),
         "assignees": [{"username": a.get("username")} for a in x.get("assignees", [])]} for x in data]
 print(json.dumps(out))
 PY
             ;;
         prioritizer)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 print(json.dumps([{"iid": x.get("iid"), "title": x.get("title"), "labels": x.get("labels", []),
                    "author": {"username": (x.get("author") or {}).get("username")}} for x in data]))
 PY
             ;;
         issue_creator)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 out = [{"iid": x.get("iid"), "title": x.get("title"), "description": x.get("description"),
         "labels": x.get("labels", []),
         "author": {"username": (x.get("author") or {}).get("username")}} for x in data]
@@ -195,23 +185,23 @@ print(json.dumps(out))
 PY
             ;;
         members-summary)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 print(json.dumps([{"id": x.get("id"), "username": x.get("username"), "name": x.get("name")} for x in data]))
 PY
             ;;
         labels-summary)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-data = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+data = json.loads(sys.stdin.read())
 print(json.dumps([{"name": x.get("name"), "description": x.get("description"), "color": x.get("color")} for x in data]))
 PY
             ;;
         feedback-issue)
-            DATA="$DATA" python3 <<'PY'
-import os, json
-x = json.loads(os.environ["DATA"])
+            printf '%s' "$DATA" | python3 /dev/fd/3 3<<'PY'
+import sys, json
+x = json.loads(sys.stdin.read())
 print(json.dumps({"iid": x.get("iid"), "state": x.get("state"), "labels": x.get("labels", [])}))
 PY
             ;;

--- a/tools/test-github-code-review-normalize.sh
+++ b/tools/test-github-code-review-normalize.sh
@@ -222,6 +222,27 @@ assert_eq "10" "$E2E_IID" "e2e reviewer: view carries iid through pipe"
 assert_eq "True" "$E2E_DRAFT" "e2e reviewer: draft flows through pipe"
 assert_eq "alice" "$E2E_AUTHOR" "e2e reviewer: author.username preserved"
 
+# --- Large payload (>200 KB) regression test for #279 ---
+# 50 PRs × ~5 KB body each exceeds MAX_ARG_STRLEN when passed via env var.
+# Fix: normalize_pulls reads HTTP body from stdin instead of env var.
+# The payload is generated INSIDE the bash -c scope so the test harness itself
+# does not hit the exec argv limit it is trying to certify the wrapper against.
+LARGE_PRELUDE=$(mktemp)
+build_prelude "$LARGE_PRELUDE"
+# shellcheck disable=SC1090,SC2016
+LARGE_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    python3 -c "import json; print(json.dumps([{\"number\":i,\"title\":f\"t{i}\",\"body\":\"x\"*5000,\"state\":\"open\",\"labels\":[],\"user\":{\"login\":\"u\"},\"base\":{\"ref\":\"main\"},\"head\":{\"ref\":\"f\"},\"merged_at\":None,\"created_at\":\"2026-01-01T00:00:00Z\",\"updated_at\":\"2026-01-01T00:00:00Z\",\"changed_files\":0,\"additions\":0,\"deletions\":0} for i in range(50)]))" | normalize_pulls
+' _ "$LARGE_PRELUDE")
+LARGE_RC=$?
+rm -f "$LARGE_PRELUDE"
+assert_eq "0" "$LARGE_RC" "normalize_pulls: large payload (>200 KB) exits 0 (#279)"
+if [ -n "$LARGE_OUT" ]; then
+    pass "normalize_pulls: large payload produces non-empty stdout (#279)"
+else
+    fail "normalize_pulls: large payload produces non-empty stdout (#279): stdout was empty"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-github-implementation-normalize.sh
+++ b/tools/test-github-implementation-normalize.sh
@@ -334,6 +334,27 @@ assert_eq "iid,merged_at,target_branch,title" "$E2E_MR_KEYS" "e2e impl: view key
 assert_eq "2026-04-05T12:00:00Z" "$E2E_MR_MERGED" "e2e impl: merged_at carried through"
 assert_eq "main" "$E2E_MR_TGT" "e2e impl: target_branch carried through"
 
+# --- Large payload (>200 KB) regression test for #279 ---
+# 50 PRs × ~5 KB body each exceeds MAX_ARG_STRLEN when passed via env var.
+# Fix: normalize_pulls reads HTTP body from stdin instead of env var.
+# The payload is generated INSIDE the bash -c scope so the test harness itself
+# does not hit the exec argv limit it is trying to certify the wrapper against.
+LARGE_PRELUDE=$(mktemp)
+build_prelude "$LARGE_PRELUDE"
+# shellcheck disable=SC1090,SC2016
+LARGE_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    python3 -c "import json; print(json.dumps([{\"number\":i,\"title\":f\"t{i}\",\"body\":\"x\"*5000,\"state\":\"open\",\"labels\":[],\"user\":{\"login\":\"u\"},\"base\":{\"ref\":\"main\"},\"head\":{\"ref\":\"f\"},\"merged_at\":None,\"created_at\":\"2026-01-01T00:00:00Z\",\"updated_at\":\"2026-01-01T00:00:00Z\",\"changed_files\":0,\"additions\":0,\"deletions\":0} for i in range(50)]))" | normalize_pulls
+' _ "$LARGE_PRELUDE")
+LARGE_RC=$?
+rm -f "$LARGE_PRELUDE"
+assert_eq "0" "$LARGE_RC" "normalize_pulls: large payload (>200 KB) exits 0 (#279)"
+if [ -n "$LARGE_OUT" ]; then
+    pass "normalize_pulls: large payload produces non-empty stdout (#279)"
+else
+    fail "normalize_pulls: large payload produces non-empty stdout (#279): stdout was empty"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-github-planning-normalize.sh
+++ b/tools/test-github-planning-normalize.sh
@@ -260,6 +260,27 @@ assert_eq "changes_count,description,iid,labels,merged_at,target_branch,title,us
 assert_eq "2026-04-05T12:00:00Z" "$E2E_MR_MERGED" "e2e planning-mr: merged_at carried through"
 assert_eq "main" "$E2E_MR_TGT" "e2e planning-mr: target_branch carried through"
 
+# --- Large payload (>200 KB) regression test for #279 ---
+# 50 PRs × ~5 KB body each exceeds MAX_ARG_STRLEN when passed via env var.
+# Fix: normalize_pulls reads HTTP body from stdin instead of env var.
+# The payload is generated INSIDE the bash -c scope so the test harness itself
+# does not hit the exec argv limit it is trying to certify the wrapper against.
+LARGE_PRELUDE=$(mktemp)
+build_prelude "$LARGE_PRELUDE"
+# shellcheck disable=SC1090,SC2016
+LARGE_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    python3 -c "import json; print(json.dumps([{\"number\":i,\"title\":f\"t{i}\",\"body\":\"x\"*5000,\"state\":\"open\",\"labels\":[],\"user\":{\"login\":\"u\"},\"base\":{\"ref\":\"main\"},\"head\":{\"ref\":\"f\"},\"merged_at\":None,\"created_at\":\"2026-01-01T00:00:00Z\",\"updated_at\":\"2026-01-01T00:00:00Z\",\"changed_files\":0,\"additions\":0,\"deletions\":0} for i in range(50)]))" | normalize_pulls
+' _ "$LARGE_PRELUDE")
+LARGE_RC=$?
+rm -f "$LARGE_PRELUDE"
+assert_eq "0" "$LARGE_RC" "normalize_pulls: large payload (>200 KB) exits 0 (#279)"
+if [ -n "$LARGE_OUT" ]; then
+    pass "normalize_pulls: large payload produces non-empty stdout (#279)"
+else
+    fail "normalize_pulls: large payload produces non-empty stdout (#279): stdout was empty"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-github-release-normalize.sh
+++ b/tools/test-github-release-normalize.sh
@@ -326,6 +326,27 @@ assert_eq "description,iid,labels,merged_at,target_branch,title" "$E2E_MR_KEYS" 
 assert_eq "21" "$E2E_MR_IID" "e2e release-mr: iid through pipe"
 assert_eq "2026-04-05T12:00:00Z" "$E2E_MR_STATE_MERGED" "e2e release-mr: merged_at through pipe"
 
+# --- Large payload (>200 KB) regression test for #279 ---
+# 50 PRs × ~5 KB body each exceeds MAX_ARG_STRLEN when passed via env var.
+# Fix: normalize_pulls reads HTTP body from stdin instead of env var.
+# The payload is generated INSIDE the bash -c scope so the test harness itself
+# does not hit the exec argv limit it is trying to certify the wrapper against.
+LARGE_PRELUDE=$(mktemp)
+build_prelude "$LARGE_PRELUDE"
+# shellcheck disable=SC1090,SC2016
+LARGE_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    python3 -c "import json; print(json.dumps([{\"number\":i,\"title\":f\"t{i}\",\"body\":\"x\"*5000,\"state\":\"open\",\"labels\":[],\"user\":{\"login\":\"u\"},\"base\":{\"ref\":\"main\"},\"head\":{\"ref\":\"f\"},\"merged_at\":None,\"created_at\":\"2026-01-01T00:00:00Z\",\"updated_at\":\"2026-01-01T00:00:00Z\",\"changed_files\":0,\"additions\":0,\"deletions\":0} for i in range(50)]))" | normalize_pulls
+' _ "$LARGE_PRELUDE")
+LARGE_RC=$?
+rm -f "$LARGE_PRELUDE"
+assert_eq "0" "$LARGE_RC" "normalize_pulls: large payload (>200 KB) exits 0 (#279)"
+if [ -n "$LARGE_OUT" ]; then
+    pass "normalize_pulls: large payload produces non-empty stdout (#279)"
+else
+    fail "normalize_pulls: large payload produces non-empty stdout (#279): stdout was empty"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-github-triage-normalize.sh
+++ b/tools/test-github-triage-normalize.sh
@@ -221,6 +221,27 @@ assert_eq "author,iid,labels,title" "$E2E_KEYS" "e2e: labeler view keys match gi
 assert_eq "1" "$E2E_IID" "e2e: labeler view carries iid through pipe"
 assert_eq "alice" "$E2E_AUTHOR" "e2e: labeler view carries author.username through pipe"
 
+# --- Large payload (>200 KB) regression test for #279 ---
+# 50 issues × ~5 KB body each exceeds MAX_ARG_STRLEN when passed via env var.
+# Fix: normalize_issues reads HTTP body from stdin instead of env var.
+# The payload is generated INSIDE the bash -c scope so the test harness itself
+# does not hit the exec argv limit it is trying to certify the wrapper against.
+LARGE_PRELUDE=$(mktemp)
+build_prelude "$LARGE_PRELUDE"
+# shellcheck disable=SC1090,SC2016
+LARGE_OUT=$(GITHUB_URL=http://x GITHUB_TOKEN=y GITHUB_OWNER=o GITHUB_REPO=r bash -c '
+    source "$1"
+    python3 -c "import json; print(json.dumps([{\"number\":i,\"title\":f\"t{i}\",\"body\":\"x\"*5000,\"state\":\"open\",\"labels\":[],\"user\":{\"login\":\"u\"},\"assignees\":[],\"created_at\":\"2026-01-01T00:00:00Z\",\"updated_at\":\"2026-01-01T00:00:00Z\",\"comments\":0} for i in range(50)]))" | normalize_issues
+' _ "$LARGE_PRELUDE")
+LARGE_RC=$?
+rm -f "$LARGE_PRELUDE"
+assert_eq "0" "$LARGE_RC" "normalize_issues: large payload (>200 KB) exits 0 (#279)"
+if [ -n "$LARGE_OUT" ]; then
+    pass "normalize_issues: large payload produces non-empty stdout (#279)"
+else
+    fail "normalize_issues: large payload produces non-empty stdout (#279): stdout was empty"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes #279. Follow-up to #277 (which unblocked `forge-api.sh` dispatch and made this failure observable).

Every `dev-apprenticeship/*/scripts/github-api.sh` wrapper stuffed the raw HTTP body into a `DATA=` env var before passing it to `python3 <<'PY'`. On Linux, execve's per-arg limit (`MAX_ARG_STRLEN`, 128 KiB) means a single closed-PR list response (>20 items with non-trivial bodies) pushes past the limit and the wrapper dies with `E2BIG` before `normalize_*` ever runs.

## Changes

- 35 `DATA=` sites across 5 `github-api.sh` wrappers: drop the env-var indirection, read stdin directly inside the Python heredoc.
- 2 `NORM=` sites (implementation + planning merge-requests filter): move `NORM` to stdin, keep tiny `SINCE`/`MERGED` on env line.
- 5 `tools/test-github-*-normalize.sh` harnesses: add one large-payload regression test each (50 items × ~5 KB body = ~260 KB, well past `MAX_ARG_STRLEN`).
- `dev-apprenticeship/CHANGELOG.md`: one-line `Fixed` entry under `[Unreleased]`.

### Deviation from plan

The plan's literal diff (`python3 <<'PY'` + `sys.stdin.read()`) cannot work because `<<'PY'` redirects stdin to the heredoc. Switched to `python3 /dev/fd/3 3<<'PY'` — the heredoc becomes fd 3, stdin stays wired to the pipe. Net result is identical to the plan's intent (payload via stdin, not env var), same portability story (Linux + macOS bash ≥3.2).

## Test plan

- [x] `bash -n` on all 5 wrappers
- [x] `./tools/test-github-triage-normalize.sh` — 27 passed (was 25; +2 from the new #279 test)
- [x] `./tools/test-github-implementation-normalize.sh` — 52 passed (was 50)
- [x] `./tools/test-github-planning-normalize.sh` — 34 passed (was 32)
- [x] `./tools/test-github-release-normalize.sh` — 49 passed (was 47)
- [x] `./tools/test-github-code-review-normalize.sh` — 34 passed (was 32)
- [x] `./tools/colony-lint.sh` — 103 passed / 0 failed / 1 skipped

## Non-goals

- No `install.sh` changes (#277 / #278 / #280 handle those separately).
- No `VERSION` bump (fold into next patch release).
- No `.ag` agent touches — wrapper-only.
- No `federation-dashboard/` touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)