### PR TITLE
docs: post-#441/#442 doc polish (versions, 5-tribe state, kill-federation refs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,11 @@
 
 ## Project overview
 
-A home for [Agentis](https://github.com/Replikanti/agentis) agent **federations** plus federation-agnostic **platform components**. The platform contract every federation must satisfy is normative in [ADR-0003](./doc/adr/ADR-0003-federation-portability-contract.md). Today exactly one federation is shipped: `dev-apprenticeship/` — 5 colonies, 21 agents that learn a developer's workflow by observing how they work on GitLab/GitHub. All 21 agents implement the full confidence gradient (observe / suggest / act). Federation patterns beyond the coder workflow live in [`doc/federation-patterns.md`](./doc/federation-patterns.md).
+A home for [Agentis](https://github.com/Replikanti/agentis) agent **federations** plus federation-agnostic **platform components**. The platform contract every federation must satisfy is normative in [ADR-0003](./doc/adr/ADR-0003-federation-portability-contract.md). Two federations ship today: `dev-apprenticeship/` — 5 colonies, 21 agents that learn a developer's workflow by observing how they work on GitLab/GitHub (Beta), and `tribes-bench/` — 5 tribes hunting CVE-grade memory safety bugs in vendored Rust crates via a deterministic verifier (Experimental, research scaffold). All `dev-apprenticeship/` agents implement the full confidence gradient (observe / suggest / act). Federation patterns beyond the coder workflow live in [`doc/federation-patterns.md`](./doc/federation-patterns.md).
 
 This file is split into two parts:
 - **Platform invariants** — federation-agnostic. Tier contract, release process, ADRs, scaffolding, agent and script conventions. Applies to any federation in this repo.
-- **dev-apprenticeship specifics** — only true for the one federation that ships today: bus-event wiring, confidence keys, trigger labels, the 21-agent inventory.
+- **dev-apprenticeship specifics** — only true for the dev-apprenticeship federation: bus-event wiring, confidence keys, trigger labels, the 21-agent inventory.
 
 # Platform invariants
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ graph TD
 
 | Federation | Version | Description | Agents | Status |
 |------------|---------|-------------|--------|--------|
-| [dev-apprenticeship](./dev-apprenticeship/) | [`1.3.0`](https://github.com/Replikanti/agentis-colonies/releases/tag/dev-apprenticeship-v1.3.0) | Learns a developer's complete workflow by observing how you work on GitLab or GitHub. Covers triage, code review, planning, implementation, and release. | 21 | Beta |
-| [tribes-bench](./tribes-bench/) | unreleased | Tribal-emergence harness — two seed colonies hunt command-injection bugs in a synthetic Rust target via a deterministic verifier. Stage 0 wiring test only; replication, market, and reputation arrive in Stage 1+. | 2 | Experimental |
+| [dev-apprenticeship](./dev-apprenticeship/) | [`2.0.0`](https://github.com/Replikanti/agentis-colonies/releases/tag/dev-apprenticeship-v2.0.0) | Learns a developer's complete workflow by observing how you work on GitLab or GitHub. Covers triage, code review, planning, implementation, and release. | 21 | Beta |
+| [tribes-bench](./tribes-bench/) | unreleased | Tribal-emergence harness — five seed colonies hunt CVE-grade memory safety bugs in vendored Rust crates via a deterministic verifier. Stage 2 M3 reached: 5-tribe ecosystem vs 1-tribe baseline verdict apparatus + N=3 paired pilot results. | 5 | Experimental |
 
 To start a new federation, see [`tools/new-federation.sh`](./tools/new-federation.sh) and [`doc/federation-patterns.md`](./doc/federation-patterns.md). The contract every federation must satisfy is [ADR-0003](./doc/adr/ADR-0003-federation-portability-contract.md).
 
@@ -53,7 +53,7 @@ Federation-agnostic components are versioned and released independently so fixes
 
 | Component | Version | Description |
 |-----------|---------|-------------|
-| [federation-dashboard](./federation-dashboard/) | [`0.6.0`](https://github.com/Replikanti/agentis-colonies/releases/tag/federation-dashboard-v0.6.0) | Generic web dashboard with operator controls (promote / demote / evolve / restart / kill), 5-tab surface (Status / Cost / Recovery / Logs & Events / Config), per-agent table, federation-wide Experience tile, collapsible Promotion Progress, and Forge Rate Limits tile. Auto-discovers colonies + agents from any federation directory. |
+| [federation-dashboard](./federation-dashboard/) | [`0.9.1`](https://github.com/Replikanti/agentis-colonies/releases/tag/federation-dashboard-v0.9.1) | Generic web dashboard with operator controls (promote / demote / evolve / restart / kill), 5-tab surface (Status / Cost / Recovery / Logs & Events / Config), per-agent table, federation-wide Experience tile, collapsible Promotion Progress, and Forge Rate Limits tile. Auto-discovers colonies + agents from any federation directory. |
 
 ### Status
 
@@ -70,7 +70,7 @@ Federation-agnostic components are versioned and released independently so fixes
 From a release tarball (recommended — install-ready, no git clone needed):
 
 ```bash
-VERSION=0.3.3   # or any tagged dev-apprenticeship release
+VERSION=2.0.0   # or any tagged dev-apprenticeship release
 curl -LO https://github.com/Replikanti/agentis-colonies/releases/download/dev-apprenticeship-v${VERSION}/dev-apprenticeship-v${VERSION}.tar.gz
 tar xzf dev-apprenticeship-v${VERSION}.tar.gz
 cd dev-apprenticeship-v${VERSION}/dev-apprenticeship
@@ -87,7 +87,7 @@ docker run --rm -d \
   -e GITLAB_PROJECT=my-org/my-project \
   -e GITLAB_TOKEN=glpat-... \
   -v $PWD/data:/data \
-  ghcr.io/replikanti/agentis-colonies:dev-apprenticeship-1.2.0
+  ghcr.io/replikanti/agentis-colonies:dev-apprenticeship-2.0.0
 ```
 
 Sample compose + Kubernetes manifests under [`examples/docker/`](./examples/docker/) and [`examples/k8s/`](./examples/k8s/).

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -1,8 +1,8 @@
 # Dev Apprenticeship
 
-![Version: 1.3.0](https://img.shields.io/badge/version-1.3.0-blue) ![Agentis >= v1.4.7](https://img.shields.io/badge/agentis-%3E%3D%20v1.4.7-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
+![Version: 2.0.0](https://img.shields.io/badge/version-2.0.0-blue) ![Agentis >= v1.4.7](https://img.shields.io/badge/agentis-%3E%3D%20v1.4.7-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
 
-**Version:** `1.3.0` · [Changelog](./CHANGELOG.md) · **Requires:** agentis >= `1.4.7`
+**Version:** `2.0.0` · [Changelog](./CHANGELOG.md) · **Requires:** agentis >= `1.4.7`
 
 > **One example federation** built on the [`agentis-colonies`](../) platform. The platform contract every federation must satisfy is [ADR-0003](../doc/adr/ADR-0003-federation-portability-contract.md); to scaffold a different kind of federation (data-ops, research, support-triage, monitoring-ops, …) see [`doc/federation-patterns.md`](../doc/federation-patterns.md) and [`tools/new-federation.sh`](../tools/new-federation.sh).
 
@@ -56,7 +56,7 @@ graph LR
 
 ## What you need
 
-- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.4.1** (v1.4.0 provides the `tier()` builtin required by the four-tier confidence gating in all 21 agents; v1.4.1 wires `fitness_delta` from the `outcome` argument to `learn()` so downstream consumers — auto-promote, evolve, dashboard — see non-zero deltas)
+- [Agentis](https://github.com/Replikanti/agentis) runtime **>= v1.4.7** (v1.4.0 provides the `tier()` builtin required by the four-tier confidence gating in all 21 agents; v1.4.1 wires `fitness_delta` from the `outcome` argument to `learn()` so downstream consumers — auto-promote, evolve, dashboard — see non-zero deltas; v1.4.7 is the floor pinned by the [2.0.0] CHANGELOG entry)
 - An LLM backend (Claude CLI, Ollama, or any OpenAI-compatible API)
 - GitLab instance with API access (personal access token with `api` scope)
 - Python 3 and git
@@ -68,7 +68,7 @@ Pick one of the two install paths.
 **Option A — release tarball** (recommended for running the federation; install-ready, no git tree required):
 
 ```bash
-VERSION=0.1.0
+VERSION=2.0.0
 curl -LO https://github.com/Replikanti/agentis-colonies/releases/download/dev-apprenticeship-v${VERSION}/dev-apprenticeship-v${VERSION}.tar.gz
 curl -LO https://github.com/Replikanti/agentis-colonies/releases/download/dev-apprenticeship-v${VERSION}/dev-apprenticeship-v${VERSION}.tar.gz.sha256
 sha256sum -c dev-apprenticeship-v${VERSION}.tar.gz.sha256   # optional but recommended
@@ -93,7 +93,8 @@ The install script checks prerequisites, creates configs for all 5 colonies, wri
 
 ```bash
 ./start-federation.sh           # Start all 5 colonies (21 agents)
-agentis daemon stop --all       # Stop everything
+./kill-federation.sh            # Stop everything reliably (preferred)
+agentis daemon stop --all       # Fallback only — known false-positive / false-negative on stale registry entries (see top-level README)
 ```
 
 > Agents must be launched via `start-federation.sh` or a colony's
@@ -108,7 +109,7 @@ agentis daemon stop --all       # Stop everything
 
 A web dashboard that shows agent health, confidence levels, phase readiness with ETA, knowledge growth trends, remediation history, and a live suggestion feed. Auto-refreshes every 60 seconds. Includes a kill switch (two-click safety) to stop the entire federation from the browser.
 
-The dashboard is a [separately-versioned standalone component](../federation-dashboard/) ([#252](https://github.com/Replikanti/agentis-colonies/issues/252)). This federation recommends `federation-dashboard >= 0.1.0` (pinned in [`.dashboard-version`](./.dashboard-version)); `install.sh` step 8 offers to install it for you, and `./dashboard.sh` is a thin resolver that finds the installed binary.
+The dashboard is a [separately-versioned standalone component](../federation-dashboard/) ([#252](https://github.com/Replikanti/agentis-colonies/issues/252)). This federation recommends `federation-dashboard >= 0.8.0` (pinned in [`.dashboard-version`](./.dashboard-version)); `install.sh` step 8 offers to install it for you, and `./dashboard.sh` is a thin resolver that finds the installed binary.
 
 Per-agent **confidence bump** controls (▲▼) in the Confidence Levels card walk each agent through the canonical tier ladder: `shadow` (0.4) → `propose` (0.6) → `review-gated` (0.8) → `autonomous` (0.95). Promotions to `autonomous` trigger a confirmation dialog since at that level the agent performs terminal external writes (merge, tag, publish) without a second gate. Every change is appended to `.dashboard/confidence-log.jsonl` for audit. The CLI path (`agentis memo set <agent>:confidence <value>`) still works and is equivalent.
 

--- a/federation-dashboard/README.md
+++ b/federation-dashboard/README.md
@@ -1,8 +1,8 @@
 # federation-dashboard
 
-![Version: 0.2.0](https://img.shields.io/badge/version-0.2.0-blue) ![Standalone component](https://img.shields.io/badge/component-standalone-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
+![Version: 0.9.1](https://img.shields.io/badge/version-0.9.1-blue) ![Standalone component](https://img.shields.io/badge/component-standalone-green) ![Status: Beta](https://img.shields.io/badge/status-beta-yellow)
 
-**Version:** `0.2.0` · [Changelog](./CHANGELOG.md) · **Recommended for:** dev-apprenticeship >= `0.3.3` + `--restart-agent` mode in `start-colony.sh`
+**Version:** `0.9.1` · [Changelog](./CHANGELOG.md) · **Recommended for:** dev-apprenticeship >= `2.0.0` + `--restart-agent` mode in `start-colony.sh`
 
 Generic web dashboard for any [Agentis](https://github.com/Replikanti/agentis)
 federation. Auto-discovers colonies and agents from the federation directory,
@@ -13,7 +13,7 @@ evolve, restart, kill).
 This component is **separately versioned** from the federations it serves
 ([#252](https://github.com/Replikanti/agentis-colonies/issues/252)). Federations
 declare a soft minimum (e.g. `dev-apprenticeship` requires
-`federation-dashboard >= 0.2.0`) and the dashboard ships its own release
+`federation-dashboard >= 0.8.0`) and the dashboard ships its own release
 tarball, install script, and changelog.
 
 ## Install
@@ -93,7 +93,7 @@ The dashboard itself does not crash.
 
 | federation-dashboard | dev-apprenticeship |
 |----------------------|--------------------|
-| `>= 0.1.0`           | `>= 0.3.3`         |
+| `>= 0.8.0`           | `>= 2.0.0`         |
 
 Earlier `dev-apprenticeship` versions (`<= 0.3.2`) shipped a vendored copy of
 the dashboard inside their own bundle; do not mix that with this standalone

--- a/tribes-bench/README.md
+++ b/tribes-bench/README.md
@@ -145,7 +145,7 @@ Stage 1 primitives (`replicate()`, Malthusian per-replica cost,
 asymmetric first-finder reward) ship in M2 and M3 — they are explicitly
 **not** part of M1.
 
-**M1 proves:**
+**M1 proves** (historical — current `start-federation.sh` spawns 5 tribes after Stage 2 M2 added `tribe-delta` + `tribe-epsilon`; see Stage 2 sections below):
 
 - Three-tribe topology launches cleanly (`tribe-alpha`, `tribe-beta`,
   `tribe-gamma`) via `start-federation.sh`.
@@ -173,7 +173,7 @@ asymmetric first-finder reward) ship in M2 and M3 — they are explicitly
   ./install.sh                                # idempotent: copies tribe-gamma config too
   bash tools/test-verify-finding.sh           # Stage 0 fixtures (back-compat)
   STAGE1=1 bash tools/test-verify-finding.sh  # Stage 1 fixtures (3 classes)
-  bash start-federation.sh                    # spawns 3 tribes against targets/stage0 by default
+  bash start-federation.sh                    # M1: spawns 3 tribes against targets/stage0; M2 added delta + epsilon for 5 total
   ```
 
   To exercise targets/stage1 manually, set `TARGET_DIR` and
@@ -374,15 +374,13 @@ always run:
 
 ```
 tribes-bench/
-  tribe-alpha/        First tribe colony (one hunter agent)
-    agents/hunter.ag  Seed prompt: format!()-as-shell-builder heuristic
-    config/, scripts/
-  tribe-beta/         Second tribe colony (one hunter agent)
-    agents/hunter.ag  Seed prompt: source-to-sink data-flow heuristic
-    config/, scripts/
-  tribe-gamma/        Third tribe colony (one hunter agent, Stage 1 M1)
-    agents/hunter.ag  Seed prompt: error-path data-flow heuristic
-    config/, scripts/
+  tribe-alpha/        Seed colony, one hunter agent (Stage 0/1 prompt: format!()-as-shell-builder; Stage 2 specialty: uninitialised memory)
+  tribe-beta/         Seed colony, one hunter agent (Stage 0/1 prompt: source-to-sink data-flow; Stage 2 specialty: heap overflow)
+  tribe-gamma/        Stage 1 M1 colony, one hunter agent (Stage 1 prompt: error-path data-flow; Stage 2 specialty: memory corruption)
+  tribe-delta/        Stage 2 M2 colony, one hunter agent (specialty: use after free)
+  tribe-epsilon/      Stage 2 M2 colony, one hunter agent (specialty: use after free, panic-unwind variant)
+  templates/
+    tribe-baseline/   Stage 2 M3 baseline-arm template (single-tribe generalist with stubbed market primitives)
   targets/stage0/
     vulnerable.rs     ~50 LOC Rust with three planted bugs
     bugs.json         Ground-truth manifest (id, line, line_tolerance, signature)
@@ -391,16 +389,27 @@ tribes-bench/
     path_io.rs        3 path-traversal bugs (CWE-22), ~120 LOC
     fmt_str.rs        3 format-string bugs (CWE-134), ~140 LOC
     bugs.json         Ground-truth manifest with `class` field
+  targets/stage2/     Stage 2 — vendored real-world Rust crate(s) with RUSTSEC bug palette
+    smallvec-v0.6.13/ Vendored smallvec lib.rs with 5 CVE-grade memory safety bugs
+    bugs.json         Ground-truth manifest keyed on RUSTSEC bug class
   tools/
-    verify-finding.sh  Pure-shell + jq verifier (no LLM, no agentis)
-                       Optional `class` dispatch for Stage 1
-    test-verify-finding.sh  Six-fixture unit test (Stage 0)
-                            STAGE1=1 mode adds 6 Stage 1 fixtures
-    run-stage0.sh      Hermetic one-shot run wrapper (Stage 0)
-    analyse-stage0.py  Telemetry CSV producer (Stage 0, 7 columns)
-    analyse-stage1.py  Telemetry CSV producer (Stage 1 M1, 10 columns)
-  start-federation.sh  ADR-0003-friendly launcher (3 tribes)
-  install.sh           Memo seed + colony.toml copy
+    verify-finding.sh         Pure-shell + jq verifier (no LLM, no agentis), Stage 0/1 dispatch
+    verify-finding-stage2.sh  Stage 2 verifier with bug-class match + signature substring check
+    test-verify-finding.sh    Six-fixture unit test (Stage 0); STAGE1=1 mode adds Stage 1 fixtures
+    run-stage0.sh             Hermetic one-shot run wrapper (Stage 0)
+    run-stage1.sh             Hermetic one-shot run wrapper (Stage 1 M1)
+    run-stage2.sh             Hermetic one-shot run wrapper (Stage 2 M3 ecosystem arm)
+    run-baseline.sh           Hermetic one-shot run wrapper (Stage 2 M3 baseline arm)
+    run-verdict-pair.sh       Orchestrator: run-stage2 -> run-baseline -> analyse with --baseline (Stage 2 M3)
+    analyse-stage0.py         Telemetry CSV producer (Stage 0, 7 columns)
+    analyse-stage1.py         Telemetry CSV producer (Stage 1 M1, 10 columns)
+    analyse-stage2.py         Telemetry CSV + comparison.md producer (Stage 2 M3)
+    check-agentis-version.sh  Runtime floor check; prints download URL when binary missing
+    snapshot-stanza.sh        Append per-pilot snapshot stanza to runs/<ts>/snapshots/
+    test-stage2-*.sh          Six fixture-driven + opportunistic-live tests for Stage 2 M3
+    test-run-verdict-pair.sh  Smoke test for run-verdict-pair.sh dry-run output
+  start-federation.sh         ADR-0003-friendly launcher (5 tribes after Stage 2 M2)
+  install.sh                  Memo seed + colony.toml copy + Next-steps summary
 ```
 
 ## Tier contract
@@ -430,6 +439,8 @@ calling it from the propose branch is consistent with ADR-0001.
 
 ## Related
 
-- Issue: [#363](https://github.com/Replikanti/agentis-colonies/issues/363) — Stage 0 wiring (this PR)
+- Issue: [#363](https://github.com/Replikanti/agentis-colonies/issues/363) — Stage 0 wiring
 - Issue: [#364](https://github.com/Replikanti/agentis-colonies/issues/364) — Stage 1 replication + scarcity
 - Issue: [#365](https://github.com/Replikanti/agentis-colonies/issues/365) — Stage 2 selection + market + reputation
+- Issue: [#394](https://github.com/Replikanti/agentis-colonies/issues/394) — Stage 2 M3 verdict apparatus (5-tribe vs baseline)
+- Issue: [#439](https://github.com/Replikanti/agentis-colonies/issues/439) — Stage 3 emergence prerequisites (multi-node, mutation, target rotation, real selection pressure)


### PR DESCRIPTION
## Summary

Doc-only PR addressing post-merge audit findings after #441 and #442 landed. Five commits, no logic changes, no test changes — just bringing READMEs and CLAUDE.md back in sync with code reality.

## Findings addressed

Findings come from a doc-auditor pass run after the two PRs above merged. Mapping to commits:

| Commit | Audit findings |
|---|---|
| `docs(readme): bump federation + dashboard versions, refresh tribes-bench summary` | M1, M2, M3, M4, M5 |
| `docs(claude): reflect two-federation reality (dev-apprenticeship + tribes-bench)` | L1, L2 |
| `docs(dev-apprenticeship): bump README to v2.0.0, recommend kill-federation.sh` | M6, M7, M8, L10 |
| `docs(federation-dashboard): bump README to v0.9.1, refresh compatibility table` | M9 |
| `docs(tribes-bench): refresh README to current 5-tribe Stage 2 M3 reality` | L4, L5, L6, L7, L8, L9 |

## What changed

**Top-level `README.md`** — `dev-apprenticeship` 1.3.0 → 2.0.0, `federation-dashboard` 0.6.0 → 0.9.1, tribes-bench summary now reflects 5 tribes / Stage 2 M3 (was "two seed colonies / Stage 0 wiring test only"), Quickstart `VERSION=0.3.3` → `VERSION=2.0.0`, Docker tag `dev-apprenticeship-1.2.0` → `dev-apprenticeship-2.0.0`.

**`CLAUDE.md`** — "Today exactly one federation is shipped" → "Two federations ship today: dev-apprenticeship/ ... and tribes-bench/ ...". `dev-apprenticeship specifics` section header reframed to refer to the federation by name rather than implying it is the only one.

**`dev-apprenticeship/README.md`** — Badge + heading 1.3.0 → 2.0.0, agentis floor consolidated to >= v1.4.7 (matches [2.0.0] CHANGELOG), Quickstart VERSION 0.1.0 → 2.0.0, recommend `./kill-federation.sh` over `agentis daemon stop --all` (the latter has known false-positive / false-negative behaviour that the top-level README already documents), dashboard recommends >= 0.8.0 (matches `.dashboard-version`).

**`federation-dashboard/README.md`** — Badge + heading 0.2.0 → 0.9.1, recommended-for dev-apprenticeship 0.3.3 → 2.0.0, compatibility table floor 0.1.0/0.3.3 → 0.8.0/2.0.0.

**`tribes-bench/README.md`** — M1 reproduction recipe annotated as historical (start-federation.sh now spawns 5 tribes after M2 added delta + epsilon, not 3); Layout block restructured: per-tribe Stage 2 specialty labels added (uninitialised memory / heap overflow / memory corruption / use after free / panic-unwind UAF), `templates/tribe-baseline/` added, `targets/stage2/` subtree added, tools section now lists run-stage2.sh, run-baseline.sh, run-verdict-pair.sh, analyse-stage2.py, verify-finding-stage2.sh, check-agentis-version.sh, snapshot-stanza.sh, test-stage2-*.sh, test-run-verdict-pair.sh; start-federation.sh comment "(3 tribes)" → "(5 tribes after M2)"; Related section: dropped "(this PR)" leftover from #363, added #394 (M3) and #439 (Stage 3) tracker rows.

## Test plan

- [x] `bash tools/colony-lint.sh` → 166 passed, 0 failed, 3 skipped (no regression).
- [x] No `.ag`, `.sh`, `.py` files touched. Doc-only.
- [x] No internal absolute paths in any committed line (`grep -r "/home/nitramyloh\|worktrees/" -- *.md` returns nothing).