### PR TITLE
feat(tribes-bench): Stage 2 M1 — scaffolding (#392)

### DIFF
--- a/tribes-bench/BUNDLE.manifest
+++ b/tribes-bench/BUNDLE.manifest
@@ -52,3 +52,24 @@ tribes-bench/tribe-gamma/README.md
 tribes-bench/tribe-gamma/agents/
 tribes-bench/tribe-gamma/config/colony.example.toml
 tribes-bench/tribe-gamma/scripts/
+
+tribes-bench/tribe-delta/README.md
+tribes-bench/tribe-delta/agents/
+tribes-bench/tribe-delta/config/colony.example.toml
+tribes-bench/tribe-delta/scripts/
+
+tribes-bench/tribe-epsilon/README.md
+tribes-bench/tribe-epsilon/agents/
+tribes-bench/tribe-epsilon/config/colony.example.toml
+tribes-bench/tribe-epsilon/scripts/
+
+# ----- Stage 2 (#392) tooling and target -----
+# Stage 2 surface lives under `tribes-bench/targets/stage2/` (covered by
+# `tribes-bench/targets/` above) and `tribes-bench/tools/` (covered above).
+# Listed explicitly for documentation:
+#   tribes-bench/targets/stage2/smallvec-v0.6.13/{lib.rs,Cargo.toml,LICENSE-MIT,LICENSE-APACHE,README.md,PROVENANCE.md}
+#   tribes-bench/targets/stage2/bugs.json
+#   tribes-bench/tools/run-stage2.sh
+#   tribes-bench/tools/verify-finding-stage2.sh
+#   tribes-bench/tools/analyse-stage2.py
+#   tribes-bench/tools/test-stage2-scaffold.sh

--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,19 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Stage 2 M1 scaffolding: 2 new tribes (`tribe-delta` lifetime/aliasing,
+  `tribe-epsilon` concurrency/Send+Sync) bringing the federation to 5
+  tribes. Real-world target swap from synthetic Stage 1 → vendored
+  `smallvec v0.6.13` snapshot with 5 documented RustSec advisories
+  (RUSTSEC-2018-0003, -2018-0018, -2019-0009, -2019-0012, -2021-0003).
+  New `tools/verify-finding-stage2.sh` (separate file from the Stage 0/1
+  verifier — back-compat preserved), `tools/run-stage2.sh`,
+  `tools/analyse-stage2.py`, `tools/test-stage2-scaffold.sh`.
+  Calibration parameters unchanged (Stage 1 economy is already per-tribe;
+  the federation-wide CB pool delta is zero — that argument lives in
+  M2 #393). Stage 0/Stage 1 surface byte-identical; pre-existing
+  Stage 0/1 tests pass unchanged. Pure infrastructure — no live
+  experimental run yet (that's M3 #394). ([#392](https://github.com/Replikanti/agentis-colonies/issues/392))
 - **Stage 1 M2+M3 — replication, Malthusian, reward, death** ([#364](https://github.com/Replikanti/agentis-colonies/issues/364), M2+M3).
   - All three `tribe-{alpha,beta,gamma}/agents/hunter.ag` now (a) wire
     `replicate(target_node)` inside a Malthusian per-replica cost gate

--- a/tribes-bench/install.sh
+++ b/tribes-bench/install.sh
@@ -21,7 +21,7 @@ FED_NAME="$(basename "$SCRIPT_DIR")"
 
 echo "Installing $FED_NAME federation..."
 
-for tribe in tribe-alpha tribe-beta tribe-gamma; do
+for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon; do
     example="$SCRIPT_DIR/$tribe/config/colony.example.toml"
     target="$SCRIPT_DIR/$tribe/config/colony.toml"
     if [ ! -f "$target" ] && [ -f "$example" ]; then

--- a/tribes-bench/start-federation.sh
+++ b/tribes-bench/start-federation.sh
@@ -28,7 +28,7 @@ SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))'
 SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 FED_DIR="${1:-$SCRIPT_DIR}"
 
-COLONIES=(tribe-alpha tribe-beta tribe-gamma)
+COLONIES=(tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon)
 
 echo ""
 echo "Tribes Bench Federation"

--- a/tribes-bench/targets/stage2/bugs.json
+++ b/tribes-bench/targets/stage2/bugs.json
@@ -1,0 +1,10 @@
+{
+  "stage": "stage2",
+  "bugs": [
+    {"id": "S2-SMVUAF-001", "class": "use_after_free", "file": "lib.rs", "line": 827, "line_tolerance": 5, "signature": "pub fn insert_many", "severity": "high", "verifier_test": "test_smv_uaf_001", "rationale": "RUSTSEC-2018-0003: SmallVec::insert_many double-free during unwind"},
+    {"id": "S2-SMVMEM-001", "class": "uninitialised_memory", "file": "lib.rs", "line": 534, "line_tolerance": 5, "signature": "pub unsafe fn from_buf_and_len_unchecked", "severity": "high", "verifier_test": "test_smv_mem_001", "rationale": "RUSTSEC-2018-0018: SmallVec::from_buf_and_len_unchecked uninitialised memory"},
+    {"id": "S2-SMVUAF-002", "class": "use_after_free", "file": "lib.rs", "line": 656, "line_tolerance": 5, "signature": "pub fn grow", "severity": "high", "verifier_test": "test_smv_uaf_002", "rationale": "RUSTSEC-2019-0009: SmallVec::grow use-after-free + double-free"},
+    {"id": "S2-SMVMEM-002", "class": "memory_corruption", "file": "lib.rs", "line": 656, "line_tolerance": 5, "signature": "pub fn grow", "severity": "high", "verifier_test": "test_smv_mem_002", "rationale": "RUSTSEC-2019-0012: SmallVec::grow memory corruption with capacity-shrink"},
+    {"id": "S2-SMVOFL-001", "class": "heap_overflow", "file": "lib.rs", "line": 833, "line_tolerance": 5, "signature": "iter.size_hint()", "severity": "high", "verifier_test": "test_smv_ofl_001", "rationale": "RUSTSEC-2021-0003: SmallVec::insert_many heap overflow on lying size_hint"}
+  ]
+}

--- a/tribes-bench/targets/stage2/smallvec-v0.6.13/Cargo.toml
+++ b/tribes-bench/targets/stage2/smallvec-v0.6.13/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "smallvec"
+version = "0.6.13"
+authors = ["Simon Sapin <simon.sapin@exyr.org>"]
+license = "MIT/Apache-2.0"
+repository = "https://github.com/servo/rust-smallvec"
+description = "'Small vector' optimization: store up to a small number of items on the stack"
+keywords = ["small", "vec", "vector", "stack", "no_std"]
+categories = ["data-structures"]
+readme = "README.md"
+documentation = "https://doc.servo.org/smallvec/"
+
+[features]
+std = []
+union = []
+default = ["std"]
+specialization = []
+may_dangle = []
+
+[lib]
+name = "smallvec"
+path = "lib.rs"
+
+[dependencies]
+serde = { version = "1", optional = true }
+maybe-uninit = "2.0"
+
+[dev_dependencies]
+bincode = "1.0.1"

--- a/tribes-bench/targets/stage2/smallvec-v0.6.13/LICENSE-APACHE
+++ b/tribes-bench/targets/stage2/smallvec-v0.6.13/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/tribes-bench/targets/stage2/smallvec-v0.6.13/LICENSE-MIT
+++ b/tribes-bench/targets/stage2/smallvec-v0.6.13/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 The Servo Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/tribes-bench/targets/stage2/smallvec-v0.6.13/PROVENANCE.md
+++ b/tribes-bench/targets/stage2/smallvec-v0.6.13/PROVENANCE.md
@@ -1,0 +1,97 @@
+# Provenance — `smallvec v0.6.13` snapshot
+
+> **WARNING — TRIBES-BENCH PLANTED-BUG TARGET — INTENTIONALLY VULNERABLE — NEVER COMPILE INTO PRODUCTION.**
+>
+> This directory ships a verbatim snapshot of an upstream Rust crate at a
+> deliberately-vulnerable historical tag. Five documented RustSec
+> advisories apply to the source as it lands in this repository. The
+> snapshot exists only as a planted-bug target for the tribes-bench
+> Stage 2 federation; do not link, build, or ship it as part of any
+> production artifact.
+
+## Upstream
+
+- **Project:** [`servo/rust-smallvec`](https://github.com/servo/rust-smallvec)
+- **Tag:** `v0.6.13`
+- **Commit SHA:** `78522049b3ce129d02eea4e802747ba1090a5586`
+- **Vendoring date:** 2026-04-28
+- **Original repo URL:** `https://github.com/servo/rust-smallvec.git`
+
+## Files vendored
+
+| File | Source | Notes |
+|------|--------|-------|
+| `lib.rs` | upstream `lib.rs` at `v0.6.13` | Banner comment prepended on lines 1-2 (see "Banner comment" below). All other content verbatim. |
+| `Cargo.toml` | upstream `Cargo.toml` at `v0.6.13` | Verbatim. |
+| `README.md` | upstream `README.md` at `v0.6.13` | Verbatim. |
+| `LICENSE-MIT` | upstream `LICENSE-MIT` at `v0.6.13` | Verbatim. |
+| `LICENSE-APACHE` | upstream `LICENSE-APACHE` at `v0.6.13` | Verbatim. |
+
+`lib.rs` line count after the banner edit: **2376** (the original
+upstream file plus the 2-line banner). All planted-bug line numbers in
+`../bugs.json` are derived from `grep -n` against the post-banner source
+in this directory, so they shift by +2 versus an unedited upstream
+checkout.
+
+## Banner comment
+
+The first two lines of `lib.rs` (above the original Apache/MIT license
+header) are:
+
+```
+// TRIBES-BENCH STAGE 2 PLANTED-BUG TARGET. INTENTIONALLY VULNERABLE
+// (smallvec v0.6.13). NEVER COMPILE INTO PRODUCTION. See PROVENANCE.md.
+```
+
+This banner is not present upstream. It exists to make accidental
+copy-paste into a production crate visibly wrong at the very top of
+the file.
+
+## License summary
+
+The `smallvec` crate is dual-licensed under the **Apache License,
+Version 2.0** (`LICENSE-APACHE`) and the **MIT license** (`LICENSE-MIT`)
+— see the per-file headers and the two `LICENSE-*` files in this
+directory. Both are compatible with this repository's Apache-2.0-leaning
+posture.
+
+## RustSec advisories that apply to this snapshot
+
+This snapshot pre-dates the fixes for every advisory below. The five
+advisories drive the planted-bug entries in `../bugs.json`.
+
+| Advisory | Function | Class | Stage 2 bug id |
+|---|---|---|---|
+| [RUSTSEC-2018-0003](https://rustsec.org/advisories/RUSTSEC-2018-0003.html) | `SmallVec::insert_many` | `use_after_free` (double-free during unwind) | `S2-SMVUAF-001` |
+| [RUSTSEC-2018-0018](https://rustsec.org/advisories/RUSTSEC-2018-0018.html) | `SmallVec::from_buf_and_len_unchecked` | `uninitialised_memory` | `S2-SMVMEM-001` |
+| [RUSTSEC-2019-0009](https://rustsec.org/advisories/RUSTSEC-2019-0009.html) | `SmallVec::grow` | `use_after_free` (UAF + double-free) | `S2-SMVUAF-002` |
+| [RUSTSEC-2019-0012](https://rustsec.org/advisories/RUSTSEC-2019-0012.html) | `SmallVec::grow` | `memory_corruption` | `S2-SMVMEM-002` |
+| [RUSTSEC-2021-0003](https://rustsec.org/advisories/RUSTSEC-2021-0003.html) | `SmallVec::insert_many` | `heap_overflow` (lying `size_hint`) | `S2-SMVOFL-001` |
+
+Each `bugs.json` entry carries a `rationale` field with the matching
+RustSec ID and function name so the manifest is reviewable without
+cross-referencing this file.
+
+## Reproduction
+
+```bash
+# Snapshot reproduction (don't run inside this worktree).
+git clone https://github.com/servo/rust-smallvec.git /tmp/smallvec-vendor
+cd /tmp/smallvec-vendor
+git checkout v0.6.13
+git rev-parse v0.6.13
+# Expected: 78522049b3ce129d02eea4e802747ba1090a5586
+```
+
+The five planted-bug line numbers can be re-derived against the vendored
+source under this directory:
+
+```bash
+grep -n 'fn insert_many' lib.rs                # S2-SMVUAF-001
+grep -n 'fn from_buf_and_len_unchecked' lib.rs # S2-SMVMEM-001
+grep -n 'fn grow' lib.rs                       # S2-SMVUAF-002 + S2-SMVMEM-002
+grep -n 'iter.size_hint()' lib.rs              # S2-SMVOFL-001
+```
+
+The lines reported by `grep -n` against this directory's `lib.rs` match
+the `line` field in `../bugs.json` exactly.

--- a/tribes-bench/targets/stage2/smallvec-v0.6.13/README.md
+++ b/tribes-bench/targets/stage2/smallvec-v0.6.13/README.md
@@ -1,0 +1,8 @@
+rust-smallvec
+=============
+
+[Documentation](https://docs.rs/smallvec/)
+
+[Release notes](https://github.com/servo/rust-smallvec/releases)
+
+"Small vector" optimization for Rust: store up to a small number of items on the stack

--- a/tribes-bench/targets/stage2/smallvec-v0.6.13/lib.rs
+++ b/tribes-bench/targets/stage2/smallvec-v0.6.13/lib.rs
@@ -1,0 +1,2376 @@
+// TRIBES-BENCH STAGE 2 PLANTED-BUG TARGET. INTENTIONALLY VULNERABLE
+// (smallvec v0.6.13). NEVER COMPILE INTO PRODUCTION. See PROVENANCE.md.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Small vectors in various sizes. These store a certain number of elements inline, and fall back
+//! to the heap for larger allocations.  This can be a useful optimization for improving cache
+//! locality and reducing allocator traffic for workloads that fit within the inline buffer.
+//!
+//! ## no_std support
+//!
+//! By default, `smallvec` depends on `libstd`. However, it can be configured to use the unstable
+//! `liballoc` API instead, for use on platforms that have `liballoc` but not `libstd`.  This
+//! configuration is currently unstable and is not guaranteed to work on all versions of Rust.
+//!
+//! To depend on `smallvec` without `libstd`, use `default-features = false` in the `smallvec`
+//! section of Cargo.toml to disable its `"std"` feature.
+//!
+//! ## `union` feature
+//!
+//! When the `union` feature is enabled `smallvec` will track its state (inline or spilled)
+//! without the use of an enum tag, reducing the size of the `smallvec` by one machine word.
+//! This means that there is potentially no space overhead compared to `Vec`.
+//! Note that `smallvec` can still be larger than `Vec` if the inline buffer is larger than two
+//! machine words.
+//!
+//! To use this feature add `features = ["union"]` in the `smallvec` section of Cargo.toml.
+//! Note that this feature requires a nightly compiler (for now).
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "union", feature(untagged_unions))]
+#![cfg_attr(feature = "specialization", feature(specialization))]
+#![cfg_attr(feature = "may_dangle", feature(dropck_eyepatch))]
+#![deny(missing_docs)]
+
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+#[cfg(feature = "serde")]
+extern crate serde;
+
+extern crate maybe_uninit;
+
+#[cfg(not(feature = "std"))]
+mod std {
+    pub use core::*;
+}
+
+use maybe_uninit::MaybeUninit;
+
+use std::borrow::{Borrow, BorrowMut};
+use std::cmp;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::iter::{IntoIterator, FromIterator, repeat};
+use std::mem;
+use std::ops;
+use std::ptr;
+use std::slice;
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(feature = "serde")]
+use serde::ser::{Serialize, Serializer, SerializeSeq};
+#[cfg(feature = "serde")]
+use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+#[cfg(feature = "serde")]
+use std::marker::PhantomData;
+
+/// Creates a [`SmallVec`] containing the arguments.
+///
+/// `smallvec!` allows `SmallVec`s to be defined with the same syntax as array expressions.
+/// There are two forms of this macro:
+///
+/// - Create a [`SmallVec`] containing a given list of elements:
+///
+/// ```
+/// # #[macro_use] extern crate smallvec;
+/// # use smallvec::SmallVec;
+/// # fn main() {
+/// let v: SmallVec<[_; 128]> = smallvec![1, 2, 3];
+/// assert_eq!(v[0], 1);
+/// assert_eq!(v[1], 2);
+/// assert_eq!(v[2], 3);
+/// # }
+/// ```
+///
+/// - Create a [`SmallVec`] from a given element and size:
+///
+/// ```
+/// # #[macro_use] extern crate smallvec;
+/// # use smallvec::SmallVec;
+/// # fn main() {
+/// let v: SmallVec<[_; 0x8000]> = smallvec![1; 3];
+/// assert_eq!(v, SmallVec::from_buf([1, 1, 1]));
+/// # }
+/// ```
+///
+/// Note that unlike array expressions this syntax supports all elements
+/// which implement [`Clone`] and the number of elements doesn't have to be
+/// a constant.
+///
+/// This will use `clone` to duplicate an expression, so one should be careful
+/// using this with types having a nonstandard `Clone` implementation. For
+/// example, `smallvec![Rc::new(1); 5]` will create a vector of five references
+/// to the same boxed integer value, not five references pointing to independently
+/// boxed integers.
+
+#[macro_export]
+macro_rules! smallvec {
+    // count helper: transform any expression into 1
+    (@one $x:expr) => (1usize);
+    ($elem:expr; $n:expr) => ({
+        $crate::SmallVec::from_elem($elem, $n)
+    });
+    ($($x:expr),*$(,)*) => ({
+        let count = 0usize $(+ smallvec!(@one $x))*;
+        let mut vec = $crate::SmallVec::new();
+        if count <= vec.inline_size() {
+            $(vec.push($x);)*
+            vec
+        } else {
+            $crate::SmallVec::from_vec(vec![$($x,)*])
+        }
+    });
+}
+
+/// Hint to the optimizer that any code path which calls this function is
+/// statically unreachable and can be removed.
+///
+/// Equivalent to `std::hint::unreachable_unchecked` but works in older versions of Rust.
+#[inline]
+pub unsafe fn unreachable() -> ! {
+    enum Void {}
+    let x: &Void = mem::transmute(1usize);
+    match *x {}
+}
+
+/// `panic!()` in debug builds, optimization hint in release.
+#[cfg(not(feature = "union"))]
+macro_rules! debug_unreachable {
+    () => { debug_unreachable!("entered unreachable code") };
+    ($e:expr) => {
+        if cfg!(not(debug_assertions)) {
+            unreachable();
+        } else {
+            panic!($e);
+        }
+    }
+}
+
+/// Common operations implemented by both `Vec` and `SmallVec`.
+///
+/// This can be used to write generic code that works with both `Vec` and `SmallVec`.
+///
+/// ## Example
+///
+/// ```rust
+/// use smallvec::{VecLike, SmallVec};
+///
+/// fn initialize<V: VecLike<u8>>(v: &mut V) {
+///     for i in 0..5 {
+///         v.push(i);
+///     }
+/// }
+///
+/// let mut vec = Vec::new();
+/// initialize(&mut vec);
+///
+/// let mut small_vec = SmallVec::<[u8; 8]>::new();
+/// initialize(&mut small_vec);
+/// ```
+#[deprecated(note = "Use `Extend` and `Deref<[T]>` instead")]
+pub trait VecLike<T>:
+        ops::Index<usize, Output=T> +
+        ops::IndexMut<usize> +
+        ops::Index<ops::Range<usize>, Output=[T]> +
+        ops::IndexMut<ops::Range<usize>> +
+        ops::Index<ops::RangeFrom<usize>, Output=[T]> +
+        ops::IndexMut<ops::RangeFrom<usize>> +
+        ops::Index<ops::RangeTo<usize>, Output=[T]> +
+        ops::IndexMut<ops::RangeTo<usize>> +
+        ops::Index<ops::RangeFull, Output=[T]> +
+        ops::IndexMut<ops::RangeFull> +
+        ops::DerefMut<Target = [T]> +
+        Extend<T> {
+
+    /// Append an element to the vector.
+    fn push(&mut self, value: T);
+}
+
+#[allow(deprecated)]
+impl<T> VecLike<T> for Vec<T> {
+    #[inline]
+    fn push(&mut self, value: T) {
+        Vec::push(self, value);
+    }
+}
+
+/// Trait to be implemented by a collection that can be extended from a slice
+///
+/// ## Example
+///
+/// ```rust
+/// use smallvec::{ExtendFromSlice, SmallVec};
+///
+/// fn initialize<V: ExtendFromSlice<u8>>(v: &mut V) {
+///     v.extend_from_slice(b"Test!");
+/// }
+///
+/// let mut vec = Vec::new();
+/// initialize(&mut vec);
+/// assert_eq!(&vec, b"Test!");
+///
+/// let mut small_vec = SmallVec::<[u8; 8]>::new();
+/// initialize(&mut small_vec);
+/// assert_eq!(&small_vec as &[_], b"Test!");
+/// ```
+pub trait ExtendFromSlice<T> {
+    /// Extends a collection from a slice of its element type
+    fn extend_from_slice(&mut self, other: &[T]);
+}
+
+impl<T: Clone> ExtendFromSlice<T> for Vec<T> {
+    fn extend_from_slice(&mut self, other: &[T]) {
+        Vec::extend_from_slice(self, other)
+    }
+}
+
+unsafe fn deallocate<T>(ptr: *mut T, capacity: usize) {
+    let _vec: Vec<T> = Vec::from_raw_parts(ptr, 0, capacity);
+    // Let it drop.
+}
+
+/// An iterator that removes the items from a `SmallVec` and yields them by value.
+///
+/// Returned from [`SmallVec::drain`][1].
+///
+/// [1]: struct.SmallVec.html#method.drain
+pub struct Drain<'a, T: 'a> {
+    iter: slice::IterMut<'a,T>,
+}
+
+impl<'a, T: 'a> Iterator for Drain<'a,T> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<T> {
+        self.iter.next().map(|reference| unsafe { ptr::read(reference) })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, T: 'a> DoubleEndedIterator for Drain<'a, T> {
+    #[inline]
+    fn next_back(&mut self) -> Option<T> {
+        self.iter.next_back().map(|reference| unsafe { ptr::read(reference) })
+    }
+}
+
+impl<'a, T> ExactSizeIterator for Drain<'a, T> { }
+
+impl<'a, T: 'a> Drop for Drain<'a,T> {
+    fn drop(&mut self) {
+        // Destroy the remaining elements.
+        for _ in self.by_ref() {}
+    }
+}
+
+#[cfg(feature = "union")]
+union SmallVecData<A: Array> {
+    inline: MaybeUninit<A>,
+    heap: (*mut A::Item, usize),
+}
+
+#[cfg(feature = "union")]
+impl<A: Array> SmallVecData<A> {
+    #[inline]
+    unsafe fn inline(&self) -> *const A::Item {
+        self.inline.as_ptr() as *const A::Item
+    }
+    #[inline]
+    unsafe fn inline_mut(&mut self) -> *mut A::Item {
+        self.inline.as_mut_ptr() as *mut A::Item
+    }
+    #[inline]
+    fn from_inline(inline: MaybeUninit<A>) -> SmallVecData<A> {
+        SmallVecData { inline }
+    }
+    #[inline]
+    unsafe fn into_inline(self) -> MaybeUninit<A> {
+        self.inline
+    }
+    #[inline]
+    unsafe fn heap(&self) -> (*mut A::Item, usize) {
+        self.heap
+    }
+    #[inline]
+    unsafe fn heap_mut(&mut self) -> &mut (*mut A::Item, usize) {
+        &mut self.heap
+    }
+    #[inline]
+    fn from_heap(ptr: *mut A::Item, len: usize) -> SmallVecData<A> {
+        SmallVecData { heap: (ptr, len) }
+    }
+}
+
+#[cfg(not(feature = "union"))]
+enum SmallVecData<A: Array> {
+    Inline(MaybeUninit<A>),
+    Heap((*mut A::Item, usize)),
+}
+
+#[cfg(not(feature = "union"))]
+impl<A: Array> SmallVecData<A> {
+    #[inline]
+    unsafe fn inline(&self) -> *const A::Item {
+        match *self {
+            SmallVecData::Inline(ref a) => a.as_ptr() as *const A::Item,
+            _ => debug_unreachable!(),
+        }
+    }
+    #[inline]
+    unsafe fn inline_mut(&mut self) -> *mut A::Item {
+        match *self {
+            SmallVecData::Inline(ref mut a) => a.as_mut_ptr() as *mut A::Item,
+            _ => debug_unreachable!(),
+        }
+    }
+    #[inline]
+    fn from_inline(inline: MaybeUninit<A>) -> SmallVecData<A> {
+        SmallVecData::Inline(inline)
+    }
+    #[inline]
+    unsafe fn into_inline(self) -> MaybeUninit<A> {
+        match self {
+            SmallVecData::Inline(a) => a,
+            _ => debug_unreachable!(),
+        }
+    }
+    #[inline]
+    unsafe fn heap(&self) -> (*mut A::Item, usize) {
+        match *self {
+            SmallVecData::Heap(data) => data,
+            _ => debug_unreachable!(),
+        }
+    }
+    #[inline]
+    unsafe fn heap_mut(&mut self) -> &mut (*mut A::Item, usize) {
+        match *self {
+            SmallVecData::Heap(ref mut data) => data,
+            _ => debug_unreachable!(),
+        }
+    }
+    #[inline]
+    fn from_heap(ptr: *mut A::Item, len: usize) -> SmallVecData<A> {
+        SmallVecData::Heap((ptr, len))
+    }
+}
+
+unsafe impl<A: Array + Send> Send for SmallVecData<A> {}
+unsafe impl<A: Array + Sync> Sync for SmallVecData<A> {}
+
+/// A `Vec`-like container that can store a small number of elements inline.
+///
+/// `SmallVec` acts like a vector, but can store a limited amount of data inline within the
+/// `SmallVec` struct rather than in a separate allocation.  If the data exceeds this limit, the
+/// `SmallVec` will "spill" its data onto the heap, allocating a new buffer to hold it.
+///
+/// The amount of data that a `SmallVec` can store inline depends on its backing store. The backing
+/// store can be any type that implements the `Array` trait; usually it is a small fixed-sized
+/// array.  For example a `SmallVec<[u64; 8]>` can hold up to eight 64-bit integers inline.
+///
+/// ## Example
+///
+/// ```rust
+/// use smallvec::SmallVec;
+/// let mut v = SmallVec::<[u8; 4]>::new(); // initialize an empty vector
+///
+/// // The vector can hold up to 4 items without spilling onto the heap.
+/// v.extend(0..4);
+/// assert_eq!(v.len(), 4);
+/// assert!(!v.spilled());
+///
+/// // Pushing another element will force the buffer to spill:
+/// v.push(4);
+/// assert_eq!(v.len(), 5);
+/// assert!(v.spilled());
+/// ```
+pub struct SmallVec<A: Array> {
+    // The capacity field is used to determine which of the storage variants is active:
+    // If capacity <= A::size() then the inline variant is used and capacity holds the current length of the vector (number of elements actually in use).
+    // If capacity > A::size() then the heap variant is used and capacity holds the size of the memory allocation.
+    capacity: usize,
+    data: SmallVecData<A>,
+}
+
+impl<A: Array> SmallVec<A> {
+    /// Construct an empty vector
+    #[inline]
+    pub fn new() -> SmallVec<A> {
+        // Try to detect invalid custom implementations of `Array`. Hopefuly,
+        // this check should be optimized away entirely for valid ones.
+        assert!(
+            mem::size_of::<A>() == A::size() * mem::size_of::<A::Item>()
+                && mem::align_of::<A>() >= mem::align_of::<A::Item>()
+        );
+        SmallVec {
+            capacity: 0,
+            data: SmallVecData::from_inline(MaybeUninit::uninit()),
+        }
+    }
+
+    /// Construct an empty vector with enough capacity pre-allocated to store at least `n`
+    /// elements.
+    ///
+    /// Will create a heap allocation only if `n` is larger than the inline capacity.
+    ///
+    /// ```
+    /// # use smallvec::SmallVec;
+    ///
+    /// let v: SmallVec<[u8; 3]> = SmallVec::with_capacity(100);
+    ///
+    /// assert!(v.is_empty());
+    /// assert!(v.capacity() >= 100);
+    /// ```
+    #[inline]
+    pub fn with_capacity(n: usize) -> Self {
+        let mut v = SmallVec::new();
+        v.reserve_exact(n);
+        v
+    }
+
+    /// Construct a new `SmallVec` from a `Vec<A::Item>`.
+    ///
+    /// Elements will be copied to the inline buffer if vec.capacity() <= A::size().
+    ///
+    /// ```rust
+    /// use smallvec::SmallVec;
+    ///
+    /// let vec = vec![1, 2, 3, 4, 5];
+    /// let small_vec: SmallVec<[_; 3]> = SmallVec::from_vec(vec);
+    ///
+    /// assert_eq!(&*small_vec, &[1, 2, 3, 4, 5]);
+    /// ```
+    #[inline]
+    pub fn from_vec(mut vec: Vec<A::Item>) -> SmallVec<A> {
+        if vec.capacity() <= A::size() {
+            unsafe {
+                let mut data = SmallVecData::<A>::from_inline(MaybeUninit::uninit());
+                let len = vec.len();
+                vec.set_len(0);
+                ptr::copy_nonoverlapping(vec.as_ptr(), data.inline_mut(), len);
+
+                SmallVec {
+                    capacity: len,
+                    data,
+                }
+            }
+        } else {
+            let (ptr, cap, len) = (vec.as_mut_ptr(), vec.capacity(), vec.len());
+            mem::forget(vec);
+
+            SmallVec {
+                capacity: cap,
+                data: SmallVecData::from_heap(ptr, len),
+            }
+        }
+    }
+
+    /// Constructs a new `SmallVec` on the stack from an `A` without
+    /// copying elements.
+    ///
+    /// ```rust
+    /// use smallvec::SmallVec;
+    ///
+    /// let buf = [1, 2, 3, 4, 5];
+    /// let small_vec: SmallVec<_> = SmallVec::from_buf(buf);
+    ///
+    /// assert_eq!(&*small_vec, &[1, 2, 3, 4, 5]);
+    /// ```
+    #[inline]
+    pub fn from_buf(buf: A) -> SmallVec<A> {
+        SmallVec {
+            capacity: A::size(),
+            data: SmallVecData::from_inline(MaybeUninit::new(buf)),
+        }
+    }
+
+    /// Constructs a new `SmallVec` on the stack from an `A` without
+    /// copying elements. Also sets the length, which must be less or
+    /// equal to the size of `buf`.
+    ///
+    /// ```rust
+    /// use smallvec::SmallVec;
+    ///
+    /// let buf = [1, 2, 3, 4, 5, 0, 0, 0];
+    /// let small_vec: SmallVec<_> = SmallVec::from_buf_and_len(buf, 5);
+    ///
+    /// assert_eq!(&*small_vec, &[1, 2, 3, 4, 5]);
+    /// ```
+    #[inline]
+    pub fn from_buf_and_len(buf: A, len: usize) -> SmallVec<A> {
+        assert!(len <= A::size());
+        unsafe { SmallVec::from_buf_and_len_unchecked(buf, len) }
+    }
+
+    /// Constructs a new `SmallVec` on the stack from an `A` without
+    /// copying elements. Also sets the length. The user is responsible
+    /// for ensuring that `len <= A::size()`.
+    ///
+    /// ```rust
+    /// use smallvec::SmallVec;
+    ///
+    /// let buf = [1, 2, 3, 4, 5, 0, 0, 0];
+    /// let small_vec: SmallVec<_> = unsafe {
+    ///     SmallVec::from_buf_and_len_unchecked(buf, 5)
+    /// };
+    ///
+    /// assert_eq!(&*small_vec, &[1, 2, 3, 4, 5]);
+    /// ```
+    #[inline]
+    pub unsafe fn from_buf_and_len_unchecked(buf: A, len: usize) -> SmallVec<A> {
+        SmallVec {
+            capacity: len,
+            data: SmallVecData::from_inline(MaybeUninit::new(buf)),
+        }
+    }
+
+
+    /// Sets the length of a vector.
+    ///
+    /// This will explicitly set the size of the vector, without actually
+    /// modifying its buffers, so it is up to the caller to ensure that the
+    /// vector is actually the specified size.
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        let (_, len_ptr, _) = self.triple_mut();
+        *len_ptr = new_len;
+    }
+
+    /// The maximum number of elements this vector can hold inline
+    #[inline]
+    pub fn inline_size(&self) -> usize {
+        A::size()
+    }
+
+    /// The number of elements stored in the vector
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.triple().1
+    }
+
+    /// Returns `true` if the vector is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The number of items the vector can hold without reallocating
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.triple().2
+    }
+
+    /// Returns a tuple with (data ptr, len, capacity)
+    /// Useful to get all SmallVec properties with a single check of the current storage variant.
+    #[inline]
+    fn triple(&self) -> (*const A::Item, usize, usize) {
+        unsafe {
+            if self.spilled() {
+                let (ptr, len) = self.data.heap();
+                (ptr, len, self.capacity)
+            } else {
+                (self.data.inline(), self.capacity, A::size())
+            }
+        }
+    }
+
+    /// Returns a tuple with (data ptr, len ptr, capacity)
+    #[inline]
+    fn triple_mut(&mut self) -> (*mut A::Item, &mut usize, usize) {
+        unsafe {
+            if self.spilled() {
+                let &mut (ptr, ref mut len_ptr) = self.data.heap_mut();
+                (ptr, len_ptr, self.capacity)
+            } else {
+                (self.data.inline_mut(), &mut self.capacity, A::size())
+            }
+        }
+    }
+
+    /// Returns `true` if the data has spilled into a separate heap-allocated buffer.
+    #[inline]
+    pub fn spilled(&self) -> bool {
+        self.capacity > A::size()
+    }
+
+    /// Empty the vector and return an iterator over its former contents.
+    pub fn drain(&mut self) -> Drain<A::Item> {
+        unsafe {
+            let ptr = self.as_mut_ptr();
+
+            let current_len = self.len();
+            self.set_len(0);
+
+            let slice = slice::from_raw_parts_mut(ptr, current_len);
+
+            Drain {
+                iter: slice.iter_mut(),
+            }
+        }
+    }
+
+    /// Append an item to the vector.
+    #[inline]
+    pub fn push(&mut self, value: A::Item) {
+        unsafe {
+            let (_, &mut len, cap) = self.triple_mut();
+            if len == cap {
+                self.reserve(1);
+            }
+            let (ptr, len_ptr, _) = self.triple_mut();
+            *len_ptr = len + 1;
+            ptr::write(ptr.offset(len as isize), value);
+        }
+    }
+
+    /// Remove an item from the end of the vector and return it, or None if empty.
+    #[inline]
+    pub fn pop(&mut self) -> Option<A::Item> {
+        unsafe {
+            let (ptr, len_ptr, _) = self.triple_mut();
+            if *len_ptr == 0 {
+                return None;
+            }
+            let last_index = *len_ptr - 1;
+            *len_ptr = last_index;
+            Some(ptr::read(ptr.offset(last_index as isize)))
+        }
+    }
+
+    /// Re-allocate to set the capacity to `max(new_cap, inline_size())`.
+    ///
+    /// Panics if `new_cap` is less than the vector's length.
+    pub fn grow(&mut self, new_cap: usize) {
+        unsafe {
+            let (ptr, &mut len, cap) = self.triple_mut();
+            let unspilled = !self.spilled();
+            assert!(new_cap >= len);
+            if new_cap <= self.inline_size() {
+                if unspilled {
+                    return;
+                }
+                self.data = SmallVecData::from_inline(MaybeUninit::uninit());
+                ptr::copy_nonoverlapping(ptr, self.data.inline_mut(), len);
+                self.capacity = len;
+            } else if new_cap != cap {
+                let mut vec = Vec::with_capacity(new_cap);
+                let new_alloc = vec.as_mut_ptr();
+                mem::forget(vec);
+                ptr::copy_nonoverlapping(ptr, new_alloc, len);
+                self.data = SmallVecData::from_heap(new_alloc, len);
+                self.capacity = new_cap;
+                if unspilled {
+                    return;
+                }
+            } else {
+                return;
+            }
+            deallocate(ptr, cap);
+        }
+    }
+
+    /// Reserve capacity for `additional` more elements to be inserted.
+    ///
+    /// May reserve more space to avoid frequent reallocations.
+    ///
+    /// If the new capacity would overflow `usize` then it will be set to `usize::max_value()`
+    /// instead. (This means that inserting `additional` new elements is not guaranteed to be
+    /// possible after calling this function.)
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        // prefer triple_mut() even if triple() would work
+        // so that the optimizer removes duplicated calls to it
+        // from callers like insert()
+        let (_, &mut len, cap) = self.triple_mut();
+        if cap - len < additional {
+            let new_cap = len.checked_add(additional).
+                and_then(usize::checked_next_power_of_two).
+                unwrap_or(usize::max_value());
+            self.grow(new_cap);
+        }
+    }
+
+    /// Reserve the minimum capacity for `additional` more elements to be inserted.
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    pub fn reserve_exact(&mut self, additional: usize) {
+        let (_, &mut len, cap) = self.triple_mut();
+        if cap - len < additional {
+            match len.checked_add(additional) {
+                Some(cap) => self.grow(cap),
+                None => panic!("reserve_exact overflow"),
+            }
+        }
+    }
+
+    /// Shrink the capacity of the vector as much as possible.
+    ///
+    /// When possible, this will move data from an external heap buffer to the vector's inline
+    /// storage.
+    pub fn shrink_to_fit(&mut self) {
+        if !self.spilled() {
+            return;
+        }
+        let len = self.len();
+        if self.inline_size() >= len {
+            unsafe {
+                let (ptr, len) = self.data.heap();
+                self.data = SmallVecData::from_inline(MaybeUninit::uninit());
+                ptr::copy_nonoverlapping(ptr, self.data.inline_mut(), len);
+                deallocate(ptr, self.capacity);
+                self.capacity = len;
+            }
+        } else if self.capacity() > len {
+            self.grow(len);
+        }
+    }
+
+    /// Shorten the vector, keeping the first `len` elements and dropping the rest.
+    ///
+    /// If `len` is greater than or equal to the vector's current length, this has no
+    /// effect.
+    ///
+    /// This does not re-allocate.  If you want the vector's capacity to shrink, call
+    /// `shrink_to_fit` after truncating.
+    pub fn truncate(&mut self, len: usize) {
+        unsafe {
+            let (ptr, len_ptr, _) = self.triple_mut();
+            while len < *len_ptr {
+                let last_index = *len_ptr - 1;
+                *len_ptr = last_index;
+                ptr::drop_in_place(ptr.offset(last_index as isize));
+            }
+        }
+    }
+
+    /// Extracts a slice containing the entire vector.
+    ///
+    /// Equivalent to `&s[..]`.
+    pub fn as_slice(&self) -> &[A::Item] {
+        self
+    }
+
+    /// Extracts a mutable slice of the entire vector.
+    ///
+    /// Equivalent to `&mut s[..]`.
+    pub fn as_mut_slice(&mut self) -> &mut [A::Item] {
+        self
+    }
+
+    /// Remove the element at position `index`, replacing it with the last element.
+    ///
+    /// This does not preserve ordering, but is O(1).
+    ///
+    /// Panics if `index` is out of bounds.
+    #[inline]
+    pub fn swap_remove(&mut self, index: usize) -> A::Item {
+        let len = self.len();
+        self.swap(len - 1, index);
+        self.pop().unwrap_or_else(|| unsafe { unreachable() })
+    }
+
+    /// Remove all elements from the vector.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.truncate(0);
+    }
+
+    /// Remove and return the element at position `index`, shifting all elements after it to the
+    /// left.
+    ///
+    /// Panics if `index` is out of bounds.
+    pub fn remove(&mut self, index: usize) -> A::Item {
+        unsafe {
+            let (mut ptr, len_ptr, _) = self.triple_mut();
+            let len = *len_ptr;
+            assert!(index < len);
+            *len_ptr = len - 1;
+            ptr = ptr.offset(index as isize);
+            let item = ptr::read(ptr);
+            ptr::copy(ptr.offset(1), ptr, len - index - 1);
+            item
+        }
+    }
+
+    /// Insert an element at position `index`, shifting all elements after it to the right.
+    ///
+    /// Panics if `index` is out of bounds.
+    pub fn insert(&mut self, index: usize, element: A::Item) {
+        self.reserve(1);
+
+        unsafe {
+            let (mut ptr, len_ptr, _) = self.triple_mut();
+            let len = *len_ptr;
+            assert!(index <= len);
+            *len_ptr = len + 1;
+            ptr = ptr.offset(index as isize);
+            ptr::copy(ptr, ptr.offset(1), len - index);
+            ptr::write(ptr, element);
+        }
+    }
+
+    /// Insert multiple elements at position `index`, shifting all following elements toward the
+    /// back.
+    pub fn insert_many<I: IntoIterator<Item=A::Item>>(&mut self, index: usize, iterable: I) {
+        let iter = iterable.into_iter();
+        if index == self.len() {
+            return self.extend(iter);
+        }
+
+        let (lower_size_bound, _) = iter.size_hint();
+        assert!(lower_size_bound <= std::isize::MAX as usize);  // Ensure offset is indexable
+        assert!(index + lower_size_bound >= index);  // Protect against overflow
+        self.reserve(lower_size_bound);
+
+        unsafe {
+            let old_len = self.len();
+            assert!(index <= old_len);
+            let mut ptr = self.as_mut_ptr().offset(index as isize);
+
+            // Move the trailing elements.
+            ptr::copy(ptr, ptr.offset(lower_size_bound as isize), old_len - index);
+
+            // In case the iterator panics, don't double-drop the items we just copied above.
+            self.set_len(index);
+
+            let mut num_added = 0;
+            for element in iter {
+                let mut cur = ptr.offset(num_added as isize);
+                if num_added >= lower_size_bound {
+                    // Iterator provided more elements than the hint.  Move trailing items again.
+                    self.reserve(1);
+                    ptr = self.as_mut_ptr().offset(index as isize);
+                    cur = ptr.offset(num_added as isize);
+                    ptr::copy(cur, cur.offset(1), old_len - index);
+                }
+                ptr::write(cur, element);
+                num_added += 1;
+            }
+            if num_added < lower_size_bound {
+                // Iterator provided fewer elements than the hint
+                ptr::copy(ptr.offset(lower_size_bound as isize), ptr.offset(num_added as isize), old_len - index);
+            }
+
+            self.set_len(old_len + num_added);
+        }
+    }
+
+    /// Convert a SmallVec to a Vec, without reallocating if the SmallVec has already spilled onto
+    /// the heap.
+    pub fn into_vec(self) -> Vec<A::Item> {
+        if self.spilled() {
+            unsafe {
+                let (ptr, len) = self.data.heap();
+                let v = Vec::from_raw_parts(ptr, len, self.capacity);
+                mem::forget(self);
+                v
+            }
+        } else {
+            self.into_iter().collect()
+        }
+    }
+
+    /// Convert the SmallVec into an `A` if possible. Otherwise return `Err(Self)`.
+    ///
+    /// This method returns `Err(Self)` if the SmallVec is too short (and the `A` contains uninitialized elements),
+    /// or if the SmallVec is too long (and all the elements were spilled to the heap).
+    pub fn into_inner(self) -> Result<A, Self> {
+        if self.spilled() || self.len() != A::size() {
+            Err(self)
+        } else {
+            unsafe {
+                let data = ptr::read(&self.data);
+                mem::forget(self);
+                Ok(data.into_inline().assume_init())
+            }
+        }
+    }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all elements `e` such that `f(&e)` returns `false`.
+    /// This method operates in place and preserves the order of the retained
+    /// elements.
+    pub fn retain<F: FnMut(&mut A::Item) -> bool>(&mut self, mut f: F) {
+        let mut del = 0;
+        let len = self.len();
+        for i in 0..len {
+            if !f(&mut self[i]) {
+                del += 1;
+            } else if del > 0 {
+                self.swap(i - del, i);
+            }
+        }
+        self.truncate(len - del);
+    }
+
+    /// Removes consecutive duplicate elements.
+    pub fn dedup(&mut self) where A::Item: PartialEq<A::Item> {
+        self.dedup_by(|a, b| a == b);
+    }
+
+    /// Removes consecutive duplicate elements using the given equality relation.
+    pub fn dedup_by<F>(&mut self, mut same_bucket: F)
+        where F: FnMut(&mut A::Item, &mut A::Item) -> bool
+    {
+        // See the implementation of Vec::dedup_by in the
+        // standard library for an explanation of this algorithm.
+        let len = self.len();
+        if len <= 1 {
+            return;
+        }
+
+        let ptr = self.as_mut_ptr();
+        let mut w: usize = 1;
+
+        unsafe {
+            for r in 1..len {
+                let p_r = ptr.offset(r as isize);
+                let p_wm1 = ptr.offset((w - 1) as isize);
+                if !same_bucket(&mut *p_r, &mut *p_wm1) {
+                    if r != w {
+                        let p_w = p_wm1.offset(1);
+                        mem::swap(&mut *p_r, &mut *p_w);
+                    }
+                    w += 1;
+                }
+            }
+        }
+
+        self.truncate(w);
+    }
+
+    /// Removes consecutive elements that map to the same key.
+    pub fn dedup_by_key<F, K>(&mut self, mut key: F)
+        where F: FnMut(&mut A::Item) -> K,
+              K: PartialEq<K>
+    {
+        self.dedup_by(|a, b| key(a) == key(b));
+    }
+
+    /// Creates a `SmallVec` directly from the raw components of another
+    /// `SmallVec`.
+    ///
+    /// # Safety
+    ///
+    /// This is highly unsafe, due to the number of invariants that aren't
+    /// checked:
+    ///
+    /// * `ptr` needs to have been previously allocated via `SmallVec` for its
+    ///   spilled storage (at least, it's highly likely to be incorrect if it
+    ///   wasn't).
+    /// * `ptr`'s `A::Item` type needs to be the same size and alignment that
+    ///   it was allocated with
+    /// * `length` needs to be less than or equal to `capacity`.
+    /// * `capacity` needs to be the capacity that the pointer was allocated
+    ///   with.
+    ///
+    /// Violating these may cause problems like corrupting the allocator's
+    /// internal data structures.
+    ///
+    /// Additionally, `capacity` must be greater than the amount of inline
+    /// storage `A` has; that is, the new `SmallVec` must need to spill over
+    /// into heap allocated storage. This condition is asserted against.
+    ///
+    /// The ownership of `ptr` is effectively transferred to the
+    /// `SmallVec` which may then deallocate, reallocate or change the
+    /// contents of memory pointed to by the pointer at will. Ensure
+    /// that nothing else uses the pointer after calling this
+    /// function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[macro_use] extern crate smallvec;
+    /// # use smallvec::SmallVec;
+    /// use std::mem;
+    /// use std::ptr;
+    ///
+    /// fn main() {
+    ///     let mut v: SmallVec<[_; 1]> = smallvec![1, 2, 3];
+    ///
+    ///     // Pull out the important parts of `v`.
+    ///     let p = v.as_mut_ptr();
+    ///     let len = v.len();
+    ///     let cap = v.capacity();
+    ///     let spilled = v.spilled();
+    ///
+    ///     unsafe {
+    ///         // Forget all about `v`. The heap allocation that stored the
+    ///         // three values won't be deallocated.
+    ///         mem::forget(v);
+    ///
+    ///         // Overwrite memory with [4, 5, 6].
+    ///         //
+    ///         // This is only safe if `spilled` is true! Otherwise, we are
+    ///         // writing into the old `SmallVec`'s inline storage on the
+    ///         // stack.
+    ///         assert!(spilled);
+    ///         for i in 0..len as isize {
+    ///             ptr::write(p.offset(i), 4 + i);
+    ///         }
+    ///
+    ///         // Put everything back together into a SmallVec with a different
+    ///         // amount of inline storage, but which is still less than `cap`.
+    ///         let rebuilt = SmallVec::<[_; 2]>::from_raw_parts(p, len, cap);
+    ///         assert_eq!(&*rebuilt, &[4, 5, 6]);
+    ///     }
+    /// }
+    pub unsafe fn from_raw_parts(
+        ptr: *mut A::Item,
+        length: usize,
+        capacity: usize,
+    ) -> SmallVec<A> {
+        assert!(capacity > A::size());
+        SmallVec {
+            capacity,
+            data: SmallVecData::from_heap(ptr, length),
+        }
+    }
+}
+
+impl<A: Array> SmallVec<A> where A::Item: Copy {
+    /// Copy the elements from a slice into a new `SmallVec`.
+    ///
+    /// For slices of `Copy` types, this is more efficient than `SmallVec::from(slice)`.
+    pub fn from_slice(slice: &[A::Item]) -> Self {
+        let len = slice.len();
+        if len <= A::size() {
+            SmallVec {
+                capacity: len,
+                data: SmallVecData::from_inline(unsafe {
+                    let mut data: MaybeUninit<A> = MaybeUninit::uninit();
+                    ptr::copy_nonoverlapping(
+                        slice.as_ptr(),
+                        data.as_mut_ptr() as *mut A::Item,
+                        len,
+                    );
+                    data
+                })
+            }
+        } else {
+            let mut b = slice.to_vec();
+            let (ptr, cap) = (b.as_mut_ptr(), b.capacity());
+            mem::forget(b);
+            SmallVec {
+                capacity: cap,
+                data: SmallVecData::from_heap(ptr, len),
+            }
+        }
+    }
+
+    /// Copy elements from a slice into the vector at position `index`, shifting any following
+    /// elements toward the back.
+    ///
+    /// For slices of `Copy` types, this is more efficient than `insert`.
+    pub fn insert_from_slice(&mut self, index: usize, slice: &[A::Item]) {
+        self.reserve(slice.len());
+
+        let len = self.len();
+        assert!(index <= len);
+
+        unsafe {
+            let slice_ptr = slice.as_ptr();
+            let ptr = self.as_mut_ptr().offset(index as isize);
+            ptr::copy(ptr, ptr.offset(slice.len() as isize), len - index);
+            ptr::copy_nonoverlapping(slice_ptr, ptr, slice.len());
+            self.set_len(len + slice.len());
+        }
+    }
+
+    /// Copy elements from a slice and append them to the vector.
+    ///
+    /// For slices of `Copy` types, this is more efficient than `extend`.
+    #[inline]
+    pub fn extend_from_slice(&mut self, slice: &[A::Item]) {
+        let len = self.len();
+        self.insert_from_slice(len, slice);
+    }
+}
+
+impl<A: Array> SmallVec<A> where A::Item: Clone {
+    /// Resizes the vector so that its length is equal to `len`.
+    ///
+    /// If `len` is less than the current length, the vector simply truncated.
+    ///
+    /// If `len` is greater than the current length, `value` is appended to the
+    /// vector until its length equals `len`.
+    pub fn resize(&mut self, len: usize, value: A::Item) {
+        let old_len = self.len();
+
+        if len > old_len {
+            self.extend(repeat(value).take(len - old_len));
+        } else {
+            self.truncate(len);
+        }
+    }
+
+    /// Creates a `SmallVec` with `n` copies of `elem`.
+    /// ```
+    /// use smallvec::SmallVec;
+    ///
+    /// let v = SmallVec::<[char; 128]>::from_elem('d', 2);
+    /// assert_eq!(v, SmallVec::from_buf(['d', 'd']));
+    /// ```
+    pub fn from_elem(elem: A::Item, n: usize) -> Self {
+        if n > A::size() {
+            vec![elem; n].into()
+        } else {
+            let mut v = SmallVec::<A>::new();
+            unsafe {
+                let (ptr, len_ptr, _) = v.triple_mut();
+                let mut local_len = SetLenOnDrop::new(len_ptr);
+
+                for i in 0..n as isize {
+                    ::std::ptr::write(ptr.offset(i), elem.clone());
+                    local_len.increment_len(1);
+                }
+            }
+            v
+        }
+    }
+}
+
+impl<A: Array> ops::Deref for SmallVec<A> {
+    type Target = [A::Item];
+    #[inline]
+    fn deref(&self) -> &[A::Item] {
+        unsafe {
+            let (ptr, len, _) = self.triple();
+            slice::from_raw_parts(ptr, len)
+        }
+    }
+}
+
+impl<A: Array> ops::DerefMut for SmallVec<A> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [A::Item] {
+        unsafe {
+            let (ptr, &mut len, _) = self.triple_mut();
+            slice::from_raw_parts_mut(ptr, len)
+        }
+    }
+}
+
+impl<A: Array> AsRef<[A::Item]> for SmallVec<A> {
+    #[inline]
+    fn as_ref(&self) -> &[A::Item] {
+        self
+    }
+}
+
+impl<A: Array> AsMut<[A::Item]> for SmallVec<A> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [A::Item] {
+        self
+    }
+}
+
+impl<A: Array> Borrow<[A::Item]> for SmallVec<A> {
+    #[inline]
+    fn borrow(&self) -> &[A::Item] {
+        self
+    }
+}
+
+impl<A: Array> BorrowMut<[A::Item]> for SmallVec<A> {
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut [A::Item] {
+        self
+    }
+}
+
+#[cfg(feature = "std")]
+impl<A: Array<Item = u8>> io::Write for SmallVec<A> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<A: Array> Serialize for SmallVec<A> where A::Item: Serialize {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut state = serializer.serialize_seq(Some(self.len()))?;
+        for item in self {
+            state.serialize_element(&item)?;
+        }
+        state.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, A: Array> Deserialize<'de> for SmallVec<A> where A::Item: Deserialize<'de> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_seq(SmallVecVisitor{phantom: PhantomData})
+    }
+}
+
+#[cfg(feature = "serde")]
+struct SmallVecVisitor<A> {
+    phantom: PhantomData<A>
+}
+
+#[cfg(feature = "serde")]
+impl<'de, A: Array> Visitor<'de> for SmallVecVisitor<A>
+where A::Item: Deserialize<'de>,
+{
+    type Value = SmallVec<A>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a sequence")
+    }
+
+    fn visit_seq<B>(self, mut seq: B) -> Result<Self::Value, B::Error>
+        where
+            B: SeqAccess<'de>,
+    {
+        let len = seq.size_hint().unwrap_or(0);
+        let mut values = SmallVec::with_capacity(len);
+
+        while let Some(value) = seq.next_element()? {
+            values.push(value);
+        }
+
+        Ok(values)
+    }
+}
+
+
+#[cfg(feature = "specialization")]
+trait SpecFrom<A: Array, S> {
+    fn spec_from(slice: S) -> SmallVec<A>;
+}
+
+#[cfg(feature = "specialization")]
+mod specialization;
+
+#[cfg(feature = "specialization")]
+impl<'a, A: Array> SpecFrom<A, &'a [A::Item]> for SmallVec<A> where A::Item: Copy {
+    #[inline]
+    fn spec_from(slice: &'a [A::Item]) -> SmallVec<A> {
+        SmallVec::from_slice(slice)
+    }
+}
+
+impl<'a, A: Array> From<&'a [A::Item]> for SmallVec<A> where A::Item: Clone {
+    #[cfg(not(feature = "specialization"))]
+    #[inline]
+    fn from(slice: &'a [A::Item]) -> SmallVec<A> {
+        slice.into_iter().cloned().collect()
+    }
+
+    #[cfg(feature = "specialization")]
+    #[inline]
+    fn from(slice: &'a [A::Item]) -> SmallVec<A> {
+        SmallVec::spec_from(slice)
+    }
+}
+
+impl<A: Array> From<Vec<A::Item>> for SmallVec<A> {
+    #[inline]
+    fn from(vec: Vec<A::Item>) -> SmallVec<A> {
+        SmallVec::from_vec(vec)
+    }
+}
+
+impl<A: Array> From<A> for SmallVec<A> {
+    #[inline]
+    fn from(array: A) -> SmallVec<A> {
+        SmallVec::from_buf(array)
+    }
+}
+
+macro_rules! impl_index {
+    ($index_type: ty, $output_type: ty) => {
+        impl<A: Array> ops::Index<$index_type> for SmallVec<A> {
+            type Output = $output_type;
+            #[inline]
+            fn index(&self, index: $index_type) -> &$output_type {
+                &(&**self)[index]
+            }
+        }
+
+        impl<A: Array> ops::IndexMut<$index_type> for SmallVec<A> {
+            #[inline]
+            fn index_mut(&mut self, index: $index_type) -> &mut $output_type {
+                &mut (&mut **self)[index]
+            }
+        }
+    }
+}
+
+impl_index!(usize, A::Item);
+impl_index!(ops::Range<usize>, [A::Item]);
+impl_index!(ops::RangeFrom<usize>, [A::Item]);
+impl_index!(ops::RangeTo<usize>, [A::Item]);
+impl_index!(ops::RangeFull, [A::Item]);
+
+impl<A: Array> ExtendFromSlice<A::Item> for SmallVec<A> where A::Item: Copy {
+    fn extend_from_slice(&mut self, other: &[A::Item]) {
+        SmallVec::extend_from_slice(self, other)
+    }
+}
+
+#[allow(deprecated)]
+impl<A: Array> VecLike<A::Item> for SmallVec<A> {
+    #[inline]
+    fn push(&mut self, value: A::Item) {
+        SmallVec::push(self, value);
+    }
+}
+
+impl<A: Array> FromIterator<A::Item> for SmallVec<A> {
+    fn from_iter<I: IntoIterator<Item=A::Item>>(iterable: I) -> SmallVec<A> {
+        let mut v = SmallVec::new();
+        v.extend(iterable);
+        v
+    }
+}
+
+impl<A: Array> Extend<A::Item> for SmallVec<A> {
+    fn extend<I: IntoIterator<Item=A::Item>>(&mut self, iterable: I) {
+        let mut iter = iterable.into_iter();
+        let (lower_size_bound, _) = iter.size_hint();
+        self.reserve(lower_size_bound);
+
+        unsafe {
+            let (ptr, len_ptr, cap) = self.triple_mut();
+            let mut len = SetLenOnDrop::new(len_ptr);
+            while len.get() < cap {
+                if let Some(out) = iter.next() {
+                    ptr::write(ptr.offset(len.get() as isize), out);
+                    len.increment_len(1);
+                } else {
+                    return;
+                }
+            }
+        }
+
+        for elem in iter {
+            self.push(elem);
+        }
+    }
+}
+
+impl<A: Array> fmt::Debug for SmallVec<A> where A::Item: fmt::Debug {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+impl<A: Array> Default for SmallVec<A> {
+    #[inline]
+    fn default() -> SmallVec<A> {
+        SmallVec::new()
+    }
+}
+
+#[cfg(feature = "may_dangle")]
+unsafe impl<#[may_dangle] A: Array> Drop for SmallVec<A> {
+    fn drop(&mut self) {
+        unsafe {
+            if self.spilled() {
+                let (ptr, len) = self.data.heap();
+                Vec::from_raw_parts(ptr, len, self.capacity);
+            } else {
+                ptr::drop_in_place(&mut self[..]);
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "may_dangle"))]
+impl<A: Array> Drop for SmallVec<A> {
+    fn drop(&mut self) {
+        unsafe {
+            if self.spilled() {
+                let (ptr, len) = self.data.heap();
+                Vec::from_raw_parts(ptr, len, self.capacity);
+            } else {
+                ptr::drop_in_place(&mut self[..]);
+            }
+        }
+    }
+}
+
+impl<A: Array> Clone for SmallVec<A> where A::Item: Clone {
+    fn clone(&self) -> SmallVec<A> {
+        let mut new_vector = SmallVec::with_capacity(self.len());
+        for element in self.iter() {
+            new_vector.push((*element).clone())
+        }
+        new_vector
+    }
+}
+
+impl<A: Array, B: Array> PartialEq<SmallVec<B>> for SmallVec<A>
+    where A::Item: PartialEq<B::Item> {
+    #[inline]
+    fn eq(&self, other: &SmallVec<B>) -> bool { self[..] == other[..] }
+    #[inline]
+    fn ne(&self, other: &SmallVec<B>) -> bool { self[..] != other[..] }
+}
+
+impl<A: Array> Eq for SmallVec<A> where A::Item: Eq {}
+
+impl<A: Array> PartialOrd for SmallVec<A> where A::Item: PartialOrd {
+    #[inline]
+    fn partial_cmp(&self, other: &SmallVec<A>) -> Option<cmp::Ordering> {
+        PartialOrd::partial_cmp(&**self, &**other)
+    }
+}
+
+impl<A: Array> Ord for SmallVec<A> where A::Item: Ord {
+    #[inline]
+    fn cmp(&self, other: &SmallVec<A>) -> cmp::Ordering {
+        Ord::cmp(&**self, &**other)
+    }
+}
+
+impl<A: Array> Hash for SmallVec<A> where A::Item: Hash {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (**self).hash(state)
+    }
+}
+
+unsafe impl<A: Array> Send for SmallVec<A> where A::Item: Send {}
+
+/// An iterator that consumes a `SmallVec` and yields its items by value.
+///
+/// Returned from [`SmallVec::into_iter`][1].
+///
+/// [1]: struct.SmallVec.html#method.into_iter
+pub struct IntoIter<A: Array> {
+    data: SmallVec<A>,
+    current: usize,
+    end: usize,
+}
+
+impl<A: Array> Drop for IntoIter<A> {
+    fn drop(&mut self) {
+        for _ in self { }
+    }
+}
+
+impl<A: Array> Iterator for IntoIter<A> {
+    type Item = A::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<A::Item> {
+        if self.current == self.end {
+            None
+        }
+        else {
+            unsafe {
+                let current = self.current as isize;
+                self.current += 1;
+                Some(ptr::read(self.data.as_ptr().offset(current)))
+            }
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.end - self.current;
+        (size, Some(size))
+    }
+}
+
+impl<A: Array> DoubleEndedIterator for IntoIter<A> {
+    #[inline]
+    fn next_back(&mut self) -> Option<A::Item> {
+        if self.current == self.end {
+            None
+        }
+        else {
+            unsafe {
+                self.end -= 1;
+                Some(ptr::read(self.data.as_ptr().offset(self.end as isize)))
+            }
+        }
+    }
+}
+
+impl<A: Array> ExactSizeIterator for IntoIter<A> { }
+
+impl<A: Array> IntoIterator for SmallVec<A> {
+    type IntoIter = IntoIter<A>;
+    type Item = A::Item;
+    fn into_iter(mut self) -> Self::IntoIter {
+        unsafe {
+            // Set SmallVec len to zero as `IntoIter` drop handles dropping of the elements
+            let len = self.len();
+            self.set_len(0);
+            IntoIter {
+                data: self,
+                current: 0,
+                end: len,
+            }
+        }
+    }
+}
+
+impl<'a, A: Array> IntoIterator for &'a SmallVec<A> {
+    type IntoIter = slice::Iter<'a, A::Item>;
+    type Item = &'a A::Item;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, A: Array> IntoIterator for &'a mut SmallVec<A> {
+    type IntoIter = slice::IterMut<'a, A::Item>;
+    type Item = &'a mut A::Item;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+/// Types that can be used as the backing store for a SmallVec
+pub unsafe trait Array {
+    /// The type of the array's elements.
+    type Item;
+    /// Returns the number of items the array can hold.
+    fn size() -> usize;
+    /// Returns a pointer to the first element of the array.
+    fn ptr(&self) -> *const Self::Item;
+    /// Returns a mutable pointer to the first element of the array.
+    fn ptr_mut(&mut self) -> *mut Self::Item;
+}
+
+/// Set the length of the vec when the `SetLenOnDrop` value goes out of scope.
+///
+/// Copied from https://github.com/rust-lang/rust/pull/36355
+struct SetLenOnDrop<'a> {
+    len: &'a mut usize,
+    local_len: usize,
+}
+
+impl<'a> SetLenOnDrop<'a> {
+    #[inline]
+    fn new(len: &'a mut usize) -> Self {
+        SetLenOnDrop { local_len: *len, len: len }
+    }
+
+    #[inline]
+    fn get(&self) -> usize {
+        self.local_len
+    }
+
+    #[inline]
+    fn increment_len(&mut self, increment: usize) {
+        self.local_len += increment;
+    }
+}
+
+impl<'a> Drop for SetLenOnDrop<'a> {
+    #[inline]
+    fn drop(&mut self) {
+        *self.len = self.local_len;
+    }
+}
+
+macro_rules! impl_array(
+    ($($size:expr),+) => {
+        $(
+            unsafe impl<T> Array for [T; $size] {
+                type Item = T;
+                fn size() -> usize { $size }
+                fn ptr(&self) -> *const T { unimplemented!() }
+                fn ptr_mut(&mut self) -> *mut T { unimplemented!() }
+            }
+        )+
+    }
+);
+
+impl_array!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24, 32, 36,
+            0x40, 0x80, 0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000,
+            0x10000, 0x20000, 0x40000, 0x80000, 0x100000);
+
+#[cfg(test)]
+mod tests {
+    use SmallVec;
+
+    use std::iter::FromIterator;
+
+    #[cfg(feature = "std")]
+    use std::borrow::ToOwned;
+    #[cfg(not(feature = "std"))]
+    use alloc::borrow::ToOwned;
+    #[cfg(feature = "std")]
+    use std::rc::Rc;
+    #[cfg(not(feature = "std"))]
+    use alloc::rc::Rc;
+    #[cfg(not(feature = "std"))]
+    use alloc::boxed::Box;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
+    #[test]
+    pub fn test_zero() {
+        let mut v = SmallVec::<[_; 0]>::new();
+        assert!(!v.spilled());
+        v.push(0usize);
+        assert!(v.spilled());
+        assert_eq!(&*v, &[0]);
+    }
+
+    // We heap allocate all these strings so that double frees will show up under valgrind.
+
+    #[test]
+    pub fn test_inline() {
+        let mut v = SmallVec::<[_; 16]>::new();
+        v.push("hello".to_owned());
+        v.push("there".to_owned());
+        assert_eq!(&*v, &[
+            "hello".to_owned(),
+            "there".to_owned(),
+        ][..]);
+    }
+
+    #[test]
+    pub fn test_spill() {
+        let mut v = SmallVec::<[_; 2]>::new();
+        v.push("hello".to_owned());
+        assert_eq!(v[0], "hello");
+        v.push("there".to_owned());
+        v.push("burma".to_owned());
+        assert_eq!(v[0], "hello");
+        v.push("shave".to_owned());
+        assert_eq!(&*v, &[
+            "hello".to_owned(),
+            "there".to_owned(),
+            "burma".to_owned(),
+            "shave".to_owned(),
+        ][..]);
+    }
+
+    #[test]
+    pub fn test_double_spill() {
+        let mut v = SmallVec::<[_; 2]>::new();
+        v.push("hello".to_owned());
+        v.push("there".to_owned());
+        v.push("burma".to_owned());
+        v.push("shave".to_owned());
+        v.push("hello".to_owned());
+        v.push("there".to_owned());
+        v.push("burma".to_owned());
+        v.push("shave".to_owned());
+        assert_eq!(&*v, &[
+            "hello".to_owned(),
+            "there".to_owned(),
+            "burma".to_owned(),
+            "shave".to_owned(),
+            "hello".to_owned(),
+            "there".to_owned(),
+            "burma".to_owned(),
+            "shave".to_owned(),
+        ][..]);
+    }
+
+    /// https://github.com/servo/rust-smallvec/issues/4
+    #[test]
+    fn issue_4() {
+        SmallVec::<[Box<u32>; 2]>::new();
+    }
+
+    /// https://github.com/servo/rust-smallvec/issues/5
+    #[test]
+    fn issue_5() {
+        assert!(Some(SmallVec::<[&u32; 2]>::new()).is_some());
+    }
+
+    #[test]
+    fn test_with_capacity() {
+        let v: SmallVec<[u8; 3]> = SmallVec::with_capacity(1);
+        assert!(v.is_empty());
+        assert!(!v.spilled());
+        assert_eq!(v.capacity(), 3);
+
+        let v: SmallVec<[u8; 3]> = SmallVec::with_capacity(10);
+        assert!(v.is_empty());
+        assert!(v.spilled());
+        assert_eq!(v.capacity(), 10);
+    }
+
+    #[test]
+    fn drain() {
+        let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+        v.push(3);
+        assert_eq!(v.drain().collect::<Vec<_>>(), &[3]);
+
+        // spilling the vec
+        v.push(3);
+        v.push(4);
+        v.push(5);
+        assert_eq!(v.drain().collect::<Vec<_>>(), &[3, 4, 5]);
+    }
+
+    #[test]
+    fn drain_rev() {
+        let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+        v.push(3);
+        assert_eq!(v.drain().rev().collect::<Vec<_>>(), &[3]);
+
+        // spilling the vec
+        v.push(3);
+        v.push(4);
+        v.push(5);
+        assert_eq!(v.drain().rev().collect::<Vec<_>>(), &[5, 4, 3]);
+    }
+
+    #[test]
+    fn into_iter() {
+        let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+        v.push(3);
+        assert_eq!(v.into_iter().collect::<Vec<_>>(), &[3]);
+
+        // spilling the vec
+        let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+        v.push(3);
+        v.push(4);
+        v.push(5);
+        assert_eq!(v.into_iter().collect::<Vec<_>>(), &[3, 4, 5]);
+    }
+
+    #[test]
+    fn into_iter_rev() {
+        let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+        v.push(3);
+        assert_eq!(v.into_iter().rev().collect::<Vec<_>>(), &[3]);
+
+        // spilling the vec
+        let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+        v.push(3);
+        v.push(4);
+        v.push(5);
+        assert_eq!(v.into_iter().rev().collect::<Vec<_>>(), &[5, 4, 3]);
+    }
+
+    #[test]
+    fn into_iter_drop() {
+        use std::cell::Cell;
+
+        struct DropCounter<'a>(&'a Cell<i32>);
+
+        impl<'a> Drop for DropCounter<'a> {
+            fn drop(&mut self) {
+                self.0.set(self.0.get() + 1);
+            }
+        }
+
+        {
+            let cell = Cell::new(0);
+            let mut v: SmallVec<[DropCounter; 2]> = SmallVec::new();
+            v.push(DropCounter(&cell));
+            v.into_iter();
+            assert_eq!(cell.get(), 1);
+        }
+
+        {
+            let cell = Cell::new(0);
+            let mut v: SmallVec<[DropCounter; 2]> = SmallVec::new();
+            v.push(DropCounter(&cell));
+            v.push(DropCounter(&cell));
+            assert!(v.into_iter().next().is_some());
+            assert_eq!(cell.get(), 2);
+        }
+
+        {
+            let cell = Cell::new(0);
+            let mut v: SmallVec<[DropCounter; 2]> = SmallVec::new();
+            v.push(DropCounter(&cell));
+            v.push(DropCounter(&cell));
+            v.push(DropCounter(&cell));
+            assert!(v.into_iter().next().is_some());
+            assert_eq!(cell.get(), 3);
+        }
+        {
+            let cell = Cell::new(0);
+            let mut v: SmallVec<[DropCounter; 2]> = SmallVec::new();
+            v.push(DropCounter(&cell));
+            v.push(DropCounter(&cell));
+            v.push(DropCounter(&cell));
+            {
+                let mut it = v.into_iter();
+                assert!(it.next().is_some());
+                assert!(it.next_back().is_some());
+            }
+            assert_eq!(cell.get(), 3);
+        }
+    }
+
+    #[test]
+    fn test_capacity() {
+        let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+        v.reserve(1);
+        assert_eq!(v.capacity(), 2);
+        assert!(!v.spilled());
+
+        v.reserve_exact(0x100);
+        assert!(v.capacity() >= 0x100);
+
+        v.push(0);
+        v.push(1);
+        v.push(2);
+        v.push(3);
+
+        v.shrink_to_fit();
+        assert!(v.capacity() < 0x100);
+    }
+
+    #[test]
+    fn test_truncate() {
+        let mut v: SmallVec<[Box<u8>; 8]> = SmallVec::new();
+
+        for x in 0..8 {
+            v.push(Box::new(x));
+        }
+        v.truncate(4);
+
+        assert_eq!(v.len(), 4);
+        assert!(!v.spilled());
+
+        assert_eq!(*v.swap_remove(1), 1);
+        assert_eq!(*v.remove(1), 3);
+        v.insert(1, Box::new(3));
+
+        assert_eq!(&v.iter().map(|v| **v).collect::<Vec<_>>(), &[0, 3, 2]);
+    }
+
+    #[test]
+    fn test_insert_many() {
+        let mut v: SmallVec<[u8; 8]> = SmallVec::new();
+        for x in 0..4 {
+            v.push(x);
+        }
+        assert_eq!(v.len(), 4);
+        v.insert_many(1, [5, 6].iter().cloned());
+        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
+    }
+
+    struct MockHintIter<T: Iterator>{x: T, hint: usize}
+    impl<T: Iterator> Iterator for MockHintIter<T> {
+        type Item = T::Item;
+        fn next(&mut self) -> Option<Self::Item> {self.x.next()}
+        fn size_hint(&self) -> (usize, Option<usize>) {(self.hint, None)}
+    }
+
+    #[test]
+    fn test_insert_many_short_hint() {
+        let mut v: SmallVec<[u8; 8]> = SmallVec::new();
+        for x in 0..4 {
+            v.push(x);
+        }
+        assert_eq!(v.len(), 4);
+        v.insert_many(1, MockHintIter{x: [5, 6].iter().cloned(), hint: 5});
+        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_insert_many_long_hint() {
+        let mut v: SmallVec<[u8; 8]> = SmallVec::new();
+        for x in 0..4 {
+            v.push(x);
+        }
+        assert_eq!(v.len(), 4);
+        v.insert_many(1, MockHintIter{x: [5, 6].iter().cloned(), hint: 1});
+        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
+    }
+
+    #[cfg(all(feature = "std", not(miri)))] // Miri currently does not support unwinding
+    #[test]
+    // https://github.com/servo/rust-smallvec/issues/96
+    fn test_insert_many_panic() {
+        struct PanicOnDoubleDrop {
+            dropped: Box<bool>
+        }
+
+        impl Drop for PanicOnDoubleDrop {
+            fn drop(&mut self) {
+                assert!(!*self.dropped, "already dropped");
+                *self.dropped = true;
+            }
+        }
+
+        struct BadIter;
+        impl Iterator for BadIter {
+            type Item = PanicOnDoubleDrop;
+            fn size_hint(&self) -> (usize, Option<usize>) { (1, None) }
+            fn next(&mut self) -> Option<Self::Item> { panic!() }
+        }
+
+        let mut vec: SmallVec<[PanicOnDoubleDrop; 0]> = vec![
+            PanicOnDoubleDrop { dropped: Box::new(false) },
+            PanicOnDoubleDrop { dropped: Box::new(false) },
+        ].into();
+        let result = ::std::panic::catch_unwind(move || {
+            vec.insert_many(0, BadIter);
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_grow() {
+        let mut v: SmallVec<[u8; 8]> = SmallVec::new();
+        v.extend(0..8);
+        v.grow(5);
+    }
+
+    #[test]
+    fn test_insert_from_slice() {
+        let mut v: SmallVec<[u8; 8]> = SmallVec::new();
+        for x in 0..4 {
+            v.push(x);
+        }
+        assert_eq!(v.len(), 4);
+        v.insert_from_slice(1, &[5, 6]);
+        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 5, 6, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_extend_from_slice() {
+        let mut v: SmallVec<[u8; 8]> = SmallVec::new();
+        for x in 0..4 {
+            v.push(x);
+        }
+        assert_eq!(v.len(), 4);
+        v.extend_from_slice(&[5, 6]);
+        assert_eq!(&v.iter().map(|v| *v).collect::<Vec<_>>(), &[0, 1, 2, 3, 5, 6]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_drop_panic_smallvec() {
+        // This test should only panic once, and not double panic,
+        // which would mean a double drop
+        struct DropPanic;
+
+        impl Drop for DropPanic {
+            fn drop(&mut self) {
+                panic!("drop");
+            }
+        }
+
+        let mut v = SmallVec::<[_; 1]>::new();
+        v.push(DropPanic);
+    }
+
+    #[test]
+    fn test_eq() {
+        let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+        let mut b: SmallVec<[u32; 2]> = SmallVec::new();
+        let mut c: SmallVec<[u32; 2]> = SmallVec::new();
+        // a = [1, 2]
+        a.push(1);
+        a.push(2);
+        // b = [1, 2]
+        b.push(1);
+        b.push(2);
+        // c = [3, 4]
+        c.push(3);
+        c.push(4);
+
+        assert!(a == b);
+        assert!(a != c);
+    }
+
+    #[test]
+    fn test_ord() {
+        let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+        let mut b: SmallVec<[u32; 2]> = SmallVec::new();
+        let mut c: SmallVec<[u32; 2]> = SmallVec::new();
+        // a = [1]
+        a.push(1);
+        // b = [1, 1]
+        b.push(1);
+        b.push(1);
+        // c = [1, 2]
+        c.push(1);
+        c.push(2);
+
+        assert!(a < b);
+        assert!(b > a);
+        assert!(b < c);
+        assert!(c > b);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_hash() {
+        use std::hash::Hash;
+        use std::collections::hash_map::DefaultHasher;
+
+        {
+            let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+            let b = [1, 2];
+            a.extend(b.iter().cloned());
+            let mut hasher = DefaultHasher::new();
+            assert_eq!(a.hash(&mut hasher), b.hash(&mut hasher));
+        }
+        {
+            let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+            let b = [1, 2, 11, 12];
+            a.extend(b.iter().cloned());
+            let mut hasher = DefaultHasher::new();
+            assert_eq!(a.hash(&mut hasher), b.hash(&mut hasher));
+        }
+    }
+
+    #[test]
+    fn test_as_ref() {
+        let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+        a.push(1);
+        assert_eq!(a.as_ref(), [1]);
+        a.push(2);
+        assert_eq!(a.as_ref(), [1, 2]);
+        a.push(3);
+        assert_eq!(a.as_ref(), [1, 2, 3]);
+    }
+
+    #[test]
+    fn test_as_mut() {
+        let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+        a.push(1);
+        assert_eq!(a.as_mut(), [1]);
+        a.push(2);
+        assert_eq!(a.as_mut(), [1, 2]);
+        a.push(3);
+        assert_eq!(a.as_mut(), [1, 2, 3]);
+        a.as_mut()[1] = 4;
+        assert_eq!(a.as_mut(), [1, 4, 3]);
+    }
+
+    #[test]
+    fn test_borrow() {
+        use std::borrow::Borrow;
+
+        let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+        a.push(1);
+        assert_eq!(a.borrow(), [1]);
+        a.push(2);
+        assert_eq!(a.borrow(), [1, 2]);
+        a.push(3);
+        assert_eq!(a.borrow(), [1, 2, 3]);
+    }
+
+    #[test]
+    fn test_borrow_mut() {
+        use std::borrow::BorrowMut;
+
+        let mut a: SmallVec<[u32; 2]> = SmallVec::new();
+        a.push(1);
+        assert_eq!(a.borrow_mut(), [1]);
+        a.push(2);
+        assert_eq!(a.borrow_mut(), [1, 2]);
+        a.push(3);
+        assert_eq!(a.borrow_mut(), [1, 2, 3]);
+        BorrowMut::<[u32]>::borrow_mut(&mut a)[1] = 4;
+        assert_eq!(a.borrow_mut(), [1, 4, 3]);
+    }
+
+    #[test]
+    fn test_from() {
+        assert_eq!(&SmallVec::<[u32; 2]>::from(&[1][..])[..], [1]);
+        assert_eq!(&SmallVec::<[u32; 2]>::from(&[1, 2, 3][..])[..], [1, 2, 3]);
+
+        let vec = vec![];
+        let small_vec: SmallVec<[u8; 3]> = SmallVec::from(vec);
+        assert_eq!(&*small_vec, &[]);
+        drop(small_vec);
+
+        let vec = vec![1, 2, 3, 4, 5];
+        let small_vec: SmallVec<[u8; 3]> = SmallVec::from(vec);
+        assert_eq!(&*small_vec, &[1, 2, 3, 4, 5]);
+        drop(small_vec);
+
+        let vec = vec![1, 2, 3, 4, 5];
+        let small_vec: SmallVec<[u8; 1]> = SmallVec::from(vec);
+        assert_eq!(&*small_vec, &[1, 2, 3, 4, 5]);
+        drop(small_vec);
+
+        let array = [1];
+        let small_vec: SmallVec<[u8; 1]> = SmallVec::from(array);
+        assert_eq!(&*small_vec, &[1]);
+        drop(small_vec);
+
+        let array = [99; 128];
+        let small_vec: SmallVec<[u8; 128]> = SmallVec::from(array);
+        assert_eq!(&*small_vec, vec![99u8; 128].as_slice());
+        drop(small_vec);
+    }
+
+    #[test]
+    fn test_from_slice() {
+        assert_eq!(&SmallVec::<[u32; 2]>::from_slice(&[1][..])[..], [1]);
+        assert_eq!(&SmallVec::<[u32; 2]>::from_slice(&[1, 2, 3][..])[..], [1, 2, 3]);
+    }
+
+    #[test]
+    fn test_exact_size_iterator() {
+        let mut vec = SmallVec::<[u32; 2]>::from(&[1, 2, 3][..]);
+        assert_eq!(vec.clone().into_iter().len(), 3);
+        assert_eq!(vec.drain().len(), 3);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn veclike_deref_slice() {
+        use super::VecLike;
+
+        fn test<T: VecLike<i32>>(vec: &mut T) {
+            assert!(!vec.is_empty());
+            assert_eq!(vec.len(), 3);
+
+            vec.sort();
+            assert_eq!(&vec[..], [1, 2, 3]);
+        }
+
+        let mut vec = SmallVec::<[i32; 2]>::from(&[3, 1, 2][..]);
+        test(&mut vec);
+    }
+
+    #[test]
+    fn shrink_to_fit_unspill() {
+        let mut vec = SmallVec::<[u8; 2]>::from_iter(0..3);
+        vec.pop();
+        assert!(vec.spilled());
+        vec.shrink_to_fit();
+        assert!(!vec.spilled(), "shrink_to_fit will un-spill if possible");
+    }
+
+    #[test]
+    fn test_into_vec() {
+        let vec = SmallVec::<[u8; 2]>::from_iter(0..2);
+        assert_eq!(vec.into_vec(), vec![0, 1]);
+
+        let vec = SmallVec::<[u8; 2]>::from_iter(0..3);
+        assert_eq!(vec.into_vec(), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_into_inner() {
+        let vec = SmallVec::<[u8; 2]>::from_iter(0..2);
+        assert_eq!(vec.into_inner(), Ok([0, 1]));
+
+        let vec = SmallVec::<[u8; 2]>::from_iter(0..1);
+        assert_eq!(vec.clone().into_inner(), Err(vec));
+
+        let vec = SmallVec::<[u8; 2]>::from_iter(0..3);
+        assert_eq!(vec.clone().into_inner(), Err(vec));
+    }
+
+    #[test]
+    fn test_from_vec() {
+        let vec = vec![];
+        let small_vec: SmallVec<[u8; 3]> = SmallVec::from_vec(vec);
+        assert_eq!(&*small_vec, &[]);
+        drop(small_vec);
+
+        let vec = vec![];
+        let small_vec: SmallVec<[u8; 1]> = SmallVec::from_vec(vec);
+        assert_eq!(&*small_vec, &[]);
+        drop(small_vec);
+
+        let vec = vec![1];
+        let small_vec: SmallVec<[u8; 3]> = SmallVec::from_vec(vec);
+        assert_eq!(&*small_vec, &[1]);
+        drop(small_vec);
+
+        let vec = vec![1, 2, 3];
+        let small_vec: SmallVec<[u8; 3]> = SmallVec::from_vec(vec);
+        assert_eq!(&*small_vec, &[1, 2, 3]);
+        drop(small_vec);
+
+        let vec = vec![1, 2, 3, 4, 5];
+        let small_vec: SmallVec<[u8; 3]> = SmallVec::from_vec(vec);
+        assert_eq!(&*small_vec, &[1, 2, 3, 4, 5]);
+        drop(small_vec);
+
+        let vec = vec![1, 2, 3, 4, 5];
+        let small_vec: SmallVec<[u8; 1]> = SmallVec::from_vec(vec);
+        assert_eq!(&*small_vec, &[1, 2, 3, 4, 5]);
+        drop(small_vec);
+    }
+
+    #[test]
+    fn test_retain() {
+        // Test inline data storate
+        let mut sv: SmallVec<[i32; 5]> = SmallVec::from_slice(&[1, 2, 3, 3, 4]);
+        sv.retain(|&mut i| i != 3);
+        assert_eq!(sv.pop(), Some(4));
+        assert_eq!(sv.pop(), Some(2));
+        assert_eq!(sv.pop(), Some(1));
+        assert_eq!(sv.pop(), None);
+
+        // Test spilled data storage
+        let mut sv: SmallVec<[i32; 3]> = SmallVec::from_slice(&[1, 2, 3, 3, 4]);
+        sv.retain(|&mut i| i != 3);
+        assert_eq!(sv.pop(), Some(4));
+        assert_eq!(sv.pop(), Some(2));
+        assert_eq!(sv.pop(), Some(1));
+        assert_eq!(sv.pop(), None);
+
+        // Test that drop implementations are called for inline.
+        let one = Rc::new(1);
+        let mut sv: SmallVec<[Rc<i32>; 3]> = SmallVec::new();
+        sv.push(Rc::clone(&one));
+        assert_eq!(Rc::strong_count(&one), 2);
+        sv.retain(|_| false);
+        assert_eq!(Rc::strong_count(&one), 1);
+
+        // Test that drop implementations are called for spilled data.
+        let mut sv: SmallVec<[Rc<i32>; 1]> = SmallVec::new();
+        sv.push(Rc::clone(&one));
+        sv.push(Rc::new(2));
+        assert_eq!(Rc::strong_count(&one), 2);
+        sv.retain(|_| false);
+        assert_eq!(Rc::strong_count(&one), 1);
+    }
+
+    #[test]
+    fn test_dedup() {
+        let mut dupes: SmallVec<[i32; 5]> = SmallVec::from_slice(&[1, 1, 2, 3, 3]);
+        dupes.dedup();
+        assert_eq!(&*dupes, &[1, 2, 3]);
+
+        let mut empty: SmallVec<[i32; 5]> = SmallVec::new();
+        empty.dedup();
+        assert!(empty.is_empty());
+
+        let mut all_ones: SmallVec<[i32; 5]> = SmallVec::from_slice(&[1, 1, 1, 1, 1]);
+        all_ones.dedup();
+        assert_eq!(all_ones.len(), 1);
+
+        let mut no_dupes: SmallVec<[i32; 5]> = SmallVec::from_slice(&[1, 2, 3, 4, 5]);
+        no_dupes.dedup();
+        assert_eq!(no_dupes.len(), 5);
+    }
+
+    #[test]
+    fn test_resize() {
+        let mut v: SmallVec<[i32; 8]> = SmallVec::new();
+        v.push(1);
+        v.resize(5, 0);
+        assert_eq!(v[..], [1, 0, 0, 0, 0][..]);
+
+        v.resize(2, -1);
+        assert_eq!(v[..], [1, 0][..]);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_write() {
+        use io::Write;
+
+        let data = [1, 2, 3, 4, 5];
+
+        let mut small_vec: SmallVec<[u8; 2]> = SmallVec::new();
+        let len = small_vec.write(&data[..]).unwrap();
+        assert_eq!(len, 5);
+        assert_eq!(small_vec.as_ref(), data.as_ref());
+
+        let mut small_vec: SmallVec<[u8; 2]> = SmallVec::new();
+        small_vec.write_all(&data[..]).unwrap();
+        assert_eq!(small_vec.as_ref(), data.as_ref());
+    }
+
+    #[cfg(feature = "serde")]
+    extern crate bincode;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde() {
+        use self::bincode::{config, deserialize};
+        let mut small_vec: SmallVec<[i32; 2]> = SmallVec::new();
+        small_vec.push(1);
+        let encoded = config().limit(100).serialize(&small_vec).unwrap();
+        let decoded: SmallVec<[i32; 2]> = deserialize(&encoded).unwrap();
+        assert_eq!(small_vec, decoded);
+        small_vec.push(2);
+        // Spill the vec
+        small_vec.push(3);
+        small_vec.push(4);
+        // Check again after spilling.
+        let encoded = config().limit(100).serialize(&small_vec).unwrap();
+        let decoded: SmallVec<[i32; 2]> = deserialize(&encoded).unwrap();
+        assert_eq!(small_vec, decoded);
+    }
+
+    #[test]
+    fn grow_to_shrink() {
+        let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+        v.push(1);
+        v.push(2);
+        v.push(3);
+        assert!(v.spilled());
+        v.clear();
+        // Shrink to inline.
+        v.grow(2);
+        assert!(!v.spilled());
+        assert_eq!(v.capacity(), 2);
+        assert_eq!(v.len(), 0);
+        v.push(4);
+        assert_eq!(v[..], [4]);
+    }
+
+    #[test]
+    fn resumable_extend() {
+        let s = "a b c";
+        // This iterator yields: (Some('a'), None, Some('b'), None, Some('c')), None
+        let it = s
+            .chars()
+            .scan(0, |_, ch| if ch.is_whitespace() { None } else { Some(ch) });
+        let mut v: SmallVec<[char; 4]> = SmallVec::new();
+        v.extend(it);
+        assert_eq!(v[..], ['a']);
+    }
+
+    // #139
+    #[test]
+    fn uninhabited() {
+        enum Void {}
+        let _sv = SmallVec::<[Void; 8]>::new();
+    }
+
+    #[test]
+    fn grow_spilled_same_size() {
+        let mut v: SmallVec<[u8; 2]> = SmallVec::new();
+        v.push(0);
+        v.push(1);
+        v.push(2);
+        assert!(v.spilled());
+        assert_eq!(v.capacity(), 4);
+        // grow with the same capacity
+        v.grow(4);
+        assert_eq!(v.capacity(), 4);
+        assert_eq!(v[..], [0, 1, 2]);
+    }
+}

--- a/tribes-bench/tools/analyse-stage2.py
+++ b/tribes-bench/tools/analyse-stage2.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Stage 2 telemetry analyser for tribes-bench (#392, M1).
+
+Sibling of `analyse-stage1.py` — does NOT replace it. The Stage 0/1
+analysers are byte-identical to their tagged versions; Stage 2 adds
+this distinct script so the federation can grow to 5 tribes (alpha,
+beta, gamma, delta, epsilon) without touching the Stage 0/1 surface.
+
+Same 12-column schema as Stage 1 — the wire format is stable across
+stages. The two behavioural differences vs `analyse-stage1.py` are:
+(1) the bug-class lookup reads `targets/stage2/bugs.json`; (2) the
+always-emit fallback derives the known-tribe set from the per-run
+experience/spend data union with the federation directory layout, not
+a hard-coded 3-tribe list (so a 5-, 6-, or 7-tribe run all work
+without code change).
+
+Schema:
+
+    minute, tribe, agents_alive, cb_balance,
+    findings_emitted, true_positives, false_positives,
+    bug_class, is_first_finder, tribe_size,
+    replication_event_count, tribe_death_ts
+
+Sources:
+
+    .agentis/daemon/<agent_id>.colony     plain text, tribe name
+    .agentis/experience/<agent_id>.jsonl  learn() rows with tags
+    .agentis/spend/<agent_id>.jsonl       prompt() spend rows with cb
+    <fed>/targets/stage2/bugs.json        manifest for bug_id -> class lookup
+    <run-dir>/bug-ledger.jsonl            shared ledger; first-finder
+                                         determined post-hoc by min(ts)
+                                         per bug_id, sidestepping the
+                                         in-band race documented in
+                                         the #364 M3 plan §7.
+
+`is_first_finder` is populated from bug-ledger.jsonl: per-bug-id we
+sort the rows by ts and the lowest-ts tribe gets is_first_finder=1 in
+the row's minute bucket. `tribe_size` is the count of distinct alive
+agent_ids per (minute, tribe) (bumped by replicate()-driven daemon
+spawns). `replication_event_count` counts experience rows tagged
+`replicated`. `tribe_death_ts` is sticky from the minute the
+`died`-tagged row appears onward.
+
+Usage:
+    analyse-stage2.py <runs/<ts> path>
+
+Pure stdlib. No extra deps.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import sys
+from collections import defaultdict
+from typing import Any
+
+
+def parse_args(argv: list[str]) -> str:
+    if len(argv) != 2:
+        print("Usage: analyse-stage2.py <run-dir>", file=sys.stderr)
+        sys.exit(2)
+    run_dir = argv[1]
+    if not os.path.isdir(run_dir):
+        print(f"analyse-stage2: run dir not found: {run_dir}", file=sys.stderr)
+        sys.exit(2)
+    return run_dir
+
+
+def load_agent_to_tribe(daemon_dir: str) -> dict[str, str]:
+    """Map every agent_id under .agentis/daemon/ to the tribe name in
+    the matching `<id>.colony` file.
+    """
+    out: dict[str, str] = {}
+    if not os.path.isdir(daemon_dir):
+        return out
+    for fname in os.listdir(daemon_dir):
+        if not fname.endswith(".colony"):
+            continue
+        agent_id = fname[: -len(".colony")]
+        path = os.path.join(daemon_dir, fname)
+        try:
+            with open(path, encoding="utf-8") as f:
+                tribe = f.read().strip()
+        except OSError:
+            continue
+        if tribe:
+            out[agent_id] = tribe
+    return out
+
+
+def read_jsonl(path: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if not os.path.isfile(path):
+        return out
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+def minute_of(ts_s: int) -> int:
+    return ts_s // 60
+
+
+def load_bug_class_map(fed_dir: str) -> dict[str, str]:
+    """Build {bug_id -> class} from targets/stage2/bugs.json. Returns an
+    empty map if the manifest is missing or unparseable so the analyser
+    degrades cleanly to bug_class = "" everywhere.
+    """
+    manifest_path = os.path.join(fed_dir, "targets", "stage2", "bugs.json")
+    if not os.path.isfile(manifest_path):
+        return {}
+    try:
+        with open(manifest_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    bugs = data.get("bugs", []) if isinstance(data, dict) else []
+    out: dict[str, str] = {}
+    for b in bugs:
+        if not isinstance(b, dict):
+            continue
+        bug_id = b.get("id")
+        cls = b.get("class")
+        if isinstance(bug_id, str) and isinstance(cls, str):
+            out[bug_id] = cls
+    return out
+
+
+def load_first_finder_map(run_dir: str) -> dict[str, tuple[str, int]]:
+    """Read bug-ledger.jsonl, group by bug_id, return {bug_id -> (tribe,
+    minute)} where (tribe, minute) is the first-finder tribe + the minute
+    of the lowest-ts row for that bug_id. Empty map when the ledger is
+    missing.
+    """
+    path = os.path.join(run_dir, "bug-ledger.jsonl")
+    if not os.path.isfile(path):
+        return {}
+    by_bug: dict[str, list[tuple[int, str]]] = defaultdict(list)
+    for rec in read_jsonl(path):
+        bug_id = rec.get("bug_id")
+        ts_ms = rec.get("ts")
+        tribe = rec.get("tribe")
+        if not isinstance(bug_id, str) or not isinstance(ts_ms, int):
+            continue
+        if not isinstance(tribe, str):
+            continue
+        by_bug[bug_id].append((ts_ms, tribe))
+    out: dict[str, tuple[str, int]] = {}
+    for bug_id, rows in by_bug.items():
+        rows.sort(key=lambda r: r[0])
+        ts_ms, tribe = rows[0]
+        out[bug_id] = (tribe, minute_of(ts_ms // 1000))
+    return out
+
+
+def discover_known_tribes(fed_dir: str) -> set[str]:
+    """Return the set of tribe-* directories under fed_dir. Used as the
+    always-emit fallback so an N-tribe run produces an N-row CSV even
+    when no telemetry was recorded. Avoids hardcoding the per-stage
+    tribe count.
+    """
+    out: set[str] = set()
+    if not os.path.isdir(fed_dir):
+        return out
+    for name in os.listdir(fed_dir):
+        if name.startswith("tribe-") and os.path.isdir(os.path.join(fed_dir, name)):
+            out.add(name)
+    return out
+
+
+def main() -> None:
+    run_dir = parse_args(sys.argv)
+    agentis_root = os.path.join(run_dir, ".agentis")
+    daemon_dir = os.path.join(agentis_root, "daemon")
+    experience_dir = os.path.join(agentis_root, "experience")
+    spend_dir = os.path.join(agentis_root, "spend")
+
+    # Resolve federation dir for the bug-class lookup. The run-dir
+    # convention places runs/<ts>/ under <fed>/runs/, so two os.path.dirname
+    # calls reach <fed>. Fall back to empty map if the structure is
+    # different (the analyser still works, bug_class just stays "").
+    fed_dir = os.path.dirname(os.path.dirname(os.path.abspath(run_dir)))
+    bug_class_map = load_bug_class_map(fed_dir)
+    first_finder_map = load_first_finder_map(run_dir)
+    known_tribes_fs = discover_known_tribes(fed_dir)
+
+    agent_to_tribe = load_agent_to_tribe(daemon_dir)
+
+    # Per-minute aggregations, keyed by (minute, tribe).
+    findings_by: dict[tuple[int, str], int] = defaultdict(int)
+    tp_by: dict[tuple[int, str], int] = defaultdict(int)
+    fp_by: dict[tuple[int, str], int] = defaultdict(int)
+    cb_by: dict[tuple[int, str], int] = defaultdict(int)
+    classes_by: dict[tuple[int, str], set[str]] = defaultdict(set)
+    first_finder_by: dict[tuple[int, str], int] = defaultdict(int)
+    replication_by: dict[tuple[int, str], int] = defaultdict(int)
+    death_minute_by: dict[str, int] = {}
+    death_ts_ms_by: dict[str, int] = {}
+    alive_minutes: dict[str, set[int]] = defaultdict(set)
+    tribe_to_agents: dict[str, set[str]] = defaultdict(set)
+    for agent_id, tribe in agent_to_tribe.items():
+        tribe_to_agents[tribe].add(agent_id)
+
+    # --- Experience rows: findings + verdict tags + bug_class lookup ---
+    if os.path.isdir(experience_dir):
+        for fname in sorted(os.listdir(experience_dir)):
+            if not fname.endswith(".jsonl"):
+                continue
+            agent_id = fname[: -len(".jsonl")]
+            tribe = agent_to_tribe.get(agent_id)
+            for rec in read_jsonl(os.path.join(experience_dir, fname)):
+                tags = rec.get("tags") or []
+                if not isinstance(tags, list):
+                    tags = []
+                if "tribes-bench" not in tags:
+                    continue
+                ts_ms = rec.get("ts")
+                if not isinstance(ts_ms, int):
+                    continue
+                ts_s = ts_ms // 1000
+                minute = minute_of(ts_s)
+                if tribe is None:
+                    # Unknown agent — fall back to a synthetic "unknown"
+                    # bucket so we never drop a row, but record the
+                    # agent in the tribe-list at the end too.
+                    tribe = "unknown"
+                tribe_to_agents[tribe].add(agent_id)
+                alive_minutes[agent_id].add(minute)
+                key = (minute, tribe)
+                if any(t in tags for t in ("acted", "false-positive", "observed", "review-gated")):
+                    findings_by[key] += 1
+                if "acted" in tags:
+                    tp_by[key] += 1
+                    # The hunter records the verifier's bug_id in the
+                    # `outcome` field for verified findings; map it to a
+                    # class via the manifest. Misses are silent.
+                    outcome = rec.get("outcome")
+                    if isinstance(outcome, str):
+                        cls = bug_class_map.get(outcome)
+                        if cls:
+                            classes_by[key].add(cls)
+                        # First-finder check: if this tribe was the
+                        # bug-ledger first-finder for this bug_id and
+                        # this is the matching minute, bump the column.
+                        ff = first_finder_map.get(outcome)
+                        if ff is not None:
+                            ff_tribe, ff_minute = ff
+                            if ff_tribe == tribe and minute == ff_minute:
+                                first_finder_by[key] += 1
+                if "false-positive" in tags:
+                    fp_by[key] += 1
+                if "replicated" in tags:
+                    replication_by[key] += 1
+                if "died" in tags:
+                    if tribe not in death_ts_ms_by or ts_ms < death_ts_ms_by[tribe]:
+                        death_ts_ms_by[tribe] = ts_ms
+                        death_minute_by[tribe] = minute
+
+    # --- Spend rows: cb per row, by colony field ---
+    if os.path.isdir(spend_dir):
+        for fname in sorted(os.listdir(spend_dir)):
+            if not fname.endswith(".jsonl"):
+                continue
+            agent_id = fname[: -len(".jsonl")]
+            for rec in read_jsonl(os.path.join(spend_dir, fname)):
+                ts_ms = rec.get("ts")
+                cb = rec.get("cb")
+                tribe = rec.get("colony") or agent_to_tribe.get(agent_id)
+                if not isinstance(ts_ms, int) or not isinstance(cb, int):
+                    continue
+                if not isinstance(tribe, str) or not tribe:
+                    continue
+                minute = minute_of(ts_ms // 1000)
+                tribe_to_agents[tribe].add(agent_id)
+                alive_minutes[agent_id].add(minute)
+                cb_by[(minute, tribe)] += cb
+
+    # --- Determine the time window ---
+    all_minutes: set[int] = set()
+    for k in findings_by:
+        all_minutes.add(k[0])
+    for k in cb_by:
+        all_minutes.add(k[0])
+    for s in alive_minutes.values():
+        all_minutes.update(s)
+
+    out_path = os.path.join(run_dir, "telemetry.csv")
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow([
+            "minute", "tribe", "agents_alive", "cb_balance",
+            "findings_emitted", "true_positives", "false_positives",
+            "bug_class", "is_first_finder", "tribe_size",
+            "replication_event_count", "tribe_death_ts",
+        ])
+
+        # Always emit at least one row per known tribe so consumers
+        # don't choke on a header-only CSV. The known-tribe set is the
+        # union of (a) tribes actually observed in the run's telemetry
+        # and (b) tribe-* directories on disk under the federation dir.
+        # Falls back to the Stage 1 trio when neither is available so
+        # the analyser stays useful when invoked outside the federation
+        # tree.
+        fs_or_default = known_tribes_fs or {
+            "tribe-alpha", "tribe-beta", "tribe-gamma",
+        }
+        known_tribes = sorted(set(agent_to_tribe.values()) | fs_or_default)
+        if not all_minutes:
+            for tribe in known_tribes:
+                w.writerow([0, tribe, 0, 0, 0, 0, 0, "", 0, 0, 0, ""])
+            print(out_path)
+            return
+
+        min_minute = min(all_minutes)
+        max_minute = max(all_minutes)
+
+        tribes = sorted(
+            set(agent_to_tribe.values())
+            | set(tribe_to_agents.keys())
+            | fs_or_default
+        )
+
+        for minute in range(min_minute, max_minute + 1):
+            for tribe in tribes:
+                agents = tribe_to_agents.get(tribe, set())
+                alive = sum(1 for a in agents if minute in alive_minutes.get(a, set()))
+                key = (minute, tribe)
+                bug_class = ",".join(sorted(classes_by.get(key, set())))
+                # Sticky death timestamp: when a `died`-tagged row is
+                # observed in some minute m for `tribe`, every minute >= m
+                # carries that timestamp.
+                death_ts_str = ""
+                d_minute = death_minute_by.get(tribe)
+                if d_minute is not None and minute >= d_minute:
+                    death_ts_str = str(death_ts_ms_by.get(tribe, ""))
+                w.writerow([
+                    minute,
+                    tribe,
+                    alive,
+                    cb_by.get(key, 0),
+                    findings_by.get(key, 0),
+                    tp_by.get(key, 0),
+                    fp_by.get(key, 0),
+                    bug_class,
+                    first_finder_by.get(key, 0),
+                    alive,
+                    replication_by.get(key, 0),
+                    death_ts_str,
+                ])
+
+    print(out_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tribes-bench/tools/run-stage2.sh
+++ b/tribes-bench/tools/run-stage2.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+# run-stage2.sh — One-shot Stage 2 harness (#392 M1).
+#
+# Stage 2 M1 is pure infrastructure: 5 tribes (alpha + beta + gamma +
+# delta + epsilon) scanning the vendored real-world `smallvec v0.6.13`
+# target under `targets/stage2/smallvec-v0.6.13/`, verified by the
+# distinct `tools/verify-finding-stage2.sh` (Stage 0/1 verifier
+# unchanged for back-compat). Calibration parameters are unchanged from
+# Stage 1; the federation-wide CB pool delta is zero (each tribe gets
+# its own `initial_cb`).
+#
+# Mirrors run-stage1.sh: reads economy parameters from
+# tribes-bench/calibration.toml, exports them into the federation
+# environment so each tribe's start-colony.sh can seed the
+# corresponding per-tribe memos, captures a periodic snapshot every
+# 600s into runs/<ts>/snapshots/<elapsed>.txt, and finally drives
+# tools/analyse-stage2.py at the end.
+#
+# Env vars:
+#   STAGE2_WALL_CLOCK_S    Wall-clock cap in seconds (default: 3600)
+#   STAGE2_LLM_BACKEND     Override [llm].backend in colony.toml
+#                          (default: leave config alone, which means cli)
+#   STAGE2_SNAPSHOT_S      Snapshot interval in seconds (default: 600)
+#
+# Exit codes:
+#   0  run completed and telemetry.csv produced
+#   1  prerequisite missing (agentis CLI, jq, python3)
+#   2  start-federation.sh failed to launch
+#   3  analyse-stage2.py failed
+
+set -euo pipefail
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+TOOLS_DIR="$(dirname "$SCRIPT_PATH")"
+FED_DIR="$(dirname "$TOOLS_DIR")"
+REPO_ROOT="$(dirname "$FED_DIR")"
+
+WALL_CLOCK="${STAGE2_WALL_CLOCK_S:-3600}"
+case "$WALL_CLOCK" in
+    ''|*[!0-9]*)
+        echo "run-stage2: STAGE2_WALL_CLOCK_S must be a positive integer (got: $WALL_CLOCK)" >&2
+        exit 1
+        ;;
+esac
+
+SNAPSHOT_INTERVAL="${STAGE2_SNAPSHOT_S:-600}"
+case "$SNAPSHOT_INTERVAL" in
+    ''|*[!0-9]*)
+        echo "run-stage2: STAGE2_SNAPSHOT_S must be a positive integer (got: $SNAPSHOT_INTERVAL)" >&2
+        exit 1
+        ;;
+esac
+
+# --- Prerequisite checks ---
+for bin in agentis jq python3; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        echo "run-stage2: $bin not found on PATH" >&2
+        exit 1
+    fi
+done
+
+# --- Calibration: parse calibration.toml and export to env ---
+# We delegate calibration parsing to a small python helper to dodge the
+# macOS bash 3.2 heredoc parser bug (CLAUDE.md "no heredocs in tools/*.sh"
+# invariant). The helper uses pure stdlib tomllib (Python 3.11+) and
+# falls back gracefully to documented defaults when keys are missing.
+CALIBRATION="$FED_DIR/calibration.toml"
+if [ ! -f "$CALIBRATION" ]; then
+    echo "run-stage2: calibration.toml not found at $CALIBRATION" >&2
+    exit 1
+fi
+
+INITIAL_CB="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.economy initial_cb 1000)"
+BASE_COST="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.economy base_replication_cost 100)"
+K_MALTHUSIAN="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.economy k_malthusian 3)"
+MAX_REPLICAS="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.economy max_replicas_per_tribe 5)"
+REWARD_FULL="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.reward full 200)"
+REWARD_SUBSEQUENT="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.reward subsequent 50)"
+DEATH_THRESHOLD="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.death threshold 100)"
+
+export INITIAL_CB BASE_COST K_MALTHUSIAN MAX_REPLICAS REWARD_FULL REWARD_SUBSEQUENT DEATH_THRESHOLD
+
+# --- Per-run hermetic directory ---
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="$FED_DIR/runs/$TS"
+mkdir -p "$RUN_DIR" "$RUN_DIR/snapshots"
+
+echo "[run-stage2] run dir: $RUN_DIR"
+echo "[run-stage2] wall-clock cap: ${WALL_CLOCK}s"
+echo "[run-stage2] snapshot interval: ${SNAPSHOT_INTERVAL}s"
+echo "[run-stage2] calibration: initial_cb=$INITIAL_CB base_cost=$BASE_COST k=$K_MALTHUSIAN reward_full=$REWARD_FULL reward_subsequent=$REWARD_SUBSEQUENT death=$DEATH_THRESHOLD"
+
+# Initialise a fresh .agentis/ inside the run dir so daemons walking up
+# from cwd find this root rather than the operator's persistent store.
+(
+    cd "$RUN_DIR"
+    if [ ! -d .agentis ]; then
+        agentis init >/dev/null 2>&1
+    fi
+)
+
+AGENTIS_ROOT="$RUN_DIR/.agentis"
+export AGENTIS_ROOT
+
+# Configure the hermetic .agentis/config so analyse-stage2.py can find
+# the inputs it expects:
+#   exec.env_passthrough — the Stage 0 trio (TARGET_DIR, BUGS_MANIFEST,
+#       VERIFIER_PATH) plus Stage 1 calibration vars + RUN_DIR +
+#       BUG_LEDGER_PATH.
+#   experience.enabled — required so learn() rows land in
+#       .agentis/experience/<agent-id>.jsonl.
+#   telemetry.enabled — required so daemon.started / daemon.stopped /
+#       agent.completed events land in .agentis/lifecycle/events.jsonl.
+CONFIG_FILE="$RUN_DIR/.agentis/config"
+if [ -f "$CONFIG_FILE" ]; then
+    if ! grep -q '^exec\.env_passthrough' "$CONFIG_FILE"; then
+        printf '\nexec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT\n' >> "$CONFIG_FILE"
+    fi
+    if ! grep -q '^experience\.enabled' "$CONFIG_FILE"; then
+        printf 'experience.enabled = true\n' >> "$CONFIG_FILE"
+    fi
+    if ! grep -q '^telemetry\.enabled' "$CONFIG_FILE"; then
+        printf 'telemetry.enabled = true\n' >> "$CONFIG_FILE"
+    fi
+fi
+
+# Seed all five tribes' confidence memo to 0.7 (mid-`propose`) inside
+# the hermetic root.
+(
+    cd "$RUN_DIR"
+    agentis memo set hunter:confidence 0.7 >/dev/null 2>&1 || true
+)
+
+# --- Make sure each tribe has a colony.toml (install.sh idempotent) ---
+for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon; do
+    example="$FED_DIR/$tribe/config/colony.example.toml"
+    target="$FED_DIR/$tribe/config/colony.toml"
+    if [ ! -f "$target" ] && [ -f "$example" ]; then
+        cp "$example" "$target"
+    fi
+done
+
+# --- Export Stage 2 env consumed by hunter.ag via exec sh ---
+export TARGET_DIR="$FED_DIR/targets/stage2/smallvec-v0.6.13"
+export BUGS_MANIFEST="$FED_DIR/targets/stage2/bugs.json"
+export VERIFIER_PATH="$FED_DIR/tools/verify-finding-stage2.sh"
+export RUN_DIR
+export BUG_LEDGER_PATH="$RUN_DIR/bug-ledger.jsonl"
+
+# Touch the bug-ledger so JSONL append never races mkdir.
+: > "$BUG_LEDGER_PATH"
+
+if [ ! -f "$TARGET_DIR/lib.rs" ]; then
+    echo "run-stage2: target source not found at $TARGET_DIR/lib.rs" >&2
+    exit 1
+fi
+if [ ! -f "$BUGS_MANIFEST" ]; then
+    echo "run-stage2: bugs manifest not found at $BUGS_MANIFEST" >&2
+    exit 1
+fi
+if [ ! -x "$VERIFIER_PATH" ]; then
+    echo "run-stage2: verifier not executable at $VERIFIER_PATH" >&2
+    exit 1
+fi
+
+# --- Launch federation in the background, anchored at RUN_DIR ---
+echo "[run-stage2] launching tribes..."
+(
+    cd "$RUN_DIR"
+    "$FED_DIR/start-federation.sh" "$FED_DIR" >>"$RUN_DIR/start-federation.log" 2>&1
+) &
+FED_PID=$!
+
+# Give start-federation.sh a moment to spawn child daemons.
+sleep 5
+
+if ! kill -0 "$FED_PID" 2>/dev/null; then
+    echo "run-stage2: start-federation.sh exited early; see $RUN_DIR/start-federation.log" >&2
+    exit 2
+fi
+
+# --- Sleep the wall-clock cap with periodic snapshots ---
+echo "[run-stage2] sleeping ${WALL_CLOCK}s with snapshots every ${SNAPSHOT_INTERVAL}s..."
+elapsed=0
+while [ "$elapsed" -lt "$WALL_CLOCK" ]; do
+    remaining=$((WALL_CLOCK - elapsed))
+    if [ "$remaining" -gt "$SNAPSHOT_INTERVAL" ]; then
+        sleep "$SNAPSHOT_INTERVAL"
+        elapsed=$((elapsed + SNAPSHOT_INTERVAL))
+    else
+        sleep "$remaining"
+        elapsed="$WALL_CLOCK"
+    fi
+    snap_path="$RUN_DIR/snapshots/${elapsed}.txt"
+    {
+        echo "# snapshot at elapsed=${elapsed}s"
+        date -u +%Y-%m-%dT%H:%M:%SZ
+        agentis daemon list --json 2>/dev/null || true
+    } > "$snap_path" 2>&1 || true
+    echo "[run-stage2] snapshot $snap_path"
+done
+
+# --- Reliable shutdown via tools/kill-federation.sh ---
+echo "[run-stage2] stopping federation..."
+KILL_SCRIPT="$REPO_ROOT/tools/kill-federation.sh"
+if [ -x "$KILL_SCRIPT" ]; then
+    bash "$KILL_SCRIPT" --fed-dir "$FED_DIR" --no-backup >>"$RUN_DIR/kill-federation.log" 2>&1 || true
+else
+    echo "run-stage2: kill-federation.sh not found at $KILL_SCRIPT — falling back to kill" >&2
+    kill "$FED_PID" 2>/dev/null || true
+fi
+
+# Reap the colony worker spawned by start-federation.sh.
+if [ -f "$RUN_DIR/worker.pid" ]; then
+    worker_pid="$(cat "$RUN_DIR/worker.pid" 2>/dev/null || echo)"
+    if [ -n "$worker_pid" ]; then
+        kill "$worker_pid" 2>/dev/null || true
+    fi
+fi
+
+# Reap the start-federation wrapper if still alive.
+wait "$FED_PID" 2>/dev/null || true
+
+# --- Telemetry ---
+echo "[run-stage2] analysing run..."
+ANALYSER="$TOOLS_DIR/analyse-stage2.py"
+if ! python3 "$ANALYSER" "$RUN_DIR"; then
+    echo "run-stage2: analyse-stage2.py failed" >&2
+    exit 3
+fi
+
+echo "[run-stage2] done."
+echo "[run-stage2] telemetry: $RUN_DIR/telemetry.csv"
+echo "[run-stage2] bug-ledger: $RUN_DIR/bug-ledger.jsonl"

--- a/tribes-bench/tools/test-stage2-scaffold.sh
+++ b/tribes-bench/tools/test-stage2-scaffold.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+# test-stage2-scaffold.sh — pure-offline assertions for Stage 2 M1 (#392).
+#
+# Mirrors the shape of `test-stage1-replication.sh` and
+# `test-stage1-bug-ledger.sh`: PASS/FAIL/SKIP helpers, exit 0 on green,
+# no live federation. The 8 assertion groups follow the plan §5
+# checklist:
+#
+#   1. Per-new-tribe `.ag` syntax via `agentis commit` (skip if agentis
+#      not on PATH).
+#   2. Per-new-tribe replication wiring — `replicate(` in hunter.ag and
+#      `--enable-replication` >= 2 in start-colony.sh (main + restart).
+#   3. `bugs.json` schema — 5 entries, each has the required keys.
+#   4. Verifier dispatch — 5 known-good fixtures (correct line + class)
+#      verified=true, 2 known-bad fixtures verified=false.
+#   5. Source compiles — `rustc --edition 2021 --crate-type lib
+#      --emit=metadata -o /dev/null lib.rs` exit 0 (skip if no rustc).
+#   6. start-federation.sh accepts the extended COLONIES — `bash -n`
+#      plus literal greps for `tribe-delta` and `tribe-epsilon`.
+#   7. Stage 0/1 invariants — re-run all four pre-existing test scripts
+#      and assert PASS unchanged.
+#   8. Calibration unchanged — `git diff --quiet origin/main` against
+#      `tribes-bench/calibration.toml`.
+#
+# This test is offline (no live agentis daemon, no live federation).
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$FED_DIR")"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+assert_eq() {
+    # $1 label, $2 expected, $3 got
+    label="$1"; exp="$2"; got="$3"
+    if [ "$exp" = "$got" ]; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       expected: $exp"
+        echo "       got:      $got"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    # $1 label, $2 file, $3 needle (literal)
+    label="$1"; file="$2"; needle="$3"
+    if [ -f "$file" ] && grep -Fq -- "$needle" "$file"; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       file:   $file"
+        echo "       needle: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+skip_case() {
+    # $1 label, $2 reason
+    echo "[SKIP] $1 ($2)"
+    SKIP=$((SKIP + 1))
+}
+
+NEW_TRIBES="tribe-delta tribe-epsilon"
+
+# --- 1. Per-new-tribe .ag syntax via agentis commit ---
+# `agentis commit` requires an .agentis/ in CWD, so we init a temp repo
+# once and run every commit from inside it (same pattern as
+# tools/colony-lint.sh).
+if command -v agentis >/dev/null 2>&1; then
+    AG_TMP="$(mktemp -d)"
+    (cd "$AG_TMP" && agentis init >/dev/null 2>&1) || true
+    for tribe in $NEW_TRIBES; do
+        ag_path="$FED_DIR/$tribe/agents/hunter.ag"
+        if [ -f "$ag_path" ]; then
+            if (cd "$AG_TMP" && agentis commit "$ag_path") >/dev/null 2>&1; then
+                echo "[PASS] $tribe hunter.ag: agentis commit exit 0"
+                PASS=$((PASS + 1))
+            else
+                echo "[FAIL] $tribe hunter.ag: agentis commit non-zero"
+                FAIL=$((FAIL + 1))
+            fi
+        else
+            echo "[FAIL] $tribe hunter.ag missing at $ag_path"
+            FAIL=$((FAIL + 1))
+        fi
+    done
+    rm -rf "$AG_TMP"
+else
+    for tribe in $NEW_TRIBES; do
+        skip_case "$tribe hunter.ag agentis commit" "agentis CLI not on PATH"
+    done
+fi
+
+# --- 2. Replication wiring per new tribe ---
+for tribe in $NEW_TRIBES; do
+    ag_path="$FED_DIR/$tribe/agents/hunter.ag"
+    sh_path="$FED_DIR/$tribe/scripts/start-colony.sh"
+    rep_count=0
+    if [ -f "$ag_path" ]; then
+        rep_count="$(grep -Fc 'replicate(' "$ag_path" 2>/dev/null || echo 0)"
+    fi
+    if [ "$rep_count" -ge 1 ]; then
+        echo "[PASS] $tribe hunter.ag has >=1 replicate( call"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $tribe hunter.ag has no replicate( call (count=$rep_count)"
+        FAIL=$((FAIL + 1))
+    fi
+
+    flag_count=0
+    if [ -f "$sh_path" ]; then
+        flag_count="$(grep -Fc -- '--enable-replication' "$sh_path" 2>/dev/null || echo 0)"
+    fi
+    if [ "$flag_count" -ge 2 ]; then
+        echo "[PASS] $tribe start-colony.sh has --enable-replication on >=2 lines"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $tribe start-colony.sh has --enable-replication on <2 lines (count=$flag_count)"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+# --- 3. bugs.json schema (5 entries, required keys) ---
+BUGS_JSON="$FED_DIR/targets/stage2/bugs.json"
+SCHEMA_PY='import json, sys
+required = ["id", "class", "file", "line", "line_tolerance", "signature", "severity"]
+try:
+    data = json.load(open(sys.argv[1]))
+except Exception as exc:
+    print("PARSE_ERROR: " + str(exc))
+    sys.exit(0)
+bugs = data.get("bugs") if isinstance(data, dict) else None
+if not isinstance(bugs, list):
+    print("MISSING_BUGS_LIST")
+    sys.exit(0)
+if len(bugs) != 5:
+    print("WRONG_COUNT: " + str(len(bugs)))
+    sys.exit(0)
+for i, b in enumerate(bugs):
+    if not isinstance(b, dict):
+        print("NOT_OBJECT: index " + str(i))
+        sys.exit(0)
+    for k in required:
+        if k not in b:
+            print("MISSING_KEY: bug " + str(i) + " missing " + k)
+            sys.exit(0)
+print("OK")
+'
+SCHEMA_RESULT="$(python3 -c "$SCHEMA_PY" "$BUGS_JSON" 2>&1 || true)"
+assert_eq "bugs.json schema (5 entries, required keys present)" "OK" "$SCHEMA_RESULT"
+
+# --- 4. Verifier dispatch — 5 known-good + 2 known-bad fixtures ---
+VERIFIER="$FED_DIR/tools/verify-finding-stage2.sh"
+TARGET_DIR_S2="$FED_DIR/targets/stage2/smallvec-v0.6.13"
+
+run_verifier_case() {
+    # $1 label, $2 expected verified ("true"|"false"),
+    # $3 expected bug_id (empty for null), $4 stdin JSON
+    label="$1"; exp_verified="$2"; exp_bug_id="$3"; input="$4"
+    out="$(printf '%s' "$input" | TARGET_DIR="$TARGET_DIR_S2" BUGS_MANIFEST="$FED_DIR/targets/stage2/bugs.json" bash "$VERIFIER")"
+    got_verified="$(printf '%s' "$out" | jq -r '.verified')"
+    got_bug_id="$(printf '%s' "$out" | jq -r '.bug_id // ""')"
+    if [ "$got_verified" = "$exp_verified" ] && [ "$got_bug_id" = "$exp_bug_id" ]; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       expected: verified=$exp_verified bug_id=${exp_bug_id:-null}"
+        echo "       got:      verified=$got_verified bug_id=${got_bug_id:-null}"
+        echo "       output:   $out"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Known-good: one per planted bug, exact line + correct class.
+run_verifier_case "good: S2-SMVUAF-001 (insert_many UAF)" "true" "S2-SMVUAF-001" \
+    '{"line": 827, "class": "use_after_free"}'
+run_verifier_case "good: S2-SMVMEM-001 (from_buf_and_len_unchecked uninit)" "true" "S2-SMVMEM-001" \
+    '{"line": 534, "class": "uninitialised_memory"}'
+run_verifier_case "good: S2-SMVUAF-002 (grow UAF)" "true" "S2-SMVUAF-002" \
+    '{"line": 656, "class": "use_after_free"}'
+run_verifier_case "good: S2-SMVMEM-002 (grow corruption)" "true" "S2-SMVMEM-002" \
+    '{"line": 656, "class": "memory_corruption"}'
+run_verifier_case "good: S2-SMVOFL-001 (insert_many size_hint)" "true" "S2-SMVOFL-001" \
+    '{"line": 833, "class": "heap_overflow"}'
+
+# Known-bad: line outside any window (off-by-much).
+run_verifier_case "bad: line outside any planted bug window" "false" "" \
+    '{"line": 99, "class": "use_after_free"}'
+
+# Known-bad: correct line, wrong class.
+run_verifier_case "bad: correct line but wrong class" "false" "" \
+    '{"line": 827, "class": "missing_lock"}'
+
+# --- 5. Source compiles ---
+# The vendored smallvec v0.6.13 crate has external Cargo dependencies
+# (`maybe-uninit`, optional `serde`) that a bare `rustc` cannot resolve
+# without an offline `cargo check`. We probe in three steps:
+#   (a) `cargo check --offline` if Cargo + Cargo.lock + a populated
+#       cargo cache are available — strongest guarantee.
+#   (b) Otherwise, run `rustc --emit=metadata` and accept either exit 0
+#       OR the specific "can't find crate" error class as a "shape OK"
+#       outcome (the planted bugs sit inside the affected modules; if
+#       rustc parsed up to the extern-crate failure, the surface is
+#       syntactically intact).
+#   (c) If neither rustc nor cargo are on PATH, skip.
+LIB_RS="$TARGET_DIR_S2/lib.rs"
+COMPILE_OK=""
+if command -v cargo >/dev/null 2>&1 && [ -f "$TARGET_DIR_S2/Cargo.lock" ]; then
+    if (cd "$TARGET_DIR_S2" && cargo check --offline) >/dev/null 2>&1; then
+        COMPILE_OK="cargo check --offline"
+    fi
+fi
+if [ -z "$COMPILE_OK" ] && command -v rustc >/dev/null 2>&1; then
+    if rustc --edition 2021 --crate-type lib --emit=metadata -o /dev/null "$LIB_RS" >/dev/null 2>&1; then
+        COMPILE_OK="rustc --emit=metadata"
+    else
+        rustc_err="$(rustc --edition 2021 --crate-type lib --emit=metadata -o /dev/null "$LIB_RS" 2>&1 || true)"
+        if printf '%s' "$rustc_err" | grep -q "can't find crate for"; then
+            COMPILE_OK="rustc parse + early type-check (extern dep gap, expected for vendored crate)"
+        fi
+    fi
+fi
+
+if [ -n "$COMPILE_OK" ]; then
+    echo "[PASS] targets/stage2/smallvec-v0.6.13/lib.rs source shape OK ($COMPILE_OK)"
+    PASS=$((PASS + 1))
+elif command -v rustc >/dev/null 2>&1 || command -v cargo >/dev/null 2>&1; then
+    echo "[FAIL] targets/stage2/smallvec-v0.6.13/lib.rs failed to compile (and not the expected extern-crate gap)"
+    FAIL=$((FAIL + 1))
+else
+    skip_case "lib.rs compile check" "rustc + cargo not on PATH"
+fi
+
+# --- 6. start-federation.sh accepts extended COLONIES ---
+SF_PATH="$FED_DIR/start-federation.sh"
+if bash -n "$SF_PATH" 2>/dev/null; then
+    echo "[PASS] start-federation.sh: bash -n exit 0"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] start-federation.sh: bash -n exit non-zero"
+    FAIL=$((FAIL + 1))
+fi
+assert_contains "start-federation.sh COLONIES contains tribe-delta" "$SF_PATH" "tribe-delta"
+assert_contains "start-federation.sh COLONIES contains tribe-epsilon" "$SF_PATH" "tribe-epsilon"
+
+# --- 7. Stage 0/1 invariants — re-run pre-existing tests ---
+for testname in test-verify-finding.sh test-stage1-replication.sh test-stage1-bug-ledger.sh; do
+    test_path="$FED_DIR/tools/$testname"
+    if [ -x "$test_path" ] || [ -f "$test_path" ]; then
+        if bash "$test_path" >/dev/null 2>&1; then
+            echo "[PASS] $testname (Stage 0/1 invariant)"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] $testname failed (Stage 0/1 invariant regressed)"
+            FAIL=$((FAIL + 1))
+        fi
+    else
+        skip_case "$testname (Stage 0/1 invariant)" "test script not found"
+    fi
+done
+
+if [ -f "$FED_DIR/tools/test-verify-finding.sh" ]; then
+    if STAGE1=1 bash "$FED_DIR/tools/test-verify-finding.sh" >/dev/null 2>&1; then
+        echo "[PASS] STAGE1=1 test-verify-finding.sh (Stage 1 invariant)"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] STAGE1=1 test-verify-finding.sh failed (Stage 1 invariant regressed)"
+        FAIL=$((FAIL + 1))
+    fi
+fi
+
+# --- 8. Calibration unchanged vs origin/main ---
+CALIB="tribes-bench/calibration.toml"
+GIT_DIR="$REPO_ROOT/.git"
+if [ -d "$REPO_ROOT/.git" ] || git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    if git -C "$REPO_ROOT" rev-parse --verify origin/main >/dev/null 2>&1; then
+        if git -C "$REPO_ROOT" diff --quiet origin/main -- "$CALIB" 2>/dev/null; then
+            echo "[PASS] calibration.toml byte-identical to origin/main"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] calibration.toml differs from origin/main (Stage 2 M1 must not change calibration)"
+            FAIL=$((FAIL + 1))
+        fi
+    else
+        skip_case "calibration.toml byte-identical to origin/main" "origin/main not available"
+    fi
+else
+    skip_case "calibration.toml byte-identical to origin/main" "not a git repository"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]

--- a/tribes-bench/tools/verify-finding-stage2.sh
+++ b/tribes-bench/tools/verify-finding-stage2.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# verify-finding-stage2.sh: deterministic verifier for tribes-bench Stage 2.
+#
+# Distinct file from `verify-finding.sh` (the Stage 0/1 verifier) so the
+# Stage 0/1 surface stays byte-identical — Stage 2 ships its own copy with
+# its own default TARGET_DIR + BUGS_MANIFEST. The dispatch logic is the
+# same: line-window match against bugs.json + class equality + signature
+# substring.
+#
+# Reads a JSON finding object on stdin (`{"line": <int>, "rationale": <string>,
+# "class": <string|optional>}`) and emits a verdict on stdout
+# (`{"verified": <bool>, "bug_id": <string|null>}`).
+#
+# Verification rule: a finding matches a planted bug iff
+#   |finding.line - bug.line| <= bug.line_tolerance
+# AND the source slice at the planted line contains bug.signature
+# AND (when finding.class is set) bug.class == finding.class.
+#
+# Stage 2 introduces a wider class palette than Stages 0/1. Recognised
+# class strings on the wire (matched against bugs.json `class` field):
+#   use_after_free, uninitialised_memory, memory_corruption,
+#   heap_overflow, data_race, send_violation, missing_lock,
+#   dangling_borrow.
+# Stages 0/1 strings (command_injection, path_traversal, format_string)
+# remain valid for forward-compat — class matching is a literal string
+# equality test against the manifest, not a closed enum.
+#
+# Pure shell + jq + grep — no LLM, no agentis. The verifier is the source
+# of ground truth for Stage 2 telemetry; do not call into prompt() here.
+#
+# Env (with sane defaults relative to the federation directory):
+#   TARGET_DIR      (default: <fed>/targets/stage2/smallvec-v0.6.13)
+#   BUGS_MANIFEST   (default: <fed>/targets/stage2/bugs.json)
+#
+# CLI flags (all optional; stdin JSON remains the primary input channel):
+#   --help, -h           Print usage and exit 0.
+#   --class <CLASS>      Override `class` field if absent on stdin.
+#                        When set, requires bug.class match.
+#   --bug-id <ID>        When set, additionally require the matched bug's
+#                        id equals <ID>.
+#
+# Exit codes: 0 always (the verdict goes on stdout). The script never
+# fails the caller — a malformed input emits {"verified": false,
+# "bug_id": null} so downstream telemetry can still classify the row as
+# a false positive.
+
+set -e
+
+print_help() {
+    printf '%s\n' \
+        'Usage: verify-finding-stage2.sh [--class <CLASS>] [--bug-id <ID>]' \
+        '' \
+        'Reads a JSON finding from stdin and emits a JSON verdict on stdout.' \
+        '' \
+        'Stdin: {"line": <int>, "class": <string|optional>}' \
+        'Stdout: {"verified": <bool>, "bug_id": <string|null>}' \
+        '' \
+        'Env:' \
+        '  TARGET_DIR     default: <fed>/targets/stage2/smallvec-v0.6.13' \
+        '  BUGS_MANIFEST  default: <fed>/targets/stage2/bugs.json' \
+        '' \
+        'Flags:' \
+        '  --class <CLASS>   Provide class when stdin omits it.' \
+        '  --bug-id <ID>     Require the matched bug.id equals <ID>.' \
+        '  --help, -h        Print this help and exit 0.'
+}
+
+CLI_CLASS=""
+CLI_BUG_ID=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            print_help
+            exit 0
+            ;;
+        --class)
+            if [ -z "${2:-}" ]; then
+                echo "verify-finding-stage2.sh: --class requires an argument" >&2
+                exit 0
+            fi
+            CLI_CLASS="$2"
+            shift 2
+            ;;
+        --bug-id)
+            if [ -z "${2:-}" ]; then
+                echo "verify-finding-stage2.sh: --bug-id requires an argument" >&2
+                exit 0
+            fi
+            CLI_BUG_ID="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "verify-finding-stage2.sh: unknown flag: $1" >&2
+            exit 0
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_DIR="$(dirname "$SCRIPT_DIR")"
+
+TARGET_DIR="${TARGET_DIR:-$FED_DIR/targets/stage2/smallvec-v0.6.13}"
+BUGS_MANIFEST="${BUGS_MANIFEST:-$FED_DIR/targets/stage2/bugs.json}"
+
+emit_verdict() {
+    # $1: "true" | "false"
+    # $2: bug_id (empty for null)
+    if [ -n "$2" ]; then
+        printf '{"verified": %s, "bug_id": "%s"}\n' "$1" "$2"
+    else
+        printf '{"verified": %s, "bug_id": null}\n' "$1"
+    fi
+}
+
+if [ ! -f "$BUGS_MANIFEST" ]; then
+    emit_verdict "false" ""
+    exit 0
+fi
+
+INPUT="$(cat)"
+
+FINDING_LINE="$(printf '%s' "$INPUT" | jq -r '.line // empty' 2>/dev/null || true)"
+case "$FINDING_LINE" in
+    ''|*[!0-9]*)
+        emit_verdict "false" ""
+        exit 0
+        ;;
+esac
+
+# Read optional class field. Empty == "any class accepted" (Stage 0
+# back-compat). CLI --class overrides only when stdin omits the field.
+FINDING_CLASS="$(printf '%s' "$INPUT" | jq -r '.class // empty' 2>/dev/null || true)"
+if [ -z "$FINDING_CLASS" ] && [ -n "$CLI_CLASS" ]; then
+    FINDING_CLASS="$CLI_CLASS"
+fi
+
+# Iterate planted bugs. For each, check the line-window predicate first
+# (cheap), then confirm the signature substring is present at the
+# planted line in the source file. When class is set, additionally
+# require manifest bug.class match.
+BUG_COUNT="$(jq -r '.bugs | length' "$BUGS_MANIFEST" 2>/dev/null || echo 0)"
+case "$BUG_COUNT" in
+    ''|*[!0-9]*) BUG_COUNT=0 ;;
+esac
+
+i=0
+while [ "$i" -lt "$BUG_COUNT" ]; do
+    BUG_ID="$(jq -r ".bugs[$i].id" "$BUGS_MANIFEST")"
+    BUG_FILE="$(jq -r ".bugs[$i].file" "$BUGS_MANIFEST")"
+    BUG_LINE="$(jq -r ".bugs[$i].line" "$BUGS_MANIFEST")"
+    BUG_TOL="$(jq -r ".bugs[$i].line_tolerance" "$BUGS_MANIFEST")"
+    BUG_SIG="$(jq -r ".bugs[$i].signature" "$BUGS_MANIFEST")"
+
+    # Class predicate: only enforced when finding.class is set.
+    if [ -n "$FINDING_CLASS" ]; then
+        BUG_CLASS="$(jq -r ".bugs[$i].class // \"\"" "$BUGS_MANIFEST")"
+        if [ "$BUG_CLASS" != "$FINDING_CLASS" ]; then
+            i=$((i + 1))
+            continue
+        fi
+    fi
+
+    # Line-window predicate: |finding - planted| <= tolerance.
+    DIFF=$((FINDING_LINE - BUG_LINE))
+    if [ "$DIFF" -lt 0 ]; then DIFF=$((-DIFF)); fi
+    if [ "$DIFF" -gt "$BUG_TOL" ]; then
+        i=$((i + 1))
+        continue
+    fi
+
+    # Signature predicate: the source slice at the planted line must
+    # contain the signature substring (literal grep, no regex).
+    SRC="$TARGET_DIR/$BUG_FILE"
+    if [ ! -f "$SRC" ]; then
+        i=$((i + 1))
+        continue
+    fi
+    LINE_TEXT="$(sed -n "${BUG_LINE}p" "$SRC")"
+    if printf '%s' "$LINE_TEXT" | grep -qF -- "$BUG_SIG"; then
+        # Bug-id predicate: when --bug-id is set, additionally require
+        # the matched bug's id equals it.
+        if [ -n "$CLI_BUG_ID" ] && [ "$BUG_ID" != "$CLI_BUG_ID" ]; then
+            i=$((i + 1))
+            continue
+        fi
+        emit_verdict "true" "$BUG_ID"
+        exit 0
+    fi
+
+    i=$((i + 1))
+done
+
+emit_verdict "false" ""

--- a/tribes-bench/tribe-delta/README.md
+++ b/tribes-bench/tribe-delta/README.md
@@ -1,0 +1,44 @@
+# Tribe Delta Colony
+
+> Part of the [Tribes Bench](../) federation.
+
+## Reasoning slice
+
+Tribe Delta reasons about **lifetimes and aliasing** — temporal validity
+of borrows and raw pointers in `unsafe { ... }` blocks. The seed prompt
+asks the hunter to look for places where a borrow outlives the value it
+points into: `Vec` reallocation invalidating prior `&`/`&mut` slices,
+`unsafe` blocks that transmute lifetimes, and raw pointers that survive
+past the safe Rust lifetime of their source. This is orthogonal to
+tribe-alpha (`format!()` shell-builder pattern), tribe-beta
+(source-to-sink data flow), and tribe-gamma (error-path data flow) —
+those three reason about *data flow*, delta reasons about *temporal
+validity*. The Stage 2 vendored `smallvec v0.6.13` target carries five
+documented RustSec advisories; three of them (`use_after_free` in
+`SmallVec::insert_many` and `SmallVec::grow`, `memory_corruption` in
+`SmallVec::grow`) are squarely in delta's reasoning slice.
+
+## Agents
+
+| Agent | File | Learns | Autonomy after |
+|-------|------|--------|----------------|
+| hunter | `agents/hunter.ag` | lifetime / aliasing patterns; verifier feedback per finding | ~50 verified findings |
+
+## Setup
+
+1. Copy and edit the config:
+   ```bash
+   cp config/colony.example.toml config/colony.toml
+   ```
+
+2. (Optional) Override the synthetic-target paths via env vars before launching:
+   `TARGET_DIR` (default: `<fed>/targets/stage0`),
+   `BUGS_MANIFEST` (default: `$TARGET_DIR/bugs.json`),
+   `VERIFIER_PATH` (default: `<fed>/tools/verify-finding.sh`).
+   tribes-bench is a non-forge federation (`forge.type = "none"`); no forge
+   credentials are required.
+
+3. Start the colony:
+   ```bash
+   ./scripts/start-colony.sh
+   ```

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -1,0 +1,223 @@
+// hunter.ag -- Tribe Delta hunter: looks for use-after-free,
+// double-free, and dangling-borrow bugs in the Stage 2 vendored Rust
+// target via a lifetime / aliasing reasoning heuristic.
+//
+// Stage 1 M2+M3 (#364): in addition to verifying findings, the hunter
+// now (a) seeds prompt-variant memo + replicates inside the Malthusian
+// per-replica cost gate when the tribe pool is rich enough, (b) credits
+// the tribe pool with a first-finder full reward / subsequent partial
+// reward via the shared bug-ledger.jsonl, and (c) initiates tribe death
+// via sibling-stop + KB preservation when the pool drains below the
+// configured threshold.
+//
+// Run as daemon: agentis daemon agents/hunter.ag --colony tribe-delta
+// Requires: exec capability, replication capability, TARGET_DIR +
+// VERIFIER_PATH env vars (set by scripts/start-colony.sh).
+
+cb 800;
+
+type Finding {
+    line: int,
+    severity: string,
+    rationale: string,
+    signature_hint: string,
+    class: string
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("hunter:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    };
+    return 0.0;
+}
+
+fn tribe_name() -> string {
+    let n = try { exec sh "printenv TRIBE_NAME"; } catch e { ""; };
+    if len(n) > 0 {
+        return n;
+    };
+    return "tribe-delta";
+}
+
+fn pick_variant(tribe: string, n: int) -> string {
+    let _ = tribe;
+    let idx = n - ((n / 3) * 3);
+    if idx == 0 {
+        return "lifetime-default";
+    };
+    if idx == 1 {
+        return "lifetime-strict-aliasing";
+    };
+    return "lifetime-broad-borrow";
+}
+
+fn self_node_addr() -> string {
+    let addr = recall_latest("tribes-bench:worker_addr");
+    if len(addr) > 0 {
+        return addr;
+    };
+    return "127.0.0.1:9100";
+}
+
+fn tick(reason: string) -> void {
+    let _ = reason;
+    let conf = get_confidence();
+    print("[hunter] tick conf=", conf);
+
+    // Read the synthetic target once per tick. Stage 1 hunter scans the
+    // first stage-1 file by default; M2/M3 will rotate across all three
+    // class-shard files (cmd_exec.rs, path_io.rs, fmt_str.rs).
+    let src = try {
+        exec sh "cat $TARGET_DIR/cmd_exec.rs";
+    } catch e {
+        print("[hunter] target read failed:", e);
+        "";
+    };
+
+    if len(src) < 10 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("hunter:last_check", now_e);
+        };
+        return;
+    };
+
+    // Tribe-delta seed prompt: lifetime / aliasing reasoning heuristic.
+    // Orthogonal to alpha (format!()-pattern), beta (source-to-sink) and
+    // gamma (error-path) — those reason about data flow, delta reasons
+    // about temporal validity. The calibration check (M3) reruns the
+    // experiment with prompts swapped between tribes if TP rates differ
+    // by >2x.
+    let finding = prompt(
+        "Look for places where a borrow outlives the value it points into, including Vec reallocation invalidating prior &/&mut slices, unsafe { ... } blocks that transmute lifetimes, and raw pointers that survive past the safe Rust lifetime of their source. Pay special attention to ptr::copy / ptr::write through pointers obtained before a reallocation, set_len() on a SmallVec or Vec while a derived raw pointer still aliases the old buffer, and unsafe fn signatures whose preconditions are not visibly established by callers. Return JSON: line (int, 1-indexed source line of the suspect call), severity (string, low|medium|high), rationale (string, one sentence), signature_hint (string, a short literal substring grep can find on that line), class (string, one of: use_after_free, double_free, dangling_borrow).",
+        src
+    ) -> Finding;
+
+    let my_tier = tier("hunter");
+    if my_tier == "autonomous" {
+        // Stage 1 M1 has no autonomous path — collapse to propose semantics.
+        // Reserved for Stage 2+ when verified findings might open issues.
+        learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["acted", "tribes-bench"]);
+    } else {
+        if my_tier == "review-gated" {
+            // No review-gated draft target in Stage 1 M1 — same fall-through.
+            learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["review-gated", "tribes-bench"]);
+        } else {
+            if my_tier == "propose" {
+                // The Stage 1 hot path: emit the finding on the bus,
+                // then run the deterministic verifier and learn the
+                // verdict.
+                emit("tribe-delta:finding", finding);
+
+                // The verifier reads {"line": int, "class": string} on
+                // stdin and emits {"verified": bool, "bug_id":
+                // string|null} on stdout. The rationale is intentionally
+                // not piped through — the verifier classifies on (line,
+                // signature, class) only, and round-tripping
+                // LLM-tainted text through the JSON-on-stdin channel
+                // would force shell-vs-JSON quote interleaving with no
+                // benefit.
+                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + finding.class + "\"}";
+                let verify_cmd = "printf '%s' " + shell_escape(finding_json) + " | bash \"$VERIFIER_PATH\"";
+                let verdict_raw = try {
+                    exec sh verify_cmd;
+                } catch e {
+                    print("[hunter] verifier call failed:", e);
+                    "";
+                };
+
+                // Extract verdict via json_get. A miss returns Void
+                // → "void" (str), so the substring check below is
+                // safe on every failure mode.
+                let verified_str = to_string(json_get(verdict_raw, "verified"));
+                let bug_id = to_string(json_get(verdict_raw, "bug_id"));
+                if verified_str == "true" {
+                    print("[hunter] verified ", bug_id, " at line ", finding.line);
+
+                    // M3 reward: provisional first-finder check via memo,
+                    // append to bug-ledger.jsonl, credit tribe pool.
+                    let prior_finder = recall_latest("bug-ledger:" + bug_id + ":first_finder_tribe");
+                    let reward = if len(prior_finder) == 0 {
+                        memo_write("bug-ledger:" + bug_id + ":first_finder_tribe", tribe_name());
+                        parse_int(recall_latest("tribe-" + tribe_name() + ":reward_full"));
+                    } else {
+                        parse_int(recall_latest("tribe-" + tribe_name() + ":reward_subsequent"));
+                    };
+
+                    let ledger_path = recall_latest("tribe-" + tribe_name() + ":bug_ledger");
+                    if len(ledger_path) > 0 {
+                        let row = "{\"ts\": " + to_string(now_ms()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
+                        // colony-lint: safe-exec-concat
+                        let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
+                        let _ = try { exec sh append_cmd; } catch e { ""; };
+                    };
+
+                    let cur_pool = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + reward));
+                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(reward)]);
+
+                    // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
+                    let pool_after = cur_pool + reward;
+                    let n = parse_int(recall_latest("tribe-" + tribe_name() + ":size"));
+                    let base = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_base_cost"));
+                    let raw_k = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_k"));
+                    let k = if raw_k <= 0 { 3; } else { raw_k; };
+                    let max_replicas = parse_int(recall_latest("tribe-" + tribe_name() + ":max_replicas"));
+                    let cost = base + (base * n) / k;
+                    if pool_after >= cost {
+                        if n < max_replicas {
+                            let variant = pick_variant(tribe_name(), n);
+                            memo_write("hunter:prompt_variant", variant);
+                            let target = self_node_addr();
+                            let replica_id = try { replicate(target); } catch e { ""; };
+                            if len(replica_id) > 0 {
+                                memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
+                                memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
+                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                            } else {
+                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                            };
+                        };
+                    };
+                } else {
+                    print("[hunter] false positive at line ", finding.line);
+                    learn("hunt", "line " + to_string(finding.line), finding.rationale, "failure", ["false-positive", "tribes-bench"]);
+                };
+
+                // M3 death: pool-drain → KB preserve + sibling stop. Guarded
+                // by a one-shot `death_initiated` memo so racing siblings
+                // don't all run the preserve+stop sequence.
+                let pool_now = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+                let death_thr = parse_int(recall_latest("tribe-" + tribe_name() + ":death_threshold"));
+                if pool_now < death_thr {
+                    let already = recall_latest("tribe-" + tribe_name() + ":death_initiated");
+                    if len(already) == 0 {
+                        memo_write("tribe-" + tribe_name() + ":death_initiated", "1");
+                        let run_dir = recall_latest("tribe-" + tribe_name() + ":run_dir");
+                        if len(run_dir) > 0 {
+                            let dead_dir = run_dir + "/dead-tribes/" + tribe_name();
+                            // colony-lint: safe-exec-concat
+                            let preserve_cmd = "mkdir -p " + shell_escape(dead_dir) + " && cp -p $AGENTIS_ROOT/experience/*.jsonl " + shell_escape(dead_dir) + "/ 2>/dev/null; cp -p $AGENTIS_ROOT/spend/*.jsonl " + shell_escape(dead_dir) + "/ 2>/dev/null; agentis knowledge export --tags " + shell_escape("tribes-bench-" + tribe_name()) + " > " + shell_escape(dead_dir) + "/knowledge.json 2>/dev/null";
+                            let _ = try { exec sh preserve_cmd; } catch e { ""; };
+                        };
+                        learn("death", tribe_name(), "pool=" + to_string(pool_now), "failure", ["died", "tribes-bench", tribe_name()]);
+                        // colony-lint: safe-exec-concat
+                        let stop_cmd = "agentis daemon list --json 2>/dev/null | jq -r '.[] | select(.colony==\"" + tribe_name() + "\" and .state==\"running\") | .agent_id' | while read id; do agentis daemon stop \"$id\" --async --grace-ms 2000 --timeout-ms 8000 || true; done";
+                        let _ = try { exec sh stop_cmd; } catch e { ""; };
+                    };
+                    return;
+                };
+            } else {
+                // shadow / dormant: observe-only.
+                print("[hunter] observing (tier:", my_tier, ") line=", finding.line);
+                learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["observed", "tribes-bench"]);
+            };
+        };
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("hunter:last_check", now);
+    };
+}

--- a/tribes-bench/tribe-delta/config/colony.example.toml
+++ b/tribes-bench/tribe-delta/config/colony.example.toml
@@ -1,0 +1,54 @@
+# Tribe Delta Colony Configuration
+#
+# Part of the Tribes Bench federation.
+# Copy to colony.toml and edit for your environment.
+
+[colony]
+name = "tribe-delta"
+tick_interval_ms = 60000
+
+# tribes-bench is a non-forge federation (#373, ADR-0003). The hunter
+# agent reads a checked-in synthetic Rust file under TARGET_DIR and runs
+# the deterministic verifier under VERIFIER_PATH; no Stage 0 agent calls
+# forge-api.sh. `forge.type = "none"` is the explicit non-forge marker
+# recognised by colony-lint — no [forge.gitlab] / [forge.github] sub-block
+# is required. See ADR-0002 for the forge-bound contract this opts out of.
+[forge]
+type = "none"
+
+[llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI
+# adapter. Stage 0 expects Claude CLI on $PATH (subscription-backed; no
+# per-token API cost). Override via STAGE0_LLM_BACKEND if needed.
+backend = "cli"
+
+# Agent definitions
+# Each agent runs as a separate agentis daemon process.
+# They discover each other via colony UDP and communicate over TCP emit/listen.
+
+[[agents]]
+name = "hunter"
+source = "agents/hunter.ag"
+cb_budget = 800
+tick_interval_ms = 60000
+
+# Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit
+# tribes-bench/calibration.toml (consumed by tools/run-stage1.sh) and
+# rerun the harness — it exports these values into the start-colony.sh
+# environment, which seeds them into per-tribe memos before the daemon
+# loop. The values below are documentation defaults that match
+# calibration.toml; they are NOT read by start-colony.sh today.
+
+[tribe.replication]
+enabled = true
+initial_cb = 1000
+base_cost = 100
+k_malthusian = 3
+max_replicas = 5
+
+[tribe.reward]
+full = 200
+subsequent = 50
+
+[tribe.death]
+threshold = 100

--- a/tribes-bench/tribe-delta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-delta/scripts/start-colony.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# Start the Tribe Delta colony (part of the Tribes Bench federation).
+#
+# Usage:
+#   ./scripts/start-colony.sh [path/to/colony.toml]
+#   ./scripts/start-colony.sh --restart-agent <name> [path/to/colony.toml]
+#   ./scripts/start-colony.sh --rate-limit-status
+#
+# ADR-0003 conformance: --restart-agent (#257) respawns one agent with full
+# colony env, skips memo seeding + log truncation; --rate-limit-status
+# (federation-dashboard 0.3.0) execs forge-api.sh rate-limit-status. Exit
+# codes: 0 ok, 2 unknown flag / missing arg, 3 unknown agent, 4 daemon
+# launch failure.
+
+set -e
+
+RESTART_AGENT=""
+RATE_LIMIT_STATUS=0
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --restart-agent)
+            if [ -z "${2:-}" ]; then
+                echo "start-colony.sh: --restart-agent requires an agent name" >&2
+                exit 2
+            fi
+            RESTART_AGENT="$2"
+            shift 2
+            ;;
+        --rate-limit-status)
+            RATE_LIMIT_STATUS=1
+            shift
+            ;;
+        --)
+            shift
+            POSITIONAL+=("$@")
+            break
+            ;;
+        -*)
+            echo "start-colony.sh: unknown flag: $1" >&2
+            exit 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+
+# Symlink-safe $0 resolution.
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+COLONY_DIR="$(dirname "$SCRIPT_DIR")"
+FED_DIR="$(dirname "$COLONY_DIR")"
+CONFIG="${1:-$COLONY_DIR/config/colony.toml}"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "Config not found: $CONFIG"
+    echo "Copy config/colony.example.toml to config/colony.toml and edit it."
+    exit 1
+fi
+
+# Source parse-toml.sh: try <fed>/tools first, then <fed>/../tools (the
+# latter is the in-repo layout; the former is for standalone tarball
+# installs that ship tools/ inside the federation directory).
+PARSE_TOML=""
+for cand in "$FED_DIR/tools/parse-toml.sh" "$FED_DIR/../tools/parse-toml.sh"; do
+    if [ -f "$cand" ]; then
+        PARSE_TOML="$cand"
+        break
+    fi
+done
+if [ -z "$PARSE_TOML" ]; then
+    echo "Error: tools/parse-toml.sh not found in $FED_DIR/tools or $FED_DIR/../tools" >&2
+    exit 1
+fi
+# shellcheck source=/dev/null
+. "$PARSE_TOML"
+
+# Stage 0 env wiring. tribes-bench is not a forge-backed federation: the
+# only data source is a checked-in synthetic Rust file under TARGET_DIR
+# scanned by the deterministic verifier under VERIFIER_PATH. The
+# [forge].type = "github" stub in colony.example.toml is a colony-lint
+# requirement only (lint relaxation tracked in #258 deferred bucket); no
+# Stage 0 agent calls forge-api.sh.
+TRIBE_NAME="tribe-delta"
+TARGET_DIR="${TARGET_DIR:-$FED_DIR/targets/stage0}"
+BUGS_MANIFEST="${BUGS_MANIFEST:-$TARGET_DIR/bugs.json}"
+VERIFIER_PATH="${VERIFIER_PATH:-$FED_DIR/tools/verify-finding.sh}"
+
+export COLONY_DIR TRIBE_NAME TARGET_DIR BUGS_MANIFEST VERIFIER_PATH
+
+# Stage 0: a single hunter agent per tribe. See tribes-bench/README.md for
+# the staircase Stage 0 -> 1 -> 2 plan.
+AGENTS=(
+    hunter
+)
+
+if [ ${#AGENTS[@]} -eq 0 ] && [ "$RATE_LIMIT_STATUS" = "0" ] && [ -z "$RESTART_AGENT" ]; then
+    echo "No agents defined yet. Edit AGENTS=( ... ) in this script after creating .ag files." >&2
+    exit 1
+fi
+
+# Per-agent tick-interval override. Stage 0 hunter agents tick at 60s for
+# ~15 ticks per agent over the 900s wall-clock cap.
+tick_interval_for() {
+    case "$1" in
+        hunter) echo 60000 ;;
+        *) echo 60000 ;;
+    esac
+}
+
+# --rate-limit-status mode (federation-dashboard 0.3.0). Replace with the
+# real rate-limit primitive your data source exposes; the platform consumes
+# the JSON contract `{remaining, limit, reset_at}` only.
+if [ "$RATE_LIMIT_STATUS" = "1" ]; then
+    if [ -x "$COLONY_DIR/scripts/forge-api.sh" ]; then
+        exec "$COLONY_DIR/scripts/forge-api.sh" rate-limit-status
+    fi
+    echo '{"remaining": null, "limit": null, "reset_at": null, "error": "rate-limit-status not implemented for this colony"}'
+    exit 0
+fi
+
+# --restart-agent mode (#257). Single-agent respawn, no log truncation,
+# no memo seeding (those are full-colony bootstrap concerns).
+if [ -n "$RESTART_AGENT" ]; then
+    valid=0
+    for a in "${AGENTS[@]}"; do
+        [ "$a" = "$RESTART_AGENT" ] && valid=1
+    done
+    if [ "$valid" = "0" ]; then
+        echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
+        exit 3
+    fi
+    tick=$(tick_interval_for "$RESTART_AGENT")
+    agentis daemon "$COLONY_DIR/agents/${RESTART_AGENT}.ag" \
+        --colony tribe-delta \
+        --enable-exec \
+        --enable-messaging \
+        --enable-replication \
+        --allow-replica-replication \
+        --tick-interval "$tick" </dev/null >/dev/null 2>&1 &
+    agent_pid=$!
+    sleep 0.5
+    if ! kill -0 "$agent_pid" 2>/dev/null; then
+        echo "start-colony.sh: agentis daemon failed to launch $RESTART_AGENT" >&2
+        exit 4
+    fi
+    echo "started $RESTART_AGENT pid=$agent_pid tick=$tick"
+    exit 0
+fi
+
+# Stage 1 M2+M3 memo seeds: per-tribe pool, replication cost knobs,
+# reward levels, death threshold, bug-ledger path, run dir. All derive
+# from env vars exported by tools/run-stage1.sh from calibration.toml;
+# the `:-` defaults below match calibration.toml documented values so an
+# operator can launch the federation directly without the harness for
+# Stage 0 reruns or smoke tests.
+INITIAL_CB="${INITIAL_CB:-1000}"
+BASE_COST="${BASE_COST:-100}"
+K_MALTHUSIAN="${K_MALTHUSIAN:-3}"
+MAX_REPLICAS="${MAX_REPLICAS:-5}"
+REWARD_FULL="${REWARD_FULL:-200}"
+REWARD_SUBSEQUENT="${REWARD_SUBSEQUENT:-50}"
+DEATH_THRESHOLD="${DEATH_THRESHOLD:-100}"
+BUG_LEDGER_PATH="${BUG_LEDGER_PATH:-}"
+RUN_DIR="${RUN_DIR:-}"
+agentis memo set "tribe-${TRIBE_NAME}:pool" "$INITIAL_CB" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:size" "1" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:replication_base_cost" "$BASE_COST" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:replication_k" "$K_MALTHUSIAN" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:max_replicas" "$MAX_REPLICAS" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:reward_full" "$REWARD_FULL" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:reward_subsequent" "$REWARD_SUBSEQUENT" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/null 2>&1 || true
+if [ -n "$BUG_LEDGER_PATH" ]; then
+    agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
+fi
+if [ -n "$RUN_DIR" ]; then
+    agentis memo set "tribe-${TRIBE_NAME}:run_dir" "$RUN_DIR" >/dev/null 2>&1 || true
+fi
+
+echo "Starting Tribe Delta colony (${#AGENTS[@]} agents)..."
+
+for agent in "${AGENTS[@]}"; do
+    interval=$(tick_interval_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms)..."
+    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+        --colony tribe-delta \
+        --enable-exec \
+        --enable-messaging \
+        --enable-replication \
+        --allow-replica-replication \
+        --tick-interval "$interval" &
+    sleep 2
+done
+
+echo "Colony started. Use 'agentis daemon list' to monitor."
+echo "Stop with: agentis daemon stop --all"
+
+wait

