### PR TITLE
feat(tribes-bench): seed initial tribe pool > DEATH_THRESHOLD (finite-pool follow-up)

### DIFF
--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -47,6 +47,15 @@
 #                              hunter just for existing. Creates
 #                              carrying-capacity pressure (more hunters
 #                              = more drain). Default 0 = OFF.
+#   STAGE3_TRIBE_INITIAL_POOL  #487 finite-pool follow-up: starting
+#                              capital for the shared tribe pool. Lets
+#                              tribes accumulate replication budget
+#                              before metabolic drain or DEATH_THRESHOLD
+#                              culls them. Default 0 = OFF (legacy
+#                              cold-start economy where pool begins at 0
+#                              and any positive METABOLIC_COST drives
+#                              the tribe immediately into death-pressure
+#                              regime before the burst phase can land).
 #   STAGE3_LLM_BACKEND         llm.backend value injected into both
 #                              hermetic configs. Default: openai (#445).
 #   STAGE3_OPENAI_MODEL        Model id when STAGE3_LLM_BACKEND=openai.
@@ -155,6 +164,7 @@ DEATH_THRESHOLD="${STAGE3_DEATH_THRESHOLD:-300}"
 # unbounded pool, byte-identical to v1.7.4). Set non-zero to activate Option 2.
 TRIBE_POOL_CAP="${STAGE3_TRIBE_POOL_CAP:-0}"
 TRIBE_METABOLIC_COST="${STAGE3_TRIBE_METABOLIC_COST:-0}"
+TRIBE_INITIAL_POOL="${STAGE3_TRIBE_INITIAL_POOL:-0}"
 LLM_BACKEND="${STAGE3_LLM_BACKEND:-openai}"
 OPENAI_MODEL="${STAGE3_OPENAI_MODEL:-gpt-4o-mini}"
 OPENAI_ENDPOINT="${STAGE3_OPENAI_ENDPOINT:-https://api.openai.com/v1/chat/completions}"
@@ -421,8 +431,8 @@ write_bootstrap() {
             # file to seed the tribe-<name>:bug_ledger memo from. Without
             # it, hunters verify findings but the JSONL ledger never
             # grows (visible in experience but missing from bug-ledger).
-            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
-                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$tribe" "$tribe"
+            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s INITIAL_POOL=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
+                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$TRIBE_INITIAL_POOL" "$tribe" "$tribe"
         done
         printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'
         printf 'exit 0\n'

--- a/tribes-bench/tribe-alpha/scripts/start-colony.sh
+++ b/tribes-bench/tribe-alpha/scripts/start-colony.sh
@@ -198,6 +198,7 @@ agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/
 # orchestrator env to activate Option 2 emergence-research dynamics.
 agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:pool" "${INITIAL_POOL:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-beta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-beta/scripts/start-colony.sh
@@ -198,6 +198,7 @@ agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/
 # orchestrator env to activate Option 2 emergence-research dynamics.
 agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:pool" "${INITIAL_POOL:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-delta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-delta/scripts/start-colony.sh
@@ -198,6 +198,7 @@ agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/
 # orchestrator env to activate Option 2 emergence-research dynamics.
 agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:pool" "${INITIAL_POOL:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-epsilon/scripts/start-colony.sh
+++ b/tribes-bench/tribe-epsilon/scripts/start-colony.sh
@@ -198,6 +198,7 @@ agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/
 # orchestrator env to activate Option 2 emergence-research dynamics.
 agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:pool" "${INITIAL_POOL:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-gamma/scripts/start-colony.sh
+++ b/tribes-bench/tribe-gamma/scripts/start-colony.sh
@@ -198,6 +198,7 @@ agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/
 # orchestrator env to activate Option 2 emergence-research dynamics.
 agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
+agentis memo set "tribe-${TRIBE_NAME}:pool" "${INITIAL_POOL:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi


### PR DESCRIPTION
## Summary
- #485 finite-pool R&D substrate landed zero-sum reward + carrying-capacity drain, but the cold-start economy (pool starts at 0) makes Goldilocks tuning impossible: any reasonable DEATH_THRESHOLD fires before exponential reward income from replicates can build up.
- Add `STAGE3_TRIBE_INITIAL_POOL` knob so tribes start with capital. Defaults to 0 = OFF (legacy cold-start, byte-identical to v1.7.4 behaviour).
- Plumbed: env var → bootstrap printf → 5 × `start-colony.sh` memo seed `tribe-<name>:pool` from `$INITIAL_POOL`.

## Empirical motivation

| Smoke | METABOLIC | DEATH | INITIAL_POOL | Spawns | Mortality |
|-------|-----------|-------|--------------|--------|-----------|
| #15 | 5 | (no cascade) | 0 | 18 | 0% |
| #16 | 50 | 2000 | 0 | 5 | 50% |
| #17 | 15 | 2000 | 0 | 4 | 56% |
| #18 | 15 | 500 | 0 | 18 | 0% |

DEATH=2000 (#16, #17) kills tribes before exponential phase lands (cold-start drain hits DEATH within first ~20 ticks). DEATH=500 (#18) never triggers because metabolic drain doesn't reach it — but mortality stays at 0%. There is no static DEATH/METABOLIC pair that produces both ≥10 spawns AND ≥30% mortality from a zero pool.

With `INITIAL_POOL=5000 + DEATH=2000 + METABOLIC=15`:
- pool drops below DEATH at ~tick 40 (5000 − 75/tick × 40 = 2000) without rewards
- replicates fed by `reward=200/replicate` stretch the lifeline → burst phase before death pressure
- POOL_CAP=10000 caps runaway growth (zero-sum competition still active)

## Acceptance

- Default INITIAL_POOL=0 byte-identical to v1.7.4 behaviour. Verified by lint pass + zero-knob smoke runs upstream.
- Smoke #19 (next, with INITIAL_POOL=5000 / DEATH=2000 / METABOLIC=15) will validate that both ≥10 spawns AND ≥30% mortality emerge in the same run.

## Out of scope

- agentis-core changes (this is colonies-only; the runtime contract is unchanged).
- Adaptive INITIAL_POOL per tribe rep / population.

## Test plan
- [x] `colony-lint.sh` passes (168 passed, 0 failed, 3 skipped)
- [ ] Smoke #19 with INITIAL_POOL=5000 / DEATH=2000 / METABOLIC=15 → both ≥10 spawns AND ≥30% mortality
- [ ] QA agent verdict (post-smoke)

Refs: #485 (finite-pool initial), #459 (Stage 4 emergent behavior R&D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)