### PR TITLE
feat(dashboard): federation-wide timeline tile + /timeline endpoint (#315 PR 2)

### DIFF
--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -9,6 +9,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Federation-wide chronological action timeline** — completes the timeline
+  story for [#315](https://github.com/Replikanti/agentis-colonies/issues/315)
+  (PR 2 of 2). Combined with PR 1 (per-agent modal section + collector-side
+  `build_agent_timeline()` merge of experience / spend / confidence-log /
+  lifecycle JSONL streams), the timeline story is complete. PR 2 lands the
+  federation-wide tile + a new `GET /timeline` HTTP endpoint with pagination.
+
+  The collector emits a new top-level `timeline[]` array (last 200 rows,
+  reverse-chronological across all agents) as part of `COLLECTOR_JSON`.
+  Each row carries the PR 1 envelope (`{ts, agent_id, kind, payload,
+  severity}`) plus two new fields — `agent_name` and `colony` — so the
+  client renders colony chips without a second `agents` lookup. The
+  merge re-uses the per-source bucketing PR 1 already does
+  (lifecycle + confidence-log keyed by `agent_id` once across the
+  federation; experience + spend re-read per agent from the same files
+  the per-agent timelines slice). Total complexity stays
+  `O(N_lifecycle + N_experience + N_spend + N_confidence)` — no
+  quadratic per-agent re-reads.
+
+  The federation-wide Event Timeline tile (template lines around 696–710)
+  drops the legacy regex log scraper (`data.events`) and renders directly
+  from the structured `data.timeline[]`. Each row shows: timestamp
+  (ABS / REL toggle), agent name, colony chip, kind icon, and a 1-line
+  summary string per kind that mirrors the per-agent modal verbatim.
+  Filter UI grows two new layers: a colony dropdown built from
+  `colonyList`, and a kind chip row (`learn` / `prompt` /
+  `confidence_change` / `lifecycle`) that supersedes the pre-PR2
+  classifier-typed chips. Pre-existing filters survive: blanket cursor
+  (Clear all), per-(agent_name, kind) cursor (Clear stale), per-row
+  dismiss set, time-mode toggle, auto-hide-stale on `error`-severity
+  rows from cleanly-ticking agents. Every chip / filter persists in
+  `localStorage` namespaced by `FED_NAME`. Reuses the existing
+  `timeline-entry` / `timeline-ts` / `timeline-type` CSS so colour cues
+  match the per-agent modal palette. Live updates flow through the
+  `agentis:snapshot` SSE channel landed by [#344](https://github.com/Replikanti/agentis-colonies/issues/344)
+  (#313 PR 2): `renderEventTimeline(data)` is one of the eleven
+  `renderXxx` functions called on every fresh snapshot, so the tile
+  refreshes in place without `location.reload()`.
+
+  **`GET /timeline?since=<unix-ms>&limit=<N>&colony=<name>&kind=<csv>`**
+  — new read-only HTTP endpoint that returns
+  `{rows: [...], next_cursor: <ts>|null}` of timeline rows OLDER than
+  `since` (default = current time, returning the most-recent N rows).
+  `limit` defaults to 200, capped at 500 to bound memory. `colony` is
+  an exact-match string filter; `kind` is a comma-separated list of
+  kinds. Backed by a precomputed `<dash-dir>/timeline-full.jsonl`
+  written atomically by the wrapper alongside `snapshot.json` after
+  each generate cycle (last 7 days OR 5000 rows, whichever is smaller,
+  reverse-chronological). The new
+  `lib/federation-dashboard-timeline.py` helper reads the four source
+  streams once and writes the JSONL output directly without going
+  through the embedded 200-row cap. Endpoint contract: `200` on
+  success (including missing file → empty rows), `400` on malformed
+  query params (bad since/limit, limit out of `[1, 500]`), `500` on
+  internal read error. No side effects, no signals, no daemon
+  mutation — purely read-only.
+
+  New tests in `tools/test-timeline-rendering.sh`:
+  - **t30**: drives the collector against a 3-agent fixture and
+    asserts `data.timeline[]` is non-empty, ts-desc sorted, capped at
+    200, contains rows from at least 2 distinct agents, and every row
+    carries `agent_name` + `colony`.
+  - **t31**: HTTP smoke against `/timeline?since=<future>&limit=5` —
+    asserts `rows` is ts-desc sorted, length ≤ 5, and `next_cursor`
+    is non-null when more rows remain.
+  - **t32**: HTTP smoke against `/timeline?colony=colony-b` — asserts
+    every returned row carries `colony=colony-b` and only the
+    expected agent ids appear.
+
+  Out of scope (deferred): calendar-picker date range, CSV export,
+  full-text search, per-row drill-in to a separate page.
+
 - **Live tile updates via Server-Sent Events** — IIFE → `renderXxx(data)`
   refactor that closes [#313](https://github.com/Replikanti/agentis-colonies/issues/313)
   (PR 2 of 2). Combined with PR 1 (server-side `/events` plumbing,

--- a/federation-dashboard/bin/federation-dashboard
+++ b/federation-dashboard/bin/federation-dashboard
@@ -70,6 +70,10 @@ HISTORY_FILE="$DASH_DIR/history.json"
 # rename); the server's watcher thread polls mtime every 250ms and pushes
 # `event: snapshot` frames to /events subscribers on change.
 SNAPSHOT_FILE="$DASH_DIR/snapshot.json"
+# #315 PR 2: full timeline (last 7 days or 5000 rows, ts-desc) written
+# alongside snapshot.json. The /timeline HTTP endpoint reads from this file
+# to serve older rows than the in-page tile carries (capped at 200).
+TIMELINE_FULL_FILE="$DASH_DIR/timeline-full.jsonl"
 
 mkdir -p "$DASH_DIR"
 
@@ -257,6 +261,34 @@ generate() {
         mv -f "${SNAPSHOT_FILE}.tmp.$$" "$SNAPSHOT_FILE" 2>/dev/null \
             || rm -f "${SNAPSHOT_FILE}.tmp.$$" 2>/dev/null || true
     fi
+
+    # #315 PR 2: write the full federation-wide timeline (last 7 days,
+    # 5000-row cap, ts-desc) as JSONL alongside snapshot.json. The
+    # /timeline HTTP endpoint reads from this file to paginate beyond the
+    # 200-row in-page cap. Atomic temp + rename so concurrent reads never
+    # see a torn payload. Failure is non-fatal — /timeline returns 200
+    # with an empty rows array if the file is missing or unreadable.
+    # The dedicated helper lib/federation-dashboard-timeline.py re-reads
+    # the four source streams ONCE and writes the JSONL output directly,
+    # without going through the embedded 200-row cap.
+    local SPEND_DIR="${FED_DIR}/.agentis/spend"
+    if [ ! -d "$SPEND_DIR" ]; then
+        SPEND_DIR="${FED_DIR}/../.agentis/spend"
+    fi
+    if [ ! -d "$SPEND_DIR" ]; then
+        SPEND_DIR=".agentis/spend"
+    fi
+    local LIFECYCLE_DIR="${FED_DIR}/.agentis/lifecycle"
+    if [ ! -d "$LIFECYCLE_DIR" ]; then
+        LIFECYCLE_DIR="${FED_DIR}/../.agentis/lifecycle"
+    fi
+    if [ ! -d "$LIFECYCLE_DIR" ]; then
+        LIFECYCLE_DIR=".agentis/lifecycle"
+    fi
+    python3 "$LIB_DIR/federation-dashboard-timeline.py" \
+        "$EXPERIENCE_DIR" "$SPEND_DIR" "$LIFECYCLE_DIR" \
+        "$DASH_DIR" "$AGENT_COLONY_MAP" "@$DAEMON_FILE" \
+        "$TIMELINE_FULL_FILE" 2>/dev/null || true
 }
 
 # --- Regen-only mode ---

--- a/federation-dashboard/lib/federation-dashboard-collector.py
+++ b/federation-dashboard/lib/federation-dashboard-collector.py
@@ -1045,6 +1045,157 @@ for rec in result:
         lifecycle_by_aid.get(aid, []),
     )
 
+# --- Federation-wide unified timeline (#315 PR 2) ---
+# Merge every agent's normalized rows into one reverse-chronological feed for
+# the federation-wide tile. Each row inherits the PR 1 envelope ({ts,
+# agent_id, kind, payload, severity}) and is augmented with agent_name +
+# colony for chip rendering on the client.
+#
+# Implementation note: we deliberately rebuild per-agent rows from the
+# already-loaded source dicts rather than reading rec['timeline'], because
+# the per-agent slice is capped at TIMELINE_PER_AGENT_CAP (50). For the
+# federation-wide top-N we want the absolute newest rows across all agents
+# regardless of any single agent's per-agent volume — an agent firing 100
+# events in the last hour shouldn't lose its 51st-newest entry just because
+# the per-agent view trimmed it. Total complexity stays O(N_lifecycle +
+# N_experience + N_spend + N_confidence) — the source dicts are already
+# bucketed (lifecycle_by_aid, conf_by_aid) or read once per agent above.
+TIMELINE_FED_CAP = 200
+
+# Lookup table: agent_id -> {name, colony}. Built once for O(1) augmentation
+# of every row in the merged stream.
+aid_to_meta = {}
+for rec in result:
+    aid = rec.get('agent_id') or ''
+    if aid:
+        aid_to_meta[aid] = {
+            'agent_name': rec.get('name', ''),
+            'colony': rec.get('colony', ''),
+        }
+
+federation_timeline = []
+for rec in result:
+    aid = rec.get('agent_id') or ''
+    if not aid:
+        continue
+    meta = aid_to_meta.get(aid, {'agent_name': rec.get('name', ''),
+                                 'colony': rec.get('colony', '')})
+    # Re-read just enough to build a per-agent row stream WITHOUT the
+    # 50-row per-agent cap. The four source-bucketing reads above already
+    # touched experience + spend + lifecycle + confidence-log exactly once
+    # apiece across all agents, so this re-read pulls from in-memory state
+    # only.
+    exp_for_agent = []
+    if exp_dir and os.path.isdir(exp_dir):
+        ep = os.path.join(exp_dir, aid + '.jsonl')
+        if os.path.isfile(ep):
+            try:
+                with open(ep) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            exp_for_agent.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            continue
+            except OSError:
+                pass
+
+    spend_for_agent = []
+    if spend_dir and os.path.isdir(spend_dir):
+        sp = os.path.join(spend_dir, aid + '.jsonl')
+        if os.path.isfile(sp):
+            try:
+                with open(sp) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            spend_for_agent.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            continue
+            except OSError:
+                pass
+
+    # Use build_agent_timeline with a temporarily-disabled cap by passing
+    # the same lists; build_agent_timeline always caps at TIMELINE_PER_AGENT_CAP
+    # so we re-implement the merge inline to keep the cap separate.
+    rows = []
+    for e in exp_for_agent:
+        if not isinstance(e, dict):
+            continue
+        ts_ms = _coerce_ms(e.get('ts'))
+        if ts_ms == 0:
+            continue
+        payload = {
+            'outcome': e.get('outcome'),
+            'delta':   e.get('delta'),
+            'action':  e.get('action'),
+            'in':      e.get('in'),
+        }
+        rows.append({
+            'ts': ts_ms, 'agent_id': aid, 'kind': 'learn',
+            'payload': payload,
+            'severity': _summary_severity('learn', payload),
+        })
+    for s in spend_for_agent:
+        if not isinstance(s, dict):
+            continue
+        ts_ms = _coerce_ms(s.get('ts'))
+        if ts_ms == 0:
+            continue
+        payload = {
+            'cost_usd':      s.get('cost_usd'),
+            'input_tokens':  s.get('input_tokens'),
+            'output_tokens': s.get('output_tokens'),
+            'model':         s.get('model'),
+            'backend':       s.get('backend'),
+            'ok':            s.get('ok', True),
+        }
+        rows.append({
+            'ts': ts_ms, 'agent_id': aid, 'kind': 'prompt',
+            'payload': payload,
+            'severity': _summary_severity('prompt', payload),
+        })
+    for c in conf_by_aid.get(aid, []):
+        if not isinstance(c, dict):
+            continue
+        ts_ms = _coerce_ms(c.get('ts'))
+        if ts_ms == 0:
+            continue
+        payload = {
+            'from':   c.get('from') if c.get('from') is not None else c.get('prev'),
+            'to':     c.get('to')   if c.get('to')   is not None else c.get('new'),
+            'delta':  c.get('delta'),
+            'reason': c.get('reason') or c.get('source'),
+        }
+        rows.append({
+            'ts': ts_ms, 'agent_id': aid, 'kind': 'confidence_change',
+            'payload': payload,
+            'severity': _summary_severity('confidence_change', payload),
+        })
+    for ev in lifecycle_by_aid.get(aid, []):
+        if not isinstance(ev, dict):
+            continue
+        ts_ms = _coerce_ms(ev.get('ts'))
+        if ts_ms == 0:
+            continue
+        payload = {k: v for k, v in ev.items() if k != 'agent_id'}
+        rows.append({
+            'ts': ts_ms, 'agent_id': aid, 'kind': 'lifecycle',
+            'payload': payload,
+            'severity': _summary_severity('lifecycle', payload),
+        })
+    for row in rows:
+        row['agent_name'] = meta['agent_name']
+        row['colony'] = meta['colony']
+        federation_timeline.append(row)
+
+federation_timeline.sort(key=lambda r: r.get('ts', 0), reverse=True)
+federation_timeline = federation_timeline[:TIMELINE_FED_CAP]
+
 # Inject per-agent cost windows into each agent record (mirrors the
 # experience_count placement above). The agent table can then expose a
 # "$ today" sortable column without requiring a second lookup at render time.
@@ -1190,5 +1341,7 @@ output = {
     'forge_rate_limits': forge_rate_limits,
     'cost': cost,
     'cost_cap': cost_cap,
+    # #315 PR 2: federation-wide unified timeline (last 200, ts-desc).
+    'timeline': federation_timeline,
 }
 print(json.dumps(output))

--- a/federation-dashboard/lib/federation-dashboard-collector.py
+++ b/federation-dashboard/lib/federation-dashboard-collector.py
@@ -1081,10 +1081,11 @@ for rec in result:
     meta = aid_to_meta.get(aid, {'agent_name': rec.get('name', ''),
                                  'colony': rec.get('colony', '')})
     # Re-read just enough to build a per-agent row stream WITHOUT the
-    # 50-row per-agent cap. The four source-bucketing reads above already
-    # touched experience + spend + lifecycle + confidence-log exactly once
-    # apiece across all agents, so this re-read pulls from in-memory state
-    # only.
+    # 50-row per-agent cap. Spend / experience JSONLs are re-opened here
+    # (one short pass per agent — bounded by the spend / experience file
+    # size, NOT by total federation history); lifecycle + confidence-log
+    # are pulled from the buckets the four source-bucketing reads above
+    # already filled in memory, so they're free at this point.
     exp_for_agent = []
     if exp_dir and os.path.isdir(exp_dir):
         ep = os.path.join(exp_dir, aid + '.jsonl')

--- a/federation-dashboard/lib/federation-dashboard-server.py
+++ b/federation-dashboard/lib/federation-dashboard-server.py
@@ -398,8 +398,122 @@ def restart_daemon(agent):
         'events': events,
     }
 
+# #315 PR 2: timeline-full.jsonl path. Written by the wrapper after each
+# generate() cycle (last 7 days, 5000-row cap, ts-desc). The /timeline
+# endpoint reads from this file. Missing file is non-fatal: /timeline
+# returns 200 with an empty rows array so the client can degrade gracefully.
+timeline_full_path = os.path.join(serve_dir, 'timeline-full.jsonl')
+
+
+def _serve_timeline(handler):
+    """GET /timeline?since=<unix-ms>&limit=<N>&colony=<name>&kind=<csv>.
+
+    Returns JSON {rows: [...], next_cursor: <ts>|null} of timeline rows
+    OLDER than `since` (default = current time, returning the most-recent
+    N rows). limit is capped at 500 to bound memory; default 200.
+    Read-only: no side effects, no daemon mutation.
+
+    400 on bad params (limit > 500, malformed since/limit), 500 on
+    internal read error, 200 on success including missing file.
+    """
+    parsed = urllib.parse.urlparse(handler.path)
+    qs = urllib.parse.parse_qs(parsed.query, keep_blank_values=False)
+
+    # Parse `since` (default: now). Older rows = ts < since.
+    since_raw = (qs.get('since') or [''])[0]
+    if since_raw:
+        try:
+            since_ms = int(since_raw)
+            if since_ms < 0:
+                raise ValueError('negative since')
+        except (ValueError, TypeError):
+            handler.send_response(400)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'error': 'bad since (expected unix-ms int)'}).encode())
+            return
+    else:
+        since_ms = int(time.time() * 1000) + 1  # +1 so ts < since includes "now"
+
+    # Parse `limit` (default 200, max 500).
+    limit_raw = (qs.get('limit') or [''])[0]
+    if limit_raw:
+        try:
+            limit = int(limit_raw)
+        except (ValueError, TypeError):
+            handler.send_response(400)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'error': 'bad limit (expected int)'}).encode())
+            return
+        if limit < 1 or limit > 500:
+            handler.send_response(400)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'error': 'limit out of range [1, 500]'}).encode())
+            return
+    else:
+        limit = 200
+
+    colony_filter = (qs.get('colony') or [''])[0].strip()
+    kind_raw = (qs.get('kind') or [''])[0].strip()
+    kind_filter = set(k.strip() for k in kind_raw.split(',') if k.strip()) if kind_raw else set()
+
+    # Read timeline-full.jsonl. Missing file → empty rows (graceful).
+    rows = []
+    if os.path.isfile(timeline_full_path):
+        try:
+            with open(timeline_full_path, encoding='utf-8') as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(row, dict):
+                        continue
+                    ts = row.get('ts')
+                    if not isinstance(ts, (int, float)) or ts >= since_ms:
+                        continue
+                    if colony_filter and row.get('colony', '') != colony_filter:
+                        continue
+                    if kind_filter and row.get('kind', '') not in kind_filter:
+                        continue
+                    rows.append(row)
+                    if len(rows) > limit:
+                        # Defer trim until end so we keep the absolute-newest
+                        # `limit` rows (file is already ts-desc; this is just
+                        # belt-and-braces against an unsorted producer).
+                        pass
+        except OSError as e:
+            handler.send_response(500)
+            handler.send_header('Content-Type', 'application/json')
+            handler.end_headers()
+            handler.wfile.write(json.dumps({'error': 'read failed: ' + str(e)}).encode())
+            return
+
+    # File is already ts-desc, but resort defensively (cheap on bounded N).
+    rows.sort(key=lambda r: r.get('ts', 0), reverse=True)
+    if len(rows) > limit:
+        rows = rows[:limit]
+
+    next_cursor = rows[-1].get('ts') if rows else None
+    handler.send_response(200)
+    handler.send_header('Content-Type', 'application/json')
+    handler.end_headers()
+    handler.wfile.write(json.dumps({
+        'rows': rows,
+        'next_cursor': next_cursor,
+    }).encode())
+
+
 class Handler(SimpleHTTPRequestHandler):
     def do_GET(self):
