### PR TITLE
fix(tribes-bench): drop bogus rewrite-cb call + init before serve (#439)

### DIFF
--- a/tribes-bench/tools/run-stage3-multinode.sh
+++ b/tribes-bench/tools/run-stage3-multinode.sh
@@ -257,10 +257,14 @@ stop_local_serve() {
 }
 
 # --- 3) hermetic .agentis/config injection (federation.enabled = true) ---
+# Note: cb_budget rewriting (run-stage2-rewrite-cb.py) is NOT done here.
+# That script operates on tribe colony.toml files, not on the run-dir's
+# top-level .agentis/config. Default cb_budget values from each tribe's
+# colony.example.toml carry through for Stage 3; calibration tuning is a
+# Stage 2 optimisation, not a Stage 3 prerequisite.
 configure_local_node() {
     emit_step "configuring laptop hermetic .agentis/config (federation.enabled=true, llm.backend=$LLM_BACKEND)"
     emit_cmd "cd $RUN_DIR && agentis init >/dev/null 2>&1 || true"
-    emit_cmd "python3 $TOOLS_DIR/run-stage2-rewrite-cb.py --noop-if-missing $RUN_DIR/.agentis/config || true"
     emit_cmd "printf 'federation.enabled = true\\n' >>$RUN_DIR/.agentis/config"
     emit_cmd "printf 'llm.backend = $LLM_BACKEND\\n' >>$RUN_DIR/.agentis/config"
     if [ "$LLM_BACKEND" = "openai" ]; then
@@ -368,10 +372,14 @@ stitch_telemetry() {
 # --- Orchestration body ---
 install_cleanup_trap
 open_tunnel
-start_remote_serve
-start_local_serve
+# Init the hermetic .agentis/ on both nodes BEFORE start_*_serve writes
+# files (serve.log, serve.pid) into the run-root. agentis init refuses
+# to initialize into a non-empty directory, so doing init first keeps
+# the order: empty run-root → init → write serve.* → start serve.
 configure_local_node
 configure_remote_node
+start_remote_serve
+start_local_serve
 push_server_scaffolding
 write_run_meta
 spawn_laptop_daemons


### PR DESCRIPTION
## Summary

Two more orchestrator bugs surfaced by smoke retry after #451:

1. \`configure_local_node\` called \`run-stage2-rewrite-cb.py --noop-if-missing \$RUN_DIR/.agentis/config\` — fundamentally wrong (script expects \`<toml-path> <new-cb-budget>\` and operates on tribe colony.toml files, not the top-level \`.agentis/config\`). Drop the call; defaults from colony.example.toml carry through.
2. Orchestration body ran \`start_*_serve\` BEFORE \`configure_*_node\` on both nodes. \`start_remote_serve\` wrote \`serve.{log,pid}\` into the remote run-root, leaving it non-empty when \`configure_remote_node\`'s \`agentis init\` later ran. \`agentis init\` in non-empty dirs doesn't create \`.agentis/\`. Subsequent printf appends to \`.agentis/config\` then failed. Reorder: configure runs first, then serve.

## Discovery

Smoke retry at 20:28 UTC (after #451 mkdir-race fix merge) crashed with the rewrite-cb error first, then the printf-to-missing-config error. \`runs/stage3-<ts>/multinode.log\` confirmed the order issue: configure_local_node ran rewrite-cb (silently masked by \`|| true\`), the printf appends succeeded locally because local agentis init had a clean dir; but on the remote, \`agentis init\` ran AFTER serve.{log,pid} writes, which made the dir non-empty and the init silently bailed.

## Test plan

- [x] \`bash tribes-bench/tools/test-run-stage3-multinode.sh\` — 25 passed, 0 failed.
- [x] \`bash tools/colony-lint.sh\` — clean.
- [ ] End-to-end smoke after merge.

Refs #439.