### PR TITLE
feat(tribes-bench): Stage 2 M2 — cognitive market + reputation (#393)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,85 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Stage 2 M2 — cognitive market + reputation** ([#393](https://github.com/Replikanti/agentis-colonies/issues/393)).
+  - All 5 `tribe-{alpha,beta,gamma,delta,epsilon}/agents/hunter.ag`
+    now (a) update a `reputation:tribes-bench-<tribe>` float memo
+    inline (`+0.05` clamp 1.0 on verified findings, `-0.10` clamp 0.0
+    on false positives), (b) sell every verified finding via
+    `knowledge_sell` on a per-finder topic prefix
+    (`tribes-bench-<finder>/<bug_id>`) at the reputation-keyed ask
+    `max(1, floor(rep*10) + 1)`, (c) buy a sibling's head ledger row
+    via `knowledge_buy` at the start of every 8th tick (pool-aware
+    skip below `pool_minimum_for_buy`) at the reputation-keyed
+    `max_cb = floor(rep*20) + 5`, (d) list a
+    `tribes-bench-bundle/<tribe>` espionage topic once per
+    `bundle_period` verified findings when reputation > 0.7, and
+    (e) buy the highest-rep sibling's bundle at a 5× premium when own
+    reputation < 0.3 and own pool ≥ `cb_surplus_threshold` and at
+    least one sibling clears the 0.7 reputation gate. Per-finder
+    topic-prefix discipline eliminates the `query_by_tags` seller-
+    collision class entirely (plan §9 risk 3). Every buy and every
+    sell call wraps a lifecycle-event discriminator
+    (`recall_latest("agent:lifecycle:cognitive:last_event_kind")`)
+    and emits a `cognitive.cache_hit`-aware `learn("market", ...)`
+    row so the federation experience log surfaces free-ride traffic
+    (plan §9 risk 1+2).
+  - All 5 `tribe-*/scripts/start-colony.sh` seed the new memos
+    (`reputation:tribes-bench-<tribe>` = `0.5`, `cb_surplus_threshold`
+    = `300`, `bundle_period` = `3`, `pool_minimum_for_buy` = `50`,
+    `tribes-bench-<tribe>:knowledge_market_csv` from `RUN_DIR` when
+    set) before the daemon loop fires.
+  - `tribes-bench/tools/check-agentis-version.sh` (new, ~50 LOC)
+    refuses install or start when `agentis --version` parses below
+    `v1.5.0` (the floor where `knowledge_buy` / `knowledge_sell`
+    ship as `.ag` builtins). Wired into `install.sh` first executable
+    line and every `tribe-*/scripts/start-colony.sh` first executable
+    line. Refusal exit code is 78 (`EX_CONFIG`); error text points at
+    `https://github.com/Replikanti/agentis/releases/tag/v1.5.0`. Plan
+    §9 risk 7 mitigation — zero crash exposure on pre-v1.5.0 runtimes.
+  - `tribes-bench/calibration.toml` (extended) — new `[reputation]`
+    and `[knowledge_market]` blocks documenting the four formulas
+    (ask, max_cb, premium_ask, premium_max_cb), the buy-gate modulus,
+    pool-aware skip threshold, bundle pacing, and the surplus
+    threshold. M1's `[tribe.economy]`/`[tribe.reward]`/`[tribe.death]`
+    sections are byte-identical (asserted in
+    `test-stage2-scaffold.sh` test 8).
+  - `tribes-bench/tools/analyse-stage2.py` (extended) — adds
+    `load_market_log` reader, `resolve_downstream_verified` (scans
+    each buyer's experience JSONL within 5 ticks of every buy ts to
+    mark verified=1 / false=0 / no-finding=""), and `write_market_log`
+    that rewrites `<run-dir>/knowledge-market.csv` with a header line.
+    Existing `telemetry.csv` schema byte-identical.
+  - `tribes-bench/tools/test-stage2-cognitive-market.sh` (new) — 41
+    pure-offline assertions covering knowledge_sell + knowledge_buy
+    placement, topic-prefix discipline, ask/max_cb formula sanity,
+    bundle listing, espionage three-predicate gate, CSV column count,
+    and the cache-hit-aware revenue contract (plan §9 risk 2).
+  - `tribes-bench/tools/test-stage2-reputation.sh` (new) — 56 pure-
+    offline assertions covering initial seed, verified `+0.05`,
+    false-positive `-0.10`, ceiling/floor clamps after 30 simulated
+    ticks, and the gate effect on ask_price + max_cb. Includes a
+    regression check that the four pre-existing test scripts continue
+    to PASS unchanged (`test-verify-finding.sh`,
+    `test-stage1-replication.sh`, `test-stage1-bug-ledger.sh`,
+    `test-stage2-scaffold.sh`).
+  - `tribes-bench/tools/test-stage2-scaffold.sh` test 8 relaxed from
+    full-file byte-identity to "M1 [tribe.economy/reward/death]
+    sections unchanged" — M2 appends `[reputation]` and
+    `[knowledge_market]` sections so the M1 byte-identity gate is
+    stale; the section-scoped diff preserves the original spirit of
+    the assertion (M2 must not edit M1 calibration values).
+  - Runtime floor bumped from `agentis >= 1.4.1` to
+    `agentis >= 1.5.0` in `tribes-bench/README.md`. README gains a
+    Stage 2 M2 ecosystem section (~80 lines) documenting the four
+    deliverables, the analyser revenue contract, and the
+    calibration knobs.
+  - Stage 0/Stage 1 surface (`targets/stage0/`, `targets/stage1/`,
+    `targets/stage2/`, `tools/run-stage{0,1,2}.sh`,
+    `tools/verify-finding{,−stage2}.sh`, `tools/test-verify-finding.sh`,
+    `tools/test-stage1-replication.sh`,
+    `tools/test-stage1-bug-ledger.sh`) byte-identical. Pre-existing
+    Stage 0/1 + Stage 2 M1 tests continue to PASS unchanged.
 - Stage 2 M1 scaffolding: 2 new tribes (`tribe-delta` lifetime/aliasing,
   `tribe-epsilon` concurrency/Send+Sync) bringing the federation to 5
   tribes. Real-world target swap from synthetic Stage 1 → vendored

--- a/tribes-bench/README.md
+++ b/tribes-bench/README.md
@@ -2,7 +2,7 @@
 
 ![Version: unreleased](https://img.shields.io/badge/version-unreleased-lightgrey) ![Status: Experimental](https://img.shields.io/badge/status-experimental-purple)
 
-**Version:** `0.0.0` (unreleased) · [Changelog](./CHANGELOG.md) · **Requires:** agentis >= `1.4.1` · **Status:** Experimental
+**Version:** `0.0.0` (unreleased) · [Changelog](./CHANGELOG.md) · **Requires:** agentis >= `1.5.0` · **Status:** Experimental
 
 > A research scaffold that tests whether the agentis runtime's
 > emergent-layer primitives (replication, scarcity, selection,
@@ -192,6 +192,83 @@ echo '{"line": 12, "class": "command_injection"}' \
       bash tribes-bench/tools/verify-finding.sh
 # {"verified": true, "bug_id": "S1-CMDINJ-001"}
 ```
+
+## Stage 2 (M2 — cognitive market + reputation)
+
+Stage 2 M2 ([#393](https://github.com/Replikanti/agentis-colonies/issues/393))
+turns the 5-tribe federation into an **ecosystem** by wiring four
+inter-tribe coordination primitives on top of the M1 scaffolding. Pure
+infrastructure — no live experimental run lands here (that's M3, #394).
+
+**The four deliverables:**
+
+1. **Reputation memos.** Every tribe carries a single float in
+   `reputation:tribes-bench-<tribe>` initialised to `0.5` and updated
+   inline in the hunter on every verified finding (`+0.05`, clamp 1.0)
+   and every false positive (`-0.10`, clamp 0.0). The asymmetry
+   produces a ~10-find ceiling and a ~5-find floor; no per-tick decay
+   to keep the M3 cost-per-finding reading clean.
+
+2. **Knowledge market wiring.** The hunter calls `knowledge_sell` on
+   every verified finding (per-finder topic prefix
+   `tribes-bench-<finder>/<bug_id>`) and `knowledge_buy` at the start
+   of every 8th tick (pool-aware skip below `pool_minimum_for_buy`).
+   The seller's ask-price formula is `max(1, floor(rep*10) + 1)`; the
+   buyer's max_cb is `floor(rep*20) + 5`. Bootstrap stays trade-active
+   at t=0 because every tribe's mid-band reputation (0.5) lists at ask
+   6 against a max_cb of 15.
+
+3. **Espionage primitive.** High-rep tribes (rep > 0.7) list a
+   `tribes-bench-bundle/<self>` topic once per `bundle_period` verified
+   findings, holding the last-K bug_ids. Low-rep tribes (rep < 0.3)
+   with a CB surplus above `cb_surplus_threshold` buy the highest-rep
+   sibling's bundle at a 5× premium. Asymmetric information at premium
+   price; M3 will measure whether this stratifies the federation.
+
+4. **Telemetry CSV.** Every buy and every sell call writes one row to
+   `<run-dir>/knowledge-market.csv` via an `exec sh "printf >> ..."`
+   path-safe append. Schema:
+
+   ```
+   ts_ms, agent_id, tribe, op, topic, topic_kind,
+   ask_price, max_cb, paid_price, cache_hit,
+   downstream_verified, op_outcome
+   ```
+
+   `tools/analyse-stage2.py` reads the log, resolves
+   `downstream_verified` post-hoc by scanning the buyer's experience
+   JSONL within 5 ticks, and rewrites the CSV with a header line.
+
+**Analyser revenue contract** (per #393 §9 risk 2): seller revenue is
+
+> `revenue = Σ(ask_price for r in rows where r.op="buy" AND r.cache_hit=0)`
+
+NOT total trade volume. The runtime caches successful purchases under
+`knowledge:<topic>`; subsequent buyers in the TTL window get
+`cognitive.cache_hit` and pay zero CB to the original seller. The
+trade CSV's `cache_hit` column tags every free-ride row so the M3
+analyser can compute revenue strictly on substrate (non-cache-hit)
+purchases.
+
+**Calibration.** All knobs (`buy_gate_modulus`, `pool_minimum_for_buy`,
+`bundle_period`, `cb_surplus_threshold`, `ask_floor`,
+`ask_max_at_full_rep`, `max_cb_at_full_rep`, `premium_multiplier`,
+`reputation.{initial,verify_step,false_positive_step,ceiling,floor}`)
+ship in [`tribes-bench/calibration.toml`](./calibration.toml) under
+`[reputation]` and `[knowledge_market]`. Defaults match the in-script
+`:-` fallbacks and the hard-coded values in the hunter formulas;
+operators tune via the M3 harness (#394) without touching `.ag`.
+
+**Stage 2 M2 reproduction recipe** (offline / pure-test):
+
+```bash
+cd tribes-bench/
+./install.sh                                          # idempotent; refuses on agentis < 1.5.0
+bash tools/test-stage2-cognitive-market.sh            # market wiring assertions
+bash tools/test-stage2-reputation.sh                  # reputation primitive assertions
+```
+
+End-to-end multi-day live runs land in M3 (#394).
 
 ## Layout
 

--- a/tribes-bench/calibration.toml
+++ b/tribes-bench/calibration.toml
@@ -53,3 +53,59 @@ subsequent = 50
 # without rewards a tribe drains from initial_cb (1000) to threshold
 # (100) in ~18 min at 50 CB/tick × 60 ticks/hour.
 threshold = 100
+[reputation]
+# Stage 2 M2 (#393) cognitive-market knobs. None of the values below
+# are read by start-colony.sh today — they are documentation defaults
+# that match the in-script `:-` fallbacks and the hard-coded values in
+# the hunter.ag formulas. AC #7-equivalent calibration runs (M3, #394)
+# will refute or refine these via the trade CSV
+# (`<run-dir>/knowledge-market.csv`).
+#
+# Initial reputation seeded by every tribe's start-colony.sh (mid-band
+# bootstrap; see plan §2 for why every tribe trades at t=0). Updated
+# inline in hunter.ag on verified findings (+verify_step, clamp ceiling)
+# and on false positives (-false_positive_step, clamp floor).
+initial = 0.5
+verify_step = 0.05
+false_positive_step = 0.10
+ceiling = 1.0
+floor = 0.0
+
+[knowledge_market]
+# Buy-gate modulus on now_ms() % buy_gate_modulus == 0 (default 8 ⇒
+# ~12.5% of ticks fire a buy). Plan §9 risk 5: at full federation
+# replication this caps the buy-side CB drain below the per-replica
+# replenish rate.
+buy_gate_modulus = 8
+
+# Pool-aware skip: tribes near the death threshold do not buy. Plan
+# §9 risk 5 mitigation; lets the federation degrade gracefully under
+# famine instead of deadlocking.
+pool_minimum_for_buy = 50
+
+# Bundle pacing: high-rep tribes (rep > 0.7) list a `tribes-bench-bundle/<tribe>`
+# topic once per `bundle_period` verified findings. Default 3.
+bundle_period = 3
+
+# Espionage-buy gate: low-rep tribes (rep < 0.3) buy bundle topics from
+# high-rep siblings only when their own pool clears this surplus. Plan
+# §4 — this is the asymmetric-information premium-price entry point.
+cb_surplus_threshold = 300
+
+# Ask-price formula: `ask = max(ask_floor, floor(rep * 10) + 1)`.
+# Range at rep ∈ [0, 1]: [1, 11]. Floor of 1 keeps every tribe on-market
+# even at rep=0.0; ceiling of 11 makes a verified finding worth ~2x a
+# single knowledge_buy round-trip CB cost.
+ask_floor = 1
+ask_max_at_full_rep = 11
+
+# max_cb formula: `max_cb = floor(rep * 20) + 5`. Range [5, 25]. Covers
+# the [1, 11] ask range with margin so high-rep buyers can win against
+# competing buyers; low-rep buyers (rep=0.0, max_cb=5) still afford the
+# floor-priced listings.
+max_cb_at_full_rep = 25
+
+# Premium multiplier on bundle topics: `premium = multiplier * (floor(rep * 10) + 1)`.
+# Asks ~5× a single-finding ask; buyers cap their max_cb at the same
+# formula keyed on the seller's reputation.
+premium_multiplier = 5

--- a/tribes-bench/install.sh
+++ b/tribes-bench/install.sh
@@ -19,6 +19,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FED_NAME="$(basename "$SCRIPT_DIR")"
 
+# §9 risk 7: refuse install if the agentis runtime cannot reach the M2
+# floor. The federation's hunters call `knowledge_buy` / `knowledge_sell`
+# unconditionally; pre-v1.5.0 daemons quarantine on first tick.
+"$SCRIPT_DIR/tools/check-agentis-version.sh"
+
 echo "Installing $FED_NAME federation..."
 
 for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon; do

--- a/tribes-bench/tools/analyse-stage2.py
+++ b/tribes-bench/tools/analyse-stage2.py
@@ -177,6 +177,133 @@ def discover_known_tribes(fed_dir: str) -> set[str]:
     return out
 
 
+# --- Stage 2 M2 (#393) cognitive-market readers + downstream resolver ---
+
+MARKET_COLUMNS = [
+    "ts_ms", "agent_id", "tribe", "op", "topic", "topic_kind",
+    "ask_price", "max_cb", "paid_price", "cache_hit",
+    "downstream_verified", "op_outcome",
+]
+
+
+def load_market_log(run_dir: str) -> list[dict[str, Any]]:
+    """Read `<run-dir>/knowledge-market.csv` (the append-only trade log
+    written by hunter.ag's `emit_market_csv` helper) into a list of dict
+    rows. Schema is fixed at MARKET_COLUMNS; the hunter writes data rows
+    only (no header), so this reader synthesises the column names. Empty
+    file → empty list. Missing file → empty list (the analyser stays
+    useful when the M2 wiring did not run).
+    """
+    path = os.path.join(run_dir, "knowledge-market.csv")
+    out: list[dict[str, Any]] = []
+    if not os.path.isfile(path):
+        return out
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            parts = line.split(",")
+            # Defensive: tolerate rows with too few/too many columns by
+            # padding/truncating to the fixed schema.
+            if len(parts) < len(MARKET_COLUMNS):
+                parts = parts + [""] * (len(MARKET_COLUMNS) - len(parts))
+            elif len(parts) > len(MARKET_COLUMNS):
+                parts = parts[: len(MARKET_COLUMNS)]
+            row: dict[str, Any] = {}
+            for k, v in zip(MARKET_COLUMNS, parts):
+                row[k] = v
+            out.append(row)
+    return out
+
+
+def resolve_downstream_verified(
+    market_rows: list[dict[str, Any]], experience_dir: str
+) -> None:
+    """For each `op == "buy"` row, scan the buyer tribe's experience
+    JSONL within ±5 ticks of the buy ts; mark `downstream_verified` to
+    `1` when an `acted` (verified) tribes-bench row appears, `0` when a
+    `false-positive` row appears, `""` when neither fires. Mutates
+    market_rows in place. Sell rows are left untouched.
+
+    Tick boundary chosen as 5 minutes (300_000 ms) per plan §5; the
+    buyer's seed prompt fires once per minute, so 5 ticks is the worst-
+    case "within next 5 ticks" window the plan calls for.
+    """
+    if not os.path.isdir(experience_dir):
+        return
+    # Build per-tribe sorted list of (ts_ms, kind ∈ {"verified", "false"}).
+    by_tribe: dict[str, list[tuple[int, str]]] = defaultdict(list)
+    for fname in sorted(os.listdir(experience_dir)):
+        if not fname.endswith(".jsonl"):
+            continue
+        for rec in read_jsonl(os.path.join(experience_dir, fname)):
+            tags = rec.get("tags") or []
+            if not isinstance(tags, list):
+                continue
+            if "tribes-bench" not in tags:
+                continue
+            ts_ms = rec.get("ts")
+            if not isinstance(ts_ms, int):
+                continue
+            tribe = next((t for t in tags if t.startswith("tribe-")), None)
+            if not tribe:
+                continue
+            if "acted" in tags:
+                by_tribe[tribe].append((ts_ms, "verified"))
+            elif "false-positive" in tags:
+                by_tribe[tribe].append((ts_ms, "false"))
+    for v in by_tribe.values():
+        v.sort(key=lambda r: r[0])
+    window_ms = 5 * 60 * 1000
+    for row in market_rows:
+        if row.get("op") != "buy":
+            continue
+        try:
+            ts = int(row.get("ts_ms") or 0)
+        except (TypeError, ValueError):
+            continue
+        tribe = row.get("tribe") or ""
+        if not isinstance(tribe, str) or not tribe:
+            continue
+        events = by_tribe.get(tribe, [])
+        verdict = ""
+        for ev_ts, kind in events:
+            if ev_ts < ts:
+                continue
+            if ev_ts > ts + window_ms:
+                break
+            if kind == "verified":
+                verdict = "1"
+                break
+            if kind == "false":
+                verdict = "0"
+                break
+        row["downstream_verified"] = verdict
+
+
+def write_market_log(run_dir: str, rows: list[dict[str, Any]]) -> str | None:
+    """Write resolved market rows back to `<run-dir>/knowledge-market.csv`
+    with a header line prepended. Existing file (header-less append-only
+    from hunter.ag) is overwritten. No-op when rows is empty.
+
+    Per plan §9 risk 2: the analyser revenue contract is
+    `revenue = sum(ask_price for r in rows if r.op=="buy" and r.cache_hit=="0")`,
+    NOT total trade volume. cache_hit=1 rows must be excluded from
+    seller-revenue accounting. The CSV preserves the cache_hit column so
+    downstream consumers can compute revenue correctly.
+    """
+    if not rows:
+        return None
+    path = os.path.join(run_dir, "knowledge-market.csv")
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(MARKET_COLUMNS)
+        for row in rows:
+            w.writerow([row.get(k, "") for k in MARKET_COLUMNS])
+    return path
+
+
 def main() -> None:
     run_dir = parse_args(sys.argv)
     agentis_root = os.path.join(run_dir, ".agentis")
@@ -358,6 +485,19 @@ def main() -> None:
                 ])
 
     print(out_path)
+
+    # Stage 2 M2 (#393) sidecar CSV: read the append-only trade log
+    # written by every hunter.ag's `emit_market_csv`, resolve the
+    # `downstream_verified` column post-hoc by scanning each buyer's
+    # experience JSONL within 5 ticks, and rewrite the CSV with a
+    # header line. No-op when no trade rows exist (M2 wiring not run
+    # or hunter never reached the buy/sell branch).
+    market_rows = load_market_log(run_dir)
+    if market_rows:
+        resolve_downstream_verified(market_rows, experience_dir)
+        market_path = write_market_log(run_dir, market_rows)
+        if market_path:
+            print(market_path)
 
 
 if __name__ == "__main__":

--- a/tribes-bench/tools/check-agentis-version.sh
+++ b/tribes-bench/tools/check-agentis-version.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# check-agentis-version.sh — refuses install or start when the agentis
+# runtime is older than v1.5.0 (the floor where knowledge_buy /
+# knowledge_sell ship as .ag builtins; pre-v1.5.0 hunters quarantine on
+# first tick — see #393 §9 risk 7).
+#
+# Usage: check-agentis-version.sh
+#
+# Exit 0  : version >= 1.5.0
+# Exit 78 : EX_CONFIG, version too low or unparseable
+#
+# Bash 3.2 portable (no mapfile, no `${var,,}`, no GNU-only sed). The
+# SemVer comparison is delegated to a python3 one-liner so we do not
+# need to depend on `sort -V`.
+
+set -eu
+
+REQUIRED="1.5.0"
+RELEASE_URL="https://github.com/Replikanti/agentis/releases/tag/v1.5.0"
+
+if ! command -v agentis >/dev/null 2>&1; then
+    echo "check-agentis-version: agentis CLI not on PATH" >&2
+    echo "                       install agentis >= ${REQUIRED}: ${RELEASE_URL}" >&2
+    exit 78
+fi
+
+raw="$(agentis --version 2>/dev/null || true)"
+ver="$(printf '%s' "$raw" | sed -n 's/^agentis v\([0-9][0-9.]*\).*$/\1/p' | head -1)"
+
+if [ -z "$ver" ]; then
+    echo "check-agentis-version: could not parse 'agentis --version' output: ${raw}" >&2
+    echo "                       require agentis >= ${REQUIRED}: ${RELEASE_URL}" >&2
+    exit 78
+fi
+
+if ! python3 -c "
+import sys
+def parse(v):
+    return tuple(int(x) for x in v.split('.'))
+sys.exit(0 if parse('${ver}') >= parse('${REQUIRED}') else 1)
+" 2>/dev/null; then
+    echo "check-agentis-version: agentis v${ver} is too old (require >= ${REQUIRED})" >&2
+    echo "                       upgrade: ${RELEASE_URL}" >&2
+    exit 78
+fi
+
+exit 0

--- a/tribes-bench/tools/test-stage2-cognitive-market.sh
+++ b/tribes-bench/tools/test-stage2-cognitive-market.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# test-stage2-cognitive-market.sh — pure-offline assertions for Stage 2
+# M2 (#393) cognitive-market wiring.
+#
+# Mirrors the shape of `test-stage1-replication.sh` and
+# `test-stage1-bug-ledger.sh`: PASS/FAIL/SKIP helpers, exit 0 on green,
+# no live federation. Asserts that:
+#
+#   1. All 5 hunter.ag files contain `knowledge_sell(` inside the
+#      verified-finding branch (after the existing reward + replication
+#      arithmetic).
+#   2. All 5 hunter.ag files contain `knowledge_buy(` BEFORE the seed
+#      `prompt(` fires.
+#   3. Topic shape: every hunter constructs the sell topic as
+#      `"tribes-bench-" + tribe_name() + "/" + bug_id` (per-finder
+#      prefix, §9 risk 3 mitigation).
+#   4. ask_price formula sanity (shell-arith): `max(1, floor(rep*10)+1)`.
+#   5. max_cb formula sanity (shell-arith): `floor(rep*20) + 5`.
+#   6. Bundle listing: every hunter contains a
+#      `knowledge_sell("tribes-bench-bundle/...` call.
+#   7. Espionage detection: every hunter contains the three-predicate
+#      gate (`rep_bucket(own_rep_str_e) < 3`, surplus pool, sibling > 0.7).
+#   8. CSV shape (3 sell + 2 buy rows simulator, one-shot Python reducer
+#      on column count + cache-hit-aware revenue formula).
+#   9. emit_market_csv helper present + analyse-stage2.py readers
+#      present. (Sanity check that the sidecar wiring exists.)
+#
+# Pure-shell + python3 + agentis-aware (skip when not on PATH).
+# Bash 3.2 portable.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_DIR="$(dirname "$SCRIPT_DIR")"
+
+PASS=0
+FAIL=0
+SKIP=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_eq() {
+    label="$1"; exp="$2"; got="$3"
+    if [ "$exp" = "$got" ]; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       expected: $exp"
+        echo "       got:      $got"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    label="$1"; file="$2"; needle="$3"
+    if [ -f "$file" ] && grep -Fq -- "$needle" "$file"; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       file:   $file"
+        echo "       needle: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+ALL_TRIBES="tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon"
+
+# --- 1. knowledge_sell( inside verified-finding branch ---
+for tribe in $ALL_TRIBES; do
+    assert_contains "$tribe hunter.ag has knowledge_sell( call" \
+        "$FED_DIR/$tribe/agents/hunter.ag" "knowledge_sell("
+done
+
+# --- 2. knowledge_buy( present (and located before the seed prompt) ---
+for tribe in $ALL_TRIBES; do
+    ag="$FED_DIR/$tribe/agents/hunter.ag"
+    if [ -f "$ag" ]; then
+        buy_line="$(grep -n -F 'knowledge_buy(' "$ag" | head -1 | cut -d: -f1)"
+        prompt_line="$(grep -n -F 'let finding = prompt(' "$ag" | head -1 | cut -d: -f1)"
+        if [ -n "$buy_line" ] && [ -n "$prompt_line" ] && [ "$buy_line" -lt "$prompt_line" ]; then
+            echo "[PASS] $tribe hunter.ag: knowledge_buy( fires before seed prompt (lines $buy_line < $prompt_line)"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] $tribe hunter.ag: knowledge_buy ($buy_line) not before seed prompt ($prompt_line)"
+            FAIL=$((FAIL + 1))
+        fi
+    else
+        echo "[FAIL] $tribe hunter.ag missing"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+# --- 3. Sell topic shape: tribes-bench-<self>/<bug_id> ---
+for tribe in $ALL_TRIBES; do
+    assert_contains "$tribe hunter.ag uses per-finder sell topic prefix" \
+        "$FED_DIR/$tribe/agents/hunter.ag" \
+        '"tribes-bench-" + tribe_name() + "/" + bug_id'
+done
+
+# --- 4. ask_price formula: max(1, floor(rep*10) + 1) ---
+ask_for_rep() {
+    # $1 rep_int_in_tenths (0..10)
+    bucket="$1"
+    v=$((bucket + 1))
+    if [ "$v" -lt 1 ]; then
+        echo 1
+    else
+        echo "$v"
+    fi
+}
+assert_eq "ask_for_rep(0) == 1 (floor)"  "1"  "$(ask_for_rep 0)"
+assert_eq "ask_for_rep(5) == 6 (mid)"    "6"  "$(ask_for_rep 5)"
+assert_eq "ask_for_rep(10) == 11 (ceil)" "11" "$(ask_for_rep 10)"
+
+# --- 5. max_cb formula: floor(rep*20) + 5 ---
+max_cb_for_rep() {
+    bucket="$1"
+    echo $((bucket * 2 + 5))
+}
+assert_eq "max_cb_for_rep(0) == 5 (floor)"   "5"  "$(max_cb_for_rep 0)"
+assert_eq "max_cb_for_rep(5) == 15 (mid)"    "15" "$(max_cb_for_rep 5)"
+assert_eq "max_cb_for_rep(10) == 25 (ceil)"  "25" "$(max_cb_for_rep 10)"
+
+# --- 6. Bundle listing: knowledge_sell("tribes-bench-bundle/...) ---
+for tribe in $ALL_TRIBES; do
+    assert_contains "$tribe hunter.ag lists bundle topic" \
+        "$FED_DIR/$tribe/agents/hunter.ag" \
+        '"tribes-bench-bundle/" + tribe_name()'
+done
+
+# --- 7. Espionage three-predicate gate ---
+for tribe in $ALL_TRIBES; do
+    ag="$FED_DIR/$tribe/agents/hunter.ag"
+    p1="$(grep -Fc 'rep_bucket(own_rep_str_e) < 3' "$ag" 2>/dev/null || echo 0)"
+    p2="$(grep -Fc 'pool_for_buy >= cb_surplus_e' "$ag" 2>/dev/null || echo 0)"
+    p3="$(grep -Fc 'rep_bucket(best_s) > 7' "$ag" 2>/dev/null || echo 0)"
+    if [ "$p1" -ge 1 ] && [ "$p2" -ge 1 ] && [ "$p3" -ge 1 ]; then
+        echo "[PASS] $tribe hunter.ag has 3-predicate espionage gate"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $tribe hunter.ag: own_rep<3 ($p1), surplus ($p2), sibling>7 ($p3)"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+# --- 8. Trade CSV shape: 12 columns, simulator + reducer ---
+CSV="$TMP/knowledge-market.csv"
+: > "$CSV"
+# 3 sell rows
+printf '1700000000000,tribe-alpha,tribe-alpha,sell,tribes-bench-tribe-alpha/BUG-1,finding,6,,,,,succeeded\n' >> "$CSV"
+printf '1700000010000,tribe-beta,tribe-beta,sell,tribes-bench-tribe-beta/BUG-2,finding,7,,,,,succeeded\n' >> "$CSV"
+printf '1700000020000,tribe-gamma,tribe-gamma,sell,tribes-bench-tribe-gamma/BUG-3,finding,8,,,,,succeeded\n' >> "$CSV"
+# 2 buy rows: one substrate (cache_hit=0), one cache-hit (cache_hit=1)
+printf '1700000060000,tribe-delta,tribe-delta,buy,tribes-bench-tribe-alpha/BUG-1,finding,,15,,0,,succeeded\n' >> "$CSV"
+printf '1700000061000,tribe-epsilon,tribe-epsilon,buy,tribes-bench-tribe-alpha/BUG-1,finding,,15,,1,,cache_hit\n' >> "$CSV"
+
+# Verify column count
+got_cols="$(awk -F, '{ print NF; exit }' "$CSV")"
+assert_eq "knowledge-market.csv row column count == 12" "12" "$got_cols"
+
+# Cache-hit-aware revenue contract (§9 risk 2): exclude cache_hit=1 rows.
+# Buy rows don't carry ask_price; the revenue is summed on sell rows
+# joined to substrate (non-cache-hit) buy rows by topic. For this
+# offline simulator we approximate: sum ask_price over sell rows where
+# the matching topic has at least one substrate (cache_hit=0) buy row.
+revenue="$(python3 -c "
+import csv, sys
+rows = list(csv.reader(open(sys.argv[1])))
+buy_substrate = set()
+for r in rows:
+    if len(r) < 12: continue
+    if r[3] == 'buy' and r[9] == '0':
+        buy_substrate.add(r[4])
+total = 0
+for r in rows:
+    if len(r) < 12: continue
+    if r[3] == 'sell' and r[4] in buy_substrate:
+        try: total += int(r[6])
+        except ValueError: pass
+print(total)
+" "$CSV")"
+assert_eq "revenue contract: only substrate-bought sells count (= 6, alpha's BUG-1)" "6" "$revenue"
+
+# --- 9. emit_market_csv helper + analyse-stage2.py readers present ---
+for tribe in $ALL_TRIBES; do
+    assert_contains "$tribe hunter.ag has emit_market_csv helper" \
+        "$FED_DIR/$tribe/agents/hunter.ag" "fn emit_market_csv("
+done
+assert_contains "analyse-stage2.py has load_market_log reader" \
+    "$FED_DIR/tools/analyse-stage2.py" "def load_market_log("
+assert_contains "analyse-stage2.py has resolve_downstream_verified" \
+    "$FED_DIR/tools/analyse-stage2.py" "def resolve_downstream_verified("
+assert_contains "analyse-stage2.py has write_market_log writer" \
+    "$FED_DIR/tools/analyse-stage2.py" "def write_market_log("
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]

--- a/tribes-bench/tools/test-stage2-reputation.sh
+++ b/tribes-bench/tools/test-stage2-reputation.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# test-stage2-reputation.sh — pure-offline assertions for Stage 2 M2
+# (#393) reputation primitive.
+#
+# Mirrors the shape of `test-stage2-cognitive-market.sh` and
+# `test-stage1-replication.sh`: PASS/FAIL/SKIP helpers, exit 0 on green,
+# no live federation. Asserts that:
+#
+#   1. All 5 start-colony.sh scripts seed `reputation:tribes-bench-<tribe>`
+#      with `"0.5"` (mid-band per plan §2 bootstrap analysis).
+#   2. All 5 hunter.ag files contain the `+0.05` clamp-1.0 update inside
+#      the verified-finding branch.
+#   3. All 5 hunter.ag files contain the `-0.10` clamp-0.0 update inside
+#      the false-positive branch.
+#   4. Floor / ceiling sanity (shell-arith): 30 verified ticks → rep=1.0
+#      (clamped); 30 false-positive ticks → rep=0.0 (clamped).
+#   5. Gate effect on ask_price: at rep=0.0 ask=1; at rep=1.0 ask=11.
+#   6. Gate effect on max_cb: at rep=0.0 max_cb=5; at rep=1.0 max_cb=25.
+#   7. Stage 2 M2 memo seeds: `cb_surplus_threshold`, `bundle_period`,
+#      `pool_minimum_for_buy`, `tribes-bench-<tribe>:knowledge_market_csv`.
+#   8. Pre-existing test scripts continue to PASS unchanged
+#      (test-verify-finding.sh, test-stage1-replication.sh,
+#      test-stage1-bug-ledger.sh, test-stage2-scaffold.sh).
+#
+# Pure-shell + python3. Bash 3.2 portable.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_DIR="$(dirname "$SCRIPT_DIR")"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+assert_eq() {
+    label="$1"; exp="$2"; got="$3"
+    if [ "$exp" = "$got" ]; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       expected: $exp"
+        echo "       got:      $got"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    label="$1"; file="$2"; needle="$3"
+    if [ -f "$file" ] && grep -Fq -- "$needle" "$file"; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       file:   $file"
+        echo "       needle: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+skip_case() {
+    echo "[SKIP] $1 ($2)"
+    SKIP=$((SKIP + 1))
+}
+
+ALL_TRIBES="tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon"
+
+# --- 1. Initial reputation memo seeded at 0.5 ---
+for tribe in $ALL_TRIBES; do
+    assert_contains "$tribe start-colony.sh seeds reputation:tribes-bench-<tribe> = 0.5" \
+        "$FED_DIR/$tribe/scripts/start-colony.sh" \
+        'reputation:tribes-bench-${TRIBE_NAME}" "0.5"'
+done
+
+# --- 2. Verified-branch +0.05 reputation update + clamp ceiling ---
+for tribe in $ALL_TRIBES; do
+    ag="$FED_DIR/$tribe/agents/hunter.ag"
+    assert_contains "$tribe hunter.ag: verified-branch +0.05 step" \
+        "$ag" "cur_rep_v + 0.05"
+    assert_contains "$tribe hunter.ag: verified-branch ceiling clamp at 1.0" \
+        "$ag" "cur_rep_v + 0.05 > 1.0 { 1.0"
+done
+
+# --- 3. False-positive branch -0.10 reputation update + clamp floor ---
+for tribe in $ALL_TRIBES; do
+    ag="$FED_DIR/$tribe/agents/hunter.ag"
+    assert_contains "$tribe hunter.ag: false-positive branch -0.10 step" \
+        "$ag" "cur_rep_f - 0.10"
+    assert_contains "$tribe hunter.ag: false-positive floor clamp at 0.0" \
+        "$ag" "cur_rep_f - 0.10 < 0.0 { 0.0"
+done
+
+# --- 4. Floor / ceiling sanity via Python (avoids float / awk locale) ---
+ceiling_after_30="$(python3 -c "
+r = 0.5
+for _ in range(30):
+    r = min(1.0, r + 0.05)
+print(round(r, 4))
+")"
+assert_eq "30 verified ticks from 0.5 clamp at 1.0" "1.0" "$ceiling_after_30"
+
+floor_after_30="$(python3 -c "
+r = 0.5
+for _ in range(30):
+    r = max(0.0, r - 0.10)
+print(round(r, 4))
+")"
+assert_eq "30 false-positive ticks from 0.5 clamp at 0.0" "0.0" "$floor_after_30"
+
+# --- 5. Gate effect on ask_price: at rep=0.0 ask=1; at rep=1.0 ask=11 ---
+ask_for_rep() {
+    bucket="$1"
+    v=$((bucket + 1))
+    if [ "$v" -lt 1 ]; then echo 1; else echo "$v"; fi
+}
+assert_eq "ask at rep=0.0 (bucket 0) == 1"  "1"  "$(ask_for_rep 0)"
+assert_eq "ask at rep=1.0 (bucket 10) == 11" "11" "$(ask_for_rep 10)"
+
+# --- 6. Gate effect on max_cb: at rep=0.0 max_cb=5; at rep=1.0 max_cb=25 ---
+max_cb_for_rep() {
+    bucket="$1"
+    echo $((bucket * 2 + 5))
+}
+assert_eq "max_cb at rep=0.0 (bucket 0) == 5"  "5"  "$(max_cb_for_rep 0)"
+assert_eq "max_cb at rep=1.0 (bucket 10) == 25" "25" "$(max_cb_for_rep 10)"
+
+# --- 7. Stage 2 M2 memo seeds present in every start-colony.sh ---
+for tribe in $ALL_TRIBES; do
+    sc="$FED_DIR/$tribe/scripts/start-colony.sh"
+    assert_contains "$tribe start-colony.sh seeds cb_surplus_threshold" \
+        "$sc" '"cb_surplus_threshold" "300"'
+    assert_contains "$tribe start-colony.sh seeds bundle_period" \
+        "$sc" '"bundle_period" "3"'
+    assert_contains "$tribe start-colony.sh seeds pool_minimum_for_buy" \
+        "$sc" '"pool_minimum_for_buy" "50"'
+    assert_contains "$tribe start-colony.sh seeds knowledge_market_csv path" \
+        "$sc" 'tribes-bench-${TRIBE_NAME}:knowledge_market_csv'
+done
+
+# --- 8. Regression: pre-existing tests unchanged ---
+for testname in test-verify-finding.sh test-stage1-replication.sh test-stage1-bug-ledger.sh test-stage2-scaffold.sh; do
+    test_path="$FED_DIR/tools/$testname"
+    if [ -f "$test_path" ]; then
+        if bash "$test_path" >/dev/null 2>&1; then
+            echo "[PASS] $testname (regression)"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] $testname regressed"
+            FAIL=$((FAIL + 1))
+        fi
+    else
+        skip_case "$testname (regression)" "test script not found"
+    fi
+done
+
+if [ -f "$FED_DIR/tools/test-verify-finding.sh" ]; then
+    if STAGE1=1 bash "$FED_DIR/tools/test-verify-finding.sh" >/dev/null 2>&1; then
+        echo "[PASS] STAGE1=1 test-verify-finding.sh (regression)"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] STAGE1=1 test-verify-finding.sh regressed"
+        FAIL=$((FAIL + 1))
+    fi
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]

--- a/tribes-bench/tools/test-stage2-scaffold.sh
+++ b/tribes-bench/tools/test-stage2-scaffold.sh
@@ -278,23 +278,33 @@ if [ -f "$FED_DIR/tools/test-verify-finding.sh" ]; then
     fi
 fi
 
-# --- 8. Calibration unchanged vs origin/main ---
+# --- 8. Calibration: M1 economy sections unchanged vs origin/main ---
+# Stage 2 M2 (#393) appends `[reputation]` and `[knowledge_market]`
+# blocks to calibration.toml; the original M1-shipped sections
+# `[tribe.economy]`, `[tribe.reward]`, `[tribe.death]` must remain
+# byte-identical so the existing run-stage1.sh harness keeps reading
+# the same defaults. This assertion was a byte-identity gate in M1; it
+# is relaxed to a section-scoped diff for M2 forward.
 CALIB="tribes-bench/calibration.toml"
-GIT_DIR="$REPO_ROOT/.git"
 if [ -d "$REPO_ROOT/.git" ] || git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
     if git -C "$REPO_ROOT" rev-parse --verify origin/main >/dev/null 2>&1; then
-        if git -C "$REPO_ROOT" diff --quiet origin/main -- "$CALIB" 2>/dev/null; then
-            echo "[PASS] calibration.toml byte-identical to origin/main"
+        # Extract the M1-defined economy block: from line 1 through the
+        # last line of [tribe.death]. M2 additions live BELOW that.
+        upstream="$(git -C "$REPO_ROOT" show "origin/main:$CALIB" 2>/dev/null || true)"
+        upstream_econ="$(printf '%s' "$upstream" | awk 'BEGIN{p=1} /^\[reputation\]|^\[knowledge_market\]/{p=0} p{print}')"
+        local_econ="$(awk 'BEGIN{p=1} /^\[reputation\]|^\[knowledge_market\]/{p=0} p{print}' "$REPO_ROOT/$CALIB" 2>/dev/null || true)"
+        if [ "$upstream_econ" = "$local_econ" ] && [ -n "$upstream_econ" ]; then
+            echo "[PASS] calibration.toml: M1 [tribe.economy/reward/death] sections unchanged"
             PASS=$((PASS + 1))
         else
-            echo "[FAIL] calibration.toml differs from origin/main (Stage 2 M1 must not change calibration)"
+            echo "[FAIL] calibration.toml: M1 [tribe.economy/reward/death] sections changed (M2 must only APPEND new blocks)"
             FAIL=$((FAIL + 1))
         fi
     else
-        skip_case "calibration.toml byte-identical to origin/main" "origin/main not available"
+        skip_case "calibration.toml: M1 sections unchanged" "origin/main not available"
     fi
 else
-    skip_case "calibration.toml byte-identical to origin/main" "not a git repository"
+    skip_case "calibration.toml: M1 sections unchanged" "not a git repository"
 fi
 
 echo ""

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -58,6 +58,100 @@ fn self_node_addr() -> string {
     return "127.0.0.1:9100";
 }
 
+// --- Stage 2 M2 (#393) cognitive-market helpers ---------------------------
+//
+// Reputation, ask/max_cb formulas, sibling round-robin, trade-CSV row
+// emission. These helpers are byte-identical across all 5 tribes; only
+// the seed prompts and variant tags above this fence differ.
+
+fn pick_sibling(idx: int, self_tribe: string) -> string {
+    let i = idx - ((idx / 4) * 4);
+    if self_tribe == "tribe-alpha" {
+        if i == 0 { return "tribe-beta"; };
+        if i == 1 { return "tribe-gamma"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-beta" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-gamma"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-gamma" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-beta"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-delta" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-beta"; };
+        if i == 2 { return "tribe-gamma"; };
+        return "tribe-epsilon";
+    };
+    if i == 0 { return "tribe-alpha"; };
+    if i == 1 { return "tribe-beta"; };
+    if i == 2 { return "tribe-gamma"; };
+    return "tribe-delta";
+}
+
+fn rep_bucket(rep_str: string) -> int {
+    if len(rep_str) == 0 {
+        return 5;
+    };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys; r=float(sys.argv[1] or 0.5); v=int(r*10); print(0 if v<0 else (10 if v>10 else v))' " + shell_escape(rep_str);
+    let out = try { exec sh cmd; } catch e { "5"; };
+    let i = parse_int(out);
+    if i < 0 { return 0; };
+    if i > 10 { return 10; };
+    return i;
+}
+
+fn ask_for_rep(rep_str: string) -> int {
+    let v = rep_bucket(rep_str) + 1;
+    if v < 1 { return 1; };
+    return v;
+}
+
+fn max_cb_for_rep(rep_str: string) -> int {
+    return rep_bucket(rep_str) * 2 + 5;
+}
+
+fn premium_factor_for_rep(rep_str: string) -> int {
+    return 5 * (rep_bucket(rep_str) + 1);
+}
+
+fn pick_highest_rep_sibling(self_tribe: string) -> string {
+    let ba = if self_tribe == "tribe-alpha" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-alpha")); };
+    let bb = if self_tribe == "tribe-beta" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-beta")); };
+    let bg = if self_tribe == "tribe-gamma" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-gamma")); };
+    let bd = if self_tribe == "tribe-delta" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-delta")); };
+    let be = if self_tribe == "tribe-epsilon" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-epsilon")); };
+    let m1 = if ba >= bb { ba; } else { bb; };
+    let n1 = if ba >= bb { "tribe-alpha"; } else { "tribe-beta"; };
+    let m2 = if m1 >= bg { m1; } else { bg; };
+    let n2 = if m1 >= bg { n1; } else { "tribe-gamma"; };
+    let m3 = if m2 >= bd { m2; } else { bd; };
+    let n3 = if m2 >= bd { n2; } else { "tribe-delta"; };
+    let m4 = if m3 >= be { m3; } else { be; };
+    let n4 = if m3 >= be { n3; } else { "tribe-epsilon"; };
+    if m4 < 0 { return ""; };
+    return n4;
+}
+
+fn emit_market_csv(op: string, topic: string, topic_kind: string, ask_price_s: string, max_cb_s: string, paid_price_s: string, cache_hit_s: string, op_outcome: string) -> void {
+    let csv_path = recall_latest("tribes-bench-" + tribe_name() + ":knowledge_market_csv");
+    if len(csv_path) == 0 {
+        return;
+    };
+    let row = to_string(now_ms()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
+    // colony-lint: safe-exec-concat
+    let append_cmd = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(csv_path);
+    let _ = try { exec sh append_cmd; } catch e { ""; };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let conf = get_confidence();
@@ -79,6 +173,80 @@ fn tick(reason: string) -> void {
             memo_write("hunter:last_check", now_e);
         };
         return;
+    };
+
+    // Stage 2 M2 (#393): cognitive-market buy at start of tick, before
+    // seed prompt fires. Buy-gate widened to %8 + pool-aware skip per
+    // §9 risk 5; lifecycle discriminator + cache-hit learn() per risk 1+2.
+    let m_now = now_ms();
+    let pool_for_buy = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+    let pool_min_buy_str = recall_latest("pool_minimum_for_buy");
+    let pool_min_buy = if len(pool_min_buy_str) > 0 { parse_int(pool_min_buy_str); } else { 50; };
+    if (m_now - ((m_now / 8) * 8)) == 0 {
+        if pool_for_buy > pool_min_buy {
+            let sib_idx = m_now - ((m_now / 4) * 4);
+            let sibling = pick_sibling(sib_idx, tribe_name());
+            let sib_ledger = recall_latest("tribe-" + sibling + ":bug_ledger");
+            if len(sib_ledger) > 0 {
+                // colony-lint: safe-exec-concat
+                let head_cmd = "grep -F '\"tribe\": \"" + sibling + "\"' " + shell_escape(sib_ledger) + " 2>/dev/null | head -1 | jq -r '.bug_id // empty' 2>/dev/null";
+                let head_bug = try { exec sh head_cmd; } catch e { ""; };
+                if len(head_bug) > 0 {
+                    let buy_topic = "tribes-bench-" + sibling + "/" + head_bug;
+                    let cur_rep_buy_str = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
+                    let bought = knowledge_buy(buy_topic, max_cb_buy);
+                    let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_buy = if len(bought) > 0 {
+                        if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
+                    } else {
+                        if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
+                    if len(bought) > 0 {
+                        if outcome_buy == "cache_hit" {
+                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + tribe_name(), "topic_kind:finding"]);
+                        };
+                        memo_write("hunter:bought_context", bought);
+                    };
+                    emit_market_csv("buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
+                };
+            };
+        };
+    };
+
+    // Espionage buy (§4): low own-rep + surplus pool + at least one
+    // high-rep sibling => buy a bundle topic at premium price. Same
+    // lifecycle discriminator + cache-hit learn() pattern.
+    let own_rep_str_e = recall_latest("reputation:tribes-bench-" + tribe_name());
+    let cb_surplus_str_e = recall_latest("cb_surplus_threshold");
+    let cb_surplus_e = if len(cb_surplus_str_e) > 0 { parse_int(cb_surplus_str_e); } else { 300; };
+    if rep_bucket(own_rep_str_e) < 3 {
+        if pool_for_buy >= cb_surplus_e {
+            let best_t = pick_highest_rep_sibling(tribe_name());
+            if len(best_t) > 0 {
+                let best_s = recall_latest("reputation:tribes-bench-" + best_t);
+                if rep_bucket(best_s) > 7 {
+                    let espionage_topic = "tribes-bench-bundle/" + best_t;
+                    let prem_max_cb = premium_factor_for_rep(best_s);
+                    let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
+                    let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
+                    } else {
+                        if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
+                    if len(bought_b) > 0 {
+                        if outcome_eb == "cache_hit" {
+                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + tribe_name(), "topic_kind:bundle"]);
+                        };
+                        memo_write("hunter:bought_context", bought_b);
+                    };
+                    emit_market_csv("buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
+                };
+            };
+        };
     };
 
     // Tribe-alpha seed prompt: format!()-as-shell-builder heuristic.
@@ -173,9 +341,80 @@ fn tick(reason: string) -> void {
                             };
                         };
                     };
