### PR TITLE
feat(start-colony): per-repo env wiring + GITHUB_REPOS_JSON (#316 M2)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -28,6 +28,19 @@ is asserted until multi-version CI is in place.
 - `tools/migrate-to-multi-repo.sh` rewrites a legacy single `[forge.github]`
   block to a single-entry `[[forge.github]]` array. Idempotent. Preserves
   operator hand-edits.
+- Multi-repo runtime wiring (#316 M2): when a colony.toml uses the
+  `[[forge.github]]` array form, all 5 `dev-apprenticeship/*/scripts/
+  start-colony.sh` scripts now export `GITHUB_REPOS_JSON` — a JSON array
+  carrying every entry's resolved `{url, owner, repo, token, me}` —
+  alongside the existing `GITHUB_OWNER`/`GITHUB_REPO`/`GITHUB_TOKEN`/
+  `GITHUB_URL`/`GITHUB_ME` env vars. Back-compat: single-block configs
+  continue to set only the latter; multi-block configs additionally set
+  the back-compat vars from entry [0] so M2-only deployments keep
+  working against the first repo until M3 lands per-repo iteration in
+  agents. `secret://` URI tokens resolve to plaintext before
+  serialisation. The existing `dev-apprenticeship/.agentis/config`
+  `exec.env_passthrough = ...,GITHUB_*` glob carries `GITHUB_REPOS_JSON`
+  through to `exec sh` children for free.
 
 ### Deprecated
 

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -111,26 +111,78 @@ case "$FORGE_TYPE" in
         export GITLAB_ME
         ;;
     github)
-        GITHUB_URL=$(parse_toml forge.github url)
-        GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
-        GITHUB_OWNER=$(parse_toml forge.github owner)
-        GITHUB_REPO=$(parse_toml forge.github repo)
-        GITHUB_TOKEN=$(parse_toml forge.github token)
-        GITHUB_ME=$(parse_toml forge.github me)
+        # #316 M2: detect single-block [forge.github] vs array-of-tables
+        # [[forge.github]]. parse_toml_array_count returns 0 for the legacy
+        # single-table shape, N>0 for the new shape. M1's lint guarantees
+        # exactly one shape is present (both-forms is a hard fail).
+        REPO_COUNT=$(parse_toml_array_count forge.github)
+        REPO_COUNT="${REPO_COUNT:-0}"
 
-        if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
-            echo "Error: GitHub config incomplete in $CONFIG"
-            echo "Required: owner, repo, token under [forge.github]"
-            exit 1
+        if [ "$REPO_COUNT" = "0" ]; then
+            # Legacy single-block path — byte-identical to pre-#316 behaviour.
+            GITHUB_URL=$(parse_toml forge.github url)
+            GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+            GITHUB_OWNER=$(parse_toml forge.github owner)
+            GITHUB_REPO=$(parse_toml forge.github repo)
+            GITHUB_TOKEN=$(parse_toml forge.github token)
+            GITHUB_ME=$(parse_toml forge.github me)
+
+            if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
+                echo "Error: GitHub config incomplete in $CONFIG"
+                echo "Required: owner, repo, token under [forge.github]"
+                exit 1
+            fi
+
+            export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME
+            # GITHUB_REPOS_JSON intentionally NOT exported on this path —
+            # M3 agents probe `${GITHUB_REPOS_JSON:-}` and fall back to the
+            # single-repo flow when empty.
+        else
+            # #316 M2: multi-block path. Build a JSON array of every entry
+            # and export as GITHUB_REPOS_JSON; back-compat-export entry [0]
+            # as GITHUB_OWNER/GITHUB_REPO/etc. so M2-only deployments (no
+            # M3 agents yet) keep working against the first repo.
+            REPOS_JSON_TMP=""
+            FIRST_OWNER=""; FIRST_REPO=""; FIRST_TOKEN=""; FIRST_URL=""; FIRST_ME=""
+            i=0
+            while [ "$i" -lt "$REPO_COUNT" ]; do
+                ent_url=$(parse_toml_array_get forge.github "$i" url)
+                ent_url="${ent_url:-https://api.github.com}"
+                ent_owner=$(parse_toml_array_get forge.github "$i" owner)
+                ent_repo=$(parse_toml_array_get forge.github "$i" repo)
+                ent_token=$(parse_toml_array_get forge.github "$i" token)
+                ent_me=$(parse_toml_array_get forge.github "$i" me)
+
+                if [ -z "$ent_owner" ] || [ -z "$ent_repo" ] || [ -z "$ent_token" ]; then
+                    echo "Error: GitHub config incomplete in $CONFIG" >&2
+                    echo "Required: owner, repo, token under [[forge.github]] entry [$i]" >&2
+                    exit 1
+                fi
+
+                if [ "$i" = "0" ]; then
+                    FIRST_URL="$ent_url"; FIRST_OWNER="$ent_owner"; FIRST_REPO="$ent_repo"
+                    FIRST_TOKEN="$ent_token"; FIRST_ME="$ent_me"
+                fi
+
+                # Build per-entry JSON via env (NEVER argv — tokens stay off `ps`).
+                ent_json=$(GH_URL="$ent_url" GH_OWNER="$ent_owner" GH_REPO="$ent_repo" \
+                           GH_TOKEN="$ent_token" GH_ME="$ent_me" \
+                    python3 -c 'import json,os; print(json.dumps({"url":os.environ["GH_URL"],"owner":os.environ["GH_OWNER"],"repo":os.environ["GH_REPO"],"token":os.environ["GH_TOKEN"],"me":os.environ.get("GH_ME","")}))')
+
+                if [ -z "$REPOS_JSON_TMP" ]; then
+                    REPOS_JSON_TMP="$ent_json"
+                else
+                    REPOS_JSON_TMP="$REPOS_JSON_TMP,$ent_json"
+                fi
+                i=$((i + 1))
+            done
+
+            GITHUB_REPOS_JSON="[$REPOS_JSON_TMP]"
+            GITHUB_URL="$FIRST_URL"; GITHUB_OWNER="$FIRST_OWNER"; GITHUB_REPO="$FIRST_REPO"
+            GITHUB_TOKEN="$FIRST_TOKEN"; GITHUB_ME="$FIRST_ME"
+
+            export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME GITHUB_REPOS_JSON
         fi
-
-        GITLAB_PROJECT_RAW="$GITHUB_OWNER/$GITHUB_REPO"
-
-        export GITHUB_URL
-        export GITHUB_OWNER
-        export GITHUB_REPO
-        export GITHUB_TOKEN
-        export GITHUB_ME
         ;;
     *)
         echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -111,28 +111,78 @@ case "$FORGE_TYPE" in
         export GITLAB_ME
         ;;
     github)
