### PR TITLE
feat(colony-lint): accept forge.type="none" for non-forge federations (#373)

### DIFF
--- a/doc/adr/ADR-0002-forge-abstraction.md
+++ b/doc/adr/ADR-0002-forge-abstraction.md
@@ -104,6 +104,20 @@ authoritative. Operators on pre-#256 configs must move their
 `[forge].type = "gitlab"` — the post-PR-7 start-colony.sh rejects
 configs that lack `[forge]`.
 
+#### Non-forge federations (`forge.type = "none"`)
+
+[ADR-0003](./ADR-0003-federation-portability-contract.md) explicitly
+allows federations that do not talk to a forge ("a federation that does
+not talk to a forge has no obligation to that ADR"). Since #373, the
+post-#256 `[forge]`-required contract enforced by `colony-lint`
+recognises `[forge].type = "none"` as the explicit non-forge marker:
+the `[forge]` block stays present (so the schema check still passes)
+but no `[forge.gitlab]` / `[forge.github]` sub-block is required, and
+any backend-specific keys are ignored. This ADR remains normative for
+every forge-bound colony; non-forge colonies opt out of it
+block-and-tackle. `tribes-bench/tribe-alpha` and `tribes-bench/tribe-beta`
+are the first consumers.
+
 ### Normalized shape contract (normative)
 
 Every subcommand emits a fixed JSON shape. The following table is the

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -126,11 +126,18 @@ if 'forge' not in data or not isinstance(data.get('forge'), dict):
     errors.append('missing [forge] section (post-#256: required)')
 else:
     forge_type = data['forge'].get('type')
-    if forge_type not in ('gitlab', 'github'):
-        errors.append(f'[forge].type must be \"gitlab\" or \"github\" (got {forge_type!r})')
-    if forge_type == 'gitlab' and 'gitlab' not in data['forge']:
+    if forge_type not in ('gitlab', 'github', 'none'):
+        errors.append(f'[forge].type must be \"gitlab\", \"github\", or \"none\" (got {forge_type!r})')
+    elif forge_type == 'none':
+        # ADR-0003 explicitly allows non-forge federations. forge.type = \"none\"
+        # is the explicit opt-out (#373): the [forge] block is present so the
+        # post-#256 schema check still passes, but no [forge.gitlab] / [forge.github]
+        # sub-block is required and any present sub-block is ignored. ADR-0002
+        # remains normative for forge-bound colonies.
+        pass
+    elif forge_type == 'gitlab' and 'gitlab' not in data['forge']:
         errors.append('[forge].type = \"gitlab\" but [forge.gitlab] is missing')
-    if forge_type == 'github' and 'github' not in data['forge']:
+    elif forge_type == 'github' and 'github' not in data['forge']:
         errors.append('[forge].type = \"github\" but [forge.github] is missing')
 if 'llm' not in data:
     errors.append('missing [llm] section')

--- a/tools/new-federation.sh
+++ b/tools/new-federation.sh
@@ -451,8 +451,13 @@ case "$FORGE_TYPE" in
         fi
         export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME
         ;;
+    none)
+        # ADR-0003 / #373 — non-forge federation: nothing to export here.
+        # If this colony's agents need data-source env vars (e.g. TARGET_DIR,
+        # VERIFIER_PATH), wire them below this case block.
+        ;;
     *)
-        echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2
+        echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github|none)" >&2
         exit 1
         ;;
 esac

--- a/tools/new-federation.sh
+++ b/tools/new-federation.sh
@@ -7,14 +7,16 @@
 # start-colony.sh that already supports the --restart-agent and
 # --rate-limit-status flags consumed by federation-dashboard.
 #
