### PR TITLE
feat(tribes-bench): per-hunter age mortality (workaround for shared-state RMW race)

### DIFF
--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -56,6 +56,13 @@
 #                              and any positive METABOLIC_COST drives
 #                              the tribe immediately into death-pressure
 #                              regime before the burst phase can land).
+#   STAGE3_HUNTER_MAX_AGE      #487 follow-up: per-hunter age cap. Each
+#                              hunter increments its own age counter
+#                              (keyed on PPID, no shared-state RMW race)
+#                              and suicides via `agentis daemon stop`
+#                              when age > MAX_AGE. Default 0 = OFF (no
+#                              per-hunter age mortality; tribe-wide
+#                              cascade still applies as before).
 #   STAGE3_LLM_BACKEND         llm.backend value injected into both
 #                              hermetic configs. Default: openai (#445).
 #   STAGE3_OPENAI_MODEL        Model id when STAGE3_LLM_BACKEND=openai.
@@ -165,6 +172,12 @@ DEATH_THRESHOLD="${STAGE3_DEATH_THRESHOLD:-300}"
 TRIBE_POOL_CAP="${STAGE3_TRIBE_POOL_CAP:-0}"
 TRIBE_METABOLIC_COST="${STAGE3_TRIBE_METABOLIC_COST:-0}"
 TRIBE_INITIAL_POOL="${STAGE3_TRIBE_INITIAL_POOL:-0}"
+# #487 follow-up: per-hunter age mortality. Each hunter has its own
+# monotonic age counter keyed on PPID; suicides via `agentis daemon stop`
+# when age > HUNTER_MAX_AGE. Eliminates the shared-state RMW race the
+# tribe-pool drain pattern hits. Default 0 = OFF (byte-identical to
+# v1.7.5; tribe-wide cascade still applies as before).
+HUNTER_MAX_AGE="${STAGE3_HUNTER_MAX_AGE:-0}"
 LLM_BACKEND="${STAGE3_LLM_BACKEND:-openai}"
 OPENAI_MODEL="${STAGE3_OPENAI_MODEL:-gpt-4o-mini}"
 OPENAI_ENDPOINT="${STAGE3_OPENAI_ENDPOINT:-https://api.openai.com/v1/chat/completions}"
@@ -431,8 +444,8 @@ write_bootstrap() {
             # file to seed the tribe-<name>:bug_ledger memo from. Without
             # it, hunters verify findings but the JSONL ledger never
             # grows (visible in experience but missing from bug-ledger).
-            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s INITIAL_POOL=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
-                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$TRIBE_INITIAL_POOL" "$tribe" "$tribe"
+            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s INITIAL_POOL=%s HUNTER_MAX_AGE=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
+                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$TRIBE_INITIAL_POOL" "$HUNTER_MAX_AGE" "$tribe" "$tribe"
         done
         printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'
         printf 'exit 0\n'

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -213,6 +213,40 @@ fn tick(reason: string) -> void {
     };
 
 
+    // #487 follow-up: per-hunter age mortality. Each hunter has its own
+    // monotonic age counter keyed on its PPID (stable for the daemon's
+    // lifetime, unique across tribe-mates and replicas). When age exceeds
+    // hunter:max_age, the hunter suicides via `agentis daemon stop` --
+    // eliminating the shared-state RMW race that the tribe-pool drain
+    // pattern hits (5 hunters concurrent read-modify-write on
+    // tribe-X:pool lose updates), and giving individual hunters
+    // predictable lifespans + per-hunter reproductive pressure rather
+    // than tribe-wide cascade. Default-absent memo => OFF, byte-identical
+    // to v1.7.5 behaviour. Only seeded by start-colony.sh under the
+    // STAGE3_HUNTER_MAX_AGE env var.
+    let max_age = parse_int(recall_latest("hunter:max_age"));
+    if max_age > 0 {
+        let self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+        if len(self_pid) > 0 {
+            let age_key = "hunter:" + self_pid + ":age";
+            let age_pre = parse_int(recall_latest(age_key));
+            let age = age_pre + 1;
+            memo_write(age_key, to_string(age));
+            if age > max_age {
+                print("[hunter] self_death pid=", self_pid, " age=", age, " > max_age=", max_age);
+                learn("self_death", tribe_name() + "/" + self_pid, "age=" + to_string(age), "failure", ["died", "self-aged", "tribes-bench", tribe_name()]);
+                // Look up own agent_id by finding the .pid registry file
+                // matching $PPID, then async-stop self. Variables are
+                // shell-side ($PPID, $AGENTIS_ROOT, $own_id) -- no .ag-side
+                // concatenation, so the static-string `exec sh` is safe.
+                let stop_cmd = "own_id=$(grep -l \"^$PPID\\$\" \"$AGENTIS_ROOT/daemon\"/*.pid 2>/dev/null | head -1 | xargs -I{} basename {} .pid 2>/dev/null); if [ -n \"$own_id\" ]; then agentis daemon stop \"$own_id\" --async --grace-ms 1000 --timeout-ms 5000 >/dev/null 2>&1 || true; fi";
+                let _ = try { exec sh stop_cmd; } catch e { ""; };
+                return;
+            };
+        };
+    };
+
+
     // Read the synthetic target once per tick. Stage 0 deliberately
     // re-reads on every tick: the target is a checked-in static file,
     // not a live forge, so there is no upstream "since last tick" gate.

--- a/tribes-bench/tribe-alpha/scripts/start-colony.sh
+++ b/tribes-bench/tribe-alpha/scripts/start-colony.sh
@@ -199,6 +199,7 @@ agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/
 agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:pool" "${INITIAL_POOL:-0}" >/dev/null 2>&1 || true
+agentis memo set "hunter:max_age" "${HUNTER_MAX_AGE:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -214,6 +214,40 @@ fn tick(reason: string) -> void {
     };
 
 
