### PR TITLE
fix(tribes-bench): resolve host.containers.internal to IP for replicate target (#474)

### DIFF
--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -356,7 +356,12 @@ write_bootstrap() {
         # Indexed key + count memo shape is read by the hunter helper
         # via recall_latest("...:peer_worker_addr:0") plus
         # recall_latest("...:peer_worker_count").
-        printf '(cd /run-root && agentis memo set tribes-bench:peer_worker_addr:0 host.containers.internal:%s >/dev/null 2>&1 || true)\n' "$peer_worker_port"
+        # #474: agentis-core perform_replication() parses target via
+        # SocketAddr::parse() which rejects hostnames; resolve
+        # host.containers.internal to its IP at container exec time and
+        # seed the memo with IP:port so the parse succeeds.
+        printf 'PEER_HOST_IP=$(getent hosts host.containers.internal | awk '\''{print $1}'\'')\n'
+        printf '(cd /run-root && agentis memo set tribes-bench:peer_worker_addr:0 "$PEER_HOST_IP:%s" >/dev/null 2>&1 || true)\n' "$peer_worker_port"
         printf '(cd /run-root && agentis memo set tribes-bench:peer_worker_count 1 >/dev/null 2>&1 || true)\n'
         printf 'agentis serve 0.0.0.0:%s > /run-root/serve.log 2>&1 &\n' "$self_port"
         printf 'echo $! > /run-root/serve.pid\n'

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -129,12 +129,15 @@ assert_contains "header documents STAGE3_WORKER_SECRET" \
 assert_contains "bootstrap body spawns agentis worker on self_worker_port" \
     "$(cat "$ORCH")" \
     "agentis worker 0.0.0.0:%s --secret \"\$WORKER_SECRET\" --max-concurrent 8"
-assert_contains "bootstrap body seeds peer_worker_addr memo at worker port" \
+assert_contains "bootstrap body resolves host.containers.internal to IP via getent" \
     "$(cat "$ORCH")" \
-    'agentis memo set tribes-bench:peer_worker_addr:0 host.containers.internal:%s'
+    "PEER_HOST_IP=\$(getent hosts host.containers.internal | awk"
+assert_contains "bootstrap body seeds peer_worker_addr memo at resolved IP:worker_port" \
+    "$(cat "$ORCH")" \
+    'agentis memo set tribes-bench:peer_worker_addr:0 "$PEER_HOST_IP:%s"'
 assert_contains "peer_worker_addr memo printf binds to peer_worker_port (not peer_port)" \
     "$(cat "$ORCH")" \
-    'host.containers.internal:%s >/dev/null 2>&1 || true)\n'"'"' "$peer_worker_port"'
+    '"$PEER_HOST_IP:%s" >/dev/null 2>&1 || true)\n'"'"' "$peer_worker_port"'
 assert_contains "bootstrap body polls /dev/tcp before tribe launch" \
     "$(cat "$ORCH")" \
     "/dev/tcp/127.0.0.1/%s"


### PR DESCRIPTION
## Summary

- Resolve `host.containers.internal` to its actual IP at container exec time via `getent`, seed `peer_worker_addr:0` memo with `<IP>:port` instead of `<hostname>:port`
- Closes #474 — the actual root cause of cross-container replicate failure across smokes #4-#7
- 2 files changed, 12 insertions / 4 deletions

## Why this is the actual root cause

`agentis-core src/evaluator/mod.rs:1192-1198`:

```rust
let addr: SocketAddr = target
    .parse()
    .map_err(|_| format!("invalid target address: {target}"))?;
```

`SocketAddr::from_str` accepts ONLY `IP:port` (no hostnames). Memo seed had been writing `host.containers.internal:9201` which fails parse → `Err("invalid target address: ...")` → PR-A's catch-arm tags `replicate-error` → call never reaches TCP connect.

This explains why smokes #4-#7 all showed:
- Workers logging only 1 `auth failed` line per node (replicate calls never reached the worker)
- 100% `replicate-error` rate even after auth/bind/worker/secret/CB all fixed
- No correlation between CB pool size and replicate success rate

Each of the 6 prior fixes (#461, #462, #464, #466, #469, #471/#472/#473) was real and necessary, but every replicate call was hitting the SocketAddr-parse gate before any of them could matter.

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] `tools/test-run-stage3-docker.sh` — 47 passed, 0 failed (was 46 baseline; +1 new for getent resolution assertion; replaced 2 assertions to match new IP-based memo seed pattern)
- [x] `tools/colony-lint.sh` — 168 passed, 0 failed, 3 skipped
- [ ] Post-merge live verification: 30-min Stage 3 docker smoke. Acceptance per #470 / #474:
  - `lineage.json` contains parent/child rows where `child.node != root.node`
  - Experience JSONL contains `outcome:success` rows for `action:replicate`
  - `telemetry-combined.csv` shows both `laptop` AND `server` rows past minute=0
  - Worker logs contain MORE than 1 connection (currently always 1 because replicate never reaches them)

## Graceful degradation

If `host.containers.internal` does not resolve in the network setup (rare under default rootless podman+pasta but possible), `$PEER_HOST_IP` is empty and the memo seeds `:9201`. PR-A's `len(target) > 0` guard catches that and tags `replicate-skip` — better than the silent SocketAddr-parse failure today.

## Out of scope

- `federation.peers = host.containers.internal:9101` config line (line 306) is also a hostname; if federation handshake (#612) also goes through SocketAddr-parse it has the same bug. Not addressed here — separate concern, daemon-config different code path from replicate-target.
- Helper optimization (#470 Option B) — irrelevant to this issue
- Per-replica `initial_cb` bump
- Multinode SSH variant (#467) — uses `127.0.0.1:port` which IS valid SocketAddr, so this layer doesn't affect it