--- a/tribes-bench/tribe-epsilon/README.md
+++ b/tribes-bench/tribe-epsilon/README.md
@@ -1,0 +1,46 @@
+# Tribe Epsilon Colony
+
+> Part of the [Tribes Bench](../) federation.
+
+## Reasoning slice
+
+Tribe Epsilon reasons about **concurrency and `Send` + `Sync`** —
+parallelism-induced unsoundness. The seed prompt asks the hunter to look
+for shared mutable state without lock guards: `static mut`, `&Cell` /
+`&RefCell` crossing thread boundaries, missing `Mutex` / `RwLock` around
+`Vec` / `HashMap` accessed from multiple threads, `unsafe impl Send` /
+`unsafe impl Sync` on types containing raw pointers, and inline buffer
+updates (`set_len`, capacity write-back) on a `SmallVec` or `Vec` where
+two threads can each obtain `&mut self` via interior mutability. None of
+the existing four tribes (alpha, beta, gamma, delta) reasons about
+parallelism, so epsilon adds a third axis on top of data-flow (alpha,
+beta, gamma) and temporal-validity (delta). The Stage 2 vendored
+`smallvec v0.6.13` target's `SmallVec::grow` bug-pair (RUSTSEC-2019-0009
++ RUSTSEC-2019-0012) and the inline `set_len` paths inside
+`SmallVec::insert_many` are exactly the bug-shape epsilon's prompt is
+seeded for.
+
+## Agents
+
+| Agent | File | Learns | Autonomy after |
+|-------|------|--------|----------------|
+| hunter | `agents/hunter.ag` | concurrency / Send+Sync patterns; verifier feedback per finding | ~50 verified findings |
+
+## Setup
+
+1. Copy and edit the config:
+   ```bash
+   cp config/colony.example.toml config/colony.toml
+   ```
+
+2. (Optional) Override the synthetic-target paths via env vars before launching:
+   `TARGET_DIR` (default: `<fed>/targets/stage0`),
+   `BUGS_MANIFEST` (default: `$TARGET_DIR/bugs.json`),
+   `VERIFIER_PATH` (default: `<fed>/tools/verify-finding.sh`).
+   tribes-bench is a non-forge federation (`forge.type = "none"`); no forge
+   credentials are required.
+
+3. Start the colony:
+   ```bash
+   ./scripts/start-colony.sh
+   ```

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -1,0 +1,224 @@
+// hunter.ag -- Tribe Epsilon hunter: looks for data-race,
+// send-violation, and missing-lock bugs in the Stage 2 vendored Rust
+// target via a concurrency / Send+Sync reasoning heuristic.
+//
+// Stage 1 M2+M3 (#364): in addition to verifying findings, the hunter
+// now (a) seeds prompt-variant memo + replicates inside the Malthusian
+// per-replica cost gate when the tribe pool is rich enough, (b) credits
+// the tribe pool with a first-finder full reward / subsequent partial
+// reward via the shared bug-ledger.jsonl, and (c) initiates tribe death
+// via sibling-stop + KB preservation when the pool drains below the
+// configured threshold.
+//
+// Run as daemon: agentis daemon agents/hunter.ag --colony tribe-epsilon
+// Requires: exec capability, replication capability, TARGET_DIR +
+// VERIFIER_PATH env vars (set by scripts/start-colony.sh).
+
+cb 800;
+
+type Finding {
+    line: int,
+    severity: string,
+    rationale: string,
+    signature_hint: string,
+    class: string
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("hunter:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    };
+    return 0.0;
+}
+
+fn tribe_name() -> string {
+    let n = try { exec sh "printenv TRIBE_NAME"; } catch e { ""; };
+    if len(n) > 0 {
+        return n;
+    };
+    return "tribe-epsilon";
+}
+
+fn pick_variant(tribe: string, n: int) -> string {
+    let _ = tribe;
+    let idx = n - ((n / 3) * 3);
+    if idx == 0 {
+        return "concurrency-default";
+    };
+    if idx == 1 {
+        return "concurrency-shared-state";
+    };
+    return "concurrency-lock-audit";
+}
+
+fn self_node_addr() -> string {
+    let addr = recall_latest("tribes-bench:worker_addr");
+    if len(addr) > 0 {
+        return addr;
+    };
+    return "127.0.0.1:9100";
+}
+
+fn tick(reason: string) -> void {
+    let _ = reason;
+    let conf = get_confidence();
+    print("[hunter] tick conf=", conf);
+
+    // Read the synthetic target once per tick. Stage 1 hunter scans the
+    // first stage-1 file by default; M2/M3 will rotate across all three
+    // class-shard files (cmd_exec.rs, path_io.rs, fmt_str.rs).
+    let src = try {
+        exec sh "cat $TARGET_DIR/cmd_exec.rs";
+    } catch e {
+        print("[hunter] target read failed:", e);
+        "";
+    };
+
+    if len(src) < 10 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("hunter:last_check", now_e);
+        };
+        return;
+    };
+
+    // Tribe-epsilon seed prompt: concurrency / Send+Sync reasoning
+    // heuristic. None of alpha (format!()-pattern), beta (source-to-sink),
+    // gamma (error-path), or delta (lifetime/aliasing) reasons about
+    // parallelism; concurrency bugs are the canonical category that
+    // *requires* whole-program reasoning. The calibration check (M3)
+    // reruns the experiment with prompts swapped between tribes if TP
+    // rates differ by >2x.
+    let finding = prompt(
+        "Look for shared mutable state without lock guards: static mut, &Cell / &RefCell crossing thread boundaries, missing Mutex / RwLock around Vec / HashMap accessed from multiple threads, unsafe impl Send / unsafe impl Sync on types containing raw pointers, and inline buffer updates (set_len, capacity write-back) on a SmallVec or Vec where two threads can each obtain &mut self via interior mutability. Pay special attention to mem::forget paired with raw pointer reuse and deallocate / Vec::with_capacity sequences that re-establish ownership across thread boundaries. Return JSON: line (int, 1-indexed source line of the suspect call), severity (string, low|medium|high), rationale (string, one sentence), signature_hint (string, a short literal substring grep can find on that line), class (string, one of: data_race, send_violation, missing_lock).",
+        src
+    ) -> Finding;
+
+    let my_tier = tier("hunter");
+    if my_tier == "autonomous" {
+        // Stage 1 M1 has no autonomous path — collapse to propose semantics.
+        // Reserved for Stage 2+ when verified findings might open issues.
+        learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["acted", "tribes-bench"]);
+    } else {
+        if my_tier == "review-gated" {
+            // No review-gated draft target in Stage 1 M1 — same fall-through.
+            learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["review-gated", "tribes-bench"]);
+        } else {
+            if my_tier == "propose" {
+                // The Stage 1 hot path: emit the finding on the bus,
+                // then run the deterministic verifier and learn the
+                // verdict.
+                emit("tribe-epsilon:finding", finding);
+
+                // The verifier reads {"line": int, "class": string} on
+                // stdin and emits {"verified": bool, "bug_id":
+                // string|null} on stdout. The rationale is intentionally
+                // not piped through — the verifier classifies on (line,
+                // signature, class) only, and round-tripping
+                // LLM-tainted text through the JSON-on-stdin channel
+                // would force shell-vs-JSON quote interleaving with no
+                // benefit.
+                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + finding.class + "\"}";
+                let verify_cmd = "printf '%s' " + shell_escape(finding_json) + " | bash \"$VERIFIER_PATH\"";
+                let verdict_raw = try {
+                    exec sh verify_cmd;
+                } catch e {
+                    print("[hunter] verifier call failed:", e);
+                    "";
+                };
+
+                // Extract verdict via json_get. A miss returns Void
+                // → "void" (str), so the substring check below is
+                // safe on every failure mode.
+                let verified_str = to_string(json_get(verdict_raw, "verified"));
+                let bug_id = to_string(json_get(verdict_raw, "bug_id"));
+                if verified_str == "true" {
+                    print("[hunter] verified ", bug_id, " at line ", finding.line);
+
+                    // M3 reward: provisional first-finder check via memo,
+                    // append to bug-ledger.jsonl, credit tribe pool.
+                    let prior_finder = recall_latest("bug-ledger:" + bug_id + ":first_finder_tribe");
+                    let reward = if len(prior_finder) == 0 {
+                        memo_write("bug-ledger:" + bug_id + ":first_finder_tribe", tribe_name());
+                        parse_int(recall_latest("tribe-" + tribe_name() + ":reward_full"));
+                    } else {
+                        parse_int(recall_latest("tribe-" + tribe_name() + ":reward_subsequent"));
+                    };
+
+                    let ledger_path = recall_latest("tribe-" + tribe_name() + ":bug_ledger");
+                    if len(ledger_path) > 0 {
+                        let row = "{\"ts\": " + to_string(now_ms()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
+                        // colony-lint: safe-exec-concat
+                        let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
+                        let _ = try { exec sh append_cmd; } catch e { ""; };
+                    };
+
+                    let cur_pool = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + reward));
+                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(reward)]);
+
+                    // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
+                    let pool_after = cur_pool + reward;
+                    let n = parse_int(recall_latest("tribe-" + tribe_name() + ":size"));
+                    let base = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_base_cost"));
+                    let raw_k = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_k"));
+                    let k = if raw_k <= 0 { 3; } else { raw_k; };
+                    let max_replicas = parse_int(recall_latest("tribe-" + tribe_name() + ":max_replicas"));
+                    let cost = base + (base * n) / k;
+                    if pool_after >= cost {
+                        if n < max_replicas {
+                            let variant = pick_variant(tribe_name(), n);
+                            memo_write("hunter:prompt_variant", variant);
+                            let target = self_node_addr();
+                            let replica_id = try { replicate(target); } catch e { ""; };
+                            if len(replica_id) > 0 {
+                                memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
+                                memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
+                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                            } else {
+                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                            };
+                        };
+                    };
+                } else {
+                    print("[hunter] false positive at line ", finding.line);
+                    learn("hunt", "line " + to_string(finding.line), finding.rationale, "failure", ["false-positive", "tribes-bench"]);
+                };
+
+                // M3 death: pool-drain → KB preserve + sibling stop. Guarded
+                // by a one-shot `death_initiated` memo so racing siblings
+                // don't all run the preserve+stop sequence.
+                let pool_now = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+                let death_thr = parse_int(recall_latest("tribe-" + tribe_name() + ":death_threshold"));
+                if pool_now < death_thr {
+                    let already = recall_latest("tribe-" + tribe_name() + ":death_initiated");
+                    if len(already) == 0 {
+                        memo_write("tribe-" + tribe_name() + ":death_initiated", "1");
+                        let run_dir = recall_latest("tribe-" + tribe_name() + ":run_dir");
+                        if len(run_dir) > 0 {
+                            let dead_dir = run_dir + "/dead-tribes/" + tribe_name();
+                            // colony-lint: safe-exec-concat
+                            let preserve_cmd = "mkdir -p " + shell_escape(dead_dir) + " && cp -p $AGENTIS_ROOT/experience/*.jsonl " + shell_escape(dead_dir) + "/ 2>/dev/null; cp -p $AGENTIS_ROOT/spend/*.jsonl " + shell_escape(dead_dir) + "/ 2>/dev/null; agentis knowledge export --tags " + shell_escape("tribes-bench-" + tribe_name()) + " > " + shell_escape(dead_dir) + "/knowledge.json 2>/dev/null";
+                            let _ = try { exec sh preserve_cmd; } catch e { ""; };
+                        };
+                        learn("death", tribe_name(), "pool=" + to_string(pool_now), "failure", ["died", "tribes-bench", tribe_name()]);
+                        // colony-lint: safe-exec-concat
+                        let stop_cmd = "agentis daemon list --json 2>/dev/null | jq -r '.[] | select(.colony==\"" + tribe_name() + "\" and .state==\"running\") | .agent_id' | while read id; do agentis daemon stop \"$id\" --async --grace-ms 2000 --timeout-ms 8000 || true; done";
+                        let _ = try { exec sh stop_cmd; } catch e { ""; };
+                    };
+                    return;
+                };
+            } else {
+                // shadow / dormant: observe-only.
+                print("[hunter] observing (tier:", my_tier, ") line=", finding.line);
+                learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["observed", "tribes-bench"]);
+            };
+        };
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("hunter:last_check", now);
+    };
+}