+    // #487 follow-up: per-hunter age mortality. Each hunter has its own
+    // monotonic age counter keyed on its PPID (stable for the daemon's
+    // lifetime, unique across tribe-mates and replicas). When age exceeds
+    // hunter:max_age, the hunter suicides via `agentis daemon stop` --
+    // eliminating the shared-state RMW race that the tribe-pool drain
+    // pattern hits (5 hunters concurrent read-modify-write on
+    // tribe-X:pool lose updates), and giving individual hunters
+    // predictable lifespans + per-hunter reproductive pressure rather
+    // than tribe-wide cascade. Default-absent memo => OFF, byte-identical
+    // to v1.7.5 behaviour. Only seeded by start-colony.sh under the
+    // STAGE3_HUNTER_MAX_AGE env var.
+    let max_age = parse_int(recall_latest("hunter:max_age"));
+    if max_age > 0 {
+        let self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+        if len(self_pid) > 0 {
+            let age_key = "hunter:" + self_pid + ":age";
+            let age_pre = parse_int(recall_latest(age_key));
+            let age = age_pre + 1;
+            memo_write(age_key, to_string(age));
+            if age > max_age {
+                print("[hunter] self_death pid=", self_pid, " age=", age, " > max_age=", max_age);
+                learn("self_death", tribe_name() + "/" + self_pid, "age=" + to_string(age), "failure", ["died", "self-aged", "tribes-bench", tribe_name()]);
+                // Look up own agent_id by finding the .pid registry file
+                // matching $PPID, then async-stop self. Variables are
+                // shell-side ($PPID, $AGENTIS_ROOT, $own_id) -- no .ag-side
+                // concatenation, so the static-string `exec sh` is safe.
+                let stop_cmd = "own_id=$(grep -l \"^$PPID\\$\" \"$AGENTIS_ROOT/daemon\"/*.pid 2>/dev/null | head -1 | xargs -I{} basename {} .pid 2>/dev/null); if [ -n \"$own_id\" ]; then agentis daemon stop \"$own_id\" --async --grace-ms 1000 --timeout-ms 5000 >/dev/null 2>&1 || true; fi";
+                let _ = try { exec sh stop_cmd; } catch e { ""; };
+                return;
+            };
+        };
+    };
+
+
     // Read the synthetic target once per tick. Stage 0 deliberately
     // re-reads on every tick: the target is a checked-in static file,
     // not a live forge, so there is no upstream "since last tick" gate.

--- a/tribes-bench/tribe-beta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-beta/scripts/start-colony.sh
@@ -199,6 +199,7 @@ agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/
 agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:pool" "${INITIAL_POOL:-0}" >/dev/null 2>&1 || true