+
+                    // Stage 2 M2 (#393): reputation +0.05 (clamp 1.0) on
+                    // verified finding. Asymmetry +0.05/-0.10 absorbs
+                    // single-tick lag (§9 risk 6) and gives natural
+                    // ~10-find ceiling, ~5-find floor.
+                    let rep_str_v = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_v = if len(rep_str_v) > 0 { parse_float(rep_str_v); } else { 0.5; };
+                    let next_rep_v = if cur_rep_v + 0.05 > 1.0 { 1.0; } else { cur_rep_v + 0.05; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_v));
+                    let new_rep_str_v = to_string(next_rep_v);
+
+                    // Knowledge sell on per-finder topic prefix (§9
+                    // risk 3 mitigation eliminates seller-collision class).
+                    let sell_topic = "tribes-bench-" + tribe_name() + "/" + bug_id;
+                    let answer = "line=" + to_string(finding.line) + " bug=" + bug_id + " rationale=" + finding.rationale;
+                    let ask_price = ask_for_rep(new_rep_str_v);
+                    let sold = knowledge_sell(sell_topic, answer, ask_price);
+                    let kind_s = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_s = if sold {
+                        "succeeded";
+                    } else {
+                        if kind_s == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    if sold == false {
+                        learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "tribes-bench"]);
+                    };
+                    emit_market_csv("sell", sell_topic, "finding", to_string(ask_price), "", "", "0", outcome_s);
+
+                    // Bundle listing (§4): high-rep tribes proactively
+                    // list a bundle topic once per `bundle_period` verified
+                    // findings. Counter increments on every verified
+                    // finding; bundle fires when post-increment counter
+                    // is divisible by bundle_period.
+                    let bc_str = recall_latest("hunter:bundle_counter");
+                    let bc = if len(bc_str) > 0 { parse_int(bc_str); } else { 0; };
+                    let new_bc = bc + 1;
+                    memo_write("hunter:bundle_counter", to_string(new_bc));
+                    let bp_str = recall_latest("bundle_period");
+                    let bp = if len(bp_str) > 0 { parse_int(bp_str); } else { 3; };
+                    if rep_bucket(new_rep_str_v) > 7 {
+                        if (new_bc - ((new_bc / bp) * bp)) == 0 {
+                            let bundle_topic = "tribes-bench-bundle/" + tribe_name();
+                            let bundle_summary = if len(ledger_path) > 0 {
+                                // colony-lint: safe-exec-concat
+                                let last_k_cmd = "grep -F '\"tribe\": \"" + tribe_name() + "\"' " + shell_escape(ledger_path) + " 2>/dev/null | tail -" + to_string(bp) + " | jq -r '.bug_id' 2>/dev/null | tr '\n' ';'";
+                                try { exec sh last_k_cmd; } catch e { ""; };
+                            } else {
+                                "";
+                            };
+                            let prem_ask = premium_factor_for_rep(new_rep_str_v);
+                            let sold_b = knowledge_sell(bundle_topic, bundle_summary, prem_ask);
+                            let kind_bs = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                            let outcome_bs = if sold_b {
+                                "succeeded";
+                            } else {
+                                if kind_bs == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                            };
+                            if sold_b == false {
+                                learn("knowledge_sell", bundle_topic, "", "failure", ["sell-failed", "tribes-bench"]);
+                            };
+                            emit_market_csv("sell", bundle_topic, "bundle", to_string(prem_ask), "", "", "0", outcome_bs);
+                        };
+                    };
                 } else {
                     print("[hunter] false positive at line ", finding.line);
                     learn("hunt", "line " + to_string(finding.line), finding.rationale, "failure", ["false-positive", "tribes-bench"]);
+
+                    // Stage 2 M2 (#393): reputation -0.10 (clamp 0.0) on
+                    // false positive. Asymmetry vs verified-finding
+                    // +0.05 keeps the signal direction-stable.
+                    let rep_str_f = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_f = if len(rep_str_f) > 0 { parse_float(rep_str_f); } else { 0.5; };
+                    let next_rep_f = if cur_rep_f - 0.10 < 0.0 { 0.0; } else { cur_rep_f - 0.10; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_f));
                 };
 
                 // M3 death: pool-drain → KB preserve + sibling stop. Guarded