+        if self.path.startswith('/timeline?') or self.path == '/timeline':
+            _serve_timeline(self)
+            return
         if self.path == '/events':
             # #313 PR 1: live SSE channel. Holds the connection open, pushes
             # one `event: snapshot\ndata: <COLLECTOR_JSON>\n\n` frame whenever

--- a/federation-dashboard/lib/federation-dashboard-server.py
+++ b/federation-dashboard/lib/federation-dashboard-server.py
@@ -482,11 +482,9 @@ def _serve_timeline(handler):
                     if kind_filter and row.get('kind', '') not in kind_filter:
                         continue
                     rows.append(row)
-                    if len(rows) > limit:
-                        # Defer trim until end so we keep the absolute-newest
-                        # `limit` rows (file is already ts-desc; this is just
-                        # belt-and-braces against an unsorted producer).
-                        pass
+                    # No early-trim — sort + slice happens once after the loop
+                    # below so we always keep the absolute-newest `limit` rows
+                    # even when the producer wrote out of order.
         except OSError as e:
             handler.send_response(500)
             handler.send_header('Content-Type', 'application/json')

--- a/federation-dashboard/lib/federation-dashboard-timeline.py
+++ b/federation-dashboard/lib/federation-dashboard-timeline.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""federation-dashboard-timeline.py - Write the full federation-wide
+timeline as JSONL for the /timeline HTTP endpoint to read (#315 PR 2).
+
+The wrapper invokes this helper after each generate() cycle. We read the
+four canonical source streams once (experience, spend, lifecycle,
+confidence-log), merge them into the unified envelope, augment with
+agent_name + colony, sort ts-desc, cap at 7 days OR 5000 rows (whichever
+is smaller), and write the result atomically (temp + rename).
+
+The embedded `output['timeline']` in the collector caps at 200 rows for
+the in-page tile; this helper writes a wider window for paginated
+queries. Schema per row matches the per-agent timeline envelope:
+    {ts: <int, ms>, agent_id: "<sha8>", kind: "<enum>",
+     payload: <object>, severity: "info"|"warning"|"error",
+     agent_name: "<role>", colony: "<colony>"}
+
+DO NOT inline this back into the wrapper — federation-dashboard.sh has a
+zero-heredoc invariant (test 19 of test-timeline-rendering.sh enforces).
+
+Args (positional):
+    1: exp_dir          path to .agentis/experience/
+    2: spend_dir        path to .agentis/spend/
+    3: lifecycle_dir    path to .agentis/lifecycle/
+    4: dash_dir         dashboard cache dir (for confidence-log.jsonl)
+    5: agent_map_json   JSON array of {agent, colony} pairs
+    6: daemons_json     JSON array from `agentis daemon list --json`,
+                        or "@<path>" to read from file (#293)
+    7: out_path         where to write timeline-full.jsonl
+
+The file is written newline-delimited JSON, one row per line, in
+reverse-chronological order (newest first). Every row that is not a
+valid JSON object on parse is silently dropped (mirrors the collector's
+tolerance pattern).
+"""
+
+import os
+import sys
+import json
+import time
+
+TIMELINE_FULL_CAP = 5000
+SEVEN_DAYS_MS = 7 * 24 * 3600 * 1000
+
+
+def _read_arg(arg):
+    if arg.startswith('@'):
+        try:
+            with open(arg[1:], 'r', encoding='utf-8') as f:
+                return f.read()
+        except OSError:
+            return ''
+    return arg
+
+
+def _coerce_ms(ts):
+    """Coerce a timestamp to epoch-ms. Accepts seconds (10-digit), ms
+    (13-digit), or None/garbage. Returns 0 on failure."""
+    if not isinstance(ts, (int, float)):
+        return 0
+    n = int(ts)
+    if n <= 0:
+        return 0
+    return n if n >= 10 ** 11 else n * 1000
+
+
+def _read_jsonl(path):
+    """Yield dict rows from a JSONL file; tolerate missing file +
+    malformed lines silently."""
+    if not path or not os.path.isfile(path):
+        return []
+    out = []
+    try:
+        with open(path, encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict):
+                    out.append(row)
+    except OSError:
+        pass
+    return out
+
+
+def _severity(kind, payload):
+    """Same classifier as the collector's _summary_severity."""
+    if kind == 'learn':
+        outcome = (payload.get('outcome') or '').lower()
+        return 'error' if outcome == 'failure' else 'info'
+    if kind == 'prompt':
+        return 'info' if payload.get('ok', True) else 'error'
+    if kind == 'confidence_change':
+        return 'info'
+    if kind == 'lifecycle':
+        ev = (payload.get('event') or '').lower()
+        if 'critical' in (payload.get('new_status') or '').lower():
+            return 'warning'
+        if 'quarantine' in ev or 'restart' in ev or 'health_changed' in ev:
+            return 'warning'
+        if 'failed' in ev or 'crashed' in ev:
+            return 'error'
+    return 'info'
+
+
+def main():
+    if len(sys.argv) != 8:
+        sys.stderr.write(
+            'Usage: %s exp_dir spend_dir lifecycle_dir dash_dir '
+            'agent_map_json daemons_json out_path\n' % sys.argv[0]
+        )
+        sys.exit(2)
+
+    exp_dir       = sys.argv[1]
+    spend_dir     = sys.argv[2]
+    lifecycle_dir = sys.argv[3]
+    dash_dir      = sys.argv[4]
+    agent_map_raw = sys.argv[5]
+    daemons_raw   = _read_arg(sys.argv[6])
+    out_path      = sys.argv[7]
+
+    try:
+        agent_map = json.loads(agent_map_raw or '[]')
+    except (ValueError, json.JSONDecodeError):
+        agent_map = []
+    try:
+        daemons = json.loads(daemons_raw or '[]')
+    except (ValueError, json.JSONDecodeError):
+        daemons = []
+
+    # role -> {agent_name (== role), colony}
+    role_to_colony = {e.get('agent', ''): e.get('colony', '')
+                      for e in agent_map if isinstance(e, dict)}
+    # agent_id -> {agent_name, colony}. Source field on each daemon row
+    # carries the .ag basename which is the role / agent_name.
+    aid_to_meta = {}
+    for d in daemons:
+        if not isinstance(d, dict):
+            continue
+        aid = d.get('agent_id') or ''
+        src = d.get('source') or ''
+        if not aid or not src:
+            continue
+        role = os.path.basename(src)
+        if role.endswith('.ag'):
+            role = role[:-3]
+        aid_to_meta[aid] = {
+            'agent_name': role,
+            'colony': role_to_colony.get(role, ''),
+        }
+
+    now_ms = int(time.time() * 1000)
+    cutoff = now_ms - SEVEN_DAYS_MS
+
+    # Bucket lifecycle + confidence-log by agent_id ONCE — both files are
+    # federation-wide and would otherwise be re-read per agent.
+    lifecycle_by_aid = {}
+    lifecycle_path = os.path.join(lifecycle_dir, 'events.jsonl') if lifecycle_dir else ''
+    for ev in _read_jsonl(lifecycle_path):
+        aid = ev.get('agent_id') or ''
+        if aid:
+            lifecycle_by_aid.setdefault(aid, []).append(ev)
+
+    conf_by_aid = {}
+    conf_path = os.path.join(dash_dir, 'confidence-log.jsonl') if dash_dir else ''
+    for c in _read_jsonl(conf_path):
+        aid = c.get('agent_id') or ''
+        if aid:
+            conf_by_aid.setdefault(aid, []).append(c)
+
+    rows = []
+    for aid, meta in aid_to_meta.items():
+        # Experience (epoch-seconds → ms)
+        ep = os.path.join(exp_dir, aid + '.jsonl') if exp_dir else ''
+        for e in _read_jsonl(ep):
+            t = _coerce_ms(e.get('ts'))
+            if t == 0 or t < cutoff:
+                continue
+            payload = {
+                'outcome': e.get('outcome'),
+                'delta':   e.get('delta'),
+                'action':  e.get('action'),
+                'in':      e.get('in'),
+            }
+            rows.append({
+                'ts': t, 'agent_id': aid, 'kind': 'learn',
+                'payload': payload,
+                'severity': _severity('learn', payload),
+                'agent_name': meta['agent_name'],
+                'colony': meta['colony'],
+            })
+
+        # Spend (already ms)
+        sp = os.path.join(spend_dir, aid + '.jsonl') if spend_dir else ''
+        for s in _read_jsonl(sp):
+            t = _coerce_ms(s.get('ts'))
+            if t == 0 or t < cutoff:
+                continue
+            payload = {
+                'cost_usd':      s.get('cost_usd'),
+                'input_tokens':  s.get('input_tokens'),
+                'output_tokens': s.get('output_tokens'),
+                'model':         s.get('model'),
+                'backend':       s.get('backend'),
+                'ok':            s.get('ok', True),
+            }
+            rows.append({
+                'ts': t, 'agent_id': aid, 'kind': 'prompt',
+                'payload': payload,
+                'severity': _severity('prompt', payload),
+                'agent_name': meta['agent_name'],
+                'colony': meta['colony'],
+            })
+
+        for c in conf_by_aid.get(aid, []):
+            t = _coerce_ms(c.get('ts'))
+            if t == 0 or t < cutoff:
+                continue
+            payload = {
+                'from':  c.get('from') if c.get('from') is not None else c.get('prev'),
+                'to':    c.get('to')   if c.get('to')   is not None else c.get('new'),
+                'delta': c.get('delta'),
+                'reason': c.get('reason') or c.get('source'),
+            }
+            rows.append({
+                'ts': t, 'agent_id': aid, 'kind': 'confidence_change',
+                'payload': payload,
+                'severity': _severity('confidence_change', payload),
+                'agent_name': meta['agent_name'],
+                'colony': meta['colony'],
+            })
+
+        for ev in lifecycle_by_aid.get(aid, []):
+            t = _coerce_ms(ev.get('ts'))
+            if t == 0 or t < cutoff:
+                continue
+            payload = {k: v for k, v in ev.items() if k != 'agent_id'}
+            rows.append({
+                'ts': t, 'agent_id': aid, 'kind': 'lifecycle',
+                'payload': payload,
+                'severity': _severity('lifecycle', payload),
+                'agent_name': meta['agent_name'],
+                'colony': meta['colony'],
+            })
+
+    rows.sort(key=lambda r: r.get('ts', 0), reverse=True)
+    rows = rows[:TIMELINE_FULL_CAP]
+
+    tmp = out_path + '.tmp.' + str(os.getpid())
+    try:
+        with open(tmp, 'w', encoding='utf-8') as f:
+            for r in rows:
+                f.write(json.dumps(r, separators=(',', ':')))
+                f.write('\n')
+        os.replace(tmp, out_path)
+    except OSError:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/federation-dashboard/lib/federation-dashboard.html.template
+++ b/federation-dashboard/lib/federation-dashboard.html.template
@@ -311,6 +311,28 @@
   .timeline-chip.active.error { color: var(--red); border-color: var(--red); }
   .timeline-chip.active.action { color: var(--cyan); border-color: var(--cyan); }
   .timeline-chip.active.finding { color: var(--magenta); border-color: var(--magenta); }
+  /* #315 PR 2: kind chips for the federation-wide timeline tile. The four
+     kinds (learn/prompt/confidence_change/lifecycle) reuse the existing
+     active-chip palette via type-name aliases below. */
+  .timeline-chip.active.learn { color: var(--cyan); border-color: var(--cyan); }
+  .timeline-chip.active.prompt { color: var(--green); border-color: var(--green); }
+  .timeline-chip.active.confidence_change { color: var(--magenta); border-color: var(--magenta); }
+  .timeline-chip.active.lifecycle { color: var(--yellow); border-color: var(--yellow); }
+  /* #315 PR 2: colony filter dropdown. Inline with chip row so the entire
+     filter bar reads as a single line. */
+  .timeline-colony-filter {
+    background: transparent; border: 1px solid var(--border2);
+    color: var(--muted); font-family: 'Share Tech Mono', monospace;
+    font-size: 10px; padding: 2px 8px;
+    text-transform: uppercase; letter-spacing: 1px;
+    border-radius: 10px;
+  }
+  .timeline-colony-filter:focus { outline: none; color: var(--text); border-color: var(--text); }
+  .timeline-colony-chip {
+    color: var(--cyan); font-size: 10px; padding: 1px 6px;
+    border: 1px solid var(--border2); border-radius: 8px;
+    flex-shrink: 0; text-transform: lowercase;
+  }
   .timeline-dismiss {
     background: transparent; border: none; color: var(--muted);
     font-family: inherit; font-size: 12px; cursor: pointer;
@@ -342,6 +364,12 @@
   .timeline-type.error { color: var(--red); }
   .timeline-type.action { color: var(--cyan); }
   .timeline-type.finding { color: var(--magenta); }
+  /* #315 PR 2: kind-keyed type cells for the federation-wide timeline tile.
+     Mirrors the per-agent modal palette so colour cues line up across views. */
+  .timeline-type.learn { color: var(--cyan); }
+  .timeline-type.prompt { color: var(--green); }
+  .timeline-type.confidence_change { color: var(--magenta); }
+  .timeline-type.lifecycle { color: var(--yellow); }
   .timeline-content { color: var(--text); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   /* --- Charts --- */
@@ -696,6 +724,7 @@
 <div class="timeline-header">
   <h2>Event Timeline</h2>
   <div class="timeline-actions">
+    <select class="timeline-colony-filter" id="timeline-colony-filter" title="Filter timeline rows by colony"></select>
     <label class="timeline-toggle" title="Auto-hide errors from agents that have ticked cleanly in the last hour">
       <input type="checkbox" id="timeline-auto-hide-stale"> Auto-hide stale
     </label>
@@ -807,6 +836,12 @@ const TIMELINE_AUTO_HIDE_STALE_KEY = 'dashboard.timeline.autoHideStale.' + FED_N
 const TIMELINE_STALE_WINDOW_MS = 3600 * 1000;
 // #167: every class the timeline emits, in render order.
 const TIMELINE_CLASSES = ['emit', 'recv', 'suggest', 'error', 'action', 'finding'];
+// #315 PR 2: colony filter persistence for the federation-wide timeline tile.
+// '' (empty string) means "all colonies".
+const TIMELINE_COLONY_FILTER_KEY = 'dashboard.timeline.colonyFilter.' + FED_NAME;
+// #315 PR 2: every kind the unified timeline emits, in render order. Drives
+// the chip-row build and the kind-filter checkbox group.
+const TIMELINE_KINDS = ['learn', 'prompt', 'confidence_change', 'lifecycle'];
 // #163: magnitude below which the fitness slope over the last 100 experience
 // entries is treated as flat and evolve is disabled as an Opus plateau. Raised
 // from the original 1e-6 guess to 1e-4 after production calibration against
@@ -870,6 +905,9 @@ document.addEventListener('keydown', (e) => {
 let agents = data.agents || [];
 let experienceCounts = data.experience_counts || {};
 let events = data.events || [];
+// #315 PR 2: federation-wide unified timeline (last 200 rows, ts-desc).
+// Source for renderEventTimeline (which used to scrape `events`).
+let timelineRows = data.timeline || [];
 let confChanges = data.confidence_changes || [];
 // #248: scheduler verdicts per agent (promote/evolve/skip + evidence).
 // Emitted by federation-dashboard-collector.py via auto-promote-decisions.py
@@ -893,6 +931,7 @@ function extractRefs(d) {
   agents = d.agents || [];
   experienceCounts = d.experience_counts || {};
   events = d.events || [];
+  timelineRows = d.timeline || [];
   confChanges = d.confidence_changes || [];
   decisions = d.decisions || [];
   sidecar = d.sidecar || {installed: false, enabled: false, interval_s: null, last_tick_ts: null};
@@ -1719,24 +1758,40 @@ function renderPromoteCandidates(data) {
 }
 
 // --- Event Timeline ---
+// #315 PR 2: federation-wide unified timeline tile. Switched from the
+// regex-log-scraper `events[]` source to the structured `data.timeline[]`
+// stream the collector produces (PR 1 envelope: {ts, agent_id, kind,
+// payload, severity, agent_name, colony}). Renders up to 200 rows reverse-
+// chronological with timestamp, agent + colony chip, kind-keyed type cell,
+// and a 1-line summary string per kind (mirrors the per-agent modal).
+//
+// Filter UI:
+//   * Colony dropdown (built from colonyList).
+//   * Per-kind chips (learn / prompt / confidence_change / lifecycle).
+//   * Pre-existing filters survive verbatim: blanket cursor (Clear all),
+//     per-(agent_name, kind) cursor (Clear stale), dismissed set, time
+//     mode toggle, auto-hide-stale on `error`-severity rows from cleanly-
+//     ticking agents.
 function renderEventTimeline(data) {
   const el = document.getElementById('event-timeline');
   if (!el) return;
   const banner = document.getElementById('timeline-banner');
   const chipsEl = document.getElementById('timeline-chips');
+  const colonySelect = document.getElementById('timeline-colony-filter');
   // #313 PR 2: preserve scroll position across live re-renders so the
   // operator's view doesn't snap to the top mid-snapshot.
   const prevScroll = el.scrollTop;
 
-  // Read all five filter layers from localStorage.
+  // Read all six filter layers from localStorage.
   const cursor = parseInt(localStorage.getItem(TIMELINE_CURSOR_KEY) || '0', 10);
   const cursorClass = tlReadJSON(TIMELINE_CURSOR_CLASS_KEY, {}) || {};
   const dismissedArr = tlReadJSON(TIMELINE_DISMISSED_KEY, []) || [];
   const dismissed = new Set(dismissedArr);
-  const hiddenClassesArr = tlReadJSON(TIMELINE_CLASS_FILTER_KEY, []) || [];
-  const hiddenClasses = new Set(hiddenClassesArr);
+  const hiddenKindsArr = tlReadJSON(TIMELINE_CLASS_FILTER_KEY, []) || [];
+  const hiddenKinds = new Set(hiddenKindsArr);
   const timeMode = (localStorage.getItem(TIMELINE_TIME_MODE_KEY) === 'rel') ? 'rel' : 'abs';
   const autoHideStale = (localStorage.getItem(TIMELINE_AUTO_HIDE_STALE_KEY) === 'on');
+  const colonyFilter = localStorage.getItem(TIMELINE_COLONY_FILTER_KEY) || '';
 
   // Index agents by name for O(1) `agent_last_ok_ts` lookup in the
   // stale-error filter.
@@ -1744,43 +1799,70 @@ function renderEventTimeline(data) {
   agents.forEach(a => { agentByName[a.name] = a; });
   const nowMs = Date.now();
 
+  // The federation-wide stream: each row carries {ts, agent_id, kind,
+  // payload, severity, agent_name, colony}.
+  const allRows = Array.isArray(timelineRows) ? timelineRows : [];
+
   // Filter rules, in order. An entry must pass ALL of them. Entries
   // with ts === 0 (no parseable timestamp) bypass the time-based
   // filters so the operator can still see them.
-  function visible(e) {
-    if (hiddenClasses.has(e.type)) return false;
-    if (e.ts && cursor && e.ts < cursor) return false;
-    const ckey = e.agent + ':' + e.type;
-    if (e.ts && cursorClass[ckey] && e.ts < cursorClass[ckey]) return false;
-    if (e.ts && dismissed.has(e.agent + ':' + e.ts)) return false;
-    if (autoHideStale && e.type === 'error') {
-      const a = agentByName[e.agent];
+  function visible(r) {
+    const kind = r.kind || '';
+    const agentName = r.agent_name || '';
+    if (hiddenKinds.has(kind)) return false;
+    if (colonyFilter && (r.colony || '') !== colonyFilter) return false;
+    if (r.ts && cursor && r.ts < cursor) return false;
+    const ckey = agentName + ':' + kind;
+    if (r.ts && cursorClass[ckey] && r.ts < cursorClass[ckey]) return false;
+    if (r.ts && dismissed.has(agentName + ':' + r.ts)) return false;
+    if (autoHideStale && r.severity === 'error') {
+      const a = agentByName[agentName];
       if (a && a.agent_last_ok_ts && (nowMs - a.agent_last_ok_ts) >= TIMELINE_STALE_WINDOW_MS) {
         return false;
       }
     }
     return true;
   }
-  const filtered = events.filter(visible);
-  const hidden = events.length - filtered.length;
+  const filtered = allRows.filter(visible);
+  const hidden = allRows.length - filtered.length;
 
-  // Render class-filter chips. A chip is `active` (highlighted) when
-  // its class is currently SHOWN; clicking toggles its hidden state.
+  // Build the colony dropdown from colonyList. Selected option mirrors
+  // localStorage so the filter survives reloads.
+  if (colonySelect) {
+    let opts = '<option value="">all colonies</option>';
+    colonyList.forEach(c => {
+      opts += '<option value="' + esc(c) + '"' +
+        (colonyFilter === c ? ' selected' : '') + '>' + esc(c) + '</option>';
+    });
+    colonySelect.innerHTML = opts;
+    colonySelect.onchange = () => {
+      const v = colonySelect.value || '';
+      if (v) {
+        localStorage.setItem(TIMELINE_COLONY_FILTER_KEY, v);
+      } else {
+        localStorage.removeItem(TIMELINE_COLONY_FILTER_KEY);
+      }
+      location.reload();
+    };
+  }
+
+  // Render kind-filter chips. A chip is `active` (highlighted) when
+  // its kind is currently SHOWN; clicking toggles its hidden state.
   if (chipsEl) {
     let chipsHtml = '';
-    TIMELINE_CLASSES.forEach(cls => {
-      const isShown = !hiddenClasses.has(cls);
-      const cnt = events.filter(e => e.type === cls).length;
-      chipsHtml += '<button type="button" class="timeline-chip ' + cls +
-        (isShown ? ' active' : '') + '" data-class="' + cls + '">' +
-        cls + (cnt ? ' (' + cnt + ')' : '') + '</button>';
+    TIMELINE_KINDS.forEach(kind => {
+      const isShown = !hiddenKinds.has(kind);
+      const cnt = allRows.filter(r => r.kind === kind).length;
+      chipsHtml += '<button type="button" class="timeline-chip ' + kind +
+        (isShown ? ' active' : '') + '" data-kind="' + kind + '">' +
+        kind + (cnt ? ' (' + cnt + ')' : '') + '</button>';
     });
     chipsEl.innerHTML = chipsHtml;
     chipsEl.querySelectorAll('.timeline-chip').forEach(chip => {
       chip.addEventListener('click', () => {
-        const cls = chip.dataset.class;
-        const next = new Set(hiddenClasses);
-        if (next.has(cls)) next.delete(cls); else next.add(cls);
+        const kind = chip.dataset.kind;
+        const next = new Set(hiddenKinds);
+        if (next.has(kind)) next.delete(kind); else next.add(kind);
         tlWriteJSON(TIMELINE_CLASS_FILTER_KEY, Array.from(next));
         location.reload();
       });
@@ -1795,9 +1877,9 @@ function renderEventTimeline(data) {
       const showAll = document.getElementById('timeline-show-all');
       if (showAll) {
         // "Show all" only resets dismissal-style filters (cursor,
-        // per-(agent,class) cursor, dismissed set). Class chips,
-        // time-mode, and auto-hide are operator-set preferences and
-        // survive — they get their own controls.
+        // per-(agent_name, kind) cursor, dismissed set). Kind chips,
+        // colony filter, time-mode, and auto-hide are operator-set
+        // preferences and survive — they get their own controls.
         showAll.addEventListener('click', () => {
           localStorage.removeItem(TIMELINE_CURSOR_KEY);
           localStorage.removeItem(TIMELINE_CURSOR_CLASS_KEY);
@@ -1811,36 +1893,76 @@ function renderEventTimeline(data) {
     }
   }
 
+  // 1-line summary string per kind. Mirrors the per-agent modal renderer
+  // so the colour cues + content shape line up across the two views.
+  function summarizeRow(r) {
+    const kind = r.kind || '';
+    const payload = r.payload || {};
+    if (kind === 'learn') {
+      const outcome = payload.outcome || '';
+      const delta = (typeof payload.delta === 'number')
+        ? (payload.delta >= 0 ? '+' : '') + payload.delta.toFixed(3) : '';
+      return 'outcome=' + outcome + (delta ? ', fitness_delta=' + delta : '');
+    }
+    if (kind === 'prompt') {
+      const cost = (typeof payload.cost_usd === 'number') ? fmtUsd(payload.cost_usd) : '$?';
+      const inp = payload.input_tokens || 0;
+      const out = payload.output_tokens || 0;
+      const model = payload.model || '';
+      return cost + ' · ' + inp + '/' + out + ' tokens · ' + model;
+    }
+    if (kind === 'confidence_change') {
+      const fromV = (typeof payload.from === 'number') ? payload.from.toFixed(2) : (payload.from || '?');
+      const toV = (typeof payload.to === 'number') ? payload.to.toFixed(2) : (payload.to || '?');
+      const delta = (typeof payload.delta === 'number')
+        ? (payload.delta >= 0 ? '+' : '') + payload.delta.toFixed(3) : '';
+      return fromV + ' → ' + toV + (delta ? ' (Δ' + delta + ')' : '');
+    }
+    if (kind === 'lifecycle') {
+      return payload.event || '';
+    }
+    return JSON.stringify(payload);
+  }
+
   if (!filtered.length) {
-    el.innerHTML = '<span class="empty">No inter-agent events captured yet.</span>';
+    el.innerHTML = '<span class="empty">No timeline rows captured yet.</span>';
   } else {
     let html = '';
-    filtered.forEach(e => {
+    filtered.forEach(r => {
+      const kind = r.kind || 'log';
+      const agentName = r.agent_name || '';
+      const colony = r.colony || '';
       let tsDisplay;
-      if (timeMode === 'rel' && e.ts) {
-        tsDisplay = relTime(e.ts / 1000);
+      if (timeMode === 'rel' && r.ts) {
+        tsDisplay = relTime(r.ts / 1000);
       } else {
-        tsDisplay = formatTimestamp(e.ts) || '?';
+        tsDisplay = formatTimestamp(r.ts) || '?';
       }
       let tip;
-      if (e.ts) {
-        try { tip = new Date(e.ts).toISOString() + '\n' + relTime(e.ts / 1000); }
-        catch (err) { tip = String(e.ts); }
+      if (r.ts) {
+        try { tip = new Date(r.ts).toISOString() + '\n' + relTime(r.ts / 1000); }
+        catch (err) { tip = String(r.ts); }
       } else {
-        tip = 'no timestamp parsed from log line';
+        tip = 'no timestamp parsed';
       }
-      const tsAttr = String(e.ts || 0);
-      const dismissData = e.ts ? (' data-agent="' + esc(e.agent) + '" data-ts="' + tsAttr + '"') : '';
-      const dismissBtn = e.ts
+      const tsAttr = String(r.ts || 0);
+      const dismissData = r.ts ? (' data-agent="' + esc(agentName) + '" data-ts="' + tsAttr + '"') : '';
+      const dismissBtn = r.ts
         ? '<button type="button" class="timeline-dismiss" title="Dismiss this row"' + dismissData + '>&times;</button>'
         : '';
+      const summary = summarizeRow(r);
+      // severity escalates the type cell colour: error -> red, warning -> orange.
+      let typeClass = kind;
+      if (r.severity === 'error') typeClass = kind + ' error';
+      else if (r.severity === 'warning') typeClass = kind + ' suggest';
       html += '<div class="timeline-entry">' +
         '<span class="timeline-ts tooltip">' + esc(tsDisplay) +
           '<span class="tip-text">' + esc(tip) + '</span>' +
         '</span>' +
-        '<span class="timeline-agent">' + esc(e.agent) + '</span>' +
-        '<span class="timeline-type ' + e.type + '">' + esc(e.type) + '</span>' +
-        '<span class="timeline-content">' + esc(e.content) + '</span>' +
+        '<span class="timeline-agent">' + esc(agentName) + '</span>' +
+        (colony ? '<span class="timeline-colony-chip">' + esc(colony) + '</span>' : '') +
+        '<span class="timeline-type ' + typeClass + '">' + esc(kind) + '</span>' +
+        '<span class="timeline-content">' + esc(summary) + '</span>' +
         dismissBtn +
         '</div>';
     });
@@ -1873,23 +1995,24 @@ function renderEventTimeline(data) {
     });
   }
 
-  // Wire "Clear stale" — for each (agent, error) pair currently
-  // visible whose agent has ticked cleanly in the last hour, snapshot
-  // a per-(agent, error) cursor at "now". Snapshot semantics so that
-  // operators get reproducible behaviour even if they later disable
-  // auto-hide.
+  // Wire "Clear stale" — for each (agent_name, kind) pair currently
+  // visible whose severity is `error` and whose agent has ticked cleanly
+  // in the last hour, snapshot a per-(agent_name, kind) cursor at "now".
+  // Snapshot semantics so that operators get reproducible behaviour even
+  // if they later disable auto-hide.
   const clearStaleBtn = document.getElementById('timeline-clear-stale-btn');
   if (clearStaleBtn) {
     clearStaleBtn.addEventListener('click', () => {
       const map = tlReadJSON(TIMELINE_CURSOR_CLASS_KEY, {}) || {};
       const stamp = Date.now();
       let changed = 0;
-      events.forEach(e => {
-        if (e.type !== 'error') return;
-        const a = agentByName[e.agent];
+      allRows.forEach(r => {
+        if (r.severity !== 'error') return;
+        const agentName = r.agent_name || '';
+        const a = agentByName[agentName];
         if (!a || !a.agent_last_ok_ts) return;
         if ((stamp - a.agent_last_ok_ts) >= TIMELINE_STALE_WINDOW_MS) return;
-        const k = e.agent + ':error';
+        const k = agentName + ':' + (r.kind || '');
         if (!map[k] || map[k] < stamp) {
           map[k] = stamp;
           changed += 1;

--- a/tools/test-timeline-rendering.sh
+++ b/tools/test-timeline-rendering.sh
@@ -193,36 +193,37 @@ else
 fi
 
 # --- Test 6: no raw 13-digit ms leaks into rendered timeline rows. The
-#     events array literal in the JS source legitimately contains the raw
+#     timeline array literal in the JS source legitimately contains the raw
 #     ms values (that's the JSON payload), so we restrict the check to
-#     the JS that builds the row HTML — i.e. the timeline IIFE body and
-#     the format helpers must not contain a 13-digit standalone literal
-#     in a way that would render in the row. We instead assert that the
-#     row template uses formatTimestamp(e.ts), not bare e.ts string
-#     concatenation. ---
+#     the JS that builds the row HTML — i.e. the timeline renderer body
+#     must not contain a 13-digit standalone literal in a way that would
+#     render in the row. We instead assert that the row template uses
+#     formatTimestamp(<row>.ts), not bare <row>.ts string concatenation.
+#     #315 PR 2: federation-wide timeline now iterates `r` over
+#     data.timeline[]; pre-PR2 it was `e` over data.events[]. Accept both
+#     names so this test stays useful across the refactor.
 if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
 import sys, re
 with open(sys.argv[1]) as f:
     html = f.read()
-# Locate the timeline IIFE: from "// --- Event Timeline ---" to the next
-# "// --- " marker.
+# Locate the timeline renderer: from "// --- Event Timeline ---" to the
+# next "// --- " marker.
 m = re.search(r'// --- Event Timeline ---(.*?)// --- ', html, re.DOTALL)
 if not m:
     sys.exit(1)
 body = m.group(1)
-# Must reference formatTimestamp on e.ts; must NOT concat e.ts directly
-# into a span without going through formatTimestamp/esc/Date.
-if 'formatTimestamp(e.ts)' not in body:
+# Must reference formatTimestamp on the row var (`e` pre-PR2, `r` post).
+if not re.search(r'formatTimestamp\(\s*[er]\.ts\s*\)', body):
     sys.exit(1)
-# Defensive: ensure no naked '+ e.ts +' that would dump a 13-digit number.
-if re.search(r'\+\s*e\.ts\s*\+', body):
+# Defensive: ensure no naked '+ <row>.ts +' that would dump a 13-digit number.
+if re.search(r'\+\s*[er]\.ts\s*\+', body):
     sys.exit(1)
 sys.exit(0)
 PY
 then
-    pass "6: timeline row template renders e.ts via formatTimestamp, no raw-ms leak"
+    pass "6: timeline row template renders ts via formatTimestamp, no raw-ms leak"
 else
-    fail "6: rendered timeline row template still references e.ts directly"
+    fail "6: rendered timeline row template still references ts directly"
 fi
 
 # --- Test 7: /kill regression smoke (issue #161). ---
@@ -243,20 +244,21 @@ else
 fi
 
 # --- Test 8: unit-mismatch guard. relTime() expects epoch-SECONDS. The
-#     timeline IIFE works in epoch-ms (post-#158) and must divide by 1000
+#     timeline body works in epoch-ms (post-#158) and must divide by 1000
 #     before passing to relTime. Recent Experience modal works in epoch-
 #     seconds and must NOT divide. Lock both in to prevent the next
-#     refactor from mixing units. ---
+#     refactor from mixing units. #315 PR 2 renamed the timeline loop var
+#     from `e` to `r`; accept both. ---
 if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
 import sys, re
 with open(sys.argv[1]) as f:
     html = f.read()
-# Timeline IIFE must call relTime(e.ts / 1000) (or e.ts/1000) somewhere.
+# Timeline body must call relTime(<row>.ts / 1000) somewhere.
 m = re.search(r'// --- Event Timeline ---(.*?)// --- ', html, re.DOTALL)
 if not m:
     sys.exit(1)
 timeline_body = m.group(1)
-if not re.search(r'relTime\(\s*e\.ts\s*/\s*1000\s*\)', timeline_body):
+if not re.search(r'relTime\(\s*[er]\.ts\s*/\s*1000\s*\)', timeline_body):
     sys.exit(1)
 # Recent Experience modal must call relTime(e.ts) — no division. Locate
 # the modal block by its header marker.
@@ -853,6 +855,293 @@ else
     fail "28: per-agent timeline injection regressed — see stderr above"
 fi
 rm -rf "$QA_FED"
+
+# --- #315 PR 2: federation-wide unified timeline + /timeline endpoint.
+#     Build a 3-agent fixture so we can assert the merged stream contains
+#     rows from multiple agents, ts-desc sorted, capped at 200. Then boot
+#     the dashboard against the same fixture and smoke /timeline with
+#     pagination + colony filtering. ---
+QA_FED2="/tmp/qa-315-pr2-fed"
+COLLECTOR_PY="$REPO_ROOT/federation-dashboard/lib/federation-dashboard-collector.py"
+rm -rf "$QA_FED2"
+mkdir -p "$QA_FED2/.agentis/experience" \
+         "$QA_FED2/.agentis/spend" \
+         "$QA_FED2/.agentis/lifecycle" \
+         "$QA_FED2/.dashboard" \
+         "$QA_FED2/colony-a/agents" \
+         "$QA_FED2/colony-a/config" \
+         "$QA_FED2/colony-b/agents" \
+         "$QA_FED2/colony-b/config"
+cat > "$QA_FED2/colony-a/config/colony.toml" <<'TOML'
+[colony]
+name = "colony-a"
+TOML
+cat > "$QA_FED2/colony-b/config/colony.toml" <<'TOML'
+[colony]
+name = "colony-b"
+TOML
+
+# Three agents: agent_a1, agent_a2 in colony-a; agent_b1 in colony-b.
+for ag_pair in colony-a/agents/agent_a1.ag colony-a/agents/agent_a2.ag colony-b/agents/agent_b1.ag; do
+    cat > "$QA_FED2/$ag_pair" <<'AG'
+cb 100;
+fn tick() { return Void; }
+AG
+done
+
+QA_AID_A1="aaaaaaa1"
+QA_AID_A2="aaaaaaa2"
+QA_AID_B1="bbbbbbb1"
+QA_NOW2="$(date '+%s')"
+QA_NOW2_MS=$((QA_NOW2 * 1000))
+
+# Each agent gets >=1 experience row + >=1 spend row + >=1 lifecycle row,
+# so the merged feed carries rows from all three. Stagger ts so the desc
+# sort is observable.
+cat > "$QA_FED2/.agentis/experience/$QA_AID_A1.jsonl" <<EXP
+{"v":1,"ts":$((QA_NOW2 - 300)),"agent":"$QA_AID_A1","action":"draft","in":"MR 1","outcome":"success","delta":0.05}
+{"v":1,"ts":$((QA_NOW2 - 200)),"agent":"$QA_AID_A1","action":"draft","in":"MR 2","outcome":"success","delta":0.10}
+EXP
+cat > "$QA_FED2/.agentis/experience/$QA_AID_A2.jsonl" <<EXP
+{"v":1,"ts":$((QA_NOW2 - 250)),"agent":"$QA_AID_A2","action":"review","in":"MR 3","outcome":"failure","delta":-0.02}
+EXP
+cat > "$QA_FED2/.agentis/experience/$QA_AID_B1.jsonl" <<EXP
+{"v":1,"ts":$((QA_NOW2 - 150)),"agent":"$QA_AID_B1","action":"merge","in":"MR 4","outcome":"success","delta":0.20}
+EXP
+
+cat > "$QA_FED2/.agentis/spend/$QA_AID_A1.jsonl" <<SPEND
+{"v":1,"ts":$((QA_NOW2_MS - 280000)),"agent":"$QA_AID_A1","colony":"colony-a","backend":"claude-cli","model":"claude-sonnet-4-20250514","input_tokens":100,"output_tokens":50,"cost_usd":0.0123,"cost_source":"native","cb":50,"instr_hash":"deadbeef","cached":false,"ok":true}
+SPEND
+cat > "$QA_FED2/.agentis/spend/$QA_AID_A2.jsonl" <<SPEND
+{"v":1,"ts":$((QA_NOW2_MS - 220000)),"agent":"$QA_AID_A2","colony":"colony-a","backend":"claude-cli","model":"claude-sonnet-4-20250514","input_tokens":120,"output_tokens":60,"cost_usd":0.0150,"cost_source":"native","cb":50,"instr_hash":"cafebabe","cached":false,"ok":true}
+SPEND
+cat > "$QA_FED2/.agentis/spend/$QA_AID_B1.jsonl" <<SPEND
+{"v":1,"ts":$((QA_NOW2_MS - 100000)),"agent":"$QA_AID_B1","colony":"colony-b","backend":"claude-cli","model":"claude-sonnet-4-20250514","input_tokens":150,"output_tokens":70,"cost_usd":0.0180,"cost_source":"native","cb":50,"instr_hash":"feedface","cached":false,"ok":true}
+SPEND
+
+cat > "$QA_FED2/.agentis/lifecycle/events.jsonl" <<LIFE
+{"agent_id":"$QA_AID_A1","event":"daemon.started","cb_per_tick":2000,"tick_interval_ms":60000,"ts":$((QA_NOW2 - 350))}
+{"agent_id":"$QA_AID_A2","event":"daemon.started","cb_per_tick":2000,"tick_interval_ms":60000,"ts":$((QA_NOW2 - 340))}
+{"agent_id":"$QA_AID_B1","event":"daemon.started","cb_per_tick":2000,"tick_interval_ms":60000,"ts":$((QA_NOW2 - 330))}
+LIFE
+
+QA_DAEMONS2=$(python3 -c "
+import json
+print(json.dumps([
+  {'agent_id':'$QA_AID_A1','source':'$QA_FED2/colony-a/agents/agent_a1.ag','state':'running','health':'healthy','pid':0,'confidence':0.5,'tick_ok':1,'tick_err':0,'started_at':$QA_NOW2 - 400},
+  {'agent_id':'$QA_AID_A2','source':'$QA_FED2/colony-a/agents/agent_a2.ag','state':'running','health':'healthy','pid':0,'confidence':0.5,'tick_ok':1,'tick_err':0,'started_at':$QA_NOW2 - 400},
+  {'agent_id':'$QA_AID_B1','source':'$QA_FED2/colony-b/agents/agent_b1.ag','state':'running','health':'healthy','pid':0,'confidence':0.5,'tick_ok':1,'tick_err':0,'started_at':$QA_NOW2 - 400},
+]))
+")
+QA_AGENT_MAP2='[{"agent":"agent_a1","colony":"colony-a"},{"agent":"agent_a2","colony":"colony-a"},{"agent":"agent_b1","colony":"colony-b"}]'
+QA_COLONIES2='["colony-a","colony-b"]'
+
+QA_JSON2="$(python3 "$COLLECTOR_PY" \
+    "$QA_DAEMONS2" \
+    "$QA_AGENT_MAP2" \
+    "$QA_FED2" \
+    "$QA_NOW2" \
+    "$QA_FED2/.agentis/experience" \
+    "$QA_FED2/.agentis/logs" \
+    "$QA_FED2/.dashboard" \
+    "$QA_COLONIES2" \
+    "" \
+    agent_a1 agent_a2 agent_b1 2>/dev/null)"
+
+t30_ok=1
+if [ -z "$QA_JSON2" ]; then
+    echo "  collector returned empty output"
+    t30_ok=0
+elif ! python3 - <<PY 2>&1
+import json, sys
+blob = json.loads('''$QA_JSON2''')
+tl = blob.get('timeline')
+if not isinstance(tl, list):
+    sys.stderr.write('federation-wide timeline missing or not a list: %r\n' % type(tl)); sys.exit(2)
+if len(tl) == 0:
+    sys.stderr.write('federation-wide timeline is empty\n'); sys.exit(3)
+if len(tl) > 200:
+    sys.stderr.write('federation-wide timeline exceeds 200-row cap: %d\n' % len(tl)); sys.exit(4)
+# ts-desc sort.
+ts_seq = [r.get('ts') for r in tl if isinstance(r.get('ts'), int)]
+if ts_seq != sorted(ts_seq, reverse=True):
+    sys.stderr.write('federation-wide timeline not ts-desc sorted: %r\n' % ts_seq[:10]); sys.exit(5)
+# Rows from MULTIPLE agents — at least 2 distinct agent_ids must appear.
+aids = set(r.get('agent_id') for r in tl)
+if len(aids) < 2:
+    sys.stderr.write('only one agent in federation timeline: %r\n' % aids); sys.exit(6)
+# Augmentation: every row carries agent_name + colony.
+for r in tl:
+    if 'agent_name' not in r or 'colony' not in r:
+        sys.stderr.write('row missing agent_name/colony: %r\n' % r); sys.exit(7)
+# Per-agent timelines also still populated (PR1 contract preserved).
+for a in blob.get('agents') or []:
+    if not isinstance(a.get('timeline'), list):
+        sys.stderr.write('per-agent timeline regression on %s\n' % a.get('name')); sys.exit(8)
+sys.exit(0)
+PY
+then
+    t30_ok=0
+fi
+if [ "$t30_ok" -eq 1 ]; then
+    pass "30: data.timeline[] federation-wide field exists, ts-desc, capped at 200, multi-agent (#315 PR 2)"
+else
+    fail "30: federation-wide timeline assertion failed — see stderr above"
+fi
+
+# --- t31 / t32: HTTP smoke against /timeline endpoint. We boot
+#     federation-dashboard-server.py directly (NOT the wrapper) against a
+#     hand-written timeline-full.jsonl in the dashboard cache dir.
+#     Booting the wrapper would shell out to `agentis daemon list --json`
+#     which hits the global registry and returns daemons unrelated to the
+#     fixture — causing the wrapper's timeline regen to write zero rows.
+#     The server endpoint contract is "read timeline-full.jsonl from
+#     <dash-dir>"; we exercise that contract directly. ---
+DASH_DIR2="$QA_FED2/.dashboard"
+TIMELINE_FULL2="$DASH_DIR2/timeline-full.jsonl"
+# Hand-write 9 rows: 3 per agent × 3 agents, ts-desc.
+python3 - <<PY
+import json, os, time
+out = "$TIMELINE_FULL2"
+QA_NOW2_MS = $((QA_NOW2 * 1000))
+rows = [
+  # colony-a, agent_a1
+  {"ts": QA_NOW2_MS - 200000, "agent_id": "aaaaaaa1", "kind": "learn",
+   "payload": {"outcome": "success", "delta": 0.10}, "severity": "info",
+   "agent_name": "agent_a1", "colony": "colony-a"},
+  {"ts": QA_NOW2_MS - 280000, "agent_id": "aaaaaaa1", "kind": "prompt",
+   "payload": {"cost_usd": 0.0123, "input_tokens": 100, "output_tokens": 50,
+               "model": "claude-sonnet-4-20250514", "ok": True}, "severity": "info",
+   "agent_name": "agent_a1", "colony": "colony-a"},
+  {"ts": QA_NOW2_MS - 350000, "agent_id": "aaaaaaa1", "kind": "lifecycle",
+   "payload": {"event": "daemon.started"}, "severity": "info",
+   "agent_name": "agent_a1", "colony": "colony-a"},
+  # colony-a, agent_a2
+  {"ts": QA_NOW2_MS - 250000, "agent_id": "aaaaaaa2", "kind": "learn",
+   "payload": {"outcome": "failure", "delta": -0.02}, "severity": "error",
+   "agent_name": "agent_a2", "colony": "colony-a"},
+  {"ts": QA_NOW2_MS - 220000, "agent_id": "aaaaaaa2", "kind": "prompt",
+   "payload": {"cost_usd": 0.0150, "input_tokens": 120, "output_tokens": 60,
+               "model": "claude-sonnet-4-20250514", "ok": True}, "severity": "info",
+   "agent_name": "agent_a2", "colony": "colony-a"},
+  {"ts": QA_NOW2_MS - 340000, "agent_id": "aaaaaaa2", "kind": "lifecycle",
+   "payload": {"event": "daemon.started"}, "severity": "info",
+   "agent_name": "agent_a2", "colony": "colony-a"},
+  # colony-b, agent_b1
+  {"ts": QA_NOW2_MS - 150000, "agent_id": "bbbbbbb1", "kind": "learn",
+   "payload": {"outcome": "success", "delta": 0.20}, "severity": "info",
+   "agent_name": "agent_b1", "colony": "colony-b"},
+  {"ts": QA_NOW2_MS - 100000, "agent_id": "bbbbbbb1", "kind": "prompt",
+   "payload": {"cost_usd": 0.0180, "input_tokens": 150, "output_tokens": 70,
+               "model": "claude-sonnet-4-20250514", "ok": True}, "severity": "info",
+   "agent_name": "agent_b1", "colony": "colony-b"},
+  {"ts": QA_NOW2_MS - 330000, "agent_id": "bbbbbbb1", "kind": "lifecycle",
+   "payload": {"event": "daemon.started"}, "severity": "info",
+   "agent_name": "agent_b1", "colony": "colony-b"},
+]
+rows.sort(key=lambda r: r["ts"], reverse=True)
+os.makedirs(os.path.dirname(out), exist_ok=True)
+with open(out, "w") as f:
+    for r in rows:
+        f.write(json.dumps(r, separators=(",", ":")))
+        f.write("\n")
+PY
+
+PORT2="$(python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); p=s.getsockname()[1]; s.close(); print(p)")"
+LOG2="$TMPDIR_TEST/server-pr2.log"
+SERVER_PY_PR2="$DASH_LIB_DIR/federation-dashboard-server.py"
+# Direct server boot. Args: serve_dir, port, script_path, fed_dir,
+# allowed_agents, agent_map_json, fed_tools_dir.
+setsid python3 "$SERVER_PY_PR2" "$DASH_DIR2" "$PORT2" \
+    "$DASHBOARD_SH" "$QA_FED2" \
+    "agent_a1,agent_a2,agent_b1" "$QA_AGENT_MAP2" "" \
+    >"$LOG2" 2>&1 &
+DASH_PID2=$!
+
+ready2=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -f -s -o /dev/null "http://127.0.0.1:$PORT2/timeline?limit=1" 2>/dev/null; then
+        ready2=1
+        break
+    fi
+    sleep 0.5
+done
+if [ "$ready2" -ne 1 ]; then
+    fail "31/32: server-pr2 never became ready" "log tail: $(tail -10 "$LOG2" 2>/dev/null | tr '\n' ' ')"
+    kill -TERM "-$DASH_PID2" 2>/dev/null || kill -TERM "$DASH_PID2" 2>/dev/null || true
+    rm -rf "$QA_FED2"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# --- t31: /timeline?since=<future-ms>&limit=10 returns rows + next_cursor.
+#     The fixture has ~9 timeline-eligible rows (3 exp + 3 spend + 3 lifecycle
+#     after the 7-day window filter), but the contract is "returns up to limit
+#     rows with non-null next_cursor when more remain". Use limit=5 so we
+#     reliably get a non-null next_cursor. ---
+FUTURE_MS=$(( ( QA_NOW2 + 3600 ) * 1000 ))
+TL_RESP="$TMPDIR_TEST/timeline.json"
+curl -s "http://127.0.0.1:$PORT2/timeline?since=$FUTURE_MS&limit=5" -o "$TL_RESP" || true
+if python3 - "$TL_RESP" <<'PY' 2>/dev/null
+import sys, json
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+assert isinstance(data, dict), 'response is not a dict'
+rows = data.get('rows')
+assert isinstance(rows, list), 'rows is not a list: %r' % type(rows)
+# At least 1 row from the 9-row fixture + limit cap respected.
+if len(rows) == 0:
+    sys.stderr.write('no rows returned by /timeline\n'); sys.exit(2)
+if len(rows) > 5:
+    sys.stderr.write('rows exceeds limit=5: %d\n' % len(rows)); sys.exit(3)
+# ts-desc sort within the response.
+ts_seq = [r.get('ts') for r in rows]
+if ts_seq != sorted(ts_seq, reverse=True):
+    sys.stderr.write('rows not ts-desc: %r\n' % ts_seq); sys.exit(4)
+# next_cursor non-null because the fixture has more rows than limit=5.
+if data.get('next_cursor') is None:
+    sys.stderr.write('next_cursor is null but more rows should remain\n'); sys.exit(5)
+sys.exit(0)
+PY
+then
+    pass "31: /timeline?since=<future>&limit=5 returns rows ts-desc with non-null next_cursor (#315 PR 2)"
+else
+    fail "31: /timeline pagination smoke regressed — body: $(head -c 400 "$TL_RESP" 2>/dev/null)"
+fi
+
+# --- t32: /timeline?colony=<name> filters correctly. colony-b has only
+#     agent_b1, which contributes 3 rows (1 exp + 1 spend + 1 lifecycle). ---
+TL_RESP_B="$TMPDIR_TEST/timeline-b.json"
+curl -s "http://127.0.0.1:$PORT2/timeline?colony=colony-b&since=$FUTURE_MS&limit=200" -o "$TL_RESP_B" || true
+if python3 - "$TL_RESP_B" <<'PY' 2>/dev/null
+import sys, json
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+rows = data.get('rows') or []
+if not rows:
+    sys.stderr.write('no rows returned for colony=colony-b\n'); sys.exit(2)
+# Every row must carry colony=colony-b.
+for r in rows:
+    if r.get('colony') != 'colony-b':
+        sys.stderr.write('row leaked from another colony: %r\n' % r); sys.exit(3)
+# Same agent_id across all rows (only agent_b1 in colony-b).
+aids = set(r.get('agent_id') for r in rows)
+if aids != {'bbbbbbb1'}:
+    sys.stderr.write('unexpected agents under colony-b filter: %r\n' % aids); sys.exit(4)
+sys.exit(0)
+PY
+then
+    pass "32: /timeline?colony=colony-b returns only colony-b rows (#315 PR 2)"
+else
+    fail "32: /timeline colony filter regressed — body: $(head -c 400 "$TL_RESP_B" 2>/dev/null)"
+fi
+
+# Tear down the second dashboard before finishing.
+kill -TERM "-$DASH_PID2" 2>/dev/null || kill -TERM "$DASH_PID2" 2>/dev/null || true
+sleep 0.5
+kill -KILL "-$DASH_PID2" 2>/dev/null || kill -KILL "$DASH_PID2" 2>/dev/null || true
+rm -rf "$QA_FED2"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

- Land PR 2 of 2 for [#315](https://github.com/Replikanti/agentis-colonies/issues/315): federation-wide timeline tile + `GET /timeline` HTTP endpoint with pagination. Combined with [PR 1](https://github.com/Replikanti/agentis-colonies/pull/343) (per-agent modal section + collector-side `build_agent_timeline()` collector that merges experience / spend / confidence-log / lifecycle JSONL streams), the timeline story is complete.
- Collector emits a new top-level `timeline[]` array in `COLLECTOR_JSON` (last 200 rows reverse-chronological across all agents) augmented with `agent_name` + `colony` for chip rendering. The federation-wide Event Timeline tile drops the legacy regex-log scraper and renders directly from the structured stream with per-kind chips (`learn` / `prompt` / `confidence_change` / `lifecycle`), a colony dropdown built from `colonyList`, and a 1-line summary string per kind that mirrors the per-agent modal verbatim. Pre-existing filter layers (blanket cursor, per-(agent, kind) cursor, dismissed set, time mode, auto-hide-stale) survive. Live updates flow through the `agentis:snapshot` SSE channel landed by [#344](https://github.com/Replikanti/agentis-colonies/pull/344) (#313 PR 2).
- New `GET /timeline?since=<unix-ms>&limit=<N>&colony=<name>&kind=<csv>` returns `{rows, next_cursor}` for paginated queries beyond the in-page 200-row cap. Endpoint is read-only — 200 on success, 400 on malformed params, 500 on internal read error.

## Architecture

The endpoint reads from a **precomputed** `<dash-dir>/timeline-full.jsonl` written atomically by the wrapper after each `generate()` cycle (last 7 days OR 5000 rows, whichever is smaller, reverse-chronological). A new dedicated helper `federation-dashboard/lib/federation-dashboard-timeline.py` re-reads the four source streams (experience, spend, lifecycle, confidence-log) exactly once each and writes JSONL output directly — without going through the embedded 200-row cap that the in-page `data.timeline[]` uses. This keeps the endpoint's read path trivial (`open + filter + slice`) and bounds memory at the writer side. The precomputed file path was chosen over re-read-on-request because the wrapper already does the merge for the embedded `data.timeline[]`, and writing the wider file is a single additional helper invocation per regen cycle. The helper degrades gracefully (empty file) when no daemons match, when source files are missing, or when the experience/spend dirs are empty — matching the collector's tolerance pattern. Total complexity stays `O(N_lifecycle + N_experience + N_spend + N_confidence)`.

## Test plan

- [x] `bash tools/test-timeline-rendering.sh` — 32 / 0 (29 baseline + 3 new: `t30` federation-wide collector field shape, `t31` `/timeline` pagination, `t32` `/timeline` colony filter). `t31` / `t32` boot `federation-dashboard-server.py` directly against a hand-written `timeline-full.jsonl` because the wrapper would shell out to `agentis daemon list --json` and pick up the live federation's daemons (unrelated to the fixture).
- [x] `bash tools/test-make-dashboard-bundle.sh` — 13 / 0 (the new `lib/federation-dashboard-timeline.py` helper is auto-included by `BUNDLE.manifest`'s recursive `federation-dashboard/` entry).
- [x] `AGENTIS_RUN_KILL_TESTS=0 bash tools/colony-lint.sh` — 116 / 0 / 3 baseline preserved.
- [x] `python3 -m py_compile` on collector / server / new timeline helper — clean.
- [x] `bash -n federation-dashboard/bin/federation-dashboard` — clean.
- [x] `bash tools/test-sse-stream.sh` — 9 / 0 (test 8 internally re-runs the timeline tests under the SSE refactor).

## Out of scope

- Calendar-picker date range UI (deferred).
- CSV / JSON export buttons (deferred).
- Full-text search over timeline rows (deferred).
- Per-row drill-in to a separate page (deferred).

Closes #315.
