### PR TITLE
feat(tribes-bench): B2 variant evolution — 7-variant pool + mutation + per-variant fitness telemetry

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,22 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **B2 variant evolution: 7-variant prompt pool with mutation + per-variant fitness telemetry**
+  (Stage 4 emergence work, follow-up to #490). `pick_variant()` in all 5
+  hunter.ag files now picks from a 7-variant pool (vs prior 3-variant
+  cyclic) with a 20% mutation rate that breaks cyclic ruts and exposes
+  fresh variants to selection pressure. The pseudo-random source is
+  `now_ms_via_shell() % 100` (same builtin already cached at top of
+  tick). Each tribe keeps its own domain-specific variant set
+  (format-pattern-* for alpha, source-sink-* for beta, etc., 7 each).
+  Hunters cache the active variant once per tick (`_variant`) and
+  increment per-variant counters on every verified finding
+  (`variant_stats:<variant>:verified`) and false positive
+  (`variant_stats:<variant>:falsepos`). The counters are
+  tribe-aggregated and provide selection-feedback observability over
+  the variant pool, so analyse-stage3 can produce per-variant fitness
+  curves once smoke #42 lands.
+
 - **Multi-LLM config injection in `run-stage2.sh`**
   ([#438](https://github.com/Replikanti/agentis-colonies/issues/438)).
   `agentis init` only seeds `llm.backend` in the hermetic per-run

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -61,14 +61,39 @@ fn target_file() -> string {
 
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
-    let idx = n - ((n / 3) * 3);
+    // B2 variation source: 7-variant pool with 20% mutation rate.
+    // Cyclic baseline (n mod 7) gives sibling diversity at spawn time.
+    // Mutation roll uses now_ms_via_shell() pseudo-random to pick a
+    // different variant ~20% of the time, breaking cyclic ruts and
+    // exposing new variants to selection pressure.
+    let cyclic_idx = n - ((n / 7) * 7);
+    let mut_now = now_ms_via_shell();
+    let mut_roll = mut_now - ((mut_now / 100) * 100);
+    let idx = if mut_roll < 20 {
+        let rand_idx = mut_now - ((mut_now / 7) * 7);
+        rand_idx;
+    } else {
+        cyclic_idx;
+    };
     if idx == 0 {
         return "format-pattern-default";
     };
     if idx == 1 {
         return "format-pattern-strict-literal";
     };
-    return "format-pattern-broad-shellbuilder";
+    if idx == 2 {
+        return "format-pattern-broad-shellbuilder";
+    };
+    if idx == 3 {
+        return "format-pattern-substitution-aware";
+    };
+    if idx == 4 {
+        return "format-pattern-quoting-edge";
+    };
+    if idx == 5 {
+        return "format-pattern-pipe-chain";
+    };
+    return "format-pattern-deferred-eval";
 }
 
 fn self_node_addr() -> string {
@@ -210,6 +235,10 @@ fn tick(reason: string) -> void {
     // self-id; computing it once here saves two extra `exec sh` forks
     // (~50 CB each) per tick.
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    // B2: cache current prompt variant once per tick. Used by
+    // variant_stats:* memos at verified-finding / false-positive sites
+    // for per-variant fitness telemetry.
+    let _variant = recall_latest("hunter:prompt_variant");
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
     // #485 finite-pool: per-tick metabolic cost drains the shared tribe
@@ -486,7 +515,7 @@ fn tick(reason: string) -> void {
     // memo; appending it as a Focus: suffix lets sibling replicas lean
     // into different interpretations of the same seed. Empty memo (Stage
     // 2 single-tribe / no replication) is a no-op.
-    let variant = recall_latest("hunter:prompt_variant");
+    let variant = _variant;
     let variant_prefix = if len(variant) > 0 {
         "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
     } else {
@@ -585,6 +614,15 @@ fn tick(reason: string) -> void {
                             memo_write("hunter:" + _self_pid + ":fitness", to_string(fit_pre_v + fit_reward));
                         };
                     };
+
+                    // B2: per-variant verified-finding counter. Tribe-aggregated
+                    // (each hunter writes under its own _variant tag), drives
+                    // selection feedback over variant pool.
+                    if len(_variant) > 0 {
+                        let vs_v = parse_int(recall_latest("variant_stats:" + _variant + ":verified"));
+                        memo_write("variant_stats:" + _variant + ":verified", to_string(vs_v + 1));
+                    };
+
 
                     // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
                     let pool_after = cur_pool + actual_reward;
@@ -720,6 +758,15 @@ fn tick(reason: string) -> void {
                             memo_write("hunter:" + _self_pid + ":fitness", to_string(fit_pre_f - fit_penalty));
                         };
                     };
+
+                    // B2: per-variant false-positive counter. Mirror of the
+                    // verified-finding stats; a variant with high falsepos and
+                    // low verified loses replicating parents over time.
+                    if len(_variant) > 0 {
+                        let vs_f = parse_int(recall_latest("variant_stats:" + _variant + ":falsepos"));
+                        memo_write("variant_stats:" + _variant + ":falsepos", to_string(vs_f + 1));
+                    };
+
 
                     // Stage 2 M2 (#393): reputation -0.10 (clamp 0.0) on
                     // false positive. Asymmetry vs verified-finding

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -62,14 +62,39 @@ fn target_file() -> string {
 
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
-    let idx = n - ((n / 3) * 3);
+    // B2 variation source: 7-variant pool with 20% mutation rate.
+    // Cyclic baseline (n mod 7) gives sibling diversity at spawn time.
+    // Mutation roll uses now_ms_via_shell() pseudo-random to pick a
+    // different variant ~20% of the time, breaking cyclic ruts and
+    // exposing new variants to selection pressure.
+    let cyclic_idx = n - ((n / 7) * 7);
+    let mut_now = now_ms_via_shell();
+    let mut_roll = mut_now - ((mut_now / 100) * 100);
+    let idx = if mut_roll < 20 {
+        let rand_idx = mut_now - ((mut_now / 7) * 7);
+        rand_idx;
+    } else {
+        cyclic_idx;
+    };
     if idx == 0 {
         return "source-sink-default";
     };
     if idx == 1 {
         return "source-sink-arg-only";
     };
-    return "source-sink-broad-flow";
+    if idx == 2 {
+        return "source-sink-broad-flow";
+    };
+    if idx == 3 {
+        return "source-sink-call-graph";
+    };
+    if idx == 4 {
+        return "source-sink-async-boundary";
+    };
+    if idx == 5 {
+        return "source-sink-trait-dispatch";
+    };
+    return "source-sink-iterator-chain";
 }
 
 fn self_node_addr() -> string {
@@ -211,6 +236,10 @@ fn tick(reason: string) -> void {
     // self-id; computing it once here saves two extra `exec sh` forks
     // (~50 CB each) per tick.
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    // B2: cache current prompt variant once per tick. Used by
+    // variant_stats:* memos at verified-finding / false-positive sites
+    // for per-variant fitness telemetry.
+    let _variant = recall_latest("hunter:prompt_variant");
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
     // #485 finite-pool: per-tick metabolic cost drains the shared tribe
@@ -486,7 +515,7 @@ fn tick(reason: string) -> void {
     // memo; appending it as a Focus: suffix lets sibling replicas lean
     // into different interpretations of the same seed. Empty memo (Stage
     // 2 single-tribe / no replication) is a no-op.
-    let variant = recall_latest("hunter:prompt_variant");
+    let variant = _variant;
     let variant_prefix = if len(variant) > 0 {
         "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
     } else {
@@ -585,6 +614,15 @@ fn tick(reason: string) -> void {
                             memo_write("hunter:" + _self_pid + ":fitness", to_string(fit_pre_v + fit_reward));
                         };
                     };
+
+                    // B2: per-variant verified-finding counter. Tribe-aggregated
+                    // (each hunter writes under its own _variant tag), drives
+                    // selection feedback over variant pool.
+                    if len(_variant) > 0 {
+                        let vs_v = parse_int(recall_latest("variant_stats:" + _variant + ":verified"));
+                        memo_write("variant_stats:" + _variant + ":verified", to_string(vs_v + 1));
+                    };
+
 
                     // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
                     let pool_after = cur_pool + actual_reward;
@@ -720,6 +758,15 @@ fn tick(reason: string) -> void {
                             memo_write("hunter:" + _self_pid + ":fitness", to_string(fit_pre_f - fit_penalty));
                         };
                     };
+
+                    // B2: per-variant false-positive counter. Mirror of the
+                    // verified-finding stats; a variant with high falsepos and
+                    // low verified loses replicating parents over time.
+                    if len(_variant) > 0 {
+                        let vs_f = parse_int(recall_latest("variant_stats:" + _variant + ":falsepos"));
+                        memo_write("variant_stats:" + _variant + ":falsepos", to_string(vs_f + 1));
+                    };
+
 
                     // Stage 2 M2 (#393): reputation -0.10 (clamp 0.0) on
                     // false positive. Asymmetry vs verified-finding

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -62,14 +62,39 @@ fn target_file() -> string {
 
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
-    let idx = n - ((n / 3) * 3);
+    // B2 variation source: 7-variant pool with 20% mutation rate.
+    // Cyclic baseline (n mod 7) gives sibling diversity at spawn time.
+    // Mutation roll uses now_ms_via_shell() pseudo-random to pick a
+    // different variant ~20% of the time, breaking cyclic ruts and
+    // exposing new variants to selection pressure.
+    let cyclic_idx = n - ((n / 7) * 7);
+    let mut_now = now_ms_via_shell();
+    let mut_roll = mut_now - ((mut_now / 100) * 100);
+    let idx = if mut_roll < 20 {
+        let rand_idx = mut_now - ((mut_now / 7) * 7);
+        rand_idx;
+    } else {
+        cyclic_idx;
+    };
     if idx == 0 {
         return "lifetime-default";
     };
     if idx == 1 {
         return "lifetime-strict-aliasing";
     };
-    return "lifetime-broad-borrow";
+    if idx == 2 {
+        return "lifetime-broad-borrow";
+    };
+    if idx == 3 {
+        return "lifetime-elision-corner";
+    };
+    if idx == 4 {
+        return "lifetime-static-promotion";
+    };
+    if idx == 5 {
+        return "lifetime-self-referential";
+    };
+    return "lifetime-trait-object-bounds";
 }
 
 fn self_node_addr() -> string {
@@ -211,6 +236,10 @@ fn tick(reason: string) -> void {
     // self-id; computing it once here saves two extra `exec sh` forks
     // (~50 CB each) per tick.
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    // B2: cache current prompt variant once per tick. Used by
+    // variant_stats:* memos at verified-finding / false-positive sites
+    // for per-variant fitness telemetry.
+    let _variant = recall_latest("hunter:prompt_variant");
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
     // #485 finite-pool: per-tick metabolic cost drains the shared tribe
@@ -486,7 +515,7 @@ fn tick(reason: string) -> void {
     // memo; appending it as a Focus: suffix lets sibling replicas lean
     // into different interpretations of the same seed. Empty memo (Stage
     // 2 single-tribe / no replication) is a no-op.
-    let variant = recall_latest("hunter:prompt_variant");
+    let variant = _variant;
     let variant_prefix = if len(variant) > 0 {
         "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
     } else {
@@ -585,6 +614,15 @@ fn tick(reason: string) -> void {
                             memo_write("hunter:" + _self_pid + ":fitness", to_string(fit_pre_v + fit_reward));
                         };
                     };
+
+                    // B2: per-variant verified-finding counter. Tribe-aggregated
+                    // (each hunter writes under its own _variant tag), drives
+                    // selection feedback over variant pool.
+                    if len(_variant) > 0 {
+                        let vs_v = parse_int(recall_latest("variant_stats:" + _variant + ":verified"));
+                        memo_write("variant_stats:" + _variant + ":verified", to_string(vs_v + 1));
+                    };
+
 
                     // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
                     let pool_after = cur_pool + actual_reward;
@@ -720,6 +758,15 @@ fn tick(reason: string) -> void {
                             memo_write("hunter:" + _self_pid + ":fitness", to_string(fit_pre_f - fit_penalty));
                         };
                     };
+
+                    // B2: per-variant false-positive counter. Mirror of the
+                    // verified-finding stats; a variant with high falsepos and
+                    // low verified loses replicating parents over time.
+                    if len(_variant) > 0 {
+                        let vs_f = parse_int(recall_latest("variant_stats:" + _variant + ":falsepos"));
+                        memo_write("variant_stats:" + _variant + ":falsepos", to_string(vs_f + 1));
+                    };
+
 
                     // Stage 2 M2 (#393): reputation -0.10 (clamp 0.0) on
                     // false positive. Asymmetry vs verified-finding

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -62,14 +62,39 @@ fn target_file() -> string {
 
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
-    let idx = n - ((n / 3) * 3);
+    // B2 variation source: 7-variant pool with 20% mutation rate.
+    // Cyclic baseline (n mod 7) gives sibling diversity at spawn time.
+    // Mutation roll uses now_ms_via_shell() pseudo-random to pick a
+    // different variant ~20% of the time, breaking cyclic ruts and
+    // exposing new variants to selection pressure.
+    let cyclic_idx = n - ((n / 7) * 7);
+    let mut_now = now_ms_via_shell();
+    let mut_roll = mut_now - ((mut_now / 100) * 100);
+    let idx = if mut_roll < 20 {
+        let rand_idx = mut_now - ((mut_now / 7) * 7);
+        rand_idx;
+    } else {
+        cyclic_idx;
+    };
     if idx == 0 {
         return "concurrency-default";
     };
     if idx == 1 {
         return "concurrency-shared-state";
     };
-    return "concurrency-lock-audit";
+    if idx == 2 {
+        return "concurrency-lock-audit";
+    };
+    if idx == 3 {
+        return "concurrency-channel-deadlock";
+    };
+    if idx == 4 {
+        return "concurrency-atomic-ordering";
+    };
+    if idx == 5 {
+        return "concurrency-cell-interior-mut";
+    };
+    return "concurrency-async-await-races";
 }
 
 fn self_node_addr() -> string {
@@ -211,6 +236,10 @@ fn tick(reason: string) -> void {
     // self-id; computing it once here saves two extra `exec sh` forks
     // (~50 CB each) per tick.
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    // B2: cache current prompt variant once per tick. Used by
+    // variant_stats:* memos at verified-finding / false-positive sites
+    // for per-variant fitness telemetry.
+    let _variant = recall_latest("hunter:prompt_variant");
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
     // #485 finite-pool: per-tick metabolic cost drains the shared tribe
@@ -487,7 +516,7 @@ fn tick(reason: string) -> void {
     // memo; appending it as a Focus: suffix lets sibling replicas lean
     // into different interpretations of the same seed. Empty memo (Stage
     // 2 single-tribe / no replication) is a no-op.
-    let variant = recall_latest("hunter:prompt_variant");
+    let variant = _variant;
     let variant_prefix = if len(variant) > 0 {
         "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
     } else {
@@ -586,6 +615,15 @@ fn tick(reason: string) -> void {
                             memo_write("hunter:" + _self_pid + ":fitness", to_string(fit_pre_v + fit_reward));
                         };
                     };
+
+                    // B2: per-variant verified-finding counter. Tribe-aggregated
+                    // (each hunter writes under its own _variant tag), drives
+                    // selection feedback over variant pool.
+                    if len(_variant) > 0 {
+                        let vs_v = parse_int(recall_latest("variant_stats:" + _variant + ":verified"));
+                        memo_write("variant_stats:" + _variant + ":verified", to_string(vs_v + 1));
+                    };
+
 
                     // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
                     let pool_after = cur_pool + actual_reward;
@@ -721,6 +759,15 @@ fn tick(reason: string) -> void {
                             memo_write("hunter:" + _self_pid + ":fitness", to_string(fit_pre_f - fit_penalty));
                         };
                     };
+
+                    // B2: per-variant false-positive counter. Mirror of the
+                    // verified-finding stats; a variant with high falsepos and
+                    // low verified loses replicating parents over time.
+                    if len(_variant) > 0 {
+                        let vs_f = parse_int(recall_latest("variant_stats:" + _variant + ":falsepos"));
+                        memo_write("variant_stats:" + _variant + ":falsepos", to_string(vs_f + 1));
+                    };
+
 
                     // Stage 2 M2 (#393): reputation -0.10 (clamp 0.0) on
                     // false positive. Asymmetry vs verified-finding

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -62,14 +62,39 @@ fn target_file() -> string {
 
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
-    let idx = n - ((n / 3) * 3);
+    // B2 variation source: 7-variant pool with 20% mutation rate.
+    // Cyclic baseline (n mod 7) gives sibling diversity at spawn time.
+    // Mutation roll uses now_ms_via_shell() pseudo-random to pick a
+    // different variant ~20% of the time, breaking cyclic ruts and
+    // exposing new variants to selection pressure.
+    let cyclic_idx = n - ((n / 7) * 7);
+    let mut_now = now_ms_via_shell();
+    let mut_roll = mut_now - ((mut_now / 100) * 100);
+    let idx = if mut_roll < 20 {
+        let rand_idx = mut_now - ((mut_now / 7) * 7);
+        rand_idx;
+    } else {
+        cyclic_idx;
+    };
     if idx == 0 {
         return "error-path-default";
     };
     if idx == 1 {
         return "error-path-unwrap-only";
     };
-    return "error-path-broad-fallible";
+    if idx == 2 {
+        return "error-path-broad-fallible";
+    };
+    if idx == 3 {
+        return "error-path-question-mark";
+    };
+    if idx == 4 {
+        return "error-path-panic-recovery";
+    };
+    if idx == 5 {
+        return "error-path-result-coercion";
+    };
+    return "error-path-error-conversion";
 }
 
 fn self_node_addr() -> string {
@@ -211,6 +236,10 @@ fn tick(reason: string) -> void {
     // self-id; computing it once here saves two extra `exec sh` forks
     // (~50 CB each) per tick.
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    // B2: cache current prompt variant once per tick. Used by
+    // variant_stats:* memos at verified-finding / false-positive sites
+    // for per-variant fitness telemetry.
+    let _variant = recall_latest("hunter:prompt_variant");
     let conf = get_confidence();
     print("[hunter] tick conf=", conf);
     // #485 finite-pool: per-tick metabolic cost drains the shared tribe
@@ -485,7 +514,7 @@ fn tick(reason: string) -> void {
     // memo; appending it as a Focus: suffix lets sibling replicas lean
     // into different interpretations of the same seed. Empty memo (Stage
     // 2 single-tribe / no replication) is a no-op.
-    let variant = recall_latest("hunter:prompt_variant");
+    let variant = _variant;
     let variant_prefix = if len(variant) > 0 {
         "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
     } else {
@@ -584,6 +613,15 @@ fn tick(reason: string) -> void {
                             memo_write("hunter:" + _self_pid + ":fitness", to_string(fit_pre_v + fit_reward));
                         };
                     };
+
+                    // B2: per-variant verified-finding counter. Tribe-aggregated
+                    // (each hunter writes under its own _variant tag), drives
+                    // selection feedback over variant pool.
+                    if len(_variant) > 0 {
+                        let vs_v = parse_int(recall_latest("variant_stats:" + _variant + ":verified"));
+                        memo_write("variant_stats:" + _variant + ":verified", to_string(vs_v + 1));
+                    };
+
 
                     // M2 replication: Malthusian-gated. C(n) = base * (1 + n/k).
                     let pool_after = cur_pool + actual_reward;
@@ -719,6 +757,15 @@ fn tick(reason: string) -> void {
                             memo_write("hunter:" + _self_pid + ":fitness", to_string(fit_pre_f - fit_penalty));
                         };
                     };
+
+                    // B2: per-variant false-positive counter. Mirror of the
+                    // verified-finding stats; a variant with high falsepos and
+                    // low verified loses replicating parents over time.
+                    if len(_variant) > 0 {
+                        let vs_f = parse_int(recall_latest("variant_stats:" + _variant + ":falsepos"));
+                        memo_write("variant_stats:" + _variant + ":falsepos", to_string(vs_f + 1));
+                    };
+
 
                     // Stage 2 M2 (#393): reputation -0.10 (clamp 0.0) on
                     // false positive. Asymmetry vs verified-finding


### PR DESCRIPTION
## Summary

Stage 4 emergence work — add variation source so fitness selection has something to select *for*.

- Each tribe's `pick_variant()` grows from 3 to 7 domain-specific variants (alpha: format-pattern-\*, beta: source-sink-\*, gamma: error-path-\*, delta: lifetime-\*, epsilon: concurrency-\*).
- 20% mutation rate inside `pick_variant()` breaks the cyclic rut and exposes fresh variants to selection pressure. Pseudo-random source is `now_ms_via_shell() % 100`.
- Hunters cache the active variant once per tick (`_variant`) and increment `variant_stats:<variant>:verified` / `variant_stats:<variant>:falsepos` on every verified finding / false positive.

## Smoke #42 results (30 min wall clock, same params as smoke #41)

**Apparatus works as designed.** `variant_stats` memos populated cleanly across all 5 tribes. Selection signal direction is correct.

| variant (sample) | tribe | verified | falsepos | verdict |
|---|---|---|---|---|
| `format-pattern-default` | alpha | 0 | 59 | **dead** |
| `lifetime-broad-borrow` | delta | 0 | 37 | **dead** |
| `concurrency-cell-interior-mut` (new B2) | epsilon | 2 | 3 | leader |
| `format-pattern-substitution-aware` (new B2) | alpha | 1 | 1 | leader |
| `lifetime-self-referential` (new B2) | delta | 1 | 0 | early-stage |
| `error-path-panic-recovery` (new B2) | gamma | 1 | 1 | early-stage |
| `source-sink-call-graph` (new B2) | beta | 1 | 4 | testing |
| `concurrency-channel-deadlock` (new B2) | epsilon | 1 | 4 | testing |

5 of 5 newly introduced variants from the expanded pool scored verified findings — mutation roll works, brought them into the gene pool.

**Sustained divergence not achieved in v1.** All 14 verified findings landed in the first 5:23 minutes. Remaining 25 minutes produced 0 new verified, just falsepos accumulation on the dead variants. Root cause: `hunter:prompt_variant` memo is tribe-shared and race-prone — fast-replicating early hunters running `format-pattern-default` flooded the memo before the live variants could propagate. Selection correctly identified the bad variants, the inheritance channel propagated them anyway.

## Follow-ups (not in this PR)

1. **B2 v2: per-instance variant inheritance via wire bump** (`HUNTER_INITIAL_VARIANT` env, like the fitness inheritance fix in agentis 1.7.7). Required for sustained variant evolution. Will file as agentis-core issue.
2. **Fix `analyse-stage3.py`** to read `variant_stats:*` memos and per-tribe variant pools. Current `comparison-stage3.md` "Top-3 surviving variants" table is unreliable for B2 — it uses a hardcoded 3-variant model and synthesizes mutation-diff.csv from agent IDs, not actual hunter state. Will file as colonies issue.

## Test plan

- [x] `colony-lint.sh` 168 passed / 0 failed / 3 skipped
- [x] CI (`colony-lint`) green
- [x] Smoke #42 ran clean to EXIT=0, variant_stats memos populated across all 5 tribes, 4+ distinct variants per tribe testing
- [x] 5 of 5 new B2 variants reached the active gene pool via mutation roll
- [x] Selection signal direction confirmed (2 dead variants identified at >30 falsepos, 0 verified each)
- [ ] Sustained divergence — deferred to B2 v2 with per-instance wire delivery

## Out of scope

- M98-style self-evolution: B1 deferred
- Per-PPID variant inheritance via wire bump: deferred to B2 v2
- analyse-stage3 per-variant chart: deferred to follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)