### PR TITLE
feat: retire legacy single-block [forge.github] (#316 M6a)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -90,6 +90,32 @@ is asserted until multi-version CI is in place.
   it. Run `tools/migrate-to-multi-repo.sh <colony.toml>` to migrate ahead of
   the cutover.
 
+### Removed
+
+- Legacy single-table `[forge.github]` config form (#316 M6, MAJOR). Use
+  `[[forge.github]]` array-of-tables instead — single-entry arrays are
+  byte-identical at runtime to the retired single-table form. **Breaking**
+  for operators upgrading from v1.x — run
+  `tools/migrate-to-multi-repo.sh <colony.toml>` once per colony before
+  starting v2.0.0. `colony-lint.sh` now hard-fails on a single-table
+  `[forge.github]` block with the migration command in the error message.
+  `[forge.gitlab]` single-table form is **unchanged** in v2.0.0 — its
+  symmetric retirement waits for a future GitLab multi-repo runtime
+  milestone.
+
+  Migration recipe:
+
+  ```bash
+  for colony in triage code-review planning implementation release; do
+    ./tools/migrate-to-multi-repo.sh dev-apprenticeship/$colony/config/colony.toml
+  done
+  ./tools/colony-lint.sh dev-apprenticeship/
+  ./dev-apprenticeship/kill-federation.sh
+  ./dev-apprenticeship/start-federation.sh
+  ```
+
+  The migration tool is idempotent (test 11 of `test-multi-repo-schema.sh`).
+
 ## [1.3.0] — 2026-04-26
 
 LLM cost-cap and per-colony LLM-backend wiring continue maturing. New

--- a/dev-apprenticeship/code-review/config/colony.example.toml
+++ b/dev-apprenticeship/code-review/config/colony.example.toml
@@ -21,12 +21,15 @@ token   = "glpat-your-token-here"
 project = "your-org/your-project"
 me      = ""  # your GitLab username (optional, enables personal/team tagging)
 
-# [forge.github]
+# [[forge.github]]
 # url   = "https://api.github.com"  # optional; override for GitHub Enterprise
 # owner = "your-org-or-user"
 # repo  = "your-repo"
 # token = "ghp_your-token-here"
 # me    = ""  # your GitHub username (optional)
+#
+# To serve N repos from this colony, repeat the [[forge.github]] block once
+# per repo. Each entry has its own owner/repo/token/url/me.
 
 # Per-colony LLM backend override (#319, schema reserved for forward-
 # compat — NO RUNTIME EFFECT today; see #351). All four keys are

--- a/dev-apprenticeship/implementation/config/colony.example.toml
+++ b/dev-apprenticeship/implementation/config/colony.example.toml
@@ -22,13 +22,16 @@ project        = "your-org/your-project"
 me             = ""      # your GitLab username (optional)
 default_branch = "main"  # primary branch (#224)
 
-# [forge.github]
+# [[forge.github]]
 # url            = "https://api.github.com"  # optional; override for GitHub Enterprise
 # owner          = "your-org-or-user"
 # repo           = "your-repo"
 # token          = "ghp_your-token-here"
 # me             = ""      # your GitHub username (optional)
 # default_branch = "main"  # primary branch
+#
+# To serve N repos from this colony, repeat the [[forge.github]] block once
+# per repo. Each entry has its own owner/repo/token/url/me.
 
 [implementation]
 # GitLab label used to filter issues that are ready for implementation work.

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -429,25 +429,28 @@ if [ "$WRITE_CREDS" -eq 1 ] && [ "$FORGE_TYPE" = "github" ]; then
 
     for colony in "${COLONIES[@]}"; do
         CONFIG="$SCRIPT_DIR/$colony/config/colony.toml"
-        # Two-step rewrite: (1) uncomment the [forge.github] template
+        # Two-step rewrite: (1) uncomment the [[forge.github]] template
         # block if it ships commented (default in colony.example.toml),
-        # (2) section-scoped key rewrites inside [forge.github]. The
+        # (2) section-scoped key rewrites inside [[forge.github]]. The
         # [forge.gitlab] section is untouched so operators can switch
         # back via FEDERATION_FORGE_TYPE without losing credentials.
+        # Post-#316 M6: templates ship the array-of-tables `[[forge.github]]`
+        # form; the section parser below treats the doubled-bracket header
+        # as the same logical section as `[forge.github]` for key rewrite.
         python3 - "$CONFIG" "$GITHUB_URL" "$GITHUB_TOKEN" "$GITHUB_OWNER" "$GITHUB_REPO" "$GITHUB_ME" <<'PY'
 import sys, re
 path, url, token, owner, repo, me = sys.argv[1:7]
 with open(path) as f:
     lines = f.readlines()
 
-# Step 1: uncomment [forge.github] block if it's fully commented.
-# Enter on `# [forge.github]`, stay while subsequent lines match
+# Step 1: uncomment [[forge.github]] block if it's fully commented.
+# Enter on `# [[forge.github]]`, stay while subsequent lines match
 # `# key = ...`, exit on the first line that doesn't (blank,
 # next section header, or anything else).
 out = []
 in_block = False
 for line in lines:
-    if re.match(r'\s*#\s*\[forge\.github\]\s*$', line):
+    if re.match(r'\s*#\s*\[\[forge\.github\]\]\s*$', line):
         in_block = True
         out.append(re.sub(r'^(\s*)#\s?', r'\1', line))
         continue
@@ -458,7 +461,10 @@ for line in lines:
         in_block = False
     out.append(line)
 
-# Step 2: rewrite keys inside the [forge.github] section.
+# Step 2: rewrite keys inside the [[forge.github]] section. The
+# bracket-strip below collapses `[[forge.github]]` to `forge.github`
+# so the post-M6 array-of-tables header matches the same logical
+# section that the legacy single-table form used.
 content = ''.join(out)
 lines = content.splitlines(keepends=True)
 section = None
@@ -466,7 +472,10 @@ out2 = []
 for line in lines:
     stripped = line.strip()
     if stripped.startswith('[') and stripped.endswith(']'):
-        section = stripped[1:-1].strip()
+        inner = stripped[1:-1].strip()
+        if inner.startswith('[') and inner.endswith(']'):
+            inner = inner[1:-1].strip()
+        section = inner
     if section == 'forge.github':
         if url:
             line = re.sub(r'(url\s*=\s*)"[^"]*"', lambda m: m.group(1) + '"' + url + '"', line)

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -40,12 +40,15 @@ token   = "glpat-your-token-here"
 project = "your-org/your-project"
 me      = ""  # your GitLab username (optional, enables personal/team tagging)
 
-# [forge.github]
+# [[forge.github]]
 # url   = "https://api.github.com"  # optional; override for GitHub Enterprise
 # owner = "your-org-or-user"
 # repo  = "your-repo"
 # token = "ghp_your-token-here"
 # me    = ""  # your GitHub username (optional)
+#
+# To serve N repos from this colony, repeat the [[forge.github]] block once
+# per repo. Each entry has its own owner/repo/token/url/me.
 
 # Per-colony LLM backend override (#319, schema reserved for forward-
 # compat — NO RUNTIME EFFECT today; see #351). All four keys are

--- a/dev-apprenticeship/release/config/colony.example.toml
+++ b/dev-apprenticeship/release/config/colony.example.toml
@@ -22,13 +22,16 @@ project        = "your-org/your-project"
 me             = ""      # your GitLab username (optional)
 default_branch = "main"  # primary branch (#224)
 
-# [forge.github]
+# [[forge.github]]
 # url            = "https://api.github.com"  # optional; override for GitHub Enterprise
 # owner          = "your-org-or-user"
 # repo           = "your-repo"
 # token          = "ghp_your-token-here"
 # me             = ""      # your GitHub username (optional)
 # default_branch = "main"  # primary branch
+#
+# To serve N repos from this colony, repeat the [[forge.github]] block once
+# per repo. Each entry has its own owner/repo/token/url/me.
 
 # Per-colony LLM backend override (#319, schema reserved for forward-
 # compat — NO RUNTIME EFFECT today; see #351). All four keys are

--- a/dev-apprenticeship/triage/config/colony.example.toml
+++ b/dev-apprenticeship/triage/config/colony.example.toml
@@ -21,12 +21,15 @@ token   = "glpat-your-token-here"
 project = "your-org/your-project"
 me      = ""  # your GitLab username (optional, enables personal/team tagging)
 
-# [forge.github]
+# [[forge.github]]
 # url   = "https://api.github.com"  # optional; override for GitHub Enterprise
 # owner = "your-org-or-user"
 # repo  = "your-repo"
 # token = "ghp_your-token-here"
 # me    = ""  # your GitHub username (optional)
+#
+# To serve N repos from this colony, repeat the [[forge.github]] block once
+# per repo. Each entry has its own owner/repo/token/url/me.
 
 # Per-colony LLM backend override (#319, schema reserved for forward-
 # compat — NO RUNTIME EFFECT today; see #351). All four keys are

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -126,7 +126,7 @@ for _backend in ('github', 'gitlab'):
     _has_single = any(ln == '[forge.' + _backend + ']' for ln in _raw_lines)
     _has_multi  = any(ln == '[[forge.' + _backend + ']]' for ln in _raw_lines)
     if _has_single and _has_multi:
-        errors.append('config has both [forge.' + _backend + '] and [[forge.' + _backend + ']] — pick one (run tools/migrate-to-multi-repo.sh to migrate)')
+        errors.append('config has both [forge.' + _backend + '] and [[forge.' + _backend + ']] — drop the [forge.' + _backend + '] block (single-table form retired in v2.0.0; run tools/migrate-to-multi-repo.sh)')
 
 if errors:
     print('\n'.join(errors))
@@ -185,10 +185,8 @@ else:
                     if not entry.get(required_key):
                         errors.append(f'[[forge.github]][{i}] missing required key: {required_key}')
         elif isinstance(gh, dict):
-            # Legacy single-block schema. Still supported in M1.
-            for required_key in ('owner', 'repo'):
-                if not gh.get(required_key):
-                    errors.append(f'[forge.github] missing required key: {required_key}')
+            # M6 (#316): single-table form retired in v2.0.0.
+            errors.append('[forge.github] single-table form is retired in v2.0.0 (#316 M6). Run tools/migrate-to-multi-repo.sh <colony.toml> to convert to [[forge.github]] array form.')
         else:
             errors.append(f'[forge.github] is wrong type: {type(gh).__name__}')
 if 'llm' not in data:

--- a/tools/test-forge-config.sh
+++ b/tools/test-forge-config.sh
@@ -70,11 +70,11 @@ for colony in $COLONIES; do
         fail "$colony: [forge.gitlab] block missing"
         continue
     fi
-    if ! grep -qE '^# \[forge\.github\]$' "$cfg"; then
-        fail "$colony: commented-out [forge.github] block missing (operators need a template to uncomment)"
+    if ! grep -qE '^# \[\[forge\.github\]\]$' "$cfg"; then
+        fail "$colony: commented-out [[forge.github]] array-of-tables block missing (operators need a template to uncomment; #316 M6 retired the single-table form)"
         continue
     fi
-    pass "$colony: [forge] + [forge.gitlab] + commented [forge.github] present in colony.example.toml"
+    pass "$colony: [forge] + [forge.gitlab] + commented [[forge.github]] present in colony.example.toml"
 done
 
 # -----------------------------------------------------------------------------

--- a/tools/test-multi-repo-schema.sh
+++ b/tools/test-multi-repo-schema.sh
@@ -6,10 +6,12 @@
 #   Test 1: parse_toml_array_count on a 0-block config returns 0
 #   Test 2: parse_toml_array_count on a 3-block config returns 3
 #   Test 3: parse_toml_array_get returns the right owner/repo per index
-#   Test 4: legacy single-block config passes colony-lint
+#   Test 4: legacy single-block config FAILS colony-lint with v2.0.0 retirement
+#           message (#316 M6) and names tools/migrate-to-multi-repo.sh
 #   Test 5: multi-block (1 entry) passes colony-lint
 #   Test 6: multi-block (5 entries) passes colony-lint
-#   Test 7: both-forms config fails colony-lint with "pick one" message
+#   Test 7: both-forms config fails colony-lint with new "drop the [forge.github]
+#           block" wording (#316 M6)
 #   Test 8: missing owner in entry [1] fails colony-lint
 #   Test 9: empty [[forge.github]] array fails colony-lint
 #   Test 10: migration tool round-trip — legacy -> migrate -> lint -> multi-repo passes
@@ -19,6 +21,10 @@
 #   Test 14: migration preserves operator hand-edited indentation
 #   Test 15: migration on already-migrated file exits 0 with "already migrated" message
 #   Test 16: migration on bare-`[forge.gitlab]`-only config exits 3 (no github block)
+#   Test 17: migration tool on a fresh-from-template (already `[[forge.github]]`)
+#            colony.example.toml exits 0 with "already migrated" (#316 M6)
+#   Test 18: lint the post-M6 fresh dev-apprenticeship/triage/config/colony.example.toml
+#            directly — must pass (#316 M6)
 #
 # Standard scaffold: set -eu, mktemp -d isolation, EXIT trap for cleanup.
 # Auto-discovered by colony-lint.sh's tools-test loop.
@@ -132,7 +138,10 @@ else
          "owner[0]='$got_owner_0' repo[1]='$got_repo_1' repo[2]='$got_repo_2' oor='$got_oor'"
 fi
 
-# --- Test 4: legacy single-block config passes colony-lint -------------
+# --- Test 4: legacy single-block config FAILS colony-lint (#316 M6) ----
+# Post-M6 lint hard-fails on `[forge.github]` single-table form. The
+# error message must name `tools/migrate-to-multi-repo.sh` so operators
+# upgrading from v1.x have an actionable migration step.
 make_fixture "fed-4-legacy" "col-a" <<'TOML'
 [colony]
 name = "col-a"
@@ -156,11 +165,12 @@ source = "agents/demo.ag"
 cb_budget = 100
 TOML
 out="$(run_lint_on "fed-4-legacy" || true)"
-if printf '%s\n' "$out" | grep -q "fed-4-legacy/col-a: config OK"; then
-    pass "test 4: legacy single-block config passes colony-lint"
+if printf '%s\n' "$out" | grep -q 'single-table form is retired in v2.0.0' \
+   && printf '%s\n' "$out" | grep -q 'tools/migrate-to-multi-repo.sh'; then
+    pass "test 4: legacy single-block config FAILS colony-lint with v2.0.0 retirement message and migration command (#316 M6)"
 else
-    fail "test 4: legacy single-block config passes colony-lint" \
-         "expected '[PASS] fed-4-legacy/col-a: config OK', got: $out"
+    fail "test 4: legacy single-block config FAILS colony-lint with v2.0.0 retirement message and migration command (#316 M6)" \
+         "expected 'single-table form is retired in v2.0.0' AND 'tools/migrate-to-multi-repo.sh' in output, got: $out"
 fi
 
 # --- Test 5: multi-block (1 entry) passes colony-lint ------------------
@@ -243,7 +253,7 @@ else
          "expected '[PASS] fed-6-multi-5/col-c: config OK', got: $out"
 fi
 
-# --- Test 7: both-forms config fails colony-lint with "pick one" -------
+# --- Test 7: both-forms config fails colony-lint (#316 M6 wording) -----
 make_fixture "fed-7-both-forms" "col-d" <<'TOML'
 [colony]
 name = "col-d"
@@ -270,11 +280,11 @@ source = "agents/demo.ag"
 cb_budget = 100
 TOML
 out="$(run_lint_on "fed-7-both-forms" || true)"
-if printf '%s\n' "$out" | grep -q 'pick one (run tools/migrate-to-multi-repo.sh'; then
-    pass "test 7: both-forms config fails colony-lint with 'pick one' message"
+if printf '%s\n' "$out" | grep -q 'drop the \[forge.github\] block'; then
+    pass "test 7: both-forms config fails colony-lint with 'drop the [forge.github] block' message"
 else
-    fail "test 7: both-forms config fails colony-lint with 'pick one' message" \
-         "expected 'pick one (run tools/migrate-to-multi-repo.sh' in output, got: $out"
+    fail "test 7: both-forms config fails colony-lint with 'drop the [forge.github] block' message" \
+         "expected 'drop the [forge.github] block' in output, got: $out"
 fi
 
 # --- Test 8: missing owner in entry [1] fails colony-lint --------------
@@ -516,6 +526,107 @@ if [ "$rc16" -eq 3 ]; then
 else
     fail "test 16: migration on bare-[forge.gitlab]-only config exits 3 (no github block)" \
          "rc=$rc16 out='$out16'"
+fi
+
+# --- Test 17: migrate on fresh-from-template colony.example.toml -------
+# Post-#316 M6 the 5 dev-apprenticeship colony.example.toml templates ship
+# the array-of-tables `[[forge.github]]` form. After an operator has
+# uncommented the github block (via dev-apprenticeship/install.sh's writer
+# step or by hand), the config carries an active `[[forge.github]]`
+# header. Running the migration tool on this fresh-active-github shape
+# MUST be a no-op and print "already migrated" — operators bootstrapping
+# a v2.0.0 federation (or running the tool defensively in a CI step)
+# should never see a spurious rewrite or a non-zero exit code.
+TARGET17="$TMPDIR_TEST/fresh-template.toml"
+{
+    printf '%s\n' '[colony]'
+    printf '%s\n' 'name = "fresh-template"'
+    printf '%s\n' ''
+    printf '%s\n' '[forge]'
+    printf '%s\n' 'type = "github"'
+    printf '%s\n' ''
+    printf '%s\n' '[[forge.github]]'
+    printf '%s\n' 'url   = "https://api.github.com"'
+    printf '%s\n' 'owner = "your-org-or-user"'
+    printf '%s\n' 'repo  = "your-repo"'
+    printf '%s\n' 'token = "ghp_your-token-here"'
+    printf '%s\n' 'me    = ""'
+    printf '%s\n' ''
+    printf '%s\n' '#'
+    printf '%s\n' '# To serve N repos from this colony, repeat the [[forge.github]] block once'
+    printf '%s\n' '# per repo. Each entry has its own owner/repo/token/url/me.'
+} > "$TARGET17"
+set +e
+out17="$("$MIGRATE" "$TARGET17" 2>&1)"
+rc17=$?
+set -e
+if [ "$rc17" -eq 0 ] && printf '%s' "$out17" | grep -q 'already migrated'; then
+    pass "test 17: migrate on fresh-from-template colony.example.toml exits 0 with 'already migrated' (#316 M6)"
+else
+    fail "test 17: migrate on fresh-from-template colony.example.toml exits 0 with 'already migrated' (#316 M6)" \
+         "rc=$rc17 out='$out17'"
+fi
+
+# --- Test 18: lint the post-M6 fresh dev-apprenticeship triage template -
+# After #316 M6 the shipped dev-apprenticeship/triage/config/colony.example.toml
+# carries `# [[forge.github]]` (commented). The lint must accept this template
+# unchanged — it is what every fresh `tools/new-colony.sh`-style scaffold
+# produces and what `dev-apprenticeship/install.sh` copies before writing
+# credentials. A regression here would mean every fresh install fails lint.
+SCRIPT_DIR_LINT="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT_LINT="$(cd "$SCRIPT_DIR_LINT/.." && pwd)"
+TRIAGE_TEMPLATE="$REPO_ROOT_LINT/dev-apprenticeship/triage/config/colony.example.toml"
+if [ ! -f "$TRIAGE_TEMPLATE" ]; then
+    fail "test 18: post-M6 fresh dev-apprenticeship/triage/config/colony.example.toml lints clean" \
+         "fixture missing: $TRIAGE_TEMPLATE"
+else
+    set +e
+    out18=$(python3 - "$TRIAGE_TEMPLATE" <<'PY' 2>&1
+import sys
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        print("SKIP: no TOML parser")
+        sys.exit(0)
+
+with open(sys.argv[1], 'r', encoding='utf-8') as _f:
+    _raw_lines = [ln.strip() for ln in _f]
+
+errors = []
+for _backend in ('github', 'gitlab'):
+    _has_single = any(ln == '[forge.' + _backend + ']' for ln in _raw_lines)
+    _has_multi  = any(ln == '[[forge.' + _backend + ']]' for ln in _raw_lines)
+    if _has_single and _has_multi:
+        errors.append('config has both [forge.' + _backend + '] and [[forge.' + _backend + ']]')
+
+if errors:
+    print('\n'.join(errors))
+    sys.exit(1)
+
+with open(sys.argv[1], 'rb') as f:
+    data = tomllib.load(f)
+
+forge_type = data.get('forge', {}).get('type')
+if forge_type == 'github':
+    gh = data.get('forge', {}).get('github')
+    if isinstance(gh, dict):
+        print('FAIL: [forge.github] single-table form still present')
+        sys.exit(1)
+
+print('OK')
+PY
+)
+    rc18=$?
+    set -e
+    if [ "$rc18" -eq 0 ] && (printf '%s' "$out18" | grep -q '^OK$' || printf '%s' "$out18" | grep -q '^SKIP'); then
+        pass "test 18: post-M6 fresh dev-apprenticeship/triage/config/colony.example.toml lints clean (#316 M6)"
+    else
+        fail "test 18: post-M6 fresh dev-apprenticeship/triage/config/colony.example.toml lints clean (#316 M6)" \
+             "rc=$rc18 out='$out18'"
+    fi
 fi
 
 echo ""

--- a/tools/test-single-block-byte-identity.sh
+++ b/tools/test-single-block-byte-identity.sh
@@ -1,21 +1,30 @@
 #!/bin/bash
-# tools/test-single-block-byte-identity.sh: pin the #316 M3a byte-identity
-# guarantee — pre-M3 single-block configs and post-M3 single-entry array
-# configs MUST produce identical experience rows + memo keys + bus emit
-# semantics.
+# tools/test-single-block-byte-identity.sh: pin the #316 M3a runtime
+# byte-identity guarantee — the empty-owner sentinel path (legacy
+# GITHUB_OWNER env without GITHUB_REPOS_JSON) and the single-entry
+# GITHUB_REPOS_JSON path MUST produce identical experience rows + memo
+# keys + bus emit semantics.
+#
+# Post-#316 M6 the legacy single-table `[forge.github]` config form is
+# retired at the lint layer (colony-lint.sh hard-fails) so no operator
+# config can produce the no-GITHUB_REPOS_JSON env shape via the M6+
+# config path. The runtime sentinel path remains load-bearing for
+# non-forge federations (tribes-bench-style, no `colony.toml` at all)
+# and for any colony.toml-less harness that exports GITHUB_OWNER /
+# GITHUB_REPO directly without going through start-colony.sh's
+# GITHUB_REPOS_JSON composition.
 #
 # This test is the load-bearing defence against per-repo scoping silently
-# regressing legacy operators. Plan §13: "MUST pass 5/5".
+# regressing those callers. Plan §13: "MUST pass 5/5".
 #
 # Method (per plan §9 point 2): run the triage/router agent twice — once
-# against a synthetic legacy `[forge.github]`-shape config (no
-# GITHUB_REPOS_JSON env), once against a synthetic single-entry
-# `[[forge.github]]`-shape config (GITHUB_REPOS_JSON env carrying one
-# entry whose owner/repo/url/me match the legacy config). Both runs use
-# the same forge-api stub that returns `[]` for every call, so the agent
-# exits its tick early with the same memo updates. Compare the memo
-# files, experience JSONL, and the agent runtime descriptors that
-# callers can observe.
+# with the legacy env shape (no GITHUB_REPOS_JSON), once with the
+# single-entry GITHUB_REPOS_JSON env carrying one entry whose
+# owner/repo/url/me match the legacy env. Both runs use the same
+# forge-api stub that returns `[]` for every call, so the agent exits
+# its tick early with the same memo updates. Compare the memo files,
+# experience JSONL, and the agent runtime descriptors that callers can
+# observe.
 #
 # Cases:
 #   1. Both runs produce a memo file named `router:last_check.jsonl`


### PR DESCRIPTION
## Summary

Sixth milestone of #316 — **breaking change**. M1-M5 shipped multi-repo capability while keeping single-block `[forge.github]` configs working byte-identically. M6a retires the single-block form: `colony-lint.sh` hard-fails it with a migration message, the 5 `colony.example.toml` templates and `install.sh` writer flip to single-entry `[[forge.github]]` arrays. **M6b** (release dev-apprenticeship v2.0.0) follows in a separate PR.

- **`tools/colony-lint.sh`**: legacy single-table `[forge.github]` branch flipped from accept → hard-fail with `single-table form is retired in v2.0.0 (#316 M6). Run tools/migrate-to-multi-repo.sh ...`. Both-forms pre-check wording updated.
- **5 × `dev-apprenticeship/<colony>/config/colony.example.toml`**: template comment header `# [forge.github]` → `# [[forge.github]]`, plus new line documenting "repeat the block once per repo".
- **`dev-apprenticeship/install.sh`**: writer flipped to produce `[[forge.github]]` shape. Two surgical changes: uncomment regex updated; section parser bracket-strip extended to handle doubled brackets.
- **`dev-apprenticeship/CHANGELOG.md`**: new `### Removed` block under `[Unreleased]` with explicit migration recipe (3-line `for colony in ...` loop). Existing `### Deprecated` line from M1 stays as historical context.
- **Tests**: `test-multi-repo-schema.sh` Test 4 flipped (single-block now FAILS with migration message); Test 7 wording tweaked; new Test 17 (migrate tool on active `[[forge.github]]` exits 0 "already migrated") and Test 18 (lint fresh post-M6 `colony.example.toml` directly — must pass). `test-forge-config.sh` Test 1 grep flipped. `test-single-block-byte-identity.sh` header comment updated to clarify sentinel-path semantics post-M6.

### What stays out of M6a (deferred by design)

- `dev-apprenticeship/VERSION` bump → M6b
- Cutting `[Unreleased]` to `[2.0.0]` → M6b
- Removing dead single-block branch in 5 × `start-colony.sh` → v2.1.0 cleanup PR (focus M6a on user-facing breaking change)
- `[forge.gitlab]` single-block retirement → future "GitLab multi-repo" milestone (no validated runtime for `[[forge.gitlab]]` array form yet; retiring single before array ships would brick gitlab operators)
- `tools/migrate-to-multi-repo.{sh,py}` byte-identical (operators depend on it for migration)

### `[forge.gitlab]` operators

Unaffected by M6a. CHANGELOG explicitly: *"`[forge.gitlab]` single-table form is **unchanged** in v2.0.0 — its symmetric retirement waits for a future GitLab multi-repo runtime milestone."*

Plan: #316 M6 detail comment.

## Test plan

- [x] `bash -n` + `shellcheck` clean on all 4 modified shell scripts (no findings)
- [x] `bash -n dev-apprenticeship/install.sh` clean; all 5 embedded Python heredocs `compile()`-clean
- [x] **`tools/test-multi-repo-schema.sh` — 18/18 PASS** (Tests 1-3, 5-6, 8-16 unchanged; Test 4 flipped; Tests 17-18 new)
- [x] `tools/test-forge-config.sh` — 45/45 PASS (Test 1 grep flipped)
- [x] `tools/test-single-block-byte-identity.sh` — 6/6 PASS (logic unchanged, header updated)
- [x] M1-M5 regression: test-iter-repos (6/6), test-forge-api-multi-repo (9/9), test-start-colony-multi-repo (6/6), test-start-colony-restart (26/26), test-per-repo-confidence (5/5), test-per-repo-confidence-overlay (2/2), test-rate-limit-tile-multi-repo (3/3), test-start-colony-per-repo-labels (3/3), test-colony-lint-bash32 (6/6), test-labeler-autonomous-verdict (20/20), test-learn-idempotency (24/24), test-parse-toml (41/41), test-rate-limit-tile (8/8) — ALL PASS
- [x] **`colony-lint .` — 125/24/3** byte-identical to origin/main baseline (24 pre-existing `.ag` syntax env-collision failures reproduce on canonical clone; net new = 0)
- [x] **`tools/migrate-to-multi-repo.{sh,py}` byte-identical** (operators depend on this for migration — load-bearing)
- [x] **All 5 `start-colony.sh`, `forge-api.sh`, `github-api.sh` byte-identical** (no runtime touch in M6a)
- [x] **All 21 `.ag` files byte-identical** (no agent code change)
- [x] **`federation-dashboard/`, `tribes-bench/`, ADR-0002 byte-identical**
- [x] `dev-apprenticeship/.dashboard-version`, `.agentis/config`, **VERSION** byte-identical (M6b owns VERSION bump)
- [ ] CI green
- [ ] QA agent report

## Note for reviewer

After this lands + M6b cuts v2.0.0 + tag pushed, **#316 closes**. Operators upgrading from v1.x MUST run the migration recipe in the CHANGELOG `Removed` block before starting v2.0.0. The migration tool is idempotent.