--- a/tribes-bench/tribe-alpha/scripts/start-colony.sh
+++ b/tribes-bench/tribe-alpha/scripts/start-colony.sh
@@ -14,6 +14,10 @@
 
 set -e
 
+# §9 risk 7: refuse start if the agentis runtime cannot reach the M2
+# floor (knowledge_buy / knowledge_sell are not .ag builtins pre-v1.5.0).
+"$(cd "$(dirname "$0")/../.." && pwd)/tools/check-agentis-version.sh"
+
 RESTART_AGENT=""
 RATE_LIMIT_STATUS=0
 POSITIONAL=()
@@ -179,6 +183,18 @@ if [ -n "$BUG_LEDGER_PATH" ]; then
 fi
 if [ -n "$RUN_DIR" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:run_dir" "$RUN_DIR" >/dev/null 2>&1 || true
+fi
+
+# Stage 2 M2 (#393) cognitive-market memos. Initial reputation 0.5
+# (mid-band per plan §2 bootstrap analysis); cb_surplus_threshold,
+# bundle_period, pool_minimum_for_buy are calibration-tunable knobs
+# documented in calibration.toml [knowledge_market].
+agentis memo set "reputation:tribes-bench-${TRIBE_NAME}" "0.5" >/dev/null 2>&1 || true
+agentis memo set "cb_surplus_threshold" "300" >/dev/null 2>&1 || true
+agentis memo set "bundle_period" "3" >/dev/null 2>&1 || true
+agentis memo set "pool_minimum_for_buy" "50" >/dev/null 2>&1 || true
+if [ -n "$RUN_DIR" ]; then
+    agentis memo set "tribes-bench-${TRIBE_NAME}:knowledge_market_csv" "$RUN_DIR/knowledge-market.csv" >/dev/null 2>&1 || true
 fi
 
 echo "Starting Tribe Alpha colony (${#AGENTS[@]} agents)..."

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -59,6 +59,100 @@ fn self_node_addr() -> string {
     return "127.0.0.1:9100";
 }
 
+// --- Stage 2 M2 (#393) cognitive-market helpers ---------------------------
+//
+// Reputation, ask/max_cb formulas, sibling round-robin, trade-CSV row
+// emission. These helpers are byte-identical across all 5 tribes; only
+// the seed prompts and variant tags above this fence differ.
+
+fn pick_sibling(idx: int, self_tribe: string) -> string {
+    let i = idx - ((idx / 4) * 4);
+    if self_tribe == "tribe-alpha" {
+        if i == 0 { return "tribe-beta"; };
+        if i == 1 { return "tribe-gamma"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-beta" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-gamma"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-gamma" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-beta"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-delta" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-beta"; };
+        if i == 2 { return "tribe-gamma"; };
+        return "tribe-epsilon";
+    };
+    if i == 0 { return "tribe-alpha"; };
+    if i == 1 { return "tribe-beta"; };
+    if i == 2 { return "tribe-gamma"; };
+    return "tribe-delta";
+}
+
+fn rep_bucket(rep_str: string) -> int {
+    if len(rep_str) == 0 {
+        return 5;
+    };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys; r=float(sys.argv[1] or 0.5); v=int(r*10); print(0 if v<0 else (10 if v>10 else v))' " + shell_escape(rep_str);
+    let out = try { exec sh cmd; } catch e { "5"; };
+    let i = parse_int(out);
+    if i < 0 { return 0; };
+    if i > 10 { return 10; };
+    return i;
+}
+
+fn ask_for_rep(rep_str: string) -> int {
+    let v = rep_bucket(rep_str) + 1;
+    if v < 1 { return 1; };
+    return v;
+}
+
+fn max_cb_for_rep(rep_str: string) -> int {
+    return rep_bucket(rep_str) * 2 + 5;
+}
+
+fn premium_factor_for_rep(rep_str: string) -> int {
+    return 5 * (rep_bucket(rep_str) + 1);
+}
+
+fn pick_highest_rep_sibling(self_tribe: string) -> string {
+    let ba = if self_tribe == "tribe-alpha" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-alpha")); };
+    let bb = if self_tribe == "tribe-beta" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-beta")); };
+    let bg = if self_tribe == "tribe-gamma" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-gamma")); };
+    let bd = if self_tribe == "tribe-delta" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-delta")); };
+    let be = if self_tribe == "tribe-epsilon" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-epsilon")); };
+    let m1 = if ba >= bb { ba; } else { bb; };
+    let n1 = if ba >= bb { "tribe-alpha"; } else { "tribe-beta"; };
+    let m2 = if m1 >= bg { m1; } else { bg; };
+    let n2 = if m1 >= bg { n1; } else { "tribe-gamma"; };
+    let m3 = if m2 >= bd { m2; } else { bd; };
+    let n3 = if m2 >= bd { n2; } else { "tribe-delta"; };
+    let m4 = if m3 >= be { m3; } else { be; };
+    let n4 = if m3 >= be { n3; } else { "tribe-epsilon"; };
+    if m4 < 0 { return ""; };
+    return n4;
+}
+
+fn emit_market_csv(op: string, topic: string, topic_kind: string, ask_price_s: string, max_cb_s: string, paid_price_s: string, cache_hit_s: string, op_outcome: string) -> void {
+    let csv_path = recall_latest("tribes-bench-" + tribe_name() + ":knowledge_market_csv");
+    if len(csv_path) == 0 {
+        return;
+    };
+    let row = to_string(now_ms()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
+    // colony-lint: safe-exec-concat
+    let append_cmd = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(csv_path);
+    let _ = try { exec sh append_cmd; } catch e { ""; };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let conf = get_confidence();
@@ -80,6 +174,80 @@ fn tick(reason: string) -> void {
             memo_write("hunter:last_check", now_e);
         };
         return;
+    };
+
+    // Stage 2 M2 (#393): cognitive-market buy at start of tick, before
+    // seed prompt fires. Buy-gate widened to %8 + pool-aware skip per
+    // §9 risk 5; lifecycle discriminator + cache-hit learn() per risk 1+2.
+    let m_now = now_ms();
+    let pool_for_buy = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+    let pool_min_buy_str = recall_latest("pool_minimum_for_buy");
+    let pool_min_buy = if len(pool_min_buy_str) > 0 { parse_int(pool_min_buy_str); } else { 50; };
+    if (m_now - ((m_now / 8) * 8)) == 0 {
+        if pool_for_buy > pool_min_buy {
+            let sib_idx = m_now - ((m_now / 4) * 4);
+            let sibling = pick_sibling(sib_idx, tribe_name());
+            let sib_ledger = recall_latest("tribe-" + sibling + ":bug_ledger");
+            if len(sib_ledger) > 0 {
+                // colony-lint: safe-exec-concat
+                let head_cmd = "grep -F '\"tribe\": \"" + sibling + "\"' " + shell_escape(sib_ledger) + " 2>/dev/null | head -1 | jq -r '.bug_id // empty' 2>/dev/null";
+                let head_bug = try { exec sh head_cmd; } catch e { ""; };
+                if len(head_bug) > 0 {
+                    let buy_topic = "tribes-bench-" + sibling + "/" + head_bug;
+                    let cur_rep_buy_str = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
+                    let bought = knowledge_buy(buy_topic, max_cb_buy);
+                    let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_buy = if len(bought) > 0 {
+                        if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
+                    } else {
+                        if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
+                    if len(bought) > 0 {
+                        if outcome_buy == "cache_hit" {
+                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + tribe_name(), "topic_kind:finding"]);
+                        };
+                        memo_write("hunter:bought_context", bought);
+                    };
+                    emit_market_csv("buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
+                };
+            };
+        };
+    };
+
+    // Espionage buy (§4): low own-rep + surplus pool + at least one
+    // high-rep sibling => buy a bundle topic at premium price. Same
+    // lifecycle discriminator + cache-hit learn() pattern.
+    let own_rep_str_e = recall_latest("reputation:tribes-bench-" + tribe_name());
+    let cb_surplus_str_e = recall_latest("cb_surplus_threshold");
+    let cb_surplus_e = if len(cb_surplus_str_e) > 0 { parse_int(cb_surplus_str_e); } else { 300; };
+    if rep_bucket(own_rep_str_e) < 3 {
+        if pool_for_buy >= cb_surplus_e {
+            let best_t = pick_highest_rep_sibling(tribe_name());
+            if len(best_t) > 0 {
+                let best_s = recall_latest("reputation:tribes-bench-" + best_t);
+                if rep_bucket(best_s) > 7 {
+                    let espionage_topic = "tribes-bench-bundle/" + best_t;
+                    let prem_max_cb = premium_factor_for_rep(best_s);
+                    let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
+                    let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
+                    } else {
+                        if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
+                    if len(bought_b) > 0 {
+                        if outcome_eb == "cache_hit" {
+                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + tribe_name(), "topic_kind:bundle"]);
+                        };
+                        memo_write("hunter:bought_context", bought_b);
+                    };
+                    emit_market_csv("buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
+                };
+            };
+        };
     };
 
     // Tribe-beta seed prompt: source-to-sink data-flow heuristic.
@@ -176,9 +344,80 @@ fn tick(reason: string) -> void {
                             };
                         };
                     };
