### PR TITLE
feat(dashboard): intent-driven tab restructure (Status/Cost/Recovery/Progress/Config) + 4 bug fixes (#359)

### DIFF
--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -7,7 +7,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Intent-driven 5-tab dashboard restructure**
+  ([#359](https://github.com/Replikanti/agentis-colonies/issues/359),
+  follow-up to [#352](https://github.com/Replikanti/agentis-colonies/issues/352)
+  + [#357](https://github.com/Replikanti/agentis-colonies/issues/357)).
+  The dashboard now opens to one of five operator-question tabs instead
+  of six topic tabs:
+  - **Status** — am I healthy NOW? Federation health verdict pill
+    (✅/⚠️/❌), 21-cell pulse-grid (color encodes per-agent state, click
+    drills into the existing per-agent detail modal), sidecar status
+    pills + last-tick age, last-error timestamp + count. NO charts, NO
+    bars, NO tables, NO `<details>` — pure single-glance verdict.
+    Vertical budget ≤480 px.
+  - **Cost** — am I burning money? 4 projection tiles (per-min $/min,
+    per-min tokens/min, projected 1h, projected 1d with 1w / 1m in the
+    tooltip), today/7d/30d cumulative row, cost-cap progress bar + per-
+    colony split. Traffic-light color from a 5-min cost-rate EMA against
+    operator-tunable thresholds (`[dashboard].cost_yellow_per_h` /
+    `.cost_red_per_h`, default $1/h yellow / $5/h red).
+  - **Recovery** — what do I need to restart? Bulk "Restart all stopped"
+    button, per-agent restart table (one [Restart] button per row,
+    disabled when running), per-sidecar restart, federation kill switch
+    with type-the-name confirm modal (defensive double-confirm). Last
+    10 watchdog kills as a forensic timeline. Per-agent log-tail
+    expandable behind a `<details>` (lazy-fetched from new
+    `/log-tail/<agent_id>` endpoint, 20 lines by default).
+  - **Progress** — are agents climbing? Confidence Trend +
+    Experience Growth charts default-EXPANDED (the `<details>` wrapper
+    from #248 PR C is removed on this tab). Phase Readiness as a small
+    capped-height card (no longer dominant). Per-agent promotion ladder
+    + ETA + limiting prereq + Promote Candidates + Event Timeline.
+  - **Config** — what's running where? The #357 per-scope editor
+    is preserved; #359 adds bulk apply (per-colony checkbox group on
+    the confirm modal when editing federation-wide keys, server-side
+    `/config/apply` accepts `scopes:[...]` + reports per-scope
+    success/failure) and a cross-colony matrix view (one row per
+    dotted key with at least one override).
+  Eliminated tabs (their content moved): Overview → split across Status
+  + Cost + Recovery; Agents → folds into Status pulse-grid + drill-in
+  modal + Progress agent-table; Promotions → folds into Progress;
+  Learning → folds into Progress (charts + Event Timeline). Default
+  first-paint tab is `status` (was `overview`); legacy localStorage
+  values migrate via `LEGACY_TAB_MIGRATION` so a returning operator
+  doesn't see a blank tab on first load post-upgrade. Keyboard shortcuts:
+  digits 1-5 jump between tabs (was 1-6).
+
 ### Fixed
+
+- **Stray-quote rendering on Config tab inline arrays / tables**
+  ([#359](https://github.com/Replikanti/agentis-colonies/issues/359)
+  Bug 1). The pre-#359 collector's strip-quotes logic only fired when a
+  value started AND ended with the same quote character; inline arrays
+  (`labels = ["a", "b"]`) and inline tables (`limits = { hi=1 }`) slipped
+  through and the Config tab rendered them as editable `<input>`s. Any
+  edit then corrupted the array because the line-level patcher only
+  handles scalars. Collector now emits a `complex_value: true` flag for
+  inline-array / inline-table values; the renderer shows them read-only
+  with a "complex" marker so the operator can see the value but can't
+  accidentally mutate it. Scalar string values (`backend = "cli"`) keep
+  their existing strip-quotes path and render `<input value="cli">`,
+  not `<input value="\"cli\"">`. Test 51 is the regression guard.
+
+- **60-second flicker + lost in-flight state**
+  ([#359](https://github.com/Replikanti/agentis-colonies/issues/359)
+  Bug 2 + Bug 4). The `<meta http-equiv="refresh" content="60">` tag
+  on line 5 of the template triggered a full-page reload every minute.
+  That wiped any operator in-flight state (modal scroll position, sort
+  column, expanded `<details>`, mid-edit Config rows) — and the SSE
+  channel from #313 was already keeping the page fresh in-place
+  anyway. The meta tag is now removed; SSE is the single source of
+  live updates. A small `#sse-dot` in the page header surfaces the
+  EventSource lifecycle (green steady on `onopen`, brief pulse on each
+  snapshot, red on `onerror`) so the operator can see at a glance
+  whether updates are flowing. `?debug=1` enables `console.log` on
+  every renderer entry for browser-DevTools verification. Tests 52 + 53
+  are the regression guards.
 
 - **Overview tab compactness, Forge Rate Limits relocation, and Config tab
   writability**

--- a/federation-dashboard/lib/federation-dashboard-collector.py
+++ b/federation-dashboard/lib/federation-dashboard-collector.py
@@ -825,6 +825,143 @@ def collect_spend_log(spend_dir, name_to_colony, id_to_role, epoch_s):
 spend_dir = os.path.join(os.path.dirname(exp_dir), 'spend') if exp_dir else ''
 cost = collect_spend_log(spend_dir, name_to_colony, id_to_role, epoch)
 
+
+# --- #359: per-minute burn rate + projections (Cost tab) ---
+# 5-minute EMA of cost_usd + tokens from spend log, plus 1h/1d/1w/1m
+# projections. Surfaced on the Cost tab as 4 stat tiles. Operator can also
+# override the traffic-light thresholds via <fed>/.agentis/config:
+#   [dashboard]
+#   cost_yellow_per_h = 1.0   # default
+#   cost_red_per_h    = 5.0   # default
+def collect_cost_burn_rate(spend_dir, epoch_s, fed_config_keys):
+    """Walk the spend log, compute the 5-min EMA of cost & tokens, and
+    project out to 1h / 1d / 1w / 1m. Returns a dict with 7 numeric
+    fields suitable for direct rendering. All zero if spend dir missing
+    or empty (the live federation will trickle in fresh rows over time).
+    """
+    window_seconds = 300  # 5 minutes
+    cutoff_ms = (epoch_s - window_seconds) * 1000
+    sum_cost = 0.0
+    sum_tokens = 0
+    if spend_dir and os.path.isdir(spend_dir):
+        try:
+            for fn in os.listdir(spend_dir):
+                if not fn.endswith('.jsonl'):
+                    continue
+                path = os.path.join(spend_dir, fn)
+                try:
+                    with open(path) as f:
+                        for raw in f:
+                            raw = raw.strip()
+                            if not raw:
+                                continue
+                            try:
+                                row = json.loads(raw)
+                            except json.JSONDecodeError:
+                                continue
+                            if not isinstance(row, dict):
+                                continue
+                            ts = row.get('ts')
+                            if not isinstance(ts, (int, float)):
+                                continue
+                            ts_ms = int(ts)
+                            if ts_ms < cutoff_ms:
+                                continue
+                            c = row.get('cost_usd')
+                            if isinstance(c, (int, float)):
+                                sum_cost += float(c)
+                            i_tok = row.get('input_tokens') or 0
+                            o_tok = row.get('output_tokens') or 0
+                            try:
+                                sum_tokens += int(i_tok) + int(o_tok)
+                            except (TypeError, ValueError):
+                                pass
+                except OSError:
+                    continue
+        except OSError:
+            pass
+    rate_per_min_usd = sum_cost / 5.0
+    rate_per_min_tokens = sum_tokens / 5.0
+    # Threshold overrides: read from fed_config_keys (the federation-wide
+    # `[dashboard]` section). Yellow defaults to $1/h, red to $5/h —
+    # operator-tunable so cheap dev backends can stay green and expensive
+    # fleets can flag faster.
+    cost_yellow = 1.0
+    cost_red = 5.0
+    for kv in (fed_config_keys or []):
+        if kv.get('section') != 'dashboard':
+            continue
+        try:
+            if kv.get('key') == 'cost_yellow_per_h':
+                cost_yellow = float((kv.get('raw_value') or '').strip()
+                                    .strip('"').strip("'") or '1.0')
+            elif kv.get('key') == 'cost_red_per_h':
+                cost_red = float((kv.get('raw_value') or '').strip()
+                                 .strip('"').strip("'") or '5.0')
+        except (TypeError, ValueError):
+            pass
+    return {
+        'rate_per_min_usd': round(rate_per_min_usd, 6),
+        'rate_per_min_tokens': int(rate_per_min_tokens),
+        'projected_1h_usd':  round(rate_per_min_usd * 60, 4),
+        'projected_1d_usd':  round(rate_per_min_usd * 60 * 24, 4),
+        'projected_1w_usd':  round(rate_per_min_usd * 60 * 24 * 7, 4),
+        'projected_1m_usd':  round(rate_per_min_usd * 60 * 24 * 30, 4),
+        'cost_threshold_yellow_usd_per_h': cost_yellow,
+        'cost_threshold_red_usd_per_h': cost_red,
+        'window_seconds': window_seconds,
+    }
+
+
+# --- #359: forensic last-N watchdog kills (Recovery tab) ---
+# Reads <fed>/.agentis/lifecycle/events.jsonl, filters to the watchdog
+# kill flavour (heuristic: event names containing "killed", "watchdog",
+# or "respawn"; severity inferred from new_status). Returns up to 10
+# most-recent rows, ts-desc, with {ts, agent, reason} for the renderer.
+def collect_watchdog_kills(lifecycle_path, id_to_role, max_rows=10):
+    if not lifecycle_path or not os.path.isfile(lifecycle_path):
+        return []
+    out = []
+    try:
+        with open(lifecycle_path) as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    row = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                ev = (row.get('event') or '').lower()
+                ns = (row.get('new_status') or '').lower()
+                # Match any kill / watchdog / respawn flavour. Real-world
+                # writers haven't standardised yet; this catches every
+                # variant we know about + leaves room for new ones.
+                if not ('killed' in ev or 'watchdog' in ev or 'sigkill' in ev
+                        or 'respawn' in ev or 'critical' in ns):
+                    continue
+                ts = row.get('ts')
+                if not isinstance(ts, (int, float)):
+                    continue
+                ts_ms = int(ts) if int(ts) >= 10**11 else int(ts) * 1000
+                aid = row.get('agent_id') or ''
+                role = id_to_role.get(aid, aid)
+                reason = (row.get('reason') or row.get('event')
+                          or 'watchdog kill')
+                out.append({
+                    'ts': ts_ms,
+                    'agent_id': aid,
+                    'agent': role or '?',
+                    'event': row.get('event') or '',
+                    'reason': reason,
+                })
+    except OSError:
+        return []
+    out.sort(key=lambda r: r['ts'], reverse=True)
+    return out[:max_rows]
+
 # --- Per-agent unified timeline (#315 PR 1) ---
 # Merges four on-disk JSONL streams into a single chronological array per
 # agent: experience (kind=learn), spend (kind=prompt), confidence-log
@@ -1481,20 +1618,40 @@ def _read_toml_scope(path):
                 k, _, v = line.partition('=')
                 k = k.strip()
                 v = v.strip()
-                # Strip trailing comment
-                if '#' in v and not v.startswith('"') and not v.startswith("'"):
+                # #359: detect inline arrays (`labels = ["a", "b"]`) and inline
+                # tables (`limits = { hi = 1, lo = 0 }`) BEFORE the strip-quotes
+                # logic below. The strip-quotes branch only fires when the
+                # value starts AND ends with the same quote char, so an inline
+                # array slipped through unmodified — but the rendered <input>
+                # then carried the literal `["a", "b"]` text and any operator
+                # edit corrupted the array. Mark complex values so the
+                # renderer can show them read-only with a "complex value"
+                # marker instead of an editable input.
+                complex_value = False
+                if v.startswith('[') or v.startswith('{'):
+                    complex_value = True
+                # Strip trailing comment (only on scalar values; complex
+                # values can contain `#` legitimately inside string elements).
+                if (not complex_value and '#' in v
+                        and not v.startswith('"') and not v.startswith("'")):
                     v = v.partition('#')[0].rstrip()
-                # Unwrap surrounding double quotes / single quotes so the
-                # editor renders a clean value field. The raw form (with
-                # quotes intact) is reserved for a future "raw mode" view
-                # — for v1 of the Config tab the unquoted value is what
-                # the operator wants to edit.
-                if len(v) >= 2 and ((v[0] == '"' and v[-1] == '"') or (v[0] == "'" and v[-1] == "'")):
+                # Unwrap surrounding double quotes / single quotes on SCALAR
+                # values so the editor renders a clean value field. The raw
+                # form (with quotes intact) is reserved for a future
+                # "raw mode" view — for v1 of the Config tab the unquoted
+                # value is what the operator wants to edit.
+                # Complex values (inline arrays / tables) skip the strip so
+                # the read-only marker shows the on-disk text verbatim.
+                if (not complex_value
+                        and len(v) >= 2
+                        and ((v[0] == '"' and v[-1] == '"')
+                             or (v[0] == "'" and v[-1] == "'"))):
                     v = v[1:-1]
                 rec['keys'].append({
                     'section': section,
                     'key': k,
                     'raw_value': v,
+                    'complex_value': complex_value,
                 })
     except (OSError, ValueError) as e:
         rec['error'] = str(e)
@@ -1523,11 +1680,74 @@ for col in colonies:
     rec['label'] = col + ' override'
     config_scopes.append(rec)
 
+# #359: cross-colony matrix. One row per dotted key that has at least one
+# override; columns = federation default + per-colony scopes. The renderer
+# shows the matrix on the Config tab so an operator can see at-a-glance
+# which colonies override which keys without flipping between scopes.
+def _build_config_matrix(scopes):
+    """Build {dotted_key: {scope_name: value}} from the scopes list. We
+    only emit rows where at least one colony overrides the federation
+    default — pure-federation keys are not interesting here."""
+    by_key = {}  # dotted_key -> {scope_name: value}
+    for s in scopes:
+        scope_name = s.get('scope') or ''
+        if not scope_name:
+            continue
+        for kv in (s.get('keys') or []):
+            section = kv.get('section') or ''
+            key = kv.get('key') or ''
+            if not key:
+                continue
+            dotted = (section + '.' + key) if section else key
+            row = by_key.setdefault(dotted, {})
+            row[scope_name] = {
+                'value': kv.get('raw_value'),
+                'complex_value': bool(kv.get('complex_value')),
+            }
+    # Filter: keep rows where at least one non-federation scope sets the
+    # key (== an override exists). Pure-federation keys are uninteresting.
+    matrix_rows = []
+    for dotted in sorted(by_key.keys()):
+        cells = by_key[dotted]
+        non_fed_scopes = [s for s in cells.keys() if s != 'federation']
+        if not non_fed_scopes:
+            continue
+        matrix_rows.append({
+            'key': dotted,
+            'cells': cells,
+        })
+    return matrix_rows
+
+config_matrix = _build_config_matrix(config_scopes)
+
 config_editor_block = {
     'operator_writes_disabled': operator_writes_disabled,
     'scopes': config_scopes,
     'audit_log_path': os.path.join(fed_dir, '.agentis', 'logs', 'config-edits.jsonl'),
+    # #359: cross-colony matrix — sorted list of dotted keys × per-scope
+    # values for every key with at least one override.
+    'matrix': config_matrix,
 }
+
+# #359: per-minute burn rate + projections (Cost tab) and forensic last-N
+# watchdog kills (Recovery tab). Both source from existing on-disk streams
+# already touched by the collector — no extra disk traffic on the hot path
+# beyond the spend / lifecycle reads we already perform once each.
+cost_burn = collect_cost_burn_rate(spend_dir, epoch,
+                                   fed_config_scope.get('keys') or [])
+cost.update({
+    'rate_per_min_usd': cost_burn['rate_per_min_usd'],
+    'rate_per_min_tokens': cost_burn['rate_per_min_tokens'],
+    'projected_1h_usd': cost_burn['projected_1h_usd'],
+    'projected_1d_usd': cost_burn['projected_1d_usd'],
+    'projected_1w_usd': cost_burn['projected_1w_usd'],
+    'projected_1m_usd': cost_burn['projected_1m_usd'],
+    'cost_threshold_yellow_usd_per_h': cost_burn['cost_threshold_yellow_usd_per_h'],
+    'cost_threshold_red_usd_per_h': cost_burn['cost_threshold_red_usd_per_h'],
+    'burn_window_seconds': cost_burn['window_seconds'],
+})
+
+watchdog_kills = collect_watchdog_kills(lifecycle_path, id_to_role, max_rows=10)
 
 output = {
     'agents': result,
@@ -1545,7 +1765,12 @@ output = {
     'timeline': federation_timeline,
     # #352 (rewritten #357): config editor scope + defensive opt-out
     # gate. Default-editable; `operator_writes_disabled = true` flips to
-    # read-only.
+    # read-only. Plus cross-colony matrix per #359.
     'config_editor': config_editor_block,
+    # #359: forensic last-10 watchdog-kill events (Recovery tab).
+    'watchdog_kills': watchdog_kills,
+    # #359: epoch-now stamp so renderers don't have to derive a "stale"
+    # cue from a missing field; SSE pushes update this in-place.
+    'now_epoch': epoch,
 }
 print(json.dumps(output))

--- a/federation-dashboard/lib/federation-dashboard-server.py
+++ b/federation-dashboard/lib/federation-dashboard-server.py
@@ -708,6 +708,75 @@ class Handler(SimpleHTTPRequestHandler):
         if self.path.startswith('/timeline?') or self.path == '/timeline':
             _serve_timeline(self)
             return
+        # #359: /log-tail/<agent_id>?lines=N — read-only tail of an agent's
+        # log file from <fed>/.agentis/logs/<agent_id>.log. Used by the
+        # Recovery tab's per-agent <details> expand. Defaults: 20 lines,
+        # max 200 lines (defensive — log file can be megabytes). Returns
+        # text/plain. 404 if the log file is missing, 400 if the agent_id
+        # is structurally invalid.
+        if self.path.startswith('/log-tail/'):
+            tail = self.path[len('/log-tail/'):]
+            qpos = tail.find('?')
+            qs = ''
+            if qpos >= 0:
+                qs = tail[qpos + 1:]
+                tail = tail[:qpos]
+            agent_id = tail.strip()
+            # SHA-8 lowercase hex is the daemon's canonical id; allow
+            # alphanumerics + underscore + dash so a future scheme can be
+            # accommodated without re-coding the gate.
+            import re as _re
+            if not agent_id or not _re.match(r'^[a-zA-Z0-9_\-]{1,64}$', agent_id):
+                self.send_response(400)
+                self.send_header('Content-Type', 'text/plain')
+                self.end_headers()
+                self.wfile.write(b'invalid agent_id')
+                return
+            n_lines = 20
+            if 'lines=' in qs:
+                try:
+                    raw_n = qs.split('lines=', 1)[1].split('&', 1)[0]
+                    n_lines = max(1, min(200, int(raw_n)))
+                except (TypeError, ValueError):
+                    n_lines = 20
+            log_path = os.path.join(fed_dir, '.agentis', 'logs', agent_id + '.log')
+            if not os.path.isfile(log_path):
+                # Try parent-level fallback (mirrors the resolved exp_dir
+                # convention used by the collector).
+                log_path_alt = os.path.join(fed_dir, '..', '.agentis', 'logs',
+                                            agent_id + '.log')
+                if not os.path.isfile(log_path_alt):
+                    self.send_response(404)
+                    self.send_header('Content-Type', 'text/plain')
+                    self.end_headers()
+                    self.wfile.write(b'log file not found')
+                    return
+                log_path = log_path_alt
+            try:
+                # Tail-only read: seek to last ~n_lines * 4KB worth of bytes,
+                # split into lines, take the last n_lines. Avoids slurping
+                # gigabyte-sized log files into memory.
+                size = os.path.getsize(log_path)
+                read_bytes = min(size, n_lines * 4096)
+                with open(log_path, 'rb') as f:
+                    if size > read_bytes:
+                        f.seek(size - read_bytes)
+                        f.readline()  # discard partial first line
+                    chunk = f.read()
+                text = chunk.decode('utf-8', errors='replace')
+                lines = text.splitlines()
+                tail_lines = lines[-n_lines:]
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/plain; charset=utf-8')
+                self.send_header('Cache-Control', 'no-cache')
+                self.end_headers()
+                self.wfile.write(('\n'.join(tail_lines) + '\n').encode())
+            except (OSError, ValueError) as e:
+                self.send_response(500)
+                self.send_header('Content-Type', 'text/plain')
+                self.end_headers()
+                self.wfile.write(f'log read failed: {e}'.encode())
+            return
         if self.path == '/events':
             # #313 PR 1: live SSE channel. Holds the connection open, pushes
             # one `event: snapshot\ndata: <COLLECTOR_JSON>\n\n` frame whenever
@@ -1424,24 +1493,39 @@ class Handler(SimpleHTTPRequestHandler):
                 self.end_headers()
                 self.wfile.write(b'malformed JSON body')
                 return
+            # #359: dual-mode payload. Single-scope (legacy):
+            #   {scope: <name>, mtime_ms: <int>, changes: [{key,value,type}]}
+            # Multi-scope (bulk apply):
+            #   {scopes: [<n1>, <n2>, ...], mtime_ms: <int>,
+            #    changes: [{key,value,type}]}
+            # The bulk path loops over scopes and reuses the same line-level
+            # patcher per scope. Each scope's file write is atomic; the
+            # cross-scope apply is best-effort and the response surfaces
+            # `applied_scopes: [...]` + `failed_scopes: [{scope, reason}]`.
             scope = (body.get('scope') or '').strip()
-            # Accept the new {changes:[{key, value, type}]} contract +
-            # the legacy {updates:[{input_id, value}]} shape (audit-only
-            # fallback) so any in-flight tab open during the upgrade
-            # doesn't crash the server. Empty changes ⇒ 400.
+            scopes_list = body.get('scopes')
             changes = body.get('changes')
             mtime_ms = body.get('mtime_ms') or 0
             try:
                 mtime_ms = int(mtime_ms)
             except (ValueError, TypeError):
                 mtime_ms = 0
+            # If `scopes` is provided + non-empty, dispatch to the
+            # multi-scope path early so we return a single aggregated
+            # response. Otherwise fall through to single-scope (back-compat).
+            if (isinstance(scopes_list, list) and scopes_list
+                    and isinstance(changes, list) and changes):
+                return self._apply_config_multi(
+                    scopes_list, changes, fed_dir, config_audit_log,
+                )
             if not scope or not isinstance(changes, list) or not changes:
                 self.send_response(400)
                 self.send_header('Content-Type', 'application/json')
                 self.end_headers()
                 self.wfile.write(json.dumps({
                     'ok': False,
-                    'summary': 'scope + changes[] (with at least one entry) required',
+                    'summary': ('scope + changes[] (with at least one entry) '
+                                'OR scopes:[...] + changes[] required'),
                 }).encode())
                 return
             # Resolve target file. scope = "fed" or "federation" → fed-
@@ -1634,6 +1718,174 @@ class Handler(SimpleHTTPRequestHandler):
             return
 
         self.send_error(404)
+
+    # #359: bulk /config/apply helper. Loops over the requested scopes,
+    # reusing the same single-scope line-level patcher logic for each.
+    # Best-effort: a per-scope failure does NOT abort the rest. Returns
+    # a 200 if at least one scope succeeded, 207 if all scopes failed
+    # (so the dashboard can surface partial-success without an error
+    # toast). Each scope's file write is atomic; the cross-scope apply
+    # is intentionally NOT wrapped in a single transaction (mtime drift
+    # on one colony shouldn't roll back a clean apply on the others).
+    def _apply_config_multi(self, scopes, changes, fed_dir_arg, audit_log):
+        if _read_operator_writes_disabled():
+            self.send_response(503)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({
+                'ok': False,
+                'summary': ('config_editor.operator_writes_disabled is '
+                            'true; the Config tab is locked.'),
+            }).encode())
+            return
+        applied_scopes = []
+        failed_scopes = []
+        per_scope_results = {}
+        for scope_name in scopes:
+            scope_name = (scope_name or '').strip()
+            if not scope_name:
+                failed_scopes.append({'scope': '', 'reason': 'empty scope'})
+                continue
+            if scope_name in ('fed', 'federation'):
+                target_path = os.path.join(fed_dir_arg, '.agentis', 'config')
+                target_colony = ''
+            else:
+                target_path = os.path.join(fed_dir_arg, scope_name,
+                                           'config', 'colony.toml')
+                target_colony = scope_name
+            if not os.path.isfile(target_path):
+                failed_scopes.append({
+                    'scope': scope_name,
+                    'reason': f'target file not found: {target_path}',
+                })
+                continue
+            # Read source as a list of lines. Patch in-memory, write back
+            # atomically. Mirrors the single-scope path but trimmed of
+            # the per-scope error responses (we collect into the
+            # aggregated response instead).
+            try:
+                with open(target_path, encoding='utf-8') as f:
+                    lines = f.readlines()
+            except OSError as e:
+                failed_scopes.append({
+                    'scope': scope_name,
+                    'reason': f'read failed: {e}',
+                })
+                continue
+            sections_present = _scan_sections(lines)
+            applied_here = []
+            try:
+                for change in changes:
+                    if not isinstance(change, dict):
+                        raise TypeMismatchError('change entries must be objects')
+                    dotted_key = (change.get('key') or '').strip()
+                    declared_type = (change.get('type') or 'text').strip().lower()
+                    new_value = change.get('value')
+                    if not dotted_key or new_value is None:
+                        raise TypeMismatchError(
+                            f'change missing key or value: {change!r}'
+                        )
+                    target_section, bare_key = _split_dotted_key(
+                        dotted_key, sections_present,
+                    )
+                    formatted = _format_toml_value(new_value, declared_type)
+                    idx, old_value = _patch_line(
+                        lines, target_section, bare_key, formatted,
+                    )
+                    applied_here.append({
+                        'key': dotted_key,
+                        'section': target_section,
+                        'bare_key': bare_key,
+                        'old_value': old_value.strip(),
+                        'new_value': str(new_value),
+                        'line': idx + 1,
+                    })
+            except (MultilineValueError, KeyNotFoundError,
+                    TypeMismatchError) as e:
+                failed_scopes.append({
+                    'scope': scope_name,
+                    'reason': type(e).__name__ + ': ' + str(e),
+                })
+                continue
+            try:
+                _atomic_write(target_path, ''.join(lines))
+            except OSError as e:
+                failed_scopes.append({
+                    'scope': scope_name,
+                    'reason': f'atomic write failed: {e}',
+                })
+                continue
+            ts_now = int(time.time())
+            try:
+                os.makedirs(os.path.dirname(audit_log), exist_ok=True)
+                with open(audit_log, 'a') as af:
+                    for a in applied_here:
+                        af.write(json.dumps({
+                            'ts': ts_now,
+                            'scope': scope_name,
+                            'key': a['key'],
+                            'old_value': a['old_value'],
+                            'new_value': a['new_value'],
+                            'line': a['line'],
+                            'remote': self.client_address[0],
+                            'bulk': True,
+                        }) + '\n')
+            except OSError:
+                pass
+            # Restart trigger — same convention as single-scope.
+            restart_results = []
+            try:
+                if target_colony:
+                    colony_dir = os.path.join(fed_dir_arg, target_colony)
+                    agents_dir = os.path.join(colony_dir, 'agents')
+                    if os.path.isdir(agents_dir):
+                        names = sorted(
+                            f[:-3] for f in os.listdir(agents_dir)
+                            if f.endswith('.ag')
+                        )
+                        restart_results = _restart_colony_agents(
+                            colony_dir, names,
+                        )
+                else:
+                    for entry in sorted(os.listdir(fed_dir_arg)):
+                        sub = os.path.join(fed_dir_arg, entry)
+                        if not os.path.isdir(sub):
+                            continue
+                        agents_dir = os.path.join(sub, 'agents')
+                        if not os.path.isdir(agents_dir):
+                            continue
+                        names = sorted(
+                            f[:-3] for f in os.listdir(agents_dir)
+                            if f.endswith('.ag')
+                        )
+                        restart_results.extend(
+                            _restart_colony_agents(sub, names)
+                        )
+            except OSError:
+                pass
+            applied_scopes.append(scope_name)
+            per_scope_results[scope_name] = {
+                'applied': applied_here,
+                'restart_results': restart_results,
+                'new_mtime_ms': int(os.path.getmtime(target_path) * 1000),
+            }
+        # 200 if anything succeeded; 207 (Multi-Status, repurposed
+        # informally) if every scope failed so the operator can see the
+        # per-scope reasons without a generic 500 / 400.
+        if applied_scopes:
+            status_code = 200
+        else:
+            status_code = 207
+        self.send_response(status_code)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({
+            'ok': bool(applied_scopes),
+            'applied_scopes': applied_scopes,
+            'failed_scopes': failed_scopes,
+            'per_scope': per_scope_results,
+            'audit_log_path': audit_log,
+        }).encode())
 
     def log_message(self, format, *args):
         pass

--- a/federation-dashboard/lib/federation-dashboard.html.template
+++ b/federation-dashboard/lib/federation-dashboard.html.template
@@ -2,7 +2,15 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="refresh" content="60">
+<!--
+  #359 (Bug 2 + Bug 4): the <meta http-equiv="refresh" content="60"> tag
+  used to live on this line. It triggered a full-page reload every 60s
+  which (a) caused the dashboard to flicker and (b) wiped any operator
+  in-flight state (modal scroll, sort column, expanded <details>). The
+  SSE channel (/events) already keeps the dashboard updated in-place via
+  rerender(snap); the meta refresh was redundant + harmful and is now
+  removed. The kill-switch state machine no longer has to scrub it.
+-->
 <title>{{FED_NAME}} // Agentis Federation</title>
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
@@ -1166,6 +1174,186 @@
   ::-webkit-scrollbar { width: 4px; }
   ::-webkit-scrollbar-track { background: transparent; }
   ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+  /* --- #359 SSE status dot (header-right, next to refresh button) --- */
+  /* Three states bound to EventSource lifecycle:
+       sse-dot-init (unknown / connecting) — muted gray
+       sse-dot-ok   (es.onopen fired)      — green steady
+       sse-dot-err  (es.onerror fired)     — red, no shadow
+     The .pulse class is added briefly (200ms) on each `snapshot` event
+     to give the operator a visual confirmation that updates are flowing.
+  */
+  .sse-dot {
+    display: inline-block; width: 8px; height: 8px;
+    border-radius: 50%; background: var(--muted);
+    margin-left: 4px; vertical-align: middle;
+    transition: background 0.15s, box-shadow 0.15s;
+  }
+  .sse-dot-init { background: var(--muted); }
+  .sse-dot-ok   { background: var(--green); box-shadow: 0 0 4px rgba(0,255,0,0.4); }
+  .sse-dot-err  { background: var(--red);   box-shadow: 0 0 4px rgba(255,68,68,0.4); }
+  .sse-dot.pulse { box-shadow: 0 0 12px rgba(0,255,0,0.9); transform: scale(1.4); }
+
+  /* --- #359 Status tab — single-glance verdict --- */
+  /* Pure text + colored pulse cells; no charts, no tables, no <details>.
+     The vertical budget is ≤480px so the operator can absorb the federation
+     state in one eye-pass without scrolling. */
+  .status-verdict-pill {
+    display: inline-block;
+    padding: 4px 16px; border-radius: 20px;
+    font-size: 14px; letter-spacing: 2px; text-transform: uppercase;
+    border: 1px solid var(--green); color: var(--green);
+    text-shadow: 0 0 8px rgba(0,255,0,0.4);
+    margin-bottom: 16px;
+  }
+  .status-verdict-pill.warn {
+    border-color: var(--yellow); color: var(--yellow);
+    text-shadow: 0 0 8px rgba(255,255,0,0.4);
+  }
+  .status-verdict-pill.crit {
+    border-color: var(--red); color: var(--red);
+    text-shadow: 0 0 8px rgba(255,68,68,0.4);
+  }
+  .pulse-grid {
+    display: grid; grid-template-columns: repeat(7, 1fr);
+    gap: 6px; margin: 12px 0; max-width: 560px;
+  }
+  .pulse-cell {
+    aspect-ratio: 1 / 1; border-radius: 4px; cursor: pointer;
+    border: 1px solid var(--border); position: relative;
+    transition: transform 0.1s, box-shadow 0.1s;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 9px; color: var(--muted); padding: 2px;
+    text-align: center; word-break: break-all; line-height: 1.1;
+  }
+  .pulse-cell:hover { transform: scale(1.06); box-shadow: 0 0 10px var(--cyan); }
+  .pulse-cell.pulse-running   { background: rgba(0,255,0,0.18);   border-color: var(--green); color: var(--green); }
+  .pulse-cell.pulse-degraded  { background: rgba(255,255,0,0.16); border-color: var(--yellow); color: var(--yellow); }
+  .pulse-cell.pulse-stopped   { background: rgba(255,68,68,0.18); border-color: var(--red); color: var(--red); }
+  .pulse-cell.pulse-zombie    { background: rgba(255,68,68,0.30); border-color: var(--red); color: #fff; }
+  .pulse-cell.pulse-quarantine { background: rgba(255,0,255,0.16); border-color: var(--magenta); color: var(--magenta); }
+  .status-meta { font-size: 11px; color: var(--muted); display: flex; gap: 16px; flex-wrap: wrap; margin-top: 6px; }
+  .status-meta strong { color: var(--text); font-weight: normal; }
+  .status-pill-row { display: flex; gap: 12px; margin: 12px 0; flex-wrap: wrap; }
+  .status-pill {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 4px 12px; border-radius: 14px; border: 1px solid var(--border);
+    font-size: 11px; letter-spacing: 1px; text-transform: uppercase;
+  }
+  .status-pill.ok    { border-color: var(--green);  color: var(--green);  }
+  .status-pill.warn  { border-color: var(--yellow); color: var(--yellow); }
+  .status-pill.crit  { border-color: var(--red);    color: var(--red);    }
+  .status-pill.muted { color: var(--muted); }
+  .status-pill .status-pill-age { color: var(--muted); font-size: 10px; }
+
+  /* --- #359 Cost tab projection tiles --- */
+  .projection-row {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 12px; margin-bottom: 16px;
+  }
+  .projection-tile {
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: 4px; padding: 12px; text-align: center;
+    position: relative;
+  }
+  .projection-tile.warn { border-color: var(--yellow); }
+  .projection-tile.crit { border-color: var(--red); }
+  .projection-tile-label { font-size: 9px; color: var(--muted); text-transform: uppercase; letter-spacing: 2px; }
+  .projection-tile-value { font-size: 22px; color: var(--cyan); margin-top: 4px; font-variant-numeric: tabular-nums; }
+  .projection-tile.warn .projection-tile-value { color: var(--yellow); }
+  .projection-tile.crit .projection-tile-value { color: var(--red); }
+  .projection-tile-extra { font-size: 9px; color: var(--muted); margin-top: 4px; }
+
+  /* --- #359 Recovery tab --- */
+  .recovery-actions {
+    display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 12px;
+  }
+  .recovery-actions button {
+    background: transparent; border: 1px solid var(--border);
+    color: var(--text); font-family: inherit; font-size: 11px;
+    padding: 6px 14px; cursor: pointer; border-radius: 3px;
+    text-transform: uppercase; letter-spacing: 1px;
+  }
+  .recovery-actions button:hover { border-color: var(--cyan); color: var(--cyan); }
+  .recovery-actions button.crit { border-color: var(--red); color: var(--red); }
+  .recovery-actions button.crit:hover { background: var(--red); color: #000; }
+  .recovery-table { width: 100%; border-collapse: collapse; font-size: 11px; }
+  .recovery-table th, .recovery-table td { padding: 5px 8px; border-bottom: 1px solid var(--border2); text-align: left; }
+  .recovery-row-restart-btn {
+    background: transparent; border: 1px solid var(--border);
+    color: var(--cyan); font-family: inherit; font-size: 10px;
+    padding: 2px 8px; cursor: pointer; border-radius: 2px;
+  }
+  .recovery-row-restart-btn:hover { background: rgba(0,255,255,0.06); }
+  .recovery-row-restart-btn:disabled { color: var(--muted); border-color: var(--border2); cursor: default; }
+  .watchdog-timeline {
+    max-height: 200px; overflow-y: auto; font-size: 11px;
+    border: 1px solid var(--border2); border-radius: 4px;
+    padding: 8px; margin-top: 8px;
+  }
+  .watchdog-row {
+    display: grid; grid-template-columns: 110px 110px 1fr;
+    gap: 8px; padding: 3px 0; border-bottom: 1px solid var(--border2);
+  }
+  .watchdog-row:last-child { border-bottom: none; }
+  .watchdog-ts { color: var(--muted); font-variant-numeric: tabular-nums; }
+  .watchdog-agent { color: var(--cyan); }
+  .watchdog-reason { color: var(--text); }
+  .log-tail-block {
+    background: #050505; border: 1px solid var(--border2);
+    color: var(--text); padding: 8px; border-radius: 3px;
+    font-family: 'Share Tech Mono', monospace; font-size: 10px;
+    white-space: pre-wrap; max-height: 280px; overflow: auto;
+    margin-top: 4px;
+  }
+
+  /* Kill-confirm modal: defensive double-confirm (operator types fed name). */
+  .kill-confirm-input {
+    width: 100%; background: #050505; border: 1px solid var(--red);
+    color: var(--red); padding: 6px 10px; font-family: inherit;
+    font-size: 13px; border-radius: 3px; margin: 8px 0;
+  }
+  .kill-confirm-input:focus { outline: none; box-shadow: 0 0 8px rgba(255,68,68,0.4); }
+  .kill-confirm-fed { color: var(--red); font-weight: bold; letter-spacing: 1px; }
+
+  /* Cross-colony matrix (Config tab). */
+  .config-matrix-table { width: 100%; border-collapse: collapse; font-size: 11px; margin-top: 12px; }
+  .config-matrix-table th, .config-matrix-table td {
+    padding: 4px 8px; border-bottom: 1px solid var(--border2);
+    text-align: left; vertical-align: top;
+  }
+  .config-matrix-table th { color: var(--muted); font-weight: 400; font-size: 10px; text-transform: uppercase; letter-spacing: 1px; }
+  .config-matrix-key { color: var(--cyan); font-family: 'Share Tech Mono', monospace; }
+  .config-matrix-value { color: var(--text); font-family: 'Share Tech Mono', monospace; }
+  .config-matrix-value.fed-default { color: var(--muted); font-style: italic; }
+  .config-matrix-value.complex { color: var(--orange); }
+  .config-matrix-value.empty { color: var(--muted); }
+
+  /* Bulk-apply scopes checkbox group inside the confirm modal. */
+  .config-confirm-scopes {
+    display: flex; gap: 12px; flex-wrap: wrap;
+    margin: 8px 0; padding: 8px;
+    border: 1px solid var(--border2); border-radius: 4px;
+  }
+  .config-confirm-scopes label {
+    font-size: 11px; color: var(--text);
+    display: inline-flex; align-items: center; gap: 4px;
+    cursor: pointer;
+  }
+  .config-confirm-scopes input[type="checkbox"] { vertical-align: middle; }
+
+  /* Complex value marker on Config tab rows. */
+  .config-row.complex { opacity: 0.85; }
+  .config-row.complex .config-input {
+    pointer-events: none; cursor: not-allowed; color: var(--muted);
+    background: rgba(255,136,0,0.05); border: 1px dashed var(--orange);
+  }
+  .config-complex-marker {
+    display: inline-block; padding: 1px 6px; border-radius: 2px;
+    font-size: 9px; letter-spacing: 1px; text-transform: uppercase;
+    border: 1px solid var(--orange); color: var(--orange);
+    margin-left: 6px;
+  }
 </style>
 </head>
 <body>
@@ -1177,7 +1365,7 @@
   <div class="header-right" style="display:flex;align-items:center;gap:16px;">
     <div>
       <div class="time" id="clock"></div>
-      <div><span id="countdown">auto-refresh in 60s</span> <button class="refresh-btn" id="refresh-btn" onclick="manualRefresh()" title="Refresh now (press 'r')" aria-label="Refresh now">&#x21bb;</button></div>
+      <div><span id="countdown" title="SSE pushes updates live; counter is a fallback poll cue">live</span> <span id="sse-dot" class="sse-dot sse-dot-init" title="SSE connecting…" aria-label="SSE status"></span> <button class="refresh-btn" id="refresh-btn" onclick="manualRefresh()" title="Refresh now (press 'r')" aria-label="Refresh now">&#x21bb;</button></div>
     </div>
     <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px;">
       <button class="kill-btn" id="kill-btn" onclick="killSwitch()">Kill Federation</button>
@@ -1193,110 +1381,39 @@
 
 <div class="fed-health-banner" id="fed-health-banner"></div>
 
-<!-- #352: Six-tab single-page app. The tab buttons toggle visibility of
-     the matching `<section data-tab="...">` block; renderers fire on
-     every snapshot regardless of which tab is currently visible (pure CSS
-     toggle, no re-fetch). Default tab is overview; persisted via
-     localStorage. Keyboard shortcuts: digits 1-6. -->
+<!-- #359: 5-tab intent-driven cut, replacing the 6-tab #352 layout.
+     Each tab maps to a single operator question:
+       Status   — am I healthy NOW? (verdict + pulse grid + sidecars)
+       Cost     — am I burning money? (per-min rate + projections + caps)
+       Recovery — what do I need to restart? (bulk + per-agent + sidecars + kill)
+       Progress — are agents climbing? (charts default-expanded + ETA)
+       Config   — what's running where? (editor + cross-colony matrix + bulk apply)
+     Default first paint is `status` (was `overview`; Overview is gone).
+     Persisted via localStorage `agentis:dashboard:active-tab`. Keyboard
+     shortcuts: digits 1-5. -->
 <div class="tabs" id="tabs" role="tablist">
-  <button class="tab-btn" role="tab" data-tab="overview"  ><span class="tab-key">1</span>Overview</button>
-  <button class="tab-btn" role="tab" data-tab="agents"    ><span class="tab-key">2</span>Agents</button>
-  <button class="tab-btn" role="tab" data-tab="promotions"><span class="tab-key">3</span>Promotions</button>
-  <button class="tab-btn" role="tab" data-tab="learning"  ><span class="tab-key">4</span>Learning</button>
-  <button class="tab-btn" role="tab" data-tab="cost"      ><span class="tab-key">5</span>Cost</button>
-  <button class="tab-btn" role="tab" data-tab="config"    ><span class="tab-key">6</span>Config</button>
+  <button class="tab-btn" role="tab" data-tab="status"  ><span class="tab-key">1</span>Status</button>
+  <button class="tab-btn" role="tab" data-tab="cost"    ><span class="tab-key">2</span>Cost</button>
+  <button class="tab-btn" role="tab" data-tab="recovery"><span class="tab-key">3</span>Recovery</button>
+  <button class="tab-btn" role="tab" data-tab="progress"><span class="tab-key">4</span>Progress</button>
+  <button class="tab-btn" role="tab" data-tab="config"  ><span class="tab-key">5</span>Config</button>
 </div>
 
-<!-- TAB: Overview — federation health snapshot, sidecar listing,
-     bulk-restart actions. #357 dropped Phase Readiness (moved to
-     Promotions, top card) and Forge Rate Limits (moved into per-colony
-     modal, opened from Promotions/Agents colony headers) so the tab fits
-     ~480 px of actionable surface and leaves headroom for the Health
-     Banner to expand without scroll. -->
-<section data-tab="overview">
-  <div class="stats-row" id="stats-row"></div>
-  <div class="grid">
-    <div class="card full">
-      <h2>Sidecars</h2>
-      <div id="sidecar-status"></div>
-    </div>
-    <div class="card full" id="bulk-actions-card" style="display:none;">
-      <h2>Bulk Actions</h2>
-      <div id="bulk-actions" class="bulk-actions"></div>
-    </div>
-  </div>
+<!-- TAB: Status — single-glance verdict. NO charts, NO bars, NO tables,
+     NO `<details>`. Operator absorbs the whole federation in one eye-pass.
+     Vertical budget ≤480 px. -->
+<section data-tab="status">
+  <div id="status-verdict"></div>
+  <div id="status-pulse"></div>
+  <div id="status-sidecar-pills"></div>
+  <div id="status-meta"></div>
 </section>
 
-<!-- TAB: Agents — per-agent dossier table. Sortable, modal-expandable. -->
-<section data-tab="agents">
-  <div class="grid">
-    <div class="card full">
-      <h2>Agents</h2>
-      <div id="agent-table" style="overflow-x:auto;"></div>
-    </div>
-  </div>
-</section>
-
-<!-- TAB: Promotions — Phase Readiness (federation-wide tier counts, #357
-     relocated from Overview), per-agent promotion ladder, scheduler
-     verdicts. -->
-<section data-tab="promotions">
-  <div class="grid">
-    <div class="card full">
-      <h2>Phase Readiness</h2>
-      <div id="readiness"></div>
-    </div>
-    <div class="card full">
-      <h2>Promotion Ladder</h2>
-      <div id="promotion-ladder"></div>
-    </div>
-    <div class="card full">
-      <h2>Promote Candidates</h2>
-      <div id="promote-candidates"></div>
-    </div>
-  </div>
-</section>
-
-<!-- TAB: Learning — federation-wide event timeline + activity charts. -->
-<section data-tab="learning">
-  <div class="grid">
-    <div class="card full">
-      <div class="timeline-header">
-        <h2>Event Timeline</h2>
-        <div class="timeline-actions">
-          <select class="timeline-colony-filter" id="timeline-colony-filter" title="Filter timeline rows by colony"></select>
-          <label class="timeline-toggle" title="Auto-hide errors from agents that have ticked cleanly in the last hour">
-            <input type="checkbox" id="timeline-auto-hide-stale"> Auto-hide stale
-          </label>
-          <button class="timeline-clear-btn" id="timeline-time-mode-btn" title="Toggle absolute / relative timestamps">Time: ABS</button>
-          <button class="timeline-clear-btn" id="timeline-clear-stale-btn" title="Snapshot-clear errors from cleanly-ticking agents (per-(agent, error) cursor)">Clear stale</button>
-          <button class="timeline-clear-btn" id="timeline-clear-btn" title="Hide every entry older than now (per-federation cursor)">Clear all</button>
-        </div>
-      </div>
-      <div class="timeline-chips" id="timeline-chips"></div>
-      <div class="timeline-banner" id="timeline-banner" hidden></div>
-      <div id="event-timeline" class="timeline"></div>
-    </div>
-    <!-- #248 PR C: legacy charts demoted behind <details>. Per-agent
-         entries_total + per-agent confidence-on-card answer the operator
-         questions these once served; charts remain for trend-spotters. -->
-    <div class="card">
-      <details class="card-collapse">
-        <summary><span class="summary-h2">Experience Growth</span></summary>
-        <div id="experience-trend" class="chart-container"></div>
-      </details>
-    </div>
-    <div class="card">
-      <details class="card-collapse">
-        <summary><span class="summary-h2">Confidence Trend</span></summary>
-        <div id="confidence-trend" class="chart-container"></div>
-      </details>
-    </div>
-  </div>
-</section>
-
-<!-- TAB: Cost — tokens (top) + USD (bottom) split + cost-cap status. -->
+<!-- TAB: Cost — 4 projection tiles (per-min × {1h, 1d, 1w, 1m}) +
+     cumulative row + cost-cap progress + per-colony split. Vertical
+     budget ≤700 px. -->
 <section data-tab="cost">
+  <div id="cost-projections"></div>
   <div class="grid">
     <div class="card full">
       <h2>LLM Tokens</h2>
@@ -1318,17 +1435,101 @@
   </div>
 </section>
 
+<!-- TAB: Recovery — bulk-restart, per-agent restart, per-sidecar restart,
+     federation kill switch (with confirm-by-name modal), watchdog kills
+     timeline (forensic), per-agent log tail (<details> per agent). -->
+<section data-tab="recovery">
+  <div class="grid">
+    <div class="card full">
+      <h2>Recovery Actions</h2>
+      <div id="recovery-bulk-actions" class="recovery-actions"></div>
+      <div id="recovery-agents"></div>
+    </div>
+    <div class="card full">
+      <h2>Sidecars</h2>
+      <div id="sidecar-status"></div>
+    </div>
+    <div class="card full">
+      <h2>Watchdog Kills (last 10)</h2>
+      <div id="watchdog-kills" class="watchdog-timeline"></div>
+    </div>
+    <div class="card full">
+      <h2>Per-Agent Log Tail</h2>
+      <div id="recovery-log-tails"></div>
+    </div>
+  </div>
+</section>
+
+<!-- TAB: Progress — Confidence Trend + Experience Growth charts default
+     EXPANDED (no <details> wrapper); Phase Readiness as a small card;
+     per-agent promotion ladder + ETA + limiting prereq. Vertical budget
+     ≤700 px. -->
+<section data-tab="progress">
+  <div class="grid">
+    <div class="card">
+      <h2>Confidence Trend</h2>
+      <div id="confidence-trend" class="chart-container"></div>
+    </div>
+    <div class="card">
+      <h2>Experience Growth</h2>
+      <div id="experience-trend" class="chart-container"></div>
+    </div>
+    <div class="card full">
+      <h2>Phase Readiness</h2>
+      <div id="readiness" style="max-height:200px;overflow-y:auto;"></div>
+    </div>
+    <div class="card full">
+      <h2>Promotion Ladder</h2>
+      <div id="promotion-ladder"></div>
+    </div>
+    <div class="card full">
+      <h2>Promote Candidates</h2>
+      <div id="promote-candidates"></div>
+    </div>
+    <div class="card full">
+      <div class="timeline-header">
+        <h2>Event Timeline</h2>
+        <div class="timeline-actions">
+          <select class="timeline-colony-filter" id="timeline-colony-filter" title="Filter timeline rows by colony"></select>
+          <label class="timeline-toggle" title="Auto-hide errors from agents that have ticked cleanly in the last hour">
+            <input type="checkbox" id="timeline-auto-hide-stale"> Auto-hide stale
+          </label>
+          <button class="timeline-clear-btn" id="timeline-time-mode-btn" title="Toggle absolute / relative timestamps">Time: ABS</button>
+          <button class="timeline-clear-btn" id="timeline-clear-stale-btn" title="Snapshot-clear errors from cleanly-ticking agents (per-(agent, error) cursor)">Clear stale</button>
+          <button class="timeline-clear-btn" id="timeline-clear-btn" title="Hide every entry older than now (per-federation cursor)">Clear all</button>
+        </div>
+      </div>
+      <div class="timeline-chips" id="timeline-chips"></div>
+      <div class="timeline-banner" id="timeline-banner" hidden></div>
+      <div id="event-timeline" class="timeline"></div>
+    </div>
+    <!-- Per-agent dossier table preserved for full drill-in. The Status
+         tab's pulse-grid hands operators here when they click a cell. -->
+    <div class="card full">
+      <h2>Agents</h2>
+      <div id="agent-table" style="overflow-x:auto;"></div>
+    </div>
+  </div>
+</section>
+
 <!-- TAB: Config — per-colony + federation-wide TOML editor. Editable by
      default after #357 (the v0.6.0 read-only gate was a feature
      regression). Setting `[config_editor].operator_writes_disabled =
      true` in `<fed>/.agentis/config` flips the tab back to read-only as
      a defensive opt-out. Each Apply pops a structured confirm modal
-     listing every key change before the POST /config/apply fires. -->
+     listing every key change before the POST /config/apply fires. #359
+     adds bulk apply (per-scope checkbox group on the modal) and a
+     cross-colony matrix view (one row per dotted key with at least one
+     override). -->
 <section data-tab="config">
   <div class="grid">
     <div class="card full">
       <h2>Configuration</h2>
       <div id="config-editor"></div>
+    </div>
+    <div class="card full">
+      <h2>Cross-Colony Matrix</h2>
+      <div id="config-matrix"></div>
     </div>
   </div>
 </section>
@@ -1349,6 +1550,13 @@
      operator sees exactly what writes before they fire). -->
 <div class="modal-overlay" id="config-confirm-modal">
 <div class="modal-content" id="config-confirm-body"></div>
+</div>
+
+<!-- Kill Confirm Modal (#359: defensive double-confirm for the federation
+     kill switch. Operator must type the federation name to enable Kill —
+     the type-to-confirm pattern is borrowed from GitHub repo deletion. -->
+<div class="modal-overlay" id="kill-confirm-modal">
+<div class="modal-content" id="kill-confirm-body"></div>
 </div>
 
 <!-- #160: Why panel for disabled buttons + skipped recommendations -->
@@ -1512,16 +1720,24 @@ function tlWriteJSON(key, value) {
   try { localStorage.setItem(key, JSON.stringify(value)); } catch (e) {}
 }
 
-// --- Refresh countdown ---
+// --- Refresh status (#359) ---
+// The pre-#359 dashboard relied on a `<meta http-equiv="refresh" content="60">`
+// tag to do a full-page reload every minute. That meta tag is gone (it caused
+// flicker + wiped operator in-flight state); the SSE channel already keeps
+// every renderer in sync with the live snapshot. The countdown element now
+// just surfaces seconds-since-last-snapshot so the operator can see at a
+// glance how fresh the data is.
 (function() {
-  const REFRESH_MS = 60000;
   const el = document.getElementById('countdown');
   if (!el) return;
-  const loadedAt = Date.now();
   function tick() {
-    const remaining = Math.max(0, REFRESH_MS - (Date.now() - loadedAt));
-    const s = Math.ceil(remaining / 1000);
-    el.textContent = 'auto-refresh in ' + String(Math.floor(s/60)).padStart(2,'0') + ':' + String(s%60).padStart(2,'0');
+    const last = window.__lastSnapshotAt || 0;
+    if (!last) {
+      el.textContent = 'live';
+      return;
+    }
+    const age = Math.max(0, Math.floor((Date.now() - last) / 1000));
+    el.textContent = age < 5 ? 'live' : (age + 's ago');
   }
   tick();
   setInterval(tick, 1000);
@@ -1542,13 +1758,13 @@ document.addEventListener('keydown', (e) => {
     e.preventDefault();
     manualRefresh();
   }
-  if (e.key === 'Escape') { closeModal(); closeWhyPanel(); }
-  // #352: digits 1-6 jump between tabs.
+  if (e.key === 'Escape') { closeModal(); closeWhyPanel(); closeKillConfirm(); }
+  // #359: digits 1-5 jump between tabs (was 1-6 in #352).
   if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && !e.repeat) {
     const tag = (e.target && e.target.tagName) || '';
     if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target && e.target.isContentEditable)) return;
-    const TAB_KEY_ORDER = ['overview', 'agents', 'promotions', 'learning', 'cost', 'config'];
-    const idx = '123456'.indexOf(e.key);
+    const TAB_KEY_ORDER = ['status', 'cost', 'recovery', 'progress', 'config'];
+    const idx = '12345'.indexOf(e.key);
     if (idx >= 0 && idx < TAB_KEY_ORDER.length) {
       e.preventDefault();
       activateTab(TAB_KEY_ORDER[idx]);
@@ -1556,14 +1772,26 @@ document.addEventListener('keydown', (e) => {
   }
 });
 
-// #352: tab switcher. Persists the active tab in localStorage so an
-// operator's last view survives a reload. Pure CSS toggle: every renderXxx()
-// still fires on every snapshot regardless of which tab is currently
-// visible — switching tabs reads pre-rendered DOM, no re-fetch.
+// #359: 5-tab intent-driven cut (Status / Cost / Recovery / Progress /
+// Config). Replaces the 6-tab #352 layout (Overview / Agents / Promotions
+// / Learning / Cost / Config). Persists the active tab in localStorage so
+// an operator's last view survives a reload. Pure CSS toggle: every
+// renderXxx() still fires on every snapshot regardless of which tab is
+// currently visible — switching tabs reads pre-rendered DOM, no re-fetch.
+// Default first paint is `status` (Overview is gone). Legacy values for
+// the localStorage key (`overview`, `agents`, `promotions`, `learning`)
+// migrate to a sensible new home so a returning operator doesn't see a
+// blank tab on the first load post-upgrade.
 const ACTIVE_TAB_KEY = 'agentis:dashboard:active-tab';
-const TAB_NAMES = ['overview', 'agents', 'promotions', 'learning', 'cost', 'config'];
+const TAB_NAMES = ['status', 'cost', 'recovery', 'progress', 'config'];
+const LEGACY_TAB_MIGRATION = {
+  'overview':   'status',
+  'agents':     'progress',
+  'promotions': 'progress',
+  'learning':   'progress',
+};
 function activateTab(name) {
-  if (!TAB_NAMES.includes(name)) name = 'overview';
+  if (!TAB_NAMES.includes(name)) name = 'status';
   document.querySelectorAll('section[data-tab]').forEach(sec => {
     if (sec.getAttribute('data-tab') === name) {
       sec.classList.add('active');
@@ -1591,7 +1819,10 @@ function activateTab(name) {
   });
   let initial;
   try { initial = localStorage.getItem(ACTIVE_TAB_KEY); } catch (e) { initial = null; }
-  if (!initial || !TAB_NAMES.includes(initial)) initial = 'overview';
+  if (initial && LEGACY_TAB_MIGRATION[initial]) {
+    initial = LEGACY_TAB_MIGRATION[initial];
+  }
+  if (!initial || !TAB_NAMES.includes(initial)) initial = 'status';
   activateTab(initial);
 })();
 
@@ -1626,6 +1857,12 @@ let sidecars = data.sidecars || [];
 // also pin read-only via `data.config_editor.read_only_override = true`
 // without touching the disabled gate.
 let configEditor = data.config_editor || {operator_writes_disabled: false, scopes: []};
+// #359: forensic watchdog kills (Recovery tab) + per-minute burn rate
+// fields are inline on data.cost (already exposed via the `data` shorthand
+// in renderXxx callbacks). watchdog_kills gets a top-level shorthand only
+// so the Status verdict + Recovery timeline don't have to thread the data
+// arg through every helper.
+let watchdogKills = data.watchdog_kills || [];
 
 // #313 PR 2: re-derives the shorthands above from a fresh snapshot.
 // Called once at init (the lets above) and once per SSE push (rerender).
@@ -1643,6 +1880,7 @@ function extractRefs(d) {
   sidecar = d.sidecar || {installed: false, enabled: false, interval_s: null, last_tick_ts: null};
   sidecars = d.sidecars || [];
   configEditor = d.config_editor || {operator_writes_disabled: false, scopes: []};
+  watchdogKills = d.watchdog_kills || [];
   // History + nowEpoch travel out-of-band when the snapshot carries
   // them; PR 1's snapshot.json contract is full COLLECTOR_JSON only,
   // so .history / .now_epoch may be undefined — fall back to the
@@ -2472,33 +2710,58 @@ function renderConfigEditor(data) {
       // #357: stash the dotted path + base value so applyConfigEdits()
       // can build a clean {key, value} payload + diff old vs new.
       const dottedKey = kv.section ? (kv.section + '.' + kv.key) : kv.key;
+      // #359: complex_value flag from the collector (inline arrays /
+      // inline tables — `labels = ["a", "b"]`, `limits = {hi=1, lo=0}`).
+      // Render read-only with a "complex value (edit colony.toml directly)"
+      // marker so an operator can see the value without accidentally
+      // corrupting the array via the line-level patcher (which only
+      // handles scalar values).
+      const isComplex = !!kv.complex_value;
       __configBaseValues[active.scope][inputId] = {
         section: kv.section || '',
         key: kv.key,
         dotted: dottedKey,
         type: t,
         raw_value: kv.raw_value,
+        complex_value: isComplex,
       };
-      html += '<div class="config-row" data-config-row="1" data-input-id="' + esc(inputId) + '" data-dotted="' + esc(dottedKey) + '">';
+      const rowCls = 'config-row' + (isComplex ? ' complex' : '');
+      html += '<div class="' + rowCls + '" data-config-row="1" data-input-id="' + esc(inputId) + '" data-dotted="' + esc(dottedKey) + '"' + (isComplex ? ' data-complex-value="1"' : '') + '>';
       html += '<span class="config-key">' + esc(kv.key) + '</span>';
-      const ro = writable ? '' : ' readonly disabled';
-      if (t === 'bool') {
-        const checked = (String(kv.raw_value).trim().toLowerCase() === 'true') ? ' checked' : '';
-        html += '<input type="checkbox" class="config-input" id="' + inputId + '"' + checked + (writable ? '' : ' disabled') + '>';
-      } else if (t === 'enum') {
-        const vocab = CONFIG_ENUM_VOCAB[kv.key] || [];
-        const cur = String(kv.raw_value).trim().replace(/^["']|["']$/g, '');
-        html += '<select class="config-input" id="' + inputId + '"' + (writable ? '' : ' disabled') + '>';
-        if (!vocab.includes(cur)) html += '<option value="' + esc(cur) + '" selected>' + esc(cur) + '</option>';
-        vocab.forEach(v => {
-          html += '<option value="' + esc(v) + '"' + (v === cur ? ' selected' : '') + '>' + esc(v) + '</option>';
-        });
-        html += '</select>';
-      } else if (t === 'int' || t === 'float') {
-        html += '<input type="number" class="config-input" id="' + inputId + '" value="' + esc(kv.raw_value) + '"' + ro + '>';
+      if (isComplex) {
+        // Complex values: render as a read-only text input (so the row
+        // structure stays consistent) with a "complex value" marker.
+        // applyConfigEdits() skips these rows by checking the
+        // complex_value flag in __configBaseValues.
+        const cv = String(kv.raw_value || '');
+        html += '<input type="text" class="config-input" id="' + inputId +
+                '" value="' + esc(cv.length > 80 ? cv.slice(0, 78) + '…' : cv) +
+                '" readonly disabled>';
+        html += '<span class="config-complex-marker" title="Inline array / table — edit colony.toml directly">complex</span>';
       } else {
-        const v = String(kv.raw_value).replace(/^["']|["']$/g, '');
-        html += '<input type="text" class="config-input" id="' + inputId + '" value="' + esc(v) + '"' + ro + '>';
+        const ro = writable ? '' : ' readonly disabled';
+        if (t === 'bool') {
+          const checked = (String(kv.raw_value).trim().toLowerCase() === 'true') ? ' checked' : '';
+          html += '<input type="checkbox" class="config-input" id="' + inputId + '"' + checked + (writable ? '' : ' disabled') + '>';
+        } else if (t === 'enum') {
+          const vocab = CONFIG_ENUM_VOCAB[kv.key] || [];
+          const cur = String(kv.raw_value).trim().replace(/^["']|["']$/g, '');
+          html += '<select class="config-input" id="' + inputId + '"' + (writable ? '' : ' disabled') + '>';
+          if (!vocab.includes(cur)) html += '<option value="' + esc(cur) + '" selected>' + esc(cur) + '</option>';
+          vocab.forEach(v => {
+            html += '<option value="' + esc(v) + '"' + (v === cur ? ' selected' : '') + '>' + esc(v) + '</option>';
+          });
+          html += '</select>';
+        } else if (t === 'int' || t === 'float') {
+          html += '<input type="number" class="config-input" id="' + inputId + '" value="' + esc(kv.raw_value) + '"' + ro + '>';
+        } else {
+          // SCALAR string value. The collector strips surrounding quotes
+          // before emitting raw_value, so the input renders the bare
+          // value (e.g. `cli`, not `"cli"`). #359 verifies this with
+          // test 51.
+          const v = String(kv.raw_value);
+          html += '<input type="text" class="config-input" id="' + inputId + '" value="' + esc(v) + '"' + ro + '>';
+        }
       }
       html += '</div>';
     });
@@ -2554,6 +2817,11 @@ function applyConfigEdits() {
   inputs.forEach(inp => {
     const meta = base[inp.id];
     if (!meta) return;
+    // #359: skip complex_value rows. They render read-only with a
+    // "complex" marker; the operator must edit colony.toml directly to
+    // mutate inline arrays / tables. The line-level patcher would
+    // corrupt them.
+    if (meta.complex_value) return;
     const newVal = (inp.type === 'checkbox')
       ? (inp.checked ? 'true' : 'false')
       : String(inp.value);
@@ -2579,11 +2847,29 @@ function _showConfigConfirm(scope, changes) {
   const overlay = document.getElementById('config-confirm-modal');
   const body = document.getElementById('config-confirm-body');
   if (!overlay || !body) return;
+  // #359: bulk-apply scope checkbox group. When the operator is editing
+  // a federation-wide key, the modal renders a per-colony checkbox group
+  // (federation default + every colony) pre-checked. Operator can uncheck
+  // a colony to skip it. Only meaningful when scope === 'federation'; for
+  // colony-scoped edits the existing single-scope path is preserved.
+  const isFedScope = (scope === 'federation' || scope === 'fed');
+  const colonyScopes = (configEditor && configEditor.scopes
+    ? configEditor.scopes.map(s => s.scope).filter(s => s && s !== 'federation')
+    : []);
   let html = '<div class="modal-header">';
   html += '<h2>Apply ' + changes.length + ' change' + (changes.length === 1 ? '' : 's') + '<span class="colony-tag">' + esc(scope) + '</span></h2>';
   html += '<button class="modal-close" onclick="_closeConfigConfirm()">×</button>';
   html += '</div>';
-  html += '<div class="modal-desc">The following keys will be written to <code>' + esc(scope) + '</code> and any affected agents will be restarted.</div>';
+  html += '<div class="modal-desc">The following keys will be written and any affected agents will be restarted.</div>';
+  if (isFedScope && colonyScopes.length > 0) {
+    html += '<div class="modal-desc" style="margin-top:8px;">Apply to which scopes?</div>';
+    html += '<div class="config-confirm-scopes" data-bulk-scopes="1">';
+    html += '<label><input type="checkbox" class="bulk-apply-scope" value="federation" checked> federation default</label>';
+    colonyScopes.forEach(c => {
+      html += '<label><input type="checkbox" class="bulk-apply-scope" value="' + esc(c) + '" checked> ' + esc(c) + '</label>';
+    });
+    html += '</div>';
+  }
   html += '<div class="config-confirm-rows">';
   changes.forEach(c => {
     html += '<div class="config-confirm-row" data-confirm-row="1">';
@@ -2603,6 +2889,7 @@ function _showConfigConfirm(scope, changes) {
   // without going through the DOM a second time.
   overlay.__pendingChanges = changes;
   overlay.__pendingScope = scope;
+  overlay.__pendingBulk = isFedScope && colonyScopes.length > 0;
   overlay.classList.add('visible');
 }
 
@@ -2618,22 +2905,60 @@ function _postConfigApply() {
   const overlay = document.getElementById('config-confirm-modal');
   if (!overlay || !overlay.__pendingChanges) return;
   const scope = overlay.__pendingScope;
+  const isBulk = !!overlay.__pendingBulk;
   const changes = overlay.__pendingChanges.map(c => ({
     key: c.key,
     value: c.new_value,
     type: c.type,
   }));
-  const mtime_ms = (typeof __configMtimes[scope] === 'number')
-    ? Math.round(__configMtimes[scope] * 1000) : 0;
+  // #359 bulk apply: collect every checked scope from the per-colony
+  // checkbox group. If at least one colony is checked, send the bulk
+  // payload (`scopes:[...]`); otherwise fall back to single-scope.
+  let payload;
+  if (isBulk) {
+    const checked = Array.from(document.querySelectorAll('.bulk-apply-scope:checked'))
+      .map(c => c.value).filter(Boolean);
+    if (!checked.length) {
+      showSimpleToast('No scopes selected — uncheck Cancel or check at least one scope.', 'var(--orange)', 'err');
+      return;
+    }
+    // Drop the legacy mtime drift check on bulk apply — it doesn't
+    // generalise across N scopes (the file mtime depends on which scope
+    // was last touched). Server still validates per-scope.
+    payload = {scopes: checked, mtime_ms: 0, changes: changes};
+  } else {
+    const mtime_ms = (typeof __configMtimes[scope] === 'number')
+      ? Math.round(__configMtimes[scope] * 1000) : 0;
+    payload = {scope: scope, mtime_ms: mtime_ms, changes: changes};
+  }
   _closeConfigConfirm();
   fetch('/config/apply', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({scope: scope, mtime_ms: mtime_ms, changes: changes}),
+    body: JSON.stringify(payload),
   }).then(r => r.text().then(t => ({status: r.status, body: t})))
     .then(({status, body}) => {
       if (status === 200) {
-        showSimpleToast('Config applied (' + changes.length + ' change' + (changes.length === 1 ? '' : 's') + ')', 'var(--green)', 'ok');
+        // Bulk path returns {applied_scopes:[...], failed_scopes:[...]}.
+        // Surface partial-success in the toast.
+        if (isBulk) {
+          let summary;
+          try {
+            const j = JSON.parse(body);
+            const a = (j.applied_scopes || []).length;
+            const f = (j.failed_scopes || []).length;
+            summary = 'Applied to ' + a + ' scope' + (a === 1 ? '' : 's') +
+                      (f ? ' (' + f + ' failed)' : '');
+          } catch (e) {
+            summary = 'Config applied';
+          }
+          showSimpleToast(summary, 'var(--green)', 'ok');
+        } else {
+          showSimpleToast('Config applied (' + changes.length + ' change' + (changes.length === 1 ? '' : 's') + ')', 'var(--green)', 'ok');
+        }
+      } else if (status === 207) {
+        showSimpleToast('Bulk apply: every scope failed. See console.', 'var(--red)', 'err');
+        if (window.console) console.warn('[bulk-apply] all scopes failed', body);
       } else if (status === 409) {
         showSimpleToast('Drift detected — file changed externally. Reload required.', 'var(--orange)', 'err');
       } else if (status === 422) {
@@ -3537,6 +3862,445 @@ function renderConfidenceTrend(data) {
   colonyList.forEach(col => { legend += '<span><span class="legend-dot" style="background:'+colonyColors[col]+';box-shadow:0 0 4px '+colonyColors[col]+'"></span>'+col+'</span>'; });
   legend += '</div>';
   el.innerHTML = svg + legend;
+}
+
+// =====================================================================
+// #359 Status / Cost / Recovery / Progress / Config — new renderers
+// =====================================================================
+// All five new tab bodies render through these functions. The data shape
+// is unchanged from #357 except for three additions:
+//   data.cost.{rate_per_min_usd, rate_per_min_tokens, projected_*}
+//   data.config_editor.matrix (cross-colony override view)
+//   data.watchdog_kills (forensic last 10)
+// Each renderer is fully idempotent — SSE rerender(snap) calls them all
+// regardless of which tab the operator is currently viewing.
+
+// --- Status verdict pill + 21-cell pulse grid + sidecar status pills ---
+// Status tab body: NO charts, NO bars, NO tables, NO `<details>`. Pure
+// single-glance verdict. Operator absorbs the federation in one eye-pass.
+function renderStatusVerdict(data) {
+  const verdEl = document.getElementById('status-verdict');
+  const pulseEl = document.getElementById('status-pulse');
+  const pillsEl = document.getElementById('status-sidecar-pills');
+  const metaEl = document.getElementById('status-meta');
+  if (!verdEl || !pulseEl || !pillsEl || !metaEl) return;
+
+  // Verdict pill: ✅ running 21/21 / ⚠️ degraded / ❌ stopped.
+  const total = totalAgents || agents.length || 0;
+  const running = agents.filter(a => a.is_running).length;
+  const stopped = agents.filter(a => a.state !== 'running').length;
+  const zombies = agents.filter(a => a.state === 'running'
+                                  && a.pid > 0 && !a.pid_alive).length;
+  const quarantined = agents.filter(a => a.quarantine === 'yes').length;
+  let verdict, vClass;
+  if (total > 0 && running === total && zombies === 0 && quarantined === 0) {
+    verdict = '✅ Running ' + running + '/' + total;
+    vClass = '';
+  } else if (running === 0) {
+    verdict = '❌ Federation stopped';
+    vClass = 'crit';
+  } else if (zombies > 0 || quarantined > 0) {
+    verdict = '⚠️ Degraded — running ' + running + '/' + total +
+              (zombies ? ', ' + zombies + ' zombie' + (zombies > 1 ? 's' : '') : '') +
+              (quarantined ? ', ' + quarantined + ' quarantined' : '');
+    vClass = 'warn';
+  } else {
+    verdict = '⚠️ Running ' + running + '/' + total;
+    vClass = 'warn';
+  }
+  verdEl.innerHTML = '<span class="status-verdict-pill ' + vClass + '">' + esc(verdict) + '</span>';
+
+  // 21-cell pulse-grid (7 cols × 3 rows for the canonical 21-agent
+  // dev-apprenticeship federation; auto-flexes for federations of any
+  // size since CSS grid wraps naturally). Color encodes per-agent state.
+  // Click-through opens the existing per-agent detail modal.
+  let pulseHtml = '<div class="pulse-grid" role="grid" aria-label="Per-agent status pulse">';
+  // Sort by colony then name so cells stay stable across re-renders.
+  const sorted = agents.slice().sort((a, b) => {
+    const ca = (a.colony || '').toLowerCase();
+    const cb = (b.colony || '').toLowerCase();
+    if (ca !== cb) return ca < cb ? -1 : 1;
+    const na = (a.name || '').toLowerCase();
+    const nb = (b.name || '').toLowerCase();
+    return na < nb ? -1 : 1;
+  });
+  sorted.forEach(a => {
+    let cls = 'pulse-running';
+    if (a.quarantine === 'yes') cls = 'pulse-quarantine';
+    else if (a.state === 'running' && a.pid > 0 && !a.pid_alive) cls = 'pulse-zombie';
+    else if (a.state !== 'running') cls = 'pulse-stopped';
+    else if (a.state === 'running' && a.health && a.health !== 'healthy') cls = 'pulse-degraded';
+    const tip = a.colony + '/' + a.name + ' — ' + (a.state || '?') +
+                (a.confidence != null ? ' (conf ' + a.confidence.toFixed(2) + ')' : '');
+    pulseHtml += '<div class="pulse-cell ' + cls + '" tabindex="0" ' +
+                 'onclick="openDetail(\'' + esc(a.name) + '\')" ' +
+                 'onkeydown="if(event.key===\'Enter\'||event.key===\' \'){openDetail(\'' + esc(a.name) + '\');event.preventDefault();}" ' +
+                 'title="' + esc(tip) + '">' + esc(a.name) + '</div>';
+  });
+  pulseHtml += '</div>';
+  pulseEl.innerHTML = pulseHtml;
+
+  // Sidecar status pills + age. Compact single-line summary (no <details>).
+  const sc = sidecars || [];
+  let pillsHtml = '<div class="status-pill-row">';
+  sc.forEach(s => {
+    const name = s.name || '?';
+    let ageTxt = '—';
+    if (s.last_tick_ts) {
+      const diff = Math.max(0, nowEpoch - s.last_tick_ts);
+      if (diff < 60) ageTxt = diff + 's ago';
+      else if (diff < 3600) ageTxt = Math.floor(diff/60) + 'm ago';
+      else if (diff < 86400) ageTxt = Math.floor(diff/3600) + 'h ago';
+      else ageTxt = Math.floor(diff/86400) + 'd ago';
+    } else if (!s.installed) ageTxt = 'not installed';
+    else if (!s.enabled) ageTxt = 'disabled';
+    else ageTxt = 'never';
+    let pillCls = 'muted';
+    const status = (s.status || '').toLowerCase();
+    if (status === 'healthy') pillCls = 'ok';
+    else if (status === 'degraded' || status === 'silent') pillCls = 'warn';
+    else if (status === 'down') pillCls = 'crit';
+    pillsHtml += '<span class="status-pill ' + pillCls + '">' + esc(name) +
+                 '<span class="status-pill-age">' + esc(ageTxt) + '</span>' +
+                 '</span>';
+  });
+  pillsHtml += '</div>';
+  pillsEl.innerHTML = pillsHtml;
+
+  // Last-error timestamp + count. Pulled from the federation-wide
+  // timeline (severity === 'error'); cheap because the timeline is already
+  // ts-desc and capped at 200 rows.
+  const errorRows = (timelineRows || []).filter(r => r.severity === 'error');
+  const errorCount = errorRows.length;
+  let lastErrTxt = '— none —';
+  if (errorCount > 0) {
+    const newest = errorRows[0];
+    const ts = newest.ts ? Math.floor(newest.ts / 1000) : 0;
+    const ago = ts > 0 ? Math.max(0, nowEpoch - ts) : 0;
+    let agoStr;
+    if (ago < 60) agoStr = ago + 's';
+    else if (ago < 3600) agoStr = Math.floor(ago/60) + 'm';
+    else if (ago < 86400) agoStr = Math.floor(ago/3600) + 'h';
+    else agoStr = Math.floor(ago/86400) + 'd';
+    lastErrTxt = errorCount + ' error' + (errorCount === 1 ? '' : 's') +
+                 ' (last ' + agoStr + ' ago: ' + (newest.agent_name || newest.agent_id || '?') + ')';
+  }
+  metaEl.innerHTML = '<div class="status-meta">' +
+                    '<span><strong>' + running + '/' + total + '</strong> running</span>' +
+                    '<span><strong>' + quarantined + '</strong> quarantined</span>' +
+                    '<span><strong>' + zombies + '</strong> zombie PID' + (zombies === 1 ? '' : 's') + '</span>' +
+                    '<span>last error: ' + esc(lastErrTxt) + '</span>' +
+                    '</div>';
+}
+
+// --- Cost projection tiles (Cost tab top row) ---
+// Four tiles: $/min, tokens/min, projected 1h, projected 1d. The 1w / 1m
+// projections live in the tooltip on the 1d tile so the headline row stays
+// at four cells. Traffic-light color: green when projected $/h <
+// `cost_threshold_yellow_usd_per_h`, yellow up to red, red above
+// `cost_threshold_red_usd_per_h`.
+function renderCostProjections(data) {
+  const el = document.getElementById('cost-projections');
+  if (!el) return;
+  const c = (data && data.cost) || {};
+  const ratePerMinUsd  = +c.rate_per_min_usd || 0;
+  const ratePerMinTok  = +c.rate_per_min_tokens || 0;
+  const proj1h = +c.projected_1h_usd || 0;
+  const proj1d = +c.projected_1d_usd || 0;
+  const proj1w = +c.projected_1w_usd || 0;
+  const proj1m = +c.projected_1m_usd || 0;
+  const yel = +c.cost_threshold_yellow_usd_per_h || 1.0;
+  const red = +c.cost_threshold_red_usd_per_h    || 5.0;
+  function tileClass(usdPerH) {
+    if (usdPerH >= red) return 'crit';
+    if (usdPerH >= yel) return 'warn';
+    return '';
+  }
+  const cls = tileClass(proj1h);
+  function tile(label, value, extra, klass) {
+    return '<div class="projection-tile ' + (klass || '') + '">' +
+           '<div class="projection-tile-label">' + esc(label) + '</div>' +
+           '<div class="projection-tile-value">' + esc(value) + '</div>' +
+           (extra ? '<div class="projection-tile-extra">' + esc(extra) + '</div>' : '') +
+           '</div>';
+  }
+  const win = c.burn_window_seconds || 300;
+  const winMin = Math.round(win / 60);
+  const html =
+    '<div class="projection-row">' +
+      tile('$/min',        fmtUsd(ratePerMinUsd),     winMin + 'm EMA', cls) +
+      tile('tokens/min',   ratePerMinTok.toLocaleString(), winMin + 'm EMA', '') +
+      tile('Projected 1h', fmtUsd(proj1h),
+           'thresholds: yellow ' + fmtUsd(yel) + '/h, red ' + fmtUsd(red) + '/h',
+           cls) +
+      tile('Projected 1d', fmtUsd(proj1d),
+           '1w ' + fmtUsd(proj1w) + ' / 1m ' + fmtUsd(proj1m),
+           cls) +
+    '</div>';
+  el.innerHTML = html;
+}
+
+// --- Recovery tab: bulk + per-agent + watchdog timeline + log tails ---
+// renderRecoveryActions wires the bulk-restart button + federation kill
+// switch (with confirm-by-name modal). renderRecoveryAgents builds the
+// per-agent table with one [restart] button per row (disabled when
+// running). renderWatchdogKills renders the forensic 10-row timeline
+// from data.watchdog_kills. renderLogTails generates per-agent <details>
+// blocks; expand fetches /log-tail/<agent_id> on demand.
+function renderRecoveryActions(data) {
+  const el = document.getElementById('recovery-bulk-actions');
+  if (!el) return;
+  const stopped = agents.filter(a => {
+    if (a.state !== 'running') return true;
+    if (a.pid && !a.pid_alive) return true;
+    return false;
+  });
+  const stoppedCount = stopped.length;
+  let html = '';
+  html += '<button onclick="restartAllStopped(' + stoppedCount + ')"' +
+          (stoppedCount === 0 ? ' disabled' : '') + ' title="Restart every non-running agent">' +
+          'Restart all stopped (' + stoppedCount + ')</button>';
+  html += '<button class="crit" onclick="openKillConfirm()" title="Kill the federation (confirm by typing the federation name)">' +
+          'Kill Federation …</button>';
+  el.innerHTML = html;
+}
+
+function renderRecoveryAgents(data) {
+  const el = document.getElementById('recovery-agents');
+  if (!el) return;
+  if (!agents.length) {
+    el.innerHTML = '<span class="empty">No agents discovered.</span>';
+    return;
+  }
+  const sorted = agents.slice().sort((a, b) => {
+    const ca = (a.colony || '').toLowerCase();
+    const cb = (b.colony || '').toLowerCase();
+    if (ca !== cb) return ca < cb ? -1 : 1;
+    return (a.name || '').localeCompare(b.name || '');
+  });
+  let html = '<table class="recovery-table">';
+  html += '<tr><th>Agent</th><th>Colony</th><th>State</th><th>PID alive</th><th>Action</th></tr>';
+  sorted.forEach(a => {
+    const isRunning = a.is_running;
+    const pidAliveTxt = (a.pid > 0)
+      ? (a.pid_alive ? '✅' : '❌')
+      : '—';
+    html += '<tr>';
+    html += '<td><span class="agent-name">' + esc(a.name) + '</span></td>';
+    html += '<td><span class="colony-name">' + esc(a.colony) + '</span></td>';
+    html += '<td>' + esc(a.state || '?') + '</td>';
+    html += '<td>' + pidAliveTxt + '</td>';
+    html += '<td>';
+    html += '<button class="recovery-row-restart-btn" ' +
+            'onclick="restartAgent(\'' + esc(a.name) + '\')"' +
+            (isRunning ? ' disabled title="Already running"' : '') +
+            '>Restart</button>';
+    html += '</td>';
+    html += '</tr>';
+  });
+  html += '</table>';
+  el.innerHTML = html;
+}
+
+function renderWatchdogKills(data) {
+  const el = document.getElementById('watchdog-kills');
+  if (!el) return;
+  const rows = (data && data.watchdog_kills) || [];
+  if (!rows.length) {
+    el.innerHTML = '<span class="empty">No watchdog kills recorded.</span>';
+    return;
+  }
+  let html = '';
+  rows.forEach(r => {
+    const ts = r.ts ? Math.floor(r.ts / 1000) : 0;
+    const ago = ts > 0 ? Math.max(0, nowEpoch - ts) : 0;
+    let agoStr;
+    if (ago < 60) agoStr = ago + 's ago';
+    else if (ago < 3600) agoStr = Math.floor(ago/60) + 'm ago';
+    else if (ago < 86400) agoStr = Math.floor(ago/3600) + 'h ago';
+    else agoStr = Math.floor(ago/86400) + 'd ago';
+    html += '<div class="watchdog-row" data-watchdog="1">';
+    html += '<span class="watchdog-ts">' + esc(agoStr) + '</span>';
+    html += '<span class="watchdog-agent">' + esc(r.agent || '?') + '</span>';
+    html += '<span class="watchdog-reason">' + esc(r.reason || r.event || '') + '</span>';
+    html += '</div>';
+  });
+  el.innerHTML = html;
+}
+
+function renderLogTails(data) {
+  const el = document.getElementById('recovery-log-tails');
+  if (!el) return;
+  if (!agents.length) {
+    el.innerHTML = '<span class="empty">No agents discovered.</span>';
+    return;
+  }
+  const sorted = agents.slice().sort((a, b) => {
+    const ca = (a.colony || '').toLowerCase();
+    const cb = (b.colony || '').toLowerCase();
+    if (ca !== cb) return ca < cb ? -1 : 1;
+    return (a.name || '').localeCompare(b.name || '');
+  });
+  let html = '';
+  sorted.forEach(a => {
+    const aid = a.agent_id || a.name;
+    html += '<details class="recovery-log-tail" data-log-tail="1" data-aid="' + esc(aid) + '"' +
+            ' ontoggle="if(this.open) loadLogTail(this);">';
+    html += '<summary><span class="agent-name">' + esc(a.name) + '</span> ' +
+            '<span class="muted">(' + esc(a.colony) + ')</span></summary>';
+    html += '<div class="log-tail-block" data-empty="1">click to load…</div>';
+    html += '</details>';
+  });
+  el.innerHTML = html;
+}
+
+// Lazy fetch of /log-tail/<agent_id>?lines=20 — one HTTP per agent,
+// fired only when the operator expands the <details>. Updates the
+// .log-tail-block in place.
+function loadLogTail(detailsEl) {
+  if (!detailsEl) return;
+  const aid = detailsEl.getAttribute('data-aid') || '';
+  if (!aid) return;
+  const block = detailsEl.querySelector('.log-tail-block');
+  if (!block) return;
+  if (block.getAttribute('data-loaded') === '1') return;  // dedupe re-opens
+  block.textContent = 'loading…';
+  fetch('/log-tail/' + encodeURIComponent(aid) + '?lines=20')
+    .then(r => r.text().then(t => ({status: r.status, body: t})))
+    .then(({status, body}) => {
+      if (status === 200) {
+        block.textContent = body || '(empty)';
+        block.setAttribute('data-loaded', '1');
+      } else {
+        block.textContent = '(error: ' + status + ' ' + body.slice(0, 200) + ')';
+      }
+    })
+    .catch(e => { block.textContent = '(fetch error: ' + e + ')'; });
+}
+
+// --- Federation kill confirm modal (Recovery tab) ---
+// Defensive double-confirm: operator must TYPE the federation name. The
+// kill-no-backup checkbox + the existing /kill endpoint stay; only the
+// trigger UX changes. Reuses the .modal-overlay infra used by detail-modal.
+function openKillConfirm() {
+  const overlay = document.getElementById('kill-confirm-modal');
+  if (!overlay) return;
+  const body = document.getElementById('kill-confirm-body');
+  if (!body) return;
+  let html = '<div class="modal-header">';
+  html += '<h2>Confirm Kill Federation</h2>';
+  html += '<button class="modal-close" onclick="closeKillConfirm()">×</button>';
+  html += '</div>';
+  html += '<div class="modal-desc">Killing <span class="kill-confirm-fed">' + esc(FED_NAME) + '</span> will SIGTERM/SIGKILL every running agent + sidecar. Type the federation name to confirm.</div>';
+  html += '<input type="text" class="kill-confirm-input" id="kill-confirm-input" placeholder="' + esc(FED_NAME) + '" autocomplete="off" onkeydown="if(event.key===\'Enter\')_killConfirmSubmit();">';
+  html += '<label style="font-size:11px;color:var(--muted);"><input type="checkbox" id="kill-confirm-no-backup"> skip backup</label>';
+  html += '<div class="config-apply-bar" style="margin-top:14px;">';
+  html += '<button class="config-apply-btn" onclick="closeKillConfirm()">Cancel</button>';
+  html += '<button class="config-apply-btn" id="kill-confirm-submit" onclick="_killConfirmSubmit()" style="border-color:var(--red);color:var(--red);">Kill</button>';
+  html += '</div>';
+  body.innerHTML = html;
+  overlay.classList.add('visible');
+  setTimeout(() => {
+    const inp = document.getElementById('kill-confirm-input');
+    if (inp) inp.focus();
+  }, 30);
+}
+function closeKillConfirm() {
+  const overlay = document.getElementById('kill-confirm-modal');
+  if (overlay) overlay.classList.remove('visible');
+}
+function _killConfirmSubmit() {
+  const inp = document.getElementById('kill-confirm-input');
+  const noBackup = !!(document.getElementById('kill-confirm-no-backup') || {}).checked;
+  if (!inp) return;
+  if ((inp.value || '').trim() !== String(FED_NAME)) {
+    inp.style.boxShadow = '0 0 12px rgba(255,68,68,0.6)';
+    setTimeout(() => { inp.style.boxShadow = ''; }, 600);
+    return;
+  }
+  closeKillConfirm();
+  // Delegate to the existing kill flow; reuse the existing kill-no-backup
+  // checkbox by mirroring the value before invoking the legacy entrypoint.
+  const legacyChk = document.getElementById('kill-no-backup');
+  if (legacyChk) legacyChk.checked = noBackup;
+  // Bypass the arm-confirm state machine — operator already confirmed
+  // by typing the name. Set the flag and call killSwitch() directly.
+  killArmed = true;
+  killSwitch();
+}
+
+// --- Cross-colony matrix (Config tab) ---
+// One row per dotted key with at least one override. Columns: federation
+// default + every colony scope. Cells render the value verbatim, marker
+// for complex values, italic for federation default echo, "—" for
+// no-override. Read-only by intent; the operator goes back to the editor
+// pane to mutate.
+function renderConfigMatrix(data) {
+  const el = document.getElementById('config-matrix');
+  if (!el) return;
+  const ce = (data && data.config_editor) || configEditor || {};
+  const matrix = ce.matrix || [];
+  const scopes = (ce.scopes || []).map(s => s.scope).filter(Boolean);
+  if (!scopes.length) {
+    el.innerHTML = '<span class="empty">No scopes discovered.</span>';
+    return;
+  }
+  if (!matrix.length) {
+    el.innerHTML = '<span class="empty">No cross-colony overrides — every colony inherits the federation default.</span>';
+    return;
+  }
+  let html = '<table class="config-matrix-table">';
+  html += '<tr><th>Key</th>';
+  scopes.forEach(s => { html += '<th>' + esc(s) + '</th>'; });
+  html += '</tr>';
+  matrix.forEach(row => {
+    html += '<tr>';
+    html += '<td><span class="config-matrix-key">' + esc(row.key) + '</span></td>';
+    scopes.forEach(s => {
+      const cell = row.cells[s];
+      if (!cell) {
+        html += '<td><span class="config-matrix-value empty">—</span></td>';
+      } else {
+        const v = cell.value === null || cell.value === undefined ? '' : String(cell.value);
+        let cls = 'config-matrix-value';
+        if (cell.complex_value) cls += ' complex';
+        if (s !== 'federation') {
+          // If a colony's value matches federation default, render italic
+          // ("inherits"). Otherwise render plain.
+          const fed = row.cells['federation'];
+          if (fed && fed.value === cell.value) cls += ' fed-default';
+        }
+        html += '<td><span class="' + cls + '" title="' + esc(v) + '">' + esc(v.length > 32 ? v.slice(0, 30) + '…' : v) + '</span></td>';
+      }
+    });
+    html += '</tr>';
+  });
+  html += '</table>';
+  el.innerHTML = html;
+}
+
+// --- Single-agent restart helper (Recovery tab per-row button) ---
+// Mirrors restartAllStopped() but for one agent. POSTs /restart with
+// the agent name in the body — reuses the existing legacy endpoint.
+function restartAgent(name) {
+  if (!name) return;
+  if (!confirm('Restart agent ' + name + '?')) return;
+  showSimpleToast('Restarting ' + name + '…', 'var(--yellow)');
+  fetch('/restart', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    body: 'agent=' + encodeURIComponent(name),
+  })
+    .then(r => r.text().then(t => ({status: r.status, body: t})))
+    .then(({status, body}) => {
+      if (status === 200) {
+        showSimpleToast('Restarted ' + name, 'var(--green)', 'ok');
+        scheduleReload(5000);
+      } else {
+        showSimpleToast('Restart failed (' + status + '): ' + body.slice(0, 200), 'var(--red)', 'err');
+      }
+    })
+    .catch(e => { showSimpleToast('Error: ' + e, 'var(--red)', 'err'); });
 }
 
 // --- #160: Capability + fitness gating + Why panel ---
@@ -4609,7 +5373,7 @@ function killSwitch() {
     });
 }
 
-// --- SSE live snapshot consumer (#313 PR 1) ---
+// --- SSE live snapshot consumer (#313 PR 1, extended in #359) ---
 // Server pushes one `event: snapshot` frame per regen tick whenever
 // .dashboard/snapshot.json changes. PR 1 dispatches an `agentis:snapshot`
 // CustomEvent + dedupes by the server-injected 8-char `__hash`; PR 2
@@ -4620,14 +5384,54 @@ function killSwitch() {
 // snapshots, when it breaks (older browser, CORS proxy stripping
 // text/event-stream) the existing background regen + manual refresh
 // paths keep the dashboard alive.
+//
+// #359 additions:
+//   * SSE status indicator (small dot in the page header). Bound to
+//     EventSource lifecycle so an operator can see at a glance whether
+//     SSE is live, briefly pulsing on each snapshot, or dead (channel
+//     fell over and the operator should reload).
+//   * `?debug=1` query-string flag enables console.log on `onopen` and
+//     each `renderXxx(snap)` entry so production-mode operators don't
+//     see noise but a debugger can verify the wiring.
+const SSE_DEBUG = (function() {
+  try {
+    return new URLSearchParams(window.location.search).get('debug') === '1';
+  } catch (e) { return false; }
+})();
+function _sseSetDot(state) {
+  const el = document.getElementById('sse-dot');
+  if (!el) return;
+  el.classList.remove('sse-dot-init', 'sse-dot-ok', 'sse-dot-err', 'pulse');
+  if (state === 'ok') {
+    el.classList.add('sse-dot-ok'); el.title = 'SSE live';
+  } else if (state === 'err') {
+    el.classList.add('sse-dot-err'); el.title = 'SSE disconnected — falling back to manual refresh';
+  } else {
+    el.classList.add('sse-dot-init'); el.title = 'SSE connecting…';
+  }
+}
+function _ssePulse() {
+  const el = document.getElementById('sse-dot');
+  if (!el) return;
+  el.classList.add('pulse');
+  setTimeout(() => { if (el) el.classList.remove('pulse'); }, 200);
+}
 (function setupSSE() {
-  if (!('EventSource' in window)) return;  // graceful no-op on ancient browsers
+  if (!('EventSource' in window)) {
+    _sseSetDot('err');
+    return;  // graceful no-op on ancient browsers
+  }
   let es;
   try {
     es = new EventSource('/events');
   } catch (_) {
+    _sseSetDot('err');
     return;
   }
+  es.onopen = function () {
+    _sseSetDot('ok');
+    if (SSE_DEBUG && window.console) console.log('[sse] onopen');
+  };
   es.addEventListener('snapshot', function (ev) {
     let snap;
     try { snap = JSON.parse(ev.data); }
@@ -4639,12 +5443,18 @@ function killSwitch() {
     const h = snap.__hash || null;
     if (h && window.__lastSnapshotHash === h) return;  // dedupe identical pushes
     window.__lastSnapshotHash = h;
+    window.__lastSnapshotAt = Date.now();
+    _ssePulse();
+    if (SSE_DEBUG && window.console) console.log('[sse] snapshot', h);
     window.dispatchEvent(new CustomEvent('agentis:snapshot', { detail: snap }));
   });
   es.onerror = function () {
-    // EventSource auto-reconnects with backoff. Nothing to do here; the
-    // existing 60s background regen keeps the dashboard fresh in the
+    // EventSource auto-reconnects with backoff. Surface the dead channel
+    // on the dot so the operator knows updates are stale; the existing
+    // background regen + manual refresh keep the dashboard alive in the
     // meantime.
+    _sseSetDot('err');
+    if (SSE_DEBUG && window.console) console.log('[sse] onerror');
   };
 })();
 
@@ -4671,6 +5481,11 @@ function rerender(snap) {
   extractRefs(snap);
   renderFedDownBanner(snap);
   renderFedHealthBanner(snap);
+  // #359: stats-row removed from the main page (its tiles are folded
+  // into Status verdict + Cost tab). Renderer kept only as a no-op so
+  // legacy callers don't crash. The function checks for #stats-row
+  // presence and bails if the element is missing — same pattern as
+  // every other renderer.
   renderStatsRow(snap);
   renderAgentTable(snap);
   renderPhaseReadiness(snap);
@@ -4683,8 +5498,7 @@ function rerender(snap) {
   renderLlmUsd(snap);
   renderCostCap(snap);
   renderPromoteCandidates(snap);
-  // #352: new renderers — sidecar listing, bulk-actions, promotion
-  // ladder, config editor.
+  // #352: sidecar listing, bulk-actions, promotion ladder, config editor.
   renderSidecarStatus(snap);
   renderBulkActions(snap);
   renderPromotionLadder(snap);
@@ -4692,6 +5506,15 @@ function rerender(snap) {
   renderEventTimeline(snap);
   renderExperienceTrend(snap);
   renderConfidenceTrend(snap);
+  // #359: new tab-driven renderers.
+  renderStatusVerdict(snap);
+  renderCostProjections(snap);
+  renderRecoveryActions(snap);
+  renderRecoveryAgents(snap);
+  renderWatchdogKills(snap);
+  renderLogTails(snap);
+  renderConfigMatrix(snap);
+  if (SSE_DEBUG && window.console) console.log('[render] rerender done');
 }
 
 window.addEventListener('agentis:snapshot', function (ev) {

--- a/tools/test-timeline-rendering.sh
+++ b/tools/test-timeline-rendering.sh
@@ -508,13 +508,12 @@ else
     fail "21: SLOPE_FLAT_THRESHOLD missing, wrong value, orphaned, or 1e-6 guard survived (#163)"
 fi
 
-# --- #342 + #357: Phase Readiness — stacked tier bars on Promotions tab ---
-# #342 replaced the #248 PR C compact tier counter with a per-colony stack
-# of 5 progress bars (dormant / shadow / propose / review-gated / autonomous).
-# #357 RELOCATED the markup container from the Overview tab to the top of
-# the Promotions tab (above the per-agent ladders) so the Overview tab is
-# actionable-first and the readiness pairs with the ladder. Test enforces
-# both class wiring (#342) and section placement (#357).
+# --- #359: Phase Readiness — relocated from Promotions to Progress tab ---
+# #342 introduced stacked tier bars; #357 moved markup from Overview to
+# Promotions; #359 collapses Promotions/Learning into Progress and so the
+# Phase Readiness card now lives on the Progress tab (as a SMALL card
+# capped at 200px max-height, not the dominant tile). Test enforces class
+# wiring + section placement on the new Progress tab.
 if python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
 import sys, re
 with open(sys.argv[1]) as f:
@@ -531,17 +530,14 @@ required = ['phase-bar', 'phase-bar-fill', 'phase-bar-label-left', 'phase-bar-la
 for cls in required:
     if cls not in src:
         sys.stderr.write('missing class: ' + cls + '\n'); sys.exit(3)
-# Renderer still classifies via tierFor() against the canonical tier names.
 if "tierFor" not in src or "'dormant'" not in src or "'autonomous'" not in src:
     sys.stderr.write('tierFor / dormant / autonomous missing\n'); sys.exit(4)
-# h2-in-summary anti-pattern must be gone in favour of .summary-h2 span.
 if '<summary><h2>' in src:
     sys.stderr.write('h2-in-summary anti-pattern still present\n'); sys.exit(5)
 if 'summary-h2' not in src:
     sys.stderr.write('summary-h2 class missing\n'); sys.exit(6)
-# #357: id="readiness" must live INSIDE the Promotions <section>, not the
-# Overview <section>. Slice on data-tab="promotions"...next data-tab=, and
-# require id="readiness" inside that slice + absent from the overview slice.
+# #359: id="readiness" must live INSIDE the Progress <section>, not on
+# any of the eliminated Overview / Agents / Promotions / Learning tabs.
 def slice_section(haystack, name):
     m = re.search(r'<section\s+data-tab="' + re.escape(name) + r'"[^>]*>', haystack)
     if not m: return None
@@ -549,45 +545,53 @@ def slice_section(haystack, name):
     n = re.search(r'<section\s+data-tab="', haystack[start:])
     end = start + n.start() if n else len(haystack)
     return haystack[start:end]
-overview = slice_section(src, 'overview') or ''
-promotions = slice_section(src, 'promotions') or ''
-if 'id="readiness"' not in promotions:
-    sys.stderr.write('Phase Readiness markup missing from Promotions tab (#357)\n'); sys.exit(7)
-if 'id="readiness"' in overview:
-    sys.stderr.write('Phase Readiness markup still in Overview tab (should be Promotions per #357)\n'); sys.exit(8)
+progress = slice_section(src, 'progress') or ''
+if 'id="readiness"' not in progress:
+    sys.stderr.write('Phase Readiness markup missing from Progress tab (#359)\n'); sys.exit(7)
 sys.exit(0)
 PY
 then
-    pass "22: Phase Readiness stacked tier bars relocated to Promotions tab (#357, was #342 in Overview)"
+    pass "22: Phase Readiness stacked tier bars relocated to Progress tab (#359, was Promotions in #357)"
 else
-    fail "22: Phase Readiness regression — class wiring missing or markup not in Promotions tab"
+    fail "22: Phase Readiness regression — class wiring missing or markup not in Progress tab"
 fi
 
-# --- #248 PR C: Confidence Trend + Experience Growth demoted behind <details> ---
-# Both charts were heavy panels of marginal value; they live inside collapsed
-# <details> now. Lock the contract so neither gets accidentally promoted back
-# to the always-on grid.
+# --- #359 (was #248 PR C): Confidence Trend + Experience Growth charts on
+#     the Progress tab are NOW DEFAULT-EXPANDED (no <details> wrapper).
+#     The charts moved from the demoted #248 PR C placement on the
+#     Learning tab to first-class cards on Progress. Lock the contract:
+#     neither chart container is wrapped in <details> on the Progress tab.
+#     (Test 54 below adds a stricter check.)
 if python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
 import sys, re
 with open(sys.argv[1]) as f:
     src = f.read()
-# Both chart containers must sit inside a <details class="card-collapse">.
-# Single-line regex-friendly check: each id must be preceded (within ~400
-# chars upward) by a "<details" with matching close before another card.
+# Find the Progress tab body slice.
+m_sec = re.search(r'<section\s+data-tab="progress"[^>]*>', src)
+if not m_sec:
+    sys.stderr.write('Progress tab section not found\n'); sys.exit(1)
+start = m_sec.end()
+m_next = re.search(r'<section\s+data-tab="', src[start:])
+end = start + m_next.start() if m_next else len(src)
+progress = src[start:end]
+# Each chart container must NOT sit inside a <details>.
 for chart_id in ('experience-trend', 'confidence-trend'):
-    m = re.search(r'<details[^>]*class="card-collapse"[^>]*>([^<]|<(?!/details))*?id="' + chart_id + '"', src, re.DOTALL)
-    if not m:
-        sys.stderr.write(chart_id + ' not inside <details class=card-collapse>\n'); sys.exit(2)
-    # Default-collapsed: the <details> tag must NOT have an `open` attribute.
-    tag = m.group(0).split('>', 1)[0]
-    if re.search(r'\bopen\b', tag):
-        sys.stderr.write(chart_id + ' details opens by default — should be collapsed\n'); sys.exit(3)
+    if 'id="' + chart_id + '"' not in progress:
+        sys.stderr.write(chart_id + ' not in Progress tab\n'); sys.exit(2)
+    # Walk backwards from the id to nearest opening <details> or <section>.
+    pos = progress.find('id="' + chart_id + '"')
+    head = progress[:pos]
+    last_open = head.rfind('<details')
+    last_close = head.rfind('</details>')
+    if last_open > last_close:
+        sys.stderr.write(chart_id + ' is wrapped in <details> on Progress tab — should be default-expanded (#359)\n')
+        sys.exit(3)
 sys.exit(0)
 PY
 then
-    pass "23: Confidence Trend + Experience Growth wrapped in collapsed <details> (#248 PR C)"
+    pass "23: Confidence Trend + Experience Growth default-expanded on Progress tab (#359)"
 else
-    fail "23: chart-demotion regression — one or both charts no longer inside collapsed <details>"
+    fail "23: chart wrapping regressed — should NOT be inside <details> on Progress (#359)"
 fi
 
 # --- #257: federation-agnostic vocabulary regression guard. ---
@@ -1329,16 +1333,14 @@ else
     fail "35: bar arithmetic regression — see stderr above"
 fi
 
-# --- #352: tabbed layout — six <section data-tab="..."> blocks present ---
-# Plan-test 36. The body must contain exactly 6 sections with the names
-# overview / agents / promotions / learning / cost / config. The HTML
-# string is the served-page payload, which is what an operator's browser
-# reads on first paint.
+# --- #359: 5-tab intent-driven cut (was 6 tabs in #352). ---
+# Sections must be exactly: status / cost / recovery / progress / config.
+# Default first-paint tab is `status` (not `overview`; Overview is gone).
 if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
 import sys, re
 with open(sys.argv[1]) as f:
     html = f.read()
-expected = ['overview', 'agents', 'promotions', 'learning', 'cost', 'config']
+expected = ['status', 'cost', 'recovery', 'progress', 'config']
 # Filter out the literal '...' placeholder text from inline comments;
 # only real `<section data-tab="<word>"` markup counts.
 found = [m for m in re.findall(r'<section\s+data-tab="([^"]+)"', html) if m != '...']
@@ -1348,18 +1350,17 @@ if found != expected:
 sys.exit(0)
 PY
 then
-    pass "36: six <section data-tab=\"...\"> blocks in expected order (#352)"
+    pass "36: five <section data-tab=\"...\"> blocks in expected order (#359)"
 else
-    fail "36: section count or order wrong"
+    fail "36: section count or order wrong (#359 expects 5 tabs)"
 fi
 
-# --- #352: tab bar emits 6 buttons with data-tab attributes ---
-# Plan-test 37. The clickable tab bar must have one button per tab.
+# --- #359: tab bar emits 5 buttons (Status/Cost/Recovery/Progress/Config) ---
 if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
 import sys, re
 with open(sys.argv[1]) as f:
     html = f.read()
-expected = ['overview', 'agents', 'promotions', 'learning', 'cost', 'config']
+expected = ['status', 'cost', 'recovery', 'progress', 'config']
 buttons = re.findall(r'<button\s+class="tab-btn"\s+role="tab"\s+data-tab="([^"]+)"', html)
 if buttons != expected:
     sys.stderr.write('tab-btn data-tab order wrong: %r\n' % buttons)
@@ -1367,9 +1368,9 @@ if buttons != expected:
 sys.exit(0)
 PY
 then
-    pass "37: tab bar emits 6 buttons with expected data-tab attributes (#352)"
+    pass "37: tab bar emits 5 buttons with expected data-tab attributes (#359)"
 else
-    fail "37: tab bar buttons missing or out of order"
+    fail "37: tab bar buttons missing or out of order (#359 expects 5)"
 fi
 
 # --- #352: pickTextColor returns dark for #f59e0b (amber) and light
@@ -1467,33 +1468,41 @@ else
     fail "40: sidecar listing wiring regressed"
 fi
 
-# --- #352: bulk-restart action bar visible only when ≥1 agent is
-#     non-running. Two sub-assertions:
-#     (a) renderBulkActions function exists in template.
-#     (b) The fixture's agent (state=running) does NOT trigger the bar
-#         being visible by default.
+# --- #359 (was #352 test 41): bulk-restart action wired on the new
+#     Recovery tab. The pre-#359 #bulk-actions container is gone (the
+#     Overview tab is gone); the equivalent surface lives in the Recovery
+#     tab as #recovery-bulk-actions. The legacy renderBulkActions is
+#     preserved as a no-op for back-compat (its #bulk-actions container is
+#     absent → it bails). Test enforces the new path. ---
 if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
 import sys, re
 with open(sys.argv[1]) as f:
     html = f.read()
-if 'function renderBulkActions' not in html:
-    sys.stderr.write('renderBulkActions not defined\n'); sys.exit(1)
-# The bulk-actions container must be present in markup.
-if 'id="bulk-actions"' not in html:
-    sys.stderr.write('#bulk-actions container missing\n'); sys.exit(2)
-# Branch logic: filtering by `a.state !== \'running\'` must be present.
+# New Recovery-tab renderer.
+if 'function renderRecoveryActions' not in html:
+    sys.stderr.write('renderRecoveryActions not defined\n'); sys.exit(1)
+if 'id="recovery-bulk-actions"' not in html:
+    sys.stderr.write('#recovery-bulk-actions container missing\n'); sys.exit(2)
+# Branch logic: filtering by non-running state still present.
 if "a.state !== 'running'" not in html and 'a.state !== "running"' not in html:
-    sys.stderr.write('non-running filter logic missing in renderBulkActions\n')
+    sys.stderr.write('non-running filter logic missing\n')
     sys.exit(3)
-# `restartAllStopped` action handler defined.
+# `restartAllStopped` action handler still defined.
 if 'function restartAllStopped' not in html:
     sys.stderr.write('restartAllStopped handler not defined\n'); sys.exit(4)
+# Per-agent restart handler (new in #359).
+if 'function restartAgent' not in html:
+    sys.stderr.write('restartAgent handler not defined\n'); sys.exit(5)
+# The legacy renderBulkActions function stays around (back-compat
+# no-op when the #bulk-actions container is absent).
+if 'function renderBulkActions' not in html:
+    sys.stderr.write('legacy renderBulkActions removed (should remain as no-op)\n'); sys.exit(6)
 sys.exit(0)
 PY
 then
-    pass "41: renderBulkActions wired with non-running filter + restartAllStopped handler (#352)"
+    pass "41: bulk-restart wired on Recovery tab + per-agent restartAgent handler (#359)"
 else
-    fail "41: bulk-actions wiring regressed"
+    fail "41: Recovery bulk + per-agent restart wiring regressed (#359)"
 fi
 
 # --- #357: Config tab EDITABLE by default. The v0.6.0 read-only gate
@@ -1556,30 +1565,31 @@ else
     fail "42: Config tab default-editable contract regressed (#357)"
 fi
 
-# --- #352: only one section is .active at first paint (Overview). ---
+# --- #359: tab init defaults to STATUS (was 'overview' in #352). ---
 # The default-active tab is enforced via JS at init: `localStorage` read
-# falls back to 'overview' when missing. The static HTML must be
-# pre-rendered so a curl-smoke flow shows overview by default. We assert
-# that the JS init unconditionally calls `activateTab(initial)` with the
-# overview default fallback.
+# falls back to 'status' when missing. Legacy values (overview/agents/
+# promotions/learning) migrate via LEGACY_TAB_MIGRATION so a returning
+# operator from #357 doesn't see a blank tab on first load post-upgrade.
 if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
 import sys, re
 with open(sys.argv[1]) as f:
     html = f.read()
-# activateTab must default to overview when localStorage missing.
 if 'activateTab(initial)' not in html:
     sys.stderr.write('activateTab init call missing\n'); sys.exit(1)
-if "initial = 'overview'" not in html:
-    sys.stderr.write("default 'overview' fallback missing\n"); sys.exit(2)
-# `localStorage.getItem(ACTIVE_TAB_KEY)` must be the source.
+if "initial = 'status'" not in html:
+    sys.stderr.write("default 'status' fallback missing — #359 should NOT default to 'overview'\n"); sys.exit(2)
 if 'ACTIVE_TAB_KEY' not in html:
     sys.stderr.write('ACTIVE_TAB_KEY not defined\n'); sys.exit(3)
+# Legacy migration is in place so #357-era localStorage values don't
+# leave the operator on a blank tab.
+if 'LEGACY_TAB_MIGRATION' not in html:
+    sys.stderr.write('LEGACY_TAB_MIGRATION map missing — pre-#359 localStorage values would crash\n'); sys.exit(4)
 sys.exit(0)
 PY
 then
-    pass "43: tab init defaults to overview, persisted via ACTIVE_TAB_KEY localStorage (#352)"
+    pass "43: tab init defaults to status (was overview), legacy values migrate (#359)"
 else
-    fail "43: tab default + persistence regressed"
+    fail "43: tab default + persistence regressed (#359)"
 fi
 
 # --- #352: new endpoints (`/restart-all-stopped`, `/sidecar-restart`,
@@ -1618,11 +1628,10 @@ else
     fail "44: one or more #352 endpoints unreachable"
 fi
 
-# --- #357 test 45: Forge Rate Limits is NOT a top-level Overview child.
-#     The card was relocated to a per-colony modal (showColonyModal). The
-#     id="forge-rate-limits" container must NOT live inside the Overview
-#     <section> markup. The renderer function stays defined for the per-
-#     colony modal. ---
+# --- #359 (was #357 test 45): Forge Rate Limits container NOT a top-level
+#     tab child. Lives only inside the per-colony modal (showColonyModal).
+#     The Overview tab is gone in #359; we now assert the container does
+#     not appear inside any of the 5 tab sections. ---
 if python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
 import sys, re
 with open(sys.argv[1]) as f:
@@ -1634,10 +1643,11 @@ def slice_section(haystack, name):
     n = re.search(r'<section\s+data-tab="', haystack[start:])
     end = start + n.start() if n else len(haystack)
     return haystack[start:end]
-overview = slice_section(src, 'overview') or ''
-if 'id="forge-rate-limits"' in overview:
-    sys.stderr.write('Forge Rate Limits container still in Overview tab — should be in colony modal (#357)\n')
-    sys.exit(1)
+for name in ('status', 'cost', 'recovery', 'progress', 'config'):
+    body = slice_section(src, name) or ''
+    if 'id="forge-rate-limits"' in body:
+        sys.stderr.write('Forge Rate Limits container in tab "' + name + '" — should be in colony modal (#359)\n')
+        sys.exit(1)
 # Per-colony modal entry point must exist.
 if 'function showColonyModal' not in src:
     sys.stderr.write('showColonyModal not defined (#357 per-colony modal missing)\n')
@@ -1651,7 +1661,7 @@ if 'forge_rate_limits' not in src:
 sys.exit(0)
 PY
 then
-    pass "45: Forge Rate Limits relocated from Overview to per-colony modal (#357)"
+    pass "45: Forge Rate Limits stays in per-colony modal under 5-tab cut (#359)"
 else
     fail "45: Forge Rate Limits relocation regression"
 fi
@@ -1915,6 +1925,411 @@ then
     pass "50: collector emits inverted gate (operator_writes_disabled), audit_log_path always present (#357)"
 else
     fail "50: collector config_editor block contract regression"
+fi
+
+# =====================================================================
+# #359 tests 51-58: stray quote bug, SSE flicker bug, Status verdict,
+# Cost projections, cross-colony matrix, bulk-apply checkbox group.
+# =====================================================================
+
+# --- #359 test 51: stray quote scalar fix + complex-value marker ---
+# Build a fixture colony.toml with a SCALAR string (`backend = "cli"`) and
+# an INLINE ARRAY (`priority = ["p0", "p1", "p2"]`). Drive the collector
+# directly, parse data.config_editor.scopes[*].keys, assert:
+#   * scalar `backend` is emitted with raw_value="cli" (NOT "\"cli\"" and
+#     NOT empty) AND complex_value=False.
+#   * inline-array `priority` is emitted with complex_value=True so the
+#     renderer can show the read-only marker instead of an editable input.
+T51_FED="/tmp/qa-359-fed-51"
+rm -rf "$T51_FED"
+mkdir -p "$T51_FED/.agentis/experience" \
+         "$T51_FED/.agentis/spend" \
+         "$T51_FED/.agentis/lifecycle" \
+         "$T51_FED/.dashboard" \
+         "$T51_FED/triage/agents" \
+         "$T51_FED/triage/config"
+cat > "$T51_FED/triage/config/colony.toml" <<'TOML'
+name = "triage"
+
+[forge.gitlab]
+project = "owner/repo"
+
+[llm]
+backend = "cli"
+
+[planning.labels]
+epic = "epic"
+
+[triage.labels]
+priority = ["p0", "p1", "p2"]
+TOML
+cat > "$T51_FED/triage/agents/qa_agent.ag" <<'AG'
+cb 100;
+fn tick() { return Void; }
+AG
+
+T51_AID="cccccccc"
+T51_NOW="$(date '+%s')"
+T51_DAEMONS=$(python3 -c "
+import json
+print(json.dumps([{
+    'agent_id': '$T51_AID',
+    'source':   '$T51_FED/triage/agents/qa_agent.ag',
+    'state':    'running',
+    'health':   'healthy',
+    'pid':      0,
+    'confidence': 0.5,
+    'tick_ok': 1,
+    'tick_err': 0,
+    'started_at': $T51_NOW - 100,
+}]))
+")
+T51_AGENT_MAP='[{"agent":"qa_agent","colony":"triage"}]'
+T51_COLONIES='["triage"]'
+T51_JSON="$(python3 "$COLLECTOR_PY" \
+    "$T51_DAEMONS" \
+    "$T51_AGENT_MAP" \
+    "$T51_FED" \
+    "$T51_NOW" \
+    "$T51_FED/.agentis/experience" \
+    "$T51_FED/.agentis/logs" \
+    "$T51_FED/.dashboard" \
+    "$T51_COLONIES" \
+    "" \
+    qa_agent 2>/dev/null)"
+
+# Pass T51_JSON via env-var so the heredoc body can stay quoted (no
+# shell expansion / backslash munging on the embedded JSON).
+T51_JSON_FILE="$TMPDIR_TEST/t51-collector.json"
+printf '%s' "$T51_JSON" > "$T51_JSON_FILE"
+if [ -s "$T51_JSON_FILE" ] && python3 - "$T51_JSON_FILE" <<'PY' 2>&1
+import json, sys
+with open(sys.argv[1]) as f:
+    blob = json.loads(f.read())
+ce = blob.get('config_editor') or {}
+scopes = ce.get('scopes') or []
+triage = next((s for s in scopes if s.get('scope') == 'triage'), None)
+if triage is None:
+    sys.stderr.write('triage scope missing\n'); sys.exit(2)
+keys = triage.get('keys') or []
+def find(section, key):
+    for kv in keys:
+        if kv.get('section') == section and kv.get('key') == key:
+            return kv
+    return None
+backend = find('llm', 'backend')
+if not backend:
+    sys.stderr.write('[llm].backend not parsed\n'); sys.exit(3)
+if backend.get('raw_value') != 'cli':
+    sys.stderr.write('backend raw_value = %r, expected "cli" (no surrounding quotes)\n' % backend.get('raw_value'))
+    sys.exit(4)
+if backend.get('complex_value') is not False:
+    sys.stderr.write('backend complex_value = %r, expected False\n' % backend.get('complex_value'))
+    sys.exit(5)
+priority = find('triage.labels', 'priority')
+if not priority:
+    sys.stderr.write('[triage.labels].priority not parsed\n'); sys.exit(6)
+if priority.get('complex_value') is not True:
+    sys.stderr.write('priority complex_value = %r, expected True (inline array)\n' % priority.get('complex_value'))
+    sys.exit(7)
+# Scalar string `epic = "epic"` must also strip quotes cleanly.
+epic_kv = find('planning.labels', 'epic')
+if not epic_kv or epic_kv.get('raw_value') != 'epic':
+    sys.stderr.write('planning.labels.epic raw_value = %r, expected "epic"\n' % (epic_kv and epic_kv.get('raw_value')))
+    sys.exit(8)
+if epic_kv.get('complex_value'):
+    sys.stderr.write('planning.labels.epic flagged as complex (it is scalar)\n'); sys.exit(9)
+sys.exit(0)
+PY
+then
+    pass "51: stray quote — scalar strips cleanly, inline array gets complex_value flag (#359)"
+else
+    fail "51: stray quote bug regression — see stderr above (#359)"
+fi
+rm -rf "$T51_FED"
+rm -f "$T51_JSON_FILE"
+
+# --- #359 test 52: NO <meta http-equiv="refresh"> in served HTML ---
+# The pre-#359 dashboard had <meta http-equiv="refresh" content="60"> on
+# line 5 of the template. It triggered full-page reloads every minute,
+# wiping operator in-flight state (Bug 2). Removed in #359; SSE keeps
+# the page fresh in-place. Regression guard.
+if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
+import sys, re
+with open(sys.argv[1]) as f:
+    html = f.read()
+# Scrub HTML comments AND <script>/<style> blocks (which can mention the
+# tag historically in a JS/CSS comment) so the regex only matches a real
+# <meta> element in the document head.
+no_comments = re.sub(r'<!--.*?-->', '', html, flags=re.DOTALL)
+no_scripts = re.sub(r'<script\b[^>]*>.*?</script>', '', no_comments, flags=re.DOTALL | re.IGNORECASE)
+no_styles = re.sub(r'<style\b[^>]*>.*?</style>', '', no_scripts, flags=re.DOTALL | re.IGNORECASE)
+if re.search(r'<meta\b[^>]*http-equiv\s*=\s*"refresh"', no_styles, re.IGNORECASE):
+    sys.stderr.write('<meta http-equiv="refresh"> still present in document head — removed in #359 to fix flicker\n')
+    sys.exit(1)
+sys.exit(0)
+PY
+then
+    pass "52: <meta http-equiv=\"refresh\"> removed from served HTML (#359 Bug 2 + Bug 4)"
+else
+    fail "52: meta refresh tag is back — would re-introduce 60s flicker (#359)"
+fi
+
+# --- #359 test 53: SSE status indicator markup + dot states ---
+# A small `#sse-dot` lives in the page header. CSS classes sse-dot-init /
+# sse-dot-ok / sse-dot-err are bound to EventSource lifecycle.
+if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
+import sys, re
+with open(sys.argv[1]) as f:
+    html = f.read()
+needles = [
+    'id="sse-dot"',
+    'sse-dot-init',
+    'sse-dot-ok',
+    'sse-dot-err',
+    '_sseSetDot',
+    'es.onopen',
+]
+for n in needles:
+    if n not in html:
+        sys.stderr.write('SSE dot wiring missing: ' + n + '\n')
+        sys.exit(2)
+sys.exit(0)
+PY
+then
+    pass "53: SSE status indicator markup + onopen/onerror wiring present (#359)"
+else
+    fail "53: SSE dot wiring regressed (#359)"
+fi
+
+# --- #359 test 54: Confidence Trend + Experience Growth render WITHOUT
+#     <details> wrapper on the Progress tab (default-expanded). ---
+if python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
+import sys, re
+with open(sys.argv[1]) as f:
+    src = f.read()
+m_sec = re.search(r'<section\s+data-tab="progress"[^>]*>', src)
+if not m_sec:
+    sys.stderr.write('progress section missing\n'); sys.exit(1)
+start = m_sec.end()
+m_next = re.search(r'<section\s+data-tab="', src[start:])
+end = start + m_next.start() if m_next else len(src)
+progress = src[start:end]
+for cid in ('confidence-trend', 'experience-trend'):
+    pos = progress.find('id="' + cid + '"')
+    if pos < 0:
+        sys.stderr.write(cid + ' not in Progress tab\n'); sys.exit(2)
+    head = progress[:pos]
+    last_open = head.rfind('<details')
+    last_close = head.rfind('</details>')
+    if last_open > last_close:
+        sys.stderr.write(cid + ' is inside <details> on Progress tab — should be default-expanded\n'); sys.exit(3)
+sys.exit(0)
+PY
+then
+    pass "54: Confidence Trend + Experience Growth default-expanded on Progress tab (#359)"
+else
+    fail "54: charts wrapped in <details> on Progress (#359 expects default-expanded)"
+fi
+
+# --- #359 test 55: Status tab body has NO charts, NO bars, NO tables,
+#     NO `<details>` (pure single-glance verdict). ---
+# This is the operator's "no charts no bars no tables" requirement
+# expressed as a regression guard. Slice on data-tab="status" and walk
+# the contained markup; reject any of <canvas>, <svg>, <table>, <details>.
+if python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
+import sys, re
+with open(sys.argv[1]) as f:
+    src = f.read()
+m_sec = re.search(r'<section\s+data-tab="status"[^>]*>', src)
+if not m_sec:
+    sys.stderr.write('status section missing\n'); sys.exit(1)
+start = m_sec.end()
+m_next = re.search(r'<section\s+data-tab="', src[start:])
+end = start + m_next.start() if m_next else len(src)
+body = src[start:end]
+for forbidden in ('<canvas', '<svg', '<table', '<details'):
+    if forbidden in body:
+        sys.stderr.write('Status tab body contains forbidden element: ' + forbidden + '\n'); sys.exit(2)
+# Verdict pill class must be present so the test isn't a vacuous true on
+# an empty section.
+if 'status-verdict-pill' not in src:
+    sys.stderr.write('status-verdict-pill class missing — Status verdict not wired\n'); sys.exit(3)
+if 'pulse-grid' not in src:
+    sys.stderr.write('pulse-grid class missing — 21-cell pulse grid not wired\n'); sys.exit(4)
+sys.exit(0)
+PY
+then
+    pass "55: Status tab body has no charts / bars / tables / <details> (#359)"
+else
+    fail "55: Status tab body contains a forbidden element (#359 single-glance verdict)"
+fi
+
+# --- #359 test 56: Cost tab renders 4 projection stat tiles backed by
+#     data.cost.projected_* fields (1h, 1d in headline; 1w / 1m in tile
+#     extras). The collector emits all four projections; the renderer
+#     references them. ---
+if python3 - "$HTML_FILE" <<'PY' 2>/dev/null
+import sys, re, json
+with open(sys.argv[1]) as f:
+    html = f.read()
+m = re.search(r'const data\s*=\s*(\{.*?\});\n', html, re.DOTALL)
+if not m: sys.exit(1)
+data = json.loads(m.group(1))
+cost = data.get('cost') or {}
+# All four projection fields must be present (default 0.0 on a fresh
+# fed with no spend rows in the 5-min window).
+for k in ('rate_per_min_usd', 'rate_per_min_tokens',
+          'projected_1h_usd', 'projected_1d_usd',
+          'projected_1w_usd', 'projected_1m_usd'):
+    if k not in cost:
+        sys.stderr.write('cost.%s missing from collector output\n' % k); sys.exit(2)
+# Threshold fields are also surfaced so JS can render the traffic-light.
+for k in ('cost_threshold_yellow_usd_per_h', 'cost_threshold_red_usd_per_h'):
+    if k not in cost:
+        sys.stderr.write('cost.%s missing\n' % k); sys.exit(3)
+# Renderer markup: id="cost-projections" container + projection-tile class.
+if 'id="cost-projections"' not in html:
+    sys.stderr.write('cost-projections container missing\n'); sys.exit(4)
+if 'projection-tile' not in html:
+    sys.stderr.write('projection-tile class missing\n'); sys.exit(5)
+if 'function renderCostProjections' not in html:
+    sys.stderr.write('renderCostProjections renderer missing\n'); sys.exit(6)
+sys.exit(0)
+PY
+then
+    pass "56: Cost tab renders 4 projection tiles backed by data.cost.projected_* (#359)"
+else
+    fail "56: Cost projections wiring regressed (#359)"
+fi
+
+# --- #359 test 57: Cross-colony matrix renders one row per dotted key
+#     with at least one override. The collector emits
+#     data.config_editor.matrix; the renderer walks it. ---
+T57_FED="/tmp/qa-359-fed-57"
+rm -rf "$T57_FED"
+mkdir -p "$T57_FED/.agentis/logs" \
+         "$T57_FED/triage/agents" "$T57_FED/triage/config" \
+         "$T57_FED/code-review/agents" "$T57_FED/code-review/config"
+cat > "$T57_FED/.agentis/config" <<'CFG'
+[daemon]
+tick_interval_ms = 60000
+heartbeat_interval_ms = 1800000
+CFG
+cat > "$T57_FED/triage/config/colony.toml" <<'TOML'
+[daemon]
+tick_interval_ms = 30000
+
+[llm]
+backend = "cli"
+TOML
+cat > "$T57_FED/code-review/config/colony.toml" <<'TOML'
+[daemon]
+tick_interval_ms = 60000
+
+[llm]
+backend = "mock"
+TOML
+cat > "$T57_FED/triage/agents/x.ag" <<'AG'
+cb 100;
+fn tick() { return Void; }
+AG
+cat > "$T57_FED/code-review/agents/y.ag" <<'AG'
+cb 100;
+fn tick() { return Void; }
+AG
+T57_DAEMONS='[]'
+T57_AGENT_MAP='[{"agent":"x","colony":"triage"},{"agent":"y","colony":"code-review"}]'
+T57_COLONIES='["triage","code-review"]'
+T57_JSON="$(python3 "$COLLECTOR_PY" \
+    "$T57_DAEMONS" \
+    "$T57_AGENT_MAP" \
+    "$T57_FED" \
+    "$(date '+%s')" \
+    "$T57_FED/.agentis/experience" \
+    "$T57_FED/.agentis/logs" \
+    "$T57_FED/.dashboard" \
+    "$T57_COLONIES" \
+    "" \
+    x y 2>/dev/null)"
+
+T57_JSON_FILE="$TMPDIR_TEST/t57-collector.json"
+printf '%s' "$T57_JSON" > "$T57_JSON_FILE"
+if [ -s "$T57_JSON_FILE" ] && python3 - "$T57_JSON_FILE" <<'PY' 2>&1
+import json, sys
+with open(sys.argv[1]) as f:
+    blob = json.loads(f.read())
+ce = blob.get('config_editor') or {}
+matrix = ce.get('matrix')
+if not isinstance(matrix, list):
+    sys.stderr.write('config_editor.matrix missing or not list\n'); sys.exit(2)
+# At least one override exists in the fixture (triage.daemon.tick_interval_ms
+# overrides federation default; both colonies override [llm].backend).
+if not matrix:
+    sys.stderr.write('matrix empty (expected at least one override row)\n'); sys.exit(3)
+keys = [r.get('key') for r in matrix]
+if 'daemon.tick_interval_ms' not in keys:
+    sys.stderr.write('expected daemon.tick_interval_ms in matrix; got %r\n' % keys); sys.exit(4)
+if 'llm.backend' not in keys:
+    sys.stderr.write('expected llm.backend in matrix; got %r\n' % keys); sys.exit(5)
+# Each row carries cells keyed by scope name + the federation default.
+backend_row = next((r for r in matrix if r.get('key') == 'llm.backend'), None)
+cells = (backend_row or {}).get('cells') or {}
+if 'triage' not in cells or 'code-review' not in cells:
+    sys.stderr.write('per-colony cells missing on llm.backend: %r\n' % cells); sys.exit(6)
+sys.exit(0)
+PY
+then
+    T57_DATA_OK=1
+else
+    T57_DATA_OK=0
+fi
+rm -rf "$T57_FED"
+rm -f "$T57_JSON_FILE"
+
+if [ "$T57_DATA_OK" -eq 1 ] && python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
+import sys
+with open(sys.argv[1]) as f:
+    src = f.read()
+needles = ['id="config-matrix"', 'function renderConfigMatrix', 'config-matrix-table']
+for n in needles:
+    if n not in src:
+        sys.stderr.write('matrix renderer wiring missing: ' + n + '\n'); sys.exit(2)
+sys.exit(0)
+PY
+then
+    pass "57: cross-colony matrix emitted by collector + rendered on Config tab (#359)"
+else
+    fail "57: cross-colony matrix wiring regressed (#359)"
+fi
+
+# --- #359 test 58: bulk-apply confirm modal has per-colony checkbox
+#     group when editing a federation-wide key. The renderer reads
+#     configEditor.scopes to build the group; the confirm modal walks
+#     `.bulk-apply-scope:checked` to decide which scopes to include in
+#     the POST. ---
+if python3 - "$TEMPLATE_HTML" <<'PY' 2>/dev/null
+import sys
+with open(sys.argv[1]) as f:
+    src = f.read()
+# CSS class for the checkbox group.
+if 'config-confirm-scopes' not in src:
+    sys.stderr.write('config-confirm-scopes CSS class missing\n'); sys.exit(2)
+# Renderer must emit `.bulk-apply-scope` checkboxes inside the modal
+# only when scope === 'federation'.
+if 'bulk-apply-scope' not in src:
+    sys.stderr.write('bulk-apply-scope class never emitted\n'); sys.exit(3)
+# _showConfigConfirm + _postConfigApply must reference the bulk path.
+if 'isFedScope' not in src:
+    sys.stderr.write('isFedScope branch missing in _showConfigConfirm\n'); sys.exit(4)
+if "scopes:" not in src and 'scopes:' not in src and 'scopes: checked' not in src and 'scopes: ' not in src:
+    sys.stderr.write('bulk payload {scopes:[...]} never built in _postConfigApply\n'); sys.exit(5)
+sys.exit(0)
+PY
+then
+    pass "58: bulk-apply confirm modal renders per-colony checkbox group on fed-wide edits (#359)"
+else
+    fail "58: bulk-apply checkbox group wiring regressed (#359)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

5-tab intent-driven cut replacing the 6-tab #352 layout. Each tab maps to one operator question. Plus the two surgical bug fixes pinpointed in the [issue plan](https://github.com/Replikanti/agentis-colonies/issues/359#issuecomment-4323190145):
- Stray-quote rendering on Config tab inline arrays / inline tables (Bug 1).
- 60s flicker / lost in-flight state from `<meta http-equiv="refresh">` (Bug 2 + Bug 4).

## Tab restructure

| # | Tab | Body |
|---|---|---|
| 1 | **Status** | Federation health verdict pill (✅/⚠️/❌). 21-cell pulse-grid (color = state, click → drill-in modal). Sidecar status pills + last-tick age. Last-error timestamp + count. **NO charts, NO bars, NO tables, NO `<details>`** — pure single-glance verdict. ≤480 px. |
| 2 | **Cost** | 4 projection tiles ($/min, tokens/min, projected 1h, projected 1d with 1w / 1m in tooltip). Today/7d/30d cumulative. Cost-cap progress bar. Per-colony split. Token volume separated from $. |
| 3 | **Recovery** | Bulk "Restart all stopped" + per-agent restart table + per-sidecar restart + federation kill switch (type-the-name confirm modal). Last 10 watchdog kills (forensic). Per-agent log-tail behind `<details>` (lazy-fetched). |
| 4 | **Progress** | Confidence Trend + Experience Growth charts **default-expanded** (no `<details>` wrapper). Phase Readiness as small capped-height card. Per-agent next-promotion ETA + limiting prereq. Promote Candidates + Event Timeline. |
| 5 | **Config** | Per-scope editor (preserved from #357) + cross-colony override matrix + bulk apply (per-colony checkbox group on confirm modal; server `/config/apply` accepts `scopes:[...]`). |

Eliminated tabs (their content moved):
- **Overview** → split: Status verdict + Cost projections + Recovery actions.
- **Agents** → folds into Status pulse-grid + drill-in modal + Progress agent-table.
- **Promotions** → folds into Progress.
- **Learning** → folds into Progress (charts + Event Timeline).

Default first-paint is `status` (was `overview`). Legacy localStorage values migrate via `LEGACY_TAB_MIGRATION`. Keyboard shortcuts: digits 1-5 (was 1-6).

## Stray quote fix

The pre-#359 collector strip-quotes logic only fired when a value started AND ended with the same quote character. Inline arrays (`labels = [\"a\", \"b\"]`) and inline tables (`limits = { hi=1 }`) slipped through and rendered as editable `<input>`s; any operator edit then corrupted the array because the line-level patcher only handles scalars.

Fix: collector now emits `complex_value: true` for inline arrays / tables; the renderer shows them read-only with a \"complex\" marker. Scalar string values keep their existing strip-quotes path (`backend = \"cli\"` → `<input value=\"cli\">`, not `<input value=\"\\\"cli\\\"\">`). Test 51 is the regression guard.

## SSE flicker fix

The `<meta http-equiv=\"refresh\" content=\"60\">` tag on line 5 of the template triggered a full-page reload every 60 seconds. That wiped operator in-flight state (modal scroll, sort column, expanded `<details>`, mid-edit Config rows). The SSE channel from #313 was already keeping the page fresh in-place anyway.

Fix: meta tag removed. SSE is now the single source of live updates. A small `#sse-dot` in the page header surfaces the EventSource lifecycle (green steady on `onopen`, brief pulse on each snapshot, red on `onerror`). `?debug=1` enables `console.log` on every renderer entry for browser-DevTools verification. Tests 52 + 53 are the regression guards.

## Test plan

- [x] `bash tools/test-timeline-rendering.sh` — **58 passed, 0 failed** (existing 50 + 8 new: 51-58)
- [x] `bash tools/test-sse-stream.sh` — **9 passed, 0 failed**
- [x] `bash tools/test-rate-limit-tile.sh` — **8 passed, 0 failed**
- [x] `AGENTIS_RUN_KILL_TESTS=0 bash tools/colony-lint.sh` — **117 passed, 0 failed, 3 skipped**
- [x] `bash tools/test-make-dashboard-bundle.sh` — **13 passed, 0 failed**
- [x] `python3 -m py_compile` on collector + server — clean
- [x] `bash -n federation-dashboard/bin/federation-dashboard` — clean

## Out of scope

- VERSION stays `0.6.0`. The bump to `0.7.0` happens in the next release PR.
- Live federation is NOT touched. All tests use synthetic fixtures under `/tmp/qa-359-*`.
- The legacy `renderBulkActions` and `renderForgeRateLimits` functions stay around as no-op back-compat (their containers are absent on the new tabs; both bail at the `if (!el) return;` guard).
- Rebinding the per-agent restart endpoint contract — `restartAgent()` reuses the existing `/restart` endpoint; no server-side change.
- This PR does NOT address the #313 SSE handshake itself; that wiring is preserved verbatim from #313 PR 1 + PR 2.

Closes #359.