### PR TITLE
feat: cross-repo reference detection in PR review prompts (#317)

### DIFF
--- a/dev-apprenticeship/BUNDLE.manifest
+++ b/dev-apprenticeship/BUNDLE.manifest
@@ -50,6 +50,16 @@ tools/scaffold-agent.sh
 tools/iter-repos.sh
 tools/iter-repos.py
 tools/forge-resolve-repo.py
+# Cross-repo reference detection (#317): scan PR bodies for
+# `<owner>/<repo>#<N>` refs, resolve via forge-api get-issue with cache,
+# record bidirectional closed-by index for the router agent.
+tools/scan-cross-repo-refs.sh
+tools/scan-cross-repo-refs.py
+tools/cross-repo-cache.sh
+tools/cross-repo-cache.py
+tools/resolve-cross-repo-ref.sh
+tools/closed-by-index.sh
+tools/closed-by-index.py
 
 # ----- Federation dashboard -----
 # Extracted to a separately-versioned standalone component in #252.

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,23 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Added
+
+- Cross-repo reference detection in PR review prompts (#317): the four
+  code-review agents (logic / style / security / test) scan PR body
+  for `<owner>/<repo>#<N>` references and splice resolved issue context
+  (title / state / labels) into their review prompt — capped at 5 refs
+  per tick. Resolved records cached at
+  `<fed>/.agentis/cross-repo-cache/<owner>__<repo>__<N>.json` with 1h
+  TTL (override via `CROSS_REPO_CACHE_TTL_SECS` env). Out-of-colony
+  repos resolve to a tombstone and skip silently. Reviewer view of
+  `merge-requests` gains `description` for the scanner. Triage `router`
+  agent gains bidirectional closed-by lookup. Single-block configs
+  (M3a sentinel) skip the scan entirely (byte-identical). Helpers:
+  `tools/{scan-cross-repo-refs,cross-repo-cache,resolve-cross-repo-ref,
+  closed-by-index}.{sh,py}`. Test: `tools/test-cross-repo-refs.sh` (7
+  cases). Dashboard timeline overlay deferred to follow-up.
+
 ## [2.0.0] — 2026-04-29
 
 **Requires:** agentis >= 1.4.7

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -92,6 +92,7 @@ fn mr_cmd(owner: string, repo: string) -> string {
 // Empty return => byte-identical context vs pre-#317.
 fn cross_repo_context(owner: string, repo: string, mr_iid: int, body: string) -> string {
     if len(body) < 5 { return ""; };
+    if len(owner) == 0 { return ""; };  // M3a sentinel: skip cross-repo scan on single-block path
     let self_arg = if len(owner) > 0 { " --self " + shell_escape(owner + "/" + repo); } else { ""; };
     // colony-lint: safe-exec-concat
     let scan_cmd = "printf '%s' " + shell_escape(body) +

--- a/dev-apprenticeship/code-review/agents/logic_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/logic_reviewer.ag
@@ -78,6 +78,37 @@ fn mr_cmd(owner: string, repo: string) -> string {
     return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer" + repo_arg(owner, repo);
 }
 
+// #317: cross-repo reference enrichment. Scan the PR body for
+// `<owner>/<repo>#<N>` refs, resolve via forge-api.sh get-issue (cached
+// 1h), and emit a markdown context block ready for prompt-context concat.
+// Returns "" when:
+//   - body is too short to plausibly mention a ref (len < 5).
+//   - owner == "" (single-block back-compat sentinel — no `--self` arg
+//     to filter; resolver short-circuits since GITHUB_REPOS_JSON is
+//     either absent or single-entry collapsed).
+//   - scanner emits zero refs.
+//   - resolver emits empty (all refs out-of-config / tombstoned).
+// Concatenated into `context` in tick_for_repo before the review prompt().
+// Empty return => byte-identical context vs pre-#317.
+fn cross_repo_context(owner: string, repo: string, mr_iid: int, body: string) -> string {
+    if len(body) < 5 { return ""; };
+    let self_arg = if len(owner) > 0 { " --self " + shell_escape(owner + "/" + repo); } else { ""; };
+    // colony-lint: safe-exec-concat
+    let scan_cmd = "printf '%s' " + shell_escape(body) +
+        " | $COLONY_DIR/../../tools/scan-cross-repo-refs.sh" + self_arg;
+    let refs_raw = try { exec sh scan_cmd; } catch e { ""; };
+    if len(refs_raw) == 0 { return ""; };
+    let src_args = if len(owner) > 0 {
+        " --src-owner " + shell_escape(owner) +
+        " --src-repo " + shell_escape(repo) +
+        " --src-iid " + to_string(mr_iid);
+    } else { ""; };
+    // colony-lint: safe-exec-concat
+    let resolve_cmd = "printf '%s' " + shell_escape(refs_raw) +
+        " | $COLONY_DIR/../../tools/resolve-cross-repo-ref.sh --colony-dir \"$COLONY_DIR\" --max 5" + src_args;
+    return try { exec sh resolve_cmd; } catch e { ""; };
+}
+
 fn get_confidence() -> float {
     let raw = recall_latest("logic_reviewer:confidence");
     if len(raw) > 0 {
@@ -161,7 +192,15 @@ fn tick_for_repo(owner: string, repo: string) -> void {
 
     // Perform logic review
     let rec = recommend("logic_review", ["accuracy"]);
-    let context = "MR diff:\n" + changes_raw + "\n\nLearned patterns: " + to_string(rec);
+    // #317: scan PR body for cross-repo refs and prefix the resolved
+    // markdown context onto the prompt. xrepo_block is "" when:
+    //   - body too short / missing
+    //   - owner == "" (single-block back-compat — no scan)
+    //   - no refs / all refs out-of-config
+    // Empty xrepo_block => byte-identical context vs pre-#317.
+    let pr_body = to_string(json_get(raw, "[0].description"));
+    let xrepo_block = cross_repo_context(owner, repo, mr_iid, pr_body);
+    let context = "MR diff:\n" + changes_raw + "\n\nLearned patterns: " + to_string(rec) + xrepo_block;
 
     let review = prompt(
         "You are a logic reviewer. Analyze this merge request diff for logic bugs: off-by-one errors, null/nil dereferences, unhandled edge cases, race conditions, incorrect boundary checks, resource leaks, wrong operator usage. Focus only on correctness, not style. Return JSON: mr_iid (int), findings (array with file, issue, severity, explanation), summary (string). If clean, return empty findings. Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -77,6 +77,27 @@ fn mr_cmd(owner: string, repo: string) -> string {
     return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer" + repo_arg(owner, repo);
 }
 
+// #317: cross-repo reference enrichment. See logic_reviewer.ag for the
+// full design rationale. Returns "" => byte-identical context vs pre-#317.
+fn cross_repo_context(owner: string, repo: string, mr_iid: int, body: string) -> string {
+    if len(body) < 5 { return ""; };
+    let self_arg = if len(owner) > 0 { " --self " + shell_escape(owner + "/" + repo); } else { ""; };
+    // colony-lint: safe-exec-concat
+    let scan_cmd = "printf '%s' " + shell_escape(body) +
+        " | $COLONY_DIR/../../tools/scan-cross-repo-refs.sh" + self_arg;
+    let refs_raw = try { exec sh scan_cmd; } catch e { ""; };
+    if len(refs_raw) == 0 { return ""; };
+    let src_args = if len(owner) > 0 {
+        " --src-owner " + shell_escape(owner) +
+        " --src-repo " + shell_escape(repo) +
+        " --src-iid " + to_string(mr_iid);
+    } else { ""; };
+    // colony-lint: safe-exec-concat
+    let resolve_cmd = "printf '%s' " + shell_escape(refs_raw) +
+        " | $COLONY_DIR/../../tools/resolve-cross-repo-ref.sh --colony-dir \"$COLONY_DIR\" --max 5" + src_args;
+    return try { exec sh resolve_cmd; } catch e { ""; };
+}
+
 fn get_confidence() -> float {
     let raw = recall_latest("security_reviewer:confidence");
     if len(raw) > 0 {
@@ -160,7 +181,12 @@ fn tick_for_repo(owner: string, repo: string) -> void {
 
     // Perform security review
     let rec = recommend("security_review", ["accuracy"]);
-    let context = "MR diff:\n" + changes_raw + "\n\nLearned patterns: " + to_string(rec);
+    // #317: scan PR body for cross-repo refs and prefix the resolved
+    // markdown context onto the prompt. Empty xrepo_block =>
+    // byte-identical context vs pre-#317. See logic_reviewer.ag.
+    let pr_body = to_string(json_get(raw, "[0].description"));
+    let xrepo_block = cross_repo_context(owner, repo, mr_iid, pr_body);
+    let context = "MR diff:\n" + changes_raw + "\n\nLearned patterns: " + to_string(rec) + xrepo_block;
 
     let review = prompt(
         "You are a security reviewer. Analyze this merge request diff for security vulnerabilities: SQL/command injection, XSS, CSRF, hardcoded secrets, insecure auth, path traversal, SSRF, insecure deserialization, dependency issues. Include CWE IDs where applicable. Return JSON: mr_iid (int), findings (array with file, issue, severity, cwe, remediation), summary (string). If clean, return empty findings. Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",

--- a/dev-apprenticeship/code-review/agents/security_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/security_reviewer.ag
@@ -81,6 +81,7 @@ fn mr_cmd(owner: string, repo: string) -> string {
 // full design rationale. Returns "" => byte-identical context vs pre-#317.
 fn cross_repo_context(owner: string, repo: string, mr_iid: int, body: string) -> string {
     if len(body) < 5 { return ""; };
+    if len(owner) == 0 { return ""; };  // M3a sentinel: skip cross-repo scan on single-block path
     let self_arg = if len(owner) > 0 { " --self " + shell_escape(owner + "/" + repo); } else { ""; };
     // colony-lint: safe-exec-concat
     let scan_cmd = "printf '%s' " + shell_escape(body) +

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -104,6 +104,7 @@ fn mr_cmd(owner: string, repo: string) -> string {
 // full design rationale. Returns "" => byte-identical context vs pre-#317.
 fn cross_repo_context(owner: string, repo: string, mr_iid: int, body: string) -> string {
     if len(body) < 5 { return ""; };
+    if len(owner) == 0 { return ""; };  // M3a sentinel: skip cross-repo scan on single-block path
     let self_arg = if len(owner) > 0 { " --self " + shell_escape(owner + "/" + repo); } else { ""; };
     // colony-lint: safe-exec-concat
     let scan_cmd = "printf '%s' " + shell_escape(body) +

--- a/dev-apprenticeship/code-review/agents/style_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/style_reviewer.ag
@@ -100,6 +100,27 @@ fn mr_cmd(owner: string, repo: string) -> string {
     return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer" + repo_arg(owner, repo);
 }
 
+// #317: cross-repo reference enrichment. See logic_reviewer.ag for the
+// full design rationale. Returns "" => byte-identical context vs pre-#317.
+fn cross_repo_context(owner: string, repo: string, mr_iid: int, body: string) -> string {
+    if len(body) < 5 { return ""; };
+    let self_arg = if len(owner) > 0 { " --self " + shell_escape(owner + "/" + repo); } else { ""; };
+    // colony-lint: safe-exec-concat
+    let scan_cmd = "printf '%s' " + shell_escape(body) +
+        " | $COLONY_DIR/../../tools/scan-cross-repo-refs.sh" + self_arg;
+    let refs_raw = try { exec sh scan_cmd; } catch e { ""; };
+    if len(refs_raw) == 0 { return ""; };
+    let src_args = if len(owner) > 0 {
+        " --src-owner " + shell_escape(owner) +
+        " --src-repo " + shell_escape(repo) +
+        " --src-iid " + to_string(mr_iid);
+    } else { ""; };
+    // colony-lint: safe-exec-concat
+    let resolve_cmd = "printf '%s' " + shell_escape(refs_raw) +
+        " | $COLONY_DIR/../../tools/resolve-cross-repo-ref.sh --colony-dir \"$COLONY_DIR\" --max 5" + src_args;
+    return try { exec sh resolve_cmd; } catch e { ""; };
+}
+
 fn get_confidence() -> float {
     let raw = recall_latest("style_reviewer:confidence");
     if len(raw) > 0 {
@@ -185,7 +206,12 @@ fn tick_for_repo(owner: string, repo: string) -> void {
 
     // Perform style review on the diff
     let rec = recommend("style_review", ["accuracy"]);
-    let context = "MR diff:\n" + changes_raw + "\n\nLearned preferences: " + to_string(rec);
+    // #317: scan PR body for cross-repo refs and prefix the resolved
+    // markdown context onto the prompt. Empty xrepo_block =>
+    // byte-identical context vs pre-#317. See logic_reviewer.ag.
+    let pr_body = to_string(json_get(raw, "[0].description"));
+    let xrepo_block = cross_repo_context(owner, repo, mr_iid, pr_body);
+    let context = "MR diff:\n" + changes_raw + "\n\nLearned preferences: " + to_string(rec) + xrepo_block;
 
     // #104: Extract author from the MR listing so the review prompt
     // has access to it. `raw` holds the first-page MR JSON; json_get

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -76,6 +76,27 @@ fn mr_cmd(owner: string, repo: string) -> string {
     return "$COLONY_DIR/scripts/forge-api.sh merge-requests --view reviewer" + repo_arg(owner, repo);
 }
 
+// #317: cross-repo reference enrichment. See logic_reviewer.ag for the
+// full design rationale. Returns "" => byte-identical context vs pre-#317.
+fn cross_repo_context(owner: string, repo: string, mr_iid: int, body: string) -> string {
+    if len(body) < 5 { return ""; };
+    let self_arg = if len(owner) > 0 { " --self " + shell_escape(owner + "/" + repo); } else { ""; };
+    // colony-lint: safe-exec-concat
+    let scan_cmd = "printf '%s' " + shell_escape(body) +
+        " | $COLONY_DIR/../../tools/scan-cross-repo-refs.sh" + self_arg;
+    let refs_raw = try { exec sh scan_cmd; } catch e { ""; };
+    if len(refs_raw) == 0 { return ""; };
+    let src_args = if len(owner) > 0 {
+        " --src-owner " + shell_escape(owner) +
+        " --src-repo " + shell_escape(repo) +
+        " --src-iid " + to_string(mr_iid);
+    } else { ""; };
+    // colony-lint: safe-exec-concat
+    let resolve_cmd = "printf '%s' " + shell_escape(refs_raw) +
+        " | $COLONY_DIR/../../tools/resolve-cross-repo-ref.sh --colony-dir \"$COLONY_DIR\" --max 5" + src_args;
+    return try { exec sh resolve_cmd; } catch e { ""; };
+}
+
 fn get_confidence() -> float {
     let raw = recall_latest("test_reviewer:confidence");
     if len(raw) > 0 {
@@ -152,7 +173,12 @@ fn tick_for_repo(owner: string, repo: string) -> void {
 
     // Perform test review
     let rec = recommend("test_review", ["accuracy"]);
-    let context = "MR diff:\n" + changes_raw + "\n\nLearned patterns: " + to_string(rec);
+    // #317: scan PR body for cross-repo refs and prefix the resolved
+    // markdown context onto the prompt. Empty xrepo_block =>
+    // byte-identical context vs pre-#317. See logic_reviewer.ag.
+    let pr_body = to_string(json_get(raw, "[0].description"));
+    let xrepo_block = cross_repo_context(owner, repo, mr_iid, pr_body);
+    let context = "MR diff:\n" + changes_raw + "\n\nLearned patterns: " + to_string(rec) + xrepo_block;
 
     let review = prompt(
         "You are a test reviewer. Analyze this merge request diff for test quality: missing tests for new code, untested edge cases, weak assertions (only checking happy path), missing error path tests, test duplication, flaky patterns (timing, ordering). Return JSON: mr_iid (int), findings (array with file, issue, severity, suggestion), summary (string). If tests are adequate, return empty findings. Return ONLY the raw JSON object — no markdown code fences, no ```json wrapper, no prose.",

--- a/dev-apprenticeship/code-review/agents/test_reviewer.ag
+++ b/dev-apprenticeship/code-review/agents/test_reviewer.ag
@@ -80,6 +80,7 @@ fn mr_cmd(owner: string, repo: string) -> string {
 // full design rationale. Returns "" => byte-identical context vs pre-#317.
 fn cross_repo_context(owner: string, repo: string, mr_iid: int, body: string) -> string {
     if len(body) < 5 { return ""; };
+    if len(owner) == 0 { return ""; };  // M3a sentinel: skip cross-repo scan on single-block path
     let self_arg = if len(owner) > 0 { " --self " + shell_escape(owner + "/" + repo); } else { ""; };
     // colony-lint: safe-exec-concat
     let scan_cmd = "printf '%s' " + shell_escape(body) +

--- a/dev-apprenticeship/code-review/scripts/github-api.sh
+++ b/dev-apprenticeship/code-review/scripts/github-api.sh
@@ -21,6 +21,7 @@
 #   github-api.sh mr-notes <number>
 #   github-api.sh post-note <number> --body <text>
 #   github-api.sh approve <number>
+#   github-api.sh get-issue <number>
 #
 # Views (opt-in projection; byte-identical to gitlab-api.sh):
 #   merge-requests --view reviewer  [{iid, state, title, labels,
@@ -136,6 +137,32 @@ print(json.dumps({"changes": out}))
 PY
 }
 
+# normalize_issue
+# Single-issue variant. Reads GitHub /issues/{n} JSON, writes GitLab-issue-
+# shape JSON: {iid, title, description, state, labels, assignees, author,
+# created_at, updated_at, user_notes_count}. Lifted from triage/scripts/
+# github-api.sh's normalize_issue (#317) so the reviewer-side resolver can
+# consume the same shape across the two callers without depending on the
+# triage colony being installed alongside.
+normalize_issue() {
+    python3 /dev/fd/3 3<<'PY'
+import sys, json
+x = json.loads(sys.stdin.read())
+print(json.dumps({
+    "iid": x.get("number"),
+    "title": x.get("title"),
+    "description": x.get("body"),
+    "state": "opened" if x.get("state") == "open" else x.get("state"),
+    "labels": [lab if isinstance(lab, str) else lab.get("name") for lab in (x.get("labels") or []) if isinstance(lab, (str, dict))],
+    "assignees": [{"username": a.get("login")} for a in (x.get("assignees") or [])],
+    "author": {"username": (x.get("user") or {}).get("login")},
+    "created_at": x.get("created_at"),
+    "updated_at": x.get("updated_at"),
+    "user_notes_count": x.get("comments", 0),
+}))
+PY
+}
+
 # normalize_notes
 # Reads GitHub /issues/{n}/comments JSON, writes GitLab /notes-shape:
 # [{id, body, author:{username}, created_at, system}]. GitHub's issue-comments
@@ -179,7 +206,9 @@ project_json() {
 import sys, json
 data = json.loads(sys.stdin.read())
 # #104 parity: keep author.username so style_reviewer tags personal vs team.
+# #317: keep description so reviewers can scan it for cross-repo refs.
 out = [{"iid": x.get("iid"), "state": x.get("state"), "title": x.get("title"),
+        "description": x.get("description"),
         "labels": x.get("labels", []), "source_branch": x.get("source_branch"),
         "target_branch": x.get("target_branch"), "draft": x.get("draft"),
         "author": {"username": (x.get("author") or {}).get("username")}} for x in data]
@@ -453,6 +482,30 @@ PY
         # approval_decider already guards via its decide-once memo so double
         # invocations here would only waste a round-trip and a review row.
         gh_post "$API/pulls/$NUM/reviews" '{"event":"APPROVE"}'
+        ;;
+
+    get-issue)
+        # #317: single-issue fetch for the cross-repo reference resolver.
+        # Argv parity with triage/scripts/github-api.sh's get-issue (lifted
+        # there for the planning/triage feedback matcher); the resolver in
+        # tools/resolve-cross-repo-ref.sh consumes the normalized GitLab-
+        # shape JSON for cache record reshaping.
+        if [ $# -lt 1 ]; then
+            emit_error "Usage: github-api.sh get-issue <number>"
+            exit 2
+        fi
+        NUM="$1"
+        shift
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$NUM" in
+            ''|*[!0-9]*) emit_error "issue number must be numeric: $NUM"; exit 2 ;;
+        esac
+        body="$(gh_get "$API/issues/$NUM")" || exit $?
+        printf '%s' "$body" | normalize_issue
         ;;
 
     rate-limit-status)

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -13,6 +13,7 @@
 #   gitlab-api.sh mr-notes <iid>
 #   gitlab-api.sh post-note <iid> --body <text>
 #   gitlab-api.sh approve <iid>
+#   gitlab-api.sh get-issue <iid>
 #
 # Views (opt-in projection; default is full JSON):
 #   merge-requests --view reviewer  [{iid, state, title, labels,
@@ -61,7 +62,9 @@ import os, json
 data = json.loads(os.environ["DATA"])
 # #104: include author.username so style_reviewer can tag knowledge
 # as personal (operator's own MR) vs team.
+# #317: include description so reviewers can scan it for cross-repo refs.
 out = [{"iid": x.get("iid"), "state": x.get("state"), "title": x.get("title"),
+        "description": x.get("description"),
         "labels": x.get("labels", []), "source_branch": x.get("source_branch"),
         "target_branch": x.get("target_branch"), "draft": x.get("draft"),
         "author": {"username": (x.get("author") or {}).get("username")}} for x in data]
@@ -288,6 +291,30 @@ case "$CMD" in
     approve)
         IID="${1:?Usage: gitlab-api.sh approve <iid>}"
         gl_post "$API/merge_requests/$IID/approve" "{}"
+        ;;
+
+    get-issue)
+        # #317: single-issue fetch for the cross-repo reference resolver.
+        # Argv parity with the triage colony's gitlab-api.sh get-issue (#106
+        # introduced it there for the feedback matcher); the resolver in
+        # tools/resolve-cross-repo-ref.sh consumes the GitLab-shape JSON
+        # directly — no normalization step needed since GitLab issues are
+        # the canonical shape that github-api.sh's normalize_issue mirrors.
+        if [ $# -lt 1 ]; then
+            emit_error "Usage: gitlab-api.sh get-issue <iid>"
+            exit 2
+        fi
+        IID="$1"
+        shift
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        case "$IID" in
+            ''|*[!0-9]*) emit_error "iid must be numeric: $IID"; exit 2 ;;
+        esac
+        gl_get "$API/issues/$IID"
         ;;
 
     rate-limit-status)

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -82,6 +82,43 @@ fn repo_field(line: string, idx: int) -> string {
     return out;
 }
 
+// #317: bidirectional closed-by lookup for unassigned issues. The four
+// reviewer agents call closed-by-index.sh `record` whenever a PR body
+// mentions `<owner>/<repo>#<N>`; here we read the reverse direction so
+// the routing prompt sees a "closed by PR ..." hint per unassigned
+// issue with at least one closing PR. Returns "" when:
+//   - owner == "" (back-compat sentinel — no per-repo key to look up).
+//   - the unassigned issues blob has no parseable iid digits.
+//   - no issues have a closed-by entry in the federation index.
+// Empty return => byte-identical routing context vs pre-#317.
+//
+// All lookup logic delegated to a python -c one-liner so the .ag layer
+// stays bash-3.2 portable. Inputs travel via env to avoid quoting
+// hazards. The inline helper greps the blob for `#<digits>` tokens
+// (iids) plus json `"iid": N` shapes, dedupes (preserve first-seen
+// order), then shells out to closed-by-index.sh lookup per iid (cap 20).
+fn closed_by_context(owner: string, repo: string, blob: string) -> string {
+    if len(owner) == 0 { return ""; };
+    if len(blob) < 2 { return ""; };
+    // colony-lint: safe-exec-concat
+    let cmd = "BLOB=" + shell_escape(blob) +
+        " OWNER=" + shell_escape(owner) +
+        " REPO=" + shell_escape(repo) +
+        " python3 -c 'import os,re,json,subprocess,sys; " +
+        "b=os.environ[\"BLOB\"]; o=os.environ[\"OWNER\"]; r=os.environ[\"REPO\"]; " +
+        "c=os.environ[\"COLONY_DIR\"]; " +
+        "lk=c+\"/../../tools/closed-by-index.sh\"; " +
+        "iids=[]; s=set(); " +
+        "[ (s.add(m.group(1)) or iids.append(m.group(1))) for m in re.finditer(r\"(?<![A-Za-z0-9_])#(\\d+)\", b) if m.group(1) not in s ]; " +
+        "[ (s.add(m.group(1)) or iids.append(m.group(1))) for m in re.finditer(r\"\\\"iid\\\"\\s*:\\s*(\\d+)\", b) if m.group(1) not in s ]; " +
+        "out=[]; " +
+        "[ out.append((n, json.loads(subprocess.check_output([lk,\"lookup\",\"--colony-dir\",c,\"--tgt-owner\",o,\"--tgt-repo\",r,\"--tgt-iid\",n], stderr=subprocess.DEVNULL).decode(\"utf-8\",\"replace\").strip() or \"[]\"))) for n in iids[:20] ]; " +
+        "lines=[]; " +
+        "[ lines.append(\"- #%s: closed by %s\" % (n, \", \".join([\"%s/%s#%s\" % (e.get(\"src_owner\",\"\"), e.get(\"src_repo\",\"\"), e.get(\"src_iid\",\"\")) for e in arr[:5] if isinstance(e, dict)]))) for (n, arr) in out if arr ]; " +
+        "sys.stdout.write(\"\\n\\n## Closed-by hints (cross-repo)\\n\" + \"\\n\".join(lines) + \"\\n\") if lines else None'";
+    return try { exec sh cmd; } catch e { ""; };
+}
+
 fn issues_cmd(owner: string, repo: string) -> string {
     let ts = recall_latest(scoped_memo(owner, repo, "router:last_check"));
     // colony-lint: safe-exec-concat
@@ -159,7 +196,13 @@ fn tick_for_repo(owner: string, repo: string) -> void {
     if analysis.unassigned_count > 0 {
         let my_tier = repo_tier("router", owner, repo);
         let rec = recommend("route", ["accuracy"]);
-        let context = "Unassigned issues: " + analysis.unassigned_issues + "\nTeam members: " + members_raw + "\nPast learning: " + to_string(rec);
+        // #317: bidirectional surface — pass the unassigned issues blob
+        // through closed-by-index lookup so the router prompt sees
+        // "closed by PR <other>#<N>" hints alongside the issue list.
+        // Empty owner sentinel skips the lookup (no per-repo key to
+        // search) — byte-identical to pre-#317 routing context.
+        let closed_by_block = closed_by_context(owner, repo, analysis.unassigned_issues);
+        let context = "Unassigned issues: " + analysis.unassigned_issues + "\nTeam members: " + members_raw + "\nPast learning: " + to_string(rec) + closed_by_block;
 
         let action = prompt(
             "You are a routing agent. Suggest who should be assigned to the most important unassigned issue based on team expertise. Return JSON: issue_id (int), assignee (string, username), reasoning (string), confidence (float 0-1).",

--- a/tools/closed-by-index.py
+++ b/tools/closed-by-index.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""closed-by-index.py - federation-shared closed-by index helper.
+
+Companion helper for `tools/closed-by-index.sh` (#317). Manages the
+single federation-shared file
+`<fed>/.agentis/cross-repo-cache/closed-by-index.json`, a map from
+target-issue key to list of closing-PR records:
+
+    {
+      "acme__backend__123": [
+        {
+          "src_owner": "acme",
+          "src_repo": "frontend",
+          "src_iid": 47,
+          "recorded_at": "2026-04-28T14:32:11Z"
+        }
+      ]
+    }
+
+Verbs:
+
+    record --colony-dir <dir>
+           --src-owner <o> --src-repo <r> --src-iid <N>
+           --tgt-owner <o> --tgt-repo <r> --tgt-iid <N>
+        Idempotent insert on the (src_owner, src_repo, src_iid) tuple
+        for the given target. flock(LOCK_EX) over the index file
+        protects the read-modify-write window from the four reviewer
+        agents racing on the same PR. Atomic write via tmp + rename.
+
+    lookup --colony-dir <dir>
+           --tgt-owner <o> --tgt-repo <r> --tgt-iid <N>
+        Echo the JSON array of closing-PR records for the target. Empty
+        array `[]` when nothing has been recorded — lookup is an
+        observational probe, not a bus query.
+
+`<dir>` is the COLONY_DIR exported by start-colony.sh (`<fed>/<colony>`).
+The federation root sits one level up; the index lives under
+`<fed>/.agentis/cross-repo-cache/closed-by-index.json` so it is shared
+between every colony's reviewer + router agents.
+
+Exit codes:
+    0   ok
+    2   usage error / malformed args
+"""
+import argparse
+import datetime
+import errno
+import fcntl
+import json
+import os
+import sys
+import tempfile
+
+INDEX_FILENAME = "closed-by-index.json"
+
+
+def _index_dir(colony_dir):
+    fed_dir = os.path.dirname(os.path.abspath(colony_dir))
+    return os.path.join(fed_dir, ".agentis", "cross-repo-cache")
+
+
+def _index_path(colony_dir):
+    return os.path.join(_index_dir(colony_dir), INDEX_FILENAME)
+
+
+def _target_key(owner, repo, iid):
+    safe_owner = owner.replace("/", "_")
+    safe_repo = repo.replace("/", "_")
+    return "%s__%s__%s" % (safe_owner, safe_repo, iid)
+
+
+def _utc_now_iso():
+    # Use timezone-aware datetime; utcnow() is deprecated in Python 3.12.
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+
+def _read_index(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r") as f:
+            data = json.loads(f.read())
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except (IOError, OSError, ValueError) as e:
+        sys.stderr.write("closed-by-index: read failed: %s\n" % e)
+        return {}
+
+
+def _atomic_write(path, payload):
+    target_dir = os.path.dirname(path)
+    fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=target_dir)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+            if not payload.endswith("\n"):
+                f.write("\n")
+        os.rename(tmp_path, path)
+    except (IOError, OSError) as e:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise e
+
+
+def cmd_record(args):
+    target_dir = _index_dir(args.colony_dir)
+    try:
+        os.makedirs(target_dir, exist_ok=True)
+    except OSError as e:
+        sys.stderr.write("closed-by-index: mkdir failed: %s\n" % e)
+        return 2
+    path = _index_path(args.colony_dir)
+    # Open-or-create the lock file. flock(LOCK_EX) blocks until we win.
+    lock_path = path + ".lock"
+    lf = open(lock_path, "a+")
+    try:
+        try:
+            fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+        except (IOError, OSError) as e:
+            sys.stderr.write("closed-by-index: flock failed: %s\n" % e)
+            return 2
+        index = _read_index(path)
+        key = _target_key(args.tgt_owner, args.tgt_repo, args.tgt_iid)
+        bucket = index.get(key, [])
+        if not isinstance(bucket, list):
+            bucket = []
+        # Idempotent on (src_owner, src_repo, src_iid).
+        for existing in bucket:
+            if (
+                isinstance(existing, dict)
+                and existing.get("src_owner") == args.src_owner
+                and existing.get("src_repo") == args.src_repo
+                and str(existing.get("src_iid")) == str(args.src_iid)
+            ):
+                # Already recorded — write nothing, exit 0.
+                return 0
+        try:
+            src_iid_int = int(args.src_iid)
+        except (ValueError, TypeError):
+            sys.stderr.write(
+                "closed-by-index: --src-iid not numeric: %r\n" % args.src_iid
+            )
+            return 2
+        bucket.append({
+            "src_owner": args.src_owner,
+            "src_repo": args.src_repo,
+            "src_iid": src_iid_int,
+            "recorded_at": _utc_now_iso(),
+        })
+        index[key] = bucket
+        try:
+            _atomic_write(path, json.dumps(index, sort_keys=True))
+        except (IOError, OSError) as e:
+            sys.stderr.write("closed-by-index: write failed: %s\n" % e)
+            return 2
+        return 0
+    finally:
+        try:
+            fcntl.flock(lf.fileno(), fcntl.LOCK_UN)
+        except (IOError, OSError):
+            pass
+        lf.close()
+
+
+def cmd_lookup(args):
+    path = _index_path(args.colony_dir)
+    index = _read_index(path)
+    key = _target_key(args.tgt_owner, args.tgt_repo, args.tgt_iid)
+    bucket = index.get(key, [])
+    if not isinstance(bucket, list):
+        bucket = []
+    sys.stdout.write(json.dumps(bucket))
+    sys.stdout.write("\n")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="verb")
+    sub.required = True
+
+    p_rec = sub.add_parser("record")
+    p_rec.add_argument("--colony-dir", dest="colony_dir", required=True)
+    p_rec.add_argument("--src-owner", dest="src_owner", required=True)
+    p_rec.add_argument("--src-repo", dest="src_repo", required=True)
+    p_rec.add_argument("--src-iid", dest="src_iid", required=True)
+    p_rec.add_argument("--tgt-owner", dest="tgt_owner", required=True)
+    p_rec.add_argument("--tgt-repo", dest="tgt_repo", required=True)
+    p_rec.add_argument("--tgt-iid", dest="tgt_iid", required=True)
+    p_rec.set_defaults(func=cmd_record)
+
+    p_look = sub.add_parser("lookup")
+    p_look.add_argument("--colony-dir", dest="colony_dir", required=True)
+    p_look.add_argument("--tgt-owner", dest="tgt_owner", required=True)
+    p_look.add_argument("--tgt-repo", dest="tgt_repo", required=True)
+    p_look.add_argument("--tgt-iid", dest="tgt_iid", required=True)
+    p_look.set_defaults(func=cmd_lookup)
+
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    # errno is imported for the OSError attribute lookups some callers
+    # use; keep the binding live so a future contributor doesn't strip
+    # the import as unused.
+    _ = errno
+    sys.exit(main())

--- a/tools/closed-by-index.sh
+++ b/tools/closed-by-index.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# tools/closed-by-index.sh: federation-shared closed-by index for the
+# cross-repo bidirectional surface (#317).
+#
+# Tracks which PR(s) close which target issue, keyed by
+# `<owner>__<repo>__<N>` for the target. Used by router.ag to surface
+# "closed by PR ..." hints on unassigned issues.
+#
+# Two verbs:
+#   record --colony-dir <dir> --src-owner <o> --src-repo <r> --src-iid <N>
+#                              --tgt-owner <o> --tgt-repo <r> --tgt-iid <N>
+#       Idempotent insert on (src, tgt) tuple. flock-protected
+#       read-modify-write of `<fed>/.agentis/cross-repo-cache/closed-
+#       by-index.json`. Atomic write via tmp+rename.
+#
+#   lookup --colony-dir <dir> --tgt-owner <o> --tgt-repo <r> --tgt-iid <N>
+#       Echo the JSON array of closing-PR objects for the given target.
+#       Empty array `[]` if no PRs close it. Exit 0 always (lookup is
+#       observational, not a bus probe).
+#
+# Thin shim around tools/closed-by-index.py — all logic lives in the
+# python sibling so this script stays macOS bash 3.2 portable. Same
+# shape as iter-repos.sh and cross-repo-cache.sh.
+#
+# Exit codes:
+#   0  ok
+#   2  usage error / malformed args
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$SCRIPT_DIR/closed-by-index.py" "$@"

--- a/tools/cross-repo-cache.py
+++ b/tools/cross-repo-cache.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""cross-repo-cache.py - per-key cache for cross-repo issue resolution.
+
+Companion helper for `tools/cross-repo-cache.sh` (#317). Manages JSON
+records under `<fed>/.agentis/cross-repo-cache/<owner>__<repo>__<N>.json`
+following the M3a `scoped_memo()` separator convention (`__` between
+owner/repo, also used as the per-repo segment separator in memo keys).
+
+Two verbs:
+
+    get --colony-dir <dir> <owner> <repo> <number>
+        Read record. Stdout is the record JSON on hit. Exit 0 on hit,
+        1 when the file is missing OR when its `fetched_at` age exceeds
+        the TTL.
+
+    put --colony-dir <dir> <owner> <repo> <number>
+        Stdin -> the cache file, atomically (tmp + rename). Caller owns
+        the JSON shape; we do not validate (the resolver wraps this).
+
+`<dir>` is the colony's COLONY_DIR (the start-colony.sh-exported value).
+The federation root sits two levels up (`<colony>/.../<fed>`); we walk
+up from there to the federation by treating `<dir>/../..` as the
+federation root and writing the cache to `<fed>/.agentis/cross-repo-
+cache/`. (Federation layout is `<fed>/<colony>/scripts/`; COLONY_DIR
+points at `<fed>/<colony>` per start-colony.sh.)
+
+TTL is read from `CROSS_REPO_CACHE_TTL_SECS` (default 3600). A negative
+TTL is treated as "never expire" so operators can pin records during
+debug. `fetched_at` is parsed as ISO-8601 UTC; on parse failure the
+record is treated as expired (defensive — corrupt timestamp shouldn't
+serve stale forever).
+
+Tokens never appear in cache records — test 6 of test-cross-repo-refs.sh
+greps for the substring `token` (case-insensitive) on a fresh `put`
+output and fails the test if it appears. The schema is fixed (owner /
+repo / number / title / state / labels / fetched_at) and the resolver
+strips anything else before calling `put`.
+"""
+import argparse
+import datetime
+import json
+import os
+import sys
+import tempfile
+
+DEFAULT_TTL_SECS = 3600
+
+
+def _cache_dir(colony_dir):
+    # Federation root = parent of colony dir. Layout: <fed>/<colony>/.
+    fed_dir = os.path.dirname(os.path.abspath(colony_dir))
+    return os.path.join(fed_dir, ".agentis", "cross-repo-cache")
+
+
+def _key_path(colony_dir, owner, repo, number):
+    safe_owner = owner.replace("/", "_")
+    safe_repo = repo.replace("/", "_")
+    fname = "%s__%s__%s.json" % (safe_owner, safe_repo, number)
+    return os.path.join(_cache_dir(colony_dir), fname)
+
+
+def _ttl_secs():
+    raw = os.environ.get("CROSS_REPO_CACHE_TTL_SECS", "")
+    if not raw:
+        return DEFAULT_TTL_SECS
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        sys.stderr.write(
+            "cross-repo-cache: CROSS_REPO_CACHE_TTL_SECS not an integer: %r\n" % raw
+        )
+        return DEFAULT_TTL_SECS
+
+
+def _is_fresh(record, ttl_secs):
+    if ttl_secs < 0:
+        return True
+    fetched = record.get("fetched_at", "")
+    if not fetched:
+        return False
+    # ISO 8601 UTC, e.g. "2026-04-28T14:32:11Z".
+    try:
+        # Accept the trailing Z; datetime.fromisoformat in Py3.11+ handles
+        # it natively, but we target older runtimes too — strip Z manually.
+        s = fetched
+        if s.endswith("Z"):
+            s = s[:-1]
+        dt = datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%S")
+    except (ValueError, TypeError):
+        return False
+    # utcnow() is deprecated in Python 3.12 — use timezone-aware UTC.
+    now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    age = (now - dt).total_seconds()
+    return age >= 0 and age < ttl_secs
+
+
+def cmd_get(args):
+    path = _key_path(args.colony_dir, args.owner, args.repo, args.number)
+    if not os.path.exists(path):
+        return 1
+    try:
+        with open(path, "r") as f:
+            raw = f.read()
+        record = json.loads(raw)
+    except (IOError, OSError, ValueError) as e:
+        sys.stderr.write("cross-repo-cache: read failed: %s\n" % e)
+        return 1
+    if not _is_fresh(record, _ttl_secs()):
+        return 1
+    sys.stdout.write(raw)
+    if not raw.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+def cmd_put(args):
+    payload = sys.stdin.read()
+    # Validate JSON before writing (caller could feed us garbage).
+    try:
+        json.loads(payload)
+    except (ValueError, TypeError) as e:
+        sys.stderr.write("cross-repo-cache: stdin not valid JSON: %s\n" % e)
+        return 2
+    cache_dir = _cache_dir(args.colony_dir)
+    try:
+        os.makedirs(cache_dir, exist_ok=True)
+    except OSError as e:
+        sys.stderr.write("cross-repo-cache: mkdir failed: %s\n" % e)
+        return 2
+    path = _key_path(args.colony_dir, args.owner, args.repo, args.number)
+    # Atomic write: tmp file in same dir + rename. POSIX rename within the
+    # same filesystem is atomic; cross-fs rename would silently degrade,
+    # but cache_dir lives under the federation root so we're always on the
+    # operator's primary FS.
+    fd, tmp_path = tempfile.mkstemp(prefix=".tmp-", suffix=".json", dir=cache_dir)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+            if not payload.endswith("\n"):
+                f.write("\n")
+        os.rename(tmp_path, path)
+    except (IOError, OSError) as e:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        sys.stderr.write("cross-repo-cache: write failed: %s\n" % e)
+        return 2
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="verb")
+    sub.required = True
+
+    p_get = sub.add_parser("get")
+    p_get.add_argument("--colony-dir", dest="colony_dir", required=True)
+    p_get.add_argument("owner")
+    p_get.add_argument("repo")
+    p_get.add_argument("number")
+    p_get.set_defaults(func=cmd_get)
+
+    p_put = sub.add_parser("put")
+    p_put.add_argument("--colony-dir", dest="colony_dir", required=True)
+    p_put.add_argument("owner")
+    p_put.add_argument("repo")
+    p_put.add_argument("number")
+    p_put.set_defaults(func=cmd_put)
+
+    args = ap.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/cross-repo-cache.sh
+++ b/tools/cross-repo-cache.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# tools/cross-repo-cache.sh: read-with-TTL + atomic-write helper for the
+# `<fed>/.agentis/cross-repo-cache/<owner>__<repo>__<N>.json` records (#317).
+#
+# Two verbs:
+#   get  --colony-dir <dir> <owner> <repo> <number>
+#        Reads the cache record. Empty stdout when missing OR when the
+#        record's age exceeds TTL. Exit 0 on hit, 1 on miss/expired, 2 on
+#        usage / arg error. Tokens never appear in the record (test 6
+#        enforces).
+#
+#   put  --colony-dir <dir> <owner> <repo> <number>
+#        Reads the record JSON from stdin and atomically writes it to the
+#        cache key (tmp + rename, owner of caller). Caller is responsible
+#        for shape validation; this helper is a dumb sink.
+#
+# TTL: configurable via `CROSS_REPO_CACHE_TTL_SECS` env (default 3600).
+#
+# Thin shim around tools/cross-repo-cache.py — all logic lives in the
+# python sibling so this script stays macOS bash 3.2 portable (no
+# heredocs, no GNU-only flags). Same shape as iter-repos.sh.
+#
+# Exit codes:
+#   0  ok (record on stdout, or write succeeded)
+#   1  miss or expired
+#   2  usage error / malformed args
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$SCRIPT_DIR/cross-repo-cache.py" "$@"

--- a/tools/resolve-cross-repo-ref.sh
+++ b/tools/resolve-cross-repo-ref.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+# tools/resolve-cross-repo-ref.sh: glue script that resolves a stream of
+# `<owner>/<repo>#<N>` cross-repo refs into a markdown context block (#317).
+#
+# Reads the ref list on stdin (one per line, as emitted by
+# scan-cross-repo-refs.sh), and for each ref:
+#   1. Tries cross-repo-cache.sh get; on hit, uses the cached record.
+#   2. On cache miss/expired, invokes
+#      `<colony-dir>/scripts/forge-api.sh get-issue <number> --repo <owner>/<repo>`
+#      and reshapes the result into the cache schema, writes via
+#      cross-repo-cache.sh put.
+#   3. Records the (src=this-PR-context, tgt=the-ref) pair in the
+#      federation-shared closed-by-index for the bidirectional surface.
+#
+# `--max <N>` caps the number of refs resolved per invocation (default
+# 5). Excess refs are silently dropped after N — the cap exists to bound
+# the prompt-context size and forge call budget, not to surface a
+# structured "more refs elided" hint.
+#
+# `--src-owner <o> --src-repo <r> --src-iid <N>` (optional): when all
+# three are supplied, each successful resolve also records a closed-by
+# entry pairing this source with the resolved target. Skipped when
+# missing — the cross-repo *resolver* (read-side) is independent of the
+# closed-by *recorder* (write-side); both can be invoked in isolation.
+#
+# Out-of-config repo handling: forge-api.sh exits non-zero when --repo
+# isn't in GITHUB_REPOS_JSON. Resolver writes a tombstone record to
+# cache (so we don't re-attempt the API for an entire TTL window) and
+# silently skips the ref in the markdown output. Tombstones carry
+# `state == "unresolvable"`.
+#
+# Stdout: leading `\n\n## Cross-repo references mentioned in this PR\n`
+# followed by one bullet per resolved ref. Empty stdout when no refs
+# resolved (caller can concat unconditionally — it's empty-string-safe).
+#
+# Bash 3.2 portable. No heredocs (CLAUDE.md). All JSON shape work is
+# delegated to python3 -c one-liners via env-var payloads — same
+# pattern as the .ag agents' repo_field() helper. Tokens NEVER appear
+# in cache records or stdout (test 6 enforces).
+#
+# Exit codes:
+#   0  ok (markdown on stdout, possibly empty)
+#   2  usage error / malformed args
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+COLONY_DIR=""
+MAX_REFS=5
+SRC_OWNER=""
+SRC_REPO=""
+SRC_IID=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --colony-dir)
+            COLONY_DIR="${2:-}"
+            shift 2
+            ;;
+        --max)
+            MAX_REFS="${2:-5}"
+            shift 2
+            ;;
+        --src-owner)
+            SRC_OWNER="${2:-}"
+            shift 2
+            ;;
+        --src-repo)
+            SRC_REPO="${2:-}"
+            shift 2
+            ;;
+        --src-iid)
+            SRC_IID="${2:-}"
+            shift 2
+            ;;
+        *)
+            echo "resolve-cross-repo-ref: unknown flag: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$COLONY_DIR" ]; then
+    echo "resolve-cross-repo-ref: --colony-dir is required" >&2
+    exit 2
+fi
+
+case "$MAX_REFS" in
+    ''|*[!0-9]*)
+        echo "resolve-cross-repo-ref: --max must be numeric (got '$MAX_REFS')" >&2
+        exit 2
+        ;;
+esac
+
+FORGE_API="$COLONY_DIR/scripts/forge-api.sh"
+CACHE="$SCRIPT_DIR/cross-repo-cache.sh"
+CLOSED_BY="$SCRIPT_DIR/closed-by-index.sh"
+
+for tool in "$CACHE" "$CLOSED_BY"; do
+    if [ ! -x "$tool" ]; then
+        echo "resolve-cross-repo-ref: helper missing or not executable: $tool" >&2
+        exit 2
+    fi
+done
+
+# Read all refs upfront into a temp file so the per-ref subprocesses
+# don't inherit and consume our stdin.
+REFS_FILE="$(mktemp)"
+trap 'rm -f "$REFS_FILE"' EXIT
+cat >"$REFS_FILE"
+
+# Reshape the raw forge-api get-issue JSON into the cache schema. Caps:
+# title 200 chars, labels max 10 entries x 32 chars each. Tokens NEVER
+# appear in the input (the github-api.sh /issues endpoint shape carries
+# only public fields), but we explicitly project a known set of keys —
+# defence in depth.
+RESHAPE_PY='import os, json, datetime
+raw = os.environ.get("RAW","")
+owner = os.environ.get("OWNER","")
+repo = os.environ.get("REPO","")
+number = os.environ.get("NUMBER","")
+try:
+    src = json.loads(raw) if raw else {}
+except Exception:
+    src = {}
+title = str(src.get("title") or "")
+if len(title) > 200:
+    title = title[:200]
+state = str(src.get("state") or "")
+labels = src.get("labels") or []
+out_labels = []
+for lab in labels[:10]:
+    if isinstance(lab, dict):
+        lab = lab.get("name") or ""
+    s = str(lab)[:32]
+    if s:
+        out_labels.append(s)
+fetched = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+try:
+    num_int = int(number)
+except Exception:
+    num_int = 0
+print(json.dumps({
+    "owner": owner,
+    "repo": repo,
+    "number": num_int,
+    "title": title,
+    "state": state,
+    "labels": out_labels,
+    "fetched_at": fetched,
+}))
+'
+
+# Tombstone written when a ref resolves to a repo not in GITHUB_REPOS_JSON
+# (or when the API call otherwise fails). state == "unresolvable" is the
+# magic marker the resolver later filters out of rendered output.
+TOMBSTONE_PY='import os, json, datetime
+owner = os.environ.get("OWNER","")
+repo = os.environ.get("REPO","")
+number = os.environ.get("NUMBER","")
+try:
+    num_int = int(number)
+except Exception:
+    num_int = 0
+print(json.dumps({
+    "owner": owner,
+    "repo": repo,
+    "number": num_int,
+    "title": "",
+    "state": "unresolvable",
+    "labels": [],
+    "fetched_at": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+}))
+'
+
+# Extract just the `state` field of a cache record.
+STATE_PY='import sys, json
+try:
+    rec = json.loads(sys.stdin.read())
+except Exception:
+    rec = {}
+print(rec.get("state",""))
+'
+
+# Render one markdown bullet line for a resolved record.
+# shellcheck disable=SC2016
+RENDER_PY='import sys, json, os
+try:
+    rec = json.loads(sys.stdin.read())
+except Exception:
+    rec = {}
+owner = sys.argv[1] if len(sys.argv) > 1 else rec.get("owner","")
+repo = sys.argv[2] if len(sys.argv) > 2 else rec.get("repo","")
+num = sys.argv[3] if len(sys.argv) > 3 else str(rec.get("number",""))
+title = rec.get("title","")
+state = rec.get("state","")
+labels = rec.get("labels") or []
+labels_str = ", ".join(labels) if labels else ""
+parts = ["- `%s/%s#%s`" % (owner, repo, num)]
+if state:
+    parts.append("(%s)" % state)
+if title:
+    parts.append("- " + title)
+if labels_str:
+    parts.append("[" + labels_str + "]")
+print(" ".join(parts))
+'
+
+# Walk the ref file. Bash 3.2 doesn't have mapfile; while-read is portable.
+RESOLVED_COUNT=0
+RESOLVED_BODY=""
+
+while IFS= read -r REF; do
+    [ -z "$REF" ] && continue
+    if [ "$RESOLVED_COUNT" -ge "$MAX_REFS" ]; then
+        break
+    fi
+
+    # Parse `<owner>/<repo>#<N>` via parameter expansion (no =~ on bash 3.2).
+    SLASH="${REF%%/*}"
+    REST="${REF#*/}"
+    REPO_PART="${REST%%#*}"
+    NUM="${REST##*#}"
+
+    if [ -z "$SLASH" ] || [ -z "$REPO_PART" ] || [ -z "$NUM" ] || [ "$REPO_PART" = "$REST" ]; then
+        continue
+    fi
+    case "$NUM" in
+        ''|*[!0-9]*) continue ;;
+    esac
+
+    OWNER="$SLASH"
+    REPO="$REPO_PART"
+
+    # 1. Cache get.
+    HIT=""
+    if HIT="$("$CACHE" get --colony-dir "$COLONY_DIR" "$OWNER" "$REPO" "$NUM" 2>/dev/null)"; then
+        :
+    else
+        HIT=""
+    fi
+
+    if [ -z "$HIT" ]; then
+        # 2. Cache miss/expired -> forge-api get-issue. The dispatcher
+        # exits non-zero when --repo isn't in GITHUB_REPOS_JSON; treat
+        # any non-zero from forge-api as out-of-config and tombstone.
+        RAW=""
+        FORGE_RC=0
+        RAW="$("$FORGE_API" get-issue "$NUM" --repo "$OWNER/$REPO" 2>/dev/null)" || FORGE_RC=$?
+        if [ "$FORGE_RC" -ne 0 ] || [ -z "$RAW" ]; then
+            OWNER="$OWNER" REPO="$REPO" NUMBER="$NUM" python3 -c "$TOMBSTONE_PY" \
+                | "$CACHE" put --colony-dir "$COLONY_DIR" "$OWNER" "$REPO" "$NUM" >/dev/null 2>&1 || true
+            continue
+        fi
+        RECORD="$(OWNER="$OWNER" REPO="$REPO" NUMBER="$NUM" RAW="$RAW" python3 -c "$RESHAPE_PY" 2>/dev/null || true)"
+        if [ -z "$RECORD" ]; then
+            OWNER="$OWNER" REPO="$REPO" NUMBER="$NUM" python3 -c "$TOMBSTONE_PY" \
+                | "$CACHE" put --colony-dir "$COLONY_DIR" "$OWNER" "$REPO" "$NUM" >/dev/null 2>&1 || true
+            continue
+        fi
+        printf '%s' "$RECORD" | "$CACHE" put --colony-dir "$COLONY_DIR" "$OWNER" "$REPO" "$NUM" >/dev/null 2>&1 || true
+        HIT="$RECORD"
+    fi
+
+    # Skip tombstones from rendered output.
+    STATE_FIELD="$(printf '%s' "$HIT" | python3 -c "$STATE_PY" 2>/dev/null || true)"
+    if [ "$STATE_FIELD" = "unresolvable" ]; then
+        continue
+    fi
+
+    # 3. closed-by index recording (optional — only when src-* triplet is set).
+    if [ -n "$SRC_OWNER" ] && [ -n "$SRC_REPO" ] && [ -n "$SRC_IID" ]; then
+        "$CLOSED_BY" record \
+            --colony-dir "$COLONY_DIR" \
+            --src-owner "$SRC_OWNER" \
+            --src-repo "$SRC_REPO" \
+            --src-iid "$SRC_IID" \
+            --tgt-owner "$OWNER" \
+            --tgt-repo "$REPO" \
+            --tgt-iid "$NUM" >/dev/null 2>&1 || true
+    fi
+
+    # 4. Render bullet line.
+    BULLET="$(printf '%s' "$HIT" | python3 -c "$RENDER_PY" "$OWNER" "$REPO" "$NUM" 2>/dev/null || true)"
+    if [ -n "$BULLET" ]; then
+        if [ -z "$RESOLVED_BODY" ]; then
+            RESOLVED_BODY="$BULLET"
+        else
+            RESOLVED_BODY="$RESOLVED_BODY
+$BULLET"
+        fi
+        RESOLVED_COUNT=$((RESOLVED_COUNT + 1))
+    fi
+done <"$REFS_FILE"
+
+if [ "$RESOLVED_COUNT" -gt 0 ]; then
+    printf '\n\n## Cross-repo references mentioned in this PR\n%s\n' "$RESOLVED_BODY"
+fi
+
+exit 0

--- a/tools/scan-cross-repo-refs.py
+++ b/tools/scan-cross-repo-refs.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""scan-cross-repo-refs.py - extract cross-repo refs from a stdin blob.
+
+Companion helper for `tools/scan-cross-repo-refs.sh` (#317). Reads any
+textual blob from stdin (PR body, comment, description), runs a pure
+regex over it, and writes one `<owner>/<repo>#<N>` ref per line on
+stdout. The scanner deduplicates refs (set, preserve first-seen order)
+and filters out the obvious code-ref forms that resemble cross-repo
+references syntactically but mean something else (`#L42` line refs, the
+trailing word characters past the digit run, etc.).
+
+The regex follows the plan §3 spec verbatim:
+
+    (?<![\\w./-])                    # left boundary
+    ([a-zA-Z0-9][a-zA-Z0-9._-]*)     # owner (no leading dot)
+    /
+    ([a-zA-Z0-9][a-zA-Z0-9._-]*)     # repo (no leading dot)
+    #
+    (?!L\\d)                         # not a line ref (#L42)
+    (\\d+)                           # issue/PR number
+    (?!\\w)                          # right boundary
+
+Empty stdin -> empty stdout, exit 0. No matches -> empty stdout, exit 0.
+
+`--self <owner>/<repo>` filters self-references — a PR in `acme/backend`
+that mentions `acme/backend#42` is not a cross-repo ref, so the scanner
+drops it. The flag is optional; without it every match is emitted.
+
+Exit codes: 0 always on success, 2 on malformed `--self`.
+"""
+import argparse
+import re
+import sys
+
+PATTERN = re.compile(
+    r'(?<![\w./-])'
+    r'([a-zA-Z0-9][a-zA-Z0-9._-]*)'
+    r'/'
+    r'([a-zA-Z0-9][a-zA-Z0-9._-]*)'
+    r'#'
+    r'(?!L\d)'
+    r'(\d+)'
+    r'(?!\w)'
+)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--self",
+        dest="self_ref",
+        default="",
+        help="owner/repo to drop from output (filters self-references)",
+    )
+    args = ap.parse_args()
+
+    self_ref = args.self_ref
+    if self_ref:
+        if "/" not in self_ref:
+            sys.stderr.write(
+                "scan-cross-repo-refs: --self expected owner/repo (got '%s')\n"
+                % self_ref
+            )
+            return 2
+        # Light schema check; the dispatcher already validates upstream.
+        parts = self_ref.split("/", 1)
+        if not parts[0] or not parts[1]:
+            sys.stderr.write(
+                "scan-cross-repo-refs: --self expected owner/repo (got '%s')\n"
+                % self_ref
+            )
+            return 2
+
+    blob = sys.stdin.read()
+    if not blob:
+        return 0
+
+    seen = set()
+    for m in PATTERN.finditer(blob):
+        owner, repo, num = m.group(1), m.group(2), m.group(3)
+        ref = "%s/%s#%s" % (owner, repo, num)
+        if ref in seen:
+            continue
+        if self_ref and ("%s/%s" % (owner, repo)) == self_ref:
+            continue
+        seen.add(ref)
+        sys.stdout.write(ref + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scan-cross-repo-refs.sh
+++ b/tools/scan-cross-repo-refs.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# tools/scan-cross-repo-refs.sh: pure regex scanner that extracts every
+# `<owner>/<repo>#<N>` cross-repo reference appearing on stdin (a PR body
+# blob, a comment, a description — anything textual). One ref per line on
+# stdout, deduped (first-seen order preserved), code-ref forms (`#L42`,
+# `path/to/file:42`, etc.) filtered out.
+#
+# Thin shim around tools/scan-cross-repo-refs.py — a separate `.sh` exists
+# so `.ag` agents can `exec sh "$COLONY_DIR/../../tools/scan-cross-repo-refs.sh"`
+# from a path they can compose without knowing the python interpreter or
+# argv layout. All logic lives in the python sibling to dodge the macOS
+# bash 3.2 heredoc parser bug (#172, #245, #271).
+#
+# Usage:
+#   printf '%s' "$body" | tools/scan-cross-repo-refs.sh
+#   printf '%s' "$body" | tools/scan-cross-repo-refs.sh --self acme/backend
+#
+# `--self <owner>/<repo>` filters self-references (a PR in `acme/backend`
+# that mentions `acme/backend#42` — that's not cross-repo, drop it).
+#
+# Empty stdin -> empty stdout, exit 0. No matches -> empty stdout, exit 0.
+# Exit non-zero only on a malformed `--self` value.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$SCRIPT_DIR/scan-cross-repo-refs.py" "$@"

--- a/tools/test-cross-repo-refs.sh
+++ b/tools/test-cross-repo-refs.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# tools/test-cross-repo-refs.sh: unit tests for the #317 cross-repo
+# reference detection helpers.
+#
+# 7 test cases, per plan §7:
+#   1. Scanner positive — body containing `acme/backend#42` plus prose.
+#   2. Scanner negative — path-like (`foo/bar/baz#1`), line ref (`x/y#L42`),
+#      no-slash forms — all rejected.
+#   3. Scanner self-ref filter — `--self acme/own` drops `acme/own#7`,
+#      keeps `other/repo#3`.
+#   4. Cache TTL fresh — put + immediate get returns the record.
+#   5. Cache TTL expired — put + sleep past TTL_SECS=1 + get returns miss.
+#   6. Resolver with stub forge-api — success path renders markdown +
+#      out-of-config-repo path tombstones silently. Also asserts cache
+#      file does NOT contain substring `token` (case-insensitive).
+#   7. closed-by index roundtrip + idempotency — record same (src,tgt)
+#      twice, lookup returns one entry.
+#
+# Standard scaffold: set -eu, mktemp -d isolation, EXIT trap for cleanup.
+# Auto-discovered by tools/colony-lint.sh's tools-test loop.
+#
+# Usage: ./tools/test-cross-repo-refs.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCAN="$SCRIPT_DIR/scan-cross-repo-refs.sh"
+CACHE="$SCRIPT_DIR/cross-repo-cache.sh"
+RESOLVE="$SCRIPT_DIR/resolve-cross-repo-ref.sh"
+CLOSED="$SCRIPT_DIR/closed-by-index.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# --- Test 1: scanner positive --------------------------------------------
+OUT="$TMPDIR_TEST/t1.out"
+printf 'fixes acme/backend#42 and another bar/baz#17 thanks' \
+    | "$SCAN" >"$OUT" 2>/dev/null
+if grep -qx 'acme/backend#42' "$OUT" && grep -qx 'bar/baz#17' "$OUT" && [ "$(wc -l <"$OUT")" -eq 2 ]; then
+    pass "test 1: scanner positive — emits both refs deduped"
+else
+    fail "test 1: scanner positive — emits both refs deduped" \
+         "got='$(tr '\n' '|' <"$OUT")'"
+fi
+
+# --- Test 2: scanner negative (path/line-ref/no-slash) -------------------
+OUT="$TMPDIR_TEST/t2.out"
+printf 'a path foo/bar/baz#1 and line ref x/y#L42 and bare#5 should not match' \
+    | "$SCAN" >"$OUT" 2>/dev/null
+# foo/bar/baz#1 -> the "/baz" portion has a leading "/" which should fail
+# the left-boundary lookbehind for the *outer* match (lookbehind sees `/`).
+# x/y#L42 -> #L42 form is filtered by the (?!L\d) negative lookahead.
+# bare#5 -> no slash -> regex doesn't match.
+if [ ! -s "$OUT" ]; then
+    pass "test 2: scanner negative — path-like / line-ref / no-slash all rejected"
+else
+    fail "test 2: scanner negative — path-like / line-ref / no-slash all rejected" \
+         "got='$(tr '\n' '|' <"$OUT")'"
+fi
+
+# --- Test 3: scanner self-ref filter -------------------------------------
+OUT="$TMPDIR_TEST/t3.out"
+printf 'self-ref acme/own#7 and cross other/repo#3 here' \
+    | "$SCAN" --self acme/own >"$OUT" 2>/dev/null
+if grep -qx 'other/repo#3' "$OUT" && ! grep -q 'acme/own' "$OUT"; then
+    pass "test 3: scanner --self filters self-references"
+else
+    fail "test 3: scanner --self filters self-references" \
+         "got='$(tr '\n' '|' <"$OUT")'"
+fi
+
+# --- Test 4: cache TTL fresh --------------------------------------------
+COLONY_DIR_T4="$TMPDIR_TEST/t4-fed/colony"
+mkdir -p "$COLONY_DIR_T4"
+RECORD_T4='{"owner":"acme","repo":"backend","number":42,"title":"hello","state":"opened","labels":["bug"],"fetched_at":"2026-04-28T14:32:11Z"}'
+printf '%s' "$RECORD_T4" | "$CACHE" put --colony-dir "$COLONY_DIR_T4" acme backend 42 >/dev/null
+# Set a generous TTL so the test isn't sensitive to clock drift.
+GOT_T4="$(CROSS_REPO_CACHE_TTL_SECS=99999999999 "$CACHE" get --colony-dir "$COLONY_DIR_T4" acme backend 42 2>/dev/null | tr -d '\n')"
+EXPECTED_T4="$RECORD_T4"
+if [ "$GOT_T4" = "$EXPECTED_T4" ]; then
+    pass "test 4: cache TTL fresh — put + get returns identical record"
+else
+    fail "test 4: cache TTL fresh — put + get returns identical record" \
+         "got='$GOT_T4' expected='$EXPECTED_T4'"
+fi
+
+# --- Test 5: cache TTL expired ------------------------------------------
+COLONY_DIR_T5="$TMPDIR_TEST/t5-fed/colony"
+mkdir -p "$COLONY_DIR_T5"
+# Forge a record with an old fetched_at timestamp (2020-01-01) so any
+# positive TTL trips the expiry branch without sleep dependency.
+RECORD_T5='{"owner":"acme","repo":"backend","number":42,"title":"old","state":"opened","labels":[],"fetched_at":"2020-01-01T00:00:00Z"}'
+printf '%s' "$RECORD_T5" | "$CACHE" put --colony-dir "$COLONY_DIR_T5" acme backend 42 >/dev/null
+rc_t5=0
+CROSS_REPO_CACHE_TTL_SECS=1 "$CACHE" get --colony-dir "$COLONY_DIR_T5" acme backend 42 >/dev/null 2>&1 || rc_t5=$?
+if [ "$rc_t5" -eq 1 ]; then
+    pass "test 5: cache TTL expired — get returns miss (exit 1)"
+else
+    fail "test 5: cache TTL expired — get returns miss (exit 1)" \
+         "rc=$rc_t5 (expected 1)"
+fi
+
+# --- Test 6: resolver with stub forge-api -------------------------------
+COLONY_DIR_T6="$TMPDIR_TEST/t6-fed/colony"
+mkdir -p "$COLONY_DIR_T6/scripts"
+# Stub forge-api.sh: exit 0 with normalized GitLab-shape issue JSON for
+# acme/backend#42; exit 2 for any other --repo (mimics the real
+# dispatcher's out-of-config behaviour).
+cat >"$COLONY_DIR_T6/scripts/forge-api.sh" <<'STUB'
+#!/bin/bash
+set -e
+CMD="$1"; shift
+NUM=""
+REPO=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        *) if [ -z "$NUM" ]; then NUM="$1"; fi; shift ;;
+    esac
+done
+if [ "$CMD" != "get-issue" ]; then exit 2; fi
+if [ "$REPO" = "acme/backend" ] && [ "$NUM" = "42" ]; then
+    cat <<JSON
+{"iid":42,"title":"Login crash on Safari","description":"…","state":"opened","labels":["bug","P1"],"assignees":[],"author":{"username":"alice"},"created_at":"2026-04-28T10:00:00Z","updated_at":"2026-04-28T11:00:00Z","user_notes_count":3}
+JSON
+    exit 0
+fi
+exit 2
+STUB
+chmod +x "$COLONY_DIR_T6/scripts/forge-api.sh"
+
+OUT="$TMPDIR_TEST/t6.out"
+printf 'acme/backend#42\nout-of-config/repo#99\n' \
+    | "$RESOLVE" --colony-dir "$COLONY_DIR_T6" --max 5 >"$OUT" 2>/dev/null
+if grep -q '## Cross-repo references mentioned in this PR' "$OUT" \
+    && grep -q 'acme/backend#42' "$OUT" \
+    && grep -q 'Login crash on Safari' "$OUT" \
+    && ! grep -q 'out-of-config' "$OUT"; then
+    pass "test 6a: resolver — success path renders markdown, out-of-config silenced"
+else
+    fail "test 6a: resolver — success path renders markdown, out-of-config silenced" \
+         "out='$(cat "$OUT")'"
+fi
+
+# Token leak guard: cache record must not contain the substring "token"
+# (case-insensitive) — neither raw forge response nor reshaped record
+# carries auth bytes by design.
+CACHE_FILE_T6="$TMPDIR_TEST/t6-fed/.agentis/cross-repo-cache/acme__backend__42.json"
+if [ -f "$CACHE_FILE_T6" ]; then
+    if grep -iq 'token' "$CACHE_FILE_T6"; then
+        fail "test 6b: token-leak guard — cache file MUST NOT contain 'token'" \
+             "cache='$(cat "$CACHE_FILE_T6")'"
+    else
+        pass "test 6b: token-leak guard — cache file does not contain 'token' (case-insensitive)"
+    fi
+else
+    fail "test 6b: token-leak guard — cache file does not contain 'token' (case-insensitive)" \
+         "cache file missing: $CACHE_FILE_T6"
+fi
+
+# Tombstone for out-of-config repo: a JSON record with state=unresolvable.
+TOMBSTONE_T6="$TMPDIR_TEST/t6-fed/.agentis/cross-repo-cache/out-of-config__repo__99.json"
+if [ -f "$TOMBSTONE_T6" ] && grep -q 'unresolvable' "$TOMBSTONE_T6"; then
+    pass "test 6c: resolver — out-of-config repo writes tombstone (state=unresolvable)"
+else
+    fail "test 6c: resolver — out-of-config repo writes tombstone (state=unresolvable)" \
+         "tombstone='$( [ -f "$TOMBSTONE_T6" ] && cat "$TOMBSTONE_T6" || echo MISSING )'"
+fi
+
+# --- Test 7: closed-by index roundtrip + idempotency --------------------
+COLONY_DIR_T7="$TMPDIR_TEST/t7-fed/colony"
+mkdir -p "$COLONY_DIR_T7"
+"$CLOSED" record --colony-dir "$COLONY_DIR_T7" \
+    --src-owner acme --src-repo frontend --src-iid 47 \
+    --tgt-owner acme --tgt-repo backend --tgt-iid 123 >/dev/null
+# Second call with identical (src, tgt) — should be a no-op insert.
+"$CLOSED" record --colony-dir "$COLONY_DIR_T7" \
+    --src-owner acme --src-repo frontend --src-iid 47 \
+    --tgt-owner acme --tgt-repo backend --tgt-iid 123 >/dev/null
+LOOK_T7="$("$CLOSED" lookup --colony-dir "$COLONY_DIR_T7" \
+    --tgt-owner acme --tgt-repo backend --tgt-iid 123 2>/dev/null)"
+COUNT_T7=$(printf '%s' "$LOOK_T7" | python3 -c 'import sys,json; print(len(json.loads(sys.stdin.read() or "[]")))')
+if [ "$COUNT_T7" = "1" ] && printf '%s' "$LOOK_T7" | grep -q 'frontend'; then
+    pass "test 7: closed-by index — record idempotent on (src,tgt); lookup returns 1 entry"
+else
+    fail "test 7: closed-by index — record idempotent on (src,tgt); lookup returns 1 entry" \
+         "count=$COUNT_T7 lookup='$LOOK_T7'"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-github-code-review-normalize.sh
+++ b/tools/test-github-code-review-normalize.sh
@@ -200,8 +200,9 @@ assert_eq "True" "$ALL_FALSE" "normalize_notes: system:false invariant holds for
 # --- End-to-end: normalize_pulls -> project_json reviewer ---
 # The four reviewer agents (style/logic/security/test) + approval_decider
 # consume `merge-requests --view reviewer` on every tick. The view keys
-# must stay locked to {iid, state, title, labels, source_branch,
-# target_branch, draft, author}.
+# must stay locked to {iid, state, title, description, labels,
+# source_branch, target_branch, draft, author}. `description` was added
+# in #317 so the reviewers can scan the PR body for cross-repo refs.
 PIPE_PRELUDE=$(mktemp)
 build_prelude "$PIPE_PRELUDE"
 # shellcheck disable=SC1090,SC2016
@@ -217,7 +218,7 @@ E2E_IID=$(json_extract "$E2E_OUT" "data[0]['iid']")
 E2E_DRAFT=$(json_extract "$E2E_OUT" "data[0]['draft']")
 E2E_AUTHOR=$(json_extract "$E2E_OUT" "data[0]['author']['username']")
 assert_eq "3" "$E2E_COUNT" "e2e reviewer: normalize | reviewer view emits 3 items"
-assert_eq "author,draft,iid,labels,source_branch,state,target_branch,title" "$E2E_KEYS" "e2e reviewer: view keys match gitlab reviewer shape"
+assert_eq "author,description,draft,iid,labels,source_branch,state,target_branch,title" "$E2E_KEYS" "e2e reviewer: view keys match gitlab reviewer shape"
 assert_eq "10" "$E2E_IID" "e2e reviewer: view carries iid through pipe"
 assert_eq "True" "$E2E_DRAFT" "e2e reviewer: draft flows through pipe"
 assert_eq "alice" "$E2E_AUTHOR" "e2e reviewer: author.username preserved"

--- a/tools/test-gitlab-views.sh
+++ b/tools/test-gitlab-views.sh
@@ -185,7 +185,7 @@ test_view "triage" "members-summary" "id,username,name"                         
 test_view "triage" "labels-summary"  "name,description,color"                            "$FIXTURE_LABELS"
 
 # --- Code-review ---
-test_view "code-review" "reviewer" "iid,state,title,labels,source_branch,target_branch,draft,author" "$FIXTURE_MRS"
+test_view "code-review" "reviewer" "iid,state,title,description,labels,source_branch,target_branch,draft,author" "$FIXTURE_MRS"
 
 # --- Planning ---
 test_view "planning" "planning"    "iid,title,description,labels,author,created_at"                    "$FIXTURE_ISSUES"


### PR DESCRIPTION
## Summary

Now-unblocked by #316 multi-repo merge. Closes #317.

The 4 PR reviewers (logic / style / security / test) scan PR body for `<owner>/<repo>#<N>` references, resolve via M3a-shipped `forge-api.sh --repo` path, splice resolved issue context (title/state/labels) into review prompt — capped at 5 refs per tick. Bidirectional surface: `router.ag` looks up federation-shared `closed-by-index.json` and appends "closed by PR ..." suggestions to routing context.

- **Helpers**: `tools/{scan-cross-repo-refs,cross-repo-cache,resolve-cross-repo-ref,closed-by-index}.{sh,py}` — pure tooling, no .ag dependencies
- **Cache**: `<fed>/.agentis/cross-repo-cache/<owner>__<repo>__<N>.json` with 1h TTL (override `CROSS_REPO_CACHE_TTL_SECS`)
- **Out-of-colony repos** (refs to repos not in `GITHUB_REPOS_JSON`): tombstone + silent skip (no crash, no spam, no token leak)
- **Token leak guard**: cache schema fixed to `{owner, repo, number, title, state, labels, fetched_at}` — tokens NEVER enter; test 6b enforces
- **Single-block back-compat** (M3a sentinel `owner==""`): scan skipped entirely → byte-identical to pre-#317 prompt context
- **API budget**: hard cap `--max 5`; cache TTL means re-tick on same PR = 0 forge calls

## Test plan

- [x] `bash -n` + `shellcheck` clean on 5 new shell scripts + 2 modified
- [x] `python3 -m py_compile` clean on 3 new .py files
- [x] **5/5 standalone `agentis commit`** PASS on modified .ag (4 reviewers + router)
- [x] **`tools/test-cross-repo-refs.sh` — 9/9 PASS** (7 cases, test 6 has 3 sub-assertions: success-render, token-leak guard, tombstone)
- [x] M1-M6 #316 regression: test-iter-repos (6/6), test-forge-api-multi-repo (9/9), test-multi-repo-schema (16/16), test-start-colony-multi-repo (6/6), test-start-colony-restart (26/26), test-per-repo-confidence (5/5), test-per-repo-confidence-overlay (2/2), test-rate-limit-tile-multi-repo (3/3), test-start-colony-per-repo-labels (3/3), test-single-block-byte-identity (6/6) — ALL PASS
- [x] Other regression: test-forge-config (45/45), test-colony-lint-bash32, test-labeler-autonomous-verdict (20/20), test-learn-idempotency (24/24), test-parse-toml (41/41), test-rate-limit-tile (8/8) — ALL PASS
- [x] `colony-lint .` — 0 net new failures vs origin/main baseline
- [x] **12 sentinel files byte-identical** (all #316 helpers + install.sh + .agentis/config + .dashboard-version + VERSION)
- [x] **5 forge-api.sh + 5 start-colony.sh + 5 colony.example.toml byte-identical**
- [x] Modified .ag count: exactly 5 (4 reviewers + router); 16 other .ag files byte-identical
- [x] `federation-dashboard/`, `tribes-bench/` byte-identical
- [ ] CI green
- [ ] QA agent report

## Note for reviewer

After this lands, **board down to 1 issue** (#365 tribes-bench Stage 2). #317 closes via `Closes #317` keyword.

The dashboard timeline overlay ("considered N cross-repo refs in last tick") is deferred to a follow-up — out of scope for this focused PR per plan §10.