### PR TITLE
fix(colony-lint): gate destructive test-kill-{endpoint,federation}.sh behind env var (#329)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -16,6 +16,7 @@ is asserted until multi-version CI is in place.
 ## [Unreleased]
 
 ### Fixed
+- `tools/colony-lint.sh` no longer transitively runs `tools/test-kill-endpoint.sh` and `tools/test-kill-federation.sh` (which kill the live federation despite the #296 cwd-filter). The auto-discovered test loop now `[SKIP]`s both by default; opt in via `AGENTIS_RUN_KILL_TESTS=1` for CI in isolated environments ([#329](https://github.com/Replikanti/agentis-colonies/issues/329)).
 - `start-federation.sh` heartbeat-wipe path now matches the actual agentis registry. The old wipe targeted `<fed-dir>/.agentis/daemon` (empty placeholder) but the real registry lives at `<fed-dir>/../.agentis/daemon` via the per-colony symlink layout — stale heartbeat files survived restarts and the watchdog killed every fresh child on its first poll iteration with `heartbeat stale (N ms > timeout)`. Both paths are now swept (#302).
 
 ### Added

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -672,12 +672,35 @@ for t in "${test_scripts[@]}"; do
     # #272: Re-entrancy marker so test scripts that re-invoke
     # colony-lint.sh (e.g. test-colony-lint-bash32.sh test 4) can
     # detect the nested run and skip the recursive step.
-    if AGENTIS_COLONY_LINT_NESTED=1 bash "$t" &>/dev/null; then
-        pass "tools: $(basename "$t") unit tests"
-    else
-        fail "tools: $(basename "$t") unit tests"
-        AGENTIS_COLONY_LINT_NESTED=1 bash "$t" 2>&1 | tail -20
-    fi
+    case "$(basename "$t")" in
+        test-kill-endpoint.sh|test-kill-federation.sh)
+            # #329: these tests exercise kill-federation.sh which sends
+            # SIGTERM/SIGKILL to processes matching `agentis daemon-inner`
+            # in the host's scope. Despite cwd-filter (#296), in practice
+            # they still kill the operator's live federation when invoked
+            # from a worktree or shared lint pipeline. Run only when
+            # explicitly requested via AGENTIS_RUN_KILL_TESTS=1 (CI-only
+            # in isolated environments).
+            if [ "${AGENTIS_RUN_KILL_TESTS:-0}" = "1" ]; then
+                if AGENTIS_COLONY_LINT_NESTED=1 bash "$t" &>/dev/null; then
+                    pass "tools: $(basename "$t") unit tests"
+                else
+                    fail "tools: $(basename "$t") unit tests"
+                    AGENTIS_COLONY_LINT_NESTED=1 bash "$t" 2>&1 | tail -20
+                fi
+            else
+                skip "tools: $(basename "$t") (destructive — set AGENTIS_RUN_KILL_TESTS=1 to run)"
+            fi
+            ;;
+        *)
+            if AGENTIS_COLONY_LINT_NESTED=1 bash "$t" &>/dev/null; then
+                pass "tools: $(basename "$t") unit tests"
+            else
+                fail "tools: $(basename "$t") unit tests"
+                AGENTIS_COLONY_LINT_NESTED=1 bash "$t" 2>&1 | tail -20
+            fi
+            ;;
+    esac
 done
 
 # --- Summary ---

--- a/tools/test-colony-lint-bash32.sh
+++ b/tools/test-colony-lint-bash32.sh
@@ -97,6 +97,33 @@ for s in $SECRET_SCRIPTS; do
     fi
 done
 
+# --- Test 5: destructive kill-tests skipped by default (#329) ---
+# colony-lint.sh auto-discovers tools/test-*.sh and ran them all, including
+# test-kill-{endpoint,federation}.sh which shell out to kill-federation.sh
+# and (despite the #296 cwd-filter) kill the operator's live federation.
+# We assert the source carries a case-statement that gates both scripts on
+# AGENTIS_RUN_KILL_TESTS=1 with a [SKIP] emit by default. NOT spawning the
+# loop here on purpose — that would re-introduce the very bug we're
+# fixing.
+test5_ok=1
+if ! grep -q 'test-kill-endpoint.sh' "$LINT"; then
+    test5_ok=0
+fi
+if ! grep -q 'test-kill-federation.sh' "$LINT"; then
+    test5_ok=0
+fi
+if ! grep -q 'AGENTIS_RUN_KILL_TESTS' "$LINT"; then
+    test5_ok=0
+fi
+if ! grep -q 'destructive .* AGENTIS_RUN_KILL_TESTS=1 to run' "$LINT"; then
+    test5_ok=0
+fi
+if [ "$test5_ok" = "1" ]; then
+    pass "kill-tests gated behind AGENTIS_RUN_KILL_TESTS (#329)"
+else
+    fail "kill-tests guard missing or malformed in colony-lint.sh"
+fi
+
 # --- Test 4: missing tomllib/tomli triggers [SKIP], no traceback (#272) ---
 # Skip when this script is invoked from inside colony-lint.sh — running
 # the lint again from here would recurse (lint discovers this test, runs


### PR DESCRIPTION
## Summary

`tools/colony-lint.sh` auto-discovers every `tools/test-*.sh` and runs each one. Two of those — `test-kill-endpoint.sh` and `test-kill-federation.sh` — shell out to `tools/kill-federation.sh`, which sends SIGTERM/SIGKILL to processes matching `agentis daemon-inner` in the host's scope. Despite the #296 cwd-filter, in practice they still kill the operator's live federation when colony-lint runs in a worktree or in a shared lint pipeline. This has cost real session deaths.

This is the Option A fix from the issue plan: gate the two destructive scripts behind `AGENTIS_RUN_KILL_TESTS=1`. They `[SKIP]` by default; CI in isolated environments opts in via the env var. The deeper root-cause work on `kill-federation.sh` cwd-scoping stays as Option B follow-up.

- `tools/colony-lint.sh`: case-statement around the auto-discovered test-script loop. Kill-tests run only when `AGENTIS_RUN_KILL_TESTS=1`; otherwise emit a `[SKIP]` line. All other `test-*.sh` go through the existing pass/fail path unchanged.
- `tools/test-colony-lint-bash32.sh`: new test 5 that grep-asserts the guard shape (case branch + env-var gate + skip emit) on `colony-lint.sh`'s source. Deliberately does NOT spawn the lint loop — that would re-introduce the very bug being fixed.
- `dev-apprenticeship/CHANGELOG.md`: `[Unreleased]` → `Fixed` entry referencing #329.

Net delta: +57/-6 lines across 3 files.

## Test plan

- [x] `bash -n tools/colony-lint.sh` — clean
- [x] `bash -n tools/test-colony-lint-bash32.sh` — clean
- [x] `tools/test-colony-lint-bash32.sh` — 6 passed, 0 failed (existing 4 cases + bash-3.2 SKIP + new test 5)
- [x] `tools/test-secret-resolver.sh` — 16 passed, 0 failed (#321 unaffected)
- [x] Did NOT run `tools/colony-lint.sh` directly during validation (would have killed the live federation, which is the bug being fixed)
- [x] CI runs `colony-lint.sh` in an isolated environment — kill-tests will SKIP cleanly there too. To exercise the destructive paths in CI, set `AGENTIS_RUN_KILL_TESTS=1` in that one workflow step.

Fixes #329.