+
+                    // Stage 2 M2 (#393): reputation +0.05 (clamp 1.0) on
+                    // verified finding. Asymmetry +0.05/-0.10 absorbs
+                    // single-tick lag (§9 risk 6) and gives natural
+                    // ~10-find ceiling, ~5-find floor.
+                    let rep_str_v = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_v = if len(rep_str_v) > 0 { parse_float(rep_str_v); } else { 0.5; };
+                    let next_rep_v = if cur_rep_v + 0.05 > 1.0 { 1.0; } else { cur_rep_v + 0.05; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_v));
+                    let new_rep_str_v = to_string(next_rep_v);
+
+                    // Knowledge sell on per-finder topic prefix (§9
+                    // risk 3 mitigation eliminates seller-collision class).
+                    let sell_topic = "tribes-bench-" + tribe_name() + "/" + bug_id;
+                    let answer = "line=" + to_string(finding.line) + " bug=" + bug_id + " rationale=" + finding.rationale;
+                    let ask_price = ask_for_rep(new_rep_str_v);
+                    let sold = knowledge_sell(sell_topic, answer, ask_price);
+                    let kind_s = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_s = if sold {
+                        "succeeded";
+                    } else {
+                        if kind_s == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    if sold == false {
+                        learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "tribes-bench"]);
+                    };
+                    emit_market_csv("sell", sell_topic, "finding", to_string(ask_price), "", "", "0", outcome_s);
+
+                    // Bundle listing (§4): high-rep tribes proactively
+                    // list a bundle topic once per `bundle_period` verified
+                    // findings. Counter increments on every verified
+                    // finding; bundle fires when post-increment counter
+                    // is divisible by bundle_period.
+                    let bc_str = recall_latest("hunter:bundle_counter");
+                    let bc = if len(bc_str) > 0 { parse_int(bc_str); } else { 0; };
+                    let new_bc = bc + 1;
+                    memo_write("hunter:bundle_counter", to_string(new_bc));
+                    let bp_str = recall_latest("bundle_period");
+                    let bp = if len(bp_str) > 0 { parse_int(bp_str); } else { 3; };
+                    if rep_bucket(new_rep_str_v) > 7 {
+                        if (new_bc - ((new_bc / bp) * bp)) == 0 {
+                            let bundle_topic = "tribes-bench-bundle/" + tribe_name();
+                            let bundle_summary = if len(ledger_path) > 0 {
+                                // colony-lint: safe-exec-concat
+                                let last_k_cmd = "grep -F '\"tribe\": \"" + tribe_name() + "\"' " + shell_escape(ledger_path) + " 2>/dev/null | tail -" + to_string(bp) + " | jq -r '.bug_id' 2>/dev/null | tr '\n' ';'";
+                                try { exec sh last_k_cmd; } catch e { ""; };
+                            } else {
+                                "";
+                            };
+                            let prem_ask = premium_factor_for_rep(new_rep_str_v);
+                            let sold_b = knowledge_sell(bundle_topic, bundle_summary, prem_ask);
+                            let kind_bs = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                            let outcome_bs = if sold_b {
+                                "succeeded";
+                            } else {
+                                if kind_bs == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                            };
+                            if sold_b == false {
+                                learn("knowledge_sell", bundle_topic, "", "failure", ["sell-failed", "tribes-bench"]);
+                            };
+                            emit_market_csv("sell", bundle_topic, "bundle", to_string(prem_ask), "", "", "0", outcome_bs);
+                        };
+                    };
                 } else {
                     print("[hunter] false positive at line ", finding.line);
                     learn("hunt", "line " + to_string(finding.line), finding.rationale, "failure", ["false-positive", "tribes-bench"]);
+
+                    // Stage 2 M2 (#393): reputation -0.10 (clamp 0.0) on
+                    // false positive. Asymmetry vs verified-finding
+                    // +0.05 keeps the signal direction-stable.
+                    let rep_str_f = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_f = if len(rep_str_f) > 0 { parse_float(rep_str_f); } else { 0.5; };
+                    let next_rep_f = if cur_rep_f - 0.10 < 0.0 { 0.0; } else { cur_rep_f - 0.10; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_f));
                 };
 
                 // M3 death: pool-drain → KB preserve + sibling stop. Guarded

