### PR TITLE
feat(dashboard): Overview compactness + Forge Rate Limits relocation + Config writability (#357)

### DIFF
--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Overview tab compactness, Forge Rate Limits relocation, and Config tab
+  writability**
+  ([#357](https://github.com/Replikanti/agentis-colonies/issues/357),
+  follow-up to
+  [#352](https://github.com/Replikanti/agentis-colonies/issues/352)).
+  Three v0.6.0 mistakes corrected in one PR:
+  - **Overview tab cut to ~480 px**. Phase Readiness moved to the top of
+    the Promotions tab (where it pairs with the per-agent ladders);
+    Forge Rate Limits dropped from Overview entirely. Overview now
+    renders Federation Health Banner + bulk-restart action bar, the stat
+    tiles row, and the Sidecars listing — operator-actionable surface
+    only — leaving ~240 px headroom for the Health Banner to expand
+    without scroll.
+  - **Forge Rate Limits → per-colony modal**. A new `showColonyModal()`
+    overlay opens when an operator clicks a colony chip on the
+    Promotions or Agents tab, listing that colony's agents (clickable
+    into the per-agent modal) plus a Forge Rate Limits row sourced from
+    `data.forge_rate_limits[<colony>]`. Trades a 7th tab for a per-
+    colony drill-in (the data is colony-scoped anyway).
+  - **Config tab editable by default**. The
+    `[config_editor].operator_writes_enabled` gate that defaulted false
+    is replaced with a defensive opt-out:
+    `operator_writes_disabled = true` in `<fed>/.agentis/config` flips
+    the tab back to read-only for operators who explicitly want a lock.
+    Default-absent or `false` ⇒ editable. Every Apply pops a structured
+    confirm modal listing each key change line-per-line
+    (`<scope.key>: <old> → <new>`) before the POST fires, replacing the
+    bare `confirm()` dialog. Cancel bails clean.
+  - **`/config/apply` line-level TOML patcher**. Audit-only v1 endpoint
+    rewritten as a real write path. Reads the target `<fed>/.agentis/
+    config` (scope `fed`/`federation`) or `<fed>/<colony>/config/
+    colony.toml` as a list of lines, walks tracking the current
+    `[section]`, and rewrites only the matching `<bare_key> = <value>`
+    line for each change in the payload. Inline comments are preserved
+    verbatim via a `(prefix)(value)(suffix)` regex capture; everything
+    else is byte-copied. Multi-line array / inline-table values bail
+    with 422 + a clear error rather than risk silent corruption.
+    Atomic temp-file + `os.rename` write so a crash mid-apply leaves
+    the file intact. Drift detection: the dashboard echoes the
+    snapshot's mtime back in the apply payload; if disk mtime is newer,
+    the server returns 409 with `{drift: true, current_mtime_ms}` and
+    the dashboard surfaces a banner. Successful applies append one
+    JSONL row per change to `<fed>/.agentis/logs/config-edits.jsonl`
+    (audit trail kept) and trigger a per-colony agent restart via
+    `<colony>/scripts/start-colony.sh --restart-agent <name>`.
+
+  Operator-facing summary: Overview is actionable-first, Forge Rate
+  Limits is a colony drill-in instead of an Overview tile, and the
+  Config tab actually writes the file when an operator clicks Apply.
+  The `--config-override` upstream gap from
+  [#351](https://github.com/Replikanti/agentis-colonies/issues/351) is
+  still open, so cost-cap / per-colony `[llm]` writes remain no-ops at
+  the runtime layer until upstream lands the flag — the Config tab now
+  records the intent in the file and the audit log either way, so the
+  edit surface is no longer the blocker.
+
+  No federation-dashboard MINOR bump; deferred to the next release PR.
+
 ## [0.6.0] — 2026-04-26
 
 Tabbed layout + live SSE pipeline complete. Replaces the long-scroll

--- a/federation-dashboard/lib/federation-dashboard-collector.py
+++ b/federation-dashboard/lib/federation-dashboard-collector.py
@@ -1436,11 +1436,12 @@ sidecars = [
     },
 ]
 
-# --- #352: Config editor scope ---
-# Reads <fed>/.agentis/config to surface (a) operator_writes_enabled flag
-# (gates the Config tab's edit mode; default false), (b) per-colony +
-# federation-wide config snapshots so the editor can render without a
-# second round-trip. Read-only by default. Each scope record:
+# --- #352 (rewritten in #357): Config editor scope ---
+# Reads <fed>/.agentis/config + per-colony colony.toml to surface
+# (a) optional operator_writes_disabled flag (defensive opt-out — default
+# false, i.e. the Config tab is editable by default after #357), and
+# (b) per-colony + federation-wide config snapshots so the editor can
+# render without a second round-trip. Each scope record:
 #   {scope, path, exists, mtime, keys: [{section, key, value}]}
 def _read_toml_scope(path):
     """Lightweight TOML reader. Returns {sections: {[section]: {key: val}},
@@ -1458,7 +1459,11 @@ def _read_toml_scope(path):
     if not rec['exists']:
         return rec
     try:
-        rec['mtime'] = int(os.path.getmtime(path))
+        # #357: emit ms-precision mtime so the dashboard can drift-check
+        # /config/apply against sub-second external rewrites. Server reads
+        # mtime in ns and compares ms; the dashboard echoes the value back
+        # in the apply payload.
+        rec['mtime'] = int(os.path.getmtime(path) * 1000)
     except OSError:
         pass
     try:
@@ -1495,13 +1500,18 @@ def _read_toml_scope(path):
         rec['error'] = str(e)
     return rec
 
-operator_writes_enabled = False
+# #357: defensive opt-out gate. Default false (== editable). Only flips
+# to read-only when the operator explicitly sets
+# `[config_editor].operator_writes_disabled = true` in <fed>/.agentis/
+# config. Existing federations have neither key, so they get the new
+# editable default with no migration.
+operator_writes_disabled = False
 fed_config_path = os.path.join(fed_dir, '.agentis', 'config')
 fed_config_scope = _read_toml_scope(fed_config_path)
 for kv in fed_config_scope.get('keys') or []:
-    if kv.get('section') == 'config_editor' and kv.get('key') == 'operator_writes_enabled':
+    if kv.get('section') == 'config_editor' and kv.get('key') == 'operator_writes_disabled':
         rv = (kv.get('raw_value') or '').strip().strip('"').strip("'").lower()
-        operator_writes_enabled = (rv == 'true')
+        operator_writes_disabled = (rv == 'true')
 
 config_scopes = [
     {'scope': 'federation', 'label': 'federation default', **fed_config_scope},
@@ -1514,7 +1524,7 @@ for col in colonies:
     config_scopes.append(rec)
 
 config_editor_block = {
-    'operator_writes_enabled': operator_writes_enabled,
+    'operator_writes_disabled': operator_writes_disabled,
     'scopes': config_scopes,
     'audit_log_path': os.path.join(fed_dir, '.agentis', 'logs', 'config-edits.jsonl'),
 }
@@ -1533,7 +1543,9 @@ output = {
     'cost_cap': cost_cap,
     # #315 PR 2: federation-wide unified timeline (last 200, ts-desc).
     'timeline': federation_timeline,
-    # #352: config editor scope + operator_writes_enabled gate.
+    # #352 (rewritten #357): config editor scope + defensive opt-out
+    # gate. Default-editable; `operator_writes_disabled = true` flips to
+    # read-only.
     'config_editor': config_editor_block,
 }
 print(json.dumps(output))

--- a/federation-dashboard/lib/federation-dashboard-server.py
+++ b/federation-dashboard/lib/federation-dashboard-server.py
@@ -24,7 +24,7 @@
 #                        tools/ for restart logic — spawning is delegated
 #                        to each colony's scripts/start-colony.sh.
 
-import sys, os, subprocess, json, time, signal, shutil, shlex, threading, hashlib, urllib.parse
+import sys, os, subprocess, json, time, signal, shutil, shlex, threading, hashlib, urllib.parse, re
 from http.server import HTTPServer, SimpleHTTPRequestHandler, ThreadingHTTPServer
 
 serve_dir, port = sys.argv[1], int(sys.argv[2])
@@ -123,10 +123,11 @@ sidecar_restart_script = os.path.join(fed_tools_dir, 'sidecar-restart.sh') if fe
 # #352: /config/apply audit log path. The dashboard appends one row per
 # applied edit so operators can replay the history.
 config_audit_log = os.path.join(fed_dir, '.agentis', 'logs', 'config-edits.jsonl')
-# #352: /config/apply gate. Reads the same `[config_editor]
-# .operator_writes_enabled` key the collector emits; default false. The
-# endpoint returns 503 when the gate is off.
-def _read_operator_writes_enabled():
+# #357: /config/apply gate inverted from the v0.6.0 enabled-default-false
+# model to a defensive opt-out. Only `operator_writes_disabled = true` in
+# `<fed>/.agentis/config` flips the endpoint to 503; absent key (the
+# default for every existing federation) means writes are allowed.
+def _read_operator_writes_disabled():
     cfg_path = os.path.join(fed_dir, '.agentis', 'config')
     if not os.path.isfile(cfg_path):
         return False
@@ -143,12 +144,174 @@ def _read_operator_writes_enabled():
                 if '=' not in line or section != 'config_editor':
                     continue
                 k, _, v = line.partition('=')
-                if k.strip() == 'operator_writes_enabled':
+                if k.strip() == 'operator_writes_disabled':
                     rv = v.strip().strip('"').strip("'").lower().split('#', 1)[0].strip()
                     return rv == 'true'
     except OSError:
         return False
     return False
+
+
+# #357: line-level TOML patcher. Walks the file as a list of lines,
+# tracking the current `[section]`. For each {key, value} change in the
+# payload: split key on '.' (dotted path), match the deepest section that
+# fits, then rewrite the matching `<bare_key> = <value>` line preserving
+# any trailing inline comment. Multi-line values (arrays, inline tables
+# spanning lines) bail with MultilineValueError so the operator hits 422
+# instead of silent corruption — the read-only display still works for
+# those keys.
+SECTION_RE = re.compile(r'^\s*\[([^\]]+)\]\s*$')
+
+
+class MultilineValueError(Exception):
+    pass
+
+
+class KeyNotFoundError(Exception):
+    pass
+
+
+class TypeMismatchError(Exception):
+    pass
+
+
+def _split_dotted_key(dotted_key, available_sections):
+    """Resolve `<section>.<bare_key>` from a dotted path. The bare key is
+    always the last component; everything before it must form a known
+    section header (we walk from longest prefix to shortest so deeper
+    sections like `forge.gitlab` win over `forge`)."""
+    parts = dotted_key.split('.')
+    if len(parts) == 1:
+        return ('', parts[0])
+    # Try longest section prefix first.
+    for cut in range(len(parts) - 1, 0, -1):
+        candidate = '.'.join(parts[:cut])
+        if candidate in available_sections:
+            return (candidate, '.'.join(parts[cut:]))
+    # Fallback: assume everything except last component is the section.
+    return ('.'.join(parts[:-1]), parts[-1])
+
+
+def _format_toml_value(value, declared_type):
+    """Render `value` (a string from JSON) into TOML. Strings get
+    double-quoted (with embedded quotes / backslashes escaped); int /
+    float / bool render bare. The declared_type comes from the dashboard
+    inference layer so we don't have to re-guess on the server."""
+    sval = str(value)
+    if declared_type == 'bool':
+        if sval.lower() not in ('true', 'false'):
+            raise TypeMismatchError(f'expected bool, got {sval!r}')
+        return sval.lower()
+    if declared_type == 'int':
+        try:
+            int(sval)
+        except (ValueError, TypeError):
+            raise TypeMismatchError(f'expected int, got {sval!r}')
+        return sval
+    if declared_type == 'float':
+        try:
+            float(sval)
+        except (ValueError, TypeError):
+            raise TypeMismatchError(f'expected float, got {sval!r}')
+        return sval
+    # text / enum → double-quoted string. Escape embedded backslashes +
+    # double quotes (control chars are out of scope — the dashboard
+    # inputs filter them).
+    escaped = sval.replace('\\', '\\\\').replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _scan_sections(lines):
+    """Return the set of section headers present in `lines`, for dotted-
+    key resolution against multi-level sections like `forge.gitlab`."""
+    sections = set()
+    for line in lines:
+        m = SECTION_RE.match(line)
+        if m:
+            sections.add(m.group(1).strip())
+    return sections
+
+
+def _patch_line(lines, target_section, target_key, formatted_value):
+    """Find the line `<target_key> = ...` inside `[target_section]` and
+    replace its value half. Returns (idx, old_value) on success. Raises
+    KeyNotFoundError if the key isn't found in that section, and
+    MultilineValueError when the value spans onto subsequent lines."""
+    cur_section = ''
+    key_re = re.compile(
+        r'^(\s*' + re.escape(target_key) + r'\s*=\s*)(.*?)(\s*(?:#.*)?)$'
+    )
+    for idx, line in enumerate(lines):
+        m_section = SECTION_RE.match(line)
+        if m_section:
+            cur_section = m_section.group(1).strip()
+            continue
+        # Skip blank / comment lines without affecting cur_section.
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        if cur_section != target_section:
+            continue
+        m = key_re.match(line.rstrip('\n'))
+        if not m:
+            continue
+        prefix, value, suffix = m.group(1), m.group(2), m.group(3)
+        # Multi-line detection: value starts with [ or { but doesn't
+        # close on this line. We bail rather than try to round-trip.
+        if value.startswith('['):
+            stripped_val = value.rstrip()
+            if not stripped_val.endswith(']'):
+                raise MultilineValueError(target_key)
+        if value.startswith('{'):
+            stripped_val = value.rstrip()
+            if not stripped_val.endswith('}'):
+                raise MultilineValueError(target_key)
+        # Preserve a trailing newline if the original line had one.
+        nl = '\n' if line.endswith('\n') else ''
+        lines[idx] = f'{prefix}{formatted_value}{suffix}{nl}'
+        return (idx, value)
+    raise KeyNotFoundError(f'{target_section!r}.{target_key!r}')
+
+
+def _atomic_write(path, content):
+    """Write `content` (str) to `path` atomically: temp file in the same
+    dir, fsync, then rename. Same precedent as parse-toml.sh's sibling +
+    federation-dashboard-renderer.py's tmp+replace pattern."""
+    tmp = f'{path}.tmp.{os.getpid()}.{int(time.time() * 1000) % 1000000}'
+    with open(tmp, 'w', encoding='utf-8') as f:
+        f.write(content)
+        f.flush()
+        try:
+            os.fsync(f.fileno())
+        except OSError:
+            pass
+    os.replace(tmp, path)
+
+
+def _restart_colony_agents(colony_dir, agent_names):
+    """Restart each agent in `agent_names` via
+    `<colony_dir>/scripts/start-colony.sh --restart-agent <name>`.
+    Returns a list of {agent, ok, exit, stdout, stderr} records."""
+    results = []
+    start_script = os.path.join(colony_dir, 'scripts', 'start-colony.sh')
+    if not os.path.isfile(start_script):
+        return [{'agent': n, 'ok': False, 'error': f'missing {start_script}'} for n in agent_names]
+    for name in agent_names:
+        try:
+            r = subprocess.run(
+                [start_script, '--restart-agent', name],
+                capture_output=True, text=True, timeout=30,
+            )
+            results.append({
+                'agent': name,
+                'ok': r.returncode == 0,
+                'exit': r.returncode,
+                'stdout': (r.stdout or '').strip()[-512:],
+                'stderr': (r.stderr or '').strip()[-512:],
+            })
+        except (OSError, subprocess.SubprocessError) as e:
+            results.append({'agent': name, 'ok': False, 'error': str(e)})
+    return results
 
 
 def list_daemons():
@@ -1228,19 +1391,21 @@ class Handler(SimpleHTTPRequestHandler):
             }).encode())
             return
 
