### PR TITLE
fix(tribes-bench): check-learn-tags.sh inline marker no longer bleeds (#510)

### DIFF
--- a/tools/check-learn-tags.sh
+++ b/tools/check-learn-tags.sh
@@ -396,7 +396,17 @@ check_file() {
             *"colony-lint: learn-tags-ok"*) suppressed=1 ;;
         esac
         case "$prev_line" in
-            *"colony-lint: learn-tags-ok"*) suppressed=1 ;;
+            *"colony-lint: learn-tags-ok"*)
+                # If prev_line ALSO contains a learn( call, the marker was
+                # inline-paired with prev's learn() and must not propagate
+                # suppression forward to the current line (issue #510).
+                # Only above-line markers (sitting on their own line) silence
+                # the next learn() call.
+                case "$prev_line" in
+                    *learn\(*) ;;
+                    *) suppressed=1 ;;
+                esac
+                ;;
         esac
         if [ "$suppressed" = "1" ]; then
             prev_line="$line"

--- a/tools/test-check-learn-tags.sh
+++ b/tools/test-check-learn-tags.sh
@@ -237,6 +237,20 @@ else
     fail "violation-tribe-name-disallowed" "rc=$rc out=$out"
 fi
 
+# --- Test 14: inline marker on prev line does NOT bleed to next learn() (#510) ---
+f="$(write_fixture "inline-marker-no-bleed" '
+fn tick(rec: string) -> void {
+    learn("hunt", "x", "y", "success", ["acted", "tribes-bench", "fake1"]); // colony-lint: learn-tags-ok
+    learn("hunt", "x", "y", "success", ["acted", "tribes-bench", "fake2"]);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 2 ] && (printf '%s' "$out" | grep -q "VIOLATION: topic=hunt outcome=success unexpected tag fake2"); then
+    pass "inline-marker-no-bleed: inline marker silences own line only, next-line violation still reported (#510)"
+else
+    fail "inline-marker-no-bleed" "rc=$rc out=$out"
+fi
+
 # --- Summary ---
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Closes #510. Small bug fix surfaced by QA of #507.

Pre-fix: `// colony-lint: learn-tags-ok` INLINE on a `learn(...)` line ALSO silenced the next `learn(` invocation, because the prev-line check fired on any marker substring in prev's raw line without distinguishing inline-paired from above-line markers.

Post-fix: if `prev_line` contains both the marker substring AND a `learn(` call, the marker was inline-paired and suppression does NOT propagate to current line. Only above-line markers (marker alone on its own line above a learn call) still silence the next learn() — preserving the documented use case.

## What changed

- **`tools/check-learn-tags.sh`** (+11/-1): nested case at prev-line marker check. New inner `case "$prev_line" in *learn\(*) ;; *) suppressed=1 ;; esac` gates the propagation.
- **`tools/test-check-learn-tags.sh`** (+14): new Test 14 `inline-marker-no-bleed`. Fixture: two adjacent `learn()` calls, first inline-marker-suppressed with `fake1` tag, second bare with `fake2` tag. Assertion: exit 2 + violation reported for line 2's `fake2` tag.

Tests 9 (same-line) and 10 (above-line) both still pass — only the cross-line bleed scenario changes verdict.

## Validation

- [x] `test-check-learn-tags.sh`: 16 passed / 0 failed (13 existing + new Test 14)
- [x] `colony-lint.sh`: 170 passed / 0 failed / 3 skipped (baseline preserved)
- [x] `check-learn-tags.sh tribes-bench/tribe-*/agents/hunter.ag`: 0 violations (live code has no markers, unchanged behavior)

## Out of scope

- Rewriting the suppression marker syntax.
- Deprecating the inline form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)