### PR TITLE
feat(tribes-bench): cross-node replication target selection (#460)

### DIFF
--- a/tribes-bench/start-federation.sh
+++ b/tribes-bench/start-federation.sh
@@ -69,6 +69,22 @@ if [ -n "${RUN_DIR:-}" ]; then
     echo "$!" > "$RUN_DIR/worker.pid"
     agentis memo set "tribes-bench:worker_addr" "$WORKER_ADDR" >/dev/null 2>&1 || true
     echo "Started agentis worker on $WORKER_ADDR (pid=$(cat "$RUN_DIR/worker.pid"))"
+
+    # Stage 3 cross-node replication (#460 PR B): when the operator declares
+    # additional peer workers via PEER_WORKER_ADDRS (space-separated host:port
+    # list), seed the indexed memo keys + count memo so hunter's
+    # select_replication_target() rotates replicate(target) calls across
+    # nodes. Empty / unset PEER_WORKER_ADDRS keeps the legacy single-node
+    # path byte-identical (count=0 → fallback to self_node_addr()).
+    if [ -n "${PEER_WORKER_ADDRS:-}" ]; then
+        i=0
+        for addr in $PEER_WORKER_ADDRS; do
+            agentis memo set "tribes-bench:peer_worker_addr:$i" "$addr" >/dev/null 2>&1 || true
+            i=$((i + 1))
+        done
+        agentis memo set "tribes-bench:peer_worker_count" "$i" >/dev/null 2>&1 || true
+        echo "Seeded $i peer worker address(es) for cross-node replication"
+    fi
 fi
 
 TOTAL_AGENTS=0

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -318,6 +318,15 @@ write_bootstrap() {
         # mirrored from run-stage2.sh line 272). Without this seed the
         # hunter ticks at conf=0 → dormant → no LLM call → no findings.
         printf '(cd /run-root && agentis memo set hunter:confidence 0.7 >/dev/null 2>&1 || true)\n'
+        # Stage 3 cross-node replication (#460 PR B): seed the peer-worker
+        # address list so hunter's select_replication_target() rotates the
+        # replicate(target) call across nodes. Each container gets exactly
+        # one peer (the other node), reachable at host.containers.internal
+        # on the peer's in-container port. Indexed key + count memo shape
+        # is read by the hunter helper via recall_latest("...:peer_worker_addr:0")
+        # plus recall_latest("...:peer_worker_count").
+        printf '(cd /run-root && agentis memo set tribes-bench:peer_worker_addr:0 host.containers.internal:%s >/dev/null 2>&1 || true)\n' "$peer_port"
+        printf '(cd /run-root && agentis memo set tribes-bench:peer_worker_count 1 >/dev/null 2>&1 || true)\n'
         printf 'agentis serve 127.0.0.1:%s > /run-root/serve.log 2>&1 &\n' "$self_port"
         printf 'echo $! > /run-root/serve.pid\n'
         for tribe in $tribes_str; do

--- a/tribes-bench/tools/run-stage3-multinode.sh
+++ b/tribes-bench/tools/run-stage3-multinode.sh
@@ -270,6 +270,13 @@ configure_local_node() {
     if [ "$LLM_BACKEND" = "openai" ]; then
         emit_cmd "printf 'llm.openai.endpoint = $OPENAI_ENDPOINT\\nllm.openai.model = $OPENAI_MODEL\\nllm.openai.api_key_env = $OPENAI_KEY_ENV\\nllm.openai.timeout_ms = $OPENAI_TIMEOUT_MS\\n' >>$RUN_DIR/.agentis/config"
     fi
+    # Stage 3 cross-node replication (#460 PR B): seed the peer-worker
+    # address list so hunter's select_replication_target() picks the
+    # remote node when deciding where to dispatch replicate(target).
+    # Laptop -> server is reachable through the SSH local-forward
+    # 127.0.0.1:$TUNNEL_LOCAL_PORT (set up by open_tunnel above).
+    emit_cmd "cd $RUN_DIR && agentis memo set tribes-bench:peer_worker_addr:0 127.0.0.1:$TUNNEL_LOCAL_PORT >/dev/null 2>&1 || true"
+    emit_cmd "cd $RUN_DIR && agentis memo set tribes-bench:peer_worker_count 1 >/dev/null 2>&1 || true"
 }
 
 configure_remote_node() {
@@ -278,6 +285,19 @@ configure_remote_node() {
     emit_cmd "ssh -S $TUNNEL_SOCK $REMOTE_HOST bash -lc 'printf \"federation.enabled = true\\nllm.backend = $LLM_BACKEND\\n\" >>$REMOTE_RUN_ROOT/.agentis/config'"
     if [ "$LLM_BACKEND" = "openai" ]; then
         emit_cmd "ssh -S $TUNNEL_SOCK $REMOTE_HOST bash -lc 'printf \"llm.openai.endpoint = $OPENAI_ENDPOINT\\nllm.openai.model = $OPENAI_MODEL\\nllm.openai.api_key_env = $OPENAI_KEY_ENV\\nllm.openai.timeout_ms = $OPENAI_TIMEOUT_MS\\n\" >>$REMOTE_RUN_ROOT/.agentis/config'"
+    fi
+    # Stage 3 cross-node replication (#460 PR B): mirror the laptop seed
+    # so server-side hunters also rotate replicate() across nodes. The
+    # current SSH topology only opens a local-forward laptop -> server
+    # (no reverse-forward server -> laptop), so the server-side peer
+    # address is best-effort: when the operator has arranged inbound
+    # reachability to the laptop's serve port (e.g. WireGuard or a
+    # separate -R forward), $STAGE3_LAPTOP_PEER_ADDR carries it; when
+    # unset, the count stays 0 and the server-side hunter falls back to
+    # self_node_addr() the same as today.
+    if [ -n "${STAGE3_LAPTOP_PEER_ADDR:-}" ]; then
+        emit_cmd "ssh -S $TUNNEL_SOCK $REMOTE_HOST bash -lc 'cd $REMOTE_RUN_ROOT && $REMOTE_AGENTIS memo set tribes-bench:peer_worker_addr:0 $STAGE3_LAPTOP_PEER_ADDR >/dev/null 2>&1 || true'"
+        emit_cmd "ssh -S $TUNNEL_SOCK $REMOTE_HOST bash -lc 'cd $REMOTE_RUN_ROOT && $REMOTE_AGENTIS memo set tribes-bench:peer_worker_count 1 >/dev/null 2>&1 || true'"
     fi
 }
 

--- a/tribes-bench/tools/test-stage1-replication.sh
+++ b/tribes-bench/tools/test-stage1-replication.sh
@@ -122,6 +122,50 @@ for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon; do
         "$FED_DIR/$tribe/agents/hunter.ag" "replicate-skip"
 done
 
+# --- 8. Cross-node replication target selection (#460 PR B) ---
+# All 5 hunters must call select_replication_target() at the replicate()
+# call site (replacing the bare self_node_addr() seed) so Stage 3
+# Malthusian growth crosses node boundaries. The bare line must be gone
+# from the call site to prevent regressions.
+for tribe in tribe-alpha tribe-beta tribe-gamma tribe-delta tribe-epsilon; do
+    assert_contains "$tribe hunter.ag calls select_replication_target() at replicate site" \
+        "$FED_DIR/$tribe/agents/hunter.ag" "let target = select_replication_target();"
+    if grep -Fq "let target = self_node_addr();" "$FED_DIR/$tribe/agents/hunter.ag"; then
+        echo "[FAIL] $tribe hunter.ag still has bare \`let target = self_node_addr();\` at call site"
+        FAIL=$((FAIL + 1))
+    else
+        echo "[PASS] $tribe hunter.ag has no bare \`let target = self_node_addr();\` at call site"
+        PASS=$((PASS + 1))
+    fi
+done
+
+# Bootstrap seed memos for Stage 3 docker (write_bootstrap body).
+assert_contains "run-stage3-docker.sh seeds tribes-bench:peer_worker_addr:0" \
+    "$FED_DIR/tools/run-stage3-docker.sh" "tribes-bench:peer_worker_addr:0"
+assert_contains "run-stage3-docker.sh seeds tribes-bench:peer_worker_count" \
+    "$FED_DIR/tools/run-stage3-docker.sh" "tribes-bench:peer_worker_count"
+
+# start-federation.sh exposes PEER_WORKER_ADDRS env var and seeds count.
+assert_contains "start-federation.sh references PEER_WORKER_ADDRS env var" \
+    "$FED_DIR/start-federation.sh" "PEER_WORKER_ADDRS"
+assert_contains "start-federation.sh seeds tribes-bench:peer_worker_count" \
+    "$FED_DIR/start-federation.sh" "tribes-bench:peer_worker_count"
+
+# Modulus identity sanity: rr - ((rr / cnt) * cnt) for (rr=0..5, cnt=2)
+# must produce [0,1,0,1,0,1] (matches the pick_sibling/pick_variant idiom
+# the hunter helper relies on).
+modulus_idx() {
+    # $1 rr, $2 cnt
+    local rr="$1" cnt="$2"
+    echo "$((rr - ((rr / cnt) * cnt)))"
+}
+assert_eq "modulus rr=0,cnt=2 == 0" "0" "$(modulus_idx 0 2)"
+assert_eq "modulus rr=1,cnt=2 == 1" "1" "$(modulus_idx 1 2)"
+assert_eq "modulus rr=2,cnt=2 == 0" "0" "$(modulus_idx 2 2)"
+assert_eq "modulus rr=3,cnt=2 == 1" "1" "$(modulus_idx 3 2)"
+assert_eq "modulus rr=4,cnt=2 == 0" "0" "$(modulus_idx 4 2)"
+assert_eq "modulus rr=5,cnt=2 == 1" "1" "$(modulus_idx 5 2)"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -79,6 +79,23 @@ fn self_node_addr() -> string {
     return "127.0.0.1:9100";
 }
 
+fn select_replication_target() -> string {
+    let cnt_str = recall_latest("tribes-bench:peer_worker_count");
+    let cnt = if len(cnt_str) > 0 { parse_int(cnt_str); } else { 0; };
+    if cnt <= 0 {
+        return self_node_addr();
+    };
+    let rr_str = recall_latest("hunter:replicate_rr_counter");
+    let rr = if len(rr_str) > 0 { parse_int(rr_str); } else { 0; };
+    let idx = rr - ((rr / cnt) * cnt);
+    memo_write("hunter:replicate_rr_counter", to_string(rr + 1));
+    let addr = recall_latest("tribes-bench:peer_worker_addr:" + to_string(idx));
+    if len(addr) > 0 {
+        return addr;
+    };
+    return self_node_addr();
+}
+
 // --- Stage 2 M2 (#393) cognitive-market helpers ---------------------------
 //
 // Reputation, ask/max_cb formulas, sibling round-robin, trade-CSV row
@@ -375,7 +392,7 @@ fn tick(reason: string) -> void {
                         if n < max_replicas {
                             let variant = pick_variant(tribe_name(), n);
                             memo_write("hunter:prompt_variant", variant);
-                            let target = self_node_addr();
+                            let target = select_replication_target();
                             if len(target) > 0 {
                                 let replica_id = try { replicate(target); } catch e { "__replicate_error__"; };
                                 if replica_id == "__replicate_error__" {

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -80,6 +80,23 @@ fn self_node_addr() -> string {
     return "127.0.0.1:9100";
 }
 
+fn select_replication_target() -> string {
+    let cnt_str = recall_latest("tribes-bench:peer_worker_count");
+    let cnt = if len(cnt_str) > 0 { parse_int(cnt_str); } else { 0; };
+    if cnt <= 0 {
+        return self_node_addr();
+    };
+    let rr_str = recall_latest("hunter:replicate_rr_counter");
+    let rr = if len(rr_str) > 0 { parse_int(rr_str); } else { 0; };
+    let idx = rr - ((rr / cnt) * cnt);
+    memo_write("hunter:replicate_rr_counter", to_string(rr + 1));
+    let addr = recall_latest("tribes-bench:peer_worker_addr:" + to_string(idx));
+    if len(addr) > 0 {
+        return addr;
+    };
+    return self_node_addr();
+}
+
 // --- Stage 2 M2 (#393) cognitive-market helpers ---------------------------
 //
 // Reputation, ask/max_cb formulas, sibling round-robin, trade-CSV row
@@ -375,7 +392,7 @@ fn tick(reason: string) -> void {
                         if n < max_replicas {
                             let variant = pick_variant(tribe_name(), n);
                             memo_write("hunter:prompt_variant", variant);
-                            let target = self_node_addr();
+                            let target = select_replication_target();
                             if len(target) > 0 {
                                 let replica_id = try { replicate(target); } catch e { "__replicate_error__"; };
                                 if replica_id == "__replicate_error__" {

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -80,6 +80,23 @@ fn self_node_addr() -> string {
     return "127.0.0.1:9100";
 }
 
+fn select_replication_target() -> string {
+    let cnt_str = recall_latest("tribes-bench:peer_worker_count");
+    let cnt = if len(cnt_str) > 0 { parse_int(cnt_str); } else { 0; };
+    if cnt <= 0 {
+        return self_node_addr();
+    };
+    let rr_str = recall_latest("hunter:replicate_rr_counter");
+    let rr = if len(rr_str) > 0 { parse_int(rr_str); } else { 0; };
+    let idx = rr - ((rr / cnt) * cnt);
+    memo_write("hunter:replicate_rr_counter", to_string(rr + 1));
+    let addr = recall_latest("tribes-bench:peer_worker_addr:" + to_string(idx));
+    if len(addr) > 0 {
+        return addr;
+    };
+    return self_node_addr();
+}
+
 // --- Stage 2 M2 (#393) cognitive-market helpers ---------------------------
 //
 // Reputation, ask/max_cb formulas, sibling round-robin, trade-CSV row
@@ -376,7 +393,7 @@ fn tick(reason: string) -> void {
                         if n < max_replicas {
                             let variant = pick_variant(tribe_name(), n);
                             memo_write("hunter:prompt_variant", variant);
-                            let target = self_node_addr();
+                            let target = select_replication_target();
                             if len(target) > 0 {
                                 let replica_id = try { replicate(target); } catch e { "__replicate_error__"; };
                                 if replica_id == "__replicate_error__" {

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -80,6 +80,23 @@ fn self_node_addr() -> string {
     return "127.0.0.1:9100";
 }
 
+fn select_replication_target() -> string {
+    let cnt_str = recall_latest("tribes-bench:peer_worker_count");
+    let cnt = if len(cnt_str) > 0 { parse_int(cnt_str); } else { 0; };
+    if cnt <= 0 {
+        return self_node_addr();
+    };
+    let rr_str = recall_latest("hunter:replicate_rr_counter");
+    let rr = if len(rr_str) > 0 { parse_int(rr_str); } else { 0; };
+    let idx = rr - ((rr / cnt) * cnt);
+    memo_write("hunter:replicate_rr_counter", to_string(rr + 1));
+    let addr = recall_latest("tribes-bench:peer_worker_addr:" + to_string(idx));
+    if len(addr) > 0 {
+        return addr;
+    };
+    return self_node_addr();
+}
+
 // --- Stage 2 M2 (#393) cognitive-market helpers ---------------------------
 //
 // Reputation, ask/max_cb formulas, sibling round-robin, trade-CSV row
@@ -377,7 +394,7 @@ fn tick(reason: string) -> void {
                         if n < max_replicas {
                             let variant = pick_variant(tribe_name(), n);
                             memo_write("hunter:prompt_variant", variant);
-                            let target = self_node_addr();
+                            let target = select_replication_target();
                             if len(target) > 0 {
                                 let replica_id = try { replicate(target); } catch e { "__replicate_error__"; };
                                 if replica_id == "__replicate_error__" {

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -80,6 +80,23 @@ fn self_node_addr() -> string {
     return "127.0.0.1:9100";
 }
 
+fn select_replication_target() -> string {
+    let cnt_str = recall_latest("tribes-bench:peer_worker_count");
+    let cnt = if len(cnt_str) > 0 { parse_int(cnt_str); } else { 0; };
+    if cnt <= 0 {
+        return self_node_addr();
+    };
+    let rr_str = recall_latest("hunter:replicate_rr_counter");
+    let rr = if len(rr_str) > 0 { parse_int(rr_str); } else { 0; };
+    let idx = rr - ((rr / cnt) * cnt);
+    memo_write("hunter:replicate_rr_counter", to_string(rr + 1));
+    let addr = recall_latest("tribes-bench:peer_worker_addr:" + to_string(idx));
+    if len(addr) > 0 {
+        return addr;
+    };
+    return self_node_addr();
+}
+
 // --- Stage 2 M2 (#393) cognitive-market helpers ---------------------------
 //
 // Reputation, ask/max_cb formulas, sibling round-robin, trade-CSV row
@@ -375,7 +392,7 @@ fn tick(reason: string) -> void {
                         if n < max_replicas {
                             let variant = pick_variant(tribe_name(), n);
                             memo_write("hunter:prompt_variant", variant);
-                            let target = self_node_addr();
+                            let target = select_replication_target();
                             if len(target) > 0 {
                                 let replica_id = try { replicate(target); } catch e { "__replicate_error__"; };
                                 if replica_id == "__replicate_error__" {


### PR DESCRIPTION
## Summary

This is **PR B of 2** for #460. PR A merged in #461 (defensive guard around `replicate()`). PR B adds peer-aware target selection so Stage 3 multi-container Malthusian growth actually crosses node boundaries.

- **Memo seed shape (Option B, numbered keys, NOT CSV).** Each node bootstrap writes `tribes-bench:peer_worker_addr:0..N-1` plus `tribes-bench:peer_worker_count` (integer string). Empty / zero count falls through to `self_node_addr()`, so single-node behaviour stays byte-identical.
- **`select_replication_target()` helper** in all 5 tribe hunters, byte-identical, inserted directly after `self_node_addr()`. Same-tick `recall_latest` -> compute -> `memo_write` round-robin counter (`hunter:replicate_rr_counter`) mirrors the proven `hunter:bundle_counter` pattern. Uses the modulus idiom `n - ((n / k) * k)` already shipped in `pick_sibling`/`pick_variant`.
- **Call-site swap** in all 5 hunters: `let target = self_node_addr();` -> `let target = select_replication_target();`. PR-A's `len(target) > 0` guard and `replicate-skip` / `replicate-nak` / `replicate-error` tagging are preserved intact.
- **Bootstrap edits**: `tools/run-stage3-docker.sh` `write_bootstrap()` seeds the peer addr at `host.containers.internal:<peer_port>` per role; `start-federation.sh` accepts an optional space-separated `PEER_WORKER_ADDRS` env var; `tools/run-stage3-multinode.sh` seeds the laptop side via the SSH local-forward `127.0.0.1:$TUNNEL_LOCAL_PORT`, with a server-side seed gated behind a new `STAGE3_LAPTOP_PEER_ADDR` env var (existing tunnel has no reverse-forward; unset keeps server-side fallback to `self_node_addr()`).

## Builtin name verification

Per the plan's open question: confirmed via `grep -rn "parse_int\|to_string\|memo_write" tribes-bench/ --include="*.ag"` that all three names are used by shipped hunters (e.g. `tribe-delta/agents/hunter.ag` lines 45, 128, 202, 211, etc.). **No substitutions made.** `agentis commit` syntax-check via `tools/colony-lint.sh` passes cleanly for all 5 hunters with the new helper.

## Modulus idiom

Verified: `n - ((n / k) * k)` is already present in `pick_variant` (line 64) and `pick_sibling` (line 89) of every hunter. The new helper uses the same form.

## Multinode script note

`tools/run-stage3-multinode.sh` exists and was edited. The current SSH topology only opens a local-forward laptop -> server (no reverse-forward), so the laptop-side seed works directly while the server-side seed requires the operator to declare the laptop's reachable address in `STAGE3_LAPTOP_PEER_ADDR`. When unset, the server count stays 0 and server-side hunters fall back to `self_node_addr()` (no regression vs today).

## Test plan

- [x] `tribes-bench/tools/test-stage1-replication.sh` — extended with section 8 (5 hunters x 2 assertions, 4 bootstrap-seed assertions, 6 modulus-identity assertions) — **78 passed, 0 failed**
- [x] `tribes-bench/tools/test-run-stage3-docker.sh` — 30 passed, 0 failed
- [x] `tribes-bench/tools/test-run-stage3-multinode.sh` — 25 passed, 0 failed
- [x] `tribes-bench/tools/test-stage1-bug-ledger.sh` — passes
- [x] `tools/colony-lint.sh` — 168 passed, 0 failed, 3 skipped (destructive kill tests + per-config plaintext-token warnings unrelated to this PR)
- [x] `bash -n` syntax-clean on `start-federation.sh`, `run-stage3-docker.sh`, `run-stage3-multinode.sh`
- [ ] Live Stage 3 docker smoke (cross-node lineage assertion via `analyse-stage3.py`) — deferred to QA per #460 plan

Refs #460

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>