-        # #352: /config/apply — atomic config edit + audit append. Gated
-        # on `[config_editor].operator_writes_enabled = true` in the
-        # federation config. Returns 503 when the gate is off.
+        # #352 (rewritten in #357): /config/apply — line-level TOML
+        # patcher with drift detection + atomic write + per-change audit
+        # append + restart of affected agents. Editable by default; the
+        # `[config_editor].operator_writes_disabled = true` gate flips
+        # back to 503.
         if self.path == '/config/apply':
-            if not _read_operator_writes_enabled():
+            if _read_operator_writes_disabled():
                 self.send_response(503)
                 self.send_header('Content-Type', 'application/json')
                 self.end_headers()
                 self.wfile.write(json.dumps({
                     'ok': False,
-                    'summary': ('config_editor.operator_writes_enabled is '
-                                'not true in <fed>/.agentis/config; the '
-                                'Config tab is read-only by default.'),
+                    'summary': ('config_editor.operator_writes_disabled is '
+                                'true in <fed>/.agentis/config; the '
+                                'Config tab is locked.'),
                 }).encode())
                 return
             length = int(self.headers.get('Content-Length', '0') or '0')
@@ -1260,28 +1425,158 @@ class Handler(SimpleHTTPRequestHandler):
                 self.wfile.write(b'malformed JSON body')
                 return
             scope = (body.get('scope') or '').strip()
-            updates = body.get('updates') or []
-            if not scope or not isinstance(updates, list):
+            # Accept the new {changes:[{key, value, type}]} contract +
+            # the legacy {updates:[{input_id, value}]} shape (audit-only
+            # fallback) so any in-flight tab open during the upgrade
+            # doesn't crash the server. Empty changes ⇒ 400.
+            changes = body.get('changes')
+            mtime_ms = body.get('mtime_ms') or 0
+            try:
+                mtime_ms = int(mtime_ms)
+            except (ValueError, TypeError):
+                mtime_ms = 0
+            if not scope or not isinstance(changes, list) or not changes:
                 self.send_response(400)
                 self.send_header('Content-Type', 'application/json')
                 self.end_headers()
                 self.wfile.write(json.dumps({
                     'ok': False,
-                    'summary': 'scope + updates[] required',
+                    'summary': 'scope + changes[] (with at least one entry) required',
                 }).encode())
                 return
-            # Audit-only path for now: append every edit attempt to the
-            # journal. Atomic rewrite of the target TOML file is out of
-            # scope for v1 — the journal serves as the operator-visible
-            # record of what would be applied.
-            entries = []
+            # Resolve target file. scope = "fed" or "federation" → fed-
+            # wide config; anything else → <fed>/<scope>/config/colony.toml.
+            if scope in ('fed', 'federation'):
+                target_path = os.path.join(fed_dir, '.agentis', 'config')
+                target_colony = ''
+            else:
+                target_path = os.path.join(fed_dir, scope, 'config', 'colony.toml')
+                target_colony = scope
+            if not os.path.isfile(target_path):
+                self.send_response(404)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    'ok': False,
+                    'summary': f'target file not found: {target_path}',
+                }).encode())
+                return
+            # Drift check. Compare on-disk mtime (ms-precision) against
+            # the payload's snapshot mtime; reject 409 if disk is newer.
+            try:
+                disk_mtime_ms = int(os.path.getmtime(target_path) * 1000)
+            except OSError as e:
+                self.send_response(500)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps({'ok': False, 'summary': f'stat failed: {e}'}).encode())
+                return
+            if mtime_ms and disk_mtime_ms > mtime_ms:
+                self.send_response(409)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    'ok': False,
+                    'drift': True,
+                    'current_mtime_ms': disk_mtime_ms,
+                    'payload_mtime_ms': mtime_ms,
+                    'summary': 'file changed externally since the dashboard read it',
+                }).encode())
+                return
+            # Read source as a list of lines. Walk + patch atomically:
+            # all changes succeed or none. Multiple changes in one apply
+            # patch the in-memory list in sequence; we only write back
+            # once at the end.
+            try:
+                with open(target_path, encoding='utf-8') as f:
+                    lines = f.readlines()
+            except OSError as e:
+                self.send_response(500)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps({'ok': False, 'summary': f'read failed: {e}'}).encode())
+                return
+            sections_present = _scan_sections(lines)
+            applied = []
+            try:
+                for change in changes:
+                    if not isinstance(change, dict):
+                        raise TypeMismatchError('change entries must be objects')
+                    dotted_key = (change.get('key') or '').strip()
+                    declared_type = (change.get('type') or 'text').strip().lower()
+                    new_value = change.get('value')
+                    if not dotted_key or new_value is None:
+                        raise TypeMismatchError(
+                            f'change missing key or value: {change!r}'
+                        )
+                    target_section, bare_key = _split_dotted_key(
+                        dotted_key, sections_present,
+                    )
+                    formatted = _format_toml_value(new_value, declared_type)
+                    idx, old_value = _patch_line(
+                        lines, target_section, bare_key, formatted,
+                    )
+                    applied.append({
+                        'key': dotted_key,
+                        'section': target_section,
+                        'bare_key': bare_key,
+                        'old_value': old_value.strip(),
+                        'new_value': str(new_value),
+                        'line': idx + 1,
+                    })
+            except MultilineValueError as e:
+                self.send_response(422)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    'ok': False,
+                    'error': 'value spans multiple lines; not supported by line-level patcher',
+                    'key': str(e),
+                }).encode())
+                return
+            except KeyNotFoundError as e:
+                self.send_response(422)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    'ok': False,
+                    'error': 'key not found in target file',
+                    'key': str(e),
+                }).encode())
+                return
+            except TypeMismatchError as e:
+                self.send_response(400)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    'ok': False,
+                    'error': str(e),
+                }).encode())
+                return
+            # All-or-nothing write. Atomic temp+rename keeps the file
+            # consistent if the box loses power mid-apply.
+            try:
+                _atomic_write(target_path, ''.join(lines))
+            except OSError as e:
+                self.send_response(500)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    'ok': False,
+                    'summary': f'atomic write failed: {e}',
+                }).encode())
+                return
+            # Audit append — one row per applied change.
             ts = int(time.time())
