### PR TITLE
fix(dashboard): detach /start subprocess so start-federation.sh sidecar isn't killed by timeout (#286)

### DIFF
--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `/start` endpoint no longer SIGTERMs `start-federation.sh` (and its 21
+  just-spawned agents) when the sidecar loop runs past 60s. Handler now
+  detaches the subprocess with `start_new_session=True` and returns 202
+  Accepted; operator polls `agentis daemon list` for actual state
+  ([#286](https://github.com/Replikanti/agentis-colonies/issues/286)).
+
 ## [0.3.0] — 2026-04-24
 
 ### Added

--- a/federation-dashboard/lib/federation-dashboard-server.py
+++ b/federation-dashboard/lib/federation-dashboard-server.py
@@ -625,7 +625,13 @@ class Handler(SimpleHTTPRequestHandler):
             return
 
         if self.path == '/start':
-            # Start federation: look for start-federation.sh in fed_dir
+            # #286: start-federation.sh never exits (auto-promote sidecar loops
+            # forever), so subprocess.run with timeout=60 would SIGTERM it after
+            # a minute and kill the 21 agents it just spawned. Detach via Popen
+            # + start_new_session=True (new process group, so the HTTP handler's
+            # exit doesn't take the federation down with it), return 202
+            # Accepted, let operator poll `agentis daemon list` for actual
+            # state.
             start_script = os.path.join(fed_dir, 'start-federation.sh')
             if not os.path.isfile(start_script):
                 self.send_response(404)
@@ -634,30 +640,27 @@ class Handler(SimpleHTTPRequestHandler):
                 self.wfile.write(b'start-federation.sh not found')
                 return
             try:
-                result = subprocess.run(
+                logf = open('/tmp/fed-start-dashboard.log', 'ab', buffering=0)
+                subprocess.Popen(
                     ['bash', start_script],
-                    capture_output=True, text=True,
-                    cwd=fed_dir, timeout=60,
+                    cwd=fed_dir,
+                    stdin=subprocess.DEVNULL,
+                    stdout=logf, stderr=logf,
+                    start_new_session=True,
+                    close_fds=True,
                 )
-            except (OSError, subprocess.SubprocessError) as e:
+            except OSError as e:
                 self.send_response(500)
                 self.send_header('Content-Type', 'text/plain')
                 self.end_headers()
                 self.wfile.write(f'exec failed: {e}'.encode())
                 return
-            out = (result.stdout or '').strip()
-            err = (result.stderr or '').strip()
-            if result.returncode != 0:
-                self.send_response(500)
-                self.send_header('Content-Type', 'text/plain')
-                self.end_headers()
-                msg = (err or out or 'start-federation.sh failed').strip()
-                self.wfile.write(msg.encode() or b'start-federation.sh failed')
-                return
-            self.send_response(200)
+            self.send_response(202)
             self.send_header('Content-Type', 'text/plain')
             self.end_headers()
-            self.wfile.write((out + ('\n' + err if err else '') or 'Federation started').encode())
+            self.wfile.write(b'Federation spawn initiated (detached). '
+                             b'Poll agentis daemon list for agent states; '
+                             b'tail /tmp/fed-start-dashboard.log for spawn output.')
             return
 
         if self.path == '/kill':


### PR DESCRIPTION
Fixes #286.

## Context

The marquee **Start Federation** button on the dashboard was sabotaging its own federation. `/start` wrapped `start-federation.sh` in `subprocess.run(..., timeout=60)`, but that script never exits — its auto-promote sidecar loops forever. After 60 seconds `subprocess.run` sent SIGTERM to the bash child, and because the 21 just-spawned agents inherited its process group, they all died too. Operator clicks Start, sees 21 agents come up in `agentis daemon list`, then watches them vanish a minute later.

## Change

In `federation-dashboard/lib/federation-dashboard-server.py`, the `/start` handler now:

- Spawns `bash start-federation.sh` via `subprocess.Popen` with `start_new_session=True` (new process group, so the HTTP handler's eventual exit doesn't cascade down), `close_fds=True`, `stdin=subprocess.DEVNULL`, and both stdout/stderr routed to `/tmp/fed-start-dashboard.log` (append, unbuffered binary).
- No longer waits / communicates / captures output. No timeout.
- Narrows the exception from `(OSError, subprocess.SubprocessError)` to `OSError` — `Popen` cannot raise `TimeoutExpired` in this codepath.
- Returns **202 Accepted** with a body that explains how to observe the actual spawn state (`agentis daemon list` + tail the log).

Ported from a verified local-install hotfix; functional code is byte-identical aside from an inline comment rewrite that moves the issue reference from HOTFIX-local-install flavour to repo style and expands on the `start_new_session=True` rationale.

## Non-goals

- No changes to `/kill`, `/refresh`, `/confidence`, `/restart`, `/quarantine`, `/evolve`, `/cleanup`. Those keep their bounded `subprocess.run` semantics because they *do* have a terminating child.
- No `federation-dashboard/VERSION` bump. Will be folded into the next dashboard release PR per repo policy.
- No `BUNDLE.manifest` change (single recursive entry already covers the edit).
- No `dev-apprenticeship/` touch — this is a `federation-dashboard` component fix.
- No new test harness. There is no `/start` test fixture today; test plan below is manual.
- Dashboard SIGTERM crash loop is tracked separately in #287 — the forensic signal handler from the local hotfix was deliberately held back for that PR.

## Manual test plan

- [ ] From a clean state (no federation running), click **Start Federation** in the dashboard.
- [ ] `agentis daemon list` shows 21 agents within a few seconds.
- [ ] Wait **> 60 seconds**.
- [ ] All 21 agents are still alive (no SIGTERM kill-off).
- [ ] `/tmp/fed-start-dashboard.log` contains the spawn output from `start-federation.sh`.
- [ ] Re-clicking Start with the federation already running is safe (the script handles it; dashboard just fires-and-forgets).

## Changelog

`federation-dashboard/CHANGELOG.md` gets a new `### Fixed` bullet under `## [Unreleased]`.

## Files changed

- `federation-dashboard/lib/federation-dashboard-server.py` — `/start` handler rewrite (Popen + 202).
- `federation-dashboard/CHANGELOG.md` — one `### Fixed` entry under `[Unreleased]`.