### PR TITLE
fix(tribes-bench): M98 CB exhaustion + missing HUNTER_INITIAL_VARIANT env_passthrough

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,29 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Fixed
 
+- **M98 hunter CB exhaustion + missing env_passthrough for HUNTER_INITIAL_VARIANT**
+  (#499 follow-up). Two regressions surfaced in smoke #49 against PR
+  #500:
+  1. `cb 50000000;` per-tick budget was insufficient for the post-#500
+     hunter.ag tick body (expanded `pick_variant()` from 7 to 14
+     literals + class-flip path + variant parser at verifier-call
+     site). Daemons hit `CognitiveOverload: budget 0, required 1` on
+     every tick → `tick_err: 32, tick_ok: 0` per `agentis daemon list
+     --json`. Bumped `cb` declaration in all 5 hunter.ag and matching
+     `cb_budget` in colony.example.toml from 50000000 to 200000000
+     (4× headroom).
+  2. `run-stage3-docker.sh` bootstrap wrote
+     `exec.env_passthrough = ... HUNTER_INITIAL_FITNESS` but omitted
+     `HUNTER_INITIAL_VARIANT`. Even though M106 wire (agentis-core
+     v1.7.8 / #632) correctly set the env on the spawned process,
+     hunter's `exec sh "printenv HUNTER_INITIAL_VARIANT"` saw an
+     empty string because the agentis sandbox filtered it out. PR
+     #498's federation-side reader was a no-op in practice. Added
+     `HUNTER_INITIAL_VARIANT` to the env_passthrough list.
+
+  No production logic changes. Hot-fix only — restores B2 v2 + M98
+  the way they were meant to behave.
+
 - **`analyse-stage3.py` now reads the variant model observationally**
   ([#495](https://github.com/Replikanti/agentis-colonies/issues/495)).
   The previous build hardcoded a 3-element `VARIANT_CYCLE` and a

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -370,7 +370,7 @@ write_bootstrap() {
         printf '{\n'
         printf '  printf "federation.enabled = true\\n"\n'
         printf '  printf "federation.peers = host.containers.internal:%s\\n"\n' "$peer_port"
-        printf '  printf "exec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,TARGET_FILE,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT,HUNTER_INITIAL_FITNESS\\n"\n'
+        printf '  printf "exec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,TARGET_FILE,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT,HUNTER_INITIAL_FITNESS,HUNTER_INITIAL_VARIANT\\n"\n'
         printf '  printf "experience.enabled = true\\n"\n'
         printf '  printf "telemetry.enabled = true\\n"\n'
         printf '  printf "daemon.heartbeat_interval_ms = 600000\\n"\n'

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -13,7 +13,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 50000000;
+cb 200000000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-alpha/config/colony.example.toml
+++ b/tribes-bench/tribe-alpha/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 50000000
+cb_budget = 200000000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 50000000;
+cb 200000000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-beta/config/colony.example.toml
+++ b/tribes-bench/tribe-beta/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 50000000
+cb_budget = 200000000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 50000000;
+cb 200000000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-delta/config/colony.example.toml
+++ b/tribes-bench/tribe-delta/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 50000000
+cb_budget = 200000000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 50000000;
+cb 200000000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-epsilon/config/colony.example.toml
+++ b/tribes-bench/tribe-epsilon/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 50000000
+cb_budget = 200000000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -14,7 +14,7 @@
 // Requires: exec capability, replication capability, TARGET_DIR +
 // VERIFIER_PATH env vars (set by scripts/start-colony.sh).
 
-cb 50000000;
+cb 200000000;
 
 type Finding {
     line: int,

--- a/tribes-bench/tribe-gamma/config/colony.example.toml
+++ b/tribes-bench/tribe-gamma/config/colony.example.toml
@@ -29,7 +29,7 @@ backend = "cli"
 [[agents]]
 name = "hunter"
 source = "agents/hunter.ag"
-cb_budget = 50000000
+cb_budget = 200000000
 tick_interval_ms = 60000
 
 # Stage 1 M2+M3 (#364) economy knobs. Operator override path: edit


### PR DESCRIPTION
## Summary

Hot-fix for two regressions surfaced in smoke #49 against PR #500 (M98 class-evolution).

## Issue 1: CB exhaustion

Post-#500 `pick_variant()` grew from 7 to 14 literals plus class-flip path plus variant parser at verifier-call site. The `cb 50000000;` per-tick budget was insufficient.

Daemons hit `CognitiveOverload: budget 0, required 1` at every tick. `agentis daemon list --json` reported `tick_err: 32, tick_ok: 0, health: critical`. Tick body never reached `prompt()` → verifier → `learn()`, so zero verified findings, zero falsepos, zero `variant_stats:*` memo writes. Population imploded from 25 → ~5 alive in 16 minutes purely via fitness-threshold creep.

**Fix:** bumped `cb` declaration in all 5 `hunter.ag` and matching `cb_budget` in `colony.example.toml` from 50000000 to 200000000 (4× headroom).

## Issue 2: Missing env_passthrough

`run-stage3-docker.sh` bootstrap wrote `exec.env_passthrough = ... HUNTER_INITIAL_FITNESS` but omitted `HUNTER_INITIAL_VARIANT`. Even though agentis-core v1.7.8 (#632) correctly set the env on the M106-spawned process (verified visible in `/proc/<pid>/environ`), the hunter's `exec sh "printenv HUNTER_INITIAL_VARIANT"` saw an empty string because the agentis exec sandbox filtered it out.

PR #498's federation-side reader was a no-op in practice — replicas inherited variants only via the race-prone tribe-shared memo, not via wire.

**Fix:** added `HUNTER_INITIAL_VARIANT` to the env_passthrough list.

## Why neither was caught earlier

- Issue 1 lint-clean: `cb 50000000;` matches `cb_budget = 50000000` lint check. Runtime-only failure.
- Issue 2 was masked by `/proc/<pid>/environ` showing the env var set, plus M2-Malthusian replication still firing via the existing memo path. Variant_stats memos populated (via memo path), so observability looked OK in smoke #43d/#44 — but post-M98 smoke #49 made the broken path obvious because tick errors zeroed all activity.

## Validation

- [x] colony-lint: 168 passed / 0 failed / 3 skipped
- [ ] Smoke #50 (60 min wall, 5 min rotation) expected: sustained verified rate past T+5min, HUNTER_INITIAL_VARIANT visible to hunter via printenv (not just /proc), lineage class drift in `variant_stats:<class>:<phrasing>:*` keys

## Out of scope

- M98 design changes — this is purely fixup of the runtime gating.
- Smoke #50 (post-merge validation gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)