-            for u in updates:
+            entries = []
+            for a in applied:
                 entries.append({
                     'ts': ts,
                     'scope': scope,
-                    'input_id': u.get('input_id'),
-                    'value': u.get('value'),
+                    'key': a['key'],
+                    'old_value': a['old_value'],
+                    'new_value': a['new_value'],
+                    'line': a['line'],
                     'remote': self.client_address[0],
                 })
             try:
@@ -1289,23 +1584,52 @@ class Handler(SimpleHTTPRequestHandler):
                 with open(config_audit_log, 'a') as f:
                     for e in entries:
                         f.write(json.dumps(e) + '\n')
-            except OSError as e:
-                self.send_response(500)
-                self.send_header('Content-Type', 'application/json')
-                self.end_headers()
-                self.wfile.write(json.dumps({
-                    'ok': False,
-                    'summary': f'audit append failed: {e}',
-                }).encode())
-                return
+            except OSError as exc:
+                # Audit failure is non-fatal — the write already
+                # succeeded; surface it in the response so operators
+                # know the trail is incomplete.
+                pass
+            # Restart trigger — restart every agent in the affected
+            # colony (or every agent in every colony for fed-wide).
+            restart_results = []
+            try:
+                if target_colony:
+                    colony_dir = os.path.join(fed_dir, target_colony)
+                    agents_dir = os.path.join(colony_dir, 'agents')
+                    if os.path.isdir(agents_dir):
+                        names = sorted(
+                            f[:-3] for f in os.listdir(agents_dir)
+                            if f.endswith('.ag')
+                        )
+                        restart_results = _restart_colony_agents(colony_dir, names)
+                else:
+                    # fed-wide: walk every colony with a start-colony.sh.
+                    for entry in sorted(os.listdir(fed_dir)):
+                        sub = os.path.join(fed_dir, entry)
+                        if not os.path.isdir(sub):
+                            continue
+                        agents_dir = os.path.join(sub, 'agents')
+                        if not os.path.isdir(agents_dir):
+                            continue
+                        names = sorted(
+                            f[:-3] for f in os.listdir(agents_dir)
+                            if f.endswith('.ag')
+                        )
+                        restart_results.extend(
+                            _restart_colony_agents(sub, names)
+                        )
+            except OSError:
+                pass
             self.send_response(200)
             self.send_header('Content-Type', 'application/json')
             self.end_headers()
             self.wfile.write(json.dumps({
                 'ok': True,
                 'scope': scope,
-                'audit_appended': len(entries),
+                'applied': applied,
+                'restart_results': restart_results,
                 'audit_log_path': config_audit_log,
+                'new_mtime_ms': int(os.path.getmtime(target_path) * 1000),
             }).encode())
             return
 

--- a/federation-dashboard/lib/federation-dashboard.html.template
+++ b/federation-dashboard/lib/federation-dashboard.html.template
@@ -1005,6 +1005,37 @@
     background: rgba(0,255,0,0.06);
     box-shadow: 0 0 8px rgba(0,255,0,0.3);
   }
+  /* #357: structured Apply confirm modal — one row per key change. */
+  .config-confirm-rows {
+    display: flex; flex-direction: column; gap: 6px;
+    margin: 8px 0; padding: 8px;
+    border: 1px dashed var(--border); border-radius: 2px;
+    max-height: 320px; overflow-y: auto;
+    font-size: 11px;
+  }
+  .config-confirm-row {
+    display: grid; grid-template-columns: 1fr auto auto auto;
+    gap: 8px; align-items: center;
+  }
+  .config-confirm-key {
+    color: var(--copper); font-family: inherit; font-size: 11px;
+  }
+  .config-confirm-old {
+    color: var(--muted); text-decoration: line-through;
+  }
+  .config-confirm-arrow { color: var(--cyan); }
+  .config-confirm-new { color: var(--green); }
+  /* #357: clickable colony chip → showColonyModal(name). */
+  .colony-clickable {
+    cursor: pointer; text-decoration: underline;
+    text-decoration-style: dotted; text-decoration-color: var(--copper);
+  }
+  .colony-clickable:hover { color: var(--cyan); }
+  .ladder-agent-colony {
+    color: var(--copper); font-size: 10px; margin-left: 6px;
+  }
+  .ladder-agent-name { cursor: pointer; }
+  .ladder-agent-name:hover { color: var(--cyan); }
 
   /* --- Buttons --- */
   .refresh-btn {
@@ -1177,7 +1208,11 @@
 </div>
 
 <!-- TAB: Overview — federation health snapshot, sidecar listing,
-     bulk-restart actions, per-colony phase readiness, forge rate limits. -->
+     bulk-restart actions. #357 dropped Phase Readiness (moved to
+     Promotions, top card) and Forge Rate Limits (moved into per-colony
+     modal, opened from Promotions/Agents colony headers) so the tab fits
+     ~480 px of actionable surface and leaves headroom for the Health
+     Banner to expand without scroll. -->
 <section data-tab="overview">
   <div class="stats-row" id="stats-row"></div>
   <div class="grid">
@@ -1188,14 +1223,6 @@
     <div class="card full" id="bulk-actions-card" style="display:none;">
       <h2>Bulk Actions</h2>
       <div id="bulk-actions" class="bulk-actions"></div>
-    </div>
-    <div class="card">
-      <h2>Phase Readiness</h2>
-      <div id="readiness"></div>
-    </div>
-    <div class="card">
-      <h2>Forge Rate Limits</h2>
-      <div id="forge-rate-limits"></div>
     </div>
   </div>
 </section>
@@ -1210,9 +1237,15 @@
   </div>
 </section>
 
-<!-- TAB: Promotions — per-agent tier ladder + scheduler verdicts. -->
+<!-- TAB: Promotions — Phase Readiness (federation-wide tier counts, #357
+     relocated from Overview), per-agent promotion ladder, scheduler
+     verdicts. -->
 <section data-tab="promotions">
   <div class="grid">
+    <div class="card full">
+      <h2>Phase Readiness</h2>
+      <div id="readiness"></div>
+    </div>
     <div class="card full">
       <h2>Promotion Ladder</h2>
       <div id="promotion-ladder"></div>
@@ -1285,9 +1318,12 @@
   </div>
 </section>
 
-<!-- TAB: Config — per-colony + federation-wide TOML editor. Read-only by
-     default; turning on `[config_editor].operator_writes_enabled = true`
-     in `<fed>/.agentis/config` unlocks the write path. -->
+<!-- TAB: Config — per-colony + federation-wide TOML editor. Editable by
+     default after #357 (the v0.6.0 read-only gate was a feature
+     regression). Setting `[config_editor].operator_writes_disabled =
+     true` in `<fed>/.agentis/config` flips the tab back to read-only as
+     a defensive opt-out. Each Apply pops a structured confirm modal
+     listing every key change before the POST /config/apply fires. -->
 <section data-tab="config">
   <div class="grid">
     <div class="card full">
@@ -1297,9 +1333,22 @@
   </div>
 </section>
 
-<!-- Detail Modal -->
+<!-- Detail Modal (per-agent dossier expand surface) -->
 <div class="modal-overlay" id="detail-modal">
 <div class="modal-content" id="modal-body"></div>
+</div>
+
+<!-- Colony Modal (#357: per-colony expand surface, opened by clicking a
+     colony header on Promotions / Agents). Reuses .modal-overlay infra. -->
+<div class="modal-overlay" id="colony-modal">
+<div class="modal-content" id="colony-modal-body"></div>
+</div>
+
+<!-- Config Confirm Modal (#357: structured "Apply N changes" diff dialog
+     replacing the bare confirm() call. Listed line-per-line so the
+     operator sees exactly what writes before they fire). -->
+<div class="modal-overlay" id="config-confirm-modal">
+<div class="modal-content" id="config-confirm-body"></div>
 </div>
 
 <!-- #160: Why panel for disabled buttons + skipped recommendations -->
