### PR TITLE
fix(tools): scope kill-federation dashboard kills by daemon registry (#440)

### DIFF
--- a/tools/kill-federation.sh
+++ b/tools/kill-federation.sh
@@ -264,36 +264,93 @@ if [ -n "$PORT_PIDS_NL" ]; then
         | grep -v '^$' | sort -u || true)"
 fi
 
-# #296: scope dashboard PID lists to processes whose cwd lives under the
-# resolved FED_DIR. `pgrep -f federation-dashboard` matches ANY command
-# line containing that substring — including a contributor's live
-# dashboard running against a different federation. Without this filter,
-# any CI test that spawns a stub dashboard and then calls
+# #296 + #440: scope dashboard PID lists to processes that are clearly
+# part of THIS federation. `pgrep -f federation-dashboard` matches ANY
+# command line containing that substring — including a contributor's
+# live dashboard running against a different federation. Without this
+# filter, any CI test that spawns a stub dashboard and then calls
 # kill-federation.sh sweeps away the host's live dashboard too (forensic
 # sigwaitinfo proved this behaviour: sender was a
 # /tmp/tmp.XXX/fed/tools/kill-federation.sh invoked from a stub's
 # dashboard test, which matched the production dashboard by pattern).
-# AGENTIS daemons are not filtered here — they routinely detach into
-# their own sessions and their /proc/<pid>/cwd can drift to / during
-# daemonize; the DAEMON_MATCH pattern already includes the agent file's
-# full absolute path, so it's inherently fed-dir-scoped. On /proc-less
-# platforms (macOS) the filter degrades to identity (no-op), preserving
-# legacy behaviour there.
+#
+# A dashboard PID is kept in the kill set iff BOTH:
+#   (a) /proc/<pid>/cwd is rooted at $FED_DIR_ABS (same federation tree),
+#       AND
+#   (b) the PID also appears in $AGENTIS_DIR/daemon/*.pid (or the matching
+#       *.watchdog.pid sidecar) — i.e. the daemon registry recognises it
+#       as one of THIS federation's processes (#440). The registry is
+#       written by the federation's own start scripts (start-federation,
+#       start-colony, run-stage*, run-baseline), so a dashboard running
+#       under tribes-bench's fed-dir but launched by hand (e.g. via
+#       `setsid -f federation-dashboard <fed> 8420`) is NOT registered
+#       and is correctly preserved across pilot runs (#440 issue body).
+#
+# The OR-equivalent collapse: when $AGENTIS_DIR/daemon/ does not exist
+# or is empty (no registry yet), behaviour falls back to (a)-only —
+# matching the pre-#440 cwd-only filter so non-tribes-bench callers see
+# zero behavioural change.
+#
+# AGENTIS daemons (DAEMON_MATCH) are not filtered here — they routinely
+# detach into their own sessions and their /proc/<pid>/cwd can drift to
+# / during daemonize; the DAEMON_MATCH pattern already includes the
+# agent file's full absolute path, so it's inherently fed-dir-scoped.
+# On /proc-less platforms (macOS) the filter degrades to identity (no-op),
+# preserving legacy behaviour there.
 if [ -d /proc ] && command -v readlink >/dev/null 2>&1; then
     FED_DIR_ABS="$(cd "$FED_DIR" && pwd -P 2>/dev/null)"
     if [ -n "$FED_DIR_ABS" ]; then
