### PR TITLE
feat(tribes-bench): consumer-side knowledge_sell answer validation (#493, Loose category c)

### DIFF
--- a/tools/check-learn-tags.sh
+++ b/tools/check-learn-tags.sh
@@ -140,6 +140,19 @@ topic_kind:finding
 topic_kind:bundle"
             PAIR_KNOWN=1
             ;;
+        "market:rejected")
+            # #493 Loose category (c): consumer-side knowledge_sell validation
+            # rejects answers whose claimed bug_id is not in the seller's
+            # verifier-stamped bug-ledger.jsonl. Emits this learn() with
+            # reason:unverifiable so downstream telemetry can distinguish
+            # rejections from cache hits.
+            ALLOWED_LITERALS="tribes-bench"
+            ALLOWED_PARAMS="buyer:<tn>
+topic_kind:finding
+topic_kind:bundle
+reason:unverifiable"
+            PAIR_KNOWN=1
+            ;;
     esac
 }
 
@@ -190,6 +203,9 @@ EOF
                 ;;
             "topic_kind:bundle")
                 [ "$tok" = "topic_kind:bundle" ] && return 0
+                ;;
+            "reason:unverifiable")
+                [ "$tok" = "reason:unverifiable" ] && return 0
                 ;;
         esac
     done <<EOF

--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -69,6 +69,43 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   core-side runtime validator is the long-term fix and remains a
   follow-up.
 
