### PR TITLE
feat(tribes-bench): multi-LLM config injection for run-stage2.sh (#438)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,28 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Multi-LLM config injection in `run-stage2.sh`**
+  ([#438](https://github.com/Replikanti/agentis-colonies/issues/438)).
+  `agentis init` only seeds `llm.backend` in the hermetic per-run
+  config; the matching endpoint / model / api_key_env / timeout keys
+  were missing, so picking a non-default backend via
+  `STAGE2_LLM_BACKEND` left the daemon falling back to mock at first
+  dispatch. `run-stage2.sh` now injects the correct keys when
+  `STAGE2_LLM_BACKEND=openai` (`llm.openai.endpoint`, `llm.openai.model`,
+  `llm.openai.api_key_env`, `llm.openai.timeout_ms`) or
+  `STAGE2_LLM_BACKEND=ollama` (`llm.endpoint`, `llm.model`). Six new
+  env vars carry the defaults and are overrideable per-run:
+  `STAGE2_OPENAI_MODEL` (default `gpt-4o-mini`),
+  `STAGE2_OPENAI_ENDPOINT`
+  (default `https://api.openai.com/v1/chat/completions`),
+  `STAGE2_OPENAI_KEY_ENV` (default `OPENAI_API_KEY`),
+  `STAGE2_OPENAI_TIMEOUT_MS` (default `180000`),
+  `STAGE2_OLLAMA_ENDPOINT`
+  (default `http://127.0.0.1:11434/api/generate`),
+  `STAGE2_OLLAMA_MODEL` (default `llama3.1:8b`). All injections are
+  idempotent (skipped when an active key already exists). New test:
+  `tools/test-run-stage2-llm-backend.sh`.
+
 - **Install + DX polish** ([#436](https://github.com/Replikanti/agentis-colonies/issues/436)).
   - `tribes-bench/tools/run-verdict-pair.sh` (new) — operator-friendly
     orchestrator that runs `run-stage2.sh` -> `run-baseline.sh` ->

--- a/tribes-bench/README.md
+++ b/tribes-bench/README.md
@@ -51,6 +51,19 @@ For the long-form Stage 2 M3 (48h ecosystem + 1h baseline) recipe see
 [Stage 2 M3 reproduction recipe](#stage-2-m3--long-run--baseline-reproduction-recipe)
 below.
 
+**Multi-LLM backends**
+
+`STAGE2_LLM_BACKEND` selects the LLM provider for a run. The default
+is `claude` (Claude Code CLI). When `STAGE2_LLM_BACKEND=openai`,
+`run-stage2.sh` auto-injects `llm.openai.endpoint`, `llm.openai.model`,
+`llm.openai.api_key_env`, and `llm.openai.timeout_ms` into the
+hermetic per-run config; `OPENAI_API_KEY` (or whatever env var name
+`STAGE2_OPENAI_KEY_ENV` points at) must be exported in the launching
+shell. When `STAGE2_LLM_BACKEND=ollama`, `llm.endpoint` and `llm.model`
+are auto-injected pointing at a local Ollama daemon. The full list of
+backend-specific env vars (and their defaults) lives in the env-var
+preamble of [`tools/run-stage2.sh`](./tools/run-stage2.sh).
+
 ## Hypothesis
 
 A federation that uses the agentis emergent-layer primitives produces

--- a/tribes-bench/tools/run-stage2.sh
+++ b/tribes-bench/tools/run-stage2.sh
@@ -35,6 +35,23 @@
 #                          knowledge-market.csv. Snapshot numbering
 #                          continues from max(existing). A fresh
 #                          run-meta-resume-<n>.json is written.
+#   STAGE2_OPENAI_MODEL    #438: model id when STAGE2_LLM_BACKEND=openai
+#                          (default: gpt-4o-mini).
+#   STAGE2_OPENAI_ENDPOINT #438: chat-completions URL when
+#                          STAGE2_LLM_BACKEND=openai
+#                          (default: https://api.openai.com/v1/chat/completions).
+#   STAGE2_OPENAI_KEY_ENV  #438: name of the env var that carries the
+#                          OpenAI API key (default: OPENAI_API_KEY). The
+#                          named env var must itself be exported in the
+#                          shell that launches run-stage2.sh.
+#   STAGE2_OPENAI_TIMEOUT_MS #438: per-request timeout in milliseconds
+#                          when STAGE2_LLM_BACKEND=openai
+#                          (default: 180000 = 3 minutes).
+#   STAGE2_OLLAMA_ENDPOINT #438: generate URL when
+#                          STAGE2_LLM_BACKEND=ollama
+#                          (default: http://127.0.0.1:11434/api/generate).
+#   STAGE2_OLLAMA_MODEL    #438: model id when STAGE2_LLM_BACKEND=ollama
+#                          (default: llama3.1:8b).
 #
 # Exit codes:
 #   0   run completed and telemetry.csv produced
@@ -224,6 +241,26 @@ with open(p, 'w') as f: f.write(s2)
         echo "run-stage2: failed to rewrite llm.backend in $CONFIG_FILE" >&2
         exit 1
     }
+    # #438: inject backend-specific config keys so the daemon can reach
+    # the configured provider. agentis init only writes `llm.backend`; the
+    # endpoint / model / api_key_env keys are otherwise missing and the
+    # daemon falls back to mock at first dispatch.
+    if [ "$RESOLVED_BACKEND" = "openai" ]; then
+        OPENAI_MODEL="${STAGE2_OPENAI_MODEL:-gpt-4o-mini}"
+        OPENAI_ENDPOINT="${STAGE2_OPENAI_ENDPOINT:-https://api.openai.com/v1/chat/completions}"
+        OPENAI_KEY_ENV="${STAGE2_OPENAI_KEY_ENV:-OPENAI_API_KEY}"
+        OPENAI_TIMEOUT="${STAGE2_OPENAI_TIMEOUT_MS:-180000}"
+        grep -q '^llm\.openai\.endpoint'    "$CONFIG_FILE" || printf 'llm.openai.endpoint = %s\n'    "$OPENAI_ENDPOINT" >> "$CONFIG_FILE"
+        grep -q '^llm\.openai\.model'       "$CONFIG_FILE" || printf 'llm.openai.model = %s\n'       "$OPENAI_MODEL" >> "$CONFIG_FILE"
+        grep -q '^llm\.openai\.api_key_env' "$CONFIG_FILE" || printf 'llm.openai.api_key_env = %s\n' "$OPENAI_KEY_ENV" >> "$CONFIG_FILE"
+        grep -q '^llm\.openai\.timeout_ms'  "$CONFIG_FILE" || printf 'llm.openai.timeout_ms = %s\n'  "$OPENAI_TIMEOUT" >> "$CONFIG_FILE"
+    fi
+    if [ "$RESOLVED_BACKEND" = "ollama" ]; then
+        OLLAMA_ENDPOINT="${STAGE2_OLLAMA_ENDPOINT:-http://127.0.0.1:11434/api/generate}"
+        OLLAMA_MODEL="${STAGE2_OLLAMA_MODEL:-llama3.1:8b}"
+        grep -q '^llm\.endpoint' "$CONFIG_FILE" || printf 'llm.endpoint = %s\n' "$OLLAMA_ENDPOINT" >> "$CONFIG_FILE"
+        grep -q '^llm\.model'    "$CONFIG_FILE" || printf 'llm.model = %s\n'    "$OLLAMA_MODEL" >> "$CONFIG_FILE"
+    fi
 fi
 
 # Seed all five tribes' confidence memo to 0.7 (mid-`propose`) inside

--- a/tribes-bench/tools/test-run-stage2-llm-backend.sh
+++ b/tribes-bench/tools/test-run-stage2-llm-backend.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+# test-run-stage2-llm-backend.sh — assert run-stage2.sh injects the
+# right backend-specific config keys when STAGE2_LLM_BACKEND selects
+# openai or ollama, and stays inert for the default claude path (#438).
+#
+# Three cases:
+#
+#   T1: STAGE2_LLM_BACKEND=openai produces a hermetic .agentis/config
+#       containing all four llm.openai.* keys at their documented
+#       defaults.
+#   T2: STAGE2_LLM_BACKEND=ollama produces a config containing
+#       llm.endpoint and llm.model at their documented defaults.
+#   T3: STAGE2_LLM_BACKEND=claude (default) produces NO llm.openai.*
+#       and NO llm.endpoint / llm.model lines (regression guard).
+#
+# STAGE2_WALL_CLOCK_S=1 makes the harness exit after a single 1-second
+# snapshot tick. The federation daemons + worker that start-federation.sh
+# spawned are reaped by tools/kill-federation.sh in trap cleanup so the
+# next case starts from a clean slate.
+#
+# Skips when `agentis` is not on PATH (same convention as
+# test-stage2-baseline-runner.sh).
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$FED_DIR")"
+KILL_SCRIPT="$REPO_ROOT/tools/kill-federation.sh"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+assert_grep_F() {
+    # $1 label, $2 file, $3 needle (literal)
+    label="$1"; file="$2"; needle="$3"
+    if [ -f "$file" ] && grep -Fq -- "$needle" "$file"; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       file:   $file"
+        echo "       needle: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_no_active_key() {
+    # $1 label, $2 file, $3 key prefix (regex-escaped, anchored at line start)
+    # -- key MUST NOT appear as an active (uncommented) config line.
+    # `agentis init` ships a commented-out exemplar for every backend, so
+    # we anchor with `^` to skip any `# ...` line.
+    label="$1"; file="$2"; key="$3"
+    if [ ! -f "$file" ]; then
+        echo "[FAIL] $label (file missing: $file)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if grep -Eq -- "^${key}" "$file"; then
+        echo "[FAIL] $label"
+        echo "       file:        $file"
+        echo "       active key:  $key"
+        FAIL=$((FAIL + 1))
+    else
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+skip_case() {
+    echo "[SKIP] $1 ($2)"
+    SKIP=$((SKIP + 1))
+}
+
+if ! command -v agentis >/dev/null 2>&1; then
+    echo "SKIP: agentis not on PATH"
+    exit 77
+fi
+for bin in jq python3; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        echo "SKIP: $bin not on PATH"
+        exit 77
+    fi
+done
+
+# --- Cleanup helper: kill federation under the given run dir, then nuke
+# the whole runs/<ts> tree so it doesn't pollute the federation runs/.
+# Always recorded so trap can reap whatever is in flight on test exit.
+LAST_RUN_DIR=""
+cleanup_run() {
+    rd="$1"
+    if [ -z "$rd" ] || [ ! -d "$rd" ]; then
+        return 0
+    fi
+    if [ -x "$KILL_SCRIPT" ]; then
+        bash "$KILL_SCRIPT" --fed-dir "$rd" --no-backup >/dev/null 2>&1 || true
+    fi
+    if [ -f "$rd/worker.pid" ]; then
+        wpid="$(cat "$rd/worker.pid" 2>/dev/null || echo)"
+        if [ -n "$wpid" ]; then
+            kill "$wpid" 2>/dev/null || true
+        fi
+    fi
+    rm -rf "$rd" 2>/dev/null || true
+}
+
+trap 'cleanup_run "$LAST_RUN_DIR"' EXIT INT TERM
+
+# --- Snapshot existing runs/ so we can identify the new run dir each case
+list_run_dirs() {
+    if [ -d "$FED_DIR/runs" ]; then
+        ls -1d "$FED_DIR/runs"/* 2>/dev/null || true
+    fi
+}
+
+run_case() {
+    # $1 label, $2 backend value (passed via STAGE2_LLM_BACKEND env)
+    # On stdout: prints the new RUN_DIR on success, empty on failure.
+    label="$1"; backend="$2"
+    before="$(list_run_dirs)"
+    log="$(mktemp)"
+    # Pass backend explicitly; env-clear keeps the test hermetic against
+    # operator-set STAGE2_OPENAI_* overrides.
+    if [ -n "$backend" ]; then
+        env -u STAGE2_OPENAI_MODEL -u STAGE2_OPENAI_ENDPOINT \
+            -u STAGE2_OPENAI_KEY_ENV -u STAGE2_OPENAI_TIMEOUT_MS \
+            -u STAGE2_OLLAMA_ENDPOINT -u STAGE2_OLLAMA_MODEL \
+            -u STAGE2_RESUME_RUN_DIR -u STAGE2_CRASH_AT_S \
+            STAGE2_LLM_BACKEND="$backend" \
+            STAGE2_WALL_CLOCK_S=1 STAGE2_SNAPSHOT_S=1 \
+            bash "$FED_DIR/tools/run-stage2.sh" >"$log" 2>&1 || true
+    else
+        env -u STAGE2_LLM_BACKEND \
+            -u STAGE2_OPENAI_MODEL -u STAGE2_OPENAI_ENDPOINT \
+            -u STAGE2_OPENAI_KEY_ENV -u STAGE2_OPENAI_TIMEOUT_MS \
+            -u STAGE2_OLLAMA_ENDPOINT -u STAGE2_OLLAMA_MODEL \
+            -u STAGE2_RESUME_RUN_DIR -u STAGE2_CRASH_AT_S \
+            STAGE2_WALL_CLOCK_S=1 STAGE2_SNAPSHOT_S=1 \
+            bash "$FED_DIR/tools/run-stage2.sh" >"$log" 2>&1 || true
+    fi
+    after="$(list_run_dirs)"
+    new_dir=""
+    while IFS= read -r d; do
+        [ -n "$d" ] || continue
+        if ! printf '%s\n' "$before" | grep -Fxq -- "$d"; then
+            new_dir="$d"
+            break
+        fi
+    done <<EOF_RUNS
+$after
+EOF_RUNS
+    rm -f "$log"
+    if [ -z "$new_dir" ]; then
+        echo "[FAIL] $label: run-stage2.sh did not create a new runs/<ts> dir" >&2
+        return 1
+    fi
+    LAST_RUN_DIR="$new_dir"
+    printf '%s\n' "$new_dir"
+}
+
+# --- T1: openai backend ---
+echo "--- T1: STAGE2_LLM_BACKEND=openai ---"
+RUN_T1="$(run_case "T1" "openai" || true)"
+if [ -n "$RUN_T1" ]; then
+    CFG="$RUN_T1/.agentis/config"
+    assert_grep_F "T1: llm.openai.endpoint default injected" "$CFG" \
+        "llm.openai.endpoint = https://api.openai.com/v1/chat/completions"
+    assert_grep_F "T1: llm.openai.model default injected" "$CFG" \
+        "llm.openai.model = gpt-4o-mini"
+    assert_grep_F "T1: llm.openai.api_key_env default injected" "$CFG" \
+        "llm.openai.api_key_env = OPENAI_API_KEY"
+    assert_grep_F "T1: llm.openai.timeout_ms default injected" "$CFG" \
+        "llm.openai.timeout_ms = 180000"
+    assert_grep_F "T1: llm.backend rewritten to openai" "$CFG" \
+        "llm.backend = openai"
+else
+    echo "[FAIL] T1: no run dir produced"
+    FAIL=$((FAIL + 1))
+fi
+cleanup_run "$RUN_T1"
+LAST_RUN_DIR=""
+
+# --- T2: ollama backend ---
+echo "--- T2: STAGE2_LLM_BACKEND=ollama ---"
+RUN_T2="$(run_case "T2" "ollama" || true)"
+if [ -n "$RUN_T2" ]; then
+    CFG="$RUN_T2/.agentis/config"
+    assert_grep_F "T2: llm.endpoint default injected" "$CFG" \
+        "llm.endpoint = http://127.0.0.1:11434/api/generate"
+    assert_grep_F "T2: llm.model default injected" "$CFG" \
+        "llm.model = llama3.1:8b"
+    assert_grep_F "T2: llm.backend rewritten to ollama" "$CFG" \
+        "llm.backend = ollama"
+    # No openai keys leaked into the ollama path.
+    assert_no_active_key "T2: no active llm.openai.endpoint key" "$CFG" "llm\\.openai\\.endpoint"
+    assert_no_active_key "T2: no active llm.openai.model key" "$CFG" "llm\\.openai\\.model"
+else
+    echo "[FAIL] T2: no run dir produced"
+    FAIL=$((FAIL + 1))
+fi
+cleanup_run "$RUN_T2"
+LAST_RUN_DIR=""
+
+# --- T3: claude (default) backend — no regression ---
+echo "--- T3: STAGE2_LLM_BACKEND=claude ---"
+RUN_T3="$(run_case "T3" "claude" || true)"
+if [ -n "$RUN_T3" ]; then
+    CFG="$RUN_T3/.agentis/config"
+    assert_grep_F "T3: llm.backend rewritten to claude" "$CFG" \
+        "llm.backend = claude"
+    assert_no_active_key "T3: no active llm.openai.endpoint key" "$CFG" "llm\\.openai\\.endpoint"
+    assert_no_active_key "T3: no active llm.openai.model key" "$CFG" "llm\\.openai\\.model"
+    assert_no_active_key "T3: no active llm.openai.api_key_env key" "$CFG" "llm\\.openai\\.api_key_env"
+    assert_no_active_key "T3: no active llm.openai.timeout_ms key" "$CFG" "llm\\.openai\\.timeout_ms"
+    assert_no_active_key "T3: no active llm.endpoint key" "$CFG" "llm\\.endpoint"
+    assert_no_active_key "T3: no active llm.model key" "$CFG" "llm\\.model"
+else
+    echo "[FAIL] T3: no run dir produced"
+    FAIL=$((FAIL + 1))
+fi
+cleanup_run "$RUN_T3"
+LAST_RUN_DIR=""
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- `run-stage2.sh` now injects backend-specific config keys when `STAGE2_LLM_BACKEND` selects `openai` or `ollama`. `agentis init` only seeds `llm.backend`, so picking a non-default backend left the daemon falling back to mock at first dispatch.
- Six new env vars (`STAGE2_OPENAI_MODEL`, `STAGE2_OPENAI_ENDPOINT`, `STAGE2_OPENAI_KEY_ENV`, `STAGE2_OPENAI_TIMEOUT_MS`, `STAGE2_OLLAMA_ENDPOINT`, `STAGE2_OLLAMA_MODEL`) carry documented defaults and are overrideable per-run. All injections are idempotent (skipped when an active key already exists).
- New end-to-end test `tools/test-run-stage2-llm-backend.sh` (3 cases, 17 assertions) drives the harness with `STAGE2_WALL_CLOCK_S=1` against a fresh hermetic run dir per case, covers openai + ollama injection AND the default `claude` regression guard. CHANGELOG + README updated.

## Test plan

- [x] `bash tribes-bench/tools/test-stage2-scaffold.sh` — 25/0/0 (no regression).
- [x] `bash tribes-bench/tools/test-stage2-baseline-runner.sh` — 17/0/1 (1 expected SKIP for live LLM smoke without API key).
- [x] `bash tribes-bench/tools/test-run-stage2-llm-backend.sh` — 17/0/0 across the 3 backends.
- [x] `bash tools/colony-lint.sh` — 166/0/3 (clean).

Addresses #438 (the reproducibility gap blocking openai + ollama use of the Stage 2 harness). Out of scope for this PR: `gemini` injection and ollama-with-GPU model defaults — tracked separately under #438 so the issue stays open after this merges.

Refs #438.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>