### PR TITLE
fix(tribes-bench): defensive replicate target check (#460)

### DIFF
--- a/tribes-bench/tools/test-stage1-replication.sh
+++ b/tribes-bench/tools/test-stage1-replication.sh
@@ -110,6 +110,18 @@ for tribe in tribe-alpha tribe-beta tribe-gamma; do
     done
 done
 
+# --- 7. Defensive replicate target check (#460 PR A) ---
+# All 5 hunters must guard replicate() with a `len(target) > 0` check and
+# tag a distinct `replicate-skip` failure row when the target is empty,
+# so empty self_node_addr() no longer pollutes the experience log with
+# phantom `replicate-nak` rows.
+for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon; do
+    assert_contains "$tribe hunter.ag guards replicate() with len(target) > 0" \
+        "$FED_DIR/$tribe/agents/hunter.ag" "len(target) > 0"
+    assert_contains "$tribe hunter.ag tags replicate-skip on empty target" \
+        "$FED_DIR/$tribe/agents/hunter.ag" "replicate-skip"
+done
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -376,13 +376,21 @@ fn tick(reason: string) -> void {
                             let variant = pick_variant(tribe_name(), n);
                             memo_write("hunter:prompt_variant", variant);
                             let target = self_node_addr();
-                            let replica_id = try { replicate(target); } catch e { ""; };
-                            if len(replica_id) > 0 {
-                                memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
-                                memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
-                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                            if len(target) > 0 {
+                                let replica_id = try { replicate(target); } catch e { "__replicate_error__"; };
+                                if replica_id == "__replicate_error__" {
+                                    learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-error", "tribes-bench", tribe_name()]);
+                                } else {
+                                    if len(replica_id) > 0 {
+                                        memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
+                                        memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
+                                        learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                                    } else {
+                                        learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                                    };
+                                };
                             } else {
-                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-skip", "tribes-bench", tribe_name()]);
                             };
                         };
                     };

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -376,13 +376,21 @@ fn tick(reason: string) -> void {
                             let variant = pick_variant(tribe_name(), n);
                             memo_write("hunter:prompt_variant", variant);
                             let target = self_node_addr();
-                            let replica_id = try { replicate(target); } catch e { ""; };
-                            if len(replica_id) > 0 {
-                                memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
-                                memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
-                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                            if len(target) > 0 {
+                                let replica_id = try { replicate(target); } catch e { "__replicate_error__"; };
+                                if replica_id == "__replicate_error__" {
+                                    learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-error", "tribes-bench", tribe_name()]);
+                                } else {
+                                    if len(replica_id) > 0 {
+                                        memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
+                                        memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
+                                        learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                                    } else {
+                                        learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                                    };
+                                };
                             } else {
-                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-skip", "tribes-bench", tribe_name()]);
                             };
                         };
                     };

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -377,13 +377,21 @@ fn tick(reason: string) -> void {
                             let variant = pick_variant(tribe_name(), n);
                             memo_write("hunter:prompt_variant", variant);
                             let target = self_node_addr();
-                            let replica_id = try { replicate(target); } catch e { ""; };
-                            if len(replica_id) > 0 {
-                                memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
-                                memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
-                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                            if len(target) > 0 {
+                                let replica_id = try { replicate(target); } catch e { "__replicate_error__"; };
+                                if replica_id == "__replicate_error__" {
+                                    learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-error", "tribes-bench", tribe_name()]);
+                                } else {
+                                    if len(replica_id) > 0 {
+                                        memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
+                                        memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
+                                        learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                                    } else {
+                                        learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                                    };
+                                };
                             } else {
-                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-skip", "tribes-bench", tribe_name()]);
                             };
                         };
                     };

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -378,13 +378,21 @@ fn tick(reason: string) -> void {
                             let variant = pick_variant(tribe_name(), n);
                             memo_write("hunter:prompt_variant", variant);
                             let target = self_node_addr();
-                            let replica_id = try { replicate(target); } catch e { ""; };
-                            if len(replica_id) > 0 {
-                                memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
-                                memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
-                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                            if len(target) > 0 {
+                                let replica_id = try { replicate(target); } catch e { "__replicate_error__"; };
+                                if replica_id == "__replicate_error__" {
+                                    learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-error", "tribes-bench", tribe_name()]);
+                                } else {
+                                    if len(replica_id) > 0 {
+                                        memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
+                                        memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
+                                        learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                                    } else {
+                                        learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                                    };
+                                };
                             } else {
-                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-skip", "tribes-bench", tribe_name()]);
                             };
                         };
                     };

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -376,13 +376,21 @@ fn tick(reason: string) -> void {
                             let variant = pick_variant(tribe_name(), n);
                             memo_write("hunter:prompt_variant", variant);
                             let target = self_node_addr();
-                            let replica_id = try { replicate(target); } catch e { ""; };
-                            if len(replica_id) > 0 {
-                                memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
-                                memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
-                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                            if len(target) > 0 {
+                                let replica_id = try { replicate(target); } catch e { "__replicate_error__"; };
+                                if replica_id == "__replicate_error__" {
+                                    learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-error", "tribes-bench", tribe_name()]);
+                                } else {
+                                    if len(replica_id) > 0 {
+                                        memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_after - cost));
+                                        memo_write("tribe-" + tribe_name() + ":size", to_string(n + 1));
+                                        learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "success", ["replicated", "tribes-bench", tribe_name()]);
+                                    } else {
+                                        learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                                    };
+                                };
                             } else {
-                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-nak", "tribes-bench", tribe_name()]);
+                                learn("replicate", "n=" + to_string(n), "cost=" + to_string(cost), "failure", ["replicate-skip", "tribes-bench", tribe_name()]);
                             };
                         };
                     };


