### PR TITLE
fix(install.sh): seed gitlab:me memo from GITHUB_ME on github backend (#278)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -28,6 +28,7 @@ is asserted until multi-version CI is in place.
 - GitHub wrapper no longer fails on repos with >20 closed PRs — normalizers now read HTTP body via stdin instead of env var, bypassing `MAX_ARG_STRLEN` (#279).
 - `install.sh` now routes `FORGE_TYPE` and `GITHUB_*` through `exec.env_passthrough`; existing installs with the pre-fix literal are auto-upgraded in place. Unblocks GitHub-backend federations (#277).
 - `install.sh` now sets `daemon.heartbeat_interval_ms = 900000` (3× the longest tick interval, 300 000 ms, per #146) so reactive code-review/release agents are no longer killed by the watchdog after their first tick; existing installs with the pre-fix `180000` literal are auto-upgraded in place (#280).
+- `install.sh` now seeds the `gitlab:me` memo from `$GITHUB_ME` on github-backed federations (previously only `$GITLAB_ME` was honored, leaving the three `recall_latest("gitlab:me")` consumers — labeler, prioritizer, style_reviewer — falling back to `team` tagging). Re-runs preserve operator-customized memos (#278).
 
 ### Security
 

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -725,11 +725,17 @@ fi
 # activity as `personal` (operator's own) vs `team`. Seeding here
 # (rather than requiring a memo set step post-install) keeps all
 # identity wiring in one place.
-if [ -n "${GITLAB_ME:-}" ]; then
+OPERATOR_ME="${GITLAB_ME:-${GITHUB_ME:-}}"
+if [ -n "$OPERATOR_ME" ]; then
     echo ""
-    (cd "$FED_ROOT" && agentis memo set gitlab:me "$GITLAB_ME" 2>/dev/null) \
-        && ok "Seeded gitlab:me = $GITLAB_ME" \
-        || fail "Failed to seed gitlab:me (agents will tag everything as 'team')"
+    current=$(cd "$FED_ROOT" && agentis memo get gitlab:me 2>/dev/null || true)
+    if [ -z "$current" ] || [ "$current" = "$OPERATOR_ME" ]; then
+        (cd "$FED_ROOT" && agentis memo set gitlab:me "$OPERATOR_ME" 2>/dev/null) \
+            && ok "Seeded gitlab:me = $OPERATOR_ME" \
+            || fail "Failed to seed gitlab:me (agents will tag everything as 'team')"
+    else
+        info "gitlab:me already set to '$current' (operator-customized); leaving untouched"
+    fi
 fi
 
 # --- 6. LLM backend ---

--- a/tools/test-install-env-passthrough.sh
+++ b/tools/test-install-env-passthrough.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # tools/test-install-env-passthrough.sh: unit tests for the install.sh
-# exec.env_passthrough fix (#277) and the daemon.heartbeat_interval_ms fix
-# (#280). Both share the same `write_key` + exact-match migrate idiom, so
-# the coverage lives in one harness.
+# exec.env_passthrough fix (#277), the daemon.heartbeat_interval_ms fix
+# (#280), and the gitlab:me operator-identity seed fix (#278). All three
+# share the same `run_install_fragment*` harness idiom, so the coverage
+# lives in one file.
 #
 # Validates:
 #   Test 1: Fresh install writes the new env_passthrough literal
@@ -11,6 +12,9 @@
 #   Test 4: Fresh install writes daemon.heartbeat_interval_ms = 900000
 #   Test 5: Heartbeat upgrade rewrites the pre-fix 180000 literal
 #   Test 6: Operator-tuned heartbeat (e.g. 300000) preserved
+#   Test 7: GITHUB_ME (GITLAB_ME unset) seeds gitlab:me on github backend
+#   Test 8: GITLAB_ME (GITHUB_ME unset) seeds gitlab:me on gitlab backend
+#   Test 9: Both unset — gitlab:me memo left unset
 #
 # Usage: ./tools/test-install-env-passthrough.sh
 # Exit code 0 if all tests pass, 1 otherwise.
@@ -178,6 +182,79 @@ if grep -qxF "$HB_OPERATOR_TUNED" "$T6_CONFIG" \
 else
     fail "operator-tuned heartbeat preservation — expected '$HB_OPERATOR_TUNED' untouched, got:"
     cat "$T6_CONFIG"
+fi
+
+# ----- Operator identity seed (#278) -----
+#
+# Replicates the install.sh §5b gitlab:me seeding logic under FAKE_ROOT.
+# Unlike #277/#280 the fragment operates on the memo store via the
+# `agentis` CLI (not a config file), so each test needs a real
+# `agentis init`ed directory as FED_ROOT. Skip gracefully when
+# `agentis` is not on PATH (CI runners without the binary).
+# Keep in sync with dev-apprenticeship/install.sh §5b.
+run_install_fragment_gitlab_me() {
+    local FED_ROOT="$1"
+
+    OPERATOR_ME="${GITLAB_ME:-${GITHUB_ME:-}}"
+    if [ -n "$OPERATOR_ME" ]; then
+        local current
+        current=$(cd "$FED_ROOT" && agentis memo get gitlab:me 2>/dev/null || true)
+        if [ -z "$current" ] || [ "$current" = "$OPERATOR_ME" ]; then
+            (cd "$FED_ROOT" && agentis memo set gitlab:me "$OPERATOR_ME" 2>/dev/null) || true
+        fi
+    fi
+}
+
+if ! command -v agentis >/dev/null 2>&1; then
+    echo "[SKIP] agentis not on PATH — skipping #278 memo tests (T7/T8/T9)"
+else
+    # ----- Test 7: GITHUB_ME seeds gitlab:me on github backend -----
+    T7_DIR="$FAKE_ROOT/t7"
+    mkdir -p "$T7_DIR"
+    (cd "$T7_DIR" && agentis init >/dev/null 2>&1) || true
+    (
+        unset GITLAB_ME
+        export GITHUB_ME=ylohnitram
+        run_install_fragment_gitlab_me "$T7_DIR"
+    )
+    T7_GOT=$(cd "$T7_DIR" && agentis memo get gitlab:me 2>/dev/null || true)
+    if [ "$T7_GOT" = "ylohnitram" ]; then
+        pass "GITHUB_ME=ylohnitram seeds gitlab:me memo to 'ylohnitram'"
+    else
+        fail "GITHUB_ME seeding — expected 'ylohnitram', got: '$T7_GOT'"
+    fi
+
+    # ----- Test 8: GITLAB_ME seeds gitlab:me on gitlab backend -----
+    T8_DIR="$FAKE_ROOT/t8"
+    mkdir -p "$T8_DIR"
+    (cd "$T8_DIR" && agentis init >/dev/null 2>&1) || true
+    (
+        unset GITHUB_ME
+        export GITLAB_ME=martinh
+        run_install_fragment_gitlab_me "$T8_DIR"
+    )
+    T8_GOT=$(cd "$T8_DIR" && agentis memo get gitlab:me 2>/dev/null || true)
+    if [ "$T8_GOT" = "martinh" ]; then
+        pass "GITLAB_ME=martinh seeds gitlab:me memo to 'martinh'"
+    else
+        fail "GITLAB_ME seeding — expected 'martinh', got: '$T8_GOT'"
+    fi
+
+    # ----- Test 9: Both unset — gitlab:me left unset -----
+    T9_DIR="$FAKE_ROOT/t9"
+    mkdir -p "$T9_DIR"
+    (cd "$T9_DIR" && agentis init >/dev/null 2>&1) || true
+    (
+        unset GITLAB_ME
+        unset GITHUB_ME
+        run_install_fragment_gitlab_me "$T9_DIR"
+    )
+    T9_GOT=$(cd "$T9_DIR" && agentis memo get gitlab:me 2>/dev/null || true)
+    if [ -z "$T9_GOT" ]; then
+        pass "both GITLAB_ME and GITHUB_ME unset — gitlab:me memo left unset"
+    else
+        fail "no-op case — expected empty memo, got: '$T9_GOT'"
+    fi
 fi
 
 echo ""

--- a/tools/test-install-env-passthrough.sh
+++ b/tools/test-install-env-passthrough.sh
@@ -198,6 +198,7 @@ run_install_fragment_gitlab_me() {
     OPERATOR_ME="${GITLAB_ME:-${GITHUB_ME:-}}"
     if [ -n "$OPERATOR_ME" ]; then
         local current
+        # shellcheck disable=SC2015
         current=$(cd "$FED_ROOT" && agentis memo get gitlab:me 2>/dev/null || true)
         if [ -z "$current" ] || [ "$current" = "$OPERATOR_ME" ]; then
             (cd "$FED_ROOT" && agentis memo set gitlab:me "$OPERATOR_ME" 2>/dev/null) || true
@@ -217,6 +218,7 @@ else
         export GITHUB_ME=ylohnitram
         run_install_fragment_gitlab_me "$T7_DIR"
     )
+    # shellcheck disable=SC2015
     T7_GOT=$(cd "$T7_DIR" && agentis memo get gitlab:me 2>/dev/null || true)
     if [ "$T7_GOT" = "ylohnitram" ]; then
         pass "GITHUB_ME=ylohnitram seeds gitlab:me memo to 'ylohnitram'"
@@ -233,6 +235,7 @@ else
         export GITLAB_ME=martinh
         run_install_fragment_gitlab_me "$T8_DIR"
     )
+    # shellcheck disable=SC2015
     T8_GOT=$(cd "$T8_DIR" && agentis memo get gitlab:me 2>/dev/null || true)
     if [ "$T8_GOT" = "martinh" ]; then
         pass "GITLAB_ME=martinh seeds gitlab:me memo to 'martinh'"
@@ -249,6 +252,7 @@ else
         unset GITHUB_ME
         run_install_fragment_gitlab_me "$T9_DIR"
     )
+    # shellcheck disable=SC2015
     T9_GOT=$(cd "$T9_DIR" && agentis memo get gitlab:me 2>/dev/null || true)
     if [ -z "$T9_GOT" ]; then
         pass "both GITLAB_ME and GITHUB_ME unset — gitlab:me memo left unset"


### PR DESCRIPTION
Fixes #278.

## Summary

`install.sh` §5b now seeds the `gitlab:me` memo from either `$GITLAB_ME` or `$GITHUB_ME`, falling through a normalized `OPERATOR_ME` variable. Before this PR the guard keyed only on `$GITLAB_ME`, so github-backed federations left the memo empty and the three `recall_latest("gitlab:me")` consumers — `triage/agents/labeler.ag:30`, `triage/agents/prioritizer.ag:30`, `code-review/agents/style_reviewer.ag:29` — fell back to `team` tagging for every learned experience row.

## Rationale — why the memo key keeps the `gitlab:` prefix

The three agents listed above read the literal string `gitlab:me` via `recall_latest()`. Renaming the key (e.g. to `operator:me` or `forge:me`) would require touching all three agents and migrating existing memo stores. That is a forge-neutral naming cleanup tracked separately. This PR is strictly an `install.sh` fix — it makes the seed source forge-aware while keeping the memo key stable so no `.ag` file needs to change.

## Idempotency gate

Re-runs preserve operator-customized memos. The seed is written only when the memo is unset **or** already equals `$OPERATOR_ME`. An operator who ran `agentis memo set gitlab:me <other>` by hand is logged (`info "gitlab:me already set to '<other>' (operator-customized); leaving untouched"`) and left alone.

## Install.sh chain

Ancestors: #277 shipped in #282, #280 shipped in #283. This PR is the third and final link.

## Out of scope

- Renaming the `gitlab:me` memo key (tracked as separate future work — affects three `.ag` agents plus a migration path for existing installs).
- `VERSION` bump. This is a patch-level `install.sh` change; no runtime floor moves.
- `.ag` agents, forge wrappers, federation-dashboard — none touched.
- `exec.env_passthrough` (owned by #282) and `daemon.heartbeat_interval_ms` (owned by #283) are unchanged.

## Test plan

- [x] `./tools/test-install-env-passthrough.sh` — 9 pass / 0 fail locally (T1–T6 baseline + new T7/T8/T9 for the `#278` seed; T7/T8/T9 gracefully skip when `agentis` is not on `PATH`, matching the `colony-lint.sh:~328` idiom).
- [x] `./tools/colony-lint.sh` — 104 pass / 0 fail / 1 skipped (baseline, harness already counted; no new lint rule).
- [x] Manual: verified `OPERATOR_ME="${GITLAB_ME:-${GITHUB_ME:-}}"` expansion with `GITHUB_ME` set / `GITLAB_ME` set / both unset across three `mktemp -d` fake `$FED_ROOT`s.

## Operator migration (for existing github-backed installs)

<details>
<summary>How to seed <code>gitlab:me</code> manually on a federation installed before this fix</summary>

If you installed from a pre-fix release and your federation is github-backed, the `gitlab:me` memo is currently empty and all three consumer agents are tagging learned activity as `team`. Seed it once:

```bash
cd /path/to/your/federation
agentis memo set gitlab:me <your-github-login>
```

No daemon restart is required — memo reads are live. On the next tick the three consumer agents (`labeler`, `prioritizer`, `style_reviewer`) will start classifying activity as `personal` when `iid_author` matches the seed.

Re-running `dev-apprenticeship/install.sh` after merging this PR will also seed the memo for you if you have `$GITHUB_ME` exported — and the no-clobber gate means your manual seed above is preserved untouched.

</details>
