### PR TITLE
fix(tribes-bench): mirror repo-root tools/ into container's /run-root/tools (#439)

### DIFF
--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -277,7 +277,14 @@ write_bootstrap() {
             printf '  printf "llm.openai.timeout_ms = %s\\n"\n' "$OPENAI_TIMEOUT_MS"
         fi
         printf '} >> .agentis/config\n'
+        # Bring tribes-bench/tools first, then merge in the repo-root tools/
+        # which carries platform helpers (parse-toml.sh, kill-federation.sh)
+        # that start-colony.sh's `<fed>/tools/parse-toml.sh` lookup needs.
+        # The two source dirs have non-overlapping filenames so the order
+        # is stable; cp -n is a defensive no-clobber in case a future
+        # rename ever introduces a collision.
         printf 'cp -r /repo/tribes-bench/tools /run-root/tools\n'
+        printf 'cp -rn /repo/tools/. /run-root/tools/\n'
         printf 'cp -r /repo/tribes-bench/targets /run-root/targets\n'
         printf 'cp /repo/tribes-bench/calibration.toml /run-root/calibration.toml\n'
         for tribe in $tribes_str; do


### PR DESCRIPTION
## Summary

Stage 3 Docker smoke first end-to-end attempt aborted because each tribe's \`start-colony.sh\` failed with \`Error: tools/parse-toml.sh not found in /run-root/tools or /run-root/../tools\`. The bootstrap copied tribes-bench/tools to /run-root/tools (federation-local helpers) but \`parse-toml.sh\` lives in the **repo-root** tools/ directory, not in tribes-bench/tools/.

## Fix

Add \`cp -rn /repo/tools/. /run-root/tools/\` step right after the tribes-bench tools copy. Filenames don't collide; \`-n\` is a defensive no-clobber.

## Discovery

After PR #453 + #454 merged, podman build succeeded ("agentis-linux-x86_64: OK") and 2 containers came up cleanly (\`stage3-laptop\` Up 5 minutes, \`stage3-server\` Up 5 minutes), but no findings landed in bug-ledger because each tribe daemon aborted on the parse-toml.sh missing error.

## Test plan

- [x] \`bash tribes-bench/tools/test-run-stage3-docker.sh\` — 30/0 (dry-run smoke unaffected by run-time path fix).
- [x] \`bash tools/colony-lint.sh\` — clean.
- [ ] End-to-end smoke after merge.

Refs #439.