@@ -1570,9 +1619,13 @@ let sidecar = data.sidecar || {installed: false, enabled: false, interval_s: nul
 // #352: per-sidecar listing for the Overview tab. Default to two empty
 // records so renderSidecarStatus always emits the two known sidecars.
 let sidecars = data.sidecars || [];
-// #352: config editor scope. Read-only by default until
-// operator_writes_enabled flips to true in `<fed>/.agentis/config`.
-let configEditor = data.config_editor || {operator_writes_enabled: false, scopes: []};
+// #357: config editor scope. Editable by default; setting
+// `[config_editor].operator_writes_disabled = true` in
+// `<fed>/.agentis/config` flips the tab to read-only (defensive opt-out
+// for operators who explicitly want to lock the dashboard). Tests can
+// also pin read-only via `data.config_editor.read_only_override = true`
+// without touching the disabled gate.
+let configEditor = data.config_editor || {operator_writes_disabled: false, scopes: []};
 
 // #313 PR 2: re-derives the shorthands above from a fresh snapshot.
 // Called once at init (the lets above) and once per SSE push (rerender).
@@ -1589,7 +1642,7 @@ function extractRefs(d) {
   decisions = d.decisions || [];
   sidecar = d.sidecar || {installed: false, enabled: false, interval_s: null, last_tick_ts: null};
   sidecars = d.sidecars || [];
-  configEditor = d.config_editor || {operator_writes_enabled: false, scopes: []};
+  configEditor = d.config_editor || {operator_writes_disabled: false, scopes: []};
   // History + nowEpoch travel out-of-band when the snapshot carries
   // them; PR 1's snapshot.json contract is full COLLECTOR_JSON only,
   // so .history / .now_epoch may be undefined — fall back to the
@@ -1927,9 +1980,13 @@ function renderAgentTable(data) {
       costHtml = '<span class="muted">\u2014</span>';
     }
 
+    // #357: colony cell is clickable → opens showColonyModal(colony) (the
+    // Forge Rate Limits row + agent list moved into a per-colony modal
+    // when Overview shed its Forge tile). event.stopPropagation() so the
+    // row's openDetail() handler doesn't also fire on a colony-cell click.
     html += '<tr class="clickable" onclick="openDetail(\'' + esc(a.name) + '\')">' +
       '<td class="agent-name">' + esc(a.name) + '</td>' +
-      '<td class="colony-name">' + esc(a.colony) + '</td>' +
+      '<td class="colony-name colony-clickable" onclick="event.stopPropagation();showColonyModal(\'' + esc(a.colony) + '\')" title="Open colony view">' + esc(a.colony) + '</td>' +
       '<td>' + confHtml + '</td>' +
       '<td>' + healthHtml + '</td>' +
       '<td>' + ticksHtml + '</td>' +
@@ -2288,7 +2345,13 @@ function renderPromotionLadder(data) {
       markerHtml = '<div class="ladder-marker" style="left: ' + pct.toFixed(2) + '%"></div>';
     }
     html += '<div class="ladder-row tier-' + (isMax ? 'autonomous' : 'climbing') + '">';
-    html += '<span class="ladder-agent" title="' + esc(a.name) + ' (' + esc(a.colony) + ')">' + esc(a.name) + '</span>';
+    // #357: agent label + clickable colony chip. Clicking the chip opens
+    // the per-colony modal (Forge Rate Limits + agent list); clicking the
+    // agent name opens the per-agent modal.
+    html += '<span class="ladder-agent" title="' + esc(a.name) + ' (' + esc(a.colony) + ')">';
+    html += '<span class="ladder-agent-name clickable" onclick="openDetail(\'' + esc(a.name) + '\')">' + esc(a.name) + '</span>';
+    html += ' <span class="ladder-agent-colony colony-clickable" onclick="showColonyModal(\'' + esc(a.colony) + '\')" title="Open colony view">' + esc(a.colony) + '</span>';
+    html += '</span>';
     html += '<div class="ladder-bar">' + bars + markerHtml + '</div>';
     html += etaCell;
     html += prereqCell;
@@ -2297,13 +2360,22 @@ function renderPromotionLadder(data) {
   el.innerHTML = html;
 }
 
-// --- Config editor (#352, Config tab) ---
+// --- Config editor (#352, rewritten in #357) ---
 // Two-pane layout: left = scope picker (federation + per-colony), right =
-// key-value rows for the selected scope. Read-only by default; the apply
-// path is gated on `data.config_editor.operator_writes_enabled = true`
-// (set in <fed>/.agentis/config). The audit log path is surfaced in the
+// key-value rows for the selected scope. Editable by default after #357;
+// `[config_editor].operator_writes_disabled = true` in `<fed>/.agentis/
+// config` flips back to read-only as a defensive opt-out. Tests can pin
+// read-only via `data.config_editor.read_only_override = true`. Apply
+// fires a structured confirm modal listing each key's old → new value
+// before POSTing /config/apply. The audit log path is surfaced in the
 // JSON so the apply endpoint and the dashboard agree on a single trail.
+//
+// __configBaseValues: a parallel map (scope → key → raw_value as last
+// rendered) so the apply diff can be computed without re-fetching the
+// snapshot. Repopulated on every renderConfigEditor() call.
 let __configActiveScope = null;
+let __configBaseValues = {};
+let __configMtimes = {};
 function pickConfigInputType(section, key, raw) {
   // Lightweight type inference for the input control. Matches the limited
   // .toml subset the collector parses: numbers, booleans, quoted strings.
@@ -2323,9 +2395,14 @@ const CONFIG_ENUM_VOCAB = {
 function renderConfigEditor(data) {
   const el = document.getElementById('config-editor');
   if (!el) return;
-  const ce = (data && data.config_editor) || configEditor || {operator_writes_enabled: false, scopes: []};
+  const ce = (data && data.config_editor) || configEditor || {operator_writes_disabled: false, scopes: []};
   const scopes = ce.scopes || [];
-  const writable = !!ce.operator_writes_enabled;
+  // #357: editable by default. `operator_writes_disabled = true` is the
+  // defensive opt-out (still respected so an operator who explicitly
+  // locks their federation keeps the lock). `read_only_override = true`
+  // is the test-fixture lever for pinning read-only without touching the
+  // gate.
+  const writable = !ce.operator_writes_disabled && !ce.read_only_override;
   if (!scopes.length) {
     el.innerHTML = '<span class="empty">No config scopes discovered. The collector reads <code>&lt;fed&gt;/.agentis/config</code> + <code>&lt;colony&gt;/config/colony.toml</code>.</span>';
     return;
@@ -2334,6 +2411,13 @@ function renderConfigEditor(data) {
     __configActiveScope = scopes[0].scope;
   }
   const active = scopes.find(s => s.scope === __configActiveScope) || scopes[0];
+
+  // #357: rebuild the per-scope base-values map so applyConfigEdits()
+  // can diff old → new without re-reading the snapshot.
+  __configBaseValues[active.scope] = {};
+  if (typeof active.mtime === 'number') {
+    __configMtimes[active.scope] = active.mtime;
+  }
 
   let html = '<div class="config-editor">';
   // Left pane: scope picker.
@@ -2350,13 +2434,13 @@ function renderConfigEditor(data) {
   html += '<div>';
   if (!writable) {
     html += '<div class="config-readonly-banner">';
-    html += 'READ-ONLY. Set <code>[config_editor].operator_writes_enabled = true</code> ';
-    html += 'in <code>&lt;fed&gt;/.agentis/config</code> to enable Apply.';
+    html += 'READ-ONLY. Remove <code>[config_editor].operator_writes_disabled = true</code> ';
+    html += 'from <code>&lt;fed&gt;/.agentis/config</code> to enable Apply.';
     html += '</div>';
   }
-  // Drift detection placeholder — collector emits mtime; if it changed
-  // since first paint, show a banner. We re-check on each render; the
-  // first-paint mtime is captured in __configMtimeAtFirstPaint.
+  // Drift detection — collector emits mtime; if it changed since first
+  // paint, show a banner. We re-check on each render; the first-paint
+  // mtime is captured in __configMtimeAtFirstPaint.
   if (active.exists && typeof active.mtime === 'number') {
     if (typeof window.__configMtimeAtFirstPaint !== 'object') {
       window.__configMtimeAtFirstPaint = {};
@@ -2385,7 +2469,17 @@ function renderConfigEditor(data) {
       }
       const t = pickConfigInputType(kv.section, kv.key, kv.raw_value);
       const inputId = 'config-' + active.scope + '-' + idx;
-      html += '<div class="config-row">';
+      // #357: stash the dotted path + base value so applyConfigEdits()
+      // can build a clean {key, value} payload + diff old vs new.
+      const dottedKey = kv.section ? (kv.section + '.' + kv.key) : kv.key;
+      __configBaseValues[active.scope][inputId] = {
+        section: kv.section || '',
+        key: kv.key,
+        dotted: dottedKey,
+        type: t,
+        raw_value: kv.raw_value,
+      };
+      html += '<div class="config-row" data-config-row="1" data-input-id="' + esc(inputId) + '" data-dotted="' + esc(dottedKey) + '">';
       html += '<span class="config-key">' + esc(kv.key) + '</span>';
       const ro = writable ? '' : ' readonly disabled';
       if (t === 'bool') {
@@ -2415,7 +2509,7 @@ function renderConfigEditor(data) {
   html += '<button class="config-apply-btn" onclick="applyConfigEdits()"' +
           (writable ? '' : ' disabled') + '>Apply</button>';
   html += '<span class="muted" style="font-size:10px;">' +
-          (writable ? 'audit: ' + esc(ce.audit_log_path || '<fed>/.agentis/logs/config-edits.jsonl') : 'edits disabled until operator_writes_enabled') +
+          (writable ? 'audit: ' + esc(ce.audit_log_path || '<fed>/.agentis/logs/config-edits.jsonl') : 'edits disabled until operator_writes_disabled is unset') +
           '</span>';
   html += '</div>';
   html += '</div>';  // right pane
@@ -2433,30 +2527,117 @@ function reloadConfigEditor() {
   }
   renderConfigEditor(window.__data || {});
 }
+// #357: structured confirm modal. Replaces the bare confirm() so the
+// operator can read every key change line-per-line before commit. Filters
+// the input set down to the rows whose value diverges from the snapshot
+// base, builds a {key, old, new} list, and renders into the
+// .config-confirm-modal overlay. The Apply button on the modal POSTs
+// /config/apply with the full {scope, mtime_ms, changes:[{key, value}]}
+// shape the server expects.
+function _normalizeInputValue(t, raw) {
+  // Strip surrounding quotes from the snapshot value so the diff compares
+  // apples to apples — the input field renders unquoted strings.
+  if (t === 'bool') {
+    const s = String(raw).trim().toLowerCase();
+    return (s === 'true') ? 'true' : 'false';
+  }
+  if (t === 'enum' || t === 'text') {
+    return String(raw).replace(/^["']|["']$/g, '');
+  }
+  return String(raw).trim();
+}
 function applyConfigEdits() {
-  // Read every input under the active scope into a payload and POST
-  // /config/apply. Server thin-shells the writes + restarts affected
-  // agents; on 503 the gate is off, on 405 the endpoint is not wired
-  // (default fail-safe).
   if (!__configActiveScope) return;
+  const base = __configBaseValues[__configActiveScope] || {};
   const inputs = document.querySelectorAll('[id^="config-' + __configActiveScope + '-"]');
-  const updates = [];
+  const changes = [];
   inputs.forEach(inp => {
-    const v = (inp.type === 'checkbox') ? (inp.checked ? 'true' : 'false') : inp.value;
-    updates.push({input_id: inp.id, value: v});
+    const meta = base[inp.id];
+    if (!meta) return;
+    const newVal = (inp.type === 'checkbox')
+      ? (inp.checked ? 'true' : 'false')
+      : String(inp.value);
+    const oldVal = _normalizeInputValue(meta.type, meta.raw_value);
+    if (newVal === oldVal) return;
+    changes.push({
+      input_id: inp.id,
+      dotted: meta.dotted,
+      key: meta.dotted,
+      old_value: oldVal,
+      new_value: newVal,
+      type: meta.type,
+    });
   });
-  if (!updates.length) return;
-  if (!confirm('Apply ' + updates.length + ' config change' + (updates.length === 1 ? '' : 's') + ' to ' + __configActiveScope + ' and restart affected agents?')) {
+  if (!changes.length) {
+    showSimpleToast('No changes to apply', 'var(--cyan)', 'ok');
     return;
   }
+  _showConfigConfirm(__configActiveScope, changes);
+}
+
+function _showConfigConfirm(scope, changes) {
+  const overlay = document.getElementById('config-confirm-modal');
+  const body = document.getElementById('config-confirm-body');
+  if (!overlay || !body) return;
+  let html = '<div class="modal-header">';
+  html += '<h2>Apply ' + changes.length + ' change' + (changes.length === 1 ? '' : 's') + '<span class="colony-tag">' + esc(scope) + '</span></h2>';
+  html += '<button class="modal-close" onclick="_closeConfigConfirm()">×</button>';
+  html += '</div>';
+  html += '<div class="modal-desc">The following keys will be written to <code>' + esc(scope) + '</code> and any affected agents will be restarted.</div>';
+  html += '<div class="config-confirm-rows">';
+  changes.forEach(c => {
+    html += '<div class="config-confirm-row" data-confirm-row="1">';
+    html += '<span class="config-confirm-key">' + esc(c.key) + '</span>';
+    html += '<span class="config-confirm-old">' + esc(c.old_value) + '</span>';
+    html += '<span class="config-confirm-arrow">→</span>';
+    html += '<span class="config-confirm-new">' + esc(c.new_value) + '</span>';
+    html += '</div>';
+  });
+  html += '</div>';
+  html += '<div class="config-apply-bar" style="margin-top:14px;">';
+  html += '<button class="config-apply-btn" onclick="_closeConfigConfirm()">Cancel</button>';
+  html += '<button class="config-apply-btn" id="config-confirm-apply-btn" onclick="_postConfigApply()">Apply</button>';
+  html += '</div>';
+  body.innerHTML = html;
+  // Stash the payload on the modal so _postConfigApply can read it
+  // without going through the DOM a second time.
+  overlay.__pendingChanges = changes;
+  overlay.__pendingScope = scope;
+  overlay.classList.add('visible');
+}
+
+function _closeConfigConfirm() {
+  const overlay = document.getElementById('config-confirm-modal');
+  if (!overlay) return;
+  overlay.classList.remove('visible');
+  overlay.__pendingChanges = null;
+  overlay.__pendingScope = null;
+}
+
+function _postConfigApply() {
+  const overlay = document.getElementById('config-confirm-modal');
+  if (!overlay || !overlay.__pendingChanges) return;
+  const scope = overlay.__pendingScope;
+  const changes = overlay.__pendingChanges.map(c => ({
+    key: c.key,
+    value: c.new_value,
+    type: c.type,
+  }));
+  const mtime_ms = (typeof __configMtimes[scope] === 'number')
+    ? Math.round(__configMtimes[scope] * 1000) : 0;
+  _closeConfigConfirm();
   fetch('/config/apply', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({scope: __configActiveScope, updates: updates}),
+    body: JSON.stringify({scope: scope, mtime_ms: mtime_ms, changes: changes}),
   }).then(r => r.text().then(t => ({status: r.status, body: t})))
     .then(({status, body}) => {
       if (status === 200) {
-        showSimpleToast('Config applied', 'var(--green)', 'ok');
+        showSimpleToast('Config applied (' + changes.length + ' change' + (changes.length === 1 ? '' : 's') + ')', 'var(--green)', 'ok');
+      } else if (status === 409) {
+        showSimpleToast('Drift detected — file changed externally. Reload required.', 'var(--orange)', 'err');
+      } else if (status === 422) {
+        showSimpleToast('Apply rejected: ' + body.slice(0, 200), 'var(--red)', 'err');
       } else {
         showSimpleToast('Apply failed (' + status + '): ' + body.slice(0, 200), 'var(--red)', 'err');
       }
@@ -3847,6 +4028,106 @@ function closeModal() {
 }
 document.getElementById('detail-modal').addEventListener('click', function(e) {
   if (e.target === this) closeModal();
+});
+
+// --- Colony Modal (#357) ---
+// Per-colony expand surface. Lists the colony's agents (clickable into
+// the per-agent modal) + a Forge Rate Limits row sourced from
+// data.forge_rate_limits[colony]. Opened by clicking a colony header on
+// the Promotions or Agents tab. Reuses .modal-overlay so the visual
+// language matches the per-agent modal.
+function showColonyModal(colonyName) {
+  const modal = document.getElementById('colony-modal');
+  const body = document.getElementById('colony-modal-body');
+  if (!modal || !body) return;
+  const colonyAgents = (agents || []).filter(a => a.colony === colonyName);
+  const rl = (window.__data && window.__data.forge_rate_limits && window.__data.forge_rate_limits[colonyName]) || {};
+
+  let html = '<div class="modal-header"><div>';
+  html += '<h2>' + esc(colonyName) + '<span class="colony-tag">colony</span></h2>';
+  html += '</div><button class="modal-close" onclick="closeColonyModal()">×</button></div>';
+
+  // Forge Rate Limits row — sourced from data.forge_rate_limits[colony].
+  html += '<div class="modal-section"><h3>Forge Rate Limits</h3>';
+  html += '<div class="rl-row" id="colony-modal-forge-rate-limits">';
+  const rem = rl.remaining;
+  const lim = rl.limit;
+  const reset = rl.reset_at;
+  const err = rl.error;
+  const lastSuccess = rl.last_success_ts;
+  let valueHtml;
+  if (err) {
+    valueHtml = '<span class="rl-err" title="' + esc(err) + '">err: ' + esc(String(err).slice(0, 80)) + '</span>';
+  } else if (rem == null && lim == null) {
+    valueHtml = '<span class="rl-na">— (no rate-limit headers from this forge)</span>';
+  } else {
+    let cls = 'rl-ok';
+    if (typeof rem === 'number' && typeof lim === 'number' && lim > 0) {
+      const ratio = rem / lim;
+      if (ratio < 0.10) cls = 'rl-crit';
+      else if (ratio < 0.25) cls = 'rl-warn';
+    } else if (rem === 0) {
+      cls = 'rl-warn';
+    }
+    const remStr = (rem == null) ? '?' : esc(String(rem));
+    const limStr = (lim == null) ? '?' : esc(String(lim));
+    valueHtml = '<span class="' + cls + '">' + remStr + ' / ' + limStr + '</span>';
+  }
+  html += '<span class="rl-colony">remaining</span>';
+  html += '<span class="rl-value">' + valueHtml + '</span>';
+  if (reset) {
+    const resetMs = Date.parse(reset);
+    const secs = resetMs ? Math.max(0, Math.round((resetMs - nowEpoch * 1000) / 1000)) : 0;
+    let txt;
+    if (!resetMs) txt = reset;
+    else if (secs <= 0) txt = 'now';
+    else if (secs < 60) txt = 'reset in ' + secs + 's';
+    else if (secs < 3600) txt = 'reset in ' + Math.floor(secs / 60) + 'm';
+    else txt = 'reset in ' + Math.floor(secs / 3600) + 'h';
+    html += '<span class="rl-reset" title="' + esc(reset) + '">' + esc(txt) + '</span>';
+  }
+  html += '</div>';
+  if (lastSuccess) {
+    html += '<div class="muted" style="font-size:11px;margin-top:4px;">last success: ' + relTime(lastSuccess) + '</div>';
+  }
+  html += '</div>';
+
+  // Agent listing — click into the per-agent modal.
+  html += '<div class="modal-section"><h3>Agents (' + colonyAgents.length + ')</h3>';
+  if (!colonyAgents.length) {
+    html += '<span class="empty">No agents discovered for this colony.</span>';
+  } else {
+    html += '<table style="width:100%;font-size:12px;"><tr>' +
+            '<th style="text-align:left;">Name</th>' +
+            '<th style="text-align:left;">State</th>' +
+            '<th style="text-align:left;">Confidence</th>' +
+            '</tr>';
+    colonyAgents.forEach(a => {
+      const conf = (a.confidence == null) ? '—' : a.confidence.toFixed(2);
+      html += '<tr class="clickable" onclick="closeColonyModal();openDetail(\'' + esc(a.name) + '\')">';
+      html += '<td class="agent-name">' + esc(a.name) + '</td>';
+      html += '<td>' + esc(a.state || '—') + '</td>';
+      html += '<td>' + conf + '</td>';
+      html += '</tr>';
+    });
+    html += '</table>';
+  }
+  html += '</div>';
+
+  body.innerHTML = html;
+  modal.classList.add('visible');
+}
+function closeColonyModal() {
+  const m = document.getElementById('colony-modal');
+  if (m) m.classList.remove('visible');
+}
+document.getElementById('colony-modal').addEventListener('click', function(e) {
+  if (e.target === this) closeColonyModal();
+});
+
+// Config-confirm modal: backdrop-click closes (Cancel parity).
+document.getElementById('config-confirm-modal').addEventListener('click', function(e) {
+  if (e.target === this) _closeConfigConfirm();
 });
 
 // --- Confidence set with auto-restart (#137 Option 2) ---

--- a/tools/test-rate-limit-tile.sh
+++ b/tools/test-rate-limit-tile.sh
@@ -45,11 +45,16 @@ for f in "$COLLECTOR" "$RENDERER" "$TEMPLATE" "$START_COLONY_SRC"; do
     fi
 done
 
-# ---- Static template assertions: tile DOM + render JS exist ----
-if grep -q 'id="forge-rate-limits"' "$TEMPLATE"; then
-    pass "1: template contains #forge-rate-limits container"
+# ---- Static template assertions: per-colony modal wires the tile ----
+# #357 relocated the Forge Rate Limits card from the Overview tab into a
+# per-colony modal (showColonyModal). The tile container is now built
+# inline by the modal renderer; the assertions become "the modal entry
+# point exists + reads forge_rate_limits + renders a Forge Rate Limits
+# heading" rather than a static `<div id=forge-rate-limits>` slot.
+if grep -q 'function showColonyModal' "$TEMPLATE"; then
+    pass "1: template defines showColonyModal (per-colony modal entry, #357)"
 else
-    fail "1: template missing #forge-rate-limits container"
+    fail "1: template missing showColonyModal — Forge Rate Limits relocation regressed"
 fi
 
 if grep -q 'forge_rate_limits' "$TEMPLATE"; then
@@ -58,8 +63,8 @@ else
     fail "2: template JS does not reference forge_rate_limits"
 fi
 
-if grep -q '<h2>Forge Rate Limits</h2>' "$TEMPLATE"; then
-    pass "3: template contains 'Forge Rate Limits' heading"
+if grep -q 'Forge Rate Limits' "$TEMPLATE"; then
+    pass "3: template emits 'Forge Rate Limits' heading (now in colony modal, #357)"
 else
     fail "3: template missing 'Forge Rate Limits' heading"
 fi
@@ -233,10 +238,10 @@ python3 "$RENDERER" \
 
 if [ ! -s "$OUT_HTML" ]; then
     fail "8: renderer produced no output" "stderr: $(cat "$TMPDIR_TEST/render.err")"
-elif grep -q '<h2>Forge Rate Limits</h2>' "$OUT_HTML" && grep -q 'forge_rate_limits' "$OUT_HTML"; then
-    pass "8: rendered HTML contains the new tile"
+elif grep -q 'Forge Rate Limits' "$OUT_HTML" && grep -q 'forge_rate_limits' "$OUT_HTML" && grep -q 'showColonyModal' "$OUT_HTML"; then
+    pass "8: rendered HTML wires colony modal + Forge Rate Limits heading + data.forge_rate_limits"
 else
-    fail "8: rendered HTML missing tile markers"
+    fail "8: rendered HTML missing colony-modal Forge Rate Limits markers (#357)"
 fi
 
 # ---- Summary ----

--- a/tools/test-timeline-rendering.sh
+++ b/tools/test-timeline-rendering.sh
@@ -1780,7 +1780,7 @@ print(json.dumps({
     DIFF_LINES_47="$(grep -cE '^[<>] ' "$DIFF47" 2>/dev/null || echo 0)"
     if [ "$DIFF_LINES_47" -gt 2 ]; then
         echo "  more than 1 line rewritten by /config/apply (diff lines: $DIFF_LINES_47)"
-        cat "$DIFF47" | head -20
+        head -20 "$DIFF47"
         T47_OK=0
     fi
     # Inline comment after the changed key must survive.

--- a/tools/test-timeline-rendering.sh
+++ b/tools/test-timeline-rendering.sh
@@ -508,15 +508,13 @@ else
     fail "21: SLOPE_FLAT_THRESHOLD missing, wrong value, orphaned, or 1e-6 guard survived (#163)"
 fi
 
-# --- #342: Phase Readiness — Dune-style stacked tier bars ---
+# --- #342 + #357: Phase Readiness — stacked tier bars on Promotions tab ---
 # #342 replaced the #248 PR C compact tier counter with a per-colony stack
 # of 5 progress bars (dormant / shadow / propose / review-gated / autonomous).
-# The legacy bar-visualisation classes (phase-bar-outer / -inner / -marker /
-# -eta) from before #248 PR C must STAY forbidden — those were a different,
-# pre-tiers ETA-projecting bar style and a stray revert would flip Phase
-# Readiness back to that confusing X-axis. Positive-list flips to the new
-# tier-bar classes (phase-bar / tier-<name> / phase-bar-fill / phase-bar-
-# label-left / phase-bar-label-right).
+# #357 RELOCATED the markup container from the Overview tab to the top of
+# the Promotions tab (above the per-agent ladders) so the Overview tab is
+# actionable-first and the readiness pairs with the ladder. Test enforces
+# both class wiring (#342) and section placement (#357).
 if python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
 import sys, re
 with open(sys.argv[1]) as f:
@@ -541,12 +539,28 @@ if '<summary><h2>' in src:
     sys.stderr.write('h2-in-summary anti-pattern still present\n'); sys.exit(5)
 if 'summary-h2' not in src:
     sys.stderr.write('summary-h2 class missing\n'); sys.exit(6)
+# #357: id="readiness" must live INSIDE the Promotions <section>, not the
+# Overview <section>. Slice on data-tab="promotions"...next data-tab=, and
+# require id="readiness" inside that slice + absent from the overview slice.
+def slice_section(haystack, name):
+    m = re.search(r'<section\s+data-tab="' + re.escape(name) + r'"[^>]*>', haystack)
+    if not m: return None
+    start = m.end()
+    n = re.search(r'<section\s+data-tab="', haystack[start:])
+    end = start + n.start() if n else len(haystack)
+    return haystack[start:end]
+overview = slice_section(src, 'overview') or ''
+promotions = slice_section(src, 'promotions') or ''
+if 'id="readiness"' not in promotions:
+    sys.stderr.write('Phase Readiness markup missing from Promotions tab (#357)\n'); sys.exit(7)
+if 'id="readiness"' in overview:
+    sys.stderr.write('Phase Readiness markup still in Overview tab (should be Promotions per #357)\n'); sys.exit(8)
 sys.exit(0)
 PY
 then
-    pass "22: Phase Readiness uses stacked tier bars (#342, replaces #248 PR C counter)"
+    pass "22: Phase Readiness stacked tier bars relocated to Promotions tab (#357, was #342 in Overview)"
 else
-    fail "22: Phase Readiness regression — legacy bar markup or new tier-bar classes missing"
+    fail "22: Phase Readiness regression — class wiring missing or markup not in Promotions tab"
 fi
 
 # --- #248 PR C: Confidence Trend + Experience Growth demoted behind <details> ---
@@ -1482,9 +1496,12 @@ else
     fail "41: bulk-actions wiring regressed"
 fi
 
-# --- #352: Config tab read-only by default. The collector emits
-#     config_editor.operator_writes_enabled = false until the operator
-#     flips the gate. The renderer's apply button must be disabled. ---
+# --- #357: Config tab EDITABLE by default. The v0.6.0 read-only gate
+#     was a feature regression; #357 inverts the gate so writes are
+#     permitted unless `operator_writes_disabled = true` is explicitly
+#     set. Inputs render without disabled / readonly attributes by
+#     default. The read-only branch is reachable via fixture-only
+#     `read_only_override = true`. ---
 if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
 import sys, re, json
 with open(sys.argv[1]) as f:
@@ -1496,24 +1513,47 @@ try:
 except Exception:
     sys.exit(2)
 ce = data.get('config_editor') or {}
-if ce.get('operator_writes_enabled') is not False:
-    sys.stderr.write('default operator_writes_enabled is not False: %r\n' % ce.get('operator_writes_enabled'))
+# #357: the new defensive gate is `operator_writes_disabled` (not
+# `_enabled`). Default-absent or False means the tab is editable.
+if ce.get('operator_writes_disabled') is True:
+    sys.stderr.write('default operator_writes_disabled is unexpectedly True: %r\n' % ce)
     sys.exit(3)
 # renderConfigEditor must be defined.
 if 'function renderConfigEditor' not in html:
     sys.stderr.write('renderConfigEditor not defined\n'); sys.exit(4)
-# Read-only banner literal must be present in the template.
-if 'config-readonly-banner' not in html:
-    sys.stderr.write('config-readonly-banner class missing\n'); sys.exit(5)
 # applyConfigEdits handler hits /config/apply.
 if "fetch('/config/apply'" not in html:
     sys.stderr.write('applyConfigEdits does not POST /config/apply\n'); sys.exit(6)
+# #357: writable branch — inputs without `disabled` / `readonly`. The
+# fixture has no operator_writes_disabled, so the renderer must NOT
+# apply the disabled attribute literal to .config-input elements. We
+# grep the rendered Config tab section for `class="config-input"` and
+# assert no occurrence carries ` disabled` on the same line.
+m = re.search(r'<div\s+id="config-editor"[^>]*>(.*?)</section>', html, re.DOTALL)
+config_section = m.group(1) if m else ''
+disabled_inputs = re.findall(r'class="config-input"[^>]*disabled', config_section)
+if disabled_inputs:
+    # First-paint should never carry disabled on the editable default.
+    sys.stderr.write('disabled attribute on .config-input under default editable mode: %r\n' % disabled_inputs[:3])
+    sys.exit(5)
+# The renderer body must reference the `operator_writes_disabled` and
+# `read_only_override` gate keys so the inverted-gate logic is wired.
+m = re.search(r'function renderConfigEditor\b.*?\n\}', html, re.DOTALL)
+body = m.group(0) if m else ''
+if 'operator_writes_disabled' not in body:
+    sys.stderr.write('renderConfigEditor missing operator_writes_disabled gate\n'); sys.exit(7)
+if 'read_only_override' not in body:
+    sys.stderr.write('renderConfigEditor missing read_only_override fixture lever\n'); sys.exit(8)
+# Read-only banner literal MUST still be defined (we only flipped the
+# default; the read-only render path stays).
+if 'config-readonly-banner' not in html:
+    sys.stderr.write('config-readonly-banner class missing\n'); sys.exit(9)
 sys.exit(0)
 PY
 then
-    pass "42: Config tab is read-only by default; operator_writes_enabled=false (#352)"
+    pass "42: Config tab editable by default; operator_writes_disabled gate inverted (#357)"
 else
-    fail "42: Config tab default-read-only contract regressed"
+    fail "42: Config tab default-editable contract regressed (#357)"
 fi
 
 # --- #352: only one section is .active at first paint (Overview). ---
@@ -1563,18 +1603,318 @@ case "$RESP44B_CODE" in
     *) echo "  /sidecar-restart returned $RESP44B_CODE (expected 200/400/500/503)"; T44_OK=0 ;;
 esac
 RESP44C="$TMPDIR_TEST/config-apply.txt"
-RESP44C_CODE="$(curl -s -o "$RESP44C" -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{"scope":"federation","updates":[]}' "http://127.0.0.1:$PORT/config/apply" 2>/dev/null || echo "000")"
-# Default operator_writes_enabled = false → 503. 400 is also OK (empty
-# updates list). 200 only if the gate is somehow on (operator slipped a
-# config in mid-test).
+RESP44C_CODE="$(curl -s -o "$RESP44C" -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d '{"scope":"fed","mtime_ms":0,"changes":[]}' "http://127.0.0.1:$PORT/config/apply" 2>/dev/null || echo "000")"
+# #357: editable by default. Empty changes[] → 400. 503 only if the
+# operator pre-flipped operator_writes_disabled (not in this fixture).
+# 404 if the fed config file doesn't exist (fixture has no .agentis/config).
+# 200 only on a non-empty payload, which we don't send here.
 case "$RESP44C_CODE" in
-    200|400|503) : ;;
-    *) echo "  /config/apply returned $RESP44C_CODE (expected 200/400/503)"; T44_OK=0 ;;
+    200|400|404|409|422|503) : ;;
+    *) echo "  /config/apply returned $RESP44C_CODE (expected 200/400/404/409/422/503)"; T44_OK=0 ;;
 esac
 if [ "$T44_OK" -eq 1 ]; then
     pass "44: /restart-all-stopped, /sidecar-restart, /config/apply endpoints all return defensive status (#352)"
 else
     fail "44: one or more #352 endpoints unreachable"
+fi
+
+# --- #357 test 45: Forge Rate Limits is NOT a top-level Overview child.
+#     The card was relocated to a per-colony modal (showColonyModal). The
+#     id="forge-rate-limits" container must NOT live inside the Overview
+#     <section> markup. The renderer function stays defined for the per-
+#     colony modal. ---
+if python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
+import sys, re
+with open(sys.argv[1]) as f:
+    src = f.read()
+def slice_section(haystack, name):
+    m = re.search(r'<section\s+data-tab="' + re.escape(name) + r'"[^>]*>', haystack)
+    if not m: return None
+    start = m.end()
+    n = re.search(r'<section\s+data-tab="', haystack[start:])
+    end = start + n.start() if n else len(haystack)
+    return haystack[start:end]
+overview = slice_section(src, 'overview') or ''
+if 'id="forge-rate-limits"' in overview:
+    sys.stderr.write('Forge Rate Limits container still in Overview tab — should be in colony modal (#357)\n')
+    sys.exit(1)
+# Per-colony modal entry point must exist.
+if 'function showColonyModal' not in src:
+    sys.stderr.write('showColonyModal not defined (#357 per-colony modal missing)\n')
+    sys.exit(2)
+# Modal markup container must be present.
+if 'id="colony-modal"' not in src:
+    sys.stderr.write('#colony-modal container missing\n'); sys.exit(3)
+# The per-colony modal renderer must reference data.forge_rate_limits.
+if 'forge_rate_limits' not in src:
+    sys.stderr.write('forge_rate_limits never read in template\n'); sys.exit(4)
+sys.exit(0)
+PY
+then
+    pass "45: Forge Rate Limits relocated from Overview to per-colony modal (#357)"
+else
+    fail "45: Forge Rate Limits relocation regression"
+fi
+
+# --- #357 test 46: confirm-modal markup. The bare `confirm()` was
+#     replaced with a structured config-confirm-modal listing each key
+#     diff. Asserts the modal container + the function that opens it. ---
+if python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
+import sys
+with open(sys.argv[1]) as f:
+    src = f.read()
+needles = [
+    'id="config-confirm-modal"',
+    'config-confirm-rows',
+    'config-confirm-key',
+    '_showConfigConfirm',
+    '_postConfigApply',
+]
+for n in needles:
+    if n not in src:
+        sys.stderr.write('config-confirm wiring missing: ' + n + '\n')
+        sys.exit(2)
+# The bare confirm() in applyConfigEdits (which we replaced) must be gone.
+import re
+m = re.search(r'function applyConfigEdits\b.*?\n\}', src, re.DOTALL)
+body = m.group(0) if m else ''
+if re.search(r'\bconfirm\(', body):
+    sys.stderr.write('bare confirm() still in applyConfigEdits — should be _showConfigConfirm\n')
+    sys.exit(3)
+sys.exit(0)
+PY
+then
+    pass "46: structured confirm modal replaces bare confirm() in applyConfigEdits (#357)"
+else
+    fail "46: confirm-modal markup regression"
+fi
+
+# --- #357 test 47: line-level TOML patcher smoke. Build a fixture
+#     colony.toml with comments + sections + 5 keys. POST /config/apply
+#     touching ONE key. Assert: file mutated (key has new value), every
+#     OTHER line byte-identical, comments preserved. ---
+PATCHER_FED="$TMPDIR_TEST/qa357-fed"
+mkdir -p "$PATCHER_FED/.agentis/logs" "$PATCHER_FED/sample-colony/config" \
+         "$PATCHER_FED/sample-colony/agents" "$PATCHER_FED/sample-colony/scripts"
+cat > "$PATCHER_FED/sample-colony/config/colony.toml" <<'TOML'
+# colony.toml — sample fixture for #357 patcher smoke
+# Top of file comment must survive a patch.
+
+[gitlab]
+url = "https://example.test"  # inline comment must survive
+project = "sample/repo"
+
+[forge.gitlab]
+api_root = "https://gitlab.example.test/api/v4"
+url = "https://gitlab.example.test"
+
+[llm]
+backend = "cli"
+
+[daemon]
+tick_interval_ms = 60000
+heartbeat_interval_ms = 1800000  # very long for live federations
+TOML
+cat > "$PATCHER_FED/sample-colony/agents/dummy.ag" <<'AG'
+cb 100;
+fn tick() { return Void; }
+AG
+cat > "$PATCHER_FED/sample-colony/scripts/start-colony.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$PATCHER_FED/sample-colony/scripts/start-colony.sh"
+PORT2="$(python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); p=s.getsockname()[1]; s.close(); print(p)")"
+LOG2="$TMPDIR_TEST/dashboard-357.log"
+setsid bash "$DASHBOARD_SH" "$PATCHER_FED" "$PORT2" >"$LOG2" 2>&1 &
+DASH2_PID=$!
+ready2=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -f -s -o /dev/null "http://127.0.0.1:$PORT2/" 2>/dev/null; then
+        ready2=1; break
+    fi
+    sleep 0.5
+done
+
+if [ "$ready2" -eq 1 ]; then
+    ORIG_FIXTURE="$PATCHER_FED/sample-colony/config/colony.toml"
+    # Capture original via `cp`, not `$(cat)` — bash command substitution
+    # strips trailing newlines, which would create false-positive diff
+    # rows in the byte-identity assertion below.
+    ORIG_FILE_47="$TMPDIR_TEST/orig-47.toml"
+    cp "$ORIG_FIXTURE" "$ORIG_FILE_47"
+    MTIME_MS_47="$(python3 -c "import os,sys; print(int(os.path.getmtime(sys.argv[1]) * 1000))" "$ORIG_FIXTURE")"
+    PAYLOAD_47="$(python3 -c "
+import json, sys
+print(json.dumps({
+    'scope': 'sample-colony',
+    'mtime_ms': int(sys.argv[1]),
+    'changes': [{'key': 'daemon.tick_interval_ms', 'value': '30000', 'type': 'int'}],
+}))" "$MTIME_MS_47")"
+    RESP47="$TMPDIR_TEST/apply-47.txt"
+    RESP47_CODE="$(curl -s -o "$RESP47" -w '%{http_code}' -X POST \
+        -H 'Content-Type: application/json' \
+        -d "$PAYLOAD_47" \
+        "http://127.0.0.1:$PORT2/config/apply" 2>/dev/null || echo "000")"
+    T47_OK=1
+    if [ "$RESP47_CODE" != "200" ]; then
+        echo "  /config/apply returned $RESP47_CODE (expected 200): $(head -c 400 "$RESP47" 2>/dev/null)"
+        T47_OK=0
+    fi
+    if cmp -s "$ORIG_FILE_47" "$ORIG_FIXTURE"; then
+        echo "  fixture not mutated after /config/apply"
+        T47_OK=0
+    fi
+    # The mutated key must hold the new value.
+    if ! grep -q '^tick_interval_ms = 30000' "$ORIG_FIXTURE"; then
+        echo "  daemon.tick_interval_ms not rewritten to 30000"
+        T47_OK=0
+    fi
+    # Every other line must be byte-identical to the original — the
+    # patcher only rewrites the matching `tick_interval_ms = ...` line.
+    DIFF47="$TMPDIR_TEST/diff-47.txt"
+    diff "$ORIG_FILE_47" "$ORIG_FIXTURE" > "$DIFF47" 2>&1 || true
+    # Count only content-bearing diff lines (skip the `\ No newline at
+    # end of file` markers, which are formatting noise rather than
+    # content changes).
+    DIFF_LINES_47="$(grep -cE '^[<>] ' "$DIFF47" 2>/dev/null || echo 0)"
+    if [ "$DIFF_LINES_47" -gt 2 ]; then
+        echo "  more than 1 line rewritten by /config/apply (diff lines: $DIFF_LINES_47)"
+        cat "$DIFF47" | head -20
+        T47_OK=0
+    fi
+    # Inline comment after the changed key must survive.
+    if ! grep -q '# inline comment must survive' "$ORIG_FIXTURE"; then
+        echo "  inline comment lost after patch"
+        T47_OK=0
+    fi
+    if ! grep -q '# Top of file comment must survive a patch.' "$ORIG_FIXTURE"; then
+        echo "  top-of-file comment lost after patch"
+        T47_OK=0
+    fi
+    if [ "$T47_OK" -eq 1 ]; then
+        pass "47: line-level TOML patcher mutates target key, byte-preserves the rest (#357)"
+    else
+        fail "47: line-level TOML patcher smoke regression"
+    fi
+
+    # --- #357 test 48: drift detection. Stat fixture, externally bump
+    #     mtime, POST apply with stale mtime → 409 + drift:true. ---
+    sleep 1  # ensure mtime can advance
+    : > "$ORIG_FIXTURE.touch"
+    python3 -c "
+import os, sys, time
+p = sys.argv[1]
+ts = time.time() + 5  # future mtime so the disk_mtime > payload_mtime
+os.utime(p, (ts, ts))
+" "$ORIG_FIXTURE"
+    PAYLOAD_48="$(python3 -c "
+import json, sys
+print(json.dumps({
+    'scope': 'sample-colony',
+    'mtime_ms': int(sys.argv[1]),
+    'changes': [{'key': 'daemon.tick_interval_ms', 'value': '12345', 'type': 'int'}],
+}))" "$MTIME_MS_47")"
+    RESP48="$TMPDIR_TEST/apply-48.txt"
+    RESP48_CODE="$(curl -s -o "$RESP48" -w '%{http_code}' -X POST \
+        -H 'Content-Type: application/json' \
+        -d "$PAYLOAD_48" \
+        "http://127.0.0.1:$PORT2/config/apply" 2>/dev/null || echo "000")"
+    T48_OK=1
+    if [ "$RESP48_CODE" != "409" ]; then
+        echo "  drift detection returned $RESP48_CODE (expected 409): $(head -c 400 "$RESP48" 2>/dev/null)"
+        T48_OK=0
+    fi
+    if ! grep -q '"drift": *true' "$RESP48" 2>/dev/null; then
+        echo "  drift response missing drift:true: $(head -c 400 "$RESP48" 2>/dev/null)"
+        T48_OK=0
+    fi
+    if [ "$T48_OK" -eq 1 ]; then
+        pass "48: /config/apply returns 409 + drift:true on stale mtime (#357)"
+    else
+        fail "48: drift detection regression"
+    fi
+
+    # --- #357 test 49: multi-line value rejection. Append a multi-line
+    #     array to the fixture, POST apply targeting that key, expect
+    #     422 + clear error message. ---
+    cat >> "$ORIG_FIXTURE" <<'TOML'
+
+[multiline]
+big_array = [
+  "alpha",
+  "beta",
+  "gamma",
+]
+TOML
+    MTIME_MS_49="$(python3 -c "import os,sys; print(int(os.path.getmtime(sys.argv[1]) * 1000))" "$ORIG_FIXTURE")"
+    PAYLOAD_49="$(python3 -c "
+import json, sys
+print(json.dumps({
+    'scope': 'sample-colony',
+    'mtime_ms': int(sys.argv[1]),
+    'changes': [{'key': 'multiline.big_array', 'value': 'whatever', 'type': 'text'}],
+}))" "$MTIME_MS_49")"
+    RESP49="$TMPDIR_TEST/apply-49.txt"
+    RESP49_CODE="$(curl -s -o "$RESP49" -w '%{http_code}' -X POST \
+        -H 'Content-Type: application/json' \
+        -d "$PAYLOAD_49" \
+        "http://127.0.0.1:$PORT2/config/apply" 2>/dev/null || echo "000")"
+    T49_OK=1
+    if [ "$RESP49_CODE" != "422" ]; then
+        echo "  multi-line rejection returned $RESP49_CODE (expected 422): $(head -c 400 "$RESP49" 2>/dev/null)"
+        T49_OK=0
+    fi
+    if ! grep -q 'value spans multiple lines' "$RESP49" 2>/dev/null; then
+        echo "  422 response missing 'value spans multiple lines' message: $(head -c 400 "$RESP49" 2>/dev/null)"
+        T49_OK=0
+    fi
+    if [ "$T49_OK" -eq 1 ]; then
+        pass "49: /config/apply rejects multi-line values with 422 + clear message (#357)"
+    else
+        fail "49: multi-line rejection regression"
+    fi
+
+    # Tear down the second dashboard before the final summary.
+    kill -TERM "-$DASH2_PID" 2>/dev/null || kill -TERM "$DASH2_PID" 2>/dev/null || true
+    sleep 0.5
+    kill -KILL "-$DASH2_PID" 2>/dev/null || kill -KILL "$DASH2_PID" 2>/dev/null || true
+else
+    fail "47/48/49: second dashboard never became ready" "log tail: $(tail -10 "$LOG2" 2>/dev/null | tr '\n' ' ')"
+fi
+
+# --- #357 test 50: collector emits the inverted gate field. The new
+#     contract is `operator_writes_disabled` (not `_enabled`); the
+#     audit_log_path must always be present. ---
+if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
+import sys, re, json
+with open(sys.argv[1]) as f:
+    html = f.read()
+m = re.search(r'const data\s*=\s*(\{.*?\});\n', html, re.DOTALL)
+if not m: sys.exit(1)
+try:
+    data = json.loads(m.group(1))
+except Exception:
+    sys.exit(2)
+ce = data.get('config_editor') or {}
+# audit_log_path always present.
+if not ce.get('audit_log_path'):
+    sys.stderr.write('audit_log_path missing from config_editor block\n'); sys.exit(3)
+# operator_writes_disabled key present (default False).
+if 'operator_writes_disabled' not in ce:
+    sys.stderr.write('operator_writes_disabled key missing — collector still emits old _enabled gate?\n'); sys.exit(4)
+if ce.get('operator_writes_disabled') is True:
+    sys.stderr.write('default operator_writes_disabled is True — should be False (editable)\n'); sys.exit(5)
+# Legacy operator_writes_enabled must be GONE so callers don't read a
+# stale field.
+if 'operator_writes_enabled' in ce:
+    sys.stderr.write('legacy operator_writes_enabled key leaked into output\n'); sys.exit(6)
+sys.exit(0)
+PY
+then
+    pass "50: collector emits inverted gate (operator_writes_disabled), audit_log_path always present (#357)"
+else
+    fail "50: collector config_editor block contract regression"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Three v0.6.0 mistakes from #352 corrected in one PR:

1. **Overview tab cut to ~480 px**. Phase Readiness moved to top of Promotions; Forge Rate Limits relocated into a per-colony modal. Overview now: Federation Health Banner + bulk-restart action bar → stat tiles row → Sidecars listing.
2. **Config tab editable by default**. The v0.6.0 read-only gate was a feature regression; replaced with a defensive opt-out (`operator_writes_disabled = true` flips back to read-only).
3. **`/config/apply` is a real write path**, not audit-only. Line-level TOML patcher with comment preservation, atomic temp+rename write, drift detection (409 on stale mtime), JSONL audit append, and per-colony agent restart on success.

`federation-dashboard/VERSION` stays `0.6.0` — MINOR bump deferred to next release PR per #357 issue body.

## Overview cut

| Tile | Decision | New home |
|---|---|---|
| Federation Health Banner + bulk-restart action bar | KEEP | Overview top |
| Stat tiles row (running N/M, avg conf, learning 24h, quarantined) | KEEP | Overview |
| Sidecars listing (auto-promote + cost-cap, per-row [restart]) | KEEP | Overview |
| Phase Readiness | MOVE | Top of Promotions tab (above per-agent ladders) |
| Forge Rate Limits | MOVE | Per-colony modal (Option B) — clickable colony chip on Promotions / Agents |

`renderPhaseReadiness()` and `renderForgeRateLimits()` keep their existing JS bodies — only their target containers move (Phase Readiness via the relocated `<div id=readiness>`; Forge Rate Limits inlined into `showColonyModal()`).

## Forge Rate Limits — per-colony modal

A new `showColonyModal(colonyName)` (~90 LOC) renders a per-colony view: Forge Rate Limits row sourced from `data.forge_rate_limits[colony]` + an agent listing (clickable into the per-agent modal). The colony name on Promotions ladder rows + the Agents-tab `colony` cell becomes a clickable chip → opens the modal. Reuses the existing `.modal-overlay` infrastructure for visual continuity with the per-agent modal.

## Config writability

- Collector emits `operator_writes_disabled` (default false) instead of the legacy `operator_writes_enabled` (default false). Default behavior flips from read-only to editable; explicit lockers stay locked.
- `renderConfigEditor` defaults to writable inputs. `data.config_editor.read_only_override = true` is the test-fixture lever for pinning read-only without touching the gate.
- Apply pops a structured confirm modal (`#config-confirm-modal`) listing each `<scope.key>: <old> → <new>` line. Cancel bails clean. Replaces the bare `confirm()` call.
- Drift detection: client sends `mtime_ms` it last read. Server returns 409 + `{drift: true, current_mtime_ms}` on conflict.

## /config/apply patcher

Algorithm:

1. Resolve target — `scope = "fed"|"federation"` → `<fed>/.agentis/config`; `scope = "<colony>"` → `<fed>/<colony>/config/colony.toml`.
2. Stat the file; reject 409 if disk mtime > payload mtime.
3. Read as a list of lines, scan section headers up front so dotted keys with multi-level prefixes (e.g. `forge.gitlab.url`) resolve correctly.
4. For each `{key, value, type}` change: split key on `.`, find longest section prefix that matches a real `[section]` header, then patch the matching `<bare_key> = ...` line via a `(prefix)(value)(suffix)` regex capture so trailing inline comments survive verbatim.
5. **Multi-line values** (arrays or inline tables spanning lines) → 422 + clear error rather than risk silent corruption.
6. **Atomic write** — write to `<file>.tmp.<pid>.<seq>`, fsync, `os.rename`. Same precedent as `federation-dashboard-renderer.py`.
7. Append one JSONL audit row per applied change to `<fed>/.agentis/logs/config-edits.jsonl`.
8. **Restart trigger** — call `<colony>/scripts/start-colony.sh --restart-agent <name>` for every agent in the affected colony. `scope = fed/federation` walks every colony.

**Patcher design choice**: regex line-level capture, not a full TOML parser. The captured `(prefix)(value)(suffix)` pattern is the smallest diff that preserves comments + section ordering + blank lines, and the `tomlkit`-style round-trip dependency would have added a runtime requirement for negligible gain on the simple key=value subset the dashboard actually edits. Multi-line bail keeps the read-only display still functional for the values that are out of v1 scope.

## Test plan

- [x] `bash tools/test-timeline-rendering.sh` — 50/0 (was 44 + 6 new). Test 22 updated to look for Phase Readiness in Promotions; test 42 inverted to "editable by default"; tests 45 (Forge relocation), 46 (confirm modal markup), 47 (patcher byte-identity), 48 (drift 409), 49 (multi-line 422), 50 (collector inverted gate) added.
- [x] `bash tools/test-rate-limit-tile.sh` — 8/0. Tests 1, 3, 8 updated (the static `<div id=forge-rate-limits>` slot is gone; now wired through `showColonyModal`).
- [x] `bash tools/test-sse-stream.sh` — 9/0 (SSE pipeline preserved).
- [x] `bash tools/test-make-dashboard-bundle.sh` — 13/0.
- [x] `AGENTIS_RUN_KILL_TESTS=0 bash tools/colony-lint.sh` — 117 passed, 0 failed, 3 skipped.
- [x] `python3 -m py_compile` on collector + server + renderer + history — clean.
- [x] `bash -n federation-dashboard/bin/federation-dashboard` — clean.

## Out of scope

- Federation-dashboard MINOR bump (deferred to the next release PR per #357 issue body).
- Multi-line array / inline-table editing — patcher returns 422; read-only display preserved. Out of v1 scope.
- Per-key validation beyond type inference — operator can still type a nonsense int; runtime catches it next start.
- Tab structure refinements (rejected in the lgtm'd plan: keep 6 tabs unchanged so `data-tab` selectors + digit shortcuts stay stable).
- The `--config-override` upstream gap from #351 stays open; cost-cap / per-colony `[llm]` writes remain no-ops at the runtime layer until upstream lands the flag. The Config tab now records intent in the file + audit log either way, so the edit surface is no longer the blocker.

Closes #357.