### PR TITLE
fix(install.sh): raise heartbeat_interval_ms to cover reactive colonies (300s tick) (#280)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -27,6 +27,7 @@ is asserted until multi-version CI is in place.
 
 - GitHub wrapper no longer fails on repos with >20 closed PRs — normalizers now read HTTP body via stdin instead of env var, bypassing `MAX_ARG_STRLEN` (#279).
 - `install.sh` now routes `FORGE_TYPE` and `GITHUB_*` through `exec.env_passthrough`; existing installs with the pre-fix literal are auto-upgraded in place. Unblocks GitHub-backend federations (#277).
+- `install.sh` now sets `daemon.heartbeat_interval_ms = 900000` (3× the longest tick interval, 300 000 ms, per #146) so reactive code-review/release agents are no longer killed by the watchdog after their first tick; existing installs with the pre-fix `180000` literal are auto-upgraded in place (#280).
 
 ### Security
 

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -509,10 +509,16 @@ if [ -d "$AGENTIS_DIR" ]; then
     #                                 directly (e.g. debug sessions), where
     #                                 without the config key the watchdog
     #                                 uses the 1 s default.
-    #   daemon.heartbeat_interval_ms — 3× tick is long enough for a
-    #                                  Claude CLI cold start (typ. 5-30 s).
-    #                                  Default 2× tick is fine for mock,
-    #                                  but kills real-LLM agents mid-tick.
+    #   daemon.heartbeat_interval_ms — 3× the longest tick interval in the
+    #                                  federation (300 000 ms reactive per
+    #                                  #146: release + code-review colonies
+    #                                  tick at 300 s), so the watchdog waits
+    #                                  one full reactive tick before it
+    #                                  considers an agent stuck. The pre-fix
+    #                                  180 000 value was calibrated for the
+    #                                  60 s active default (3× = 180 s) and
+    #                                  killed every reactive agent on its
+    #                                  first tick (#280).
     #   daemon.cb_per_tick          — 2000 covers ~40 prompt() calls per
     #                                 tick. Default 100 overflows on the
     #                                 first prompt (50 CB each) and makes
@@ -597,7 +603,16 @@ if [ -d "$AGENTIS_DIR" ]; then
     write_key 'federation.enabled'           'true'
     write_key 'knowledge.federation_enabled' 'true'
     write_key 'daemon.tick_interval_ms'      '60000'
-    write_key 'daemon.heartbeat_interval_ms' '180000'
+    # Migrate #280 pre-fix literal in-place. Exact-match only — any operator
+    # customization (e.g. 300000 for a slow-LLM deployment) is preserved.
+    if [ -f "$AGENTIS_CONFIG" ] && grep -qxF 'daemon.heartbeat_interval_ms = 180000' "$AGENTIS_CONFIG"; then
+        # Use a tmp file + mv for atomicity; no sed -i (BSD vs GNU portability).
+        awk '/^daemon\.heartbeat_interval_ms = 180000$/ \
+             { print "daemon.heartbeat_interval_ms = 900000"; next } { print }' \
+            "$AGENTIS_CONFIG" > "$AGENTIS_CONFIG.tmp" && mv "$AGENTIS_CONFIG.tmp" "$AGENTIS_CONFIG"
+        ok "upgraded daemon.heartbeat_interval_ms (#280)"
+    fi
+    write_key 'daemon.heartbeat_interval_ms' '900000'
     write_key 'daemon.cb_per_tick'           '2000'
     write_key 'experience.enabled'           'true'
     # Migrate #277 pre-fix literal in-place. Exact-match only — any operator

--- a/tools/test-install-env-passthrough.sh
+++ b/tools/test-install-env-passthrough.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 # tools/test-install-env-passthrough.sh: unit tests for the install.sh
-# exec.env_passthrough fix and in-place upgrade block (#277).
+# exec.env_passthrough fix (#277) and the daemon.heartbeat_interval_ms fix
+# (#280). Both share the same `write_key` + exact-match migrate idiom, so
+# the coverage lives in one harness.
 #
 # Validates:
-#   Test 1: Fresh install writes the new literal with FORGE_TYPE + GITHUB_*
-#   Test 2: Upgrade path rewrites the pre-fix literal to the new value
-#   Test 3: Operator-tuned values are preserved (exact-match gate misses)
+#   Test 1: Fresh install writes the new env_passthrough literal
+#   Test 2: env_passthrough upgrade rewrites the pre-fix literal
+#   Test 3: Operator-tuned env_passthrough preserved (exact-match misses)
+#   Test 4: Fresh install writes daemon.heartbeat_interval_ms = 900000
+#   Test 5: Heartbeat upgrade rewrites the pre-fix 180000 literal
+#   Test 6: Operator-tuned heartbeat (e.g. 300000) preserved
 #
 # Usage: ./tools/test-install-env-passthrough.sh
 # Exit code 0 if all tests pass, 1 otherwise.
@@ -94,6 +99,85 @@ if grep -qxF "$OPERATOR_TUNED" "$T3_CONFIG" \
 else
     fail "operator-tuned preservation — expected '$OPERATOR_TUNED' untouched, got:"
     cat "$T3_CONFIG"
+fi
+
+# ----- Heartbeat interval (#280) -----
+
+# Replicates the install.sh write_key + upgrade logic for
+# daemon.heartbeat_interval_ms under FAKE_ROOT.
+# Keep in sync with dev-apprenticeship/install.sh §4 (heartbeat).
+run_install_fragment_heartbeat() {
+    local AGENTIS_CONFIG="$1"
+
+    write_key() {
+        local key="$1"
+        local value="$2"
+        local grep_key
+        grep_key=$(printf '%s' "$key" | sed 's/\./\\./g')
+        if ! grep -q "^${grep_key}[[:space:]]*=" "$AGENTIS_CONFIG" 2>/dev/null; then
+            printf '%s = %s\n' "$key" "$value" >> "$AGENTIS_CONFIG"
+        fi
+    }
+
+    # Migrate #280 pre-fix literal in-place. Exact-match only — any operator
+    # customization (e.g. 300000 for a slow-LLM deployment) is preserved.
+    if [ -f "$AGENTIS_CONFIG" ] && grep -qxF 'daemon.heartbeat_interval_ms = 180000' "$AGENTIS_CONFIG"; then
+        awk '/^daemon\.heartbeat_interval_ms = 180000$/ \
+             { print "daemon.heartbeat_interval_ms = 900000"; next } { print }' \
+            "$AGENTIS_CONFIG" > "$AGENTIS_CONFIG.tmp" && mv "$AGENTIS_CONFIG.tmp" "$AGENTIS_CONFIG"
+    fi
+    write_key 'daemon.heartbeat_interval_ms' '900000'
+}
+
+HB_EXPECTED_NEW='daemon.heartbeat_interval_ms = 900000'
+HB_EXPECTED_OLD='daemon.heartbeat_interval_ms = 180000'
+HB_OPERATOR_TUNED='daemon.heartbeat_interval_ms = 300000'
+
+# ----- Test 4: Fresh install writes the 900000 heartbeat -----
+T4_DIR="$FAKE_ROOT/t4"
+mkdir -p "$T4_DIR"
+T4_CONFIG="$T4_DIR/config"
+: > "$T4_CONFIG"
+
+run_install_fragment_heartbeat "$T4_CONFIG"
+
+if grep -qxF "$HB_EXPECTED_NEW" "$T4_CONFIG"; then
+    pass "fresh install writes daemon.heartbeat_interval_ms = 900000"
+else
+    fail "fresh install heartbeat — expected '$HB_EXPECTED_NEW', got:"
+    cat "$T4_CONFIG"
+fi
+
+# ----- Test 5: Upgrade path rewrites 180000 -> 900000 -----
+T5_DIR="$FAKE_ROOT/t5"
+mkdir -p "$T5_DIR"
+T5_CONFIG="$T5_DIR/config"
+printf '%s\n' "$HB_EXPECTED_OLD" > "$T5_CONFIG"
+
+run_install_fragment_heartbeat "$T5_CONFIG"
+
+if grep -qxF "$HB_EXPECTED_NEW" "$T5_CONFIG" \
+    && ! grep -qxF "$HB_EXPECTED_OLD" "$T5_CONFIG"; then
+    pass "upgrade path rewrites heartbeat 180000 to 900000"
+else
+    fail "heartbeat upgrade — expected '$HB_EXPECTED_NEW' and no '$HB_EXPECTED_OLD', got:"
+    cat "$T5_CONFIG"
+fi
+
+# ----- Test 6: Operator-tuned heartbeat preserved -----
+T6_DIR="$FAKE_ROOT/t6"
+mkdir -p "$T6_DIR"
+T6_CONFIG="$T6_DIR/config"
+printf '%s\n' "$HB_OPERATOR_TUNED" > "$T6_CONFIG"
+
+run_install_fragment_heartbeat "$T6_CONFIG"
+
+if grep -qxF "$HB_OPERATOR_TUNED" "$T6_CONFIG" \
+    && ! grep -qxF "$HB_EXPECTED_NEW" "$T6_CONFIG"; then
+    pass "operator-tuned heartbeat preserved (exact-match gate did not match)"
+else
+    fail "operator-tuned heartbeat preservation — expected '$HB_OPERATOR_TUNED' untouched, got:"
+    cat "$T6_CONFIG"
 fi
 
 echo ""


### PR DESCRIPTION
Fixes #280.

## Why

`daemon.heartbeat_interval_ms` is the watchdog ceiling — if an agent goes that long without a tick the daemon is restarted. The previous value `180000` was calibrated against the default `tick_interval_ms = 60000` (3× = 180 s, fine for a Claude CLI cold start). But per #146, `start-colony.sh` now passes per-agent `--tick-interval` values, and the federation mixes three intervals:

- **60 s** active agents (implementation, triage labeler/issue_creator, planning, most of code-review support)
- **180 s** router + prioritizer (triage)
- **300 s** reactive code-review + release agents

At the 180 s ceiling, every 300 s-tick agent exceeded the watchdog on first tick and was killed — 11 of 21 agents in the federation. The ceiling must cover the **longest** tick, not the average; the new value is `900000` = 3× 300 000 ms, leaving the same 3× margin the original value gave active agents.

The in-file comment block above `write_key` still claimed "3× tick is long enough for a Claude CLI cold start" — stale since #146 introduced per-agent intervals. It is updated in this PR to name the 300 s ceiling and explicitly call out the pre-fix breakage.

## What changes

- `dev-apprenticeship/install.sh`: bump `daemon.heartbeat_interval_ms` literal from `180000` to `900000`; add an exact-match in-place upgrade block immediately above the `write_key` call, identical in shape to the #277 / PR #282 `exec.env_passthrough` migration (`grep -qxF` gate → `awk` rewrite to `.tmp` → `mv`). Any operator-tuned value (e.g. a custom 300 000) misses the gate and is preserved.
- `tools/test-install-env-passthrough.sh`: 3 new cases (T4 fresh / T5 upgrade / T6 operator-tuned preserved) under a `# ----- Heartbeat interval (#280) -----` section header, mirroring the T1–T3 shape. Header comment updated to list both #277 and #280.
- `dev-apprenticeship/CHANGELOG.md`: one-line entry under `[Unreleased] → Fixed`.

## Test plan

- [x] `./tools/test-install-env-passthrough.sh` → 6/6 pass (3 existing + 3 new).
- [x] `./tools/colony-lint.sh` → 104 passed / 0 failed / 1 skipped (unchanged baseline).
- [x] `bash -n dev-apprenticeship/install.sh`.

<details>
<summary>Existing-install workaround</summary>

Operators with the pre-fix `180000` already on disk can upgrade out-of-band without waiting for a re-install:

```bash
sed -i 's|^daemon\.heartbeat_interval_ms = 180000$|daemon.heartbeat_interval_ms = 900000|' .agentis/config
./kill-federation.sh && ./start-federation.sh
```

Re-running `install.sh` does the same migration automatically via the new in-place block.

</details>

## Non-goals

- Does **not** fix #278 (`gitlab:me` seed logic — that is the next PR in this series).
- Does **not** touch `exec.env_passthrough` (that was #277, shipped in PR #282).
- Does **not** bump `dev-apprenticeship/VERSION` or touch `.ag` agents, forge wrappers, `federation-dashboard/`, or `tools/` outside the one test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)