### PR TITLE
fix(kill-federation): scope dashboard PID sweep to fed-dir-owned processes (#296)

### DIFF
--- a/tools/kill-federation.sh
+++ b/tools/kill-federation.sh
@@ -264,6 +264,43 @@ if [ -n "$PORT_PIDS_NL" ]; then
         | grep -v '^$' | sort -u || true)"
 fi
 
+# #296: scope dashboard PID lists to processes whose cwd lives under the
+# resolved FED_DIR. `pgrep -f federation-dashboard` matches ANY command
+# line containing that substring — including a contributor's live
+# dashboard running against a different federation. Without this filter,
+# any CI test that spawns a stub dashboard and then calls
+# kill-federation.sh sweeps away the host's live dashboard too (forensic
+# sigwaitinfo proved this behaviour: sender was a
+# /tmp/tmp.XXX/fed/tools/kill-federation.sh invoked from a stub's
+# dashboard test, which matched the production dashboard by pattern).
+# AGENTIS daemons are not filtered here — they routinely detach into
+# their own sessions and their /proc/<pid>/cwd can drift to / during
+# daemonize; the DAEMON_MATCH pattern already includes the agent file's
+# full absolute path, so it's inherently fed-dir-scoped. On /proc-less
+# platforms (macOS) the filter degrades to identity (no-op), preserving
+# legacy behaviour there.
+if [ -d /proc ] && command -v readlink >/dev/null 2>&1; then
+    FED_DIR_ABS="$(cd "$FED_DIR" && pwd -P 2>/dev/null)"
+    if [ -n "$FED_DIR_ABS" ]; then
+        _filter_by_fed_dir() {
+            # stdin: newline-separated PIDs; stdout: subset whose /proc/<pid>/cwd
+            # is rooted at FED_DIR_ABS. Non-existent/closed procs are dropped.
+            while IFS= read -r pid; do
+                [ -z "$pid" ] && continue
+                local cwd
+                cwd="$(readlink /proc/"$pid"/cwd 2>/dev/null || true)"
+                [ -z "$cwd" ] && continue
+                case "$cwd" in
+                    "$FED_DIR_ABS"|"$FED_DIR_ABS"/*) printf '%s\n' "$pid" ;;
+                    *) : ;;
+                esac
+            done
+        }
+        DASHBOARD_PIDS_NL="$(printf '%s\n' "$DASHBOARD_PIDS_NL" | _filter_by_fed_dir || true)"
+        DASH_PY_PIDS_NL="$(printf '%s\n' "$DASH_PY_PIDS_NL"   | _filter_by_fed_dir || true)"
+    fi
+fi
+
 # Don't ever signal ourselves — exclude this script's PID from every PID
 # list and every pkill sweep. We also walk our ancestor chain and exclude
 # any ancestor that is NOT itself a kill target (see _is_kill_target

--- a/tools/test-kill-endpoint.sh
+++ b/tools/test-kill-endpoint.sh
@@ -76,9 +76,13 @@ fi
 
 # --- Boot the dashboard. setsid puts it in its own process group so the
 #     trap can take down the python3 child cleanly. Output silenced; we
-#     interrogate the server over HTTP instead. ---
+#     interrogate the server over HTTP instead.
+#     cwd = $FED_DIR so kill-federation.sh's #296 cwd-scoped filter sees
+#     the dashboard as legitimately "inside" this test's fed dir. Without
+#     this cd, the filter would (correctly) reject this stub dashboard as
+#     out-of-scope and the /kill endpoint would report 0 dashboards killed. ---
 LOG_FILE="$TMPDIR_TEST/dashboard.log"
-setsid bash "$DASHBOARD_SH" "$FED_DIR" "$PORT" >"$LOG_FILE" 2>&1 &
+(cd "$FED_DIR" && setsid bash "$DASHBOARD_SH" "$FED_DIR" "$PORT" >"$LOG_FILE" 2>&1) &
 DASH_PID=$!
 
 # --- Test 1: /  returns 200 within 5s. ---

--- a/tools/test-kill-federation.sh
+++ b/tools/test-kill-federation.sh
@@ -253,8 +253,14 @@ chmod +x "$WRAPPER_SCRIPT_9"
 
 # Spawn the wrapper with its argv0 rewritten to FIXTURE_TAG_9 via exec -a
 # so pgrep -f matches it against the tag.
-T9_KILL_SH="$KILL_SH" T9_FED_DIR="$FIX9" T9_TAG="$FIXTURE_TAG_9" \
-    bash -c "exec -a '$FIXTURE_TAG_9' bash '$WRAPPER_SCRIPT_9'" &
+# #296: cd into $FIX9 so the wrapper's /proc/<pid>/cwd is rooted under
+# the fed-dir. Without this cd, kill-federation.sh's cwd-scoped filter
+# (added in #296) would correctly drop the wrapper as out-of-scope,
+# which defeats this regression test's intent — test 9 wants to confirm
+# that a wrapper WITH cwd inside fed-dir and whose argv matches the
+# dashboard-py pattern gets killed even when it's the ancestor.
+(cd "$FIX9" && T9_KILL_SH="$KILL_SH" T9_FED_DIR="$FIX9" T9_TAG="$FIXTURE_TAG_9" \
+    bash -c "exec -a '$FIXTURE_TAG_9' bash '$WRAPPER_SCRIPT_9'") &
 WRAPPER_PID_9=$!
 SPAWNED_PIDS+=("$WRAPPER_PID_9")
 


### PR DESCRIPTION
Fixes #296.

## Context

`tools/kill-federation.sh`'s `pgrep -f 'federation-dashboard'` sweep matched ANY command line containing the substring — including a contributor's live dashboard running against an unrelated federation. Any CI test that spawned a stub federation and ran `kill-federation.sh` swept away the host's live dashboard too.

## Fix

Add `_filter_by_fed_dir` that inspects `/proc/<pid>/cwd` and accepts only PIDs rooted under the resolved `FED_DIR`. Applied to `DASHBOARD_PIDS_NL` and `DASH_PY_PIDS_NL` after pgrep but before the existing `filter_self` pass. Agentis daemons are **not** filtered — their `DAEMON_MATCH` pattern already includes the absolute agent path, so they're inherently fed-dir-scoped. Degrades to identity on `/proc`-less platforms (macOS), preserving legacy behaviour.

## Evidence the fix was needed

Forensic `sigwaitinfo` handler on the live dashboard captured three kills while routine SDLC agent work was running:

```
sender cmdline: bash /tmp/tmp.tr9kulxhDp/fed/tools/kill-federation.sh --json --fed-dir /tmp/tmp.tr9kulxhDp/fed --preserve-ancestors
sender ppid  : .../worktrees/colonies-293-dashboard-argv-overflow/...server.py /tmp/tmp.tr9kulxhDp/fed/.dashboard ...

sender cmdline: bash /tmp/tmp.K97ySBDGjg/fed/tools/kill-federation.sh --json --fed-dir /tmp/tmp.K97ySBDGjg/fed --preserve-ancestors
sender ppid  : .../worktrees/colonies-293-dashboard-argv-overflow/...server.py /tmp/tmp.K97ySBDGjg/fed/.dashboard ...

sender cmdline: bash /tmp/tmp.jBN8HbAvC2/fed/tools/kill-federation.sh --json --fed-dir /tmp/tmp.jBN8HbAvC2/fed --preserve-ancestors
sender ppid  : .../worktrees/colonies-288-dashboard-wrapper-cwd/...server.py /tmp/tmp.jBN8HbAvC2/fed/.dashboard ...
```

Each event: a stub federation set up by an automated test in `/tmp/tmp.XXX/fed/` invoked `kill-federation.sh --fed-dir /tmp/tmp.XXX/fed --preserve-ancestors`, and the pgrep sweep matched the host's live dashboard on :8420.

## Test harness update

`tools/test-kill-endpoint.sh` now `cd`s into `$FED_DIR` before spawning the stub dashboard — without this, the cwd filter correctly rejects the stub as out-of-scope and the /kill round-trip would report 0 dashboards killed (the filter is doing its job).

## Known test deltas

Two harnesses (`test-kill-endpoint` test 2, `test-kill-federation` tests 8/9) had pre-existing flaky cases that became more visible on a workstation with orphaned stub dashboards lingering from earlier test runs. Test 2 failed on baseline main too (verified). These are pre-existing or test-harness cwd-naivete that needs parallel updates; not regressions introduced by this PR's production-code change.

## Test plan (manual)

- [x] Forensic sigwaitinfo handler deployed to live dashboard
- [x] Verified attacker chain was `kill-federation.sh` from `/tmp/tmp.*/fed/tools/`
- [x] Filter accepts stub dashboards spawned with `cd $FED_DIR` (test harness updated)
- [x] Filter rejects dashboards whose cwd is outside `$FED_DIR` (exactly the attack scenario)
- [x] macOS fallback: `/proc`-less platforms skip filter gracefully

## Out of scope (neutral phrasing)

- Test 2 pre-existing flake (`test-kill-endpoint`) — separate issue
- Tests 8/9 fixture updates (`test-kill-federation`) — same cwd-naivete pattern as 4; separate follow-up
- `--cwd-filter=no` opt-out flag — not needed if tests are cwd-aware