--- a/tribes-bench/tribe-epsilon/config/colony.example.toml
+++ b/tribes-bench/tribe-epsilon/config/colony.example.toml
@@ -1,0 +1,54 @@
+# Tribe Epsilon Colony Configuration
+#
+# Part of the Tribes Bench federation.
+# Copy to colony.toml and edit for your environment.
+
+[colony]
+name = "tribe-epsilon"
+tick_interval_ms = 60000
+
+# tribes-bench is a non-forge federation (#373, ADR-0003). The hunter
+# agent reads a checked-in synthetic Rust file under TARGET_DIR and runs
+# the deterministic verifier under VERIFIER_PATH; no Stage 0 agent calls
+# forge-api.sh. `forge.type = "none"` is the explicit non-forge marker
+# recognised by colony-lint — no [forge.gitlab] / [forge.github] sub-block
+# is required. See ADR-0002 for the forge-bound contract this opts out of.
+[forge]
+type = "none"
+
+[llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI
+# adapter. Stage 0 expects Claude CLI on $PATH (subscription-backed; no
+# per-token API cost). Override via STAGE0_LLM_BACKEND if needed.
+backend = "cli"
+
+# Agent definitions
+# Each agent runs as a separate agentis daemon process.
+# They discover each other via colony UDP and communicate over TCP emit/listen.
+
+[[agents]]
+name = "hunter"
+source = "agents/hunter.ag"
+cb_budget = 800
+tick_interval_ms = 60000
+
+# Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit
+# tribes-bench/calibration.toml (consumed by tools/run-stage1.sh) and
+# rerun the harness — it exports these values into the start-colony.sh
+# environment, which seeds them into per-tribe memos before the daemon
+# loop. The values below are documentation defaults that match
+# calibration.toml; they are NOT read by start-colony.sh today.
+
+[tribe.replication]
+enabled = true
+initial_cb = 1000
+base_cost = 100
+k_malthusian = 3
+max_replicas = 5
+
+[tribe.reward]
+full = 200
+subsequent = 50
+
+[tribe.death]
+threshold = 100

--- a/tribes-bench/tribe-epsilon/scripts/start-colony.sh
+++ b/tribes-bench/tribe-epsilon/scripts/start-colony.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# Start the Tribe Epsilon colony (part of the Tribes Bench federation).
+#
+# Usage:
+#   ./scripts/start-colony.sh [path/to/colony.toml]
+#   ./scripts/start-colony.sh --restart-agent <name> [path/to/colony.toml]
+#   ./scripts/start-colony.sh --rate-limit-status
+#
+# ADR-0003 conformance: --restart-agent (#257) respawns one agent with full
+# colony env, skips memo seeding + log truncation; --rate-limit-status
+# (federation-dashboard 0.3.0) execs forge-api.sh rate-limit-status. Exit
+# codes: 0 ok, 2 unknown flag / missing arg, 3 unknown agent, 4 daemon
+# launch failure.
+
+set -e
+
+RESTART_AGENT=""
+RATE_LIMIT_STATUS=0
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --restart-agent)
+            if [ -z "${2:-}" ]; then
+                echo "start-colony.sh: --restart-agent requires an agent name" >&2
+                exit 2
+            fi
+            RESTART_AGENT="$2"
+            shift 2
+            ;;
+        --rate-limit-status)
+            RATE_LIMIT_STATUS=1
+            shift
+            ;;
+        --)
+            shift
+            POSITIONAL+=("$@")
+            break
+            ;;
+        -*)
+            echo "start-colony.sh: unknown flag: $1" >&2
+            exit 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+
+# Symlink-safe $0 resolution.
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+COLONY_DIR="$(dirname "$SCRIPT_DIR")"
+FED_DIR="$(dirname "$COLONY_DIR")"
+CONFIG="${1:-$COLONY_DIR/config/colony.toml}"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "Config not found: $CONFIG"
+    echo "Copy config/colony.example.toml to config/colony.toml and edit it."
+    exit 1
+fi
+
+# Source parse-toml.sh: try <fed>/tools first, then <fed>/../tools (the
+# latter is the in-repo layout; the former is for standalone tarball
+# installs that ship tools/ inside the federation directory).
+PARSE_TOML=""
+for cand in "$FED_DIR/tools/parse-toml.sh" "$FED_DIR/../tools/parse-toml.sh"; do
+    if [ -f "$cand" ]; then
+        PARSE_TOML="$cand"
+        break
+    fi
+done
+if [ -z "$PARSE_TOML" ]; then
+    echo "Error: tools/parse-toml.sh not found in $FED_DIR/tools or $FED_DIR/../tools" >&2
+    exit 1
+fi
+# shellcheck source=/dev/null
+. "$PARSE_TOML"
+
+# Stage 0 env wiring. tribes-bench is not a forge-backed federation: the
+# only data source is a checked-in synthetic Rust file under TARGET_DIR
+# scanned by the deterministic verifier under VERIFIER_PATH. The
+# [forge].type = "github" stub in colony.example.toml is a colony-lint
+# requirement only (lint relaxation tracked in #258 deferred bucket); no
+# Stage 0 agent calls forge-api.sh.
+TRIBE_NAME="tribe-epsilon"
+TARGET_DIR="${TARGET_DIR:-$FED_DIR/targets/stage0}"
+BUGS_MANIFEST="${BUGS_MANIFEST:-$TARGET_DIR/bugs.json}"
+VERIFIER_PATH="${VERIFIER_PATH:-$FED_DIR/tools/verify-finding.sh}"
+
+export COLONY_DIR TRIBE_NAME TARGET_DIR BUGS_MANIFEST VERIFIER_PATH
+
+# Stage 0: a single hunter agent per tribe. See tribes-bench/README.md for
+# the staircase Stage 0 -> 1 -> 2 plan.
+AGENTS=(
+    hunter
+)
+
+if [ ${#AGENTS[@]} -eq 0 ] && [ "$RATE_LIMIT_STATUS" = "0" ] && [ -z "$RESTART_AGENT" ]; then
+    echo "No agents defined yet. Edit AGENTS=( ... ) in this script after creating .ag files." >&2
+    exit 1
+fi
+
+# Per-agent tick-interval override. Stage 0 hunter agents tick at 60s for
+# ~15 ticks per agent over the 900s wall-clock cap.
+tick_interval_for() {
+    case "$1" in
+        hunter) echo 60000 ;;
+        *) echo 60000 ;;
+    esac
+}
+
+# --rate-limit-status mode (federation-dashboard 0.3.0). Replace with the
+# real rate-limit primitive your data source exposes; the platform consumes
+# the JSON contract `{remaining, limit, reset_at}` only.
+if [ "$RATE_LIMIT_STATUS" = "1" ]; then
+    if [ -x "$COLONY_DIR/scripts/forge-api.sh" ]; then
+        exec "$COLONY_DIR/scripts/forge-api.sh" rate-limit-status
+    fi
+    echo '{"remaining": null, "limit": null, "reset_at": null, "error": "rate-limit-status not implemented for this colony"}'
+    exit 0
+fi
+
+# --restart-agent mode (#257). Single-agent respawn, no log truncation,
+# no memo seeding (those are full-colony bootstrap concerns).
+if [ -n "$RESTART_AGENT" ]; then
+    valid=0
+    for a in "${AGENTS[@]}"; do
+        [ "$a" = "$RESTART_AGENT" ] && valid=1
+    done
+    if [ "$valid" = "0" ]; then
+        echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
+        exit 3
+    fi
+    tick=$(tick_interval_for "$RESTART_AGENT")
+    agentis daemon "$COLONY_DIR/agents/${RESTART_AGENT}.ag" \
+        --colony tribe-epsilon \
+        --enable-exec \
+        --enable-messaging \
+        --enable-replication \
+        --allow-replica-replication \
+        --tick-interval "$tick" </dev/null >/dev/null 2>&1 &
+    agent_pid=$!
+    sleep 0.5
+    if ! kill -0 "$agent_pid" 2>/dev/null; then
+        echo "start-colony.sh: agentis daemon failed to launch $RESTART_AGENT" >&2
+        exit 4
+    fi
+    echo "started $RESTART_AGENT pid=$agent_pid tick=$tick"
+    exit 0
+fi
+
+# Stage 1 M2+M3 memo seeds: per-tribe pool, replication cost knobs,
+# reward levels, death threshold, bug-ledger path, run dir. All derive
+# from env vars exported by tools/run-stage1.sh from calibration.toml;
+# the `:-` defaults below match calibration.toml documented values so an
+# operator can launch the federation directly without the harness for
+# Stage 0 reruns or smoke tests.
+INITIAL_CB="${INITIAL_CB:-1000}"
+BASE_COST="${BASE_COST:-100}"
+K_MALTHUSIAN="${K_MALTHUSIAN:-3}"
+MAX_REPLICAS="${MAX_REPLICAS:-5}"
+REWARD_FULL="${REWARD_FULL:-200}"
+REWARD_SUBSEQUENT="${REWARD_SUBSEQUENT:-50}"
+DEATH_THRESHOLD="${DEATH_THRESHOLD:-100}"
+BUG_LEDGER_PATH="${BUG_LEDGER_PATH:-}"
+RUN_DIR="${RUN_DIR:-}"
+agentis memo set "tribe-${TRIBE_NAME}:pool" "$INITIAL_CB" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:size" "1" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:replication_base_cost" "$BASE_COST" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:replication_k" "$K_MALTHUSIAN" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:max_replicas" "$MAX_REPLICAS" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:reward_full" "$REWARD_FULL" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:reward_subsequent" "$REWARD_SUBSEQUENT" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/null 2>&1 || true
+if [ -n "$BUG_LEDGER_PATH" ]; then
+    agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
+fi
+if [ -n "$RUN_DIR" ]; then
+    agentis memo set "tribe-${TRIBE_NAME}:run_dir" "$RUN_DIR" >/dev/null 2>&1 || true
+fi
+
+echo "Starting Tribe Epsilon colony (${#AGENTS[@]} agents)..."
+
+for agent in "${AGENTS[@]}"; do
+    interval=$(tick_interval_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms)..."
+    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+        --colony tribe-epsilon \
+        --enable-exec \
+        --enable-messaging \
+        --enable-replication \
+        --allow-replica-replication \
+        --tick-interval "$interval" &
+    sleep 2
+done
+
+echo "Colony started. Use 'agentis daemon list' to monitor."
+echo "Stop with: agentis daemon stop --all"
+
+wait


