### PR TITLE
fix(tribes-bench): pass BUG_LEDGER_PATH so verified findings land in ledger (#439)

### DIFF
--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -329,7 +329,11 @@ write_bootstrap() {
             # writes once the first rotation interval elapses, but the
             # bootstrap default lets daemons land on a working Stage 2
             # target on tick 1 instead of the broken Stage 0 fallback.
-            printf 'DEATH_THRESHOLD=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
+            # BUG_LEDGER_PATH gives start-colony.sh the host-side ledger
+            # file to seed the tribe-<name>:bug_ledger memo from. Without
+            # it, hunters verify findings but the JSONL ledger never
+            # grows (visible in experience but missing from bug-ledger).
+            printf 'DEATH_THRESHOLD=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
                 "$DEATH_THRESHOLD" "$tribe" "$tribe"
         done
         printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'


### PR DESCRIPTION
## Summary

Stage 3 Docker smoke #4 (after #457 merge) **finally produced VERIFIED findings** — first-ever Stage 3 success log line:

\`\`\`
[hunter] verified S2-SMVOFL-001 at line 827
\`\`\`

Experience JSONL entries across both nodes show \`outcome: success\`, \`reward: 50\`, full Stage 2 ecosystem dynamics: hunt → reward → replicate attempt → knowledge_sell. The methodology is alive end-to-end.

Last setup gap: \`bug-ledger.jsonl\` stayed empty because \`start-colony.sh\` seeds the \`tribe-<name>:bug_ledger\` memo only when \`BUG_LEDGER_PATH\` env is set (line 194-196). Bootstrap was missing that env. Hunters' \`exec sh\` fell through to a no-op write because \`shell_escape("")\` expands to empty path.

## Fix

Add \`BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl\` to the \`start-colony.sh\` invocation env. \`exec.env_passthrough\` (added in #457) already includes it, so it propagates into hunter agents.

## Test plan

- [x] \`bash tribes-bench/tools/test-run-stage3-docker.sh\` — 30/0 (dry-run smoke unaffected by env addition).
- [x] \`bash tools/colony-lint.sh\` — clean.
- [ ] End-to-end Docker smoke after merge — expected to produce populated bug-ledger.jsonl on both nodes.

Refs #439.