### PR TITLE
fix(colony-lint): extract awk allowlist to separate file for bash 3.2 compat (#271)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -34,6 +34,7 @@ is asserted until multi-version CI is in place.
 - `install.sh` now sets `daemon.heartbeat_interval_ms = 900000` (3× the longest tick interval, 300 000 ms, per #146) so reactive code-review/release agents are no longer killed by the watchdog after their first tick; existing installs with the pre-fix `180000` literal are auto-upgraded in place (#280).
 - `install.sh` now seeds the `gitlab:me` memo from `$GITHUB_ME` on github-backed federations (previously only `$GITLAB_ME` was honored, leaving the three `recall_latest("gitlab:me")` consumers — labeler, prioritizer, style_reviewer — falling back to `team` tagging). Re-runs preserve operator-customized memos (#278).
 - `start-colony.sh --restart-agent <name>` now kills the pre-existing daemon (SIGTERM → 5s wait → SIGKILL) before spawning the new one; previous behaviour silently accumulated duplicate `agentis daemon-inner` processes across dashboard `/restart` and `/confidence`-triggered respawns (#285).
+- `tools/colony-lint.sh` no longer fails to parse on stock macOS bash 3.2 (`/bin/bash`). The inline `awk '...'` literal that extracted daemon flags from `start-colony.sh` is now sourced from `tools/colony-lint-flag-allowlist.awk` via `awk -f`, removing the multi-line single-quoted block that the bash 3.2 parser miscompiled near the case-statement at line 202. Same workaround pattern already applied to the `auto-promote.sh` family (#245) and the `federation-dashboard-*.py` family (#172). New smoke harness `tools/test-colony-lint-bash32.sh` enforces (#271).
 
 ### Security
 

--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -34,6 +34,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   detaches the subprocess with `start_new_session=True` and returns 202
   Accepted; operator polls `agentis daemon list` for actual state
   ([#286](https://github.com/Replikanti/agentis-colonies/issues/286)).
+- `tools/colony-lint.sh` (the federation lint the dashboard's CI gate
+  depends on transitively) no longer fails to parse on stock macOS
+  bash 3.2 (`/bin/bash`). The inline `awk '...'` literal at line 179 is
+  now sourced from `tools/colony-lint-flag-allowlist.awk` via `awk -f`,
+  removing the multi-line single-quoted block that the bash 3.2 parser
+  miscompiled near the case-statement at line 202. Same workaround
+  pattern already applied to the `auto-promote.sh` family
+  ([#245](https://github.com/Replikanti/agentis-colonies/issues/245))
+  and the `federation-dashboard-*.py` family
+  ([#172](https://github.com/Replikanti/agentis-colonies/issues/172)).
+  New smoke harness `tools/test-colony-lint-bash32.sh` enforces
+  ([#271](https://github.com/Replikanti/agentis-colonies/issues/271)).
 
 ## [0.3.0] — 2026-04-24
 

--- a/tools/colony-lint-flag-allowlist.awk
+++ b/tools/colony-lint-flag-allowlist.awk
@@ -1,0 +1,18 @@
+
+/^[[:space:]]*#/ { next }
+/^[[:space:]]*echo/ { next }
+/agentis[[:space:]]+daemon/ { in_cmd=1 }
+in_cmd {
+    for (i=1; i<=NF; i++) {
+        tok = $i
+        sub(/\\$/, "", tok)
+        if (tok == "&" || tok == "") continue
+        if (tok ~ /^--[a-zA-Z][a-zA-Z-]*(=.*)?$/) {
+            sub(/=.*/, "", tok)
+            print tok
+        } else if (tok ~ /^-[a-zA-Z]$/) {
+            print tok
+        }
+    }
+    if ($0 !~ /\\[[:space:]]*$/) { in_cmd = 0 }
+}

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -176,25 +176,7 @@ if errors:
         # If core adds a new daemon flag, add it here too.
         start_script="$col_path/scripts/start-colony.sh"
         if [ -f "$start_script" ]; then
-            bad_flags=$(awk '
-                /^[[:space:]]*#/ { next }
-                /^[[:space:]]*echo/ { next }
-                /agentis[[:space:]]+daemon/ { in_cmd=1 }
-                in_cmd {
-                    for (i=1; i<=NF; i++) {
-                        tok = $i
-                        sub(/\\$/, "", tok)
-                        if (tok == "&" || tok == "") continue
-                        if (tok ~ /^--[a-zA-Z][a-zA-Z-]*(=.*)?$/) {
-                            sub(/=.*/, "", tok)
-                            print tok
-                        } else if (tok ~ /^-[a-zA-Z]$/) {
-                            print tok
-                        }
-                    }
-                    if ($0 !~ /\\[[:space:]]*$/) { in_cmd = 0 }
-                }
-            ' "$start_script" | while read -r flag; do
+            bad_flags=$(awk -f "$REPO_ROOT/tools/colony-lint-flag-allowlist.awk" "$start_script" | while read -r flag; do
                 # Pattern is deliberately on one line: bash 3.2 (stock macOS)
                 # miscompiles backslash-newline inside case-pattern labels
                 # (#121). Keep all alternatives on a single line.

--- a/tools/test-colony-lint-bash32.sh
+++ b/tools/test-colony-lint-bash32.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# tools/test-colony-lint-bash32.sh: bash-3.2 compat smoke for colony-lint.sh.
+#
+# Verifies that:
+#   1. tools/colony-lint.sh parses under the host bash.
+#   2. tools/colony-lint.sh parses under bash-3.2 when available (stock macOS
+#      /bin/bash). Skipped when no bash-3.2 binary is on PATH.
+#   3. tools/colony-lint-flag-allowlist.awk parses (awk -f ... </dev/null).
+#
+# Background: #271 — the awk literal that lived inline at colony-lint.sh:179
+# tickled the same bash 3.2 parser bug already worked around for the
+# auto-promote.sh family in #245 / #172. Extracting the awk body to a
+# separate file (loaded via awk -f) keeps the shell script free of
+# heredoc / quoting shapes that bash 3.2 miscompiles.
+#
+# Usage: ./tools/test-colony-lint-bash32.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LINT="$SCRIPT_DIR/colony-lint.sh"
+AWK_FILE="$SCRIPT_DIR/colony-lint-flag-allowlist.awk"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "[SKIP] $1"; }
+
+if [ ! -f "$LINT" ]; then
+    fail "colony-lint.sh not found: $LINT"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+if [ ! -f "$AWK_FILE" ]; then
+    fail "allowlist awk file not found: $AWK_FILE"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# --- Test 1: host bash parses colony-lint.sh ---
+if bash -n "$LINT" 2>/tmp/colony-lint-bash32-err.$$; then
+    pass "bash -n colony-lint.sh"
+else
+    fail "bash -n colony-lint.sh failed: $(cat /tmp/colony-lint-bash32-err.$$)"
+fi
+rm -f /tmp/colony-lint-bash32-err.$$
+
+# --- Test 2: bash-3.2 parses colony-lint.sh (when available) ---
+if command -v bash-3.2 >/dev/null 2>&1; then
+    if bash-3.2 -n "$LINT" 2>/tmp/colony-lint-bash32-err.$$; then
+        pass "bash-3.2 -n colony-lint.sh"
+    else
+        fail "bash-3.2 -n colony-lint.sh failed: $(cat /tmp/colony-lint-bash32-err.$$)"
+    fi
+    rm -f /tmp/colony-lint-bash32-err.$$
+else
+    skip "bash-3.2 not on PATH"
+fi
+
+# --- Test 3: awk -f parses the extracted allowlist ---
+if awk -f "$AWK_FILE" </dev/null >/dev/null 2>/tmp/colony-lint-bash32-err.$$; then
+    pass "awk -f colony-lint-flag-allowlist.awk </dev/null"
+else
+    fail "awk -f colony-lint-flag-allowlist.awk failed: $(cat /tmp/colony-lint-bash32-err.$$)"
+fi
+rm -f /tmp/colony-lint-bash32-err.$$
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Fixes #271