### PR TITLE
fix(dashboard): route large payloads via temp-files to bypass MAX_ARG_STRLEN (#293)

### DIFF
--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Dashboard wrapper no longer crashes with `Argument list too long` after
+  several hours of accumulated history. `$COLLECTOR_JSON`, `$HISTORY`,
+  `$REMEDIATION`, and `$DAEMONS` now travel to the Python helpers via
+  temp files (`@<path>` argv prefix) instead of inline argv strings, so
+  they do not hit Linux's 128 KB `MAX_ARG_STRLEN` per-argv cap. Renderer
+  and collector accept both forms (`@`-prefix reads the file, plain
+  string passes through unchanged) — same class of failure as
+  [#279](https://github.com/Replikanti/agentis-colonies/issues/279) but
+  in a different code path
+  ([#293](https://github.com/Replikanti/agentis-colonies/issues/293)).
 - `/start` endpoint no longer SIGTERMs `start-federation.sh` (and its 21
   just-spawned agents) when the sidecar loop runs past 60s. Handler now
   detaches the subprocess with `start_new_session=True` and returns 202

--- a/federation-dashboard/bin/federation-dashboard
+++ b/federation-dashboard/bin/federation-dashboard
@@ -156,12 +156,35 @@ generate() {
         LOG_DIR=".agentis/logs"
     fi
 
+    # --- Temp-file argv routing (#293) ---
+    # Linux MAX_ARG_STRLEN caps any single argv string at 128 KB. After ~8 h
+    # of accumulation, $COLLECTOR_JSON / $HISTORY / $REMEDIATION / $DAEMONS
+    # cross that threshold and python3 fails with "Argument list too long".
+    # Spool large payloads to temp files and pass `@<path>` argv tokens; the
+    # Python helpers detect the prefix and read the file (non-`@` values
+    # still pass through inline for backward compat). Same class as #279
+    # (github-api.sh) but a different code path.
+    local DAEMON_FILE COLL_FILE HIST_FILE REMED_FILE
+    # Plain `mktemp` (no GNU-only --suffix flag) for macOS bash 3.2 portability;
+    # consumers locate the file by its argv slot, not by extension.
+    DAEMON_FILE="$(mktemp)"
+    COLL_FILE="$(mktemp)"
+    HIST_FILE="$(mktemp)"
+    REMED_FILE="$(mktemp)"
+    # In-function cleanup (RETURN trap) — generate() is also called from the
+    # regen-only path and from the 60 s background loop, so an EXIT trap on
+    # the wrapper would leak files for the duration of the long-running
+    # process. RETURN fires on every return path (success, set -e, return).
+    trap 'rm -f "$DAEMON_FILE" "$COLL_FILE" "$HIST_FILE" "$REMED_FILE"' RETURN
+
+    printf '%s' "$DAEMONS" > "$DAEMON_FILE"
+
     # --- Comprehensive per-agent data collection ---
     # Single python3 invocation collects all enriched data: experience stats,
     # .ag descriptions, log lines, PID liveness, event timeline, and
     # confidence change history. Outputs a single JSON blob consumed by JS.
     local COLLECTOR_JSON
-    COLLECTOR_JSON="$(python3 "$LIB_DIR/federation-dashboard-collector.py" "$DAEMONS" "$AGENT_COLONY_MAP" "$FED_DIR" "$EPOCH" "$EXPERIENCE_DIR" "$LOG_DIR" "$DASH_DIR" "$COLONY_LIST_PY" "$FED_TOOLS_DIR" "${ALL_AGENTS[@]}")"
+    COLLECTOR_JSON="$(python3 "$LIB_DIR/federation-dashboard-collector.py" "@$DAEMON_FILE" "$AGENT_COLONY_MAP" "$FED_DIR" "$EPOCH" "$EXPERIENCE_DIR" "$LOG_DIR" "$DASH_DIR" "$COLONY_LIST_PY" "$FED_TOOLS_DIR" "${ALL_AGENTS[@]}")"
     if ! echo "$COLLECTOR_JSON" | python3 -c 'import sys,json;json.loads(sys.stdin.read())' 2>/dev/null; then
         COLLECTOR_JSON='{"agents":[],"experience_counts":{"total":0},"events":[],"confidence_changes":[]}'
     fi
@@ -186,6 +209,10 @@ generate() {
     done
     COLONY_LIST_JS="[${COLONY_LIST_JS%,}]"
 
+    printf '%s' "$COLLECTOR_JSON" > "$COLL_FILE"
+    printf '%s' "$HISTORY" > "$HIST_FILE"
+    printf '%s' "$REMEDIATION" > "$REMED_FILE"
+
     # --- HTML generation ---
     # All HTML/CSS/JS lives in federation-dashboard.html.template. The renderer
     # substitutes 10 named sentinels and writes index.html atomically. This
@@ -201,9 +228,9 @@ generate() {
         "$AGENT_COUNT" \
         "$EPOCH" \
         "$TIMESTAMP" \
-        "$COLLECTOR_JSON" \
-        "$HISTORY" \
-        "$REMEDIATION" \
+        "@$COLL_FILE" \
+        "@$HIST_FILE" \
+        "@$REMED_FILE" \
         "$COLONY_LIST_JS"
 }
 

--- a/federation-dashboard/lib/federation-dashboard-collector.py
+++ b/federation-dashboard/lib/federation-dashboard-collector.py
@@ -12,7 +12,11 @@
 # and re-parsing the heredoc body as bash code at runtime.
 #
 # Args (positional):
-#   1: daemons_json        — JSON array from `agentis daemon list --json`
+#   1: daemons_json        — JSON array from `agentis daemon list --json`,
+#                            or "@<path>" to read from file (#293 — bypass
+#                            Linux MAX_ARG_STRLEN once the federation grows
+#                            past ~21 daemons and the JSON blob crosses the
+#                            128 KB per-argv-string cap).
 #   2: agent_map_json      — JSON array of {agent, colony} pairs
 #   3: fed_dir             — federation root directory
 #   4: epoch               — current epoch seconds
@@ -26,7 +30,14 @@
 
 import sys, os, json, time, re, datetime, subprocess
 
-daemons_json   = sys.argv[1]
+def _read(arg):
+    """Resolve `@<path>` argv prefix to file contents; otherwise pass through."""
+    if arg.startswith('@'):
+        with open(arg[1:], 'r', encoding='utf-8') as f:
+            return f.read()
+    return arg
+
+daemons_json   = _read(sys.argv[1])
 agent_map_json = sys.argv[2]
 fed_dir        = sys.argv[3]
 epoch          = int(sys.argv[4])

--- a/federation-dashboard/lib/federation-dashboard-renderer.py
+++ b/federation-dashboard/lib/federation-dashboard-renderer.py
@@ -22,13 +22,28 @@ Args (positional):
     6: agent_count       int as string
     7: epoch             int as string
     8: timestamp         human-readable timestamp string
-    9: collector_json    JSON blob (string)
-   10: history_json      JSON blob (string)
-   11: remediation_json  JSON blob (string)
+    9: collector_json    JSON blob (string) or "@<path>" to read from file (#293)
+   10: history_json      JSON blob (string) or "@<path>" to read from file (#293)
+   11: remediation_json  JSON blob (string) or "@<path>" to read from file (#293)
    12: colony_list_js    JS array literal (already formatted)
+
+The `@<path>` prefix on argv[9..11] is a #293 workaround for Linux's
+MAX_ARG_STRLEN (128 KB per single argv string): after several hours of
+accumulation the collector / history / remediation JSON blobs cross that
+threshold and exec(2) fails with E2BIG. The wrapper spools large payloads
+to temp files; values without the `@` prefix still pass through unchanged
+for backward compatibility.
 """
 import os
 import sys
+
+
+def _read(arg):
+    """Resolve `@<path>` argv prefix to file contents; otherwise pass through."""
+    if arg.startswith('@'):
+        with open(arg[1:], 'r', encoding='utf-8') as f:
+            return f.read()
+    return arg
 
 
 def main():
@@ -50,9 +65,9 @@ def main():
         '{{AGENT_COUNT}}': sys.argv[6],
         '{{EPOCH}}': sys.argv[7],
         '{{TIMESTAMP}}': sys.argv[8],
-        '{{COLLECTOR_JSON}}': sys.argv[9],
-        '{{HISTORY}}': sys.argv[10],
-        '{{REMEDIATION}}': sys.argv[11],
+        '{{COLLECTOR_JSON}}': _read(sys.argv[9]),
+        '{{HISTORY}}': _read(sys.argv[10]),
+        '{{REMEDIATION}}': _read(sys.argv[11]),
         '{{COLONY_LIST_JS}}': sys.argv[12],
     }
 

--- a/tools/test-dashboard-argv-overflow.sh
+++ b/tools/test-dashboard-argv-overflow.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# tools/test-dashboard-argv-overflow.sh: regression test for #293 — large
+# dashboard payloads (history.json, collector JSON, remediation JSON,
+# daemon-list JSON) must travel via temp files (`@<path>` argv prefix), not
+# as inline argv strings, so that they do not hit Linux's MAX_ARG_STRLEN
+# (128 KB per single argv string) once the federation has been running for
+# several hours.
+#
+# Same class of failure as #279 (github-api.sh overran via inline argv) but
+# in a different code path (federation-dashboard wrapper -> python3 helpers).
+#
+# Strategy:
+#   1. Stage a synthetic history.json larger than MAX_ARG_STRLEN (~200 KB).
+#      Each entry carries a unique sentinel so we can grep the rendered HTML
+#      for it afterwards.
+#   2. Run `DASHBOARD_REGEN_ONLY=1 federation-dashboard $FED_DIR` so the
+#      wrapper substitutes that history into the page and exits without
+#      backgrounding a server.
+#   3. Assert exit 0 and that index.html actually contains the sentinel —
+#      that is what proves the @-prefix temp-file plumbing reached the
+#      renderer's `{{HISTORY}}` substitution.
+#
+# Usage: ./tools/test-dashboard-argv-overflow.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DASHBOARD_SH="$REPO_ROOT/federation-dashboard/bin/federation-dashboard"
+
+PASS=0
+FAIL=0
+SKIP=0
+TMPDIR_TEST="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+skip() { echo "[SKIP] $1${2:+: $2}"; SKIP=$((SKIP + 1)); }
+
+if [ ! -x "$DASHBOARD_SH" ]; then
+    skip "0: federation-dashboard not on PATH" "$DASHBOARD_SH"
+    echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+    exit 0
+fi
+
+# --- Federation fixture ---
+FED_DIR="$TMPDIR_TEST/fed"
+mkdir -p "$FED_DIR/.dashboard" \
+         "$FED_DIR/.agentis/logs" \
+         "$FED_DIR/.agentis/daemon" \
+         "$FED_DIR/.agentis/experience" \
+         "$FED_DIR/stub-colony/agents" \
+         "$FED_DIR/stub-colony/config"
+
+cat > "$FED_DIR/stub-colony/config/colony.toml" <<'TOML'
+[colony]
+name = "stub-colony"
+TOML
+
+cat > "$FED_DIR/stub-colony/agents/argv_agent.ag" <<'AG'
+cb 100;
+fn tick() { return Void; }
+AG
+
+# --- Synthetic 200 KB+ history.json ---
+# Each entry is ~250 bytes of well-formed history schema; ~1500 entries lands
+# at >200 KB, comfortably past Linux's 128 KB MAX_ARG_STRLEN per-argv cap.
+# The first entry carries a unique sentinel string the assertion grep relies
+# on; without the #293 fix, building the argv would fail with E2BIG before
+# the renderer ever opened the template.
+#
+# Timestamps are anchored to *now* so that federation-dashboard-history.py's
+# 7-day pruning cutoff (epoch - 7*86400) does NOT drop the fixture before the
+# renderer reads it. Anything older than 7 days would be silently truncated,
+# masking the regression.
+SENTINEL="argv_overflow_sentinel_unique_marker_293_a4b9c2"
+HISTORY_FILE="$FED_DIR/.dashboard/history.json"
+NOW_EPOCH="$(date '+%s')"
+python3 - "$HISTORY_FILE" "$SENTINEL" "$NOW_EPOCH" <<'PY'
+import json, sys
+path, sentinel, now = sys.argv[1], sys.argv[2], int(sys.argv[3])
+entries = []
+# Anchor entry — the assertion grep expects this string in index.html.
+entries.append({
+    't': now - 60,
+    'experience': {'total': 0, sentinel: 0},
+    'confidence': {'stub-colony': 0.5},
+})
+# Bulk filler — push past 200 KB. Spread timestamps across the last hour so
+# nothing crosses the 7-day prune cutoff.
+for i in range(1, 1500):
+    entries.append({
+        't': now - 3600 + i,
+        'experience': {'total': i, 'colony_filler_padding_string_to_inflate_the_blob_repeated_for_size': i},
+        'confidence': {'stub-colony': round(0.5 + (i % 20) * 0.001, 3)},
+    })
+data = json.dumps(entries)
+assert len(data) > 200 * 1024, 'fixture too small: %d bytes' % len(data)
+with open(path, 'w', encoding='utf-8') as f:
+    f.write(data)
+PY
+
+# Sanity: confirm the fixture is actually large enough to have tripped the
+# pre-fix argv path. If this fails, the test would silently no-op the
+# regression.
+HIST_BYTES="$(wc -c < "$HISTORY_FILE" | tr -d ' ')"
+if [ "$HIST_BYTES" -lt 200000 ]; then
+    fail "0: history.json fixture is only $HIST_BYTES bytes (need >200000)"
+    echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+    exit 1
+fi
+
+# --- Run the dashboard in regen-only mode ---
+LOG_FILE="$TMPDIR_TEST/dashboard.log"
+set +e
+DASHBOARD_REGEN_ONLY=1 bash "$DASHBOARD_SH" "$FED_DIR" >"$LOG_FILE" 2>&1
+RC=$?
+set -e
+
+if [ "$RC" -ne 0 ]; then
+    fail "1: regen-only run exited $RC" "log tail: $(tail -10 "$LOG_FILE" 2>/dev/null | tr '\n' ' ')"
+    echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+    exit 1
+fi
+pass "1: regen-only run exited 0 with $HIST_BYTES-byte history.json"
+
+# --- Assert the sentinel landed in the rendered page ---
+HTML_FILE="$FED_DIR/.dashboard/index.html"
+if [ ! -s "$HTML_FILE" ]; then
+    fail "2: index.html was not generated"
+    echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+    exit 1
+fi
+
+if grep -q "$SENTINEL" "$HTML_FILE"; then
+    pass "2: rendered HTML contains synthetic history sentinel ($SENTINEL)"
+else
+    fail "2: sentinel missing from index.html — @-prefix routing did not reach the renderer" "html size: $(wc -c < "$HTML_FILE")"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
Fixes #293.

## Summary

Dashboard wrapper passed `$COLLECTOR_JSON`, `$HISTORY`, `$REMEDIATION`, and `$DAEMONS` as positional argv to `python3`. After ~8 h of history accumulation, the JSON blobs cross Linux's `MAX_ARG_STRLEN` (128 KB per single argv string) and the dashboard startup fails with `Argument list too long` before any helper opens its template. Same class of failure as the one addressed in #279 (also a 128 KB inline-argv overrun), but in a different code path (`federation-dashboard/bin/federation-dashboard` -> `lib/*.py`).

## Approach

Spool large payloads to `mktemp` files and pass `@<path>` argv tokens to the Python helpers. Renderer (argv[9..11]) and collector (argv[1]) detect the prefix and read the file via a tiny `_read()` helper; non-`@` values pass through unchanged so any external caller is unaffected.

Cleanup uses an in-function `RETURN` trap rather than an `EXIT` trap, because `generate()` is also called from the regen-only path and from the 60 s background loop in normal mode — an `EXIT` trap on the wrapper would leak files for the lifetime of the dashboard process.

## Files changed

| File | Net delta |
|------|-----------|
| `federation-dashboard/bin/federation-dashboard` | +33 / -2 |
| `federation-dashboard/lib/federation-dashboard-renderer.py` | +21 / -3 |
| `federation-dashboard/lib/federation-dashboard-collector.py` | +12 / -1 |
| `federation-dashboard/CHANGELOG.md` | +10 / 0 |
| `tools/test-dashboard-argv-overflow.sh` | +135 / 0 (new) |

## Test plan

- [x] `bash -n federation-dashboard/bin/federation-dashboard` clean
- [x] `python3 -c 'import ast; ast.parse(...)'` clean for renderer + collector
- [x] New regression test `tools/test-dashboard-argv-overflow.sh` stages a 240 KB synthetic `history.json` with a unique sentinel, runs `DASHBOARD_REGEN_ONLY=1 federation-dashboard $FED_DIR`, asserts exit 0 and that the rendered `index.html` contains the sentinel — proves the temp-file plumbing reaches `{{HISTORY}}` substitution. Skips gracefully when the dashboard binary is not on PATH.
- [x] `tools/colony-lint.sh` passes 106 / 0 / 1 (baseline 105 + new test).
- [x] `test-timeline-rendering.sh` test 19 (zero heredocs) still green.

## Related

Same class of MAX_ARG_STRLEN overflow as the issue tracked in #279 (different file). #286 and #288 were the prior Fixed entries in this CHANGELOG section.