### PR TITLE
fix(start-federation): sweep stale heartbeats in repo-root .agentis too (#302)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,9 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Fixed
+- `start-federation.sh` heartbeat-wipe path now matches the actual agentis registry. The old wipe targeted `<fed-dir>/.agentis/daemon` (empty placeholder) but the real registry lives at `<fed-dir>/../.agentis/daemon` via the per-colony symlink layout — stale heartbeat files survived restarts and the watchdog killed every fresh child on its first poll iteration with `heartbeat stale (N ms > timeout)`. Both paths are now swept (#302).
+
 ### Added
 
 - New `[implementation].require_assignee` config knob (default `false`) gates whether `code_writer`'s action path also fires on labeled-but-unassigned issues or stays restricted to labeled+assigned. The `implementation/scripts/{gitlab,github}-api.sh` wrappers gain a matching `--include-unassigned` flag on `assigned-issues` and `assigned-issues-by-label-events`; `start-colony.sh` seeds `code_writer:require_assignee` from the TOML, and `code_writer.ag` appends the flag when the memo reads `"false"`. Unblocks the 13 downstream agents that listen for `implementation:code_draft` / `implementation:mr_ready` on repos where labeled issues are typically unassigned ([#291](https://github.com/Replikanti/agentis-colonies/issues/291)).

--- a/dev-apprenticeship/start-federation.sh
+++ b/dev-apprenticeship/start-federation.sh
@@ -60,16 +60,26 @@ done
 # tick. Wipe them before any child writes a fresh one. Safe because
 # the double-start guard above proved there is no live federation to
 # disrupt.
-FED_AGENTIS_DIR="$FED_DIR/.agentis/daemon"
-if [ -d "$FED_AGENTIS_DIR" ]; then
-    # *.pid / *.status / *.watchdog.pid go stale on the same axis as
-    # *.heartbeat — on wake they point at PIDs from the previous boot
-    # which may now belong to an unrelated process. Sweep them all.
-    rm -f "$FED_AGENTIS_DIR"/*.heartbeat \
-          "$FED_AGENTIS_DIR"/*.pid \
-          "$FED_AGENTIS_DIR"/*.status \
-          "$FED_AGENTIS_DIR"/*.watchdog.pid 2>/dev/null || true
-fi
+#
+# #302: the original wipe targeted "$FED_DIR/.agentis/daemon" which is
+# an empty placeholder dir created by install.sh §4. The actual agentis
+# registry lives at "$FED_DIR/../.agentis/daemon" (repo root); each
+# colony has a `.agentis` symlink pointing there. Daemons resolve their
+# agentis_root by walking up from cwd, so the heartbeat files always
+# materialise in the repo-root .agentis, never the federation-dir one.
+# Sweep both paths to cover legacy installs (real .agentis under fed)
+# AND the modern symlink layout (real .agentis at repo root).
+for candidate in "$FED_DIR/.agentis/daemon" "$FED_DIR/../.agentis/daemon"; do
+    if [ -d "$candidate" ]; then
+        # *.pid / *.status / *.watchdog.pid go stale on the same axis as
+        # *.heartbeat — on wake they point at PIDs from the previous boot
+        # which may now belong to an unrelated process. Sweep them all.
+        rm -f "$candidate"/*.heartbeat \
+              "$candidate"/*.pid \
+              "$candidate"/*.status \
+              "$candidate"/*.watchdog.pid 2>/dev/null || true
+    fi
+done
 
 # Start each colony
 TOTAL_AGENTS=0


### PR DESCRIPTION
Fixes #302.

`start-federation.sh` heartbeat wipe targeted `<fed-dir>/.agentis/daemon` (an empty placeholder dir) instead of the real registry at `<fed-dir>/../.agentis/daemon` (repo root, reached via per-colony `.agentis` symlinks). Stale heartbeats from previous incarnations survived every restart, watchdog killed every fresh child on its first poll iteration.

Forensic evidence (captured today via `RUST_BACKTRACE=full timeout 15 agentis daemon agents/labeler.ag`):

```
watchdog [d93139eceb2b] child started (pid=1316686, restarts=0, degrade=0)
watchdog [d93139eceb2b] heartbeat stale (1257730ms > 900000ms) — killing hung child
```

## Test plan

- [x] `bash -n start-federation.sh` clean
- [x] CHANGELOG entry under `[Unreleased] → Fixed`
- Manual smoke: kill federation, restart — first child of every daemon should survive past first poll iteration. Pre-fix it took 0 seconds; post-fix expected to live indefinitely (until normal heartbeat write or genuine timeout).

## Out of scope

- The agentis-core watchdog `read_heartbeat`-without-child-start-floor problem is separate (it would still kill the child on a brand-new install if the file already existed). That fix lives in agentis-core, not this repo.
- VERSION bump deferred to next release PR.