--- a/tribes-bench/tribe-beta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-beta/scripts/start-colony.sh
@@ -14,6 +14,10 @@
 
 set -e
 
+# §9 risk 7: refuse start if the agentis runtime cannot reach the M2
+# floor (knowledge_buy / knowledge_sell are not .ag builtins pre-v1.5.0).
+"$(cd "$(dirname "$0")/../.." && pwd)/tools/check-agentis-version.sh"
+
 RESTART_AGENT=""
 RATE_LIMIT_STATUS=0
 POSITIONAL=()
@@ -179,6 +183,18 @@ if [ -n "$BUG_LEDGER_PATH" ]; then
 fi
 if [ -n "$RUN_DIR" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:run_dir" "$RUN_DIR" >/dev/null 2>&1 || true
+fi
+
+# Stage 2 M2 (#393) cognitive-market memos. Initial reputation 0.5
+# (mid-band per plan §2 bootstrap analysis); cb_surplus_threshold,
+# bundle_period, pool_minimum_for_buy are calibration-tunable knobs
+# documented in calibration.toml [knowledge_market].
+agentis memo set "reputation:tribes-bench-${TRIBE_NAME}" "0.5" >/dev/null 2>&1 || true
+agentis memo set "cb_surplus_threshold" "300" >/dev/null 2>&1 || true
+agentis memo set "bundle_period" "3" >/dev/null 2>&1 || true
+agentis memo set "pool_minimum_for_buy" "50" >/dev/null 2>&1 || true
+if [ -n "$RUN_DIR" ]; then
+    agentis memo set "tribes-bench-${TRIBE_NAME}:knowledge_market_csv" "$RUN_DIR/knowledge-market.csv" >/dev/null 2>&1 || true
 fi
 
 echo "Starting Tribe Beta colony (${#AGENTS[@]} agents)..."

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -60,6 +60,100 @@ fn self_node_addr() -> string {
     return "127.0.0.1:9100";
 }
 
+// --- Stage 2 M2 (#393) cognitive-market helpers ---------------------------
+//
+// Reputation, ask/max_cb formulas, sibling round-robin, trade-CSV row
+// emission. These helpers are byte-identical across all 5 tribes; only
+// the seed prompts and variant tags above this fence differ.
+
+fn pick_sibling(idx: int, self_tribe: string) -> string {
+    let i = idx - ((idx / 4) * 4);
+    if self_tribe == "tribe-alpha" {
+        if i == 0 { return "tribe-beta"; };
+        if i == 1 { return "tribe-gamma"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-beta" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-gamma"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-gamma" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-beta"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-delta" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-beta"; };
+        if i == 2 { return "tribe-gamma"; };
+        return "tribe-epsilon";
+    };
+    if i == 0 { return "tribe-alpha"; };
+    if i == 1 { return "tribe-beta"; };
+    if i == 2 { return "tribe-gamma"; };
+    return "tribe-delta";
+}
+
+fn rep_bucket(rep_str: string) -> int {
+    if len(rep_str) == 0 {
+        return 5;
+    };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys; r=float(sys.argv[1] or 0.5); v=int(r*10); print(0 if v<0 else (10 if v>10 else v))' " + shell_escape(rep_str);
+    let out = try { exec sh cmd; } catch e { "5"; };
+    let i = parse_int(out);
+    if i < 0 { return 0; };
+    if i > 10 { return 10; };
+    return i;
+}
+
+fn ask_for_rep(rep_str: string) -> int {
+    let v = rep_bucket(rep_str) + 1;
+    if v < 1 { return 1; };
+    return v;
+}
+
+fn max_cb_for_rep(rep_str: string) -> int {
+    return rep_bucket(rep_str) * 2 + 5;
+}
+
+fn premium_factor_for_rep(rep_str: string) -> int {
+    return 5 * (rep_bucket(rep_str) + 1);
+}
+
+fn pick_highest_rep_sibling(self_tribe: string) -> string {
+    let ba = if self_tribe == "tribe-alpha" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-alpha")); };
+    let bb = if self_tribe == "tribe-beta" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-beta")); };
+    let bg = if self_tribe == "tribe-gamma" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-gamma")); };
+    let bd = if self_tribe == "tribe-delta" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-delta")); };
+    let be = if self_tribe == "tribe-epsilon" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-epsilon")); };
+    let m1 = if ba >= bb { ba; } else { bb; };
+    let n1 = if ba >= bb { "tribe-alpha"; } else { "tribe-beta"; };
+    let m2 = if m1 >= bg { m1; } else { bg; };
+    let n2 = if m1 >= bg { n1; } else { "tribe-gamma"; };
+    let m3 = if m2 >= bd { m2; } else { bd; };
+    let n3 = if m2 >= bd { n2; } else { "tribe-delta"; };
+    let m4 = if m3 >= be { m3; } else { be; };
+    let n4 = if m3 >= be { n3; } else { "tribe-epsilon"; };
+    if m4 < 0 { return ""; };
+    return n4;
+}
+
+fn emit_market_csv(op: string, topic: string, topic_kind: string, ask_price_s: string, max_cb_s: string, paid_price_s: string, cache_hit_s: string, op_outcome: string) -> void {
+    let csv_path = recall_latest("tribes-bench-" + tribe_name() + ":knowledge_market_csv");
+    if len(csv_path) == 0 {
+        return;
+    };
+    let row = to_string(now_ms()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
+    // colony-lint: safe-exec-concat
+    let append_cmd = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(csv_path);
+    let _ = try { exec sh append_cmd; } catch e { ""; };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let conf = get_confidence();
@@ -81,6 +175,80 @@ fn tick(reason: string) -> void {
             memo_write("hunter:last_check", now_e);
         };
         return;
+    };
+
+    // Stage 2 M2 (#393): cognitive-market buy at start of tick, before
+    // seed prompt fires. Buy-gate widened to %8 + pool-aware skip per
+    // §9 risk 5; lifecycle discriminator + cache-hit learn() per risk 1+2.
+    let m_now = now_ms();
+    let pool_for_buy = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+    let pool_min_buy_str = recall_latest("pool_minimum_for_buy");
+    let pool_min_buy = if len(pool_min_buy_str) > 0 { parse_int(pool_min_buy_str); } else { 50; };
+    if (m_now - ((m_now / 8) * 8)) == 0 {
+        if pool_for_buy > pool_min_buy {
+            let sib_idx = m_now - ((m_now / 4) * 4);
+            let sibling = pick_sibling(sib_idx, tribe_name());
+            let sib_ledger = recall_latest("tribe-" + sibling + ":bug_ledger");
+            if len(sib_ledger) > 0 {
+                // colony-lint: safe-exec-concat
+                let head_cmd = "grep -F '\"tribe\": \"" + sibling + "\"' " + shell_escape(sib_ledger) + " 2>/dev/null | head -1 | jq -r '.bug_id // empty' 2>/dev/null";
+                let head_bug = try { exec sh head_cmd; } catch e { ""; };
+                if len(head_bug) > 0 {
+                    let buy_topic = "tribes-bench-" + sibling + "/" + head_bug;
+                    let cur_rep_buy_str = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
+                    let bought = knowledge_buy(buy_topic, max_cb_buy);
+                    let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_buy = if len(bought) > 0 {
+                        if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
+                    } else {
+                        if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
+                    if len(bought) > 0 {
+                        if outcome_buy == "cache_hit" {
+                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + tribe_name(), "topic_kind:finding"]);
+                        };
+                        memo_write("hunter:bought_context", bought);
+                    };
+                    emit_market_csv("buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
+                };
+            };
+        };
+    };
+
+    // Espionage buy (§4): low own-rep + surplus pool + at least one
+    // high-rep sibling => buy a bundle topic at premium price. Same
+    // lifecycle discriminator + cache-hit learn() pattern.
+    let own_rep_str_e = recall_latest("reputation:tribes-bench-" + tribe_name());
+    let cb_surplus_str_e = recall_latest("cb_surplus_threshold");
+    let cb_surplus_e = if len(cb_surplus_str_e) > 0 { parse_int(cb_surplus_str_e); } else { 300; };
+    if rep_bucket(own_rep_str_e) < 3 {
+        if pool_for_buy >= cb_surplus_e {
+            let best_t = pick_highest_rep_sibling(tribe_name());
+            if len(best_t) > 0 {
+                let best_s = recall_latest("reputation:tribes-bench-" + best_t);
+                if rep_bucket(best_s) > 7 {
+                    let espionage_topic = "tribes-bench-bundle/" + best_t;
+                    let prem_max_cb = premium_factor_for_rep(best_s);
+                    let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
+                    let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
+                    } else {
+                        if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
+                    if len(bought_b) > 0 {
+                        if outcome_eb == "cache_hit" {
+                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + tribe_name(), "topic_kind:bundle"]);
+                        };
+                        memo_write("hunter:bought_context", bought_b);
+                    };
+                    emit_market_csv("buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
+                };
+            };
+        };
     };
 
     // Tribe-delta seed prompt: lifetime / aliasing reasoning heuristic.
@@ -180,9 +348,80 @@ fn tick(reason: string) -> void {
                             };
                         };
                     };
