### PR TITLE
fix(tribes-bench): write colony.secret config for replicate auth (#468)

### DIFF
--- a/tribes-bench/start-federation.sh
+++ b/tribes-bench/start-federation.sh
@@ -64,6 +64,15 @@ if [ -n "${RUN_DIR:-}" ]; then
     WORKER_ADDR="${WORKER_ADDR:-127.0.0.1:9100}"
     WORKER_SECRET="$(head -c 16 /dev/urandom | base64 | tr -d '/+=' | head -c 16)"
     mkdir -p "$RUN_DIR"
+    # Stage 1 M2 colony auth (#468). Replicate's MSG_REPLICATE handshake
+    # reads colony.secret from .agentis/config; the worker will reject
+    # any caller missing the matching secret. Append unconditionally —
+    # last-line-wins overrides agentis init's random default, mirroring
+    # how federation.enabled / llm.backend overwrite the same way.
+    CONFIG_FILE="$RUN_DIR/.agentis/config"
+    if [ -f "$CONFIG_FILE" ]; then
+        printf 'colony.secret = %s\n' "$WORKER_SECRET" >> "$CONFIG_FILE"
+    fi
     agentis worker "$WORKER_ADDR" --secret "$WORKER_SECRET" --max-concurrent 8 \
         >>"$RUN_DIR/worker.log" 2>&1 &
     echo "$!" > "$RUN_DIR/worker.pid"

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -315,6 +315,7 @@ write_bootstrap() {
             printf '  printf "llm.openai.api_key_env = %s\\n"\n' "$OPENAI_KEY_ENV"
             printf '  printf "llm.openai.timeout_ms = %s\\n"\n' "$OPENAI_TIMEOUT_MS"
         fi
+        printf '  printf "colony.secret = %%s\\n" "$WORKER_SECRET"\n'
         printf '} >> .agentis/config\n'
         # Bring tribes-bench/tools first, then merge in the repo-root tools/
         # which carries platform helpers (parse-toml.sh, kill-federation.sh)

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -138,6 +138,9 @@ assert_contains "peer_worker_addr memo printf binds to peer_worker_port (not pee
 assert_contains "bootstrap body polls /dev/tcp before tribe launch" \
     "$(cat "$ORCH")" \
     "/dev/tcp/127.0.0.1/%s"
+assert_contains "bootstrap body writes colony.secret bound to \$WORKER_SECRET" \
+    "$(cat "$ORCH")" \
+    'printf "colony.secret = %%s\\n" "$WORKER_SECRET"'
 
 # 4. rotation timer
 assert_contains "rotation timer with configured interval" "$OUT" \

--- a/tribes-bench/tools/test-stage1-replication.sh
+++ b/tribes-bench/tools/test-stage1-replication.sh
@@ -101,6 +101,10 @@ assert_contains "start-federation.sh writes worker.pid" \
     "$FED_DIR/start-federation.sh" "worker.pid"
 assert_contains "start-federation.sh seeds tribes-bench:worker_addr memo" \
     "$FED_DIR/start-federation.sh" "tribes-bench:worker_addr"
+assert_contains "start-federation.sh writes colony.secret to hermetic config" \
+    "$FED_DIR/start-federation.sh" "colony.secret"
+assert_contains "start-federation.sh binds colony.secret to \$WORKER_SECRET" \
+    "$FED_DIR/start-federation.sh" 'colony.secret = %s'
 
 # --- 6. start-colony.sh seeds the M2+M3 economy memos ---
 for tribe in tribe-alpha tribe-beta tribe-gamma; do


### PR DESCRIPTION
## Summary

- MSG_REPLICATE handshake reads `colony.secret` from `.agentis/config` and forwards it as `client_auth`; without it the caller's auth field is empty and the worker rejects with `failed to fill whole buffer`.
- Stage 1 single-node and Stage 3 docker both spawn `agentis worker --secret $WORKER_SECRET` (added in #364 / #466) but neither writes the matching `colony.secret` line, so every cross-container replicate has been landing on silent auth failure.
- This PR appends `colony.secret = $WORKER_SECRET` to the hermetic `.agentis/config` in both contexts using each script's existing config idiom (single-node via a guarded `printf >>` inside `start-federation.sh`'s `RUN_DIR` block, Stage 3 docker via one extra `printf` line in `write_bootstrap()`'s config-edit block).
- Last-line-wins overrides `agentis init`'s random default, mirroring `federation.enabled` / `llm.backend`.

This is the **fourth and (hopefully) final layer** of the cross-container replicate fix sequence:
1. #460 PR A — defensive replicate-target guard (#461)
2. #463 / #464 — bind `0.0.0.0` so podman host-bridge maps the worker port
3. #465 / #466 — spawn `agentis worker` in the Stage 3 docker bootstrap
4. **This PR (#468)** — write the matching `colony.secret` config so replicate's auth handshake actually carries the shared secret

Closes #468.

## Test plan

- [x] `bash -n tribes-bench/start-federation.sh` — clean
- [x] `bash -n tribes-bench/tools/run-stage3-docker.sh` — clean
- [x] `bash tribes-bench/tools/test-run-stage3-docker.sh` — 46 passed, 0 failed (was 45/0 baseline + 1 new source-grep)
- [x] `bash tribes-bench/tools/test-stage1-replication.sh` — 80 passed, 0 failed (was 78/0 + 2 new)
- [x] `bash tools/colony-lint.sh` — 168 passed, 0 failed, 3 skipped
- [x] End-to-end variable interpolation traced manually: orchestrator emits `printf "colony.secret = %s\n" "$WORKER_SECRET"`, container-side bash with `WORKER_SECRET=testabc123` resolves it to `colony.secret = testabc123`.
- [ ] Live smoke deferred to post-merge per the plan (`STAGE3_WALL_CLOCK_S=1800 ./tools/run-stage3-docker.sh`; acceptance: no `auth failed` lines in `worker.log`, `lineage.json` shows replicas on opposite nodes).

## Deviations from plan

None. Implementation matches the approved plan on issue #468 verbatim — one orchestrator-side `printf` line in `write_bootstrap()` (last entry in the `{ ... } >> .agentis/config` block), guarded `printf >>` block in `start-federation.sh` between `mkdir -p $RUN_DIR` and the `agentis worker` spawn, plus the source-grep test assertions.