### PR TITLE
fix(tribes-bench): wire colony.workers + messaging.distributed for replicate auth (#476)

### DIFF
--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -293,6 +293,13 @@ write_bootstrap() {
         printf 'set -euo pipefail\n'
         printf 'cd /run-root\n'
         printf 'agentis init >/dev/null 2>&1 || true\n'
+        # #474 + #476: resolve host.containers.internal once at bootstrap
+        # start so the config block (colony.workers) AND the memo seed
+        # (peer_worker_addr) both see the IP form. parse_workers in
+        # agentis-core accepts hostnames in colony.workers but
+        # SocketAddr::parse() in perform_replication() rejects them, so
+        # both must be resolved at container exec time.
+        printf 'PEER_HOST_IP=$(getent hosts host.containers.internal | awk '\''{print $1}'\'')\n'
         # Mirror run-stage2.sh lines 193-263 setup. Without these keys
         # the agent runtime silently degrades: exec sh in .ag agents
         # cannot see TARGET_DIR / VERIFIER_PATH (no env_passthrough),
@@ -308,6 +315,13 @@ write_bootstrap() {
         printf '  printf "experience.enabled = true\\n"\n'
         printf '  printf "telemetry.enabled = true\\n"\n'
         printf '  printf "daemon.heartbeat_interval_ms = 600000\\n"\n'
+        # #476: agentis daemon wires colony_peers (which carries
+        # colony.secret for replicate AUTH) only when BOTH messaging.distributed
+        # is true AND colony.workers is set. Without this, the replicate caller
+        # skips the AUTH handshake and sends MSG_REPLICATE (0x1B) directly,
+        # which the worker rejects with "expected AUTH (0x09), got 0x1b".
+        printf '  printf "messaging.distributed = true\\n"\n'
+        printf '  printf "colony.workers = %%s:%%s\\n" "$PEER_HOST_IP" "%s"\n' "$peer_worker_port"
         printf '  printf "llm.backend = %s\\n"\n' "$LLM_BACKEND"
         if [ "$LLM_BACKEND" = "openai" ]; then
             printf '  printf "llm.openai.endpoint = %s\\n"\n' "$OPENAI_ENDPOINT"
@@ -357,10 +371,9 @@ write_bootstrap() {
         # via recall_latest("...:peer_worker_addr:0") plus
         # recall_latest("...:peer_worker_count").
         # #474: agentis-core perform_replication() parses target via
-        # SocketAddr::parse() which rejects hostnames; resolve
-        # host.containers.internal to its IP at container exec time and
-        # seed the memo with IP:port so the parse succeeds.
-        printf 'PEER_HOST_IP=$(getent hosts host.containers.internal | awk '\''{print $1}'\'')\n'
+        # SocketAddr::parse() which rejects hostnames; PEER_HOST_IP is
+        # resolved earlier (after agentis init) and reused here so the
+        # memo seed contains IP:port.
         printf '(cd /run-root && agentis memo set tribes-bench:peer_worker_addr:0 "$PEER_HOST_IP:%s" >/dev/null 2>&1 || true)\n' "$peer_worker_port"
         printf '(cd /run-root && agentis memo set tribes-bench:peer_worker_count 1 >/dev/null 2>&1 || true)\n'
         printf 'agentis serve 0.0.0.0:%s > /run-root/serve.log 2>&1 &\n' "$self_port"

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -144,6 +144,12 @@ assert_contains "bootstrap body polls /dev/tcp before tribe launch" \
 assert_contains "bootstrap body writes colony.secret bound to \$WORKER_SECRET" \
     "$(cat "$ORCH")" \
     'printf "colony.secret = %%s\\n" "$WORKER_SECRET"'
+assert_contains "bootstrap body enables distributed messaging in config" \
+    "$(cat "$ORCH")" \
+    'printf "messaging.distributed = true\\n"'
+assert_contains "bootstrap body writes colony.workers bound to peer worker IP:port" \
+    "$(cat "$ORCH")" \
+    'printf "colony.workers = %%s:%%s\\n" "$PEER_HOST_IP"'
 
 # 4. rotation timer
 assert_contains "rotation timer with configured interval" "$OUT" \


### PR DESCRIPTION
## Summary

- Add `messaging.distributed = true` and `colony.workers = $PEER_HOST_IP:<peer_worker_port>` to the bootstrap config block
- Hoist `PEER_HOST_IP` resolution to top of bootstrap (right after `agentis init`) so both the new config keys and the existing #475 memo seed reference the same resolved IP
- Closes #476

## Why this is the 9th layer

Smoke #8 after #475 (IP resolution) showed major progress — replicate calls finally reach the worker (worker.log: 2 → 30 lines) — but every connection rejected with:

```
[worker] auth failed from 169.254.1.2:47308: protocol error: expected AUTH (0x09), got 0x1b
```

`0x1B = MSG_REPLICATE` per `agentis-core src/network/wire.rs:94`. Caller is sending MSG_REPLICATE directly without AUTH preamble.

Per `agentis-core src/cli/daemon.rs:1007-1027`, the daemon constructs `colony_peers` (which carries `colony.secret` for replicate AUTH) only when **BOTH**:

1. `messaging.distributed = true` (or `allow`) in config
2. `colony.workers = <addrs>` in config (parsed by `parse_workers` — CSV splitter, accepts hostnames)

Our config had neither. Without `colony_peers`, the replicate caller's `perform_replication()` at `evaluator/mod.rs:1203` short-circuits the `client_auth` call and sends `MSG_REPLICATE` directly. `#469` (write `colony.secret` to config) was correct but not sufficient on its own — without `messaging.distributed` and `colony.workers`, the daemon never reads `colony.secret` for auth.

## Test plan

- [x] `bash -n` syntax check
- [x] `tools/test-run-stage3-docker.sh` — 49 passed, 0 failed (was 47 baseline; +2 for messaging.distributed + colony.workers source-grep assertions)
- [x] `tools/colony-lint.sh` — 168 passed, 0 failed, 3 skipped
- [ ] Post-merge live verification: 30-min Stage 3 docker smoke. Acceptance per #470 / #474 / #476:
  - `worker.log` stops showing `expected AUTH (0x09), got 0x1b` lines
  - `lineage.json` contains parent/child rows where `child.node != root.node`
  - Experience JSONL contains `outcome:success` rows for `action:replicate`
  - `telemetry-combined.csv` shows both `laptop` AND `server` rows past minute=0

## Layer ladder reached its (hopefully) terminus

| # | PR | Layer |
|---|---|---|
| 1 | #461 | Defensive guard surfaced `replicate-error` |
| 2 | #462 | Cross-node target selection helper |
| 3 | #464 | Bind 0.0.0.0 (cross-container TCP reach) |
| 4 | #466 | Spawn worker (MSG_REPLICATE handler) |
| 5 | #469 | Write colony.secret config (caller secret value) |
| 6 | #471/#472/#473 | CB pool bumps |
| 7 | #475 | Resolve hostname to IP (SocketAddr.parse) |
| 8 | **THIS** | Wire colony_peers (caller actually performs AUTH) |

## Out of scope

- Multinode SSH variant (#467) — same gap likely applies, file follow-up if confirmed after this lands
- agentis-core LLM cost reduction (#470 Option B/C)
- Per-replica `initial_cb` bump