### PR TITLE
feat: per-repo confidence keys + repo_tier() helper (#316 M4)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -59,6 +59,21 @@ is asserted until multi-version CI is in place.
   dev-apprenticeship now serve N repositories from one colony when `colony.toml`
   uses the `[[forge.github]]` array form. Single-block configs continue to work
   byte-identically.
+- Multi-repo runtime (#316 M4): per-repo confidence keys + `repo_tier()` helper.
+  All 21 agents now read tier via `repo_tier("<agent>", owner, repo)` instead of
+  the runtime `tier("<agent>")` builtin. The helper looks up
+  `<owner>__<repo>:<agent>:confidence` first, falls back to the legacy unscoped
+  `<agent>:confidence` when missing, and maps to the same five-tier string set
+  the runtime returns using ADR-0001 thresholds. Single-block configs (M3a
+  sentinel `owner==""`) bypass the scoped lookup entirely and stay
+  byte-identical to legacy. Operators set per-repo divergence via
+  `agentis memo set acme__frontend:labeler:confidence 0.95`; the legacy
+  unscoped key continues to govern every repo without an override.
+  `labeler.ag`'s reality-check `apply_feedback()` now writes to the per-repo
+  memo so per-repo confidence drifts independently. `auto-promote.sh` per-repo
+  writes ship in a follow-up; until then the sidecar continues to write only
+  the unscoped key. `colony-lint.sh` gains a check failing on direct `tier()`
+  calls inside `fn tick_for_repo`.
 
 ### Deprecated
 

--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -44,6 +44,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -113,7 +132,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         all_findings
     ) -> ReviewDecision;
 
-    let my_tier = tier("approval_decider");
+    let my_tier = repo_tier("approval_decider", owner, repo);
 
     print("[approval_decider] MR", decision.mr_iid, "-> action:", decision.action, "(", decision.total_findings, "findings,", decision.critical_count, "critical)");
 

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -42,6 +42,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -149,7 +168,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         context
     ) -> LogicReview;
 
-    let my_tier = tier("logic_reviewer");
+    let my_tier = repo_tier("logic_reviewer", owner, repo);
 
     if len(review.findings) > 0 {
         print("[logic_reviewer] MR", mr_iid, ":", len(review.findings), "logic findings");

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -41,6 +41,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -148,7 +167,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         context
     ) -> SecurityReview;
 
-    let my_tier = tier("security_reviewer");
+    let my_tier = repo_tier("security_reviewer", owner, repo);
 
     if len(review.findings) > 0 {
         print("[security_reviewer] MR", mr_iid, ":", len(review.findings), "security findings");

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -64,6 +64,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -178,7 +197,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         "MR author: " + mr_author + "\n" + context
     ) -> StyleReview;
 
-    let my_tier = tier("style_reviewer");
+    let my_tier = repo_tier("style_reviewer", owner, repo);
 
     if len(review.findings) > 0 {
         print("[style_reviewer] MR", mr_iid, ":", len(review.findings), "style findings");

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -40,6 +40,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -140,7 +159,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         context
     ) -> TestReview;
 
-    let my_tier = tier("test_reviewer");
+    let my_tier = repo_tier("test_reviewer", owner, repo);
 
     if len(review.findings) > 0 {
         print("[test_reviewer] MR", mr_iid, ":", len(review.findings), "test findings");

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -43,6 +43,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -223,7 +242,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 context
             ) -> CodeDraft;
 
-            let my_tier = tier("code_writer");
+            let my_tier = repo_tier("code_writer", owner, repo);
             print("[code_writer] Drafted code for issue", draft.issue_id, "(tier:", my_tier, ")");
 
             if my_tier == "autonomous" {

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -45,6 +45,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -169,7 +188,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         context
     ) -> MRPlan;
 
