### PR TITLE
feat(tribes-bench): finite shared pool zero-sum economy for emergence R&D (#485)

### DIFF
--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -37,6 +37,16 @@
 #                              Default: 1200 (20 min).
 #   STAGE3_DEATH_THRESHOLD     CB level at which a hunter is culled.
 #                              Default: 300 (Stage 2 was 100).
+#   STAGE3_TRIBE_POOL_CAP      #485 finite-pool: max value of the
+#                              shared tribe pool. Bounds reward credit;
+#                              when pool == cap, additional TPs yield 0
+#                              reward (zero-sum competition). Default 0
+#                              = OFF (legacy uncapped pool).
+#   STAGE3_TRIBE_METABOLIC_COST  #485 finite-pool: per-tick CB drain
+#                              from shared tribe pool, paid by every
+#                              hunter just for existing. Creates
+#                              carrying-capacity pressure (more hunters
+#                              = more drain). Default 0 = OFF.
 #   STAGE3_LLM_BACKEND         llm.backend value injected into both
 #                              hermetic configs. Default: openai (#445).
 #   STAGE3_OPENAI_MODEL        Model id when STAGE3_LLM_BACKEND=openai.
@@ -140,6 +150,11 @@ done
 WALL_CLOCK="${STAGE3_WALL_CLOCK_S:-21600}"
 ROTATION_INTERVAL="${STAGE3_ROTATION_INTERVAL_S:-1200}"
 DEATH_THRESHOLD="${STAGE3_DEATH_THRESHOLD:-300}"
+# #485 finite-pool R&D substrate: zero-sum reward economy + carrying-capacity
+# dynamics for niche/hierarchy emergence. Defaults are 0 = OFF (legacy
+# unbounded pool, byte-identical to v1.7.4). Set non-zero to activate Option 2.
+TRIBE_POOL_CAP="${STAGE3_TRIBE_POOL_CAP:-0}"
+TRIBE_METABOLIC_COST="${STAGE3_TRIBE_METABOLIC_COST:-0}"
 LLM_BACKEND="${STAGE3_LLM_BACKEND:-openai}"
 OPENAI_MODEL="${STAGE3_OPENAI_MODEL:-gpt-4o-mini}"
 OPENAI_ENDPOINT="${STAGE3_OPENAI_ENDPOINT:-https://api.openai.com/v1/chat/completions}"
@@ -406,8 +421,8 @@ write_bootstrap() {
             # file to seed the tribe-<name>:bug_ledger memo from. Without
             # it, hunters verify findings but the JSONL ledger never
             # grows (visible in experience but missing from bug-ledger).
-            printf 'DEATH_THRESHOLD=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
-                "$DEATH_THRESHOLD" "$tribe" "$tribe"
+            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
+                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$tribe" "$tribe"
         done
         printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'
         printf 'exit 0\n'

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -188,6 +188,17 @@ assert_contains "analyse-stage3.py invocation present in source" \
 assert_contains "death threshold 300 propagated to laptop bootstrap arg" "$OUT" \
     "death threshold: 300"
 
+# #485 finite-pool: env defaults documented + propagated through bootstrap.
+assert_contains "STAGE3_TRIBE_POOL_CAP env var documented" \
+    "$(cat "$ORCH")" \
+    "STAGE3_TRIBE_POOL_CAP"
+assert_contains "STAGE3_TRIBE_METABOLIC_COST env var documented" \
+    "$(cat "$ORCH")" \
+    "STAGE3_TRIBE_METABOLIC_COST"
+assert_contains "POOL_CAP env propagated into start-colony.sh bootstrap line" \
+    "$(cat "$ORCH")" \
+    "POOL_CAP=%s METABOLIC_COST=%s"
+
 # OpenAI backend defaults wired in.
 assert_contains "llm.backend=openai default" "$OUT" \
     "llm_backend\":\"openai"

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -200,6 +200,18 @@ fn tick(reason: string) -> void {
     let _tick_now_ms = now_ms_via_shell();
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
+    // #485 finite-pool: per-tick metabolic cost drains the shared tribe
+    // pool. Pool capacity bounded at tribe:pool_cap (default unset =
+    // legacy uncapped); metabolic creates zero-sum competition (more
+    // hunters in tribe = more drain = harder to accumulate replication
+    // budget). Both memos default-absent => byte-identical to v1.7.4
+    // behaviour, only seeded by start-colony.sh under #485 opt-in.
+    let metabolic = parse_int(recall_latest("tribe-" + tribe_name() + ":metabolic_cost"));
+    if metabolic > 0 {
+        let pool_pre = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+        memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_pre - metabolic));
+    };
+
 
     // Read the synthetic target once per tick. Stage 0 deliberately
     // re-reads on every tick: the target is a checked-in static file,
@@ -376,12 +388,28 @@ fn tick(reason: string) -> void {
                         let _ = try { exec sh append_cmd; } catch e { ""; };
                     };
 
+                    // #485 finite-pool: cap-aware reward credit. When
+                    // tribe-X:pool_cap is set, reward is bounded so pool
+                    // does not exceed cap. Without cap memo (absent or 0),
+                    // legacy uncapped behaviour preserved.
                     let cur_pool = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
-                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + reward));
-                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(reward)]);
+                    let pool_cap_str = recall_latest("tribe-" + tribe_name() + ":pool_cap");
+                    let pool_cap = if len(pool_cap_str) > 0 { parse_int(pool_cap_str); } else { 0; };
+                    let actual_reward = if pool_cap > 0 {
+                        if cur_pool >= pool_cap {
+                            0;
+                        } else {
+                            let headroom = pool_cap - cur_pool;
+                            if reward > headroom { headroom; } else { reward; }
+                        }
+                    } else {
+                        reward;
+                    };
+                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + actual_reward));
+                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(actual_reward)]);
 
                     // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