+
+                    // Stage 2 M2 (#393): reputation +0.05 (clamp 1.0) on
+                    // verified finding. Asymmetry +0.05/-0.10 absorbs
+                    // single-tick lag (§9 risk 6) and gives natural
+                    // ~10-find ceiling, ~5-find floor.
+                    let rep_str_v = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_v = if len(rep_str_v) > 0 { parse_float(rep_str_v); } else { 0.5; };
+                    let next_rep_v = if cur_rep_v + 0.05 > 1.0 { 1.0; } else { cur_rep_v + 0.05; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_v));
+                    let new_rep_str_v = to_string(next_rep_v);
+
+                    // Knowledge sell on per-finder topic prefix (§9
+                    // risk 3 mitigation eliminates seller-collision class).
+                    let sell_topic = "tribes-bench-" + tribe_name() + "/" + bug_id;
+                    let answer = "line=" + to_string(finding.line) + " bug=" + bug_id + " rationale=" + finding.rationale;
+                    let ask_price = ask_for_rep(new_rep_str_v);
+                    let sold = knowledge_sell(sell_topic, answer, ask_price);
+                    let kind_s = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_s = if sold {
+                        "succeeded";
+                    } else {
+                        if kind_s == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    if sold == false {
+                        learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "tribes-bench"]);
+                    };
+                    emit_market_csv("sell", sell_topic, "finding", to_string(ask_price), "", "", "0", outcome_s);
+
+                    // Bundle listing (§4): high-rep tribes proactively
+                    // list a bundle topic once per `bundle_period` verified
+                    // findings. Counter increments on every verified
+                    // finding; bundle fires when post-increment counter
+                    // is divisible by bundle_period.
+                    let bc_str = recall_latest("hunter:bundle_counter");
+                    let bc = if len(bc_str) > 0 { parse_int(bc_str); } else { 0; };
+                    let new_bc = bc + 1;
+                    memo_write("hunter:bundle_counter", to_string(new_bc));
+                    let bp_str = recall_latest("bundle_period");
+                    let bp = if len(bp_str) > 0 { parse_int(bp_str); } else { 3; };
+                    if rep_bucket(new_rep_str_v) > 7 {
+                        if (new_bc - ((new_bc / bp) * bp)) == 0 {
+                            let bundle_topic = "tribes-bench-bundle/" + tribe_name();
+                            let bundle_summary = if len(ledger_path) > 0 {
+                                // colony-lint: safe-exec-concat
+                                let last_k_cmd = "grep -F '\"tribe\": \"" + tribe_name() + "\"' " + shell_escape(ledger_path) + " 2>/dev/null | tail -" + to_string(bp) + " | jq -r '.bug_id' 2>/dev/null | tr '\n' ';'";
+                                try { exec sh last_k_cmd; } catch e { ""; };
+                            } else {
+                                "";
+                            };
+                            let prem_ask = premium_factor_for_rep(new_rep_str_v);
+                            let sold_b = knowledge_sell(bundle_topic, bundle_summary, prem_ask);
+                            let kind_bs = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                            let outcome_bs = if sold_b {
+                                "succeeded";
+                            } else {
+                                if kind_bs == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                            };
+                            if sold_b == false {
+                                learn("knowledge_sell", bundle_topic, "", "failure", ["sell-failed", "tribes-bench"]);
+                            };
+                            emit_market_csv("sell", bundle_topic, "bundle", to_string(prem_ask), "", "", "0", outcome_bs);
+                        };
+                    };
                 } else {
                     print("[hunter] false positive at line ", finding.line);
                     learn("hunt", "line " + to_string(finding.line), finding.rationale, "failure", ["false-positive", "tribes-bench"]);
+
+                    // Stage 2 M2 (#393): reputation -0.10 (clamp 0.0) on
+                    // false positive. Asymmetry vs verified-finding
+                    // +0.05 keeps the signal direction-stable.
+                    let rep_str_f = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_f = if len(rep_str_f) > 0 { parse_float(rep_str_f); } else { 0.5; };
+                    let next_rep_f = if cur_rep_f - 0.10 < 0.0 { 0.0; } else { cur_rep_f - 0.10; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_f));
                 };
 
                 // M3 death: pool-drain → KB preserve + sibling stop. Guarded

--- a/tribes-bench/tribe-delta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-delta/scripts/start-colony.sh
@@ -14,6 +14,10 @@
 
 set -e
 
+# §9 risk 7: refuse start if the agentis runtime cannot reach the M2
+# floor (knowledge_buy / knowledge_sell are not .ag builtins pre-v1.5.0).
+"$(cd "$(dirname "$0")/../.." && pwd)/tools/check-agentis-version.sh"
+
 RESTART_AGENT=""
 RATE_LIMIT_STATUS=0
 POSITIONAL=()
@@ -179,6 +183,18 @@ if [ -n "$BUG_LEDGER_PATH" ]; then
 fi
 if [ -n "$RUN_DIR" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:run_dir" "$RUN_DIR" >/dev/null 2>&1 || true
+fi
+
+# Stage 2 M2 (#393) cognitive-market memos. Initial reputation 0.5
+# (mid-band per plan §2 bootstrap analysis); cb_surplus_threshold,
+# bundle_period, pool_minimum_for_buy are calibration-tunable knobs
+# documented in calibration.toml [knowledge_market].
+agentis memo set "reputation:tribes-bench-${TRIBE_NAME}" "0.5" >/dev/null 2>&1 || true
+agentis memo set "cb_surplus_threshold" "300" >/dev/null 2>&1 || true
+agentis memo set "bundle_period" "3" >/dev/null 2>&1 || true
+agentis memo set "pool_minimum_for_buy" "50" >/dev/null 2>&1 || true
+if [ -n "$RUN_DIR" ]; then
+    agentis memo set "tribes-bench-${TRIBE_NAME}:knowledge_market_csv" "$RUN_DIR/knowledge-market.csv" >/dev/null 2>&1 || true
 fi
 
 echo "Starting Tribe Delta colony (${#AGENTS[@]} agents)..."

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -60,6 +60,100 @@ fn self_node_addr() -> string {
     return "127.0.0.1:9100";
 }
 
+// --- Stage 2 M2 (#393) cognitive-market helpers ---------------------------
+//
+// Reputation, ask/max_cb formulas, sibling round-robin, trade-CSV row
+// emission. These helpers are byte-identical across all 5 tribes; only
+// the seed prompts and variant tags above this fence differ.
+
+fn pick_sibling(idx: int, self_tribe: string) -> string {
+    let i = idx - ((idx / 4) * 4);
+    if self_tribe == "tribe-alpha" {
+        if i == 0 { return "tribe-beta"; };
+        if i == 1 { return "tribe-gamma"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-beta" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-gamma"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-gamma" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-beta"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-delta" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-beta"; };
+        if i == 2 { return "tribe-gamma"; };
+        return "tribe-epsilon";
+    };
+    if i == 0 { return "tribe-alpha"; };
+    if i == 1 { return "tribe-beta"; };
+    if i == 2 { return "tribe-gamma"; };
+    return "tribe-delta";
+}
+
+fn rep_bucket(rep_str: string) -> int {
+    if len(rep_str) == 0 {
+        return 5;
+    };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys; r=float(sys.argv[1] or 0.5); v=int(r*10); print(0 if v<0 else (10 if v>10 else v))' " + shell_escape(rep_str);
+    let out = try { exec sh cmd; } catch e { "5"; };
+    let i = parse_int(out);
+    if i < 0 { return 0; };
+    if i > 10 { return 10; };
+    return i;
+}
+
+fn ask_for_rep(rep_str: string) -> int {
+    let v = rep_bucket(rep_str) + 1;
+    if v < 1 { return 1; };
+    return v;
+}
+
+fn max_cb_for_rep(rep_str: string) -> int {
+    return rep_bucket(rep_str) * 2 + 5;
+}
+
+fn premium_factor_for_rep(rep_str: string) -> int {
+    return 5 * (rep_bucket(rep_str) + 1);
+}
+
+fn pick_highest_rep_sibling(self_tribe: string) -> string {
+    let ba = if self_tribe == "tribe-alpha" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-alpha")); };
+    let bb = if self_tribe == "tribe-beta" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-beta")); };
+    let bg = if self_tribe == "tribe-gamma" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-gamma")); };
+    let bd = if self_tribe == "tribe-delta" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-delta")); };
+    let be = if self_tribe == "tribe-epsilon" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-epsilon")); };
+    let m1 = if ba >= bb { ba; } else { bb; };
+    let n1 = if ba >= bb { "tribe-alpha"; } else { "tribe-beta"; };
+    let m2 = if m1 >= bg { m1; } else { bg; };
+    let n2 = if m1 >= bg { n1; } else { "tribe-gamma"; };
+    let m3 = if m2 >= bd { m2; } else { bd; };
+    let n3 = if m2 >= bd { n2; } else { "tribe-delta"; };
+    let m4 = if m3 >= be { m3; } else { be; };
+    let n4 = if m3 >= be { n3; } else { "tribe-epsilon"; };
+    if m4 < 0 { return ""; };
+    return n4;
+}
+
+fn emit_market_csv(op: string, topic: string, topic_kind: string, ask_price_s: string, max_cb_s: string, paid_price_s: string, cache_hit_s: string, op_outcome: string) -> void {
+    let csv_path = recall_latest("tribes-bench-" + tribe_name() + ":knowledge_market_csv");
+    if len(csv_path) == 0 {
+        return;
+    };
+    let row = to_string(now_ms()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
+    // colony-lint: safe-exec-concat
+    let append_cmd = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(csv_path);
+    let _ = try { exec sh append_cmd; } catch e { ""; };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let conf = get_confidence();
@@ -81,6 +175,80 @@ fn tick(reason: string) -> void {
             memo_write("hunter:last_check", now_e);
         };
         return;
+    };
+
+    // Stage 2 M2 (#393): cognitive-market buy at start of tick, before
+    // seed prompt fires. Buy-gate widened to %8 + pool-aware skip per
+    // §9 risk 5; lifecycle discriminator + cache-hit learn() per risk 1+2.
+    let m_now = now_ms();
+    let pool_for_buy = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+    let pool_min_buy_str = recall_latest("pool_minimum_for_buy");
+    let pool_min_buy = if len(pool_min_buy_str) > 0 { parse_int(pool_min_buy_str); } else { 50; };
+    if (m_now - ((m_now / 8) * 8)) == 0 {
+        if pool_for_buy > pool_min_buy {
+            let sib_idx = m_now - ((m_now / 4) * 4);
+            let sibling = pick_sibling(sib_idx, tribe_name());
+            let sib_ledger = recall_latest("tribe-" + sibling + ":bug_ledger");
+            if len(sib_ledger) > 0 {
+                // colony-lint: safe-exec-concat
+                let head_cmd = "grep -F '\"tribe\": \"" + sibling + "\"' " + shell_escape(sib_ledger) + " 2>/dev/null | head -1 | jq -r '.bug_id // empty' 2>/dev/null";
+                let head_bug = try { exec sh head_cmd; } catch e { ""; };
+                if len(head_bug) > 0 {
+                    let buy_topic = "tribes-bench-" + sibling + "/" + head_bug;
+                    let cur_rep_buy_str = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
+                    let bought = knowledge_buy(buy_topic, max_cb_buy);
+                    let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_buy = if len(bought) > 0 {
+                        if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
+                    } else {
+                        if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
+                    if len(bought) > 0 {
+                        if outcome_buy == "cache_hit" {
+                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + tribe_name(), "topic_kind:finding"]);
+                        };
+                        memo_write("hunter:bought_context", bought);
+                    };
+                    emit_market_csv("buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
+                };
+            };
+        };
+    };
+
+    // Espionage buy (§4): low own-rep + surplus pool + at least one
+    // high-rep sibling => buy a bundle topic at premium price. Same
+    // lifecycle discriminator + cache-hit learn() pattern.
+    let own_rep_str_e = recall_latest("reputation:tribes-bench-" + tribe_name());
+    let cb_surplus_str_e = recall_latest("cb_surplus_threshold");
+    let cb_surplus_e = if len(cb_surplus_str_e) > 0 { parse_int(cb_surplus_str_e); } else { 300; };
+    if rep_bucket(own_rep_str_e) < 3 {
+        if pool_for_buy >= cb_surplus_e {
+            let best_t = pick_highest_rep_sibling(tribe_name());
+            if len(best_t) > 0 {
+                let best_s = recall_latest("reputation:tribes-bench-" + best_t);
+                if rep_bucket(best_s) > 7 {
+                    let espionage_topic = "tribes-bench-bundle/" + best_t;
+                    let prem_max_cb = premium_factor_for_rep(best_s);
+                    let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
+                    let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
+                    } else {
+                        if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
+                    if len(bought_b) > 0 {
+                        if outcome_eb == "cache_hit" {
+                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + tribe_name(), "topic_kind:bundle"]);
+                        };
+                        memo_write("hunter:bought_context", bought_b);
+                    };
+                    emit_market_csv("buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
+                };
+            };
+        };
     };
 
     // Tribe-epsilon seed prompt: concurrency / Send+Sync reasoning
@@ -181,9 +349,80 @@ fn tick(reason: string) -> void {
                             };
                         };
                     };
