### PR TITLE
fix(tribes-bench): bump hunter cb 8000 -> 32000 for stage3 workload (#470)

### DIFF
--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -13,7 +13,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 8000;
+cb 32000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-alpha/config/colony.example.toml
+++ b/tribes-bench/tribe-alpha/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 8000
+cb_budget = 32000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 8000;
+cb 32000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-beta/config/colony.example.toml
+++ b/tribes-bench/tribe-beta/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 8000
+cb_budget = 32000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 8000;
+cb 32000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-delta/config/colony.example.toml
+++ b/tribes-bench/tribe-delta/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 8000
+cb_budget = 32000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 8000;
+cb 32000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-epsilon/config/colony.example.toml
+++ b/tribes-bench/tribe-epsilon/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 8000
+cb_budget = 32000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 8000;
+cb 32000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-gamma/config/colony.example.toml
+++ b/tribes-bench/tribe-gamma/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 8000
+cb_budget = 32000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit


### PR DESCRIPTION
## Summary

- Bump per-hunter CB pool from 8000 to 32000 (4x) across all 5 tribes
- Lockstep edit: `cb 8000;` in hunter.ag AND `cb_budget = 8000` in colony.example.toml (both required by colony-lint pairing check)
- 10 files, 1-line edit each, no logic changes
- `Closes #470`

## Context

Sixth and (hopefully) final layer of the cross-container replicate fix sequence. Smoke #4 after #469 showed all four protocol layers working (defensive guard, bind 0.0.0.0, worker spawn, colony.secret matched cross-node — auth failures dropped from many to 1 per worker), but hunters still hit 22 `replicate-error` tags. Daemon log root cause: `[tick:error] fn select_replication_target: CognitiveOverload: budget 0, required 5`. Pool drained mid-smoke before replicate could complete.

This is Option A from #470's fix-scope analysis (quick budget bump). Option B (helper optimization) and Option C (agentis-core memo cost reduction) remain available if 32000 still drains.

## Test plan

- [x] `tools/colony-lint.sh` — 168 passed, 0 failed, 3 skipped (pairing check verifies cb-vs-cb_budget match)
- [ ] Post-merge live verification: 30-min Stage 3 docker smoke. Acceptance per #470:
  - `lineage.json` contains parent/child rows where `child.node != root.node`
  - Experience JSONL contains `outcome:success` rows for `action:replicate`
  - `telemetry-combined.csv` shows both `laptop` AND `server` rows past minute=0
  - Daemon logs contain ZERO `tick:error CognitiveOverload` lines
  - If all four green, Stage 3 cross-node Malthusian growth works for the first time in project history.

## Risks

- 32000 might still drain if LLM prompts are heavier than estimated. Re-smoke shows; can bump further (64000) without changing logic.
- Per-replica `initial_cb = 1000` not increased here. If replicas immediately CognitiveOverload after spawn, follow-up to bump that separately.

## Out of scope

- Helper optimization (#470 Option B)
- agentis-core memo op cost reduction (#470 Option C)
- Multinode SSH variant fixes (#467)
- Per-tribe RR counter sharding (#460 deferred)