-        GITHUB_URL=$(parse_toml forge.github url)
-        GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
-        GITHUB_OWNER=$(parse_toml forge.github owner)
-        GITHUB_REPO=$(parse_toml forge.github repo)
-        GITHUB_TOKEN=$(parse_toml forge.github token)
-        GITHUB_ME=$(parse_toml forge.github me)
+        # #316 M2: detect single-block [forge.github] vs array-of-tables
+        # [[forge.github]]. parse_toml_array_count returns 0 for the legacy
+        # single-table shape, N>0 for the new shape. M1's lint guarantees
+        # exactly one shape is present (both-forms is a hard fail).
+        REPO_COUNT=$(parse_toml_array_count forge.github)
+        REPO_COUNT="${REPO_COUNT:-0}"
 
-        if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
-            echo "Error: GitHub config incomplete in $CONFIG"
-            echo "Required: owner, repo, token under [forge.github]"
-            exit 1
+        if [ "$REPO_COUNT" = "0" ]; then
+            # Legacy single-block path — byte-identical to pre-#316 behaviour.
+            GITHUB_URL=$(parse_toml forge.github url)
+            GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+            GITHUB_OWNER=$(parse_toml forge.github owner)
+            GITHUB_REPO=$(parse_toml forge.github repo)
+            GITHUB_TOKEN=$(parse_toml forge.github token)
+            GITHUB_ME=$(parse_toml forge.github me)
+
+            if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
+                echo "Error: GitHub config incomplete in $CONFIG"
+                echo "Required: owner, repo, token under [forge.github]"
+                exit 1
+            fi
+
+            export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME
+            # GITHUB_REPOS_JSON intentionally NOT exported on this path —
+            # M3 agents probe `${GITHUB_REPOS_JSON:-}` and fall back to the
+            # single-repo flow when empty.
+        else
+            # #316 M2: multi-block path. Build a JSON array of every entry
+            # and export as GITHUB_REPOS_JSON; back-compat-export entry [0]
+            # as GITHUB_OWNER/GITHUB_REPO/etc. so M2-only deployments (no
+            # M3 agents yet) keep working against the first repo.
+            REPOS_JSON_TMP=""
+            FIRST_OWNER=""; FIRST_REPO=""; FIRST_TOKEN=""; FIRST_URL=""; FIRST_ME=""
+            i=0
+            while [ "$i" -lt "$REPO_COUNT" ]; do
+                ent_url=$(parse_toml_array_get forge.github "$i" url)
+                ent_url="${ent_url:-https://api.github.com}"
+                ent_owner=$(parse_toml_array_get forge.github "$i" owner)
+                ent_repo=$(parse_toml_array_get forge.github "$i" repo)
+                ent_token=$(parse_toml_array_get forge.github "$i" token)
+                ent_me=$(parse_toml_array_get forge.github "$i" me)
+
+                if [ -z "$ent_owner" ] || [ -z "$ent_repo" ] || [ -z "$ent_token" ]; then
+                    echo "Error: GitHub config incomplete in $CONFIG" >&2
+                    echo "Required: owner, repo, token under [[forge.github]] entry [$i]" >&2
+                    exit 1
+                fi
+
+                if [ "$i" = "0" ]; then
+                    FIRST_URL="$ent_url"; FIRST_OWNER="$ent_owner"; FIRST_REPO="$ent_repo"
+                    FIRST_TOKEN="$ent_token"; FIRST_ME="$ent_me"
+                fi
+
+                # Build per-entry JSON via env (NEVER argv — tokens stay off `ps`).
+                ent_json=$(GH_URL="$ent_url" GH_OWNER="$ent_owner" GH_REPO="$ent_repo" \
+                           GH_TOKEN="$ent_token" GH_ME="$ent_me" \
+                    python3 -c 'import json,os; print(json.dumps({"url":os.environ["GH_URL"],"owner":os.environ["GH_OWNER"],"repo":os.environ["GH_REPO"],"token":os.environ["GH_TOKEN"],"me":os.environ.get("GH_ME","")}))')
+
+                if [ -z "$REPOS_JSON_TMP" ]; then
+                    REPOS_JSON_TMP="$ent_json"
+                else
+                    REPOS_JSON_TMP="$REPOS_JSON_TMP,$ent_json"
+                fi
+                i=$((i + 1))
+            done
+
+            GITHUB_REPOS_JSON="[$REPOS_JSON_TMP]"
+            GITHUB_URL="$FIRST_URL"; GITHUB_OWNER="$FIRST_OWNER"; GITHUB_REPO="$FIRST_REPO"
+            GITHUB_TOKEN="$FIRST_TOKEN"; GITHUB_ME="$FIRST_ME"
+
+            export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME GITHUB_REPOS_JSON
         fi
-
-        # Use the project-raw variable name for the summary echo below so
-        # both branches can share one format string. Value is informational.
-        GITLAB_PROJECT_RAW="$GITHUB_OWNER/$GITHUB_REPO"
-
-        export GITHUB_URL
-        export GITHUB_OWNER
-        export GITHUB_REPO
-        export GITHUB_TOKEN
-        export GITHUB_ME
         ;;
     *)
         echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2
@@ -159,9 +209,16 @@ IMPLEMENTATION_REQUIRE_ASSIGNEE="${IMPLEMENTATION_REQUIRE_ASSIGNEE:-true}"
 # is kept as GITLAB_DEFAULT_BRANCH for cross-backend parity (both
 # backend wrappers consume ${GITLAB_DEFAULT_BRANCH:-main}). PR 7 of
 # #256 retired the legacy top-level [gitlab].default_branch fallback.
+# #316 M2: under [[forge.github]] array form, pull default_branch from
+# entry [0] for back-compat with M2-only deployments. M3 moves
+# default_branch into per-repo iteration.
 case "$FORGE_TYPE" in
     github)
-        GITLAB_DEFAULT_BRANCH=$(parse_toml forge.github default_branch)
+        if [ "${REPO_COUNT:-0}" = "0" ]; then
+            GITLAB_DEFAULT_BRANCH=$(parse_toml forge.github default_branch)
+        else
+            GITLAB_DEFAULT_BRANCH=$(parse_toml_array_get forge.github 0 default_branch)
+        fi
         ;;
     *)
         GITLAB_DEFAULT_BRANCH=$(parse_toml forge.gitlab default_branch)

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -111,28 +111,78 @@ case "$FORGE_TYPE" in
         export GITLAB_ME
         ;;
     github)
