### PR TITLE
docs(readme): bump federation-dashboard version 0.3.0 → 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Federation-agnostic components are versioned and released independently so fixes
 
 | Component | Version | Description |
 |-----------|---------|-------------|
-| [federation-dashboard](./federation-dashboard/) | [`0.3.0`](https://github.com/Replikanti/agentis-colonies/releases/tag/federation-dashboard-v0.3.0) | Generic web dashboard with operator controls (promote / demote / evolve / restart / kill) plus Forge Rate Limits tile. Auto-discovers colonies + agents from any federation directory. |
+| [federation-dashboard](./federation-dashboard/) | [`0.6.0`](https://github.com/Replikanti/agentis-colonies/releases/tag/federation-dashboard-v0.6.0) | Generic web dashboard with operator controls (promote / demote / evolve / restart / kill), 5-tab surface (Status / Cost / Recovery / Logs & Events / Config), per-agent table, federation-wide Experience tile, collapsible Promotion Progress, and Forge Rate Limits tile. Auto-discovers colonies + agents from any federation directory. |
 
 ### Status
 


### PR DESCRIPTION
## Summary

The top-level README's Platform components row for `federation-dashboard` was stuck at `0.3.0` while the component shipped through `0.4.0`, `0.5.0`, and `0.6.0` (#352, #357, #359 release PRs). Description also missed the current 5-tab surface, per-agent table, federation-wide Experience tile, and collapsible Promotion Progress.

## Diff

Single line in `README.md`. No code, no tests, no CHANGELOG (README docs only).

## Test plan

- [ ] CI colony-lint pass (no markdown link breakage).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>