### PR TITLE
fix(tribes-bench): preserve filename for sha256 verification in Containerfile (#439)

### DIFF
--- a/tribes-bench/tools/Containerfile.stage3
+++ b/tribes-bench/tools/Containerfile.stage3
@@ -35,14 +35,14 @@ RUN apt-get update \
         ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL -o /tmp/agentis \
+RUN cd /tmp \
+ && curl -fsSL -o agentis-linux-x86_64 \
         "https://github.com/Replikanti/agentis/releases/download/${AGENTIS_VERSION}/agentis-linux-x86_64" \
- && curl -fsSL -o /tmp/agentis.sha256 \
+ && curl -fsSL -o agentis-linux-x86_64.sha256 \
         "https://github.com/Replikanti/agentis/releases/download/${AGENTIS_VERSION}/agentis-linux-x86_64.sha256" \
- && cd /tmp \
- && sha256sum -c agentis.sha256 \
- && install -m 0755 agentis /usr/local/bin/agentis \
- && rm /tmp/agentis /tmp/agentis.sha256
+ && sha256sum -c agentis-linux-x86_64.sha256 \
+ && install -m 0755 agentis-linux-x86_64 /usr/local/bin/agentis \
+ && rm /tmp/agentis-linux-x86_64 /tmp/agentis-linux-x86_64.sha256
 
 WORKDIR /run-root
 


### PR DESCRIPTION
## Summary

The Containerfile.stage3 from #453 downloaded the agentis binary as \`/tmp/agentis\` but the \`.sha256\` file references the original publisher filename \`agentis-linux-x86_64\`. Result: \`sha256sum -c\` failed with "agentis-linux-x86_64: FAILED open or read" and the image build aborted.

Discovery: first podman build attempt after #453 merge.

## Fix

Keep the original filename through the verification step, then \`install -m 0755 agentis-linux-x86_64 /usr/local/bin/agentis\`. The runtime path inside the container is unchanged.

## Test plan

- [x] \`podman build -t tribes-bench-stage3:latest -f tribes-bench/tools/Containerfile.stage3 tribes-bench/\` — passes, "agentis-linux-x86_64: OK", image built.
- [x] \`bash tribes-bench/tools/test-run-stage3-docker.sh\` — 30/0 (dry-run smoke unaffected by build-time fix).

Refs #439.