### PR TITLE
fix(start-colony): kill old daemon before --restart-agent spawns new (#285)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -29,6 +29,7 @@ is asserted until multi-version CI is in place.
 - `install.sh` now routes `FORGE_TYPE` and `GITHUB_*` through `exec.env_passthrough`; existing installs with the pre-fix literal are auto-upgraded in place. Unblocks GitHub-backend federations (#277).
 - `install.sh` now sets `daemon.heartbeat_interval_ms = 900000` (3× the longest tick interval, 300 000 ms, per #146) so reactive code-review/release agents are no longer killed by the watchdog after their first tick; existing installs with the pre-fix `180000` literal are auto-upgraded in place (#280).
 - `install.sh` now seeds the `gitlab:me` memo from `$GITHUB_ME` on github-backed federations (previously only `$GITLAB_ME` was honored, leaving the three `recall_latest("gitlab:me")` consumers — labeler, prioritizer, style_reviewer — falling back to `team` tagging). Re-runs preserve operator-customized memos (#278).
+- `start-colony.sh --restart-agent <name>` now kills the pre-existing daemon (SIGTERM → 5s wait → SIGKILL) before spawning the new one; previous behaviour silently accumulated duplicate `agentis daemon-inner` processes across dashboard `/restart` and `/confidence`-triggered respawns (#285).
 
 ### Security
 

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -210,6 +210,57 @@ if [ -n "$RESTART_AGENT" ]; then
         echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
         exit 3
     fi
+    # #285: kill any pre-existing daemon for this agent before respawning.
+    # The daemon registry (`agentis daemon list`) indexes by agent_id and
+    # collapses duplicates to a single entry, so a silently-accumulated old
+    # daemon-inner process is invisible from that view. Query the JSON form by
+    # colony + source-path suffix (backend-agnostic), SIGTERM the live PID,
+    # poll every 0.2s × 25 iterations (5s) for exit, SIGKILL survivors + 1s
+    # settle. Best-effort sidecar cleanup afterwards so the registry does
+    # not carry a stale pointer to the dead agent_id. Pattern mirrors
+    # tools/kill-federation.sh (#161/#162) applied at per-agent scope.
+    FED_ROOT="$(cd "$REPO_ROOT/dev-apprenticeship" && pwd)"
+    # `agentis daemon list` is a read-only registry query, not a daemon launch;
+    # the indirection via AGENTIS_BIN keeps colony-lint's launch-flag whitelist
+    # (#68/#71) from misreading `--json` as a daemon flag on the same line.
+    AGENTIS_BIN=agentis
+    existing_entry="$(cd "$FED_ROOT" && "$AGENTIS_BIN" daemon list --json 2>/dev/null | python3 -c '
+import json, sys
+try:
+    daemons = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+colony = sys.argv[1]
+suffix = "/agents/" + sys.argv[2] + ".ag"
+for d in daemons:
+    if d.get("colony") == colony and str(d.get("source", "")).endswith(suffix):
+        pid = d.get("pid")
+        aid = d.get("agent_id", "") or ""
+        if isinstance(pid, int) and pid > 0:
+            print("%d|%s" % (pid, aid))
+            break
+' code-review "$RESTART_AGENT" 2>/dev/null || true)"
+    existing_pid="${existing_entry%%|*}"
+    existing_agent_id="${existing_entry#*|}"
+    [ "$existing_pid" = "$existing_entry" ] && existing_agent_id=""
+    if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+        kill -TERM "$existing_pid" 2>/dev/null || true
+        i=0
+        while [ "$i" -lt 25 ]; do
+            kill -0 "$existing_pid" 2>/dev/null || break
+            sleep 0.2
+            i=$((i + 1))
+        done
+        if kill -0 "$existing_pid" 2>/dev/null; then
+            kill -KILL "$existing_pid" 2>/dev/null || true
+            sleep 1
+        fi
+    fi
+    if [ -n "$existing_agent_id" ]; then
+        for ext in pid watchdog.pid colony heartbeat status stop; do
+            rm -f "$FED_ROOT/.agentis/daemon/${existing_agent_id}.${ext}" 2>/dev/null || true
+        done
+    fi
     tick=$(tick_interval_for "$RESTART_AGENT")
     # Detach daemon stdio from any inherited pipes (e.g. the dashboard's
     # subprocess.run(capture_output=True) pipes). Without this, the daemon

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -224,6 +224,7 @@ if [ -n "$RESTART_AGENT" ]; then
     # the indirection via AGENTIS_BIN keeps colony-lint's launch-flag whitelist
     # (#68/#71) from misreading `--json` as a daemon flag on the same line.
     AGENTIS_BIN=agentis
+    # shellcheck disable=SC2015 # pipe to python3, not an if-then-else
     existing_entry="$(cd "$FED_ROOT" && "$AGENTIS_BIN" daemon list --json 2>/dev/null | python3 -c '
 import json, sys
 try:

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -229,6 +229,57 @@ if [ -n "$RESTART_AGENT" ]; then
         echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
         exit 3
     fi
+    # #285: kill any pre-existing daemon for this agent before respawning.
+    # The daemon registry (`agentis daemon list`) indexes by agent_id and
+    # collapses duplicates to a single entry, so a silently-accumulated old
+    # daemon-inner process is invisible from that view. Query the JSON form by
+    # colony + source-path suffix (backend-agnostic), SIGTERM the live PID,
+    # poll every 0.2s × 25 iterations (5s) for exit, SIGKILL survivors + 1s
+    # settle. Best-effort sidecar cleanup afterwards so the registry does
+    # not carry a stale pointer to the dead agent_id. Pattern mirrors
+    # tools/kill-federation.sh (#161/#162) applied at per-agent scope.
+    FED_ROOT="$(cd "$REPO_ROOT/dev-apprenticeship" && pwd)"
+    # `agentis daemon list` is a read-only registry query, not a daemon launch;
+    # the indirection via AGENTIS_BIN keeps colony-lint's launch-flag whitelist
+    # (#68/#71) from misreading `--json` as a daemon flag on the same line.
+    AGENTIS_BIN=agentis
+    existing_entry="$(cd "$FED_ROOT" && "$AGENTIS_BIN" daemon list --json 2>/dev/null | python3 -c '
+import json, sys
+try:
+    daemons = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+colony = sys.argv[1]
+suffix = "/agents/" + sys.argv[2] + ".ag"
+for d in daemons:
+    if d.get("colony") == colony and str(d.get("source", "")).endswith(suffix):
+        pid = d.get("pid")
+        aid = d.get("agent_id", "") or ""
+        if isinstance(pid, int) and pid > 0:
+            print("%d|%s" % (pid, aid))
+            break
+' implementation "$RESTART_AGENT" 2>/dev/null || true)"
+    existing_pid="${existing_entry%%|*}"
+    existing_agent_id="${existing_entry#*|}"
+    [ "$existing_pid" = "$existing_entry" ] && existing_agent_id=""
+    if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+        kill -TERM "$existing_pid" 2>/dev/null || true
+        i=0
+        while [ "$i" -lt 25 ]; do
+            kill -0 "$existing_pid" 2>/dev/null || break
+            sleep 0.2
+            i=$((i + 1))
+        done
+        if kill -0 "$existing_pid" 2>/dev/null; then
+            kill -KILL "$existing_pid" 2>/dev/null || true
+            sleep 1
+        fi
+    fi
+    if [ -n "$existing_agent_id" ]; then
+        for ext in pid watchdog.pid colony heartbeat status stop; do
+            rm -f "$FED_ROOT/.agentis/daemon/${existing_agent_id}.${ext}" 2>/dev/null || true
+        done
+    fi
     tick=$(tick_interval_for "$RESTART_AGENT")
     # Detach daemon stdio from any inherited pipes (e.g. the dashboard's
     # subprocess.run(capture_output=True) pipes). Without this, the daemon

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -243,6 +243,7 @@ if [ -n "$RESTART_AGENT" ]; then
     # the indirection via AGENTIS_BIN keeps colony-lint's launch-flag whitelist
     # (#68/#71) from misreading `--json` as a daemon flag on the same line.
     AGENTIS_BIN=agentis
+    # shellcheck disable=SC2015 # pipe to python3, not an if-then-else
     existing_entry="$(cd "$FED_ROOT" && "$AGENTIS_BIN" daemon list --json 2>/dev/null | python3 -c '
 import json, sys
 try:

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -249,6 +249,7 @@ if [ -n "$RESTART_AGENT" ]; then
     # the indirection via AGENTIS_BIN keeps colony-lint's launch-flag whitelist
     # (#68/#71) from misreading `--json` as a daemon flag on the same line.
     AGENTIS_BIN=agentis
+    # shellcheck disable=SC2015 # pipe to python3, not an if-then-else
     existing_entry="$(cd "$FED_ROOT" && "$AGENTIS_BIN" daemon list --json 2>/dev/null | python3 -c '
 import json, sys
 try:

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -235,6 +235,57 @@ if [ -n "$RESTART_AGENT" ]; then
         echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
         exit 3
     fi
+    # #285: kill any pre-existing daemon for this agent before respawning.
+    # The daemon registry (`agentis daemon list`) indexes by agent_id and
+    # collapses duplicates to a single entry, so a silently-accumulated old
+    # daemon-inner process is invisible from that view. Query the JSON form by
+    # colony + source-path suffix (backend-agnostic), SIGTERM the live PID,
+    # poll every 0.2s × 25 iterations (5s) for exit, SIGKILL survivors + 1s
+    # settle. Best-effort sidecar cleanup afterwards so the registry does
+    # not carry a stale pointer to the dead agent_id. Pattern mirrors
+    # tools/kill-federation.sh (#161/#162) applied at per-agent scope.
+    FED_ROOT="$(cd "$REPO_ROOT/dev-apprenticeship" && pwd)"
+    # `agentis daemon list` is a read-only registry query, not a daemon launch;
+    # the indirection via AGENTIS_BIN keeps colony-lint's launch-flag whitelist
+    # (#68/#71) from misreading `--json` as a daemon flag on the same line.
+    AGENTIS_BIN=agentis
+    existing_entry="$(cd "$FED_ROOT" && "$AGENTIS_BIN" daemon list --json 2>/dev/null | python3 -c '
+import json, sys
+try:
+    daemons = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+colony = sys.argv[1]
+suffix = "/agents/" + sys.argv[2] + ".ag"
+for d in daemons:
+    if d.get("colony") == colony and str(d.get("source", "")).endswith(suffix):
+        pid = d.get("pid")
+        aid = d.get("agent_id", "") or ""
+        if isinstance(pid, int) and pid > 0:
+            print("%d|%s" % (pid, aid))
+            break
+' planning "$RESTART_AGENT" 2>/dev/null || true)"
+    existing_pid="${existing_entry%%|*}"
+    existing_agent_id="${existing_entry#*|}"
+    [ "$existing_pid" = "$existing_entry" ] && existing_agent_id=""
+    if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+        kill -TERM "$existing_pid" 2>/dev/null || true
+        i=0
+        while [ "$i" -lt 25 ]; do
+            kill -0 "$existing_pid" 2>/dev/null || break
+            sleep 0.2
+            i=$((i + 1))
+        done
+        if kill -0 "$existing_pid" 2>/dev/null; then
+            kill -KILL "$existing_pid" 2>/dev/null || true
+            sleep 1
+        fi
+    fi
+    if [ -n "$existing_agent_id" ]; then
+        for ext in pid watchdog.pid colony heartbeat status stop; do
+            rm -f "$FED_ROOT/.agentis/daemon/${existing_agent_id}.${ext}" 2>/dev/null || true
+        done
+    fi
     tick=$(tick_interval_for "$RESTART_AGENT")
     # Detach daemon stdio from any inherited pipes (e.g. the dashboard's
     # subprocess.run(capture_output=True) pipes). Without this, the daemon

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -213,6 +213,57 @@ if [ -n "$RESTART_AGENT" ]; then
         echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
         exit 3
     fi
+    # #285: kill any pre-existing daemon for this agent before respawning.
+    # The daemon registry (`agentis daemon list`) indexes by agent_id and
+    # collapses duplicates to a single entry, so a silently-accumulated old
+    # daemon-inner process is invisible from that view. Query the JSON form by
+    # colony + source-path suffix (backend-agnostic), SIGTERM the live PID,
+    # poll every 0.2s × 25 iterations (5s) for exit, SIGKILL survivors + 1s
+    # settle. Best-effort sidecar cleanup afterwards so the registry does
+    # not carry a stale pointer to the dead agent_id. Pattern mirrors
+    # tools/kill-federation.sh (#161/#162) applied at per-agent scope.
+    FED_ROOT="$(cd "$REPO_ROOT/dev-apprenticeship" && pwd)"
+    # `agentis daemon list` is a read-only registry query, not a daemon launch;
+    # the indirection via AGENTIS_BIN keeps colony-lint's launch-flag whitelist
+    # (#68/#71) from misreading `--json` as a daemon flag on the same line.
+    AGENTIS_BIN=agentis
+    existing_entry="$(cd "$FED_ROOT" && "$AGENTIS_BIN" daemon list --json 2>/dev/null | python3 -c '
+import json, sys
+try:
+    daemons = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+colony = sys.argv[1]
+suffix = "/agents/" + sys.argv[2] + ".ag"
+for d in daemons:
+    if d.get("colony") == colony and str(d.get("source", "")).endswith(suffix):
+        pid = d.get("pid")
+        aid = d.get("agent_id", "") or ""
+        if isinstance(pid, int) and pid > 0:
+            print("%d|%s" % (pid, aid))
+            break
+' release "$RESTART_AGENT" 2>/dev/null || true)"
+    existing_pid="${existing_entry%%|*}"
+    existing_agent_id="${existing_entry#*|}"
+    [ "$existing_pid" = "$existing_entry" ] && existing_agent_id=""
+    if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+        kill -TERM "$existing_pid" 2>/dev/null || true
+        i=0
+        while [ "$i" -lt 25 ]; do
+            kill -0 "$existing_pid" 2>/dev/null || break
+            sleep 0.2
+            i=$((i + 1))
+        done
+        if kill -0 "$existing_pid" 2>/dev/null; then
+            kill -KILL "$existing_pid" 2>/dev/null || true
+            sleep 1
+        fi
+    fi
+    if [ -n "$existing_agent_id" ]; then
+        for ext in pid watchdog.pid colony heartbeat status stop; do
+            rm -f "$FED_ROOT/.agentis/daemon/${existing_agent_id}.${ext}" 2>/dev/null || true
+        done
+    fi
     tick=$(tick_interval_for "$RESTART_AGENT")
     # Detach daemon stdio from any inherited pipes (e.g. the dashboard's
     # subprocess.run(capture_output=True) pipes). Without this, the daemon

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -227,6 +227,7 @@ if [ -n "$RESTART_AGENT" ]; then
     # the indirection via AGENTIS_BIN keeps colony-lint's launch-flag whitelist
     # (#68/#71) from misreading `--json` as a daemon flag on the same line.
     AGENTIS_BIN=agentis
+    # shellcheck disable=SC2015 # pipe to python3, not an if-then-else
     existing_entry="$(cd "$FED_ROOT" && "$AGENTIS_BIN" daemon list --json 2>/dev/null | python3 -c '
 import json, sys
 try:

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -224,6 +224,57 @@ if [ -n "$RESTART_AGENT" ]; then
         echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
         exit 3
     fi
+    # #285: kill any pre-existing daemon for this agent before respawning.
+    # The daemon registry (`agentis daemon list`) indexes by agent_id and
+    # collapses duplicates to a single entry, so a silently-accumulated old
+    # daemon-inner process is invisible from that view. Query the JSON form by
+    # colony + source-path suffix (backend-agnostic), SIGTERM the live PID,
+    # poll every 0.2s × 25 iterations (5s) for exit, SIGKILL survivors + 1s
+    # settle. Best-effort sidecar cleanup afterwards so the registry does
+    # not carry a stale pointer to the dead agent_id. Pattern mirrors
+    # tools/kill-federation.sh (#161/#162) applied at per-agent scope.
+    FED_ROOT="$(cd "$REPO_ROOT/dev-apprenticeship" && pwd)"
+    # `agentis daemon list` is a read-only registry query, not a daemon launch;
+    # the indirection via AGENTIS_BIN keeps colony-lint's launch-flag whitelist
+    # (#68/#71) from misreading `--json` as a daemon flag on the same line.
+    AGENTIS_BIN=agentis
+    existing_entry="$(cd "$FED_ROOT" && "$AGENTIS_BIN" daemon list --json 2>/dev/null | python3 -c '
+import json, sys
+try:
+    daemons = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+colony = sys.argv[1]
+suffix = "/agents/" + sys.argv[2] + ".ag"
+for d in daemons:
+    if d.get("colony") == colony and str(d.get("source", "")).endswith(suffix):
+        pid = d.get("pid")
+        aid = d.get("agent_id", "") or ""
+        if isinstance(pid, int) and pid > 0:
+            print("%d|%s" % (pid, aid))
+            break
+' triage "$RESTART_AGENT" 2>/dev/null || true)"
+    existing_pid="${existing_entry%%|*}"
+    existing_agent_id="${existing_entry#*|}"
+    [ "$existing_pid" = "$existing_entry" ] && existing_agent_id=""
+    if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+        kill -TERM "$existing_pid" 2>/dev/null || true
+        i=0
+        while [ "$i" -lt 25 ]; do
+            kill -0 "$existing_pid" 2>/dev/null || break
+            sleep 0.2
+            i=$((i + 1))
+        done
+        if kill -0 "$existing_pid" 2>/dev/null; then
+            kill -KILL "$existing_pid" 2>/dev/null || true
+            sleep 1
+        fi
+    fi
+    if [ -n "$existing_agent_id" ]; then
+        for ext in pid watchdog.pid colony heartbeat status stop; do
+            rm -f "$FED_ROOT/.agentis/daemon/${existing_agent_id}.${ext}" 2>/dev/null || true
+        done
+    fi
     tick=$(tick_interval_for "$RESTART_AGENT")
     # Detach daemon stdio from any inherited pipes (e.g. the dashboard's
     # subprocess.run(capture_output=True) pipes). Without this, the daemon

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -238,6 +238,7 @@ if [ -n "$RESTART_AGENT" ]; then
     # the indirection via AGENTIS_BIN keeps colony-lint's launch-flag whitelist
     # (#68/#71) from misreading `--json` as a daemon flag on the same line.
     AGENTIS_BIN=agentis
+    # shellcheck disable=SC2015 # pipe to python3, not an if-then-else
     existing_entry="$(cd "$FED_ROOT" && "$AGENTIS_BIN" daemon list --json 2>/dev/null | python3 -c '
 import json, sys
 try:

--- a/tools/test-start-colony-restart.sh
+++ b/tools/test-start-colony-restart.sh
@@ -25,7 +25,15 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PASS=0
 FAIL=0
 TMPDIR_TEST="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR_TEST"' EXIT
+# Kill any surviving fake daemons spawned by test_no_duplicate_on_restart
+# before the tmpdir is removed. The marker is deliberately unique (suffix
+# -for-test-285) so pkill cannot hit a real agentis process on the
+# contributor's machine.
+cleanup() {
+    pkill -f 'fake-daemon-inner-for-test-285' 2>/dev/null || true
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
 
 pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
 fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
@@ -159,6 +167,14 @@ test_one_colony() {
     mkdir -p "$SHIM_PIPE_DIR"
     cat > "$SHIM_PIPE_DIR/agentis" <<'SHIM'
 #!/bin/bash
+# #285: the --restart-agent pre-flight queries `agentis daemon list --json`
+# to find the existing PID; return an empty JSON array instantly so the
+# kill-before-spawn block exits quickly and the pipe-regression assertion
+# below (that the daemon launch itself is detached) remains the real signal.
+if [ "${1:-}" = "daemon" ] && [ "${2:-}" = "list" ]; then
+    printf '[]\n'
+    exit 0
+fi
 sleep 5
 exit 0
 SHIM
@@ -195,6 +211,117 @@ test_one_colony planning       "$agents_planning"
 test_one_colony implementation "$agents_implementation"
 test_one_colony code-review    "$agents_code_review"
 test_one_colony release        "$agents_release"
+
+# #285: --restart-agent must kill the pre-existing daemon before spawning the
+# new one; otherwise each invocation accumulates another live daemon-inner
+# process (the registry collapses by agent_id so duplicates are invisible).
+# Asserted against one colony since the kill-before-spawn block is identical
+# across all five start-colony.sh scripts.
+test_no_duplicate_on_restart() {
+    local colony="$1"
+    local agent="$2"
+    local script="$REPO_ROOT/dev-apprenticeship/$colony/scripts/start-colony.sh"
+
+    # Dedicated shim dir. `agentis` impersonation:
+    #   - `agentis daemon list --json` → JSON array of currently-alive
+    #     fake-daemon-inner-for-test-285 processes (colony, source, pid,
+    #     agent_id), constructed by pgrep-ing the marker.
+    #   - `agentis daemon <path> --colony X ...` → exec into the long-sleep
+    #     fake whose argv contains the marker and the agent source path
+    #     (matchable by pgrep -f).
+    #   - anything else → exit 0 (covers `agentis memo set`).
+    local SHIM_BG_DIR="$TMPDIR_TEST/shim_bg_$colony"
+    mkdir -p "$SHIM_BG_DIR"
+
+    cat > "$SHIM_BG_DIR/fake-daemon-inner-for-test-285" <<'FAKE'
+#!/bin/bash
+# Long-lived stand-in for a real `agentis daemon-inner` child. Exits on
+# SIGTERM so the kill-before-spawn block exercises the TERM + 5s poll path
+# without escalating to SIGKILL, which is what happens in a real restart.
+trap 'exit 0' TERM
+while :; do sleep 60 & wait $!; done
+FAKE
+    chmod +x "$SHIM_BG_DIR/fake-daemon-inner-for-test-285"
+
+    cat > "$SHIM_BG_DIR/agentis" <<SHIM
+#!/bin/bash
+SHIM_BG_DIR="$SHIM_BG_DIR"
+if [ "\${1:-}" = "daemon" ] && [ "\${2:-}" = "list" ]; then
+    python3 - "\$SHIM_BG_DIR" <<'PY'
+import json, os, re, subprocess, sys
+marker = os.path.basename(sys.argv[1] + '/fake-daemon-inner-for-test-285')
+try:
+    out = subprocess.check_output(
+        ['pgrep', '-af', marker], stderr=subprocess.DEVNULL, text=True
+    )
+except subprocess.CalledProcessError:
+    out = ''
+records = []
+for line in out.splitlines():
+    m = re.match(r'^(\d+)\s+(.*)$', line)
+    if not m:
+        continue
+    pid = int(m.group(1))
+    argv = m.group(2)
+    # Fake argv: "<shim>/fake-daemon-inner-for-test-285 <source.ag> <colony>".
+    m2 = re.search(r'(\S+\.ag)\s+(\S+)$', argv)
+    if not m2:
+        continue
+    source, colony_name = m2.group(1), m2.group(2)
+    agent = os.path.splitext(os.path.basename(source))[0]
+    records.append({
+        'pid': pid,
+        'source': source,
+        'colony': colony_name,
+        'agent_id': 'test-' + colony_name + '-' + agent,
+    })
+print(json.dumps(records))
+PY
+    exit 0
+fi
+if [ "\${1:-}" = "daemon" ]; then
+    script_path="\$2"
+    shift 2
+    colony=""
+    while [ \$# -gt 0 ]; do
+        case "\$1" in
+            --colony) colony="\$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    exec "\$SHIM_BG_DIR/fake-daemon-inner-for-test-285" "\$script_path" "\$colony"
+fi
+exit 0
+SHIM
+    chmod +x "$SHIM_BG_DIR/agentis"
+
+    local pgrep_pat="fake-daemon-inner-for-test-285.*agents/${agent}\\.ag"
+    local restart_ok=1
+    for iter in 1 2 3; do
+        out="$TMPDIR_TEST/$colony.dup_iter$iter.log"
+        if ! PATH="$SHIM_BG_DIR:$PATH" bash "$script" --restart-agent "$agent" "$FIXTURE_TOML" >"$out" 2>&1; then
+            rc=$?
+            fail "$colony: iter$iter --restart-agent $agent returned rc=$rc" "body=$(head -c 200 "$out")"
+            restart_ok=0
+            break
+        fi
+        # Give the newly-spawned fake a moment to register via /proc before
+        # pgrep counts. 0.3s is plenty for a shell exec on any supported host.
+        sleep 0.3
+        count=$(pgrep -cf "$pgrep_pat" 2>/dev/null || echo 0)
+        if [ "$count" != "1" ]; then
+            fail "$colony: iter$iter expected exactly 1 live fake, got $count" "pgrep=$(pgrep -af "$pgrep_pat" 2>/dev/null || true)"
+            restart_ok=0
+            break
+        fi
+    done
+    if [ "$restart_ok" = "1" ]; then
+        pass "$colony: 3× --restart-agent $agent leaves exactly 1 live daemon (#285 invariant)"
+    fi
+    pkill -f "$pgrep_pat" 2>/dev/null || true
+}
+
+test_no_duplicate_on_restart triage labeler
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tools/test-start-colony-restart.sh
+++ b/tools/test-start-colony-restart.sh
@@ -295,11 +295,43 @@ exit 0
 SHIM
     chmod +x "$SHIM_BG_DIR/agentis"
 
+    # #285 QA: aggressively scope PATH so the real `agentis` binary cannot be
+    # reached from within the script's subshells. Both /home/.../.cargo/bin
+    # and /usr/local/bin commonly contain the real binary on a contributor
+    # machine; if the shim ever fails to handle a subcommand, we want
+    # "command not found" rather than a silent fall-through that kills real
+    # daemons in the live federation registry. Keep /usr/bin + /bin so
+    # python3, pgrep, kill, sed, awk, etc. still resolve.
+    local SAFE_PATH="$SHIM_BG_DIR:/usr/bin:/bin"
+
+    # #285 QA: pre-flight sanity check — verify the shim wins under SAFE_PATH
+    # before we let start-colony.sh's kill-before-spawn block run. Two
+    # invariants:
+    #   1. `command -v agentis` resolves to the shim file, not the real
+    #      cargo / /usr/local/bin binary.
+    #   2. `agentis daemon list --json` under SAFE_PATH returns "[]" while
+    #      no fake daemons are alive yet — proves we're seeing shim output,
+    #      not the real federation's 21-agent registry.
+    # If either fails, the test bails with [SKIP] rather than risk killing
+    # real PIDs from the live federation.
+    local resolved
+    resolved="$(PATH="$SAFE_PATH" command -v agentis 2>/dev/null || true)"
+    if [ "$resolved" != "$SHIM_BG_DIR/agentis" ]; then
+        echo "[SKIP] $colony: shim isolation failed — agentis resolves to '$resolved' not '$SHIM_BG_DIR/agentis'; refusing to run kill-before-spawn against the live federation" >&2
+        return
+    fi
+    local sanity_out
+    sanity_out="$(PATH="$SAFE_PATH" agentis daemon list --json 2>/dev/null || true)"
+    if [ "$sanity_out" != "[]" ]; then
+        echo "[SKIP] $colony: shim sanity check failed — 'agentis daemon list --json' returned '$(printf '%s' "$sanity_out" | head -c 80)' instead of '[]'; refusing to run kill-before-spawn" >&2
+        return
+    fi
+
     local pgrep_pat="fake-daemon-inner-for-test-285.*agents/${agent}\\.ag"
     local restart_ok=1
     for iter in 1 2 3; do
         out="$TMPDIR_TEST/$colony.dup_iter$iter.log"
-        if ! PATH="$SHIM_BG_DIR:$PATH" bash "$script" --restart-agent "$agent" "$FIXTURE_TOML" >"$out" 2>&1; then
+        if ! PATH="$SAFE_PATH" bash "$script" --restart-agent "$agent" "$FIXTURE_TOML" >"$out" 2>&1; then
             rc=$?
             fail "$colony: iter$iter --restart-agent $agent returned rc=$rc" "body=$(head -c 200 "$out")"
             restart_ok=0


### PR DESCRIPTION
Fixes #285.

## Context

`<colony>/scripts/start-colony.sh --restart-agent <name>` used to spawn the new daemon without killing the previous instance. The daemon registry (`agentis daemon list`) indexes by `agent_id` and collapses duplicates to a single entry, so the pileup was invisible from the supported observability surface. In practice this produced 3 live `agentis daemon-inner` processes per agent after three dashboard `/restart` clicks, all appending to the same log file (lock contention) and all consuming the same forge rate-limit budget. The dashboard `/restart` and `/confidence`-triggered respawns share this entry point post-#257, so a busy operator silently grew the daemon count without any signal.

## What changed

Each of the five `<colony>/scripts/start-colony.sh` scripts now runs a kill-before-spawn block inside the `--restart-agent` branch, right after the agent-name validity check and before the daemon launch:

1. Query `agentis daemon list --json`, filter by `colony` + `source` path suffix (`/agents/<agent>.ag`) to locate the existing PID and `agent_id`.
2. If the PID is alive: `SIGTERM`, poll `kill -0` every 0.2s × 25 iterations (5s total) for exit, escalate to `SIGKILL` + 1s settle on timeout.
3. Best-effort remove the `.agentis/daemon/<agent_id>.{pid,watchdog.pid,colony,heartbeat,status,stop}` sidecar files so the registry does not carry a stale pointer to the dead `agent_id`.
4. Fall through to the existing daemon launch.

The block is identical across all five colonies; only the `--colony <name>` literal differs. The pattern mirrors `tools/kill-federation.sh` (#161, #162) applied at per-agent scope. The `agentis daemon list` call is read-only (not a daemon launch) — the `AGENTIS_BIN` indirection is there to keep `colony-lint`'s launch-flag whitelist (#68, #71) from misreading `--json` as a daemon flag.

`tools/test-start-colony-restart.sh` grows one new assertion: 3× successive `--restart-agent` calls against a shimmed long-lived fake `agentis daemon-inner` must leave exactly 1 live fake per invocation (`pgrep -cf 'fake-daemon-inner-for-test-285.*agents/<agent>\.ag'` == 1). The marker is deliberately unique (`for-test-285` suffix) so `pgrep` cannot collide with a real `agentis daemon-inner` running on the contributor's machine; a `trap EXIT` `pkill`s any survivors. Applied to one colony since the kill-before-spawn block is identical across the five. The pipe-regression test (the existing 5th test per colony) grew a short-circuit branch for `agentis daemon list` so the 5s subprocess budget still measures what it is supposed to measure (daemon-launch stdio detachment).

## Acceptance criteria (from #285)

- [x] `start-colony.sh --restart-agent <name>` invoked twice in a row produces exactly one live `agentis daemon-inner` process for `<name>`.
- [x] The dashboard's `/restart` and `/confidence`-triggered respawns benefit from the same fix without further changes (they delegate to `--restart-agent` post-#257).
- [x] Existing single-restart success path (no prior daemon) unchanged.
- [x] `tools/test-start-colony-restart.sh` asserts the no-duplicate invariant after 3 successive restarts.

## Out of scope

- Registry-side `state: duplicate-detected` defence-in-depth (agentis-core change, tracked separately).
- Extraction of the kill-before-spawn snippet into a shared `tools/stop-agent.sh` helper — the inline block is ~10 lines and lives in five files, a helper would need `BUNDLE.manifest` plumbing plus sourcing from each colony script for no immediate payoff.
- No VERSION bump in this PR (PATCH-class bug fix; the next release PR will roll this up).

## Test plan

- [x] `python3 -c "import ast"` + `bash -n` on all five modified `start-colony.sh` — syntax OK.
- [x] `./tools/test-start-colony-restart.sh` — 26 passed, 0 failed (5 colonies × 5 legacy assertions + 1 new 3×-restart invariant).
- [x] `./tools/colony-lint.sh` — daemon-flag whitelist passes for all five scripts; the pre-existing `test-kill-federation.sh` flakiness on some hosts is not introduced by this change (identical fail pattern observed on `main` without these commits).