+agentis memo set "hunter:max_age" "${HUNTER_MAX_AGE:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -214,6 +214,40 @@ fn tick(reason: string) -> void {
     };
 
 
+    // #487 follow-up: per-hunter age mortality. Each hunter has its own
+    // monotonic age counter keyed on its PPID (stable for the daemon's
+    // lifetime, unique across tribe-mates and replicas). When age exceeds
+    // hunter:max_age, the hunter suicides via `agentis daemon stop` --
+    // eliminating the shared-state RMW race that the tribe-pool drain
+    // pattern hits (5 hunters concurrent read-modify-write on
+    // tribe-X:pool lose updates), and giving individual hunters
+    // predictable lifespans + per-hunter reproductive pressure rather
+    // than tribe-wide cascade. Default-absent memo => OFF, byte-identical
+    // to v1.7.5 behaviour. Only seeded by start-colony.sh under the
+    // STAGE3_HUNTER_MAX_AGE env var.
+    let max_age = parse_int(recall_latest("hunter:max_age"));
+    if max_age > 0 {
+        let self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+        if len(self_pid) > 0 {
+            let age_key = "hunter:" + self_pid + ":age";
+            let age_pre = parse_int(recall_latest(age_key));
+            let age = age_pre + 1;
+            memo_write(age_key, to_string(age));
+            if age > max_age {
+                print("[hunter] self_death pid=", self_pid, " age=", age, " > max_age=", max_age);
+                learn("self_death", tribe_name() + "/" + self_pid, "age=" + to_string(age), "failure", ["died", "self-aged", "tribes-bench", tribe_name()]);
+                // Look up own agent_id by finding the .pid registry file
+                // matching $PPID, then async-stop self. Variables are
+                // shell-side ($PPID, $AGENTIS_ROOT, $own_id) -- no .ag-side
+                // concatenation, so the static-string `exec sh` is safe.
+                let stop_cmd = "own_id=$(grep -l \"^$PPID\\$\" \"$AGENTIS_ROOT/daemon\"/*.pid 2>/dev/null | head -1 | xargs -I{} basename {} .pid 2>/dev/null); if [ -n \"$own_id\" ]; then agentis daemon stop \"$own_id\" --async --grace-ms 1000 --timeout-ms 5000 >/dev/null 2>&1 || true; fi";
+                let _ = try { exec sh stop_cmd; } catch e { ""; };
+                return;
+            };
+        };
+    };
+
+
     // Read the target file once per tick. Stage 2 scans a single file
     // selected by `$TARGET_FILE` under `$TARGET_DIR` (set by run-stage2.sh).
     // The Stage 1 per-tribe class-shard rotation referenced in the prior

--- a/tribes-bench/tribe-delta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-delta/scripts/start-colony.sh
@@ -199,6 +199,7 @@ agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/
 agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:pool" "${INITIAL_POOL:-0}" >/dev/null 2>&1 || true
+agentis memo set "hunter:max_age" "${HUNTER_MAX_AGE:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -214,6 +214,40 @@ fn tick(reason: string) -> void {
     };
 
 
