### PR TITLE
fix(tribes-bench): bump hunter cb 256000 -> 2000000 for stage3 LLM-heavy ticks (#470)

### DIFF
--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -13,7 +13,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 256000;
+cb 2000000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-alpha/config/colony.example.toml
+++ b/tribes-bench/tribe-alpha/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 256000
+cb_budget = 2000000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 256000;
+cb 2000000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-beta/config/colony.example.toml
+++ b/tribes-bench/tribe-beta/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 256000
+cb_budget = 2000000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 256000;
+cb 2000000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-delta/config/colony.example.toml
+++ b/tribes-bench/tribe-delta/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 256000
+cb_budget = 2000000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 256000;
+cb 2000000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-epsilon/config/colony.example.toml
+++ b/tribes-bench/tribe-epsilon/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 256000
+cb_budget = 2000000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 256000;
+cb 2000000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-gamma/config/colony.example.toml
+++ b/tribes-bench/tribe-gamma/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 256000
+cb_budget = 2000000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit


### PR DESCRIPTION
## Summary

- Continuation of #471 / #472. Bump per-hunter CB pool 256000 → 2000000 (8x current, 250x original 8000).
- Same lockstep shape: `cb <N>;` matches `cb_budget = <N>` across 10 files.
- Refs #470.

## Why escalate again

Smoke #6 after #472 (cb 256000) showed:

- ✅ Hunters ran full 30 ticks (CB pool no longer dies after 14 ticks like at 32000)
- ✅ 31 successful `hunt` events with `reward=200` true positives
- ❌ But drained within first 5-8 ticks; remaining 22-25 ticks per daemon all `tick:error CognitiveOverload`
- ❌ All 28 replicate events still tagged `replicate-error` (replicate path never reached due to drained CB by Malthusian threshold)

Per-tick consumption recalculated: 256000 / 6 ticks = ~42000 CB per tick (LLM gpt-4o-mini dominates, helper/replicate/memo are <500 CB combined).

For 30 ticks (30-min smoke) need ~1.26M; 2M gives ~5x margin and supports up to 1h smoke without re-bumping.

## Test plan

- [x] `tools/colony-lint.sh` — 168 passed, 0 failed, 3 skipped
- [ ] Post-merge live verification: 30-min Stage 3 docker smoke. Acceptance per #470:
  - `lineage.json` contains parent/child rows where `child.node != root.node`
  - Experience JSONL contains `outcome:success` rows for `action:replicate`
  - `telemetry-combined.csv` shows both `laptop` AND `server` rows past minute=0
  - Daemon logs contain ZERO `tick:error CognitiveOverload` lines

## Caveat

This is a brute-force fix. 2M CB pool is unsustainable for long pilots (6h would need ~12M). Real solution is upstream — helper optimization (#470 Option B) or agentis-core LLM cost model (Option C). This bump is intended as one-shot validation to close the 6-layer cross-container replicate fix sequence end-to-end. If it works, follow-up to make this sustainable.

## Out of scope

- Helper optimization (#470 Option B)
- agentis-core LLM cost model (#470 Option C)
- Per-replica `initial_cb` bump (deferred)
- Multinode SSH variant (#467)