-        GITHUB_URL=$(parse_toml forge.github url)
-        GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
-        GITHUB_OWNER=$(parse_toml forge.github owner)
-        GITHUB_REPO=$(parse_toml forge.github repo)
-        GITHUB_TOKEN=$(parse_toml forge.github token)
-        GITHUB_ME=$(parse_toml forge.github me)
+        # #316 M2: detect single-block [forge.github] vs array-of-tables
+        # [[forge.github]]. parse_toml_array_count returns 0 for the legacy
+        # single-table shape, N>0 for the new shape. M1's lint guarantees
+        # exactly one shape is present (both-forms is a hard fail).
+        REPO_COUNT=$(parse_toml_array_count forge.github)
+        REPO_COUNT="${REPO_COUNT:-0}"
 
-        if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
-            echo "Error: GitHub config incomplete in $CONFIG"
-            echo "Required: owner, repo, token under [forge.github]"
-            exit 1
+        if [ "$REPO_COUNT" = "0" ]; then
+            # Legacy single-block path — byte-identical to pre-#316 behaviour.
+            GITHUB_URL=$(parse_toml forge.github url)
+            GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+            GITHUB_OWNER=$(parse_toml forge.github owner)
+            GITHUB_REPO=$(parse_toml forge.github repo)
+            GITHUB_TOKEN=$(parse_toml forge.github token)
+            GITHUB_ME=$(parse_toml forge.github me)
+
+            if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
+                echo "Error: GitHub config incomplete in $CONFIG"
+                echo "Required: owner, repo, token under [forge.github]"
+                exit 1
+            fi
+
+            export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME
+            # GITHUB_REPOS_JSON intentionally NOT exported on this path —
+            # M3 agents probe `${GITHUB_REPOS_JSON:-}` and fall back to the
+            # single-repo flow when empty.
+        else
+            # #316 M2: multi-block path. Build a JSON array of every entry
+            # and export as GITHUB_REPOS_JSON; back-compat-export entry [0]
+            # as GITHUB_OWNER/GITHUB_REPO/etc. so M2-only deployments (no
+            # M3 agents yet) keep working against the first repo.
+            REPOS_JSON_TMP=""
+            FIRST_OWNER=""; FIRST_REPO=""; FIRST_TOKEN=""; FIRST_URL=""; FIRST_ME=""
+            i=0
+            while [ "$i" -lt "$REPO_COUNT" ]; do
+                ent_url=$(parse_toml_array_get forge.github "$i" url)
+                ent_url="${ent_url:-https://api.github.com}"
+                ent_owner=$(parse_toml_array_get forge.github "$i" owner)
+                ent_repo=$(parse_toml_array_get forge.github "$i" repo)
+                ent_token=$(parse_toml_array_get forge.github "$i" token)
+                ent_me=$(parse_toml_array_get forge.github "$i" me)
+
+                if [ -z "$ent_owner" ] || [ -z "$ent_repo" ] || [ -z "$ent_token" ]; then
+                    echo "Error: GitHub config incomplete in $CONFIG" >&2
+                    echo "Required: owner, repo, token under [[forge.github]] entry [$i]" >&2
+                    exit 1
+                fi
+
+                if [ "$i" = "0" ]; then
+                    FIRST_URL="$ent_url"; FIRST_OWNER="$ent_owner"; FIRST_REPO="$ent_repo"
+                    FIRST_TOKEN="$ent_token"; FIRST_ME="$ent_me"
+                fi
+
+                # Build per-entry JSON via env (NEVER argv — tokens stay off `ps`).
+                ent_json=$(GH_URL="$ent_url" GH_OWNER="$ent_owner" GH_REPO="$ent_repo" \
+                           GH_TOKEN="$ent_token" GH_ME="$ent_me" \
+                    python3 -c 'import json,os; print(json.dumps({"url":os.environ["GH_URL"],"owner":os.environ["GH_OWNER"],"repo":os.environ["GH_REPO"],"token":os.environ["GH_TOKEN"],"me":os.environ.get("GH_ME","")}))')
+
+                if [ -z "$REPOS_JSON_TMP" ]; then
+                    REPOS_JSON_TMP="$ent_json"
+                else
+                    REPOS_JSON_TMP="$REPOS_JSON_TMP,$ent_json"
+                fi
+                i=$((i + 1))
+            done
+
+            GITHUB_REPOS_JSON="[$REPOS_JSON_TMP]"
+            GITHUB_URL="$FIRST_URL"; GITHUB_OWNER="$FIRST_OWNER"; GITHUB_REPO="$FIRST_REPO"
+            GITHUB_TOKEN="$FIRST_TOKEN"; GITHUB_ME="$FIRST_ME"
+
+            export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME GITHUB_REPOS_JSON
         fi
-
-        # Use the project-raw variable name for the summary echo below so
-        # both branches can share one format string. Value is informational.
-        GITLAB_PROJECT_RAW="$GITHUB_OWNER/$GITHUB_REPO"
-
-        export GITHUB_URL
-        export GITHUB_OWNER
-        export GITHUB_REPO
-        export GITHUB_TOKEN
-        export GITHUB_ME
         ;;
     *)
         echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -112,30 +112,85 @@ case "$FORGE_TYPE" in
         export GITLAB_ME
         ;;
     github)
-        GITHUB_URL=$(parse_toml forge.github url)
-        GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
-        GITHUB_OWNER=$(parse_toml forge.github owner)
-        GITHUB_REPO=$(parse_toml forge.github repo)
-        GITHUB_TOKEN=$(parse_toml forge.github token)
-        GITHUB_ME=$(parse_toml forge.github me)
-        # default_branch used by create-tag (--ref default). The env var
-        # stays named GITLAB_DEFAULT_BRANCH for backend-agnostic dispatch
-        # (same name under both forge arms).
-        GITLAB_DEFAULT_BRANCH=$(parse_toml forge.github default_branch)
+        # #316 M2: detect single-block [forge.github] vs array-of-tables
+        # [[forge.github]]. parse_toml_array_count returns 0 for the legacy
+        # single-table shape, N>0 for the new shape. M1's lint guarantees
+        # exactly one shape is present (both-forms is a hard fail).
+        REPO_COUNT=$(parse_toml_array_count forge.github)
+        REPO_COUNT="${REPO_COUNT:-0}"
 