+    // #487 follow-up: per-hunter age mortality. Each hunter has its own
+    // monotonic age counter keyed on its PPID (stable for the daemon's
+    // lifetime, unique across tribe-mates and replicas). When age exceeds
+    // hunter:max_age, the hunter suicides via `agentis daemon stop` --
+    // eliminating the shared-state RMW race that the tribe-pool drain
+    // pattern hits (5 hunters concurrent read-modify-write on
+    // tribe-X:pool lose updates), and giving individual hunters
+    // predictable lifespans + per-hunter reproductive pressure rather
+    // than tribe-wide cascade. Default-absent memo => OFF, byte-identical
+    // to v1.7.5 behaviour. Only seeded by start-colony.sh under the
+    // STAGE3_HUNTER_MAX_AGE env var.
+    let max_age = parse_int(recall_latest("hunter:max_age"));
+    if max_age > 0 {
+        let self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+        if len(self_pid) > 0 {
+            let age_key = "hunter:" + self_pid + ":age";
+            let age_pre = parse_int(recall_latest(age_key));
+            let age = age_pre + 1;
+            memo_write(age_key, to_string(age));
+            if age > max_age {
+                print("[hunter] self_death pid=", self_pid, " age=", age, " > max_age=", max_age);
+                learn("self_death", tribe_name() + "/" + self_pid, "age=" + to_string(age), "failure", ["died", "self-aged", "tribes-bench", tribe_name()]);
+                // Look up own agent_id by finding the .pid registry file
+                // matching $PPID, then async-stop self. Variables are
+                // shell-side ($PPID, $AGENTIS_ROOT, $own_id) -- no .ag-side
+                // concatenation, so the static-string `exec sh` is safe.
+                let stop_cmd = "own_id=$(grep -l \"^$PPID\\$\" \"$AGENTIS_ROOT/daemon\"/*.pid 2>/dev/null | head -1 | xargs -I{} basename {} .pid 2>/dev/null); if [ -n \"$own_id\" ]; then agentis daemon stop \"$own_id\" --async --grace-ms 1000 --timeout-ms 5000 >/dev/null 2>&1 || true; fi";
+                let _ = try { exec sh stop_cmd; } catch e { ""; };
+                return;
+            };
+        };
+    };
+
+
     // Read the target file once per tick. Stage 2 scans a single file
     // selected by `$TARGET_FILE` under `$TARGET_DIR` (set by run-stage2.sh).
     // The Stage 1 per-tribe class-shard rotation referenced in the prior

--- a/tribes-bench/tribe-epsilon/scripts/start-colony.sh
+++ b/tribes-bench/tribe-epsilon/scripts/start-colony.sh
@@ -199,6 +199,7 @@ agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/
 agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:pool" "${INITIAL_POOL:-0}" >/dev/null 2>&1 || true
+agentis memo set "hunter:max_age" "${HUNTER_MAX_AGE:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -214,6 +214,40 @@ fn tick(reason: string) -> void {
     };
 
 
+    // #487 follow-up: per-hunter age mortality. Each hunter has its own
+    // monotonic age counter keyed on its PPID (stable for the daemon's
+    // lifetime, unique across tribe-mates and replicas). When age exceeds
+    // hunter:max_age, the hunter suicides via `agentis daemon stop` --
+    // eliminating the shared-state RMW race that the tribe-pool drain
+    // pattern hits (5 hunters concurrent read-modify-write on
+    // tribe-X:pool lose updates), and giving individual hunters
+    // predictable lifespans + per-hunter reproductive pressure rather
+    // than tribe-wide cascade. Default-absent memo => OFF, byte-identical
+    // to v1.7.5 behaviour. Only seeded by start-colony.sh under the
+    // STAGE3_HUNTER_MAX_AGE env var.
+    let max_age = parse_int(recall_latest("hunter:max_age"));
+    if max_age > 0 {
+        let self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+        if len(self_pid) > 0 {
+            let age_key = "hunter:" + self_pid + ":age";
+            let age_pre = parse_int(recall_latest(age_key));
+            let age = age_pre + 1;
+            memo_write(age_key, to_string(age));
+            if age > max_age {
+                print("[hunter] self_death pid=", self_pid, " age=", age, " > max_age=", max_age);
+                learn("self_death", tribe_name() + "/" + self_pid, "age=" + to_string(age), "failure", ["died", "self-aged", "tribes-bench", tribe_name()]);
+                // Look up own agent_id by finding the .pid registry file
+                // matching $PPID, then async-stop self. Variables are
+                // shell-side ($PPID, $AGENTIS_ROOT, $own_id) -- no .ag-side
+                // concatenation, so the static-string `exec sh` is safe.
+                let stop_cmd = "own_id=$(grep -l \"^$PPID\\$\" \"$AGENTIS_ROOT/daemon\"/*.pid 2>/dev/null | head -1 | xargs -I{} basename {} .pid 2>/dev/null); if [ -n \"$own_id\" ]; then agentis daemon stop \"$own_id\" --async --grace-ms 1000 --timeout-ms 5000 >/dev/null 2>&1 || true; fi";
+                let _ = try { exec sh stop_cmd; } catch e { ""; };
+                return;
+            };
+        };
+    };
+
+
     // Read the target file once per tick. Stage 2 scans a single file
     // selected by `$TARGET_FILE` under `$TARGET_DIR` (set by run-stage2.sh).
     // The Stage 1 per-tribe class-shard rotation referenced in the prior

