### PR TITLE
fix(install.sh): route FORGE_TYPE + GITHUB_* through exec.env_passthrough (#277)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -26,6 +26,7 @@ is asserted until multi-version CI is in place.
 ### Fixed
 
 - GitHub wrapper no longer fails on repos with >20 closed PRs — normalizers now read HTTP body via stdin instead of env var, bypassing `MAX_ARG_STRLEN` (#279).
+- `install.sh` now routes `FORGE_TYPE` and `GITHUB_*` through `exec.env_passthrough`; existing installs with the pre-fix literal are auto-upgraded in place. Unblocks GitHub-backend federations (#277).
 
 ### Security
 

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -600,7 +600,16 @@ if [ -d "$AGENTIS_DIR" ]; then
     write_key 'daemon.heartbeat_interval_ms' '180000'
     write_key 'daemon.cb_per_tick'           '2000'
     write_key 'experience.enabled'           'true'
-    write_key 'exec.env_passthrough'         'COLONY_DIR,GITLAB_*'
+    # Migrate #277 pre-fix literal in-place. Exact-match only — any operator
+    # customization (extra vars, reordering) is preserved untouched.
+    if [ -f "$AGENTIS_CONFIG" ] && grep -qxF 'exec.env_passthrough = COLONY_DIR,GITLAB_*' "$AGENTIS_CONFIG"; then
+        # Use a tmp file + mv for atomicity; no sed -i (BSD vs GNU portability).
+        awk '/^exec\.env_passthrough = COLONY_DIR,GITLAB_\*$/ \
+             { print "exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*"; next } { print }' \
+            "$AGENTIS_CONFIG" > "$AGENTIS_CONFIG.tmp" && mv "$AGENTIS_CONFIG.tmp" "$AGENTIS_CONFIG"
+        ok "upgraded exec.env_passthrough (#277)"
+    fi
+    write_key 'exec.env_passthrough'         'COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*'
     write_key 'exec.default_timeout_ms'      '120000'
     write_key 'pii_transmit'                 'allow'
     write_key 'knowledge.enabled'            'true'

--- a/tools/test-install-env-passthrough.sh
+++ b/tools/test-install-env-passthrough.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# tools/test-install-env-passthrough.sh: unit tests for the install.sh
+# exec.env_passthrough fix and in-place upgrade block (#277).
+#
+# Validates:
+#   Test 1: Fresh install writes the new literal with FORGE_TYPE + GITHUB_*
+#   Test 2: Upgrade path rewrites the pre-fix literal to the new value
+#   Test 3: Operator-tuned values are preserved (exact-match gate misses)
+#
+# Usage: ./tools/test-install-env-passthrough.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -e
+
+FAKE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FAKE_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+# Replicates the install.sh write_key + upgrade logic under FAKE_ROOT.
+# Keep in sync with dev-apprenticeship/install.sh §4 (env_passthrough).
+run_install_fragment() {
+    local AGENTIS_CONFIG="$1"
+
+    write_key() {
+        local key="$1"
+        local value="$2"
+        local grep_key
+        grep_key=$(printf '%s' "$key" | sed 's/\./\\./g')
+        if ! grep -q "^${grep_key}[[:space:]]*=" "$AGENTIS_CONFIG" 2>/dev/null; then
+            printf '%s = %s\n' "$key" "$value" >> "$AGENTIS_CONFIG"
+        fi
+    }
+
+    # Migrate #277 pre-fix literal in-place. Exact-match only — any operator
+    # customization (extra vars, reordering) is preserved untouched.
+    if [ -f "$AGENTIS_CONFIG" ] && grep -qxF 'exec.env_passthrough = COLONY_DIR,GITLAB_*' "$AGENTIS_CONFIG"; then
+        awk '/^exec\.env_passthrough = COLONY_DIR,GITLAB_\*$/ \
+             { print "exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*"; next } { print }' \
+            "$AGENTIS_CONFIG" > "$AGENTIS_CONFIG.tmp" && mv "$AGENTIS_CONFIG.tmp" "$AGENTIS_CONFIG"
+    fi
+    write_key 'exec.env_passthrough' 'COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*'
+}
+
+EXPECTED_NEW='exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*'
+EXPECTED_OLD='exec.env_passthrough = COLONY_DIR,GITLAB_*'
+OPERATOR_TUNED='exec.env_passthrough = COLONY_DIR,GITLAB_*,MY_CUSTOM'
+
+# ----- Test 1: Fresh install -----
+T1_DIR="$FAKE_ROOT/t1"
+mkdir -p "$T1_DIR"
+T1_CONFIG="$T1_DIR/config"
+: > "$T1_CONFIG"
+
+run_install_fragment "$T1_CONFIG"
+
+if grep -qxF "$EXPECTED_NEW" "$T1_CONFIG"; then
+    pass "fresh install writes exec.env_passthrough with FORGE_TYPE + GITHUB_*"
+else
+    fail "fresh install — expected '$EXPECTED_NEW', got:"
+    cat "$T1_CONFIG"
+fi
+
+# ----- Test 2: Upgrade path -----
+T2_DIR="$FAKE_ROOT/t2"
+mkdir -p "$T2_DIR"
+T2_CONFIG="$T2_DIR/config"
+printf '%s\n' "$EXPECTED_OLD" > "$T2_CONFIG"
+
+run_install_fragment "$T2_CONFIG"
+
+if grep -qxF "$EXPECTED_NEW" "$T2_CONFIG" \
+    && ! grep -qxF "$EXPECTED_OLD" "$T2_CONFIG"; then
+    pass "upgrade path rewrites pre-fix literal to the new value"
+else
+    fail "upgrade path — expected '$EXPECTED_NEW', got:"
+    cat "$T2_CONFIG"
+fi
+
+# ----- Test 3: Operator-tuned preserved -----
+T3_DIR="$FAKE_ROOT/t3"
+mkdir -p "$T3_DIR"
+T3_CONFIG="$T3_DIR/config"
+printf '%s\n' "$OPERATOR_TUNED" > "$T3_CONFIG"
+
+run_install_fragment "$T3_CONFIG"
+
+if grep -qxF "$OPERATOR_TUNED" "$T3_CONFIG" \
+    && ! grep -qxF "$EXPECTED_NEW" "$T3_CONFIG"; then
+    pass "operator-tuned value preserved (exact-match gate did not match)"
+else
+    fail "operator-tuned preservation — expected '$OPERATOR_TUNED' untouched, got:"
+    cat "$T3_CONFIG"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fixes #277.

Unblocks GitHub-backend federations. `forge-api.sh` (the post-#256 dispatcher) reads `FORGE_TYPE` to choose between `gitlab-api.sh` and `github-api.sh`; `github-api.sh` in turn reads `GITHUB_*` to authenticate. Both env-var families are exported by `start-colony.sh`, but the daemon strips the exec environment per `exec.env_passthrough` before `exec sh` — so without `FORGE_TYPE` and `GITHUB_*` in that allowlist, every exec falls back to the gitlab backend regardless of what `colony.toml` says, and then fails on missing `GITLAB_*` on a github-configured colony.

This PR fixes `install.sh` so fresh installs get the correct allowlist (`COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*`), and adds a targeted in-place upgrade block for operators who already ran the broken installer. The upgrade uses `grep -qxF` for exact-line match — any operator customization (extra vars, reordering) misses the gate and is preserved untouched.

## Test plan

- [x] `./tools/test-install-env-passthrough.sh` — 3/3 passes:
  - Fresh install: empty config gets `exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*`
  - Upgrade path: pre-seeded `COLONY_DIR,GITLAB_*` is rewritten in place
  - Operator-tuned preserved: `COLONY_DIR,GITLAB_*,MY_CUSTOM` is left alone
- [x] `./tools/colony-lint.sh` — 104 passed, 0 failed, 1 skipped (one new test harness added)

<details>
<summary>Existing-install workaround</summary>

Operators who already ran `install.sh` on a GitHub-backend federation and don't want to re-run it can apply the one-liner directly:

```bash
sed -i 's|^exec\.env_passthrough = COLONY_DIR,GITLAB_\*$|exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*|' .agentis/config
# then: ./kill-federation.sh && ./start-federation.sh
```

Re-running `install.sh` post-merge performs the same rewrite automatically via the new upgrade block — the sed workaround is only useful for operators who want the fix without pulling a new release.
</details>

## Non-goals

This PR does **not** fix #278 (gitlab:me seed on GitHub backends) or #280 (heartbeat interval on GitHub backends). Those are tracked separately as PR 2/3 and PR 3/3 of the #277 → #280 → #278 series.