### PR TITLE
fix(dashboard): spool COLLECTOR_JSON to history.py via @<path> (argv overflow regression from #345)

### DIFF
--- a/federation-dashboard/bin/federation-dashboard
+++ b/federation-dashboard/bin/federation-dashboard
@@ -217,7 +217,14 @@ generate() {
     # federation-dashboard-history.py — extracted in #172 alongside the
     # renderer to eliminate the last bash heredocs (macOS bash 3.2 / 5.3
     # parser was tripping on backticks in PYHISTORY and on \' in JSEOF).
-    python3 "$LIB_DIR/federation-dashboard-history.py" "$HISTORY_FILE" "$EPOCH" "$COLLECTOR_JSON" "$COLONY_LIST_PY"
+    # Spool COLLECTOR_JSON to the same @<path> temp file the renderer/server
+    # use. #315 PR 2 grew the blob past the 128 KB MAX_ARG_STRLEN cap by
+    # adding `data.timeline[]` (last 200 federation-wide rows + per-agent
+    # buckets), and history.py was the one helper still passing the JSON
+    # via inline argv — same class of failure as #279/#293. Spool now,
+    # consume via @<path>.
+    printf '%s' "$COLLECTOR_JSON" > "$COLL_FILE"
+    python3 "$LIB_DIR/federation-dashboard-history.py" "$HISTORY_FILE" "$EPOCH" "@$COLL_FILE" "$COLONY_LIST_PY"
 
     local HISTORY
     HISTORY="$(cat "$HISTORY_FILE" 2>/dev/null || echo '[]')"

--- a/federation-dashboard/lib/federation-dashboard-history.py
+++ b/federation-dashboard/lib/federation-dashboard-history.py
@@ -20,6 +20,17 @@ import os
 import sys
 
 
+def _read(arg):
+    """Resolve `@<path>` argv prefix to file contents; otherwise pass through.
+    Mirrors the collector / renderer pattern so callers can spool large
+    JSON blobs (e.g. COLLECTOR_JSON post-#315 PR 2) past Linux's 128 KB
+    MAX_ARG_STRLEN per-argv cap. Same class of failure as #279/#293."""
+    if arg.startswith('@'):
+        with open(arg[1:], 'r', encoding='utf-8') as f:
+            return f.read()
+    return arg
+
+
 def main():
     if len(sys.argv) != 5:
         sys.stderr.write(
@@ -32,14 +43,14 @@ def main():
     epoch = int(sys.argv[2])
 
     try:
-        collector = json.loads(sys.argv[3])
-    except (json.JSONDecodeError, TypeError, ValueError):
+        collector = json.loads(_read(sys.argv[3]))
+    except (json.JSONDecodeError, TypeError, ValueError, OSError):
         collector = {'agents': [], 'experience_counts': {'total': 0}}
 
     try:
         # colony_list parsed for forward compatibility; not consumed here.
-        json.loads(sys.argv[4])
-    except (json.JSONDecodeError, TypeError, ValueError):
+        json.loads(_read(sys.argv[4]))
+    except (json.JSONDecodeError, TypeError, ValueError, OSError):
         pass
 
     try:


### PR DESCRIPTION
## Summary

`federation-dashboard-history.py` was the one helper still consuming `COLLECTOR_JSON` inline via `sys.argv[3]`. After [#315 PR 2](https://github.com/Replikanti/agentis-colonies/pull/345) added `data.timeline[]` to the blob, it grew past Linux's 128 KB MAX_ARG_STRLEN per-argv cap on a 21-agent federation; first regen now crashes the wrapper with `Argument list too long`. Same class of failure as #279 (forge wrapper) and #293 (collector et al).

## Fix

Mirrors the `@<path>` temp-file resolver introduced in #293 for the collector / renderer / server:

- **`federation-dashboard/bin/federation-dashboard`**: spool `$COLLECTOR_JSON` to `$COLL_FILE` BEFORE the history.py call (the existing spool happened too late at line 231), pass `@$COLL_FILE` as argv token.
- **`federation-dashboard/lib/federation-dashboard-history.py`**: add `_read(arg)` helper — verbatim copy of `collector.py`'s pattern, resolving `@<path>` to file contents else pass-through. Apply to argv[3] (collector_json) and argv[4] (colony_list_py). Inline JSON kept for back-compat. `OSError` added to the parse-fail tuple so a misnamed temp file falls through to the same default rather than crashing at the `open()`.

## Test plan

- [x] `python3 -m py_compile federation-dashboard/lib/federation-dashboard-history.py` — clean.
- [x] `bash -n federation-dashboard/bin/federation-dashboard` — clean.
- [x] Smoke: `history.py @<tempfile>` — accepts the spooled blob, writes history.
- [x] Smoke: `history.py '<inline-json>'` — back-compat preserved (any pre-fix caller still works).
- [x] `bash tools/test-make-dashboard-bundle.sh` — 13/0.
- [x] `bash tools/test-timeline-rendering.sh` — 35/0.

No VERSION bump — rides the next federation-dashboard release PR (collecting #313 + #315 + #342 + this fix).

Closes the dashboard-startup regression introduced by #315 PR 2.

Generated with [Claude Code](https://claude.com/claude-code)
