### PR TITLE
fix(dashboard): cap Phase Readiness bar width on Progress tab

### DIFF
--- a/federation-dashboard/lib/federation-dashboard.html.template
+++ b/federation-dashboard/lib/federation-dashboard.html.template
@@ -646,6 +646,14 @@
   .phase-stack {
     display: flex; flex-direction: column; gap: 2px;
     margin: 8px 0 14px 0;
+    /* Cap bar width so Phase Readiness doesn't stretch the bars across the
+       full Progress-tab card width (operator feedback after #359 — bars
+       reading like a billboard rather than a compact summary). */
+    max-width: 480px;
+  }
+  .phase-row {
+    /* Same cap on the colony-name header so it lines up with the bars. */
+    max-width: 480px;
   }
   .phase-stack:last-child { margin-bottom: 0; }
   .phase-bar {


### PR DESCRIPTION
## Summary

After [#359](https://github.com/Replikanti/agentis-colonies/issues/359) intent-driven rework, the Phase Readiness card on the Progress tab still rendered inside `.card.full` grid span, so the per-tier stacked bars stretched the entire card width (~1080px). Operator feedback:

> "Phase Readiness by nemuselo byt roztazene pres celou delku... je to porad UX/UI fail podle me."

## Fix

Cap `.phase-stack` and `.phase-row` at `max-width: 480px` so the bars read as a compact summary, not a billboard. The card itself stays `.card.full` to preserve the grid layout (no neighboring-card reshuffle); bars left-align inside the card, leaving whitespace on the right where there's no actionable content anyway.

8-line CSS-only diff. No JS / collector / server changes.

## Test plan

- [x] `AGENTIS_RUN_KILL_TESTS=0 bash tools/colony-lint.sh` — 117 PASS / 0 FAIL / 3 SKIP. Existing test 22 (Phase Readiness markup assertion) doesn't depend on bar width — stays green.
- [x] CI `colony-lint` green + `mergeStateStatus == CLEAN`.

Closes the operator-visible UX fail.

Generated with [Claude Code](https://claude.com/claude-code)