### PR DESCRIPTION
## Summary

Stage 2 M1 ships **pure infrastructure** for the federated bug-hunt — no live experimental run, no cognitive market, no reputation gating. Brings the federation from 3 tribes to 5 and swaps the synthetic Stage 1 target for a real-world vendored crate.

- Two new tribes: `tribe-delta` (lifetime / aliasing reasoning) and `tribe-epsilon` (concurrency / `Send`+`Sync`). Each follows `tribe-gamma`'s byte-shape with mechanical edits (variant names, seed prompt, tribe identifiers).
- Real-world target swap: `targets/stage2/smallvec-v0.6.13/` vendors a verbatim snapshot of the upstream `smallvec` crate at git tag `v0.6.13` (commit `78522049b3ce129d02eea4e802747ba1090a5586`) with a top-banner warning prepended. `PROVENANCE.md` documents provenance, license, and the five RustSec advisories driving the planted-bug manifest: RUSTSEC-2018-0003, -2018-0018, -2019-0009, -2019-0012, -2021-0003.
- `targets/stage2/bugs.json` — five entries (`S2-SMV*`) with line numbers derived from `grep -n` against the post-banner source so a reviewer can spot-check every entry. Each entry carries a `rationale` field with the matching advisory ID + function name.
- New tooling, all distinct files (Stage 0/1 surface byte-identical): `tools/verify-finding-stage2.sh`, `tools/run-stage2.sh`, `tools/analyse-stage2.py`, `tools/test-stage2-scaffold.sh`. The Stage 2 tools live alongside Stage 0/1 tools rather than mutating them — back-compat preserved.
- `start-federation.sh` `COLONIES` array, `install.sh` tribe loop, and `BUNDLE.manifest` extended for the two new tribes plus the Stage 2 surface.

