### PR TITLE
fix(dashboard): sentinel-injection-safe single-pass renderer (#366)

### DIFF
--- a/federation-dashboard/lib/federation-dashboard-renderer.py
+++ b/federation-dashboard/lib/federation-dashboard-renderer.py
@@ -35,6 +35,7 @@ to temp files; values without the `@` prefix still pass through unchanged
 for backward compatibility.
 """
 import os
+import re
 import sys
 
 
@@ -74,8 +75,16 @@ def main():
     with open(template_path, 'r', encoding='utf-8') as f:
         html = f.read()
 
-    for sentinel, value in substitutions.items():
-        html = html.replace(sentinel, value)
+    # Single-pass substitution (#366): a value (notably {{COLLECTOR_JSON}}) can
+    # contain the literal text of another sentinel — e.g. an agent's experience
+    # row whose `out` field discusses "{{HISTORY}}" while reasoning about a
+    # template change. A sequential `for s in subs: html.replace(s, v)` would
+    # then re-substitute that literal in the next iteration and inject the
+    # history payload into the collector data string, breaking
+    # `const data = ...;` parsing in the browser. re.sub() advances past the
+    # replacement value, so any sentinel literal inside a value is left intact.
+    pattern = re.compile('|'.join(re.escape(s) for s in substitutions))
+    html = pattern.sub(lambda m: substitutions[m.group(0)], html)
 
     tmp = output_path + '.tmp.' + str(os.getpid())
     with open(tmp, 'w', encoding='utf-8') as f:

--- a/tools/test-timeline-rendering.sh
+++ b/tools/test-timeline-rendering.sh
@@ -2332,6 +2332,51 @@ else
     fail "58: bulk-apply checkbox group wiring regressed (#359)"
 fi
 
+# --- #366 test 59: renderer is sentinel-injection-safe. When COLLECTOR_JSON
+#     contains the literal text of another sentinel ({{HISTORY}}), the
+#     rendered output keeps the literal as-is and does NOT inject the
+#     history payload. Sequential str.replace would re-substitute and
+#     break `const data = ...;` parsing in the browser, blanking the
+#     dashboard. The fix uses a single-pass re.sub. ---
+T59_DIR="$(mktemp -d)"
+T59_TEMPLATE="$T59_DIR/template.html"
+T59_OUTPUT="$T59_DIR/output.html"
+cat > "$T59_TEMPLATE" <<'TPL'
+<!doctype html><html><body>
+const data = {{COLLECTOR_JSON}};
+let history = {{HISTORY}};
+let remediation = {{REMEDIATION}};
+</body></html>
+TPL
+# Note the {{HISTORY}} literal embedded inside the COLLECTOR_JSON value.
+T59_COLLECTOR='{"timeline":[{"out":"agent reasoned about {{HISTORY}} sentinel"}]}'
+T59_HISTORY='[{"sentinel":true}]'
+T59_REMEDIATION='[]'
+T59_OK=0
+if python3 "$RENDERER_PY" \
+        "$T59_TEMPLATE" \
+        "$T59_OUTPUT" \
+        "fed" '"fed"' "1" "1" "0" "ts" \
+        "$T59_COLLECTOR" "$T59_HISTORY" "$T59_REMEDIATION" "[]" \
+        2>/dev/null
+then
+    # The {{HISTORY}} literal must survive inside the COLLECTOR_JSON value
+    # (one occurrence). The history payload [{"sentinel":true}] must appear
+    # exactly once — at the {{HISTORY}} substitution site, NOT also injected
+    # into the COLLECTOR_JSON spot.
+    T59_HIST_LIT_COUNT="$(grep -cF '{{HISTORY}}' "$T59_OUTPUT" 2>/dev/null || echo 0)"
+    T59_PAYLOAD_COUNT="$(grep -cF '[{"sentinel":true}]' "$T59_OUTPUT" 2>/dev/null || echo 0)"
+    if [ "$T59_HIST_LIT_COUNT" = "1" ] && [ "$T59_PAYLOAD_COUNT" = "1" ]; then
+        T59_OK=1
+    fi
+fi
+if [ "$T59_OK" -eq 1 ]; then
+    pass "59: renderer is sentinel-injection-safe — {{HISTORY}} inside COLLECTOR_JSON is not re-substituted (#366)"
+else
+    fail "59: renderer re-substituted a sentinel literal inside another sentinel's value (#366)"
+fi
+rm -rf "$T59_DIR"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- Single-pass `re.sub` over all 10 template sentinels — replaces the previous sequential `html.replace(sentinel, value)` loop that allowed an agent's experience `out` field containing `{{HISTORY}}` to be re-substituted when injected via `{{COLLECTOR_JSON}}`.
- Adds regression test 59 in `tools/test-timeline-rendering.sh` (rendered output must contain `{{HISTORY}}` exactly once and `[{"sentinel":true}]` exactly once when COLLECTOR_JSON value contains `{{HISTORY}}`).

## Why P0
Live operator dashboard hit this 30 minutes ago — tabs visible but empty, SSE status dot stuck on init color. `risk_assessor` agent had processed a dashboard-related issue whose body literally mentioned `{{HISTORY}}`; its experience JSONL row carried the literal forward to the renderer; renderer's iterative substitution turned the collector data string into corrupted JSON; browser threw on `const data = ...;` parse; entire JS dispatch died.

Fully reproducible: any future agent that mentions a sentinel name in `out` reproduces the outage.

## Mitigation already applied
The offending JSONL line was rewritten in-place to neutralize the sentinel (`{{HISTORY}}` → `{{ HISTORY }}`). The dashboard recovered after one refresh cycle. This PR prevents recurrence.

## Files
- `federation-dashboard/lib/federation-dashboard-renderer.py` — `+8 -2` LOC: import `re`, replace sequential loop with `re.compile + pattern.sub(lambda)`. Behaviour-identical when no value contains a sentinel literal; safe when one does.
- `tools/test-timeline-rendering.sh` — `+38 -0` LOC: new test 59.

## Out of scope
- Escaping in the agent's experience writer (agents can write arbitrary text; the renderer is the safe layer).
- Reworking the sentinel approach (single-pass `re.sub` is sufficient).
- federation-dashboard PATCH bump → deferred to next release PR.

## Test plan
- [x] `bash tools/test-timeline-rendering.sh` — `Results: 59 passed, 0 failed`.
- [x] CI colony-lint must pass.
- [ ] Live operator confirms dashboard renders normally after refresh (already confirmed pre-PR).

Closes #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)