### PR TITLE
feat(tribes-bench): Stage 2 M3 baseline harness + crash drill + comparison report

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,80 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Stage 2 M3 — baseline harness + long-run defaults + comparison report**
+  ([#394](https://github.com/Replikanti/agentis-colonies/issues/394)).
+  - `tribes-bench/tools/run-baseline.sh` (new) — fixed-pipeline control
+    harness for the M3 thesis verdict. Runs a single tribe scanning the
+    same Stage 2 target as the 5-tribe ecosystem with `replicate` /
+    `knowledge_buy` / `knowledge_sell` stubbed via tagged `learn` rows
+    (`baseline-no-replicate`, `baseline-no-market`). Total CB is
+    `5 * initial_cb` so the single-tribe baseline burns the same total
+    compute envelope as the federation. Materialises
+    `tribes-bench/templates/tribe-baseline/` (new directory under
+    version control with `colony.toml.template` +
+    `agents/hunter-baseline.ag.template`) into a hermetic per-run dir
+    `runs/baseline-<ts>/tribe-baseline/`. Captures
+    `agentis-version.txt`, `llm-backend.txt`, `run-meta.json`. Periodic
+    snapshots use the new shared `tools/snapshot-stanza.sh` 7-section
+    payload. Reliable shutdown via `tools/kill-federation.sh
+    --no-backup`. Drives `tools/analyse-stage2.py` at the end. Env vars
+    `STAGE2_BASELINE_WALL_CLOCK_S` (default 3600s),
+    `STAGE2_BASELINE_LLM_BACKEND` (default `claude`),
+    `STAGE2_BASELINE_SNAPSHOT_S` (default 600s). Two stdlib helpers
+    (`tools/run-baseline-render.py`,
+    `tools/run-baseline-meta.py`) keep the shell heredoc-free per the
+    macOS bash 3.2 invariant.
+  - `tribes-bench/tools/run-stage2.sh` upgrades for the M3 long-run
+    reproduction recipe. Defaults: `STAGE2_WALL_CLOCK_S`
+    `3600` -> `172800` (48h); `STAGE2_SNAPSHOT_S` `600` -> `3600` (1h).
+    New env `STAGE2_CRASH_AT_S` triggers a `kill-federation.sh +
+    exit 99` after the elapsed counter reaches it (drives the M3
+    crash-recovery drill). New env `STAGE2_RESUME_RUN_DIR` reuses an
+    existing run-dir's `.agentis/` + `bug-ledger.jsonl` +
+    `knowledge-market.csv`, continues snapshot numbering from
+    `max(elapsed)`, defensively kills any stale daemon state before
+    relaunch, prunes `*.colony` files older than the snapshot mtime
+    via the new stdlib helper `tools/run-stage2-prune.py`. Snapshot
+    payload upgraded to the 7-section header-stanza form via the new
+    shared `tools/snapshot-stanza.sh` (`## daemon-list`,
+    `## experience-counts`, `## spend-counts`, `## bug-ledger`,
+    `## market-csv`, `## reputation-memos`, `## per-tribe-cb`).
+    Captures `agentis-version.txt`, `llm-backend.txt`, `run-meta.json`
+    once per run; resume path appends `run-meta-resume-<n>.json`
+    instead of clobbering the original meta.
+  - `tribes-bench/tools/analyse-stage2.py` extended (existing
+    behaviour byte-identical when `--baseline` is omitted). New
+    `--baseline <path>` flag triggers `<run-dir>/comparison.md`
+    emission with 5 fixed sections in plan Decision 4 order:
+    (1) Findings volume, (2) Cost per true positive, (3) Replication /
+    tribe-size dynamics, (4) Run shape, (5) Knowledge market activity
+    (ecosystem only). Section 5 prints `_no market activity in this
+    run_` when `knowledge-market.csv` is missing or empty. The
+    substrate-revenue aggregation excludes rows where `cache_hit=1`
+    per Risk 7 mitigation.
+  - `tribes-bench/tools/test-stage2-baseline-runner.sh` (new) — 7-case
+    test for the baseline harness. Live smoke skips when `agentis`
+    is not on PATH or no LLM API key is in env.
+  - `tribes-bench/tools/test-stage2-crash-recovery.sh` (new) — 7-case
+    drill (static doc + live crash + live resume + snapshot stanza
+    payload). `trap EXIT` cleanup runs `kill-federation.sh`
+    unconditionally.
+  - `tribes-bench/tools/test-stage2-analyse-comparison.sh` (new) —
+    fixture-driven 24-assertion test for the comparison report
+    (no live `agentis` spawn).
+  - `tribes-bench/README.md` — new "Stage 2 (M3 — long-run + baseline)
+    reproduction recipe" section documenting the 3-step recipe
+    (`run-baseline.sh` -> `run-stage2.sh` -> `analyse-stage2.py
+    --baseline`), the snapshot SHAs to pin at merge, the
+    non-determinism caveat (LLM backend dominates), and the 6-test
+    inventory split into live-fire vs fixture-only.
+  - Stage 0 / Stage 1 / Stage 2 M2 surface (`hunter.ag` files in
+    `tribe-{alpha,beta,gamma,delta,epsilon}`, calibration.toml,
+    `start-colony.sh` files, `verify-finding{,-stage2}.sh`,
+    `analyse-stage{0,1}.py`, `run-stage{0,1}.sh`,
+    pre-existing tests) byte-identical. Pre-existing
+    Stage 0/1/2 tests continue to PASS unchanged.
+
 - **Stage 2 M2 — cognitive market + reputation** ([#393](https://github.com/Replikanti/agentis-colonies/issues/393)).
   - All 5 `tribe-{alpha,beta,gamma,delta,epsilon}/agents/hunter.ag`
     now (a) update a `reputation:tribes-bench-<tribe>` float memo

--- a/tribes-bench/README.md
+++ b/tribes-bench/README.md
@@ -270,6 +270,73 @@ bash tools/test-stage2-reputation.sh                  # reputation primitive ass
 
 End-to-end multi-day live runs land in M3 (#394).
 
+## Stage 2 (M3 — long-run + baseline) reproduction recipe
+
+Stage 2 M3 ([#394](https://github.com/Replikanti/agentis-colonies/issues/394))
+ships the infrastructure for the long-run thesis verdict: a
+fixed-pipeline baseline harness, a 48h/1h-default ecosystem harness, a
+crash-recovery drill, and a comparison report. The thesis verdict
+itself is operator-driven — M3 PR ships the tooling that produces it,
+not the verdict.
+
+**3-step recipe** (plan Decision 4):
+
+1. Run the baseline (single tribe, no replication, no market):
+
+   ```bash
+   bash tools/run-baseline.sh
+   # produces: runs/baseline-<utc-ts>/telemetry.csv
+   ```
+
+2. Run the 5-tribe ecosystem (long-run defaults: 48h wall clock, 1h
+   snapshot interval):
+
+   ```bash
+   bash tools/run-stage2.sh
+   # produces: runs/<utc-ts>/{telemetry.csv,knowledge-market.csv,bug-ledger.jsonl,...}
+   ```
+
+3. Produce the comparison report:
+
+   ```bash
+   python3 tools/analyse-stage2.py runs/<eco-ts> \
+       --baseline runs/baseline-<bl-ts>/telemetry.csv
+   # produces: runs/<eco-ts>/comparison.md
+   ```
+
+**Snapshot SHAs to record at PR-merge time** (placeholders below — the
+operator running M3 must pin the actual SHAs from their pre-run
+`sha256sum` of the inputs and any reproducibility-relevant binaries):
+
+| Input | sha256 |
+|---|---|
+| `tribes-bench/calibration.toml` | `<pin at merge>` |
+| `tribes-bench/targets/stage2/smallvec-v0.6.13/lib.rs` | `<pin at merge>` |
+| `tribes-bench/targets/stage2/bugs.json` | `<pin at merge>` |
+
+**Non-determinism caveat** (plan Decision 6). The LLM backend is the
+dominant non-deterministic factor: even with identical seed prompts +
+identical CB budget + identical target, two runs through Claude (or any
+hosted LLM) will produce divergent finding sets. The harness pins
+`agentis --version`, the snapshot SHAs, and the LLM backend label
+(`runs/<ts>/llm-backend.txt`); the operator should record the LLM
+provider's model version separately. The comparison report's arithmetic
+is reproducible; the underlying telemetry is not byte-identical between
+runs.
+
+**M3 test inventory** (6 tribes-bench tests). Live-fire tests skip when
+agentis is not on PATH or no LLM API key is in env; fixture-driven tests
+always run:
+
+| Test | Mode |
+|---|---|
+| `tools/test-stage2-baseline-runner.sh` | static + opportunistic live smoke (15s) |
+| `tools/test-stage2-crash-recovery.sh` | static + opportunistic live drill |
+| `tools/test-stage2-analyse-comparison.sh` | fixture-only (no agentis spawn) |
+| `tools/test-stage2-scaffold.sh` | fixture-only (M1) |
+| `tools/test-stage2-cognitive-market.sh` | fixture-only (M2) |
+| `tools/test-stage2-reputation.sh` | fixture-only (M2) |
+
 ## Layout
 
 ```

--- a/tribes-bench/templates/tribe-baseline/agents/hunter-baseline.ag.template
+++ b/tribes-bench/templates/tribe-baseline/agents/hunter-baseline.ag.template
@@ -1,0 +1,153 @@
+// hunter-baseline.ag.template — Stage 2 M3 (#394) baseline hunter.
+//
+// Derived from tribe-alpha/agents/hunter.ag with the M3 baseline deltas
+// from plan Decision 1: the `replicate` builtin is replaced by a learn
+// row tagged "baseline-no-replicate", and the `knowledge_buy` /
+// `knowledge_sell` builtins are replaced by learn rows tagged
+// "baseline-no-market". The reputation memo updates are KEPT in place so
+// the analyser can compare the baseline reputation drift against the
+// 5-tribe ecosystem in isolation.
+//
+// {{CB_BUDGET}} is substituted by tools/run-baseline.sh at launch.
+//
+// Run as daemon: agentis daemon agents/hunter-baseline.ag --colony tribe-baseline
+
+cb {{CB_BUDGET}};
+
+type Finding {
+    line: int,
+    severity: string,
+    rationale: string,
+    signature_hint: string
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("hunter:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    };
+    return 0.0;
+}
+
+fn tribe_name() -> string {
+    let n = try { exec sh "printenv TRIBE_NAME"; } catch e { ""; };
+    if len(n) > 0 {
+        return n;
+    };
+    return "tribe-baseline";
+}
+
+fn tick(reason: string) -> void {
+    let _ = reason;
+    let conf = get_confidence();
+    print("[hunter-baseline] tick conf=", conf);
+
+    let src = try {
+        exec sh "cat $TARGET_DIR/vulnerable.rs";
+    } catch e {
+        print("[hunter-baseline] target read failed:", e);
+        "";
+    };
+
+    if len(src) < 10 {
+        let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_e) > 0 {
+            memo_write("hunter:last_check", now_e);
+        };
+        return;
+    };
+
+    // Baseline: no knowledge_buy. Record a tagged learn() row so the
+    // analyser can confirm the market wiring is stubbed.
+    learn("market", "baseline-stub", "", "stubbed", ["tribes-bench", tribe_name(), "baseline-no-market"]);
+
+    // Same seed prompt as tribe-alpha (format!()-as-shell-builder).
+    let finding = prompt(
+        "Look for places where shell or process invocation incorporates string concatenation. Suspect any format!() that builds a command string. Return JSON: line (int, 1-indexed source line of the suspect call), severity (string, low|medium|high), rationale (string, one sentence), signature_hint (string, a short literal substring grep can find on that line).",
+        src
+    ) -> Finding;
+
+    let my_tier = tier("hunter");
+    if my_tier == "autonomous" {
+        learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["acted", "tribes-bench"]);
+    } else {
+        if my_tier == "review-gated" {
+            learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["review-gated", "tribes-bench"]);
+        } else {
+            if my_tier == "propose" {
+                emit("tribe-baseline:finding", finding);
+
+                let finding_json = "{\"line\": " + to_string(finding.line) + "}";
+                let verify_cmd = "printf '%s' " + shell_escape(finding_json) + " | bash \"$VERIFIER_PATH\"";
+                let verdict_raw = try {
+                    exec sh verify_cmd;
+                } catch e {
+                    print("[hunter-baseline] verifier call failed:", e);
+                    "";
+                };
+
+                let verified_str = to_string(json_get(verdict_raw, "verified"));
+                let bug_id = to_string(json_get(verdict_raw, "bug_id"));
+                if verified_str == "true" {
+                    print("[hunter-baseline] verified ", bug_id, " at line ", finding.line);
+
+                    // Same first-finder + bug-ledger append + pool credit
+                    // as the 5-tribe hunter — preserved so the baseline's
+                    // CB economy is comparable.
+                    let prior_finder = recall_latest("bug-ledger:" + bug_id + ":first_finder_tribe");
+                    let reward = if len(prior_finder) == 0 {
+                        memo_write("bug-ledger:" + bug_id + ":first_finder_tribe", tribe_name());
+                        parse_int(recall_latest("tribe-" + tribe_name() + ":reward_full"));
+                    } else {
+                        parse_int(recall_latest("tribe-" + tribe_name() + ":reward_subsequent"));
+                    };
+
+                    let ledger_path = recall_latest("tribe-" + tribe_name() + ":bug_ledger");
+                    if len(ledger_path) > 0 {
+                        let row = "{\"ts\": " + to_string(now_ms()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
+                        // colony-lint: safe-exec-concat
+                        let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
+                        let _ = try { exec sh append_cmd; } catch e { ""; };
+                    };
+
+                    let cur_pool = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + reward));
+                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(reward)]);
+
+                    // Baseline: no replication call. Record a tagged
+                    // learn row so the analyser can confirm the
+                    // replication wiring is stubbed.
+                    learn("replicate", "baseline-stub", "", "stubbed", ["tribes-bench", tribe_name(), "baseline-no-replicate"]);
+
+                    // Reputation +0.05 (clamp 1.0) on verified finding
+                    // — kept in place per plan Decision 1 so the baseline
+                    // reputation drift is comparable to the ecosystem.
+                    let rep_str_v = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_v = if len(rep_str_v) > 0 { parse_float(rep_str_v); } else { 0.5; };
+                    let next_rep_v = if cur_rep_v + 0.05 > 1.0 { 1.0; } else { cur_rep_v + 0.05; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_v));
+
+                    // Baseline: no knowledge_sell. Stub-tagged learn() row.
+                    learn("market", "baseline-stub-sell", "", "stubbed", ["tribes-bench", tribe_name(), "baseline-no-market"]);
+                } else {
+                    print("[hunter-baseline] false positive at line ", finding.line);
+                    learn("hunt", "line " + to_string(finding.line), finding.rationale, "failure", ["false-positive", "tribes-bench"]);
+
+                    // Reputation -0.10 (clamp 0.0) on false positive.
+                    let rep_str_f = recall_latest("reputation:tribes-bench-" + tribe_name());
+                    let cur_rep_f = if len(rep_str_f) > 0 { parse_float(rep_str_f); } else { 0.5; };
+                    let next_rep_f = if cur_rep_f - 0.10 < 0.0 { 0.0; } else { cur_rep_f - 0.10; };
+                    memo_write("reputation:tribes-bench-" + tribe_name(), to_string(next_rep_f));
+                };
+            } else {
+                print("[hunter-baseline] observing (tier:", my_tier, ") line=", finding.line);
+                learn("hunt", "line " + to_string(finding.line), finding.rationale, "partial", ["observed", "tribes-bench"]);
+            };
+        };
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("hunter:last_check", now);
+    };
+}

--- a/tribes-bench/templates/tribe-baseline/colony.toml.template
+++ b/tribes-bench/templates/tribe-baseline/colony.toml.template
@@ -1,0 +1,32 @@
+# Tribe Baseline Colony Configuration (Stage 2 M3, #394)
+#
+# This is a TEMPLATE — placeholders enclosed in {{...}} are substituted
+# by tools/run-baseline.sh into runs/baseline-<ts>/tribe-baseline/colony.toml
+# at launch. Do NOT copy this file directly into a tribe directory; let
+# the harness materialise it.
+#
+# The baseline tribe is the M3 (#394) fixed-pipeline control: identical
+# scanning surface to tribe-alpha (same target, same verifier, same
+# CB budget, same seed prompt) but with `replicate(...)` and the
+# cognitive-market `knowledge_buy(...)` / `knowledge_sell(...)` calls
+# stubbed out (see agents/hunter-baseline.ag). Runs in isolation, never
+# alongside the 5-tribe ecosystem.
+
+[colony]
+name = "tribe-baseline"
+tick_interval_ms = 60000
+
+# tribes-bench is a non-forge federation. The baseline hunter scans the
+# same vendored smallvec target as the 5-tribe ecosystem; no Stage 0
+# agent calls forge-api.sh.
+[forge]
+type = "none"
+
+[llm]
+backend = "{{LLM_BACKEND}}"
+
+[[agents]]
+name = "hunter-baseline"
+source = "agents/hunter-baseline.ag"
+cb_budget = {{CB_BUDGET}}
+tick_interval_ms = 60000

--- a/tribes-bench/tools/analyse-stage2.py
+++ b/tribes-bench/tools/analyse-stage2.py
@@ -57,15 +57,48 @@ from collections import defaultdict
 from typing import Any
 
 
-def parse_args(argv: list[str]) -> str:
-    if len(argv) != 2:
-        print("Usage: analyse-stage2.py <run-dir>", file=sys.stderr)
+def parse_args(argv: list[str]) -> tuple[str, str | None]:
+    """Parse argv. Returns (run_dir, baseline_csv_path_or_None).
+
+    Backward-compatible: bare ``analyse-stage2.py <run-dir>`` returns
+    (run_dir, None) and produces byte-identical output to the M2 form.
+    The optional ``--baseline <path>`` flag (M3 #394) triggers
+    comparison-report emission to ``<run-dir>/comparison.md``.
+    """
+    args = argv[1:]
+    if not args:
+        print("Usage: analyse-stage2.py <run-dir> [--baseline <path>]", file=sys.stderr)
         sys.exit(2)
-    run_dir = argv[1]
+    run_dir: str | None = None
+    baseline: str | None = None
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--baseline":
+            if i + 1 >= len(args):
+                print("analyse-stage2: --baseline requires a path", file=sys.stderr)
+                sys.exit(2)
+            baseline = args[i + 1]
+            i += 2
+            continue
+        if a.startswith("--"):
+            print(f"analyse-stage2: unknown flag: {a}", file=sys.stderr)
+            sys.exit(2)
+        if run_dir is not None:
+            print("analyse-stage2: too many positional args", file=sys.stderr)
+            sys.exit(2)
+        run_dir = a
+        i += 1
+    if run_dir is None:
+        print("Usage: analyse-stage2.py <run-dir> [--baseline <path>]", file=sys.stderr)
+        sys.exit(2)
     if not os.path.isdir(run_dir):
         print(f"analyse-stage2: run dir not found: {run_dir}", file=sys.stderr)
         sys.exit(2)
-    return run_dir
+    if baseline is not None and not os.path.isfile(baseline):
+        print(f"analyse-stage2: baseline csv not found: {baseline}", file=sys.stderr)
+        sys.exit(2)
+    return run_dir, baseline
 
 
 def load_agent_to_tribe(daemon_dir: str) -> dict[str, str]:
@@ -305,7 +338,7 @@ def write_market_log(run_dir: str, rows: list[dict[str, Any]]) -> str | None:
 
 
 def main() -> None:
-    run_dir = parse_args(sys.argv)
+    run_dir, baseline_csv = parse_args(sys.argv)
     agentis_root = os.path.join(run_dir, ".agentis")
     daemon_dir = os.path.join(agentis_root, "daemon")
     experience_dir = os.path.join(agentis_root, "experience")
@@ -498,6 +531,236 @@ def main() -> None:
         market_path = write_market_log(run_dir, market_rows)
         if market_path:
             print(market_path)
+
+    # Stage 2 M3 (#394) optional comparison report. When --baseline is
+    # set, emit `<run-dir>/comparison.md` with the 5 fixed sections from
+    # plan Decision 4. When --baseline is omitted, behaviour is
+    # byte-identical to the M2 form (no comparison.md, no extra prints).
+    if baseline_csv is not None:
+        comparison_path = write_comparison_report(
+            run_dir=run_dir,
+            telemetry_csv=out_path,
+            baseline_csv=baseline_csv,
+            market_rows=market_rows,
+        )
+        if comparison_path:
+            print(comparison_path)
+
+
+# --- Stage 2 M3 (#394) comparison report -------------------------------------
+
+COMPARISON_COLUMNS = [
+    "minute", "tribe", "agents_alive", "cb_balance",
+    "findings_emitted", "true_positives", "false_positives",
+    "bug_class", "is_first_finder", "tribe_size",
+    "replication_event_count", "tribe_death_ts",
+]
+
+
+def _read_telemetry_csv(path: str) -> list[dict[str, str]]:
+    """Read a 12-column telemetry.csv and return rows as dicts. Skips
+    the header line. Tolerates short/long rows defensively."""
+    if not os.path.isfile(path):
+        return []
+    out: list[dict[str, str]] = []
+    with open(path, encoding="utf-8") as f:
+        reader = csv.reader(f)
+        try:
+            header = next(reader)
+        except StopIteration:
+            return []
+        # Trust the documented schema if the row count matches; otherwise
+        # the first row IS the header — skip it positionally.
+        if header[:1] != ["minute"]:
+            # Not a header — re-open to include it.
+            f.seek(0)
+            reader = csv.reader(f)
+        for row in reader:
+            if not row:
+                continue
+            d: dict[str, str] = {}
+            for i, k in enumerate(COMPARISON_COLUMNS):
+                d[k] = row[i] if i < len(row) else ""
+            out.append(d)
+    return out
+
+
+def _safe_int(s: str | int | None) -> int:
+    if isinstance(s, int):
+        return s
+    if s is None:
+        return 0
+    try:
+        return int(s)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _aggregate_telemetry(rows: list[dict[str, str]]) -> dict[str, int | float]:
+    """Aggregate a telemetry.csv into the comparison-relevant scalars.
+    Sum across all rows: total findings, TPs, FPs, CB, replication events,
+    first-finder ticks. Also count distinct minutes (run length proxy).
+    """
+    total_findings = 0
+    total_tp = 0
+    total_fp = 0
+    total_cb = 0
+    total_rep = 0
+    total_ff = 0
+    minutes: set[int] = set()
+    tribes: set[str] = set()
+    for r in rows:
+        total_findings += _safe_int(r.get("findings_emitted"))
+        total_tp += _safe_int(r.get("true_positives"))
+        total_fp += _safe_int(r.get("false_positives"))
+        total_cb += _safe_int(r.get("cb_balance"))
+        total_rep += _safe_int(r.get("replication_event_count"))
+        total_ff += _safe_int(r.get("is_first_finder"))
+        m = _safe_int(r.get("minute"))
+        minutes.add(m)
+        t = r.get("tribe") or ""
+        if t:
+            tribes.add(t)
+    cost_per_tp = (float(total_cb) / total_tp) if total_tp > 0 else 0.0
+    return {
+        "total_findings": total_findings,
+        "total_tp": total_tp,
+        "total_fp": total_fp,
+        "total_cb": total_cb,
+        "total_rep": total_rep,
+        "total_ff": total_ff,
+        "n_minutes": len(minutes),
+        "n_tribes": len(tribes),
+        "cost_per_tp": cost_per_tp,
+    }
+
+
+def _aggregate_market(rows: list[dict[str, object]]) -> dict[str, int]:
+    """Aggregate market.csv rows into substrate revenue + cache-hit count.
+    Per Risk 7 mitigation: substrate revenue excludes rows where
+    cache_hit == "1". The substrate-revenue is computed by joining sell
+    rows to substrate (cache_hit=0) buy rows on topic.
+    """
+    if not rows:
+        return {
+            "n_buy": 0,
+            "n_sell": 0,
+            "n_cache_hit": 0,
+            "substrate_revenue": 0,
+        }
+    buy_substrate: set[str] = set()
+    n_buy = 0
+    n_sell = 0
+    n_cache_hit = 0
+    for r in rows:
+        op = (r.get("op") or "")
+        cache_hit = (r.get("cache_hit") or "")
+        topic = (r.get("topic") or "")
+        if op == "buy":
+            n_buy += 1
+            if cache_hit == "1":
+                n_cache_hit += 1
+            if cache_hit == "0" and isinstance(topic, str) and topic:
+                buy_substrate.add(topic)
+        elif op == "sell":
+            n_sell += 1
+    revenue = 0
+    for r in rows:
+        if (r.get("op") or "") != "sell":
+            continue
+        topic = (r.get("topic") or "")
+        if not isinstance(topic, str) or topic not in buy_substrate:
+            continue
+        try:
+            revenue += int(r.get("ask_price") or 0)
+        except (TypeError, ValueError):
+            continue
+    return {
+        "n_buy": n_buy,
+        "n_sell": n_sell,
+        "n_cache_hit": n_cache_hit,
+        "substrate_revenue": revenue,
+    }
+
+
+def write_comparison_report(
+    run_dir: str,
+    telemetry_csv: str,
+    baseline_csv: str,
+    market_rows: list[dict[str, object]],
+) -> str | None:
+    """Emit ``<run-dir>/comparison.md`` with the 5 fixed sections from
+    plan Decision 4. Section order and headings are stable so downstream
+    consumers can grep by section.
+    """
+    eco_rows = _read_telemetry_csv(telemetry_csv)
+    base_rows = _read_telemetry_csv(baseline_csv)
+    eco = _aggregate_telemetry(eco_rows)
+    base = _aggregate_telemetry(base_rows)
+    market = _aggregate_market(market_rows)
+
+    lines: list[str] = []
+    lines.append("# Stage 2 M3 (#394) baseline-vs-ecosystem comparison")
+    lines.append("")
+    lines.append(f"- ecosystem run dir: `{run_dir}`")
+    lines.append(f"- baseline csv:       `{baseline_csv}`")
+    lines.append("")
+
+    lines.append("## 1. Findings volume")
+    lines.append("")
+    lines.append("| metric | ecosystem | baseline |")
+    lines.append("|---|---|---|")
+    lines.append(f"| total findings | {eco['total_findings']} | {base['total_findings']} |")
+    lines.append(f"| true positives | {eco['total_tp']} | {base['total_tp']} |")
+    lines.append(f"| false positives | {eco['total_fp']} | {base['total_fp']} |")
+    lines.append(f"| first-finder ticks | {eco['total_ff']} | {base['total_ff']} |")
+    lines.append("")
+
+    lines.append("## 2. Cost per true positive")
+    lines.append("")
+    lines.append("| metric | ecosystem | baseline |")
+    lines.append("|---|---|---|")
+    lines.append(f"| total CB | {eco['total_cb']} | {base['total_cb']} |")
+    lines.append(f"| TPs | {eco['total_tp']} | {base['total_tp']} |")
+    lines.append(
+        f"| CB / TP | {eco['cost_per_tp']:.2f} | {base['cost_per_tp']:.2f} |"
+    )
+    lines.append("")
+
+    lines.append("## 3. Replication / tribe-size dynamics")
+    lines.append("")
+    lines.append("| metric | ecosystem | baseline |")
+    lines.append("|---|---|---|")
+    lines.append(f"| replication events | {eco['total_rep']} | {base['total_rep']} |")
+    lines.append(f"| distinct tribes seen | {eco['n_tribes']} | {base['n_tribes']} |")
+    lines.append("")
+
+    lines.append("## 4. Run shape")
+    lines.append("")
+    lines.append("| metric | ecosystem | baseline |")
+    lines.append("|---|---|---|")
+    lines.append(f"| distinct minutes covered | {eco['n_minutes']} | {base['n_minutes']} |")
+    lines.append("")
+
+    lines.append("## 5. Knowledge market activity (ecosystem only)")
+    lines.append("")
+    if not market_rows:
+        lines.append("_no market activity in this run_")
+    else:
+        lines.append("| metric | value |")
+        lines.append("|---|---|")
+        lines.append(f"| buy ops | {market['n_buy']} |")
+        lines.append(f"| sell ops | {market['n_sell']} |")
+        lines.append(f"| cache-hit buys | {market['n_cache_hit']} |")
+        lines.append(
+            f"| substrate revenue (cache_hit=0 only) | {market['substrate_revenue']} |"
+        )
+    lines.append("")
+
+    out_path = os.path.join(run_dir, "comparison.md")
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+    return out_path
 
 
 if __name__ == "__main__":

--- a/tribes-bench/tools/run-baseline-meta.py
+++ b/tribes-bench/tools/run-baseline-meta.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""tribes-bench Stage 2 M3 (#394) run-meta.json writer.
+
+Tiny stdlib helper that emits ``run-meta.json`` with the M3 metadata
+schema. Pure stdlib.
+
+Usage:
+    run-baseline-meta.py <out_path> <started_at> <wall_clock_s> \
+                        <snapshot_s> <llm_backend> <baseline_cb> <kind>
+
+Why a separate file: CLAUDE.md "no heredocs in tools/*.sh" invariant.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 8:
+        print(
+            "Usage: run-baseline-meta.py <out> <started_at> <wall_s> "
+            "<snap_s> <llm> <cb> <kind>",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    out, started_at, wall_s, snap_s, llm, cb, kind = sys.argv[1:8]
+    payload = {
+        "started_at": started_at,
+        "wall_clock_s": int(wall_s),
+        "snapshot_s": int(snap_s),
+        "llm_backend": llm,
+        "baseline_cb": int(cb),
+        "kind": kind,
+    }
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tribes-bench/tools/run-baseline-render.py
+++ b/tribes-bench/tools/run-baseline-render.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""tribes-bench Stage 2 M3 (#394) template renderer.
+
+Substitutes ``{{KEY}}`` placeholders in a template file with values
+provided as ``KEY=value`` argv pairs and writes the result to a
+destination path. Pure stdlib.
+
+Usage:
+    run-baseline-render.py <src> <dst> KEY1=VALUE1 [KEY2=VALUE2 ...]
+
+Why a separate file: CLAUDE.md "no heredocs in tools/*.sh" invariant
+(macOS bash 3.2 parser bug, see #172 / #245 / #271). Sourcing this
+helper from tools/run-baseline.sh keeps the shell free of inline python.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def parse_args(argv: list[str]) -> tuple[str, str, dict[str, str]]:
+    if len(argv) < 4:
+        print(
+            "Usage: run-baseline-render.py <src> <dst> KEY=VAL [KEY=VAL ...]",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    src = argv[1]
+    dst = argv[2]
+    subs: dict[str, str] = {}
+    for raw in argv[3:]:
+        if "=" not in raw:
+            print(f"run-baseline-render: bad pair (no =): {raw!r}", file=sys.stderr)
+            sys.exit(2)
+        k, _, v = raw.partition("=")
+        subs[k.strip()] = v
+    return src, dst, subs
+
+
+def render(src: str, dst: str, subs: dict[str, str]) -> None:
+    with open(src, encoding="utf-8") as f:
+        content = f.read()
+    for key, val in subs.items():
+        content = content.replace("{{" + key + "}}", val)
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    with open(dst, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def main() -> None:
+    src, dst, subs = parse_args(sys.argv)
+    if not os.path.isfile(src):
+        print(f"run-baseline-render: source missing: {src}", file=sys.stderr)
+        sys.exit(2)
+    render(src, dst, subs)
+
+
+if __name__ == "__main__":
+    main()

--- a/tribes-bench/tools/run-baseline.sh
+++ b/tribes-bench/tools/run-baseline.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+# run-baseline.sh — Stage 2 M3 (#394) baseline harness.
+#
+# The M3 thesis verdict requires a fixed-pipeline control: a single tribe
+# scanning the same target as the 5-tribe ecosystem with `replicate(...)`
+# and the cognitive market (`knowledge_buy` / `knowledge_sell`) stubbed
+# out. This script builds and runs that control.
+#
+# The baseline tribe is materialised from
+# `tribes-bench/templates/tribe-baseline/` into the per-run dir
+# `tribes-bench/runs/baseline-<ts>/tribe-baseline/` (template
+# substitution is python3-driven; CLAUDE.md "no heredocs in tools/*.sh").
+# Operator-managed cleanup of `runs/baseline-*` mirrors run-stage2.sh.
+#
+# Total CB budget per plan Decision 1: BASELINE_CB = 5 * initial_cb
+# (matches the 5-tribe federation's total compute envelope).
+#
+# Env vars:
+#   STAGE2_BASELINE_WALL_CLOCK_S   Wall-clock cap in seconds (default: 3600)
+#   STAGE2_BASELINE_LLM_BACKEND    Override [llm].backend in colony.toml
+#                                   (default: claude)
+#   STAGE2_BASELINE_SNAPSHOT_S     Snapshot interval in seconds (default: 600)
+#
+# Exit codes:
+#   0  run completed and telemetry.csv produced
+#   1  prerequisite missing (agentis CLI, jq, python3) or invalid input
+#   2  start-federation/baseline launch failed
+#   3  analyse-stage2.py failed
+
+set -euo pipefail
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+TOOLS_DIR="$(dirname "$SCRIPT_PATH")"
+FED_DIR="$(dirname "$TOOLS_DIR")"
+REPO_ROOT="$(dirname "$FED_DIR")"
+
+WALL_CLOCK="${STAGE2_BASELINE_WALL_CLOCK_S:-3600}"
+case "$WALL_CLOCK" in
+    ''|*[!0-9]*)
+        echo "run-baseline: STAGE2_BASELINE_WALL_CLOCK_S must be a positive integer (got: $WALL_CLOCK)" >&2
+        exit 1
+        ;;
+esac
+
+SNAPSHOT_INTERVAL="${STAGE2_BASELINE_SNAPSHOT_S:-600}"
+case "$SNAPSHOT_INTERVAL" in
+    ''|*[!0-9]*)
+        echo "run-baseline: STAGE2_BASELINE_SNAPSHOT_S must be a positive integer (got: $SNAPSHOT_INTERVAL)" >&2
+        exit 1
+        ;;
+esac
+
+LLM_BACKEND="${STAGE2_BASELINE_LLM_BACKEND:-claude}"
+
+# --- Prerequisite checks ---
+for bin in agentis jq python3; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        echo "run-baseline: $bin not found on PATH" >&2
+        exit 1
+    fi
+done
+
+# --- Calibration: parse calibration.toml and export to env ---
+CALIBRATION="$FED_DIR/calibration.toml"
+if [ ! -f "$CALIBRATION" ]; then
+    echo "run-baseline: calibration.toml not found at $CALIBRATION" >&2
+    exit 1
+fi
+
+INITIAL_CB="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.economy initial_cb 1000)"
+BASE_COST="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.economy base_replication_cost 100)"
+K_MALTHUSIAN="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.economy k_malthusian 3)"
+MAX_REPLICAS="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.economy max_replicas_per_tribe 5)"
+REWARD_FULL="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.reward full 200)"
+REWARD_SUBSEQUENT="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.reward subsequent 50)"
+DEATH_THRESHOLD="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION" tribe.death threshold 100)"
+
+# Plan Decision 1: BASELINE_CB = 5 * initial_cb so the single-tribe baseline
+# burns the same total compute envelope as the 5-tribe ecosystem.
+BASELINE_CB="$((INITIAL_CB * 5))"
+
+export INITIAL_CB BASE_COST K_MALTHUSIAN MAX_REPLICAS REWARD_FULL REWARD_SUBSEQUENT DEATH_THRESHOLD
+
+echo "[run-baseline] total CB: $BASELINE_CB"
+
+# --- Per-run hermetic directory under runs/baseline-<ts>/ ---
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="$FED_DIR/runs/baseline-$TS"
+mkdir -p "$RUN_DIR" "$RUN_DIR/snapshots" "$RUN_DIR/tribe-baseline/agents" "$RUN_DIR/tribe-baseline/scripts" "$RUN_DIR/tribe-baseline/config"
+
+echo "[run-baseline] run dir: $RUN_DIR"
+echo "[run-baseline] wall-clock cap: ${WALL_CLOCK}s"
+echo "[run-baseline] snapshot interval: ${SNAPSHOT_INTERVAL}s"
+echo "[run-baseline] llm backend: $LLM_BACKEND"
+
+# --- Materialise tribe-baseline from template (python3 substitution) ---
+TARGET_DIR="$FED_DIR/targets/stage2/smallvec-v0.6.13"
+VERIFIER_PATH="$FED_DIR/tools/verify-finding-stage2.sh"
+BUG_LEDGER_PATH="$RUN_DIR/bug-ledger.jsonl"
+
+TEMPLATE_DIR="$FED_DIR/templates/tribe-baseline"
+if [ ! -d "$TEMPLATE_DIR" ]; then
+    echo "run-baseline: template dir missing at $TEMPLATE_DIR" >&2
+    exit 1
+fi
+
+python3 "$TOOLS_DIR/run-baseline-render.py" \
+    "$TEMPLATE_DIR/colony.toml.template" \
+    "$RUN_DIR/tribe-baseline/config/colony.toml" \
+    "CB_BUDGET=$BASELINE_CB" \
+    "LLM_BACKEND=$LLM_BACKEND" \
+    "TARGET_DIR=$TARGET_DIR" \
+    "VERIFIER_PATH=$VERIFIER_PATH" \
+    "BUG_LEDGER_PATH=$BUG_LEDGER_PATH"
+
+python3 "$TOOLS_DIR/run-baseline-render.py" \
+    "$TEMPLATE_DIR/agents/hunter-baseline.ag.template" \
+    "$RUN_DIR/tribe-baseline/agents/hunter-baseline.ag" \
+    "CB_BUDGET=$BASELINE_CB" \
+    "LLM_BACKEND=$LLM_BACKEND" \
+    "TARGET_DIR=$TARGET_DIR" \
+    "VERIFIER_PATH=$VERIFIER_PATH" \
+    "BUG_LEDGER_PATH=$BUG_LEDGER_PATH"
+
+# --- Hermetic .agentis/ root inside run dir ---
+(
+    cd "$RUN_DIR"
+    if [ ! -d .agentis ]; then
+        agentis init >/dev/null 2>&1
+    fi
+)
+
+AGENTIS_ROOT="$RUN_DIR/.agentis"
+export AGENTIS_ROOT
+
+# Configure config so analyse-stage2.py can find inputs.
+CONFIG_FILE="$RUN_DIR/.agentis/config"
+if [ -f "$CONFIG_FILE" ]; then
+    if ! grep -q '^exec\.env_passthrough' "$CONFIG_FILE"; then
+        printf '\nexec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT\n' >> "$CONFIG_FILE"
+    fi
+    if ! grep -q '^experience\.enabled' "$CONFIG_FILE"; then
+        printf 'experience.enabled = true\n' >> "$CONFIG_FILE"
+    fi
+    if ! grep -q '^telemetry\.enabled' "$CONFIG_FILE"; then
+        printf 'telemetry.enabled = true\n' >> "$CONFIG_FILE"
+    fi
+fi
+
+# Seed hunter:confidence to 0.7 (mid-propose).
+(
+    cd "$RUN_DIR"
+    agentis memo set hunter:confidence 0.7 >/dev/null 2>&1 || true
+    agentis memo set "tribe-tribe-baseline:pool" "$BASELINE_CB" >/dev/null 2>&1 || true
+    agentis memo set "tribe-tribe-baseline:size" "1" >/dev/null 2>&1 || true
+    agentis memo set "tribe-tribe-baseline:reward_full" "$REWARD_FULL" >/dev/null 2>&1 || true
+    agentis memo set "tribe-tribe-baseline:reward_subsequent" "$REWARD_SUBSEQUENT" >/dev/null 2>&1 || true
+    agentis memo set "tribe-tribe-baseline:death_threshold" "$DEATH_THRESHOLD" >/dev/null 2>&1 || true
+    agentis memo set "tribe-tribe-baseline:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
+    agentis memo set "tribe-tribe-baseline:run_dir" "$RUN_DIR" >/dev/null 2>&1 || true
+    agentis memo set "reputation:tribes-bench-tribe-baseline" "0.5" >/dev/null 2>&1 || true
+)
+
+# --- Export env consumed by hunter-baseline.ag via exec sh ---
+export TARGET_DIR
+export BUGS_MANIFEST="$FED_DIR/targets/stage2/bugs.json"
+export VERIFIER_PATH
+export RUN_DIR
+export BUG_LEDGER_PATH
+export TRIBE_NAME="tribe-baseline"
+
+: > "$BUG_LEDGER_PATH"
+
+if [ ! -f "$TARGET_DIR/lib.rs" ]; then
+    echo "run-baseline: target source not found at $TARGET_DIR/lib.rs" >&2
+    exit 1
+fi
+if [ ! -f "$BUGS_MANIFEST" ]; then
+    echo "run-baseline: bugs manifest not found at $BUGS_MANIFEST" >&2
+    exit 1
+fi
+if [ ! -x "$VERIFIER_PATH" ]; then
+    echo "run-baseline: verifier not executable at $VERIFIER_PATH" >&2
+    exit 1
+fi
+
+# Capture agentis version + llm backend + run-meta.
+agentis --version > "$RUN_DIR/agentis-version.txt" 2>&1 || true
+printf '%s\n' "$LLM_BACKEND" > "$RUN_DIR/llm-backend.txt"
+
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+python3 "$TOOLS_DIR/run-baseline-meta.py" \
+    "$RUN_DIR/run-meta.json" \
+    "$STARTED_AT" \
+    "$WALL_CLOCK" \
+    "$SNAPSHOT_INTERVAL" \
+    "$LLM_BACKEND" \
+    "$BASELINE_CB" \
+    "baseline"
+
+# --- Launch the baseline daemon directly (no start-federation.sh; the
+# baseline tribe lives outside <fed>/tribe-* and would not be picked up
+# by the COLONIES array). One daemon = one hunter-baseline. ---
+echo "[run-baseline] launching baseline tribe..."
+(
+    cd "$RUN_DIR"
+    agentis daemon "$RUN_DIR/tribe-baseline/agents/hunter-baseline.ag" \
+        --colony tribe-baseline \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval 60000 >>"$RUN_DIR/start-baseline.log" 2>&1
+) &
+FED_PID=$!
+
+sleep 5
+
+if ! kill -0 "$FED_PID" 2>/dev/null; then
+    echo "run-baseline: baseline daemon exited early; see $RUN_DIR/start-baseline.log" >&2
+    exit 2
+fi
+
+# --- Sleep wall-clock cap with periodic snapshots ---
+echo "[run-baseline] sleeping ${WALL_CLOCK}s with snapshots every ${SNAPSHOT_INTERVAL}s..."
+elapsed=0
+while [ "$elapsed" -lt "$WALL_CLOCK" ]; do
+    remaining=$((WALL_CLOCK - elapsed))
+    if [ "$remaining" -gt "$SNAPSHOT_INTERVAL" ]; then
+        sleep "$SNAPSHOT_INTERVAL"
+        elapsed=$((elapsed + SNAPSHOT_INTERVAL))
+    else
+        sleep "$remaining"
+        elapsed="$WALL_CLOCK"
+    fi
+    snap_path="$RUN_DIR/snapshots/${elapsed}.txt"
+    bash "$TOOLS_DIR/snapshot-stanza.sh" "$RUN_DIR" "$elapsed" > "$snap_path" 2>/dev/null || true
+    echo "[run-baseline] snapshot $snap_path"
+done
+
+# --- Reliable shutdown via tools/kill-federation.sh ---
+echo "[run-baseline] stopping baseline..."
+KILL_SCRIPT="$REPO_ROOT/tools/kill-federation.sh"
+if [ -x "$KILL_SCRIPT" ]; then
+    bash "$KILL_SCRIPT" --fed-dir "$FED_DIR" --no-backup >>"$RUN_DIR/kill-federation.log" 2>&1 || true
+else
+    echo "run-baseline: kill-federation.sh not found at $KILL_SCRIPT — falling back to kill" >&2
+    kill "$FED_PID" 2>/dev/null || true
+fi
+
+wait "$FED_PID" 2>/dev/null || true
+
+# --- Telemetry ---
+echo "[run-baseline] analysing run..."
+ANALYSER="$TOOLS_DIR/analyse-stage2.py"
+if ! python3 "$ANALYSER" "$RUN_DIR"; then
+    echo "run-baseline: analyse-stage2.py failed" >&2
+    exit 3
+fi
+
+echo "[run-baseline] done."
+echo "[run-baseline] telemetry: $RUN_DIR/telemetry.csv"
+echo "[run-baseline] bug-ledger: $RUN_DIR/bug-ledger.jsonl"

--- a/tribes-bench/tools/run-stage2-prune.py
+++ b/tribes-bench/tools/run-stage2-prune.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""tribes-bench Stage 2 M3 (#394) defensive prune helper.
+
+On resume, removes orphan ``*.colony`` files under
+``<run>/.agentis/daemon/`` whose mtime is older than the highest-elapsed
+snapshot file in ``<run>/snapshots/``. A daemon that crashed mid-run can
+leave behind a stale colony record that masquerades as alive when
+``agentis daemon list`` reads the registry; pruning guarantees the
+analyser sees only post-relaunch records.
+
+Pure stdlib. Conservative: keeps every record newer than the snapshot
+mtime, prunes only strictly older records.
+
+Usage:
+    run-stage2-prune.py <run-dir>
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit(2)
+    run_dir = sys.argv[1]
+    if not os.path.isdir(run_dir):
+        return
+    snapdir = os.path.join(run_dir, "snapshots")
+    daemon_dir = os.path.join(run_dir, ".agentis", "daemon")
+    if not os.path.isdir(daemon_dir):
+        return
+    cutoff_mtime = 0.0
+    if os.path.isdir(snapdir):
+        best = 0
+        best_mtime = 0.0
+        for name in os.listdir(snapdir):
+            if not name.endswith(".txt"):
+                continue
+            stem = name[: -len(".txt")]
+            try:
+                v = int(stem)
+            except ValueError:
+                continue
+            try:
+                mt = os.path.getmtime(os.path.join(snapdir, name))
+            except OSError:
+                continue
+            if v > best:
+                best = v
+                best_mtime = mt
+        cutoff_mtime = best_mtime
+    if cutoff_mtime <= 0:
+        return
+    for name in os.listdir(daemon_dir):
+        if not name.endswith(".colony"):
+            continue
+        path = os.path.join(daemon_dir, name)
+        try:
+            if os.path.getmtime(path) < cutoff_mtime:
+                os.remove(path)
+        except OSError:
+            continue
+
+
+if __name__ == "__main__":
+    main()

--- a/tribes-bench/tools/run-stage2-snapshot-max.py
+++ b/tribes-bench/tools/run-stage2-snapshot-max.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""tribes-bench Stage 2 M3 (#394) snapshot max-elapsed reader.
+
+Reads a `<run>/snapshots/` directory and emits the largest numeric stem
+(`<elapsed>.txt`) on stdout. Returns 0 when the directory is empty or
+missing. Pure stdlib.
+
+Used by tools/run-stage2.sh on resume to continue snapshot numbering
+without overwriting existing files.
+
+Usage:
+    run-stage2-snapshot-max.py <snapshots-dir>
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(0)
+        return
+    snapdir = sys.argv[1]
+    if not os.path.isdir(snapdir):
+        print(0)
+        return
+    best = 0
+    for name in os.listdir(snapdir):
+        if not name.endswith(".txt"):
+            continue
+        stem = name[: -len(".txt")]
+        try:
+            v = int(stem)
+        except ValueError:
+            continue
+        if v > best:
+            best = v
+    print(best)
+
+
+if __name__ == "__main__":
+    main()

--- a/tribes-bench/tools/run-stage2.sh
+++ b/tribes-bench/tools/run-stage2.sh
@@ -17,16 +17,31 @@
 # tools/analyse-stage2.py at the end.
 #
 # Env vars:
-#   STAGE2_WALL_CLOCK_S    Wall-clock cap in seconds (default: 3600)
+#   STAGE2_WALL_CLOCK_S    Wall-clock cap in seconds (default: 172800
+#                          = 48h, M3 #394). Lower values still work for
+#                          smoke tests; the M3 reproduction recipe
+#                          assumes the 48h default.
 #   STAGE2_LLM_BACKEND     Override [llm].backend in colony.toml
 #                          (default: leave config alone, which means cli)
-#   STAGE2_SNAPSHOT_S      Snapshot interval in seconds (default: 600)
+#   STAGE2_SNAPSHOT_S      Snapshot interval in seconds (default: 3600
+#                          = 1h, M3 #394).
+#   STAGE2_CRASH_AT_S      M3 #394: when set to a positive integer N,
+#                          run-stage2.sh calls kill-federation.sh after
+#                          elapsed >= N and exits 99. Used by the M3
+#                          crash-recovery drill.
+#   STAGE2_RESUME_RUN_DIR  M3 #394: when set to a runs/<ts> path, skip
+#                          mkdir + agentis init + memo seeding; reuse the
+#                          existing .agentis/, bug-ledger.jsonl, and
+#                          knowledge-market.csv. Snapshot numbering
+#                          continues from max(existing). A fresh
+#                          run-meta-resume-<n>.json is written.
 #
 # Exit codes:
-#   0  run completed and telemetry.csv produced
-#   1  prerequisite missing (agentis CLI, jq, python3)
-#   2  start-federation.sh failed to launch
-#   3  analyse-stage2.py failed
+#   0   run completed and telemetry.csv produced
+#   1   prerequisite missing (agentis CLI, jq, python3)
+#   2   start-federation.sh failed to launch
+#   3   analyse-stage2.py failed
+#   99  STAGE2_CRASH_AT_S simulated crash (M3 #394 drill)
 
 set -euo pipefail
 
@@ -35,7 +50,7 @@ TOOLS_DIR="$(dirname "$SCRIPT_PATH")"
 FED_DIR="$(dirname "$TOOLS_DIR")"
 REPO_ROOT="$(dirname "$FED_DIR")"
 
-WALL_CLOCK="${STAGE2_WALL_CLOCK_S:-3600}"
+WALL_CLOCK="${STAGE2_WALL_CLOCK_S:-172800}"
 case "$WALL_CLOCK" in
     ''|*[!0-9]*)
         echo "run-stage2: STAGE2_WALL_CLOCK_S must be a positive integer (got: $WALL_CLOCK)" >&2
@@ -43,13 +58,29 @@ case "$WALL_CLOCK" in
         ;;
 esac
 
-SNAPSHOT_INTERVAL="${STAGE2_SNAPSHOT_S:-600}"
+SNAPSHOT_INTERVAL="${STAGE2_SNAPSHOT_S:-3600}"
 case "$SNAPSHOT_INTERVAL" in
     ''|*[!0-9]*)
         echo "run-stage2: STAGE2_SNAPSHOT_S must be a positive integer (got: $SNAPSHOT_INTERVAL)" >&2
         exit 1
         ;;
 esac
+
+CRASH_AT="${STAGE2_CRASH_AT_S:-}"
+if [ -n "$CRASH_AT" ]; then
+    case "$CRASH_AT" in
+        ''|*[!0-9]*)
+            echo "run-stage2: STAGE2_CRASH_AT_S must be a positive integer (got: $CRASH_AT)" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+RESUME_RUN_DIR="${STAGE2_RESUME_RUN_DIR:-}"
+if [ -n "$RESUME_RUN_DIR" ] && [ ! -d "$RESUME_RUN_DIR" ]; then
+    echo "run-stage2: STAGE2_RESUME_RUN_DIR not a directory: $RESUME_RUN_DIR" >&2
+    exit 1
+fi
 
 # --- Prerequisite checks ---
 for bin in agentis jq python3; do
@@ -80,24 +111,52 @@ DEATH_THRESHOLD="$(python3 "$TOOLS_DIR/run-stage1-calibration.py" "$CALIBRATION"
 
 export INITIAL_CB BASE_COST K_MALTHUSIAN MAX_REPLICAS REWARD_FULL REWARD_SUBSEQUENT DEATH_THRESHOLD
 
-# --- Per-run hermetic directory ---
-TS="$(date -u +%Y%m%dT%H%M%SZ)"
-RUN_DIR="$FED_DIR/runs/$TS"
-mkdir -p "$RUN_DIR" "$RUN_DIR/snapshots"
+# --- Per-run hermetic directory (or resume an existing one) ---
+if [ -n "$RESUME_RUN_DIR" ]; then
+    RUN_DIR="$RESUME_RUN_DIR"
+    RESUMING=1
+    mkdir -p "$RUN_DIR/snapshots"
+    echo "[run-stage2] resuming run dir: $RUN_DIR"
+else
+    TS="$(date -u +%Y%m%dT%H%M%SZ)"
+    RUN_DIR="$FED_DIR/runs/$TS"
+    RESUMING=0
+    mkdir -p "$RUN_DIR" "$RUN_DIR/snapshots"
+    echo "[run-stage2] run dir: $RUN_DIR"
+fi
 
-echo "[run-stage2] run dir: $RUN_DIR"
 echo "[run-stage2] wall-clock cap: ${WALL_CLOCK}s"
 echo "[run-stage2] snapshot interval: ${SNAPSHOT_INTERVAL}s"
 echo "[run-stage2] calibration: initial_cb=$INITIAL_CB base_cost=$BASE_COST k=$K_MALTHUSIAN reward_full=$REWARD_FULL reward_subsequent=$REWARD_SUBSEQUENT death=$DEATH_THRESHOLD"
+if [ -n "$CRASH_AT" ]; then
+    echo "[run-stage2] STAGE2_CRASH_AT_S=${CRASH_AT}s (M3 crash-recovery drill)"
+fi
+
+# On resume, defensively kill any stale daemons under fed-dir and remove
+# orphan *.colony files older than the highest-elapsed snapshot ts so a
+# crashed daemon's leftover record doesn't masquerade as alive.
+if [ "$RESUMING" = "1" ]; then
+    KILL_SCRIPT_PRE="$REPO_ROOT/tools/kill-federation.sh"
+    if [ -x "$KILL_SCRIPT_PRE" ]; then
+        bash "$KILL_SCRIPT_PRE" --fed-dir "$FED_DIR" --no-backup \
+            >>"$RUN_DIR/kill-federation.log" 2>&1 || true
+    fi
+    if [ -d "$RUN_DIR/.agentis/daemon" ]; then
+        python3 "$TOOLS_DIR/run-stage2-prune.py" "$RUN_DIR" || true
+    fi
+fi
 
 # Initialise a fresh .agentis/ inside the run dir so daemons walking up
 # from cwd find this root rather than the operator's persistent store.
-(
-    cd "$RUN_DIR"
-    if [ ! -d .agentis ]; then
-        agentis init >/dev/null 2>&1
-    fi
-)
+# Resume path skips this — the existing .agentis/ is reused as-is.
+if [ "$RESUMING" = "0" ]; then
+    (
+        cd "$RUN_DIR"
+        if [ ! -d .agentis ]; then
+            agentis init >/dev/null 2>&1
+        fi
+    )
+fi
 
 AGENTIS_ROOT="$RUN_DIR/.agentis"
 export AGENTIS_ROOT
@@ -111,8 +170,9 @@ export AGENTIS_ROOT
 #       .agentis/experience/<agent-id>.jsonl.
 #   telemetry.enabled — required so daemon.started / daemon.stopped /
 #       agent.completed events land in .agentis/lifecycle/events.jsonl.
+# Resume path skips this — config is already correct.
 CONFIG_FILE="$RUN_DIR/.agentis/config"
-if [ -f "$CONFIG_FILE" ]; then
+if [ "$RESUMING" = "0" ] && [ -f "$CONFIG_FILE" ]; then
     if ! grep -q '^exec\.env_passthrough' "$CONFIG_FILE"; then
         printf '\nexec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT\n' >> "$CONFIG_FILE"
     fi
@@ -125,11 +185,14 @@ if [ -f "$CONFIG_FILE" ]; then
 fi
 
 # Seed all five tribes' confidence memo to 0.7 (mid-`propose`) inside
-# the hermetic root.
-(
-    cd "$RUN_DIR"
-    agentis memo set hunter:confidence 0.7 >/dev/null 2>&1 || true
-)
+# the hermetic root. Resume path skips the seed: the existing memo
+# carries the post-crash state that the test wants to verify survives.
+if [ "$RESUMING" = "0" ]; then
+    (
+        cd "$RUN_DIR"
+        agentis memo set hunter:confidence 0.7 >/dev/null 2>&1 || true
+    )
+fi
 
 # --- Make sure each tribe has a colony.toml (install.sh idempotent) ---
 for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon; do
@@ -147,8 +210,12 @@ export VERIFIER_PATH="$FED_DIR/tools/verify-finding-stage2.sh"
 export RUN_DIR
 export BUG_LEDGER_PATH="$RUN_DIR/bug-ledger.jsonl"
 
-# Touch the bug-ledger so JSONL append never races mkdir.
-: > "$BUG_LEDGER_PATH"
+# Touch the bug-ledger so JSONL append never races mkdir. Resume path
+# preserves the existing ledger (the recovery-drill assertion checks
+# that the ledger survives crash + relaunch).
+if [ "$RESUMING" = "0" ]; then
+    : > "$BUG_LEDGER_PATH"
+fi
 
 if [ ! -f "$TARGET_DIR/lib.rs" ]; then
     echo "run-stage2: target source not found at $TARGET_DIR/lib.rs" >&2
@@ -161,6 +228,37 @@ fi
 if [ ! -x "$VERIFIER_PATH" ]; then
     echo "run-stage2: verifier not executable at $VERIFIER_PATH" >&2
     exit 1
+fi
+
+# --- Capture run metadata (M3 #394). On resume, write a sidecar instead
+# of clobbering the original. ---
+RUN_LLM_BACKEND="${STAGE2_LLM_BACKEND:-cli}"
+STARTED_AT_NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+if [ "$RESUMING" = "0" ]; then
+    agentis --version > "$RUN_DIR/agentis-version.txt" 2>&1 || true
+    printf '%s\n' "$RUN_LLM_BACKEND" > "$RUN_DIR/llm-backend.txt"
+    python3 "$TOOLS_DIR/run-baseline-meta.py" \
+        "$RUN_DIR/run-meta.json" \
+        "$STARTED_AT_NOW" \
+        "$WALL_CLOCK" \
+        "$SNAPSHOT_INTERVAL" \
+        "$RUN_LLM_BACKEND" \
+        "$INITIAL_CB" \
+        "ecosystem"
+else
+    # Find the next available resume slot N.
+    n=1
+    while [ -f "$RUN_DIR/run-meta-resume-${n}.json" ]; do
+        n=$((n + 1))
+    done
+    python3 "$TOOLS_DIR/run-baseline-meta.py" \
+        "$RUN_DIR/run-meta-resume-${n}.json" \
+        "$STARTED_AT_NOW" \
+        "$WALL_CLOCK" \
+        "$SNAPSHOT_INTERVAL" \
+        "$RUN_LLM_BACKEND" \
+        "$INITIAL_CB" \
+        "ecosystem-resume-${n}"
 fi
 
 # --- Launch federation in the background, anchored at RUN_DIR ---
@@ -180,8 +278,18 @@ if ! kill -0 "$FED_PID" 2>/dev/null; then
 fi
 
 # --- Sleep the wall-clock cap with periodic snapshots ---
-echo "[run-stage2] sleeping ${WALL_CLOCK}s with snapshots every ${SNAPSHOT_INTERVAL}s..."
+# On resume, continue snapshot numbering from max(elapsed) of existing
+# snapshot files in <run>/snapshots/ (numeric stem) so the recovery-drill
+# can assert old snapshots survive AND new snapshots are appended.
 elapsed=0
+if [ "$RESUMING" = "1" ]; then
+    elapsed="$(python3 "$TOOLS_DIR/run-stage2-snapshot-max.py" "$RUN_DIR/snapshots" 2>/dev/null || echo 0)"
+    case "$elapsed" in
+        ''|*[!0-9]*) elapsed=0 ;;
+    esac
+fi
+
+echo "[run-stage2] sleeping ${WALL_CLOCK}s with snapshots every ${SNAPSHOT_INTERVAL}s (start elapsed=${elapsed})..."
 while [ "$elapsed" -lt "$WALL_CLOCK" ]; do
     remaining=$((WALL_CLOCK - elapsed))
     if [ "$remaining" -gt "$SNAPSHOT_INTERVAL" ]; then
@@ -192,12 +300,24 @@ while [ "$elapsed" -lt "$WALL_CLOCK" ]; do
         elapsed="$WALL_CLOCK"
     fi
     snap_path="$RUN_DIR/snapshots/${elapsed}.txt"
-    {
-        echo "# snapshot at elapsed=${elapsed}s"
-        date -u +%Y-%m-%dT%H:%M:%SZ
-        agentis daemon list --json 2>/dev/null || true
-    } > "$snap_path" 2>&1 || true
+    bash "$TOOLS_DIR/snapshot-stanza.sh" "$RUN_DIR" "$elapsed" > "$snap_path" 2>/dev/null || true
     echo "[run-stage2] snapshot $snap_path"
+
+    # M3 #394 crash-recovery drill: when STAGE2_CRASH_AT_S is set and
+    # elapsed has reached it, kill the federation hard and exit 99 so
+    # the operator drill can verify the ledger + .agentis/ survives and
+    # a STAGE2_RESUME_RUN_DIR=<run> rerun continues from the same dir.
+    if [ -n "$CRASH_AT" ] && [ "$elapsed" -ge "$CRASH_AT" ]; then
+        echo "[run-stage2] STAGE2_CRASH_AT_S triggered at elapsed=${elapsed}s — killing federation and exiting 99"
+        KILL_SCRIPT="$REPO_ROOT/tools/kill-federation.sh"
+        if [ -x "$KILL_SCRIPT" ]; then
+            bash "$KILL_SCRIPT" --fed-dir "$FED_DIR" --no-backup \
+                >>"$RUN_DIR/kill-federation.log" 2>&1 || true
+        else
+            kill "$FED_PID" 2>/dev/null || true
+        fi
+        exit 99
+    fi
 done
 
 # --- Reliable shutdown via tools/kill-federation.sh ---

--- a/tribes-bench/tools/snapshot-stanza.sh
+++ b/tribes-bench/tools/snapshot-stanza.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# snapshot-stanza.sh — Stage 2 M3 (#394) periodic snapshot writer.
+#
+# Emits the 7-section header-stanza form (plan Decision 3) on stdout
+# from a hermetic .agentis/ root + bug-ledger + market-csv. Used by
+# `tools/run-stage2.sh` and `tools/run-baseline.sh` periodic snapshots.
+#
+# All probes swallow stderr; missing inputs degrade to empty under each
+# stanza header. The script never fails — caller is expected to redirect
+# stdout to `<run>/snapshots/<elapsed>.txt` and ignore exit status.
+#
+# Usage:
+#   snapshot-stanza.sh <run-dir> <elapsed_s>
+#
+# Output sections (fixed order):
+#   ## daemon-list           agentis daemon list --json
+#   ## experience-counts     wc -l per .agentis/experience/*.jsonl
+#   ## spend-counts          wc -l per .agentis/spend/*.jsonl
+#   ## bug-ledger            wc -l of bug-ledger.jsonl
+#   ## market-csv            wc -l of knowledge-market.csv
+#   ## reputation-memos      agentis memo get for every tribe-* memo key
+#   ## per-tribe-cb          agentis memo get tribe-<x>:pool
+
+set -u
+
+RUN_DIR="${1:-}"
+ELAPSED="${2:-}"
+
+if [ -z "$RUN_DIR" ] || [ -z "$ELAPSED" ]; then
+    echo "Usage: snapshot-stanza.sh <run-dir> <elapsed_s>" >&2
+    exit 2
+fi
+
+AGENTIS_ROOT="$RUN_DIR/.agentis"
+BUG_LEDGER="$RUN_DIR/bug-ledger.jsonl"
+MARKET_CSV="$RUN_DIR/knowledge-market.csv"
+
+# Run agentis subcommands with AGENTIS_ROOT bound + cwd at RUN_DIR so the
+# memo store resolved is the per-run hermetic one, not the operator's.
+export AGENTIS_ROOT
+
+echo "# snapshot at elapsed=${ELAPSED}s"
+date -u +%Y-%m-%dT%H:%M:%SZ
+
+echo ""
+echo "## daemon-list"
+(cd "$RUN_DIR" 2>/dev/null && agentis daemon list --json 2>/dev/null) || true
+
+echo ""
+echo "## experience-counts"
+if [ -d "$AGENTIS_ROOT/experience" ]; then
+    for f in "$AGENTIS_ROOT/experience"/*.jsonl; do
+        [ -f "$f" ] || continue
+        n="$(wc -l < "$f" 2>/dev/null || echo 0)"
+        printf '%s %s\n' "$n" "$(basename "$f")"
+    done
+fi
+
+echo ""
+echo "## spend-counts"
+if [ -d "$AGENTIS_ROOT/spend" ]; then
+    for f in "$AGENTIS_ROOT/spend"/*.jsonl; do
+        [ -f "$f" ] || continue
+        n="$(wc -l < "$f" 2>/dev/null || echo 0)"
+        printf '%s %s\n' "$n" "$(basename "$f")"
+    done
+fi
+
+echo ""
+echo "## bug-ledger"
+if [ -f "$BUG_LEDGER" ]; then
+    n="$(wc -l < "$BUG_LEDGER" 2>/dev/null || echo 0)"
+    printf '%s bug-ledger.jsonl\n' "$n"
+fi
+
+echo ""
+echo "## market-csv"
+if [ -f "$MARKET_CSV" ]; then
+    n="$(wc -l < "$MARKET_CSV" 2>/dev/null || echo 0)"
+    printf '%s knowledge-market.csv\n' "$n"
+fi
+
+echo ""
+echo "## reputation-memos"
+for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon tribe-baseline; do
+    val="$(cd "$RUN_DIR" 2>/dev/null && agentis memo get "reputation:tribes-bench-${tribe}" 2>/dev/null || true)"
+    if [ -n "$val" ]; then
+        printf '%s = %s\n' "reputation:tribes-bench-${tribe}" "$val"
+    fi
+done
+
+echo ""
+echo "## per-tribe-cb"
+for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon tribe-baseline; do
+    val="$(cd "$RUN_DIR" 2>/dev/null && agentis memo get "tribe-${tribe}:pool" 2>/dev/null || true)"
+    if [ -n "$val" ]; then
+        printf '%s = %s\n' "tribe-${tribe}:pool" "$val"
+    fi
+done

--- a/tribes-bench/tools/test-stage2-analyse-comparison.sh
+++ b/tribes-bench/tools/test-stage2-analyse-comparison.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# test-stage2-analyse-comparison.sh — Stage 2 M3 (#394) comparison
+# report assertions. Pure fixture-driven, NO live agentis spawn.
+#
+# Mirrors the shape of test-stage2-cognitive-market.sh: PASS/FAIL/SKIP
+# helpers, exit 0 on green. Implements the 8 cases from §5 Test C of
+# the plan.
+#
+# Cases:
+#   1. analyse-stage2.py --baseline <path> requires the path arg.
+#   2. analyse-stage2.py without --baseline produces telemetry.csv but
+#      no comparison.md (back-compat).
+#   3. analyse-stage2.py --baseline <fixture-csv> produces comparison.md
+#      with the 5 fixed sections in the documented order.
+#   4. comparison.md section 5 reports `_no market activity in this run_`
+#      when knowledge-market.csv is missing or empty.
+#   5. comparison.md section 5 reports substrate revenue arithmetic
+#      correctly: substrate-bought sells count, cache-hit sells exclude.
+#   6. comparison.md section 1: findings/TPs/FPs/first-finder ticks
+#      arithmetic vs the fixture.
+#   7. comparison.md section 2: cost-per-TP arithmetic (CB / TP).
+#   8. comparison.md section 3+4: replication events + run-shape minutes
+#      + tribe count arithmetic.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_DIR="$(dirname "$SCRIPT_DIR")"
+ANALYSER="$FED_DIR/tools/analyse-stage2.py"
+
+PASS=0
+FAIL=0
+SKIP=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_eq() {
+    label="$1"; exp="$2"; got="$3"
+    if [ "$exp" = "$got" ]; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       expected: $exp"
+        echo "       got:      $got"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    label="$1"; file="$2"; needle="$3"
+    if [ -f "$file" ] && grep -Fq -- "$needle" "$file"; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       file:   $file"
+        echo "       needle: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Build a fixture run-dir + a fixture baseline CSV ----------------------
+# A fully self-contained fixture: a single experience JSONL with mixed
+# verified + false-positive + observed rows; a single spend JSONL; and a
+# knowledge-market.csv with 1 substrate buy + 1 cache-hit buy + 2 sell
+# rows (one of which is for the substrate-bought topic).
+make_fixture_run_dir() {
+    rd="$1"
+    mkdir -p "$rd/.agentis/daemon" "$rd/.agentis/experience" "$rd/.agentis/spend"
+    # Daemon -> tribe mapping
+    printf 'tribe-alpha' > "$rd/.agentis/daemon/agt-1.colony"
+    # Experience JSONL: 2 acted (verified), 1 false-positive, 1 observed,
+    # 1 replicated, all tagged tribes-bench.
+    printf '%s\n' \
+        '{"ts": 1700000060000, "topic": "hunt", "subject": "line 10", "outcome": "S2-SMVUAF-001", "tags": ["acted", "tribes-bench", "tribe-alpha", "reward=200"]}' \
+        '{"ts": 1700000120000, "topic": "hunt", "subject": "line 20", "outcome": "S2-SMVMEM-001", "tags": ["acted", "tribes-bench", "tribe-alpha", "reward=50"]}' \
+        '{"ts": 1700000180000, "topic": "hunt", "subject": "line 30", "outcome": "fp", "tags": ["false-positive", "tribes-bench"]}' \
+        '{"ts": 1700000240000, "topic": "hunt", "subject": "line 40", "outcome": "obs", "tags": ["observed", "tribes-bench"]}' \
+        '{"ts": 1700000300000, "topic": "replicate", "subject": "n=0", "outcome": "cost=100", "tags": ["replicated", "tribes-bench", "tribe-alpha"]}' \
+        > "$rd/.agentis/experience/agt-1.jsonl"
+    # Spend JSONL: 5 prompt() spends of 50 CB each = 250 CB total.
+    printf '%s\n' \
+        '{"ts": 1700000060000, "cb": 50, "colony": "tribe-alpha"}' \
+        '{"ts": 1700000120000, "cb": 50, "colony": "tribe-alpha"}' \
+        '{"ts": 1700000180000, "cb": 50, "colony": "tribe-alpha"}' \
+        '{"ts": 1700000240000, "cb": 50, "colony": "tribe-alpha"}' \
+        '{"ts": 1700000300000, "cb": 50, "colony": "tribe-alpha"}' \
+        > "$rd/.agentis/spend/agt-1.jsonl"
+    : > "$rd/bug-ledger.jsonl"
+}
+
+make_fixture_baseline_csv() {
+    bc="$1"
+    # Header + 1 row of synthetic baseline aggregates: 1 finding, 1 TP,
+    # 0 FPs, 60 CB. So baseline CB/TP = 60.
+    printf 'minute,tribe,agents_alive,cb_balance,findings_emitted,true_positives,false_positives,bug_class,is_first_finder,tribe_size,replication_event_count,tribe_death_ts\n' > "$bc"
+    printf '28333334,tribe-baseline,1,60,1,1,0,use_after_free,1,1,0,\n' >> "$bc"
+}
+
+make_market_csv_with_revenue() {
+    csv="$1"
+    # 1 substrate buy (cache_hit=0) for topic alpha/BUG-1
+    printf '1700000060000,tribe-delta,tribe-delta,buy,tribes-bench-tribe-alpha/BUG-1,finding,,15,,0,,succeeded\n' > "$csv"
+    # 1 cache-hit buy (cache_hit=1) for topic alpha/BUG-1
+    printf '1700000061000,tribe-epsilon,tribe-epsilon,buy,tribes-bench-tribe-alpha/BUG-1,finding,,15,,1,,cache_hit\n' >> "$csv"
+    # 1 sell for the substrate-bought topic at ask_price 6 (counts).
+    printf '1700000020000,tribe-alpha,tribe-alpha,sell,tribes-bench-tribe-alpha/BUG-1,finding,6,,,,,succeeded\n' >> "$csv"
+    # 1 sell for a topic with NO substrate buy, ask_price 7 (must NOT count).
+    printf '1700000021000,tribe-beta,tribe-beta,sell,tribes-bench-tribe-beta/BUG-2,finding,7,,,,,succeeded\n' >> "$csv"
+}
+
+# Need a federation-style parent dir so analyse-stage2.py's bug-class
+# lookup can find targets/stage2/bugs.json. Mock the layout under TMP.
+FAKE_FED="$TMP/fakefed"
+mkdir -p "$FAKE_FED/runs" "$FAKE_FED/targets/stage2"
+# Minimal bugs.json (the fixture references S2-SMVUAF-001 + S2-SMVMEM-001).
+printf '%s' '{"bugs": [{"id": "S2-SMVUAF-001", "class": "use_after_free"}, {"id": "S2-SMVMEM-001", "class": "uninitialised_memory"}]}' > "$FAKE_FED/targets/stage2/bugs.json"
+
+# Common run-dir under FAKE_FED so dirname/dirname reaches FAKE_FED.
+RD1="$FAKE_FED/runs/20260101T000000Z"
+make_fixture_run_dir "$RD1"
+BASELINE_CSV="$TMP/baseline.csv"
+make_fixture_baseline_csv "$BASELINE_CSV"
+
+# --- 1. --baseline requires path ---
+set +e
+out="$(python3 "$ANALYSER" "$RD1" --baseline 2>&1)"
+ec=$?
+set -e
+if [ "$ec" != "0" ] && printf '%s' "$out" | grep -qF "requires a path"; then
+    echo "[PASS] --baseline requires a path"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] --baseline missing-arg path: ec=$ec out=$out"
+    FAIL=$((FAIL + 1))
+fi
+
+# --- 2. Without --baseline: byte-identical to M2 (no comparison.md) ---
+RD2="$FAKE_FED/runs/20260102T000000Z"
+make_fixture_run_dir "$RD2"
+python3 "$ANALYSER" "$RD2" >/dev/null 2>&1
+if [ -f "$RD2/telemetry.csv" ] && [ ! -f "$RD2/comparison.md" ]; then
+    echo "[PASS] no --baseline -> no comparison.md (back-compat)"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] no --baseline produced unexpected comparison.md"
+    FAIL=$((FAIL + 1))
+fi
+
+# --- 3. With --baseline: comparison.md emitted with 5 sections ---
+RD3="$FAKE_FED/runs/20260103T000000Z"
+make_fixture_run_dir "$RD3"
+python3 "$ANALYSER" "$RD3" --baseline "$BASELINE_CSV" >/dev/null 2>&1
+CMP3="$RD3/comparison.md"
+if [ -f "$CMP3" ]; then
+    assert_contains "comparison.md section 1 header" "$CMP3" "## 1. Findings volume"
+    assert_contains "comparison.md section 2 header" "$CMP3" "## 2. Cost per true positive"
+    assert_contains "comparison.md section 3 header" "$CMP3" "## 3. Replication / tribe-size dynamics"
+    assert_contains "comparison.md section 4 header" "$CMP3" "## 4. Run shape"
+    assert_contains "comparison.md section 5 header" "$CMP3" "## 5. Knowledge market activity"
+    # Verify section order via a python helper (no awk locale gotchas).
+    order_ok="$(python3 -c "
+import sys
+text = open('$CMP3').read()
+keys = ['## 1.', '## 2.', '## 3.', '## 4.', '## 5.']
+positions = [text.find(k) for k in keys]
+print('OK' if all(p >= 0 for p in positions) and positions == sorted(positions) else 'BAD')
+")"
+    assert_eq "comparison.md sections in fixed order" "OK" "$order_ok"
+else
+    echo "[FAIL] comparison.md not produced for --baseline run"
+    FAIL=$((FAIL + 1))
+fi
+
+# --- 4. Section 5 reports _no market activity_ when CSV missing/empty ---
+assert_contains "section 5 says no market activity (no CSV)" "$CMP3" "_no market activity in this run_"
+
+# Empty CSV must also yield the no-activity message.
+RD3b="$FAKE_FED/runs/20260103T000001Z"
+make_fixture_run_dir "$RD3b"
+: > "$RD3b/knowledge-market.csv"
+python3 "$ANALYSER" "$RD3b" --baseline "$BASELINE_CSV" >/dev/null 2>&1
+assert_contains "section 5 says no market activity (empty CSV)" "$RD3b/comparison.md" "_no market activity in this run_"
+
+# --- 5. Section 5 substrate revenue arithmetic ---
+RD4="$FAKE_FED/runs/20260104T000000Z"
+make_fixture_run_dir "$RD4"
+make_market_csv_with_revenue "$RD4/knowledge-market.csv"
+python3 "$ANALYSER" "$RD4" --baseline "$BASELINE_CSV" >/dev/null 2>&1
+CMP4="$RD4/comparison.md"
+assert_contains "section 5 substrate revenue line present" "$CMP4" "substrate revenue (cache_hit=0 only)"
+assert_contains "section 5 substrate revenue == 6 (alpha BUG-1 only)" "$CMP4" "| substrate revenue (cache_hit=0 only) | 6 |"
+assert_contains "section 5 buy ops == 2" "$CMP4" "| buy ops | 2 |"
+assert_contains "section 5 sell ops == 2" "$CMP4" "| sell ops | 2 |"
+assert_contains "section 5 cache-hit buys == 1" "$CMP4" "| cache-hit buys | 1 |"
+
+# --- 6. Section 1 findings/TPs/FPs/first-finder arithmetic ---
+# Fixture: 2 acted, 1 false-positive, 1 observed, 1 replicated.
+# findings_emitted = 4 (acted+fp+observed -> +1 each), TPs=2, FPs=1.
+# first-finder ticks: depends on bug-ledger which is empty -> 0.
+assert_contains "section 1 findings_emitted == 4" "$CMP4" "| total findings | 4 |"
+assert_contains "section 1 true positives == 2" "$CMP4" "| true positives | 2 |"
+assert_contains "section 1 false positives == 1" "$CMP4" "| false positives | 1 |"
+assert_contains "section 1 first-finder ticks == 0" "$CMP4" "| first-finder ticks | 0 |"
+
+# --- 7. Section 2 cost-per-TP arithmetic: 250 CB / 2 TPs = 125.00 ---
+assert_contains "section 2 total CB == 250" "$CMP4" "| total CB | 250 |"
+assert_contains "section 2 TPs == 2" "$CMP4" "| TPs | 2 |"
+assert_contains "section 2 CB / TP == 125.00" "$CMP4" "| CB / TP | 125.00 |"
+
+# --- 8. Section 3+4 arithmetic ---
+# replication_event_count: 1 row tagged "replicated" -> 1.
+# distinct minutes covered: 5 distinct ts -> 5 minute buckets.
+# distinct tribes seen: 1 (tribe-alpha).
+assert_contains "section 3 replication events == 1" "$CMP4" "| replication events | 1 |"
+assert_contains "section 4 distinct minutes covered == 5" "$CMP4" "| distinct minutes covered | 5 |"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]

--- a/tribes-bench/tools/test-stage2-baseline-runner.sh
+++ b/tribes-bench/tools/test-stage2-baseline-runner.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# test-stage2-baseline-runner.sh — pure-offline + opportunistic-live
+# assertions for Stage 2 M3 (#394) baseline harness.
+#
+# Mirrors the shape of test-stage2-cognitive-market.sh and
+# test-stage2-reputation.sh: PASS/FAIL/SKIP helpers, exit 0 on green.
+# Implements the 7 cases from §5 Test A of the plan.
+#
+# Cases:
+#   1. tools/run-baseline.sh exists, executable, bash -n clean.
+#   2. tools/run-baseline.sh prints "[run-baseline] total CB: <n>" with
+#      n == 5 * initial_cb (calibration default 1000 → 5000).
+#   3. templates/tribe-baseline/colony.toml.template + agents/
+#      hunter-baseline.ag.template exist with the documented placeholders.
+#   4. hunter-baseline.ag.template has the three M3 deltas vs alpha:
+#      `learn(..., ["baseline-no-replicate"])`, `learn(..., ["baseline-no-market"])`,
+#      no `replicate(`, no `knowledge_buy(`, no `knowledge_sell(`.
+#   5. Live smoke: skip when `agentis` not on PATH OR
+#      ANTHROPIC_API_KEY/CLAUDE_API_KEY/equivalent unset; otherwise run
+#      with STAGE2_BASELINE_WALL_CLOCK_S=15 and assert exit 0 + a
+#      runs/baseline-* dir lands with telemetry.csv.
+#   6. run-baseline-render.py byte-substitutes correctly (positive case).
+#   7. run-baseline-meta.py emits valid JSON with the required keys.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_DIR="$(dirname "$SCRIPT_DIR")"
+
+PASS=0
+FAIL=0
+SKIP=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_eq() {
+    label="$1"; exp="$2"; got="$3"
+    if [ "$exp" = "$got" ]; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       expected: $exp"
+        echo "       got:      $got"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    label="$1"; file="$2"; needle="$3"
+    if [ -f "$file" ] && grep -Fq -- "$needle" "$file"; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       file:   $file"
+        echo "       needle: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    label="$1"; file="$2"; needle="$3"
+    if [ ! -f "$file" ]; then
+        echo "[FAIL] $label (file missing: $file)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if grep -Fq -- "$needle" "$file"; then
+        echo "[FAIL] $label"
+        echo "       file:   $file"
+        echo "       found:  $needle"
+        FAIL=$((FAIL + 1))
+    else
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+skip_case() {
+    echo "[SKIP] $1 ($2)"
+    SKIP=$((SKIP + 1))
+}
+
+# --- 1. run-baseline.sh exists, executable, bash -n clean ---
+RB="$FED_DIR/tools/run-baseline.sh"
+if [ -f "$RB" ]; then
+    if [ -x "$RB" ]; then
+        echo "[PASS] tools/run-baseline.sh exists and is executable"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] tools/run-baseline.sh exists but is NOT executable"
+        FAIL=$((FAIL + 1))
+    fi
+    if bash -n "$RB" 2>/dev/null; then
+        echo "[PASS] tools/run-baseline.sh: bash -n exit 0"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] tools/run-baseline.sh: bash -n exit non-zero"
+        FAIL=$((FAIL + 1))
+    fi
+else
+    echo "[FAIL] tools/run-baseline.sh missing"
+    FAIL=$((FAIL + 1))
+fi
+
+# --- 2. Total CB: 5 * initial_cb (calibration default 1000 -> 5000) ---
+# Read the source for the BASELINE_CB arithmetic — we don't need to run
+# the script; we just verify the formula. Then verify the calibration
+# default is 1000 so the inferred total matches expectation.
+if [ -f "$RB" ]; then
+    if grep -Fq 'BASELINE_CB="$((INITIAL_CB * 5))"' "$RB"; then
+        echo "[PASS] run-baseline.sh: BASELINE_CB = 5 * initial_cb"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] run-baseline.sh: BASELINE_CB formula not 5 * initial_cb"
+        FAIL=$((FAIL + 1))
+    fi
+    if grep -Fq '[run-baseline] total CB:' "$RB"; then
+        echo "[PASS] run-baseline.sh prints '[run-baseline] total CB:'"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] run-baseline.sh missing 'total CB' echo"
+        FAIL=$((FAIL + 1))
+    fi
+fi
+
+INITIAL_CB_TOML="$(python3 "$FED_DIR/tools/run-stage1-calibration.py" "$FED_DIR/calibration.toml" tribe.economy initial_cb 1000)"
+EXPECTED_CB=$((INITIAL_CB_TOML * 5))
+assert_eq "calibration.toml initial_cb * 5 = expected baseline CB" "5000" "$EXPECTED_CB"
+
+# --- 3. Templates exist with documented placeholders ---
+TMPL_TOML="$FED_DIR/templates/tribe-baseline/colony.toml.template"
+TMPL_AG="$FED_DIR/templates/tribe-baseline/agents/hunter-baseline.ag.template"
+for f in "$TMPL_TOML" "$TMPL_AG"; do
+    if [ -f "$f" ]; then
+        echo "[PASS] template exists: $(basename "$f")"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] template missing: $f"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
+assert_contains "colony.toml.template has {{CB_BUDGET}} placeholder" "$TMPL_TOML" "{{CB_BUDGET}}"
+assert_contains "colony.toml.template has {{LLM_BACKEND}} placeholder" "$TMPL_TOML" "{{LLM_BACKEND}}"
+assert_contains "hunter-baseline.ag.template has {{CB_BUDGET}} placeholder" "$TMPL_AG" "{{CB_BUDGET}}"
+
+# --- 4. Three M3 deltas vs alpha hunter ---
+assert_contains "hunter-baseline.ag has baseline-no-replicate tag" "$TMPL_AG" "baseline-no-replicate"
+assert_contains "hunter-baseline.ag has baseline-no-market tag" "$TMPL_AG" "baseline-no-market"
+assert_not_contains "hunter-baseline.ag does NOT call replicate(" "$TMPL_AG" "replicate("
+assert_not_contains "hunter-baseline.ag does NOT call knowledge_buy(" "$TMPL_AG" "knowledge_buy("
+assert_not_contains "hunter-baseline.ag does NOT call knowledge_sell(" "$TMPL_AG" "knowledge_sell("
+
+# --- 5. Live smoke run (opportunistic) ---
+HAS_KEY=0
+if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${CLAUDE_API_KEY:-}" ] || [ -n "${OPENAI_API_KEY:-}" ]; then
+    HAS_KEY=1
+fi
+if ! command -v agentis >/dev/null 2>&1; then
+    skip_case "live smoke run" "agentis not on PATH"
+elif [ "$HAS_KEY" = "0" ]; then
+    skip_case "live smoke run" "no LLM API key in env"
+else
+    SMOKE_OUT="$TMP/smoke.log"
+    if STAGE2_BASELINE_WALL_CLOCK_S=15 STAGE2_BASELINE_SNAPSHOT_S=10 \
+        bash "$RB" >"$SMOKE_OUT" 2>&1; then
+        last_run="$(ls -td "$FED_DIR"/runs/baseline-* 2>/dev/null | head -1 || true)"
+        if [ -n "$last_run" ] && [ -f "$last_run/telemetry.csv" ]; then
+            echo "[PASS] live smoke: telemetry.csv produced at $last_run"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] live smoke: telemetry.csv NOT produced"
+            FAIL=$((FAIL + 1))
+        fi
+    else
+        echo "[FAIL] live smoke: run-baseline.sh exited non-zero (see $SMOKE_OUT)"
+        FAIL=$((FAIL + 1))
+    fi
+fi
+
+# --- 6. run-baseline-render.py byte substitution ---
+RENDER="$FED_DIR/tools/run-baseline-render.py"
+if [ -f "$RENDER" ]; then
+    SRC="$TMP/in.txt"; DST="$TMP/out.txt"
+    printf 'cb {{CB}}; backend={{B}}; tag={{CB}}\n' > "$SRC"
+    if python3 "$RENDER" "$SRC" "$DST" "CB=42" "B=claude" 2>/dev/null; then
+        if [ -f "$DST" ]; then
+            content="$(cat "$DST")"
+            expected="cb 42; backend=claude; tag=42"
+            assert_eq "render byte substitution" "$expected" "$content"
+        else
+            echo "[FAIL] render: no output file"
+            FAIL=$((FAIL + 1))
+        fi
+    else
+        echo "[FAIL] render: exit non-zero"
+        FAIL=$((FAIL + 1))
+    fi
+else
+    echo "[FAIL] tools/run-baseline-render.py missing"
+    FAIL=$((FAIL + 1))
+fi
+
+# --- 7. run-baseline-meta.py emits valid JSON with required keys ---
+META="$FED_DIR/tools/run-baseline-meta.py"
+if [ -f "$META" ]; then
+    OUT="$TMP/meta.json"
+    if python3 "$META" "$OUT" "2026-01-01T00:00:00Z" "3600" "600" "claude" "5000" "baseline" 2>/dev/null; then
+        keys="$(python3 -c "import json; d=json.load(open('$OUT')); print(','.join(sorted(d.keys())))")"
+        expected="baseline_cb,kind,llm_backend,snapshot_s,started_at,wall_clock_s"
+        assert_eq "run-meta.json has the 6 required keys" "$expected" "$keys"
+    else
+        echo "[FAIL] run-baseline-meta.py: exit non-zero"
+        FAIL=$((FAIL + 1))
+    fi
+else
+    echo "[FAIL] tools/run-baseline-meta.py missing"
+    FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]

--- a/tribes-bench/tools/test-stage2-crash-recovery.sh
+++ b/tribes-bench/tools/test-stage2-crash-recovery.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# test-stage2-crash-recovery.sh — Stage 2 M3 (#394) crash-recovery drill.
+#
+# 7-case test from §5 Test B of the plan. Mirrors the shape of
+# test-stage2-cognitive-market.sh: PASS/FAIL/SKIP helpers, exit 0 on
+# green. Shells out to run-stage2.sh with STAGE2_CRASH_AT_S +
+# STAGE2_RESUME_RUN_DIR.
+#
+# Skip pattern: agentis not on PATH or no LLM API key in env -> SKIP all
+# live cases. Static cases (1-4) always run.
+#
+# Cases:
+#   1. run-stage2.sh declares STAGE2_CRASH_AT_S env var in its docstring.
+#   2. run-stage2.sh declares STAGE2_RESUME_RUN_DIR env var in its docstring.
+#   3. run-stage2.sh declares the new 48h / 1h defaults in its docstring.
+#   4. run-stage2.sh exit-99 path is hooked from inside the snapshot loop.
+#   5. Live: STAGE2_CRASH_AT_S=10 STAGE2_WALL_CLOCK_S=30
+#      STAGE2_SNAPSHOT_S=5 -> exit 99, runs/<ts>/ + bug-ledger.jsonl +
+#      .agentis/ + at least one snapshot persist.
+#   6. Live: STAGE2_RESUME_RUN_DIR=<the crashed run> STAGE2_WALL_CLOCK_S=20
+#      STAGE2_SNAPSHOT_S=5 -> exit 0, run-meta-resume-1.json appears,
+#      old snapshots are NOT clobbered, new snapshots are appended,
+#      bug-ledger.jsonl is NOT truncated.
+#   7. Snapshot payload: at least one snapshot under the resumed run
+#      contains the 7-section header stanzas.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_DIR="$(dirname "$SCRIPT_DIR")"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+assert_eq() {
+    label="$1"; exp="$2"; got="$3"
+    if [ "$exp" = "$got" ]; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       expected: $exp"
+        echo "       got:      $got"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    label="$1"; file="$2"; needle="$3"
+    if [ -f "$file" ] && grep -Fq -- "$needle" "$file"; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       file:   $file"
+        echo "       needle: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+skip_case() {
+    echo "[SKIP] $1 ($2)"
+    SKIP=$((SKIP + 1))
+}
+
+cleanup_federation() {
+    KILL="$FED_DIR/../tools/kill-federation.sh"
+    if [ -x "$KILL" ]; then
+        bash "$KILL" --fed-dir "$FED_DIR" --no-backup >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup_federation EXIT
+
+RS="$FED_DIR/tools/run-stage2.sh"
+
+# --- 1-3. Static doc assertions ---
+assert_contains "run-stage2.sh declares STAGE2_CRASH_AT_S" "$RS" "STAGE2_CRASH_AT_S"
+assert_contains "run-stage2.sh declares STAGE2_RESUME_RUN_DIR" "$RS" "STAGE2_RESUME_RUN_DIR"
+assert_contains "run-stage2.sh wall-clock default 172800 (48h)" "$RS" "172800"
+assert_contains "run-stage2.sh snapshot default 3600 (1h)" "$RS" "3600"
+
+# --- 4. exit 99 hooked from inside the snapshot loop ---
+assert_contains "run-stage2.sh exits 99 on simulated crash" "$RS" "exit 99"
+
+# --- 5/6/7. Live drill (skip without agentis + LLM key) ---
+HAS_KEY=0
+if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${CLAUDE_API_KEY:-}" ] || [ -n "${OPENAI_API_KEY:-}" ]; then
+    HAS_KEY=1
+fi
+if ! command -v agentis >/dev/null 2>&1; then
+    skip_case "live crash drill (T+0)" "agentis not on PATH"
+    skip_case "live resume drill (T+1)" "agentis not on PATH"
+    skip_case "snapshot stanza payload check" "agentis not on PATH"
+elif [ "$HAS_KEY" = "0" ]; then
+    skip_case "live crash drill (T+0)" "no LLM API key in env"
+    skip_case "live resume drill (T+1)" "no LLM API key in env"
+    skip_case "snapshot stanza payload check" "no LLM API key in env"
+else
+    # T+0: launch with crash trigger.
+    CRASH_LOG="$(mktemp)"
+    set +e
+    STAGE2_WALL_CLOCK_S=30 STAGE2_SNAPSHOT_S=5 STAGE2_CRASH_AT_S=10 \
+        bash "$RS" >"$CRASH_LOG" 2>&1
+    crash_exit=$?
+    set -e
+    if [ "$crash_exit" = "99" ]; then
+        echo "[PASS] live: STAGE2_CRASH_AT_S triggered exit 99"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] live: expected exit 99, got $crash_exit"
+        FAIL=$((FAIL + 1))
+    fi
+    last_run="$(ls -td "$FED_DIR"/runs/2* 2>/dev/null | head -1 || true)"
+    if [ -n "$last_run" ] && [ -d "$last_run/.agentis" ] && [ -f "$last_run/bug-ledger.jsonl" ]; then
+        echo "[PASS] live: post-crash run dir + .agentis/ + bug-ledger persist"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] live: post-crash artefacts missing under $last_run"
+        FAIL=$((FAIL + 1))
+    fi
+    pre_snap_count="$(ls "$last_run/snapshots/"*.txt 2>/dev/null | wc -l | tr -d ' ')"
+    if [ -n "$pre_snap_count" ] && [ "$pre_snap_count" -ge 1 ]; then
+        echo "[PASS] live: pre-crash snapshots persist ($pre_snap_count file(s))"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] live: pre-crash snapshots missing"
+        FAIL=$((FAIL + 1))
+    fi
+
+    # T+1: resume the same run dir.
+    if [ -n "$last_run" ]; then
+        RESUME_LOG="$(mktemp)"
+        set +e
+        STAGE2_RESUME_RUN_DIR="$last_run" STAGE2_WALL_CLOCK_S=20 STAGE2_SNAPSHOT_S=5 \
+            bash "$RS" >"$RESUME_LOG" 2>&1
+        resume_exit=$?
+        set -e
+        if [ "$resume_exit" = "0" ]; then
+            echo "[PASS] live resume: exit 0"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] live resume: expected exit 0, got $resume_exit"
+            FAIL=$((FAIL + 1))
+        fi
+        if [ -f "$last_run/run-meta-resume-1.json" ]; then
+            echo "[PASS] live resume: run-meta-resume-1.json written"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] live resume: run-meta-resume-1.json missing"
+            FAIL=$((FAIL + 1))
+        fi
+        post_snap_count="$(ls "$last_run/snapshots/"*.txt 2>/dev/null | wc -l | tr -d ' ')"
+        if [ -n "$post_snap_count" ] && [ "$post_snap_count" -gt "$pre_snap_count" ]; then
+            echo "[PASS] live resume: snapshot count grew ($pre_snap_count -> $post_snap_count)"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] live resume: snapshot count did not grow"
+            FAIL=$((FAIL + 1))
+        fi
+
+        # Snapshot stanza payload: at least one snapshot must contain
+        # the 7-section header form.
+        sample_snap="$(ls -t "$last_run/snapshots/"*.txt 2>/dev/null | head -1 || true)"
+        if [ -n "$sample_snap" ] && \
+           grep -Fq "## daemon-list" "$sample_snap" && \
+           grep -Fq "## experience-counts" "$sample_snap" && \
+           grep -Fq "## spend-counts" "$sample_snap" && \
+           grep -Fq "## bug-ledger" "$sample_snap" && \
+           grep -Fq "## market-csv" "$sample_snap" && \
+           grep -Fq "## reputation-memos" "$sample_snap" && \
+           grep -Fq "## per-tribe-cb" "$sample_snap"; then
+            echo "[PASS] live: snapshot has 7 header stanzas ($sample_snap)"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] live: snapshot missing one or more header stanzas ($sample_snap)"
+            FAIL=$((FAIL + 1))
+        fi
+    fi
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Addresses #394 (M3 infrastructure). This PR ships the M3 tooling — the operator-driven thesis verdict and the actual long-run results stay out of scope per the issue's "What's NOT in M3" enumeration. Partial #394.

## Summary

Three logically independent commits:

1. **C1 — baseline harness** (`feat(tribes-bench): Stage 2 M3 baseline harness + tribe-baseline template (#394)`) — adds `tools/run-baseline.sh` (~250 LOC), the versioned `templates/tribe-baseline/` (colony.toml + hunter-baseline.ag templates with `{{CB_BUDGET}}` / `{{LLM_BACKEND}}` / `{{TARGET_DIR}}` / `{{VERIFIER_PATH}}` / `{{BUG_LEDGER_PATH}}` placeholders), two stdlib helpers (`tools/run-baseline-render.py`, `tools/run-baseline-meta.py`), the shared `tools/snapshot-stanza.sh` 7-section snapshot writer, and `tools/test-stage2-baseline-runner.sh` (17 assertions, live smoke skipped without LLM key).

2. **C2 — crash-recovery drill + run-stage2 upgrades** (`feat(tribes-bench): Stage 2 M3 crash-recovery drill + run-stage2 48h defaults (#394)`) — `run-stage2.sh` defaults bumped to 48h wall clock / 1h snapshots, new `STAGE2_CRASH_AT_S` (kill + exit 99) and `STAGE2_RESUME_RUN_DIR` (snapshot-numbering continuation, ledger preservation, `run-meta-resume-<n>.json` sidecar, defensive pre-relaunch kill + stale `*.colony` prune), snapshot payload upgraded to the 7-stanza form. Two new stdlib helpers (`tools/run-stage2-snapshot-max.py`, `tools/run-stage2-prune.py`). `tools/test-stage2-crash-recovery.sh` 7-case drill.

3. **C3 — comparison report + reproduction recipe** (`feat(tribes-bench): Stage 2 M3 comparison report + reproduction recipe (#394)`) — `analyse-stage2.py` gains `--baseline <path>` (back-compat byte-identical without it), produces `<run-dir>/comparison.md` with 5 fixed-order sections; substrate-revenue arithmetic excludes `cache_hit=1` rows. `tools/test-stage2-analyse-comparison.sh` 24-assertion fixture-only test. README gets a "Stage 2 (M3 — long-run + baseline) reproduction recipe" section with the 3-step recipe, SHA placeholders to pin at merge, non-determinism caveat, and the 6-test inventory split. CHANGELOG `[Unreleased]` updated.

## Test plan

Local results table (run on the worktree):

| Test | Result | Notes |
|---|---|---|
| `tools/colony-lint.sh` | PASS (164/0/3) | Same skip baseline as main |
| `tribes-bench/tools/test-stage2-baseline-runner.sh` | PASS (17/0/1) | live smoke SKIPped: no LLM API key in env |
| `tribes-bench/tools/test-stage2-crash-recovery.sh` | PASS (5/0/3) | 3 live cases SKIPped: no LLM API key in env |
| `tribes-bench/tools/test-stage2-analyse-comparison.sh` | PASS (24/0/0) | Fixture-only |
| `tribes-bench/tools/test-stage2-scaffold.sh` | PASS (23/0/0) | M1 regression |
| `tribes-bench/tools/test-stage2-cognitive-market.sh` | PASS (41/0/0) | M2 regression |
| `tribes-bench/tools/test-stage2-reputation.sh` | PASS (56/0/0) | M2 regression |

Live-fire smoke tests in `test-stage2-baseline-runner.sh` test 5 and `test-stage2-crash-recovery.sh` tests 5-7 are SKIPped on this machine because no LLM API key is set in env. They are designed to PASS when run in a key-bearing environment; the operator-driven M3 verdict run will exercise them.

## Out of scope (per #394 issue body)

- The M3 thesis verdict itself (does the ecosystem beat the baseline on cost-per-TP?) is operator-driven post-merge work and is NOT addressed by this PR. The PR ships the tooling that produces the verdict.
- Calibration knob retuning based on long-run telemetry is a separate follow-up PR.
- The placeholder snapshot SHAs in the README are pinned by the operator at merge time, not by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)