### PR TITLE
fix(test-dashboard-fedpath): drop setsid for portable subshell-detach (#273)

### DIFF
--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `tools/test-dashboard-fedpath.sh` no longer fails with `setsid: command
+  not found` on stock macOS (Darwin), which does not ship `util-linux`.
+  The three `setsid bash …` callsites that boot the dashboard for the
+  fixture (cwd-aware, no-cwd, and the Case D mock-`agentis` path) now
+  use a portable subshell-detach pattern (`( cd … && bash … >log 2>&1
+  < /dev/null ) &`) instead. Cleanup trap already falls back to bare
+  pid kills when the pgroup-kill fails, so the loss of the new session
+  leader is benign. Linux runs stay green
+  ([#273](https://github.com/Replikanti/agentis-colonies/issues/273)).
 - Auto-promote sidecar card no longer reports false-positive `DEGRADED — silent NNNNm (interval 30m)` for the first 30 min after federation restart. Collector now reads `.agentis/logs/auto-promote.sidecar_started_at` (stamped by `start-federation.sh` at sidecar spawn) and emits `sidecar.in_startup_grace=true` while `now - started_at < interval_s + 120s`; the template's `sidecarSilent` predicate gates DEGRADED on `!in_startup_grace`. Federations on the pre-#274 `start-federation.sh` produce no timestamp file and behave exactly as before ([#274](https://github.com/Replikanti/agentis-colonies/issues/274)).
 - Dashboard no longer renders every agent as `state=stopped` /
   `health=unknown` when the wrapper inherits a cwd outside the

--- a/tools/test-dashboard-fedpath.sh
+++ b/tools/test-dashboard-fedpath.sh
@@ -57,9 +57,9 @@ free_port() {
 boot_dashboard() {
     local fed_dir="$1" port="$2" log_file="$3" cwd="${4:-}"
     if [ -n "$cwd" ]; then
-        ( cd "$cwd" && setsid bash "$DASHBOARD_SH" "$fed_dir" "$port" >"$log_file" 2>&1 ) &
+        ( cd "$cwd" && bash "$DASHBOARD_SH" "$fed_dir" "$port" >"$log_file" 2>&1 < /dev/null ) &
     else
-        setsid bash "$DASHBOARD_SH" "$fed_dir" "$port" >"$log_file" 2>&1 &
+        bash "$DASHBOARD_SH" "$fed_dir" "$port" >"$log_file" 2>&1 < /dev/null &
     fi
     local pid=$!
     DASH_PIDS="$DASH_PIDS $pid"
@@ -352,7 +352,7 @@ LOG_D="$TMPDIR_TEST/dashboard-D.log"
 # Boot wrapper from /tmp (cwd != FED_D) with the mock agentis on PATH.
 # boot_dashboard's cwd arg is honoured before exec, so the dashboard inherits
 # /tmp as cwd — exactly the systemd-run --user failure mode #288 reproduces.
-( cd /tmp && PATH="$MOCK_BIN_D:$PATH" setsid bash "$DASHBOARD_SH" "$FED_D" "$PORT_D" >"$LOG_D" 2>&1 ) &
+( cd /tmp && PATH="$MOCK_BIN_D:$PATH" bash "$DASHBOARD_SH" "$FED_D" "$PORT_D" >"$LOG_D" 2>&1 < /dev/null ) &
 DASH_PID_D=$!
 DASH_PIDS="$DASH_PIDS $DASH_PID_D"
 


### PR DESCRIPTION
Fixes #273