### PR TITLE
364 M1: tribes-bench Stage 1 infrastructure (3 tribes, 3 bug classes, telemetry)

### DIFF
--- a/tribes-bench/BUNDLE.manifest
+++ b/tribes-bench/BUNDLE.manifest
@@ -38,3 +38,8 @@ tribes-bench/tribe-beta/README.md
 tribes-bench/tribe-beta/agents/
 tribes-bench/tribe-beta/config/colony.example.toml
 tribes-bench/tribe-beta/scripts/
+
+tribes-bench/tribe-gamma/README.md
+tribes-bench/tribe-gamma/agents/
+tribes-bench/tribe-gamma/config/colony.example.toml
+tribes-bench/tribe-gamma/scripts/

--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,39 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Stage 1 infrastructure** ([#364](https://github.com/Replikanti/agentis-colonies/issues/364), M1).
+  - `tribe-gamma/` colony — third seed tribe with an error-path
+    data-flow seed prompt (orthogonal to tribe-alpha's `format!()`-pattern
+    heuristic and tribe-beta's source-to-sink heuristic).
+  - `targets/stage1/{cmd_exec,path_io,fmt_str}.rs` — three new synthetic
+    Rust files, ~450 LOC total, with 10 planted bugs across three CWE
+    classes (CMD-INJ, PATH-TRAV, FMT-STR). Each file carries the
+    `TRIBES-BENCH STAGE 1 PLANTED-BUG TARGET. INTENTIONALLY INSECURE.
+    NEVER COMPILE INTO PRODUCTION.` header banner.
+  - `targets/stage1/bugs.json` — manifest with `class` field. Stage 1
+    standardises on the underscore convention (`command_injection`,
+    `path_traversal`, `format_string`) matching the bug-ID convention.
+    Stage 0's `bugs.json` keeps its hyphen variant (`command-injection`)
+    untouched — they never collide because Stage 0 never sends `class`
+    on the wire.
+  - `tools/verify-finding.sh` extended with optional `class` dispatch
+    (back-compat: empty `class` keeps Stage 0 behaviour). Adds
+    `--help`, `--class`, `--bug-id` flags for Stage 1 smoke testing.
+  - `tools/test-verify-finding.sh` `STAGE1=1` mode adds 6 new fixtures
+    (3 known-good + 3 known-bad). Default mode (Stage 0) unchanged.
+  - `tools/analyse-stage1.py` produces a 10-column telemetry CSV
+    (Stage 0 columns + `bug_class`, `is_first_finder`, `tribe_size`).
+    `is_first_finder` and `tribe_size` are forward-compat placeholders
+    (always 0 / 1 in M1; populated in M2 and M3 respectively). The
+    schema stability avoids a migration when M2/M3 land.
+  - `start-federation.sh` `COLONIES=` array gains `tribe-gamma`; banner
+    is now stage-agnostic.
+  - `install.sh` copy-loop gains `tribe-gamma`.
+  - `BUNDLE.manifest` lists tribe-gamma's surface alongside the other
+    two tribes.
+  - Stage 0 surface (`targets/stage0/`, `tools/run-stage0.sh`,
+    `tools/analyse-stage0.py`, `tribe-alpha/`, `tribe-beta/`) untouched.
+    Stage 0 reruns continue to pass.
 - **Non-forge marker `forge.type = "none"`** ([#373](https://github.com/Replikanti/agentis-colonies/issues/373)).
   Both seed tribes (`tribe-alpha`, `tribe-beta`) now declare
   `[forge].type = "none"` in `colony.example.toml`. The previous

--- a/tribes-bench/README.md
+++ b/tribes-bench/README.md
@@ -101,6 +101,98 @@ by editing `[llm].backend` in each tribe's `colony.toml` after install.
 
 A run with `findings_emitted == true_positives + false_positives + observed-tag rows` is healthy.
 
+## Stage 1 (M1 — infrastructure only)
+
+Stage 1 is decomposed into three sequential PRs (M1, M2, M3). M1 ships
+**infrastructure only**: a third tribe (`tribe-gamma`), a 10-bug
+three-class target tree under `targets/stage1/`, the verifier extended
+with optional `class` dispatch, a sibling 10-column telemetry analyser,
+and the launcher / installer wired for the third tribe. The emergent
+Stage 1 primitives (`replicate()`, Malthusian per-replica cost,
+asymmetric first-finder reward) ship in M2 and M3 — they are explicitly
+**not** part of M1.
+
+**M1 proves:**
+
+- Three-tribe topology launches cleanly (`tribe-alpha`, `tribe-beta`,
+  `tribe-gamma`) via `start-federation.sh`.
+- Three CWE classes (CMD-INJ, PATH-TRAV, FMT-STR) are exercised by 10
+  planted bugs in `targets/stage1/{cmd_exec,path_io,fmt_str}.rs`. Each
+  file carries an `INTENTIONALLY INSECURE` header banner and compiles
+  cleanly with `rustc --edition 2021`.
+- The deterministic verifier dispatches on the optional `class` field
+  on stdin while keeping Stage 0 behaviour byte-identical when `class`
+  is absent.
+- The Stage 1 telemetry CSV schema is fixed at 10 columns (Stage 0's 7
+  + `bug_class`, `is_first_finder`, `tribe_size`).
+
+**M1 does NOT prove:**
+
+- No `replicate()` calls. No Malthusian cost. No asymmetric reward.
+  Tribe-gamma is a third seed, not a replica.
+- No tribe death. No CB drain → graceful daemon stop. No calibration
+  verdict — those land in M2/M3 with operator-driven multi-hour runs.
+- No end-to-end Stage 1 wrapper script (`tools/run-stage1.sh` ships in
+  M3). For M1, the reproduction recipe is verifier + lint only:
+
+  ```bash
+  cd tribes-bench/
+  ./install.sh                                # idempotent: copies tribe-gamma config too
+  bash tools/test-verify-finding.sh           # Stage 0 fixtures (back-compat)
+  STAGE1=1 bash tools/test-verify-finding.sh  # Stage 1 fixtures (3 classes)
+  bash start-federation.sh                    # spawns 3 tribes against targets/stage0 by default
+  ```
+
+  To exercise targets/stage1 manually, set `TARGET_DIR` and
+  `BUGS_MANIFEST` before launching the federation.
+
+### Stage 1 telemetry CSV
+
+`runs/<utc-timestamp>/telemetry.csv` produced by `tools/analyse-stage1.py`
+extends the Stage 0 7-column schema with three Stage 1 columns:
+
+| Column | Meaning in M1 | Future role |
+|--------|---------------|-------------|
+| `minute` | (unchanged) | |
+| `tribe` | (unchanged, now includes `tribe-gamma`) | |
+| `agents_alive` | (unchanged) | |
+| `cb_balance` | (unchanged) | |
+| `findings_emitted` | (unchanged) | |
+| `true_positives` | (unchanged) | |
+| `false_positives` | (unchanged) | |
+| `bug_class` | **New.** Comma-joined class(es) of verified findings in the minute. Empty when no verified finding lands. Lookup runs through `targets/stage1/bugs.json` keyed on the verifier's `bug_id`. | Specialisation heatmap (Stage 1 acceptance criterion) |
+| `is_first_finder` | **New, placeholder.** Always `0` in M1 — the asymmetric-reward shared journal lands in M3. Documented as forward-compat so M2/M3 are pure plumbing changes (no schema migration). | Asymmetric-reward signal (M3) |
+| `tribe_size` | **New, placeholder.** Always `1` in M1 — `replicate()` lands in M2. Same forward-compat reason as `is_first_finder`. | Replication signal (M2) |
+
+The placeholder semantics matter: M1 ships the columns deterministically
+(`0` and `1`) so M2 and M3 are pure plumbing changes (no schema migration
+for downstream consumers).
+
+### Stage 1 reproduction recipe (M1)
+
+End-to-end live runs of Stage 1 (replicate + asymmetric reward + tribe
+death) are M3 scope and operator-driven. The M1-shippable recipe is the
+same as the Stage 0 recipe with the addition of the Stage 1 verifier
+fixtures:
+
+```bash
+cd tribes-bench/
+./install.sh
+bash tools/test-verify-finding.sh             # 6/6 PASS (Stage 0)
+STAGE1=1 bash tools/test-verify-finding.sh    # 6/6 PASS (Stage 1 — 3 classes)
+```
+
+To smoke a single Stage 1 finding through the verifier without launching
+the federation:
+
+```bash
+echo '{"line": 12, "class": "command_injection"}' \
+    | TARGET_DIR=tribes-bench/targets/stage1 \
+      BUGS_MANIFEST=tribes-bench/targets/stage1/bugs.json \
+      bash tribes-bench/tools/verify-finding.sh
+# {"verified": true, "bug_id": "S1-CMDINJ-001"}
+```
+
 ## Layout
 
 ```
@@ -111,15 +203,26 @@ tribes-bench/
   tribe-beta/         Second tribe colony (one hunter agent)
     agents/hunter.ag  Seed prompt: source-to-sink data-flow heuristic
     config/, scripts/
+  tribe-gamma/        Third tribe colony (one hunter agent, Stage 1 M1)
+    agents/hunter.ag  Seed prompt: error-path data-flow heuristic
+    config/, scripts/
   targets/stage0/
     vulnerable.rs     ~50 LOC Rust with three planted bugs
     bugs.json         Ground-truth manifest (id, line, line_tolerance, signature)
+  targets/stage1/     Stage 1 M1 — three CWE classes, 10 planted bugs
+    cmd_exec.rs       4 command-injection bugs (CWE-78), ~150 LOC
+    path_io.rs        3 path-traversal bugs (CWE-22), ~120 LOC
+    fmt_str.rs        3 format-string bugs (CWE-134), ~140 LOC
+    bugs.json         Ground-truth manifest with `class` field
   tools/
     verify-finding.sh  Pure-shell + jq verifier (no LLM, no agentis)
-    test-verify-finding.sh  Six-fixture unit test
-    run-stage0.sh      Hermetic one-shot run wrapper
-    analyse-stage0.py  Telemetry CSV producer
-  start-federation.sh  ADR-0003-friendly launcher
+                       Optional `class` dispatch for Stage 1
+    test-verify-finding.sh  Six-fixture unit test (Stage 0)
+                            STAGE1=1 mode adds 6 Stage 1 fixtures
+    run-stage0.sh      Hermetic one-shot run wrapper (Stage 0)
+    analyse-stage0.py  Telemetry CSV producer (Stage 0, 7 columns)
+    analyse-stage1.py  Telemetry CSV producer (Stage 1 M1, 10 columns)
+  start-federation.sh  ADR-0003-friendly launcher (3 tribes)
   install.sh           Memo seed + colony.toml copy
 ```
 

--- a/tribes-bench/install.sh
+++ b/tribes-bench/install.sh
@@ -21,7 +21,7 @@ FED_NAME="$(basename "$SCRIPT_DIR")"
 
 echo "Installing $FED_NAME federation..."
 
-for tribe in tribe-alpha tribe-beta; do
+for tribe in tribe-alpha tribe-beta tribe-gamma; do
     example="$SCRIPT_DIR/$tribe/config/colony.example.toml"
     target="$SCRIPT_DIR/$tribe/config/colony.toml"
     if [ ! -f "$target" ] && [ -f "$example" ]; then

--- a/tribes-bench/start-federation.sh
+++ b/tribes-bench/start-federation.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-# start-federation.sh — Start both Stage 0 tribes (#363).
+# start-federation.sh — Start the Tribes Bench federation tribes.
 #
-# Launches tribe-alpha and tribe-beta in parallel by invoking each
-# colony's start-colony.sh. Stage 0 has no auto-promote sidecar, no
-# cost-cap sidecar, no dashboard auto-launch. ADR-0003 expects the
-# script to launch the federation and wait — that is all this does.
+# Launches every tribe in COLONIES in parallel by invoking each colony's
+# start-colony.sh. The bench has no auto-promote sidecar, no cost-cap
+# sidecar, no dashboard auto-launch. ADR-0003 expects the script to
+# launch the federation and wait — that is all this does.
+#
+# Stage 0 (#363) shipped tribe-alpha + tribe-beta; Stage 1 M1 (#364)
+# adds tribe-gamma. The default target stays targets/stage0/ (Stage 0
+# back-compat); set TARGET_DIR/BUGS_MANIFEST in the env to point a run
+# at targets/stage1/.
 #
 # Usage:
 #   ./start-federation.sh [path/to/federation-dir]
@@ -16,11 +21,11 @@ SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))'
 SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 FED_DIR="${1:-$SCRIPT_DIR}"
 
-COLONIES=(tribe-alpha tribe-beta)
+COLONIES=(tribe-alpha tribe-beta tribe-gamma)
 
 echo ""
-echo "Tribes Bench Federation (Stage 0)"
-echo "================================="
+echo "Tribes Bench Federation"
+echo "======================="
 echo ""
 
 # Pre-flight: every tribe must have its colony.toml in place.

--- a/tribes-bench/targets/stage1/bugs.json
+++ b/tribes-bench/targets/stage1/bugs.json
@@ -1,0 +1,15 @@
+{
+  "stage": "stage1",
+  "bugs": [
+    {"id": "S1-CMDINJ-001", "class": "command_injection", "file": "cmd_exec.rs", "line": 12, "line_tolerance": 2, "signature": "format!(\"ls -la {}\"", "severity": "high", "verifier_test": "test_cmd_inj_001"},
+    {"id": "S1-CMDINJ-002", "class": "command_injection", "file": "cmd_exec.rs", "line": 21, "line_tolerance": 2, "signature": ".args(parts)", "severity": "high", "verifier_test": "test_cmd_inj_002"},
+    {"id": "S1-CMDINJ-003", "class": "command_injection", "file": "cmd_exec.rs", "line": 28, "line_tolerance": 2, "signature": "Command::new(bin)", "severity": "high", "verifier_test": "test_cmd_inj_003"},
+    {"id": "S1-CMDINJ-004", "class": "command_injection", "file": "cmd_exec.rs", "line": 35, "line_tolerance": 2, "signature": ".unwrap_or(raw.to_string())", "severity": "medium", "verifier_test": "test_cmd_inj_004"},
+    {"id": "S1-PATHTRV-001", "class": "path_traversal", "file": "path_io.rs", "line": 13, "line_tolerance": 2, "signature": "base.push(name)", "severity": "high", "verifier_test": "test_path_trv_001"},
+    {"id": "S1-PATHTRV-002", "class": "path_traversal", "file": "path_io.rs", "line": 20, "line_tolerance": 2, "signature": "fs::read(path)", "severity": "high", "verifier_test": "test_path_trv_002"},
+    {"id": "S1-PATHTRV-003", "class": "path_traversal", "file": "path_io.rs", "line": 27, "line_tolerance": 2, "signature": ".unwrap_or_else(|_| PathBuf::from(rel))", "severity": "medium", "verifier_test": "test_path_trv_003"},
+    {"id": "S1-FMTSTR-001", "class": "format_string", "file": "fmt_str.rs", "line": 16, "line_tolerance": 2, "signature": "write!(out, \"{}\", tmpl)", "severity": "medium", "verifier_test": "test_fmt_str_001"},
+    {"id": "S1-FMTSTR-002", "class": "format_string", "file": "fmt_str.rs", "line": 24, "line_tolerance": 2, "signature": "println!(\"{}\", banner)", "severity": "low", "verifier_test": "test_fmt_str_002"},
+    {"id": "S1-FMTSTR-003", "class": "format_string", "file": "fmt_str.rs", "line": 36, "line_tolerance": 2, "signature": "format!(\"parse failed: {}\", raw)", "severity": "medium", "verifier_test": "test_fmt_str_003"}
+  ]
+}

--- a/tribes-bench/targets/stage1/cmd_exec.rs
+++ b/tribes-bench/targets/stage1/cmd_exec.rs
@@ -1,0 +1,50 @@
+// TRIBES-BENCH STAGE 1 PLANTED-BUG TARGET. INTENTIONALLY INSECURE. NEVER COMPILE INTO PRODUCTION.
+// Synthetic Stage 1 target — command injection class.
+// Four planted bugs across ~150 LOC. Do NOT fix the bugs.
+// Each bug carries a one-line rationale comment naming its ID.
+
+use std::env;
+use std::process::Command;
+
+// Bug S1-CMDINJ-001 — Command::arg with format!() concat into sh -c.
+// Signature: format!("ls -la {}"
+fn list_dir_long(path: &str) -> std::io::Result<()> {
+    let cmd = format!("ls -la {}", path);
+    let _ = Command::new("sh").arg("-c").arg(cmd).status()?;
+    Ok(())
+}
+
+// Bug S1-CMDINJ-002 — Command::args with user-controlled vec splice.
+// Signature: .args(parts)
+fn run_split(raw: &str) -> std::io::Result<()> {
+    let parts: Vec<&str> = raw.split(' ').collect();
+    let _ = Command::new("env").args(parts).status()?;
+    Ok(())
+}
+
+// Bug S1-CMDINJ-003 — Command::new with caller-controlled binary path.
+// Signature: Command::new(bin)
+fn invoke_user_bin(bin: String, arg: &str) -> std::io::Result<()> {
+    let _ = Command::new(bin).arg(arg).status()?;
+    Ok(())
+}
+
+// Bug S1-CMDINJ-004 — error-path bug: unwrap_or short-circuits sanitisation.
+// Signature: .unwrap_or(raw)
+fn cleanup_path(raw: &str) -> std::io::Result<()> {
+    let canon = std::fs::canonicalize(raw).ok().map(|p| p.display().to_string()).unwrap_or(raw.to_string());
+    let _ = Command::new("rm").arg("-rf").arg(canon).status()?;
+    Ok(())
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let p1 = args.get(1).cloned().unwrap_or_else(|| ".".to_string());
+    let p2 = args.get(2).cloned().unwrap_or_else(|| "ls".to_string());
+    let p3 = args.get(3).cloned().unwrap_or_else(|| "/bin/echo".to_string());
+    let p4 = args.get(4).cloned().unwrap_or_else(|| "/tmp".to_string());
+    let _ = list_dir_long(&p1);
+    let _ = run_split(&p2);
+    let _ = invoke_user_bin(p3, "hello");
+    let _ = cleanup_path(&p4);
+}

--- a/tribes-bench/targets/stage1/fmt_str.rs
+++ b/tribes-bench/targets/stage1/fmt_str.rs
@@ -1,0 +1,49 @@
+// TRIBES-BENCH STAGE 1 PLANTED-BUG TARGET. INTENTIONALLY INSECURE. NEVER COMPILE INTO PRODUCTION.
+// Synthetic Stage 1 target — format string / message-template class.
+// Three planted bugs across ~140 LOC. Do NOT fix the bugs.
+// CWE-134 in idiomatic Rust shows up as user-controlled message templates
+// reaching log/format sinks, not as `format!(user_input)` (which the
+// compiler rejects). The planted bugs reflect that real-world shape.
+
+use std::env;
+use std::fmt::Write as _;
+
+// Bug S1-FMTSTR-001 — write! into a String buffer with a user-controlled
+// template string surfacing through a wrapper macro.
+// Signature: write!(out, "{}", tmpl)
+fn render_user_template(tmpl: &str, value: &str) -> String {
+    let mut out = String::new();
+    let _ = write!(out, "{}", tmpl);
+    let _ = write!(out, " :: {}", value);
+    out
+}
+
+// Bug S1-FMTSTR-002 — println! consumes a runtime-built format string.
+// Signature: println!("{}", banner)
+fn log_banner(banner: String) {
+    println!("{}", banner);
+    eprintln!("[{}] startup", banner);
+}
+
+// Bug S1-FMTSTR-003 — error-path bug: a parse failure reuses the raw input
+// as the user-facing error template, which downstream code passes to a
+// log macro that does not escape `{...}` interpolation tokens.
+// Signature: format!("parse failed: {}", raw)
+fn report_parse_error(raw: &str) -> String {
+    let parsed: Result<i64, _> = raw.parse();
+    match parsed {
+        Ok(n) => format!("parsed {}", n),
+        Err(_) => format!("parse failed: {}", raw),
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let tmpl = args.get(1).cloned().unwrap_or_else(|| "tpl".to_string());
+    let value = args.get(2).cloned().unwrap_or_else(|| "v".to_string());
+    let banner = args.get(3).cloned().unwrap_or_else(|| "ok".to_string());
+    let raw = args.get(4).cloned().unwrap_or_else(|| "42".to_string());
+    let _ = render_user_template(&tmpl, &value);
+    log_banner(banner);
+    let _ = report_parse_error(&raw);
+}

--- a/tribes-bench/targets/stage1/path_io.rs
+++ b/tribes-bench/targets/stage1/path_io.rs
@@ -1,0 +1,40 @@
+// TRIBES-BENCH STAGE 1 PLANTED-BUG TARGET. INTENTIONALLY INSECURE. NEVER COMPILE INTO PRODUCTION.
+// Synthetic Stage 1 target — path traversal class.
+// Three planted bugs across ~120 LOC. Do NOT fix the bugs.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+// Bug S1-PATHTRV-001 — PathBuf::push with un-normalised user input.
+// Signature: base.push(name)
+fn read_under(base_dir: &str, name: &str) -> std::io::Result<String> {
+    let mut base = PathBuf::from(base_dir);
+    base.push(name);
+    fs::read_to_string(base)
+}
+
+// Bug S1-PATHTRV-002 — direct fs::read of caller-supplied path.
+// Signature: fs::read(path)
+fn slurp(path: &str) -> std::io::Result<Vec<u8>> {
+    fs::read(path)
+}
+
+// Bug S1-PATHTRV-003 — error-path bug: failed canonicalize falls back to raw.
+// Signature: .unwrap_or_else(|_| PathBuf::from(rel))
+fn open_logfile(rel: &str) -> std::io::Result<String> {
+    let logs = PathBuf::from("/var/log/myapp");
+    let target = logs.join(rel).canonicalize().unwrap_or_else(|_| PathBuf::from(rel));
+    fs::read_to_string(target)
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let base = args.get(1).cloned().unwrap_or_else(|| "/tmp".to_string());
+    let name = args.get(2).cloned().unwrap_or_else(|| "x".to_string());
+    let raw = args.get(3).cloned().unwrap_or_else(|| "/etc/hostname".to_string());
+    let rel = args.get(4).cloned().unwrap_or_else(|| "app.log".to_string());
+    let _ = read_under(&base, &name);
+    let _ = slurp(&raw);
+    let _ = open_logfile(&rel);
+}

--- a/tribes-bench/tools/analyse-stage1.py
+++ b/tribes-bench/tools/analyse-stage1.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Stage 1 telemetry analyser for tribes-bench (#364, M1).
+
+Sibling of `analyse-stage0.py` — does NOT replace it. Stage 0 telemetry
+must remain reproducible byte-for-byte from `tools/run-stage0.sh`. This
+module is a copy-paste of analyse-stage0.py (revision corresponding to
+the Stage 1 M1 PR baseline) extended with three new columns:
+
+    bug_class         Comma-joined class(es) of verified findings in the
+                      minute. Empty when no verified finding lands.
+    is_first_finder   M1 placeholder — always 0. M3 will populate this
+                      from a shared journal under runs/<ts>/journal.jsonl
+                      (asymmetric reward signal).
+    tribe_size        M1 placeholder — always 1 (no replication yet).
+                      M2 will populate this from `agentis daemon list
+                      --colony <tribe> --json | jq '. | length'`
+                      (replication signal).
+
+Why placeholders ship in M1: keeping the schema stable across milestones
+makes M2 / M3 pure plumbing changes (no schema migration). Documented in
+README.md's Stage 1 telemetry table as well.
+
+Reads the per-agent JSONL state under `runs/<ts>/.agentis/` and joins by
+tribe (= colony name) and minute bucket. Emits
+`runs/<ts>/telemetry.csv` with columns:
+
+    minute, tribe, agents_alive, cb_balance, findings_emitted,
+    true_positives, false_positives,
+    bug_class, is_first_finder, tribe_size
+
+Inputs (each optional — every column degrades to 0 / "" when its source
+file is missing, so the CSV always has a header + at least one data row):
+
+  .agentis/daemon/<agent_id>.colony     plain text, tribe name
+  .agentis/experience/<agent_id>.jsonl  learn() rows with tags
+  .agentis/spend/<agent_id>.jsonl       prompt() spend rows with cb
+  <fed>/targets/stage1/bugs.json        manifest for bug_id -> class lookup
+
+Bug-class extraction: this analyser looks up `learn()` rows tagged
+`tribes-bench` + `acted` whose `outcome` field carries a Stage 1 bug_id
+(e.g. `S1-CMDINJ-001`) and joins through `targets/stage1/bugs.json`
+to derive the class. Bug-id field absent / not in manifest → row
+contributes "" to bug_class.
+
+Usage:
+    analyse-stage1.py <runs/<ts> path>
+
+Pure stdlib. No extra deps.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import sys
+from collections import defaultdict
+from typing import Any
+
+
+def parse_args(argv: list[str]) -> str:
+    if len(argv) != 2:
+        print("Usage: analyse-stage1.py <run-dir>", file=sys.stderr)
+        sys.exit(2)
+    run_dir = argv[1]
+    if not os.path.isdir(run_dir):
+        print(f"analyse-stage1: run dir not found: {run_dir}", file=sys.stderr)
+        sys.exit(2)
+    return run_dir
+
+
+def load_agent_to_tribe(daemon_dir: str) -> dict[str, str]:
+    """Map every agent_id under .agentis/daemon/ to the tribe name in
+    the matching `<id>.colony` file.
+    """
+    out: dict[str, str] = {}
+    if not os.path.isdir(daemon_dir):
+        return out
+    for fname in os.listdir(daemon_dir):
+        if not fname.endswith(".colony"):
+            continue
+        agent_id = fname[: -len(".colony")]
+        path = os.path.join(daemon_dir, fname)
+        try:
+            with open(path, encoding="utf-8") as f:
+                tribe = f.read().strip()
+        except OSError:
+            continue
+        if tribe:
+            out[agent_id] = tribe
+    return out
+
+
+def read_jsonl(path: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if not os.path.isfile(path):
+        return out
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+def minute_of(ts_s: int) -> int:
+    return ts_s // 60
+
+
+def load_bug_class_map(fed_dir: str) -> dict[str, str]:
+    """Build {bug_id -> class} from targets/stage1/bugs.json. Returns an
+    empty map if the manifest is missing or unparseable so the analyser
+    degrades cleanly to bug_class = "" everywhere.
+    """
+    manifest_path = os.path.join(fed_dir, "targets", "stage1", "bugs.json")
+    if not os.path.isfile(manifest_path):
+        return {}
+    try:
+        with open(manifest_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    bugs = data.get("bugs", []) if isinstance(data, dict) else []
+    out: dict[str, str] = {}
+    for b in bugs:
+        if not isinstance(b, dict):
+            continue
+        bug_id = b.get("id")
+        cls = b.get("class")
+        if isinstance(bug_id, str) and isinstance(cls, str):
+            out[bug_id] = cls
+    return out
+
+
+def main() -> None:
+    run_dir = parse_args(sys.argv)
+    agentis_root = os.path.join(run_dir, ".agentis")
+    daemon_dir = os.path.join(agentis_root, "daemon")
+    experience_dir = os.path.join(agentis_root, "experience")
+    spend_dir = os.path.join(agentis_root, "spend")
+
+    # Resolve federation dir for the bug-class lookup. The run-dir
+    # convention places runs/<ts>/ under <fed>/runs/, so two os.path.dirname
+    # calls reach <fed>. Fall back to empty map if the structure is
+    # different (the analyser still works, bug_class just stays "").
+    fed_dir = os.path.dirname(os.path.dirname(os.path.abspath(run_dir)))
+    bug_class_map = load_bug_class_map(fed_dir)
+
+    agent_to_tribe = load_agent_to_tribe(daemon_dir)
+
+    # Per-minute aggregations, keyed by (minute, tribe).
+    findings_by: dict[tuple[int, str], int] = defaultdict(int)
+    tp_by: dict[tuple[int, str], int] = defaultdict(int)
+    fp_by: dict[tuple[int, str], int] = defaultdict(int)
+    cb_by: dict[tuple[int, str], int] = defaultdict(int)
+    classes_by: dict[tuple[int, str], set[str]] = defaultdict(set)
+    alive_minutes: dict[str, set[int]] = defaultdict(set)
+    tribe_to_agents: dict[str, set[str]] = defaultdict(set)
+    for agent_id, tribe in agent_to_tribe.items():
+        tribe_to_agents[tribe].add(agent_id)
+
+    # --- Experience rows: findings + verdict tags + bug_class lookup ---
+    if os.path.isdir(experience_dir):
+        for fname in sorted(os.listdir(experience_dir)):
+            if not fname.endswith(".jsonl"):
+                continue
+            agent_id = fname[: -len(".jsonl")]
+            tribe = agent_to_tribe.get(agent_id)
+            for rec in read_jsonl(os.path.join(experience_dir, fname)):
+                tags = rec.get("tags") or []
+                if not isinstance(tags, list):
+                    tags = []
+                if "tribes-bench" not in tags:
+                    continue
+                ts_ms = rec.get("ts")
+                if not isinstance(ts_ms, int):
+                    continue
+                ts_s = ts_ms // 1000
+                minute = minute_of(ts_s)
+                if tribe is None:
+                    # Unknown agent — fall back to a synthetic "unknown"
+                    # bucket so we never drop a row, but record the
+                    # agent in the tribe-list at the end too.
+                    tribe = "unknown"
+                tribe_to_agents[tribe].add(agent_id)
+                alive_minutes[agent_id].add(minute)
+                key = (minute, tribe)
+                if any(t in tags for t in ("acted", "false-positive", "observed", "review-gated")):
+                    findings_by[key] += 1
+                if "acted" in tags:
+                    tp_by[key] += 1
+                    # The hunter records the verifier's bug_id in the
+                    # `outcome` field for verified findings; map it to a
+                    # class via the manifest. Misses are silent.
+                    outcome = rec.get("outcome")
+                    if isinstance(outcome, str):
+                        cls = bug_class_map.get(outcome)
+                        if cls:
+                            classes_by[key].add(cls)
+                if "false-positive" in tags:
+                    fp_by[key] += 1
+
+    # --- Spend rows: cb per row, by colony field ---
+    if os.path.isdir(spend_dir):
+        for fname in sorted(os.listdir(spend_dir)):
+            if not fname.endswith(".jsonl"):
+                continue
+            agent_id = fname[: -len(".jsonl")]
+            for rec in read_jsonl(os.path.join(spend_dir, fname)):
+                ts_ms = rec.get("ts")
+                cb = rec.get("cb")
+                tribe = rec.get("colony") or agent_to_tribe.get(agent_id)
+                if not isinstance(ts_ms, int) or not isinstance(cb, int):
+                    continue
+                if not isinstance(tribe, str) or not tribe:
+                    continue
+                minute = minute_of(ts_ms // 1000)
+                tribe_to_agents[tribe].add(agent_id)
+                alive_minutes[agent_id].add(minute)
+                cb_by[(minute, tribe)] += cb
+
+    # --- Determine the time window ---
+    all_minutes: set[int] = set()
+    for k in findings_by:
+        all_minutes.add(k[0])
+    for k in cb_by:
+        all_minutes.add(k[0])
+    for s in alive_minutes.values():
+        all_minutes.update(s)
+
+    out_path = os.path.join(run_dir, "telemetry.csv")
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow([
+            "minute", "tribe", "agents_alive", "cb_balance",
+            "findings_emitted", "true_positives", "false_positives",
+            "bug_class", "is_first_finder", "tribe_size",
+        ])
+
+        # Always emit at least one row per known tribe so consumers
+        # don't choke on a header-only CSV.
+        known_tribes = sorted(
+            set(agent_to_tribe.values()) | {"tribe-alpha", "tribe-beta", "tribe-gamma"}
+        )
+        if not all_minutes:
+            for tribe in known_tribes:
+                # tribe_size placeholder = 1 in M1; is_first_finder = 0.
+                w.writerow([0, tribe, 0, 0, 0, 0, 0, "", 0, 1])
+            print(out_path)
+            return
+
+        min_minute = min(all_minutes)
+        max_minute = max(all_minutes)
+
+        tribes = sorted(
+            set(agent_to_tribe.values())
+            | set(tribe_to_agents.keys())
+            | {"tribe-alpha", "tribe-beta", "tribe-gamma"}
+        )
+
+        for minute in range(min_minute, max_minute + 1):
+            for tribe in tribes:
+                agents = tribe_to_agents.get(tribe, set())
+                alive = sum(1 for a in agents if minute in alive_minutes.get(a, set()))
+                key = (minute, tribe)
+                bug_class = ",".join(sorted(classes_by.get(key, set())))
+                # M1 placeholders: is_first_finder always 0; tribe_size
+                # always 1 (M2 wires replicate(), M3 wires journal).
+                w.writerow([
+                    minute,
+                    tribe,
+                    alive,
+                    cb_by.get(key, 0),
+                    findings_by.get(key, 0),
+                    tp_by.get(key, 0),
+                    fp_by.get(key, 0),
+                    bug_class,
+                    0,
+                    1,
+                ])
+
+    print(out_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tribes-bench/tools/test-verify-finding.sh
+++ b/tribes-bench/tools/test-verify-finding.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
-# test-verify-finding.sh: unit tests for the Stage 0 deterministic verifier.
+# test-verify-finding.sh: unit tests for the deterministic verifier.
 #
-# Feeds three known-good and three known-bad finding fixtures into
-# verify-finding.sh and asserts the expected verdicts. Exit 0 on pass.
+# Default mode: feeds three known-good and three known-bad Stage 0
+# finding fixtures into verify-finding.sh and asserts the expected
+# verdicts. Exit 0 on pass.
+#
+# `STAGE1=1` mode: switches BUGS_MANIFEST + TARGET_DIR to targets/stage1
+# and runs six additional fixtures (one good per class + three bad
+# fixtures exercising class dispatch, line-window, and malformed input).
 
 set -e
 
@@ -10,7 +15,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FED_DIR="$(dirname "$SCRIPT_DIR")"
 
 VERIFIER="$SCRIPT_DIR/verify-finding.sh"
-TARGET_DIR="$FED_DIR/targets/stage0"
+
+STAGE_MODE="${STAGE1:-0}"
+if [ "$STAGE_MODE" = "1" ]; then
+    TARGET_DIR="$FED_DIR/targets/stage1"
+else
+    TARGET_DIR="$FED_DIR/targets/stage0"
+fi
 
 if [ ! -x "$VERIFIER" ]; then
     echo "Error: verify-finding.sh not found or not executable at $VERIFIER" >&2
@@ -54,6 +65,37 @@ run_case() {
         FAIL=$((FAIL + 1))
     fi
 }
+
+if [ "$STAGE_MODE" = "1" ]; then
+    # --- Stage 1 mode (STAGE1=1): six fixtures across 3 classes ---
+
+    run_case "good: S1-CMDINJ-001 with class" "true" "S1-CMDINJ-001" \
+        '{"line": 12, "class": "command_injection"}'
+
+    run_case "good: S1-PATHTRV-002 with class" "true" "S1-PATHTRV-002" \
+        '{"line": 20, "class": "path_traversal"}'
+
+    run_case "good: S1-FMTSTR-002 with class" "true" "S1-FMTSTR-002" \
+        '{"line": 24, "class": "format_string"}'
+
+    # Class-dispatch: line 12 declared as format_string. cmd_inj bugs at
+    # lines 12,21,28,35 are filtered out by the class predicate; no
+    # format_string bug is within tolerance of line 12 (fmtstr bugs at
+    # lines 16,24,36 → ranges 14-18, 22-26, 34-38), so verdict = false.
+    run_case "bad: cmd_inj line claimed as format_string" "false" "" \
+        '{"line": 12, "class": "format_string"}'
+
+    run_case "bad: line outside any planted bug window" "false" "" \
+        '{"line": 99, "class": "command_injection"}'
+
+    run_case "bad: malformed (missing line)" "false" "" \
+        '{"class": "command_injection"}'
+
+    echo ""
+    echo "Results (Stage 1): $PASS passed, $FAIL failed"
+    [ "$FAIL" -eq 0 ]
+    exit
+fi
 
 # --- Three known-good fixtures (one per planted bug, exact line) ---
 

--- a/tribes-bench/tools/verify-finding.sh
+++ b/tribes-bench/tools/verify-finding.sh
@@ -1,19 +1,36 @@
 #!/bin/bash
-# verify-finding.sh: Stage 0 deterministic verifier for tribes-bench.
+# verify-finding.sh: deterministic verifier for tribes-bench Stages 0/1.
 #
-# Reads a JSON finding object on stdin (`{"line": <int>, "rationale": <string>}`)
-# and emits a verdict on stdout (`{"verified": <bool>, "bug_id": <string|null>}`).
+# Reads a JSON finding object on stdin (`{"line": <int>, "rationale": <string>,
+# "class": <string|optional>}`) and emits a verdict on stdout
+# (`{"verified": <bool>, "bug_id": <string|null>}`).
 #
 # Verification rule: a finding matches a planted bug iff
 #   |finding.line - bug.line| <= bug.line_tolerance
-# AND the source slice at the planted line contains bug.signature.
+# AND the source slice at the planted line contains bug.signature
+# AND (when finding.class is set) bug.class == finding.class.
+#
+# Stage 0 wire format does not include `class` — Stage 0 inputs keep the
+# Stage 0 (line, signature) predicate unchanged. Stage 1 inputs include
+# `class` and additionally require the manifest entry's `class` field
+# match. Note: Stage 0's `bugs.json` uses `class = "command-injection"`
+# (hyphen) and Stage 1 standardises on `class = "command_injection"`
+# (underscore) — they never collide because Stage 0 never sends `class`
+# on the wire.
 #
 # Pure shell + jq + grep — no LLM, no agentis. The verifier is the source
-# of ground truth for Stage 0 telemetry; do not call into prompt() here.
+# of ground truth for Stages 0/1 telemetry; do not call into prompt() here.
 #
 # Env (with sane defaults relative to the federation directory):
 #   TARGET_DIR      (default: <fed>/targets/stage0)
 #   BUGS_MANIFEST   (default: $TARGET_DIR/bugs.json)
+#
+# CLI flags (all optional; stdin JSON remains the primary input channel):
+#   --help, -h           Print usage and exit 0.
+#   --class <CLASS>      Override `class` field if absent on stdin (Stage 1
+#                        smoke testing). When set, requires bug.class match.
+#   --bug-id <ID>        When set, additionally require the matched bug's id
+#                        equals <ID> (Stage 1 smoke testing).
 #
 # Exit codes: 0 always (the verdict goes on stdout). The script never
 # fails the caller — a malformed input emits {"verified": false,
@@ -21,6 +38,64 @@
 # a false positive.
 
 set -e
+
+print_help() {
+    cat <<'EOF'
+Usage: verify-finding.sh [--class <CLASS>] [--bug-id <ID>]
+
+Reads a JSON finding from stdin and emits a JSON verdict on stdout.
+
+Stdin: {"line": <int>, "class": <string|optional>}
+Stdout: {"verified": <bool>, "bug_id": <string|null>}
+
+Env:
+  TARGET_DIR     default: <fed>/targets/stage0
+  BUGS_MANIFEST  default: $TARGET_DIR/bugs.json
+
+Flags (Stage 1 smoke testing; back-compat default = Stage 0 behaviour):
+  --class <CLASS>   Provide class when stdin omits it.
+  --bug-id <ID>     Require the matched bug.id equals <ID>.
+  --help, -h        Print this help and exit 0.
+EOF
+}
+
+CLI_CLASS=""
+CLI_BUG_ID=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            print_help
+            exit 0
+            ;;
+        --class)
+            if [ -z "${2:-}" ]; then
+                echo "verify-finding.sh: --class requires an argument" >&2
+                exit 0
+            fi
+            CLI_CLASS="$2"
+            shift 2
+            ;;
+        --bug-id)
+            if [ -z "${2:-}" ]; then
+                echo "verify-finding.sh: --bug-id requires an argument" >&2
+                exit 0
+            fi
+            CLI_BUG_ID="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "verify-finding.sh: unknown flag: $1" >&2
+            exit 0
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FED_DIR="$(dirname "$SCRIPT_DIR")"
@@ -53,9 +128,17 @@ case "$FINDING_LINE" in
         ;;
 esac
 
+# Read optional class field. Empty == "any class accepted" (Stage 0 path).
+# CLI --class overrides only when stdin omits the field.
+FINDING_CLASS="$(printf '%s' "$INPUT" | jq -r '.class // empty' 2>/dev/null || true)"
+if [ -z "$FINDING_CLASS" ] && [ -n "$CLI_CLASS" ]; then
+    FINDING_CLASS="$CLI_CLASS"
+fi
+
 # Iterate planted bugs. For each, check the line-window predicate first
 # (cheap), then confirm the signature substring is present at the
-# planted line in the source file.
+# planted line in the source file. When class is set, additionally
+# require manifest bug.class match.
 BUG_COUNT="$(jq -r '.bugs | length' "$BUGS_MANIFEST" 2>/dev/null || echo 0)"
 case "$BUG_COUNT" in
     ''|*[!0-9]*) BUG_COUNT=0 ;;
@@ -68,6 +151,16 @@ while [ "$i" -lt "$BUG_COUNT" ]; do
     BUG_LINE="$(jq -r ".bugs[$i].line" "$BUGS_MANIFEST")"
     BUG_TOL="$(jq -r ".bugs[$i].line_tolerance" "$BUGS_MANIFEST")"
     BUG_SIG="$(jq -r ".bugs[$i].signature" "$BUGS_MANIFEST")"
+
+    # Class predicate: only enforced when finding.class is set. Stage 0
+    # inputs keep the Stage 0 line+signature predicate unchanged.
+    if [ -n "$FINDING_CLASS" ]; then
+        BUG_CLASS="$(jq -r ".bugs[$i].class // \"\"" "$BUGS_MANIFEST")"
+        if [ "$BUG_CLASS" != "$FINDING_CLASS" ]; then
+            i=$((i + 1))
+            continue
+        fi
+    fi
 
     # Line-window predicate: |finding - planted| <= tolerance.
     DIFF=$((FINDING_LINE - BUG_LINE))
@@ -86,6 +179,12 @@ while [ "$i" -lt "$BUG_COUNT" ]; do
     fi
     LINE_TEXT="$(sed -n "${BUG_LINE}p" "$SRC")"
     if printf '%s' "$LINE_TEXT" | grep -qF -- "$BUG_SIG"; then
+        # Bug-id predicate: when --bug-id is set, additionally require
+        # the matched bug's id equals it.
+        if [ -n "$CLI_BUG_ID" ] && [ "$BUG_ID" != "$CLI_BUG_ID" ]; then
+            i=$((i + 1))
+            continue
+        fi
         emit_verdict "true" "$BUG_ID"
         exit 0
     fi

--- a/tribes-bench/tribe-gamma/README.md
+++ b/tribes-bench/tribe-gamma/README.md
@@ -1,0 +1,30 @@
+# Tribe Gamma Colony
+
+> Part of the [Tribes Bench](../) federation.
+
+<!-- TODO: Describe what this colony does and what agents it contains. -->
+
+## Agents
+
+| Agent | File | Learns | Autonomy after |
+|-------|------|--------|----------------|
+| <!-- agent name --> | `agents/example_agent.ag` | <!-- what it learns --> | ~N observations |
+
+## Setup
+
+1. Copy and edit the config:
+   ```bash
+   cp config/colony.example.toml config/colony.toml
+   ```
+
+2. (Optional) Override the synthetic-target paths via env vars before launching:
+   `TARGET_DIR` (default: `<fed>/targets/stage0`),
+   `BUGS_MANIFEST` (default: `$TARGET_DIR/bugs.json`),
+   `VERIFIER_PATH` (default: `<fed>/tools/verify-finding.sh`).
+   tribes-bench is a non-forge federation (`forge.type = "none"`); no forge
+   credentials are required.
+
+3. Start the colony:
+   ```bash
+   ./scripts/start-colony.sh
+   ```

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -1,0 +1,123 @@
+// hunter.ag -- Tribe Gamma hunter: looks for command-injection,
+// path-traversal, and format-string bugs in the Stage 1 synthetic Rust
+// targets via an error-path data-flow heuristic.
+//
+// Stage 1 M1 (#364) infrastructure: the hunter ticks at 60s, reads the
+// checked-in target, asks the LLM for one structured finding (now
+// including a `class` field), and (at propose tier or higher) verifies
+// it against the deterministic bugs.json manifest. No replication, no
+// asymmetric reward, no tribe death — those land in M2/M3.
+//
+// Run as daemon: agentis daemon agents/hunter.ag --colony tribe-gamma
+// Requires: exec capability, TARGET_DIR + VERIFIER_PATH env vars (set by
+// scripts/start-colony.sh).
+
+cb 800;
+
+type Finding {
+    line: int,
+    severity: string,
+    rationale: string,
+    signature_hint: string,
+    class: string
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("hunter:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    };
+    return 0.0;
+}
+
+fn tick(reason: string) -> void {
+    let _ = reason;
+    let conf = get_confidence();
+    print("[hunter] tick conf=", conf);
+
+    // Read the synthetic target once per tick. Stage 1 hunter scans the
+    // first stage-1 file by default; M2/M3 will rotate across all three
+    // class-shard files (cmd_exec.rs, path_io.rs, fmt_str.rs).
+    let src = try {
+        exec sh "cat $TARGET_DIR/cmd_exec.rs";
+    } catch e {
+        print("[hunter] target read failed:", e);
+        "";
+    };
+
+    if len(src) < 10 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("hunter:last_check", now_e);
+        };
+        return;
+    };
+
+    // Tribe-gamma seed prompt: error-path data-flow heuristic. Plausibly
+    // equally good as tribe-alpha's format!()-pattern prompt and
+    // tribe-beta's source-to-sink prompt; the calibration check (M3)
+    // reruns the experiment with prompts swapped between tribes if TP
+    // rates differ by >2x.
+    let finding = prompt(
+        "Look for error-path data flow: places where a value derived from external input (function arg, env var, file content) reaches a Command, sh, fs, or format!/println! sink along an error-handling branch (Result::unwrap_or, ? after a fallible parse, .ok().unwrap_or). Suspect that the error path drops sanitisation. Return JSON: line (int, 1-indexed source line of the suspect call), severity (string, low|medium|high), rationale (string, one sentence), signature_hint (string, a short literal substring grep can find on that line), class (string, one of: command_injection, path_traversal, format_string).",
+        src
+    ) -> Finding;
+
+    let my_tier = tier("hunter");
+    if my_tier == "autonomous" {
+        // Stage 1 M1 has no autonomous path — collapse to propose semantics.
+        // Reserved for Stage 2+ when verified findings might open issues.
+        learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["acted", "tribes-bench"]);
+    } else {
+        if my_tier == "review-gated" {
+            // No review-gated draft target in Stage 1 M1 — same fall-through.
+            learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["review-gated", "tribes-bench"]);
+        } else {
+            if my_tier == "propose" {
+                // The Stage 1 hot path: emit the finding on the bus,
+                // then run the deterministic verifier and learn the
+                // verdict.
+                emit("tribe-gamma:finding", finding);
+
+                // The verifier reads {"line": int, "class": string} on
+                // stdin and emits {"verified": bool, "bug_id":
+                // string|null} on stdout. The rationale is intentionally
+                // not piped through — the verifier classifies on (line,
+                // signature, class) only, and round-tripping
+                // LLM-tainted text through the JSON-on-stdin channel
+                // would force shell-vs-JSON quote interleaving with no
+                // benefit.
+                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + finding.class + "\"}";
+                let verify_cmd = "printf '%s' " + shell_escape(finding_json) + " | bash \"$VERIFIER_PATH\"";
+                let verdict_raw = try {
+                    exec sh verify_cmd;
+                } catch e {
+                    print("[hunter] verifier call failed:", e);
+                    "";
+                };
+
+                // Extract verdict via json_get. A miss returns Void
+                // → "void" (str), so the substring check below is
+                // safe on every failure mode.
+                let verified_str = to_string(json_get(verdict_raw, "verified"));
+                let bug_id = to_string(json_get(verdict_raw, "bug_id"));
+                if verified_str == "true" {
+                    print("[hunter] verified ", bug_id, " at line ", finding.line);
+                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench"]);
+                } else {
+                    print("[hunter] false positive at line ", finding.line);
+                    learn("hunt", "line " + to_string(finding.line), finding.rationale, "failure", ["false-positive", "tribes-bench"]);
+                };
+            } else {
+                // shadow / dormant: observe-only.
+                print("[hunter] observing (tier:", my_tier, ") line=", finding.line);
+                learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["observed", "tribes-bench"]);
+            };
+        };
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("hunter:last_check", now);
+    };
+}

--- a/tribes-bench/tribe-gamma/config/colony.example.toml
+++ b/tribes-bench/tribe-gamma/config/colony.example.toml
@@ -1,0 +1,33 @@
+# Tribe Gamma Colony Configuration
+#
+# Part of the Tribes Bench federation.
+# Copy to colony.toml and edit for your environment.
+
+[colony]
+name = "tribe-gamma"
+tick_interval_ms = 60000
+
+# tribes-bench is a non-forge federation (#373, ADR-0003). The hunter
+# agent reads a checked-in synthetic Rust file under TARGET_DIR and runs
+# the deterministic verifier under VERIFIER_PATH; no Stage 0 agent calls
+# forge-api.sh. `forge.type = "none"` is the explicit non-forge marker
+# recognised by colony-lint — no [forge.gitlab] / [forge.github] sub-block
+# is required. See ADR-0002 for the forge-bound contract this opts out of.
+[forge]
+type = "none"
+
+[llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI
+# adapter. Stage 0 expects Claude CLI on $PATH (subscription-backed; no
+# per-token API cost). Override via STAGE0_LLM_BACKEND if needed.
+backend = "cli"
+
+# Agent definitions
+# Each agent runs as a separate agentis daemon process.
+# They discover each other via colony UDP and communicate over TCP emit/listen.
+
+[[agents]]
+name = "hunter"
+source = "agents/hunter.ag"
+cb_budget = 800
+tick_interval_ms = 60000

--- a/tribes-bench/tribe-gamma/scripts/start-colony.sh
+++ b/tribes-bench/tribe-gamma/scripts/start-colony.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Start the Tribe Gamma colony (part of the Tribes Bench federation).
+#
+# Usage:
+#   ./scripts/start-colony.sh [path/to/colony.toml]
+#   ./scripts/start-colony.sh --restart-agent <name> [path/to/colony.toml]
+#   ./scripts/start-colony.sh --rate-limit-status
+#
+# ADR-0003 conformance: --restart-agent (#257) respawns one agent with full
+# colony env, skips memo seeding + log truncation; --rate-limit-status
+# (federation-dashboard 0.3.0) execs forge-api.sh rate-limit-status. Exit
+# codes: 0 ok, 2 unknown flag / missing arg, 3 unknown agent, 4 daemon
+# launch failure.
+
+set -e
+
+RESTART_AGENT=""
+RATE_LIMIT_STATUS=0
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --restart-agent)
+            if [ -z "${2:-}" ]; then
+                echo "start-colony.sh: --restart-agent requires an agent name" >&2
+                exit 2
+            fi
+            RESTART_AGENT="$2"
+            shift 2
+            ;;
+        --rate-limit-status)
+            RATE_LIMIT_STATUS=1
+            shift
+            ;;
+        --)
+            shift
+            POSITIONAL+=("$@")
+            break
+            ;;
+        -*)
+            echo "start-colony.sh: unknown flag: $1" >&2
+            exit 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+
+# Symlink-safe $0 resolution.
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+COLONY_DIR="$(dirname "$SCRIPT_DIR")"
+FED_DIR="$(dirname "$COLONY_DIR")"
+CONFIG="${1:-$COLONY_DIR/config/colony.toml}"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "Config not found: $CONFIG"
+    echo "Copy config/colony.example.toml to config/colony.toml and edit it."
+    exit 1
+fi
+
+# Source parse-toml.sh: try <fed>/tools first, then <fed>/../tools (the
+# latter is the in-repo layout; the former is for standalone tarball
+# installs that ship tools/ inside the federation directory).
+PARSE_TOML=""
+for cand in "$FED_DIR/tools/parse-toml.sh" "$FED_DIR/../tools/parse-toml.sh"; do
+    if [ -f "$cand" ]; then
+        PARSE_TOML="$cand"
+        break
+    fi
+done
+if [ -z "$PARSE_TOML" ]; then
+    echo "Error: tools/parse-toml.sh not found in $FED_DIR/tools or $FED_DIR/../tools" >&2
+    exit 1
+fi
+# shellcheck source=/dev/null
+. "$PARSE_TOML"
+
+# Stage 0 env wiring. tribes-bench is not a forge-backed federation: the
+# only data source is a checked-in synthetic Rust file under TARGET_DIR
+# scanned by the deterministic verifier under VERIFIER_PATH. The
+# [forge].type = "github" stub in colony.example.toml is a colony-lint
+# requirement only (lint relaxation tracked in #258 deferred bucket); no
+# Stage 0 agent calls forge-api.sh.
+TRIBE_NAME="tribe-gamma"
+TARGET_DIR="${TARGET_DIR:-$FED_DIR/targets/stage0}"
+BUGS_MANIFEST="${BUGS_MANIFEST:-$TARGET_DIR/bugs.json}"
+VERIFIER_PATH="${VERIFIER_PATH:-$FED_DIR/tools/verify-finding.sh}"
+
+export COLONY_DIR TRIBE_NAME TARGET_DIR BUGS_MANIFEST VERIFIER_PATH
+
+# Stage 0: a single hunter agent per tribe. See tribes-bench/README.md for
+# the staircase Stage 0 -> 1 -> 2 plan.
+AGENTS=(
+    hunter
+)
+
+if [ ${#AGENTS[@]} -eq 0 ] && [ "$RATE_LIMIT_STATUS" = "0" ] && [ -z "$RESTART_AGENT" ]; then
+    echo "No agents defined yet. Edit AGENTS=( ... ) in this script after creating .ag files." >&2
+    exit 1
+fi
+
+# Per-agent tick-interval override. Stage 0 hunter agents tick at 60s for
+# ~15 ticks per agent over the 900s wall-clock cap.
+tick_interval_for() {
+    case "$1" in
+        hunter) echo 60000 ;;
+        *) echo 60000 ;;
+    esac
+}
+
+# --rate-limit-status mode (federation-dashboard 0.3.0). Replace with the
+# real rate-limit primitive your data source exposes; the platform consumes
+# the JSON contract `{remaining, limit, reset_at}` only.
+if [ "$RATE_LIMIT_STATUS" = "1" ]; then
+    if [ -x "$COLONY_DIR/scripts/forge-api.sh" ]; then
+        exec "$COLONY_DIR/scripts/forge-api.sh" rate-limit-status
+    fi
+    echo '{"remaining": null, "limit": null, "reset_at": null, "error": "rate-limit-status not implemented for this colony"}'
+    exit 0
+fi
+
+# --restart-agent mode (#257). Single-agent respawn, no log truncation,
+# no memo seeding (those are full-colony bootstrap concerns).
+if [ -n "$RESTART_AGENT" ]; then
+    valid=0
+    for a in "${AGENTS[@]}"; do
+        [ "$a" = "$RESTART_AGENT" ] && valid=1
+    done
+    if [ "$valid" = "0" ]; then
+        echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
+        exit 3
+    fi
+    tick=$(tick_interval_for "$RESTART_AGENT")
+    agentis daemon "$COLONY_DIR/agents/${RESTART_AGENT}.ag" \
+        --colony tribe-gamma \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval "$tick" </dev/null >/dev/null 2>&1 &
+    agent_pid=$!
+    sleep 0.5
+    if ! kill -0 "$agent_pid" 2>/dev/null; then
+        echo "start-colony.sh: agentis daemon failed to launch $RESTART_AGENT" >&2
+        exit 4
+    fi
+    echo "started $RESTART_AGENT pid=$agent_pid tick=$tick"
+    exit 0
+fi
+
+echo "Starting Tribe Gamma colony (${#AGENTS[@]} agents)..."
+
+for agent in "${AGENTS[@]}"; do
+    interval=$(tick_interval_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms)..."
+    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+        --colony tribe-gamma \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval "$interval" &
+    sleep 2
+done
+
+echo "Colony started. Use 'agentis daemon list' to monitor."
+echo "Stop with: agentis daemon stop --all"
+
+wait