+
+                    // Stage 2 M2 (#393): reputation +0.05 (clamp 1.0) on
+                    // verified finding. Asymmetry +0.05/-0.10 absorbs
+                    // single-tick lag (§9 risk 6) and gives natural
+                    // ~10-find ceiling, ~5-find floor.
+                    let rep_str_v = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_v = if len(rep_str_v) > 0 { parse_float(rep_str_v); } else { 0.5; };
+                    let next_rep_v = if cur_rep_v + 0.05 > 1.0 { 1.0; } else { cur_rep_v + 0.05; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_v));
+                    let new_rep_str_v = to_string(next_rep_v);
+
+                    // Knowledge sell on per-finder topic prefix (§9
+                    // risk 3 mitigation eliminates seller-collision class).
+                    let sell_topic = "tribes-bench-" + tribe_name() + "/" + bug_id;
+                    let answer = "line=" + to_string(finding.line) + " bug=" + bug_id + " rationale=" + finding.rationale;
+                    let ask_price = ask_for_rep(new_rep_str_v);
+                    let sold = knowledge_sell(sell_topic, answer, ask_price);
+                    let kind_s = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_s = if sold {
+                        "succeeded";
+                    } else {
+                        if kind_s == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    if sold == false {
+                        learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "tribes-bench"]);
+                    };
+                    emit_market_csv("sell", sell_topic, "finding", to_string(ask_price), "", "", "0", outcome_s);
+
+                    // Bundle listing (§4): high-rep tribes proactively
+                    // list a bundle topic once per `bundle_period` verified
+                    // findings. Counter increments on every verified
+                    // finding; bundle fires when post-increment counter
+                    // is divisible by bundle_period.
+                    let bc_str = recall_latest("hunter:bundle_counter");
+                    let bc = if len(bc_str) > 0 { parse_int(bc_str); } else { 0; };
+                    let new_bc = bc + 1;
+                    memo_write("hunter:bundle_counter", to_string(new_bc));
+                    let bp_str = recall_latest("bundle_period");
+                    let bp = if len(bp_str) > 0 { parse_int(bp_str); } else { 3; };
+                    if rep_bucket(new_rep_str_v) > 7 {
+                        if (new_bc - ((new_bc / bp) * bp)) == 0 {
+                            let bundle_topic = "tribes-bench-bundle/" + tribe_name();
+                            let bundle_summary = if len(ledger_path) > 0 {
+                                // colony-lint: safe-exec-concat
+                                let last_k_cmd = "grep -F '\"tribe\": \"" + tribe_name() + "\"' " + shell_escape(ledger_path) + " 2>/dev/null | tail -" + to_string(bp) + " | jq -r '.bug_id' 2>/dev/null | tr '\n' ';'";
+                                try { exec sh last_k_cmd; } catch e { ""; };
+                            } else {
+                                "";
+                            };
+                            let prem_ask = premium_factor_for_rep(new_rep_str_v);
+                            let sold_b = knowledge_sell(bundle_topic, bundle_summary, prem_ask);
+                            let kind_bs = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                            let outcome_bs = if sold_b {
+                                "succeeded";
+                            } else {
+                                if kind_bs == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                            };
+                            if sold_b == false {
+                                learn("knowledge_sell", bundle_topic, "", "failure", ["sell-failed", "tribes-bench"]);
+                            };
+                            emit_market_csv("sell", bundle_topic, "bundle", to_string(prem_ask), "", "", "0", outcome_bs);
+                        };
+                    };
                 } else {
                     print("[hunter] false positive at line ", finding.line);
                     learn("hunt", "line " + to_string(finding.line), finding.rationale, "failure", ["false-positive", "tribes-bench"]);
+
+                    // Stage 2 M2 (#393): reputation -0.10 (clamp 0.0) on
+                    // false positive. Asymmetry vs verified-finding
+                    // +0.05 keeps the signal direction-stable.
+                    let rep_str_f = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_f = if len(rep_str_f) > 0 { parse_float(rep_str_f); } else { 0.5; };
+                    let next_rep_f = if cur_rep_f - 0.10 < 0.0 { 0.0; } else { cur_rep_f - 0.10; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_f));
                 };
 
                 // M3 death: pool-drain → KB preserve + sibling stop. Guarded

--- a/tribes-bench/tribe-epsilon/scripts/start-colony.sh
+++ b/tribes-bench/tribe-epsilon/scripts/start-colony.sh
@@ -14,6 +14,10 @@
 
 set -e
 
+# §9 risk 7: refuse start if the agentis runtime cannot reach the M2
+# floor (knowledge_buy / knowledge_sell are not .ag builtins pre-v1.5.0).
+"$(cd "$(dirname "$0")/../.." && pwd)/tools/check-agentis-version.sh"
+
 RESTART_AGENT=""
 RATE_LIMIT_STATUS=0
 POSITIONAL=()
@@ -179,6 +183,18 @@ if [ -n "$BUG_LEDGER_PATH" ]; then
 fi
 if [ -n "$RUN_DIR" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:run_dir" "$RUN_DIR" >/dev/null 2>&1 || true
+fi
+
+# Stage 2 M2 (#393) cognitive-market memos. Initial reputation 0.5
+# (mid-band per plan §2 bootstrap analysis); cb_surplus_threshold,
+# bundle_period, pool_minimum_for_buy are calibration-tunable knobs
+# documented in calibration.toml [knowledge_market].
+agentis memo set "reputation:tribes-bench-${TRIBE_NAME}" "0.5" >/dev/null 2>&1 || true
+agentis memo set "cb_surplus_threshold" "300" >/dev/null 2>&1 || true
+agentis memo set "bundle_period" "3" >/dev/null 2>&1 || true
+agentis memo set "pool_minimum_for_buy" "50" >/dev/null 2>&1 || true
+if [ -n "$RUN_DIR" ]; then
+    agentis memo set "tribes-bench-${TRIBE_NAME}:knowledge_market_csv" "$RUN_DIR/knowledge-market.csv" >/dev/null 2>&1 || true
 fi
 
 echo "Starting Tribe Epsilon colony (${#AGENTS[@]} agents)..."

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -60,6 +60,100 @@ fn self_node_addr() -> string {
     return "127.0.0.1:9100";
 }
 
+// --- Stage 2 M2 (#393) cognitive-market helpers ---------------------------
+//
+// Reputation, ask/max_cb formulas, sibling round-robin, trade-CSV row
+// emission. These helpers are byte-identical across all 5 tribes; only
+// the seed prompts and variant tags above this fence differ.
+
+fn pick_sibling(idx: int, self_tribe: string) -> string {
+    let i = idx - ((idx / 4) * 4);
+    if self_tribe == "tribe-alpha" {
+        if i == 0 { return "tribe-beta"; };
+        if i == 1 { return "tribe-gamma"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-beta" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-gamma"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-gamma" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-beta"; };
+        if i == 2 { return "tribe-delta"; };
+        return "tribe-epsilon";
+    };
+    if self_tribe == "tribe-delta" {
+        if i == 0 { return "tribe-alpha"; };
+        if i == 1 { return "tribe-beta"; };
+        if i == 2 { return "tribe-gamma"; };
+        return "tribe-epsilon";
+    };
+    if i == 0 { return "tribe-alpha"; };
+    if i == 1 { return "tribe-beta"; };
+    if i == 2 { return "tribe-gamma"; };
+    return "tribe-delta";
+}
+
+fn rep_bucket(rep_str: string) -> int {
+    if len(rep_str) == 0 {
+        return 5;
+    };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys; r=float(sys.argv[1] or 0.5); v=int(r*10); print(0 if v<0 else (10 if v>10 else v))' " + shell_escape(rep_str);
+    let out = try { exec sh cmd; } catch e { "5"; };
+    let i = parse_int(out);
+    if i < 0 { return 0; };
+    if i > 10 { return 10; };
+    return i;
+}
+
+fn ask_for_rep(rep_str: string) -> int {
+    let v = rep_bucket(rep_str) + 1;
+    if v < 1 { return 1; };
+    return v;
+}
+
+fn max_cb_for_rep(rep_str: string) -> int {
+    return rep_bucket(rep_str) * 2 + 5;
+}
+
+fn premium_factor_for_rep(rep_str: string) -> int {
+    return 5 * (rep_bucket(rep_str) + 1);
+}
+
+fn pick_highest_rep_sibling(self_tribe: string) -> string {
+    let ba = if self_tribe == "tribe-alpha" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-alpha")); };
+    let bb = if self_tribe == "tribe-beta" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-beta")); };
+    let bg = if self_tribe == "tribe-gamma" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-gamma")); };
+    let bd = if self_tribe == "tribe-delta" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-delta")); };
+    let be = if self_tribe == "tribe-epsilon" { -1; } else { rep_bucket(recall_latest("reputation:tribes-bench-tribe-epsilon")); };
+    let m1 = if ba >= bb { ba; } else { bb; };
+    let n1 = if ba >= bb { "tribe-alpha"; } else { "tribe-beta"; };
+    let m2 = if m1 >= bg { m1; } else { bg; };
+    let n2 = if m1 >= bg { n1; } else { "tribe-gamma"; };
+    let m3 = if m2 >= bd { m2; } else { bd; };
+    let n3 = if m2 >= bd { n2; } else { "tribe-delta"; };
+    let m4 = if m3 >= be { m3; } else { be; };
+    let n4 = if m3 >= be { n3; } else { "tribe-epsilon"; };
+    if m4 < 0 { return ""; };
+    return n4;
+}
+
+fn emit_market_csv(op: string, topic: string, topic_kind: string, ask_price_s: string, max_cb_s: string, paid_price_s: string, cache_hit_s: string, op_outcome: string) -> void {
+    let csv_path = recall_latest("tribes-bench-" + tribe_name() + ":knowledge_market_csv");
+    if len(csv_path) == 0 {
+        return;
+    };
+    let row = to_string(now_ms()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
+    // colony-lint: safe-exec-concat
+    let append_cmd = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(csv_path);
+    let _ = try { exec sh append_cmd; } catch e { ""; };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let conf = get_confidence();
@@ -81,6 +175,80 @@ fn tick(reason: string) -> void {
             memo_write("hunter:last_check", now_e);
         };
         return;
+    };
+
+    // Stage 2 M2 (#393): cognitive-market buy at start of tick, before
+    // seed prompt fires. Buy-gate widened to %8 + pool-aware skip per
+    // §9 risk 5; lifecycle discriminator + cache-hit learn() per risk 1+2.
+    let m_now = now_ms();
+    let pool_for_buy = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+    let pool_min_buy_str = recall_latest("pool_minimum_for_buy");
+    let pool_min_buy = if len(pool_min_buy_str) > 0 { parse_int(pool_min_buy_str); } else { 50; };
+    if (m_now - ((m_now / 8) * 8)) == 0 {
+        if pool_for_buy > pool_min_buy {
+            let sib_idx = m_now - ((m_now / 4) * 4);
+            let sibling = pick_sibling(sib_idx, tribe_name());
+            let sib_ledger = recall_latest("tribe-" + sibling + ":bug_ledger");
+            if len(sib_ledger) > 0 {
+                // colony-lint: safe-exec-concat
+                let head_cmd = "grep -F '\"tribe\": \"" + sibling + "\"' " + shell_escape(sib_ledger) + " 2>/dev/null | head -1 | jq -r '.bug_id // empty' 2>/dev/null";
+                let head_bug = try { exec sh head_cmd; } catch e { ""; };
+                if len(head_bug) > 0 {
+                    let buy_topic = "tribes-bench-" + sibling + "/" + head_bug;
+                    let cur_rep_buy_str = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
+                    let bought = knowledge_buy(buy_topic, max_cb_buy);
+                    let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_buy = if len(bought) > 0 {
+                        if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
+                    } else {
+                        if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
+                    if len(bought) > 0 {
+                        if outcome_buy == "cache_hit" {
+                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + tribe_name(), "topic_kind:finding"]);
+                        };
+                        memo_write("hunter:bought_context", bought);
+                    };
+                    emit_market_csv("buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
+                };
+            };
+        };
+    };
+
+    // Espionage buy (§4): low own-rep + surplus pool + at least one
+    // high-rep sibling => buy a bundle topic at premium price. Same
+    // lifecycle discriminator + cache-hit learn() pattern.
+    let own_rep_str_e = recall_latest("reputation:tribes-bench-" + tribe_name());
+    let cb_surplus_str_e = recall_latest("cb_surplus_threshold");
+    let cb_surplus_e = if len(cb_surplus_str_e) > 0 { parse_int(cb_surplus_str_e); } else { 300; };
+    if rep_bucket(own_rep_str_e) < 3 {
+        if pool_for_buy >= cb_surplus_e {
+            let best_t = pick_highest_rep_sibling(tribe_name());
+            if len(best_t) > 0 {
+                let best_s = recall_latest("reputation:tribes-bench-" + best_t);
+                if rep_bucket(best_s) > 7 {
+                    let espionage_topic = "tribes-bench-bundle/" + best_t;
+                    let prem_max_cb = premium_factor_for_rep(best_s);
+                    let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
+                    let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
+                    } else {
+                        if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
+                    if len(bought_b) > 0 {
+                        if outcome_eb == "cache_hit" {
+                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + tribe_name(), "topic_kind:bundle"]);
+                        };
+                        memo_write("hunter:bought_context", bought_b);
+                    };
+                    emit_market_csv("buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
+                };
+            };
+        };
     };
 
     // Tribe-gamma seed prompt: error-path data-flow heuristic. Plausibly
@@ -179,9 +347,80 @@ fn tick(reason: string) -> void {
                             };
                         };
                     };