-# Output passes `tools/colony-lint.sh` clean. The generated TOML carries a
-# forge=gitlab stub because colony-lint currently requires `[forge]` to be
-# present (post-#256 contract). Federations whose data source is not a forge
-# can keep the stub or remove it; the lint relaxation for non-forge
-# federations is in the #258 deferred bucket.
+# Output passes `tools/colony-lint.sh` clean. By default the generated TOML
+# carries a forge=gitlab stub. Pass `--no-forge` (#373) to scaffold a
+# non-forge federation: the generated `colony.example.toml` declares
+# `forge.type = "none"` and the generated `start-colony.sh` skips the
+# forge env-wiring block entirely. ADR-0002 remains normative for forge-bound
+# colonies; ADR-0003 covers the non-forge case.
 #
-# Usage: ./tools/new-federation.sh <federation-name> [<starter-colony-name>]
+# Usage: ./tools/new-federation.sh [--no-forge] <federation-name> [<starter-colony-name>]
 # Example: ./tools/new-federation.sh data-ops ingestion
+# Example: ./tools/new-federation.sh --no-forge metrics-bench ingestion
 
 set -euo pipefail
 
@@ -22,7 +24,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 usage() {
     cat <<EOF
-Usage: $0 <federation-name> [<starter-colony-name>]
+Usage: $0 [--no-forge] <federation-name> [<starter-colony-name>]
 
 Scaffolds a new federation under \$REPO_ROOT/<federation-name>/ with one
 starter colony. Output conforms to ADR-0003 and passes colony-lint.
@@ -30,9 +32,39 @@ starter colony. Output conforms to ADR-0003 and passes colony-lint.
 Arguments:
   <federation-name>        Lowercase alphanumeric with dashes. Required.
   <starter-colony-name>    Lowercase alphanumeric with dashes. Defaults to "core".
+
+Flags:
+  --no-forge               Scaffold a non-forge federation (#373). The generated
+                           colony.example.toml declares \`forge.type = "none"\`
+                           and start-colony.sh skips the forge env-wiring block.
 EOF
     exit 1
 }
+
+NO_FORGE=0
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-forge)
+            NO_FORGE=1
+            shift
+            ;;
+        --)
+            shift
+            POSITIONAL+=("$@")
+            break
+            ;;
+        -*)
+            echo "Error: unknown flag: $1" >&2
+            usage
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
 
 [ $# -ge 1 ] || usage
 [ $# -le 2 ] || usage
@@ -232,20 +264,23 @@ cat > "$COL_PATH/README.md" <<EOF
    \`\`\`
 EOF
 
-cat > "$COL_PATH/config/colony.example.toml" <<EOF
-# $COL_PRETTY Colony Configuration
-#
-# Part of the $FED_PRETTY federation.
-# Copy to colony.toml and edit for your environment.
-
-[colony]
-name = "$COLONY"
-tick_interval_ms = 60000
-
+# Build the [forge] section once, depending on --no-forge. The two branches
+# are kept as standalone heredocs (no nesting) so bash 3.2 stays happy.
+if [ "$NO_FORGE" = "1" ]; then
+    forge_block="$(cat <<'FORGE_EOF'
+# Non-forge federation (#373, ADR-0003).
+# `forge.type = "none"` is the explicit opt-out: colony-lint enforces the
+# [forge] block presence but skips sub-block validation. Replace this
+# with a real [forge] block (see ADR-0002) if/when the federation grows
+# a forge dependency.
+[forge]
+type = "none"
+FORGE_EOF
+)"
+else
+    forge_block="$(cat <<'FORGE_EOF'
 # Forge configuration (post-#256, ADR-0002).
-# Set type to either "gitlab" or "github" and fill the matching block.
-# Federations whose data source is not a forge can keep this stub for
-# colony-lint compatibility (lint relaxation tracked in #258 deferred bucket).
+# Set type to "gitlab", "github", or "none" (non-forge federation, #373).
 [forge]
 type = "gitlab"
 
@@ -260,6 +295,21 @@ me = "your-username"
 # repo  = "your-repo"
 # token = "ghp_your-token-here"
 # me    = "your-username"
+FORGE_EOF
+)"
+fi
+
+cat > "$COL_PATH/config/colony.example.toml" <<EOF
+# $COL_PRETTY Colony Configuration
+#
+# Part of the $FED_PRETTY federation.
+# Copy to colony.toml and edit for your environment.
+
+[colony]
+name = "$COLONY"
+tick_interval_ms = 60000
+
+$forge_block
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
@@ -367,6 +417,7 @@ fi
 # shellcheck source=/dev/null
 . "$PARSE_TOML"
 
+# BEGIN FORGE_BLOCK
 # Forge env wiring (ADR-0002). Replace this block with whatever env vars
 # this colony's .ag agents consume via exec sh.
 FORGE_TYPE=$(parse_toml forge type)
@@ -408,6 +459,7 @@ esac
 
 export FORGE_TYPE
 export COLONY_DIR
+# END FORGE_BLOCK
 
 # TODO: list this colony's agent names here. Each must have a matching
 # <colony>/agents/<name>.ag file.
@@ -492,9 +544,62 @@ sed -i \
     -e "s/COLONY_NAME_PLACEHOLDER/$COLONY/g" \
     "$COL_PATH/scripts/start-colony.sh"
 
+# When --no-forge is set, swap the BEGIN FORGE_BLOCK..END FORGE_BLOCK
+# range for a non-forge no-op (mirroring tribes-bench/tribe-*/scripts/
+# start-colony.sh). Done with awk for portability across macOS bash 3.2.
+if [ "$NO_FORGE" = "1" ]; then
+    NF_TMP="$(mktemp)"
+    awk '
+        /^# BEGIN FORGE_BLOCK$/ {
+            print "# Non-forge federation (#373, ADR-0003). The colony.example.toml"
+            print "# declares forge.type = \"none\" so colony-lint accepts the config"
+            print "# without a [forge.gitlab] / [forge.github] sub-block; no agent"
+            print "# in this colony calls forge-api.sh. Replace TODO env vars below"
+            print "# with whatever your data source needs (data warehouse, helpdesk"
+            print "# API, on-disk corpus, …)."
+            print "# TODO: export DATA_SOURCE_URL / TOKEN / etc. for your .ag agents."
+            print "export COLONY_DIR"
+            skip = 1
+            next
+        }
+        /^# END FORGE_BLOCK$/ {
+            skip = 0
+            next
+        }
+        skip != 1 { print }
+    ' "$COL_PATH/scripts/start-colony.sh" > "$NF_TMP"
+    mv "$NF_TMP" "$COL_PATH/scripts/start-colony.sh"
+else
+    # Strip the marker comments — they are only meaningful to the scaffolder.
+    sed -i \
+        -e '/^# BEGIN FORGE_BLOCK$/d' \
+        -e '/^# END FORGE_BLOCK$/d' \
+        "$COL_PATH/scripts/start-colony.sh"
+fi
+
 chmod +x "$COL_PATH/scripts/start-colony.sh"
 
 # --- Print next steps ---
+
+if [ "$NO_FORGE" = "1" ]; then
+    config_step="Edit $COL_PATH/config/colony.example.toml — this federation was scaffolded
+     with --no-forge, so the [forge] block declares \`type = \"none\"\` (#373,
+     ADR-0003). Wire your real data source (data warehouse, helpdesk API,
+     on-disk corpus, …) by adding env vars consumed by your .ag agents via
+     exec sh; do NOT add [forge.gitlab] / [forge.github] sub-blocks unless
+     this federation grows a forge dependency."
+    script_step="Edit $COL_PATH/scripts/start-colony.sh — fill in the AGENTS=() array
+     and replace the placeholder \`export COLONY_DIR\` block with whatever
+     env vars your agents consume via exec sh. The forge env-wiring case
+     statement was omitted because of --no-forge."
+else
+    config_step="Edit $COL_PATH/config/colony.example.toml — adapt the [forge] block
+     (set type to \"gitlab\", \"github\", or \"none\" per #373 / ADR-0003)
+     and fill the matching sub-block."
+    script_step="Edit $COL_PATH/scripts/start-colony.sh — fill in the AGENTS=() array
+     and replace the forge env block with whatever env vars your agents
+     consume via exec sh."
+fi
 
 cat <<EOF
 
@@ -505,12 +610,8 @@ Next steps:
      federation's real domain identity.
   2. Edit $FED_PATH/install.sh — add prerequisite checks + credential prompts
      for your data source (forge, data warehouse, helpdesk API, …).
-  3. Edit $COL_PATH/config/colony.example.toml — adapt the [forge] block (or
-     replace it with your data-source config; the lint relaxation for
-     non-forge federations is in #258's deferred bucket).
-  4. Edit $COL_PATH/scripts/start-colony.sh — fill in the AGENTS=() array
-     and replace the forge env block with whatever env vars your agents
-     consume via exec sh.
+  3. $config_step
+  4. $script_step
   5. Author .ag agents under $COL_PATH/agents/. Tier-gate every external
      write per ADR-0001.
   6. Add '$FEDERATION' to the COMPONENTS array in tools/check-changelog.sh

--- a/tools/test-colony-lint-no-forge.sh
+++ b/tools/test-colony-lint-no-forge.sh
@@ -16,6 +16,12 @@
 #   Test 5: negative — a colony with a typo'd forge type (e.g. "non")
 #           is rejected with the updated allowed-list message that
 #           includes "none".
+#   Test 6: integration — `new-federation.sh` (default, no `--no-forge`)
+#           generates a `start-colony.sh` whose `case "$FORGE_TYPE"` block
+#           includes a `none)` arm and an error message that lists all
+#           three valid types. Guards the post-hoc-flip path: an operator
+#           who scaffolds default and later edits `colony.toml` to
+#           `type = "none"` does not get an "unknown [forge].type" error.
 #
 # Each test builds a synthetic federation tree under $TMPDIR_TEST and
 # runs `tools/colony-lint.sh <tmpdir>` against it, then greps the output.
@@ -202,6 +208,37 @@ if printf '%s\n' "$out" | grep -q '\[forge\].type must be "gitlab", "github", or
 else
     fail "test 5: typo'd forge type rejected with updated allowed-list message" \
          "expected updated allowed-list message in output, got: $out"
+fi
+
+# --- Test 6: integration — default new-federation.sh emits none) arm ---
+# Scaffolds a default (forge-bound) federation and inspects the generated
+# start-colony.sh. The `none)` arm + updated error message let an operator
+# flip `colony.toml` to `type = "none"` post-hoc without runtime breakage.
+#
+# new-federation.sh always writes to its REPO_ROOT (parent of tools/), so
+# the test cannot redirect output to $TMPDIR_TEST. Use a unique federation
+# name and clean up explicitly. PID + RANDOM disambiguates parallel runs.
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST6_FED="fd-no-forge-test6-$$-${RANDOM}"
+TEST6_PATH="$REPO_ROOT/$TEST6_FED"
+# Add cleanup to the existing EXIT trap rather than overwriting it.
+trap 'rm -rf "$TMPDIR_TEST" "$TEST6_PATH"' EXIT
+(
+    cd "$REPO_ROOT"
+    "$SCRIPT_DIR/new-federation.sh" "$TEST6_FED" "col-default" >/dev/null 2>&1
+)
+gen_start_colony="$TEST6_PATH/col-default/scripts/start-colony.sh"
+if [ ! -f "$gen_start_colony" ]; then
+    fail "test 6: default new-federation.sh emits none) arm" \
+         "scaffolded start-colony.sh not found at $gen_start_colony"
+elif ! grep -qE '^[[:space:]]*none\)' "$gen_start_colony"; then
+    fail "test 6: default new-federation.sh emits none) arm" \
+         "no 'none)' case arm in $gen_start_colony"
+elif ! grep -q 'expected: gitlab|github|none' "$gen_start_colony"; then
+    fail "test 6: default new-federation.sh emits none) arm" \
+         "wildcard error message did not list 'none' as a valid type"
+else
+    pass "test 6: default new-federation.sh emits none) arm + updated error msg"
 fi
 
 echo ""

--- a/tools/test-colony-lint-no-forge.sh
+++ b/tools/test-colony-lint-no-forge.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# tools/test-colony-lint-no-forge.sh: unit tests for the #373 non-forge
+# opt-out in tools/colony-lint.sh.
+#
+# Validates:
+#   Test 1: positive — a colony with [forge].type = "none" and no
+#           [forge.gitlab]/[forge.github] sub-block lints clean.
+#   Test 2: positive — same colony with [forge].type = "none" plus a
+#           leftover [forge.github] sub-block also lints clean (sub-block
+#           is ignored, not validated).
+#   Test 3: negative — a colony with [forge].type = "github" and no
+#           [forge.github] sub-block still fails (regression for
+#           dev-apprenticeship-shaped configs).
+#   Test 4: negative — a colony with [forge].type = "gitlab" and no
+#           [forge.gitlab] sub-block still fails (mirror of test 3).
+#   Test 5: negative — a colony with a typo'd forge type (e.g. "non")
+#           is rejected with the updated allowed-list message that
+#           includes "none".
+#
+# Each test builds a synthetic federation tree under $TMPDIR_TEST and
+# runs `tools/colony-lint.sh <tmpdir>` against it, then greps the output.
+#
+# Usage: ./tools/test-colony-lint-no-forge.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LINT="$SCRIPT_DIR/colony-lint.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# Helper: scaffold a minimal federation+colony tree under $TMPDIR_TEST/$1
+# with the colony.example.toml body provided on stdin. Each invocation
+# uses a unique federation name so successive tests do not collide on the
+# same shared $TMPDIR_TEST root.
+make_fixture() {
+    local fed="$1" colony="$2"
+    local fed_path="$TMPDIR_TEST/$fed"
+    local col_path="$fed_path/$colony"
+    mkdir -p "$col_path/config" "$col_path/scripts" "$col_path/agents"
+    : > "$col_path/agents/.gitkeep"
+    echo "# $fed" > "$fed_path/README.md"
+    echo "# $colony" > "$col_path/README.md"
+    cat > "$col_path/config/colony.example.toml"
+    cat > "$col_path/scripts/start-colony.sh" <<'SH'
+#!/bin/bash
+exit 0
+SH
+    chmod +x "$col_path/scripts/start-colony.sh"
+}
+
+# Run colony-lint against a single-federation tree at $TMPDIR_TEST/$1
+# and capture both stdout+stderr.
+run_lint_on() {
+    local fed="$1"
+    local fed_root
+    fed_root="$(mktemp -d "$TMPDIR_TEST/lintroot.XXXXXX")"
+    # colony-lint discovers federations as sibling dirs under its arg —
+    # symlink the chosen federation into a fresh root so unrelated
+    # fixtures from earlier tests are not in scope.
+    ln -s "$TMPDIR_TEST/$fed" "$fed_root/$fed"
+    "$LINT" "$fed_root" 2>&1
+    rm -rf "$fed_root"
+}
+
+# --- Test 1: positive — [forge].type = "none", no sub-block -----------
+make_fixture "fed-1-none-clean" "col-a" <<'TOML'
+[colony]
+name = "col-a"
+
+[forge]
+type = "none"
+
+[llm]
+backend = "cli"
+
+[[agents]]
+name = "demo"
+source = "agents/demo.ag"
+cb_budget = 100
+TOML
+
+out="$(run_lint_on "fed-1-none-clean" || true)"
+if printf '%s\n' "$out" | grep -q "fed-1-none-clean/col-a: config OK"; then
+    pass "test 1: forge.type=none with no sub-block lints clean"
+else
+    fail "test 1: forge.type=none with no sub-block lints clean" \
+         "expected '[PASS] fed-1-none-clean/col-a: config OK' in output, got: $out"
+fi
+
+# --- Test 2: positive — [forge].type = "none" with leftover sub-block --
+make_fixture "fed-2-none-leftover" "col-b" <<'TOML'
+[colony]
+name = "col-b"
+
+[forge]
+type = "none"
+
+[forge.github]
+url = "https://api.github.invalid"
+owner = "leftover"
+repo = "leftover"
+token = "your-leftover-token"
+me = "leftover"
+
+[llm]
+backend = "cli"
+
+[[agents]]
+name = "demo"
+source = "agents/demo.ag"
+cb_budget = 100
+TOML
+
+out="$(run_lint_on "fed-2-none-leftover" || true)"
+if printf '%s\n' "$out" | grep -q "fed-2-none-leftover/col-b: config OK"; then
+    pass "test 2: forge.type=none with leftover [forge.github] still lints clean"
+else
+    fail "test 2: forge.type=none with leftover [forge.github] still lints clean" \
+         "expected '[PASS] fed-2-none-leftover/col-b: config OK' in output, got: $out"
+fi
+
+# --- Test 3: negative — [forge].type = "github", no sub-block ----------
+make_fixture "fed-3-github-missing" "col-c" <<'TOML'
+[colony]
+name = "col-c"
+
+[forge]
+type = "github"
+
+[llm]
+backend = "cli"
+
+[[agents]]
+name = "demo"
+source = "agents/demo.ag"
+cb_budget = 100
+TOML
+
+out="$(run_lint_on "fed-3-github-missing" || true)"
+if printf '%s\n' "$out" | grep -q '\[forge\].type = "github" but \[forge.github\] is missing'; then
+    pass "test 3: forge.type=github with no [forge.github] still fails"
+else
+    fail "test 3: forge.type=github with no [forge.github] still fails" \
+         "expected missing-[forge.github] error in output, got: $out"
+fi
+
+# --- Test 4: negative — [forge].type = "gitlab", no sub-block ----------
+make_fixture "fed-4-gitlab-missing" "col-d" <<'TOML'
+[colony]
+name = "col-d"
+
+[forge]
+type = "gitlab"
+
+[llm]
+backend = "cli"
+
+[[agents]]
+name = "demo"
+source = "agents/demo.ag"
+cb_budget = 100
+TOML
+
+out="$(run_lint_on "fed-4-gitlab-missing" || true)"
+if printf '%s\n' "$out" | grep -q '\[forge\].type = "gitlab" but \[forge.gitlab\] is missing'; then
+    pass "test 4: forge.type=gitlab with no [forge.gitlab] still fails"
+else
+    fail "test 4: forge.type=gitlab with no [forge.gitlab] still fails" \
+         "expected missing-[forge.gitlab] error in output, got: $out"
+fi
+
+# --- Test 5: negative — typo'd forge type "non" ------------------------
+make_fixture "fed-5-typo" "col-e" <<'TOML'
+[colony]
+name = "col-e"
+
+[forge]
+type = "non"
+
+[llm]
+backend = "cli"
+
+[[agents]]
+name = "demo"
+source = "agents/demo.ag"
+cb_budget = 100
+TOML
+
+out="$(run_lint_on "fed-5-typo" || true)"
+# The updated allowlist message must mention all three of: gitlab, github,
+# and none — so a contributor who fat-fingers "non" sees the full menu.
+if printf '%s\n' "$out" | grep -q '\[forge\].type must be "gitlab", "github", or "none"'; then
+    pass "test 5: typo'd forge type rejected with updated allowed-list message"
+else
+    fail "test 5: typo'd forge type rejected with updated allowed-list message" \
+         "expected updated allowed-list message in output, got: $out"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,20 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Non-forge marker `forge.type = "none"`** ([#373](https://github.com/Replikanti/agentis-colonies/issues/373)).
+  Both seed tribes (`tribe-alpha`, `tribe-beta`) now declare
+  `[forge].type = "none"` in `colony.example.toml`. The previous
+  `[forge.github]` stub block was dropped. `colony-lint` recognises the
+  marker as the explicit non-forge opt-out: the `[forge]` section stays
+  required (post-#256 contract), but no backend sub-block is needed and
+  any present sub-block is ignored. ADR-0002 documents the marker;
+  ADR-0003 remains normative for federations that do not talk to a forge.
+- **Tribe READMEs corrected** ([#373](https://github.com/Replikanti/agentis-colonies/issues/373)).
+  The misleading "Configure your forge or data-source connection in
+  `colony.toml`" Setup step in `tribe-alpha/README.md` and
+  `tribe-beta/README.md` was replaced with the actual env-var override
+  surface (`TARGET_DIR`, `BUGS_MANIFEST`, `VERIFIER_PATH`) that
+  `start-colony.sh` consumes. Closes the #363 QA finding #1.
 - **Stage 0 wiring test** ([#363](https://github.com/Replikanti/agentis-colonies/issues/363)).
   Two seed tribes (`tribe-alpha`, `tribe-beta`), each with a single
   `hunter` agent. Plus:

--- a/tribes-bench/tribe-alpha/README.md
+++ b/tribes-bench/tribe-alpha/README.md
@@ -17,7 +17,12 @@
    cp config/colony.example.toml config/colony.toml
    ```
 