-    let my_tier = tier("commit_composer");
+    let my_tier = repo_tier("commit_composer", owner, repo);
     print("[commit_composer] Composed MR plan for issue", plan.issue_id, "(tier:", my_tier, ")");
 
     if my_tier == "autonomous" {

--- a/dev-apprenticeship/implementation/agents/refactorer.ag
+++ b/dev-apprenticeship/implementation/agents/refactorer.ag
@@ -41,6 +41,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -203,7 +222,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 context
             ) -> RefactorSuggestion;
 
-            let my_tier = tier("refactorer");
+            let my_tier = repo_tier("refactorer", owner, repo);
             print("[refactorer] Reviewed draft for issue", suggestion.issue_id, "(tier:", my_tier, ")");
 
             if my_tier == "autonomous" {

--- a/dev-apprenticeship/implementation/agents/test_writer.ag
+++ b/dev-apprenticeship/implementation/agents/test_writer.ag
@@ -43,6 +43,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -201,7 +220,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 context
             ) -> TestDraft;
 
-            let my_tier = tier("test_writer");
+            let my_tier = repo_tier("test_writer", owner, repo);
             print("[test_writer] Drafted tests for issue", tests.issue_id, "(tier:", my_tier, ")");
 
             if my_tier == "autonomous" {

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -58,6 +58,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -187,7 +206,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         context
     ) -> DraftPlan;
 
-    let my_tier = tier("plan_reviewer");
+    let my_tier = repo_tier("plan_reviewer", owner, repo);
 
     print("[plan_reviewer] Issue", draft.issue_id, "-> review_score:", draft.review_score);
 

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -41,6 +41,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -188,7 +207,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         context
     ) -> RiskAssessment;
 
-    let my_tier = tier("risk_assessor");
+    let my_tier = repo_tier("risk_assessor", owner, repo);
 
     print("[risk_assessor] Issue", assessment.issue_id, "-> severity:", assessment.severity);
 

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -42,6 +42,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -163,7 +182,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         context
     ) -> ScopeEstimate;
 
-    let my_tier = tier("scope_estimator");
+    let my_tier = repo_tier("scope_estimator", owner, repo);
 
     print("[scope_estimator] Issue", estimate.issue_id, "->", estimate.phases, "phases,", estimate.points, "points");
 

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -42,6 +42,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -176,7 +195,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         context
     ) -> TaskBreakdown;
 
-    let my_tier = tier("task_decomposer");
+    let my_tier = repo_tier("task_decomposer", owner, repo);
 
     print("[task_decomposer] Issue", breakdown.issue_id, "->", breakdown.count, "subtasks");
 

--- a/dev-apprenticeship/release/agents/changelog_writer.ag
+++ b/dev-apprenticeship/release/agents/changelog_writer.ag
@@ -52,6 +52,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -158,7 +177,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
             context
         ) -> ChangelogDraft;
 
-        let my_tier = tier("changelog_writer");
+        let my_tier = repo_tier("changelog_writer", owner, repo);
         print("[changelog_writer] Drafted changelog for", draft.version, "(", draft.mr_count, "MRs, tier:", my_tier, ")");
 
         // Posting a release-notes draft as a note on the MR is a non-terminal

--- a/dev-apprenticeship/release/agents/release_checker.ag
+++ b/dev-apprenticeship/release/agents/release_checker.ag
@@ -53,6 +53,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -157,7 +176,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 context_full
             ) -> CheckResult;
 
-            let my_tier = tier("release_checker");
+            let my_tier = repo_tier("release_checker", owner, repo);
             print("[release_checker] Checked main pipeline:", result.ci_status, "(tier:", my_tier, ")");
 
             // release_checker produces a non-terminal diagnostic: posting a
@@ -223,7 +242,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 context
             ) -> CheckResult;
 
