### PR TITLE
feat(dashboard): server-side SSE + minimal browser consumer (#313 PR 1)

### DIFF
--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Server-Sent Events (SSE) live snapshot stream** — server-side plumbing
+  ([#313](https://github.com/Replikanti/agentis-colonies/issues/313) PR 1).
+  The dashboard server now exposes `GET /events` (text/event-stream); each
+  regen tick the wrapper writes the freshly-collected `COLLECTOR_JSON` to
+  `<dash-dir>/snapshot.json` atomically (temp + rename). A daemon thread
+  inside the server polls the snapshot file's mtime every 250ms and
+  `notify_all()`s a `threading.Condition`; every connected `/events`
+  handler then writes one `event: snapshot\ndata: <bytes>\n\n` frame.
+  Idle keepalive (`: keepalive\n\n`) every 30s so proxies / browsers
+  don't time the stream out. The HTTP server upgrades from
+  `HTTPServer` to `ThreadingHTTPServer` so SSE handlers don't block
+  the existing endpoints (`/refresh`, `/confidence`, `/restart`,
+  `/quarantine`, `/evolve`, `/cleanup`, `/start`, `/kill`,
+  `/cost-cap/override`). Each pushed payload carries an 8-char
+  `__hash` field (server-side sha256 of canonical JSON) so the
+  browser dedupes identical pushes. The HTML template ships a
+  minimal `EventSource('/events')` consumer that re-emits each
+  snapshot as a DOM `agentis:snapshot` CustomEvent — PR 2 will
+  refactor the per-tile IIFE renderers into `renderXxx(data)`
+  callbacks listening on this event to update the DOM in-place
+  without `location.reload()`. Static first paint of `/` is
+  unchanged; SSE is purely additive — older browsers without
+  `EventSource` keep using the existing 60s background regen path.
+
 ## [0.5.0] — 2026-04-26
 
 Cost Cap tile + Federation Health Banner cost-cap state, paired with the

--- a/federation-dashboard/bin/federation-dashboard
+++ b/federation-dashboard/bin/federation-dashboard
@@ -65,6 +65,11 @@ FED_NAME_JS="$(printf '%s' "$FED_NAME" | python3 -c 'import sys,json; print(json
 DASH_DIR="$FED_DIR/.dashboard"
 HTML_FILE="$DASH_DIR/index.html"
 HISTORY_FILE="$DASH_DIR/history.json"
+# #313 PR 1: snapshot file watched by the SSE server. After each generate()
+# cycle the wrapper writes the COLLECTOR_JSON blob here atomically (temp +
+# rename); the server's watcher thread polls mtime every 250ms and pushes
+# `event: snapshot` frames to /events subscribers on change.
+SNAPSHOT_FILE="$DASH_DIR/snapshot.json"
 
 mkdir -p "$DASH_DIR"
 
@@ -242,6 +247,16 @@ generate() {
         "@$HIST_FILE" \
         "@$REMED_FILE" \
         "$COLONY_LIST_JS"
+
+    # #313 PR 1: write the freshly-collected snapshot bytes to a stable file
+    # the SSE server watches. Atomic rename so a /events handler reading
+    # mid-write never sees a torn payload. Failure to write is non-fatal —
+    # the static index.html refresh path still works; only push-on-change
+    # degrades.
+    if printf '%s' "$COLLECTOR_JSON" > "${SNAPSHOT_FILE}.tmp.$$" 2>/dev/null; then
+        mv -f "${SNAPSHOT_FILE}.tmp.$$" "$SNAPSHOT_FILE" 2>/dev/null \
+            || rm -f "${SNAPSHOT_FILE}.tmp.$$" 2>/dev/null || true
+    fi
 }
 
 # --- Regen-only mode ---

--- a/federation-dashboard/lib/federation-dashboard-server.py
+++ b/federation-dashboard/lib/federation-dashboard-server.py
@@ -24,8 +24,8 @@
 #                        tools/ for restart logic — spawning is delegated
 #                        to each colony's scripts/start-colony.sh.
 
-import sys, os, subprocess, json, time, signal, shutil, shlex, urllib.parse
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+import sys, os, subprocess, json, time, signal, shutil, shlex, threading, hashlib, urllib.parse
+from http.server import HTTPServer, SimpleHTTPRequestHandler, ThreadingHTTPServer
 
 serve_dir, port = sys.argv[1], int(sys.argv[2])
 script_path, fed_dir_arg = sys.argv[3], sys.argv[4]
@@ -39,6 +39,69 @@ agent_to_colony = {e.get('agent',''): e.get('colony','') for e in _map if e.get(
 os.chdir(serve_dir)
 fed_dir = os.path.dirname(serve_dir)
 confidence_log = os.path.join(serve_dir, 'confidence-log.jsonl')
+
+# --- SSE plumbing (#313 PR 1) ---
+# The wrapper writes the latest collector JSON snapshot to <serve_dir>/snapshot.json
+# atomically (temp + rename) after each generate() cycle. A daemon thread polls
+# the file's mtime every 250ms; on change it loads the bytes, attaches an
+# 8-char sha hash for client-side dedupe, parks the result in latest_snapshot,
+# and notify_all()'s on snapshot_cv. /events handlers wait on the condition
+# and write each new bytes blob as one `event: snapshot\ndata: ...\n\n` frame
+# (plus a `: keepalive\n\n` comment frame every 30s when nothing fires, so
+# proxies / browsers don't time the connection out).
+snapshot_path = os.path.join(serve_dir, 'snapshot.json')
+snapshot_lock = threading.Lock()
+snapshot_cv = threading.Condition(snapshot_lock)
+latest_snapshot = None  # bytes (UTF-8 JSON with `__hash` injected) or None
+_last_snapshot_mtime = 0.0
+
+
+def _augment_snapshot(raw_bytes):
+    """Inject an 8-char `__hash` of the canonical JSON so clients can dedupe.
+    Returns augmented bytes; on parse failure returns the raw bytes unchanged
+    (the SSE consumer will catch the exception client-side)."""
+    try:
+        obj = json.loads(raw_bytes.decode('utf-8'))
+    except (ValueError, UnicodeDecodeError):
+        return raw_bytes
+    if not isinstance(obj, dict):
+        return raw_bytes
+    # Hash without the __hash field (idempotent across re-augmentations).
+    obj.pop('__hash', None)
+    canon = json.dumps(obj, sort_keys=True, separators=(',', ':')).encode('utf-8')
+    digest = hashlib.sha256(canon).hexdigest()[:8]
+    obj['__hash'] = digest
+    return json.dumps(obj, separators=(',', ':')).encode('utf-8')
+
+
+def _snapshot_watcher():
+    """Daemon thread: polls snapshot.json mtime every 250ms; on change reads
+    the bytes, augments with a hash, parks in latest_snapshot, and notifies
+    waiting /events handlers. No-op until the wrapper produces the file."""
+    global latest_snapshot, _last_snapshot_mtime
+    while True:
+        try:
+            mtime = os.path.getmtime(snapshot_path)
+        except OSError:
+            time.sleep(0.25)
+            continue
+        if mtime != _last_snapshot_mtime:
+            try:
+                with open(snapshot_path, 'rb') as f:
+                    raw = f.read()
+            except OSError:
+                time.sleep(0.25)
+                continue
+            augmented = _augment_snapshot(raw)
+            with snapshot_cv:
+                latest_snapshot = augmented
+                _last_snapshot_mtime = mtime
+                snapshot_cv.notify_all()
+        time.sleep(0.25)
+
+
+threading.Thread(target=_snapshot_watcher, daemon=True).start()
+
 # #252: kill-federation.sh lives in the federation's shared tools dir, not
 # next to this script (the dashboard is a separately-versioned standalone
 # component). The entry script resolves <fed-dir>/tools/ then
@@ -336,6 +399,59 @@ def restart_daemon(agent):
     }
 
 class Handler(SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/events':
+            # #313 PR 1: live SSE channel. Holds the connection open, pushes
+            # one `event: snapshot\ndata: <COLLECTOR_JSON>\n\n` frame whenever
+            # the snapshot file changes (the watcher thread notify_all()'s
+            # snapshot_cv). Sends a `: keepalive\n\n` comment every 30s when
+            # nothing fires so proxies / browsers don't drop the idle stream.
+            try:
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/event-stream')
+                self.send_header('Cache-Control', 'no-cache')
+                self.send_header('Connection', 'keep-alive')
+                self.send_header('X-Accel-Buffering', 'no')  # disable nginx buffering
+                self.send_header('Access-Control-Allow-Origin', '*')
+                self.end_headers()
+                # Push the most recent snapshot immediately so a fresh
+                # connection doesn't have to wait for the next regen tick.
+                with snapshot_cv:
+                    last_seen_id = id(latest_snapshot)
+                    if latest_snapshot is not None:
+                        self.wfile.write(b'event: snapshot\ndata: ')
+                        self.wfile.write(latest_snapshot)
+                        self.wfile.write(b'\n\n')
+                        self.wfile.flush()
+                while True:
+                    with snapshot_cv:
+                        # Wait up to 30s for a new snapshot; on timeout we
+                        # send a keepalive comment and loop. id() is fine
+                        # because latest_snapshot is rebound (new bytes
+                        # object) on every update.
+                        snapshot_cv.wait(timeout=30.0)
+                        current_id = id(latest_snapshot)
+                        snapshot_to_send = None
+                        if current_id != last_seen_id and latest_snapshot is not None:
+                            snapshot_to_send = latest_snapshot
+                            last_seen_id = current_id
+                    if snapshot_to_send is not None:
+                        self.wfile.write(b'event: snapshot\ndata: ')
+                        self.wfile.write(snapshot_to_send)
+                        self.wfile.write(b'\n\n')
+                    else:
+                        # Idle timeout: keepalive comment frame.
+                        self.wfile.write(b': keepalive\n\n')
+                    self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError):
+                # Client went away. The thread exits cleanly; the watcher
+                # daemon keeps running for the next subscriber.
+                return
+            return
+        # Defer to SimpleHTTPRequestHandler for static-file serving (/, /index.html,
+        # /favicon.ico, etc.).
+        return SimpleHTTPRequestHandler.do_GET(self)
+
     def do_POST(self):
         if self.path == '/refresh':
             env = dict(os.environ)
@@ -843,4 +959,12 @@ class Handler(SimpleHTTPRequestHandler):
     def log_message(self, format, *args):
         pass
 
-HTTPServer(('127.0.0.1', port), Handler).serve_forever()
+# #313 PR 1: ThreadingHTTPServer so SSE handlers (which hold their connection
+# open indefinitely) don't block other endpoints. Each request gets its own
+# thread; POST endpoints already shell out to subprocesses, so they're
+# naturally thread-safe at the HTTP layer. daemon_threads=True so an
+# Ctrl-C / SIGTERM at the wrapper level tears down lingering SSE threads
+# instead of waiting for every connected browser to close.
+server = ThreadingHTTPServer(('127.0.0.1', port), Handler)
+server.daemon_threads = True
+server.serve_forever()

--- a/federation-dashboard/lib/federation-dashboard.html.template
+++ b/federation-dashboard/lib/federation-dashboard.html.template
@@ -2795,6 +2795,46 @@ function killSwitch() {
       showError('Kill request failed (network error)', String((e && e.message) || e), () => location.reload());
     });
 }
+
+// --- SSE live snapshot consumer (#313 PR 1) ---
+// Server pushes one `event: snapshot` frame per regen tick whenever
+// .dashboard/snapshot.json changes. PR 1 just dispatches an
+// `agentis:snapshot` CustomEvent + dedupes by the server-injected
+// 8-char `__hash`; PR 2 (deferred) will refactor the IIFE renderers
+// into renderXxx(data) callbacks listeners on this event can invoke
+// to update the DOM in-place without `location.reload()`. For PR 1
+// the static first paint is unchanged; SSE is purely additive — when
+// the channel works the page silently receives snapshots, when it
+// breaks (older browser, CORS proxy stripping text/event-stream)
+// the existing background regen + manual refresh paths keep the
+// dashboard alive.
+(function setupSSE() {
+  if (!('EventSource' in window)) return;  // graceful no-op on ancient browsers
+  let es;
+  try {
+    es = new EventSource('/events');
+  } catch (_) {
+    return;
+  }
+  es.addEventListener('snapshot', function (ev) {
+    let snap;
+    try { snap = JSON.parse(ev.data); }
+    catch (e) {
+      if (window.console) console.warn('SSE snapshot parse failed', e);
+      return;
+    }
+    if (!snap || typeof snap !== 'object') return;
+    const h = snap.__hash || null;
+    if (h && window.__lastSnapshotHash === h) return;  // dedupe identical pushes
+    window.__lastSnapshotHash = h;
+    window.dispatchEvent(new CustomEvent('agentis:snapshot', { detail: snap }));
+  });
+  es.onerror = function () {
+    // EventSource auto-reconnects with backoff. Nothing to do here; the
+    // existing 60s background regen keeps the dashboard fresh in the
+    // meantime.
+  };
+})();
 </script>
 </body>
 </html>

--- a/tools/test-sse-stream.sh
+++ b/tools/test-sse-stream.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+# tools/test-sse-stream.sh: smoke test for the Server-Sent Events stream
+# in federation-dashboard (#313 PR 1). Boots the dashboard against a
+# minimal fixture federation on a free local port, then exercises:
+#
+#   t1: GET /events emits at least one `event: snapshot` frame within 5s.
+#   t2: GET /  still returns 200 + non-empty HTML (static first-paint
+#       path is unchanged).
+#   t3: when the wrapper writes a fresh snapshot, a new SSE frame
+#       arrives within ~1s (the watcher polls every 250ms).
+#   t4: an SSE client disconnect doesn't crash the server (server keeps
+#       serving / and accepts a new GET /events afterwards).
+#   t5: a second GET /events succeeds after the first one was killed
+#       (multi-client + reconnect path).
+#
+# Self-contained: only bash, python3, curl. Cleans up via trap on every
+# exit path. Auto-skips when python3 or a free port is unavailable.
+#
+# Live-federation safety: spawns its own dashboard process on a free
+# port under a temp federation fixture. Never targets the production
+# 8420 dashboard.
+#
+# Usage: ./tools/test-sse-stream.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DASHBOARD_SH="$REPO_ROOT/federation-dashboard/bin/federation-dashboard"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+DASH_PID=""
+
+cleanup() {
+    if [ -n "$DASH_PID" ]; then
+        # Kill the wrapper and its python child (same process group).
+        kill -TERM "-$DASH_PID" 2>/dev/null || kill -TERM "$DASH_PID" 2>/dev/null || true
+        sleep 1
+        kill -KILL "-$DASH_PID" 2>/dev/null || kill -KILL "$DASH_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+skip() { echo "[SKIP] $1${2:+: $2}"; }
+
+# Sanity: dashboard script exists and is executable.
+if [ ! -x "$DASHBOARD_SH" ]; then
+    fail "0: dashboard script missing or not executable" "$DASHBOARD_SH"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    skip "0: python3 not on PATH; SSE test cannot pick a free port"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 0
+fi
+
+# --- Fixture: minimal federation directory with a single colony stub. ---
+FED_DIR="$TMPDIR_TEST/fed"
+mkdir -p "$FED_DIR/.agentis/daemon" \
+         "$FED_DIR/.agentis/logs" \
+         "$FED_DIR/.agentis/experience" \
+         "$FED_DIR/stub-colony/agents" \
+         "$FED_DIR/stub-colony/config"
+
+cat > "$FED_DIR/stub-colony/config/colony.toml" <<'TOML'
+[colony]
+name = "stub-colony"
+TOML
+
+cat > "$FED_DIR/stub-colony/agents/stub_agent.ag" <<'AG'
+cb 100;
+fn tick() { return Void; }
+AG
+
+# --- Pick a free port (avoid the live 8420 dashboard). Range fallback if
+#     getsockname-with-:0 is somehow blocked. ---
+PORT="$(python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); p=s.getsockname()[1]; s.close(); print(p)" 2>/dev/null || true)"
+if [ -z "$PORT" ]; then
+    skip "0: free-port discovery failed; SSE test requires a free local port"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 0
+fi
+if [ "$PORT" = "8420" ]; then
+    # Astronomical, but the live dashboard runs on 8420 — never collide.
+    PORT=$((PORT + 1))
+fi
+
+# --- Boot the dashboard. setsid -> own process group for clean teardown. ---
+LOG_FILE="$TMPDIR_TEST/dashboard.log"
+setsid bash "$DASHBOARD_SH" "$FED_DIR" "$PORT" >"$LOG_FILE" 2>&1 &
+DASH_PID=$!
+
+# Wait for readiness (GET /).
+ready=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -f -s -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null; then
+        ready=1
+        break
+    fi
+    sleep 0.5
+done
+if [ "$ready" -ne 1 ]; then
+    fail "0: dashboard never became ready" "log tail: $(tail -10 "$LOG_FILE" 2>/dev/null | tr '\n' ' ')"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# --- Test 1: GET /events emits at least one `event: snapshot` frame. ---
+# curl -N (no buffering); --max-time 6s gives the watcher (250ms poll) and
+# the wrapper's atomic snapshot write plenty of slack. We grep for the SSE
+# event header rather than parsing the frame payload — payload validity is
+# enforced by the EventSource consumer end-to-end in the browser.
+SSE_OUT_T1="$TMPDIR_TEST/events1.txt"
+curl -N -s --max-time 6 "http://127.0.0.1:$PORT/events" >"$SSE_OUT_T1" 2>&1 || true
+if grep -q '^event: snapshot' "$SSE_OUT_T1"; then
+    pass "1: GET /events emits at least one snapshot frame within 6s"
+else
+    fail "1: no snapshot frame in /events stream" "head: $(head -5 "$SSE_OUT_T1" 2>/dev/null | tr '\n' ' ')"
+fi
+
+# Also assert the frame body parses as JSON and carries the server-injected
+# __hash field that the browser uses to dedupe identical pushes. We pull
+# the first `data: ` line out of the captured stream and feed it to
+# python3.
+DATA_LINE="$(grep -m 1 '^data: ' "$SSE_OUT_T1" 2>/dev/null | sed 's/^data: //')"
+if [ -n "$DATA_LINE" ]; then
+    if python3 - "$DATA_LINE" <<'PY' 2>/dev/null
+import sys, json
+obj = json.loads(sys.argv[1])
+assert isinstance(obj, dict), 'snapshot payload not a JSON object'
+assert '__hash' in obj, 'snapshot missing __hash field'
+assert isinstance(obj['__hash'], str) and len(obj['__hash']) >= 4, 'bad __hash'
+PY
+    then
+        pass "1b: snapshot frame payload is valid JSON with __hash field"
+    else
+        fail "1b: snapshot frame payload failed JSON / __hash validation"
+    fi
+else
+    fail "1b: no data: line captured from /events; cannot validate payload"
+fi
+
+# --- Test 2: GET / continues to serve a fully-rendered index.html. ---
+HTML_OUT="$TMPDIR_TEST/index.html"
+HTTP_CODE="$(curl -s -o "$HTML_OUT" -w '%{http_code}' "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)"
+if [ "$HTTP_CODE" = "200" ] && [ -s "$HTML_OUT" ] && grep -q '<html' "$HTML_OUT"; then
+    pass "2: GET / returns 200 + non-empty HTML (static first-paint preserved)"
+else
+    fail "2: GET / regression" "code=$HTTP_CODE size=$(wc -c <"$HTML_OUT" 2>/dev/null || echo 0)"
+fi
+
+# --- Test 3: a fresh wrapper-side snapshot triggers a new SSE frame
+#     within ~1s. We poke the snapshot file directly with a different
+#     payload (mimicking what the wrapper's regen loop writes), then
+#     listen on /events and assert the new payload arrives. The watcher
+#     polls every 250ms so 2s is generous but not flaky. ---
+SNAPSHOT_FILE="$FED_DIR/.dashboard/snapshot.json"
+if [ ! -f "$SNAPSHOT_FILE" ]; then
+    fail "3: snapshot.json was not written by the wrapper" "expected $SNAPSHOT_FILE"
+else
+    # Inject a unique sentinel into the snapshot to disambiguate the
+    # frame we expect from any earlier cached one.
+    SENTINEL="sse-test-$(date +%s%N)-$$"
+    NEW_SNAP="$TMPDIR_TEST/new-snap.json"
+    python3 - "$SNAPSHOT_FILE" "$NEW_SNAP" "$SENTINEL" <<'PY' 2>/dev/null
+import sys, json
+src, dst, sentinel = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    with open(src) as f:
+        obj = json.load(f)
+    if not isinstance(obj, dict):
+        obj = {}
+except Exception:
+    obj = {}
+obj['__test_sentinel__'] = sentinel
+# Strip any existing __hash so the watcher is forced to recompute.
+obj.pop('__hash', None)
+with open(dst, 'w') as f:
+    json.dump(obj, f)
+PY
+    if [ -s "$NEW_SNAP" ]; then
+        # Atomic update mirroring what the wrapper does.
+        mv -f "$NEW_SNAP" "$SNAPSHOT_FILE"
+        # Capture /events for 3s; the watcher's 250ms poll should pick up
+        # the mtime change and push a new frame.
+        SSE_OUT_T3="$TMPDIR_TEST/events3.txt"
+        curl -N -s --max-time 3 "http://127.0.0.1:$PORT/events" >"$SSE_OUT_T3" 2>&1 || true
+        if grep -q "$SENTINEL" "$SSE_OUT_T3"; then
+            pass "3: fresh snapshot file triggers a new SSE frame within 3s"
+        else
+            fail "3: SSE frame did not pick up the fresh snapshot sentinel" \
+                 "head: $(head -5 "$SSE_OUT_T3" 2>/dev/null | tr '\n' ' ')"
+        fi
+    else
+        fail "3: failed to construct sentinel snapshot payload"
+    fi
+fi
+
+# --- Test 4: client disconnect doesn't crash the server. We open a
+#     connection, kill it after a short window, then verify GET / still
+#     returns 200. ---
+( curl -N -s --max-time 1 "http://127.0.0.1:$PORT/events" >/dev/null 2>&1 || true ) &
+DISC_PID=$!
+sleep 0.5
+kill -TERM "$DISC_PID" 2>/dev/null || true
+wait "$DISC_PID" 2>/dev/null || true
+HTTP_CODE_T4="$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)"
+if [ "$HTTP_CODE_T4" = "200" ]; then
+    pass "4: server still serves / after a /events client disconnect"
+else
+    fail "4: server unhealthy after client disconnect" "code=$HTTP_CODE_T4"
+fi
+
+# --- Test 5: a second /events connection succeeds after a prior one was
+#     killed (multi-client / reconnect path). ---
+SSE_OUT_T5="$TMPDIR_TEST/events5.txt"
+curl -N -s --max-time 4 "http://127.0.0.1:$PORT/events" >"$SSE_OUT_T5" 2>&1 || true
+if grep -q '^event: snapshot' "$SSE_OUT_T5"; then
+    pass "5: second /events connection emits a snapshot frame (reconnect path)"
+else
+    fail "5: second /events connection did not deliver a snapshot frame" \
+         "head: $(head -5 "$SSE_OUT_T5" 2>/dev/null | tr '\n' ' ')"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

PR 1 of 2 for issue #313: lands the **server-side SSE plumbing + a minimal browser `EventSource` consumer**. Static first paint of `GET /` is unchanged; SSE is purely additive. The IIFE -> `renderXxx(data)` refactor + DOM-state preservation across re-renders is **deferred to PR 2** so this PR stays small (~443 LOC, well under the 600 LOC budget the plan budgeted before splitting was forced).

- `federation-dashboard/lib/federation-dashboard-server.py` — `HTTPServer` -> `ThreadingHTTPServer` (`daemon_threads=True`). Module-level `threading.Lock` + `Condition` guard `latest_snapshot` bytes. New daemon thread polls `<dash-dir>/snapshot.json` mtime every 250ms and `notify_all()`s on change. New `GET /events` endpoint serves `text/event-stream`, pushes one `event: snapshot\ndata: <bytes>\n\n` frame per update, plus `: keepalive\n\n` every 30s when idle. Cleanly handles client disconnect (`BrokenPipeError`, `ConnectionResetError`). Each payload carries an 8-char `__hash` (sha256 of canonical JSON) for client-side dedupe.
- `federation-dashboard/bin/federation-dashboard` — writes the freshly-collected `COLLECTOR_JSON` bytes to `<dash-dir>/snapshot.json` atomically (temp + rename) at the end of `generate()`.
- `federation-dashboard/lib/federation-dashboard.html.template` — minimal `EventSource('/events')` consumer at the bottom of the script. Dispatches each snapshot as a DOM `agentis:snapshot` CustomEvent for PR 2 to listen on. Graceful no-op on browsers without `EventSource` — the existing 60s background regen keeps the dashboard fresh.
- `federation-dashboard/CHANGELOG.md` — `[Unreleased]` `### Added` entry referencing #313.
- `tools/test-sse-stream.sh` — new test (5 cases + 1 sub-assertion) covering snapshot frame delivery, unchanged static path, watcher pickup of fresh snapshot writes, client-disconnect server health, and reconnect.

`federation-dashboard/VERSION` stays at `0.5.0`. The bump to `0.6.0` will land in a future `release: federation-dashboard v0.6.0` PR per the standard release-PR convention.

## Architecture

Threading model (single `Lock` + `Condition`, single watcher thread):

1. The wrapper's `generate()` cycle ends with an atomic write of `COLLECTOR_JSON` to `<dash-dir>/snapshot.json` (temp file + rename, mirrors the renderer's `index.html` write).
2. A daemon thread inside `federation-dashboard-server.py`, started at module load, polls `os.path.getmtime(snapshot_path)` every 250ms. On a fresh mtime it reads the file, augments the JSON with an 8-char sha256 `__hash`, parks the bytes in `latest_snapshot`, and `notify_all()`s on the shared `Condition`.
3. Each `GET /events` request runs on its own thread (`ThreadingHTTPServer`), pushes the most recent snapshot immediately, then waits up to 30s on the `Condition`. On wake it sends the new snapshot frame; on timeout it sends a `: keepalive\n\n` comment frame and loops.