-                    let pool_after = cur_pool + reward;
+                    let pool_after = cur_pool + actual_reward;
                     let n = parse_int(recall_latest("tribe-" + tribe_name() + ":size"));
                     let base = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_base_cost"));
                     let raw_k = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_k"));

--- a/tribes-bench/tribe-alpha/scripts/start-colony.sh
+++ b/tribes-bench/tribe-alpha/scripts/start-colony.sh
@@ -191,6 +191,13 @@ agentis memo set "tribe-${TRIBE_NAME}:max_replicas" "$MAX_REPLICAS" >/dev/null 2
 agentis memo set "tribe-${TRIBE_NAME}:reward_full" "$REWARD_FULL" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:reward_subsequent" "$REWARD_SUBSEQUENT" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/null 2>&1 || true
+# #485 finite-pool R&D substrate. POOL_CAP bounds the shared tribe
+# resource pool (zero-sum reward economy); METABOLIC_COST drains the
+# pool per hunter per tick (carrying-capacity dynamics). Defaults are
+# 0 = OFF (byte-identical legacy behaviour); set non-zero in the
+# orchestrator env to activate Option 2 emergence-research dynamics.
+agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -201,6 +201,18 @@ fn tick(reason: string) -> void {
     let _tick_now_ms = now_ms_via_shell();
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
+    // #485 finite-pool: per-tick metabolic cost drains the shared tribe
+    // pool. Pool capacity bounded at tribe:pool_cap (default unset =
+    // legacy uncapped); metabolic creates zero-sum competition (more
+    // hunters in tribe = more drain = harder to accumulate replication
+    // budget). Both memos default-absent => byte-identical to v1.7.4
+    // behaviour, only seeded by start-colony.sh under #485 opt-in.
+    let metabolic = parse_int(recall_latest("tribe-" + tribe_name() + ":metabolic_cost"));
+    if metabolic > 0 {
+        let pool_pre = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+        memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_pre - metabolic));
+    };
+
 
     // Read the synthetic target once per tick. Stage 0 deliberately
     // re-reads on every tick: the target is a checked-in static file,
@@ -376,12 +388,28 @@ fn tick(reason: string) -> void {
                         let _ = try { exec sh append_cmd; } catch e { ""; };
                     };
 
+                    // #485 finite-pool: cap-aware reward credit. When
+                    // tribe-X:pool_cap is set, reward is bounded so pool
+                    // does not exceed cap. Without cap memo (absent or 0),
+                    // legacy uncapped behaviour preserved.
                     let cur_pool = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
