### PR TITLE
feat(tribes-bench): M98 self-evolution — variant carries <class>:<phrasing>, 10% class-flip mutation (#499)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -45,6 +45,50 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **M98 self-evolution: variant carries `<class>:<phrasing>`, hunters
+  evolve hunt strategy via class-flip mutation**
+  ([#499](https://github.com/Replikanti/agentis-colonies/issues/499)).
+  Builds on [#498](https://github.com/Replikanti/agentis-colonies/issues/498)
+  variant inheritance to put the bug-class trait under selection pressure
+  alongside the phrasing trait. All 5 hunter.ag files now emit variant
+  strings of the form `<class>:<phrasing>` (e.g.
+  `uninitialised_memory:format-pattern-strict-literal`); `pick_variant()`
+  seeds 14 variants per tribe across 2 sibling bug classes (7 phrasings
+  each) instead of the prior 7-phrasings-only pool. Per-tribe seeding
+  follows the bench's stage2 RUSTSEC alignment: alpha primary
+  `uninitialised_memory` + sibling `memory_corruption`; beta
+  `heap_overflow` + `memory_corruption`; gamma `memory_corruption` +
+  `dangling_borrow`; delta `use_after_free` + `dangling_borrow`; epsilon
+  `use_after_free` + `send_violation`. The 8-class universe also includes
+  `data_race` and `missing_lock` — both reachable only via the new 10%
+  class-flip mutation (independent from the existing 20% phrasing-flip
+  roll, decorrelated with a different prime modulus on the same
+  `now_ms_via_shell()` source so a tick can mutate phrasing only, class
+  only, both, or neither). At the verifier-call site, the JSON `class`
+  field is now derived from the variant string (split on `:`) rather
+  than the LLM's `finding.class` -- misalignment between what the LLM
+  hunted for (per the still-frozen prompt strings) and what the variant
+  claims becomes a verifier-falsepos that selection rewards or penalises
+  through the existing `variant_stats:<variant>:{verified,falsepos}`
+  memos. Combined with #498's wire-path variant inheritance this
+  produces sustained variation × selection × inheritance over the
+  hunt-class trait, bypassing the structural bottleneck where pre-#499
+  hunter prompts hardcoded one class per tribe and the federation could
+  only flow within tribe-pinned class lanes. Each hunter declares a
+  `_tribe_default_class()` helper used as a fallback when a variant
+  string lacks the `:` separator (legacy memo replay from pre-#499
+  builds); empty `_variant` (cold start) and phrasing-only strings both
+  collapse to the tribe primary, so the cold-start verifier-payload
+  matches pre-#499 behaviour byte-for-byte. The seeded 14-literal pool
+  emits bare `return "<class>:<phrasing>";` literals so
+  `analyse-stage3.py`'s `parse_variant_pool` regex picks up the post-#499
+  pool unmodified; off-pool class-flip mutants are emitted via string
+  concatenation by design (the analyser will report them under the
+  observational "Variant outcomes per tribe" section as out-of-pool
+  entries). Runtime floor unchanged (`agentis >= 1.7.8`); the new
+  `index_of` and `substring` builtins used at the verifier-call site
+  ship since v1.5.x and are included in the existing v1.7.8 floor.
+
 - **B2 variant-evolution per-instance inheritance — federation-side reader**
   ([#497](https://github.com/Replikanti/agentis-colonies/issues/497)).
   Companion to [agentis-core#632](https://github.com/Replikanti/agentis/issues/632)

--- a/tribes-bench/tools/test-analyse-stage3.py
+++ b/tribes-bench/tools/test-analyse-stage3.py
@@ -346,9 +346,10 @@ def case_2(tmp: str) -> None:
     laptop_alpha_seed = laptop_seeds["tribe-alpha"]
     seed_path = os.path.join(run_dir, ".agentis", "experience", f"{laptop_alpha_seed}.jsonl")
     with open(seed_path, "a", encoding="utf-8") as f:
-        # Bare-name variant tag is recognised against known_variants
-        # (alpha's parsed pool); seeds the seed agent's
-        # observational prompt_variant to "format-pattern-default".
+        # #499 M98: variant tag is `<class>:<phrasing>` (alpha primary
+        # class is `uninitialised_memory`). Tag is recognised against
+        # known_variants (alpha's parsed pool); seeds the seed agent's
+        # observational prompt_variant to the alpha primary default.
         f.write(json.dumps({
             "ts": 1_700_000_000_500,
             "topic": "hunt",
@@ -356,7 +357,7 @@ def case_2(tmp: str) -> None:
             "outcome": "BUG-A",
             "tags": [
                 "acted", "tribes-bench", "tribe-alpha", "reward=10",
-                "format-pattern-default",
+                "uninitialised_memory:format-pattern-default",
             ],
         }) + "\n")
         # Death of the seed at a fixed ts so a descendant can outlive it.
@@ -378,7 +379,7 @@ def case_2(tmp: str) -> None:
     add_replicate_event(
         run_dir, laptop_alpha_seed, "tribe-alpha",
         n_before=1, ts=1_700_000_120_000,
-        variant_tag="format-pattern-default",
+        variant_tag="uninitialised_memory:format-pattern-default",
     )
     laptop_alpha_child1 = "laptop-c1"
     add_child_agent(
@@ -389,7 +390,7 @@ def case_2(tmp: str) -> None:
     add_replicate_event(
         run_dir, laptop_alpha_child1, "tribe-alpha",
         n_before=2, ts=1_700_000_240_000,
-        variant_tag="format-pattern-default",
+        variant_tag="uninitialised_memory:format-pattern-default",
     )
     laptop_alpha_child2 = "laptop-c2"
     # The child2 outlives the seed -- it is born after the seed dies.
@@ -400,15 +401,19 @@ def case_2(tmp: str) -> None:
     )
 
     # 2 server single-level lineages (one in tribe-gamma, one in
-    # tribe-delta). Each tribe uses its own pool's index-0 variant
-    # (gamma: error-path-default, delta: lifetime-default) so the
-    # mutation_kind cycle-N math resolves against the right pool. We
-    # also tag the seed agent with the same bare variant so its
-    # observational prompt_variant settles before the replicate event.
+    # tribe-delta). Each tribe uses its own pool's primary-class index-0
+    # variant (gamma: memory_corruption:error-path-default,
+    # delta: use_after_free:lifetime-default) so the mutation_kind
+    # cycle-N math resolves against the right pool. We also tag the
+    # seed agent with the same bare variant so its observational
+    # prompt_variant settles before the replicate event.
+    # #499 M98: variant tag is `<class>:<phrasing>`.
     for seed_tribe, seed_id, default_variant, child_id, ts in (
-        ("tribe-gamma", server_seeds["tribe-gamma"], "error-path-default",
+        ("tribe-gamma", server_seeds["tribe-gamma"],
+         "memory_corruption:error-path-default",
          "server-c-g", 1_700_000_300_000),
-        ("tribe-delta", server_seeds["tribe-delta"], "lifetime-default",
+        ("tribe-delta", server_seeds["tribe-delta"],
+         "use_after_free:lifetime-default",
          "server-c-d", 1_700_000_400_000),
     ):
         seed_path = os.path.join(
@@ -548,16 +553,18 @@ def case_3(tmp: str) -> None:
             "outcome": "obs",
             "tags": [
                 "observed", "tribes-bench", "tribe-beta",
-                "source-sink-default",
+                # #499 M98: beta primary class is `heap_overflow`.
+                "heap_overflow:source-sink-default",
             ],
         }) + "\n")
     # Single replicate on tribe-beta with explicit variant tag that
-    # advances the parent (source-sink-default) to the next pool
-    # position (source-sink-arg-only) -> mutation_kind = cycle-1.
+    # advances the parent (heap_overflow:source-sink-default) to the
+    # next pool position (heap_overflow:source-sink-arg-only) ->
+    # mutation_kind = cycle-1.
     add_replicate_event(
         run_dir, laptop_seeds["tribe-beta"], "tribe-beta",
         n_before=1, ts=1_700_000_300_000,
-        variant_tag="source-sink-arg-only",
+        variant_tag="heap_overflow:source-sink-arg-only",
     )
     add_child_agent(
         run_dir, "tribe-beta", "laptop-c-beta",
@@ -851,12 +858,17 @@ def test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc(tmp: str) -
         shim_path,
         "#!/bin/sh\n"
         'cat <<EOF\n'
-        "variant_stats:format-pattern-substitution-aware:verified = 4\n"
-        "variant_stats:format-pattern-substitution-aware:falsepos = 1\n"
-        "variant_stats:format-pattern-strict-literal:verified = 4\n"
-        "variant_stats:format-pattern-strict-literal:falsepos = 0\n"
-        "variant_stats:format-pattern-default:verified = 0\n"
-        "variant_stats:format-pattern-default:falsepos = 59\n"
+        # #499 M98: variant pool literals are now `<class>:<phrasing>`,
+        # so the shim emits the post-#499 alpha pool keys (primary class
+        # `uninitialised_memory`). `read_variant_stats` rpartition(':')
+        # splits on the LAST colon, so the embedded class:phrasing colon
+        # round-trips intact.
+        "variant_stats:uninitialised_memory:format-pattern-substitution-aware:verified = 4\n"
+        "variant_stats:uninitialised_memory:format-pattern-substitution-aware:falsepos = 1\n"
+        "variant_stats:uninitialised_memory:format-pattern-strict-literal:verified = 4\n"
+        "variant_stats:uninitialised_memory:format-pattern-strict-literal:falsepos = 0\n"
+        "variant_stats:uninitialised_memory:format-pattern-default:verified = 0\n"
+        "variant_stats:uninitialised_memory:format-pattern-default:falsepos = 59\n"
         "EOF\n",
     )
     os.chmod(shim_path, 0o755)
@@ -915,6 +927,9 @@ def test_mutation_diff_csv_has_observational_columns(tmp: str) -> None:
     seed_ids = {t: f"seed-{t}" for t in tribes}
     make_seed_node(run_dir, tribes, seed_ids)
     # tribe-alpha: claim default via bare tag, then replicate also tagged.
+    # #499 M98: variant tag is now `<class>:<phrasing>` (alpha primary
+    # class is `uninitialised_memory`); experience-row tag mirrors the
+    # post-#499 pool literal so the analyser resolves it to "observed".
     seed_path = os.path.join(
         run_dir, ".agentis", "experience", f"{seed_ids['tribe-alpha']}.jsonl"
     )
@@ -926,13 +941,13 @@ def test_mutation_diff_csv_has_observational_columns(tmp: str) -> None:
             "outcome": "obs",
             "tags": [
                 "observed", "tribes-bench", "tribe-alpha",
-                "format-pattern-default",
+                "uninitialised_memory:format-pattern-default",
             ],
         }) + "\n")
     add_replicate_event(
         run_dir, seed_ids["tribe-alpha"], "tribe-alpha",
         n_before=1, ts=1_700_000_400_000,
-        variant_tag="format-pattern-default",
+        variant_tag="uninitialised_memory:format-pattern-default",
     )
     add_child_agent(
         run_dir, "tribe-alpha", "obs-c1",

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -59,41 +59,107 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #499: per-tribe primary class — used as fallback when a variant string
+// lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
+// pre-#499 builds where pick_variant emitted phrasing-only strings).
+fn _tribe_default_class() -> string {
+    return "uninitialised_memory";
+}
+
+// #499: 8-class universe used by the class-flip mutation in
+// `pick_variant`. Indices 0..1 are the tribe's primary + sibling classes
+// (also seeded directly into the 14-literal pool below); 2..7 are
+// off-pool classes reachable only via the 10% class-flip mutation, so
+// `data_race` and `missing_lock` enter circulation only when the dice
+// fall that way.
+fn _class_pick_universe(idx: int) -> string {
+    if idx == 0 { return "uninitialised_memory"; };
+    if idx == 1 { return "memory_corruption"; };
+    if idx == 2 { return "use_after_free"; };
+    if idx == 3 { return "heap_overflow"; };
+    if idx == 4 { return "data_race"; };
+    if idx == 5 { return "send_violation"; };
+    if idx == 6 { return "missing_lock"; };
+    return "dangling_borrow";
+}
+
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
-    // B2 variation source: 7-variant pool with 20% mutation rate.
-    // Cyclic baseline (n mod 7) gives sibling diversity at spawn time.
-    // Mutation roll uses now_ms_via_shell() pseudo-random to pick a
-    // different variant ~20% of the time, breaking cyclic ruts and
-    // exposing new variants to selection pressure.
-    let cyclic_idx = n - ((n / 7) * 7);
+    // #499 M98 self-evolution: variant string carries `<class>:<phrasing>`
+    // so selection operates on the hunt-class trait, not just wording.
+    // Pool expanded from 7 phrasings to 14 = 7 phrasings * 2 sibling
+    // classes. Cyclic baseline `n mod 14` covers the seeded pool;
+    // `idx / 7` picks the primary (0) vs sibling (1) class, `idx % 7`
+    // picks the phrasing.
+    //
+    // Mutation operators (independent rolls, decorrelated by different
+    // moduli on the same `now_ms_via_shell()` source):
+    //   - 20% phrasing-flip (carry-over from #494): re-rolls the
+    //     phrasing within whatever class the cyclic baseline picked.
+    //   - 10% class-flip (#499 new): re-rolls the class against the
+    //     full 8-class universe. This is the only path by which
+    //     `data_race` and `missing_lock` enter circulation.
+    //
+    // Implementation note: the seeded pool is emitted as 14 bare
+    // string-literal returns so `analyse-stage3.py`'s
+    // `parse_variant_pool` regex picks them up unmodified. The
+    // class-flip mutation path falls through to a string concatenation
+    // tail that the parser ignores by design (off-pool variants).
+    let cyclic_idx = n - ((n / 14) * 14);
+    let cyclic_class_idx = cyclic_idx / 7;
+    let cyclic_phr_idx = cyclic_idx - (cyclic_class_idx * 7);
     let mut_now = now_ms_via_shell();
+    // Phrasing-flip roll: 20% (mut_now % 100 < 20).
     let mut_roll = mut_now - ((mut_now / 100) * 100);
-    let idx = if mut_roll < 20 {
-        let rand_idx = mut_now - ((mut_now / 7) * 7);
-        rand_idx;
+    let phr_idx = if mut_roll < 20 {
+        let rand_phr = mut_now - ((mut_now / 7) * 7);
+        rand_phr;
     } else {
-        cyclic_idx;
+        cyclic_phr_idx;
     };
-    if idx == 0 {
-        return "format-pattern-default";
+    // Class-flip roll: 10%, decorrelated by /7 then %100. The picked
+    // class index is decorrelated again via /11 then %8.
+    let class_now = mut_now / 7;
+    let class_roll = class_now - ((class_now / 100) * 100);
+    if class_roll < 10 {
+        let class_pick_now = mut_now / 11;
+        let class_pick = class_pick_now - ((class_pick_now / 8) * 8);
+        let phr_str_mut = if phr_idx == 0 {
+            "format-pattern-default";
+        } else { if phr_idx == 1 {
+            "format-pattern-strict-literal";
+        } else { if phr_idx == 2 {
+            "format-pattern-broad-shellbuilder";
+        } else { if phr_idx == 3 {
+            "format-pattern-substitution-aware";
+        } else { if phr_idx == 4 {
+            "format-pattern-quoting-edge";
+        } else { if phr_idx == 5 {
+            "format-pattern-pipe-chain";
+        } else {
+            "format-pattern-deferred-eval";
+        }; }; }; }; }; };
+        return _class_pick_universe(class_pick) + ":" + phr_str_mut;
     };
-    if idx == 1 {
-        return "format-pattern-strict-literal";
+    // Seeded pool: 14 bare-literal returns parsed by analyse-stage3.
+    // class_idx == 0 => primary (uninitialised_memory).
+    if cyclic_class_idx == 0 {
+        if phr_idx == 0 { return "uninitialised_memory:format-pattern-default"; };
+        if phr_idx == 1 { return "uninitialised_memory:format-pattern-strict-literal"; };
+        if phr_idx == 2 { return "uninitialised_memory:format-pattern-broad-shellbuilder"; };
+        if phr_idx == 3 { return "uninitialised_memory:format-pattern-substitution-aware"; };
+        if phr_idx == 4 { return "uninitialised_memory:format-pattern-quoting-edge"; };
+        if phr_idx == 5 { return "uninitialised_memory:format-pattern-pipe-chain"; };
+        return "uninitialised_memory:format-pattern-deferred-eval";
     };
-    if idx == 2 {
-        return "format-pattern-broad-shellbuilder";
-    };
-    if idx == 3 {
-        return "format-pattern-substitution-aware";
-    };
-    if idx == 4 {
-        return "format-pattern-quoting-edge";
-    };
-    if idx == 5 {
-        return "format-pattern-pipe-chain";
-    };
-    return "format-pattern-deferred-eval";
+    // class_idx == 1 => sibling (memory_corruption).
+    if phr_idx == 0 { return "memory_corruption:format-pattern-default"; };
+    if phr_idx == 1 { return "memory_corruption:format-pattern-strict-literal"; };
+    if phr_idx == 2 { return "memory_corruption:format-pattern-broad-shellbuilder"; };
+    if phr_idx == 3 { return "memory_corruption:format-pattern-substitution-aware"; };
+    if phr_idx == 4 { return "memory_corruption:format-pattern-quoting-edge"; };
+    if phr_idx == 5 { return "memory_corruption:format-pattern-pipe-chain"; };
+    return "memory_corruption:format-pattern-deferred-eval";
 }
 
 fn self_node_addr() -> string {
@@ -565,7 +631,25 @@ fn tick(reason: string) -> void {
                 // only, and round-tripping LLM-tainted text through the
                 // JSON-on-stdin channel would force shell-vs-JSON quote
                 // interleaving with no benefit.
-                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + finding.class + "\"}";
+                // #499 M98 self-evolution: derive the verifier-payload
+                // class from the variant string (`<class>:<phrasing>`),
+                // not from the LLM's `finding.class` field. Misalignment
+                // between LLM-hunt-target and variant-claimed class
+                // becomes a verifier-falsepos that selection rewards or
+                // penalises via `variant_stats:<full-variant>:*` memos.
+                // Empty `_variant` (cold start) or legacy phrasing-only
+                // strings (no `:`) fall back to the tribe's primary class.
+                let _colon_idx = index_of(_variant, ":");
+                let _variant_class = if len(_variant) == 0 {
+                    _tribe_default_class();
+                } else {
+                    if _colon_idx >= 0 {
+                        substring(_variant, 0, _colon_idx);
+                    } else {
+                        _tribe_default_class();
+                    };
+                };
+                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + _variant_class + "\"}";
                 let verify_cmd = "printf '%s' " + shell_escape(finding_json) + " | bash \"$VERIFIER_PATH\"";
                 let verdict_raw = try {
                     exec sh verify_cmd;

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -60,41 +60,107 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #499: per-tribe primary class — used as fallback when a variant string
+// lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
+// pre-#499 builds where pick_variant emitted phrasing-only strings).
+fn _tribe_default_class() -> string {
+    return "heap_overflow";
+}
+
+// #499: 8-class universe used by the class-flip mutation in
+// `pick_variant`. Indices 0..1 are the tribe's primary + sibling classes
+// (also seeded directly into the 14-literal pool below); 2..7 are
+// off-pool classes reachable only via the 10% class-flip mutation, so
+// `data_race` and `missing_lock` enter circulation only when the dice
+// fall that way.
+fn _class_pick_universe(idx: int) -> string {
+    if idx == 0 { return "heap_overflow"; };
+    if idx == 1 { return "memory_corruption"; };
+    if idx == 2 { return "use_after_free"; };
+    if idx == 3 { return "uninitialised_memory"; };
+    if idx == 4 { return "data_race"; };
+    if idx == 5 { return "send_violation"; };
+    if idx == 6 { return "missing_lock"; };
+    return "dangling_borrow";
+}
+
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
-    // B2 variation source: 7-variant pool with 20% mutation rate.
-    // Cyclic baseline (n mod 7) gives sibling diversity at spawn time.
-    // Mutation roll uses now_ms_via_shell() pseudo-random to pick a
-    // different variant ~20% of the time, breaking cyclic ruts and
-    // exposing new variants to selection pressure.
-    let cyclic_idx = n - ((n / 7) * 7);
+    // #499 M98 self-evolution: variant string carries `<class>:<phrasing>`
+    // so selection operates on the hunt-class trait, not just wording.
+    // Pool expanded from 7 phrasings to 14 = 7 phrasings * 2 sibling
+    // classes. Cyclic baseline `n mod 14` covers the seeded pool;
+    // `idx / 7` picks the primary (0) vs sibling (1) class, `idx % 7`
+    // picks the phrasing.
+    //
+    // Mutation operators (independent rolls, decorrelated by different
+    // moduli on the same `now_ms_via_shell()` source):
+    //   - 20% phrasing-flip (carry-over from #494): re-rolls the
+    //     phrasing within whatever class the cyclic baseline picked.
+    //   - 10% class-flip (#499 new): re-rolls the class against the
+    //     full 8-class universe. This is the only path by which
+    //     `data_race` and `missing_lock` enter circulation.
+    //
+    // Implementation note: the seeded pool is emitted as 14 bare
+    // string-literal returns so `analyse-stage3.py`'s
+    // `parse_variant_pool` regex picks them up unmodified. The
+    // class-flip mutation path falls through to a string concatenation
+    // tail that the parser ignores by design (off-pool variants).
+    let cyclic_idx = n - ((n / 14) * 14);
+    let cyclic_class_idx = cyclic_idx / 7;
+    let cyclic_phr_idx = cyclic_idx - (cyclic_class_idx * 7);
     let mut_now = now_ms_via_shell();
+    // Phrasing-flip roll: 20% (mut_now % 100 < 20).
     let mut_roll = mut_now - ((mut_now / 100) * 100);
-    let idx = if mut_roll < 20 {
-        let rand_idx = mut_now - ((mut_now / 7) * 7);
-        rand_idx;
+    let phr_idx = if mut_roll < 20 {
+        let rand_phr = mut_now - ((mut_now / 7) * 7);
+        rand_phr;
     } else {
-        cyclic_idx;
+        cyclic_phr_idx;
     };
-    if idx == 0 {
-        return "source-sink-default";
+    // Class-flip roll: 10%, decorrelated by /7 then %100. The picked
+    // class index is decorrelated again via /11 then %8.
+    let class_now = mut_now / 7;
+    let class_roll = class_now - ((class_now / 100) * 100);
+    if class_roll < 10 {
+        let class_pick_now = mut_now / 11;
+        let class_pick = class_pick_now - ((class_pick_now / 8) * 8);
+        let phr_str_mut = if phr_idx == 0 {
+            "source-sink-default";
+        } else { if phr_idx == 1 {
+            "source-sink-arg-only";
+        } else { if phr_idx == 2 {
+            "source-sink-broad-flow";
+        } else { if phr_idx == 3 {
+            "source-sink-call-graph";
+        } else { if phr_idx == 4 {
+            "source-sink-async-boundary";
+        } else { if phr_idx == 5 {
+            "source-sink-trait-dispatch";
+        } else {
+            "source-sink-iterator-chain";
+        }; }; }; }; }; };
+        return _class_pick_universe(class_pick) + ":" + phr_str_mut;
     };
-    if idx == 1 {
-        return "source-sink-arg-only";
+    // Seeded pool: 14 bare-literal returns parsed by analyse-stage3.
+    // class_idx == 0 => primary (heap_overflow).
+    if cyclic_class_idx == 0 {
+        if phr_idx == 0 { return "heap_overflow:source-sink-default"; };
+        if phr_idx == 1 { return "heap_overflow:source-sink-arg-only"; };
+        if phr_idx == 2 { return "heap_overflow:source-sink-broad-flow"; };
+        if phr_idx == 3 { return "heap_overflow:source-sink-call-graph"; };
+        if phr_idx == 4 { return "heap_overflow:source-sink-async-boundary"; };
+        if phr_idx == 5 { return "heap_overflow:source-sink-trait-dispatch"; };
+        return "heap_overflow:source-sink-iterator-chain";
     };
-    if idx == 2 {
-        return "source-sink-broad-flow";
-    };
-    if idx == 3 {
-        return "source-sink-call-graph";
-    };
-    if idx == 4 {
-        return "source-sink-async-boundary";
-    };
-    if idx == 5 {
-        return "source-sink-trait-dispatch";
-    };
-    return "source-sink-iterator-chain";
+    // class_idx == 1 => sibling (memory_corruption).
+    if phr_idx == 0 { return "memory_corruption:source-sink-default"; };
+    if phr_idx == 1 { return "memory_corruption:source-sink-arg-only"; };
+    if phr_idx == 2 { return "memory_corruption:source-sink-broad-flow"; };
+    if phr_idx == 3 { return "memory_corruption:source-sink-call-graph"; };
+    if phr_idx == 4 { return "memory_corruption:source-sink-async-boundary"; };
+    if phr_idx == 5 { return "memory_corruption:source-sink-trait-dispatch"; };
+    return "memory_corruption:source-sink-iterator-chain";
 }
 
 fn self_node_addr() -> string {
@@ -565,7 +631,25 @@ fn tick(reason: string) -> void {
                 // only, and round-tripping LLM-tainted text through the
                 // JSON-on-stdin channel would force shell-vs-JSON quote
                 // interleaving with no benefit.
-                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + finding.class + "\"}";
+                // #499 M98 self-evolution: derive the verifier-payload
+                // class from the variant string (`<class>:<phrasing>`),
+                // not from the LLM's `finding.class` field. Misalignment
+                // between LLM-hunt-target and variant-claimed class
+                // becomes a verifier-falsepos that selection rewards or
+                // penalises via `variant_stats:<full-variant>:*` memos.
+                // Empty `_variant` (cold start) or legacy phrasing-only
+                // strings (no `:`) fall back to the tribe's primary class.
+                let _colon_idx = index_of(_variant, ":");
+                let _variant_class = if len(_variant) == 0 {
+                    _tribe_default_class();
+                } else {
+                    if _colon_idx >= 0 {
+                        substring(_variant, 0, _colon_idx);
+                    } else {
+                        _tribe_default_class();
+                    };
+                };
+                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + _variant_class + "\"}";
                 let verify_cmd = "printf '%s' " + shell_escape(finding_json) + " | bash \"$VERIFIER_PATH\"";
                 let verdict_raw = try {
                     exec sh verify_cmd;

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -60,41 +60,107 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #499: per-tribe primary class — used as fallback when a variant string
+// lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
+// pre-#499 builds where pick_variant emitted phrasing-only strings).
+fn _tribe_default_class() -> string {
+    return "use_after_free";
+}
+
+// #499: 8-class universe used by the class-flip mutation in
+// `pick_variant`. Indices 0..1 are the tribe's primary + sibling classes
+// (also seeded directly into the 14-literal pool below); 2..7 are
+// off-pool classes reachable only via the 10% class-flip mutation, so
+// `data_race` and `missing_lock` enter circulation only when the dice
+// fall that way.
+fn _class_pick_universe(idx: int) -> string {
+    if idx == 0 { return "use_after_free"; };
+    if idx == 1 { return "dangling_borrow"; };
+    if idx == 2 { return "memory_corruption"; };
+    if idx == 3 { return "heap_overflow"; };
+    if idx == 4 { return "data_race"; };
+    if idx == 5 { return "send_violation"; };
+    if idx == 6 { return "missing_lock"; };
+    return "uninitialised_memory";
+}
+
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
-    // B2 variation source: 7-variant pool with 20% mutation rate.
-    // Cyclic baseline (n mod 7) gives sibling diversity at spawn time.
-    // Mutation roll uses now_ms_via_shell() pseudo-random to pick a
-    // different variant ~20% of the time, breaking cyclic ruts and
-    // exposing new variants to selection pressure.
-    let cyclic_idx = n - ((n / 7) * 7);
+    // #499 M98 self-evolution: variant string carries `<class>:<phrasing>`
+    // so selection operates on the hunt-class trait, not just wording.
+    // Pool expanded from 7 phrasings to 14 = 7 phrasings * 2 sibling
+    // classes. Cyclic baseline `n mod 14` covers the seeded pool;
+    // `idx / 7` picks the primary (0) vs sibling (1) class, `idx % 7`
+    // picks the phrasing.
+    //
+    // Mutation operators (independent rolls, decorrelated by different
+    // moduli on the same `now_ms_via_shell()` source):
+    //   - 20% phrasing-flip (carry-over from #494): re-rolls the
+    //     phrasing within whatever class the cyclic baseline picked.
+    //   - 10% class-flip (#499 new): re-rolls the class against the
+    //     full 8-class universe. This is the only path by which
+    //     `data_race` and `missing_lock` enter circulation.
+    //
+    // Implementation note: the seeded pool is emitted as 14 bare
+    // string-literal returns so `analyse-stage3.py`'s
+    // `parse_variant_pool` regex picks them up unmodified. The
+    // class-flip mutation path falls through to a string concatenation
+    // tail that the parser ignores by design (off-pool variants).
+    let cyclic_idx = n - ((n / 14) * 14);
+    let cyclic_class_idx = cyclic_idx / 7;
+    let cyclic_phr_idx = cyclic_idx - (cyclic_class_idx * 7);
     let mut_now = now_ms_via_shell();
+    // Phrasing-flip roll: 20% (mut_now % 100 < 20).
     let mut_roll = mut_now - ((mut_now / 100) * 100);
-    let idx = if mut_roll < 20 {
-        let rand_idx = mut_now - ((mut_now / 7) * 7);
-        rand_idx;
+    let phr_idx = if mut_roll < 20 {
+        let rand_phr = mut_now - ((mut_now / 7) * 7);
+        rand_phr;
     } else {
-        cyclic_idx;
+        cyclic_phr_idx;
     };
-    if idx == 0 {
-        return "lifetime-default";
+    // Class-flip roll: 10%, decorrelated by /7 then %100. The picked
+    // class index is decorrelated again via /11 then %8.
+    let class_now = mut_now / 7;
+    let class_roll = class_now - ((class_now / 100) * 100);
+    if class_roll < 10 {
+        let class_pick_now = mut_now / 11;
+        let class_pick = class_pick_now - ((class_pick_now / 8) * 8);
+        let phr_str_mut = if phr_idx == 0 {
+            "lifetime-default";
+        } else { if phr_idx == 1 {
+            "lifetime-strict-aliasing";
+        } else { if phr_idx == 2 {
+            "lifetime-broad-borrow";
+        } else { if phr_idx == 3 {
+            "lifetime-elision-corner";
+        } else { if phr_idx == 4 {
+            "lifetime-static-promotion";
+        } else { if phr_idx == 5 {
+            "lifetime-self-referential";
+        } else {
+            "lifetime-trait-object-bounds";
+        }; }; }; }; }; };
+        return _class_pick_universe(class_pick) + ":" + phr_str_mut;
     };
-    if idx == 1 {
-        return "lifetime-strict-aliasing";
+    // Seeded pool: 14 bare-literal returns parsed by analyse-stage3.
+    // class_idx == 0 => primary (use_after_free).
+    if cyclic_class_idx == 0 {
+        if phr_idx == 0 { return "use_after_free:lifetime-default"; };
+        if phr_idx == 1 { return "use_after_free:lifetime-strict-aliasing"; };
+        if phr_idx == 2 { return "use_after_free:lifetime-broad-borrow"; };
+        if phr_idx == 3 { return "use_after_free:lifetime-elision-corner"; };
+        if phr_idx == 4 { return "use_after_free:lifetime-static-promotion"; };
+        if phr_idx == 5 { return "use_after_free:lifetime-self-referential"; };
+        return "use_after_free:lifetime-trait-object-bounds";
     };
-    if idx == 2 {
-        return "lifetime-broad-borrow";
-    };
-    if idx == 3 {
-        return "lifetime-elision-corner";
-    };
-    if idx == 4 {
-        return "lifetime-static-promotion";
-    };
-    if idx == 5 {
-        return "lifetime-self-referential";
-    };
-    return "lifetime-trait-object-bounds";
+    // class_idx == 1 => sibling (dangling_borrow).
+    if phr_idx == 0 { return "dangling_borrow:lifetime-default"; };
+    if phr_idx == 1 { return "dangling_borrow:lifetime-strict-aliasing"; };
+    if phr_idx == 2 { return "dangling_borrow:lifetime-broad-borrow"; };
+    if phr_idx == 3 { return "dangling_borrow:lifetime-elision-corner"; };
+    if phr_idx == 4 { return "dangling_borrow:lifetime-static-promotion"; };
+    if phr_idx == 5 { return "dangling_borrow:lifetime-self-referential"; };
+    return "dangling_borrow:lifetime-trait-object-bounds";
 }
 
 fn self_node_addr() -> string {
@@ -566,7 +632,25 @@ fn tick(reason: string) -> void {
                 // LLM-tainted text through the JSON-on-stdin channel
                 // would force shell-vs-JSON quote interleaving with no
                 // benefit.
-                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + finding.class + "\"}";
+                // #499 M98 self-evolution: derive the verifier-payload
+                // class from the variant string (`<class>:<phrasing>`),
+                // not from the LLM's `finding.class` field. Misalignment
+                // between LLM-hunt-target and variant-claimed class
+                // becomes a verifier-falsepos that selection rewards or
+                // penalises via `variant_stats:<full-variant>:*` memos.
+                // Empty `_variant` (cold start) or legacy phrasing-only
+                // strings (no `:`) fall back to the tribe's primary class.
+                let _colon_idx = index_of(_variant, ":");
+                let _variant_class = if len(_variant) == 0 {
+                    _tribe_default_class();
+                } else {
+                    if _colon_idx >= 0 {
+                        substring(_variant, 0, _colon_idx);
+                    } else {
+                        _tribe_default_class();
+                    };
+                };
+                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + _variant_class + "\"}";
                 let verify_cmd = "printf '%s' " + shell_escape(finding_json) + " | bash \"$VERIFIER_PATH\"";
                 let verdict_raw = try {
                     exec sh verify_cmd;

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -60,41 +60,107 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #499: per-tribe primary class — used as fallback when a variant string
+// lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
+// pre-#499 builds where pick_variant emitted phrasing-only strings).
+fn _tribe_default_class() -> string {
+    return "use_after_free";
+}
+
+// #499: 8-class universe used by the class-flip mutation in
+// `pick_variant`. Indices 0..1 are the tribe's primary + sibling classes
+// (also seeded directly into the 14-literal pool below); 2..7 are
+// off-pool classes reachable only via the 10% class-flip mutation, so
+// `data_race` and `missing_lock` enter circulation only when the dice
+// fall that way.
+fn _class_pick_universe(idx: int) -> string {
+    if idx == 0 { return "use_after_free"; };
+    if idx == 1 { return "send_violation"; };
+    if idx == 2 { return "memory_corruption"; };
+    if idx == 3 { return "heap_overflow"; };
+    if idx == 4 { return "data_race"; };
+    if idx == 5 { return "dangling_borrow"; };
+    if idx == 6 { return "missing_lock"; };
+    return "uninitialised_memory";
+}
+
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
-    // B2 variation source: 7-variant pool with 20% mutation rate.
-    // Cyclic baseline (n mod 7) gives sibling diversity at spawn time.
-    // Mutation roll uses now_ms_via_shell() pseudo-random to pick a
-    // different variant ~20% of the time, breaking cyclic ruts and
-    // exposing new variants to selection pressure.
-    let cyclic_idx = n - ((n / 7) * 7);
+    // #499 M98 self-evolution: variant string carries `<class>:<phrasing>`
+    // so selection operates on the hunt-class trait, not just wording.
+    // Pool expanded from 7 phrasings to 14 = 7 phrasings * 2 sibling
+    // classes. Cyclic baseline `n mod 14` covers the seeded pool;
+    // `idx / 7` picks the primary (0) vs sibling (1) class, `idx % 7`
+    // picks the phrasing.
+    //
+    // Mutation operators (independent rolls, decorrelated by different
+    // moduli on the same `now_ms_via_shell()` source):
+    //   - 20% phrasing-flip (carry-over from #494): re-rolls the
+    //     phrasing within whatever class the cyclic baseline picked.
+    //   - 10% class-flip (#499 new): re-rolls the class against the
+    //     full 8-class universe. This is the only path by which
+    //     `data_race` and `missing_lock` enter circulation.
+    //
+    // Implementation note: the seeded pool is emitted as 14 bare
+    // string-literal returns so `analyse-stage3.py`'s
+    // `parse_variant_pool` regex picks them up unmodified. The
+    // class-flip mutation path falls through to a string concatenation
+    // tail that the parser ignores by design (off-pool variants).
+    let cyclic_idx = n - ((n / 14) * 14);
+    let cyclic_class_idx = cyclic_idx / 7;
+    let cyclic_phr_idx = cyclic_idx - (cyclic_class_idx * 7);
     let mut_now = now_ms_via_shell();
+    // Phrasing-flip roll: 20% (mut_now % 100 < 20).
     let mut_roll = mut_now - ((mut_now / 100) * 100);
-    let idx = if mut_roll < 20 {
-        let rand_idx = mut_now - ((mut_now / 7) * 7);
-        rand_idx;
+    let phr_idx = if mut_roll < 20 {
+        let rand_phr = mut_now - ((mut_now / 7) * 7);
+        rand_phr;
     } else {
-        cyclic_idx;
+        cyclic_phr_idx;
     };
-    if idx == 0 {
-        return "concurrency-default";
+    // Class-flip roll: 10%, decorrelated by /7 then %100. The picked
+    // class index is decorrelated again via /11 then %8.
+    let class_now = mut_now / 7;
+    let class_roll = class_now - ((class_now / 100) * 100);
+    if class_roll < 10 {
+        let class_pick_now = mut_now / 11;
+        let class_pick = class_pick_now - ((class_pick_now / 8) * 8);
+        let phr_str_mut = if phr_idx == 0 {
+            "concurrency-default";
+        } else { if phr_idx == 1 {
+            "concurrency-shared-state";
+        } else { if phr_idx == 2 {
+            "concurrency-lock-audit";
+        } else { if phr_idx == 3 {
+            "concurrency-channel-deadlock";
+        } else { if phr_idx == 4 {
+            "concurrency-atomic-ordering";
+        } else { if phr_idx == 5 {
+            "concurrency-cell-interior-mut";
+        } else {
+            "concurrency-async-await-races";
+        }; }; }; }; }; };
+        return _class_pick_universe(class_pick) + ":" + phr_str_mut;
     };
-    if idx == 1 {
-        return "concurrency-shared-state";
+    // Seeded pool: 14 bare-literal returns parsed by analyse-stage3.
+    // class_idx == 0 => primary (use_after_free).
+    if cyclic_class_idx == 0 {
+        if phr_idx == 0 { return "use_after_free:concurrency-default"; };
+        if phr_idx == 1 { return "use_after_free:concurrency-shared-state"; };
+        if phr_idx == 2 { return "use_after_free:concurrency-lock-audit"; };
+        if phr_idx == 3 { return "use_after_free:concurrency-channel-deadlock"; };
+        if phr_idx == 4 { return "use_after_free:concurrency-atomic-ordering"; };
+        if phr_idx == 5 { return "use_after_free:concurrency-cell-interior-mut"; };
+        return "use_after_free:concurrency-async-await-races";
     };
-    if idx == 2 {
-        return "concurrency-lock-audit";
-    };
-    if idx == 3 {
-        return "concurrency-channel-deadlock";
-    };
-    if idx == 4 {
-        return "concurrency-atomic-ordering";
-    };
-    if idx == 5 {
-        return "concurrency-cell-interior-mut";
-    };
-    return "concurrency-async-await-races";
+    // class_idx == 1 => sibling (send_violation).
+    if phr_idx == 0 { return "send_violation:concurrency-default"; };
+    if phr_idx == 1 { return "send_violation:concurrency-shared-state"; };
+    if phr_idx == 2 { return "send_violation:concurrency-lock-audit"; };
+    if phr_idx == 3 { return "send_violation:concurrency-channel-deadlock"; };
+    if phr_idx == 4 { return "send_violation:concurrency-atomic-ordering"; };
+    if phr_idx == 5 { return "send_violation:concurrency-cell-interior-mut"; };
+    return "send_violation:concurrency-async-await-races";
 }
 
 fn self_node_addr() -> string {
@@ -567,7 +633,25 @@ fn tick(reason: string) -> void {
                 // LLM-tainted text through the JSON-on-stdin channel
                 // would force shell-vs-JSON quote interleaving with no
                 // benefit.
-                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + finding.class + "\"}";
+                // #499 M98 self-evolution: derive the verifier-payload
+                // class from the variant string (`<class>:<phrasing>`),
+                // not from the LLM's `finding.class` field. Misalignment
+                // between LLM-hunt-target and variant-claimed class
+                // becomes a verifier-falsepos that selection rewards or
+                // penalises via `variant_stats:<full-variant>:*` memos.
+                // Empty `_variant` (cold start) or legacy phrasing-only
+                // strings (no `:`) fall back to the tribe's primary class.
+                let _colon_idx = index_of(_variant, ":");
+                let _variant_class = if len(_variant) == 0 {
+                    _tribe_default_class();
+                } else {
+                    if _colon_idx >= 0 {
+                        substring(_variant, 0, _colon_idx);
+                    } else {
+                        _tribe_default_class();
+                    };
+                };
+                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + _variant_class + "\"}";
                 let verify_cmd = "printf '%s' " + shell_escape(finding_json) + " | bash \"$VERIFIER_PATH\"";
                 let verdict_raw = try {
                     exec sh verify_cmd;

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -60,41 +60,107 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #499: per-tribe primary class — used as fallback when a variant string
+// lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
+// pre-#499 builds where pick_variant emitted phrasing-only strings).
+fn _tribe_default_class() -> string {
+    return "memory_corruption";
+}
+
+// #499: 8-class universe used by the class-flip mutation in
+// `pick_variant`. Indices 0..1 are the tribe's primary + sibling classes
+// (also seeded directly into the 14-literal pool below); 2..7 are
+// off-pool classes reachable only via the 10% class-flip mutation, so
+// `data_race` and `missing_lock` enter circulation only when the dice
+// fall that way.
+fn _class_pick_universe(idx: int) -> string {
+    if idx == 0 { return "memory_corruption"; };
+    if idx == 1 { return "dangling_borrow"; };
+    if idx == 2 { return "use_after_free"; };
+    if idx == 3 { return "heap_overflow"; };
+    if idx == 4 { return "data_race"; };
+    if idx == 5 { return "send_violation"; };
+    if idx == 6 { return "missing_lock"; };
+    return "uninitialised_memory";
+}
+
 fn pick_variant(tribe: string, n: int) -> string {
     let _ = tribe;
-    // B2 variation source: 7-variant pool with 20% mutation rate.
-    // Cyclic baseline (n mod 7) gives sibling diversity at spawn time.
-    // Mutation roll uses now_ms_via_shell() pseudo-random to pick a
-    // different variant ~20% of the time, breaking cyclic ruts and
-    // exposing new variants to selection pressure.
-    let cyclic_idx = n - ((n / 7) * 7);
+    // #499 M98 self-evolution: variant string carries `<class>:<phrasing>`
+    // so selection operates on the hunt-class trait, not just wording.
+    // Pool expanded from 7 phrasings to 14 = 7 phrasings * 2 sibling
+    // classes. Cyclic baseline `n mod 14` covers the seeded pool;
+    // `idx / 7` picks the primary (0) vs sibling (1) class, `idx % 7`
+    // picks the phrasing.
+    //
+    // Mutation operators (independent rolls, decorrelated by different
+    // moduli on the same `now_ms_via_shell()` source):
+    //   - 20% phrasing-flip (carry-over from #494): re-rolls the
+    //     phrasing within whatever class the cyclic baseline picked.
+    //   - 10% class-flip (#499 new): re-rolls the class against the
+    //     full 8-class universe. This is the only path by which
+    //     `data_race` and `missing_lock` enter circulation.
+    //
+    // Implementation note: the seeded pool is emitted as 14 bare
+    // string-literal returns so `analyse-stage3.py`'s
+    // `parse_variant_pool` regex picks them up unmodified. The
+    // class-flip mutation path falls through to a string concatenation
+    // tail that the parser ignores by design (off-pool variants).
+    let cyclic_idx = n - ((n / 14) * 14);
+    let cyclic_class_idx = cyclic_idx / 7;
+    let cyclic_phr_idx = cyclic_idx - (cyclic_class_idx * 7);
     let mut_now = now_ms_via_shell();
+    // Phrasing-flip roll: 20% (mut_now % 100 < 20).
     let mut_roll = mut_now - ((mut_now / 100) * 100);
-    let idx = if mut_roll < 20 {
-        let rand_idx = mut_now - ((mut_now / 7) * 7);
-        rand_idx;
+    let phr_idx = if mut_roll < 20 {
+        let rand_phr = mut_now - ((mut_now / 7) * 7);
+        rand_phr;
     } else {
-        cyclic_idx;
+        cyclic_phr_idx;
     };
-    if idx == 0 {
-        return "error-path-default";
+    // Class-flip roll: 10%, decorrelated by /7 then %100. The picked
+    // class index is decorrelated again via /11 then %8.
+    let class_now = mut_now / 7;
+    let class_roll = class_now - ((class_now / 100) * 100);
+    if class_roll < 10 {
+        let class_pick_now = mut_now / 11;
+        let class_pick = class_pick_now - ((class_pick_now / 8) * 8);
+        let phr_str_mut = if phr_idx == 0 {
+            "error-path-default";
+        } else { if phr_idx == 1 {
+            "error-path-unwrap-only";
+        } else { if phr_idx == 2 {
+            "error-path-broad-fallible";
+        } else { if phr_idx == 3 {
+            "error-path-question-mark";
+        } else { if phr_idx == 4 {
+            "error-path-panic-recovery";
+        } else { if phr_idx == 5 {
+            "error-path-result-coercion";
+        } else {
+            "error-path-error-conversion";
+        }; }; }; }; }; };
+        return _class_pick_universe(class_pick) + ":" + phr_str_mut;
     };
-    if idx == 1 {
-        return "error-path-unwrap-only";
+    // Seeded pool: 14 bare-literal returns parsed by analyse-stage3.
+    // class_idx == 0 => primary (memory_corruption).
+    if cyclic_class_idx == 0 {
+        if phr_idx == 0 { return "memory_corruption:error-path-default"; };
+        if phr_idx == 1 { return "memory_corruption:error-path-unwrap-only"; };
+        if phr_idx == 2 { return "memory_corruption:error-path-broad-fallible"; };
+        if phr_idx == 3 { return "memory_corruption:error-path-question-mark"; };
+        if phr_idx == 4 { return "memory_corruption:error-path-panic-recovery"; };
+        if phr_idx == 5 { return "memory_corruption:error-path-result-coercion"; };
+        return "memory_corruption:error-path-error-conversion";
     };
-    if idx == 2 {
-        return "error-path-broad-fallible";
-    };
-    if idx == 3 {
-        return "error-path-question-mark";
-    };
-    if idx == 4 {
-        return "error-path-panic-recovery";
-    };
-    if idx == 5 {
-        return "error-path-result-coercion";
-    };
-    return "error-path-error-conversion";
+    // class_idx == 1 => sibling (dangling_borrow).
+    if phr_idx == 0 { return "dangling_borrow:error-path-default"; };
+    if phr_idx == 1 { return "dangling_borrow:error-path-unwrap-only"; };
+    if phr_idx == 2 { return "dangling_borrow:error-path-broad-fallible"; };
+    if phr_idx == 3 { return "dangling_borrow:error-path-question-mark"; };
+    if phr_idx == 4 { return "dangling_borrow:error-path-panic-recovery"; };
+    if phr_idx == 5 { return "dangling_borrow:error-path-result-coercion"; };
+    return "dangling_borrow:error-path-error-conversion";
 }
 
 fn self_node_addr() -> string {
@@ -565,7 +631,25 @@ fn tick(reason: string) -> void {
                 // LLM-tainted text through the JSON-on-stdin channel
                 // would force shell-vs-JSON quote interleaving with no
                 // benefit.
-                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + finding.class + "\"}";
+                // #499 M98 self-evolution: derive the verifier-payload
+                // class from the variant string (`<class>:<phrasing>`),
+                // not from the LLM's `finding.class` field. Misalignment
+                // between LLM-hunt-target and variant-claimed class
+                // becomes a verifier-falsepos that selection rewards or
+                // penalises via `variant_stats:<full-variant>:*` memos.
+                // Empty `_variant` (cold start) or legacy phrasing-only
+                // strings (no `:`) fall back to the tribe's primary class.
+                let _colon_idx = index_of(_variant, ":");
+                let _variant_class = if len(_variant) == 0 {
+                    _tribe_default_class();
+                } else {
+                    if _colon_idx >= 0 {
+                        substring(_variant, 0, _colon_idx);
+                    } else {
+                        _tribe_default_class();
+                    };
+                };
+                let finding_json = "{\"line\": " + to_string(finding.line) + ", \"class\": \"" + _variant_class + "\"}";
                 let verify_cmd = "printf '%s' " + shell_escape(finding_json) + " | bash \"$VERIFIER_PATH\"";
                 let verdict_raw = try {
                     exec sh verify_cmd;


### PR DESCRIPTION
## Summary

Closes #499.

After B2 v2 (PR #498) shipped per-instance variant inheritance via wire, variants still varied only prompt phrasing — the bug class was hardcoded per tribe. Selection had nothing to differentiate over at the strategy level.

This PR encodes the hunt class itself in the variant string. Format: `<class>:<phrasing>`. Selection now operates on hunt strategy, not just wording. Lineages can drift between tribe class boundaries via mutation.

## What changed

- **`pick_variant()` in each hunter.ag**: 14-literal pool (2 classes × 7 phrasings). Per-tribe seeding:
  - alpha: `uninitialised_memory` + `memory_corruption`, prefix `format-pattern-`
  - beta: `heap_overflow` + `memory_corruption`, prefix `source-sink-`
  - gamma: `memory_corruption` + `dangling_borrow`, prefix `error-path-`
  - delta: `use_after_free` + `dangling_borrow`, prefix `lifetime-`
  - epsilon: `use_after_free` + `send_violation`, prefix `concurrency-`
- **`_tribe_default_class()` helper** per tribe — fallback when variant lacks `:` (legacy memo compat from pre-#499 smokes).
- **20% phrasing-flip mutation** (existing from #494) preserved.
- **NEW: 10% class-flip mutation** — picks one of 8 stage2 classes uniformly via `(now / 7) % 100` independent random source. `data_race` and `missing_lock` reachable only through this path.
- **Variant parser at verifier-call site**: splits `<class>:<phrasing>` via `index_of`/`substring`. Class part overrides JSON `class:` field sent to verifier. Empty/legacy variants fall back to tribe default.
- **CHANGELOG entry** under `[Unreleased] / Added`.
- **Test fixture sync** in `test-analyse-stage3.py` (4 sites updated to new pool literals, no analyser logic changes).

## Why this is META-level

A tribe-alpha hunter that mutates to `use_after_free:strict-literal` and finds verified bugs propagates that variant via the existing wire path. Over many generations, tribe boundaries blur. Tribe-alpha's population may be majority hunting `use_after_free` if that pays off in the current target. This is the divergence signature the apparatus was built to detect — at the strategy layer instead of the wording layer.

## Sample variant outputs (cyclic baseline, no mutation)

| Tribe | n=0 | n=7 | n=13 |
|---|---|---|---|
| alpha | `uninitialised_memory:format-pattern-default` | `memory_corruption:format-pattern-default` | `memory_corruption:format-pattern-deferred-eval` |
| beta | `heap_overflow:source-sink-default` | `memory_corruption:source-sink-default` | `memory_corruption:source-sink-iterator-chain` |
| gamma | `memory_corruption:error-path-default` | `dangling_borrow:error-path-default` | `dangling_borrow:error-path-error-conversion` |
| delta | `use_after_free:lifetime-default` | `dangling_borrow:lifetime-default` | `dangling_borrow:lifetime-trait-object-bounds` |
| epsilon | `use_after_free:concurrency-default` | `send_violation:concurrency-default` | `send_violation:concurrency-async-await-races` |

## Test plan

- [x] colony-lint: 168 passed / 0 failed / 3 skipped (matches origin/main baseline)
- [x] All 5 hunter.ag parse with v1.7.8 binary (3-arg replicate retained from #498)
- [ ] Smoke #48 (60 min wall, 5 min rotation): expect verified findings spread across multiple classes per tribe; lineage cross-tribe class drift visible in variant_stats; sustained verified rate past T+15min
- [ ] Risk-bail rule: if smoke #48 shows >50% drop in verified count vs #44 baseline, tune class-flip from 10% to 5% rather than revert

## Out of scope

- Free-form prompt rewriting via LLM (full M98). This PR keeps prompts as fixed templates; only varies which class label hunter sends.
- New classes outside the 8 stage2 verifier-recognised strings.
- analyse-stage3.py production logic changes (only test fixture sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)