### PR TITLE
fix(tribes-bench): bug-ledger size-delta + dup-row assertions in crash-recovery test (#399)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -358,6 +358,7 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 ### Fixed
 
 - Fixed (#398): hunters read `$TARGET_DIR/$TARGET_FILE` instead of hardcoded `vulnerable.rs` / `cmd_exec.rs` (Stage 0/1 carryovers); harness exports `TARGET_FILE=lib.rs` for Stage 2.
+- Fixed (#399): `tools/test-stage2-crash-recovery.sh` adds bug-ledger size-delta + duplicate-row assertions on resume. Belt-and-suspenders coverage for the existing `RESUMING=0` truncate guard in `run-stage2.sh`.
 
 ### Security
 

--- a/tribes-bench/tools/test-stage2-crash-recovery.sh
+++ b/tribes-bench/tools/test-stage2-crash-recovery.sh
@@ -127,6 +127,7 @@ else
         echo "[FAIL] live: pre-crash snapshots missing"
         FAIL=$((FAIL + 1))
     fi
+    pre_bl_lines="$(wc -l < "$last_run/bug-ledger.jsonl" 2>/dev/null | tr -d ' ' || echo 0)"
 
     # T+1: resume the same run dir.
     if [ -n "$last_run" ]; then
@@ -157,6 +158,31 @@ else
         else
             echo "[FAIL] live resume: snapshot count did not grow"
             FAIL=$((FAIL + 1))
+        fi
+
+        # #399: bug-ledger size-delta — resume must not truncate.
+        post_bl_lines="$(wc -l < "$last_run/bug-ledger.jsonl" 2>/dev/null | tr -d ' ' || echo 0)"
+        if [ "$post_bl_lines" -ge "$pre_bl_lines" ]; then
+            echo "[PASS] live resume: bug-ledger preserved ($pre_bl_lines -> $post_bl_lines lines)"
+            PASS=$((PASS + 1))
+        else
+            echo "[FAIL] live resume: bug-ledger truncated ($pre_bl_lines -> $post_bl_lines lines)"
+            FAIL=$((FAIL + 1))
+        fi
+
+        # #399: no duplicate (bug_id, ts) rows in resumed bug-ledger.
+        if command -v jq >/dev/null 2>&1; then
+            dup_count="$(jq -s 'group_by([.bug_id, .ts]) | map(select(length > 1)) | length' "$last_run/bug-ledger.jsonl" 2>/dev/null || echo -1)"
+            if [ "$dup_count" = "0" ]; then
+                echo "[PASS] live resume: no duplicate (bug_id, ts) rows in bug-ledger"
+                PASS=$((PASS + 1))
+            else
+                echo "[FAIL] live resume: $dup_count duplicate (bug_id, ts) row group(s) in bug-ledger"
+                FAIL=$((FAIL + 1))
+            fi
+        else
+            echo "[SKIP] live resume: jq missing — duplicate-row check skipped"
+            SKIP=$((SKIP + 1))
         fi
 
         # Snapshot stanza payload: at least one snapshot must contain


### PR DESCRIPTION
Closes #399.

## Summary

Adds two belt-and-suspenders assertions to `tribes-bench/tools/test-stage2-crash-recovery.sh` per the issue body and the inline plan posted as a comment on #399. Pure test-coverage addition — production logic in `run-stage2.sh` (lines 216-218, the `RESUMING=0` truncate guard) is unchanged.

## What changed

`tribes-bench/tools/test-stage2-crash-recovery.sh` (+22 LOC inside the existing live block):

1. **Bug-ledger size-delta on resume**: capture `pre_bl_lines` after the post-crash bug-ledger persist check; capture `post_bl_lines` after the resume snapshot-count assertion; assert `post_bl_lines >= pre_bl_lines`. Resume must not truncate.
2. **No duplicate `(bug_id, ts)` rows**: `jq -s 'group_by([.bug_id, .ts]) | map(select(length > 1)) | length'` must equal 0. Graceful SKIP on hosts without jq.

`tribes-bench/CHANGELOG.md` (+1 LOC): one bullet under existing `[Unreleased]` `### Fixed` section.

## Test plan

All 6 tribes-bench tests + colony-lint locally:

| Test | Result |
|---|---|
| `tools/colony-lint.sh` | PASS (164 / 0 / 3) |
| `tribes-bench/tools/test-stage2-crash-recovery.sh` | PASS (5 / 0 / 3 — live drills SKIP on no-LLM-key, identical to main) |
| `tribes-bench/tools/test-stage2-scaffold.sh` | PASS (25 / 0 / 0) |
| `tribes-bench/tools/test-stage2-cognitive-market.sh` | PASS (41 / 0 / 0) |
| `tribes-bench/tools/test-stage2-reputation.sh` | PASS (56 / 0 / 0) |
| `tribes-bench/tools/test-stage2-baseline-runner.sh` | PASS (17 / 0 / 1) |
| `tribes-bench/tools/test-stage2-analyse-comparison.sh` | PASS (24 / 0 / 0) |

The new assertions don't fire in this LLM-less environment (they sit inside the live block which SKIPs without an LLM key), but on hosts that exercise the live block they trivially hold for empty bug-ledgers.

## Edge cases

- Empty `bug-ledger.jsonl`: both assertions trivially hold (`0 >= 0`; `jq -s` on empty stream returns `[]`, length 0).
- `jq` missing: graceful SKIP via `command -v jq` guard. Matches the existing skip pattern in tribes-bench tests.
- `STAGE2_CRASH_AT_S` not set or LLM-key missing: live block SKIPs entirely; no regression.