+        # Build the registered-PID set once, up front. Empty when the
+        # registry dir does not exist or contains no *.pid files — the
+        # _in_fed_scope helper falls back to cwd-only in that case.
+        REGISTERED_PIDS_NL=""
+        if [ -n "$AGENTIS_DIR" ] && [ -d "$AGENTIS_DIR/daemon" ]; then
+            # Each daemon writes a single-line file containing its PID.
+            # `*.pid` covers both the primary (<id>.pid) and watchdog
+            # (<id>.watchdog.pid) sidecars.
+            REGISTERED_PIDS_NL="$(find "$AGENTIS_DIR/daemon" -maxdepth 1 -name '*.pid' -type f 2>/dev/null \
+                | while IFS= read -r f; do
+                    [ -z "$f" ] && continue
+                    _pid="$(head -n 1 "$f" 2>/dev/null | tr -d ' \t\r\n' || true)"
+                    case "$_pid" in
+                        ''|*[!0-9]*) : ;;
+                        *) printf '%s\n' "$_pid" ;;
+                    esac
+                  done | sort -u || true)"
+        fi
+        _in_fed_scope() {
+            # Stage (a): /proc/<pid>/cwd rooted at FED_DIR_ABS.
+            local pid="$1"
+            [ -z "$pid" ] && return 1
+            local cwd
+            cwd="$(readlink /proc/"$pid"/cwd 2>/dev/null || true)"
+            [ -z "$cwd" ] && return 1
+            case "$cwd" in
+                "$FED_DIR_ABS"|"$FED_DIR_ABS"/*) : ;;
+                *) return 1 ;;
+            esac
+            # Stage (b): if the registry is non-empty, require membership.
+            # If the registry is empty (or absent), accept on cwd alone —
+            # this preserves the pre-#440 behaviour for callers that do
+            # not have a daemon/ dir populated yet.
+            if [ -z "$REGISTERED_PIDS_NL" ]; then
+                return 0
+            fi
+            while IFS= read -r _rp; do
+                [ -z "$_rp" ] && continue
+                [ "$_rp" = "$pid" ] && return 0
+            done <<< "$REGISTERED_PIDS_NL"
+            return 1
+        }
         _filter_by_fed_dir() {
-            # stdin: newline-separated PIDs; stdout: subset whose /proc/<pid>/cwd
-            # is rooted at FED_DIR_ABS. Non-existent/closed procs are dropped.
+            # stdin: newline-separated PIDs; stdout: subset that pass
+            # _in_fed_scope (cwd AND registry, with registry-empty fallback
+            # to cwd-only). Non-existent/closed procs are dropped.
             while IFS= read -r pid; do
                 [ -z "$pid" ] && continue
-                local cwd
-                cwd="$(readlink /proc/"$pid"/cwd 2>/dev/null || true)"
-                [ -z "$cwd" ] && continue
-                case "$cwd" in
-                    "$FED_DIR_ABS"|"$FED_DIR_ABS"/*) printf '%s\n' "$pid" ;;
-                    *) : ;;
-                esac
+                if _in_fed_scope "$pid"; then
+                    printf '%s\n' "$pid"
+                fi
             done
         }
         DASHBOARD_PIDS_NL="$(printf '%s\n' "$DASHBOARD_PIDS_NL" | _filter_by_fed_dir || true)"

--- a/tools/test-kill-federation.sh
+++ b/tools/test-kill-federation.sh
@@ -298,6 +298,150 @@ else
     fi
 fi
 
+# --- Test 10: dashboard with cwd OUTSIDE fed-dir survives (#296 + #440) ---
+# A dashboard process whose argv matches DASHBOARD_MATCH but whose
+# /proc/<pid>/cwd is rooted OUTSIDE the resolved fed-dir must NOT be
+# signalled. This is the regression #296 originally guarded against —
+# made explicit here so the cwd-stage of the two-stage filter has its
+# own assertion.
+FIX10="$TMPDIR_TEST/fix10"
+FIX10_OUTSIDE="$TMPDIR_TEST/fix10-outside"
+mkdir -p "$FIX10/.agentis/daemon" "$FIX10_OUTSIDE"
+
+FIXTURE_TAG_10="kill-fed-test-dash-outside-$$"
+# cwd OUTSIDE fed-dir — the wrapper's /proc/<pid>/cwd must NOT match
+# the FED_DIR_ABS prefix. Mirrors test 5's spawn idiom: outer bash -c
+# runs `exec -a TAG sleep N`, replacing itself with sleep whose argv0
+# is TAG so pgrep -f matches the dashboard pattern.
+(cd "$FIX10_OUTSIDE" && exec bash -c "exec -a '$FIXTURE_TAG_10' sleep 9999") &
+DUMMY_PID_10=$!
+SPAWNED_PIDS+=("$DUMMY_PID_10")
+sleep 1
+
+if ! kill -0 "$DUMMY_PID_10" 2>/dev/null; then
+    fail "10: spawn dummy" "PID $DUMMY_PID_10 not alive after spawn"
+else
+    set +e
+    "$KILL_SH" --fed-dir "$FIX10" --no-backup \
+        --match-pattern "kill-fed-t10-no-daemon-$$" \
+        --dashboard-pattern "$FIXTURE_TAG_10" \
+        --dashboard-py-pattern "kill-fed-t10-no-dashpy-$$" >/dev/null 2>&1
+    set -e
+    # Poll up to 20s for either signal-kill or survival.
+    _t10_start=$(date +%s)
+    while kill -0 "$DUMMY_PID_10" 2>/dev/null; do
+        _t10_now=$(date +%s)
+        if [ $((_t10_now - _t10_start)) -gt 20 ]; then
+            break
+        fi
+        sleep 1
+    done
+    unset _t10_start _t10_now
+    if kill -0 "$DUMMY_PID_10" 2>/dev/null; then
+        pass "10: dashboard with cwd OUTSIDE fed-dir survives the kill"
+        kill -KILL "$DUMMY_PID_10" 2>/dev/null || true
+    else
+        fail "10: cwd-outside" "dashboard PID $DUMMY_PID_10 was killed despite cwd outside fed-dir"
+    fi
+fi
+
+# --- Test 11: dashboard with cwd INSIDE fed-dir but unregistered survives (#440) ---
+# New behaviour from #440: a dashboard whose cwd is rooted at fed-dir
+# but whose PID is NOT in $AGENTIS_DIR/daemon/*.pid must NOT be
+# signalled. Simulates the tribes-bench operator scenario where the
+# dashboard is launched by hand (`setsid -f federation-dashboard ...`)
+# and is not registered in the daemon registry. Requires at least one
+# *.pid file in daemon/ so the registered-PID set is non-empty —
+# otherwise the filter falls back to cwd-only and would kill T11.
+FIX11="$TMPDIR_TEST/fix11"
+mkdir -p "$FIX11/.agentis/daemon"
+# Seed the registry with a fake PID file (PID 1 — init, never our
+# fixture). This forces the registered-PID set to be non-empty so the
+# filter requires both cwd AND registry membership.
+echo "1" > "$FIX11/.agentis/daemon/seed.pid"
+
+FIXTURE_TAG_11="kill-fed-test-dash-inside-unregistered-$$"
+# Mirrors test 5's spawn idiom (see test 10).
+(cd "$FIX11" && exec bash -c "exec -a '$FIXTURE_TAG_11' sleep 9999") &
+DUMMY_PID_11=$!
+SPAWNED_PIDS+=("$DUMMY_PID_11")
+sleep 1
+
+if ! kill -0 "$DUMMY_PID_11" 2>/dev/null; then
+    fail "11: spawn dummy" "PID $DUMMY_PID_11 not alive after spawn"
+else
+    set +e
+    "$KILL_SH" --fed-dir "$FIX11" --no-backup \
+        --match-pattern "kill-fed-t11-no-daemon-$$" \
+        --dashboard-pattern "$FIXTURE_TAG_11" \
+        --dashboard-py-pattern "kill-fed-t11-no-dashpy-$$" >/dev/null 2>&1
+    set -e
+    _t11_start=$(date +%s)
+    while kill -0 "$DUMMY_PID_11" 2>/dev/null; do
+        _t11_now=$(date +%s)
+        if [ $((_t11_now - _t11_start)) -gt 20 ]; then
+            break
+        fi
+        sleep 1
+    done
+    unset _t11_start _t11_now
+    if kill -0 "$DUMMY_PID_11" 2>/dev/null; then
+        pass "11: dashboard with cwd INSIDE fed-dir but unregistered survives the kill"
+        kill -KILL "$DUMMY_PID_11" 2>/dev/null || true
+    else
+        fail "11: unregistered" "dashboard PID $DUMMY_PID_11 was killed despite missing daemon-registry entry"
+    fi
+fi
+
+# --- Test 12: registered dashboard inside fed-dir is killed (#440) ---
+# OR-branch coverage: a process whose argv matches DASHBOARD_MATCH,
+# whose cwd is inside fed-dir, AND whose PID is recorded in
+# $AGENTIS_DIR/daemon/<id>.pid must be killed. This mirrors the
+# behaviour the federation's own start scripts produce (each daemon
+# writes its PID into the registry). Without this assertion, an empty
+# daemon registry could silently collapse #440's filter to "no
+# dashboards killable" — which would defeat the whole script.
+FIX12="$TMPDIR_TEST/fix12"
+mkdir -p "$FIX12/.agentis/daemon"
+
+FIXTURE_TAG_12="kill-fed-test-dash-registered-$$"
+# Mirrors test 5's spawn idiom (see test 10).
+(cd "$FIX12" && exec bash -c "exec -a '$FIXTURE_TAG_12' sleep 9999") &
+DUMMY_PID_12=$!
+SPAWNED_PIDS+=("$DUMMY_PID_12")
+sleep 1
+
+# Register the dummy's PID in the daemon registry so stage (b) of the
+# filter accepts it. The file's basename is informational only — the
+# script reads its single-line content.
+echo "$DUMMY_PID_12" > "$FIX12/.agentis/daemon/dummy12.pid"
+
+if ! kill -0 "$DUMMY_PID_12" 2>/dev/null; then
+    fail "12: spawn dummy" "PID $DUMMY_PID_12 not alive after spawn"
+else
+    set +e
+    "$KILL_SH" --fed-dir "$FIX12" --no-backup \
+        --match-pattern "kill-fed-t12-no-daemon-$$" \
+        --dashboard-pattern "$FIXTURE_TAG_12" \
+        --dashboard-py-pattern "kill-fed-t12-no-dashpy-$$" >/dev/null 2>&1
+    set -e
+    _t12_start=$(date +%s)
+    while kill -0 "$DUMMY_PID_12" 2>/dev/null; do
+        _t12_now=$(date +%s)
+        if [ $((_t12_now - _t12_start)) -gt 20 ]; then
+            break
+        fi
+        sleep 1
+    done
+    unset _t12_start _t12_now
+    if kill -0 "$DUMMY_PID_12" 2>/dev/null; then
+        fail "12: registered" "registered dashboard PID $DUMMY_PID_12 still alive after kill window"
+        kill -KILL "$DUMMY_PID_12" 2>/dev/null || true
+    else
+        pass "12: registered dashboard inside fed-dir is killed"
+    fi
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tribes-bench/README.md
+++ b/tribes-bench/README.md
@@ -420,18 +420,13 @@ calling it from the propose branch is consistent with ADR-0001.
 
 ## Known gotchas
 
-- **`tools/kill-federation.sh` cascades to the dashboard.** The
-  shutdown script is called automatically at the end of every
-  `run-stage2.sh` / `run-baseline.sh` run (and therefore by
-  `run-verdict-pair.sh` too). Its current process matching is broad
-  enough that any running `federation-dashboard` instance is also
-  terminated when the federation shuts down. Workarounds: restart the
-  dashboard after each verdict pair, or run it under a separate
-  session manager (`systemd` user unit, `tmux`, `setsid`) so the
-  cascade does not reach it. Selectivity fix tracked separately in
-  [#440](https://github.com/Replikanti/agentis-colonies/issues/440)
-  (out of scope for #436 due to wider blast radius across all
-  federations).
+- **Dashboard cascade on `tools/kill-federation.sh`:** resolved by
+  [#440](https://github.com/Replikanti/agentis-colonies/issues/440).
+  The shutdown script (called automatically at the end of every
+  `run-stage2.sh` / `run-baseline.sh` / `run-verdict-pair.sh`) now
+  scopes dashboard kills by daemon-registry membership, so a
+  `federation-dashboard` launched by hand (e.g. via `setsid -f`)
+  persists across pilot runs.
 
 ## Related
 

--- a/tribes-bench/tools/run-baseline.sh
+++ b/tribes-bench/tools/run-baseline.sh
@@ -300,7 +300,7 @@ python3 "$TOOLS_DIR/snapshot-agent-tribe-map.py" "$AGENTIS_ROOT/daemon" \
 echo "[run-baseline] stopping baseline..."
 KILL_SCRIPT="$REPO_ROOT/tools/kill-federation.sh"
 if [ -x "$KILL_SCRIPT" ]; then
-    bash "$KILL_SCRIPT" --fed-dir "$FED_DIR" --no-backup >>"$RUN_DIR/kill-federation.log" 2>&1 || true
+    bash "$KILL_SCRIPT" --fed-dir "$RUN_DIR" --no-backup >>"$RUN_DIR/kill-federation.log" 2>&1 || true
 else
     echo "run-baseline: kill-federation.sh not found at $KILL_SCRIPT — falling back to kill" >&2
     kill "$FED_PID" 2>/dev/null || true

--- a/tribes-bench/tools/run-stage2.sh
+++ b/tribes-bench/tools/run-stage2.sh
@@ -138,7 +138,7 @@ fi
 if [ "$RESUMING" = "1" ]; then
     KILL_SCRIPT_PRE="$REPO_ROOT/tools/kill-federation.sh"
     if [ -x "$KILL_SCRIPT_PRE" ]; then
-        bash "$KILL_SCRIPT_PRE" --fed-dir "$FED_DIR" --no-backup \
+        bash "$KILL_SCRIPT_PRE" --fed-dir "$RUN_DIR" --no-backup \
             >>"$RUN_DIR/kill-federation.log" 2>&1 || true
     fi
     if [ -d "$RUN_DIR/.agentis/daemon" ]; then
@@ -394,7 +394,7 @@ while [ "$elapsed" -lt "$WALL_CLOCK" ]; do
         echo "[run-stage2] STAGE2_CRASH_AT_S triggered at elapsed=${elapsed}s — killing federation and exiting 99"
         KILL_SCRIPT="$REPO_ROOT/tools/kill-federation.sh"
         if [ -x "$KILL_SCRIPT" ]; then
-            bash "$KILL_SCRIPT" --fed-dir "$FED_DIR" --no-backup \
+            bash "$KILL_SCRIPT" --fed-dir "$RUN_DIR" --no-backup \
                 >>"$RUN_DIR/kill-federation.log" 2>&1 || true
         else
             kill "$FED_PID" 2>/dev/null || true
@@ -412,7 +412,7 @@ done
 echo "[run-stage2] stopping federation..."
 KILL_SCRIPT="$REPO_ROOT/tools/kill-federation.sh"
 if [ -x "$KILL_SCRIPT" ]; then
-    bash "$KILL_SCRIPT" --fed-dir "$FED_DIR" --no-backup >>"$RUN_DIR/kill-federation.log" 2>&1 || true
+    bash "$KILL_SCRIPT" --fed-dir "$RUN_DIR" --no-backup >>"$RUN_DIR/kill-federation.log" 2>&1 || true
 else
     echo "run-stage2: kill-federation.sh not found at $KILL_SCRIPT — falling back to kill" >&2
     kill "$FED_PID" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Resolves #440.

`tools/kill-federation.sh` previously matched dashboard processes by argv pattern, scoped only by `/proc/<pid>/cwd` rooted at the federation directory (#296). For tribes-bench's verdict-pair workflow this was still too broad: a `federation-dashboard` launched out-of-band against `tribes-bench/` (e.g. via `setsid -f federation-dashboard <fed> 8420`) was killed by every `run-stage2.sh` / `run-baseline.sh` / `run-verdict-pair.sh` invocation.

This PR refines the existing `_filter_by_fed_dir` cwd filter into a **two-stage** filter for dashboard PIDs only. A dashboard PID stays in the kill set iff:

1. `/proc/<pid>/cwd` is rooted at the resolved fed-dir (the pre-#440 #296 guarantee), **AND**
2. the PID appears in `$AGENTIS_DIR/daemon/*.pid` (or `*.watchdog.pid`) — i.e. the federation's own start scripts registered it.

A dashboard launched by hand never writes a `daemon/<id>.pid`, so it is preserved across pilot runs. AGENTIS daemons (`AGENTIS_PIDS_NL`) stay unfiltered — their match pattern is already fed-dir-scoped via the absolute agent file path.

**Pure additive.** When `$AGENTIS_DIR/daemon/` does not exist or is empty, behaviour collapses to the pre-#440 cwd-only filter (no regression for non-tribes-bench callers). `/proc`-less platforms (macOS) keep the pre-existing no-op fallback via the outer `[ -d /proc ]` guard.

The original plan was pure additive on the script. Smoke surfaced a wiring gap: tribes-bench callers were passing `--fed-dir tribes-bench` (the federation root) instead of the per-run hermetic dir where daemons actually register, so the registry-empty fallback was hit and the dashboard was still killed in practice. Commit 4 closes that gap by pointing kill-federation at `$RUN_DIR` from the four invocation sites in `run-stage2.sh` / `run-baseline.sh`. End-to-end smoke now passes.

## Commits

1. `tools/kill-federation.sh: scope dashboard kills by daemon-registry membership (#440)` — `_filter_by_fed_dir` becomes a two-stage filter via a new `_in_fed_scope` helper. The registered-PID set is built once up-front from `$AGENTIS_DIR/daemon/*.pid` contents; empty registry → cwd-only fallback.
2. `tools/test-kill-federation.sh: cover fed-dir-scoped dashboard exclusion (#440)` — three new tests (T10/T11/T12) below.
3. `tribes-bench/README.md: remove dashboard-cascade workaround (#440)` — replace the `setsid` / `tmux` / systemd workaround in `## Known gotchas` with a one-line "resolved by #440" pointer. Section heading kept.
4. `fix(tribes-bench): point kill-federation at per-run hermetic dir (#440)` — update four `--fed-dir "$FED_DIR"` callers in `tribes-bench/tools/run-stage2.sh` (resume preflight L141, M3 mid-run crash drill L397, end-of-pilot L415) and `run-baseline.sh` (end-of-pilot L302) to pass `--fed-dir "$RUN_DIR"` so the per-run registry is visible to kill-federation. `run-verdict-pair.sh` delegates to those two and needed no direct change.

No `CHANGELOG.md` entry: this repo has component-level CHANGELOGs only (`dev-apprenticeship/`, `federation-dashboard/`, `tribes-bench/`). The change touches `tools/kill-federation.sh` (federation-agnostic platform component, no CHANGELOG of its own) and a doc-only update to `tribes-bench/README.md` (no operator-visible API change in tribes-bench itself, so no `tribes-bench/CHANGELOG.md` line either).

## Test plan

- [x] `bash tools/test-kill-federation.sh` after commit 1 → 9/9 PASS (no regression).
- [x] `bash tools/test-kill-federation.sh` after commit 2 → 12/12 PASS:
  - **T10** — dashboard with cwd OUTSIDE fed-dir survives the kill.
  - **T11** — dashboard with cwd INSIDE fed-dir but NOT registered survives the kill (the new #440 behaviour). Fixture seeds a fake `daemon/seed.pid` so the registered-PID set is non-empty (otherwise the filter falls back to cwd-only).
  - **T12** — dashboard with cwd INSIDE fed-dir AND registered in `daemon/<id>.pid` IS killed. Locks the OR-branch so an empty registry collapsing to "no dashboards killable" does not silently defeat the script.
- [x] `bash tools/colony-lint.sh` → 166 passed, 0 failed, 3 skipped (the 3 skips are pre-existing: `test-kill-endpoint.sh`, `test-kill-federation.sh`, and the agentis-binary-required pass).
- [x] **Manual smoke (out-of-band dashboard + populated registry):**
  ```
  setsid -f federation-dashboard <fed> 8420
  echo 1 > <fed>/.agentis/daemon/seed.pid
  bash tools/kill-federation.sh --fed-dir <fed> --no-backup
  ```
  → dashboard PID survived, `lsof :8420` still showed our PID listening. **PASS.**
- [x] **End-to-end smoke (`STAGE2_BASELINE_WALL_CLOCK_S=60 bash tribes-bench/tools/run-baseline.sh` with out-of-band dashboard on :8420):** **PASS.** After commit 4 wires callers to `$RUN_DIR`, kill-federation sees the per-run registry, classifies the out-of-band dashboard as not-registered, and excludes it. Dashboard PID survives baseline completion, port 8420 still listening, same PID before and after.

## Notes

- The plan's commit 4 (`CHANGELOG.md` entry) collapsed to "document in PR body only" because there is no top-level `CHANGELOG.md` in this repo (only per-component ones). See the no-CHANGELOG-entry rationale in the Summary.
- Scope expansion from 3 commits to 4 commits during implementation. Initial 3-commit plan delivered the script-level fix; smoke revealed callers were not wired correctly to benefit from it. Commit 4 fixes the caller wiring so the issue's stated acceptance criterion (dashboard survives a verdict-pair) is met by this PR alone, without needing a follow-up.
