### PR TITLE
fix(tribes-bench): bump hunter cb 32000 -> 256000 for stage3 30min smoke (#470)

### DIFF
--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -13,7 +13,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 32000;
+cb 256000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-alpha/config/colony.example.toml
+++ b/tribes-bench/tribe-alpha/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 32000
+cb_budget = 256000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 32000;
+cb 256000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-beta/config/colony.example.toml
+++ b/tribes-bench/tribe-beta/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 32000
+cb_budget = 256000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 32000;
+cb 256000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-delta/config/colony.example.toml
+++ b/tribes-bench/tribe-delta/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 32000
+cb_budget = 256000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 32000;
+cb 256000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-epsilon/config/colony.example.toml
+++ b/tribes-bench/tribe-epsilon/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 32000
+cb_budget = 256000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 32000;
+cb 256000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-gamma/config/colony.example.toml
+++ b/tribes-bench/tribe-gamma/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 32000
+cb_budget = 256000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit


### PR DESCRIPTION
## Summary

- Continuation of #471 — bump per-hunter CB pool from 32000 to 256000 (8x current, 32x original 8000)
- Same lockstep shape: `cb <N>;` in hunter.ag matches `cb_budget = <N>` in colony.example.toml
- 10 files, numeric-only edits
- Refs #470 (issue stays open until smoke validates this bump is enough)

## Why escalate

Smoke #5 after #471 (32000) showed CognitiveOverload still by tick 6:

```
[tick:error] CognitiveOverload: budget 4, required 5
  Hint: remaining budget: 4, initial: 32000
```

Per-tick consumption ~2300 CB (LLM-dominated). Math:
- 32000 / 2300 = ~14 ticks of headroom — drains by minute 14 of 30-min smoke
- 256000 / 2300 = ~110 ticks of headroom — covers 30-min comfortably, supports 1-2h pilot

## Test plan

- [x] `tools/colony-lint.sh` — 168 passed, 0 failed, 3 skipped
- [ ] Post-merge live verification: 30-min Stage 3 docker smoke. Acceptance per #470:
  - `lineage.json` contains parent/child rows where `child.node != root.node`
  - Experience JSONL contains `outcome:success` rows for `action:replicate`
  - `telemetry-combined.csv` shows both `laptop` AND `server` rows past minute=0
  - Daemon logs contain ZERO `tick:error CognitiveOverload` lines for hunters

## Known limitation

Brute-force CB bumps don't scale to long pilots (6h smoke at this rate would need ~830000 CB). If 256000 unblocks 30-min smoke validation, follow up with #470 Option B (helper optimize) or Option C (agentis-core memo-cost reduction) for sustainable longer pilots.

## Out of scope

- Helper optimization (#470 Option B)
- agentis-core memo cost reduction (#470 Option C)
- Per-replica `initial_cb` bump (deferred)
- Multinode SSH variant (#467)