-                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + reward));
-                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(reward)]);
+                    let pool_cap_str = recall_latest("tribe-" + tribe_name() + ":pool_cap");
+                    let pool_cap = if len(pool_cap_str) > 0 { parse_int(pool_cap_str); } else { 0; };
+                    let actual_reward = if pool_cap > 0 {
+                        if cur_pool >= pool_cap {
+                            0;
+                        } else {
+                            let headroom = pool_cap - cur_pool;
+                            if reward > headroom { headroom; } else { reward; }
+                        }
+                    } else {
+                        reward;
+                    };
+                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + actual_reward));
+                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(actual_reward)]);
 
                     // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
-                    let pool_after = cur_pool + reward;
+                    let pool_after = cur_pool + actual_reward;
                     let n = parse_int(recall_latest("tribe-" + tribe_name() + ":size"));
                     let base = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_base_cost"));
                     let raw_k = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_k"));

--- a/tribes-bench/tribe-beta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-beta/scripts/start-colony.sh
@@ -191,6 +191,13 @@ agentis memo set "tribe-${TRIBE_NAME}:max_replicas" "$MAX_REPLICAS" >/dev/null 2
 agentis memo set "tribe-${TRIBE_NAME}:reward_full" "$REWARD_FULL" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:reward_subsequent" "$REWARD_SUBSEQUENT" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/null 2>&1 || true
+# #485 finite-pool R&D substrate. POOL_CAP bounds the shared tribe
+# resource pool (zero-sum reward economy); METABOLIC_COST drains the
+# pool per hunter per tick (carrying-capacity dynamics). Defaults are
+# 0 = OFF (byte-identical legacy behaviour); set non-zero in the
+# orchestrator env to activate Option 2 emergence-research dynamics.
+agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -201,6 +201,18 @@ fn tick(reason: string) -> void {
     let _tick_now_ms = now_ms_via_shell();
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
+    // #485 finite-pool: per-tick metabolic cost drains the shared tribe
+    // pool. Pool capacity bounded at tribe:pool_cap (default unset =
+    // legacy uncapped); metabolic creates zero-sum competition (more
+    // hunters in tribe = more drain = harder to accumulate replication
+    // budget). Both memos default-absent => byte-identical to v1.7.4
+    // behaviour, only seeded by start-colony.sh under #485 opt-in.
+    let metabolic = parse_int(recall_latest("tribe-" + tribe_name() + ":metabolic_cost"));
+    if metabolic > 0 {
+        let pool_pre = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+        memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_pre - metabolic));
+    };
+
 
     // Read the target file once per tick. Stage 2 scans a single file
     // selected by `$TARGET_FILE` under `$TARGET_DIR` (set by run-stage2.sh).
@@ -377,12 +389,28 @@ fn tick(reason: string) -> void {
                         let _ = try { exec sh append_cmd; } catch e { ""; };
                     };
 
+                    // #485 finite-pool: cap-aware reward credit. When
+                    // tribe-X:pool_cap is set, reward is bounded so pool
+                    // does not exceed cap. Without cap memo (absent or 0),
+                    // legacy uncapped behaviour preserved.
                     let cur_pool = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
-                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + reward));
-                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(reward)]);
+                    let pool_cap_str = recall_latest("tribe-" + tribe_name() + ":pool_cap");
+                    let pool_cap = if len(pool_cap_str) > 0 { parse_int(pool_cap_str); } else { 0; };
+                    let actual_reward = if pool_cap > 0 {
+                        if cur_pool >= pool_cap {
+                            0;
+                        } else {
+                            let headroom = pool_cap - cur_pool;
+                            if reward > headroom { headroom; } else { reward; }
+                        }
+                    } else {
+                        reward;
+                    };
+                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + actual_reward));
+                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(actual_reward)]);
 
                     // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
-                    let pool_after = cur_pool + reward;
+                    let pool_after = cur_pool + actual_reward;
                     let n = parse_int(recall_latest("tribe-" + tribe_name() + ":size"));
                     let base = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_base_cost"));
                     let raw_k = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_k"));