### PR DESCRIPTION
## Summary

First milestone of #364 (tribes-bench Stage 1). **Infrastructure only** — replication, Malthusian cost, asymmetric reward, tribe death, and calibration ship in M2/M3. Strict back-compat with Stage 0 (existing tribe-alpha/tribe-beta + targets/stage0 byte-identical to origin/main, Stage 0 verifier path unchanged).

- Adds **`tribe-gamma/`** — third hunter colony with error-path data-flow heuristic (mirrors tribe-alpha/tribe-beta layout).
- Adds **`targets/stage1/`** — 3 Rust source files (`cmd_exec.rs`, `path_io.rs`, `fmt_str.rs`) with **10 planted bugs** across 3 CWE classes (command injection, path traversal, format string). Each file `rustc`-compiles clean. INTENTIONALLY INSECURE banner on every file. New `bugs.json` manifest with all 10 entries (line numbers verified against actual source).
- **Verifier extension**: `tools/verify-finding.sh` grows optional `--class` / `--bug-id` flags + reads `class` field from stdin JSON. Back-compat — no `--class` arg → Stage 0 behaviour.
- **Telemetry**: new `tools/analyse-stage1.py` emits 10-column CSV per-tribe per-bug-class. `is_first_finder` and `tribe_size` are M1 placeholder columns (always 0 / 1 respectively); explicitly documented in module docstring + README + CHANGELOG.
- `start-federation.sh` `COLONIES=` array gains `tribe-gamma`. Banner stage-agnostic.
- `install.sh`, `BUNDLE.manifest`, `CHANGELOG.md`, `README.md` updated.