-        if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
-            echo "Error: GitHub config incomplete in $CONFIG"
-            echo "Required: owner, repo, token under [forge.github]"
-            exit 1
+        if [ "$REPO_COUNT" = "0" ]; then
+            # Legacy single-block path — byte-identical to pre-#316 behaviour.
+            GITHUB_URL=$(parse_toml forge.github url)
+            GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+            GITHUB_OWNER=$(parse_toml forge.github owner)
+            GITHUB_REPO=$(parse_toml forge.github repo)
+            GITHUB_TOKEN=$(parse_toml forge.github token)
+            GITHUB_ME=$(parse_toml forge.github me)
+            # default_branch used by create-tag (--ref default). The env var
+            # stays named GITLAB_DEFAULT_BRANCH for backend-agnostic dispatch
+            # (same name under both forge arms).
+            GITLAB_DEFAULT_BRANCH=$(parse_toml forge.github default_branch)
+
+            if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
+                echo "Error: GitHub config incomplete in $CONFIG"
+                echo "Required: owner, repo, token under [forge.github]"
+                exit 1
+            fi
+
+            export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME
+            # GITHUB_REPOS_JSON intentionally NOT exported on this path —
+            # M3 agents probe `${GITHUB_REPOS_JSON:-}` and fall back to the
+            # single-repo flow when empty.
+        else
+            # #316 M2: multi-block path. Build a JSON array of every entry
+            # and export as GITHUB_REPOS_JSON; back-compat-export entry [0]
+            # as GITHUB_OWNER/GITHUB_REPO/etc. so M2-only deployments (no
+            # M3 agents yet) keep working against the first repo.
+            REPOS_JSON_TMP=""
+            FIRST_OWNER=""; FIRST_REPO=""; FIRST_TOKEN=""; FIRST_URL=""; FIRST_ME=""
+            i=0
+            while [ "$i" -lt "$REPO_COUNT" ]; do
+                ent_url=$(parse_toml_array_get forge.github "$i" url)
+                ent_url="${ent_url:-https://api.github.com}"
+                ent_owner=$(parse_toml_array_get forge.github "$i" owner)
+                ent_repo=$(parse_toml_array_get forge.github "$i" repo)
+                ent_token=$(parse_toml_array_get forge.github "$i" token)
+                ent_me=$(parse_toml_array_get forge.github "$i" me)
+
+                if [ -z "$ent_owner" ] || [ -z "$ent_repo" ] || [ -z "$ent_token" ]; then
+                    echo "Error: GitHub config incomplete in $CONFIG" >&2
+                    echo "Required: owner, repo, token under [[forge.github]] entry [$i]" >&2
+                    exit 1
+                fi
+
+                if [ "$i" = "0" ]; then
+                    FIRST_URL="$ent_url"; FIRST_OWNER="$ent_owner"; FIRST_REPO="$ent_repo"
+                    FIRST_TOKEN="$ent_token"; FIRST_ME="$ent_me"
+                fi
+
+                # Build per-entry JSON via env (NEVER argv — tokens stay off `ps`).
+                ent_json=$(GH_URL="$ent_url" GH_OWNER="$ent_owner" GH_REPO="$ent_repo" \
+                           GH_TOKEN="$ent_token" GH_ME="$ent_me" \
+                    python3 -c 'import json,os; print(json.dumps({"url":os.environ["GH_URL"],"owner":os.environ["GH_OWNER"],"repo":os.environ["GH_REPO"],"token":os.environ["GH_TOKEN"],"me":os.environ.get("GH_ME","")}))')
+
+                if [ -z "$REPOS_JSON_TMP" ]; then
+                    REPOS_JSON_TMP="$ent_json"
+                else
+                    REPOS_JSON_TMP="$REPOS_JSON_TMP,$ent_json"
+                fi
+                i=$((i + 1))
+            done
+
+            GITHUB_REPOS_JSON="[$REPOS_JSON_TMP]"
+            GITHUB_URL="$FIRST_URL"; GITHUB_OWNER="$FIRST_OWNER"; GITHUB_REPO="$FIRST_REPO"
+            GITHUB_TOKEN="$FIRST_TOKEN"; GITHUB_ME="$FIRST_ME"
+            # default_branch first-entry rule for back-compat with M2-only
+            # deployments. M3 moves default_branch into per-repo iteration.
+            GITLAB_DEFAULT_BRANCH=$(parse_toml_array_get forge.github 0 default_branch)
+
+            export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME GITHUB_REPOS_JSON
         fi
-
-        GITLAB_PROJECT_RAW="$GITHUB_OWNER/$GITHUB_REPO"
-
-        export GITHUB_URL
-        export GITHUB_OWNER
-        export GITHUB_REPO
-        export GITHUB_TOKEN
-        export GITHUB_ME
         ;;
     *)
         echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -111,28 +111,78 @@ case "$FORGE_TYPE" in
         export GITLAB_ME
         ;;
     github)
-        GITHUB_URL=$(parse_toml forge.github url)
-        GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
-        GITHUB_OWNER=$(parse_toml forge.github owner)
-        GITHUB_REPO=$(parse_toml forge.github repo)
-        GITHUB_TOKEN=$(parse_toml forge.github token)
-        GITHUB_ME=$(parse_toml forge.github me)
+        # #316 M2: detect single-block [forge.github] vs array-of-tables
+        # [[forge.github]]. parse_toml_array_count returns 0 for the legacy
+        # single-table shape, N>0 for the new shape. M1's lint guarantees
+        # exactly one shape is present (both-forms is a hard fail).
+        REPO_COUNT=$(parse_toml_array_count forge.github)
+        REPO_COUNT="${REPO_COUNT:-0}"
 