+- **Consumer-side `knowledge_buy` answer validation (Loose category c)**
+  ([#493](https://github.com/Replikanti/agentis-colonies/issues/493),
+  partial pair with the verifier-only ledger-writer hardening tracked in
+  [#491](https://github.com/Replikanti/agentis-colonies/issues/491)).
+  Every `knowledge_buy` callsite in `tribes-bench/tribe-*/agents/hunter.ag`
+  now runs a `verify-then-trust` gate on the returned answer before the
+  buyer treats it as truth: the claimed `bug_id` is parsed out of the
+  answer string and cross-checked against the seller tribe's
+  verifier-stamped `bug-ledger.jsonl` via `grep -F`. Two callsites are
+  gated — the single-finding buy (`tribes-bench-<sibling>/<bug>` topic)
+  parses ` bug=<ID>` from the `line=N bug=ID rationale=...` producer
+  format, and the espionage bundle buy (`tribes-bench-bundle/<sibling>`
+  topic) verifies every `;`-separated id in the producer's bundle list.
+  Both gates are fail-safe — empty answer, missing seller-ledger memo,
+  parse failure, or non-zero `exec sh` exit all collapse to "reject the
+  answer" (`false`), never to "accept" — and rejection is non-punitive
+  (no reputation hit, just discard) because punishment-on-rejection is
+  itself a gaming vector that needs adversarial-reputation analysis
+  before it lands. The gate runs *after* the existing lifecycle-event
+  switch so the four memo-store outcomes (`cache_hit` / `succeeded` /
+  `rejected` / `fallback`) stay attributable; a failed semantic
+  validation collapses the outcome to a new distinct
+  `rejected_unverified` value emitted on both the `learn("market", ...)`
+  tag set (with `reason:unverifiable`) and the per-tick
+  `emit_market_csv` outcome column. On rejection the
+  `memo_write("hunter:bought_context", ...)` is suppressed so the
+  buyer's downstream prompt never sees an unverifiable answer. The
+  `_validate_bought_answer(answer, seller_tribe, topic_kind)` helper
+  and both gate sites are byte-identical across all 5 hunter.ag files;
+  no new runtime builtins, no agentis floor bump. **Limitation**: the
+  gate only catches sells whose claimed `bug_id` is absent from the
+  seller's verifier-stamped ledger. A sell that quotes a `bug_id` that
+  *did* happen but lies in the `rationale=<...>` substring is not
+  caught — the verifier never inspects free-text rationale. Closing
+  that gap (rationale-string anchoring to measurements) is an explicit
+  Loose follow-up.
+
 ### Added
 
 - **M98 v2 — class-parametrized hunter prompts**

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -59,6 +59,70 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #493: consumer-side `knowledge_buy` answer validator (Loose category c).
+// Every `knowledge_buy` callsite cross-checks the returned answer's
+// claimed `bug_id` against the seller-tribe's verifier-stamped
+// `bug-ledger.jsonl` before trusting it. Fail-safe: any parse failure,
+// missing seller-ledger memo, or non-matching grep => return `false`
+// (reject the answer). Never falsely accept.
+//
+// `topic_kind == "finding"`: answer format produced by the single-finding
+// sell at hunter.ag L903 is `line=<N> bug=<ID> rationale=<...>`. Parse
+// the `bug=` token (space-delimited) and require one verifier-stamped
+// row in the seller's ledger.
+//
+// `topic_kind == "bundle"`: answer format produced by the bundle sell at
+// hunter.ag L933 is a `;`-separated list of bug_ids. Require *all* listed
+// ids to resolve to verifier-stamped rows. Empty list => `false`.
+//
+// Limitation (deferred): the gate only catches sells whose claimed
+// `bug_id` does not exist in the seller's ledger. A sell that quotes a
+// bug_id that *did* happen but whose `rationale=<...>` substring is
+// fabricated is NOT caught — the verifier never inspects free-text
+// rationale. Tracked separately as Loose's rationale-string anchoring
+// follow-up.
+fn _validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool {
+    if len(answer) == 0 { return false; };
+    let seller_ledger = recall_latest("tribe-" + seller_tribe + ":bug_ledger");
+    if len(seller_ledger) == 0 { return false; };
+
+    if topic_kind == "finding" {
+        // Parse `bug=<ID>` from the answer. Producer guarantees the
+        // token is preceded by " bug=" (single space) per L903.
+        let bug_marker = " bug=";
+        let bm_idx = index_of(answer, bug_marker);
+        if bm_idx < 0 { return false; };
+        let bug_start = bm_idx + len(bug_marker);
+        let after = substring(answer, bug_start, len(answer));
+        let space_idx = index_of(after, " ");
+        let bug_id = if space_idx >= 0 {
+            substring(after, 0, space_idx);
+        } else {
+            after;
+        };
+        if len(bug_id) == 0 { return false; };
+        // colony-lint: safe-exec-concat
+        let grep_cmd = "grep -F " + shell_escape("\"bug_id\": \"" + bug_id + "\"") + " " + shell_escape(seller_ledger) + " 2>/dev/null | head -1";
+        let hit = try { exec sh grep_cmd; } catch e { ""; };
+        return len(hit) > 0;
+    };
+
+    if topic_kind == "bundle" {
+        // Bundle producer emits `bug_id1;bug_id2;…;` (trailing `;`).
+        // One `exec sh` splits on `;`, counts non-empty ids (denom), and
+        // counts how many resolve to a verifier-stamped row (numer).
+        // Validation passes iff denom > 0 AND numer == denom. The pipeline
+        // is total: empty answer => denom=0 => reject. shell_escape on the
+        // dynamic args keeps user-controlled string substitution safe.
+        // colony-lint: safe-exec-concat
+        let bundle_cmd = "answer=" + shell_escape(answer) + "; ledger=" + shell_escape(seller_ledger) + "; denom=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -cv '^$'); if [ \"$denom\" -eq 0 ]; then exit 0; fi; numer=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -v '^$' | while read id; do grep -F \"\\\"bug_id\\\": \\\"$id\\\"\" \"$ledger\" >/dev/null 2>&1 && echo 1; done | wc -l); if [ \"$numer\" = \"$denom\" ]; then echo OK; fi";
+        let res = try { exec sh bundle_cmd; } catch e { ""; };
+        return len(res) > 0;
+    };
+
+    return false;
+}
+
 // #499: per-tribe primary class — used as fallback when a variant string
 // lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
 // pre-#499 builds where pick_variant emitted phrasing-only strings).
@@ -587,17 +651,38 @@ fn tick(reason: string) -> void {
                     let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
                     let bought = knowledge_buy(buy_topic, max_cb_buy);
                     let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_buy = if len(bought) > 0 {
+                    let lifecycle_outcome_buy = if len(bought) > 0 {
                         if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): semantic-validation gate. Runs
+                    // *after* the lifecycle-event switch so cache_hit /
+                    // succeeded / rejected / fallback stay attributable to
+                    // the memo-store layer; a failed validation collapses to
+                    // a distinct `rejected_unverified` outcome and suppresses
+                    // the bought_context memo write so downstream prompts
+                    // never see an unverifiable answer.
+                    let validated_buy = if len(bought) > 0 {
+                        _validate_bought_answer(bought, sibling, "finding");
+                    } else {
+                        false;
+                    };
+                    let outcome_buy = if len(bought) > 0 {
+                        if validated_buy { lifecycle_outcome_buy; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_buy;
+                    };
                     let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
                     if len(bought) > 0 {
-                        if outcome_buy == "cache_hit" {
-                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                        if validated_buy {
+                            if outcome_buy == "cache_hit" {
+                                learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                            };
+                            memo_write("hunter:bought_context", bought);
+                        } else {
+                            learn("market", buy_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought);
                     };
                     emit_market_csv(_tick_now_ms, "buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
                 };
@@ -621,17 +706,36 @@ fn tick(reason: string) -> void {
                     let prem_max_cb = premium_factor_for_rep(best_s);
                     let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
                     let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_eb = if len(bought_b) > 0 {
+                    let lifecycle_outcome_eb = if len(bought_b) > 0 {
                         if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): bundle semantic-validation
+                    // gate. Every `;`-separated bug_id in the bundle must
+                    // resolve to a verifier-stamped row in the seller's
+                    // ledger; first miss => `rejected_unverified` + suppress
+                    // memo write.
+                    let validated_eb = if len(bought_b) > 0 {
+                        _validate_bought_answer(bought_b, best_t, "bundle");
+                    } else {
+                        false;
+                    };
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if validated_eb { lifecycle_outcome_eb; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_eb;
+                    };
                     let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
                     if len(bought_b) > 0 {
-                        if outcome_eb == "cache_hit" {
-                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                        if validated_eb {
+                            if outcome_eb == "cache_hit" {
+                                learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                            };
+                            memo_write("hunter:bought_context", bought_b);
+                        } else {
+                            learn("market", espionage_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought_b);
                     };
                     emit_market_csv(_tick_now_ms, "buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
                 };

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -60,6 +60,70 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #493: consumer-side `knowledge_buy` answer validator (Loose category c).
+// Every `knowledge_buy` callsite cross-checks the returned answer's
+// claimed `bug_id` against the seller-tribe's verifier-stamped
+// `bug-ledger.jsonl` before trusting it. Fail-safe: any parse failure,
+// missing seller-ledger memo, or non-matching grep => return `false`
+// (reject the answer). Never falsely accept.
+//
+// `topic_kind == "finding"`: answer format produced by the single-finding
+// sell at hunter.ag L903 is `line=<N> bug=<ID> rationale=<...>`. Parse
+// the `bug=` token (space-delimited) and require one verifier-stamped
+// row in the seller's ledger.
+//
+// `topic_kind == "bundle"`: answer format produced by the bundle sell at
+// hunter.ag L933 is a `;`-separated list of bug_ids. Require *all* listed
+// ids to resolve to verifier-stamped rows. Empty list => `false`.
+//
+// Limitation (deferred): the gate only catches sells whose claimed
+// `bug_id` does not exist in the seller's ledger. A sell that quotes a
+// bug_id that *did* happen but whose `rationale=<...>` substring is
+// fabricated is NOT caught — the verifier never inspects free-text
+// rationale. Tracked separately as Loose's rationale-string anchoring
+// follow-up.
+fn _validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool {
+    if len(answer) == 0 { return false; };
+    let seller_ledger = recall_latest("tribe-" + seller_tribe + ":bug_ledger");
+    if len(seller_ledger) == 0 { return false; };
+
+    if topic_kind == "finding" {
+        // Parse `bug=<ID>` from the answer. Producer guarantees the
+        // token is preceded by " bug=" (single space) per L903.
+        let bug_marker = " bug=";
+        let bm_idx = index_of(answer, bug_marker);
+        if bm_idx < 0 { return false; };
+        let bug_start = bm_idx + len(bug_marker);
+        let after = substring(answer, bug_start, len(answer));
+        let space_idx = index_of(after, " ");
+        let bug_id = if space_idx >= 0 {
+            substring(after, 0, space_idx);
+        } else {
+            after;
+        };
+        if len(bug_id) == 0 { return false; };
+        // colony-lint: safe-exec-concat
+        let grep_cmd = "grep -F " + shell_escape("\"bug_id\": \"" + bug_id + "\"") + " " + shell_escape(seller_ledger) + " 2>/dev/null | head -1";
+        let hit = try { exec sh grep_cmd; } catch e { ""; };
+        return len(hit) > 0;
+    };
+
+    if topic_kind == "bundle" {
+        // Bundle producer emits `bug_id1;bug_id2;…;` (trailing `;`).
+        // One `exec sh` splits on `;`, counts non-empty ids (denom), and
+        // counts how many resolve to a verifier-stamped row (numer).
+        // Validation passes iff denom > 0 AND numer == denom. The pipeline
+        // is total: empty answer => denom=0 => reject. shell_escape on the
+        // dynamic args keeps user-controlled string substitution safe.
+        // colony-lint: safe-exec-concat
+        let bundle_cmd = "answer=" + shell_escape(answer) + "; ledger=" + shell_escape(seller_ledger) + "; denom=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -cv '^$'); if [ \"$denom\" -eq 0 ]; then exit 0; fi; numer=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -v '^$' | while read id; do grep -F \"\\\"bug_id\\\": \\\"$id\\\"\" \"$ledger\" >/dev/null 2>&1 && echo 1; done | wc -l); if [ \"$numer\" = \"$denom\" ]; then echo OK; fi";
+        let res = try { exec sh bundle_cmd; } catch e { ""; };
+        return len(res) > 0;
+    };
+
+    return false;
+}
+
 // #499: per-tribe primary class — used as fallback when a variant string
 // lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
 // pre-#499 builds where pick_variant emitted phrasing-only strings).
@@ -588,17 +652,38 @@ fn tick(reason: string) -> void {
                     let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
                     let bought = knowledge_buy(buy_topic, max_cb_buy);
                     let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_buy = if len(bought) > 0 {
+                    let lifecycle_outcome_buy = if len(bought) > 0 {
                         if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): semantic-validation gate. Runs
+                    // *after* the lifecycle-event switch so cache_hit /
+                    // succeeded / rejected / fallback stay attributable to
+                    // the memo-store layer; a failed validation collapses to
+                    // a distinct `rejected_unverified` outcome and suppresses
+                    // the bought_context memo write so downstream prompts
+                    // never see an unverifiable answer.
+                    let validated_buy = if len(bought) > 0 {
+                        _validate_bought_answer(bought, sibling, "finding");
+                    } else {
+                        false;
+                    };
+                    let outcome_buy = if len(bought) > 0 {
+                        if validated_buy { lifecycle_outcome_buy; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_buy;
+                    };
                     let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
                     if len(bought) > 0 {
-                        if outcome_buy == "cache_hit" {
-                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                        if validated_buy {
+                            if outcome_buy == "cache_hit" {
+                                learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                            };
+                            memo_write("hunter:bought_context", bought);
+                        } else {
+                            learn("market", buy_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought);
                     };
                     emit_market_csv(_tick_now_ms, "buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
                 };
@@ -622,17 +707,36 @@ fn tick(reason: string) -> void {
                     let prem_max_cb = premium_factor_for_rep(best_s);
                     let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
                     let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_eb = if len(bought_b) > 0 {
+                    let lifecycle_outcome_eb = if len(bought_b) > 0 {
                         if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): bundle semantic-validation
+                    // gate. Every `;`-separated bug_id in the bundle must
+                    // resolve to a verifier-stamped row in the seller's
+                    // ledger; first miss => `rejected_unverified` + suppress
+                    // memo write.
+                    let validated_eb = if len(bought_b) > 0 {
+                        _validate_bought_answer(bought_b, best_t, "bundle");
+                    } else {
+                        false;
+                    };
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if validated_eb { lifecycle_outcome_eb; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_eb;
+                    };
                     let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
                     if len(bought_b) > 0 {
-                        if outcome_eb == "cache_hit" {
-                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                        if validated_eb {
+                            if outcome_eb == "cache_hit" {
+                                learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                            };
+                            memo_write("hunter:bought_context", bought_b);
+                        } else {
+                            learn("market", espionage_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought_b);
                     };
                     emit_market_csv(_tick_now_ms, "buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
                 };

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -60,6 +60,70 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #493: consumer-side `knowledge_buy` answer validator (Loose category c).
+// Every `knowledge_buy` callsite cross-checks the returned answer's
+// claimed `bug_id` against the seller-tribe's verifier-stamped
+// `bug-ledger.jsonl` before trusting it. Fail-safe: any parse failure,
+// missing seller-ledger memo, or non-matching grep => return `false`
+// (reject the answer). Never falsely accept.
+//
+// `topic_kind == "finding"`: answer format produced by the single-finding
+// sell at hunter.ag L903 is `line=<N> bug=<ID> rationale=<...>`. Parse
+// the `bug=` token (space-delimited) and require one verifier-stamped
+// row in the seller's ledger.
+//
+// `topic_kind == "bundle"`: answer format produced by the bundle sell at
+// hunter.ag L933 is a `;`-separated list of bug_ids. Require *all* listed
+// ids to resolve to verifier-stamped rows. Empty list => `false`.
+//
+// Limitation (deferred): the gate only catches sells whose claimed
+// `bug_id` does not exist in the seller's ledger. A sell that quotes a
+// bug_id that *did* happen but whose `rationale=<...>` substring is
+// fabricated is NOT caught — the verifier never inspects free-text
+// rationale. Tracked separately as Loose's rationale-string anchoring
+// follow-up.
+fn _validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool {
+    if len(answer) == 0 { return false; };
+    let seller_ledger = recall_latest("tribe-" + seller_tribe + ":bug_ledger");
+    if len(seller_ledger) == 0 { return false; };
+
+    if topic_kind == "finding" {
+        // Parse `bug=<ID>` from the answer. Producer guarantees the
+        // token is preceded by " bug=" (single space) per L903.
+        let bug_marker = " bug=";
+        let bm_idx = index_of(answer, bug_marker);
+        if bm_idx < 0 { return false; };
+        let bug_start = bm_idx + len(bug_marker);
+        let after = substring(answer, bug_start, len(answer));
+        let space_idx = index_of(after, " ");
+        let bug_id = if space_idx >= 0 {
+            substring(after, 0, space_idx);
+        } else {
+            after;
+        };
+        if len(bug_id) == 0 { return false; };
+        // colony-lint: safe-exec-concat
+        let grep_cmd = "grep -F " + shell_escape("\"bug_id\": \"" + bug_id + "\"") + " " + shell_escape(seller_ledger) + " 2>/dev/null | head -1";
+        let hit = try { exec sh grep_cmd; } catch e { ""; };
+        return len(hit) > 0;
+    };
+
+    if topic_kind == "bundle" {
+        // Bundle producer emits `bug_id1;bug_id2;…;` (trailing `;`).
+        // One `exec sh` splits on `;`, counts non-empty ids (denom), and
+        // counts how many resolve to a verifier-stamped row (numer).
+        // Validation passes iff denom > 0 AND numer == denom. The pipeline
+        // is total: empty answer => denom=0 => reject. shell_escape on the
+        // dynamic args keeps user-controlled string substitution safe.
+        // colony-lint: safe-exec-concat
+        let bundle_cmd = "answer=" + shell_escape(answer) + "; ledger=" + shell_escape(seller_ledger) + "; denom=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -cv '^$'); if [ \"$denom\" -eq 0 ]; then exit 0; fi; numer=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -v '^$' | while read id; do grep -F \"\\\"bug_id\\\": \\\"$id\\\"\" \"$ledger\" >/dev/null 2>&1 && echo 1; done | wc -l); if [ \"$numer\" = \"$denom\" ]; then echo OK; fi";
+        let res = try { exec sh bundle_cmd; } catch e { ""; };
+        return len(res) > 0;
+    };
+
+    return false;
+}
+
 // #499: per-tribe primary class — used as fallback when a variant string
 // lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
 // pre-#499 builds where pick_variant emitted phrasing-only strings).
@@ -589,17 +653,38 @@ fn tick(reason: string) -> void {
                     let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
                     let bought = knowledge_buy(buy_topic, max_cb_buy);
                     let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_buy = if len(bought) > 0 {
+                    let lifecycle_outcome_buy = if len(bought) > 0 {
                         if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): semantic-validation gate. Runs
+                    // *after* the lifecycle-event switch so cache_hit /
+                    // succeeded / rejected / fallback stay attributable to
+                    // the memo-store layer; a failed validation collapses to
+                    // a distinct `rejected_unverified` outcome and suppresses
+                    // the bought_context memo write so downstream prompts
+                    // never see an unverifiable answer.
+                    let validated_buy = if len(bought) > 0 {
+                        _validate_bought_answer(bought, sibling, "finding");
+                    } else {
+                        false;
+                    };
+                    let outcome_buy = if len(bought) > 0 {
+                        if validated_buy { lifecycle_outcome_buy; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_buy;
+                    };
                     let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
                     if len(bought) > 0 {
-                        if outcome_buy == "cache_hit" {
-                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                        if validated_buy {
+                            if outcome_buy == "cache_hit" {
+                                learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                            };
+                            memo_write("hunter:bought_context", bought);
+                        } else {
+                            learn("market", buy_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought);
                     };
                     emit_market_csv(_tick_now_ms, "buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
                 };
@@ -623,17 +708,36 @@ fn tick(reason: string) -> void {
                     let prem_max_cb = premium_factor_for_rep(best_s);
                     let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
                     let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_eb = if len(bought_b) > 0 {
+                    let lifecycle_outcome_eb = if len(bought_b) > 0 {
                         if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): bundle semantic-validation
+                    // gate. Every `;`-separated bug_id in the bundle must
+                    // resolve to a verifier-stamped row in the seller's
+                    // ledger; first miss => `rejected_unverified` + suppress
+                    // memo write.
+                    let validated_eb = if len(bought_b) > 0 {
+                        _validate_bought_answer(bought_b, best_t, "bundle");
+                    } else {
+                        false;
+                    };
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if validated_eb { lifecycle_outcome_eb; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_eb;
+                    };
                     let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
                     if len(bought_b) > 0 {
-                        if outcome_eb == "cache_hit" {
-                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                        if validated_eb {
+                            if outcome_eb == "cache_hit" {
+                                learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                            };
+                            memo_write("hunter:bought_context", bought_b);
+                        } else {
+                            learn("market", espionage_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought_b);
                     };
                     emit_market_csv(_tick_now_ms, "buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
                 };

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -60,6 +60,70 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #493: consumer-side `knowledge_buy` answer validator (Loose category c).
+// Every `knowledge_buy` callsite cross-checks the returned answer's
+// claimed `bug_id` against the seller-tribe's verifier-stamped
+// `bug-ledger.jsonl` before trusting it. Fail-safe: any parse failure,
+// missing seller-ledger memo, or non-matching grep => return `false`
+// (reject the answer). Never falsely accept.
+//
+// `topic_kind == "finding"`: answer format produced by the single-finding
+// sell at hunter.ag L903 is `line=<N> bug=<ID> rationale=<...>`. Parse
+// the `bug=` token (space-delimited) and require one verifier-stamped
+// row in the seller's ledger.
+//
+// `topic_kind == "bundle"`: answer format produced by the bundle sell at
+// hunter.ag L933 is a `;`-separated list of bug_ids. Require *all* listed
+// ids to resolve to verifier-stamped rows. Empty list => `false`.
+//
+// Limitation (deferred): the gate only catches sells whose claimed
+// `bug_id` does not exist in the seller's ledger. A sell that quotes a
+// bug_id that *did* happen but whose `rationale=<...>` substring is
+// fabricated is NOT caught — the verifier never inspects free-text
+// rationale. Tracked separately as Loose's rationale-string anchoring
+// follow-up.
+fn _validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool {
+    if len(answer) == 0 { return false; };
+    let seller_ledger = recall_latest("tribe-" + seller_tribe + ":bug_ledger");
+    if len(seller_ledger) == 0 { return false; };
+
+    if topic_kind == "finding" {
+        // Parse `bug=<ID>` from the answer. Producer guarantees the
+        // token is preceded by " bug=" (single space) per L903.
+        let bug_marker = " bug=";
+        let bm_idx = index_of(answer, bug_marker);
+        if bm_idx < 0 { return false; };
+        let bug_start = bm_idx + len(bug_marker);
+        let after = substring(answer, bug_start, len(answer));
+        let space_idx = index_of(after, " ");
+        let bug_id = if space_idx >= 0 {
+            substring(after, 0, space_idx);
+        } else {
+            after;
+        };
+        if len(bug_id) == 0 { return false; };
+        // colony-lint: safe-exec-concat
+        let grep_cmd = "grep -F " + shell_escape("\"bug_id\": \"" + bug_id + "\"") + " " + shell_escape(seller_ledger) + " 2>/dev/null | head -1";
+        let hit = try { exec sh grep_cmd; } catch e { ""; };
+        return len(hit) > 0;
+    };
+
+    if topic_kind == "bundle" {
+        // Bundle producer emits `bug_id1;bug_id2;…;` (trailing `;`).
+        // One `exec sh` splits on `;`, counts non-empty ids (denom), and
+        // counts how many resolve to a verifier-stamped row (numer).
+        // Validation passes iff denom > 0 AND numer == denom. The pipeline
+        // is total: empty answer => denom=0 => reject. shell_escape on the
+        // dynamic args keeps user-controlled string substitution safe.
+        // colony-lint: safe-exec-concat
+        let bundle_cmd = "answer=" + shell_escape(answer) + "; ledger=" + shell_escape(seller_ledger) + "; denom=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -cv '^$'); if [ \"$denom\" -eq 0 ]; then exit 0; fi; numer=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -v '^$' | while read id; do grep -F \"\\\"bug_id\\\": \\\"$id\\\"\" \"$ledger\" >/dev/null 2>&1 && echo 1; done | wc -l); if [ \"$numer\" = \"$denom\" ]; then echo OK; fi";
+        let res = try { exec sh bundle_cmd; } catch e { ""; };
+        return len(res) > 0;
+    };
+
+    return false;
+}
+
 // #499: per-tribe primary class — used as fallback when a variant string
 // lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
 // pre-#499 builds where pick_variant emitted phrasing-only strings).
@@ -589,17 +653,38 @@ fn tick(reason: string) -> void {
                     let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
                     let bought = knowledge_buy(buy_topic, max_cb_buy);
                     let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_buy = if len(bought) > 0 {
+                    let lifecycle_outcome_buy = if len(bought) > 0 {
                         if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): semantic-validation gate. Runs
+                    // *after* the lifecycle-event switch so cache_hit /
+                    // succeeded / rejected / fallback stay attributable to
+                    // the memo-store layer; a failed validation collapses to
+                    // a distinct `rejected_unverified` outcome and suppresses
+                    // the bought_context memo write so downstream prompts
+                    // never see an unverifiable answer.
+                    let validated_buy = if len(bought) > 0 {
+                        _validate_bought_answer(bought, sibling, "finding");
+                    } else {
+                        false;
+                    };
+                    let outcome_buy = if len(bought) > 0 {
+                        if validated_buy { lifecycle_outcome_buy; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_buy;
+                    };
                     let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
                     if len(bought) > 0 {
-                        if outcome_buy == "cache_hit" {
-                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                        if validated_buy {
+                            if outcome_buy == "cache_hit" {
+                                learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                            };
+                            memo_write("hunter:bought_context", bought);
+                        } else {
+                            learn("market", buy_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought);
                     };
                     emit_market_csv(_tick_now_ms, "buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
                 };
@@ -623,17 +708,36 @@ fn tick(reason: string) -> void {
                     let prem_max_cb = premium_factor_for_rep(best_s);
                     let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
                     let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_eb = if len(bought_b) > 0 {
+                    let lifecycle_outcome_eb = if len(bought_b) > 0 {
                         if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): bundle semantic-validation
+                    // gate. Every `;`-separated bug_id in the bundle must
+                    // resolve to a verifier-stamped row in the seller's
+                    // ledger; first miss => `rejected_unverified` + suppress
+                    // memo write.
+                    let validated_eb = if len(bought_b) > 0 {
+                        _validate_bought_answer(bought_b, best_t, "bundle");
+                    } else {
+                        false;
+                    };
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if validated_eb { lifecycle_outcome_eb; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_eb;
+                    };
                     let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
                     if len(bought_b) > 0 {
-                        if outcome_eb == "cache_hit" {
-                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                        if validated_eb {
+                            if outcome_eb == "cache_hit" {
+                                learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                            };
+                            memo_write("hunter:bought_context", bought_b);
+                        } else {
+                            learn("market", espionage_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought_b);
                     };
                     emit_market_csv(_tick_now_ms, "buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
                 };

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -60,6 +60,70 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #493: consumer-side `knowledge_buy` answer validator (Loose category c).
+// Every `knowledge_buy` callsite cross-checks the returned answer's
+// claimed `bug_id` against the seller-tribe's verifier-stamped
+// `bug-ledger.jsonl` before trusting it. Fail-safe: any parse failure,
+// missing seller-ledger memo, or non-matching grep => return `false`
+// (reject the answer). Never falsely accept.
+//
+// `topic_kind == "finding"`: answer format produced by the single-finding
+// sell at hunter.ag L903 is `line=<N> bug=<ID> rationale=<...>`. Parse
+// the `bug=` token (space-delimited) and require one verifier-stamped
+// row in the seller's ledger.
+//
+// `topic_kind == "bundle"`: answer format produced by the bundle sell at
+// hunter.ag L933 is a `;`-separated list of bug_ids. Require *all* listed
+// ids to resolve to verifier-stamped rows. Empty list => `false`.
+//
+// Limitation (deferred): the gate only catches sells whose claimed
+// `bug_id` does not exist in the seller's ledger. A sell that quotes a
+// bug_id that *did* happen but whose `rationale=<...>` substring is
+// fabricated is NOT caught — the verifier never inspects free-text
+// rationale. Tracked separately as Loose's rationale-string anchoring
+// follow-up.
+fn _validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool {
+    if len(answer) == 0 { return false; };
+    let seller_ledger = recall_latest("tribe-" + seller_tribe + ":bug_ledger");
+    if len(seller_ledger) == 0 { return false; };
+
+    if topic_kind == "finding" {
+        // Parse `bug=<ID>` from the answer. Producer guarantees the
+        // token is preceded by " bug=" (single space) per L903.
+        let bug_marker = " bug=";
+        let bm_idx = index_of(answer, bug_marker);
+        if bm_idx < 0 { return false; };
+        let bug_start = bm_idx + len(bug_marker);
+        let after = substring(answer, bug_start, len(answer));
+        let space_idx = index_of(after, " ");
+        let bug_id = if space_idx >= 0 {
+            substring(after, 0, space_idx);
+        } else {
+            after;
+        };
+        if len(bug_id) == 0 { return false; };
+        // colony-lint: safe-exec-concat
+        let grep_cmd = "grep -F " + shell_escape("\"bug_id\": \"" + bug_id + "\"") + " " + shell_escape(seller_ledger) + " 2>/dev/null | head -1";
+        let hit = try { exec sh grep_cmd; } catch e { ""; };
+        return len(hit) > 0;
+    };
+
+    if topic_kind == "bundle" {
+        // Bundle producer emits `bug_id1;bug_id2;…;` (trailing `;`).
+        // One `exec sh` splits on `;`, counts non-empty ids (denom), and
+        // counts how many resolve to a verifier-stamped row (numer).
+        // Validation passes iff denom > 0 AND numer == denom. The pipeline
+        // is total: empty answer => denom=0 => reject. shell_escape on the
+        // dynamic args keeps user-controlled string substitution safe.
+        // colony-lint: safe-exec-concat
+        let bundle_cmd = "answer=" + shell_escape(answer) + "; ledger=" + shell_escape(seller_ledger) + "; denom=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -cv '^$'); if [ \"$denom\" -eq 0 ]; then exit 0; fi; numer=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -v '^$' | while read id; do grep -F \"\\\"bug_id\\\": \\\"$id\\\"\" \"$ledger\" >/dev/null 2>&1 && echo 1; done | wc -l); if [ \"$numer\" = \"$denom\" ]; then echo OK; fi";
+        let res = try { exec sh bundle_cmd; } catch e { ""; };
+        return len(res) > 0;
+    };
+
+    return false;
+}
+
 // #499: per-tribe primary class — used as fallback when a variant string
 // lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
 // pre-#499 builds where pick_variant emitted phrasing-only strings).
@@ -589,17 +653,38 @@ fn tick(reason: string) -> void {
                     let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
                     let bought = knowledge_buy(buy_topic, max_cb_buy);
                     let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_buy = if len(bought) > 0 {
+                    let lifecycle_outcome_buy = if len(bought) > 0 {
                         if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): semantic-validation gate. Runs
+                    // *after* the lifecycle-event switch so cache_hit /
+                    // succeeded / rejected / fallback stay attributable to
+                    // the memo-store layer; a failed validation collapses to
+                    // a distinct `rejected_unverified` outcome and suppresses
+                    // the bought_context memo write so downstream prompts
+                    // never see an unverifiable answer.
+                    let validated_buy = if len(bought) > 0 {
+                        _validate_bought_answer(bought, sibling, "finding");
+                    } else {
+                        false;
+                    };
+                    let outcome_buy = if len(bought) > 0 {
+                        if validated_buy { lifecycle_outcome_buy; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_buy;
+                    };
                     let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
                     if len(bought) > 0 {
-                        if outcome_buy == "cache_hit" {
-                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                        if validated_buy {
+                            if outcome_buy == "cache_hit" {
+                                learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                            };
+                            memo_write("hunter:bought_context", bought);
+                        } else {
+                            learn("market", buy_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought);
                     };
                     emit_market_csv(_tick_now_ms, "buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
                 };
@@ -623,17 +708,36 @@ fn tick(reason: string) -> void {
                     let prem_max_cb = premium_factor_for_rep(best_s);
                     let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
                     let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_eb = if len(bought_b) > 0 {
+                    let lifecycle_outcome_eb = if len(bought_b) > 0 {
                         if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): bundle semantic-validation
+                    // gate. Every `;`-separated bug_id in the bundle must
+                    // resolve to a verifier-stamped row in the seller's
+                    // ledger; first miss => `rejected_unverified` + suppress
+                    // memo write.
+                    let validated_eb = if len(bought_b) > 0 {
+                        _validate_bought_answer(bought_b, best_t, "bundle");
+                    } else {
+                        false;
+                    };
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if validated_eb { lifecycle_outcome_eb; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_eb;
+                    };
                     let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
                     if len(bought_b) > 0 {
-                        if outcome_eb == "cache_hit" {
-                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                        if validated_eb {
+                            if outcome_eb == "cache_hit" {
+                                learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                            };
+                            memo_write("hunter:bought_context", bought_b);
+                        } else {
+                            learn("market", espionage_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought_b);
                     };
                     emit_market_csv(_tick_now_ms, "buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
                 };


### PR DESCRIPTION
## Summary

Closes #493. Third and final Loose anti-gaming guardrail (#491 + #492 + #493).

Every `knowledge_buy(topic)` caller in hunter.ag now validates the seller's claimed `bug=<ID>` against the seller-tribe's verifier-stamped bug-ledger.jsonl before treating it as truth. A gaming-evolved hunter that broadcasts plausible-sounding-but-unverified answers gets rejected at the consumer site.

## What changed

- **Helper `_validate_bought_answer(answer, seller_tribe, kind)`** added near the top of each hunter.ag (byte-identical across 5 tribes). Resolves seller's ledger path via existing `recall_latest("tribe-" + seller_tribe + ":bug_ledger")` memo. For findings: parses ` bug=<ID>` (space-delimited), greps seller ledger. For bundles: splits the `;`-list, counts non-empty ids, greps each. Returns true iff all claimed bug_ids exist in seller's verifier-stamped ledger.
- **Validation gate at both `knowledge_buy(...)` sites** in each hunter.ag (alpha L588 single-finding, L622 bundle; ±1-2 in peers):
  1. After `knowledge_buy(...)` returns, compute existing 4-way `lifecycle_outcome` (cache_hit/succeeded/rejected/fallback)
  2. Run `_validate_bought_answer(bought, seller_tribe, "finding"|"bundle")` when `len(bought) > 0`
  3. Final `outcome = if validated { lifecycle_outcome } else { "rejected_unverified" }`
  4. Validated → keep existing `cache_hit` `learn()` + `memo_write("hunter:bought_context", bought)`. Unverified → emit `learn("market", topic, "", "rejected", [..., "reason:unverifiable"])` and skip the memo write.
  5. `emit_market_csv(...)` always fires with the final outcome.
- All `exec sh` dynamic values wrapped in `shell_escape()` + `// colony-lint: safe-exec-concat` markers.
- **CHANGELOG**: `### Security` entry under `[Unreleased]`.

## Threat model + scope

Closes Loose category (c) for **bug_id-claim** lies. A seller that broadcasts an answer with `bug=<ID>` that does NOT appear in their verifier-stamped ledger (which post-#491 means the verifier did NOT confirm it) gets rejected at every consumer site.

Does NOT close: a seller that broadcasts an answer with a REAL bug_id but a lied-about `rationale` text. The rationale is not cross-checkable against the ledger (verifier stamps `bug_id` only, not rationale). Documented as out-of-scope in CHANGELOG.

## Validation

- [x] `colony-lint.sh`: 168 passed / 0 failed / 3 skipped (matches baseline; this PR adds no new lint)
- [x] All 5 hunter.ag parse with v1.7.9 (`agentis commit` clean for each, distinct genesis hashes)
- [x] Helper + gate region byte-identical across 5 tribes (md5 `684bab46...` for finding-gate, `11180315...` for bundle-gate, `2b294eeb...` for helper)
- [x] Spot-check: each tribe has 1× helper definition, 2× knowledge_buy callsites, 2× validation invocations, 4× `rejected_unverified` references

## Fail-safe behavior

- Empty seller ledger memo → reject (return false)
- `bug=` not present in answer → reject
- `exec sh grep` non-zero exit → reject
- Parse failure → reject

Never falsely accepts. No reputation penalty on rejection (rejection-as-punishment is itself a gaming vector, deferred to future work).

## Out of scope

- Rationale-text validation against bug-pattern signatures.
- Cross-node ledger reconciliation (current setup has both nodes on shared volume mount; cross-node ledger reads work because path resolution is consistent).
- Lint-side (Path A) format enforcement on knowledge_sell answer construction site.
- Reputation penalty on rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)