### PR TITLE
feat: dashboard per-repo Forge Rate Limits + confidence overlay + per-repo trigger labels (#316 M5a)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -74,6 +74,14 @@ is asserted until multi-version CI is in place.
   writes ship in a follow-up; until then the sidecar continues to write only
   the unscoped key. `colony-lint.sh` gains a check failing on direct `tier()`
   calls inside `fn tick_for_repo`.
+- Multi-repo runtime (#316 M5): per-repo trigger label memo seeding. `triage`,
+  `planning`, and `implementation` start-colony.sh now read each
+  `[[forge.github]]` entry's `labels = { trigger = "..." }` inline table and
+  seed `<owner>__<repo>:<colony>:labels:trigger` on full-colony bootstrap.
+  Single-block configs continue to seed only the legacy unscoped vocabulary
+  memos. `tools/parse-toml.sh` grows `parse_toml_array_get_inline` for
+  inline-table subkey lookup. **Recommends:** federation-dashboard >= **0.8.0**
+  (M5b) for the per-repo Forge Rate Limits + confidence overlay on dashboard.
 
 ### Deprecated
 

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -193,6 +193,17 @@ esac
 export FORGE_TYPE
 export COLONY_DIR
 
+# #316 M5a: --print-repos-json probe for the federation-dashboard collector.
+# Emits the GITHUB_REPOS_JSON value (empty string for legacy single-block
+# configs) and exits. Probed once per colony per dashboard regen so the
+# collector can fan rate-limit + per-(agent, repo) memo lookups out across
+# every entry. Placed right after env load so the probe is fast (no daemon
+# launches, no memo seeding) and stays cheap to call every refresh cycle.
+if [ "${1:-}" = "--print-repos-json" ]; then
+    echo "${GITHUB_REPOS_JSON:-}"
+    exit 0
+fi
+
 AGENTS=(
     style_reviewer
     logic_reviewer

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -231,6 +231,17 @@ export IMPLEMENTATION_REQUIRE_ASSIGNEE
 export GITLAB_DEFAULT_BRANCH
 export COLONY_DIR
 
+# #316 M5a: --print-repos-json probe for the federation-dashboard collector.
+# Emits the GITHUB_REPOS_JSON value (empty string for legacy single-block
+# configs) and exits. Probed once per colony per dashboard regen so the
+# collector can fan rate-limit + per-(agent, repo) memo lookups out across
+# every entry. Placed right after env load so the probe is fast (no daemon
+# launches, no memo seeding) and stays cheap to call every refresh cycle.
+if [ "${1:-}" = "--print-repos-json" ]; then
+    echo "${GITHUB_REPOS_JSON:-}"
+    exit 0
+fi
+
 # #291: seed code_writer:require_assignee memo so the .ag agent can read the
 # knob via recall_latest() and pick the `--include-unassigned` forge flag on
 # assigned-issues polls. Skipped on single-agent respawn / rate-limit-status
@@ -238,6 +249,26 @@ export COLONY_DIR
 if [ -z "$RESTART_AGENT" ] && [ "$RATE_LIMIT_STATUS" = "0" ]; then
     FED_ROOT="$(cd "$REPO_ROOT/dev-apprenticeship" && pwd)"
     (cd "$FED_ROOT" && agentis memo set code_writer:require_assignee "$IMPLEMENTATION_REQUIRE_ASSIGNEE" >/dev/null 2>&1) || true
+
+    # #316 M5a: per-repo trigger label memo seeding. When the colony is
+    # configured with [[forge.github]] array form (REPO_COUNT > 0), loop
+    # entries and seed `<owner>__<repo>:implementation:labels:trigger` for
+    # each entry that declares an inline `labels = { trigger = "..." }`
+    # value. Single-block configs (REPO_COUNT=0) skip this loop entirely
+    # — implementation has no legacy unscoped trigger memo, only the
+    # IMPLEMENTATION_TRIGGER_LABEL env var, so this is purely additive.
+    if [ "${REPO_COUNT:-0}" -gt 0 ]; then
+        i=0
+        while [ "$i" -lt "$REPO_COUNT" ]; do
+            ent_owner=$(parse_toml_array_get forge.github "$i" owner)
+            ent_repo=$(parse_toml_array_get forge.github "$i" repo)
+            ent_trigger=$(parse_toml_array_get_inline forge.github "$i" labels trigger)
+            if [ -n "$ent_owner" ] && [ -n "$ent_repo" ] && [ -n "$ent_trigger" ]; then
+                (cd "$FED_ROOT" && agentis memo set "${ent_owner}__${ent_repo}:implementation:labels:trigger" "$ent_trigger" >/dev/null 2>&1) || true
+            fi
+            i=$((i + 1))
+        done
+    fi
 fi
 
 AGENTS=(

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -201,6 +201,17 @@ export FORGE_TYPE
 export PLANNING_TRIGGER_LABEL
 export COLONY_DIR
 
+# #316 M5a: --print-repos-json probe for the federation-dashboard collector.
+# Emits the GITHUB_REPOS_JSON value (empty string for legacy single-block
+# configs) and exits. Probed once per colony per dashboard regen so the
+# collector can fan rate-limit + per-(agent, repo) memo lookups out across
+# every entry. Placed right after env load so the probe is fast (no daemon
+# launches, no memo seeding) and stays cheap to call every refresh cycle.
+if [ "${1:-}" = "--print-repos-json" ]; then
+    echo "${GITHUB_REPOS_JSON:-}"
+    exit 0
+fi
+
 AGENTS=(
     scope_estimator
     risk_assessor
@@ -225,6 +236,26 @@ if [ -z "$RESTART_AGENT" ] && [ "$RATE_LIMIT_STATUS" = "0" ]; then
     fi
     if [ -n "$EPIC_LABELS" ]; then
         (cd "$FED_ROOT" && agentis memo set planning:labels:epic "$EPIC_LABELS" >/dev/null 2>&1) || true
+    fi
+
+    # #316 M5a: per-repo trigger label memo seeding. When the colony is
+    # configured with [[forge.github]] array form (REPO_COUNT > 0), loop
+    # entries and seed `<owner>__<repo>:planning:labels:trigger` for each
+    # entry that declares an inline `labels = { trigger = "..." }` value.
+    # Single-block configs (REPO_COUNT=0) skip this loop entirely so the
+    # legacy unscoped seeds above stay the only memo writes — preserves
+    # byte-identity for v1.3.0 operators.
+    if [ "${REPO_COUNT:-0}" -gt 0 ]; then
+        i=0
+        while [ "$i" -lt "$REPO_COUNT" ]; do
+            ent_owner=$(parse_toml_array_get forge.github "$i" owner)
+            ent_repo=$(parse_toml_array_get forge.github "$i" repo)
+            ent_trigger=$(parse_toml_array_get_inline forge.github "$i" labels trigger)
+            if [ -n "$ent_owner" ] && [ -n "$ent_repo" ] && [ -n "$ent_trigger" ]; then
+                (cd "$FED_ROOT" && agentis memo set "${ent_owner}__${ent_repo}:planning:labels:trigger" "$ent_trigger" >/dev/null 2>&1) || true
+            fi
+            i=$((i + 1))
+        done
     fi
 fi
 

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -202,6 +202,17 @@ export GITLAB_DEFAULT_BRANCH
 export FORGE_TYPE
 export COLONY_DIR
 
+# #316 M5a: --print-repos-json probe for the federation-dashboard collector.
+# Emits the GITHUB_REPOS_JSON value (empty string for legacy single-block
+# configs) and exits. Probed once per colony per dashboard regen so the
+# collector can fan rate-limit + per-(agent, repo) memo lookups out across
+# every entry. Placed right after env load so the probe is fast (no daemon
+# launches, no memo seeding) and stays cheap to call every refresh cycle.
+if [ "${1:-}" = "--print-repos-json" ]; then
+    echo "${GITHUB_REPOS_JSON:-}"
+    exit 0
+fi
+
 AGENTS=(
     release_checker
     ship_decider

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -193,6 +193,17 @@ esac
 export FORGE_TYPE
 export COLONY_DIR
 
+# #316 M5a: --print-repos-json probe for the federation-dashboard collector.
+# Emits the GITHUB_REPOS_JSON value (empty string for legacy single-block
+# configs) and exits. Probed once per colony per dashboard regen so the
+# collector can fan rate-limit + per-(agent, repo) memo lookups out across
+# every entry. Placed right after env load so the probe is fast (no daemon
+# launches, no memo seeding) and stays cheap to call every refresh cycle.
+if [ "${1:-}" = "--print-repos-json" ]; then
+    echo "${GITHUB_REPOS_JSON:-}"
+    exit 0
+fi
+
 AGENTS=(
     issue_creator
     labeler
@@ -213,6 +224,26 @@ if [ -z "$RESTART_AGENT" ] && [ "$RATE_LIMIT_STATUS" = "0" ]; then
     FED_ROOT="$(cd "$REPO_ROOT/dev-apprenticeship" && pwd)"
     if [ -n "$PRIORITY_LABELS" ]; then
         (cd "$FED_ROOT" && agentis memo set triage:labels:priority "$PRIORITY_LABELS" >/dev/null 2>&1) || true
+    fi
+
+    # #316 M5a: per-repo trigger label memo seeding. When the colony is
+    # configured with [[forge.github]] array form (REPO_COUNT > 0), loop
+    # entries and seed `<owner>__<repo>:triage:labels:trigger` for each
+    # entry that declares an inline `labels = { trigger = "..." }` value.
+    # Single-block configs (REPO_COUNT=0) skip this loop entirely so the
+    # legacy unscoped seed above stays the only memo write — preserves
+    # byte-identity for v1.3.0 operators.
+    if [ "${REPO_COUNT:-0}" -gt 0 ]; then
+        i=0
+        while [ "$i" -lt "$REPO_COUNT" ]; do
+            ent_owner=$(parse_toml_array_get forge.github "$i" owner)
+            ent_repo=$(parse_toml_array_get forge.github "$i" repo)
+            ent_trigger=$(parse_toml_array_get_inline forge.github "$i" labels trigger)
+            if [ -n "$ent_owner" ] && [ -n "$ent_repo" ] && [ -n "$ent_trigger" ]; then
+                (cd "$FED_ROOT" && agentis memo set "${ent_owner}__${ent_repo}:triage:labels:trigger" "$ent_trigger" >/dev/null 2>&1) || true
+            fi
+            i=$((i + 1))
+        done
     fi
 fi
 

--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **dashboard**: per-repo Forge Rate Limits — multi-repo colonies (`[[forge.github]]` with N>=2 entries) now render one rate-limit row per repo inside the per-colony modal, with a colony-wide aggregate footer (sum-of-remaining / sum-of-limit, earliest reset_at). Single-block and N=1 multi-block colonies keep the v0.7.0 single-row layout byte-identical. New `data.forge_rate_limits[colony].repos[]` shape on multi-repo. (#316 M5)
+- **dashboard**: per-repo confidence overlay on the per-agent table — when M4-shipped `<owner>__<repo>:<agent>:confidence` memos are seeded, the agent row carries a `(per-repo)` pill and the per-agent modal grows a "Per-repo overrides" subsection. New per-agent collector field `data.agents[].per_repo_confidence`. (#316 M5)
+
 ## [0.7.0] — 2026-04-29
 
 5-tab Status redesign + Promotion Progress collapsible + orphan sidecar

--- a/federation-dashboard/lib/federation-dashboard-collector.py
+++ b/federation-dashboard/lib/federation-dashboard-collector.py
@@ -58,6 +58,47 @@ colonies   = safe_json(colony_list_json, [])
 
 name_to_colony = {e.get('agent',''): e.get('colony','') for e in agent_map}
 
+# #316 M5a: pre-compute multi-repo expansion per colony.
+# Each colony's `start-colony.sh --print-repos-json` echoes the
+# `GITHUB_REPOS_JSON` env value the script would export under the
+# multi-block `[[forge.github]]` configuration shape, or empty for
+# legacy single-block configs. Parsed once here so the rate-limit
+# loop and the per-agent confidence overlay below can both reuse the
+# answer without re-spawning subprocesses. Empty list means "single-
+# block / N=1 / no GitHub backend" — every downstream call site MUST
+# fall back to the legacy single-record behaviour for byte-identity.
+repos_for_colony = {}
+for colony in colonies:
+    repos_for_colony[colony] = []
+    script = os.path.join(fed_dir, colony, 'scripts', 'start-colony.sh')
+    if not os.path.isfile(script):
+        continue
+    try:
+        probe = subprocess.run(
+            ['bash', script, '--print-repos-json'],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (subprocess.SubprocessError, OSError):
+        continue
+    if probe.returncode != 0:
+        continue
+    raw = (probe.stdout or '').strip()
+    if not raw:
+        continue
+    try:
+        repos = json.loads(raw)
+    except json.JSONDecodeError:
+        continue
+    if not isinstance(repos, list):
+        continue
+    for entry in repos:
+        if not isinstance(entry, dict):
+            continue
+        owner = str(entry.get('owner') or '').strip()
+        repo  = str(entry.get('repo')  or '').strip()
+        if owner and repo:
+            repos_for_colony[colony].append((owner, repo))
+
 # Build role -> daemon mapping from daemon list source field
 role_to_daemon = {}
 id_to_role = {}
@@ -258,6 +299,42 @@ for agent in all_agents:
             except OSError:
                 pass
 
+    # #316 M5a: per-repo confidence overlay. Multi-repo colonies (N>=2
+    # entries in [[forge.github]]) carry per-(agent, repo) overrides via
+    # M4-shipped `<owner>__<repo>:<agent>:confidence` memos. We surface
+    # the overrides as a sibling field so the dashboard's per-agent
+    # row + modal can render a `(per-repo)` pill plus drill-down.
+    # Bound the cost: only fetch when (a) the colony actually has >=2
+    # repos and (b) the daemon's unscoped confidence is non-None (a
+    # daemon with no confidence at all has nothing to override). Default
+    # to an empty list so legacy single-block / N=1 / GitLab colonies
+    # render byte-identical to v0.7.0.
+    rec['per_repo_confidence'] = []
+    repos = repos_for_colony.get(colony, [])
+    if len(repos) >= 2 and rec['confidence'] is not None:
+        for owner, repo in repos:
+            memo_key = '%s__%s:%s:confidence' % (owner, repo, agent)
+            conf_value = None
+            try:
+                memo_proc = subprocess.run(
+                    ['agentis', 'memo', 'get', memo_key, '--raw'],
+                    cwd=fed_dir, capture_output=True, text=True, timeout=2,
+                )
+                if memo_proc.returncode == 0:
+                    raw = (memo_proc.stdout or '').strip()
+                    if raw:
+                        try:
+                            conf_value = float(raw)
+                        except (TypeError, ValueError):
+                            conf_value = None
+            except (subprocess.SubprocessError, OSError):
+                conf_value = None
+            rec['per_repo_confidence'].append({
+                'owner': owner,
+                'repo': repo,
+                'confidence': conf_value,
+            })
+
     result.append(rec)
 
 colony_exp['total'] = total_exp
@@ -384,7 +461,7 @@ if os.path.isfile(conf_log_path):
         pass
 conf_changes = conf_changes[-50:]
 
-# --- Forge rate-limits (federation-dashboard 0.3.0) ---
+# --- Forge rate-limits (federation-dashboard 0.3.0; #316 M5a per-repo) ---
 # Per-colony forge API budget. Each colony's `start-colony.sh
 # --rate-limit-status` execs its `forge-api.sh rate-limit-status` in the
 # fully-loaded env (FORGE_TYPE + GITLAB_*/GITHUB_*) and prints the JSON
@@ -393,6 +470,79 @@ conf_changes = conf_changes[-50:]
 # Failure modes (timeout, non-zero exit, malformed JSON) collapse into
 # `{remaining: null, limit: null, reset_at: null, error: "<reason>"}` so
 # the tile can render a per-colony status without bringing down regen.
+#
+# #316 M5a: when the colony's [[forge.github]] array carries N>=2 entries
+# (read from the pre-computed `repos_for_colony` map above), fan the
+# rate-limit fetch out across each repo via `start-colony.sh
+# --rate-limit-status --repo owner/repo` and emit a new shape:
+#     forge_rate_limits[colony] = {
+#         repos:    [{owner, repo, remaining, limit, reset_at}, ...],
+#         aggregate: {remaining, limit, reset_at},
+#     }
+# The aggregate is sum-of-remaining / sum-of-limit / earliest reset_at
+# across the per-repo records (None values skipped). Single-block / N=1
+# / GitLab colonies preserve the existing scalar shape byte-identically
+# — that is the load-bearing back-compat invariant for v0.7.0 operators.
+def _scalar_rate_limit(script):
+    """Run start-colony.sh --rate-limit-status (no per-repo arg) and
+    return a `{remaining, limit, reset_at}` dict (with optional `error`
+    field when the call fails). Mirrors the v0.7.0 scalar contract."""
+    try:
+        rl_out = subprocess.run(
+            ['bash', script, '--rate-limit-status'],
+            capture_output=True, text=True, timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return {'remaining': None, 'limit': None, 'reset_at': None, 'error': 'timeout'}
+    except (subprocess.SubprocessError, OSError) as e:
+        return {'remaining': None, 'limit': None, 'reset_at': None, 'error': type(e).__name__}
+    if rl_out.returncode != 0:
+        return {'remaining': None, 'limit': None, 'reset_at': None,
+                'error': 'exit ' + str(rl_out.returncode)}
+    try:
+        payload = json.loads(rl_out.stdout or '{}')
+    except json.JSONDecodeError:
+        return {'remaining': None, 'limit': None, 'reset_at': None,
+                'error': 'malformed json'}
+    return {
+        'remaining': payload.get('remaining'),
+        'limit':     payload.get('limit'),
+        'reset_at':  payload.get('reset_at'),
+    }
+
+
+def _per_repo_rate_limit(script, owner, repo):
+    """Run start-colony.sh --rate-limit-status --repo owner/repo and
+    return the per-repo `{remaining, limit, reset_at}` dict (with
+    optional `error` field). Same failure-mode contract as the scalar
+    helper above; the `--repo` flag is consumed by forge-api.sh
+    (M3a-shipped) which re-resolves GITHUB_OWNER/REPO/TOKEN/URL/ME via
+    tools/forge-resolve-repo.py before exec'ing the backend wrapper."""
+    repo_arg = '%s/%s' % (owner, repo)
+    try:
+        rl_out = subprocess.run(
+            ['bash', script, '--rate-limit-status', '--repo', repo_arg],
+            capture_output=True, text=True, timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return {'remaining': None, 'limit': None, 'reset_at': None, 'error': 'timeout'}
+    except (subprocess.SubprocessError, OSError) as e:
+        return {'remaining': None, 'limit': None, 'reset_at': None, 'error': type(e).__name__}
+    if rl_out.returncode != 0:
+        return {'remaining': None, 'limit': None, 'reset_at': None,
+                'error': 'exit ' + str(rl_out.returncode)}
+    try:
+        payload = json.loads(rl_out.stdout or '{}')
+    except json.JSONDecodeError:
+        return {'remaining': None, 'limit': None, 'reset_at': None,
+                'error': 'malformed json'}
+    return {
+        'remaining': payload.get('remaining'),
+        'limit':     payload.get('limit'),
+        'reset_at':  payload.get('reset_at'),
+    }
+
+
 forge_rate_limits = {}
 for colony in colonies:
     script = os.path.join(fed_dir, colony, 'scripts', 'start-colony.sh')
@@ -400,34 +550,42 @@ for colony in colonies:
         forge_rate_limits[colony] = {'remaining': None, 'limit': None,
                                      'reset_at': None, 'error': 'no start-colony.sh'}
         continue
-    try:
-        rl_out = subprocess.run(
-            ['bash', script, '--rate-limit-status'],
-            capture_output=True, text=True, timeout=10,
-        )
-        if rl_out.returncode != 0:
-            forge_rate_limits[colony] = {
-                'remaining': None, 'limit': None, 'reset_at': None,
-                'error': 'exit ' + str(rl_out.returncode),
-            }
-            continue
-        try:
-            payload = json.loads(rl_out.stdout or '{}')
-        except json.JSONDecodeError:
-            forge_rate_limits[colony] = {'remaining': None, 'limit': None,
-                                         'reset_at': None, 'error': 'malformed json'}
-            continue
-        forge_rate_limits[colony] = {
-            'remaining': payload.get('remaining'),
-            'limit':     payload.get('limit'),
-            'reset_at':  payload.get('reset_at'),
-        }
-    except subprocess.TimeoutExpired:
-        forge_rate_limits[colony] = {'remaining': None, 'limit': None,
-                                     'reset_at': None, 'error': 'timeout'}
-    except (subprocess.SubprocessError, OSError) as e:
-        forge_rate_limits[colony] = {'remaining': None, 'limit': None,
-                                     'reset_at': None, 'error': type(e).__name__}
+    repos = repos_for_colony.get(colony, [])
+    if len(repos) < 2:
+        # Single-block / N=1 / GitLab — byte-identical to v0.7.0.
+        forge_rate_limits[colony] = _scalar_rate_limit(script)
+        continue
+    # Multi-block N>=2: fan out per-repo, then derive an aggregate.
+    per_repo_records = []
+    for owner, repo in repos:
+        rec_repo = _per_repo_rate_limit(script, owner, repo)
+        per_repo_records.append({
+            'owner': owner,
+            'repo': repo,
+            'remaining': rec_repo.get('remaining'),
+            'limit': rec_repo.get('limit'),
+            'reset_at': rec_repo.get('reset_at'),
+            'error': rec_repo.get('error'),
+        })
+    rem_total = 0
+    lim_total = 0
+    earliest_reset = None
+    for r in per_repo_records:
+        if isinstance(r['remaining'], (int, float)):
+            rem_total += r['remaining']
+        if isinstance(r['limit'], (int, float)):
+            lim_total += r['limit']
+        if r['reset_at']:
+            if earliest_reset is None or r['reset_at'] < earliest_reset:
+                earliest_reset = r['reset_at']
+    forge_rate_limits[colony] = {
+        'repos': per_repo_records,
+        'aggregate': {
+            'remaining': rem_total if rem_total > 0 else None,
+            'limit': lim_total if lim_total > 0 else None,
+            'reset_at': earliest_reset,
+        },
+    }
 
 # --- Promote decisions (#248) ---
 # Invoke auto-promote-decisions.py in --preview mode so the dashboard's

--- a/federation-dashboard/lib/federation-dashboard.html.template
+++ b/federation-dashboard/lib/federation-dashboard.html.template
@@ -2245,6 +2245,17 @@ function renderAgentTable(data) {
         if (ch.value > ch.prev) confHtml += '<span class="conf-indicator up">\u25B2</span>';
         else if (ch.value < ch.prev) confHtml += '<span class="conf-indicator down">\u25BC</span>';
       }
+      // #316 M5a: per-repo override pill. Multi-repo colonies (N>=2)
+      // surface per-(agent, repo) confidence overrides via M4-shipped
+      // memos; the per-agent modal renders the full breakdown. Render
+      // the pill only when the override list is non-empty AND at least
+      // one override carries a numeric confidence (a list of all-null
+      // entries means no operator has seeded any override yet, so the
+      // pill would mislead).
+      if (a.per_repo_confidence && a.per_repo_confidence.length > 0
+          && a.per_repo_confidence.some(function(p){ return p.confidence != null; })) {
+        confHtml += '<span class="conf-indicator" style="margin-left:4px;color:var(--cyan);font-size:10px;" title="per-repo confidence overrides — open agent for breakdown">(per-repo)</span>';
+      }
     }
 
     // Health display
@@ -4698,6 +4709,36 @@ function openDetail(agentName) {
   }
   html += '</div>';
 
+  // #316 M5a: per-repo confidence overrides subsection. Multi-repo
+  // colonies (N>=2 entries in [[forge.github]]) carry per-(agent, repo)
+  // confidence via M4-shipped `<owner>__<repo>:<agent>:confidence`
+  // memos. Render the breakdown only when the collector populated the
+  // overlay list (default empty for legacy single-block and non-github
+  // backends — those keep the v0.7.0 modal byte-identical).
+  if (a.per_repo_confidence && a.per_repo_confidence.length > 0) {
+    html += '<div class="modal-section"><h3>Per-repo overrides</h3>';
+    html += '<table style="width:100%;font-size:12px;"><tr>' +
+            '<th style="text-align:left;">Repo</th>' +
+            '<th style="text-align:left;">Confidence</th>' +
+            '</tr>';
+    a.per_repo_confidence.forEach(function(p) {
+      const label = esc(p.owner + '/' + p.repo);
+      let val;
+      if (p.confidence == null) {
+        val = '<span class="muted">— (no override)</span>';
+      } else {
+        const phase = p.confidence >= 0.95 ? 'autonomous'
+          : p.confidence >= 0.8 ? 'review-gated'
+          : p.confidence >= 0.6 ? 'propose'
+          : p.confidence >= 0.4 ? 'shadow'
+          : 'dormant';
+        val = '<span class="badge badge-' + phase + '">' + p.confidence.toFixed(2) + '</span>';
+      }
+      html += '<tr><td>' + label + '</td><td>' + val + '</td></tr>';
+    });
+    html += '</table></div>';
+  }
+
   // Charts row (confidence history + learning rate)
   html += '<div class="modal-grid">';
 
@@ -4985,19 +5026,19 @@ function showColonyModal(colonyName) {
   html += '</div><button class="modal-close" onclick="closeColonyModal()">×</button></div>';
 
   // Forge Rate Limits row — sourced from data.forge_rate_limits[colony].
-  html += '<div class="modal-section"><h3>Forge Rate Limits</h3>';
-  html += '<div class="rl-row" id="colony-modal-forge-rate-limits">';
-  const rem = rl.remaining;
-  const lim = rl.limit;
-  const reset = rl.reset_at;
-  const err = rl.error;
-  const lastSuccess = rl.last_success_ts;
-  let valueHtml;
-  if (err) {
-    valueHtml = '<span class="rl-err" title="' + esc(err) + '">err: ' + esc(String(err).slice(0, 80)) + '</span>';
-  } else if (rem == null && lim == null) {
-    valueHtml = '<span class="rl-na">— (no rate-limit headers from this forge)</span>';
-  } else {
+  // #316 M5a: per-repo fan-out. When `rl.repos` is an array (multi-block
+  // [[forge.github]] with N>=2 entries), render one .rl-row per repo plus
+  // an aggregate footer (sum-of-remaining / sum-of-limit, earliest reset).
+  // Single-block / N=1 / non-github keeps the v0.7.0 single-row layout
+  // byte-identical — the load-bearing back-compat invariant for v0.7.0
+  // operators.
+  function _rlValueHtml(rem, lim, err) {
+    if (err) {
+      return '<span class="rl-err" title="' + esc(err) + '">err: ' + esc(String(err).slice(0, 80)) + '</span>';
+    }
+    if (rem == null && lim == null) {
+      return '<span class="rl-na">— (no rate-limit headers from this forge)</span>';
+    }
     let cls = 'rl-ok';
     if (typeof rem === 'number' && typeof lim === 'number' && lim > 0) {
       const ratio = rem / lim;
@@ -5008,11 +5049,10 @@ function showColonyModal(colonyName) {
     }
     const remStr = (rem == null) ? '?' : esc(String(rem));
     const limStr = (lim == null) ? '?' : esc(String(lim));
-    valueHtml = '<span class="' + cls + '">' + remStr + ' / ' + limStr + '</span>';
+    return '<span class="' + cls + '">' + remStr + ' / ' + limStr + '</span>';
   }
-  html += '<span class="rl-colony">remaining</span>';
-  html += '<span class="rl-value">' + valueHtml + '</span>';
-  if (reset) {
+  function _rlResetHtml(reset) {
+    if (!reset) return '';
     const resetMs = Date.parse(reset);
     const secs = resetMs ? Math.max(0, Math.round((resetMs - nowEpoch * 1000) / 1000)) : 0;
     let txt;
@@ -5021,11 +5061,67 @@ function showColonyModal(colonyName) {
     else if (secs < 60) txt = 'reset in ' + secs + 's';
     else if (secs < 3600) txt = 'reset in ' + Math.floor(secs / 60) + 'm';
     else txt = 'reset in ' + Math.floor(secs / 3600) + 'h';
-    html += '<span class="rl-reset" title="' + esc(reset) + '">' + esc(txt) + '</span>';
+    return '<span class="rl-reset" title="' + esc(reset) + '">' + esc(txt) + '</span>';
   }
-  html += '</div>';
-  if (lastSuccess) {
-    html += '<div class="muted" style="font-size:11px;margin-top:4px;">last success: ' + relTime(lastSuccess) + '</div>';
+  html += '<div class="modal-section"><h3>Forge Rate Limits</h3>';
+  if (Array.isArray(rl.repos) && rl.repos.length > 0) {
+    // #316 M5a: multi-repo per-(owner, repo) layout.
+    rl.repos.forEach(function(r) {
+      html += '<div class="rl-row">';
+      html += '<span class="rl-colony">' + esc(r.owner + '/' + r.repo) + '</span>';
+      html += '<span class="rl-value">' + _rlValueHtml(r.remaining, r.limit, r.error) + '</span>';
+      html += _rlResetHtml(r.reset_at);
+      html += '</div>';
+    });
+    const agg = rl.aggregate || {};
+    html += '<div class="rl-row" style="border-top:1px solid var(--border);padding-top:4px;margin-top:4px;">';
+    html += '<span class="rl-colony"><strong>aggregate</strong></span>';
+    html += '<span class="rl-value">' + _rlValueHtml(agg.remaining, agg.limit, null) + '</span>';
+    html += _rlResetHtml(agg.reset_at);
+    html += '</div>';
+  } else {
+    // Legacy / single-block / N=1 path — byte-identical to v0.7.0.
+    html += '<div class="rl-row" id="colony-modal-forge-rate-limits">';
+    const rem = rl.remaining;
+    const lim = rl.limit;
+    const reset = rl.reset_at;
+    const err = rl.error;
+    const lastSuccess = rl.last_success_ts;
+    let valueHtml;
+    if (err) {
+      valueHtml = '<span class="rl-err" title="' + esc(err) + '">err: ' + esc(String(err).slice(0, 80)) + '</span>';
+    } else if (rem == null && lim == null) {
+      valueHtml = '<span class="rl-na">— (no rate-limit headers from this forge)</span>';
+    } else {
+      let cls = 'rl-ok';
+      if (typeof rem === 'number' && typeof lim === 'number' && lim > 0) {
+        const ratio = rem / lim;
+        if (ratio < 0.10) cls = 'rl-crit';
+        else if (ratio < 0.25) cls = 'rl-warn';
+      } else if (rem === 0) {
+        cls = 'rl-warn';
+      }
+      const remStr = (rem == null) ? '?' : esc(String(rem));
+      const limStr = (lim == null) ? '?' : esc(String(lim));
+      valueHtml = '<span class="' + cls + '">' + remStr + ' / ' + limStr + '</span>';
+    }
+    html += '<span class="rl-colony">remaining</span>';
+    html += '<span class="rl-value">' + valueHtml + '</span>';
+    if (reset) {
+      const resetMs = Date.parse(reset);
+      const secs = resetMs ? Math.max(0, Math.round((resetMs - nowEpoch * 1000) / 1000)) : 0;
+      let txt;
+      if (!resetMs) txt = reset;
+      else if (secs <= 0) txt = 'now';
+      else if (secs < 60) txt = 'reset in ' + secs + 's';
+      else if (secs < 3600) txt = 'reset in ' + Math.floor(secs / 60) + 'm';
+      else txt = 'reset in ' + Math.floor(secs / 3600) + 'h';
+      html += '<span class="rl-reset" title="' + esc(reset) + '">' + esc(txt) + '</span>';
+    }
+    html += '</div>';
+    if (lastSuccess) {
+      html += '<div class="muted" style="font-size:11px;margin-top:4px;">last success: ' + relTime(lastSuccess) + '</div>';
+    }
   }
   html += '</div>';
 

--- a/tools/parse-toml-secret.py
+++ b/tools/parse-toml-secret.py
@@ -154,12 +154,68 @@ def _array_lookup(path, section):
     return entries
 
 
-def _array_main(argv):
-    """Dispatch the three new array-of-tables argv shapes.
+def _inline_table_lookup(value, subkey):
+    """Return the SUBKEY scalar from an inline TOML table string.
 
-    --array-count <path> <section>            -> integer count on stdout
-    --array-get   <path> <section> <idx> <key> -> scalar (resolves secret://)
-    --array-keys  <path> <section> <idx>       -> newline-separated key list
+    Given a value like `{ trigger = "needs-triage", color = "red" }` and a
+    subkey of `trigger`, returns `needs-triage` (with surrounding quotes
+    stripped). Returns '' when the value is not an inline table or when
+    the subkey is not present. Added in #316 M5a so per-repo trigger-label
+    memo seeding can read inline-table values without taking a hard
+    Python `tomllib` dependency on operator boxes.
+
+    The parser is intentionally lenient: it splits on top-level commas,
+    matches `<subkey> = <value>` per entry, strips surrounding quotes.
+    Comma-inside-quotes tolerance mirrors the host TOML grammar.
+    """
+    if not value:
+        return ''
+    s = value.strip()
+    if not (s.startswith('{') and s.endswith('}')):
+        return ''
+    body = s[1:-1].strip()
+    if not body:
+        return ''
+    entries = []
+    buf = []
+    quote = None
+    for ch in body:
+        if quote:
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+            continue
+        if ch in ('"', "'"):
+            quote = ch
+            buf.append(ch)
+            continue
+        if ch == ',':
+            entries.append(''.join(buf))
+            buf = []
+            continue
+        buf.append(ch)
+    if buf:
+        entries.append(''.join(buf))
+    for entry in entries:
+        key_part, sep, val_part = entry.partition('=')
+        if not sep:
+            continue
+        if key_part.strip() != subkey:
+            continue
+        v = val_part.strip()
+        if len(v) >= 2 and v[0] == v[-1] and v[0] in ('"', "'"):
+            v = v[1:-1]
+        return v
+    return ''
+
+
+def _array_main(argv):
+    """Dispatch the four new array-of-tables argv shapes.
+
+    --array-count       <path> <section>                      -> integer count on stdout
+    --array-get         <path> <section> <idx> <key>          -> scalar (resolves secret://)
+    --array-keys        <path> <section> <idx>                -> newline-separated key list
+    --array-get-inline  <path> <section> <idx> <key> <subkey> -> inline-table subkey value
     """
     op = argv[0]
     if op == '--array-count':
@@ -209,6 +265,28 @@ def _array_main(argv):
         for k in entries[idx].keys():
             sys.stdout.write(k)
             sys.stdout.write('\n')
+        return 0
+    if op == '--array-get-inline':
+        if len(argv) != 6:
+            sys.stderr.write('Usage: %s --array-get-inline <path> <section> <idx> <key> <subkey>\n' % sys.argv[0])
+            return 2
+        _, path, section, idx_str, key, subkey = argv
+        try:
+            idx = int(idx_str)
+        except ValueError:
+            sys.stderr.write('parse-toml-secret: --array-get-inline IDX must be an integer (got %r)\n' % idx_str)
+            return 2
+        entries = _array_lookup(path, section)
+        if idx < 0 or idx >= len(entries):
+            return 0
+        raw = entries[idx].get(key, '')
+        if not raw:
+            return 0
+        sub_value = _inline_table_lookup(raw, subkey)
+        if not sub_value:
+            return 0
+        sys.stdout.write(sub_value)
+        sys.stdout.write('\n')
         return 0
     sys.stderr.write('parse-toml-secret: unknown array op %r\n' % op)
     return 2
@@ -378,13 +456,14 @@ def main():
             sys.stdout.write(value)
             sys.stdout.write('\n')
         return 0
-    # New (#316 M1): array-of-tables count + per-index lookup. Three argv shapes:
-    #   --array-count <path> <section>            -> integer count on stdout
-    #   --array-get   <path> <section> <idx> <key> -> scalar value or empty
-    #   --array-keys  <path> <section> <idx>       -> newline-separated key list
+    # New (#316 M1): array-of-tables count + per-index lookup. Four argv shapes:
+    #   --array-count       <path> <section>                      -> integer count on stdout
+    #   --array-get         <path> <section> <idx> <key>          -> scalar value or empty
+    #   --array-keys        <path> <section> <idx>                -> newline-separated key list
+    #   --array-get-inline  <path> <section> <idx> <key> <subkey> -> inline-table subkey (#316 M5a)
     # `<section>` is the inner-table name, e.g. `forge.github`. The lookup
     # walks `[[<section>]]` headers in order, 0-indexed.
-    if argv and argv[0] in ('--array-count', '--array-get', '--array-keys'):
+    if argv and argv[0] in ('--array-count', '--array-get', '--array-keys', '--array-get-inline'):
         return _array_main(argv)
     if len(argv) != 3:
         sys.stderr.write('Usage: %s <path> <section> <key>\n' % sys.argv[0])

--- a/tools/parse-toml.sh
+++ b/tools/parse-toml.sh
@@ -68,3 +68,20 @@ parse_toml_array_keys() {
     fi
     python3 "$_PARSE_TOML_DIR/parse-toml-secret.py" --array-keys "$CONFIG" "$1" "$2"
 }
+
+# parse_toml_array_get_inline SECTION IDX KEY SUBKEY
+# Echo the SUBKEY value of an inline TOML table assigned to KEY in the
+# IDX-th (0-indexed) `[[SECTION]]` entry. For example, given an entry
+#   [[forge.github]]
+#   labels = { trigger = "needs-triage" }
+# `parse_toml_array_get_inline forge.github 0 labels trigger` echoes
+# `needs-triage`. Empty stdout when the index, key, or subkey is missing.
+# Added in #316 M5a so per-repo trigger-label memo seeding can read inline-
+# table values without paying for a heavyweight TOML library.
+parse_toml_array_get_inline() {
+    if [ "$#" -ne 4 ]; then
+        echo "parse_toml_array_get_inline: usage: parse_toml_array_get_inline SECTION IDX KEY SUBKEY (got $# args)" >&2
+        return 2
+    fi
+    python3 "$_PARSE_TOML_DIR/parse-toml-secret.py" --array-get-inline "$CONFIG" "$1" "$2" "$3" "$4"
+}

--- a/tools/test-parse-toml.sh
+++ b/tools/test-parse-toml.sh
@@ -204,6 +204,88 @@ token = "secret://env/AGENTIS_TEST_TOKEN_321"
 AGENTIS_TEST_TOKEN_321="ghp_resolved_via_env" \
     assert_eq "#321: secret://env resolves" "ghp_resolved_via_env" "$(AGENTIS_TEST_TOKEN_321=ghp_resolved_via_env parse_toml forge.gitlab token)"
 
+# --- Test 15: #316 M5a — parse_toml_array_get_inline round-trips ---
+# Inline table values declared on per-array-entry keys must be readable
+# via the new wrapper. Used by start-colony.sh per-repo trigger label
+# memo seeding (`labels = { trigger = "..." }`).
+fixture "inline-roundtrip" '[forge]
+type = "github"
+
+[[forge.github]]
+owner = "acme"
+repo = "frontend"
+token = "x"
+labels = { trigger = "needs-triage" }
+'
+assert_eq "#316 M5a: inline subkey round-trip" "needs-triage" "$(parse_toml_array_get_inline forge.github 0 labels trigger)"
+
+# --- Test 16: #316 M5a — missing inline subkey returns empty ---
+# Entry has the `labels` key declared but no `trigger` subkey inside the
+# inline table. The parse must collapse to empty stdout (not error out).
+fixture "inline-missing-subkey" '[forge]
+type = "github"
+
+[[forge.github]]
+owner = "acme"
+repo = "frontend"
+token = "x"
+labels = { color = "red" }
+'
+assert_eq "#316 M5a: missing subkey returns empty" "" "$(parse_toml_array_get_inline forge.github 0 labels trigger)"
+# And missing `labels` key entirely also returns empty.
+fixture "inline-missing-key" '[forge]
+type = "github"
+
+[[forge.github]]
+owner = "acme"
+repo = "frontend"
+token = "x"
+'
+assert_eq "#316 M5a: missing inline-table key returns empty" "" "$(parse_toml_array_get_inline forge.github 0 labels trigger)"
+
+# --- Test 17: #316 M5a — quoted vs unquoted subkey values ---
+# Subkey value strings may carry surrounding double or single quotes; the
+# helper strips matching pairs and passes plaintext through unchanged.
+fixture "inline-quoted" '[forge]
+type = "github"
+
+[[forge.github]]
+owner = "acme"
+repo = "frontend"
+token = "x"
+labels = { trigger = "double-quoted-trigger" }
+
+[[forge.github]]
+owner = "acme"
+repo = "backend"
+token = "y"
+labels = { trigger = '"'"'single-quoted-trigger'"'"' }
+'
+assert_eq "#316 M5a: double-quoted subkey value" "double-quoted-trigger" "$(parse_toml_array_get_inline forge.github 0 labels trigger)"
+assert_eq "#316 M5a: single-quoted subkey value" "single-quoted-trigger" "$(parse_toml_array_get_inline forge.github 1 labels trigger)"
+
+# --- Test 18: #316 M5a — interior whitespace tolerated ---
+# Operators may declare inline tables with extra spaces around `=`, `,`,
+# and the surrounding braces. The lookup must tolerate all three patterns.
+fixture "inline-spaces" '[forge]
+type = "github"
+
+[[forge.github]]
+owner = "acme"
+repo = "frontend"
+token = "x"
+labels = {trigger="no-spaces"}
+
+[[forge.github]]
+owner = "acme"
+repo = "backend"
+token = "y"
+labels = {   trigger   =   "lots-of-spaces"   ,   color   =   "blue"   }
+'
+assert_eq "#316 M5a: inline-table no spaces" "no-spaces" "$(parse_toml_array_get_inline forge.github 0 labels trigger)"
+assert_eq "#316 M5a: inline-table extra spaces around tokens" "lots-of-spaces" "$(parse_toml_array_get_inline forge.github 1 labels trigger)"
+assert_eq "#316 M5a: inline-table second subkey tolerates spaces" "blue" "$(parse_toml_array_get_inline forge.github 1 labels color)"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-per-repo-confidence-overlay.sh
+++ b/tools/test-per-repo-confidence-overlay.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# tools/test-per-repo-confidence-overlay.sh: end-to-end test for the
+# #316 M5a per-(agent, repo) confidence overlay in
+# federation-dashboard-collector.py.
+#
+# When a colony's [[forge.github]] array has N>=2 entries AND a daemon
+# carries a non-None `confidence` field, the collector now fetches per-
+# (agent, repo) memo `<owner>__<repo>:<agent>:confidence` via
+# `agentis memo get ... --raw` and appends the result to each agent
+# record as `per_repo_confidence: [{owner, repo, confidence}, ...]`.
+#
+# Cases:
+#   1. No memo seeded: collector still emits the overlay key but every
+#      record's confidence is None (override list is the iteration
+#      template; absence of memos means "no override").
+#   2. Memos seeded: collector reads each per-repo memo and reflects
+#      the float value in `confidence`.
+#
+# Standard scaffold: set -u, mktemp -d isolation, EXIT trap for cleanup.
+# Auto-discovered by tools/colony-lint.sh's tools-test loop.
+#
+# Usage: ./tools/test-per-repo-confidence-overlay.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+COLLECTOR="$REPO_ROOT/federation-dashboard/lib/federation-dashboard-collector.py"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# Build a fixture federation with one colony that knows two repos.
+# $1 = fed_dir, $2 = colony name, $3 = colon-separated memo seeds
+# of the form "key=value:key=value:...". The shimmed `agentis` reads
+# AGENTIS_MEMO_DB env to look up `memo get <key> --raw` results.
+build_fed() {
+    local fed="$1" colony="$2"
+    mkdir -p "$fed/$colony/scripts" "$fed/$colony/agents" \
+             "$fed/$colony/config" \
+             "$fed/.agentis/logs" "$fed/.agentis/experience"
+    # Stub start-colony.sh: --print-repos-json prints 2-entry JSON,
+    # --rate-limit-status prints scalar JSON (unused in this test but
+    # the collector still calls it so the whole pipeline must succeed).
+    cat > "$fed/$colony/scripts/start-colony.sh" <<'SCRIPT'
+#!/bin/bash
+if [ "$1" = "--print-repos-json" ]; then
+    echo "[{\"owner\":\"acme\",\"repo\":\"frontend\",\"token\":\"x\",\"url\":\"https://api.github.com\"},{\"owner\":\"acme\",\"repo\":\"backend\",\"token\":\"y\",\"url\":\"https://api.github.com\"}]"
+    exit 0
+fi
+if [ "$1" = "--rate-limit-status" ]; then
+    echo "{\"remaining\": 5000, \"limit\": 5000, \"reset_at\": \"2026-04-29T12:00:00Z\"}"
+    exit 0
+fi
+exit 0
+SCRIPT
+    chmod +x "$fed/$colony/scripts/start-colony.sh"
+}
+
+# Shim `agentis memo get <key> --raw`. Reads AGENTIS_MEMO_DB env: a
+# pipe-separated `key=value|key=value` map (colon is unusable as a
+# pair separator because it appears inside scoped memo keys like
+# `<owner>__<repo>:<agent>:confidence`). Unknown keys exit non-zero
+# (mirrors real `agentis memo get` behaviour for missing memos).
+SHIM_DIR="$TMPDIR_TEST/shim"
+mkdir -p "$SHIM_DIR"
+cat > "$SHIM_DIR/agentis" <<'SHIM'
+#!/bin/bash
+if [ "${1:-}" = "memo" ] && [ "${2:-}" = "get" ]; then
+    KEY="${3:-}"
+    DB="${AGENTIS_MEMO_DB:-}"
+    OLD_IFS="$IFS"
+    IFS='|'
+    for pair in $DB; do
+        case "$pair" in
+            "${KEY}="*)
+                printf '%s\n' "${pair#*=}"
+                IFS="$OLD_IFS"
+                exit 0
+                ;;
+        esac
+    done
+    IFS="$OLD_IFS"
+    exit 1
+fi
+if [ "${1:-}" = "daemon" ] && [ "${2:-}" = "list" ]; then
+    printf '[]\n'
+    exit 0
+fi
+exit 0
+SHIM
+chmod +x "$SHIM_DIR/agentis"
+
+# Run the collector with one synthetic agent record passed via daemons
+# JSON. The daemons array carries `confidence` so the per-repo overlay
+# branch fires. agent_map_json maps agent->colony.
+run_collector_with_agent() {
+    local fed_dir="$1" colony="$2" agent="$3" out_path="$4" memo_db="$5"
+    local daemons_json
+    daemons_json="$(printf '[{"source":"%s/agents/%s.ag","colony":"%s","agent_id":"aid-%s","confidence":0.55,"state":"running","health":"healthy","pid":99999}]' \
+        "$colony" "$agent" "$colony" "$agent")"
+    local agent_map_json
+    agent_map_json="$(printf '[{"agent":"%s","colony":"%s"}]' "$agent" "$colony")"
+
+    AGENTIS_MEMO_DB="$memo_db" PATH="$SHIM_DIR:$PATH" python3 "$COLLECTOR" \
+        "$daemons_json" \
+        "$agent_map_json" \
+        "$fed_dir" \
+        "$(date '+%s')" \
+        "$fed_dir/.agentis/experience" \
+        "$fed_dir/.agentis/logs" \
+        "$TMPDIR_TEST/dash" \
+        "[\"$colony\"]" \
+        "" \
+        "$agent" \
+        > "$out_path" 2>"$TMPDIR_TEST/collector.err"
+}
+
+# --- Test 1: no memo seeded -> overlay emits None entries ------------
+# Build a fed with 2 repos but no memo seeds. The collector should
+# still emit `per_repo_confidence` as a 2-entry list, both `confidence`
+# fields None — proves the iteration template fires even without
+# operator data.
+FED1="$TMPDIR_TEST/fed1"
+COLONY1="multi"
+AGENT1="router"
+build_fed "$FED1" "$COLONY1"
+
+OUT1="$TMPDIR_TEST/out1.json"
+run_collector_with_agent "$FED1" "$COLONY1" "$AGENT1" "$OUT1" ""
+
+if python3 -c "
+import json, sys
+with open('$OUT1') as f:
+    d = json.load(f)
+agents = d.get('agents') or []
+assert len(agents) == 1, 'expected 1 agent, got ' + str(len(agents))
+a = agents[0]
+prc = a.get('per_repo_confidence')
+assert isinstance(prc, list), 'per_repo_confidence must be a list, got ' + repr(type(prc))
+assert len(prc) == 2, 'expected 2 per-repo records, got ' + str(len(prc))
+for r in prc:
+    assert r['confidence'] is None, 'expected None confidence (no memo), got ' + repr(r)
+" 2>"$TMPDIR_TEST/assert1.err"; then
+    pass "test 1: collector emits per_repo_confidence with None entries when no memo seeded"
+else
+    fail "test 1: per_repo_confidence default-empty regressed" "$(cat "$TMPDIR_TEST/assert1.err")"
+fi
+
+# --- Test 2: memos seeded -> collector reads float confidence values
+# Same fixture with two memo seeds:
+#     acme__frontend:router:confidence = 0.85
+#     acme__backend:router:confidence  = 0.42
+# The collector must surface each value in the matching record.
+OUT2="$TMPDIR_TEST/out2.json"
+MEMO_DB='acme__frontend:router:confidence=0.85|acme__backend:router:confidence=0.42'
+run_collector_with_agent "$FED1" "$COLONY1" "$AGENT1" "$OUT2" "$MEMO_DB"
+
+if python3 -c "
+import json, sys
+with open('$OUT2') as f:
+    d = json.load(f)
+agents = d.get('agents') or []
+prc = agents[0].get('per_repo_confidence') or []
+front = next((r for r in prc if r['repo'] == 'frontend'), None)
+back  = next((r for r in prc if r['repo'] == 'backend'), None)
+assert front is not None, 'frontend record missing'
+assert back is not None, 'backend record missing'
+assert abs(front['confidence'] - 0.85) < 1e-6, 'expected 0.85 for frontend, got ' + repr(front['confidence'])
+assert abs(back['confidence'] - 0.42) < 1e-6, 'expected 0.42 for backend, got ' + repr(back['confidence'])
+" 2>"$TMPDIR_TEST/assert2.err"; then
+    pass "test 2: collector reads per-repo memo confidence values when seeded"
+else
+    fail "test 2: per-repo memo confidence read regressed" "$(cat "$TMPDIR_TEST/assert2.err")"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-rate-limit-tile-multi-repo.sh
+++ b/tools/test-rate-limit-tile-multi-repo.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# tools/test-rate-limit-tile-multi-repo.sh: end-to-end test for the
+# #316 M5a per-repo Forge Rate Limits fan-out in
+# federation-dashboard-collector.py.
+#
+# The collector now pre-computes a `repos_for_colony` map by execing
+# `<colony>/scripts/start-colony.sh --print-repos-json` per colony.
+# When N>=2, the rate-limit fetch fans out across each repo via
+# `start-colony.sh --rate-limit-status --repo owner/repo` and the
+# emitted shape becomes:
+#     forge_rate_limits[colony] = {
+#         repos:    [{owner, repo, remaining, limit, reset_at}, ...],
+#         aggregate: {remaining, limit, reset_at},
+#     }
+# Single-block / N=1 / GitLab colonies preserve the v0.7.0 scalar
+# shape byte-identically — the load-bearing back-compat invariant.
+#
+# Cases:
+#   1. Single-block legacy shape: collector emits scalar
+#      `{remaining, limit, reset_at}` (no `repos[]`, no `aggregate`).
+#   2. N=2 multi-block: collector emits `repos[]` with one record per
+#      repo and the aggregate footer.
+#   3. Aggregate sums per-repo `remaining` and `limit` and picks the
+#      earliest `reset_at`.
+#
+# Standard scaffold: set -u, mktemp -d isolation, EXIT trap for cleanup.
+# Auto-discovered by tools/colony-lint.sh's tools-test loop.
+#
+# Usage: ./tools/test-rate-limit-tile-multi-repo.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+COLLECTOR="$REPO_ROOT/federation-dashboard/lib/federation-dashboard-collector.py"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# Run the collector against a fixture federation. $1 = fed_dir,
+# $2 = colony list JSON, output captured into $3 (path).
+run_collector() {
+    local fed_dir="$1" colony_json="$2" out_path="$3"
+    python3 "$COLLECTOR" \
+        '[]' \
+        '[]' \
+        "$fed_dir" \
+        "$(date '+%s')" \
+        "$fed_dir/.agentis/experience" \
+        "$fed_dir/.agentis/logs" \
+        "$TMPDIR_TEST/dash" \
+        "$colony_json" \
+        "" \
+        > "$out_path" 2>"$TMPDIR_TEST/collector.err"
+}
+
+# Build a minimal fixture colony with custom start-colony.sh stub.
+# $1 = fed_dir, $2 = colony name, $3 = start-colony.sh content.
+build_colony() {
+    local fed="$1" colony="$2" script_body="$3"
+    mkdir -p "$fed/$colony/scripts" "$fed/$colony/agents" \
+             "$fed/$colony/config" \
+             "$fed/.agentis/logs" "$fed/.agentis/experience"
+    printf '%s\n' "$script_body" > "$fed/$colony/scripts/start-colony.sh"
+    chmod +x "$fed/$colony/scripts/start-colony.sh"
+}
+
+# --- Test 1: single-block legacy shape (byte-identity gate) ----------
+# A start-colony.sh stub that prints empty for --print-repos-json
+# (legacy single-block) and the scalar `{remaining, limit, reset_at}`
+# JSON for --rate-limit-status. The collector must emit the scalar
+# shape — no `repos[]`, no `aggregate`, just remaining/limit/reset_at.
+FED1="$TMPDIR_TEST/fed1"
+COLONY1="solo"
+# shellcheck disable=SC2016  # script body is bash literal; do not expand here
+SCRIPT1='#!/bin/bash
+if [ "$1" = "--print-repos-json" ]; then exit 0; fi
+if [ "$1" = "--rate-limit-status" ]; then
+    echo "{\"remaining\": 4321, \"limit\": 5000, \"reset_at\": \"2026-04-29T12:00:00Z\"}"
+    exit 0
+fi
+exit 0'
+build_colony "$FED1" "$COLONY1" "$SCRIPT1"
+OUT1="$TMPDIR_TEST/out1.json"
+run_collector "$FED1" "[\"$COLONY1\"]" "$OUT1"
+
+if python3 -c "
+import json, sys
+with open('$OUT1') as f:
+    d = json.load(f)
+rl = d.get('forge_rate_limits') or {}
+c = rl.get('$COLONY1') or {}
+assert c.get('remaining') == 4321, c
+assert c.get('limit') == 5000, c
+assert c.get('reset_at') == '2026-04-29T12:00:00Z', c
+assert 'repos' not in c, 'single-block must NOT emit repos[] (byte-identity)'
+assert 'aggregate' not in c, 'single-block must NOT emit aggregate (byte-identity)'
+" 2>"$TMPDIR_TEST/assert1.err"; then
+    pass "test 1: single-block legacy scalar shape preserved (byte-identity)"
+else
+    fail "test 1: single-block scalar shape regressed" "$(cat "$TMPDIR_TEST/assert1.err")"
+fi
+
+# --- Test 2: N=2 multi-block emits repos[] with per-repo records -----
+# A start-colony.sh stub that prints a 2-entry JSON array for
+# --print-repos-json and per-repo rate-limit JSON for
+# --rate-limit-status --repo owner/repo. Different remaining/limit per
+# repo so we can prove the records are not aliased.
+FED2="$TMPDIR_TEST/fed2"
+COLONY2="multi"
+# shellcheck disable=SC2016  # script body is bash literal; do not expand here
+SCRIPT2='#!/bin/bash
+if [ "$1" = "--print-repos-json" ]; then
+    echo "[{\"owner\":\"acme\",\"repo\":\"frontend\",\"token\":\"x\",\"url\":\"https://api.github.com\"},{\"owner\":\"acme\",\"repo\":\"backend\",\"token\":\"y\",\"url\":\"https://api.github.com\"}]"
+    exit 0
+fi
+if [ "$1" = "--rate-limit-status" ]; then
+    if [ "$2" = "--repo" ] && [ "$3" = "acme/frontend" ]; then
+        echo "{\"remaining\": 1000, \"limit\": 5000, \"reset_at\": \"2026-04-29T13:00:00Z\"}"
+        exit 0
+    fi
+    if [ "$2" = "--repo" ] && [ "$3" = "acme/backend" ]; then
+        echo "{\"remaining\": 2500, \"limit\": 5000, \"reset_at\": \"2026-04-29T12:30:00Z\"}"
+        exit 0
+    fi
+    # Fallback aggregate (would be wrong shape if hit; tests guard).
+    echo "{\"remaining\": 99999, \"limit\": 99999, \"reset_at\": \"2026-04-29T11:00:00Z\"}"
+    exit 0
+fi
+exit 0'
+build_colony "$FED2" "$COLONY2" "$SCRIPT2"
+OUT2="$TMPDIR_TEST/out2.json"
+run_collector "$FED2" "[\"$COLONY2\"]" "$OUT2"
+
+if python3 -c "
+import json, sys
+with open('$OUT2') as f:
+    d = json.load(f)
+rl = d.get('forge_rate_limits') or {}
+c = rl.get('$COLONY2') or {}
+assert isinstance(c.get('repos'), list), 'multi-block must emit repos[] as list, got ' + repr(c)
+assert len(c['repos']) == 2, 'expected 2 per-repo records, got ' + str(len(c['repos']))
+front = next(r for r in c['repos'] if r['repo'] == 'frontend')
+back  = next(r for r in c['repos'] if r['repo'] == 'backend')
+assert front['owner'] == 'acme'
+assert front['remaining'] == 1000
+assert front['limit'] == 5000
+assert back['remaining'] == 2500
+assert back['limit'] == 5000
+assert isinstance(c.get('aggregate'), dict), 'multi-block must emit aggregate dict'
+" 2>"$TMPDIR_TEST/assert2.err"; then
+    pass "test 2: multi-block (N=2) emits repos[] with per-repo records"
+else
+    fail "test 2: multi-block fan-out regressed" "$(cat "$TMPDIR_TEST/assert2.err")"
+fi
+
+# --- Test 3: aggregate sums remaining + limit and picks earliest reset
+# Same fed2 fixture: 1000 + 2500 = 3500 remaining, 5000 + 5000 = 10000
+# limit, earliest reset_at is "2026-04-29T12:30:00Z" (backend).
+if python3 -c "
+import json, sys
+with open('$OUT2') as f:
+    d = json.load(f)
+agg = (d.get('forge_rate_limits') or {}).get('$COLONY2', {}).get('aggregate') or {}
+assert agg.get('remaining') == 3500, 'expected 3500, got ' + repr(agg.get('remaining'))
+assert agg.get('limit') == 10000, 'expected 10000, got ' + repr(agg.get('limit'))
+assert agg.get('reset_at') == '2026-04-29T12:30:00Z', 'expected earliest reset, got ' + repr(agg.get('reset_at'))
+" 2>"$TMPDIR_TEST/assert3.err"; then
+    pass "test 3: aggregate sums remaining/limit and picks earliest reset_at"
+else
+    fail "test 3: aggregate math wrong" "$(cat "$TMPDIR_TEST/assert3.err")"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-single-block-byte-identity.sh
+++ b/tools/test-single-block-byte-identity.sh
@@ -267,6 +267,101 @@ else
          "A: $EMIT_A / B: $EMIT_B"
 fi
 
+# --- Test 6: collector forge_rate_limits shape byte-identity (#316 M5a) -
+# M5a extends the dashboard collector to fan rate-limit fetches out per
+# repo when N>=2. The byte-identity guarantee for legacy operators must
+# hold for BOTH single-block (no GITHUB_REPOS_JSON) AND N=1 multi-block
+# (single-entry GITHUB_REPOS_JSON). Both must produce the v0.7.0 scalar
+# `{remaining, limit, reset_at}` shape — no `repos[]`, no `aggregate`.
+# Builds two minimal fixture colonies whose start-colony.sh stubs differ
+# only in their --print-repos-json output (empty vs 1-entry JSON), runs
+# the collector against each, and asserts the emitted forge_rate_limits
+# record is shape-identical.
+COLLECTOR="$REPO_ROOT/federation-dashboard/lib/federation-dashboard-collector.py"
+if [ -f "$COLLECTOR" ]; then
+    TEST6_DIR="$TMPDIR_TEST/test6"
+    FED_LEGACY="$TEST6_DIR/legacy"
+    FED_MULTI1="$TEST6_DIR/multi1"
+    COLONY6="solo"
+    for fed in "$FED_LEGACY" "$FED_MULTI1"; do
+        mkdir -p "$fed/$COLONY6/scripts" "$fed/$COLONY6/agents" \
+                 "$fed/$COLONY6/config" \
+                 "$fed/.agentis/logs" "$fed/.agentis/experience"
+    done
+    # Legacy single-block: --print-repos-json prints nothing.
+    cat > "$FED_LEGACY/$COLONY6/scripts/start-colony.sh" <<'SCRIPT_LEG'
+#!/bin/bash
+if [ "$1" = "--print-repos-json" ]; then exit 0; fi
+if [ "$1" = "--rate-limit-status" ]; then
+    echo '{"remaining": 4321, "limit": 5000, "reset_at": "2026-04-29T12:00:00Z"}'
+    exit 0
+fi
+exit 0
+SCRIPT_LEG
+    chmod +x "$FED_LEGACY/$COLONY6/scripts/start-colony.sh"
+    # N=1 multi-block: --print-repos-json prints a 1-entry JSON array.
+    # The collector's `len(repos) >= 2` guard means N=1 falls through
+    # to the scalar code path — same byte-identity contract as legacy.
+    cat > "$FED_MULTI1/$COLONY6/scripts/start-colony.sh" <<'SCRIPT_M1'
+#!/bin/bash
+if [ "$1" = "--print-repos-json" ]; then
+    echo '[{"owner":"acme","repo":"only","token":"x","url":"https://api.github.com"}]'
+    exit 0
+fi
+if [ "$1" = "--rate-limit-status" ]; then
+    echo '{"remaining": 4321, "limit": 5000, "reset_at": "2026-04-29T12:00:00Z"}'
+    exit 0
+fi
+exit 0
+SCRIPT_M1
+    chmod +x "$FED_MULTI1/$COLONY6/scripts/start-colony.sh"
+
+    OUT_LEG="$TEST6_DIR/legacy.json"
+    OUT_M1="$TEST6_DIR/multi1.json"
+    for run in legacy multi1; do
+        if [ "$run" = "legacy" ]; then
+            FED_DIR_RUN="$FED_LEGACY"
+            OUT_RUN="$OUT_LEG"
+        else
+            FED_DIR_RUN="$FED_MULTI1"
+            OUT_RUN="$OUT_M1"
+        fi
+        python3 "$COLLECTOR" \
+            '[]' \
+            '[]' \
+            "$FED_DIR_RUN" \
+            "$(date '+%s')" \
+            "$FED_DIR_RUN/.agentis/experience" \
+            "$FED_DIR_RUN/.agentis/logs" \
+            "$TEST6_DIR/dash" \
+            "[\"$COLONY6\"]" \
+            "" \
+            > "$OUT_RUN" 2>"$TEST6_DIR/$run.err"
+    done
+
+    if python3 -c "
+import json, sys
+with open('$OUT_LEG') as f:
+    a = json.load(f).get('forge_rate_limits', {}).get('$COLONY6', {})
+with open('$OUT_M1') as f:
+    b = json.load(f).get('forge_rate_limits', {}).get('$COLONY6', {})
+# Both must be scalar shape: same keys, same values.
+assert set(a.keys()) == set(b.keys()), 'key sets differ: legacy=%s n1=%s' % (sorted(a.keys()), sorted(b.keys()))
+assert 'repos' not in a and 'repos' not in b, 'repos[] leaked into single-block path'
+assert 'aggregate' not in a and 'aggregate' not in b, 'aggregate leaked into single-block path'
+assert a.get('remaining') == b.get('remaining'), 'remaining differs: %r vs %r' % (a.get('remaining'), b.get('remaining'))
+assert a.get('limit') == b.get('limit'), 'limit differs'
+assert a.get('reset_at') == b.get('reset_at'), 'reset_at differs'
+" 2>"$TEST6_DIR/assert.err"; then
+        pass "test 6: collector forge_rate_limits shape byte-identical for single-block AND N=1 multi-block (#316 M5a)"
+    else
+        fail "test 6: collector forge_rate_limits shape regressed" \
+             "$(cat "$TEST6_DIR/assert.err")"
+    fi
+else
+    echo "[SKIP] test 6: collector not found at $COLLECTOR"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-start-colony-per-repo-labels.sh
+++ b/tools/test-start-colony-per-repo-labels.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# tools/test-start-colony-per-repo-labels.sh: unit tests for #316 M5a —
+# per-repo trigger label memo seeding by start-colony.sh.
+#
+# M5a extends triage / planning / implementation start-colony.sh memo
+# seeding so that when the colony runs against [[forge.github]] array
+# entries (REPO_COUNT > 0), each entry that declares an inline
+# `labels = { trigger = "..." }` table seeds an `<owner>__<repo>:<colony>:
+# labels:trigger` memo. Single-block configs (REPO_COUNT = 0) skip the
+# new loop entirely so the legacy unscoped seeds stay byte-identical.
+#
+# Cases:
+#   1. Single-block: only the legacy unscoped memos are seeded; no
+#      `<owner>__<repo>:` memo writes happen at all.
+#   2. Multi-repo (N=2) with `labels = { trigger = "..." }` per entry:
+#      both `<owner>__<repo>:triage:labels:trigger` memos are seeded
+#      AND the legacy unscoped seeds still fire.
+#   3. Multi-repo (N=2) with `labels` block missing on one entry:
+#      the entry without `labels` is silently skipped; the entry with
+#      `labels` seeds its memo.
+#
+# Standard scaffold: set -eu, mktemp -d isolation, EXIT trap for cleanup.
+# Auto-discovered by tools/colony-lint.sh's tools-test loop.
+#
+# Usage: ./tools/test-start-colony-per-repo-labels.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+START_TRIAGE="$REPO_ROOT/dev-apprenticeship/triage/scripts/start-colony.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    pkill -f 'fake-daemon-for-test-316m5a' 2>/dev/null || true
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# Shim `agentis` so all `agentis memo set ...` calls land in a log file.
+# Each invocation appends one line: `memo set <key> <value>`. Daemon
+# launches still execute (rewritten to `sleep`) so the script reaches
+# the post-memo-seeding `agentis daemon` arm; the EXIT-trap pkill -f
+# marker reaps the strays.
+SHIM_DIR="$TMPDIR_TEST/shim"
+mkdir -p "$SHIM_DIR"
+MEMO_LOG="$TMPDIR_TEST/memo-calls.log"
+: > "$MEMO_LOG"
+cat > "$SHIM_DIR/agentis" <<SHIM
+#!/bin/bash
+if [ "\${1:-}" = "memo" ] && [ "\${2:-}" = "set" ]; then
+    printf 'memo set %s %s\n' "\${3:-}" "\${4:-}" >> "$MEMO_LOG"
+    exit 0
+fi
+if [ "\${1:-}" = "daemon" ] && [ "\${2:-}" = "list" ]; then
+    printf '[]\n'
+    exit 0
+fi
+if [ "\${1:-}" = "daemon" ]; then
+    exec -a fake-daemon-for-test-316m5a sleep 2
+fi
+exit 0
+SHIM
+chmod +x "$SHIM_DIR/agentis"
+
+# Run start-colony.sh against $1, capturing all memo calls into MEMO_LOG.
+# Truncates MEMO_LOG before each call so per-test assertions see only
+# the new run's writes. Returns the script's exit code; stdout/stderr
+# captured to TMPDIR_TEST/{stdout,stderr} for forensic inspection.
+run_start() {
+    local config="$1" rc=0
+    : > "$MEMO_LOG"
+    PATH="$SHIM_DIR:$PATH" timeout 4 bash "$START_TRIAGE" "$config" \
+        >"$TMPDIR_TEST/stdout" 2>"$TMPDIR_TEST/stderr" || rc=$?
+    pkill -f 'fake-daemon-for-test-316m5a' 2>/dev/null || true
+    return $rc
+}
+
+memo_count_for_key() {
+    grep -c "^memo set $1 " "$MEMO_LOG" 2>/dev/null || true
+}
+
+memo_value_for_key() {
+    grep "^memo set $1 " "$MEMO_LOG" 2>/dev/null | head -1 | sed -E 's|^memo set [^ ]+ ||'
+}
+
+count_per_repo_memos() {
+    grep -cE '^memo set [^ ]+__[^ ]+:[^ ]+:' "$MEMO_LOG" 2>/dev/null || true
+}
+
+# --- Test 1: single-block legacy regression --------------------------
+# A pre-#316 single-block colony.toml with `triage.labels.priority` set
+# must seed exactly the legacy `triage:labels:priority` memo and skip
+# the per-repo seeding loop entirely (no `<owner>__<repo>:` memo
+# writes). Byte-identity for v1.3.0 operators.
+CFG1="$TMPDIR_TEST/single.toml"
+{
+    printf '%s\n' '[forge]'
+    printf '%s\n' 'type = "github"'
+    printf '%s\n' ''
+    printf '%s\n' '[forge.github]'
+    printf '%s\n' 'url = "https://api.github.com"'
+    printf '%s\n' 'owner = "single-owner"'
+    printf '%s\n' 'repo = "single-repo"'
+    printf '%s\n' 'token = "single-token"'
+    printf '%s\n' 'me = "single-me"'
+    printf '%s\n' ''
+    printf '%s\n' '[triage.labels]'
+    printf '%s\n' 'priority = "P0, P1, P2"'
+} > "$CFG1"
+
+# Daemon-launch returns non-zero from sleep timeout; we don't care
+# about start-colony.sh's exit code, only the MEMO_LOG contents.
+run_start "$CFG1" || true
+
+LEGACY_COUNT="$(memo_count_for_key 'triage:labels:priority')"
+LEGACY_VALUE="$(memo_value_for_key 'triage:labels:priority')"
+PER_REPO_COUNT="$(count_per_repo_memos)"
+if [ "$LEGACY_COUNT" -ge 1 ] \
+   && [ "$LEGACY_VALUE" = "P0, P1, P2" ] \
+   && [ "$PER_REPO_COUNT" = "0" ]; then
+    pass "test 1: single-block seeds only legacy unscoped memo (no per-repo memos)"
+else
+    fail "test 1: single-block seeds only legacy unscoped memo (no per-repo memos)" \
+         "legacy_count=$LEGACY_COUNT legacy_value='$LEGACY_VALUE' per_repo_count=$PER_REPO_COUNT log:$(cat "$MEMO_LOG")"
+fi
+
+# --- Test 2: multi-repo N=2 with labels per entry --------------------
+# Both `[[forge.github]]` entries declare `labels = { trigger = "..." }`.
+# The legacy unscoped seed must still fire (back-compat for vocabulary
+# memos) AND each entry must seed its `<owner>__<repo>:triage:labels:
+# trigger` memo with the right value.
+CFG2="$TMPDIR_TEST/multi-2.toml"
+{
+    printf '%s\n' '[forge]'
+    printf '%s\n' 'type = "github"'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'owner = "acme"'
+    printf '%s\n' 'repo = "frontend"'
+    printf '%s\n' 'token = "x"'
+    printf '%s\n' 'me = "acme-me"'
+    printf '%s\n' 'labels = { trigger = "needs-frontend-triage" }'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'owner = "acme"'
+    printf '%s\n' 'repo = "backend"'
+    printf '%s\n' 'token = "y"'
+    printf '%s\n' 'me = "acme-me"'
+    printf '%s\n' 'labels = { trigger = "needs-backend-triage" }'
+    printf '%s\n' ''
+    printf '%s\n' '[triage.labels]'
+    printf '%s\n' 'priority = "P0, P1, P2"'
+} > "$CFG2"
+
+run_start "$CFG2" || true
+
+LEGACY_VALUE2="$(memo_value_for_key 'triage:labels:priority')"
+FRONTEND_VALUE="$(memo_value_for_key 'acme__frontend:triage:labels:trigger')"
+BACKEND_VALUE="$(memo_value_for_key 'acme__backend:triage:labels:trigger')"
+if [ "$LEGACY_VALUE2" = "P0, P1, P2" ] \
+   && [ "$FRONTEND_VALUE" = "needs-frontend-triage" ] \
+   && [ "$BACKEND_VALUE" = "needs-backend-triage" ]; then
+    pass "test 2: multi-repo (N=2) seeds per-repo trigger memos AND legacy unscoped vocabulary"
+else
+    fail "test 2: multi-repo (N=2) seeds per-repo trigger memos AND legacy unscoped vocabulary" \
+         "legacy='$LEGACY_VALUE2' frontend='$FRONTEND_VALUE' backend='$BACKEND_VALUE' log:$(cat "$MEMO_LOG")"
+fi
+
+# --- Test 3: multi-repo N=2 with labels missing on one entry ---------
+# Only entry [0] declares `labels`. Entry [1] has no `labels` block;
+# the per-repo loop must silently skip it (no error, no memo write)
+# and still seed the entry-[0] memo.
+CFG3="$TMPDIR_TEST/multi-mixed.toml"
+{
+    printf '%s\n' '[forge]'
+    printf '%s\n' 'type = "github"'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'owner = "acme"'
+    printf '%s\n' 'repo = "with-labels"'
+    printf '%s\n' 'token = "x"'
+    printf '%s\n' 'labels = { trigger = "labeled-trigger" }'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'owner = "acme"'
+    printf '%s\n' 'repo = "without-labels"'
+    printf '%s\n' 'token = "y"'
+} > "$CFG3"
+
+run_start "$CFG3" || true
+
+LABELED_VALUE="$(memo_value_for_key 'acme__with-labels:triage:labels:trigger')"
+UNLABELED_COUNT="$(memo_count_for_key 'acme__without-labels:triage:labels:trigger')"
+if [ "$LABELED_VALUE" = "labeled-trigger" ] && [ "$UNLABELED_COUNT" = "0" ]; then
+    pass "test 3: missing labels block in entry silently skipped"
+else
+    fail "test 3: missing labels block in entry silently skipped" \
+         "labeled='$LABELED_VALUE' unlabeled_count=$UNLABELED_COUNT log:$(cat "$MEMO_LOG")"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Fifth milestone of #316. **M5a feature** — federation + dashboard surfaces per-repo metrics. **M5b release** (federation-dashboard v0.8.0) follows in a separate PR.

### Federation side
- `start-colony.sh` (all 5 colonies): new `--print-repos-json` arm exposes `GITHUB_REPOS_JSON` for the dashboard collector to probe.
- `triage`/`planning`/`implementation` `start-colony.sh`: extended memo-seeding loop for `[[forge.github]]` entries with `labels = { trigger = "..." }` inline tables → seeds `<owner>__<repo>:<colony>:labels:trigger` per repo.
- `tools/parse-toml.sh` + `tools/parse-toml-secret.py`: new `parse_toml_array_get_inline` helper for inline-table subkey lookup. Tested with 4 cases.

### Dashboard side
- **Per-repo Forge Rate Limits**: collector replaces single-record-per-colony shape with `{repos: [{owner, repo, remaining, limit, reset_at}], aggregate: {...}}` when N≥2 entries. Per-colony modal renders one row per repo + aggregate footer. Single-block + N=1 keep v0.7.0 single-row layout (byte-identical).
- **Per-repo confidence overlay**: collector reads M4-shipped `<owner>__<repo>:<agent>:confidence` memos and emits `data.agents[].per_repo_confidence` array. Per-agent table grows `(per-repo)` pill when overrides exist; per-agent modal shows "Per-repo overrides" subsection.
- 3 new tests + 1 extended (test-single-block-byte-identity gets case 6 for collector shape parity).

### Strict back-compat invariants
- `dev-apprenticeship/install.sh`, `.agentis/config`, all 5 `colony.example.toml`: byte-identical to origin/main
- All 5 `forge-api.sh`, `github-api.sh`: byte-identical (M3a-shipped)
- All M1/M2/M3a/M3b/M4 helpers + tests not extended in M5a: byte-identical
- 21 `.ag` files: byte-identical (no agent code changes in M5)
- ADR-0002, tribes-bench: byte-identical
- **Dashboard UI byte-identical for legacy single-block operators** (load-bearing — locked by extended test-single-block-byte-identity.sh case 6)

Plan: #316 M5 detail comment.

## Test plan

- [x] `bash -n` + `shellcheck` clean on all touched/new scripts
- [x] `python3 -m py_compile` clean on parse-toml-secret.py + collector.py
- [x] **`test-start-colony-per-repo-labels.sh`** — 3/3 PASS
- [x] **`test-rate-limit-tile-multi-repo.sh`** — 3/3 PASS
- [x] **`test-per-repo-confidence-overlay.sh`** — 2/2 PASS
- [x] **`test-single-block-byte-identity.sh` — 6/6 PASS** (extended with case 6)
- [x] `test-parse-toml.sh` — 41/41 PASS (37 existing + 4 new inline-table cases)
- [x] M1-M4 regression (test-iter-repos, test-forge-api-multi-repo, test-multi-repo-schema, test-start-colony-multi-repo, test-start-colony-restart, test-per-repo-confidence, test-forge-config, test-colony-lint-bash32, test-labeler-autonomous-verdict, test-learn-idempotency, **test-rate-limit-tile** existing dashboard test): all PASS
- [x] `colony-lint .` — net new failures = 0 vs origin/main baseline
- [x] **All 28 sentinel back-compat surfaces byte-identical**
- [ ] CI green
- [ ] QA agent report

## Notable

- `agentis memo list --json` does NOT exist on this runtime. Collector falls back to per-call `agentis memo get <key>` (worst case ~100 calls per regen for 21 agents × 5 repos, each bounded by 2s timeout). Documented in collector comment.
- Dashboard UI extension is purely additive — single-block / N=1 paths render byte-identically to v0.7.0.

## Note for reviewer

After this lands, **5.5 of 6 milestones done**: M1, M2, M3a, M3b, M4, **M5a**. Only M5b (release federation-dashboard v0.8.0 — version-bump-only PR) and M6 (retire single-block, MAJOR, v2.0.0) remain.