### PR TITLE
feat(tribes-bench): hunter variant-memo consumption for replica differentiation (#439)

### DIFF
--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -284,9 +284,21 @@ fn tick(reason: string) -> void {
     // `MaybeUninit::uninit().assume_init()` is called before the inner
     // type is fully written. Stage 1+ will mutate this prompt across
     // replicas.
+    //
+    // Stage 3 (#439): replicas inherit the parent's `hunter:prompt_variant`
+    // memo; appending it as a Focus: suffix lets sibling replicas lean
+    // into different interpretations of the same seed. Empty memo (Stage
+    // 2 single-tribe / no replication) is a no-op.
+    let variant = recall_latest("hunter:prompt_variant");
+    let variant_prefix = if len(variant) > 0 {
+        "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
+    } else {
+        "";
+    };
+    let src_with_focus = variant_prefix + src;
     let finding = prompt(
         "Your specific target function is `from_buf_and_len_unchecked` -- it lives near line 534 of the file. The bug is INSIDE that function's signature: it takes a buffer + length but does NOT check that buf[0..len] is initialised. Find that EXACT function declaration line and report it. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for uninitialised memory exposure: a function that accepts a raw buffer plus a length parameter and constructs a SmallVec / Vec / array without verifying that buf[0..len] is fully initialised, or unsafe code that calls MaybeUninit::uninit().assume_init() before every byte of the inner type has been written. The classic example is: pub unsafe fn from_buf_and_len_unchecked(buf: A, len: usize) -> Self { /* no init check */ SmallVec { capacity: len, data: SmallVecData::from_inline(buf) } }. Pay attention to signatures with _unchecked suffixes, MaybeUninit, assume_init, mem::zeroed used on types that contain references, raw *const T pointers exposed to safe code, and any constructor whose len parameter is not bounded by an initialised-region check. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"uninitialised_memory\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.",
-        src
+        src_with_focus
     ) -> Finding;
 
     let my_tier = tier("hunter");

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -284,9 +284,21 @@ fn tick(reason: string) -> void {
     // size_hint() / len() and the loop body trusts that hint without
     // re-checking, so a malicious iterator that returns a small lower
     // bound but yields more elements writes past the allocated buffer.
+    //
+    // Stage 3 (#439): replicas inherit the parent's `hunter:prompt_variant`
+    // memo; appending it as a Focus: suffix lets sibling replicas lean
+    // into different interpretations of the same seed. Empty memo (Stage
+    // 2 single-tribe / no replication) is a no-op.
+    let variant = recall_latest("hunter:prompt_variant");
+    let variant_prefix = if len(variant) > 0 {
+        "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
+    } else {
+        "";
+    };
+    let src_with_focus = variant_prefix + src;
     let finding = prompt(
         "Your specific target function is `pub fn insert_many` -- it lives near line 827 of the file. The bug is the heap overflow inside this function: `iter.size_hint()` returns a lower bound that the function trusts to size the buffer, but a hostile iterator can lie (return lower=0 then yield N items) and the inner ptr::write loop blows past the allocation. Find `pub fn insert_many` (NOT `from_buf_and_len_unchecked`, NOT `grow`) and report THAT function's signature line. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for heap overflow: code that allocates capacity based on an externally-controllable iterator's size_hint() or len() and copies more elements than allocated when the iterator lies about its length. SmallVec / Vec methods named extend, insert_many, from_iter, append are the typical environment. The classic example is: let (lower, _) = iter.size_hint(); self.reserve(lower); for x in iter { unsafe { ptr::write(self.as_mut_ptr().add(idx), x); idx += 1; } } -- a hostile iterator returns lower=0 but yields N items, blowing past the buffer. Pay attention to size_hint, ptr::write, ptr::add, set_len without prior re-grow, missing capacity recheck inside the copy loop, and any unsafe block inside an iterator-driven extend / insert / append. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"heap_overflow\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.",
-        src
+        src_with_focus
     ) -> Finding;
 
     let my_tier = tier("hunter");

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -284,9 +284,21 @@ fn tick(reason: string) -> void {
     // about temporal validity. The calibration check (M3) reruns the
     // experiment with prompts swapped between tribes if TP rates differ
     // by >2x.
+    //
+    // Stage 3 (#439): replicas inherit the parent's `hunter:prompt_variant`
+    // memo; appending it as a Focus: suffix lets sibling replicas lean
+    // into different interpretations of the same seed. Empty memo (Stage
+    // 2 single-tribe / no replication) is a no-op.
+    let variant = recall_latest("hunter:prompt_variant");
+    let variant_prefix = if len(variant) > 0 {
+        "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
+    } else {
+        "";
+    };
+    let src_with_focus = variant_prefix + src;
     let finding = prompt(
         "You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for use-after-free / double-free, with two related shapes: (1) a borrow outlives the value it points into -- Vec / SmallVec reallocation invalidating prior &/&mut slices, unsafe { ... } blocks that transmute lifetimes, raw pointers that survive past the safe Rust lifetime of their source, and (2) panic / unwind during insert_many / extend leaves the buffer in a transitionally-inconsistent state where Drop::drop re-frees pointers that were already moved or partially copied. The classic example is: pub fn insert_many<I: IntoIterator>(&mut self, idx: usize, iter: I) { ptr::copy(p.add(idx), p.add(idx + n), tail_len); for (i, x) in iter.enumerate() { ptr::write(p.add(idx + i), x); /* iter.next() panics here -> drop runs, double-frees moved-but-not-yet-shifted-back tail */ } }. Pay attention to ptr::copy / ptr::write through pointers obtained before a reallocation, set_len on a SmallVec / Vec while a derived raw pointer still aliases the old buffer, ManuallyDrop / mem::forget around partial moves, and RAII corner cases triggered by panics inside an unsafe block. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"use_after_free\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.",
-        src
+        src_with_focus
     ) -> Finding;
 
     let my_tier = tier("hunter");

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -285,9 +285,21 @@ fn tick(reason: string) -> void {
     // *requires* whole-program reasoning. The calibration check (M3)
     // reruns the experiment with prompts swapped between tribes if TP
     // rates differ by >2x.
+    //
+    // Stage 3 (#439): replicas inherit the parent's `hunter:prompt_variant`
+    // memo; appending it as a Focus: suffix lets sibling replicas lean
+    // into different interpretations of the same seed. Empty memo (Stage
+    // 2 single-tribe / no replication) is a no-op.
+    let variant = recall_latest("hunter:prompt_variant");
+    let variant_prefix = if len(variant) > 0 {
+        "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
+    } else {
+        "";
+    };
+    let src_with_focus = variant_prefix + src;
     let finding = prompt(
         "Your specific target function is `pub fn insert_many` -- it lives near line 827 of the file. The bug shape you specialize in is the panic-unwind path: when `iter.next()` inside the insert loop panics, `Drop::drop` runs on a partially-moved buffer and double-frees pointers that were already shifted. Find `pub fn insert_many` (NOT `from_buf_and_len_unchecked`, NOT `grow`) and report that function's signature line. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for use-after-free / double-free triggered by panic / unwind on the early-exit path: code that takes ownership of a raw allocation, then panics or returns early via `?` without `mem::forget`-ing the original RAII guard, so when the stack unwinds both the original guard's Drop and the destination owner free the same pointer. The classic example is: let buf = unsafe { alloc::alloc(layout) }; let _guard = AllocGuard { ptr: buf, layout }; some_fallible_op()?; transfer_ownership(buf); mem::forget(_guard); -- if `?` triggers before the forget, _guard.drop() AND the eventual destination both dealloc(buf). Pay attention to `?` early-return inside an unsafe block, panic! / assert! between an alloc and a corresponding mem::forget, Drop::drop cascading on partially-moved values, ManuallyDrop wrappers that are forgotten on the happy path but not on the error path, and any sequence where a raw pointer is handed to a new owner without the source being defused first. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"use_after_free\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.",
-        src
+        src_with_focus
     ) -> Finding;
 
     let my_tier = tier("hunter");

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -283,9 +283,21 @@ fn tick(reason: string) -> void {
     // tribe-beta's source-to-sink prompt; the calibration check (M3)
     // reruns the experiment with prompts swapped between tribes if TP
     // rates differ by >2x.
+    //
+    // Stage 3 (#439): replicas inherit the parent's `hunter:prompt_variant`
+    // memo; appending it as a Focus: suffix lets sibling replicas lean
+    // into different interpretations of the same seed. Empty memo (Stage
+    // 2 single-tribe / no replication) is a no-op.
+    let variant = recall_latest("hunter:prompt_variant");
+    let variant_prefix = if len(variant) > 0 {
+        "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
+    } else {
+        "";
+    };
+    let src_with_focus = variant_prefix + src;
     let finding = prompt(
         "Your specific target function is `pub fn grow` -- it lives near line 656 of the file. The bug is the capacity-shrink: `grow` accepts a `new_cap` smaller than the current `len`, leaving derived raw pointers overrunning the new (smaller) buffer. Do NOT report `insert_many` -- that's a different tribe's target. Find `pub fn grow` and report THAT function's signature line. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for memory corruption: arithmetic in grow / reserve / set_len / shrink_to_fit that accepts a smaller capacity than the current length, leading to derived raw pointers that overrun the new buffer, or to layout mismatches between alloc and dealloc. The classic example is: pub fn grow(&mut self, new_cap: usize) { /* no check that new_cap >= self.len */ let new_alloc = unsafe { alloc::alloc(Layout::array::<T>(new_cap).unwrap()) }; ptr::copy_nonoverlapping(self.as_ptr(), new_alloc as *mut T, self.len()); /* copies len() bytes into new_cap-sized buffer */ }. Pay attention to set_len, capacity assignments, alloc::dealloc, Layout::from_size_align, ptr::copy / ptr::copy_nonoverlapping with unchecked length parameters, and any path where new_cap < self.len() is reachable. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"memory_corruption\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.",
-        src
+        src_with_focus
     ) -> Finding;
 
     let my_tier = tier("hunter");


### PR DESCRIPTION
## Summary

Stage 3 piece 3 of #439: wire `hunter:prompt_variant` memo consumption into all 5 tribe `hunter.ag` files so replicas behave differently from their parents.

Each tribe's hunter now `recall_latest("hunter:prompt_variant")` at the top of the prompt-construction site and prepends a `[Replica focus: ...]` header to the source-code argument passed into the LLM. When the memo is empty (Stage 2 single-tribe / no replication path), the prefix collapses to the empty string -- byte-identical context to pre-change behavior.

## Implementation note

The agentis 1.6 `prompt(...)` builtin requires its first argument (the instruction) to be a string literal at parse time (`PARSE ERROR: expected string literal for prompt instruction`). Concatenating the variant onto the instruction string -- the original plan -- fails the parser. The functionally equivalent path is to inject the variant via the **second** argument (data context); the LLM sees the same focus directive, just upstream of the source listing instead of as a trailing sentence on the instruction.

Mechanically identical edit across all 5 tribes (alpha, beta, gamma, delta, epsilon).

- Refs #439

## Test plan

- [x] `bash tools/colony-lint.sh` -> 166 passed, 0 failed, 3 skipped
- [x] `agentis test tribes-bench/tribe-{alpha,beta,gamma,delta,epsilon}/agents/hunter.ag` -> all parse cleanly
- [x] `bash tribes-bench/tools/test-stage2-cognitive-market.sh` -> 41 passed, 0 failed
- [x] `bash tribes-bench/tools/test-stage2-reputation.sh` -> 56 passed, 0 failed
- [x] `bash tribes-bench/tools/test-verify-finding.sh` -> 6 passed, 0 failed
- [ ] Live tribes-bench Stage 3 run with replication firing (out of scope for this PR; requires Stage 3 piece 4 wiring)

## Files

| File | Lines |
|------|-------|
| `tribes-bench/tribe-alpha/agents/hunter.ag` | +13 / -1 |
| `tribes-bench/tribe-beta/agents/hunter.ag`  | +13 / -1 |
| `tribes-bench/tribe-gamma/agents/hunter.ag` | +13 / -1 |
| `tribes-bench/tribe-delta/agents/hunter.ag` | +13 / -1 |
| `tribes-bench/tribe-epsilon/agents/hunter.ag` | +13 / -1 |