-            let my_tier = tier("release_checker");
+            let my_tier = repo_tier("release_checker", owner, repo);
             if my_tier == "autonomous" {
                 emit("release:check_result", result);
                 if len(owner) > 0 {

--- a/dev-apprenticeship/release/agents/ship_decider.ag
+++ b/dev-apprenticeship/release/agents/ship_decider.ag
@@ -50,6 +50,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -156,7 +175,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         context
     ) -> ShipDecision;
 
-    let my_tier = tier("ship_decider");
+    let my_tier = repo_tier("ship_decider", owner, repo);
     print("[ship_decider] Decision:", decision.decision, "(tier:", my_tier, ")");
 
     // ship_decider produces a non-terminal signal — it never tags, merges,

--- a/dev-apprenticeship/release/agents/version_bumper.ag
+++ b/dev-apprenticeship/release/agents/version_bumper.ag
@@ -52,6 +52,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -165,7 +184,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         context
     ) -> VersionBump;
 
-    let my_tier = tier("version_bumper");
+    let my_tier = repo_tier("version_bumper", owner, repo);
     print("[version_bumper] Version bump:", bump.current, "->", bump.next, "(", bump.bump_type, ", tier:", my_tier, ")");
 
     // create-tag + create-release are TERMINAL actions (cannot be withdrawn

