### PR TITLE
fix(tribes-bench): hunters read $TARGET_FILE env var (#398)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -357,6 +357,8 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Fixed
 
+- Fixed (#398): hunters read `$TARGET_DIR/$TARGET_FILE` instead of hardcoded `vulnerable.rs` / `cmd_exec.rs` (Stage 0/1 carryovers); harness exports `TARGET_FILE=lib.rs` for Stage 2.
+
 ### Security
 
 <!--

--- a/tribes-bench/templates/tribe-baseline/agents/hunter-baseline.ag.template
+++ b/tribes-bench/templates/tribe-baseline/agents/hunter-baseline.ag.template
@@ -43,7 +43,7 @@ fn tick(reason: string) -> void {
     print("[hunter-baseline] tick conf=", conf);
 
     let src = try {
-        exec sh "cat $TARGET_DIR/vulnerable.rs";
+        exec sh "cat $TARGET_DIR/$TARGET_FILE";
     } catch e {
         print("[hunter-baseline] target read failed:", e);
         "";

--- a/tribes-bench/tools/run-baseline.sh
+++ b/tribes-bench/tools/run-baseline.sh
@@ -137,7 +137,7 @@ export AGENTIS_ROOT
 CONFIG_FILE="$RUN_DIR/.agentis/config"
 if [ -f "$CONFIG_FILE" ]; then
     if ! grep -q '^exec\.env_passthrough' "$CONFIG_FILE"; then
-        printf '\nexec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT\n' >> "$CONFIG_FILE"
+        printf '\nexec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,TARGET_FILE,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT\n' >> "$CONFIG_FILE"
     fi
     if ! grep -q '^experience\.enabled' "$CONFIG_FILE"; then
         printf 'experience.enabled = true\n' >> "$CONFIG_FILE"
@@ -163,6 +163,7 @@ fi
 
 # --- Export env consumed by hunter-baseline.ag via exec sh ---
 export TARGET_DIR
+export TARGET_FILE="lib.rs"
 export BUGS_MANIFEST="$FED_DIR/targets/stage2/bugs.json"
 export VERIFIER_PATH
 export RUN_DIR
@@ -171,8 +172,8 @@ export TRIBE_NAME="tribe-baseline"
 
 : > "$BUG_LEDGER_PATH"
 
-if [ ! -f "$TARGET_DIR/lib.rs" ]; then
-    echo "run-baseline: target source not found at $TARGET_DIR/lib.rs" >&2
+if [ ! -f "$TARGET_DIR/$TARGET_FILE" ]; then
+    echo "run-baseline: target source not found at $TARGET_DIR/$TARGET_FILE" >&2
     exit 1
 fi
 if [ ! -f "$BUGS_MANIFEST" ]; then

--- a/tribes-bench/tools/run-stage2.sh
+++ b/tribes-bench/tools/run-stage2.sh
@@ -174,7 +174,7 @@ export AGENTIS_ROOT
 CONFIG_FILE="$RUN_DIR/.agentis/config"
 if [ "$RESUMING" = "0" ] && [ -f "$CONFIG_FILE" ]; then
     if ! grep -q '^exec\.env_passthrough' "$CONFIG_FILE"; then
-        printf '\nexec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT\n' >> "$CONFIG_FILE"
+        printf '\nexec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,TARGET_FILE,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT\n' >> "$CONFIG_FILE"
     fi
     if ! grep -q '^experience\.enabled' "$CONFIG_FILE"; then
         printf 'experience.enabled = true\n' >> "$CONFIG_FILE"
@@ -205,6 +205,7 @@ done
 
 # --- Export Stage 2 env consumed by hunter.ag via exec sh ---
 export TARGET_DIR="$FED_DIR/targets/stage2/smallvec-v0.6.13"
+export TARGET_FILE="lib.rs"
 export BUGS_MANIFEST="$FED_DIR/targets/stage2/bugs.json"
 export VERIFIER_PATH="$FED_DIR/tools/verify-finding-stage2.sh"
 export RUN_DIR
@@ -217,8 +218,8 @@ if [ "$RESUMING" = "0" ]; then
     : > "$BUG_LEDGER_PATH"
 fi
 
-if [ ! -f "$TARGET_DIR/lib.rs" ]; then
-    echo "run-stage2: target source not found at $TARGET_DIR/lib.rs" >&2
+if [ ! -f "$TARGET_DIR/$TARGET_FILE" ]; then
+    echo "run-stage2: target source not found at $TARGET_DIR/$TARGET_FILE" >&2
     exit 1
 fi
 if [ ! -f "$BUGS_MANIFEST" ]; then

--- a/tribes-bench/tools/test-stage2-scaffold.sh
+++ b/tribes-bench/tools/test-stage2-scaffold.sh
@@ -307,6 +307,12 @@ else
     skip_case "calibration.toml: M1 sections unchanged" "not a git repository"
 fi
 
+# --- 9. #398 — TARGET_FILE in env_passthrough of harness scripts ---
+assert_contains "run-stage2.sh exec.env_passthrough lists TARGET_FILE" \
+    "$FED_DIR/tools/run-stage2.sh" "TARGET_DIR,TARGET_FILE,"
+assert_contains "run-baseline.sh exec.env_passthrough lists TARGET_FILE" \
+    "$FED_DIR/tools/run-baseline.sh" "TARGET_DIR,TARGET_FILE,"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
 [ "$FAIL" -eq 0 ]

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -161,7 +161,7 @@ fn tick(reason: string) -> void {
     // re-reads on every tick: the target is a checked-in static file,
     // not a live forge, so there is no upstream "since last tick" gate.
     let src = try {
-        exec sh "cat $TARGET_DIR/vulnerable.rs";
+        exec sh "cat $TARGET_DIR/$TARGET_FILE";
     } catch e {
         print("[hunter] target read failed:", e);
         "";

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -162,7 +162,7 @@ fn tick(reason: string) -> void {
     // re-reads on every tick: the target is a checked-in static file,
     // not a live forge, so there is no upstream "since last tick" gate.
     let src = try {
-        exec sh "cat $TARGET_DIR/vulnerable.rs";
+        exec sh "cat $TARGET_DIR/$TARGET_FILE";
     } catch e {
         print("[hunter] target read failed:", e);
         "";

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -159,11 +159,12 @@ fn tick(reason: string) -> void {
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
 
-    // Read the synthetic target once per tick. Stage 1 hunter scans the
-    // first stage-1 file by default; M2/M3 will rotate across all three
-    // class-shard files (cmd_exec.rs, path_io.rs, fmt_str.rs).
+    // Read the target file once per tick. Stage 2 scans a single file
+    // selected by `$TARGET_FILE` under `$TARGET_DIR` (set by run-stage2.sh).
+    // The Stage 1 per-tribe class-shard rotation referenced in the prior
+    // comment was never wired and is out-of-scope for #398.
     let src = try {
-        exec sh "cat $TARGET_DIR/cmd_exec.rs";
+        exec sh "cat $TARGET_DIR/$TARGET_FILE";
     } catch e {
         print("[hunter] target read failed:", e);
         "";

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -159,11 +159,12 @@ fn tick(reason: string) -> void {
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
 
-    // Read the synthetic target once per tick. Stage 1 hunter scans the
-    // first stage-1 file by default; M2/M3 will rotate across all three
-    // class-shard files (cmd_exec.rs, path_io.rs, fmt_str.rs).
+    // Read the target file once per tick. Stage 2 scans a single file
+    // selected by `$TARGET_FILE` under `$TARGET_DIR` (set by run-stage2.sh).
+    // The Stage 1 per-tribe class-shard rotation referenced in the prior
+    // comment was never wired and is out-of-scope for #398.
     let src = try {
-        exec sh "cat $TARGET_DIR/cmd_exec.rs";
+        exec sh "cat $TARGET_DIR/$TARGET_FILE";
     } catch e {
         print("[hunter] target read failed:", e);
         "";

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -159,11 +159,12 @@ fn tick(reason: string) -> void {
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
 
-    // Read the synthetic target once per tick. Stage 1 hunter scans the
-    // first stage-1 file by default; M2/M3 will rotate across all three
-    // class-shard files (cmd_exec.rs, path_io.rs, fmt_str.rs).
+    // Read the target file once per tick. Stage 2 scans a single file
+    // selected by `$TARGET_FILE` under `$TARGET_DIR` (set by run-stage2.sh).
+    // The Stage 1 per-tribe class-shard rotation referenced in the prior
+    // comment was never wired and is out-of-scope for #398.
     let src = try {
-        exec sh "cat $TARGET_DIR/cmd_exec.rs";
+        exec sh "cat $TARGET_DIR/$TARGET_FILE";
     } catch e {
         print("[hunter] target read failed:", e);
         "";


### PR DESCRIPTION
Closes #398.

## Summary

Stage 2 hunters previously read hardcoded `vulnerable.rs` (alpha / beta / baseline) or `cmd_exec.rs` (gamma / delta / epsilon) — Stage 0/1 carryovers that no longer exist under `targets/stage2/smallvec-v0.6.13/`. Hunters silently scanned empty input every tick, so every Stage 2 / baseline run since M1 produced zero true positives by construction.

This PR ships **Option 4 (env-var passthrough)**, the synthesis of Options 1–3 raised in the issue body:

- **Not Option 1** (drop a `vulnerable.rs` symlink in the target tree): keeps `tribes-bench/targets/**` immutable.
- **Not Option 2** (rewrite hunters to hardcode `lib.rs`): would re-introduce a Stage-2-only literal in the agents.
- **Not Option 3** (per-tribe class-shard rotation): never wired and out-of-scope; comment in gamma/delta/epsilon hunters explicitly calls that out.
- **Option 4 — env passthrough**: harness exports `TARGET_FILE=lib.rs` and adds it to the `exec.env_passthrough` allowlist; every hunter cats `$TARGET_DIR/$TARGET_FILE`. Stage 2 / baseline pick up `lib.rs`; future stages override `TARGET_FILE` from the harness without touching any `.ag`.

`tribes-bench/targets/**` is byte-identical. Stage 0 / Stage 1 surface (`run-stage0.sh`, `run-stage1.sh`, `analyse-stage0.py`, `analyse-stage1.py`, `verify-finding.sh`) byte-identical.

## Files changed (8 + CHANGELOG + 1 test, total 10)

- `tribes-bench/tools/run-stage2.sh` — append `TARGET_FILE` to `exec.env_passthrough`; export `TARGET_FILE="lib.rs"`; gate uses `$TARGET_FILE`.
- `tribes-bench/tools/run-baseline.sh` — same three changes mirrored.
- `tribes-bench/tribe-alpha/agents/hunter.ag` — `vulnerable.rs` → `$TARGET_FILE`.
- `tribes-bench/tribe-beta/agents/hunter.ag` — `vulnerable.rs` → `$TARGET_FILE`.
- `tribes-bench/tribe-gamma/agents/hunter.ag` — `cmd_exec.rs` → `$TARGET_FILE`; misleading Stage-1 class-shard rotation comment rewritten to describe Stage 2 reality.
- `tribes-bench/tribe-delta/agents/hunter.ag` — same as gamma.
- `tribes-bench/tribe-epsilon/agents/hunter.ag` — same as gamma.
- `tribes-bench/templates/tribe-baseline/agents/hunter-baseline.ag.template` — `vulnerable.rs` → `$TARGET_FILE`.
- `tribes-bench/CHANGELOG.md` — bullet under `[Unreleased] / Fixed`.
- `tribes-bench/tools/test-stage2-scaffold.sh` — 2 belt-and-suspenders assertions that `TARGET_FILE` appears in both harnesses' `exec.env_passthrough` allowlist.

## Local test results

| Test | Result |
|------|--------|
| `bash -n` on `run-stage2.sh`, `run-baseline.sh`, `test-stage2-scaffold.sh` | PASS (3/3) |
| `tools/colony-lint.sh` | PASS (164 passed, 0 failed, 3 skipped) |
| `tribes-bench/tools/test-stage2-scaffold.sh` | PASS (25 / 0 / 0) |
| `tribes-bench/tools/test-stage2-baseline-runner.sh` | PASS (17 / 0 / 1 — live smoke skips: no LLM key) |
| `tribes-bench/tools/test-stage2-cognitive-market.sh` | PASS (41 / 0 / 0) |
| `tribes-bench/tools/test-stage2-crash-recovery.sh` | PASS (5 / 0 / 3 — live drills skip: no LLM key) |
| `tribes-bench/tools/test-stage2-reputation.sh` | PASS (56 / 0 / 0) |
| `tribes-bench/tools/test-stage2-analyse-comparison.sh` | PASS (24 / 0 / 0) |
| `tribes-bench/tools/test-verify-finding.sh` (Stage 0 + STAGE1=1) | PASS (6 / 0, 6 / 0) |
| `tribes-bench/tools/test-stage1-replication.sh` | PASS (48 / 0) |
| `tribes-bench/tools/test-stage1-bug-ledger.sh` | PASS (10 / 0) |

No FAIL anywhere. All SKIPs are the pre-existing live-smoke skips (no LLM API key in CI env).

## Test plan

- [x] `bash -n` on every modified shell.
- [x] `tools/colony-lint.sh` reports 0 failures.
- [x] All 6 Stage 2 tribes-bench tests PASS (or SKIP-on-no-LLM-key).
- [x] Pre-existing Stage 0 / Stage 1 tests still PASS unchanged.
- [x] `tribes-bench/targets/**` byte-identical (Option 4 contract).
- [ ] Operator dry run: `STAGE2_WALL_CLOCK_S=120 STAGE2_SNAPSHOT_S=60 tribes-bench/tools/run-stage2.sh` produces non-empty `cat $TARGET_DIR/$TARGET_FILE` reads in hunter logs (requires LLM key — out of CI scope).