### PR TITLE
fix(tribes-bench): mirror run-stage2 config completeness in Docker bootstrap (#439)

### DIFF
--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -266,9 +266,21 @@ write_bootstrap() {
         printf 'set -euo pipefail\n'
         printf 'cd /run-root\n'
         printf 'agentis init >/dev/null 2>&1 || true\n'
+        # Mirror run-stage2.sh lines 193-263 setup. Without these keys
+        # the agent runtime silently degrades: exec sh in .ag agents
+        # cannot see TARGET_DIR / VERIFIER_PATH (no env_passthrough),
+        # learn() rows never land in .agentis/experience/ (experience
+        # disabled), telemetry events vanish (telemetry disabled), and
+        # slow LLM rounds trigger watchdog kill cascade (default
+        # heartbeat = tick_interval * 2 = 120s; openai gpt-4o-mini at
+        # 20k tokens can take 90+ seconds).
         printf '{\n'
         printf '  printf "federation.enabled = true\\n"\n'
         printf '  printf "federation.peers = host.containers.internal:%s\\n"\n' "$peer_port"
+        printf '  printf "exec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,TARGET_FILE,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT\\n"\n'
+        printf '  printf "experience.enabled = true\\n"\n'
+        printf '  printf "telemetry.enabled = true\\n"\n'
+        printf '  printf "daemon.heartbeat_interval_ms = 600000\\n"\n'
         printf '  printf "llm.backend = %s\\n"\n' "$LLM_BACKEND"
         if [ "$LLM_BACKEND" = "openai" ]; then
             printf '  printf "llm.openai.endpoint = %s\\n"\n' "$OPENAI_ENDPOINT"


### PR DESCRIPTION
## Summary

Stage 3 Docker smoke #3 (after #456 merge) finally produced LLM calls and finding line=827 (correct smallvec bug location) but verifier exec failed and findings never landed in bug-ledger:

\`\`\`
[hunter] verifier call failed: ExecFailed: exec sh failed (exit 127): bash: : No such file or directory
[tribe-alpha] tick conf= 0.7 false positive at line 827
[tick:error] experience not enabled (set experience.enabled = true)
\`\`\`

Four config keys missing from Docker bootstrap that run-stage2.sh has been setting since Stage 2 M1 (lines 193-263):

- \`exec.env_passthrough\` — propagate TARGET_DIR / VERIFIER_PATH / BUGS_MANIFEST env into .ag agent \`exec sh\` calls. Without it, the verifier invocation has empty path arg.
- \`experience.enabled\` — \`learn()\` writes rows to .agentis/experience/<id>.jsonl. Without it, no bug-ledger.
- \`telemetry.enabled\` — daemon lifecycle events. Without it, analyse-stage3.py can't reconstruct lineage.
- \`daemon.heartbeat_interval_ms = 600000\` — bump default 120s → 10min so slow LLM rounds (openai 20k token prompts) don't trigger watchdog kill.

## Discovery

Smoke #3 ran containers cleanly, hunter agents ticked at conf=0.7 and produced LLM-derived finding line=827 (correct smallvec UAF bug at \`pub fn insert_many\`), but the verifier \`exec sh\` failed because env_passthrough was missing → no findings reached bug-ledger.

## Test plan

- [x] \`bash tribes-bench/tools/test-run-stage3-docker.sh\` — 30/0 (dry-run smoke unaffected by config-key additions).
- [x] \`bash tools/colony-lint.sh\` — clean.
- [ ] End-to-end Docker smoke after merge — should produce first verified findings.

Refs #439.