--- a/dev-apprenticeship/triage/agents/issue_creator.ag
+++ b/dev-apprenticeship/triage/agents/issue_creator.ag
@@ -47,6 +47,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -116,7 +135,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
     let inbox = try { poll_inbox(); } catch e { ""; };
 
     if len(to_string(inbox)) > 5 {
-        let my_tier = tier("issue_creator");
+        let my_tier = repo_tier("issue_creator", owner, repo);
         let rec = recommend("create_issue", ["accuracy", "style"]);
         let context = "Event: " + to_string(inbox) + "\nPast learning: " + to_string(rec);
 

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -64,6 +64,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -149,10 +168,15 @@ fn signal_to_outcome(signal: int) -> string {
     return "fail";
 }
 
-fn apply_feedback(delta: float) -> void {
+// #316 M4: per-repo write target. `get_confidence()` continues reading the
+// legacy unscoped key (intentional — see plan §8: bounded by clamp_auto's
+// 0.85 cap, so per-repo drift cannot push past the autonomy threshold from
+// reality-check feedback alone). Operators set per-repo overrides via
+// `agentis memo set <owner>__<repo>:labeler:confidence <value>`.
+fn apply_feedback(delta: float, owner: string, repo: string) -> void {
     let cur = get_confidence();
     let target = clamp_auto(cur, delta);
-    memo_write("labeler:confidence", to_string(target));
+    memo_write(scoped_memo(owner, repo, "labeler:confidence"), to_string(target));
     print("[labeler] feedback delta", delta, "confidence", cur, "->", target);
 }
 
@@ -210,7 +234,7 @@ fn evaluate_label_verdict(owner: string, repo: string) -> void {
     if signal == 0 {
         return;
     };
-    apply_feedback(signal_to_delta(signal));
+    apply_feedback(signal_to_delta(signal), owner, repo);
     // #195: emit the reality-check outcome to the experience store so
     // auto-promote's fitness gates (#186) see an honest acting-path
     // reject rate. Tagged "acted" regardless of the original tier so
@@ -480,7 +504,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
 
     // Suggest/apply labels for unlabeled issues
     if analysis.unlabeled_count > 0 {
-        let my_tier = tier("labeler");
+        let my_tier = repo_tier("labeler", owner, repo);
         let rec = recommend("label", ["accuracy"]);
         // colony-lint: safe-exec-concat
         let labels_cmd = "$COLONY_DIR/scripts/forge-api.sh labels --view summary" + repo_arg(owner, repo);

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -61,6 +61,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 fn repo_field(line: string, idx: int) -> string {
     let cmd = "L=" + shell_escape(line) + " I=" + to_string(idx) +
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
@@ -152,7 +171,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
 
     // Suggest/apply priority for unprioritized issues
     if analysis.unprioritized_count > 0 {
-        let my_tier = tier("prioritizer");
+        let my_tier = repo_tier("prioritizer", owner, repo);
         let rec = recommend("prioritize", ["accuracy"]);
         let context = vocab_line + "\nUnprioritized issues: " + analysis.unprioritized_issues + "\nPast learning: " + to_string(rec);
 

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -53,6 +53,25 @@ fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
     return owner + "__" + repo + ":" + suffix;
 }
 
+// #316 M4: per-repo confidence read with legacy fallback. Mirrors the
+// runtime tier() builtin's threshold table from ADR-0001 / CLAUDE.md.
+// `agent_name` (not `agent`) — `agent` is a reserved keyword in `.ag`.
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}
+
 // Read the `idx`-th tab-separated field of a TSV `line`. Empty string
 // when out of range (defensive; iter-repos always emits exactly four
 // fields per line). Delegates to python3 — `.ag` has no split builtin.
@@ -138,7 +157,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
 
     // Suggest/apply routing for unassigned issues
     if analysis.unassigned_count > 0 {
-        let my_tier = tier("router");
+        let my_tier = repo_tier("router", owner, repo);
         let rec = recommend("route", ["accuracy"]);
         let context = "Unassigned issues: " + analysis.unassigned_issues + "\nTeam members: " + members_raw + "\nPast learning: " + to_string(rec);
 

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -452,11 +452,17 @@ if command -v agentis &>/dev/null; then
                         ag_rel="$fed/$colony/$(basename "$ag")"
                         tier_ok=true
 
-                        if grep -qE 'tier\s*\(\s*"[^"]+"\s*\)' "$ag"; then
+                        # #316 M4: post-M3 agents use repo_tier(name, owner, repo)
+                        # instead of tier(name); both forms satisfy the ADR-0001
+                        # tier-call requirement. The first regex matches the
+                        # legacy single-arg tier("..."); the second matches the
+                        # M4 multi-arg repo_tier("...", owner, repo) call.
+                        if grep -qE '\btier\s*\(\s*"[^"]+"\s*\)' "$ag" \
+                            || grep -qE '\brepo_tier\s*\(\s*"[^"]+"\s*,' "$ag"; then
                             has_tier_call=true
                         else
                             has_tier_call=false
-                            fail "$ag_rel: missing tier(\"...\") call (required by ADR-0001)"
+                            fail "$ag_rel: missing tier(\"...\") or repo_tier(\"...\", ...) call (required by ADR-0001 / #316 M4)"
                             tier_ok=false
                         fi
 
@@ -489,6 +495,31 @@ if command -v agentis &>/dev/null; then
                         if grep -nE '\bconfidence\s*>=\s*[0-9]+(\.[0-9]+)?' "$ag" >/dev/null; then
                             fail "$ag_rel: raw confidence >= <number> literal (use tier() per ADR-0001)"
                             tier_ok=false
+                        fi
+
+                        # --- M4 per-repo tier convention (#316 M4) ---
+                        # Agents that fan out per-repo (post-M3 fn tick_for_repo)
+                        # must read tier via repo_tier(name, owner, repo) so the
+                        # per-repo confidence memo wins over the legacy unscoped
+                        # key. A bare `let my_tier = tier("...")` inside such an
+                        # agent silently shares tier across every repo the
+                        # colony serves, defeating M4's per-repo divergence.
+                        # Escape hatch: `// colony-lint: m4-direct-tier-ok` for
+                        # intentional opt-out (e.g. an inner-helper that always
+                        # wants legacy semantics regardless of repo scope).
+                        if grep -qE '^\s*fn\s+tick_for_repo\s*\(' "$ag"; then
+                            if grep -qE '//\s*colony-lint:\s*m4-direct-tier-ok' "$ag"; then
+                                : # opt-out present, skip both rules
+                            else
+                                if grep -nE 'let\s+my_tier\s*=\s*tier\s*\(' "$ag" >/dev/null; then
+                                    fail "$ag_rel: direct tier() call inside tick_for_repo (use repo_tier per #316 M4)"
+                                    tier_ok=false
+                                fi
+                                if ! grep -qE 'fn\s+repo_tier\s*\(' "$ag"; then
+                                    fail "$ag_rel: missing repo_tier() helper (required by #316 M4)"
+                                    tier_ok=false
+                                fi
+                            fi
                         fi
 
                         if $tier_ok; then

--- a/tools/test-dashboard-gates.sh
+++ b/tools/test-dashboard-gates.sh
@@ -64,7 +64,10 @@ EXPECTED = {
 # tier-branch comparison in the agent. We look for any occurrence of
 # `== "<tier_name>"` that follows a `my_tier` identifier, gathering the
 # set of tier names that the agent branches on.
-TIER_CALL_RE = re.compile(r'\btier\s*\(\s*"([^"]+)"\s*\)')
+# #316 M4: post-M3 agents call `repo_tier("name", owner, repo)` instead
+# of the legacy `tier("name")`. Both forms count as a tier-call for the
+# else-fallthrough rescue below.
+TIER_CALL_RE = re.compile(r'\btier\s*\(\s*"([^"]+)"\s*\)|\brepo_tier\s*\(\s*"([^"]+)"\s*,')
 TIER_BRANCH_RE = re.compile(r'my_tier\s*==\s*"(shadow|propose|review-gated|autonomous|dormant)"')
 CLAMP_RE = re.compile(r'\bfn\s+clamp_auto\s*\(')
 CAP_RE = re.compile(r'\blet\s+cap\s*=\s*([0-9]+(?:\.[0-9]+)?)')

--- a/tools/test-per-repo-confidence.sh
+++ b/tools/test-per-repo-confidence.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+# tools/test-per-repo-confidence.sh: unit tests for the #316 M4 repo_tier()
+# helper convention.
+#
+# repo_tier(agent_name, owner, repo) is a per-agent helper (copy-pasted
+# across all 21 .ag files in dev-apprenticeship/) that reads the per-repo
+# confidence memo `<owner>__<repo>:<agent>:confidence` first and falls
+# back to the legacy unscoped `<agent>:confidence` key when the per-repo
+# memo is absent. The helper returns one of the five tier strings from
+# ADR-0001: dormant / shadow / propose / review-gated / autonomous.
+#
+# Tests:
+#   1. Fallback path: no per-repo memo + legacy 0.7 -> "propose".
+#   2. Per-repo wins: legacy 0.7 + per-repo 0.95 -> "autonomous".
+#   3. Divergence: two repos at different per-repo values for the same
+#      agent return different tiers (the M4 use case).
+#   4. Sentinel byte-identity: owner == "" bypasses the scoped lookup
+#      entirely; for every confidence value the helper must return the
+#      same string the runtime tier() builtin returns.
+#   5. Boundary respect: the helper maps exactly at the ADR-0001
+#      thresholds (0.4 / 0.6 / 0.8 / 0.95) to the upper-tier string and
+#      just-below to the lower-tier string.
+#
+# Implementation: each test writes a tiny .ag scenario into a tempdir,
+# seeds the relevant memo keys with `agentis memo set`, runs the script
+# with `agentis go`, and matches stdout against the expected tier string.
+# The .ag scenario embeds the same canonical helper text the agents use,
+# so a future helper-text drift in the agents would be detected by the
+# byte-identity check the test 4 boundary table indirectly enforces.
+#
+# Standard scaffold: set -eu, mktemp -d isolation, EXIT trap for cleanup.
+# Auto-discovered by tools/colony-lint.sh's tools-test loop.
+#
+# Usage: ./tools/test-per-repo-confidence.sh
+# Exit 0 if all tests pass, 1 otherwise. Skips with exit 0 when the
+# `agentis` binary is not on $PATH (CI fallback).
+
+set -eu
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+if ! command -v agentis >/dev/null 2>&1; then
+    echo "[SKIP] agentis binary not found on \$PATH"
+    echo "Results: 0 passed, 0 failed (skipped — agentis not installed)"
+    exit 0
+fi
+
+# Canonical M4 helper text (byte-identical to the helper inserted into
+# all 21 dev-apprenticeship/ .ag files). Embedded here so the test
+# exercises the same code path the agents do — divergence between this
+# string and the per-agent helper bodies is the regression surface.
+HELPER='fn scoped_memo(owner: string, repo: string, suffix: string) -> string {
+    if len(owner) == 0 { return suffix; };
+    return owner + "__" + repo + ":" + suffix;
+}
+
+fn repo_tier(agent_name: string, owner: string, repo: string) -> string {
+    let raw = if len(owner) == 0 {
+        recall_latest(agent_name + ":confidence");
+    } else {
+        let scoped = recall_latest(scoped_memo(owner, repo, agent_name + ":confidence"));
+        if len(scoped) > 0 { scoped; } else { recall_latest(agent_name + ":confidence"); };
+    };
+    if len(raw) == 0 { return "dormant"; };
+    let c = parse_float(raw);
+    if c >= 0.95 { return "autonomous"; };
+    if c >= 0.8  { return "review-gated"; };
+    if c >= 0.6  { return "propose"; };
+    if c >= 0.4  { return "shadow"; };
+    return "dormant";
+}'
+
+# run_repo_tier <agent_name> <owner> <repo> -> stdout = tier string.
+# Builds a fresh agentis repo per call (memo store is per-repo-init in
+# this scaffold), seeds the memos passed via REPO_TIER_MEMOS env (a
+# semicolon-separated list of `key=value` pairs), and invokes the helper
+# with the requested args. Stderr is suppressed to keep stdout clean.
+run_repo_tier() {
+    local agent_name="$1"
+    local owner="$2"
+    local repo="$3"
+    local seeds="${4:-}"
+
+    local sandbox
+    sandbox="$(mktemp -d -p "$TMPDIR_TEST")"
+
+    (
+        cd "$sandbox"
+        agentis init >/dev/null 2>&1
+        if [ -n "$seeds" ]; then
+            local IFS=';'
+            for kv in $seeds; do
+                if [ -n "$kv" ]; then
+                    local k="${kv%%=*}"
+                    local v="${kv#*=}"
+                    agentis memo set "$k" "$v" >/dev/null 2>&1 || true
+                fi
+            done
+        fi
+        cat > probe.ag <<EOF
+cb 100;
+
+$HELPER
+
+print(repo_tier("$agent_name", "$owner", "$repo"));
+EOF
+        # `agentis go` runs the file as a script; the top-level print(...)
+        # emits exactly one line carrying the tier string we test against.
+        # `[genesis] <hash>` is unconditionally printed first; tail -n 1
+        # selects the helper output.
+        agentis go probe.ag 2>/dev/null | tail -n 1
+    )
+
+    rm -rf "$sandbox"
+}
+
+# --- Test 1: fallback path -----------------------------------------------
+# No per-repo memo set, legacy unscoped key at 0.7 -> "propose".
+GOT="$(run_repo_tier "router" "acme" "frontend" "router:confidence=0.7")"
+if [ "$GOT" = "propose" ]; then
+    pass "test 1: fallback (legacy 0.7, no per-repo) -> propose"
+else
+    fail "test 1: fallback (legacy 0.7, no per-repo) -> propose" \
+         "got='$GOT'"
+fi
+
+# --- Test 2: per-repo wins ------------------------------------------------
+# Legacy 0.7 + per-repo 0.95 for the same (agent, owner, repo) triple ->
+# scoped_memo lookup wins, tier = "autonomous".
+GOT="$(run_repo_tier "router" "acme" "frontend" \
+    "router:confidence=0.7;acme__frontend:router:confidence=0.95")"
+if [ "$GOT" = "autonomous" ]; then
+    pass "test 2: per-repo wins (legacy 0.7 + per-repo 0.95) -> autonomous"
+else
+    fail "test 2: per-repo wins (legacy 0.7 + per-repo 0.95) -> autonomous" \
+         "got='$GOT'"
+fi
+
+# --- Test 3: divergence across two repos ----------------------------------
+# Same agent, two repos, two per-repo values -> two different tiers.
+# This is the M4 use case: an agent can be "propose" on repo A and
+# "autonomous" on repo B at the same point in time.
+SEEDS="router:confidence=0.5;acme__frontend:router:confidence=0.65;acme__backend:router:confidence=0.97"
+GOT_A="$(run_repo_tier "router" "acme" "frontend" "$SEEDS")"
+GOT_B="$(run_repo_tier "router" "acme" "backend" "$SEEDS")"
+if [ "$GOT_A" = "propose" ] && [ "$GOT_B" = "autonomous" ]; then
+    pass "test 3: divergence (frontend=0.65 -> propose, backend=0.97 -> autonomous)"
+else
+    fail "test 3: divergence (frontend=0.65 -> propose, backend=0.97 -> autonomous)" \
+         "frontend='$GOT_A' backend='$GOT_B'"
+fi
+
+# --- Test 4: sentinel byte-identity ---------------------------------------
+# owner == "" must bypass the scoped lookup entirely. For every legacy
+# confidence value, the helper returns the same string the runtime tier()
+# builtin returns. The boundary table here mirrors ADR-0001 — divergence
+# between this list and the helper body is what test 4 catches.
+sentinel_ok=true
+for pair in \
+    "0.0=dormant" \
+    "0.39=dormant" \
+    "0.4=shadow" \
+    "0.59=shadow" \
+    "0.6=propose" \
+    "0.79=propose" \
+    "0.8=review-gated" \
+    "0.94=review-gated" \
+    "0.95=autonomous" \
+    "1.0=autonomous"
+do
+    val="${pair%%=*}"
+    expected="${pair#*=}"
+    GOT="$(run_repo_tier "router" "" "" "router:confidence=$val")"
+    if [ "$GOT" != "$expected" ]; then
+        sentinel_ok=false
+        fail "test 4: sentinel owner='' value=$val -> $expected" \
+             "got='$GOT'"
+    fi
+done
+if $sentinel_ok; then
+    pass "test 4: sentinel byte-identity (owner='' matches runtime tier() across 10 values)"
+fi
+
+# --- Test 5: boundary respect ---------------------------------------------
+# Per-repo path: the helper must map exactly at the ADR-0001 thresholds
+# (0.4 / 0.6 / 0.8 / 0.95) to the upper-tier string and just-below to
+# the lower tier. Same table as test 4 but seeded as the per-repo key
+# so the scoped-memo branch is exercised explicitly.
+boundary_ok=true
+for pair in \
+    "0.39=dormant" \
+    "0.4=shadow" \
+    "0.59=shadow" \
+    "0.6=propose" \
+    "0.79=propose" \
+    "0.8=review-gated" \
+    "0.94=review-gated" \
+    "0.95=autonomous"
+do
+    val="${pair%%=*}"
+    expected="${pair#*=}"
+    SEEDS="router:confidence=0.0;acme__frontend:router:confidence=$val"
+    GOT="$(run_repo_tier "router" "acme" "frontend" "$SEEDS")"
+    if [ "$GOT" != "$expected" ]; then
+        boundary_ok=false
+        fail "test 5: boundary per-repo value=$val -> $expected" \
+             "got='$GOT'"
+    fi
+done
+if $boundary_ok; then
+    pass "test 5: boundary respect (8 ADR-0001 boundary points map to expected tier)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Fourth milestone of #316 (multi-repo). Introduces per-repo confidence: same agent can be `propose` on repo A and `autonomous` on repo B.

- **`repo_tier()` helper** added to all 21 agents (federation-side, mirrors runtime `tier()` builtin's threshold table from ADR-0001/CLAUDE.md).
- Reads `<owner>__<repo>:<agent>:confidence` first; falls back to legacy `<agent>:confidence` when missing; sentinel `owner==""` (single-block path) bypasses scoped lookup entirely → byte-identical to legacy `tier()`.
- All 21 `tier("<agent>")` call sites inside `tick_for_repo` swapped to `repo_tier("<agent>", owner, repo)`. `release_checker.ag` had 2 sites — both swapped.
- **`labeler.ag`'s `apply_feedback(delta, owner, repo)`** writes to per-repo memo so the reality-check loop drifts independently per repo.
- **`tools/colony-lint.sh`**: new rule fails on direct `tier()` call inside `fn tick_for_repo` (escape hatch: `// colony-lint: m4-direct-tier-ok`). Existing tier-presence regex extended to accept both `tier(...)` and `repo_tier(...)`.
- **`tools/test-per-repo-confidence.sh`** (new, 5 tests): fallback / per-repo wins / divergence between two repos / sentinel byte-identity / threshold boundaries.

**Investigation finding:** `learn()` is NOT what writes confidence memos. Three external paths do (install.sh seed, auto-promote sidecar, dashboard /confidence + labeler.ag's apply_feedback). M4's federation-side scope is therefore narrower than the spec naively implied: read-side helper + opt-in write in labeler. **install.sh, auto-promote.sh, dashboard stay legacy-only in M4** — operators set per-repo divergence via `agentis memo set acme__frontend:labeler:confidence 0.95`. M5+ extends the auto-promote/dashboard surface.

Plan: #316 M4 detail comment.

## Test plan

- [x] 21/21 standalone `agentis commit` PASS on modified .ag files
- [x] **`tools/test-per-repo-confidence.sh` — 5/5 PASS** (incl. byte-identity for sentinel path + threshold boundaries)
- [x] **`tools/test-single-block-byte-identity.sh` — 5/5 PASS** (M3a load-bearing test still green)
- [x] M3a/M3b regression: `test-iter-repos.sh` (6/6), `test-forge-api-multi-repo.sh` (9/9)
- [x] M1/M2 regression: `test-multi-repo-schema.sh` (16/16), `test-start-colony-multi-repo.sh` (6/6), `test-start-colony-restart.sh` (26/26), `test-forge-config.sh` (45/45), `test-colony-lint-bash32.sh`, `test-labeler-autonomous-verdict.sh` (20/20), `test-learn-idempotency.sh` (24/24)
- [x] `colony-lint .` — **146 PASS / 0 FAIL / 3 SKIP** (lint clean — first time since M1 landed; new lint rule fires zero times on the modified tree)
- [x] All M1/M2/M3a/M3b-shipped surfaces byte-identical (install.sh, .agentis/config, all 5 colony.example.toml, all 5 forge-api.sh / github-api.sh / start-colony.sh, ADR-0002, tribes-bench, all earlier tests, all earlier helpers)
- [ ] CI green
- [ ] QA agent report (will be posted)

## Plan deviations (small)

1. Helper parameter renamed `agent` → `agent_name` (`agent` is reserved keyword in .ag).
2. Existing colony-lint tier-presence regex extended to accept `repo_tier(...)` form (without it, lint would fail on all 21 migrated agents).
3. `apply_feedback` has only one call site in labeler (plan said two — investigated, single site updated).

## Note for reviewer

After this lands, **5 of 6 milestones done**: M1 (schema), M2 (env wiring), M3a (plumbing + triage), M3b (fan-out 17), **M4 (per-repo confidence)**. Only M5 (dashboard per-repo metrics) and M6 (retire single-block, MAJOR, v2.0.0) remain.