+
+                    // Stage 2 M2 (#393): reputation +0.05 (clamp 1.0) on
+                    // verified finding. Asymmetry +0.05/-0.10 absorbs
+                    // single-tick lag (§9 risk 6) and gives natural
+                    // ~10-find ceiling, ~5-find floor.
+                    let rep_str_v = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_v = if len(rep_str_v) > 0 { parse_float(rep_str_v); } else { 0.5; };
+                    let next_rep_v = if cur_rep_v + 0.05 > 1.0 { 1.0; } else { cur_rep_v + 0.05; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_v));
+                    let new_rep_str_v = to_string(next_rep_v);
+
+                    // Knowledge sell on per-finder topic prefix (§9
+                    // risk 3 mitigation eliminates seller-collision class).
+                    let sell_topic = "tribes-bench-" + tribe_name() + "/" + bug_id;
+                    let answer = "line=" + to_string(finding.line) + " bug=" + bug_id + " rationale=" + finding.rationale;
+                    let ask_price = ask_for_rep(new_rep_str_v);
+                    let sold = knowledge_sell(sell_topic, answer, ask_price);
+                    let kind_s = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                    let outcome_s = if sold {
+                        "succeeded";
+                    } else {
+                        if kind_s == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                    };
+                    if sold == false {
+                        learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "tribes-bench"]);
+                    };
+                    emit_market_csv("sell", sell_topic, "finding", to_string(ask_price), "", "", "0", outcome_s);
+
+                    // Bundle listing (§4): high-rep tribes proactively
+                    // list a bundle topic once per `bundle_period` verified
+                    // findings. Counter increments on every verified
+                    // finding; bundle fires when post-increment counter
+                    // is divisible by bundle_period.
+                    let bc_str = recall_latest("hunter:bundle_counter");
+                    let bc = if len(bc_str) > 0 { parse_int(bc_str); } else { 0; };
+                    let new_bc = bc + 1;
+                    memo_write("hunter:bundle_counter", to_string(new_bc));
+                    let bp_str = recall_latest("bundle_period");
+                    let bp = if len(bp_str) > 0 { parse_int(bp_str); } else { 3; };
+                    if rep_bucket(new_rep_str_v) > 7 {
+                        if (new_bc - ((new_bc / bp) * bp)) == 0 {
+                            let bundle_topic = "tribes-bench-bundle/" + tribe_name();
+                            let bundle_summary = if len(ledger_path) > 0 {
+                                // colony-lint: safe-exec-concat
+                                let last_k_cmd = "grep -F '\"tribe\": \"" + tribe_name() + "\"' " + shell_escape(ledger_path) + " 2>/dev/null | tail -" + to_string(bp) + " | jq -r '.bug_id' 2>/dev/null | tr '\n' ';'";
+                                try { exec sh last_k_cmd; } catch e { ""; };
+                            } else {
+                                "";
+                            };
+                            let prem_ask = premium_factor_for_rep(new_rep_str_v);
+                            let sold_b = knowledge_sell(bundle_topic, bundle_summary, prem_ask);
+                            let kind_bs = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+                            let outcome_bs = if sold_b {
+                                "succeeded";
+                            } else {
+                                if kind_bs == "cognitive.rejected" { "rejected"; } else { "fallback"; };
+                            };
+                            if sold_b == false {
+                                learn("knowledge_sell", bundle_topic, "", "failure", ["sell-failed", "tribes-bench"]);
+                            };
+                            emit_market_csv("sell", bundle_topic, "bundle", to_string(prem_ask), "", "", "0", outcome_bs);
+                        };
+                    };
                 } else {
                     print("[hunter] false positive at line ", finding.line);
                     learn("hunt", "line " + to_string(finding.line), finding.rationale, "failure", ["false-positive", "tribes-bench"]);
+
+                    // Stage 2 M2 (#393): reputation -0.10 (clamp 0.0) on
+                    // false positive. Asymmetry vs verified-finding
+                    // +0.05 keeps the signal direction-stable.
+                    let rep_str_f = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_f = if len(rep_str_f) > 0 { parse_float(rep_str_f); } else { 0.5; };
+                    let next_rep_f = if cur_rep_f - 0.10 < 0.0 { 0.0; } else { cur_rep_f - 0.10; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_f));
                 };
 
                 // M3 death: pool-drain → KB preserve + sibling stop. Guarded

--- a/tribes-bench/tribe-gamma/scripts/start-colony.sh
+++ b/tribes-bench/tribe-gamma/scripts/start-colony.sh
@@ -14,6 +14,10 @@
 
 set -e
 
+# §9 risk 7: refuse start if the agentis runtime cannot reach the M2
+# floor (knowledge_buy / knowledge_sell are not .ag builtins pre-v1.5.0).
+"$(cd "$(dirname "$0")/../.." && pwd)/tools/check-agentis-version.sh"
+
 RESTART_AGENT=""
 RATE_LIMIT_STATUS=0
 POSITIONAL=()
@@ -179,6 +183,18 @@ if [ -n "$BUG_LEDGER_PATH" ]; then
 fi
 if [ -n "$RUN_DIR" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:run_dir" "$RUN_DIR" >/dev/null 2>&1 || true
+fi
+
+# Stage 2 M2 (#393) cognitive-market memos. Initial reputation 0.5
+# (mid-band per plan §2 bootstrap analysis); cb_surplus_threshold,
+# bundle_period, pool_minimum_for_buy are calibration-tunable knobs
+# documented in calibration.toml [knowledge_market].
+agentis memo set "reputation:tribes-bench-${TRIBE_NAME}" "0.5" >/dev/null 2>&1 || true
+agentis memo set "cb_surplus_threshold" "300" >/dev/null 2>&1 || true
+agentis memo set "bundle_period" "3" >/dev/null 2>&1 || true
+agentis memo set "pool_minimum_for_buy" "50" >/dev/null 2>&1 || true
+if [ -n "$RUN_DIR" ]; then
+    agentis memo set "tribes-bench-${TRIBE_NAME}:knowledge_market_csv" "$RUN_DIR/knowledge-market.csv" >/dev/null 2>&1 || true
 fi
 
 echo "Starting Tribe Gamma colony (${#AGENTS[@]} agents)..."


### PR DESCRIPTION
## Summary

Wires inter-tribe coordination primitives so the 5-tribe federation becomes an actual ecosystem. Pure infrastructure — no live experimental run (M3 territory, #394). Four deliverables:

- **Reputation memo per tribe** (`reputation:tribes-bench-<tribe>`), updated inline on every verified finding (`+0.05` clamp 1.0) and every false positive (`-0.10` clamp 0.0). Asymmetric step keeps direction stable; ~10-find ceiling, ~5-find floor; no per-tick decay so M3 cost-per-finding analysis stays clean.
- **Knowledge market wiring**: `knowledge_sell` on every verified finding (per-finder topic prefix `tribes-bench-<finder>/<bug_id>`); `knowledge_buy` at start of every 8th tick (pool-aware skip below `pool_minimum_for_buy`). Ask formula `max(1, floor(rep*10) + 1)`; max_cb `floor(rep*20) + 5`. Mid-band reputation (0.5) keeps every tribe trade-active at t=0.
- **Espionage primitive**: high-rep tribes (rep > 0.7) list a `tribes-bench-bundle/<self>` topic once per `bundle_period` verified findings; low-rep tribes (rep < 0.3) with surplus pool buy the highest-rep sibling's bundle at 5× premium.
- **Telemetry CSV** at `<run-dir>/knowledge-market.csv`: 12-column row per buy/sell call. `tools/analyse-stage2.py` reads the log, resolves `downstream_verified` post-hoc, rewrites with header. Existing `telemetry.csv` byte-identical.

## Mitigation-driven additions (plan §9 risks 1/2/3/5/7)

- **Risk 1** (buy-side cannot read seller's ask before paying) — every buy/sell call wraps `recall_latest("agent:lifecycle:cognitive:last_event_kind")` and writes one of `op_outcome ∈ {succeeded, cache_hit, rejected, fallback}` into the trade-CSV row. M3's analyser does not need to cross-join the lifecycle log.
- **Risk 2** (cache-hit free-rides the seller) — every `cognitive.cache_hit` buy emits `learn("market", topic, "", "cache_hit", [..., topic_kind:<finding|bundle>])` so the federation experience log shows free-ride traffic. Analyser revenue contract documented as `Σ(rows where op="buy" AND cache_hit=0) × ask_price` in code comment + README ecosystem section.
- **Risk 3** (`query_by_tags` seller-collision among tribes finding the same bug) — sell topic is `tribes-bench-<finder>/<bug_id>` (per-finder prefix). Two tribes finding the same bug list under DIFFERENT topics. Risk eliminated by construction.
- **Risk 5** (CB drain at federation scale) — buy-gate widened to `now_ms() % 8 == 0` (~12.5% of ticks); pool-aware skip predicate `pool_balance() > pool_minimum_for_buy` (memo, default 50). Both knobs exposed in `calibration.toml [knowledge_market]`.
- **Risk 7** (pre-v1.5.0 runtime quarantines on first tick) — new `tools/check-agentis-version.sh` (~50 LOC) refuses install (via `install.sh` first executable line) AND start (via every `tribe-*/scripts/start-colony.sh` first executable line) when `agentis --version` parses below `v1.5.0`. Refusal exit 78 (`EX_CONFIG`); error text points at the v1.5.0 release tag.

## Test plan

- [x] `bash tribes-bench/tools/test-stage2-cognitive-market.sh` — **41/0/0**
- [x] `bash tribes-bench/tools/test-stage2-reputation.sh` — **56/0/0** (includes regression run of the 4 pre-existing test scripts)
- [x] `bash tribes-bench/tools/test-verify-finding.sh` — Stage 0, **6/0**
- [x] `STAGE1=1 bash tribes-bench/tools/test-verify-finding.sh` — Stage 1, **6/0**
- [x] `bash tribes-bench/tools/test-stage1-replication.sh` — **48/0**
- [x] `bash tribes-bench/tools/test-stage1-bug-ledger.sh` — 10/10 unique first-finders
- [x] `bash tribes-bench/tools/test-stage2-scaffold.sh` — **23/0/0** (test 8 relaxed from full-file byte-identity to section-scoped diff so M2 can append `[reputation]` + `[knowledge_market]` while M1 economy stays byte-identical)
- [x] `bash tools/colony-lint.sh` (federation-wide) — **164/0/3** (same as origin/main baseline; no new failures)
- [x] Byte-identity guard on protected paths (`targets/stage{0,1,2}`, `run-stage*.sh`, `verify-finding*.sh`, `test-verify-finding.sh`, `test-stage1-*.sh`) — `git diff --quiet origin/main -- ...` exits 0
- [x] All 5 `tribe-*/agents/hunter.ag` compile via `agentis commit` (tested with v1.4.10; the M2 builtins resolve at runtime in v1.5.0+)
- [x] M2 helpers section + buy block + sell/reputation/bundle block byte-identical across the 5 hunters (sed-substitution-equivalent on structural code; only seed prompts + variant tags + `class` field on Stage 1+ Finding type differ)

## Out of scope (per plan §H)

- Any agentis-core change (v1.5.0 already shipped).
- A 6th tribe (zeta).
- M3 baseline harness, M3 outcome, multi-day live run (those are #394).
- Cross-federation propagation (knowledge market stays inside tribes-bench).
- Bumping `tribes-bench/VERSION` (federation stays unreleased).
- Touching `tools/run-stage2.sh`, `tools/verify-finding-stage2.sh`, `targets/stage2/` (M1 surface — byte-identical regression).

Addresses #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)