Single `Lock` + 250ms poll is the simplest pattern that lets a fresh `/events` connection see the latest state without waiting for the next regen tick. No SIGUSR1, no Unix sockets, no signal handling. POST endpoints continue to shell out to subprocesses, so they're naturally thread-safe at the HTTP layer.

## Test plan

- [x] `bash tools/test-sse-stream.sh` -> **6/0** (5 tests + 1 payload sub-assertion).
- [x] `AGENTIS_RUN_KILL_TESTS=0 bash tools/colony-lint.sh` -> **115/0/3** (115 passed because the new test was auto-discovered by the `find tools/test-*.sh` loop; 0 failed; 3 skipped = 2 destructive kill-tests + 1 long-standing skip).
- [x] `bash tools/test-timeline-rendering.sh` -> **28/0** (existing rendering path untouched).
- [x] `bash tools/test-make-dashboard-bundle.sh` -> **13/0** (bundle harness sees no template-shape change).
- [x] `python3 -m py_compile federation-dashboard/lib/federation-dashboard-server.py` -> clean.
- [x] `bash -n federation-dashboard/bin/federation-dashboard` -> clean.
- [x] Live federation untouched: tests spawn an isolated dashboard on a free port under a temp federation fixture (`/tmp/.../fed/`); production 8420 dashboard left running.

## Out of scope

Deferred to **PR 2** (the follow-up that addresses #313 in full):

- Refactoring the existing IIFE blocks into top-level `function renderXxx(data)` calls invoked by the SSE consumer.
- DOM-state preservation across re-renders (open modal payload, scroll position, sort order, per-tile collapse state).
- Per-tile diff payloads — full snapshot per tick is plenty for PR 1.
- Bandwidth optimisations.

Out of scope for the issue altogether (per the lgtm'd plan):

- Live colony-bus event tap (#314 — separate scope).
- Per-agent decision rationale (#312 — blocked upstream).
- WebSocket bidirectional (issue body explicitly punts).

Addresses #313.
