### PR TITLE
feat(tribes-bench): install + DX polish (#436)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,24 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Install + DX polish** ([#436](https://github.com/Replikanti/agentis-colonies/issues/436)).
+  - `tribes-bench/tools/run-verdict-pair.sh` (new) — operator-friendly
+    orchestrator that runs `run-stage2.sh` -> `run-baseline.sh` ->
+    `analyse-stage2.py --baseline <latest>` and prints `comparison.md`
+    inline. Each step is echoed with a leading `+ ` prefix BEFORE
+    executing so operators can copy individual lines. Defaults
+    `STAGE2_WALL_CLOCK_S=1800` and `STAGE2_BASELINE_WALL_CLOCK_S=1800`
+    (30 min each) for a fast verdict pair. Flags: `--dry-run`,
+    `--skip-stage2`, `--skip-baseline`. Smoke test:
+    `tools/test-run-verdict-pair.sh`.
+  - `tribes-bench/README.md` — new **Quick start** section near the top
+    (prerequisites + three-line recipe) and **Known gotchas** section
+    near the bottom (kill-federation cascade behaviour, links the
+    selectivity-fix follow-up #440).
+  - `tribes-bench/install.sh` — post-install Next-steps block listing
+    the optional dashboard install, the `run-verdict-pair.sh`
+    invocation, and the dashboard URL labelled "after starting it".
+
 - **Stage 2 M3 — baseline harness + long-run defaults + comparison report**
   ([#394](https://github.com/Replikanti/agentis-colonies/issues/394)).
   - `tribes-bench/tools/run-baseline.sh` (new) — fixed-pipeline control
@@ -350,6 +368,13 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   source-to-sink data-flow seed prompt.
 
 ### Changed
+
+- `tribes-bench/tools/check-agentis-version.sh` missing-binary branch
+  now prints a multi-line message pointing operators to
+  https://github.com/Replikanti/agentis (the runtime is a proprietary
+  closed source binary distributed for free for Linux and macOS) and
+  exits 1 instead of 78. The version-floor branch is unchanged
+  ([#436](https://github.com/Replikanti/agentis-colonies/issues/436)).
 
 ### Deprecated
 

--- a/tribes-bench/README.md
+++ b/tribes-bench/README.md
@@ -18,6 +18,39 @@ This federation was scaffolded via
 agent contract follows
 [ADR-0001](../doc/adr/ADR-0001-confidence-tiers.md) end-to-end.
 
+## Quick start
+
+**Prerequisites**
+
+- The `agentis` runtime binary on PATH. It is a proprietary closed
+  source binary distributed for free for Linux and macOS at
+  https://github.com/Replikanti/agentis. tribes-bench requires
+  `agentis >= 1.5.0`.
+- Claude Code CLI (`claude`) on PATH for the LLM backend.
+- `git`, `python3`, and `jq` on PATH (standard on most distros).
+
+**Three-line recipe**
+
+```bash
+bash tribes-bench/install.sh                    # idempotent setup
+bash tribes-bench/tools/run-verdict-pair.sh     # ~30-min ecosystem + baseline pair
+# (optional) open dashboard at http://localhost:8420 after starting it
+```
+
+`install.sh` checks the runtime version, copies each tribe's
+`colony.toml` from the example, and seeds `hunter:confidence = 0.7`.
+`run-verdict-pair.sh` orchestrates `run-stage2.sh` -> `run-baseline.sh`
+-> `analyse-stage2.py --baseline <latest>` and prints the resulting
+`comparison.md` to stdout. Each step is echoed with a leading `+ `
+prefix before executing so operators can copy individual lines if
+they want to drive the steps manually. Defaults:
+`STAGE2_WALL_CLOCK_S=1800` and `STAGE2_BASELINE_WALL_CLOCK_S=1800`
+(30 min each); override the env vars for longer pilots.
+
+For the long-form Stage 2 M3 (48h ecosystem + 1h baseline) recipe see
+[Stage 2 M3 reproduction recipe](#stage-2-m3--long-run--baseline-reproduction-recipe)
+below.
+
 ## Hypothesis
 
 A federation that uses the agentis emergent-layer primitives produces
@@ -384,6 +417,21 @@ confidence ladder defined in
 Stage 0 hunters seed at `0.7` (mid-`propose`). Verification (running
 `tools/verify-finding.sh`) is internal — not an external write — so
 calling it from the propose branch is consistent with ADR-0001.
+
+## Known gotchas
+
+- **`tools/kill-federation.sh` cascades to the dashboard.** The
+  shutdown script is called automatically at the end of every
+  `run-stage2.sh` / `run-baseline.sh` run (and therefore by
+  `run-verdict-pair.sh` too). Its current process matching is broad
+  enough that any running `federation-dashboard` instance is also
+  terminated when the federation shuts down. Workarounds: restart the
+  dashboard after each verdict pair, or run it under a separate
+  session manager (`systemd` user unit, `tmux`, `setsid`) so the
+  cascade does not reach it. Selectivity fix tracked separately in
+  [#440](https://github.com/Replikanti/agentis-colonies/issues/440)
+  (out of scope for #436 due to wider blast radius across all
+  federations).
 
 ## Related
 

--- a/tribes-bench/install.sh
+++ b/tribes-bench/install.sh
@@ -48,4 +48,9 @@ else
 fi
 
 echo
-echo "Done. Next: bash tools/run-stage0.sh"
+echo "Done."
+echo
+echo "Next steps:"
+echo "  1. (optional) install dashboard: bash federation-dashboard/install.sh"
+echo "  2. run a 30-min verdict pair:    bash tribes-bench/tools/run-verdict-pair.sh"
+echo "  3. open dashboard at http://localhost:8420 (after starting it)"

--- a/tribes-bench/tools/check-agentis-version.sh
+++ b/tribes-bench/tools/check-agentis-version.sh
@@ -17,11 +17,20 @@ set -eu
 
 REQUIRED="1.5.0"
 RELEASE_URL="https://github.com/Replikanti/agentis/releases/tag/v1.5.0"
+RUNTIME_DOWNLOAD_URL="https://github.com/Replikanti/agentis"
 
 if ! command -v agentis >/dev/null 2>&1; then
     echo "check-agentis-version: agentis CLI not on PATH" >&2
-    echo "                       install agentis >= ${REQUIRED}: ${RELEASE_URL}" >&2
-    exit 78
+    echo "" >&2
+    echo "  The agentis runtime is a proprietary closed source binary" >&2
+    echo "  distributed for free for Linux and macOS at:" >&2
+    echo "" >&2
+    echo "    ${RUNTIME_DOWNLOAD_URL}" >&2
+    echo "" >&2
+    echo "  Download the binary for your platform, place it on your PATH," >&2
+    echo "  then re-run this command. tribes-bench requires agentis >= ${REQUIRED}." >&2
+    echo "" >&2
+    exit 1
 fi
 
 raw="$(agentis --version 2>/dev/null || true)"

--- a/tribes-bench/tools/run-verdict-pair.sh
+++ b/tribes-bench/tools/run-verdict-pair.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# run-verdict-pair.sh — orchestrate one ecosystem + one baseline pilot
+# and print the resulting comparison.md inline.
+#
+# This is the operator-friendly wrapper for the Stage 2 M3 (#394)
+# 3-step recipe documented in tribes-bench/README.md. It compresses the
+# five separate commands the operator otherwise has to type — run-stage2,
+# run-baseline, two `ls -td` lookups, analyse-stage2 — into one
+# invocation that echoes each command on its own line with a leading
+# `+ ` prefix BEFORE executing it. Operators who want to copy any
+# individual step can do so from the echoed line.
+#
+# Defaults match the README's quick-start (1800s = 30min for fast
+# verdict). Override via the existing run-stage2 / run-baseline env
+# vars if a longer pilot is wanted.
+#
+# Flags:
+#   --dry-run        Echo every command but do not execute.
+#   --skip-stage2    Skip the run-stage2.sh step (use the latest
+#                    runs/<ts> directory that already exists).
+#   --skip-baseline  Skip the run-baseline.sh step (use the latest
+#                    runs/baseline-<ts> directory that already exists).
+#
+# Exit codes:
+#   0   verdict pair completed and comparison.md printed
+#   1   prerequisite missing or unknown flag
+#   2   run-stage2.sh failed
+#   3   run-baseline.sh failed
+#   4   analyse-stage2.py failed
+#   5   no eligible runs/<ts> or runs/baseline-<ts> directory found
+
+set -euo pipefail
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+TOOLS_DIR="$(dirname "$SCRIPT_PATH")"
+FED_DIR="$(dirname "$TOOLS_DIR")"
+
+DRY_RUN=0
+SKIP_STAGE2=0
+SKIP_BASELINE=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --skip-stage2)
+            SKIP_STAGE2=1
+            shift
+            ;;
+        --skip-baseline)
+            SKIP_BASELINE=1
+            shift
+            ;;
+        -h|--help)
+            sed -n '2,30p' "$SCRIPT_PATH" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "run-verdict-pair: unknown flag: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Default wall clocks for a fast 30-minute verdict pair. Operators who
+# already exported STAGE2_WALL_CLOCK_S / STAGE2_BASELINE_WALL_CLOCK_S
+# keep their override.
+export STAGE2_WALL_CLOCK_S="${STAGE2_WALL_CLOCK_S:-1800}"
+export STAGE2_BASELINE_WALL_CLOCK_S="${STAGE2_BASELINE_WALL_CLOCK_S:-1800}"
+
+# `+ <cmd>` echo helper. Always prints to stdout; runs the command
+# unless --dry-run is set.
+run() {
+    echo "+ $*"
+    if [ "$DRY_RUN" -eq 0 ]; then
+        "$@"
+    fi
+}
+
+# Resolve "the latest runs/<ts>/ that is NOT a baseline-* dir" via
+# `ls -td`. Mirrors the ad-hoc procedure operators already use.
+latest_eco_dir() {
+    # shellcheck disable=SC2012
+    ls -td "$FED_DIR"/runs/*/ 2>/dev/null \
+        | grep -v '/runs/baseline-' \
+        | head -1 \
+        | sed 's:/$::'
+}
+
+latest_baseline_dir() {
+    # shellcheck disable=SC2012
+    ls -td "$FED_DIR"/runs/baseline-*/ 2>/dev/null \
+        | head -1 \
+        | sed 's:/$::'
+}
+
+# --- Step 1: ecosystem run ---
+if [ "$SKIP_STAGE2" -eq 0 ]; then
+    if ! run bash "$TOOLS_DIR/run-stage2.sh"; then
+        echo "run-verdict-pair: run-stage2.sh failed" >&2
+        exit 2
+    fi
+fi
+
+# --- Step 2: baseline run ---
+if [ "$SKIP_BASELINE" -eq 0 ]; then
+    if ! run bash "$TOOLS_DIR/run-baseline.sh"; then
+        echo "run-verdict-pair: run-baseline.sh failed" >&2
+        exit 3
+    fi
+fi
+
+# --- Step 3: resolve dirs and run the comparison ---
+ECO_DIR="$(latest_eco_dir || true)"
+BASELINE_DIR="$(latest_baseline_dir || true)"
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    if [ -z "$ECO_DIR" ] || [ ! -d "$ECO_DIR" ]; then
+        echo "run-verdict-pair: no ecosystem run dir found under $FED_DIR/runs/" >&2
+        exit 5
+    fi
+    if [ -z "$BASELINE_DIR" ] || [ ! -d "$BASELINE_DIR" ]; then
+        echo "run-verdict-pair: no baseline run dir found under $FED_DIR/runs/baseline-*" >&2
+        exit 5
+    fi
+else
+    # Dry-run sentinel paths so the echoed analyse line has something
+    # concrete to show.
+    ECO_DIR="${ECO_DIR:-$FED_DIR/runs/<eco-ts>}"
+    BASELINE_DIR="${BASELINE_DIR:-$FED_DIR/runs/baseline-<bl-ts>}"
+fi
+
+echo "[run-verdict-pair] ecosystem run: $ECO_DIR"
+echo "[run-verdict-pair] baseline run:  $BASELINE_DIR"
+
+if ! run python3 "$TOOLS_DIR/analyse-stage2.py" "$ECO_DIR" --baseline "$BASELINE_DIR/telemetry.csv"; then
+    echo "run-verdict-pair: analyse-stage2.py failed" >&2
+    exit 4
+fi
+
+# --- Step 4: print comparison.md inline ---
+COMPARISON_MD="$ECO_DIR/comparison.md"
+run cat "$COMPARISON_MD"

--- a/tribes-bench/tools/test-run-verdict-pair.sh
+++ b/tribes-bench/tools/test-run-verdict-pair.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# test-run-verdict-pair.sh — smoke-test the orchestrator's --dry-run CLI
+# surface (#436).
+#
+# Asserts:
+#   1. tools/run-verdict-pair.sh exists, is executable, and bash -n clean.
+#   2. --dry-run exits 0.
+#   3. --dry-run echoes the four expected command lines in order:
+#        + bash <...>/run-stage2.sh
+#        + bash <...>/run-baseline.sh
+#        + python3 <...>/analyse-stage2.py <eco-dir> --baseline <baseline-dir>/telemetry.csv
+#        + cat <eco-dir>/comparison.md
+#
+# No daemons launched. No fixtures touched. Mirrors the
+# PASS/FAIL/SKIP shape of the other tribes-bench test-*.sh files.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/run-verdict-pair.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    label="$1"; exp="$2"; got="$3"
+    if [ "$exp" = "$got" ]; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       expected: $exp"
+        echo "       got:      $got"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_match() {
+    label="$1"; haystack="$2"; needle="$3"
+    if printf '%s\n' "$haystack" | grep -Fq -- "$needle"; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       needle missing: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# 1. exists + executable + bash -n
+if [ ! -x "$TARGET" ]; then
+    echo "[FAIL] run-verdict-pair.sh exists and is executable"
+    FAIL=$((FAIL + 1))
+else
+    echo "[PASS] run-verdict-pair.sh exists and is executable"
+    PASS=$((PASS + 1))
+fi
+
+if bash -n "$TARGET" 2>/dev/null; then
+    echo "[PASS] run-verdict-pair.sh bash -n clean"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] run-verdict-pair.sh bash -n clean"
+    FAIL=$((FAIL + 1))
+fi
+
+# 2. --dry-run exits 0
+set +e
+OUT="$(bash "$TARGET" --dry-run 2>&1)"
+RC=$?
+set -e
+assert_eq "--dry-run exits 0" "0" "$RC"
+
+# 3. four command lines in order. Use grep -nF to pull the line numbers
+# of each `+ ` prefixed step and assert ordering.
+LINES="$(printf '%s\n' "$OUT" | grep -nF '+ ' | sed 's/:.*//')"
+COUNT="$(printf '%s\n' "$LINES" | grep -c . || true)"
+assert_eq "--dry-run prints 4 echoed command lines" "4" "$COUNT"
+
+assert_match "step 1 is run-stage2.sh"   "$OUT" "+ bash $SCRIPT_DIR/run-stage2.sh"
+assert_match "step 2 is run-baseline.sh" "$OUT" "+ bash $SCRIPT_DIR/run-baseline.sh"
+assert_match "step 3 invokes analyse-stage2.py with --baseline" "$OUT" "+ python3 $SCRIPT_DIR/analyse-stage2.py"
+assert_match "step 3 passes --baseline telemetry.csv" "$OUT" "--baseline"
+assert_match "step 4 cats comparison.md" "$OUT" "comparison.md"
+
+# 3b. order check: step 1 line < step 2 line < step 3 line < step 4 line
+L1="$(printf '%s\n' "$OUT" | grep -nF '+ bash ' | grep -F 'run-stage2.sh' | head -1 | cut -d: -f1)"
+L2="$(printf '%s\n' "$OUT" | grep -nF '+ bash ' | grep -F 'run-baseline.sh' | head -1 | cut -d: -f1)"
+L3="$(printf '%s\n' "$OUT" | grep -nF '+ python3 ' | grep -F 'analyse-stage2.py' | head -1 | cut -d: -f1)"
+L4="$(printf '%s\n' "$OUT" | grep -nF '+ cat ' | grep -F 'comparison.md' | head -1 | cut -d: -f1)"
+
+if [ -n "$L1" ] && [ -n "$L2" ] && [ -n "$L3" ] && [ -n "$L4" ] \
+    && [ "$L1" -lt "$L2" ] && [ "$L2" -lt "$L3" ] && [ "$L3" -lt "$L4" ]; then
+    echo "[PASS] command lines appear in correct order"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] command lines appear in correct order"
+    echo "       L1=$L1 L2=$L2 L3=$L3 L4=$L4"
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Implements the corrigendum-version plan from #436
([comment 4378661938](https://github.com/Replikanti/agentis-colonies/issues/436#issuecomment-4378661938)).
First-time-operator polish for `tribes-bench/`: friendlier
missing-runtime message, post-install Next-steps block, a single
`run-verdict-pair.sh` orchestrator that compresses the five-command
M3 reproduction recipe into one invocation, a smoke test for the
orchestrator, README Quick start + Known gotchas sections, and a
CHANGELOG entry.

Resolves #436.

## Commits

1. `fix(tribes-bench): soften check-agentis-version when binary is missing (#436)` — multi-line message pointing at the free runtime download at https://github.com/Replikanti/agentis when `agentis` is not on PATH; exits 1 instead of 78. Version-floor branch unchanged.
2. `feat(tribes-bench): add run-verdict-pair.sh orchestrator (#436)` — runs `run-stage2.sh` -> `run-baseline.sh` -> `analyse-stage2.py --baseline <latest>` and cats `comparison.md`. Each step echoed with `+ ` prefix BEFORE executing. Flags: `--dry-run`, `--skip-stage2`, `--skip-baseline`. Defaults `STAGE2_WALL_CLOCK_S=1800` and `STAGE2_BASELINE_WALL_CLOCK_S=1800` (30 min each).
3. `test(tribes-bench): smoke test for run-verdict-pair.sh (#436)` — 10 PASS assertions on `--dry-run` CLI surface; no daemons; no fixtures touched.
4. `feat(tribes-bench): post-install summary + dashboard hint in install.sh (#436)` — three-line Next-steps block (optional dashboard install, run-verdict-pair, dashboard URL "after starting it").
5. `docs(tribes-bench): add Quick start + kill-federation cascade note to README (#436)` — Quick start near the top (prerequisites + three-line recipe), Known gotchas near the bottom (kill-federation cascade workarounds + link to follow-up #440).
6. `docs(tribes-bench): CHANGELOG entry for DX polish (#436)` — `[Unreleased]` Added + Changed bullets.

## Follow-up filed

- #440 — `tools/kill-federation.sh` selectivity. The cascade behaviour is documented in this PR; the underlying selectivity change is out of scope for #436 due to wider blast radius across all federations.

## Acceptance criteria (from the plan)

- [x] Without `agentis` on PATH: `bash tribes-bench/install.sh` prints a clear message pointing to https://github.com/Replikanti/agentis. Exit code 1.
- [x] `bash tribes-bench/tools/run-verdict-pair.sh --dry-run` echoes four orchestrated commands and exits 0 without launching daemons.
- [x] `bash tribes-bench/tools/test-run-verdict-pair.sh` passes locally (10/0).
- [x] `tools/colony-lint.sh` exits 0 (166 passed, 0 failed, 3 skipped).
- [x] README Quick start fits on one screen; the kill-federation gotcha is reachable from a top-level heading.

## Test plan

- [x] `bash tools/colony-lint.sh` — 166 passed, 0 failed, 3 skipped.
- [x] `bash tribes-bench/tools/test-run-verdict-pair.sh` — 10 passed, 0 failed.
- [x] `PATH=/usr/bin:/bin bash tribes-bench/tools/check-agentis-version.sh` — prints the new multi-line message and exits 1.
- [x] `bash tribes-bench/tools/run-verdict-pair.sh --dry-run` — echoes 4 `+ `-prefixed commands in order and exits 0.
- [ ] Operator-side smoke: real `bash tribes-bench/install.sh` without `agentis` on PATH (post-merge, on a fresh laptop without the runtime).