--- a/tribes-bench/tribe-delta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-delta/scripts/start-colony.sh
@@ -191,6 +191,13 @@ agentis memo set "tribe-${TRIBE_NAME}:max_replicas" "$MAX_REPLICAS" >/dev/null 2
 agentis memo set "tribe-${TRIBE_NAME}:reward_full" "$REWARD_FULL" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:reward_subsequent" "$REWARD_SUBSEQUENT" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/null 2>&1 || true
+# #485 finite-pool R&D substrate. POOL_CAP bounds the shared tribe
+# resource pool (zero-sum reward economy); METABOLIC_COST drains the
+# pool per hunter per tick (carrying-capacity dynamics). Defaults are
+# 0 = OFF (byte-identical legacy behaviour); set non-zero in the
+# orchestrator env to activate Option 2 emergence-research dynamics.
+agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -201,6 +201,18 @@ fn tick(reason: string) -> void {
     let _tick_now_ms = now_ms_via_shell();
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
+    // #485 finite-pool: per-tick metabolic cost drains the shared tribe
+    // pool. Pool capacity bounded at tribe:pool_cap (default unset =
+    // legacy uncapped); metabolic creates zero-sum competition (more
+    // hunters in tribe = more drain = harder to accumulate replication
+    // budget). Both memos default-absent => byte-identical to v1.7.4
+    // behaviour, only seeded by start-colony.sh under #485 opt-in.
+    let metabolic = parse_int(recall_latest("tribe-" + tribe_name() + ":metabolic_cost"));
+    if metabolic > 0 {
+        let pool_pre = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+        memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_pre - metabolic));
+    };
+
 
     // Read the target file once per tick. Stage 2 scans a single file
     // selected by `$TARGET_FILE` under `$TARGET_DIR` (set by run-stage2.sh).
@@ -378,12 +390,28 @@ fn tick(reason: string) -> void {
                         let _ = try { exec sh append_cmd; } catch e { ""; };
                     };
 
+                    // #485 finite-pool: cap-aware reward credit. When
+                    // tribe-X:pool_cap is set, reward is bounded so pool
+                    // does not exceed cap. Without cap memo (absent or 0),
+                    // legacy uncapped behaviour preserved.
                     let cur_pool = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
-                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + reward));
-                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(reward)]);
+                    let pool_cap_str = recall_latest("tribe-" + tribe_name() + ":pool_cap");
+                    let pool_cap = if len(pool_cap_str) > 0 { parse_int(pool_cap_str); } else { 0; };
+                    let actual_reward = if pool_cap > 0 {
+                        if cur_pool >= pool_cap {
+                            0;
+                        } else {
+                            let headroom = pool_cap - cur_pool;
+                            if reward > headroom { headroom; } else { reward; }
+                        }
+                    } else {
+                        reward;
+                    };
+                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + actual_reward));
+                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(actual_reward)]);
 
                     // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
-                    let pool_after = cur_pool + reward;
+                    let pool_after = cur_pool + actual_reward;
                     let n = parse_int(recall_latest("tribe-" + tribe_name() + ":size"));
                     let base = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_base_cost"));
                     let raw_k = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_k"));

--- a/tribes-bench/tribe-epsilon/scripts/start-colony.sh
+++ b/tribes-bench/tribe-epsilon/scripts/start-colony.sh
@@ -191,6 +191,13 @@ agentis memo set "tribe-${TRIBE_NAME}:max_replicas" "$MAX_REPLICAS" >/dev/null 2
 agentis memo set "tribe-${TRIBE_NAME}:reward_full" "$REWARD_FULL" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:reward_subsequent" "$REWARD_SUBSEQUENT" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/null 2>&1 || true
