### PR TITLE
fix(tribes-bench): mkdir REMOTE_RUN_ROOT before remote serve writes (#439)

### DIFF
--- a/tribes-bench/tools/run-stage3-multinode.sh
+++ b/tribes-bench/tools/run-stage3-multinode.sh
@@ -231,7 +231,10 @@ close_tunnel() {
 # --- 2) agentis serve (remote + local) ---
 start_remote_serve() {
     emit_step "starting remote agentis serve on 127.0.0.1:$TUNNEL_REMOTE_PORT"
-    emit_cmd "ssh -S $TUNNEL_SOCK $REMOTE_HOST bash -lc '$REMOTE_AGENTIS serve 127.0.0.1:$TUNNEL_REMOTE_PORT >>$REMOTE_RUN_ROOT/serve.log 2>&1 & echo \$! >$REMOTE_RUN_ROOT/serve.pid'"
+    # mkdir -p $REMOTE_RUN_ROOT must run before serve.log/serve.pid writes
+    # — the dir is otherwise created later by configure_remote_node, but
+    # the writes here would fail with "no such file or directory".
+    emit_cmd "ssh -S $TUNNEL_SOCK $REMOTE_HOST bash -lc 'mkdir -p $REMOTE_RUN_ROOT && $REMOTE_AGENTIS serve 127.0.0.1:$TUNNEL_REMOTE_PORT >>$REMOTE_RUN_ROOT/serve.log 2>&1 & echo \$! >$REMOTE_RUN_ROOT/serve.pid'"
 }
 
 stop_remote_serve() {


### PR DESCRIPTION
## Summary

`start_remote_serve()` in `tribes-bench/tools/run-stage3-multinode.sh` writes the remote agentis serve PID + log to `\$REMOTE_RUN_ROOT/serve.{pid,log}`, but the directory was not yet created at that point in the orchestration body — `configure_remote_node()` creates it, and that runs LATER. Result: any real (non-dry-run) execution aborted within seconds with "No such file or directory" and the cleanup trap fired.

## Discovery

First end-to-end smoke attempt against `ylohnitram@94.112.2.177` (2026-05-06 ~07:11 UTC) failed within ~30 seconds. Log:

```
bash: line 1: /home/ylohnitram/tribes-bench-stage3-runs/serve.pid: No such file or directory
bash: line 1: /home/ylohnitram/tribes-bench-stage3-runs/serve.log: No such file or directory
Exit request sent.
```

The orchestrator's existing `--dry-run` smoke test (`test-run-stage3-multinode.sh`, 25/0) does not catch this because dry-run only echoes commands without executing them, so the missing-directory failure mode never manifests.

## Fix

Single-line change inside `start_remote_serve()`: prefix the remote ssh command with `mkdir -p $REMOTE_RUN_ROOT &&`. Idempotent — `configure_remote_node()` still runs its own `mkdir -p` later, second invocation is a no-op.

## Test plan

- [x] `bash tribes-bench/tools/test-run-stage3-multinode.sh` — 25 passed, 0 failed (dry-run smoke unchanged).
- [x] `bash tools/colony-lint.sh` — 167 passed, 0 failed, 3 skipped.
- [ ] End-to-end smoke against the operator's home server — blocked separately by intermittent SSH disconnects to the home server, tracked in the issue thread.

Refs #439.