### PR TITLE
fix(tribes-bench): test-llm-per-colony.sh retry-on-read for flush races (#509)

### DIFF
--- a/tools/test-llm-per-colony.sh
+++ b/tools/test-llm-per-colony.sh
@@ -123,6 +123,25 @@ make_colony_fixture() {
     } > "$fed/triage/config/colony.toml"
 }
 
+# Retry-with-backoff read of the recorded argv file. The shim `agentis`
+# appends to `$record_file` via `>>` from a forked child of start-colony.sh,
+# and our follow-up read can race the kernel flush of that append on busy
+# hosts. Up to 10 attempts x 150ms backoff (~1.5s ceiling) suppresses the
+# race without changing the shim or start-colony.sh. See #509 (flush race)
+# and #257 (the underlying `--restart-agent` flow that owns the real
+# ordering bug).
+read_recorded_argv() {
+    local record_file="$1"
+    local content=""
+    local _i
+    for _i in 1 2 3 4 5 6 7 8 9 10; do
+        content="$(cat "$record_file" 2>/dev/null || true)"
+        [ -n "$content" ] && break
+        sleep 0.15
+    done
+    printf '%s' "$content"
+}
+
 # Run start-colony.sh --restart-agent labeler for a fixture and capture
 # the daemon-launch argv into the recorded file. Returns the exit code
 # of start-colony.sh.
@@ -141,7 +160,7 @@ run_for_fixture() {
             "$fed/triage/config/colony.toml" \
             >"$FIXTURE_ROOT/$tag/start-colony.stdout" \
             2>"$FIXTURE_ROOT/$tag/start-colony.stderr" || true
-    cat "$record_file"
+    read_recorded_argv "$record_file"
 }
 
 # Count exact occurrences of `llm.<key>=<value>` lines in the recorded
@@ -186,11 +205,20 @@ assert_restart_ok() {
     # start-colony.sh exits 0 on success and prints `started <agent> pid=<n> tick=<ms>`.
     # The shim's `sleep 1` keeps the simulated agentis-daemon alive long enough
     # for the start-colony.sh `kill -0` liveness probe.
-    if grep -qE '^started ' "$FIXTURE_ROOT/$tag/start-colony.stdout" 2>/dev/null; then
-        pass "$name"
-    else
-        fail "$name" "expected 'started <agent>' line in stdout: $(cat "$FIXTURE_ROOT/$tag/start-colony.stdout" 2>/dev/null) / stderr: $(cat "$FIXTURE_ROOT/$tag/start-colony.stderr" 2>/dev/null)"
-    fi
+    #
+    # Retry-with-backoff: same flush race as `read_recorded_argv` — the
+    # start-colony.sh stdout redirect can lag the immediate grep on busy
+    # hosts. Up to 10 attempts x 150ms backoff (~1.5s ceiling). See #509.
+    local stdout_file="$FIXTURE_ROOT/$tag/start-colony.stdout"
+    local _i
+    for _i in 1 2 3 4 5 6 7 8 9 10; do
+        if grep -qE '^started ' "$stdout_file" 2>/dev/null; then
+            pass "$name"
+            return 0
+        fi
+        sleep 0.15
+    done
+    fail "$name" "expected 'started <agent>' line in stdout: $(cat "$stdout_file" 2>/dev/null) / stderr: $(cat "$FIXTURE_ROOT/$tag/start-colony.stderr" 2>/dev/null)"
 }
 
 # ----- t1: no [llm] block at all -----
@@ -250,7 +278,9 @@ assert_restart_ok "t5: --restart-agent succeeds with both override file AND [llm
 # token is absent. This is the primary safety net for future drift.
 ALL_RECORDED=""
 for tag in t1 t2 t3 t4 t5; do
-    ALL_RECORDED="$ALL_RECORDED $(cat "$FIXTURE_ROOT/$tag/agentis-argv.log" 2>/dev/null)"
+    # Re-read via the retry helper for the same flush-race reason
+    # documented above (#509).
+    ALL_RECORDED="$ALL_RECORDED $(read_recorded_argv "$FIXTURE_ROOT/$tag/agentis-argv.log")"
 done
 if printf '%s\n' "$ALL_RECORDED" | tr ' ' '\n' | grep -qx -- '--config-override'; then
     fail "t6: --config-override token leaked across one of t1-t5" "$ALL_RECORDED"


### PR DESCRIPTION
## Summary

Closes #509. Eliminates the test-llm-per-colony.sh flake (~1 in 10 CI runs flagged in QA of #506).

## Root cause — two flush races, not one

Original hypothesis from issue body identified the shim's `>>` append to `agentis-argv.log` vs immediate `cat` read in the test. That's race #1.

Empirical reproduction (pre-fix: 44/50 pass, 6 flakes mixed across t1/t2/t3/t5 `assert_restart_ok`) revealed race #2: `start-colony.sh`'s stdout-redirect write of `started <agent> pid=... tick=...` vs the immediate `grep -qE '^started '` in `assert_restart_ok`.

## Fix

Test-only, retry-on-read both sides:

- New `read_recorded_argv()` helper (10 attempts × 150ms backoff, ~1.5s ceiling). Replaces direct `cat agentis-argv.log` in `run_for_fixture` final assertion and t6 aggregate loop.
- `assert_restart_ok` retries the `grep -qE '^started '` on `start-colony.stdout` with the same 10×150ms shape. On exhaustion falls through to the original `fail` message.
- Inline comments at both retry sites reference #509 (race) and #257 (the underlying `--restart-agent` ordering bug the harness papers over).

## Plan deviation

Plan called for 3 × 150ms retry. Empirical: 3× suppressed 6/50 → 3/50 but not 0. Escalated to 10×150ms because the second race site (start-colony.stdout, not agentis-argv.log) was outside the `flock` fallback's scope anyway. Reviewer can request the deeper flock fallback if they prefer the retry-only fix is too shallow.

## Validation

| Test | Result |
|---|---|
| Pre-fix loop (50 iterations) | 44/50 pass (6 flakes) |
| After argv-only 3×150ms | 47/50 (still flakes) |
| After argv + stdout 10×150ms | **50/50 × 3 consecutive loops** |
| `colony-lint.sh` | 170 passed / 0 failed / 3 skipped (baseline preserved) |

## Out of scope

- Deeper `--restart-agent` ordering refactor (the underlying ordering bug, #257 territory).
- Replacing the retry with `flock`-based serialization (heavier, two race sites would each need their own lockfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)