### PR DESCRIPTION
## Summary

- Guards `replicate(target)` in all 5 tribes-bench hunters against an empty `self_node_addr()` so empty-target cases stop minting phantom `replicate-nak` experience rows on Stage 0 / single-node runs.
- Adds two distinct failure tags so the analyser can separate the failure modes: `replicate-skip` (no worker available) and `replicate-error` (the rare case where `replicate()` itself raises). The existing `replicate-nak` tag is reserved for runtime rejection by the worker.
- Extends `tribes-bench/tools/test-stage1-replication.sh` with offline assertions across all 5 hunters that the `len(target) > 0` guard and the `replicate-skip` tag literal are present.

This is **PR A of 2** for #460. PR B (cross-node target selection backed by a `tribes-bench:peer_worker_addrs` memo seeded by Stage 3 bootstrap) is tracked separately in the same issue. Lands A first to stop the false-failure flood; B will land on top of cleaner experience-row signal.

## Notes

- The plan sketch posted on #460 used `&&` and `else if` for the failure-branch dispatch. The `.ag` parser supports neither, so the implemented shape uses nested `if`/`else` blocks. The five hunters share a byte-identical patch.
- `replicate-error` distinguishability uses an internal sentinel (`__replicate_error__`) returned from the `catch` arm; dropped at the next branch and never lands in a `learn()` row. The HItL-approved `replicate-error` tag is wired in.
- `colony-lint.sh` passes 168/0/3 against the change. `agentis commit` parse-checks all 5 hunter files clean. `tribes-bench/tools/test-stage*.sh` (stage1-replication, stage1-bug-ledger, stage2-scaffold, stage2-cognitive-market, stage2-reputation, stage2-rewrite-cb-decl) all green.

## Test plan

- [x] `tribes-bench/tools/test-stage1-replication.sh` passes 58/58 (was 48/48 before this change; +10 new assertions: 5 hunters × 2 literal-substring checks)
- [x] `tools/colony-lint.sh` passes 168/0/3
- [x] `agentis commit` parses each of the 5 hunter `.ag` files cleanly
- [x] No live `agentis serve` smoke run was performed; offline assertions only (per PR scope)

closes (partially) #460