### PR TITLE
fix(tribes-bench): cb_budget calibration override + 8000 default unblocks live runs (#404)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -360,6 +360,7 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 - Fixed (#398): hunters read `$TARGET_DIR/$TARGET_FILE` instead of hardcoded `vulnerable.rs` / `cmd_exec.rs` (Stage 0/1 carryovers); harness exports `TARGET_FILE=lib.rs` for Stage 2.
 - Fixed (#399): `tools/test-stage2-crash-recovery.sh` adds bug-ledger size-delta + duplicate-row assertions on resume. Belt-and-suspenders coverage for the existing `RESUMING=0` truncate guard in `run-stage2.sh`.
 - Fixed (#402): hunter agents detour `now_ms()` through `exec sh "date +%s%3N"` because agentis 1.6.0 does not expose `now_ms` as an `.ag` evaluator builtin. Every M2 hunter tick was failing with `undefined function: now_ms` before this fix; this is what blocked the operator-driven verdict run. Tracked upstream as a follow-up to register `now_ms` as a proper builtin in agentis-core.
+- Fixed (#404): hunters previously CB-exhausted after ~2 ticks because `cb 800;` per-tick budget was insufficient for one LLM `prompt()` call + helper fns. Bumped default `initial_cb` to 8000 (calibration.toml + hunter.ag + colony.example.toml). Harness `tools/run-stage2.sh` now rewrites per-tribe `cb_budget` in scaffolded `colony.toml` from `INITIAL_CB` at launch via new `tools/run-stage2-rewrite-cb.py`. Note: the agent-side `cb <N>;` declaration at the top of `hunter.ag` is still hardcoded at compile time and not yet calibration-driven — tracked as a follow-up.
 
 ### Security
 

--- a/tribes-bench/calibration.toml
+++ b/tribes-bench/calibration.toml
@@ -13,11 +13,15 @@
 # it with empirical evidence.
 
 [tribe.economy]
-# Initial CB pool seeded into each tribe at federation start. ≈ 13
-# minutes of warmup before any reward (50 CB/tick × 1 tick/min ≈ 65 min
-# of pure-cost operation; with replication gating off until first
-# verification, the worst case is the tribe's first verified bug).
-initial_cb = 1000
+# Initial CB pool seeded into each tribe at federation start. Bumped
+# from 1000 → 8000 in #404 to give hunters enough per-tick budget for
+# one prompt() LLM call (~hundreds of CB) plus helper fns + exec sh +
+# bookkeeping per tick. tools/run-stage2.sh now templates this value
+# into each scaffolded colony.toml's [[agents]] cb_budget, making
+# calibration the single source of truth for the per-tick budget. The
+# `cb <N>;` declaration at the top of hunter.ag is still hardcoded at
+# compile time and must match this default — tracked as a follow-up.
+initial_cb = 8000
 
 # Replication base cost: C(0) = base = 100. C(1) = base * (1 + 1/k) =
 # 133. C(3) = base * (1 + 3/3) = 200, i.e. doubles. Gates replication

--- a/tribes-bench/tools/run-baseline.sh
+++ b/tribes-bench/tools/run-baseline.sh
@@ -113,6 +113,16 @@ python3 "$TOOLS_DIR/run-baseline-render.py" \
     "VERIFIER_PATH=$VERIFIER_PATH" \
     "BUG_LEDGER_PATH=$BUG_LEDGER_PATH"
 
+# #404: rewrite cb_budget in the rendered baseline colony.toml from
+# INITIAL_CB so the per-tick budget matches the calibration default
+# (the hunter-baseline.ag `cb <N>;` keeps BASELINE_CB = 5 * INITIAL_CB
+# as its lifetime CB pool — different concept from the per-tick budget).
+python3 "$TOOLS_DIR/run-stage2-rewrite-cb.py" \
+    "$RUN_DIR/tribe-baseline/config/colony.toml" "$INITIAL_CB" || {
+    echo "run-baseline: failed to rewrite cb_budget in baseline colony.toml" >&2
+    exit 1
+}
+
 python3 "$TOOLS_DIR/run-baseline-render.py" \
     "$TEMPLATE_DIR/agents/hunter-baseline.ag.template" \
     "$RUN_DIR/tribe-baseline/agents/hunter-baseline.ag" \

--- a/tribes-bench/tools/run-stage2-rewrite-cb.py
+++ b/tribes-bench/tools/run-stage2-rewrite-cb.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""tribes-bench Stage 2 cb_budget rewriter (#404).
+
+Rewrites every ``cb_budget`` value across all ``[[agents]]`` tables in a
+per-tribe ``colony.toml`` to a new value taken from the harness env
+(``INITIAL_CB``, sourced from ``tribes-bench/calibration.toml``). Used
+by ``tools/run-stage2.sh`` and ``tools/run-baseline.sh`` to keep
+calibration as the single source of truth for the per-tick CB budget.
+
+Usage:
+    run-stage2-rewrite-cb.py <toml-path> <new-cb-budget>
+
+The new value must be a non-negative integer. The TOML file is parsed
+with stdlib ``tomllib`` (Python 3.11+). When the parse fails, exit 1
+with a stderr message — the harness aborts the run rather than launch
+with a stale budget.
+
+Why a separate file: CLAUDE.md "no heredocs in tools/*.sh" invariant
+(macOS bash 3.2 parser bug, see #172 / #245 / #271). Sourcing this
+helper from tools/run-stage2.sh and tools/run-baseline.sh keeps the
+shell free of inline python.
+
+Implementation notes:
+- Parse via ``tomllib`` to validate; rewrite via line-oriented regex on
+  the original file content so we do NOT need ``tomli_w`` (not
+  vendored). Comments + key ordering are preserved.
+- Every ``cb_budget = <int>`` line at the start of a (possibly
+  whitespace-indented) line is rewritten. The TOML grammar guarantees
+  this token never appears inside a multi-line string under our
+  scaffolded colony.toml shape.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+def parse_args(argv: list[str]) -> tuple[str, int]:
+    if len(argv) != 3:
+        print(
+            "Usage: run-stage2-rewrite-cb.py <toml-path> <new-cb-budget>",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    path = argv[1]
+    raw = argv[2]
+    try:
+        new_cb = int(raw)
+    except ValueError:
+        print(
+            f"run-stage2-rewrite-cb: cb_budget must be an integer (got: {raw!r})",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if new_cb < 0:
+        print(
+            f"run-stage2-rewrite-cb: cb_budget must be non-negative (got: {new_cb})",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return path, new_cb
+
+
+def validate_toml(path: str) -> None:
+    try:
+        import tomllib
+    except ImportError:
+        # Python < 3.11. Skip validation; the line rewrite below is
+        # still safe because we only touch `cb_budget = <int>` lines.
+        return
+    try:
+        with open(path, "rb") as f:
+            tomllib.load(f)
+    except OSError as exc:
+        print(f"run-stage2-rewrite-cb: cannot read {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except tomllib.TOMLDecodeError as exc:
+        print(
+            f"run-stage2-rewrite-cb: malformed TOML at {path}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+CB_LINE = re.compile(r"^(\s*)cb_budget(\s*)=(\s*)([0-9]+)(\s*)(#.*)?$")
+
+
+def rewrite(path: str, new_cb: int) -> int:
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError as exc:
+        print(f"run-stage2-rewrite-cb: cannot read {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    changed = 0
+    out: list[str] = []
+    for line in lines:
+        # Preserve trailing newline (or its absence) untouched.
+        if line.endswith("\n"):
+            body = line[:-1]
+            tail = "\n"
+        else:
+            body = line
+            tail = ""
+        m = CB_LINE.match(body)
+        if m is None:
+            out.append(line)
+            continue
+        lead, eq_pre, eq_post, _old, val_post, comment = m.groups()
+        comment_part = comment if comment else ""
+        if comment_part and not val_post:
+            val_post = " "
+        rebuilt = f"{lead}cb_budget{eq_pre}={eq_post}{new_cb}{val_post}{comment_part}{tail}"
+        out.append(rebuilt)
+        changed += 1
+
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(out)
+    except OSError as exc:
+        print(f"run-stage2-rewrite-cb: cannot write {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    return changed
+
+
+def main() -> None:
+    path, new_cb = parse_args(sys.argv)
+    validate_toml(path)
+    n = rewrite(path, new_cb)
+    if n == 0:
+        print(
+            f"run-stage2-rewrite-cb: no cb_budget lines found in {path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tribes-bench/tools/run-stage2.sh
+++ b/tribes-bench/tools/run-stage2.sh
@@ -203,6 +203,20 @@ for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon; do
     fi
 done
 
+# --- #404: rewrite cb_budget in each scaffolded colony.toml from
+# INITIAL_CB so calibration.toml is the single source of truth for the
+# per-tick budget. Always rewrite (even on a pre-existing colony.toml
+# from a prior run) — the operator's calibration edit must propagate.
+for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon; do
+    target="$FED_DIR/$tribe/config/colony.toml"
+    if [ -f "$target" ]; then
+        python3 "$TOOLS_DIR/run-stage2-rewrite-cb.py" "$target" "$INITIAL_CB" || {
+            echo "run-stage2: failed to rewrite cb_budget in $target" >&2
+            exit 1
+        }
+    fi
+done
+
 # --- Export Stage 2 env consumed by hunter.ag via exec sh ---
 export TARGET_DIR="$FED_DIR/targets/stage2/smallvec-v0.6.13"
 export TARGET_FILE="lib.rs"

--- a/tribes-bench/tools/test-stage2-baseline-runner.sh
+++ b/tribes-bench/tools/test-stage2-baseline-runner.sh
@@ -9,7 +9,7 @@
 # Cases:
 #   1. tools/run-baseline.sh exists, executable, bash -n clean.
 #   2. tools/run-baseline.sh prints "[run-baseline] total CB: <n>" with
-#      n == 5 * initial_cb (calibration default 1000 → 5000).
+#      n == 5 * initial_cb (calibration default 8000 → 40000 post-#404).
 #   3. templates/tribe-baseline/colony.toml.template + agents/
 #      hunter-baseline.ag.template exist with the documented placeholders.
 #   4. hunter-baseline.ag.template has the three M3 deltas vs alpha:
@@ -104,10 +104,10 @@ else
     FAIL=$((FAIL + 1))
 fi
 
-# --- 2. Total CB: 5 * initial_cb (calibration default 1000 -> 5000) ---
+# --- 2. Total CB: 5 * initial_cb (calibration default 8000 -> 40000) ---
 # Read the source for the BASELINE_CB arithmetic — we don't need to run
 # the script; we just verify the formula. Then verify the calibration
-# default is 1000 so the inferred total matches expectation.
+# default is 8000 (#404) so the inferred total matches expectation.
 if [ -f "$RB" ]; then
     if grep -Fq 'BASELINE_CB="$((INITIAL_CB * 5))"' "$RB"; then
         echo "[PASS] run-baseline.sh: BASELINE_CB = 5 * initial_cb"
@@ -125,9 +125,9 @@ if [ -f "$RB" ]; then
     fi
 fi
 
-INITIAL_CB_TOML="$(python3 "$FED_DIR/tools/run-stage1-calibration.py" "$FED_DIR/calibration.toml" tribe.economy initial_cb 1000)"
+INITIAL_CB_TOML="$(python3 "$FED_DIR/tools/run-stage1-calibration.py" "$FED_DIR/calibration.toml" tribe.economy initial_cb 8000)"
 EXPECTED_CB=$((INITIAL_CB_TOML * 5))
-assert_eq "calibration.toml initial_cb * 5 = expected baseline CB" "5000" "$EXPECTED_CB"
+assert_eq "calibration.toml initial_cb * 5 = expected baseline CB" "40000" "$EXPECTED_CB"
 
 # --- 3. Templates exist with documented placeholders ---
 TMPL_TOML="$FED_DIR/templates/tribe-baseline/colony.toml.template"

--- a/tribes-bench/tools/test-stage2-scaffold.sh
+++ b/tribes-bench/tools/test-stage2-scaffold.sh
@@ -278,26 +278,50 @@ if [ -f "$FED_DIR/tools/test-verify-finding.sh" ]; then
     fi
 fi
 
-# --- 8. Calibration: M1 economy sections unchanged vs origin/main ---
+# --- 8. Calibration: M1 economy sections structurally unchanged vs origin/main ---
 # Stage 2 M2 (#393) appends `[reputation]` and `[knowledge_market]`
 # blocks to calibration.toml; the original M1-shipped sections
 # `[tribe.economy]`, `[tribe.reward]`, `[tribe.death]` must remain
-# byte-identical so the existing run-stage1.sh harness keeps reading
-# the same defaults. This assertion was a byte-identity gate in M1; it
-# is relaxed to a section-scoped diff for M2 forward.
+# structurally intact so the existing run-stage1.sh harness keeps
+# reading the same set of keys. #404 bumped `initial_cb` from 1000 to
+# 8000 (and rewrote the surrounding comment) — the only intentional
+# evolution of the M1 economy block — so this assertion now masks out
+# the `initial_cb` value + the comment lines that immediately precede
+# the `[tribe.economy]` table on both sides before diffing.
 CALIB="tribes-bench/calibration.toml"
+mask_m1_economy() {
+    awk 'BEGIN{p=1} /^\[reputation\]|^\[knowledge_market\]/{p=0} p{print}' \
+        | awk '
+            /^initial_cb[[:space:]]*=/ { print "initial_cb = <masked>"; next }
+            { print }
+        '
+}
 if [ -d "$REPO_ROOT/.git" ] || git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
     if git -C "$REPO_ROOT" rev-parse --verify origin/main >/dev/null 2>&1; then
-        # Extract the M1-defined economy block: from line 1 through the
-        # last line of [tribe.death]. M2 additions live BELOW that.
         upstream="$(git -C "$REPO_ROOT" show "origin/main:$CALIB" 2>/dev/null || true)"
-        upstream_econ="$(printf '%s' "$upstream" | awk 'BEGIN{p=1} /^\[reputation\]|^\[knowledge_market\]/{p=0} p{print}')"
-        local_econ="$(awk 'BEGIN{p=1} /^\[reputation\]|^\[knowledge_market\]/{p=0} p{print}' "$REPO_ROOT/$CALIB" 2>/dev/null || true)"
+        upstream_econ="$(printf '%s' "$upstream" | mask_m1_economy)"
+        local_econ="$(mask_m1_economy < "$REPO_ROOT/$CALIB" 2>/dev/null || true)"
+        # Strip the immediate comment block above [tribe.economy] (the
+        # initial_cb rationale) on both sides — the comment was rewritten
+        # in #404 to document the bump and the new templating path.
+        strip_econ_comment() {
+            awk '
+                BEGIN { in_econ_comment = 0 }
+                /^\[tribe\.economy\]/ { in_econ_comment = 1; print; next }
+                in_econ_comment == 1 {
+                    if ($0 ~ /^#/) { next }
+                    in_econ_comment = 0
+                }
+                { print }
+            '
+        }
+        upstream_econ="$(printf '%s\n' "$upstream_econ" | strip_econ_comment)"
+        local_econ="$(printf '%s\n' "$local_econ" | strip_econ_comment)"
         if [ "$upstream_econ" = "$local_econ" ] && [ -n "$upstream_econ" ]; then
-            echo "[PASS] calibration.toml: M1 [tribe.economy/reward/death] sections unchanged"
+            echo "[PASS] calibration.toml: M1 [tribe.economy/reward/death] structure unchanged (initial_cb value + rationale comment masked per #404)"
             PASS=$((PASS + 1))
         else
-            echo "[FAIL] calibration.toml: M1 [tribe.economy/reward/death] sections changed (M2 must only APPEND new blocks)"
+            echo "[FAIL] calibration.toml: M1 [tribe.economy/reward/death] structure changed (M2 must only APPEND new blocks; #404 only bumps initial_cb + its rationale comment)"
             FAIL=$((FAIL + 1))
         fi
     else

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -13,7 +13,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 800;
+cb 8000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-alpha/config/colony.example.toml
+++ b/tribes-bench/tribe-alpha/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 800
+cb_budget = 8000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 800;
+cb 8000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-beta/config/colony.example.toml
+++ b/tribes-bench/tribe-beta/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 800
+cb_budget = 8000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 800;
+cb 8000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-delta/config/colony.example.toml
+++ b/tribes-bench/tribe-delta/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 800
+cb_budget = 8000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 800;
+cb 8000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-epsilon/config/colony.example.toml
+++ b/tribes-bench/tribe-epsilon/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 800
+cb_budget = 8000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 800;
+cb 8000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-gamma/config/colony.example.toml
+++ b/tribes-bench/tribe-gamma/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 800
+cb_budget = 8000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit


### PR DESCRIPTION
Closes #404.

## Summary

Operator pilot of `tools/run-stage2.sh` (after #402's `now_ms()` shell-detour landed) surfaced that hunters CB-exhausted after ~2 ticks: `cb 800;` per-tick budget could not cover one LLM `prompt()` call (~hundreds of CB) plus helper fns + `exec sh` + bookkeeping. Calibration's `initial_cb = 1000` was documentation-only; the real ceiling came from `colony.toml` `cb_budget = 800`.

Implements **Option B** from the issue: the harness templates `cb_budget` from `INITIAL_CB` at scaffold time, and the default is bumped high enough that hunters do not exhaust mid-tick.

## What changed

- `tribes-bench/calibration.toml` — `initial_cb` 1000 -> **8000**, with the rationale comment rewritten to document the new templating path.
- `tribes-bench/tools/run-stage2-rewrite-cb.py` (**new**, ~115 LOC, pure stdlib) — validates the TOML with `tomllib`, then line-rewrites every `cb_budget = <int>` value while preserving comments + key ordering. Falls back gracefully on malformed TOML / non-integer args / missing files.
- `tribes-bench/tools/run-stage2.sh` — after the existing `colony.example.toml` -> `colony.toml` scaffold loop, always invoke `run-stage2-rewrite-cb.py` with `$INITIAL_CB` so an operator's calibration edit always propagates, even when `colony.toml` already exists from a prior run.
- `tribes-bench/tools/run-baseline.sh` — same rewrite applied to the rendered baseline `colony.toml` (the per-tick budget). The `hunter-baseline.ag` template still substitutes `BASELINE_CB` (= 5 * `INITIAL_CB`) for its `cb <N>;` lifetime pool — different concept from the per-tick budget.
- `tribes-bench/tribe-{alpha,beta,gamma,delta,epsilon}/agents/hunter.ag` — `cb 800;` -> `cb 8000;` (the daemon-enforced per-tick budget, hardcoded at compile time; cannot be calibration-templated without a code-gen step — tracked as the follow-up issue below).
- `tribes-bench/tribe-{alpha,beta,gamma,delta,epsilon}/config/colony.example.toml` — `cb_budget = 800` -> `cb_budget = 8000` so single-tribe debug runs without the harness also get the new default.
- `tribes-bench/tools/test-stage2-baseline-runner.sh` — expected baseline CB `5000` -> `40000` (5 * 8000).
- `tribes-bench/tools/test-stage2-scaffold.sh` test 8 — `[tribe.economy/reward/death]` vs `origin/main` diff now masks `initial_cb`'s value plus the rationale comment block above `[tribe.economy]`. #404 is the only intentional evolution of the M1 economy block; the rest of the structure remains pinned.
- `tribes-bench/CHANGELOG.md` — `[Unreleased]` `### Fixed` bullet for #404, noting the residual `cb <N>;` template gap as a follow-up.

## Test results (local)

| Test | Result |
| --- | --- |
| `tools/colony-lint.sh` | 164 PASS / 0 FAIL / 3 SKIP (destructive tests gated on `AGENTIS_RUN_KILL_TESTS=1`) |
| `tribes-bench/tools/test-stage2-scaffold.sh` | 25 / 0 / 0 |
| `tribes-bench/tools/test-stage2-cognitive-market.sh` | 41 / 0 / 0 |
| `tribes-bench/tools/test-stage2-reputation.sh` | 56 / 0 / 0 |
| `tribes-bench/tools/test-stage2-baseline-runner.sh` | 17 / 0 / 1 (live smoke skip — no LLM API key) |
| `tribes-bench/tools/test-stage2-crash-recovery.sh` | 5 / 0 / 3 (live drills skip — no LLM API key) |
| `tribes-bench/tools/test-stage2-analyse-comparison.sh` | 24 / 0 / 0 |

## Follow-up scope (out of band)

The agent-side `cb <N>;` declaration at the top of every `hunter.ag` is enforced by the daemon at compile time and the harness can't template it without a code-gen step (e.g. a per-tribe `hunter.ag.template`). Out of scope for this PR; tracked as #407.

## Test plan

- [x] `colony-lint.sh` clean (0 failures).
- [x] All 6 `tribes-bench` tests PASS or SKIP-on-no-LLM-key.
- [x] Helper handles malformed TOML, non-integer arg, and missing file paths gracefully.
- [ ] Follow-up: live-fire `STAGE2_WALL_CLOCK_S=600 bash tools/run-stage2.sh` with API key wired, expect >50 successful ticks across 5 tribes.