### PR TITLE
fix(tribes-bench): analyse-stage3 reads variant_stats memos + per-tribe pools (#495)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -14,6 +14,35 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`analyse-stage3.py` now reads the variant model observationally**
+  ([#495](https://github.com/Replikanti/agentis-colonies/issues/495)).
+  The previous build hardcoded a 3-element `VARIANT_CYCLE` and a
+  Python `pick_variant()` mirror that synthesised every agent's
+  `prompt_variant` and parent/child mutation kind. Post-#494 each
+  tribe owns a 7-variant pool with disjoint domain prefixes
+  (`format-pattern-*`, `source-sink-*`, `error-path-*`, `lifetime-*`,
+  `concurrency-*`), and hunters write per-variant `variant_stats:*`
+  memos but no longer emit per-row variant tags. The synthesised
+  output silently masked the smoke #42 truth that
+  `format-pattern-default` was a 0-verified / 59-falsepos dead
+  variant. The analyser now (a) parses each tribe's pool from
+  `tribe-<name>/agents/hunter.ag` via `parse_variant_pool()` and
+  fails loud on an empty pool, (b) aggregates `variant_stats:*` memos
+  per node via `agentis memo list --prefix variant_stats:`, (c)
+  replaces the synthetic "Top-3 surviving variants per tribe" table
+  with an observational "Variant outcomes per tribe" listing every
+  variant with `verified + falsepos > 0` ordered by `verified DESC,
+  falsepos ASC, name ASC` plus a per-tribe dead-variants subsection,
+  and (d) augments `mutation-diff.csv` with `source` (`observed` /
+  `unresolved`), `parent_variant_verified`, and
+  `parent_variant_falsepos` columns. New CLI flags: `--fed-root`
+  (default autodetect), `--no-variant-stats` (skip memo reads in
+  offline tests), `--legacy-top-variants` (emit the pre-#495 table
+  alongside for one release of diff-review continuity). The five
+  `hunter.ag` files are unchanged.
+
 ### Added
 
 - **B2 variant evolution: 7-variant prompt pool with mutation + per-variant fitness telemetry**

--- a/tribes-bench/tools/analyse-stage3.py
+++ b/tribes-bench/tools/analyse-stage3.py
@@ -20,9 +20,14 @@ operator-readable bundle:
                              its tps > root tps) per Stage 3 success
                              criterion in #439.
     mutation-diff.csv        One row per replicate event. Records the
-                             `parent_variant -> child_variant` pair plus
-                             a `mutation_kind` derived from the
-                             `pick_variant(tribe, n)` cycle in hunter.ag.
+                             observed `parent_variant -> child_variant`
+                             pair, a `mutation_kind` over the parsed
+                             per-tribe variant pool, a `source` flag
+                             (`observed` when the replicate row carried
+                             a `variant:` tag, `unresolved` otherwise),
+                             and the parent variant's aggregated
+                             `verified` / `falsepos` counts from the
+                             `variant_stats:*` memos.
     comparison-stage3.md     Operator-readable summary mirroring the
                              Stage 2 comparison.md shape but with the
                              6 sections from this PR's plan: run shape,
@@ -63,6 +68,7 @@ import argparse
 import csv
 import json
 import os
+import re
 import subprocess
 import sys
 from collections import defaultdict
@@ -100,32 +106,215 @@ TELEMETRY_COLUMNS = [
     "replication_event_count", "tribe_death_ts",
 ]
 
-# pick_variant() in hunter.ag rotates over a 3-element cycle keyed by
-# the tribe's current size. We re-implement it in Python so the
-# analyser can compute parent/child variant-deltas without depending on
-# the .ag scenario being available at analysis time.
-VARIANT_CYCLE = (
-    "format-pattern-default",
-    "format-pattern-strict-literal",
-    "format-pattern-broad-shellbuilder",
-)
+# Per-tribe variant pools are parsed from each tribe's hunter.ag at
+# analysis time. The analyser is observational only -- it does NOT
+# re-implement pick_variant(). Variant attribution to agents comes
+# from `variant:<name>` tags written by hunter.ag on each replicate
+# row, plus per-tribe `variant_stats:<variant>:{verified,falsepos}`
+# memos that hunters increment on findings/false-positives.
+#
+# Any future hunter.ag refactor that returns variants via concatenation
+# or a lookup table (i.e. not bare `return "<literal>";` lines inside
+# `fn pick_variant`) MUST add a sibling `pick_variant_pool() ->
+# list<string>` helper or a `tribe-<name>/agents/variant-pool.txt`
+# metadata file so this analyser can keep enumerating the pool.
+
+_VARIANT_POOL_CACHE: dict[str, list[str]] = {}
 
 
-def pick_variant(tribe: str, n: int) -> str:
-    """Mirror of hunter.ag::pick_variant. `tribe` is unused (the .ag
-    helper takes the tribe name purely for symmetry with future
-    per-tribe overrides). `n` is the tribe's size at replicate time."""
-    _ = tribe
-    return VARIANT_CYCLE[n % 3]
+def parse_variant_pool(hunter_ag_path: str) -> list[str]:
+    """Regex-scan the body of `fn pick_variant(...) { ... }` in a
+    tribe's hunter.ag and return the list of bare-literal `return
+    "<value>";` strings in source order.
+
+    Raises ValueError when the function body has zero return literals
+    -- a silent empty pool would re-introduce the stale-variant model
+    bug that #495 fixes. Caches results by absolute path.
+    """
+    abs_path = os.path.abspath(hunter_ag_path)
+    cached = _VARIANT_POOL_CACHE.get(abs_path)
+    if cached is not None:
+        return list(cached)
+    try:
+        with open(abs_path, encoding="utf-8") as f:
+            src = f.read()
+    except OSError as exc:
+        raise ValueError(f"parse_variant_pool: cannot read {abs_path}: {exc}") from exc
+    # Locate the start of `fn pick_variant(...)` and scan the matching
+    # body. The grammar is brace-delimited, so we count `{` / `}`
+    # characters until the function body closes. This survives nested
+    # `if { ... }` blocks inside pick_variant (which every tribe has).
+    fn_match = re.search(r"\bfn\s+pick_variant\b[^{]*\{", src)
+    if fn_match is None:
+        raise ValueError(
+            f"parse_variant_pool: no `fn pick_variant` in {abs_path}"
+        )
+    body_start = fn_match.end()
+    depth = 1
+    i = body_start
+    while i < len(src) and depth > 0:
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        i += 1
+    body = src[body_start:i - 1]
+    literals = re.findall(r'return\s+"([^"\\]*)"\s*;', body)
+    if not literals:
+        raise ValueError(
+            f"parse_variant_pool: zero return literals in `fn pick_variant` "
+            f"of {abs_path}; refactor must add a pick_variant_pool() helper "
+            f"or variant-pool.txt metadata file"
+        )
+    _VARIANT_POOL_CACHE[abs_path] = list(literals)
+    return list(literals)
 
 
-def parse_args(argv: list[str]) -> tuple[str, str, str, str]:
-    """Parse argv into (run_dir, laptop_dir, server_runs_dir, out_dir).
+def discover_tribe_pools(fed_root: str) -> dict[str, list[str]]:
+    """Walk `<fed_root>/tribe-*/agents/hunter.ag` and return a dict
+    `{tribe_name: [variant, ...]}`. Asserts the union of pools is
+    duplicate-free (every tribe uses a disjoint domain prefix).
+    """
+    pools: dict[str, list[str]] = {}
+    if not os.path.isdir(fed_root):
+        return pools
+    for name in sorted(os.listdir(fed_root)):
+        if not name.startswith("tribe-"):
+            continue
+        hunter = os.path.join(fed_root, name, "agents", "hunter.ag")
+        if not os.path.isfile(hunter):
+            continue
+        pools[name] = parse_variant_pool(hunter)
+    seen: dict[str, str] = {}
+    for tribe, variants in pools.items():
+        for v in variants:
+            if v in seen and seen[v] != tribe:
+                raise ValueError(
+                    f"discover_tribe_pools: variant {v!r} appears in both "
+                    f"{seen[v]} and {tribe}; pools must be disjoint"
+                )
+            seen[v] = tribe
+    return pools
+
+
+def _resolve_fed_root(fed_root_arg: str | None, run_dir: str) -> str:
+    """Resolve the federation root used for variant-pool discovery.
+
+    Order: explicit --fed-root > $AGENTIS_FED_ROOT > autodetect via
+    run_dir/../.. (the tribes-bench/runs/<ts> shape produced by
+    run-stage3-docker.sh).
+    """
+    if fed_root_arg:
+        return os.path.abspath(fed_root_arg)
+    env = os.environ.get("AGENTIS_FED_ROOT")
+    if env:
+        return os.path.abspath(env)
+    # Autodetect: tribes-bench/runs/<ts>/  ->  tribes-bench/
+    candidate = os.path.abspath(os.path.join(run_dir, "..", ".."))
+    return candidate
+
+
+def read_variant_stats(node_dir: str) -> dict[str, dict[str, int]]:
+    """Invoke `agentis memo list --prefix variant_stats:` from
+    `node_dir` (so the hermetic .agentis/ tree is the runtime's cwd)
+    and parse the `variant_stats:<variant>:{verified,falsepos} = <n>`
+    pairs into `{variant: {"verified": int, "falsepos": int}}`.
+
+    Decoupled from the runtime's storage backend by going through the
+    CLI rather than reading sled directly. Missing binary, non-zero
+    exit, or empty output -> `{}` with a stderr warning. Never raises.
+    """
+    out: dict[str, dict[str, int]] = {}
+    try:
+        proc = subprocess.run(
+            ["agentis", "memo", "list", "--prefix", "variant_stats:"],
+            cwd=node_dir,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print(
+            "analyse-stage3: warning: `agentis` binary not on PATH; "
+            "variant_stats memos skipped",
+            file=sys.stderr,
+        )
+        return {}
+    except OSError as exc:
+        print(
+            f"analyse-stage3: warning: cannot invoke agentis memo list "
+            f"in {node_dir}: {exc}",
+            file=sys.stderr,
+        )
+        return {}
+    if proc.returncode != 0:
+        return out
+    for raw_line in (proc.stdout or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        # Expected shape: `variant_stats:<variant>:<metric> = <int>`
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not key.startswith("variant_stats:"):
+            continue
+        rest = key[len("variant_stats:"):]
+        if ":" not in rest:
+            continue
+        variant, _, metric = rest.rpartition(":")
+        if metric not in ("verified", "falsepos"):
+            continue
+        try:
+            n = int(value)
+        except ValueError:
+            continue
+        out.setdefault(variant, {"verified": 0, "falsepos": 0})[metric] = n
+    return out
+
+
+def aggregate_variant_stats(
+    node_dirs: list[str],
+    tribe_pools: dict[str, list[str]],
+) -> dict[str, dict[str, dict[str, int]]]:
+    """Reverse-lookup variant -> tribe via tribe_pools, then aggregate
+    `read_variant_stats()` from every node into `{tribe: {variant:
+    {"verified": N, "falsepos": N}}}`.
+    """
+    variant_to_tribe: dict[str, str] = {}
+    for tribe, variants in tribe_pools.items():
+        for v in variants:
+            variant_to_tribe[v] = tribe
+    aggregated: dict[str, dict[str, dict[str, int]]] = {
+        tribe: {v: {"verified": 0, "falsepos": 0} for v in variants}
+        for tribe, variants in tribe_pools.items()
+    }
+    for node_dir in node_dirs:
+        per_node = read_variant_stats(node_dir)
+        for variant, counts in per_node.items():
+            tribe = variant_to_tribe.get(variant)
+            if tribe is None:
+                continue
+            slot = aggregated.setdefault(tribe, {}).setdefault(
+                variant, {"verified": 0, "falsepos": 0}
+            )
+            slot["verified"] += int(counts.get("verified", 0))
+            slot["falsepos"] += int(counts.get("falsepos", 0))
+    return aggregated
+
+
+def parse_args(argv: list[str]) -> tuple[str, str, str, str, str | None, bool, bool]:
+    """Parse argv into (run_dir, laptop_dir, server_runs_dir, out_dir,
+    fed_root, no_variant_stats, legacy_top_variants).
 
     Defaults:
         --laptop-dir   <run-dir>                 (SSH multinode shape)
         --server-runs  <run-dir>/server-runs/    (SSH multinode shape)
         --out          <run-dir>/
+        --fed-root     autodetect via run_dir/../.. (or $AGENTIS_FED_ROOT)
 
     Docker (#478) shape: pass --laptop-dir <run-dir>/laptop-node and
     --server-runs <run-dir>/server-node. discover_server_node_dirs
@@ -158,6 +347,24 @@ def parse_args(argv: list[str]) -> tuple[str, str, str, str]:
         default=None,
         help="output dir for stitched artefacts (default: <run-dir>)",
     )
+    p.add_argument(
+        "--fed-root",
+        default=None,
+        help="federation root (tribes-bench/) for variant-pool discovery; "
+             "default autodetect via run_dir/../.. or $AGENTIS_FED_ROOT",
+    )
+    p.add_argument(
+        "--no-variant-stats",
+        action="store_true",
+        help="skip `agentis memo list` reads (for tests / hosts without "
+             "the agentis binary on PATH)",
+    )
+    p.add_argument(
+        "--legacy-top-variants",
+        action="store_true",
+        help="emit the pre-#495 synthetic Top-3 surviving variants table "
+             "alongside the observational Variant outcomes table",
+    )
     try:
         ns = p.parse_args(argv[1:])
     except SystemExit as e:
@@ -188,7 +395,10 @@ def parse_args(argv: list[str]) -> tuple[str, str, str, str]:
         except OSError as exc:
             print(f"analyse-stage3: cannot create out dir {out_dir}: {exc}", file=sys.stderr)
             sys.exit(2)
-    return run_dir, laptop_dir, server_runs, out_dir
+    return (
+        run_dir, laptop_dir, server_runs, out_dir,
+        ns.fed_root, bool(ns.no_variant_stats), bool(ns.legacy_top_variants),
+    )
 
 
 # --- Per-node telemetry -----------------------------------------------------
@@ -365,22 +575,67 @@ def _replicate_events(experience_dir: str, agent_id: str) -> list[dict[str, Any]
     return out
 
 
-def _variant_from_tags(tags: list[Any]) -> str:
+def _variant_from_tags(
+    tags: list[Any],
+    known_variants: set[str] | None = None,
+) -> str:
     """Extract a prompt_variant value from a learn() tag list. Tries
-    `variant:<name>` and bare-name match against VARIANT_CYCLE so the
-    analyser stays compatible with both the legacy hunter.ag (no
-    variant tag) and the post-#447 form that includes it."""
+    `variant:<name>` first; falls back to a bare-name match against
+    `known_variants` (the union of every tribe's parsed pool) when the
+    legacy untagged hunter.ag form is in play."""
     for t in tags:
         if not isinstance(t, str):
             continue
         if t.startswith("variant:"):
             return t.split(":", 1)[1]
-        if t in VARIANT_CYCLE:
+        if known_variants is not None and t in known_variants:
             return t
     return ""
 
 
-def collect_node_agents(node_root: str, node_label: str) -> dict[str, dict[str, Any]]:
+def _agent_observed_variant(
+    experience_dir: str,
+    agent_id: str,
+    known_variants: set[str] | None = None,
+) -> str:
+    """Earliest variant claim seen on any learn row authored by the
+    agent. Recognises `variant:<name>` tags first, then -- when
+    `known_variants` is supplied -- bare-name tags matching the union
+    of every tribe's parsed pool. Empty string when no claim is found.
+    Observational fallback used by collect_node_agents() to seed each
+    agent's prompt_variant before lineage linking runs.
+    """
+    path = os.path.join(experience_dir, f"{agent_id}.jsonl")
+    earliest_ts: int | None = None
+    earliest_variant = ""
+    for rec in read_jsonl(path):
+        tags = rec.get("tags") or []
+        if not isinstance(tags, list):
+            continue
+        ts = rec.get("ts")
+        if not isinstance(ts, int):
+            continue
+        for t in tags:
+            if not isinstance(t, str):
+                continue
+            claim = ""
+            if t.startswith("variant:"):
+                claim = t.split(":", 1)[1]
+            elif known_variants is not None and t in known_variants:
+                claim = t
+            if claim:
+                if earliest_ts is None or ts < earliest_ts:
+                    earliest_ts = ts
+                    earliest_variant = claim
+                break
+    return earliest_variant
+
+
+def collect_node_agents(
+    node_root: str,
+    node_label: str,
+    known_variants: set[str] | None = None,
+) -> dict[str, dict[str, Any]]:
     """Build a per-agent dict keyed by agent_id, populated with
     (tribe, node, born_ts, died_ts, tps, fps, replicate_events). The
     parent_id and prompt_variant fields are filled in by
@@ -397,6 +652,9 @@ def collect_node_agents(node_root: str, node_label: str) -> dict[str, dict[str, 
         died = _agent_death_ts(experience_dir, agent_id)
         tps, fps = _agent_tps_fps(experience_dir, agent_id)
         rep_events = _replicate_events(experience_dir, agent_id)
+        observed_variant = _agent_observed_variant(
+            experience_dir, agent_id, known_variants
+        )
         out[agent_id] = {
             "agent_id": agent_id,
             "tribe": tribe,
@@ -406,6 +664,7 @@ def collect_node_agents(node_root: str, node_label: str) -> dict[str, dict[str, 
             "tps_total": tps,
             "fps_total": fps,
             "_replicate_events": rep_events,
+            "_observed_variant": observed_variant,
         }
     # Ensure every JSONL author appears in the inventory even when the
     # daemon snapshot lost their .colony entry (the post-kill cleanup
@@ -432,6 +691,9 @@ def collect_node_agents(node_root: str, node_label: str) -> dict[str, dict[str, 
             died = _agent_death_ts(experience_dir, agent_id)
             tps, fps = _agent_tps_fps(experience_dir, agent_id)
             rep_events = _replicate_events(experience_dir, agent_id)
+            observed_variant = _agent_observed_variant(
+            experience_dir, agent_id, known_variants
+        )
             out[agent_id] = {
                 "agent_id": agent_id,
                 "tribe": tribe,
@@ -441,11 +703,15 @@ def collect_node_agents(node_root: str, node_label: str) -> dict[str, dict[str, 
                 "tps_total": tps,
                 "fps_total": fps,
                 "_replicate_events": rep_events,
+                "_observed_variant": observed_variant,
             }
     return out
 
 
-def _link_parents(agents: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+def _link_parents(
+    agents: dict[str, dict[str, Any]],
+    known_variants: set[str] | None = None,
+) -> list[dict[str, Any]]:
     """Walk every agent's per-tribe replicate event list and link each
     Nth replicate event (for tribe T) to the (N+1)th-born agent in
     that tribe. The first agent in each tribe (lowest born_ts) is the
@@ -460,11 +726,15 @@ def _link_parents(agents: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
         if a["tribe"]:
             by_tribe[a["tribe"]].append(a)
     for tribe, lst in by_tribe.items():
+        _ = tribe  # symmetry with prior signature; tribe unused below
         lst.sort(key=lambda x: (x["born_ts"], x["agent_id"]))
-        # Root: first agent.
+        # Root: first agent. The prompt_variant is observational --
+        # taken from the earliest `variant:<name>` tag the agent
+        # actually emitted (collect_node_agents:_observed_variant).
+        # Empty when the agent never tagged a variant.
         for idx, a in enumerate(lst):
             a["_birth_index"] = idx
-            a["prompt_variant"] = pick_variant(tribe, idx)
+            a["prompt_variant"] = a.get("_observed_variant", "") or ""
             if idx == 0:
                 a["parent_id"] = None
             else:
@@ -489,11 +759,14 @@ def _link_parents(agents: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
         if not tribe:
             continue
         children = pending_children.get(tribe, [])
+        tags = rec.get("tags") or []
+        tag_variant = (
+            _variant_from_tags(tags, known_variants)
+            if isinstance(tags, list) else ""
+        )
         if not children:
             # No more un-parented children -- record the event with an
             # unresolved child for mutation-diff anyway.
-            tags = rec.get("tags") or []
-            tag_variant = _variant_from_tags(tags) if isinstance(tags, list) else ""
             events_out.append({
                 "ts": ts,
                 "parent_id": parent["agent_id"],
@@ -501,16 +774,14 @@ def _link_parents(agents: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
                 "tribe": tribe,
                 "parent_variant": parent.get("prompt_variant", ""),
                 "child_variant": tag_variant,
+                "source": "unresolved",
             })
             continue
         child = children.pop(0)
         child["parent_id"] = parent["agent_id"]
-        # Prefer the variant tagged on the replicate row when present
-        # (post-#447 hunter.ag). Fall back to the deterministic
-        # pick_variant() rotation when the legacy hunter.ag emitted no
-        # variant tag.
-        tags = rec.get("tags") or []
-        tag_variant = _variant_from_tags(tags) if isinstance(tags, list) else ""
+        # The on-row `variant:` tag is the legitimate observational
+        # source of the child variant; absence stays empty (no
+        # synthesised cycle fallback after #495).
         if tag_variant:
             child["prompt_variant"] = tag_variant
         events_out.append({
@@ -520,13 +791,15 @@ def _link_parents(agents: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
             "tribe": tribe,
             "parent_variant": parent.get("prompt_variant", ""),
             "child_variant": child.get("prompt_variant", ""),
+            "source": "observed" if tag_variant else "unresolved",
         })
     return events_out
 
 
-def build_lineage(agents: dict[str, dict[str, Any]]) -> tuple[
-    list[dict[str, Any]], list[dict[str, Any]]
-]:
+def build_lineage(
+    agents: dict[str, dict[str, Any]],
+    known_variants: set[str] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Return (lineage_roots, replicate_events).
 
     `lineage_roots` is a list of dicts in the schema documented in the
@@ -534,7 +807,7 @@ def build_lineage(agents: dict[str, dict[str, Any]]) -> tuple[
     `replicate_events` is the parent->child event list used by
     mutation-diff.csv.
     """
-    events = _link_parents(agents)
+    events = _link_parents(agents, known_variants)
     children_of: dict[str, list[str]] = defaultdict(list)
     for a in agents.values():
         if a.get("parent_id"):
@@ -628,39 +901,80 @@ def write_survivor_analysis(out_dir: str, roots: list[dict[str, Any]]) -> str:
 
 # --- Mutation diff ----------------------------------------------------------
 
-def _mutation_kind(parent_variant: str, child_variant: str) -> str:
+def _mutation_kind(
+    parent_variant: str,
+    child_variant: str,
+    tribe: str = "",
+    tribe_pools: dict[str, list[str]] | None = None,
+) -> str:
+    """Classify the parent->child variant transition. Empty parent or
+    child stays `""` (unresolved). Same-name -> `same`. When a tribe
+    pool is available and both ends are known members, the cycle delta
+    is `cycle-N` over that pool; otherwise the relation is `other`.
+    """
     if not parent_variant or not child_variant:
         return ""
     if parent_variant == child_variant:
         return "same"
-    try:
-        pi = VARIANT_CYCLE.index(parent_variant)
-        ci = VARIANT_CYCLE.index(child_variant)
-    except ValueError:
-        return "other"
-    delta = (ci - pi) % len(VARIANT_CYCLE)
-    if delta == 0:
-        return "same"
-    return f"cycle-{delta}"
+    if tribe_pools and tribe and tribe in tribe_pools:
+        pool = tribe_pools[tribe]
+        try:
+            pi = pool.index(parent_variant)
+            ci = pool.index(child_variant)
+        except ValueError:
+            return "other"
+        delta = (ci - pi) % len(pool)
+        if delta == 0:
+            return "same"
+        return f"cycle-{delta}"
+    return "other"
 
 
-def write_mutation_diff(out_dir: str, events: list[dict[str, Any]]) -> str:
+def write_mutation_diff(
+    out_dir: str,
+    events: list[dict[str, Any]],
+    tribe_pools: dict[str, list[str]] | None = None,
+    aggregated_stats: dict[str, dict[str, dict[str, int]]] | None = None,
+) -> str:
+    """Emit `mutation-diff.csv` augmented with the observational
+    columns `source` (`observed` when the replicate row carried a
+    `variant:` tag, `unresolved` otherwise) and the parent variant's
+    aggregated `verified` / `falsepos` counts pulled from the
+    `variant_stats:*` memos. Empty parent_variant rows leave the two
+    stat columns blank.
+    """
     out_path = os.path.join(out_dir, "mutation-diff.csv")
     with open(out_path, "w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
         w.writerow([
             "ts", "parent_id", "child_id", "tribe",
             "parent_variant", "child_variant", "mutation_kind",
+            "source", "parent_variant_verified", "parent_variant_falsepos",
         ])
         for ev in sorted(events, key=lambda e: int(e.get("ts") or 0)):
+            tribe = ev.get("tribe", "")
+            parent_variant = ev.get("parent_variant", "")
+            verified_cell: str = ""
+            falsepos_cell: str = ""
+            if aggregated_stats and tribe and parent_variant:
+                stats = aggregated_stats.get(tribe, {}).get(parent_variant)
+                if stats is not None:
+                    verified_cell = str(stats.get("verified", 0))
+                    falsepos_cell = str(stats.get("falsepos", 0))
             w.writerow([
                 ev.get("ts", 0),
                 ev.get("parent_id", ""),
                 ev.get("child_id", ""),
-                ev.get("tribe", ""),
-                ev.get("parent_variant", ""),
+                tribe,
+                parent_variant,
                 ev.get("child_variant", ""),
-                _mutation_kind(ev.get("parent_variant", ""), ev.get("child_variant", "")),
+                _mutation_kind(
+                    parent_variant, ev.get("child_variant", ""),
+                    tribe=tribe, tribe_pools=tribe_pools,
+                ),
+                ev.get("source", ""),
+                verified_cell,
+                falsepos_cell,
             ])
     return out_path
 
@@ -731,6 +1045,9 @@ def write_comparison_md(
     events: list[dict[str, Any]],
     market_rows: list[dict[str, Any]],
     server_node_count: int,
+    tribe_pools: dict[str, list[str]] | None = None,
+    aggregated_stats: dict[str, dict[str, dict[str, int]]] | None = None,
+    legacy_top_variants: bool = False,
 ) -> str:
     out_path = os.path.join(out_dir, "comparison-stage3.md")
     meta = _read_run_meta(run_dir)
@@ -770,7 +1087,10 @@ def write_comparison_md(
     # Mutation outcomes.
     mut_counts: dict[str, int] = defaultdict(int)
     for ev in events:
-        mut_counts[_mutation_kind(ev.get("parent_variant", ""), ev.get("child_variant", ""))] += 1
+        mut_counts[_mutation_kind(
+            ev.get("parent_variant", ""), ev.get("child_variant", ""),
+            tribe=ev.get("tribe", ""), tribe_pools=tribe_pools,
+        )] += 1
     n_unauthored = 0
     for root in roots:
         descendants = _collect_descendants(root)
@@ -906,8 +1226,66 @@ def write_comparison_md(
     lines.append("")
     lines.append(f"unauthored-specialist lineages: {n_unauthored}")
     lines.append("")
-    if top_variants_per_tribe:
-        lines.append("Top-3 surviving variants per tribe (ranked by aggregate TPs):")
+    # #495: Variant outcomes per tribe -- observational, sourced from
+    # `variant_stats:<variant>:{verified,falsepos}` memos that hunters
+    # increment on every finding. Replaces the synthetic Top-3 surviving
+    # variants table that was driven by a hardcoded 3-element cycle.
+    if aggregated_stats:
+        any_active = any(
+            (counts.get("verified", 0) + counts.get("falsepos", 0)) > 0
+            for variants in aggregated_stats.values()
+            for counts in variants.values()
+        )
+        if any_active:
+            lines.append("Variant outcomes per tribe "
+                         "(observational, from variant_stats memos):")
+            lines.append("")
+            lines.append("| tribe | variant | verified | falsepos | hit_rate |")
+            lines.append("|---|---|---|---|---|")
+            for tribe in sorted(aggregated_stats.keys()):
+                ordered = sorted(
+                    aggregated_stats[tribe].items(),
+                    key=lambda kv: (
+                        -int(kv[1].get("verified", 0)),
+                        int(kv[1].get("falsepos", 0)),
+                        kv[0],
+                    ),
+                )
+                for variant, counts in ordered:
+                    v_n = int(counts.get("verified", 0))
+                    fp_n = int(counts.get("falsepos", 0))
+                    if v_n + fp_n == 0:
+                        continue
+                    hit_rate = (v_n / (v_n + fp_n)) if (v_n + fp_n) > 0 else 0.0
+                    lines.append(
+                        f"| {tribe} | {variant} | {v_n} | {fp_n} | "
+                        f"{hit_rate:.2f} |"
+                    )
+            lines.append("")
+            # Dead variants: pool members with verified=0 AND falsepos>=1.
+            dead_lines: list[str] = []
+            for tribe in sorted(aggregated_stats.keys()):
+                dead = [
+                    (variant, int(counts.get("falsepos", 0)))
+                    for variant, counts in aggregated_stats[tribe].items()
+                    if int(counts.get("verified", 0)) == 0
+                    and int(counts.get("falsepos", 0)) >= 1
+                ]
+                dead.sort(key=lambda kv: (-kv[1], kv[0]))
+                for variant, fp_n in dead:
+                    dead_lines.append(f"| {tribe} | {variant} | {fp_n} |")
+            if dead_lines:
+                lines.append("Dead variants per tribe (0 verified, >=1 falsepos):")
+                lines.append("")
+                lines.append("| tribe | variant | falsepos |")
+                lines.append("|---|---|---|")
+                lines.extend(dead_lines)
+                lines.append("")
+    if legacy_top_variants and top_variants_per_tribe:
+        lines.append(
+            "Top-3 surviving variants per tribe (legacy synthetic; "
+            "kept behind --legacy-top-variants for diff-review continuity):"
+        )
         lines.append("")
         lines.append("| tribe | rank | variant | tps |")
         lines.append("|---|---|---|---|")
@@ -942,7 +1320,10 @@ def write_comparison_md(
 # --- Main -------------------------------------------------------------------
 
 def main() -> None:
-    run_dir, laptop_dir, server_runs, out_dir = parse_args(sys.argv)
+    (
+        run_dir, laptop_dir, server_runs, out_dir,
+        fed_root_arg, no_variant_stats, legacy_top_variants,
+    ) = parse_args(sys.argv)
 
     server_node_dirs = discover_server_node_dirs(server_runs)
     if not server_node_dirs:
@@ -959,6 +1340,21 @@ def main() -> None:
                 file=sys.stderr,
             )
 
+    # Discover per-tribe variant pools from hunter.ag sources. A
+    # missing fed root is non-fatal -- variants that show up only via
+    # `variant:` tags on replicate rows will still resolve, and the
+    # mutation_kind column will fall back to "other".
+    fed_root = _resolve_fed_root(fed_root_arg, run_dir)
+    tribe_pools: dict[str, list[str]] = {}
+    try:
+        tribe_pools = discover_tribe_pools(fed_root)
+    except ValueError as exc:
+        print(
+            f"analyse-stage3: warning: variant-pool discovery failed: {exc}",
+            file=sys.stderr,
+        )
+    known_variants: set[str] = {v for vs in tribe_pools.values() for v in vs}
+
     laptop_rows = run_stage2_analyser(laptop_dir)
     server_rows_by_node: list[list[list[str]]] = []
     for node_dir in server_node_dirs:
@@ -968,10 +1364,12 @@ def main() -> None:
     print(combined_path)
 
     # Per-node agent inventory.
-    laptop_agents = collect_node_agents(laptop_dir, "laptop")
+    laptop_agents = collect_node_agents(laptop_dir, "laptop", known_variants)
     server_agents: dict[str, dict[str, Any]] = {}
     for node_dir in server_node_dirs:
-        server_agents.update(collect_node_agents(node_dir, "server"))
+        server_agents.update(
+            collect_node_agents(node_dir, "server", known_variants)
+        )
 
     # Collision-safe merge: laptop wins on duplicate agent_id (should
     # never happen in practice -- the daemon registry uses 16-byte hex
@@ -980,14 +1378,34 @@ def main() -> None:
     all_agents.update(server_agents)
     all_agents.update(laptop_agents)
 
-    roots, events = build_lineage(all_agents)
+    roots, events = build_lineage(all_agents, known_variants)
     lineage_path = write_lineage_json(out_dir, roots)
     print(lineage_path)
 
     survivor_path = write_survivor_analysis(out_dir, roots)
     print(survivor_path)
 
-    mutation_path = write_mutation_diff(out_dir, events)
+    # Aggregate `variant_stats:*` memos across every node (laptop +
+    # each server node). When --no-variant-stats was passed (or the
+    # binary is missing), aggregated_stats stays a skeleton keyed by
+    # tribe pool with all counters 0; the comparison md skips its
+    # outcomes table when nothing has fired.
+    aggregated_stats: dict[str, dict[str, dict[str, int]]]
+    if no_variant_stats:
+        aggregated_stats = {
+            tribe: {v: {"verified": 0, "falsepos": 0} for v in variants}
+            for tribe, variants in tribe_pools.items()
+        }
+    else:
+        aggregated_stats = aggregate_variant_stats(
+            [laptop_dir, *server_node_dirs], tribe_pools,
+        )
+
+    mutation_path = write_mutation_diff(
+        out_dir, events,
+        tribe_pools=tribe_pools,
+        aggregated_stats=aggregated_stats,
+    )
     print(mutation_path)
 
     rotations = _read_rotations(run_dir)
@@ -1009,6 +1427,9 @@ def main() -> None:
         events=events,
         market_rows=market_rows,
         server_node_count=len(server_node_dirs),
+        tribe_pools=tribe_pools,
+        aggregated_stats=aggregated_stats,
+        legacy_top_variants=legacy_top_variants,
     )
     print(comparison_path)
 

--- a/tribes-bench/tools/test-analyse-stage3.py
+++ b/tribes-bench/tools/test-analyse-stage3.py
@@ -38,6 +38,28 @@ import tempfile
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 ANALYSER = os.path.join(SCRIPT_DIR, "analyse-stage3.py")
+# `tribes-bench/` (the fed root) -- one level up from `tools/`. Tests
+# pass it via --fed-root so per-tribe variant pools resolve regardless
+# of where the temporary run dir lives. --no-variant-stats avoids any
+# `agentis memo list` invocation in the offline test harness.
+FED_ROOT = os.path.dirname(SCRIPT_DIR)
+
+
+def _import_analyser():
+    """Import analyse-stage3.py as a module so the new #495 helpers
+    (parse_variant_pool, discover_tribe_pools, read_variant_stats) can
+    be unit-tested in-process. The hyphenated filename forces the
+    importlib spec dance; we rely on this everywhere a test exercises
+    a function rather than the CLI."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "analyse_stage3", ANALYSER,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("test-analyse-stage3: cannot import analyser module")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
 
 PASS = 0
 FAIL = 0
@@ -211,8 +233,17 @@ def add_child_agent(
     write_jsonl(os.path.join(exp, f"{agent_id}.jsonl"), rows)
 
 
-def run_analyser(run_dir: str, extra_args: list[str] | None = None) -> tuple[int, str, str]:
+def run_analyser(
+    run_dir: str,
+    extra_args: list[str] | None = None,
+    fed_root: str | None = FED_ROOT,
+    no_variant_stats: bool = True,
+) -> tuple[int, str, str]:
     cmd = [sys.executable, ANALYSER, run_dir]
+    if fed_root:
+        cmd.extend(["--fed-root", fed_root])
+    if no_variant_stats:
+        cmd.append("--no-variant-stats")
     if extra_args:
         cmd.extend(extra_args)
     proc = subprocess.run(cmd, capture_output=True, text=True)
@@ -315,12 +346,18 @@ def case_2(tmp: str) -> None:
     laptop_alpha_seed = laptop_seeds["tribe-alpha"]
     seed_path = os.path.join(run_dir, ".agentis", "experience", f"{laptop_alpha_seed}.jsonl")
     with open(seed_path, "a", encoding="utf-8") as f:
+        # Bare-name variant tag is recognised against known_variants
+        # (alpha's parsed pool); seeds the seed agent's
+        # observational prompt_variant to "format-pattern-default".
         f.write(json.dumps({
             "ts": 1_700_000_000_500,
             "topic": "hunt",
             "subject": "line 7",
             "outcome": "BUG-A",
-            "tags": ["acted", "tribes-bench", "tribe-alpha", "reward=10"],
+            "tags": [
+                "acted", "tribes-bench", "tribe-alpha", "reward=10",
+                "format-pattern-default",
+            ],
         }) + "\n")
         # Death of the seed at a fixed ts so a descendant can outlive it.
         f.write(json.dumps({
@@ -363,27 +400,39 @@ def case_2(tmp: str) -> None:
     )
 
     # 2 server single-level lineages (one in tribe-gamma, one in
-    # tribe-delta).
-    server_gamma_seed = server_seeds["tribe-gamma"]
-    add_replicate_event(
-        server_dir, server_gamma_seed, "tribe-gamma",
-        n_before=1, ts=1_700_000_300_000,
-        variant_tag="format-pattern-default",
-    )
-    add_child_agent(
-        server_dir, "tribe-gamma", "server-c-g",
-        born_ts=1_700_000_360_000, tps=2, fps=0,
-    )
-    server_delta_seed = server_seeds["tribe-delta"]
-    add_replicate_event(
-        server_dir, server_delta_seed, "tribe-delta",
-        n_before=1, ts=1_700_000_400_000,
-        variant_tag="format-pattern-default",
-    )
-    add_child_agent(
-        server_dir, "tribe-delta", "server-c-d",
-        born_ts=1_700_000_460_000, tps=2, fps=0,
-    )
+    # tribe-delta). Each tribe uses its own pool's index-0 variant
+    # (gamma: error-path-default, delta: lifetime-default) so the
+    # mutation_kind cycle-N math resolves against the right pool. We
+    # also tag the seed agent with the same bare variant so its
+    # observational prompt_variant settles before the replicate event.
+    for seed_tribe, seed_id, default_variant, child_id, ts in (
+        ("tribe-gamma", server_seeds["tribe-gamma"], "error-path-default",
+         "server-c-g", 1_700_000_300_000),
+        ("tribe-delta", server_seeds["tribe-delta"], "lifetime-default",
+         "server-c-d", 1_700_000_400_000),
+    ):
+        seed_path = os.path.join(
+            server_dir, ".agentis", "experience", f"{seed_id}.jsonl"
+        )
+        with open(seed_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps({
+                "ts": ts - 100_000,
+                "topic": "hunt",
+                "subject": "line 4",
+                "outcome": "obs",
+                "tags": [
+                    "observed", "tribes-bench", seed_tribe, default_variant,
+                ],
+            }) + "\n")
+        add_replicate_event(
+            server_dir, seed_id, seed_tribe,
+            n_before=1, ts=ts,
+            variant_tag=default_variant,
+        )
+        add_child_agent(
+            server_dir, seed_tribe, child_id,
+            born_ts=ts + 60_000, tps=2, fps=0,
+        )
 
     write_text(os.path.join(run_dir, "bug-ledger.jsonl"), "")
     write_text(os.path.join(server_dir, "bug-ledger.jsonl"), "")
@@ -485,13 +534,30 @@ def case_3(tmp: str) -> None:
     make_seed_node(run_dir, laptop_tribes, laptop_seeds)
     make_seed_node(server_dir, server_tribes, server_seeds)
 
+    # The tribe-beta seed claims the pool's index-0 variant via a bare
+    # observable tag on its first learn row, so its prompt_variant
+    # resolves observationally before the replicate event fires.
+    beta_seed_path = os.path.join(
+        run_dir, ".agentis", "experience", f"{laptop_seeds['tribe-beta']}.jsonl"
+    )
+    with open(beta_seed_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps({
+            "ts": 1_700_000_000_500,
+            "topic": "hunt",
+            "subject": "line 4",
+            "outcome": "obs",
+            "tags": [
+                "observed", "tribes-bench", "tribe-beta",
+                "source-sink-default",
+            ],
+        }) + "\n")
     # Single replicate on tribe-beta with explicit variant tag that
-    # advances the parent (default) to the next cycle position
-    # (strict-literal) -> mutation_kind = cycle-1.
+    # advances the parent (source-sink-default) to the next pool
+    # position (source-sink-arg-only) -> mutation_kind = cycle-1.
     add_replicate_event(
         run_dir, laptop_seeds["tribe-beta"], "tribe-beta",
         n_before=1, ts=1_700_000_300_000,
-        variant_tag="format-pattern-strict-literal",
+        variant_tag="source-sink-arg-only",
     )
     add_child_agent(
         run_dir, "tribe-beta", "laptop-c-beta",
@@ -559,6 +625,397 @@ def case_4(tmp: str) -> None:
 
 
 # -------------------------------------------------------------------------
+# #495 unit tests: variant-pool discovery + variant_stats memo reads
+# -------------------------------------------------------------------------
+
+ALPHA_FIXTURE = """
+fn helper() -> int { return 1; }
+
+fn pick_variant(tribe: string, n: int) -> string {
+    let _ = tribe;
+    let idx = n - ((n / 3) * 3);
+    if idx == 0 {
+        return "format-pattern-default";
+    };
+    if idx == 1 {
+        return "format-pattern-strict-literal";
+    };
+    return "format-pattern-broad-shellbuilder";
+}
+
+fn after_pick() -> string { return "tail"; }
+"""
+
+EXTENDED_FIXTURE = """
+fn pick_variant(tribe: string, n: int) -> string {
+    let _ = tribe;
+    let idx = n - ((n / 7) * 7);
+    if idx == 0 { return "x-default"; };
+    if idx == 1 { return "x-arg-only"; };
+    if idx == 2 { return "x-broad-flow"; };
+    if idx == 3 { return "x-call-graph"; };
+    if idx == 4 { return "x-async-boundary"; };
+    if idx == 5 { return "x-trait-dispatch"; };
+    return "x-iterator-chain";
+}
+"""
+
+EMPTY_POOL_FIXTURE = """
+fn pick_variant(tribe: string, n: int) -> string {
+    let _ = tribe;
+    let computed = "x-" + to_string(n);
+    return computed;
+}
+"""
+
+
+def test_parse_variant_pool_alpha(tmp: str) -> None:
+    mod = _import_analyser()
+    fixture = os.path.join(tmp, "alpha-hunter.ag")
+    write_text(fixture, ALPHA_FIXTURE)
+    pool = mod.parse_variant_pool(fixture)
+    assert_eq(
+        "test_parse_variant_pool_alpha: 3-literal pool in source order",
+        [
+            "format-pattern-default",
+            "format-pattern-strict-literal",
+            "format-pattern-broad-shellbuilder",
+        ],
+        pool,
+    )
+
+
+def test_parse_variant_pool_extended_pool(tmp: str) -> None:
+    mod = _import_analyser()
+    fixture = os.path.join(tmp, "extended-hunter.ag")
+    write_text(fixture, EXTENDED_FIXTURE)
+    pool = mod.parse_variant_pool(fixture)
+    assert_eq(
+        "test_parse_variant_pool_extended_pool: all 7 literals in source order",
+        [
+            "x-default", "x-arg-only", "x-broad-flow", "x-call-graph",
+            "x-async-boundary", "x-trait-dispatch", "x-iterator-chain",
+        ],
+        pool,
+    )
+
+
+def test_parse_variant_pool_raises_on_empty(tmp: str) -> None:
+    mod = _import_analyser()
+    fixture = os.path.join(tmp, "empty-hunter.ag")
+    write_text(fixture, EMPTY_POOL_FIXTURE)
+    try:
+        mod.parse_variant_pool(fixture)
+    except ValueError:
+        report_pass("test_parse_variant_pool_raises_on_empty: ValueError raised")
+        return
+    report_fail(
+        "test_parse_variant_pool_raises_on_empty: ValueError raised",
+        "no exception",
+    )
+
+
+def test_discover_tribe_pools_disjoint_prefixes(tmp: str) -> None:
+    mod = _import_analyser()
+    fed = os.path.join(tmp, "fake-fed")
+    pools_layout = {
+        "tribe-alpha": ["alpha-1", "alpha-2", "alpha-3"],
+        "tribe-beta": ["beta-1", "beta-2", "beta-3"],
+        "tribe-gamma": ["gamma-1", "gamma-2", "gamma-3"],
+    }
+    for tribe, variants in pools_layout.items():
+        body = "\n".join(
+            [f'    if idx == {i} {{ return "{v}"; }};' for i, v in enumerate(variants[:-1])]
+        )
+        ag = (
+            "fn pick_variant(tribe: string, n: int) -> string {\n"
+            "    let _ = tribe;\n"
+            "    let idx = n - ((n / 3) * 3);\n"
+            f"{body}\n"
+            f'    return "{variants[-1]}";\n'
+            "}\n"
+        )
+        write_text(os.path.join(fed, tribe, "agents", "hunter.ag"), ag)
+    discovered = mod.discover_tribe_pools(fed)
+    assert_eq(
+        "test_discover_tribe_pools_disjoint_prefixes: tribe set",
+        sorted(pools_layout.keys()), sorted(discovered.keys()),
+    )
+    union: list[str] = []
+    for variants in discovered.values():
+        union.extend(variants)
+    assert_eq(
+        "test_discover_tribe_pools_disjoint_prefixes: union duplicate-free",
+        len(union), len(set(union)),
+    )
+
+
+def test_read_variant_stats_parses_memo_list_output(tmp: str) -> None:
+    mod = _import_analyser()
+    canned_stdout = (
+        "variant_stats:format-pattern-default:verified = 0\n"
+        "variant_stats:format-pattern-default:falsepos = 59\n"
+        "variant_stats:format-pattern-substitution-aware:verified = 4\n"
+        "variant_stats:format-pattern-substitution-aware:falsepos = 1\n"
+    )
+
+    class _Proc:
+        returncode = 0
+        stdout = canned_stdout
+        stderr = ""
+
+    real_run = subprocess.run
+
+    def fake_run(*args, **kwargs):  # noqa: ANN001, ANN201
+        cmd = args[0] if args else kwargs.get("args", [])
+        if isinstance(cmd, list) and cmd and cmd[0] == "agentis":
+            return _Proc()
+        return real_run(*args, **kwargs)
+
+    subprocess.run = fake_run  # type: ignore[assignment]
+    try:
+        result = mod.read_variant_stats(tmp)
+    finally:
+        subprocess.run = real_run  # type: ignore[assignment]
+    expected = {
+        "format-pattern-default": {"verified": 0, "falsepos": 59},
+        "format-pattern-substitution-aware": {"verified": 4, "falsepos": 1},
+    }
+    assert_eq(
+        "test_read_variant_stats_parses_memo_list_output: parsed dict",
+        expected, result,
+    )
+
+
+def test_read_variant_stats_missing_binary_returns_empty(tmp: str) -> None:
+    mod = _import_analyser()
+    real_run = subprocess.run
+
+    def fake_run(*args, **kwargs):  # noqa: ANN001, ANN201
+        raise FileNotFoundError("no agentis binary")
+
+    subprocess.run = fake_run  # type: ignore[assignment]
+    try:
+        # Capture stderr so the warning does not pollute test output.
+        from io import StringIO
+        old_err = sys.stderr
+        sys.stderr = StringIO()
+        try:
+            result = mod.read_variant_stats(tmp)
+            captured = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_err
+    finally:
+        subprocess.run = real_run  # type: ignore[assignment]
+    assert_eq(
+        "test_read_variant_stats_missing_binary_returns_empty: dict",
+        {}, result,
+    )
+    if "agentis" in captured.lower() and "warning" in captured.lower():
+        report_pass(
+            "test_read_variant_stats_missing_binary_returns_empty: stderr warning"
+        )
+    else:
+        report_fail(
+            "test_read_variant_stats_missing_binary_returns_empty: stderr warning",
+            f"captured={captured!r}",
+        )
+
+
+def test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc(tmp: str) -> None:
+    """End-to-end: feed the analyser a run dir whose comparison.md
+    has to render the new "Variant outcomes per tribe" table in the
+    documented order. We use a custom variant_stats input by writing
+    .agentis/memo/variant_stats:* files... but the runtime backend is
+    sled, not files, so instead we monkeypatch read_variant_stats to
+    return a canned aggregation directly. The output we assert on is
+    the comparison.md text.
+    """
+    run_dir = os.path.join(tmp, "outcomes")
+    os.makedirs(run_dir, exist_ok=True)
+    tribes = ["tribe-alpha"]
+    seed_ids = {t: f"seed-{t}" for t in tribes}
+    make_seed_node(run_dir, tribes, seed_ids)
+    write_text(os.path.join(run_dir, "bug-ledger.jsonl"), "")
+    write_text(os.path.join(run_dir, "rotations.csv"), "ts,target_dir,bugs_manifest\n")
+    write_text(
+        os.path.join(run_dir, "run-meta.json"),
+        json.dumps({"started_at": "2026-05-05T12:00:00Z", "wall_clock_s": 60,
+                    "rotation_interval_s": 60}),
+    )
+    # Seed an `agentis` shim on PATH that emits the canned counts.
+    bin_dir = os.path.join(tmp, "bin")
+    os.makedirs(bin_dir, exist_ok=True)
+    shim_path = os.path.join(bin_dir, "agentis")
+    write_text(
+        shim_path,
+        "#!/bin/sh\n"
+        'cat <<EOF\n'
+        "variant_stats:format-pattern-substitution-aware:verified = 4\n"
+        "variant_stats:format-pattern-substitution-aware:falsepos = 1\n"
+        "variant_stats:format-pattern-strict-literal:verified = 4\n"
+        "variant_stats:format-pattern-strict-literal:falsepos = 0\n"
+        "variant_stats:format-pattern-default:verified = 0\n"
+        "variant_stats:format-pattern-default:falsepos = 59\n"
+        "EOF\n",
+    )
+    os.chmod(shim_path, 0o755)
+    env = dict(os.environ)
+    env["PATH"] = bin_dir + os.pathsep + env.get("PATH", "")
+    cmd = [
+        sys.executable, ANALYSER, run_dir,
+        "--fed-root", FED_ROOT,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if proc.returncode != 0:
+        report_fail(
+            "test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc: analyser ok",
+            f"rc={proc.returncode} stderr={proc.stderr}",
+        )
+        return
+    cmp_path = os.path.join(run_dir, "comparison-stage3.md")
+    with open(cmp_path, encoding="utf-8") as f:
+        body = f.read()
+    if "Variant outcomes per tribe" not in body:
+        report_fail(
+            "test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc: header",
+            f"comparison.md missing header; body={body[:400]!r}",
+        )
+        return
+    report_pass(
+        "test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc: header"
+    )
+    # Strict order: strict-literal (4v/0fp) before substitution-aware
+    # (4v/1fp); both before any 0v line. format-pattern-default in dead.
+    sl_idx = body.find("format-pattern-strict-literal")
+    sa_idx = body.find("format-pattern-substitution-aware")
+    if sl_idx > 0 and sa_idx > 0 and sl_idx < sa_idx:
+        report_pass(
+            "test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc: tie-break"
+        )
+    else:
+        report_fail(
+            "test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc: tie-break",
+            f"sl_idx={sl_idx} sa_idx={sa_idx}",
+        )
+    if "Dead variants per tribe" in body and "format-pattern-default" in body:
+        report_pass(
+            "test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc: dead section"
+        )
+    else:
+        report_fail(
+            "test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc: dead section"
+        )
+
+
+def test_mutation_diff_csv_has_observational_columns(tmp: str) -> None:
+    run_dir = os.path.join(tmp, "obs-cols")
+    os.makedirs(run_dir, exist_ok=True)
+    tribes = ["tribe-alpha", "tribe-beta"]
+    seed_ids = {t: f"seed-{t}" for t in tribes}
+    make_seed_node(run_dir, tribes, seed_ids)
+    # tribe-alpha: claim default via bare tag, then replicate also tagged.
+    seed_path = os.path.join(
+        run_dir, ".agentis", "experience", f"{seed_ids['tribe-alpha']}.jsonl"
+    )
+    with open(seed_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps({
+            "ts": 1_700_000_000_500,
+            "topic": "hunt",
+            "subject": "line 9",
+            "outcome": "obs",
+            "tags": [
+                "observed", "tribes-bench", "tribe-alpha",
+                "format-pattern-default",
+            ],
+        }) + "\n")
+    add_replicate_event(
+        run_dir, seed_ids["tribe-alpha"], "tribe-alpha",
+        n_before=1, ts=1_700_000_400_000,
+        variant_tag="format-pattern-default",
+    )
+    add_child_agent(
+        run_dir, "tribe-alpha", "obs-c1",
+        born_ts=1_700_000_460_000, tps=1, fps=0,
+    )
+    write_text(os.path.join(run_dir, "bug-ledger.jsonl"), "")
+    write_text(os.path.join(run_dir, "rotations.csv"), "ts,target_dir,bugs_manifest\n")
+    write_text(
+        os.path.join(run_dir, "run-meta.json"),
+        json.dumps({"started_at": "2026-05-05T12:00:00Z", "wall_clock_s": 60,
+                    "rotation_interval_s": 60}),
+    )
+    rc, _stdout, _stderr = run_analyser(run_dir)
+    assert_eq(
+        "test_mutation_diff_csv_has_observational_columns: analyser ok",
+        0, rc,
+    )
+    csv_path = os.path.join(run_dir, "mutation-diff.csv")
+    with open(csv_path, encoding="utf-8") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+    if not rows:
+        report_fail(
+            "test_mutation_diff_csv_has_observational_columns: header",
+            "empty file",
+        )
+        return
+    header = rows[0]
+    expected_cols = {"source", "parent_variant_verified", "parent_variant_falsepos"}
+    if expected_cols.issubset(set(header)):
+        report_pass(
+            "test_mutation_diff_csv_has_observational_columns: header"
+        )
+    else:
+        report_fail(
+            "test_mutation_diff_csv_has_observational_columns: header",
+            f"missing={expected_cols - set(header)} header={header}",
+        )
+        return
+    src_idx = header.index("source")
+    sources = {r[src_idx] for r in rows[1:] if r}
+    if "observed" in sources:
+        report_pass(
+            "test_mutation_diff_csv_has_observational_columns: at least one observed row"
+        )
+    else:
+        report_fail(
+            "test_mutation_diff_csv_has_observational_columns: at least one observed row",
+            f"sources={sources}",
+        )
+
+
+# -------------------------------------------------------------------------
+# Snapshot test (#495): runs against a real archived stage3-docker run dir
+# when it is available, otherwise reports a [SKIP].
+# -------------------------------------------------------------------------
+
+SNAPSHOT_DIR = os.environ.get(
+    "AGENTIS_STAGE3_SNAPSHOT_DIR",
+    os.path.join(
+        os.path.dirname(FED_ROOT), "tribes-bench",
+        "runs", "stage3-docker-20260510T120610Z",
+    ),
+)
+
+
+def case_snapshot() -> None:
+    if not os.path.isdir(SNAPSHOT_DIR):
+        print(f"[SKIP] snapshot: reference run dir absent ({SNAPSHOT_DIR})")
+        return
+    rc, _stdout, _stderr = run_analyser(
+        SNAPSHOT_DIR,
+        extra_args=["--out", os.path.join(SNAPSHOT_DIR, "_495-snapshot")],
+    )
+    assert_eq("snapshot: analyser exits 0", 0, rc)
+    cmp_path = os.path.join(SNAPSHOT_DIR, "_495-snapshot", "comparison-stage3.md")
+    if not os.path.isfile(cmp_path):
+        report_fail("snapshot: comparison.md produced", f"missing {cmp_path}")
+        return
+    report_pass("snapshot: comparison.md produced")
+
+
+# -------------------------------------------------------------------------
 # Driver
 # -------------------------------------------------------------------------
 
@@ -572,6 +1029,16 @@ def main() -> int:
         case_2(tmp)
         case_3(tmp)
         case_4(tmp)
+        # #495 unit tests: per-tribe variant pools + variant_stats memos.
+        test_parse_variant_pool_alpha(tmp)
+        test_parse_variant_pool_extended_pool(tmp)
+        test_parse_variant_pool_raises_on_empty(tmp)
+        test_discover_tribe_pools_disjoint_prefixes(tmp)
+        test_read_variant_stats_parses_memo_list_output(tmp)
+        test_read_variant_stats_missing_binary_returns_empty(tmp)
+        test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc(tmp)
+        test_mutation_diff_csv_has_observational_columns(tmp)
+        case_snapshot()
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
     print("")

--- a/tribes-bench/tools/test-tribes-bench-analyse-stage3.sh
+++ b/tribes-bench/tools/test-tribes-bench-analyse-stage3.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# test-tribes-bench-analyse-stage3.sh -- federation-local snapshot
+# driver for the #495 observational analyser. Runs analyse-stage3.py
+# against the canonical archived smoke #42 run dir and asserts the
+# tribe-alpha and tribe-epsilon leaderboards plus the dead-variants
+# subsection in comparison-stage3.md.
+#
+# Skips when the snapshot dir is absent (for example on CI runners
+# that do not vendor archived runs). Set AGENTIS_STAGE3_SNAPSHOT_DIR
+# to override the default location.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_ROOT="$(dirname "$SCRIPT_DIR")"
+ANALYSER="$SCRIPT_DIR/analyse-stage3.py"
+SNAPSHOT_DIR="${AGENTIS_STAGE3_SNAPSHOT_DIR:-$FED_ROOT/runs/stage3-docker-20260510T120610Z}"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "[SKIP] $1"; SKIP=$((SKIP + 1)); }
+
+if [ ! -f "$ANALYSER" ]; then
+    fail "analyser missing: $ANALYSER"
+    echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+    exit 1
+fi
+
+if [ ! -d "$SNAPSHOT_DIR" ]; then
+    skip "snapshot dir absent: $SNAPSHOT_DIR"
+    echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+    exit 0
+fi
+
+OUT_DIR="$SNAPSHOT_DIR/_495-snapshot-shell"
+mkdir -p "$OUT_DIR"
+
+if ! python3 "$ANALYSER" "$SNAPSHOT_DIR" \
+        --fed-root "$FED_ROOT" \
+        --out "$OUT_DIR" >/dev/null 2>&1; then
+    fail "analyser invocation"
+    echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+    exit 1
+fi
+pass "analyser invocation"
+
+CMP_PATH="$OUT_DIR/comparison-stage3.md"
+if [ ! -f "$CMP_PATH" ]; then
+    fail "comparison-stage3.md produced"
+    echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+    exit 1
+fi
+pass "comparison-stage3.md produced"
+
+# tribe-alpha leader = format-pattern-substitution-aware: it is the
+# first format-pattern-* row in the Variant outcomes table.
+ALPHA_LEADER="$(awk '/^\| tribe-alpha \|/{print $4; exit}' "$CMP_PATH" || true)"
+if [ "$ALPHA_LEADER" = "format-pattern-substitution-aware" ]; then
+    pass "tribe-alpha leader = format-pattern-substitution-aware"
+else
+    fail "tribe-alpha leader = format-pattern-substitution-aware (got: $ALPHA_LEADER)"
+fi
+
+# tribe-epsilon leader = concurrency-cell-interior-mut.
+EPSILON_LEADER="$(awk '/^\| tribe-epsilon \|/{print $4; exit}' "$CMP_PATH" || true)"
+if [ "$EPSILON_LEADER" = "concurrency-cell-interior-mut" ]; then
+    pass "tribe-epsilon leader = concurrency-cell-interior-mut"
+else
+    fail "tribe-epsilon leader = concurrency-cell-interior-mut (got: $EPSILON_LEADER)"
+fi
+
+# format-pattern-default appears in alpha's dead-variants subsection.
+if awk '/^Dead variants per tribe/,0' "$CMP_PATH" \
+        | grep -q "tribe-alpha .* format-pattern-default"; then
+    pass "format-pattern-default in alpha dead-variants"
+else
+    fail "format-pattern-default in alpha dead-variants"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Fix analyse-stage3.py producing misleading `comparison-stage3.md` reports after PR #494 (B2 variant evolution).

Closes #495.

## What changed

- **Per-tribe variant pools** parsed from each `tribes-bench/tribe-<X>/agents/hunter.ag` via regex (replaces hardcoded 3-element alpha cycle that was applied to all 5 tribes)
- **Observational variant_stats** read from each node's memo store via `agentis memo list --prefix variant_stats:` subprocess (replaces synthetic `pick_variant(tribe, idx)` reconstruction)
- **"Variant outcomes per tribe" table** replaces "Top-3 surviving variants" — every variant with verified+falsepos > 0, sorted by verified DESC then falsepos ASC, with dead-variants subsection
- **`mutation-diff.csv`** gains `source` (`observed` / `unresolved`), `parent_variant_verified`, `parent_variant_falsepos` columns
- **CLI flags** `--fed-root <path>`, `--no-variant-stats`, `--legacy-top-variants` (legacy table kept one release for diff continuity)

Rationale: in smoke #42 the old report claimed every tribe led on `format-pattern-default` (the actual dead variant at 0v/59fp). True leaders like `concurrency-cell-interior-mut` (2v/3fp) and `format-pattern-substitution-aware` (1v/1fp) were absent. The synthesis was hiding the experiment.

## Test plan

- [x] 9 new unit tests in `test-analyse-stage3.py` (parse, discover, memo read, ordering, mutation-diff columns, snapshot)
- [x] Shell snapshot driver `test-tribes-bench-analyse-stage3.sh` (skips gracefully when run dir absent)
- [x] Python suite: 56 passed, 0 failed
- [x] `colony-lint.sh`: 168 passed / 0 failed / 3 skipped

## Caveat

The smoke #42 reference run dir (`runs/stage3-docker-20260510T120610Z/`) does not exist in this branch — it lived in the now-deleted `b2-variant-evolution` worktree. Snapshot test skips cleanly. After the next stage3 run lands in main, snapshot can be activated via `AGENTIS_STAGE3_SNAPSHOT_DIR=<run-dir>`.

## Out of scope

- Per-variant fitness curves over time (separate work)
- Cross-run aggregation (separate work)
- B2 v2 wire bump (tracked in agentis-core#632)

🤖 Generated with [Claude Code](https://claude.com/claude-code)