+# #485 finite-pool R&D substrate. POOL_CAP bounds the shared tribe
+# resource pool (zero-sum reward economy); METABOLIC_COST drains the
+# pool per hunter per tick (carrying-capacity dynamics). Defaults are
+# 0 = OFF (byte-identical legacy behaviour); set non-zero in the
+# orchestrator env to activate Option 2 emergence-research dynamics.
+agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -201,6 +201,18 @@ fn tick(reason: string) -> void {
     let _tick_now_ms = now_ms_via_shell();
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
+    // #485 finite-pool: per-tick metabolic cost drains the shared tribe
+    // pool. Pool capacity bounded at tribe:pool_cap (default unset =
+    // legacy uncapped); metabolic creates zero-sum competition (more
+    // hunters in tribe = more drain = harder to accumulate replication
+    // budget). Both memos default-absent => byte-identical to v1.7.4
+    // behaviour, only seeded by start-colony.sh under #485 opt-in.
+    let metabolic = parse_int(recall_latest("tribe-" + tribe_name() + ":metabolic_cost"));
+    if metabolic > 0 {
+        let pool_pre = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
+        memo_write("tribe-" + tribe_name() + ":pool", to_string(pool_pre - metabolic));
+    };
+
 
     // Read the target file once per tick. Stage 2 scans a single file
     // selected by `$TARGET_FILE` under `$TARGET_DIR` (set by run-stage2.sh).
@@ -376,12 +388,28 @@ fn tick(reason: string) -> void {
                         let _ = try { exec sh append_cmd; } catch e { ""; };
                     };
 
+                    // #485 finite-pool: cap-aware reward credit. When
+                    // tribe-X:pool_cap is set, reward is bounded so pool
+                    // does not exceed cap. Without cap memo (absent or 0),
+                    // legacy uncapped behaviour preserved.
                     let cur_pool = parse_int(recall_latest("tribe-" + tribe_name() + ":pool"));
-                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + reward));
-                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(reward)]);
+                    let pool_cap_str = recall_latest("tribe-" + tribe_name() + ":pool_cap");
+                    let pool_cap = if len(pool_cap_str) > 0 { parse_int(pool_cap_str); } else { 0; };
+                    let actual_reward = if pool_cap > 0 {
+                        if cur_pool >= pool_cap {
+                            0;
+                        } else {
+                            let headroom = pool_cap - cur_pool;
+                            if reward > headroom { headroom; } else { reward; }
+                        }
+                    } else {
+                        reward;
+                    };
+                    memo_write("tribe-" + tribe_name() + ":pool", to_string(cur_pool + actual_reward));
+                    learn("hunt", "line " + to_string(finding.line), bug_id, "success", ["acted", "tribes-bench", tribe_name(), "reward=" + to_string(actual_reward)]);
 
                     // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
-                    let pool_after = cur_pool + reward;
+                    let pool_after = cur_pool + actual_reward;
                     let n = parse_int(recall_latest("tribe-" + tribe_name() + ":size"));
                     let base = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_base_cost"));
                     let raw_k = parse_int(recall_latest("tribe-" + tribe_name() + ":replication_k"));

--- a/tribes-bench/tribe-gamma/scripts/start-colony.sh
+++ b/tribes-bench/tribe-gamma/scripts/start-colony.sh
@@ -191,6 +191,13 @@ agentis memo set "tribe-${TRIBE_NAME}:max_replicas" "$MAX_REPLICAS" >/dev/null 2
 agentis memo set "tribe-${TRIBE_NAME}:reward_full" "$REWARD_FULL" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:reward_subsequent" "$REWARD_SUBSEQUENT" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/null 2>&1 || true
+# #485 finite-pool R&D substrate. POOL_CAP bounds the shared tribe
+# resource pool (zero-sum reward economy); METABOLIC_COST drains the
+# pool per hunter per tick (carrying-capacity dynamics). Defaults are
+# 0 = OFF (byte-identical legacy behaviour); set non-zero in the
+# orchestrator env to activate Option 2 emergence-research dynamics.
+agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi


### PR DESCRIPTION
## Summary

- Add carrying-capacity dynamics to tribes-bench tribe pool: capped shared resource + per-tick metabolic drain
- Default 0 = OFF (legacy uncapped pool, byte-identical to current behaviour)
- Activate via `STAGE3_TRIBE_POOL_CAP=N STAGE3_TRIBE_METABOLIC_COST=M` env vars
- 12 files (5 hunter.ag + 5 start-colony.sh + run-stage3-docker.sh + test) +218 / -17
- `Closes #485`