-        if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
-            echo "Error: GitHub config incomplete in $CONFIG"
-            echo "Required: owner, repo, token under [forge.github]"
-            exit 1
+        if [ "$REPO_COUNT" = "0" ]; then
+            # Legacy single-block path — byte-identical to pre-#316 behaviour.
+            GITHUB_URL=$(parse_toml forge.github url)
+            GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+            GITHUB_OWNER=$(parse_toml forge.github owner)
+            GITHUB_REPO=$(parse_toml forge.github repo)
+            GITHUB_TOKEN=$(parse_toml forge.github token)
+            GITHUB_ME=$(parse_toml forge.github me)
+
+            if [ -z "$GITHUB_OWNER" ] || [ -z "$GITHUB_REPO" ] || [ -z "$GITHUB_TOKEN" ]; then
+                echo "Error: GitHub config incomplete in $CONFIG"
+                echo "Required: owner, repo, token under [forge.github]"
+                exit 1
+            fi
+
+            export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME
+            # GITHUB_REPOS_JSON intentionally NOT exported on this path —
+            # M3 agents probe `${GITHUB_REPOS_JSON:-}` and fall back to the
+            # single-repo flow when empty.
+        else
+            # #316 M2: multi-block path. Build a JSON array of every entry
+            # and export as GITHUB_REPOS_JSON; back-compat-export entry [0]
+            # as GITHUB_OWNER/GITHUB_REPO/etc. so M2-only deployments (no
+            # M3 agents yet) keep working against the first repo.
+            REPOS_JSON_TMP=""
+            FIRST_OWNER=""; FIRST_REPO=""; FIRST_TOKEN=""; FIRST_URL=""; FIRST_ME=""
+            i=0
+            while [ "$i" -lt "$REPO_COUNT" ]; do
+                ent_url=$(parse_toml_array_get forge.github "$i" url)
+                ent_url="${ent_url:-https://api.github.com}"
+                ent_owner=$(parse_toml_array_get forge.github "$i" owner)
+                ent_repo=$(parse_toml_array_get forge.github "$i" repo)
+                ent_token=$(parse_toml_array_get forge.github "$i" token)
+                ent_me=$(parse_toml_array_get forge.github "$i" me)
+
+                if [ -z "$ent_owner" ] || [ -z "$ent_repo" ] || [ -z "$ent_token" ]; then
+                    echo "Error: GitHub config incomplete in $CONFIG" >&2
+                    echo "Required: owner, repo, token under [[forge.github]] entry [$i]" >&2
+                    exit 1
+                fi
+
+                if [ "$i" = "0" ]; then
+                    FIRST_URL="$ent_url"; FIRST_OWNER="$ent_owner"; FIRST_REPO="$ent_repo"
+                    FIRST_TOKEN="$ent_token"; FIRST_ME="$ent_me"
+                fi
+
+                # Build per-entry JSON via env (NEVER argv — tokens stay off `ps`).
+                ent_json=$(GH_URL="$ent_url" GH_OWNER="$ent_owner" GH_REPO="$ent_repo" \
+                           GH_TOKEN="$ent_token" GH_ME="$ent_me" \
+                    python3 -c 'import json,os; print(json.dumps({"url":os.environ["GH_URL"],"owner":os.environ["GH_OWNER"],"repo":os.environ["GH_REPO"],"token":os.environ["GH_TOKEN"],"me":os.environ.get("GH_ME","")}))')
+
+                if [ -z "$REPOS_JSON_TMP" ]; then
+                    REPOS_JSON_TMP="$ent_json"
+                else
+                    REPOS_JSON_TMP="$REPOS_JSON_TMP,$ent_json"
+                fi
+                i=$((i + 1))
+            done
+
+            GITHUB_REPOS_JSON="[$REPOS_JSON_TMP]"
+            GITHUB_URL="$FIRST_URL"; GITHUB_OWNER="$FIRST_OWNER"; GITHUB_REPO="$FIRST_REPO"
+            GITHUB_TOKEN="$FIRST_TOKEN"; GITHUB_ME="$FIRST_ME"
+
+            export GITHUB_URL GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_ME GITHUB_REPOS_JSON
         fi
-
-        # Use the project-raw variable name for the summary echo below so
-        # both branches can share one format string. Value is informational.
-        GITLAB_PROJECT_RAW="$GITHUB_OWNER/$GITHUB_REPO"
-
-        export GITHUB_URL
-        export GITHUB_OWNER
-        export GITHUB_REPO
-        export GITHUB_TOKEN
-        export GITHUB_ME
         ;;
     *)
         echo "Error: unknown [forge].type '$FORGE_TYPE' in $CONFIG (expected: gitlab|github)" >&2