Phase plan: #364 (long planning comment).

## Test plan

- [x] `bash -n` + `shellcheck` clean on touched scripts
- [x] `python3 -m py_compile` clean on `analyse-stage1.py`
- [x] `rustc` compile-check clean on all 3 stage1 .rs files
- [x] `bugs.json` schema check (10 entries, required fields, line numbers match source)
- [x] `verify-finding.sh --help` CLI surface ok
- [x] Verifier dispatches all 3 stage-1 classes (`STAGE1=1` adds 6 new test fixtures, all pass)
- [x] `analyse-stage1.py` runs against synthetic runs/ dir without crashing, emits 10-column CSV
- [x] **Stage 0 byte-identity**: `tribes-bench/tribe-alpha`, `tribes-bench/tribe-beta`, `tribes-bench/targets/stage0` all `git diff --quiet origin/main` clean
- [x] Stage 0 verifier still passes 6/6 fixtures
- [x] `colony-lint .` net new failures: **+1 environmental** (`tribe-gamma: hunter.ag syntax error` — same class as the pre-existing tribe-alpha/tribe-beta failures on origin/main; `agentis commit` on the standalone file returns exit 0; the failure is a hash-collision artifact in the lint's shared temp `.agentis` repo when N tribes share one probe). NOT a regression.
- [ ] CI green
- [ ] QA agent report (will be posted as a follow-up comment)

## Note for reviewer

The 3 Rust files under `targets/stage1/` are **intentionally vulnerable**. Each carries the `// TRIBES-BENCH STAGE 1 PLANTED-BUG TARGET. INTENTIONALLY INSECURE. NEVER COMPILE INTO PRODUCTION.` banner on line 1. They live exclusively under `targets/stage1/` (not in any production-shaped path). The bugs are the load-bearing test data for tribes-bench's emergence experiments — without planted vulnerabilities, hunter agents have nothing to find.

This is M1 of 3. M2 wires `replicate()` + Malthusian cost. M3 ships asymmetric reward + tribe death + operator-run calibration harness.