### PR TITLE
feat(tribes-bench): static learn() tag schema lint (#492, Loose category b)

### DIFF
--- a/tools/check-learn-tags.sh
+++ b/tools/check-learn-tags.sh
@@ -1,0 +1,558 @@
+#!/bin/bash
+# tools/check-learn-tags.sh: Validate `learn()` tag streams in tribes-bench
+# hunter agents against a per-call-site schema (#492).
+#
+# Background — Loose category (b)
+# ===============================
+# `tribes-bench/` fitness aggregation reads free-form `learn()` tags as
+# authoritative. The auto-promote / selection-fitness path classifies
+# experience rows by tag (`acted`, `replicated`, `false-positive`,
+# `reward=<int>`, ...). Once Stage 4 lineage variation lands, an evolved
+# hunter could emit `learn("hunt", ..., "success", ["acted", "reward=999"])`
+# without producing a verified finding and harvest selection reward.
+#
+# This is a **static lint-time** guardrail. For every literal tag list
+# present in `tribes-bench/tribe-*/agents/hunter.ag`, every tag must be
+# in the allowlist for the (topic, outcome) pair it belongs to. Unknown
+# (topic, outcome) pairs always FAIL — adding a new call site forces an
+# explicit schema update in this file.
+#
+# Known gap — dynamic tag evasion
+# -------------------------------
+# A tag list built from a variable or with `+`-concatenation cannot be
+# proven correct statically. The default mode WARNs on every such call
+# site (no failure); set `COLONY_LINT_STRICT_LEARN_TAGS=1` to upgrade to
+# a hard FAIL. A core-side runtime validator is the long-term fix
+# (follow-up to #492).
+#
+# Suppression
+# -----------
+# Add `// colony-lint: learn-tags-ok` on the `learn(` line itself or on
+# the immediately preceding line to silence a specific intentional
+# violation (e.g. a deliberate experimental tag during development).
+#
+# Usage: ./tools/check-learn-tags.sh [path]
+# Exit 0 on clean, 2 on schema violations, 3 on usage error.
+
+set -euo pipefail
+
+SCAN_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+if [ ! -e "$SCAN_ROOT" ]; then
+    echo "check-learn-tags: scan root does not exist: $SCAN_ROOT" >&2
+    exit 3
+fi
+
+STRICT="${COLONY_LINT_STRICT_LEARN_TAGS:-0}"
+
+FAIL=0
+WARN=0
+
+# Per (topic, outcome) literal-tag allowlist + parametric-tag patterns.
+# `<tn>` denotes a tribe-name placeholder accepted as either the literal
+# `tribe-{alpha,beta,gamma,delta,epsilon}` or the bareword `_tribe_name`
+# variable reference.
+#
+# Schema is derived from `grep -hn 'learn(' tribes-bench/tribe-*/agents/hunter.ag`
+# as of #492 (19 call sites per hunter, identical across 5 tribes).
+#
+# An unknown (topic, outcome) pair is a hard schema violation. New call
+# sites MUST update this table.
+check_pair_schema() {
+    # Inputs: $1 = topic, $2 = outcome
+    # Sets globals: ALLOWED_LITERALS (newline-separated), ALLOWED_PARAMS,
+    #   PAIR_KNOWN (0/1).
+    ALLOWED_LITERALS=""
+    ALLOWED_PARAMS=""
+    PAIR_KNOWN=0
+
+    case "$1:$2" in
+        "hunt:success")
+            ALLOWED_LITERALS="acted
+tribes-bench
+<tn>"
+            ALLOWED_PARAMS="reward=<int>"
+            PAIR_KNOWN=1
+            ;;
+        "hunt:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+tribes-bench"
+            PAIR_KNOWN=1
+            ;;
+        "hunt:failure")
+            ALLOWED_LITERALS="false-positive
+tribes-bench"
+            PAIR_KNOWN=1
+            ;;
+        "replicate:success")
+            ALLOWED_LITERALS="replicated
+tribes-bench
+<tn>"
+            PAIR_KNOWN=1
+            ;;
+        "replicate:failure")
+            ALLOWED_LITERALS="replicate-skip
+replicate-error
+replicate-nak
+tribes-bench
+<tn>"
+            PAIR_KNOWN=1
+            ;;
+        "reproductive_replicate:success")
+            ALLOWED_LITERALS="replicated
+reproductive
+tribes-bench
+<tn>"
+            PAIR_KNOWN=1
+            ;;
+        "self_death:failure")
+            ALLOWED_LITERALS="died
+self-aged
+tribes-bench
+<tn>"
+            PAIR_KNOWN=1
+            ;;
+        "selection_death:failure")
+            ALLOWED_LITERALS="died
+low-fitness
+tribes-bench
+<tn>"
+            PAIR_KNOWN=1
+            ;;
+        "death:failure")
+            ALLOWED_LITERALS="died
+tribes-bench
+<tn>"
+            PAIR_KNOWN=1
+            ;;
+        "knowledge_sell:failure")
+            ALLOWED_LITERALS="sell-failed
+tribes-bench"
+            PAIR_KNOWN=1
+            ;;
+        "market:cache_hit")
+            ALLOWED_LITERALS="tribes-bench"
+            ALLOWED_PARAMS="buyer:<tn>
+topic_kind:finding
+topic_kind:bundle"
+            PAIR_KNOWN=1
+            ;;
+    esac
+}
+
+# Test a single token against ALLOWED_LITERALS + ALLOWED_PARAMS.
+# Returns 0 (match) or 1 (no match) via $?.
+token_allowed() {
+    local tok="$1"
+    local lit
+    while IFS= read -r lit; do
+        [ -z "$lit" ] && continue
+        if [ "$tok" = "$lit" ]; then return 0; fi
+    done <<EOF
+$ALLOWED_LITERALS
+EOF
+    # Tribe-name placeholder: literal tribe-* or `_tribe_name` bareword.
+    case "$tok" in
+        tribe-alpha|tribe-beta|tribe-gamma|tribe-delta|tribe-epsilon|_tribe_name)
+            # `<tn>` is only allowed when the schema explicitly lists it.
+            case "$ALLOWED_LITERALS" in
+                *"<tn>"*) return 0 ;;
+            esac
+            ;;
+    esac
+    local pat
+    while IFS= read -r pat; do
+        [ -z "$pat" ] && continue
+        case "$pat" in
+            "reward=<int>")
+                case "$tok" in
+                    reward=*)
+                        local n="${tok#reward=}"
+                        case "$n" in
+                            ""|*[!0-9]*) ;;
+                            *) return 0 ;;
+                        esac
+                        ;;
+                esac
+                ;;
+            "buyer:<tn>")
+                case "$tok" in
+                    buyer:tribe-alpha|buyer:tribe-beta|buyer:tribe-gamma|buyer:tribe-delta|buyer:tribe-epsilon|buyer:_tribe_name)
+                        return 0
+                        ;;
+                esac
+                ;;
+            "topic_kind:finding")
+                [ "$tok" = "topic_kind:finding" ] && return 0
+                ;;
+            "topic_kind:bundle")
+                [ "$tok" = "topic_kind:bundle" ] && return 0
+                ;;
+        esac
+    done <<EOF
+$ALLOWED_PARAMS
+EOF
+    return 1
+}
+
+# Resolve a literal-only tag token from a single comma-separated tag
+# expression. Returns the literal via stdout, or an empty string when
+# the expression is non-literal (variable / `+`-concatenated runtime
+# value). Recognised literal shapes:
+#   - "<bareword>"                                -> bareword
+#   - "<prefix>" + <bareword-var>                 -> non-literal (returns "")
+#   - "reward=" + to_string(...) etc              -> reward=<int>  (parametric)
+#   - "buyer:" + _tribe_name                      -> buyer:<tn>    (parametric)
+extract_token() {
+    local expr="$1"
+    # Strip leading + trailing whitespace.
+    expr="${expr#"${expr%%[![:space:]]*}"}"
+    expr="${expr%"${expr##*[![:space:]]}"}"
+    [ -z "$expr" ] && { echo ""; return 0; }
+
+    # Pure quoted literal: "..."
+    case "$expr" in
+        \"*\")
+            local inner="${expr#\"}"
+            inner="${inner%\"}"
+            # Reject if it still contains a quote (means it was already a
+            # concat). Belt-and-suspenders — the caller's tokeniser
+            # already split on commas at depth 0.
+            case "$inner" in
+                *\"*) echo ""; return 0 ;;
+            esac
+            echo "$inner"
+            return 0
+            ;;
+    esac
+
+    # Bareword identifier (e.g. `_tribe_name`).
+    case "$expr" in
+        [a-zA-Z_]*)
+            local rest="$expr"
+            local clean=1
+            local c
+            local i=0
+            while [ "$i" -lt "${#rest}" ]; do
+                c="${rest:$i:1}"
+                case "$c" in
+                    [a-zA-Z0-9_]) ;;
+                    *) clean=0; break ;;
+                esac
+                i=$((i + 1))
+            done
+            if [ "$clean" = "1" ]; then
+                echo "$expr"
+                return 0
+            fi
+            ;;
+    esac
+
+    # `"prefix" + <rhs>` -> parametric. Used to recognise the well-known
+    # `"buyer:" + _tribe_name` and `"reward=" + to_string(...)` shapes.
+    # We open-code the parse so leading/trailing whitespace around `+`
+    # does not defeat us (the `case` glob `\"*\"*+*` would match even
+    # when `+` is inside the closing quote, so do it manually).
+    if [ "${expr:0:1}" = "\"" ]; then
+        # Find the next un-escaped `"` (we already rejected embedded
+        # quotes in the pure-literal branch above, so a second `"`
+        # always closes the prefix string).
+        local rest="${expr:1}"
+        local close="${rest%%\"*}"
+        if [ "$close" != "$rest" ]; then
+            local prefix="$close"
+            local after="${rest#"$close"\"}"
+            # Strip whitespace around the `+`.
+            after="${after#"${after%%[![:space:]]*}"}"
+            if [ "${after:0:1}" = "+" ]; then
+                local tail="${after#+}"
+                tail="${tail#"${tail%%[![:space:]]*}"}"
+                tail="${tail%"${tail##*[![:space:]]}"}"
+                case "$prefix" in
+                    "buyer:")
+                        if [ "$tail" = "_tribe_name" ]; then
+                            echo "buyer:_tribe_name"
+                            return 0
+                        fi
+                        ;;
+                    "reward=")
+                        case "$tail" in
+                            to_string\(*)
+                                echo "reward=0"
+                                return 0
+                                ;;
+                        esac
+                        ;;
+                esac
+            fi
+        fi
+    fi
+
+    # Anything else: dynamic. Signal to caller via empty string.
+    echo ""
+    return 0
+}
+
+# Split a top-level argument string `s` on commas at parenthesis/bracket
+# depth 0. Emits one token per line.
+split_top_level_commas() {
+    local s="$1"
+    local depth=0
+    local cur=""
+    local i=0
+    local c
+    local in_str=0
+    local esc=0
+    while [ "$i" -lt "${#s}" ]; do
+        c="${s:$i:1}"
+        if [ "$in_str" = "1" ]; then
+            cur="$cur$c"
+            if [ "$esc" = "1" ]; then
+                esc=0
+            elif [ "$c" = "\\" ]; then
+                esc=1
+            elif [ "$c" = "\"" ]; then
+                in_str=0
+            fi
+            i=$((i + 1))
+            continue
+        fi
+        case "$c" in
+            \")
+                in_str=1
+                cur="$cur$c"
+                ;;
+            \(|\[)
+                depth=$((depth + 1))
+                cur="$cur$c"
+                ;;
+            \)|\])
+                depth=$((depth - 1))
+                cur="$cur$c"
+                ;;
+            ,)
+                if [ "$depth" -le 0 ]; then
+                    printf '%s\n' "$cur"
+                    cur=""
+                else
+                    cur="$cur$c"
+                fi
+                ;;
+            *)
+                cur="$cur$c"
+                ;;
+        esac
+        i=$((i + 1))
+    done
+    if [ -n "$cur" ]; then
+        printf '%s\n' "$cur"
+    fi
+}
+
+check_file() {
+    local ag_file="$1"
+    local prev_line=""
+    local nr=0
+    local line clean
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        nr=$((nr + 1))
+        # Strip `//` line comment (everything from `//` onward) before
+        # matching; suppression check uses the ORIGINAL line so the
+        # `// colony-lint: learn-tags-ok` marker still works.
+        clean="$line"
+        case "$clean" in
+            *"//"*) clean="${clean%%//*}" ;;
+        esac
+
+        # Skip lines that don't begin a learn( call.
+        case "$clean" in
+            *learn\(*) ;;
+            *) prev_line="$line"; continue ;;
+        esac
+
+        # Suppression marker on this or previous line.
+        local suppressed=0
+        case "$line" in
+            *"colony-lint: learn-tags-ok"*) suppressed=1 ;;
+        esac
+        case "$prev_line" in
+            *"colony-lint: learn-tags-ok"*) suppressed=1 ;;
+        esac
+        if [ "$suppressed" = "1" ]; then
+            prev_line="$line"
+            continue
+        fi
+
+        # Strip up to and including `learn(`, then balance parens to find
+        # the matching `)`. Multi-line `learn(` would require a buffered
+        # read; current hunters always one-line so we stop at end-of-line.
+        local body="${clean#*learn\(}"
+
+        # Walk `body` until parens balance back to zero. Track strings so
+        # `(` / `)` inside `"..."` are not counted.
+        local depth=1
+        local arg=""
+        local i=0
+        local c esc=0 in_str=0
+        while [ "$i" -lt "${#body}" ]; do
+            c="${body:$i:1}"
+            if [ "$in_str" = "1" ]; then
+                arg="$arg$c"
+                if [ "$esc" = "1" ]; then
+                    esc=0
+                elif [ "$c" = "\\" ]; then
+                    esc=1
+                elif [ "$c" = "\"" ]; then
+                    in_str=0
+                fi
+                i=$((i + 1))
+                continue
+            fi
+            case "$c" in
+                \")
+                    in_str=1
+                    arg="$arg$c"
+                    ;;
+                \()
+                    depth=$((depth + 1))
+                    arg="$arg$c"
+                    ;;
+                \))
+                    depth=$((depth - 1))
+                    if [ "$depth" -le 0 ]; then break; fi
+                    arg="$arg$c"
+                    ;;
+                *)
+                    arg="$arg$c"
+                    ;;
+            esac
+            i=$((i + 1))
+        done
+
+        if [ "$depth" -gt 0 ]; then
+            # Multi-line learn() — out of scope, warn + skip.
+            printf 'check-learn-tags: %s:%d: WARN: multi-line learn() call skipped\n' "$ag_file" "$nr" >&2
+            WARN=$((WARN + 1))
+            prev_line="$line"
+            continue
+        fi
+
+        # `arg` now holds the comma-separated argument list (top-level).
+        # Split on top-level commas into 5 args:
+        # learn(topic, key, value, outcome, [tags...]).
+        local args
+        args="$(split_top_level_commas "$arg")"
+
+        local arg1 arg4 arg5
+        # shellcheck disable=SC2034
+        arg1="$(printf '%s\n' "$args" | sed -n '1p')"
+        arg4="$(printf '%s\n' "$args" | sed -n '4p')"
+        arg5="$(printf '%s\n' "$args" | sed -n '5p')"
+
+        local topic outcome
+        topic="$(extract_token "$arg1")"
+        outcome="$(extract_token "$arg4")"
+
+        if [ -z "$topic" ] || [ -z "$outcome" ]; then
+            printf 'check-learn-tags: %s:%d: WARN: dynamic topic/outcome (topic=%s outcome=%s) — cannot validate statically\n' "$ag_file" "$nr" "${topic:-<dyn>}" "${outcome:-<dyn>}" >&2
+            WARN=$((WARN + 1))
+            prev_line="$line"
+            continue
+        fi
+
+        check_pair_schema "$topic" "$outcome"
+        if [ "$PAIR_KNOWN" = "0" ]; then
+            # shellcheck disable=SC2016
+            printf '%s:%d — VIOLATION: unknown (topic=%s, outcome=%s) — extend tools/check-learn-tags.sh schema or annotate with `// colony-lint: learn-tags-ok`\n' "$ag_file" "$nr" "$topic" "$outcome"
+            FAIL=$((FAIL + 1))
+            prev_line="$line"
+            continue
+        fi
+
+        # Extract the tag list (5th arg). Expect shape: `[ a, b, c ]`.
+        local tag_body="$arg5"
+        # Strip leading/trailing whitespace.
+        tag_body="${tag_body#"${tag_body%%[![:space:]]*}"}"
+        tag_body="${tag_body%"${tag_body##*[![:space:]]}"}"
+        case "$tag_body" in
+            \[*\])
+                tag_body="${tag_body#\[}"
+                tag_body="${tag_body%\]}"
+                ;;
+            *)
+                # Tag list is a variable reference, not a literal list.
+                if [ "$STRICT" = "1" ]; then
+                    printf '%s:%d — VIOLATION: non-literal tag list (topic=%s outcome=%s) under COLONY_LINT_STRICT_LEARN_TAGS=1\n' "$ag_file" "$nr" "$topic" "$outcome"
+                    FAIL=$((FAIL + 1))
+                else
+                    printf 'check-learn-tags: %s:%d: WARN: non-literal tag list (topic=%s outcome=%s) — runtime evasion gap; rerun with COLONY_LINT_STRICT_LEARN_TAGS=1 to fail\n' "$ag_file" "$nr" "$topic" "$outcome" >&2
+                    WARN=$((WARN + 1))
+                fi
+                prev_line="$line"
+                continue
+                ;;
+        esac
+
+        # Tokenize tags on top-level commas.
+        local tag_list
+        tag_list="$(split_top_level_commas "$tag_body")"
+
+        local raw tok any_dynamic=0
+        while IFS= read -r raw; do
+            [ -z "${raw// /}" ] && continue
+            tok="$(extract_token "$raw")"
+            if [ -z "$tok" ]; then
+                any_dynamic=1
+                continue
+            fi
+            if ! token_allowed "$tok"; then
+                printf '%s:%d — VIOLATION: topic=%s outcome=%s unexpected tag %s\n' "$ag_file" "$nr" "$topic" "$outcome" "$tok"
+                FAIL=$((FAIL + 1))
+            fi
+        done <<EOF
+$tag_list
+EOF
+
+        if [ "$any_dynamic" = "1" ]; then
+            if [ "$STRICT" = "1" ]; then
+                printf '%s:%d — VIOLATION: dynamic tag token in (topic=%s outcome=%s) under COLONY_LINT_STRICT_LEARN_TAGS=1\n' "$ag_file" "$nr" "$topic" "$outcome"
+                FAIL=$((FAIL + 1))
+            else
+                printf 'check-learn-tags: %s:%d: WARN: dynamic tag token (topic=%s outcome=%s) — runtime evasion gap; rerun with COLONY_LINT_STRICT_LEARN_TAGS=1 to fail\n' "$ag_file" "$nr" "$topic" "$outcome" >&2
+                WARN=$((WARN + 1))
+            fi
+        fi
+
+        prev_line="$line"
+    done < "$ag_file"
+}
+
+# Main: walk tribes-bench/tribe-*/agents/*.ag (hunter agents today; the
+# glob is intentionally one level broader so a future scout.ag /
+# verifier.ag picks up coverage automatically). Skip `runs/` snapshots.
+if [ -f "$SCAN_ROOT" ]; then
+    check_file "$SCAN_ROOT"
+else
+    while IFS= read -r -d '' f; do
+        case "$f" in
+            */runs/*) continue ;;
+        esac
+        check_file "$f"
+    done < <(find "$SCAN_ROOT" -type f -path '*/tribes-bench/tribe-*/agents/*.ag' -print0)
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "" >&2
+    echo "check-learn-tags: $FAIL violation(s), $WARN warning(s)" >&2
+    exit 2
+fi
+
+if [ "$WARN" -gt 0 ]; then
+    echo "check-learn-tags: $WARN warning(s) (dynamic tag construction — known evasion gap)" >&2
+fi
+
+exit 0

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -579,6 +579,27 @@ if [ -x "$REPO_ROOT/tools/check-prompt-gate.sh" ]; then
     fi
 fi
 
+# --- Check learn() tag schema in tribes-bench hunters (#492) ---
+# `tribes-bench/` fitness aggregation reads free-form `learn()` tags as
+# authoritative — auto-promote / selection-fitness classifies experience
+# rows by tag (acted / replicated / reward=<int> / ...). An evolved
+# hunter could emit `learn("hunt", ..., "success", ["acted", "reward=999"])`
+# without producing a verified finding and harvest selection reward.
+# This static lint blocks unknown literal tags at edit-time. Dynamic
+# tag construction (variable refs / `+`-concat tag lists) is a known
+# evasion gap — WARN by default, FAIL under
+# `COLONY_LINT_STRICT_LEARN_TAGS=1`. See the script header for the full
+# Loose category (b) context.
+if [ -x "$REPO_ROOT/tools/check-learn-tags.sh" ]; then
+    check_out="$("$REPO_ROOT/tools/check-learn-tags.sh" "$REPO_ROOT" 2>&1)" && check_rc=0 || check_rc=$?
+    if [ "$check_rc" -eq 0 ]; then
+        pass "check-learn-tags: tribes-bench learn() tag streams match per-call-site schema (#492)"
+    else
+        fail "check-learn-tags: schema violation in tribes-bench learn() tag stream (#492)"
+        printf '%s\n' "$check_out"
+    fi
+fi
+
 # --- Plaintext token detection (#321) ---
 # Walks `[forge.*]` sections in every colony.toml / colony.example.toml
 # under the repo and flags `token` / `*api_key*` / `*secret*` values

--- a/tools/test-check-learn-tags.sh
+++ b/tools/test-check-learn-tags.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+# tools/test-check-learn-tags.sh: unit tests for tools/check-learn-tags.sh.
+#
+# Self-contained. Creates temporary .ag fixture files, runs the checker
+# against them, asserts exit code + output pattern. Cleans up on exit.
+#
+# Usage: ./tools/test-check-learn-tags.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECKER="$SCRIPT_DIR/check-learn-tags.sh"
+
+if [ ! -x "$CHECKER" ]; then
+    echo "[FAIL] checker not found or not executable: $CHECKER"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# write_fixture <name> <content>
+# Returns: path to the fixture file via stdout.
+write_fixture() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name.ag"
+    printf '%s' "$content" > "$path"
+    printf '%s' "$path"
+}
+
+# run_checker <fixture-path> [strict]
+# Captures combined stdout+stderr in $out, exit code in $rc.
+run_checker() {
+    set +e
+    if [ "${2:-0}" = "1" ]; then
+        out="$(COLONY_LINT_STRICT_LEARN_TAGS=1 "$CHECKER" "$1" 2>&1)"
+    else
+        out="$("$CHECKER" "$1" 2>&1)"
+    fi
+    rc=$?
+    set -e
+}
+
+# --- Test 1: positive snapshot — current hunter.ag must pass clean ---
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+run_checker "$REPO_ROOT/tribes-bench/tribe-alpha/agents/hunter.ag"
+if [ "$rc" -eq 0 ]; then
+    pass "snapshot tribe-alpha hunter.ag passes (0 violations, exit 0)"
+else
+    fail "snapshot tribe-alpha hunter.ag" "rc=$rc out=$out"
+fi
+
+# Loop over all 5 tribes too — same expectation.
+all_tribes_ok=1
+for trb in alpha beta gamma delta epsilon; do
+    run_checker "$REPO_ROOT/tribes-bench/tribe-$trb/agents/hunter.ag"
+    if [ "$rc" -ne 0 ]; then
+        all_tribes_ok=0
+        echo "  tribe-$trb: rc=$rc out=$out"
+    fi
+done
+if [ "$all_tribes_ok" = "1" ]; then
+    pass "snapshot all 5 tribes (alpha/beta/gamma/delta/epsilon) pass clean"
+else
+    fail "snapshot all 5 tribes" "at least one tribe failed (see above)"
+fi
+
+# --- Test 2: violation A — extraneous parametric tag ---
+f="$(write_fixture "violation-fake-reward" '
+fn tick() -> void {
+    learn("hunt", "line 1", "x", "success", ["acted", "tribes-bench", "tribe-alpha", "fake-reward=999"]);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 2 ] && [ -n "$out" ] && (printf '%s' "$out" | grep -q "VIOLATION: topic=hunt outcome=success unexpected tag fake-reward=999"); then
+    pass "violation-A: hunt/success rejects fake-reward=999 with exit 2"
+else
+    fail "violation-A" "rc=$rc out=$out"
+fi
+
+# --- Test 3: violation B — replicated tag under hunt/success ---
+f="$(write_fixture "violation-replicated" '
+fn tick() -> void {
+    learn("hunt", "k", "v", "success", ["acted", "replicated", "tribes-bench"]);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 2 ] && (printf '%s' "$out" | grep -q "VIOLATION: topic=hunt outcome=success unexpected tag replicated"); then
+    pass "violation-B: hunt/success rejects replicated tag with exit 2"
+else
+    fail "violation-B" "rc=$rc out=$out"
+fi
+
+# --- Test 4: unknown (topic, outcome) pair ---
+f="$(write_fixture "unknown-pair" '
+fn tick() -> void {
+    learn("promote_self", "k", "v", "success", ["tribes-bench"]);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 2 ] && (printf '%s' "$out" | grep -q "VIOLATION: unknown (topic=promote_self, outcome=success)"); then
+    pass "unknown-pair: promote_self/success rejected with exit 2"
+else
+    fail "unknown-pair" "rc=$rc out=$out"
+fi
+
+# --- Test 5: variable-bound tag list — WARN default, FAIL under strict ---
+f="$(write_fixture "variable-tag-list" '
+fn tick() -> void {
+    let dyn_tags = ["acted", "tribes-bench"];
+    learn("hunt", "k", "v", "success", dyn_tags);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && (printf '%s' "$out" | grep -q "WARN: non-literal tag list"); then
+    pass "variable-tag-list (default): WARN, exit 0"
+else
+    fail "variable-tag-list default" "rc=$rc out=$out"
+fi
+
+run_checker "$f" 1
+if [ "$rc" -eq 2 ] && (printf '%s' "$out" | grep -q "VIOLATION: non-literal tag list"); then
+    pass "variable-tag-list (strict): VIOLATION, exit 2"
+else
+    fail "variable-tag-list strict" "rc=$rc out=$out"
+fi
+
+# --- Test 6: known parametric tag — reward=<int> accepted ---
+f="$(write_fixture "ok-parametric-reward" '
+fn tick() -> void {
+    learn("hunt", "k", "v", "success", ["acted", "tribes-bench", _tribe_name, "reward=" + to_string(actual_reward)]);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "ok-parametric-reward: reward=<int> accepted, exit 0, no warn"
+else
+    fail "ok-parametric-reward" "rc=$rc out=$out"
+fi
+
+# --- Test 7: known parametric tag — buyer:<tn> accepted ---
+f="$(write_fixture "ok-parametric-buyer" '
+fn tick() -> void {
+    learn("market", topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "ok-parametric-buyer: buyer:<tn> + topic_kind:finding accepted, exit 0"
+else
+    fail "ok-parametric-buyer" "rc=$rc out=$out"
+fi
+
+# --- Test 8: tribe-name placeholder — _tribe_name accepted where <tn> allowed ---
+f="$(write_fixture "ok-tribe-name" '
+fn tick() -> void {
+    learn("self_death", _tribe_name, "age=1", "failure", ["died", "self-aged", "tribes-bench", _tribe_name]);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "ok-tribe-name: _tribe_name accepted in self_death/failure, exit 0"
+else
+    fail "ok-tribe-name" "rc=$rc out=$out"
+fi
+
+# --- Test 9: suppression marker on same line silences the violation ---
+f="$(write_fixture "suppressed-same-line" '
+fn tick() -> void {
+    learn("hunt", "k", "v", "success", ["acted", "tribes-bench", "fake-reward=999"]); // colony-lint: learn-tags-ok
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "suppressed-same-line: marker on the learn() line silences finding"
+else
+    fail "suppressed-same-line" "rc=$rc out=$out"
+fi
+
+# --- Test 10: suppression marker on preceding line silences ---
+f="$(write_fixture "suppressed-prev-line" '
+fn tick() -> void {
+    // colony-lint: learn-tags-ok
+    learn("hunt", "k", "v", "success", ["acted", "tribes-bench", "fake-reward=999"]);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "suppressed-prev-line: marker on prev line silences finding"
+else
+    fail "suppressed-prev-line" "rc=$rc out=$out"
+fi
+
+# --- Test 11: usage error — scan root does not exist ---
+set +e
+out="$("$CHECKER" /nonexistent/path/that/does/not/exist 2>&1)"
+rc=$?
+set -e
+if [ "$rc" -eq 3 ]; then
+    pass "usage-error: missing scan root returns exit 3"
+else
+    fail "usage-error" "rc=$rc out=$out"
+fi
+
+# --- Test 12: replicate/failure accepts all 3 failure modes ---
+f="$(write_fixture "ok-replicate-failures" '
+fn tick() -> void {
+    learn("replicate", "n=1", "cost=2", "failure", ["replicate-skip", "tribes-bench", _tribe_name]);
+    learn("replicate", "n=1", "cost=2", "failure", ["replicate-error", "tribes-bench", _tribe_name]);
+    learn("replicate", "n=1", "cost=2", "failure", ["replicate-nak", "tribes-bench", _tribe_name]);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    pass "ok-replicate-failures: all 3 failure-modes accepted"
+else
+    fail "ok-replicate-failures" "rc=$rc out=$out"
+fi
+
+# --- Test 13: tribe-name placeholder NOT allowed for hunt/failure (no <tn>) ---
+f="$(write_fixture "violation-tribe-name-where-disallowed" '
+fn tick() -> void {
+    learn("hunt", "k", "v", "failure", ["false-positive", "tribes-bench", _tribe_name]);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 2 ] && (printf '%s' "$out" | grep -q "VIOLATION: topic=hunt outcome=failure unexpected tag _tribe_name"); then
+    pass "violation-tribe-name-disallowed: hunt/failure does not allow _tribe_name"
+else
+    fail "violation-tribe-name-disallowed" "rc=$rc out=$out"
+fi
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -43,6 +43,32 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   `exec.env_passthrough` and seeds them on the per-tribe
   `start-colony.sh` invocation.
 
+- **Static `learn()` tag-schema lint for tribes-bench hunters**
+  ([#492](https://github.com/Replikanti/agentis-colonies/issues/492),
+  Loose category b). Fitness aggregation reads free-form `learn()` tags
+  as authoritative — auto-promote / selection-fitness classifies
+  experience rows by tag (`acted`, `replicated`, `false-positive`,
+  `reward=<int>`, ...). Once Stage 4 lineage variation lands, an
+  evolved hunter could emit
+  `learn("hunt", ..., "success", ["acted", "reward=999"])` without
+  producing a verified finding and harvest selection reward. New
+  `tools/check-learn-tags.sh` walks every
+  `tribes-bench/tribe-*/agents/*.ag`, parses each `learn(` call (topic,
+  outcome, tag list), and rejects any literal tag that is not in the
+  per-`(topic, outcome)` allowlist — the schema covers the 11 pairs
+  emitted by the current `hunter.ag` (19 call sites × 5 tribes = 95
+  identical-shape sites). Unknown `(topic, outcome)` pairs always FAIL,
+  forcing an explicit schema update on every new call site. Suppression
+  marker `// colony-lint: learn-tags-ok` is available for intentional
+  experimental violations. Wired into `tools/colony-lint.sh` (baseline
+  168 → 169 passing checks). Self-test: `tools/test-check-learn-tags.sh`
+  (15 cases). **Known gap — dynamic tag evasion:** a tag list built
+  from a variable or `+`-concatenation cannot be proven correct
+  statically. Default mode WARNs on every such call site; set
+  `COLONY_LINT_STRICT_LEARN_TAGS=1` to upgrade to a hard FAIL. A
+  core-side runtime validator is the long-term fix and remains a
+  follow-up.
+
 ### Added
 
 - **M98 v2 — class-parametrized hunter prompts**


### PR DESCRIPTION
## Summary

Closes #492. Second of 3 Loose anti-gaming guardrails (#491 + #492 + #493 landing tonight in parallel PRs).

Adds a static lint that asserts every `learn()` invocation in tribes-bench hunter.ag uses an allowed (topic, outcome, tags) combination. A gaming-evolved hunter that learns to emit fitness-inflating tags (e.g. crafted `reward=999` or false `replicated` claims) gets caught at commit time, before the offending mutation lands in main.

## What changed

- **`tools/check-learn-tags.sh`** (new, 558 lines): static schema validator. Parses each `learn(topic, key, value, outcome, [tags])` invocation across `tribes-bench/tribe-*/agents/*.ag`, enforces a per-(topic, outcome) allowlist. Exit 0 clean / 2 violations / 3 usage error. Honors `// colony-lint: learn-tags-ok` suppression marker. Dynamic tag construction (variable refs, `+` concat) WARNs by default, FAILs under `COLONY_LINT_STRICT_LEARN_TAGS=1`.
- **`tools/test-check-learn-tags.sh`** (new, 246 lines, 15 test cases): positive snapshot of all 5 tribes, parametric tag acceptance, unknown-pair rejection, literal violations, dynamic tag WARN/strict-FAIL, both suppression marker positions, replicate-failure mode coverage, tribe-name placeholder gating, usage error.
- **`tools/colony-lint.sh`** dispatch entry between `check-prompt-gate` and `[forge.*]` scanner.
- **CHANGELOG**: `### Security` entry under `[Unreleased]` documenting the gap (dynamic tags) and the strict-mode escape hatch.

## Schema (11 pairs)

| (topic, outcome) | Allowed tags |
|---|---|
| `hunt:success` | acted, tribes-bench, `<tn>`, `reward=<int>` |
| `hunt:partial` | acted, review-gated, emitted, observed, tribes-bench |
| `hunt:failure` | false-positive, tribes-bench |
| `replicate:success` | replicated, tribes-bench, `<tn>` |
| `replicate:failure` | replicate-skip, replicate-error, replicate-nak, tribes-bench, `<tn>` |
| `reproductive_replicate:success` | replicated, reproductive, tribes-bench, `<tn>` |
| `self_death:failure` | died, self-aged, tribes-bench, `<tn>` |
| `selection_death:failure` | died, low-fitness, tribes-bench, `<tn>` |
| `death:failure` | died, tribes-bench, `<tn>` |
| `knowledge_sell:failure` | sell-failed, tribes-bench |
| `market:cache_hit` | tribes-bench, `buyer:<tn>`, `topic_kind:finding|bundle` |

`<tn>` matches one of the 5 tribe-name placeholders.

## Validation

- [x] `colony-lint.sh`: **170 passed / 0 failed / 3 skipped** (baseline 168 + 1 dispatch + 1 auto-discovered test)
- [x] `test-check-learn-tags.sh`: 15 passed / 0 failed
- [x] `check-learn-tags.sh` against current main hunter.ag: 0 violations, 0 warnings
- [x] Shellcheck: clean
- [x] Injected violation smoke-test (`fake-reward=999`): correctly reports `file:line — VIOLATION: topic=hunt outcome=success unexpected tag fake-reward=999` and exits 2

## Threat model + scope

Closes Loose category (b) **for static commits**. Catches a hunter.ag commit that introduces unauthorized tags. Does NOT catch a runtime-mutated hunter that constructs tags via dynamic strings (e.g. evolved prompt → `learn(... [computed_tag])`). The dynamic-tag-evasion gap is intentional and documented; full coverage = core-side runtime `learn()` validator, separate follow-up.

## Out of scope

- Core-side runtime `learn()` argument validation.
- Cross-check between `learn()` tags and `bug-ledger.jsonl` rows (overlap with #491).
- Per-tribe specialty tag enums (current schema is federation-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)