### PR TITLE
fix(tribes-bench): synchronize mkdir before backgrounded serve to avoid serve.pid race (#439)

### DIFF
--- a/tribes-bench/tools/run-stage3-multinode.sh
+++ b/tribes-bench/tools/run-stage3-multinode.sh
@@ -231,10 +231,14 @@ close_tunnel() {
 # --- 2) agentis serve (remote + local) ---
 start_remote_serve() {
     emit_step "starting remote agentis serve on 127.0.0.1:$TUNNEL_REMOTE_PORT"
-    # mkdir -p $REMOTE_RUN_ROOT must run before serve.log/serve.pid writes
-    # — the dir is otherwise created later by configure_remote_node, but
-    # the writes here would fail with "no such file or directory".
-    emit_cmd "ssh -S $TUNNEL_SOCK $REMOTE_HOST bash -lc 'mkdir -p $REMOTE_RUN_ROOT && $REMOTE_AGENTIS serve 127.0.0.1:$TUNNEL_REMOTE_PORT >>$REMOTE_RUN_ROOT/serve.log 2>&1 & echo \$! >$REMOTE_RUN_ROOT/serve.pid'"
+    # mkdir must complete BEFORE the parent shell's `echo $! >serve.pid`
+    # runs — otherwise echo's redirect race-condition fails (serve dir
+    # not yet created by the backgrounded `mkdir && serve` chain). Use
+    # `;` so mkdir is sequential, then group `serve & echo $! >pid` in
+    # `{ ; }` so the brace-group's exit (echo's exit) is the SSH return
+    # status the orchestrator's `set -e` checks. mkdir -p is idempotent
+    # so configure_remote_node still works after this without conflict.
+    emit_cmd "ssh -S $TUNNEL_SOCK $REMOTE_HOST bash -lc 'mkdir -p $REMOTE_RUN_ROOT; { $REMOTE_AGENTIS serve 127.0.0.1:$TUNNEL_REMOTE_PORT >>$REMOTE_RUN_ROOT/serve.log 2>&1 & echo \$! >$REMOTE_RUN_ROOT/serve.pid; }'"
 }
 
 stop_remote_serve() {


### PR DESCRIPTION
## Summary

Smoke retry after #450 (mkdir prefix added) still aborted because of a sequencing race in start_remote_serve.

The original line:
\`\`\`
mkdir -p X && agentis serve >>X/log 2>&1 & echo \$! >X/serve.pid
\`\`\`

Bash precedence: \`&\` has lower precedence than \`&&\`. Result:
\`\`\`
(mkdir -p X && agentis serve >>X/log 2>&1) & echo \$! >X/serve.pid
\`\`\`

So \`(mkdir && serve)\` is backgrounded, and \`echo \$! >X/serve.pid\` runs in the parent shell IMMEDIATELY — while the backgrounded mkdir may not yet have created X. echo's redirect then fails with "No such file or directory", bash returns non-zero, the orchestrator's \`set -e\` fires, cleanup trap tears down the run. agentis serve was actually starting fine in the background — but the parent's failed echo killed the orchestrator before any other step could run.

## Fix

Change \`&&\` to \`;\` so mkdir is synchronous, then group \`serve & echo \$! >pid\` in \`{ ; }\`. After the change:
\`\`\`
mkdir -p X; { serve >>X/log 2>&1 & echo \$! >X/serve.pid; }
\`\`\`

Now mkdir runs to completion first, then the brace group backgrounds serve and writes serve.pid sequentially. The brace-group's exit status (echo's exit) is what SSH returns and what the orchestrator's \`set -e\` checks.

## Discovery

Smoke attempt at 20:04 UTC (after #450 merge) crashed within seconds. \`runs/stage3-<ts>/multinode.log\` showed start_remote_serve emitted but no further steps. \`/tmp/stage3-smoke.log\` showed the bash race-condition error sequence.

## Test plan

- [x] \`bash tribes-bench/tools/test-run-stage3-multinode.sh\` — 25 passed, 0 failed (dry-run smoke unchanged).
- [x] \`bash tools/colony-lint.sh\` — clean.
- [ ] End-to-end smoke run after this PR merges.

Refs #439.