### PR TITLE
feat: per-repo iteration for remaining 17 agents (#316 M3b)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -53,6 +53,12 @@ is asserted until multi-version CI is in place.
   `tools/iter-repos.sh` is the per-tick fan-out helper. ADR-0002 grows a
   "Multi-repo dispatch" subsection. Per-repo confidence keys ship in M4;
   per-repo trigger label vocabulary in M5.
+- Multi-repo runtime (#316 M3b): the remaining 17 agents (5 code-review + 4 planning
+  + 4 implementation + 4 release) now iterate per-repo on each tick, completing the
+  M3 fan-out started in M3a (4 triage agents, PR #381). All 21 agents in
+  dev-apprenticeship now serve N repositories from one colony when `colony.toml`
+  uses the `[[forge.github]]` array form. Single-block configs continue to work
+  byte-identically.
 
 ### Deprecated
 

--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -25,7 +25,33 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-fn tick(reason: string) -> void {
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn tick_for_repo(owner: string, repo: string) -> void {
     // #147: cheap delta-check. approval_decider has no GitLab poll —
     // its input is the colony bus. If no reviewer emitted findings
     // since the last tick (all four `listen()` calls returned Void —
@@ -48,13 +74,14 @@ fn tick(reason: string) -> void {
     if total_len < 24 {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
-            memo_write("approval_decider:last_check", now_e);
+            memo_write(scoped_memo(owner, repo, "approval_decider:last_check"), now_e);
         };
         return;
     };
 
     // Learn from past human approval/rejection patterns
-    let mr_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view reviewer";
+    // colony-lint: safe-exec-concat
+    let mr_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view reviewer" + repo_arg(owner, repo);
     let recent_merged = try { exec sh mr_cmd; } catch e { "[]"; };
 
     // Cold-path via upstream rate-limit: the bus-load early-exit above
@@ -69,7 +96,11 @@ fn tick(reason: string) -> void {
     ) -> string;
 
     if len(approval_patterns) > 10 {
-        learn("approval_decision", "merged MRs batch", approval_patterns, "success", ["observed", "code-review"]);
+        if len(owner) > 0 {
+            learn("approval_decision", "merged MRs batch", approval_patterns, "success", ["observed", "code-review", repo_tag(owner, repo)]);
+        } else {
+            learn("approval_decision", "merged MRs batch", approval_patterns, "success", ["observed", "code-review"]);
+        };
     };
 
     // Aggregate findings and decide
@@ -88,20 +119,30 @@ fn tick(reason: string) -> void {
 
     if my_tier == "autonomous" {
         if decision.action == "approve" {
-            let approve_cmd = "$COLONY_DIR/scripts/forge-api.sh approve " + to_string(decision.mr_iid);
+            // colony-lint: safe-exec-concat
+            let approve_cmd = "$COLONY_DIR/scripts/forge-api.sh approve " + to_string(decision.mr_iid) + repo_arg(owner, repo);
             try { exec sh approve_cmd; } catch e {
                 print("[approval_decider] Failed to approve:", e);
             };
             print("[approval_decider] Approved MR", decision.mr_iid);
-            learn("approval_decision", "MR " + to_string(decision.mr_iid), "approved: " + decision.reasoning, "success", ["acted", "code-review"]);
+            if len(owner) > 0 {
+                learn("approval_decision", "MR " + to_string(decision.mr_iid), "approved: " + decision.reasoning, "success", ["acted", "code-review", repo_tag(owner, repo)]);
+            } else {
+                learn("approval_decision", "MR " + to_string(decision.mr_iid), "approved: " + decision.reasoning, "success", ["acted", "code-review"]);
+            };
         } else {
             if decision.action == "request_changes" {
                 let comment = "**Review Summary** (automated)\n\n" + decision.reasoning + "\n\nFindings: " + to_string(decision.total_findings) + " total, " + to_string(decision.critical_count) + " critical";
-                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment);
+                // colony-lint: safe-exec-concat
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
                 try { exec sh post_cmd; } catch e {
                     print("[approval_decider] Failed to post:", e);
                 };
-                learn("approval_decision", "MR " + to_string(decision.mr_iid), "request_changes: " + decision.reasoning, "success", ["acted", "code-review"]);
+                if len(owner) > 0 {
+                    learn("approval_decision", "MR " + to_string(decision.mr_iid), "request_changes: " + decision.reasoning, "success", ["acted", "code-review", repo_tag(owner, repo)]);
+                } else {
+                    learn("approval_decision", "MR " + to_string(decision.mr_iid), "request_changes: " + decision.reasoning, "success", ["acted", "code-review"]);
+                };
             } else {
                 print("[approval_decider] Escalating MR", decision.mr_iid, "to human");
                 emit("review:escalation", decision);
@@ -113,20 +154,33 @@ fn tick(reason: string) -> void {
             // a human can promote the approve / request_changes action instead
             // of acting directly.
             let comment = "[draft-review-decision] **Review Summary** (automated, pending approval): suggested action `" + decision.action + "`\n\n" + decision.reasoning + "\n\nFindings: " + to_string(decision.total_findings) + " total, " + to_string(decision.critical_count) + " critical";
-            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment);
+            // colony-lint: safe-exec-concat
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
             try { exec sh post_cmd; } catch e {
                 print("[approval_decider] Failed to post draft summary:", e);
             };
             emit("review:decision_suggestion", decision);
-            learn("approval_decision", "MR " + to_string(decision.mr_iid), "drafted: " + decision.action + " — " + decision.reasoning, "partial", ["code-review", "review-gated"]);
+            if len(owner) > 0 {
+                learn("approval_decision", "MR " + to_string(decision.mr_iid), "drafted: " + decision.action + " — " + decision.reasoning, "partial", ["code-review", "review-gated", repo_tag(owner, repo)]);
+            } else {
+                learn("approval_decision", "MR " + to_string(decision.mr_iid), "drafted: " + decision.action + " — " + decision.reasoning, "partial", ["code-review", "review-gated"]);
+            };
         } else {
             if my_tier == "propose" {
                 print("[approval_decider] Suggesting:", decision.action, "for MR", decision.mr_iid);
                 emit("review:decision_suggestion", decision);
-                learn("approval_decision", "MR " + to_string(decision.mr_iid), "suggested: " + decision.action + " — " + decision.reasoning, "partial", ["emitted", "code-review"]);
+                if len(owner) > 0 {
+                    learn("approval_decision", "MR " + to_string(decision.mr_iid), "suggested: " + decision.action + " — " + decision.reasoning, "partial", ["emitted", "code-review", repo_tag(owner, repo)]);
+                } else {
+                    learn("approval_decision", "MR " + to_string(decision.mr_iid), "suggested: " + decision.action + " — " + decision.reasoning, "partial", ["emitted", "code-review"]);
+                };
             } else {
                 print("[approval_decider] Observing (tier:", my_tier, ")");
-                learn("approval_decision", "MR " + to_string(decision.mr_iid), "observed: " + decision.action + " — " + decision.reasoning, "partial", ["observed", "code-review"]);
+                if len(owner) > 0 {
+                    learn("approval_decision", "MR " + to_string(decision.mr_iid), "observed: " + decision.action + " — " + decision.reasoning, "partial", ["observed", "code-review", repo_tag(owner, repo)]);
+                } else {
+                    learn("approval_decision", "MR " + to_string(decision.mr_iid), "observed: " + decision.action + " — " + decision.reasoning, "partial", ["observed", "code-review"]);
+                };
             };
         };
     };
@@ -139,6 +193,29 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("approval_decider:last_check", now);
+        memo_write(scoped_memo(owner, repo, "approval_decider:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -21,12 +21,42 @@ type LogicReview {
     summary: string
 }
 
-fn mr_cmd() -> string {
-    let ts = recall_latest("logic_reviewer:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through —
+// the memo keys and experience tags stay byte-identical to pre-M3 on
+// the back-compat path.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn mr_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "logic_reviewer:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer" + repo_arg(owner, repo);
     };
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer" + repo_arg(owner, repo);
 }
 
 fn get_confidence() -> float {
@@ -37,12 +67,12 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // #147: cheap delta-check. `mr_cmd()` filters --since last_check;
     // an empty `[]` response means no MR updates since last tick and we
     // early-exit before any prompt(). last_check is refreshed so the
     // --since window advances on quiet projects.
-    let cmd = mr_cmd();
+    let cmd = mr_cmd(owner, repo);
     let raw = try {
         exec sh cmd;
     } catch e {
@@ -53,7 +83,7 @@ fn tick(reason: string) -> void {
     if len(raw) < 3 {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
-            memo_write("logic_reviewer:last_check", now_e);
+            memo_write(scoped_memo(owner, repo, "logic_reviewer:last_check"), now_e);
         };
         return;
     };
@@ -63,7 +93,8 @@ fn tick(reason: string) -> void {
     if mr_iid <= 0 {
         return;
     };
-    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
+    // colony-lint: safe-exec-concat
+    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid) + repo_arg(owner, repo);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -76,7 +107,7 @@ fn tick(reason: string) -> void {
     // this block and re-summarizes identical notes. Gate the observe
     // prompt on a 1800s window aligned with the #187 planning gate.
     let now_epoch_s = try { exec sh "date -u +%s"; } catch e { ""; };
-    let last_learn = recall_latest("logic_reviewer:last_pattern_learn_ts");
+    let last_learn = recall_latest(scoped_memo(owner, repo, "logic_reviewer:last_pattern_learn_ts"));
     let should_learn = if len(last_learn) > 0 {
         if len(now_epoch_s) > 0 {
             let delta = parse_int(now_epoch_s) - parse_int(last_learn);
@@ -88,7 +119,8 @@ fn tick(reason: string) -> void {
 
     if should_learn == 1 {
         // Learn from human logic-related comments
-        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid);
+        // colony-lint: safe-exec-concat
+        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid) + repo_arg(owner, repo);
         let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
         let human_patterns = prompt(
@@ -97,9 +129,13 @@ fn tick(reason: string) -> void {
         ) -> string;
 
         if len(human_patterns) > 5 {
-            learn("logic_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            if len(owner) > 0 {
+                learn("logic_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review", repo_tag(owner, repo)]);
+            } else {
+                learn("logic_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            };
             if len(now_epoch_s) > 0 {
-                memo_write("logic_reviewer:last_pattern_learn_ts", now_epoch_s);
+                memo_write(scoped_memo(owner, repo, "logic_reviewer:last_pattern_learn_ts"), now_epoch_s);
             };
         };
     };
@@ -121,31 +157,49 @@ fn tick(reason: string) -> void {
         if my_tier == "autonomous" {
             emit("review:logic_findings", review);
             let comment = "**Logic Review** (automated)\n\n" + review.summary;
-            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            // colony-lint: safe-exec-concat
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
             try { exec sh post_cmd; } catch e {
                 print("[logic_reviewer] Failed to post comment:", e);
             };
-            learn("logic_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted"]);
+            if len(owner) > 0 {
+                learn("logic_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted", repo_tag(owner, repo)]);
+            } else {
+                learn("logic_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted"]);
+            };
         } else {
             if my_tier == "review-gated" {
                 emit("review:logic_findings", review);
                 let comment = "[draft-review] **Logic Review** (automated, pending approval)\n\n" + review.summary;
-                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                // colony-lint: safe-exec-concat
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
                 let result = try { exec sh post_cmd; } catch e {
                     print("[logic_reviewer] Failed to post draft comment:", e);
                     "";
                 };
                 if len(result) > 0 {
-                    memo_write("logic_reviewer:approved:" + to_string(mr_iid), "drafted");
-                    learn("logic_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated"]);
+                    memo_write(scoped_memo(owner, repo, "logic_reviewer:approved:" + to_string(mr_iid)), "drafted");
+                    if len(owner) > 0 {
+                        learn("logic_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated", repo_tag(owner, repo)]);
+                    } else {
+                        learn("logic_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated"]);
+                    };
                 };
             } else {
                 if my_tier == "propose" {
                     emit("review:logic_findings", review);
-                    learn("logic_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                    if len(owner) > 0 {
+                        learn("logic_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted", repo_tag(owner, repo)]);
+                    } else {
+                        learn("logic_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                    };
                 } else {
                     print("[logic_reviewer] MR", mr_iid, ": observing (tier:", my_tier, ")");
-                    learn("logic_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                    if len(owner) > 0 {
+                        learn("logic_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed", repo_tag(owner, repo)]);
+                    } else {
+                        learn("logic_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                    };
                 };
             };
         };
@@ -166,6 +220,29 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("logic_reviewer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "logic_reviewer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -22,12 +22,40 @@ type SecurityReview {
     summary: string
 }
 
-fn mr_cmd() -> string {
-    let ts = recall_latest("security_reviewer:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn mr_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "security_reviewer:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer" + repo_arg(owner, repo);
     };
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer" + repo_arg(owner, repo);
 }
 
 fn get_confidence() -> float {
@@ -38,12 +66,12 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // #147: cheap delta-check. `mr_cmd()` filters --since last_check; an
     // empty `[]` response means no MR updates since last tick and we
     // early-exit before any prompt(). last_check is refreshed so the
     // --since window advances on quiet projects.
-    let cmd = mr_cmd();
+    let cmd = mr_cmd(owner, repo);
     let raw = try {
         exec sh cmd;
     } catch e {
@@ -54,7 +82,7 @@ fn tick(reason: string) -> void {
     if len(raw) < 3 {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
-            memo_write("security_reviewer:last_check", now_e);
+            memo_write(scoped_memo(owner, repo, "security_reviewer:last_check"), now_e);
         };
         return;
     };
@@ -64,7 +92,8 @@ fn tick(reason: string) -> void {
     if mr_iid <= 0 {
         return;
     };
-    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
+    // colony-lint: safe-exec-concat
+    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid) + repo_arg(owner, repo);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -77,7 +106,7 @@ fn tick(reason: string) -> void {
     // this block and re-summarizes identical notes. Gate the observe
     // prompt on a 1800s window aligned with the #187 planning gate.
     let now_epoch_s = try { exec sh "date -u +%s"; } catch e { ""; };
-    let last_learn = recall_latest("security_reviewer:last_pattern_learn_ts");
+    let last_learn = recall_latest(scoped_memo(owner, repo, "security_reviewer:last_pattern_learn_ts"));
     let should_learn = if len(last_learn) > 0 {
         if len(now_epoch_s) > 0 {
             let delta = parse_int(now_epoch_s) - parse_int(last_learn);
@@ -89,7 +118,8 @@ fn tick(reason: string) -> void {
 
     if should_learn == 1 {
         // Learn from human security-related comments
-        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid);
+        // colony-lint: safe-exec-concat
+        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid) + repo_arg(owner, repo);
         let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
         let human_patterns = prompt(
@@ -98,9 +128,13 @@ fn tick(reason: string) -> void {
         ) -> string;
 
         if len(human_patterns) > 5 {
-            learn("security_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            if len(owner) > 0 {
+                learn("security_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review", repo_tag(owner, repo)]);
+            } else {
+                learn("security_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            };
             if len(now_epoch_s) > 0 {
-                memo_write("security_reviewer:last_pattern_learn_ts", now_epoch_s);
+                memo_write(scoped_memo(owner, repo, "security_reviewer:last_pattern_learn_ts"), now_epoch_s);
             };
         };
     };
@@ -122,31 +156,49 @@ fn tick(reason: string) -> void {
         if my_tier == "autonomous" {
             emit("review:security_findings", review);
             let comment = "**Security Review** (automated)\n\n" + review.summary;
-            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            // colony-lint: safe-exec-concat
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
             try { exec sh post_cmd; } catch e {
                 print("[security_reviewer] Failed to post comment:", e);
             };
-            learn("security_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted"]);
+            if len(owner) > 0 {
+                learn("security_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted", repo_tag(owner, repo)]);
+            } else {
+                learn("security_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted"]);
+            };
         } else {
             if my_tier == "review-gated" {
                 emit("review:security_findings", review);
                 let comment = "[draft-review] **Security Review** (automated, pending approval)\n\n" + review.summary;
-                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                // colony-lint: safe-exec-concat
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
                 let result = try { exec sh post_cmd; } catch e {
                     print("[security_reviewer] Failed to post draft comment:", e);
                     "";
                 };
                 if len(result) > 0 {
-                    memo_write("security_reviewer:approved:" + to_string(mr_iid), "drafted");
-                    learn("security_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated"]);
+                    memo_write(scoped_memo(owner, repo, "security_reviewer:approved:" + to_string(mr_iid)), "drafted");
+                    if len(owner) > 0 {
+                        learn("security_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated", repo_tag(owner, repo)]);
+                    } else {
+                        learn("security_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated"]);
+                    };
                 };
             } else {
                 if my_tier == "propose" {
                     emit("review:security_findings", review);
-                    learn("security_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                    if len(owner) > 0 {
+                        learn("security_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted", repo_tag(owner, repo)]);
+                    } else {
+                        learn("security_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                    };
                 } else {
                     print("[security_reviewer] MR", mr_iid, ": observing (tier:", my_tier, ")");
-                    learn("security_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                    if len(owner) > 0 {
+                        learn("security_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed", repo_tag(owner, repo)]);
+                    } else {
+                        learn("security_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                    };
                 };
             };
         };
@@ -167,6 +219,29 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("security_reviewer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "security_reviewer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -45,12 +45,40 @@ fn sanitize_author(s: string) -> string {
     return s;
 }
 
-fn mr_cmd() -> string {
-    let ts = recall_latest("style_reviewer:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn mr_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "style_reviewer:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer" + repo_arg(owner, repo);
     };
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer" + repo_arg(owner, repo);
 }
 
 fn get_confidence() -> float {
@@ -61,12 +89,12 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // #147: cheap delta-check. `mr_cmd()` filters --since last_check;
     // an empty `[]` response means no MR updates since last tick and we
     // early-exit before any prompt(). last_check is refreshed so the
     // --since window advances on quiet projects.
-    let cmd = mr_cmd();
+    let cmd = mr_cmd(owner, repo);
     let raw = try {
         exec sh cmd;
     } catch e {
@@ -77,7 +105,7 @@ fn tick(reason: string) -> void {
     if len(raw) < 3 {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
-            memo_write("style_reviewer:last_check", now_e);
+            memo_write(scoped_memo(owner, repo, "style_reviewer:last_check"), now_e);
         };
         return;
     };
@@ -88,7 +116,8 @@ fn tick(reason: string) -> void {
     if mr_iid <= 0 {
         return;
     };
-    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
+    // colony-lint: safe-exec-concat
+    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid) + repo_arg(owner, repo);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -101,7 +130,7 @@ fn tick(reason: string) -> void {
     // this block and re-summarizes identical notes. Gate the observe
     // prompt on a 1800s window aligned with the #187 planning gate.
     let now_epoch_s = try { exec sh "date -u +%s"; } catch e { ""; };
-    let last_learn = recall_latest("style_reviewer:last_pattern_learn_ts");
+    let last_learn = recall_latest(scoped_memo(owner, repo, "style_reviewer:last_pattern_learn_ts"));
     let should_learn = if len(last_learn) > 0 {
         if len(now_epoch_s) > 0 {
             let delta = parse_int(now_epoch_s) - parse_int(last_learn);
@@ -113,7 +142,8 @@ fn tick(reason: string) -> void {
 
     if should_learn == 1 {
         // Check for existing human review comments to learn from
-        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid);
+        // colony-lint: safe-exec-concat
+        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid) + repo_arg(owner, repo);
         let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
         // Learn from human style comments
@@ -123,9 +153,13 @@ fn tick(reason: string) -> void {
         ) -> string;
 
         if len(human_patterns) > 5 {
-            learn("style_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            if len(owner) > 0 {
+                learn("style_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review", repo_tag(owner, repo)]);
+            } else {
+                learn("style_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            };
             if len(now_epoch_s) > 0 {
-                memo_write("style_reviewer:last_pattern_learn_ts", now_epoch_s);
+                memo_write(scoped_memo(owner, repo, "style_reviewer:last_pattern_learn_ts"), now_epoch_s);
             };
         };
     };
@@ -153,7 +187,8 @@ fn tick(reason: string) -> void {
             // Post review comment directly (terminal voice on the MR).
             emit("review:style_findings", review);
             let comment = "**Style Review** (automated)\n\n" + review.summary;
-            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            // colony-lint: safe-exec-concat
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
             let result = try { exec sh post_cmd; } catch e {
                 print("[style_reviewer] Failed to post comment:", e);
                 "";
@@ -161,7 +196,11 @@ fn tick(reason: string) -> void {
             if len(result) > 0 {
                 // #104: tag knowledge as personal (operator's own MR) vs team.
                 let scope = scope_for_author(review.author);
-                learn("style_review", "posted on MR " + to_string(mr_iid), review.summary, "success", [scope, "code-review", "acted"]);
+                if len(owner) > 0 {
+                    learn("style_review", "posted on MR " + to_string(mr_iid), review.summary, "success", [scope, "code-review", "acted", repo_tag(owner, repo)]);
+                } else {
+                    learn("style_review", "posted on MR " + to_string(mr_iid), review.summary, "success", [scope, "code-review", "acted"]);
+                };
             };
         } else {
             if my_tier == "review-gated" {
@@ -169,25 +208,38 @@ fn tick(reason: string) -> void {
                 // record an approval marker so downstream promotion can pick it up.
                 emit("review:style_findings", review);
                 let comment = "[draft-review] **Style Review** (automated, pending approval)\n\n" + review.summary;
-                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                // colony-lint: safe-exec-concat
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
                 let result = try { exec sh post_cmd; } catch e {
                     print("[style_reviewer] Failed to post draft comment:", e);
                     "";
                 };
                 if len(result) > 0 {
-                    memo_write("style_reviewer:approved:" + to_string(mr_iid), "drafted");
+                    memo_write(scoped_memo(owner, repo, "style_reviewer:approved:" + to_string(mr_iid)), "drafted");
                     let scope = scope_for_author(review.author);
-                    learn("style_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", [scope, "code-review", "review-gated"]);
+                    if len(owner) > 0 {
+                        learn("style_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", [scope, "code-review", "review-gated", repo_tag(owner, repo)]);
+                    } else {
+                        learn("style_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", [scope, "code-review", "review-gated"]);
+                    };
                 };
             } else {
                 if my_tier == "propose" {
                     // Emit on bus for approval_decider; no external write.
                     emit("review:style_findings", review);
-                    learn("style_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                    if len(owner) > 0 {
+                        learn("style_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted", repo_tag(owner, repo)]);
+                    } else {
+                        learn("style_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                    };
                 } else {
                     // shadow / dormant: observe only, no emit, no external write.
                     print("[style_reviewer] MR", mr_iid, ": observing (tier:", my_tier, ")");
-                    learn("style_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                    if len(owner) > 0 {
+                        learn("style_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed", repo_tag(owner, repo)]);
+                    } else {
+                        learn("style_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                    };
                 };
             };
         };
@@ -210,6 +262,29 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("style_reviewer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "style_reviewer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -21,12 +21,40 @@ type TestReview {
     summary: string
 }
 
-fn mr_cmd() -> string {
-    let ts = recall_latest("test_reviewer:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn mr_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "test_reviewer:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --since " + shell_escape(ts) + " --view reviewer" + repo_arg(owner, repo);
     };
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer" + repo_arg(owner, repo);
 }
 
 fn get_confidence() -> float {
@@ -37,8 +65,8 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-fn tick(reason: string) -> void {
-    let cmd = mr_cmd();
+fn tick_for_repo(owner: string, repo: string) -> void {
+    let cmd = mr_cmd(owner, repo);
     let raw = try {
         exec sh cmd;
     } catch e {
@@ -55,7 +83,8 @@ fn tick(reason: string) -> void {
     if mr_iid <= 0 {
         return;
     };
-    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
+    // colony-lint: safe-exec-concat
+    let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid) + repo_arg(owner, repo);
     let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
     if len(changes_raw) < 10 {
@@ -69,7 +98,7 @@ fn tick(reason: string) -> void {
     // observe prompt on a 1800s window aligned with the #187 planning
     // gate.
     let now_epoch_s = try { exec sh "date -u +%s"; } catch e { ""; };
-    let last_learn = recall_latest("test_reviewer:last_pattern_learn_ts");
+    let last_learn = recall_latest(scoped_memo(owner, repo, "test_reviewer:last_pattern_learn_ts"));
     let should_learn = if len(last_learn) > 0 {
         if len(now_epoch_s) > 0 {
             let delta = parse_int(now_epoch_s) - parse_int(last_learn);
@@ -81,7 +110,8 @@ fn tick(reason: string) -> void {
 
     if should_learn == 1 {
         // Learn from human test-related comments
-        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid);
+        // colony-lint: safe-exec-concat
+        let notes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-notes " + to_string(mr_iid) + repo_arg(owner, repo);
         let notes_raw = try { exec sh notes_cmd; } catch e { "[]"; };
 
         let human_patterns = prompt(
@@ -90,9 +120,13 @@ fn tick(reason: string) -> void {
         ) -> string;
 
         if len(human_patterns) > 5 {
-            learn("test_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            if len(owner) > 0 {
+                learn("test_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review", repo_tag(owner, repo)]);
+            } else {
+                learn("test_review", "MR " + to_string(mr_iid), human_patterns, "success", ["observed", "code-review"]);
+            };
             if len(now_epoch_s) > 0 {
-                memo_write("test_reviewer:last_pattern_learn_ts", now_epoch_s);
+                memo_write(scoped_memo(owner, repo, "test_reviewer:last_pattern_learn_ts"), now_epoch_s);
             };
         };
     };
@@ -114,31 +148,49 @@ fn tick(reason: string) -> void {
         if my_tier == "autonomous" {
             emit("review:test_findings", review);
             let comment = "**Test Review** (automated)\n\n" + review.summary;
-            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+            // colony-lint: safe-exec-concat
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
             try { exec sh post_cmd; } catch e {
                 print("[test_reviewer] Failed to post comment:", e);
             };
-            learn("test_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted"]);
+            if len(owner) > 0 {
+                learn("test_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted", repo_tag(owner, repo)]);
+            } else {
+                learn("test_review", "MR " + to_string(mr_iid), review.summary, "success", ["code-review", "acted"]);
+            };
         } else {
             if my_tier == "review-gated" {
                 emit("review:test_findings", review);
                 let comment = "[draft-review] **Test Review** (automated, pending approval)\n\n" + review.summary;
-                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment);
+                // colony-lint: safe-exec-concat
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
                 let result = try { exec sh post_cmd; } catch e {
                     print("[test_reviewer] Failed to post draft comment:", e);
                     "";
                 };
                 if len(result) > 0 {
-                    memo_write("test_reviewer:approved:" + to_string(mr_iid), "drafted");
-                    learn("test_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated"]);
+                    memo_write(scoped_memo(owner, repo, "test_reviewer:approved:" + to_string(mr_iid)), "drafted");
+                    if len(owner) > 0 {
+                        learn("test_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated", repo_tag(owner, repo)]);
+                    } else {
+                        learn("test_review", "drafted on MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "review-gated"]);
+                    };
                 };
             } else {
                 if my_tier == "propose" {
                     emit("review:test_findings", review);
-                    learn("test_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                    if len(owner) > 0 {
+                        learn("test_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted", repo_tag(owner, repo)]);
+                    } else {
+                        learn("test_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "emitted"]);
+                    };
                 } else {
                     print("[test_reviewer] MR", mr_iid, ": observing (tier:", my_tier, ")");
-                    learn("test_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                    if len(owner) > 0 {
+                        learn("test_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed", repo_tag(owner, repo)]);
+                    } else {
+                        learn("test_review", "MR " + to_string(mr_iid), review.summary, "partial", ["code-review", "observed"]);
+                    };
                 };
             };
         };
@@ -159,6 +211,29 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("test_reviewer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "test_reviewer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -24,12 +24,40 @@ type CodeDraft {
     confidence: float
 }
 
-fn merged_mr_cmd() -> string {
-    let ts = recall_latest("code_writer:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn merged_mr_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "code_writer:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl" + repo_arg(owner, repo);
     };
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl" + repo_arg(owner, repo);
 }
 
 // #291: the forge wrappers' assigned-issues* subcommands gate on BOTH the
@@ -62,7 +90,7 @@ fn get_confidence() -> float {
 // input. Gate on (iid, updated_at) so that issue edits (title,
 // description, labels — anything that bumps updated_at) trigger a
 // fresh draft.
-fn should_draft_code(iid_str: string, upd: string) -> bool {
+fn should_draft_code(owner: string, repo: string, iid_str: string, upd: string) -> bool {
     // Malformed GitLab payload (missing iid) would otherwise collapse
     // all drafts into the shared "void" memo slot. Skip entirely — we
     // have nothing to gate on, and the next tick will re-poll.
@@ -72,14 +100,14 @@ fn should_draft_code(iid_str: string, upd: string) -> bool {
     if len(iid_str) == 0 {
         return false;
     };
-    let last_iid = recall_latest("code_writer:last_drafted_iid");
+    let last_iid = recall_latest(scoped_memo(owner, repo, "code_writer:last_drafted_iid"));
     if len(last_iid) == 0 {
         return true;
     };
     if iid_str != last_iid {
         return true;
     };
-    let last_upd = recall_latest("code_writer:last_drafted_updated_at");
+    let last_upd = recall_latest(scoped_memo(owner, repo, "code_writer:last_drafted_updated_at"));
     if upd != last_upd {
         return true;
     };
@@ -94,12 +122,12 @@ fn should_draft_code(iid_str: string, upd: string) -> bool {
 // hundreds of duplicate `Learned from MR <N>` log entries and an
 // OOM-class load on long-lived MRs. Single-key memo, no TTL: we want
 // at-most-once per distinct MR iid.
-fn should_learn_from_mr(mr_iid: int) -> bool {
+fn should_learn_from_mr(owner: string, repo: string, mr_iid: int) -> bool {
     if mr_iid <= 0 {
         return false;
     };
     let iid_str = to_string(mr_iid);
-    let last_iid = recall_latest("code_writer:last_learned_mr_iid");
+    let last_iid = recall_latest(scoped_memo(owner, repo, "code_writer:last_learned_mr_iid"));
     if len(last_iid) == 0 {
         return true;
     };
@@ -109,9 +137,9 @@ fn should_learn_from_mr(mr_iid: int) -> bool {
     return false;
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // 1. Learn from recently merged MRs
-    let cmd = merged_mr_cmd();
+    let cmd = merged_mr_cmd(owner, repo);
     let raw = try {
         exec sh cmd;
     } catch e {
@@ -122,9 +150,10 @@ fn tick(reason: string) -> void {
     if len(raw) > 10 {
         let mr_iid = parse_int(to_string(json_get(raw, "[0].iid")));
 
-        if should_learn_from_mr(mr_iid) {
-            memo_write("code_writer:last_learned_mr_iid", to_string(mr_iid));
-            let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
+        if should_learn_from_mr(owner, repo, mr_iid) {
+            memo_write(scoped_memo(owner, repo, "code_writer:last_learned_mr_iid"), to_string(mr_iid));
+            // colony-lint: safe-exec-concat
+            let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid) + repo_arg(owner, repo);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
             if len(changes_raw) > 10 {
@@ -133,13 +162,23 @@ fn tick(reason: string) -> void {
                     changes_raw
                 ) -> CodePatterns;
 
-                learn(
-                    "code_write",
-                    "MR " + to_string(mr_iid),
-                    "naming: " + patterns.naming + " | structure: " + patterns.structure + " | errors: " + patterns.error_handling,
-                    "success",
-                    ["observed", "implementation"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "code_write",
+                        "MR " + to_string(mr_iid),
+                        "naming: " + patterns.naming + " | structure: " + patterns.structure + " | errors: " + patterns.error_handling,
+                        "success",
+                        ["observed", "implementation", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "code_write",
+                        "MR " + to_string(mr_iid),
+                        "naming: " + patterns.naming + " | structure: " + patterns.structure + " | errors: " + patterns.error_handling,
+                        "success",
+                        ["observed", "implementation"]
+                    );
+                };
                 print("[code_writer] Learned from MR", mr_iid);
             };
         };
@@ -150,12 +189,13 @@ fn tick(reason: string) -> void {
     // lived trigger labels (e.g. "DEV::not started" transitioning through
     // scoped states in seconds) aren't missed. The first tick falls back
     // to the current-state snapshot — byte-identical to pre-#235 boot.
-    let prev_check = recall_latest("code_writer:last_check");
+    let prev_check = recall_latest(scoped_memo(owner, repo, "code_writer:last_check"));
     let unassigned_flag = include_unassigned_flag();
+    // colony-lint: safe-exec-concat
     let issues_cmd = if len(prev_check) > 0 {
-        "$COLONY_DIR/scripts/forge-api.sh assigned-issues-by-label-events --since " + shell_escape(prev_check) + " --view assigned" + unassigned_flag;
+        "$COLONY_DIR/scripts/forge-api.sh assigned-issues-by-label-events --since " + shell_escape(prev_check) + " --view assigned" + unassigned_flag + repo_arg(owner, repo);
     } else {
-        "$COLONY_DIR/scripts/forge-api.sh assigned-issues --view assigned" + unassigned_flag;
+        "$COLONY_DIR/scripts/forge-api.sh assigned-issues --view assigned" + unassigned_flag + repo_arg(owner, repo);
     };
     let issues_raw = try {
         exec sh issues_cmd;
@@ -172,9 +212,9 @@ fn tick(reason: string) -> void {
         // the `draft = prompt(...)` call below.
         let first_iid_str = to_string(json_get(issues_raw, "[0].iid"));
         let first_upd = to_string(json_get(issues_raw, "[0].updated_at"));
-        if should_draft_code(first_iid_str, first_upd) {
-            memo_write("code_writer:last_drafted_iid", first_iid_str);
-            memo_write("code_writer:last_drafted_updated_at", first_upd);
+        if should_draft_code(owner, repo, first_iid_str, first_upd) {
+            memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_iid"), first_iid_str);
+            memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_updated_at"), first_upd);
             let rec = recommend("code_write", ["accuracy"]);
             let context = "Assigned issues: " + issues_raw + "\nLearned code patterns: " + to_string(rec);
 
@@ -188,7 +228,8 @@ fn tick(reason: string) -> void {
 
             if my_tier == "autonomous" {
                 // Create branch
-                let branch_cmd = "$COLONY_DIR/scripts/forge-api.sh create-branch --name " + shell_escape(draft.branch_name) + " --ref main";
+                // colony-lint: safe-exec-concat
+                let branch_cmd = "$COLONY_DIR/scripts/forge-api.sh create-branch --name " + shell_escape(draft.branch_name) + " --ref main" + repo_arg(owner, repo);
                 let branch_result = try { exec sh branch_cmd; } catch e {
                     print("[code_writer] Branch creation failed:", e);
                     "";
@@ -196,7 +237,8 @@ fn tick(reason: string) -> void {
 
                 if len(branch_result) > 0 {
                     // Generate actual code and commit it to the branch
-                    let issue_cmd = "$COLONY_DIR/scripts/forge-api.sh issue " + to_string(draft.issue_id);
+                    // colony-lint: safe-exec-concat
+                    let issue_cmd = "$COLONY_DIR/scripts/forge-api.sh issue " + to_string(draft.issue_id) + repo_arg(owner, repo);
                     let issue_detail = try { exec sh issue_cmd; } catch e { ""; };
                     let code_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec);
 
@@ -206,7 +248,7 @@ fn tick(reason: string) -> void {
                     ) -> string;
 
                     // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-                    let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json);
+                    let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json) + repo_arg(owner, repo);
                     let commit_result = try { exec sh commit_cmd; } catch e {
                         print("[code_writer] Commit failed:", e);
                         "";
@@ -215,7 +257,11 @@ fn tick(reason: string) -> void {
                     if len(commit_result) > 0 {
                         print("[code_writer] Committed code to", draft.branch_name);
                         emit("implementation:code_draft", draft);
-                        learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation"]);
+                        if len(owner) > 0 {
+                            learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation", repo_tag(owner, repo)]);
+                        } else {
+                            learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation"]);
+                        };
                     };
                 };
             } else {
@@ -224,19 +270,32 @@ fn tick(reason: string) -> void {
                     // on the issue so a human can approve before we create a branch
                     // and commit code. No branch or commit at this tier.
                     let note = "[draft-impl] **Implementation Plan** (automated, pending approval)\n\nBranch: `" + draft.branch_name + "`\n\n" + draft.summary + "\n\nFiles:\n" + draft.files;
-                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(note);
+                    // colony-lint: safe-exec-concat
+                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(note) + repo_arg(owner, repo);
                     try { exec sh post_cmd; } catch e {
                         print("[code_writer] Failed to post draft plan:", e);
                     };
                     emit("implementation:code_draft", draft);
-                    learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["implementation", "review-gated"]);
+                    if len(owner) > 0 {
+                        learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["implementation", "review-gated", repo_tag(owner, repo)]);
+                    } else {
+                        learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["implementation", "review-gated"]);
+                    };
                 } else {
                     if my_tier == "propose" {
                         emit("implementation:code_draft", draft);
-                        learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["emitted", "implementation"]);
+                        if len(owner) > 0 {
+                            learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["emitted", "implementation", repo_tag(owner, repo)]);
+                        } else {
+                            learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["emitted", "implementation"]);
+                        };
                     } else {
                         print("[code_writer] Observing (tier:", my_tier, ")");
-                        learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["observed", "implementation"]);
+                        if len(owner) > 0 {
+                            learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["observed", "implementation", repo_tag(owner, repo)]);
+                        } else {
+                            learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "partial", ["observed", "implementation"]);
+                        };
                     };
                 };
             };
@@ -251,6 +310,29 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("code_writer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "code_writer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -26,12 +26,40 @@ type MRPlan {
     confidence: float
 }
 
-fn merged_mr_cmd() -> string {
-    let ts = recall_latest("commit_composer:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn merged_mr_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "commit_composer:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl" + repo_arg(owner, repo);
     };
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl" + repo_arg(owner, repo);
 }
 
 fn get_confidence() -> float {
@@ -48,12 +76,12 @@ fn get_confidence() -> float {
 // keeps getting bumped, so the learning-path prompt re-fires every
 // tick at cb_budget 600. Single-key memo, no TTL: at-most-once per
 // distinct MR iid.
-fn should_learn_from_mr(mr_iid: int) -> bool {
+fn should_learn_from_mr(owner: string, repo: string, mr_iid: int) -> bool {
     if mr_iid <= 0 {
         return false;
     };
     let iid_str = to_string(mr_iid);
-    let last_iid = recall_latest("commit_composer:last_learned_mr_iid");
+    let last_iid = recall_latest(scoped_memo(owner, repo, "commit_composer:last_learned_mr_iid"));
     if len(last_iid) == 0 {
         return true;
     };
@@ -63,9 +91,9 @@ fn should_learn_from_mr(mr_iid: int) -> bool {
     return false;
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // 1. Learn commit conventions from recently merged MRs
-    let cmd = merged_mr_cmd();
+    let cmd = merged_mr_cmd(owner, repo);
     let raw = try {
         exec sh cmd;
     } catch e {
@@ -76,9 +104,10 @@ fn tick(reason: string) -> void {
     if len(raw) > 10 {
         let mr_iid = parse_int(to_string(json_get(raw, "[0].iid")));
 
-        if should_learn_from_mr(mr_iid) {
-            memo_write("commit_composer:last_learned_mr_iid", to_string(mr_iid));
-            let commits_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-commits " + to_string(mr_iid);
+        if should_learn_from_mr(owner, repo, mr_iid) {
+            memo_write(scoped_memo(owner, repo, "commit_composer:last_learned_mr_iid"), to_string(mr_iid));
+            // colony-lint: safe-exec-concat
+            let commits_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-commits " + to_string(mr_iid) + repo_arg(owner, repo);
             let commits_raw = try { exec sh commits_cmd; } catch e { "[]"; };
 
             if len(commits_raw) > 10 {
@@ -88,13 +117,23 @@ fn tick(reason: string) -> void {
                 ) -> CommitStyle;
 
                 if style.commits_seen > 0 {
-                    learn(
-                        "commit_compose",
-                        "MR " + to_string(mr_iid) + " (" + to_string(style.commits_seen) + " commits)",
-                        "format: " + style.format + " | grouping: " + style.grouping + " | prefixes: " + style.prefixes,
-                        "success",
-                        ["observed", "implementation"]
-                    );
+                    if len(owner) > 0 {
+                        learn(
+                            "commit_compose",
+                            "MR " + to_string(mr_iid) + " (" + to_string(style.commits_seen) + " commits)",
+                            "format: " + style.format + " | grouping: " + style.grouping + " | prefixes: " + style.prefixes,
+                            "success",
+                            ["observed", "implementation", repo_tag(owner, repo)]
+                        );
+                    } else {
+                        learn(
+                            "commit_compose",
+                            "MR " + to_string(mr_iid) + " (" + to_string(style.commits_seen) + " commits)",
+                            "format: " + style.format + " | grouping: " + style.grouping + " | prefixes: " + style.prefixes,
+                            "success",
+                            ["observed", "implementation"]
+                        );
+                    };
                     print("[commit_composer] Learned from", style.commits_seen, "commits in MR", mr_iid);
                 };
             };
@@ -109,7 +148,7 @@ fn tick(reason: string) -> void {
         // No code draft ready yet, nothing to compose
         let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now) > 0 {
-            memo_write("commit_composer:last_check", now);
+            memo_write(scoped_memo(owner, repo, "commit_composer:last_check"), now);
         };
         return;
     };
@@ -135,7 +174,8 @@ fn tick(reason: string) -> void {
 
     if my_tier == "autonomous" {
         // Create the MR
-        let mr_cmd = "$COLONY_DIR/scripts/forge-api.sh create-mr --source " + shell_escape(plan.branch_name) + " --title " + shell_escape(plan.mr_title) + " --description " + shell_escape(plan.mr_description);
+        // colony-lint: safe-exec-concat
+        let mr_cmd = "$COLONY_DIR/scripts/forge-api.sh create-mr --source " + shell_escape(plan.branch_name) + " --title " + shell_escape(plan.mr_title) + " --description " + shell_escape(plan.mr_description) + repo_arg(owner, repo);
         let mr_result = try { exec sh mr_cmd; } catch e {
             print("[commit_composer] MR creation failed:", e);
             "";
@@ -144,32 +184,72 @@ fn tick(reason: string) -> void {
         if len(mr_result) > 0 {
             print("[commit_composer] Created MR for issue", plan.issue_id);
             emit("implementation:mr_ready", plan);
-            learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "success", ["acted", "implementation"]);
+            if len(owner) > 0 {
+                learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "success", ["acted", "implementation", repo_tag(owner, repo)]);
+            } else {
+                learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "success", ["acted", "implementation"]);
+            };
         };
     } else {
         if my_tier == "review-gated" {
             // Non-terminal draft: post the MR plan as a comment on the issue
             // so a human can approve before we actually open a non-draft MR.
             let note = "[draft-mr] **Merge Request Plan** (automated, pending approval)\n\nBranch: `" + plan.branch_name + "`\nTitle: " + plan.mr_title + "\n\n" + plan.mr_description + "\n\nCommits:\n" + plan.commits;
-            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(plan.issue_id) + " --body " + shell_escape(note);
+            // colony-lint: safe-exec-concat
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(plan.issue_id) + " --body " + shell_escape(note) + repo_arg(owner, repo);
             try { exec sh post_cmd; } catch e {
                 print("[commit_composer] Failed to post draft plan:", e);
             };
             emit("implementation:mr_ready", plan);
-            learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["implementation", "review-gated"]);
+            if len(owner) > 0 {
+                learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["implementation", "review-gated", repo_tag(owner, repo)]);
+            } else {
+                learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["implementation", "review-gated"]);
+            };
         } else {
             if my_tier == "propose" {
                 emit("implementation:mr_ready", plan);
-                learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["emitted", "implementation"]);
+                if len(owner) > 0 {
+                    learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["emitted", "implementation", repo_tag(owner, repo)]);
+                } else {
+                    learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["emitted", "implementation"]);
+                };
             } else {
                 print("[commit_composer] Observing (tier:", my_tier, ")");
-                learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["observed", "implementation"]);
+                if len(owner) > 0 {
+                    learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["observed", "implementation", repo_tag(owner, repo)]);
+                } else {
+                    learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "partial", ["observed", "implementation"]);
+                };
             };
         };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("commit_composer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "commit_composer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -22,12 +22,40 @@ type RefactorSuggestion {
     confidence: float
 }
 
-fn merged_mr_cmd() -> string {
-    let ts = recall_latest("refactorer:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn merged_mr_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "refactorer:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl" + repo_arg(owner, repo);
     };
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl" + repo_arg(owner, repo);
 }
 
 fn get_confidence() -> float {
@@ -44,7 +72,7 @@ fn get_confidence() -> float {
 // the bus shouldn't see dupes, but if it does we don't re-pay the LLM
 // cost. Cooldown expires so a genuine new draft for the same issue
 // after an edit eventually passes.
-fn should_handle_refactor(iid_str: string) -> bool {
+fn should_handle_refactor(owner: string, repo: string, iid_str: string) -> bool {
     // Malformed bus payload (missing issue_id) would otherwise collapse
     // all drafts into the shared "void" memo slot. Skip — we have
     // nothing to gate on.
@@ -54,14 +82,14 @@ fn should_handle_refactor(iid_str: string) -> bool {
     if len(iid_str) == 0 {
         return false;
     };
-    let last_iid = recall_latest("refactorer:last_handled_iid");
+    let last_iid = recall_latest(scoped_memo(owner, repo, "refactorer:last_handled_iid"));
     if len(last_iid) == 0 {
         return true;
     };
     if iid_str != last_iid {
         return true;
     };
-    let last_ts_str = recall_latest("refactorer:last_handled_ts");
+    let last_ts_str = recall_latest(scoped_memo(owner, repo, "refactorer:last_handled_ts"));
     if len(last_ts_str) == 0 {
         return true;
     };
@@ -83,12 +111,12 @@ fn should_handle_refactor(iid_str: string) -> bool {
 // keeps getting bumped, so the learning-path prompt re-fires every
 // tick at cb_budget 1000. Single-key memo, no TTL: at-most-once per
 // distinct MR iid.
-fn should_learn_from_mr(mr_iid: int) -> bool {
+fn should_learn_from_mr(owner: string, repo: string, mr_iid: int) -> bool {
     if mr_iid <= 0 {
         return false;
     };
     let iid_str = to_string(mr_iid);
-    let last_iid = recall_latest("refactorer:last_learned_mr_iid");
+    let last_iid = recall_latest(scoped_memo(owner, repo, "refactorer:last_learned_mr_iid"));
     if len(last_iid) == 0 {
         return true;
     };
@@ -98,9 +126,9 @@ fn should_learn_from_mr(mr_iid: int) -> bool {
     return false;
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // 1. Learn from refactoring patterns in merged MRs
-    let cmd = merged_mr_cmd();
+    let cmd = merged_mr_cmd(owner, repo);
     let raw = try {
         exec sh cmd;
     } catch e {
@@ -111,13 +139,15 @@ fn tick(reason: string) -> void {
     if len(raw) > 10 {
         let mr_iid = parse_int(to_string(json_get(raw, "[0].iid")));
 
-        if should_learn_from_mr(mr_iid) {
-            memo_write("refactorer:last_learned_mr_iid", to_string(mr_iid));
-            let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
+        if should_learn_from_mr(owner, repo, mr_iid) {
+            memo_write(scoped_memo(owner, repo, "refactorer:last_learned_mr_iid"), to_string(mr_iid));
+            // colony-lint: safe-exec-concat
+            let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid) + repo_arg(owner, repo);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
             if len(changes_raw) > 10 {
-                let commits_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-commits " + to_string(mr_iid);
+                // colony-lint: safe-exec-concat
+                let commits_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-commits " + to_string(mr_iid) + repo_arg(owner, repo);
                 let commits_raw = try { exec sh commits_cmd; } catch e { "[]"; };
 
                 let patterns = prompt(
@@ -126,13 +156,23 @@ fn tick(reason: string) -> void {
                 ) -> RefactorPatterns;
 
                 if patterns.refactor_mrs > 0 {
-                    learn(
-                        "refactor",
-                        "MR " + to_string(mr_iid),
-                        "smells: " + patterns.smells_fixed + " | techniques: " + patterns.techniques,
-                        "success",
-                        ["observed", "implementation"]
-                    );
+                    if len(owner) > 0 {
+                        learn(
+                            "refactor",
+                            "MR " + to_string(mr_iid),
+                            "smells: " + patterns.smells_fixed + " | techniques: " + patterns.techniques,
+                            "success",
+                            ["observed", "implementation", repo_tag(owner, repo)]
+                        );
+                    } else {
+                        learn(
+                            "refactor",
+                            "MR " + to_string(mr_iid),
+                            "smells: " + patterns.smells_fixed + " | techniques: " + patterns.techniques,
+                            "success",
+                            ["observed", "implementation"]
+                        );
+                    };
                     print("[refactorer] Learned refactoring patterns from MR", mr_iid);
                 };
             };
@@ -149,11 +189,11 @@ fn tick(reason: string) -> void {
         // call. Stash the memos *before* prompt() so downstream failures
         // don't force re-burn.
         let incoming_iid = to_string(json_get(draft_str, "issue_id"));
-        if should_handle_refactor(incoming_iid) {
-            memo_write("refactorer:last_handled_iid", incoming_iid);
+        if should_handle_refactor(owner, repo, incoming_iid) {
+            memo_write(scoped_memo(owner, repo, "refactorer:last_handled_iid"), incoming_iid);
             let ts_now = try { exec sh "date +%s"; } catch e { ""; };
             if len(ts_now) > 0 {
-                memo_write("refactorer:last_handled_ts", ts_now);
+                memo_write(scoped_memo(owner, repo, "refactorer:last_handled_ts"), ts_now);
             };
             let rec = recommend("refactor", ["accuracy"]);
             let context = "Code draft to review: " + draft_str + "\nLearned refactoring patterns: " + to_string(rec);
@@ -177,7 +217,7 @@ fn tick(reason: string) -> void {
                     refactor_context
                 ) -> string;
                 // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-                let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(branch) + " --message " + shell_escape("refactor: apply improvements for #" + to_string(suggestion.issue_id)) + " --actions " + shell_escape(actions_json);
+                let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(branch) + " --message " + shell_escape("refactor: apply improvements for #" + to_string(suggestion.issue_id)) + " --actions " + shell_escape(actions_json) + repo_arg(owner, repo);
                 let commit_result = try { exec sh commit_cmd; } catch e {
                     print("[refactorer] Commit failed:", e);
                     "";
@@ -185,7 +225,11 @@ fn tick(reason: string) -> void {
                 if len(commit_result) > 0 {
                     print("[refactorer] Committed refactoring to", branch);
                     emit("implementation:refactor_suggestions", suggestion);
-                    learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "success", ["acted", "implementation"]);
+                    if len(owner) > 0 {
+                        learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "success", ["acted", "implementation", repo_tag(owner, repo)]);
+                    } else {
+                        learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "success", ["acted", "implementation"]);
+                    };
                 };
             } else {
                 if my_tier == "review-gated" {
@@ -193,19 +237,32 @@ fn tick(reason: string) -> void {
                     // comment on the issue so a human can approve before we
                     // commit refactored files. No commit at this tier.
                     let note = "[draft-refactor] **Refactoring Suggestions** (automated, pending approval) — priority: " + suggestion.priority + "\n\n" + suggestion.suggestions;
-                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(suggestion.issue_id) + " --body " + shell_escape(note);
+                    // colony-lint: safe-exec-concat
+                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(suggestion.issue_id) + " --body " + shell_escape(note) + repo_arg(owner, repo);
                     try { exec sh post_cmd; } catch e {
                         print("[refactorer] Failed to post draft note:", e);
                     };
                     emit("implementation:refactor_suggestions", suggestion);
-                    learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["implementation", "review-gated"]);
+                    if len(owner) > 0 {
+                        learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["implementation", "review-gated", repo_tag(owner, repo)]);
+                    } else {
+                        learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["implementation", "review-gated"]);
+                    };
                 } else {
                     if my_tier == "propose" {
                         emit("implementation:refactor_suggestions", suggestion);
-                        learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["emitted", "implementation"]);
+                        if len(owner) > 0 {
+                            learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["emitted", "implementation", repo_tag(owner, repo)]);
+                        } else {
+                            learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["emitted", "implementation"]);
+                        };
                     } else {
                         print("[refactorer] Observing (tier:", my_tier, ")");
-                        learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["observed", "implementation"]);
+                        if len(owner) > 0 {
+                            learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["observed", "implementation", repo_tag(owner, repo)]);
+                        } else {
+                            learn("refactor", "issue " + to_string(suggestion.issue_id), suggestion.suggestions, "partial", ["observed", "implementation"]);
+                        };
                     };
                 };
             };
@@ -214,6 +271,29 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("refactorer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "refactorer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -24,12 +24,40 @@ type TestDraft {
     confidence: float
 }
 
-fn merged_mr_cmd() -> string {
-    let ts = recall_latest("test_writer:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn merged_mr_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "test_writer:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl" + repo_arg(owner, repo);
     };
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl" + repo_arg(owner, repo);
 }
 
 fn get_confidence() -> float {
@@ -46,7 +74,7 @@ fn get_confidence() -> float {
 // gate so the bus shouldn't see dupes, but if it does we don't re-pay
 // the LLM cost for generating identical tests. Cooldown expires so a
 // genuine new draft for the same issue after an edit eventually passes.
-fn should_handle_test_draft(iid_str: string) -> bool {
+fn should_handle_test_draft(owner: string, repo: string, iid_str: string) -> bool {
     // Malformed bus payload (missing issue_id) would otherwise collapse
     // all drafts into the shared "void" memo slot. Skip — we have
     // nothing to gate on.
@@ -56,14 +84,14 @@ fn should_handle_test_draft(iid_str: string) -> bool {
     if len(iid_str) == 0 {
         return false;
     };
-    let last_iid = recall_latest("test_writer:last_handled_iid");
+    let last_iid = recall_latest(scoped_memo(owner, repo, "test_writer:last_handled_iid"));
     if len(last_iid) == 0 {
         return true;
     };
     if iid_str != last_iid {
         return true;
     };
-    let last_ts_str = recall_latest("test_writer:last_handled_ts");
+    let last_ts_str = recall_latest(scoped_memo(owner, repo, "test_writer:last_handled_ts"));
     if len(last_ts_str) == 0 {
         return true;
     };
@@ -85,12 +113,12 @@ fn should_handle_test_draft(iid_str: string) -> bool {
 // keeps getting bumped, so the learning-path prompt re-fires every
 // tick at cb_budget 1500. Single-key memo, no TTL: at-most-once per
 // distinct MR iid.
-fn should_learn_from_mr(mr_iid: int) -> bool {
+fn should_learn_from_mr(owner: string, repo: string, mr_iid: int) -> bool {
     if mr_iid <= 0 {
         return false;
     };
     let iid_str = to_string(mr_iid);
-    let last_iid = recall_latest("test_writer:last_learned_mr_iid");
+    let last_iid = recall_latest(scoped_memo(owner, repo, "test_writer:last_learned_mr_iid"));
     if len(last_iid) == 0 {
         return true;
     };
@@ -100,9 +128,9 @@ fn should_learn_from_mr(mr_iid: int) -> bool {
     return false;
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // 1. Learn from test files in recently merged MRs
-    let cmd = merged_mr_cmd();
+    let cmd = merged_mr_cmd(owner, repo);
     let raw = try {
         exec sh cmd;
     } catch e {
@@ -113,9 +141,10 @@ fn tick(reason: string) -> void {
     if len(raw) > 10 {
         let mr_iid = parse_int(to_string(json_get(raw, "[0].iid")));
 
-        if should_learn_from_mr(mr_iid) {
-            memo_write("test_writer:last_learned_mr_iid", to_string(mr_iid));
-            let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid);
+        if should_learn_from_mr(owner, repo, mr_iid) {
+            memo_write(scoped_memo(owner, repo, "test_writer:last_learned_mr_iid"), to_string(mr_iid));
+            // colony-lint: safe-exec-concat
+            let changes_cmd = "$COLONY_DIR/scripts/forge-api.sh mr-changes " + to_string(mr_iid) + repo_arg(owner, repo);
             let changes_raw = try { exec sh changes_cmd; } catch e { ""; };
 
             if len(changes_raw) > 10 {
@@ -125,13 +154,23 @@ fn tick(reason: string) -> void {
                 ) -> TestPatterns;
 
                 if patterns.test_files_seen > 0 {
-                    learn(
-                        "test_write",
-                        "MR " + to_string(mr_iid) + " (" + to_string(patterns.test_files_seen) + " test files)",
-                        "structure: " + patterns.structure + " | assertions: " + patterns.assertion_style + " | fixtures: " + patterns.fixture_patterns,
-                        "success",
-                        ["observed", "implementation"]
-                    );
+                    if len(owner) > 0 {
+                        learn(
+                            "test_write",
+                            "MR " + to_string(mr_iid) + " (" + to_string(patterns.test_files_seen) + " test files)",
+                            "structure: " + patterns.structure + " | assertions: " + patterns.assertion_style + " | fixtures: " + patterns.fixture_patterns,
+                            "success",
+                            ["observed", "implementation", repo_tag(owner, repo)]
+                        );
+                    } else {
+                        learn(
+                            "test_write",
+                            "MR " + to_string(mr_iid) + " (" + to_string(patterns.test_files_seen) + " test files)",
+                            "structure: " + patterns.structure + " | assertions: " + patterns.assertion_style + " | fixtures: " + patterns.fixture_patterns,
+                            "success",
+                            ["observed", "implementation"]
+                        );
+                    };
                     print("[test_writer] Learned from", patterns.test_files_seen, "test files in MR", mr_iid);
                 };
             };
@@ -148,11 +187,11 @@ fn tick(reason: string) -> void {
         // LLM call. Stash the memos *before* prompt() so downstream
         // failures don't force re-burn.
         let incoming_iid = to_string(json_get(draft_str, "issue_id"));
-        if should_handle_test_draft(incoming_iid) {
-            memo_write("test_writer:last_handled_iid", incoming_iid);
+        if should_handle_test_draft(owner, repo, incoming_iid) {
+            memo_write(scoped_memo(owner, repo, "test_writer:last_handled_iid"), incoming_iid);
             let ts_now = try { exec sh "date +%s"; } catch e { ""; };
             if len(ts_now) > 0 {
-                memo_write("test_writer:last_handled_ts", ts_now);
+                memo_write(scoped_memo(owner, repo, "test_writer:last_handled_ts"), ts_now);
             };
             let rec = recommend("test_write", ["accuracy"]);
             let context = "Code draft: " + draft_str + "\nLearned test patterns: " + to_string(rec);
@@ -175,7 +214,7 @@ fn tick(reason: string) -> void {
                 ) -> string;
 
                 // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-                let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(tests.branch_name) + " --message " + shell_escape("test: add tests for #" + to_string(tests.issue_id)) + " --actions " + shell_escape(actions_json);
+                let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(tests.branch_name) + " --message " + shell_escape("test: add tests for #" + to_string(tests.issue_id)) + " --actions " + shell_escape(actions_json) + repo_arg(owner, repo);
                 let commit_result = try { exec sh commit_cmd; } catch e {
                     print("[test_writer] Commit failed:", e);
                     "";
@@ -184,26 +223,43 @@ fn tick(reason: string) -> void {
                 if len(commit_result) > 0 {
                     print("[test_writer] Committed tests to", tests.branch_name);
                     emit("implementation:test_draft", tests);
-                    learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "success", ["acted", "implementation"]);
+                    if len(owner) > 0 {
+                        learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "success", ["acted", "implementation", repo_tag(owner, repo)]);
+                    } else {
+                        learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "success", ["acted", "implementation"]);
+                    };
                 };
             } else {
                 if my_tier == "review-gated" {
                     // Non-terminal draft: post the test plan as a comment on the
                     // issue so a human can approve before we commit test files.
                     let note = "[draft-tests] **Test Plan** (automated, pending approval)\n\nBranch: `" + tests.branch_name + "`\n\n" + tests.summary + "\n\nTest files:\n" + tests.test_files;
-                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(tests.issue_id) + " --body " + shell_escape(note);
+                    // colony-lint: safe-exec-concat
+                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(tests.issue_id) + " --body " + shell_escape(note) + repo_arg(owner, repo);
                     try { exec sh post_cmd; } catch e {
                         print("[test_writer] Failed to post draft note:", e);
                     };
                     emit("implementation:test_draft", tests);
-                    learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["implementation", "review-gated"]);
+                    if len(owner) > 0 {
+                        learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["implementation", "review-gated", repo_tag(owner, repo)]);
+                    } else {
+                        learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["implementation", "review-gated"]);
+                    };
                 } else {
                     if my_tier == "propose" {
                         emit("implementation:test_draft", tests);
-                        learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["emitted", "implementation"]);
+                        if len(owner) > 0 {
+                            learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["emitted", "implementation", repo_tag(owner, repo)]);
+                        } else {
+                            learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["emitted", "implementation"]);
+                        };
                     } else {
                         print("[test_writer] Observing (tier:", my_tier, ")");
-                        learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["observed", "implementation"]);
+                        if len(owner) > 0 {
+                            learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["observed", "implementation", repo_tag(owner, repo)]);
+                        } else {
+                            learn("test_write", "issue " + to_string(tests.issue_id), tests.summary, "partial", ["observed", "implementation"]);
+                        };
                     };
                 };
             };
@@ -212,6 +268,29 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("test_writer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "test_writer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -39,13 +39,39 @@ fn received(s: string) -> bool {
     return len(s) > 2;
 }
 
-fn stash(slot: string, issue_id: int, body: string) -> void {
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn stash(owner: string, repo: string, slot: string, issue_id: int, body: string) -> void {
     if len(body) > 2 {
-        memo_write("plan_reviewer:" + to_string(issue_id) + ":" + slot, body);
+        memo_write(scoped_memo(owner, repo, "plan_reviewer:" + to_string(issue_id) + ":" + slot), body);
     };
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // 1. Collect peer outputs emitted this tick (partial over time).
     let scope = listen("planning:scope_estimate", 500);
     let risks = listen("planning:risks", 500);
@@ -61,13 +87,13 @@ fn tick(reason: string) -> void {
     // and re-prompting. The stash body keeps the Display repr because
     // the downstream assembly prompt consumes that.
     if received(scope_str) {
-        stash("scope", scope.issue_id, scope_str);
+        stash(owner, repo, "scope", scope.issue_id, scope_str);
     };
     if received(risks_str) {
-        stash("risks", risks.issue_id, risks_str);
+        stash(owner, repo, "risks", risks.issue_id, risks_str);
     };
     if received(breakdown_str) {
-        stash("breakdown", breakdown.issue_id, breakdown_str);
+        stash(owner, repo, "breakdown", breakdown.issue_id, breakdown_str);
     };
 
     // 3. Pick the newest unplanned issue and see if we have all three
@@ -79,11 +105,12 @@ fn tick(reason: string) -> void {
     // #235: use issues-by-label-events when we have a prior window so
     // short-lived trigger labels aren't missed; fall back to the current-
     // state snapshot on first tick (byte-identical to pre-#235 boot).
-    let prev_check = recall_latest("plan_reviewer:last_check");
+    let prev_check = recall_latest(scoped_memo(owner, repo, "plan_reviewer:last_check"));
+    // colony-lint: safe-exec-concat
     let issues_cmd = if len(prev_check) > 0 {
-        "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(prev_check) + " --view planning";
+        "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(prev_check) + " --view planning" + repo_arg(owner, repo);
     } else {
-        "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning";
+        "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning" + repo_arg(owner, repo);
     };
     let issues_raw = try {
         exec sh issues_cmd;
@@ -95,7 +122,7 @@ fn tick(reason: string) -> void {
     if len(issues_raw) < 3 {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
-            memo_write("plan_reviewer:last_check", now_e);
+            memo_write(scoped_memo(owner, repo, "plan_reviewer:last_check"), now_e);
         };
         return;
     };
@@ -108,7 +135,7 @@ fn tick(reason: string) -> void {
     if target_iid <= 0 {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
-            memo_write("plan_reviewer:last_check", now_e);
+            memo_write(scoped_memo(owner, repo, "plan_reviewer:last_check"), now_e);
         };
         return;
     };
@@ -121,18 +148,18 @@ fn tick(reason: string) -> void {
     // post a GitLab note (autonomous + review-gated); propose/shadow do
     // no external write, so leaving them unmarked is correct.
     let iid_str = to_string(target_iid);
-    let posted_key = "plan_reviewer:" + iid_str + ":posted";
+    let posted_key = scoped_memo(owner, repo, "plan_reviewer:" + iid_str + ":posted");
     if len(recall_latest(posted_key)) > 0 {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
-            memo_write("plan_reviewer:last_check", now_e);
+            memo_write(scoped_memo(owner, repo, "plan_reviewer:last_check"), now_e);
         };
         return;
     };
 
-    let s = recall_latest("plan_reviewer:" + to_string(target_iid) + ":scope");
-    let r = recall_latest("plan_reviewer:" + to_string(target_iid) + ":risks");
-    let b = recall_latest("plan_reviewer:" + to_string(target_iid) + ":breakdown");
+    let s = recall_latest(scoped_memo(owner, repo, "plan_reviewer:" + to_string(target_iid) + ":scope"));
+    let r = recall_latest(scoped_memo(owner, repo, "plan_reviewer:" + to_string(target_iid) + ":risks"));
+    let b = recall_latest(scoped_memo(owner, repo, "plan_reviewer:" + to_string(target_iid) + ":breakdown"));
 
     if len(s) < 2 {
         print("[plan_reviewer] Waiting on scope for issue", target_iid);
@@ -166,7 +193,8 @@ fn tick(reason: string) -> void {
 
     if my_tier == "autonomous" {
         // Direct external write: post the plan as an issue note.
-        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft.plan);
+        // colony-lint: safe-exec-concat
+        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft.plan) + repo_arg(owner, repo);
         let post_result = try { exec sh post_cmd; } catch e {
             print("[plan_reviewer] Failed to post note:", e);
             "";
@@ -178,29 +206,50 @@ fn tick(reason: string) -> void {
         // next tick retries instead of silently consuming the issue.
         if len(post_result) > 0 {
             memo_write(posted_key, "1");
-            learn(
-                "review_plan",
-                "issue " + to_string(draft.issue_id),
-                "posted: score=" + to_string(draft.review_score),
-                "success",
-                ["acted", "planning"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "review_plan",
+                    "issue " + to_string(draft.issue_id),
+                    "posted: score=" + to_string(draft.review_score),
+                    "success",
+                    ["acted", "planning", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "review_plan",
+                    "issue " + to_string(draft.issue_id),
+                    "posted: score=" + to_string(draft.review_score),
+                    "success",
+                    ["acted", "planning"]
+                );
+            };
             print("[plan_reviewer] Posted plan to issue", draft.issue_id);
         } else {
-            learn(
-                "review_plan",
-                "issue " + to_string(draft.issue_id),
-                "post-failed: score=" + to_string(draft.review_score),
-                "fail",
-                ["acted", "planning"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "review_plan",
+                    "issue " + to_string(draft.issue_id),
+                    "post-failed: score=" + to_string(draft.review_score),
+                    "fail",
+                    ["acted", "planning", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "review_plan",
+                    "issue " + to_string(draft.issue_id),
+                    "post-failed: score=" + to_string(draft.review_score),
+                    "fail",
+                    ["acted", "planning"]
+                );
+            };
         };
     } else {
         if my_tier == "review-gated" {
             // Draft external write: post with [draft-plan] prefix so a human
             // reviewer can promote or discard it.
             let draft_body = "[draft-plan] **Plan Review** (automated, pending approval)\n\n" + draft.plan;
-            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft_body);
+            // colony-lint: safe-exec-concat
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(draft.issue_id) + " --body " + shell_escape(draft_body) + repo_arg(owner, repo);
             let draft_result = try { exec sh post_cmd; } catch e {
                 print("[plan_reviewer] Failed to post draft note:", e);
                 "";
@@ -209,49 +258,112 @@ fn tick(reason: string) -> void {
             // the GitLab call actually succeeded.
             if len(draft_result) > 0 {
                 memo_write(posted_key, "1");
-                learn(
-                    "review_plan",
-                    "issue " + to_string(draft.issue_id),
-                    "drafted: score=" + to_string(draft.review_score),
-                    "partial",
-                    ["planning", "review-gated"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "review_plan",
+                        "issue " + to_string(draft.issue_id),
+                        "drafted: score=" + to_string(draft.review_score),
+                        "partial",
+                        ["planning", "review-gated", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "review_plan",
+                        "issue " + to_string(draft.issue_id),
+                        "drafted: score=" + to_string(draft.review_score),
+                        "partial",
+                        ["planning", "review-gated"]
+                    );
+                };
                 print("[plan_reviewer] Drafted plan for issue", draft.issue_id);
             } else {
-                learn(
-                    "review_plan",
-                    "issue " + to_string(draft.issue_id),
-                    "draft-post-failed: score=" + to_string(draft.review_score),
-                    "fail",
-                    ["planning", "review-gated"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "review_plan",
+                        "issue " + to_string(draft.issue_id),
+                        "draft-post-failed: score=" + to_string(draft.review_score),
+                        "fail",
+                        ["planning", "review-gated", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "review_plan",
+                        "issue " + to_string(draft.issue_id),
+                        "draft-post-failed: score=" + to_string(draft.review_score),
+                        "fail",
+                        ["planning", "review-gated"]
+                    );
+                };
             };
         } else {
             if my_tier == "propose" {
                 emit("planning:draft_plan", draft);
-                learn(
-                    "review_plan",
-                    "issue " + to_string(draft.issue_id),
-                    "emitted: score=" + to_string(draft.review_score),
-                    "partial",
-                    ["emitted", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "review_plan",
+                        "issue " + to_string(draft.issue_id),
+                        "emitted: score=" + to_string(draft.review_score),
+                        "partial",
+                        ["emitted", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "review_plan",
+                        "issue " + to_string(draft.issue_id),
+                        "emitted: score=" + to_string(draft.review_score),
+                        "partial",
+                        ["emitted", "planning"]
+                    );
+                };
                 print("[plan_reviewer] Emitted draft plan for issue", draft.issue_id);
             } else {
                 print("[plan_reviewer] Observing (tier:", my_tier, ")");
-                learn(
-                    "review_plan",
-                    "issue " + to_string(draft.issue_id),
-                    "observed: score=" + to_string(draft.review_score),
-                    "partial",
-                    ["observed", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "review_plan",
+                        "issue " + to_string(draft.issue_id),
+                        "observed: score=" + to_string(draft.review_score),
+                        "partial",
+                        ["observed", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "review_plan",
+                        "issue " + to_string(draft.issue_id),
+                        "observed: score=" + to_string(draft.review_score),
+                        "partial",
+                        ["observed", "planning"]
+                    );
+                };
             };
         };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("plan_reviewer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "plan_reviewer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -22,19 +22,47 @@ type IncidentPatterns {
     recurring_themes: string
 }
 
-fn unplanned_cmd() -> string {
-    let ts = recall_latest("risk_assessor:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn unplanned_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "risk_assessor:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
         // #235: events-aware query closes the short-lived-label gap.
         // issues-by-label-events unions currently-labeled + issues where
         // the trigger label was added at any point in [ts, now] per
         // resource_label_events. Catches transitions we'd miss between
         // 60 s polls with a pure current-state snapshot.
-        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
+        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning" + repo_arg(owner, repo);
     };
     // First-tick fallback: no prior window to diff against; the snapshot
     // preserves pre-#235 boot behavior byte-identically.
-    return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning" + repo_arg(owner, repo);
 }
 
 fn get_confidence() -> float {
@@ -45,7 +73,7 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // Staleness gate for the observe step (#187): the pattern library
     // only feeds `recommend()` inside the act branch below, which rarely
     // fires on low-activity projects. Re-running the observe prompt on
@@ -54,7 +82,7 @@ fn tick(reason: string) -> void {
     // observe was >= OBSERVE_MIN_INTERVAL_SEC ago. 1 800 s (30 min) keeps
     // the library fresh without the heartbeat-LLM pathology.
     let now_epoch = try { exec sh "date -u +%s"; } catch e { ""; };
-    let last_obs = recall_latest("risk_assessor:observe_last_ts");
+    let last_obs = recall_latest(scoped_memo(owner, repo, "risk_assessor:observe_last_ts"));
     let observe_stale = if len(last_obs) > 0 {
         if len(now_epoch) > 0 {
             // Negative delta (operator ran `date -s <past>` or similar
@@ -70,8 +98,10 @@ fn tick(reason: string) -> void {
 
     // 1. Observe: pull recent opened issues and skim for incident-style patterns
     if observe_stale == 1 {
+        // colony-lint: safe-exec-concat
+        let recent_cmd = "$COLONY_DIR/scripts/forge-api.sh issues --view planning" + repo_arg(owner, repo);
         let recent_raw = try {
-            exec sh "$COLONY_DIR/scripts/forge-api.sh issues --view planning";
+            exec sh recent_cmd;
         } catch e {
             print("[risk_assessor] GitLab issues poll failed:", e);
             "";
@@ -97,15 +127,25 @@ fn tick(reason: string) -> void {
             ) -> IncidentPatterns;
 
             if patterns.observed_count > 0 {
-                learn(
-                    "risk_assessment",
-                    "batch of " + to_string(patterns.observed_count) + " incident-style issues",
-                    patterns.recurring_themes,
-                    "success",
-                    ["observed", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "risk_assessment",
+                        "batch of " + to_string(patterns.observed_count) + " incident-style issues",
+                        patterns.recurring_themes,
+                        "success",
+                        ["observed", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "risk_assessment",
+                        "batch of " + to_string(patterns.observed_count) + " incident-style issues",
+                        patterns.recurring_themes,
+                        "success",
+                        ["observed", "planning"]
+                    );
+                };
                 if len(now_epoch) > 0 {
-                    memo_write("risk_assessor:observe_last_ts", now_epoch);
+                    memo_write(scoped_memo(owner, repo, "risk_assessor:observe_last_ts"), now_epoch);
                 };
                 print("[risk_assessor] Observed", patterns.observed_count, "incident-style issues");
             };
@@ -113,7 +153,7 @@ fn tick(reason: string) -> void {
     };
 
     // 2. Act: assess risk for the next unplanned issue
-    let cmd = unplanned_cmd();
+    let cmd = unplanned_cmd(owner, repo);
     let issues_raw = try {
         exec sh cmd;
     } catch e {
@@ -135,7 +175,7 @@ fn tick(reason: string) -> void {
     if target_iid <= 0 {
         return;
     };
-    let posted_key = "risk_assessor:" + to_string(target_iid) + ":posted";
+    let posted_key = scoped_memo(owner, repo, "risk_assessor:" + to_string(target_iid) + ":posted");
     if len(recall_latest(posted_key)) > 0 {
         return;
     };
@@ -156,7 +196,8 @@ fn tick(reason: string) -> void {
         // Direct external write: post the risk assessment as an issue note.
         emit("planning:risks", assessment);
         let note = "**Risk Assessment** (automated): " + assessment.severity + "\n\n" + assessment.risks;
-        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(assessment.issue_id) + " --body " + shell_escape(note);
+        // colony-lint: safe-exec-concat
+        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(assessment.issue_id) + " --body " + shell_escape(note) + repo_arg(owner, repo);
         let post_result = try { exec sh post_cmd; } catch e {
             print("[risk_assessor] Failed to post note:", e);
             "";
@@ -167,60 +208,133 @@ fn tick(reason: string) -> void {
         // instead of silently consuming the issue.
         if len(post_result) > 0 {
             memo_write(posted_key, "1");
-            learn(
-                "risk_assessment",
-                "issue " + to_string(assessment.issue_id),
-                assessment.severity + ": " + assessment.risks,
-                "success",
-                ["acted", "planning"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "risk_assessment",
+                    "issue " + to_string(assessment.issue_id),
+                    assessment.severity + ": " + assessment.risks,
+                    "success",
+                    ["acted", "planning", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "risk_assessment",
+                    "issue " + to_string(assessment.issue_id),
+                    assessment.severity + ": " + assessment.risks,
+                    "success",
+                    ["acted", "planning"]
+                );
+            };
         } else {
-            learn(
-                "risk_assessment",
-                "issue " + to_string(assessment.issue_id),
-                "post-failed: " + assessment.severity,
-                "fail",
-                ["acted", "planning"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "risk_assessment",
+                    "issue " + to_string(assessment.issue_id),
+                    "post-failed: " + assessment.severity,
+                    "fail",
+                    ["acted", "planning", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "risk_assessment",
+                    "issue " + to_string(assessment.issue_id),
+                    "post-failed: " + assessment.severity,
+                    "fail",
+                    ["acted", "planning"]
+                );
+            };
         };
     } else {
         if my_tier == "review-gated" {
             // Draft external write: stash in plan_reviewer's memo slot so
             // plan_reviewer can pick it up and optionally promote to a real post.
             emit("planning:risks", assessment);
-            memo_write("plan_reviewer:" + to_string(assessment.issue_id) + ":risks_drafted", "true");
-            learn(
-                "risk_assessment",
-                "issue " + to_string(assessment.issue_id),
-                assessment.severity + ": " + assessment.risks,
-                "partial",
-                ["planning", "review-gated"]
-            );
+            memo_write(scoped_memo(owner, repo, "plan_reviewer:" + to_string(assessment.issue_id) + ":risks_drafted"), "true");
+            if len(owner) > 0 {
+                learn(
+                    "risk_assessment",
+                    "issue " + to_string(assessment.issue_id),
+                    assessment.severity + ": " + assessment.risks,
+                    "partial",
+                    ["planning", "review-gated", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "risk_assessment",
+                    "issue " + to_string(assessment.issue_id),
+                    assessment.severity + ": " + assessment.risks,
+                    "partial",
+                    ["planning", "review-gated"]
+                );
+            };
         } else {
             if my_tier == "propose" {
                 emit("planning:risks", assessment);
-                learn(
-                    "risk_assessment",
-                    "issue " + to_string(assessment.issue_id),
-                    assessment.severity + ": " + assessment.risks,
-                    "partial",
-                    ["emitted", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "risk_assessment",
+                        "issue " + to_string(assessment.issue_id),
+                        assessment.severity + ": " + assessment.risks,
+                        "partial",
+                        ["emitted", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "risk_assessment",
+                        "issue " + to_string(assessment.issue_id),
+                        assessment.severity + ": " + assessment.risks,
+                        "partial",
+                        ["emitted", "planning"]
+                    );
+                };
             } else {
                 print("[risk_assessor] Observing (tier:", my_tier, ")");
-                learn(
-                    "risk_assessment",
-                    "issue " + to_string(assessment.issue_id),
-                    assessment.severity + ": " + assessment.risks,
-                    "partial",
-                    ["observed", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "risk_assessment",
+                        "issue " + to_string(assessment.issue_id),
+                        assessment.severity + ": " + assessment.risks,
+                        "partial",
+                        ["observed", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "risk_assessment",
+                        "issue " + to_string(assessment.issue_id),
+                        assessment.severity + ": " + assessment.risks,
+                        "partial",
+                        ["observed", "planning"]
+                    );
+                };
             };
         };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("risk_assessor:last_check", now);
+        memo_write(scoped_memo(owner, repo, "risk_assessor:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -23,14 +23,42 @@ type CalibrationSummary {
     tendencies: string
 }
 
-fn unplanned_cmd() -> string {
-    let ts = recall_latest("scope_estimator:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn unplanned_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "scope_estimator:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
         // #235: events-aware query — see risk_assessor.ag for rationale.
-        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
+        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning" + repo_arg(owner, repo);
     };
     // First-tick fallback: no prior window; snapshot preserves pre-#235 boot behavior.
-    return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning" + repo_arg(owner, repo);
 }
 
 fn get_confidence() -> float {
@@ -41,13 +69,13 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // Staleness gate for the observe step (#187). See risk_assessor.ag
     // for rationale. 1 800 s = 30 min between observe prompts keeps
     // calibration fresh without a heartbeat-LLM pathology on idle
     // projects where the act branch rarely fires.
     let now_epoch = try { exec sh "date -u +%s"; } catch e { ""; };
-    let last_obs = recall_latest("scope_estimator:observe_last_ts");
+    let last_obs = recall_latest(scoped_memo(owner, repo, "scope_estimator:observe_last_ts"));
     let observe_stale = if len(last_obs) > 0 {
         if len(now_epoch) > 0 {
             // Negative delta (operator ran `date -s <past>` or similar
@@ -63,8 +91,10 @@ fn tick(reason: string) -> void {
 
     // 1. Observe: pull recent merged MRs and learn calibration
     if observe_stale == 1 {
+        // colony-lint: safe-exec-concat
+        let merged_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view planning-mr" + repo_arg(owner, repo);
         let merged_raw = try {
-            exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view planning-mr";
+            exec sh merged_cmd;
         } catch e {
             print("[scope_estimator] GitLab merged-MR poll failed:", e);
             "";
@@ -77,15 +107,25 @@ fn tick(reason: string) -> void {
             ) -> CalibrationSummary;
 
             if summary.observed_pairs > 0 {
-                learn(
-                    "scope_estimate",
-                    "batch of " + to_string(summary.observed_pairs) + " shipped MRs",
-                    "ratio: " + summary.ratio_hint + " | " + summary.tendencies,
-                    "success",
-                    ["observed", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "scope_estimate",
+                        "batch of " + to_string(summary.observed_pairs) + " shipped MRs",
+                        "ratio: " + summary.ratio_hint + " | " + summary.tendencies,
+                        "success",
+                        ["observed", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "scope_estimate",
+                        "batch of " + to_string(summary.observed_pairs) + " shipped MRs",
+                        "ratio: " + summary.ratio_hint + " | " + summary.tendencies,
+                        "success",
+                        ["observed", "planning"]
+                    );
+                };
                 if len(now_epoch) > 0 {
-                    memo_write("scope_estimator:observe_last_ts", now_epoch);
+                    memo_write(scoped_memo(owner, repo, "scope_estimator:observe_last_ts"), now_epoch);
                 };
                 print("[scope_estimator] Observed", summary.observed_pairs, "shipped pairs");
             };
@@ -93,7 +133,7 @@ fn tick(reason: string) -> void {
     };
 
     // 2. Act: estimate scope for the next unplanned issue
-    let cmd = unplanned_cmd();
+    let cmd = unplanned_cmd(owner, repo);
     let issues_raw = try {
         exec sh cmd;
     } catch e {
@@ -110,7 +150,7 @@ fn tick(reason: string) -> void {
     if target_iid <= 0 {
         return;
     };
-    let posted_key = "scope_estimator:" + to_string(target_iid) + ":posted";
+    let posted_key = scoped_memo(owner, repo, "scope_estimator:" + to_string(target_iid) + ":posted");
     if len(recall_latest(posted_key)) > 0 {
         return;
     };
@@ -130,7 +170,8 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         emit("planning:scope_estimate", estimate);
         let note = "**Scope Estimate** (automated): " + to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points\n\n" + estimate.reasoning;
-        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(estimate.issue_id) + " --body " + shell_escape(note);
+        // colony-lint: safe-exec-concat
+        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(estimate.issue_id) + " --body " + shell_escape(note) + repo_arg(owner, repo);
         let post_result = try { exec sh post_cmd; } catch e {
             print("[scope_estimator] Failed to post note:", e);
             "";
@@ -138,58 +179,131 @@ fn tick(reason: string) -> void {
         // #227: gate marker + success learn on non-empty post result.
         if len(post_result) > 0 {
             memo_write(posted_key, "1");
-            learn(
-                "scope_estimate",
-                "issue " + to_string(estimate.issue_id),
-                to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
-                "success",
-                ["acted", "planning"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "scope_estimate",
+                    "issue " + to_string(estimate.issue_id),
+                    to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                    "success",
+                    ["acted", "planning", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "scope_estimate",
+                    "issue " + to_string(estimate.issue_id),
+                    to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                    "success",
+                    ["acted", "planning"]
+                );
+            };
         } else {
-            learn(
-                "scope_estimate",
-                "issue " + to_string(estimate.issue_id),
-                "post-failed: " + to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points",
-                "fail",
-                ["acted", "planning"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "scope_estimate",
+                    "issue " + to_string(estimate.issue_id),
+                    "post-failed: " + to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points",
+                    "fail",
+                    ["acted", "planning", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "scope_estimate",
+                    "issue " + to_string(estimate.issue_id),
+                    "post-failed: " + to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points",
+                    "fail",
+                    ["acted", "planning"]
+                );
+            };
         };
     } else {
         if my_tier == "review-gated" {
             emit("planning:scope_estimate", estimate);
-            memo_write("plan_reviewer:" + to_string(estimate.issue_id) + ":scope_drafted", "true");
-            learn(
-                "scope_estimate",
-                "issue " + to_string(estimate.issue_id),
-                to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
-                "partial",
-                ["planning", "review-gated"]
-            );
+            memo_write(scoped_memo(owner, repo, "plan_reviewer:" + to_string(estimate.issue_id) + ":scope_drafted"), "true");
+            if len(owner) > 0 {
+                learn(
+                    "scope_estimate",
+                    "issue " + to_string(estimate.issue_id),
+                    to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                    "partial",
+                    ["planning", "review-gated", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "scope_estimate",
+                    "issue " + to_string(estimate.issue_id),
+                    to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                    "partial",
+                    ["planning", "review-gated"]
+                );
+            };
         } else {
             if my_tier == "propose" {
                 emit("planning:scope_estimate", estimate);
-                learn(
-                    "scope_estimate",
-                    "issue " + to_string(estimate.issue_id),
-                    to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
-                    "partial",
-                    ["emitted", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "scope_estimate",
+                        "issue " + to_string(estimate.issue_id),
+                        to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                        "partial",
+                        ["emitted", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "scope_estimate",
+                        "issue " + to_string(estimate.issue_id),
+                        to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                        "partial",
+                        ["emitted", "planning"]
+                    );
+                };
             } else {
                 print("[scope_estimator] Observing (tier:", my_tier, ")");
-                learn(
-                    "scope_estimate",
-                    "issue " + to_string(estimate.issue_id),
-                    to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
-                    "partial",
-                    ["observed", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "scope_estimate",
+                        "issue " + to_string(estimate.issue_id),
+                        to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                        "partial",
+                        ["observed", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "scope_estimate",
+                        "issue " + to_string(estimate.issue_id),
+                        to_string(estimate.phases) + " phases, " + to_string(estimate.points) + " points: " + estimate.reasoning,
+                        "partial",
+                        ["observed", "planning"]
+                    );
+                };
             };
         };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("scope_estimator:last_check", now);
+        memo_write(scoped_memo(owner, repo, "scope_estimator:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -23,14 +23,42 @@ type DecompositionPatterns {
     style: string
 }
 
-fn unplanned_cmd() -> string {
-    let ts = recall_latest("task_decomposer:last_check");
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn unplanned_cmd(owner: string, repo: string) -> string {
+    let ts = recall_latest(scoped_memo(owner, repo, "task_decomposer:last_check"));
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
         // #235: events-aware query — see risk_assessor.ag for rationale.
-        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning";
+        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning" + repo_arg(owner, repo);
     };
     // First-tick fallback: no prior window; snapshot preserves pre-#235 boot behavior.
-    return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning" + repo_arg(owner, repo);
 }
 
 fn get_confidence() -> float {
@@ -41,13 +69,13 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // Staleness gate for the observe step (#187). See risk_assessor.ag
     // for rationale. 1 800 s = 30 min between observe prompts keeps
     // the decomposition-pattern library fresh without a heartbeat-LLM
     // pathology on idle projects where the act branch rarely fires.
     let now_epoch = try { exec sh "date -u +%s"; } catch e { ""; };
-    let last_obs = recall_latest("task_decomposer:observe_last_ts");
+    let last_obs = recall_latest(scoped_memo(owner, repo, "task_decomposer:observe_last_ts"));
     let observe_stale = if len(last_obs) > 0 {
         if len(now_epoch) > 0 {
             // Negative delta (operator ran `date -s <past>` or similar
@@ -63,8 +91,10 @@ fn tick(reason: string) -> void {
 
     // 1. Observe: analyze recent issues to infer decomposition style
     if observe_stale == 1 {
+        // colony-lint: safe-exec-concat
+        let recent_cmd = "$COLONY_DIR/scripts/forge-api.sh issues --view planning" + repo_arg(owner, repo);
         let recent_raw = try {
-            exec sh "$COLONY_DIR/scripts/forge-api.sh issues --view planning";
+            exec sh recent_cmd;
         } catch e {
             print("[task_decomposer] GitLab issues poll failed:", e);
             "";
@@ -90,15 +120,25 @@ fn tick(reason: string) -> void {
             ) -> DecompositionPatterns;
 
             if patterns.epics_seen > 0 {
-                learn(
-                    "task_decomposition",
-                    "batch of " + to_string(patterns.epics_seen) + " epics",
-                    "avg " + to_string(patterns.avg_subtasks) + " subtasks | " + patterns.style,
-                    "success",
-                    ["observed", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "task_decomposition",
+                        "batch of " + to_string(patterns.epics_seen) + " epics",
+                        "avg " + to_string(patterns.avg_subtasks) + " subtasks | " + patterns.style,
+                        "success",
+                        ["observed", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "task_decomposition",
+                        "batch of " + to_string(patterns.epics_seen) + " epics",
+                        "avg " + to_string(patterns.avg_subtasks) + " subtasks | " + patterns.style,
+                        "success",
+                        ["observed", "planning"]
+                    );
+                };
                 if len(now_epoch) > 0 {
-                    memo_write("task_decomposer:observe_last_ts", now_epoch);
+                    memo_write(scoped_memo(owner, repo, "task_decomposer:observe_last_ts"), now_epoch);
                 };
                 print("[task_decomposer] Observed", patterns.epics_seen, "epics, avg", patterns.avg_subtasks, "subtasks");
             };
@@ -106,7 +146,7 @@ fn tick(reason: string) -> void {
     };
 
     // 2. Act: propose a subtask breakdown for the next unplanned issue
-    let cmd = unplanned_cmd();
+    let cmd = unplanned_cmd(owner, repo);
     let issues_raw = try {
         exec sh cmd;
     } catch e {
@@ -123,7 +163,7 @@ fn tick(reason: string) -> void {
     if target_iid <= 0 {
         return;
     };
-    let posted_key = "task_decomposer:" + to_string(target_iid) + ":posted";
+    let posted_key = scoped_memo(owner, repo, "task_decomposer:" + to_string(target_iid) + ":posted");
     if len(recall_latest(posted_key)) > 0 {
         return;
     };
@@ -143,7 +183,8 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         emit("planning:breakdown", breakdown);
         let note = "**Task Breakdown** (automated): " + to_string(breakdown.count) + " subtasks\n\n" + breakdown.subtasks;
-        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(breakdown.issue_id) + " --body " + shell_escape(note);
+        // colony-lint: safe-exec-concat
+        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(breakdown.issue_id) + " --body " + shell_escape(note) + repo_arg(owner, repo);
         let post_result = try { exec sh post_cmd; } catch e {
             print("[task_decomposer] Failed to post note:", e);
             "";
@@ -151,58 +192,131 @@ fn tick(reason: string) -> void {
         // #227: gate marker + success learn on non-empty post result.
         if len(post_result) > 0 {
             memo_write(posted_key, "1");
-            learn(
-                "task_decomposition",
-                "issue " + to_string(breakdown.issue_id),
-                to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
-                "success",
-                ["acted", "planning"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "task_decomposition",
+                    "issue " + to_string(breakdown.issue_id),
+                    to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                    "success",
+                    ["acted", "planning", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "task_decomposition",
+                    "issue " + to_string(breakdown.issue_id),
+                    to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                    "success",
+                    ["acted", "planning"]
+                );
+            };
         } else {
-            learn(
-                "task_decomposition",
-                "issue " + to_string(breakdown.issue_id),
-                "post-failed: " + to_string(breakdown.count) + " subtasks",
-                "fail",
-                ["acted", "planning"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "task_decomposition",
+                    "issue " + to_string(breakdown.issue_id),
+                    "post-failed: " + to_string(breakdown.count) + " subtasks",
+                    "fail",
+                    ["acted", "planning", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "task_decomposition",
+                    "issue " + to_string(breakdown.issue_id),
+                    "post-failed: " + to_string(breakdown.count) + " subtasks",
+                    "fail",
+                    ["acted", "planning"]
+                );
+            };
         };
     } else {
         if my_tier == "review-gated" {
             emit("planning:breakdown", breakdown);
-            memo_write("plan_reviewer:" + to_string(breakdown.issue_id) + ":breakdown_drafted", "true");
-            learn(
-                "task_decomposition",
-                "issue " + to_string(breakdown.issue_id),
-                to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
-                "partial",
-                ["planning", "review-gated"]
-            );
+            memo_write(scoped_memo(owner, repo, "plan_reviewer:" + to_string(breakdown.issue_id) + ":breakdown_drafted"), "true");
+            if len(owner) > 0 {
+                learn(
+                    "task_decomposition",
+                    "issue " + to_string(breakdown.issue_id),
+                    to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                    "partial",
+                    ["planning", "review-gated", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "task_decomposition",
+                    "issue " + to_string(breakdown.issue_id),
+                    to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                    "partial",
+                    ["planning", "review-gated"]
+                );
+            };
         } else {
             if my_tier == "propose" {
                 emit("planning:breakdown", breakdown);
-                learn(
-                    "task_decomposition",
-                    "issue " + to_string(breakdown.issue_id),
-                    to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
-                    "partial",
-                    ["emitted", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "task_decomposition",
+                        "issue " + to_string(breakdown.issue_id),
+                        to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                        "partial",
+                        ["emitted", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "task_decomposition",
+                        "issue " + to_string(breakdown.issue_id),
+                        to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                        "partial",
+                        ["emitted", "planning"]
+                    );
+                };
             } else {
                 print("[task_decomposer] Observing (tier:", my_tier, ")");
-                learn(
-                    "task_decomposition",
-                    "issue " + to_string(breakdown.issue_id),
-                    to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
-                    "partial",
-                    ["observed", "planning"]
-                );
+                if len(owner) > 0 {
+                    learn(
+                        "task_decomposition",
+                        "issue " + to_string(breakdown.issue_id),
+                        to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                        "partial",
+                        ["observed", "planning", repo_tag(owner, repo)]
+                    );
+                } else {
+                    learn(
+                        "task_decomposition",
+                        "issue " + to_string(breakdown.issue_id),
+                        to_string(breakdown.count) + " subtasks: " + breakdown.subtasks,
+                        "partial",
+                        ["observed", "planning"]
+                    );
+                };
             };
         };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("task_decomposer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "task_decomposer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -33,7 +33,33 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-fn tick(reason: string) -> void {
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn tick_for_repo(owner: string, repo: string) -> void {
     // #147: changelog_writer is pure event-driven. It reacts to a
     // `release:ship_decision` emit from ship_decider. If the inbox is
     // empty, early-exit before any prompt() (including the release-
@@ -44,15 +70,17 @@ fn tick(reason: string) -> void {
     if len(decision_str) < 5 {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
-            memo_write("changelog_writer:last_check", now_e);
+            memo_write(scoped_memo(owner, repo, "changelog_writer:last_check"), now_e);
         };
         return;
     };
 
     // 1. Learn changelog style from past releases (only when we're
     //    actually about to write one — gated by the delta-check above).
+    // colony-lint: safe-exec-concat
+    let releases_cmd = "$COLONY_DIR/scripts/forge-api.sh releases --per-page 10 --view release-summary" + repo_arg(owner, repo);
     let releases_raw = try {
-        exec sh "$COLONY_DIR/scripts/forge-api.sh releases --per-page 10 --view release-summary";
+        exec sh releases_cmd;
     } catch e {
         print("[changelog_writer] GitLab releases poll failed:", e);
         "";
@@ -65,13 +93,23 @@ fn tick(reason: string) -> void {
         ) -> ChangelogStyle;
 
         if style.releases_seen > 0 {
-            learn(
-                "changelog_write",
-                "batch of " + to_string(style.releases_seen) + " releases",
-                "grouping: " + style.grouping + " | tone: " + style.tone + " | include: " + style.inclusions + " | exclude: " + style.exclusions,
-                "success",
-                ["observed", "release"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "changelog_write",
+                    "batch of " + to_string(style.releases_seen) + " releases",
+                    "grouping: " + style.grouping + " | tone: " + style.tone + " | include: " + style.inclusions + " | exclude: " + style.exclusions,
+                    "success",
+                    ["observed", "release", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "changelog_write",
+                    "batch of " + to_string(style.releases_seen) + " releases",
+                    "grouping: " + style.grouping + " | tone: " + style.tone + " | include: " + style.inclusions + " | exclude: " + style.exclusions,
+                    "success",
+                    ["observed", "release"]
+                );
+            };
             print("[changelog_writer] Learned from", style.releases_seen, "past release notes");
         };
     };
@@ -86,14 +124,16 @@ fn tick(reason: string) -> void {
         print("[changelog_writer] Ship decision is no-ship, skipping changelog");
         let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now) > 0 {
-            memo_write("changelog_writer:last_check", now);
+            memo_write(scoped_memo(owner, repo, "changelog_writer:last_check"), now);
         };
         return;
     };
 
     // Get the latest release tag to find MRs merged since then
+    // colony-lint: safe-exec-concat
+    let latest_release_cmd = "$COLONY_DIR/scripts/forge-api.sh releases --per-page 1 --view release-summary" + repo_arg(owner, repo);
     let latest_release = try {
-        exec sh "$COLONY_DIR/scripts/forge-api.sh releases --per-page 1 --view release-summary";
+        exec sh latest_release_cmd;
     } catch e { "[]"; };
 
     let since_date = prompt(
@@ -102,7 +142,8 @@ fn tick(reason: string) -> void {
     ) -> string;
 
     // Fetch MRs merged since last release
-    let mrs_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(since_date) + " --view release-mr";
+    // colony-lint: safe-exec-concat
+    let mrs_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(since_date) + " --view release-mr" + repo_arg(owner, repo);
     let mrs_raw = try { exec sh mrs_cmd; } catch e {
         print("[changelog_writer] MR fetch failed:", e);
         "";
@@ -124,37 +165,59 @@ fn tick(reason: string) -> void {
         // external write. The terminal action (create-release / create-tag)
         // belongs to version_bumper and is gated on autonomous there.
         if my_tier == "autonomous" {
-            let mr_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+            // colony-lint: safe-exec-concat
+            let mr_listing_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1" + repo_arg(owner, repo);
+            let mr_raw = try { exec sh mr_listing_cmd; } catch e { "[]"; };
             let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
             if mr_iid > 0 {
                 let note = "**Release Notes Draft** (automated)\n\n" + draft.changelog;
-                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                // colony-lint: safe-exec-concat
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note) + repo_arg(owner, repo);
                 try { exec sh post_cmd; } catch e {
                     print("[changelog_writer] Failed to post note:", e);
                 };
             };
             emit("release:changelog_draft", draft);
-            learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "success", ["acted", "release"]);
+            if len(owner) > 0 {
+                learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "success", ["acted", "release", repo_tag(owner, repo)]);
+            } else {
+                learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "success", ["acted", "release"]);
+            };
         } else {
             if my_tier == "review-gated" {
-                let mr_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+                // colony-lint: safe-exec-concat
+                let mr_listing_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1" + repo_arg(owner, repo);
+                let mr_raw = try { exec sh mr_listing_cmd; } catch e { "[]"; };
                 let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
                 if mr_iid > 0 {
                     let note = "[draft-changelog] **Release Notes Draft** (automated, pending approval)\n\n" + draft.changelog;
-                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                    // colony-lint: safe-exec-concat
+                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note) + repo_arg(owner, repo);
                     try { exec sh post_cmd; } catch e {
                         print("[changelog_writer] Failed to post draft note:", e);
                     };
                 };
                 emit("release:changelog_draft", draft);
-                learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["release", "review-gated"]);
+                if len(owner) > 0 {
+                    learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["release", "review-gated", repo_tag(owner, repo)]);
+                } else {
+                    learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["release", "review-gated"]);
+                };
             } else {
                 if my_tier == "propose" {
                     emit("release:changelog_draft", draft);
-                    learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["emitted", "release"]);
+                    if len(owner) > 0 {
+                        learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["emitted", "release", repo_tag(owner, repo)]);
+                    } else {
+                        learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["emitted", "release"]);
+                    };
                 } else {
                     print("[changelog_writer] Observing (tier:", my_tier, ")");
-                    learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["observed", "release"]);
+                    if len(owner) > 0 {
+                        learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["observed", "release", repo_tag(owner, repo)]);
+                    } else {
+                        learn("changelog_write", "release " + draft.version, to_string(draft.mr_count) + " MRs", "partial", ["observed", "release"]);
+                    };
                 };
             };
         };
@@ -162,6 +225,29 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("changelog_writer:last_check", now);
+        memo_write(scoped_memo(owner, repo, "changelog_writer:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -34,16 +34,44 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-// #147: build the merged-MR delta query with optional --since. Used by
-// the tick's pre-prompt delta-check.
-fn mr_delta_cmd_for(ts: string) -> string {
-    if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --per-page 1";
-    };
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --per-page 1";
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
 }
 
-fn tick(reason: string) -> void {
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+// #147: build the merged-MR delta query with optional --since. Used by
+// the tick's pre-prompt delta-check.
+fn mr_delta_cmd_for(owner: string, repo: string, ts: string) -> string {
+    // colony-lint: safe-exec-concat
+    if len(ts) > 0 {
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --per-page 1" + repo_arg(owner, repo);
+    };
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --per-page 1" + repo_arg(owner, repo);
+}
+
+fn tick_for_repo(owner: string, repo: string) -> void {
     // #147: cheap delta-check BEFORE any prompt(). release_checker's
     // real work is driven by two signals: `implementation:mr_ready`
     // (a new MR needs a pre-release check) and newly-merged MRs (re-
@@ -53,7 +81,7 @@ fn tick(reason: string) -> void {
     let mr_str = to_string(mr_ready);
     let has_event = len(mr_str) >= 5;
 
-    let mr_delta_cmd = mr_delta_cmd_for(recall_latest("release_checker:last_check"));
+    let mr_delta_cmd = mr_delta_cmd_for(owner, repo, recall_latest(scoped_memo(owner, repo, "release_checker:last_check")));
     let mr_delta = try { exec sh mr_delta_cmd; } catch e { "[]"; };
     let has_new_mr = len(mr_delta) >= 3;
 
@@ -61,7 +89,7 @@ fn tick(reason: string) -> void {
         if !has_new_mr {
             let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
             if len(now_e) > 0 {
-                memo_write("release_checker:last_check", now_e);
+                memo_write(scoped_memo(owner, repo, "release_checker:last_check"), now_e);
             };
             return;
         };
@@ -69,8 +97,10 @@ fn tick(reason: string) -> void {
 
     // 1. Learn from past releases and their pipeline outcomes (only when
     //    there IS new work — gated by the delta-check above).
+    // colony-lint: safe-exec-concat
+    let releases_cmd = "$COLONY_DIR/scripts/forge-api.sh releases --per-page 10 --view release-summary" + repo_arg(owner, repo);
     let releases_raw = try {
-        exec sh "$COLONY_DIR/scripts/forge-api.sh releases --per-page 10 --view release-summary";
+        exec sh releases_cmd;
     } catch e {
         print("[release_checker] GitLab releases poll failed:", e);
         "";
@@ -83,13 +113,23 @@ fn tick(reason: string) -> void {
         ) -> CheckPatterns;
 
         if patterns.releases_seen > 0 {
-            learn(
-                "release_check",
-                "batch of " + to_string(patterns.releases_seen) + " releases",
-                "ci_gates: " + patterns.ci_gates + " | validation: " + patterns.validation_steps + " | failures: " + patterns.failure_patterns,
-                "success",
-                ["observed", "release"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "release_check",
+                    "batch of " + to_string(patterns.releases_seen) + " releases",
+                    "ci_gates: " + patterns.ci_gates + " | validation: " + patterns.validation_steps + " | failures: " + patterns.failure_patterns,
+                    "success",
+                    ["observed", "release", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "release_check",
+                    "batch of " + to_string(patterns.releases_seen) + " releases",
+                    "ci_gates: " + patterns.ci_gates + " | validation: " + patterns.validation_steps + " | failures: " + patterns.failure_patterns,
+                    "success",
+                    ["observed", "release"]
+                );
+            };
             print("[release_checker] Learned from", patterns.releases_seen, "past releases");
         };
     };
@@ -97,8 +137,10 @@ fn tick(reason: string) -> void {
     // 2. Check pipeline state for the pending MR (or periodic check).
 
     // Also check the default branch pipeline status
+    // colony-lint: safe-exec-concat
+    let pipeline_cmd = "$COLONY_DIR/scripts/forge-api.sh pipelines --ref main --view pipeline-summary" + repo_arg(owner, repo);
     let pipeline_raw = try {
-        exec sh "$COLONY_DIR/scripts/forge-api.sh pipelines --ref main --view pipeline-summary";
+        exec sh pipeline_cmd;
     } catch e {
         print("[release_checker] Pipeline poll failed:", e);
         "";
@@ -127,32 +169,50 @@ fn tick(reason: string) -> void {
                 let mr_iid = mr_ready.issue_id;
                 if mr_iid > 0 {
                     let note = "**Pre-release Check** (automated): " + result.ci_status + "\n\nIssues: " + result.issues_found;
-                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                    // colony-lint: safe-exec-concat
+                    let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note) + repo_arg(owner, repo);
                     try { exec sh post_cmd; } catch e {
                         print("[release_checker] Failed to post note:", e);
                     };
                 };
                 emit("release:check_result", result);
-                learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "success", ["acted", "release"]);
+                if len(owner) > 0 {
+                    learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "success", ["acted", "release", repo_tag(owner, repo)]);
+                } else {
+                    learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "success", ["acted", "release"]);
+                };
             } else {
                 if my_tier == "review-gated" {
                     let mr_iid = mr_ready.issue_id;
                     if mr_iid > 0 {
                         let note = "[draft-check] **Pre-release Check** (automated, pending approval): " + result.ci_status + "\n\nIssues: " + result.issues_found;
-                        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                        // colony-lint: safe-exec-concat
+                        let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note) + repo_arg(owner, repo);
                         try { exec sh post_cmd; } catch e {
                             print("[release_checker] Failed to post draft note:", e);
                         };
                     };
                     emit("release:check_result", result);
-                    learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["release", "review-gated"]);
+                    if len(owner) > 0 {
+                        learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["release", "review-gated", repo_tag(owner, repo)]);
+                    } else {
+                        learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["release", "review-gated"]);
+                    };
                 } else {
                     if my_tier == "propose" {
                         emit("release:check_result", result);
-                        learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["emitted", "release"]);
+                        if len(owner) > 0 {
+                            learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["emitted", "release", repo_tag(owner, repo)]);
+                        } else {
+                            learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["emitted", "release"]);
+                        };
                     } else {
                         print("[release_checker] Observing (tier:", my_tier, ")");
-                        learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["observed", "release"]);
+                        if len(owner) > 0 {
+                            learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["observed", "release", repo_tag(owner, repo)]);
+                        } else {
+                            learn("release_check", "pipeline check", result.ci_status + " | " + result.issues_found, "partial", ["observed", "release"]);
+                        };
                     };
                 };
             };
@@ -166,17 +226,33 @@ fn tick(reason: string) -> void {
             let my_tier = tier("release_checker");
             if my_tier == "autonomous" {
                 emit("release:check_result", result);
-                learn("release_check", "periodic check", result.ci_status, "success", ["acted", "release"]);
+                if len(owner) > 0 {
+                    learn("release_check", "periodic check", result.ci_status, "success", ["acted", "release", repo_tag(owner, repo)]);
+                } else {
+                    learn("release_check", "periodic check", result.ci_status, "success", ["acted", "release"]);
+                };
             } else {
                 if my_tier == "review-gated" {
                     emit("release:check_result", result);
-                    learn("release_check", "periodic check", result.ci_status, "partial", ["release", "review-gated"]);
+                    if len(owner) > 0 {
+                        learn("release_check", "periodic check", result.ci_status, "partial", ["release", "review-gated", repo_tag(owner, repo)]);
+                    } else {
+                        learn("release_check", "periodic check", result.ci_status, "partial", ["release", "review-gated"]);
+                    };
                 } else {
                     if my_tier == "propose" {
                         emit("release:check_result", result);
-                        learn("release_check", "periodic check", result.ci_status, "partial", ["emitted", "release"]);
+                        if len(owner) > 0 {
+                            learn("release_check", "periodic check", result.ci_status, "partial", ["emitted", "release", repo_tag(owner, repo)]);
+                        } else {
+                            learn("release_check", "periodic check", result.ci_status, "partial", ["emitted", "release"]);
+                        };
                     } else {
-                        learn("release_check", "periodic check", result.ci_status, "partial", ["observed", "release"]);
+                        if len(owner) > 0 {
+                            learn("release_check", "periodic check", result.ci_status, "partial", ["observed", "release", repo_tag(owner, repo)]);
+                        } else {
+                            learn("release_check", "periodic check", result.ci_status, "partial", ["observed", "release"]);
+                        };
                     };
                 };
             };
@@ -185,6 +261,29 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("release_checker:last_check", now);
+        memo_write(scoped_memo(owner, repo, "release_checker:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -31,17 +31,45 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
 // #147: build the merged-MR delta query with optional --since. Used by
 // the tick's pre-prompt delta-check to tell whether any release-relevant
 // work has landed since the last tick.
-fn mr_delta_cmd_for(ts: string) -> string {
+fn mr_delta_cmd_for(owner: string, repo: string, ts: string) -> string {
+    // colony-lint: safe-exec-concat
     if len(ts) > 0 {
-        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --per-page 1";
+        return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --per-page 1" + repo_arg(owner, repo);
     };
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --per-page 1";
+    // colony-lint: safe-exec-concat
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --per-page 1" + repo_arg(owner, repo);
 }
 
-fn tick(reason: string) -> void {
+fn tick_for_repo(owner: string, repo: string) -> void {
     // #147: cheap delta-check BEFORE any prompt(). ship_decider's work
     // is reactive: decide ship/no-ship when `release:check_result`
     // arrives, and re-learn release cadence when new merged MRs show
@@ -51,7 +79,7 @@ fn tick(reason: string) -> void {
     let check_str = to_string(check_result);
     let has_event = len(check_str) >= 5;
 
-    let mr_delta_cmd = mr_delta_cmd_for(recall_latest("ship_decider:last_check"));
+    let mr_delta_cmd = mr_delta_cmd_for(owner, repo, recall_latest(scoped_memo(owner, repo, "ship_decider:last_check")));
     let mr_delta = try { exec sh mr_delta_cmd; } catch e { "[]"; };
     let has_new_mr = len(mr_delta) >= 3;
 
@@ -59,23 +87,27 @@ fn tick(reason: string) -> void {
         if !has_new_mr {
             let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
             if len(now_e) > 0 {
-                memo_write("ship_decider:last_check", now_e);
+                memo_write(scoped_memo(owner, repo, "ship_decider:last_check"), now_e);
             };
             return;
         };
     };
 
     // 1. Learn release patterns from history (only when there IS new work)
+    // colony-lint: safe-exec-concat
+    let releases_cmd = "$COLONY_DIR/scripts/forge-api.sh releases --per-page 20 --view release-summary" + repo_arg(owner, repo);
     let releases_raw = try {
-        exec sh "$COLONY_DIR/scripts/forge-api.sh releases --per-page 20 --view release-summary";
+        exec sh releases_cmd;
     } catch e {
         print("[ship_decider] GitLab releases poll failed:", e);
         "";
     };
 
     if len(releases_raw) > 10 {
+        // colony-lint: safe-exec-concat
+        let tags_cmd = "$COLONY_DIR/scripts/forge-api.sh tags --per-page 20 --view tag-summary" + repo_arg(owner, repo);
         let tags_raw = try {
-            exec sh "$COLONY_DIR/scripts/forge-api.sh tags --per-page 20 --view tag-summary";
+            exec sh tags_cmd;
         } catch e { "[]"; };
 
         let patterns = prompt(
@@ -84,13 +116,23 @@ fn tick(reason: string) -> void {
         ) -> ShipPatterns;
 
         if patterns.releases_seen > 0 {
-            learn(
-                "ship_decide",
-                "batch of " + to_string(patterns.releases_seen) + " releases",
-                "cadence: " + patterns.cadence + " | blockers: " + patterns.blocker_types + " | risk: " + patterns.risk_tolerance,
-                "success",
-                ["observed", "release"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "ship_decide",
+                    "batch of " + to_string(patterns.releases_seen) + " releases",
+                    "cadence: " + patterns.cadence + " | blockers: " + patterns.blocker_types + " | risk: " + patterns.risk_tolerance,
+                    "success",
+                    ["observed", "release", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "ship_decide",
+                    "batch of " + to_string(patterns.releases_seen) + " releases",
+                    "cadence: " + patterns.cadence + " | blockers: " + patterns.blocker_types + " | risk: " + patterns.risk_tolerance,
+                    "success",
+                    ["observed", "release"]
+                );
+            };
             print("[ship_decider] Learned from", patterns.releases_seen, "past releases");
         };
     };
@@ -101,7 +143,7 @@ fn tick(reason: string) -> void {
     if !has_event {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
-            memo_write("ship_decider:last_check", now_e);
+            memo_write(scoped_memo(owner, repo, "ship_decider:last_check"), now_e);
         };
         return;
     };
@@ -122,43 +164,88 @@ fn tick(reason: string) -> void {
     // review-gated = post draft-flagged note + emit. propose = emit only.
     // shadow/dormant = observe.
     if my_tier == "autonomous" {
-        let mr_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+        // colony-lint: safe-exec-concat
+        let mr_listing_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1" + repo_arg(owner, repo);
+        let mr_raw = try { exec sh mr_listing_cmd; } catch e { "[]"; };
         let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
         if mr_iid > 0 {
             let note = "**Ship Decision** (automated): " + decision.decision + "\n\n" + decision.reasoning;
-            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+            // colony-lint: safe-exec-concat
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note) + repo_arg(owner, repo);
             try { exec sh post_cmd; } catch e {
                 print("[ship_decider] Failed to post note:", e);
             };
         };
         emit("release:ship_decision", decision);
-        learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "success", ["acted", "release"]);
+        if len(owner) > 0 {
+            learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "success", ["acted", "release", repo_tag(owner, repo)]);
+        } else {
+            learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "success", ["acted", "release"]);
+        };
     } else {
         if my_tier == "review-gated" {
-            let mr_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+            // colony-lint: safe-exec-concat
+            let mr_listing_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1" + repo_arg(owner, repo);
+            let mr_raw = try { exec sh mr_listing_cmd; } catch e { "[]"; };
             let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
             if mr_iid > 0 {
                 let note = "[draft-ship] **Ship Decision** (automated, pending approval): " + decision.decision + "\n\n" + decision.reasoning;
-                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                // colony-lint: safe-exec-concat
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note) + repo_arg(owner, repo);
                 try { exec sh post_cmd; } catch e {
                     print("[ship_decider] Failed to post draft note:", e);
                 };
             };
             emit("release:ship_decision", decision);
-            learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["release", "review-gated"]);
+            if len(owner) > 0 {
+                learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["release", "review-gated", repo_tag(owner, repo)]);
+            } else {
+                learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["release", "review-gated"]);
+            };
         } else {
             if my_tier == "propose" {
                 emit("release:ship_decision", decision);
-                learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["emitted", "release"]);
+                if len(owner) > 0 {
+                    learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["emitted", "release", repo_tag(owner, repo)]);
+                } else {
+                    learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["emitted", "release"]);
+                };
             } else {
                 print("[ship_decider] Observing (tier:", my_tier, ")");
-                learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["observed", "release"]);
+                if len(owner) > 0 {
+                    learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["observed", "release", repo_tag(owner, repo)]);
+                } else {
+                    learn("ship_decide", "decision: " + decision.decision, decision.reasoning, "partial", ["observed", "release"]);
+                };
             };
         };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("ship_decider:last_check", now);
+        memo_write(scoped_memo(owner, repo, "ship_decider:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/dev-apprenticeship/release/agents/version_bumper.ag
+++ b/dev-apprenticeship/release/agents/version_bumper.ag
@@ -33,7 +33,33 @@ fn get_confidence() -> float {
     return 0.0;
 }
 
-fn tick(reason: string) -> void {
+// #316 M3b: per-tick fan-out helpers. See triage/agents/router.ag for
+// the full rationale. Single-block configs collapse to owner=="" sentinel,
+// repo_arg/repo_tag return "", scoped_memo passes the suffix through.
+
+fn repo_arg(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return " --repo " + shell_escape(owner + "/" + repo);
+}
+
+fn repo_tag(owner: string, repo: string) -> string {
+    if len(owner) == 0 { return ""; };
+    return "repo:" + owner + "/" + repo;
+}
+
+fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_field(line: string, idx: int) -> string {
+    let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
+        " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+fn tick_for_repo(owner: string, repo: string) -> void {
     // #147: version_bumper is pure event-driven. It reacts to a
     // `release:ship_decision` emit from ship_decider — no GitLab poll
     // is needed to decide whether to do work. If the inbox is empty,
@@ -45,15 +71,17 @@ fn tick(reason: string) -> void {
     if len(decision_str) < 5 {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
-            memo_write("version_bumper:last_check", now_e);
+            memo_write(scoped_memo(owner, repo, "version_bumper:last_check"), now_e);
         };
         return;
     };
 
     // 1. Learn versioning patterns from tags (only when we're actually
     //    about to bump — gated by the delta-check above).
+    // colony-lint: safe-exec-concat
+    let tags_cmd = "$COLONY_DIR/scripts/forge-api.sh tags --per-page 20 --view tag-summary" + repo_arg(owner, repo);
     let tags_raw = try {
-        exec sh "$COLONY_DIR/scripts/forge-api.sh tags --per-page 20 --view tag-summary";
+        exec sh tags_cmd;
     } catch e {
         print("[version_bumper] GitLab tags poll failed:", e);
         "";
@@ -66,13 +94,23 @@ fn tick(reason: string) -> void {
         ) -> VersionPatterns;
 
         if patterns.tags_seen > 0 {
-            learn(
-                "version_bump",
-                "batch of " + to_string(patterns.tags_seen) + " version tags",
-                "format: " + patterns.format + " | strategy: " + patterns.bump_strategy + " | prerelease: " + patterns.prerelease,
-                "success",
-                ["observed", "release"]
-            );
+            if len(owner) > 0 {
+                learn(
+                    "version_bump",
+                    "batch of " + to_string(patterns.tags_seen) + " version tags",
+                    "format: " + patterns.format + " | strategy: " + patterns.bump_strategy + " | prerelease: " + patterns.prerelease,
+                    "success",
+                    ["observed", "release", repo_tag(owner, repo)]
+                );
+            } else {
+                learn(
+                    "version_bump",
+                    "batch of " + to_string(patterns.tags_seen) + " version tags",
+                    "format: " + patterns.format + " | strategy: " + patterns.bump_strategy + " | prerelease: " + patterns.prerelease,
+                    "success",
+                    ["observed", "release"]
+                );
+            };
             print("[version_bumper] Learned from", patterns.tags_seen, "version tags");
         };
     };
@@ -87,7 +125,7 @@ fn tick(reason: string) -> void {
         print("[version_bumper] Ship decision is no-ship, skipping version bump");
         let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now) > 0 {
-            memo_write("version_bumper:last_check", now);
+            memo_write(scoped_memo(owner, repo, "version_bumper:last_check"), now);
         };
         return;
     };
@@ -97,13 +135,17 @@ fn tick(reason: string) -> void {
     let changelog_str = to_string(changelog_draft);
 
     // Get latest tags for current version context
+    // colony-lint: safe-exec-concat
+    let latest_tags_cmd = "$COLONY_DIR/scripts/forge-api.sh tags --per-page 5 --view tag-summary" + repo_arg(owner, repo);
     let latest_tags = try {
-        exec sh "$COLONY_DIR/scripts/forge-api.sh tags --per-page 5 --view tag-summary";
+        exec sh latest_tags_cmd;
     } catch e { "[]"; };
 
     // Fetch merged MRs since last release for bump analysis
+    // colony-lint: safe-exec-concat
+    let latest_release_cmd = "$COLONY_DIR/scripts/forge-api.sh releases --per-page 1 --view release-summary" + repo_arg(owner, repo);
     let latest_release = try {
-        exec sh "$COLONY_DIR/scripts/forge-api.sh releases --per-page 1 --view release-summary";
+        exec sh latest_release_cmd;
     } catch e { "[]"; };
 
     let since_date = prompt(
@@ -111,7 +153,8 @@ fn tick(reason: string) -> void {
         latest_release
     ) -> string;
 
-    let mrs_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(since_date) + " --view release-mr";
+    // colony-lint: safe-exec-concat
+    let mrs_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(since_date) + " --view release-mr" + repo_arg(owner, repo);
     let mrs_raw = try { exec sh mrs_cmd; } catch e { "[]"; };
 
     let rec = recommend("version_bump", ["accuracy"]);
@@ -131,7 +174,7 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         // Create the tag
         // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-        let tag_cmd = "$COLONY_DIR/scripts/forge-api.sh create-tag --name " + shell_escape(bump.next) + " --ref main --message " + shell_escape("Release " + bump.next);
+        let tag_cmd = "$COLONY_DIR/scripts/forge-api.sh create-tag --name " + shell_escape(bump.next) + " --ref main --message " + shell_escape("Release " + bump.next) + repo_arg(owner, repo);
         let tag_result = try { exec sh tag_cmd; } catch e {
             print("[version_bumper] Tag creation failed:", e);
             "";
@@ -144,7 +187,7 @@ fn tick(reason: string) -> void {
             let release_desc = changelog_str + bump.reasoning;
 
             // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-            let release_cmd = "$COLONY_DIR/scripts/forge-api.sh create-release --tag " + shell_escape(bump.next) + " --name " + shell_escape("Release " + bump.next) + " --description " + shell_escape(release_desc);
+            let release_cmd = "$COLONY_DIR/scripts/forge-api.sh create-release --tag " + shell_escape(bump.next) + " --name " + shell_escape("Release " + bump.next) + " --description " + shell_escape(release_desc) + repo_arg(owner, repo);
             let release_result = try { exec sh release_cmd; } catch e {
                 print("[version_bumper] Release creation failed:", e);
                 "";
@@ -155,37 +198,79 @@ fn tick(reason: string) -> void {
             };
 
             emit("release:version_bumped", bump);
-            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "success", ["acted", "release"]);
+            if len(owner) > 0 {
+                learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "success", ["acted", "release", repo_tag(owner, repo)]);
+            } else {
+                learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "success", ["acted", "release"]);
+            };
         };
     } else {
         if my_tier == "review-gated" {
             // Non-terminal proposal: post a draft note on the latest MR flagged as
             // a pending bump so a human can approve before we tag. No tag/release
             // is created at this tier.
-            let mr_raw = try { exec sh "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1"; } catch e { "[]"; };
+            // colony-lint: safe-exec-concat
+            let mr_listing_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --per-page 1" + repo_arg(owner, repo);
+            let mr_raw = try { exec sh mr_listing_cmd; } catch e { "[]"; };
             let mr_iid = parse_int(to_string(json_get(mr_raw, "[0].iid")));
             if mr_iid > 0 {
                 let note = "[draft-bump] **Version Bump Proposal** (automated, pending approval): " + bump.current + " -> " + bump.next + " (" + bump.bump_type + ")\n\n" + bump.reasoning;
-                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note);
+                // colony-lint: safe-exec-concat
+                let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(mr_iid) + " --body " + shell_escape(note) + repo_arg(owner, repo);
                 try { exec sh post_cmd; } catch e {
                     print("[version_bumper] Failed to post draft bump note:", e);
                 };
             };
             emit("release:version_bumped", bump);
-            learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["release", "review-gated"]);
+            if len(owner) > 0 {
+                learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["release", "review-gated", repo_tag(owner, repo)]);
+            } else {
+                learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["release", "review-gated"]);
+            };
         } else {
             if my_tier == "propose" {
                 emit("release:version_bumped", bump);
-                learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["emitted", "release"]);
+                if len(owner) > 0 {
+                    learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["emitted", "release", repo_tag(owner, repo)]);
+                } else {
+                    learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["emitted", "release"]);
+                };
             } else {
                 print("[version_bumper] Observing (tier:", my_tier, ")");
-                learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["observed", "release"]);
+                if len(owner) > 0 {
+                    learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["observed", "release", repo_tag(owner, repo)]);
+                } else {
+                    learn("version_bump", bump.next, bump.bump_type + ": " + bump.reasoning, "partial", ["observed", "release"]);
+                };
             };
         };
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("version_bumper:last_check", now);
+        memo_write(scoped_memo(owner, repo, "version_bumper:last_check"), now);
     };
+}
+
+// Recursive iterator over `iter-repos.sh` output. See router.ag for the
+// empty-owner sentinel rationale.
+fn tick_at(spool: string, line_no: int) -> void {
+    let line_cmd = "SP=" + shell_escape(spool) + " N=" + to_string(line_no) +
+        " python3 -c 'import os; lines=os.environ[\"SP\"].splitlines(); n=int(os.environ[\"N\"]); print(lines[n] if 0<=n<len(lines) else \"\")'";
+    let line = try { exec sh line_cmd; } catch e { ""; };
+    if len(line) == 0 { return; };
+    let owner = repo_field(line, 0);
+    let repo = repo_field(line, 1);
+    tick_for_repo(owner, repo);
+    return tick_at(spool, line_no + 1);
+}
+
+fn tick(reason: string) -> void {
+    // #316 M3b: per-repo fan-out. See triage/agents/router.ag for the
+    // back-compat sentinel pattern and byte-identity rationale.
+    let spool = try { exec sh "$COLONY_DIR/../../tools/iter-repos.sh"; } catch e { ""; };
+    if len(spool) == 0 {
+        return;
+    };
+    tick_at(spool, 0);
 }

--- a/tools/test-learn-idempotency.sh
+++ b/tools/test-learn-idempotency.sh
@@ -46,22 +46,30 @@ check_agent() {
         bad "gate function missing"
     fi
 
-    if grep -Fq "recall_latest(\"${agent}:last_learned_mr_iid\")" "$file"; then
-        ok "gate reads ${agent}:last_learned_mr_iid"
+    # Post-#316 M3b, the per-repo memo key is built via scoped_memo(owner,
+    # repo, "<agent>:last_learned_mr_iid"). On single-block configs scoped_memo
+    # passes the suffix through unchanged so the resolved key is byte-identical
+    # to the pre-M3 literal `<agent>:last_learned_mr_iid`. The literal suffix
+    # must still appear (as the third arg to scoped_memo) anywhere in the file.
+    if grep -Fq "scoped_memo(owner, repo, \"${agent}:last_learned_mr_iid\")" "$file"; then
+        ok "gate reads ${agent}:last_learned_mr_iid via scoped_memo (M3b per-repo)"
     else
-        bad "gate does not recall ${agent}:last_learned_mr_iid"
+        bad "gate does not recall ${agent}:last_learned_mr_iid via scoped_memo"
     fi
 
     if grep -Fq "if should_learn_from_mr(" "$file"; then
-        ok "tick() calls gate"
+        ok "tick_for_repo() calls gate"
     else
-        bad "tick() does not call should_learn_from_mr"
+        bad "tick_for_repo() does not call should_learn_from_mr"
     fi
 
-    if grep -Fq "memo_write(\"${agent}:last_learned_mr_iid\"," "$file"; then
-        ok "memo_write stashes iid"
+    # The memo_write call now wraps the key in scoped_memo; the literal
+    # suffix `<agent>:last_learned_mr_iid` must still appear inside that
+    # scoped_memo call (matched by the recall check above).
+    if grep -Fq "memo_write(scoped_memo(owner, repo, \"${agent}:last_learned_mr_iid\")," "$file"; then
+        ok "memo_write stashes iid via scoped_memo (M3b per-repo)"
     else
-        bad "memo_write for ${agent}:last_learned_mr_iid missing"
+        bad "memo_write for ${agent}:last_learned_mr_iid via scoped_memo missing"
     fi
 
     # Ordering invariant (QA #6): memo_write MUST appear before the first
@@ -71,7 +79,7 @@ check_agent() {
     # after prompt() re-opens the re-burn window on prompt failures.
     local gate_line memo_line prompt_line
     gate_line="$(grep -n "if should_learn_from_mr(" "$file" | head -1 | cut -d: -f1 || true)"
-    memo_line="$(grep -n "memo_write(\"${agent}:last_learned_mr_iid\"," "$file" | head -1 | cut -d: -f1 || true)"
+    memo_line="$(grep -n "memo_write(scoped_memo(owner, repo, \"${agent}:last_learned_mr_iid\")," "$file" | head -1 | cut -d: -f1 || true)"
     prompt_line="$(awk -v g="${gate_line:-0}" 'NR>g && /prompt\(/ {print NR; exit}' "$file")"
     if [ -n "$gate_line" ] && [ -n "$memo_line" ] && [ -n "$prompt_line" ] \
        && [ "$memo_line" -gt "$gate_line" ] && [ "$memo_line" -lt "$prompt_line" ]; then


### PR DESCRIPTION
## Summary

Second half of #316 M3 (split per scope risk). Mechanical fan-out of the M3a iteration pattern (4 triage agents, PR #381) to the remaining 17 agents. After this lands, **all 21 agents in dev-apprenticeship serve N repos from one colony** when colony.toml uses `[[forge.github]]`.

- 5 code-review agents (logic, style, security, test, approval_decider) wrapped
- 4 planning agents (scope_estimator, risk_assessor, task_decomposer, plan_reviewer) wrapped
- 4 implementation agents (code_writer, test_writer, refactorer, commit_composer) wrapped
- 4 release agents (ship_decider, changelog_writer, version_bumper, release_checker) wrapped

Each agent: 5 helper fns (`repo_arg`, `repo_tag`, `scoped_memo`, `repo_field`, `tick_at`), new `tick()` outer fan-out, legacy logic moved to `tick_for_repo(owner, repo)`, per-repo memo keys via `scoped_memo()`, conditional `repo:<owner>/<repo>` learn tags.

**Cross-agent memo coordination** — `scope_estimator`/`risk_assessor`/`task_decomposer` write `plan_reviewer:<iid>:scope_drafted`/`risks_drafted`/`breakdown_drafted` markers; all consistently scoped under `scoped_memo()` so per-repo same-iid configs cannot collide. `plan_reviewer.ag`'s `stash()` helper signature extended to `stash(owner, repo, ...)` for the same reason.

**Test parallel update** — `tools/test-learn-idempotency.sh` greps for the new `scoped_memo(...)` wrapping (mirrors M3a's `tools/test-labeler-autonomous-verdict.sh` update for triage's labeler).

**No CB budget bumps needed** — fan-out helpers add ~50 CB per repo per tick; single-block configs collapse to ~100 CB per tick (well within all 17 agents' existing budgets, range 400-2000).

Plan: #316 M3 detail comment.

## Test plan

- [x] Standalone `agentis commit` per agent: 17/17 PASS (each .ag syntactically valid)
- [x] **`tools/test-single-block-byte-identity.sh` — 5/5 PASS** (load-bearing — proves M3b doesn't regress single-block path)
- [x] M3a regression: `test-iter-repos.sh` (6/6), `test-forge-api-multi-repo.sh` (9/9)
- [x] M1/M2 regression: `test-multi-repo-schema.sh` (16/16), `test-start-colony-multi-repo.sh` (6/6), `test-start-colony-restart.sh` (26/26), `test-forge-config.sh` (45/45), `test-colony-lint-bash32.sh` (6 PASS / 1 SKIP), `test-labeler-autonomous-verdict.sh` (20/20), `test-learn-idempotency.sh` (24/24 after parallel update)
- [x] `colony-lint .` — 121 PASS / 24 FAIL / 3 SKIP, **net new failures = 0** vs origin/main baseline
- [x] **4 triage agents byte-identical** to M3a-merged state (a4e19fa)
- [x] All `colony.example.toml`, `tools/iter-repos.{sh,py}`, `tools/forge-resolve-repo.py`, `tools/parse-toml.sh`, `tools/colony-lint.sh`, `dev-apprenticeship/.agentis/config`, `install.sh`, `tribes-bench/` all byte-identical
- [ ] CI green
- [ ] QA agent report (will be posted)

## Note for reviewer

After this lands, **5 of 6 milestones done**: M1 (schema), M2 (env wiring), M3a (plumbing + triage), M3b (fan-out 17). M4 per-repo confidence keys + `tier()` fallback. M5 dashboard per-repo metrics. M6 retire single-block (MAJOR, v2.0.0). #316 closes at M6.