## Why

Smoke #14 (v1.7.4 multi-gen + DEATH_THRESHOLD=2000) plateau'd at 5 spawns + 5 deaths — same shape as #13 (DEATH=2000) and #12 (DEATH=300, no multi-gen). Static threshold trilemma:

- low DEATH (300) = exponential growth ✅, mortality ❌
- high DEATH (2000) = mortality ✅, exponential ❌
- neither delivers both

Real Malthusian dynamics require **carrying-capacity** mechanics, not static threshold. Pool that depletes faster than it replenishes when population is high → resource scarcity → death pressure scales with population → equilibrium found dynamically.

This is the textbook substrate for niche/hierarchy/cooperation emergence (Stage 4 emergence research, #459 Phase 0).

## What

1. **Two new tribe memos** (default 0 = OFF):
   - `tribe-X:pool_cap` — bounds reward credit. When pool ≥ cap, additional TPs yield 0 reward → zero-sum competition.
   - `tribe-X:metabolic_cost` — per-tick CB drain paid by every hunter just for existing → carrying-capacity scales with population.

2. **hunter.ag** (5 byte-identical edits):
   - Tick start: drain metabolic from tribe pool
   - Reward path: cap-aware credit (`actual_reward = min(headroom, nominal)`); replication gate uses `actual_reward`

3. **start-colony.sh** (5 per-tribe scripts): seed `pool_cap` + `metabolic_cost` memos from `POOL_CAP` / `METABOLIC_COST` env vars

4. **run-stage3-docker.sh**: `STAGE3_TRIBE_POOL_CAP` + `STAGE3_TRIBE_METABOLIC_COST` env vars threaded through bootstrap; header doc updated

5. **Tests**: 3 new assertions (`test-run-stage3-docker.sh` 49 → 52)

## Expected dynamics post-merge (with cap=10000, metabolic=5)

- Per-tribe pool fluctuates around carrying-capacity equilibrium
- Hunters compete for finite reward stream → some win consistently, others starve
- Differential survival (consistent winners replicate, losers drain CB → die)
- Population grows until metabolic drain exceeds reward income → death cascade
- Survivors expand → cycle repeats
- **Both exponential growth phase AND 50%+ mortality** in same pilot

This is the substrate Stage 4 emergence research (#459) sits on top of: niche formation, social hierarchy, cooperation under group competition.

## Test plan

- [x] `bash -n` syntax check on all modified shells
- [x] `tools/test-run-stage3-docker.sh` — 52 passed, 0 failed (was 49)
- [x] `tools/test-stage1-replication.sh` — 80 passed, 0 failed (unchanged)
- [x] `tools/colony-lint.sh` — 168 passed, 0 failed, 3 skipped
- [ ] Post-merge live smoke with `STAGE3_TRIBE_POOL_CAP=10000 STAGE3_TRIBE_METABOLIC_COST=5`. Acceptance:
  - Pool memo values fluctuate (not monotonic)
  - Mortality > 50%
  - Some lineage branches survive longer than others (differential survival visible in `lineage.json` if #483 lineage parent_id linkage lands; otherwise visible via experience.jsonl tps_total comparison)

## SemVer

PATCH for tribes-bench (Apache 2.0 federation; not a versioned-component release). Default-OFF behaviour preserves byte-identical legacy. No agentis-core changes needed.

## Out of scope

- Cross-tribe pool sharing (group-vs-group competition) — interesting follow-up
- Dynamic replenishment tied to total federation TPs — future
- agentis-colonies #483 (lineage parent_id linkage) — separate observability concern; mortality/reproduction visibility partial without it but still measurable via per-hunter experience.jsonl
- agentis-colonies #467 (multinode SSH variant) — would inherit transparently

## Related

- agentis-core #623 / PR #624 (v1.7.4) — multi-gen replication; prerequisite (children must be able to replicate for finite pool to create proper Malthusian cycles)
- agentis-colonies #470 — CB calibration (different layer; per-agent budget vs tribe-level pool)
- agentis-colonies #459 Phase 0 — Stage 4 emergence research; this is foundational substrate