-2. Configure your forge or data-source connection in `colony.toml`.
+2. (Optional) Override the synthetic-target paths via env vars before launching:
+   `TARGET_DIR` (default: `<fed>/targets/stage0`),
+   `BUGS_MANIFEST` (default: `$TARGET_DIR/bugs.json`),
+   `VERIFIER_PATH` (default: `<fed>/tools/verify-finding.sh`).
+   tribes-bench is a non-forge federation (`forge.type = "none"`); no forge
+   credentials are required.
 
 3. Start the colony:
    ```bash

--- a/tribes-bench/tribe-alpha/config/colony.example.toml
+++ b/tribes-bench/tribe-alpha/config/colony.example.toml
@@ -7,21 +7,14 @@
 name = "tribe-alpha"
 tick_interval_ms = 60000
 
-# Forge stub. tribes-bench is not a forge-backed federation: the hunter
+# tribes-bench is a non-forge federation (#373, ADR-0003). The hunter
 # agent reads a checked-in synthetic Rust file under TARGET_DIR and runs
-# the deterministic verifier under VERIFIER_PATH. The [forge] block here
-# satisfies the post-#256 colony-lint contract only — no Stage 0 agent
-# calls forge-api.sh. Lint relaxation for non-forge federations is in the
-# #258 deferred bucket.
+# the deterministic verifier under VERIFIER_PATH; no Stage 0 agent calls
+# forge-api.sh. `forge.type = "none"` is the explicit non-forge marker
+# recognised by colony-lint — no [forge.gitlab] / [forge.github] sub-block
+# is required. See ADR-0002 for the forge-bound contract this opts out of.
 [forge]
-type = "github"
-
-[forge.github]
-url = "https://api.github.invalid"
-owner = "tribes-bench-stub"
-repo = "tribes-bench-stub"
-token = "your-tribes-bench-stub-token"
-me = "tribes-bench-stub"
+type = "none"
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI

--- a/tribes-bench/tribe-beta/README.md
+++ b/tribes-bench/tribe-beta/README.md
@@ -17,7 +17,12 @@
    cp config/colony.example.toml config/colony.toml
    ```
 