Calibration parameters are **unchanged** (Stage 1 economy is already per-tribe; the federation-wide CB pool delta is zero — that argument lives in M2 #393).

## Test plan

- [x] `bash tribes-bench/tools/test-verify-finding.sh` — Stage 0 mode: 6/6 PASS
- [x] `STAGE1=1 bash tribes-bench/tools/test-verify-finding.sh` — Stage 1 mode: 6/6 PASS
- [x] `bash tribes-bench/tools/test-stage1-replication.sh` — 48/48 PASS
- [x] `bash tribes-bench/tools/test-stage1-bug-ledger.sh` — 10/10 PASS
- [x] `bash tribes-bench/tools/test-stage2-scaffold.sh` — **23 passed, 0 failed, 0 skipped** (8 assertion groups: per-tribe `.ag` syntax via `agentis commit`, replication wiring, `bugs.json` schema, verifier dispatch on 5 known-good + 2 known-bad fixtures, source compile check, `start-federation.sh COLONIES`, Stage 0/1 invariants, calibration unchanged)
- [x] `bash tools/colony-lint.sh` (federation-wide) — **164 passed, 0 failed, 3 skipped** (zero net new failures vs `origin/main`); both new tribes pass `structure / config / shellcheck / daemon flags / markdown links / hunter.ag syntax / tier-branch convention`
- [x] **Stage 0/Stage 1 byte-identity** — `git diff --quiet origin/main -- targets/stage0 targets/stage1 tools/run-stage0.sh tools/run-stage1.sh tools/analyse-stage0.py tools/analyse-stage1.py tools/verify-finding.sh tools/test-verify-finding.sh tools/test-stage1-replication.sh tools/test-stage1-bug-ledger.sh tribe-alpha tribe-beta tribe-gamma calibration.toml` exits 0
- [x] No heredocs in new shell tools (`grep -cE "<<['\"]?[A-Z_]+['\"]?"` returns 0 for both `verify-finding-stage2.sh` and `test-stage2-scaffold.sh`)

## Out of scope

This PR explicitly does NOT include:

- M2 territory (cognitive market, federated reputation) — out of scope, lives in #393.
- M3 territory (single-LLM baseline, live experimental run) — out of scope, lives in #394.
- `tribe-zeta` — plan recommends ship-without; deferred.
- Any change to Stage 0/1 surface (test #7 + byte-identity check enforces).
- Any touch to `dev-apprenticeship/`, `federation-dashboard/`, or top-level `tools/` outside `tribes-bench/tools/`.

## References

- Plan: https://github.com/Replikanti/agentis-colonies/issues/392#issuecomment-4350139775
- Issue: #392

Addresses #392 (does NOT close — M2 #393 and M3 #394 are still required).