--- a/tools/test-start-colony-multi-repo.sh
+++ b/tools/test-start-colony-multi-repo.sh
@@ -1,0 +1,363 @@
+#!/bin/bash
+# tools/test-start-colony-multi-repo.sh: unit tests for #316 M2 — start-
+# colony.sh per-repo env wiring.
+#
+# Tests:
+#   1. Regression: single-block exports GITHUB_OWNER/REPO/TOKEN/URL/ME, no GITHUB_REPOS_JSON.
+#   2. Multi-block (1 entry): GITHUB_REPOS_JSON has 1 entry; back-compat vars carry first-entry values.
+#   3. Multi-block (3 entries): GITHUB_REPOS_JSON has 3 entries in source order.
+#   4. Multi-block + secret:// URI tokens -> resolved plaintext (skip if no secret-tool).
+#   5. Malformed multi-block (missing owner in entry [1]) -> exit non-zero with clear error.
+#   6. Env-passthrough: GITHUB_REPOS_JSON in shell env at daemon-launch + .agentis/config glob accepts it.
+#
+# Standard scaffold: set -eu, mktemp -d isolation, EXIT trap for cleanup.
+# Auto-discovered by tools/colony-lint.sh's tools-test loop.
+#
+# Usage: ./tools/test-start-colony-multi-repo.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+START="$REPO_ROOT/dev-apprenticeship/triage/scripts/start-colony.sh"
+INSTALL_SH="$REPO_ROOT/dev-apprenticeship/install.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    pkill -f 'fake-daemon-for-test-316m2' 2>/dev/null || true
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+skip() { echo "[SKIP] $1${2:+: $2}"; }
+
+# Shim: stub `agentis` so daemon launch dumps env then sleeps. The
+# `exec -a fake-daemon-for-test-316m2 sleep 5` form rewrites argv[0]
+# so the EXIT-trap pkill -f marker can find and reap the stray sleeps.
+SHIM_DIR="$TMPDIR_TEST/shim"
+mkdir -p "$SHIM_DIR"
+cat > "$SHIM_DIR/agentis" <<'SHIM'
+#!/bin/bash
+[ "${1:-}" = "daemon" ] && [ "${2:-}" = "list" ] && { printf '[]\n'; exit 0; }
+[ "${1:-}" = "memo" ] && exit 0
+if [ "${1:-}" = "daemon" ]; then
+    [ -n "${T316M2_ENV_DUMP:-}" ] && env > "$T316M2_ENV_DUMP"
+    exec -a fake-daemon-for-test-316m2 sleep 5
+fi
+exit 0
+SHIM
+chmod +x "$SHIM_DIR/agentis"
+
+# Run the triage start-colony.sh against $1 with `--restart-agent
+# issue_creator`, dumping the env that reaches the (shimmed) `agentis
+# daemon` invocation to $2. timeout 4s caps the test budget per call.
+run_start() {
+    local config="$1" envdump="$2" rc=0
+    T316M2_ENV_DUMP="$envdump" PATH="$SHIM_DIR:$PATH" \
+        timeout 4 bash "$START" --restart-agent issue_creator "$config" \
+            >"$TMPDIR_TEST/stdout" 2>"$TMPDIR_TEST/stderr" || rc=$?
+    pkill -f 'fake-daemon-for-test-316m2' 2>/dev/null || true
+    return $rc
+}
+
+# Read the first matching `KEY=...` line from an env-dump file.
+envdump_get() { grep -E "^${2}=" "$1" 2>/dev/null | head -1 | cut -d= -f2-; }
+
+# JSON helpers — invoked from the shell to keep assertions terse.
+json_count() { python3 -c 'import json,sys;print(len(json.loads(sys.argv[1])))' "$1"; }
+json_get()   { python3 -c 'import json,sys;a=json.loads(sys.argv[1]);print(a[int(sys.argv[2])][sys.argv[3]])' "$1" "$2" "$3"; }
+
+# --- Test 1: single-block regression ---------------------------------
+# A pre-#316 single-block colony.toml must keep exporting GITHUB_OWNER /
+# GITHUB_REPO / GITHUB_TOKEN / GITHUB_URL / GITHUB_ME exactly as before
+# AND must NOT export GITHUB_REPOS_JSON (M3 agents probe its absence to
+# stay on the legacy single-repo path).
+CFG1="$TMPDIR_TEST/single.toml"
+{
+    printf '%s\n' '[forge]'
+    printf '%s\n' 'type = "github"'
+    printf '%s\n' ''
+    printf '%s\n' '[forge.github]'
+    printf '%s\n' 'url = "https://api.github.com"'
+    printf '%s\n' 'owner = "single-owner"'
+    printf '%s\n' 'repo = "single-repo"'
+    printf '%s\n' 'token = "single-token"'
+    printf '%s\n' 'me = "single-me"'
+} > "$CFG1"
+ENV1="$TMPDIR_TEST/env1.dump"
+if run_start "$CFG1" "$ENV1"; then
+    got_owner="$(envdump_get "$ENV1" GITHUB_OWNER)"
+    got_repo="$(envdump_get "$ENV1" GITHUB_REPO)"
+    got_token="$(envdump_get "$ENV1" GITHUB_TOKEN)"
+    got_url="$(envdump_get "$ENV1" GITHUB_URL)"
+    got_me="$(envdump_get "$ENV1" GITHUB_ME)"
+    has_json="$(grep -c '^GITHUB_REPOS_JSON=' "$ENV1" 2>/dev/null || true)"
+    if [ "$got_owner" = "single-owner" ] \
+       && [ "$got_repo" = "single-repo" ] \
+       && [ "$got_token" = "single-token" ] \
+       && [ "$got_url" = "https://api.github.com" ] \
+       && [ "$got_me" = "single-me" ] \
+       && [ "$has_json" = "0" ]; then
+        pass "test 1: single-block exports GITHUB_OWNER/REPO/TOKEN/URL/ME, no GITHUB_REPOS_JSON"
+    else
+        fail "test 1: single-block exports GITHUB_OWNER/REPO/TOKEN/URL/ME, no GITHUB_REPOS_JSON" \
+             "owner='$got_owner' repo='$got_repo' token='$got_token' url='$got_url' me='$got_me' has_json=$has_json"
+    fi
+else
+    fail "test 1: single-block start-colony.sh exited non-zero" \
+         "stdout=$(head -c 200 "$TMPDIR_TEST/stdout") stderr=$(head -c 200 "$TMPDIR_TEST/stderr")"
+fi
+
+# --- Test 2: multi-block (1 entry) -----------------------------------
+# A 1-entry [[forge.github]] config must export GITHUB_REPOS_JSON with
+# exactly one element AND back-compat-export the entry-[0] values to
+# the legacy GITHUB_OWNER/REPO/TOKEN/URL/ME vars.
+CFG2="$TMPDIR_TEST/multi-1.toml"
+{
+    printf '%s\n' '[forge]'
+    printf '%s\n' 'type = "github"'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'url = "https://api.github.com"'
+    printf '%s\n' 'owner = "alpha-owner"'
+    printf '%s\n' 'repo = "alpha-repo"'
+    printf '%s\n' 'token = "alpha-token"'
+    printf '%s\n' 'me = "alpha-me"'
+} > "$CFG2"
+ENV2="$TMPDIR_TEST/env2.dump"
+if run_start "$CFG2" "$ENV2"; then
+    got_owner="$(envdump_get "$ENV2" GITHUB_OWNER)"
+    got_repo="$(envdump_get "$ENV2" GITHUB_REPO)"
+    got_token="$(envdump_get "$ENV2" GITHUB_TOKEN)"
+    got_url="$(envdump_get "$ENV2" GITHUB_URL)"
+    got_me="$(envdump_get "$ENV2" GITHUB_ME)"
+    got_json="$(envdump_get "$ENV2" GITHUB_REPOS_JSON)"
+    if [ -n "$got_json" ]; then
+        json_n="$(json_count "$got_json")"
+        json_owner0="$(json_get "$got_json" 0 owner)"
+        json_repo0="$(json_get "$got_json" 0 repo)"
+        json_token0="$(json_get "$got_json" 0 token)"
+    else
+        json_n="MISSING"; json_owner0=""; json_repo0=""; json_token0=""
+    fi
+    if [ "$got_owner" = "alpha-owner" ] \
+       && [ "$got_repo" = "alpha-repo" ] \
+       && [ "$got_token" = "alpha-token" ] \
+       && [ "$got_url" = "https://api.github.com" ] \
+       && [ "$got_me" = "alpha-me" ] \
+       && [ "$json_n" = "1" ] \
+       && [ "$json_owner0" = "alpha-owner" ] \
+       && [ "$json_repo0" = "alpha-repo" ] \
+       && [ "$json_token0" = "alpha-token" ]; then
+        pass "test 2: multi-block (1 entry) exports JSON with 1 entry + back-compat vars"
+    else
+        fail "test 2: multi-block (1 entry) exports JSON with 1 entry + back-compat vars" \
+             "owner='$got_owner' repo='$got_repo' json_n='$json_n' json_owner0='$json_owner0' json_repo0='$json_repo0'"
+    fi
+else
+    fail "test 2: multi-block (1 entry) start-colony.sh exited non-zero" \
+         "stderr=$(head -c 200 "$TMPDIR_TEST/stderr")"
+fi
+
+# --- Test 3: multi-block (3 entries, source order) -------------------
+# A 3-entry [[forge.github]] config must export a JSON array of length
+# 3 with entries in source order. Back-compat vars carry entry [0].
+CFG3="$TMPDIR_TEST/multi-3.toml"
+{
+    printf '%s\n' '[forge]'
+    printf '%s\n' 'type = "github"'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'url = "https://api.github.com"'
+    printf '%s\n' 'owner = "acme"'
+    printf '%s\n' 'repo = "frontend"'
+    printf '%s\n' 'token = "tok-fe"'
+    printf '%s\n' 'me = "alice"'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'url = "https://api.github.com"'
+    printf '%s\n' 'owner = "acme"'
+    printf '%s\n' 'repo = "backend"'
+    printf '%s\n' 'token = "tok-be"'
+    printf '%s\n' 'me = "alice"'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'url = "https://api.github.com"'
+    printf '%s\n' 'owner = "acme"'
+    printf '%s\n' 'repo = "infra"'
+    printf '%s\n' 'token = "tok-inf"'
+    printf '%s\n' 'me = "bob"'
+} > "$CFG3"
+ENV3="$TMPDIR_TEST/env3.dump"
+if run_start "$CFG3" "$ENV3"; then
+    got_owner="$(envdump_get "$ENV3" GITHUB_OWNER)"
+    got_repo="$(envdump_get "$ENV3" GITHUB_REPO)"
+    got_json="$(envdump_get "$ENV3" GITHUB_REPOS_JSON)"
+    if [ -n "$got_json" ]; then
+        n="$(json_count "$got_json")"
+        repo0="$(json_get "$got_json" 0 repo)"
+        repo1="$(json_get "$got_json" 1 repo)"
+        repo2="$(json_get "$got_json" 2 repo)"
+        token2="$(json_get "$got_json" 2 token)"
+        me2="$(json_get "$got_json" 2 me)"
+    else
+        n="MISSING"; repo0=""; repo1=""; repo2=""; token2=""; me2=""
+    fi
+    if [ "$got_owner" = "acme" ] \
+       && [ "$got_repo" = "frontend" ] \
+       && [ "$n" = "3" ] \
+       && [ "$repo0" = "frontend" ] \
+       && [ "$repo1" = "backend" ] \
+       && [ "$repo2" = "infra" ] \
+       && [ "$token2" = "tok-inf" ] \
+       && [ "$me2" = "bob" ]; then
+        pass "test 3: multi-block (3 entries) JSON has 3 entries in source order"
+    else
+        fail "test 3: multi-block (3 entries) JSON has 3 entries in source order" \
+             "owner='$got_owner' repo='$got_repo' n='$n' repos=[$repo0,$repo1,$repo2] token2='$token2' me2='$me2'"
+    fi
+else
+    fail "test 3: multi-block (3 entries) start-colony.sh exited non-zero" \
+         "stderr=$(head -c 200 "$TMPDIR_TEST/stderr")"
+fi
+
+# --- Test 4: secret:// URI tokens resolved to plaintext --------------
+# Skip when secret-tool is not on PATH (CI runners + macOS hosts without
+# libsecret). When available, store a token under a unique label, build
+# a 1-entry config that points at the secret://, and assert the env
+# dump carries the resolved plaintext (not the URI).
+if command -v secret-tool >/dev/null 2>&1; then
+    # parse-toml-secret.py resolves `secret://libsecret/<service>/<key>`
+    # via `secret-tool lookup service <service> key <key>`. Match that
+    # attribute schema exactly when storing.
+    SECRET_SERVICE="agentis-test-316m2-$$"
+    SECRET_KEY="token-$$"
+    SECRET_VALUE="resolved-plaintext-$$"
+    secret_setup_ok=1
+    printf '%s' "$SECRET_VALUE" | secret-tool store --label="agentis test 316 m2" \
+        service "$SECRET_SERVICE" key "$SECRET_KEY" 2>/dev/null || secret_setup_ok=0
+    if [ "$secret_setup_ok" = "1" ]; then
+        CFG4="$TMPDIR_TEST/multi-secret.toml"
+        {
+            printf '%s\n' '[forge]'
+            printf '%s\n' 'type = "github"'
+            printf '%s\n' ''
+            printf '%s\n' '[[forge.github]]'
+            printf '%s\n' 'url = "https://api.github.com"'
+            printf '%s\n' 'owner = "secret-owner"'
+            printf '%s\n' 'repo = "secret-repo"'
+            printf '%s\n' "token = \"secret://libsecret/$SECRET_SERVICE/$SECRET_KEY\""
+            printf '%s\n' 'me = "secret-me"'
+        } > "$CFG4"
+        ENV4="$TMPDIR_TEST/env4.dump"
+        if run_start "$CFG4" "$ENV4"; then
+            got_token="$(envdump_get "$ENV4" GITHUB_TOKEN)"
+            got_json="$(envdump_get "$ENV4" GITHUB_REPOS_JSON)"
+            json_token0="$(json_get "$got_json" 0 token 2>/dev/null || echo MISSING)"
+            if [ "$got_token" = "$SECRET_VALUE" ] && [ "$json_token0" = "$SECRET_VALUE" ]; then
+                pass "test 4: secret:// URI tokens resolved to plaintext in both back-compat var + JSON"
+            else
+                fail "test 4: secret:// URI tokens resolved to plaintext" \
+                     "got_token='$got_token' json_token0='$json_token0' expected='$SECRET_VALUE'"
+            fi
+        else
+            fail "test 4: secret:// URI tokens — start-colony.sh exited non-zero" \
+                 "stderr=$(head -c 200 "$TMPDIR_TEST/stderr")"
+        fi
+        secret-tool clear service "$SECRET_SERVICE" key "$SECRET_KEY" 2>/dev/null || true
+    else
+        skip "test 4: secret-tool present but store failed (no libsecret session)"
+    fi
+else
+    skip "test 4: secret-tool not on PATH — secret:// resolution path uncovered"
+fi
+
+# --- Test 5: malformed multi-block (missing owner in entry [1]) ------
+# A [[forge.github]] entry that omits owner must abort the script with a
+# non-zero exit AND a stderr error message naming the offending entry.
+CFG5="$TMPDIR_TEST/multi-bad.toml"
+{
+    printf '%s\n' '[forge]'
+    printf '%s\n' 'type = "github"'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'url = "https://api.github.com"'
+    printf '%s\n' 'owner = "ok-owner"'
+    printf '%s\n' 'repo = "ok-repo"'
+    printf '%s\n' 'token = "ok-token"'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'url = "https://api.github.com"'
+    printf '%s\n' 'repo = "no-owner-repo"'
+    printf '%s\n' 'token = "no-owner-token"'
+} > "$CFG5"
+ENV5="$TMPDIR_TEST/env5.dump"
+set +e
+run_start "$CFG5" "$ENV5"
+rc5=$?
+set -e
+if [ "$rc5" -ne 0 ] && grep -q 'entry \[1\]' "$TMPDIR_TEST/stderr" \
+   && grep -q 'GitHub config incomplete' "$TMPDIR_TEST/stderr"; then
+    pass "test 5: malformed multi-block (missing owner) exits non-zero with clear error"
+else
+    fail "test 5: malformed multi-block (missing owner) exits non-zero with clear error" \
+         "rc=$rc5 stderr=$(head -c 300 "$TMPDIR_TEST/stderr")"
+fi
+
+# --- Test 6: env passthrough --------------------------------------------
+# Two facts must hold:
+#   (6a) GITHUB_REPOS_JSON is in the shell env at daemon-launch — the env
+#        dump captured by the shim already proves this in tests 2/3, so
+#        we re-assert here with a fresh run for clarity.
+#   (6b) The literal `GITHUB_*` glob from `dev-apprenticeship/install.sh`
+#        (per plan §5: env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,
+#        GITHUB_*) accepts the new var name. Glob match is the bash
+#        case-pattern operator — `case GITHUB_REPOS_JSON in GITHUB_*) ;;`.
+CFG6="$TMPDIR_TEST/multi-passthrough.toml"
+{
+    printf '%s\n' '[forge]'
+    printf '%s\n' 'type = "github"'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'url = "https://api.github.com"'
+    printf '%s\n' 'owner = "passthrough-owner"'
+    printf '%s\n' 'repo = "passthrough-repo"'
+    printf '%s\n' 'token = "passthrough-token"'
+} > "$CFG6"
+ENV6="$TMPDIR_TEST/env6.dump"
+sub6_a=0
+sub6_b=0
+sub6_c=0
+if run_start "$CFG6" "$ENV6"; then
+    got_json="$(envdump_get "$ENV6" GITHUB_REPOS_JSON)"
+    if [ -n "$got_json" ]; then
+        sub6_a=1
+    fi
+fi
+# Intentionally a constant case — proves the literal var name matches
+# the literal glob from install.sh's env_passthrough line.
+# shellcheck disable=SC2194
+case GITHUB_REPOS_JSON in
+    GITHUB_*) sub6_b=1 ;;
+esac
+# Probe the install.sh literal that writes env_passthrough. The line
+# substitutes the GITHUB_* glob into the .agentis/config — search for
+# it byte-for-byte. install.sh is the source of truth for what the
+# operator's federation file looks like post-install.
+if [ -f "$INSTALL_SH" ] && grep -q 'GITHUB_\*' "$INSTALL_SH"; then
+    sub6_c=1
+fi
+if [ "$sub6_a" = "1" ] && [ "$sub6_b" = "1" ] && [ "$sub6_c" = "1" ]; then
+    pass "test 6: GITHUB_REPOS_JSON reaches daemon-launch + GITHUB_* glob accepts it"
+else
+    fail "test 6: GITHUB_REPOS_JSON reaches daemon-launch + GITHUB_* glob accepts it" \
+         "in_env=$sub6_a glob_match=$sub6_b install_writes_glob=$sub6_c"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Second milestone of #316 (multi-repo). M1 (PR #376, SHA `4b89aa3`) shipped the schema + parser; this M2 wires the runtime — all 5 `dev-apprenticeship/*/scripts/start-colony.sh` now detect single vs multi `[forge.github]` and export `GITHUB_REPOS_JSON` carrying the full per-repo list.

