### PR TITLE
fix(tribes-bench): now_ms() shell-detour helper unblocks live runs (#402)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -359,6 +359,7 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 - Fixed (#398): hunters read `$TARGET_DIR/$TARGET_FILE` instead of hardcoded `vulnerable.rs` / `cmd_exec.rs` (Stage 0/1 carryovers); harness exports `TARGET_FILE=lib.rs` for Stage 2.
 - Fixed (#399): `tools/test-stage2-crash-recovery.sh` adds bug-ledger size-delta + duplicate-row assertions on resume. Belt-and-suspenders coverage for the existing `RESUMING=0` truncate guard in `run-stage2.sh`.
+- Fixed (#402): hunter agents detour `now_ms()` through `exec sh "date +%s%3N"` because agentis 1.6.0 does not expose `now_ms` as an `.ag` evaluator builtin. Every M2 hunter tick was failing with `undefined function: now_ms` before this fix; this is what blocked the operator-driven verdict run. Tracked upstream as a follow-up to register `now_ms` as a proper builtin in agentis-core.
 
 ### Security
 

--- a/tribes-bench/templates/tribe-baseline/agents/hunter-baseline.ag.template
+++ b/tribes-bench/templates/tribe-baseline/agents/hunter-baseline.ag.template
@@ -37,6 +37,11 @@ fn tribe_name() -> string {
     return "tribe-baseline";
 }
 
+fn now_ms_via_shell() -> int {
+    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
+    return parse_int(s);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let conf = get_confidence();
@@ -104,7 +109,7 @@ fn tick(reason: string) -> void {
 
                     let ledger_path = recall_latest("tribe-" + tribe_name() + ":bug_ledger");
                     if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(now_ms()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
+                        let row = "{\"ts\": " + to_string(now_ms_via_shell()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
                         // colony-lint: safe-exec-concat
                         let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
                         let _ = try { exec sh append_cmd; } catch e { ""; };

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -38,6 +38,11 @@ fn tribe_name() -> string {
     return "tribe-alpha";
 }
 
+fn now_ms_via_shell() -> int {
+    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
+    return parse_int(s);
+}
+
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
     let idx = n - ((n / 3) * 3);
@@ -146,7 +151,7 @@ fn emit_market_csv(op: string, topic: string, topic_kind: string, ask_price_s: s
     if len(csv_path) == 0 {
         return;
     };
-    let row = to_string(now_ms()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
+    let row = to_string(now_ms_via_shell()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
     // colony-lint: safe-exec-concat
     let append_cmd = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(csv_path);
     let _ = try { exec sh append_cmd; } catch e { ""; };
@@ -178,7 +183,7 @@ fn tick(reason: string) -> void {
     // Stage 2 M2 (#393): cognitive-market buy at start of tick, before
     // seed prompt fires. Buy-gate widened to %8 + pool-aware skip per
     // §9 risk 5; lifecycle discriminator + cache-hit learn() per risk 1+2.
-    let m_now = now_ms();
+    let m_now = now_ms_via_shell();
     let pool_for_buy = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
     let pool_min_buy_str = recall_latest("pool_minimum_for_buy");
     let pool_min_buy = if len(pool_min_buy_str) > 0 { parse_int(pool_min_buy_str); } else { 50; };
@@ -308,7 +313,7 @@ fn tick(reason: string) -> void {
 
                     let ledger_path = recall_latest("tribe-" + tribe_name() + ":bug_ledger");
                     if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(now_ms()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
+                        let row = "{\"ts\": " + to_string(now_ms_via_shell()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
                         // colony-lint: safe-exec-concat
                         let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
                         let _ = try { exec sh append_cmd; } catch e { ""; };

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -39,6 +39,11 @@ fn tribe_name() -> string {
     return "tribe-beta";
 }
 
+fn now_ms_via_shell() -> int {
+    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
+    return parse_int(s);
+}
+
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
     let idx = n - ((n / 3) * 3);
@@ -147,7 +152,7 @@ fn emit_market_csv(op: string, topic: string, topic_kind: string, ask_price_s: s
     if len(csv_path) == 0 {
         return;
     };
-    let row = to_string(now_ms()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
+    let row = to_string(now_ms_via_shell()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
     // colony-lint: safe-exec-concat
     let append_cmd = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(csv_path);
     let _ = try { exec sh append_cmd; } catch e { ""; };
@@ -179,7 +184,7 @@ fn tick(reason: string) -> void {
     // Stage 2 M2 (#393): cognitive-market buy at start of tick, before
     // seed prompt fires. Buy-gate widened to %8 + pool-aware skip per
     // §9 risk 5; lifecycle discriminator + cache-hit learn() per risk 1+2.
-    let m_now = now_ms();
+    let m_now = now_ms_via_shell();
     let pool_for_buy = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
     let pool_min_buy_str = recall_latest("pool_minimum_for_buy");
     let pool_min_buy = if len(pool_min_buy_str) > 0 { parse_int(pool_min_buy_str); } else { 50; };
@@ -311,7 +316,7 @@ fn tick(reason: string) -> void {
 
                     let ledger_path = recall_latest("tribe-" + tribe_name() + ":bug_ledger");
                     if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(now_ms()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
+                        let row = "{\"ts\": " + to_string(now_ms_via_shell()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
                         // colony-lint: safe-exec-concat
                         let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
                         let _ = try { exec sh append_cmd; } catch e { ""; };

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -40,6 +40,11 @@ fn tribe_name() -> string {
     return "tribe-delta";
 }
 
+fn now_ms_via_shell() -> int {
+    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
+    return parse_int(s);
+}
+
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
     let idx = n - ((n / 3) * 3);
@@ -148,7 +153,7 @@ fn emit_market_csv(op: string, topic: string, topic_kind: string, ask_price_s: s
     if len(csv_path) == 0 {
         return;
     };
-    let row = to_string(now_ms()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
+    let row = to_string(now_ms_via_shell()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
     // colony-lint: safe-exec-concat
     let append_cmd = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(csv_path);
     let _ = try { exec sh append_cmd; } catch e { ""; };
@@ -181,7 +186,7 @@ fn tick(reason: string) -> void {
     // Stage 2 M2 (#393): cognitive-market buy at start of tick, before
     // seed prompt fires. Buy-gate widened to %8 + pool-aware skip per
     // §9 risk 5; lifecycle discriminator + cache-hit learn() per risk 1+2.
-    let m_now = now_ms();
+    let m_now = now_ms_via_shell();
     let pool_for_buy = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
     let pool_min_buy_str = recall_latest("pool_minimum_for_buy");
     let pool_min_buy = if len(pool_min_buy_str) > 0 { parse_int(pool_min_buy_str); } else { 50; };
@@ -316,7 +321,7 @@ fn tick(reason: string) -> void {
 
                     let ledger_path = recall_latest("tribe-" + tribe_name() + ":bug_ledger");
                     if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(now_ms()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
+                        let row = "{\"ts\": " + to_string(now_ms_via_shell()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
                         // colony-lint: safe-exec-concat
                         let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
                         let _ = try { exec sh append_cmd; } catch e { ""; };

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -40,6 +40,11 @@ fn tribe_name() -> string {
     return "tribe-epsilon";
 }
 
+fn now_ms_via_shell() -> int {
+    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
+    return parse_int(s);
+}
+
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
     let idx = n - ((n / 3) * 3);
@@ -148,7 +153,7 @@ fn emit_market_csv(op: string, topic: string, topic_kind: string, ask_price_s: s
     if len(csv_path) == 0 {
         return;
     };
-    let row = to_string(now_ms()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
+    let row = to_string(now_ms_via_shell()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
     // colony-lint: safe-exec-concat
     let append_cmd = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(csv_path);
     let _ = try { exec sh append_cmd; } catch e { ""; };
@@ -181,7 +186,7 @@ fn tick(reason: string) -> void {
     // Stage 2 M2 (#393): cognitive-market buy at start of tick, before
     // seed prompt fires. Buy-gate widened to %8 + pool-aware skip per
     // §9 risk 5; lifecycle discriminator + cache-hit learn() per risk 1+2.
-    let m_now = now_ms();
+    let m_now = now_ms_via_shell();
     let pool_for_buy = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
     let pool_min_buy_str = recall_latest("pool_minimum_for_buy");
     let pool_min_buy = if len(pool_min_buy_str) > 0 { parse_int(pool_min_buy_str); } else { 50; };
@@ -317,7 +322,7 @@ fn tick(reason: string) -> void {
 
                     let ledger_path = recall_latest("tribe-" + tribe_name() + ":bug_ledger");
                     if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(now_ms()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
+                        let row = "{\"ts\": " + to_string(now_ms_via_shell()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
                         // colony-lint: safe-exec-concat
                         let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
                         let _ = try { exec sh append_cmd; } catch e { ""; };

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -40,6 +40,11 @@ fn tribe_name() -> string {
     return "tribe-gamma";
 }
 
+fn now_ms_via_shell() -> int {
+    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
+    return parse_int(s);
+}
+
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
     let idx = n - ((n / 3) * 3);
@@ -148,7 +153,7 @@ fn emit_market_csv(op: string, topic: string, topic_kind: string, ask_price_s: s
     if len(csv_path) == 0 {
         return;
     };
-    let row = to_string(now_ms()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
+    let row = to_string(now_ms_via_shell()) + "," + tribe_name() + "," + tribe_name() + "," + op + "," + topic + "," + topic_kind + "," + ask_price_s + "," + max_cb_s + "," + paid_price_s + "," + cache_hit_s + ",," + op_outcome;
     // colony-lint: safe-exec-concat
     let append_cmd = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(csv_path);
     let _ = try { exec sh append_cmd; } catch e { ""; };
@@ -181,7 +186,7 @@ fn tick(reason: string) -> void {
     // Stage 2 M2 (#393): cognitive-market buy at start of tick, before
     // seed prompt fires. Buy-gate widened to %8 + pool-aware skip per
     // §9 risk 5; lifecycle discriminator + cache-hit learn() per risk 1+2.
-    let m_now = now_ms();
+    let m_now = now_ms_via_shell();
     let pool_for_buy = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
     let pool_min_buy_str = recall_latest("pool_minimum_for_buy");
     let pool_min_buy = if len(pool_min_buy_str) > 0 { parse_int(pool_min_buy_str); } else { 50; };
@@ -315,7 +320,7 @@ fn tick(reason: string) -> void {
 
                     let ledger_path = recall_latest("tribe-" + tribe_name() + ":bug_ledger");
                     if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(now_ms()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
+                        let row = "{\"ts\": " + to_string(now_ms_via_shell()) + ", \"tribe\": \"" + tribe_name() + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
                         // colony-lint: safe-exec-concat
                         let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
                         let _ = try { exec sh append_cmd; } catch e { ""; };


### PR DESCRIPTION
## Summary

Closes #402.

agentis 1.6.0 does not expose `now_ms` as an `.ag` evaluator builtin, so every M2 hunter tick was failing with `undefined function: now_ms`. That is what blocked the operator-driven verdict run.

Per the Option A plan posted on #402, this PR introduces a `now_ms_via_shell()` helper in each affected hunter that detours through `exec sh "date +%s%3N"` and substitutes every `now_ms()` call site (16 total) to the helper. The inline composition shape of the call sites (CSV trade-row, JSON ledger entry, lifecycle modulus) is preserved byte-for-byte aside from the function name.

This is a federation-side workaround. The clean fix is to register `now_ms` as a proper `.ag` builtin in the agentis-core evaluator; that will be filed as a follow-up upstream issue against `Replikanti/agentis` after this PR merges.

## Files changed

- `tribes-bench/tribe-alpha/agents/hunter.ag` — helper added; 3 sites swapped
- `tribes-bench/tribe-beta/agents/hunter.ag` — helper added; 3 sites swapped
- `tribes-bench/tribe-gamma/agents/hunter.ag` — helper added; 3 sites swapped
- `tribes-bench/tribe-delta/agents/hunter.ag` — helper added; 3 sites swapped
- `tribes-bench/tribe-epsilon/agents/hunter.ag` — helper added; 3 sites swapped
- `tribes-bench/templates/tribe-baseline/agents/hunter-baseline.ag.template` — helper added; 1 site swapped
- `tribes-bench/CHANGELOG.md` — `[Unreleased]` / Fixed (#402) bullet appended

`git diff --stat`:

```
 tribes-bench/CHANGELOG.md                                     |  1 +
 .../tribe-baseline/agents/hunter-baseline.ag.template         |  7 ++++++-
 tribes-bench/tribe-alpha/agents/hunter.ag                     | 11 ++++++++---
 tribes-bench/tribe-beta/agents/hunter.ag                      | 11 ++++++++---
 tribes-bench/tribe-delta/agents/hunter.ag                     | 11 ++++++++---
 tribes-bench/tribe-epsilon/agents/hunter.ag                   | 11 ++++++++---
 tribes-bench/tribe-gamma/agents/hunter.ag                     | 11 ++++++++---
 7 files changed, 47 insertions(+), 16 deletions(-)
```

## Local test results

| Test | Result |
|------|--------|
| `tools/colony-lint.sh` | PASS (164 passed / 0 failed / 3 skipped — destructive + plaintext-token soft warning unrelated) |
| `tribes-bench/tools/test-stage2-scaffold.sh` | PASS (25 / 0 / 0) |
| `tribes-bench/tools/test-stage2-cognitive-market.sh` | PASS (41 / 0 / 0) |
| `tribes-bench/tools/test-stage2-reputation.sh` | PASS (56 / 0 / 0) |
| `tribes-bench/tools/test-stage2-baseline-runner.sh` | PASS (17 / 0 / 1 — 1 skip: live smoke, no LLM API key) |
| `tribes-bench/tools/test-stage2-crash-recovery.sh` | PASS (5 / 0 / 3 — 3 skips: live drills, no LLM API key) |
| `tribes-bench/tools/test-stage2-analyse-comparison.sh` | PASS (24 / 0 / 0) |

Verification grep (no bare `now_ms(` calls remain):

```
$ grep -rE 'now_ms\(' tribes-bench/tribe-*/agents/hunter.ag tribes-bench/templates/tribe-baseline/agents/hunter-baseline.ag.template | grep -vE 'now_ms_via_shell\(' || echo "clean"
clean
```

## Test plan

- [x] `colony-lint.sh` passes 0-failure
- [x] All 6 Stage 2 tests pass (live-fire paths skip on no-LLM-key as expected)
- [x] No bare `now_ms(` call remains in any hunter or template
- [x] No call-site composition shape change beyond the function name swap
- [ ] Operator runs a 2-min live-fire smoke against a real LLM backend post-merge to close the loop end-to-end
- [ ] Companion upstream issue filed against `Replikanti/agentis` to register `now_ms` as a proper `.ag` builtin (operator follow-up after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)