-2. Configure your forge or data-source connection in `colony.toml`.
+2. (Optional) Override the synthetic-target paths via env vars before launching:
+   `TARGET_DIR` (default: `<fed>/targets/stage0`),
+   `BUGS_MANIFEST` (default: `$TARGET_DIR/bugs.json`),
+   `VERIFIER_PATH` (default: `<fed>/tools/verify-finding.sh`).
+   tribes-bench is a non-forge federation (`forge.type = "none"`); no forge
+   credentials are required.
 
 3. Start the colony:
    ```bash

--- a/tribes-bench/tribe-beta/config/colony.example.toml
+++ b/tribes-bench/tribe-beta/config/colony.example.toml
@@ -7,21 +7,14 @@
 name = "tribe-beta"
 tick_interval_ms = 60000
 
-# Forge stub. tribes-bench is not a forge-backed federation: the hunter
+# tribes-bench is a non-forge federation (#373, ADR-0003). The hunter
 # agent reads a checked-in synthetic Rust file under TARGET_DIR and runs
-# the deterministic verifier under VERIFIER_PATH. The [forge] block here
-# satisfies the post-#256 colony-lint contract only — no Stage 0 agent
-# calls forge-api.sh. Lint relaxation for non-forge federations is in the
-# #258 deferred bucket.
+# the deterministic verifier under VERIFIER_PATH; no Stage 0 agent calls
+# forge-api.sh. `forge.type = "none"` is the explicit non-forge marker
+# recognised by colony-lint — no [forge.gitlab] / [forge.github] sub-block
+# is required. See ADR-0002 for the forge-bound contract this opts out of.
 [forge]
-type = "github"
-
-[forge.github]
-url = "https://api.github.invalid"
-owner = "tribes-bench-stub"
-repo = "tribes-bench-stub"
-token = "your-tribes-bench-stub-token"
-me = "tribes-bench-stub"
+type = "none"
 
 [llm]
 # Only "backend" is read today. "cli" uses the agentis daemon default CLI


### PR DESCRIPTION
## Summary

- `colony-lint`: accept `forge.type = "none"` as the explicit non-forge marker; sub-block validation short-circuits (ADR-0003-aligned).
- `tribes-bench/tribe-{alpha,beta}`: drop the `[forge.github]` GitHub stub from `colony.example.toml`, replace with `[forge].type = "none"`; rewrite the misleading "Configure your forge" line in both per-tribe READMEs (this also addresses #363 QA finding #1 in passing — does NOT auto-close it, so the QA-finding tracker can stay open if there's other work attached).
- `tools/new-federation.sh --no-forge`: scaffold non-forge federations from day one (delimited heredoc swap; bash-3.2-portable, single-pass).
- ADR-0002: new "Non-forge federations" subsection with cross-link to ADR-0003.
- New `tools/test-colony-lint-no-forge.sh`: 5 cases (2 positive opt-out, 3 negative regression incl. typo).

Plan reviewed and approved on the issue: #373 (see the long planning comment for the file-by-file mapping).

Closes #373

## Test plan

- [x] `bash -n` clean on `tools/colony-lint.sh`, `tools/test-colony-lint-no-forge.sh`, `tools/new-federation.sh`
- [x] `tools/test-colony-lint-no-forge.sh` — 5/5 PASS
- [x] `tools/new-federation.sh --no-forge <fed>` smoke: scaffold + colony-lint clean
- [x] `tools/colony-lint.sh .` — 109 PASS / 23 FAIL / 3 skipped on this branch; the 23 FAILs are pre-existing `.ag` syntax errors on `origin/main` (canonical checkout reproduces identically), not introduced by this PR
- [x] `tools/check-changelog.sh` — no PR-context, no-op (as designed for local runs); `tribes-bench/CHANGELOG.md` `[Unreleased]` updated
- [x] `shellcheck` clean on all three edited/new shell scripts
- [x] Pre-existing tests still green: `test-colony-lint-bash32.sh`, `test-forge-config.sh`, `test-check-changelog.sh`
- [ ] CI green
- [ ] QA agent report (will be posted as a follow-up comment)