### PR TITLE
fix(tribes-bench): serve binds 0.0.0.0 in stage3 docker (#463)

### DIFF
--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -327,7 +327,7 @@ write_bootstrap() {
         # plus recall_latest("...:peer_worker_count").
         printf '(cd /run-root && agentis memo set tribes-bench:peer_worker_addr:0 host.containers.internal:%s >/dev/null 2>&1 || true)\n' "$peer_port"
         printf '(cd /run-root && agentis memo set tribes-bench:peer_worker_count 1 >/dev/null 2>&1 || true)\n'
-        printf 'agentis serve 127.0.0.1:%s > /run-root/serve.log 2>&1 &\n' "$self_port"
+        printf 'agentis serve 0.0.0.0:%s > /run-root/serve.log 2>&1 &\n' "$self_port"
         printf 'echo $! > /run-root/serve.pid\n'
         for tribe in $tribes_str; do
             # Pass TARGET_DIR + TARGET_FILE + BUGS_MANIFEST + VERIFIER_PATH


### PR DESCRIPTION
## Summary

- Fix Stage 3 docker bootstrap to bind `agentis serve 0.0.0.0:<port>` instead of `127.0.0.1:<port>` so cross-container TCP via `host.containers.internal` actually reaches the listening daemon
- Single-line edit in `tribes-bench/tools/run-stage3-docker.sh:330`
- Closes #463

## Context

Stage 3 docker smoke for #460 PR B (cross-node target selection) reproduced #463 — every hunter's `replicate(host.containers.internal:<peer-port>)` connection-refused, manifesting as `replicate-error` tags across all 5 tribes and `{"roots":[]}` in `lineage.json`. Run dir kept at `tribes-bench/runs/stage3-docker-20260508T052125Z/` as diagnostic.

Root cause: `netavark + pasta` (default rootless podman on this host) forwards `-p host:container` mappings to the container's external interface, not its loopback. Binding `127.0.0.1` made the container's serve unreachable from peer containers despite the port mapping.

Binding `0.0.0.0` does not change host-side exposure — the explicit `-p` mapping remains the only ingress.

## Test plan

- [x] `bash -n tribes-bench/tools/run-stage3-docker.sh` — syntax clean
- [x] `tools/test-run-stage3-docker.sh` — 30 passed, 0 failed (no test pinned the bind addr literal, so no test update needed)
- [x] `tools/colony-lint.sh` — 168 passed, 0 failed, 3 skipped (expected — agentis binary not installed)
- [ ] Post-merge live verification: re-run 30min docker smoke. Acceptance per #463: `lineage.json` contains at least one root with `child.node != root.node`, experience JSONL contains a non-error replicate row, `telemetry-combined.csv` shows both `laptop` and `server` rows.

## Out of scope

- The analyser warning `server-runs dir missing` reproduced in the failed smoke — separate analyser-arg issue, file separately if it persists post-fix.
- A `replicate-success` tag for the hunter success branch (currently success is implicit via non-empty `replica_id`) — file follow-up if diagnostic clarity needs it.