- **Single-block path** byte-identical to pre-M2 — operators on legacy configs see no change.
- **Multi-block path** exports `GITHUB_REPOS_JSON='[{url,owner,repo,token,me}, ...]'` (source order, plaintext tokens resolved from `secret://` URIs) AND back-compat `GITHUB_OWNER`/`GITHUB_REPO`/`GITHUB_TOKEN`/`GITHUB_URL`/`GITHUB_ME` from entry [0] so M3-pre agents keep working against the first repo.
- **Per-colony deltas**: `implementation` + `release` get a single-vs-multi `default_branch` lookup (first-entry rule on multi-block).
- **No agent code touched** — M3 wires per-repo iteration in `.ag` agents.
- **No `.agentis/config` change** — existing `exec.env_passthrough = ...,GITHUB_*` glob already carries `GITHUB_REPOS_JSON` for free.
- **Token leak guard**: JSON builder passes tokens via env vars to `python3 -c '...'`, never via argv. `ps -ef` cannot see token values.

Plan: #316 (long M2 detail comment).

## Test plan

- [x] `bash -n` clean on all 5 modified `start-colony.sh` files
- [x] `bash -n` + `shellcheck` clean on new `tools/test-start-colony-multi-repo.sh`
- [x] `tools/test-start-colony-multi-repo.sh` — 6/6 PASS (test 4 ran with libsecret available)
- [x] `tools/test-start-colony-restart.sh` regression — 26/26 PASS
- [x] `tools/test-multi-repo-schema.sh` (M1 regression) — 16/16 PASS
- [x] `tools/test-forge-config.sh` regression — 45/45 PASS
- [x] `tools/colony-lint.sh .` — 0 net new failures vs origin/main (24 pre-existing `.ag` syntax fails reproduce on baseline)
- [x] **Back-compat invariants**: 5 `colony.example.toml`, `.agentis/config`, `install.sh`, `parse-toml.sh`, `parse-toml-secret.py`, `colony-lint.sh` all `git diff --quiet origin/main` clean
- [x] **Zero .ag files touched**
- [ ] CI green
- [ ] QA agent report (will be posted as a follow-up comment)

## Note for reviewer

3 of 6 milestones now done: M1 (schema+lint+migration), M2 (runtime env wiring). M3 (agent iteration), M4 (per-repo confidence), M5 (dashboard), M6 (retire single-block, MAJOR) follow.