--- a/tribes-bench/tribe-gamma/scripts/start-colony.sh
+++ b/tribes-bench/tribe-gamma/scripts/start-colony.sh
@@ -199,6 +199,7 @@ agentis memo set "tribe-${TRIBE_NAME}:death_threshold" "$DEATH_THRESHOLD" >/dev/
 agentis memo set "tribe-${TRIBE_NAME}:pool_cap" "${POOL_CAP:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:metabolic_cost" "${METABOLIC_COST:-0}" >/dev/null 2>&1 || true
 agentis memo set "tribe-${TRIBE_NAME}:pool" "${INITIAL_POOL:-0}" >/dev/null 2>&1 || true
+agentis memo set "hunter:max_age" "${HUNTER_MAX_AGE:-0}" >/dev/null 2>&1 || true
 if [ -n "$BUG_LEDGER_PATH" ]; then
     agentis memo set "tribe-${TRIBE_NAME}:bug_ledger" "$BUG_LEDGER_PATH" >/dev/null 2>&1 || true
 fi


### PR DESCRIPTION
## Summary
- Add per-hunter age counter keyed on PPID (no shared-state race). Hunter suicides via \`agentis daemon stop\` when age > \`hunter:max_age\`.
- New env var \`STAGE3_HUNTER_MAX_AGE\` (default 0 = OFF). Tribe-wide cascade still applies as fallback.
- 5 × \`hunter.ag\` + 5 × \`start-colony.sh\` + 1 × \`run-stage3-docker.sh\`. 190 insertions.

## Why

Smokes #15-#21 exposed shared-state RMW race in the tribe-pool drain pattern: 5 hunters concurrent read-modify-write on \`tribe-X:pool\` lose updates. Cap drain at ~1 hunter/min regardless of population. Smoke #21 (post-v1.7.5 colony plumb) confirmed colony plumb landed (pool drained 22× faster) but reproduced the race shape — pool dropped 5000→1052 in 10min then tribe-wide cascade killed everyone in one wave.

## Why per-hunter, not atomic memo_decrement

Considered shipping a runtime \`memo_increment\` builtin in agentis-core, but rejected: a convenience primitive without authority/quorum model would silently break under Byzantine adversary (defense use case — single compromised agent drains shared counter undetected). Per-hunter age keeps the runtime contract clean (each hunter writes its OWN unique key, no concurrency primitive needed), preserves the defense positioning, and unblocks the colonies-side R&D goal.

## Implementation

\`hunter.ag\` (5 tribes, identical block inserted after existing metabolic block):
- Read \`hunter:max_age\` memo (default 0 = OFF, byte-identical to v1.7.5)
- Get \`\$PPID\` via \`exec sh\` (stable per daemon, unique across tribe-mates + replicas thanks to v1.7.5 colony plumb)
- Read+increment+write \`hunter:\$PPID:age\` (no race — only this hunter writes this key)
- If age > max_age: \`learn(\"self_death\")\` + lookup own agent_id from \`.pid\` registry + \`agentis daemon stop \$own_id --async\`

\`start-colony.sh\` (5 tribes): seed \`hunter:max_age\` from \`\$HUNTER_MAX_AGE\` env, default 0.

\`run-stage3-docker.sh\`: \`STAGE3_HUNTER_MAX_AGE\` env var + plumb into bootstrap printf as \`HUNTER_MAX_AGE=%s\`.

## Acceptance

- Default OFF (HUNTER_MAX_AGE unset) byte-identical to v1.7.5.
- Smoke #22 with \`HUNTER_MAX_AGE=20\` + \`INITIAL_POOL=20000\` (pool starvation pushed far out so per-hunter is the dominant mortality) demonstrates **both** ≥10 spawns AND ≥30% mortality in the same run, with replication continuing through hunter deaths (not the smoke #21 mass-extinction shape).

## Test plan
- [x] \`colony-lint.sh\` passes (168 passed, 0 failed)
- [ ] Stage3 docker smoke #22 with HUNTER_MAX_AGE=20 / INITIAL_POOL=20000

Refs: #485 (finite-pool), #487 (initial pool seed), Replikanti/agentis-core v1.7.5 (M106 colony plumb), #459 (Stage 4 R&D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)