### PR TITLE
feat(tribes-bench): per-class fitness curves + variant-trajectory.csv in analyse-stage3 (#513)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -108,6 +108,34 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **`analyse-stage3.py` per-class fitness curves + `variant-trajectory.csv`**
+  ([#513](https://github.com/Replikanti/agentis-colonies/issues/513)).
+  Closes the observability gap for the
+  [#459](https://github.com/Replikanti/agentis-colonies/issues/459)
+  Stage 4 Phase 1 commit decision: until #513, `comparison-stage3.md`
+  reduced fitness to a per-tribe variant table that hid cross-tribe
+  drift on the 8 stage2 bug classes the post-#499 class-flip path emits
+  (`uninitialised_memory`, `use_after_free`, `memory_corruption`,
+  `heap_overflow`, `data_race`, `send_violation`, `missing_lock`,
+  `dangling_borrow`). Two new artefacts: a `variant-trajectory.csv`
+  reconstructed per-(tribe, class, phrasing) time series, and a
+  `### Per-class fitness summary` markdown section appended to the
+  existing comparison report with 8 fixed rows (one per stage2 class,
+  zero-row included so cross-run diffs stay comparable) plus a
+  trailing `unknown:<class>` block for any off-pool class-flip
+  mutations. The trajectory CSV is a **proportional reconstruction**
+  over the `mutation-diff.csv` event timeline -- end-of-run totals
+  distributed across replicate-event ordinals -- not observed history;
+  the file carries an inline `# trajectory: reconstructed from
+  end-of-run totals + replicate-event timeline. Hunter-side
+  write-through is the observed alternative, deferred (#513).` header
+  comment and the markdown section repeats the caveat so downstream
+  readers do not misread the curve as real per-tick dynamics. No
+  hunter-side changes; reuses the `variant_stats:*` memos hunters
+  already increment plus the per-event timeline that #496 emits. Per-run
+  only, no cross-run aggregation. Schema:
+  `ts,tribe,class,phrasing,verified_cumul,falsepos_cumul,hit_rate`.
+
 - **M98 v2 — class-parametrized hunter prompts**
   ([#504](https://github.com/Replikanti/agentis-colonies/issues/504),
   builds on

--- a/tribes-bench/tools/analyse-stage3.py
+++ b/tribes-bench/tools/analyse-stage3.py
@@ -106,6 +106,20 @@ TELEMETRY_COLUMNS = [
     "replication_event_count", "tribe_death_ts",
 ]
 
+# Stage2 bug-class universe (#513) mirrors the 8 classes the post-#499
+# hunter.ag class-flip path emits (`_class_pick_universe`). The list is
+# the canonical row order for the per-class fitness summary table in
+# `comparison-stage3.md` and the per-class CSV reductions in
+# `variant-trajectory.csv`. Unknown classes seen in `variant_stats:*`
+# memos are appended after these 8 in sorted order with an `unknown:`
+# prefix so an off-pool class-flip mutation does not silently disappear
+# from the operator-facing summary.
+STAGE2_CLASSES = [
+    "uninitialised_memory", "use_after_free", "memory_corruption",
+    "heap_overflow", "data_race", "send_violation", "missing_lock",
+    "dangling_borrow",
+]
+
 # Per-tribe variant pools are parsed from each tribe's hunter.ag at
 # analysis time. The analyser is observational only -- it does NOT
 # re-implement pick_variant(). Variant attribution to agents comes
@@ -979,6 +993,193 @@ def write_mutation_diff(
     return out_path
 
 
+# --- Per-class trajectory + summary (#513) ---------------------------------
+
+def _split_class_phrasing(variant: str) -> tuple[str, str]:
+    """Parse a variant string into `(class, phrasing)`. Post-#499 the
+    canonical variant shape is `<class>:<phrasing>`. Empty or
+    separator-less inputs collapse to `("", "")` so callers can filter
+    them out of the trajectory and summary.
+    """
+    if not variant or ":" not in variant:
+        return ("", "")
+    cls, _, phrasing = variant.partition(":")
+    return (cls, phrasing)
+
+
+def emit_variant_trajectory(
+    out_dir: str,
+    events: list[dict[str, Any]],
+    aggregated_stats: dict[str, dict[str, dict[str, int]]] | None = None,
+) -> str:
+    """Emit `variant-trajectory.csv` (#513): a reconstructed per-(tribe,
+    class, phrasing) time series.
+
+    The trajectory is NOT observed history. Hunters do not write
+    per-tick `variant_stats` snapshots; we only know the end-of-run
+    totals plus the replicate-event timeline from `mutation-diff.csv`.
+    For each (tribe, variant) we distribute the final verified /
+    falsepos counters proportionally across the replicate events that
+    targeted that (tribe, variant) pair, using each event's ordinal
+    position over `event_count[tribe,variant]`.
+
+    The hunter-side write-through (observed trajectory) is the deferred
+    path; the CSV header carries an inline caveat that links #513 so
+    downstream operators do not misread the file as real per-tick
+    dynamics. Schema (after the comment line):
+
+        ts,tribe,class,phrasing,verified_cumul,falsepos_cumul,hit_rate
+    """
+    out_path = os.path.join(out_dir, "variant-trajectory.csv")
+    caveat = (
+        "# trajectory: reconstructed from end-of-run totals + "
+        "replicate-event timeline. Hunter-side write-through is the "
+        "observed alternative, deferred (#513).\n"
+    )
+    header_cols = [
+        "ts", "tribe", "class", "phrasing",
+        "verified_cumul", "falsepos_cumul", "hit_rate",
+    ]
+    # Filter to events that carry a usable (tribe, child_variant) pair.
+    usable: list[dict[str, Any]] = []
+    for ev in events:
+        tribe = ev.get("tribe", "")
+        variant = ev.get("child_variant", "")
+        if not tribe or not variant:
+            continue
+        usable.append(ev)
+    usable.sort(key=lambda e: (int(e.get("ts") or 0), e.get("tribe", "")))
+    # Event count per (tribe, variant) over the usable timeline.
+    event_count: dict[tuple[str, str], int] = defaultdict(int)
+    for ev in usable:
+        event_count[(ev.get("tribe", ""), ev.get("child_variant", ""))] += 1
+    # Walk timeline; emit one CSV row per usable event whose
+    # (tribe, variant) has end totals > 0. Cumulative counters are
+    # rounded(final * seen / event_count) so the final row matches the
+    # end-of-run total byte-for-byte.
+    seen: dict[tuple[str, str], int] = defaultdict(int)
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        f.write(caveat)
+        w = csv.writer(f)
+        w.writerow(header_cols)
+        if not usable or not aggregated_stats:
+            return out_path
+        for ev in usable:
+            tribe = ev.get("tribe", "")
+            variant = ev.get("child_variant", "")
+            stats = aggregated_stats.get(tribe, {}).get(variant)
+            if stats is None:
+                continue
+            final_v = int(stats.get("verified", 0))
+            final_fp = int(stats.get("falsepos", 0))
+            if final_v + final_fp == 0:
+                continue
+            n = event_count[(tribe, variant)]
+            if n <= 0:
+                continue
+            seen[(tribe, variant)] += 1
+            k = seen[(tribe, variant)]
+            verified_cumul = int(round(final_v * k / n))
+            falsepos_cumul = int(round(final_fp * k / n))
+            denom = verified_cumul + falsepos_cumul
+            hit_rate = (verified_cumul / denom) if denom > 0 else 0.0
+            cls, phrasing = _split_class_phrasing(variant)
+            w.writerow([
+                int(ev.get("ts") or 0),
+                tribe,
+                cls,
+                phrasing,
+                verified_cumul,
+                falsepos_cumul,
+                f"{hit_rate:.4f}",
+            ])
+    return out_path
+
+
+def render_per_class_summary(
+    aggregated_stats: dict[str, dict[str, dict[str, int]]] | None,
+) -> list[str]:
+    """Render the `### Per-class fitness summary` section lines (#513).
+
+    Returns the markdown lines (no trailing blank) for the new section
+    appended to `comparison-stage3.md`. The table has 8 fixed rows in
+    `STAGE2_CLASSES` order even when a class has zero counters, so
+    cross-tribe drift is visible at a glance. Unknown classes (e.g. an
+    off-pool class-flip mutation) are appended sorted with an
+    `unknown:` prefix.
+
+    Columns: `class | verified | falsepos | hit_rate | dominant_tribe |
+    spread`. `dominant_tribe` is the tribe with the most verified
+    counters for the class (`-` when zero); `spread` counts tribes with
+    verified > 0 for the class (0-5).
+    """
+    # Aggregate verified / falsepos per (class, tribe).
+    per_class_tribe_verified: dict[str, dict[str, int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
+    per_class_verified: dict[str, int] = defaultdict(int)
+    per_class_falsepos: dict[str, int] = defaultdict(int)
+    seen_classes: set[str] = set()
+    if aggregated_stats:
+        for tribe, variants in aggregated_stats.items():
+            for variant, counts in variants.items():
+                cls, _ = _split_class_phrasing(variant)
+                if not cls:
+                    continue
+                v_n = int(counts.get("verified", 0))
+                fp_n = int(counts.get("falsepos", 0))
+                per_class_tribe_verified[cls][tribe] += v_n
+                per_class_verified[cls] += v_n
+                per_class_falsepos[cls] += fp_n
+                seen_classes.add(cls)
+    # Fixed rows first; unknown classes appended sorted with prefix.
+    unknown_classes = sorted(
+        c for c in seen_classes if c not in STAGE2_CLASSES
+    )
+    row_classes = list(STAGE2_CLASSES) + unknown_classes
+    lines: list[str] = []
+    lines.append("### Per-class fitness summary")
+    lines.append("")
+    lines.append(
+        "Reconstructed per-class rollup over `variant_stats:*` memos "
+        "(#513). End-of-run totals only; the per-tick fitness curve in "
+        "`variant-trajectory.csv` is proportionally reconstructed -- "
+        "hunter-side write-through is the deferred observed-trajectory "
+        "path."
+    )
+    lines.append("")
+    lines.append(
+        "| class | verified | falsepos | hit_rate | dominant_tribe | spread |"
+    )
+    lines.append("|---|---|---|---|---|---|")
+    for cls in row_classes:
+        v_n = per_class_verified.get(cls, 0)
+        fp_n = per_class_falsepos.get(cls, 0)
+        denom = v_n + fp_n
+        hit_rate_cell = f"{v_n / denom:.2f}" if denom > 0 else "n/a"
+        tribe_counts = per_class_tribe_verified.get(cls, {})
+        if v_n > 0 and tribe_counts:
+            dominant = sorted(
+                tribe_counts.items(),
+                key=lambda kv: (-int(kv[1]), kv[0]),
+            )
+            # The first entry with verified > 0 is the dominant tribe.
+            dominant_tribe = "-"
+            for t, c in dominant:
+                if int(c) > 0:
+                    dominant_tribe = t
+                    break
+        else:
+            dominant_tribe = "-"
+        spread = sum(1 for c in tribe_counts.values() if int(c) > 0)
+        label = cls if cls in STAGE2_CLASSES else f"unknown:{cls}"
+        lines.append(
+            f"| {label} | {v_n} | {fp_n} | {hit_rate_cell} | "
+            f"{dominant_tribe} | {spread} |"
+        )
+    return lines
+
+
 # --- Comparison report ------------------------------------------------------
 
 def _read_run_meta(run_dir: str) -> dict[str, Any]:
@@ -1298,6 +1499,12 @@ def write_comparison_md(
                 lines.append(f"| {tribe} | {i} | {v} | {tps} |")
         lines.append("")
 
+    # #513: per-class fitness summary. Always emitted (8 fixed rows even
+    # when zero counters) so the cross-tribe drift surface stays
+    # comparable across runs even before the first verified finding.
+    lines.extend(render_per_class_summary(aggregated_stats))
+    lines.append("")
+
     lines.append("## 6. Knowledge market activity")
     lines.append("")
     if not market_rows:
@@ -1407,6 +1614,14 @@ def main() -> None:
         aggregated_stats=aggregated_stats,
     )
     print(mutation_path)
+
+    # #513: reconstructed per-(tribe, class, phrasing) trajectory CSV.
+    # The trajectory is proportional reconstruction over the replicate
+    # timeline, not observed history -- caveat lives in the CSV header.
+    trajectory_path = emit_variant_trajectory(
+        out_dir, events, aggregated_stats=aggregated_stats,
+    )
+    print(trajectory_path)
 
     rotations = _read_rotations(run_dir)
     market_rows: list[dict[str, Any]] = []

--- a/tribes-bench/tools/test-analyse-stage3.py
+++ b/tribes-bench/tools/test-analyse-stage3.py
@@ -1001,6 +1001,392 @@ def test_mutation_diff_csv_has_observational_columns(tmp: str) -> None:
 
 
 # -------------------------------------------------------------------------
+# #513: per-class fitness summary + variant-trajectory.csv
+# -------------------------------------------------------------------------
+
+def test_per_class_summary_table_orders_by_stage2_class_order(_tmp: str) -> None:
+    """All 8 STAGE2_CLASSES appear as fixed rows in the canonical
+    order, even when zero counters are present."""
+    mod = _import_analyser()
+    lines = mod.render_per_class_summary({})
+    body = "\n".join(lines)
+    if "### Per-class fitness summary" not in body:
+        report_fail(
+            "test_per_class_summary_table_orders_by_stage2_class_order: header"
+        )
+        return
+    report_pass(
+        "test_per_class_summary_table_orders_by_stage2_class_order: header"
+    )
+    indices = []
+    for cls in mod.STAGE2_CLASSES:
+        idx = body.find(f"| {cls} ")
+        indices.append((cls, idx))
+    missing = [cls for cls, idx in indices if idx < 0]
+    if missing:
+        report_fail(
+            "test_per_class_summary_table_orders_by_stage2_class_order: all 8 rows",
+            f"missing classes: {missing}",
+        )
+        return
+    report_pass(
+        "test_per_class_summary_table_orders_by_stage2_class_order: all 8 rows"
+    )
+    ordered = all(
+        indices[i][1] < indices[i + 1][1]
+        for i in range(len(indices) - 1)
+    )
+    if ordered:
+        report_pass(
+            "test_per_class_summary_table_orders_by_stage2_class_order: order"
+        )
+    else:
+        report_fail(
+            "test_per_class_summary_table_orders_by_stage2_class_order: order",
+            f"indices={indices}",
+        )
+
+
+def test_per_class_summary_aggregates_across_tribes(_tmp: str) -> None:
+    """verified and falsepos sum across tribes (and phrasings) for a
+    given class."""
+    mod = _import_analyser()
+    stats = {
+        "tribe-alpha": {
+            "use_after_free:format-pattern-default": {
+                "verified": 3, "falsepos": 1,
+            },
+            "use_after_free:format-pattern-strict-literal": {
+                "verified": 2, "falsepos": 0,
+            },
+        },
+        "tribe-beta": {
+            "use_after_free:source-sink-call-graph": {
+                "verified": 4, "falsepos": 2,
+            },
+        },
+    }
+    lines = mod.render_per_class_summary(stats)
+    body = "\n".join(lines)
+    # use_after_free row: verified=9, falsepos=3, hit_rate=0.75
+    target = "| use_after_free | 9 | 3 | 0.75 |"
+    if target in body:
+        report_pass(
+            "test_per_class_summary_aggregates_across_tribes: aggregation"
+        )
+    else:
+        report_fail(
+            "test_per_class_summary_aggregates_across_tribes: aggregation",
+            f"target={target!r} not in body",
+        )
+
+
+def test_per_class_summary_dominant_tribe(_tmp: str) -> None:
+    """dominant_tribe is the tribe with most verified for the class."""
+    mod = _import_analyser()
+    stats = {
+        "tribe-alpha": {
+            "heap_overflow:format-pattern-default": {
+                "verified": 2, "falsepos": 0,
+            },
+        },
+        "tribe-beta": {
+            "heap_overflow:source-sink-call-graph": {
+                "verified": 7, "falsepos": 1,
+            },
+        },
+        "tribe-gamma": {
+            "heap_overflow:error-path-trait-dispatch": {
+                "verified": 1, "falsepos": 0,
+            },
+        },
+    }
+    lines = mod.render_per_class_summary(stats)
+    body = "\n".join(lines)
+    # heap_overflow row should name tribe-beta as dominant.
+    heap_line = ""
+    for ln in lines:
+        if ln.startswith("| heap_overflow |"):
+            heap_line = ln
+            break
+    if "tribe-beta" in heap_line:
+        report_pass(
+            "test_per_class_summary_dominant_tribe: dominant naming"
+        )
+    else:
+        report_fail(
+            "test_per_class_summary_dominant_tribe: dominant naming",
+            f"heap_line={heap_line!r}",
+        )
+    # Sanity: a class with no verified rows should show `-`.
+    for cls in ("data_race", "send_violation", "missing_lock"):
+        for ln in lines:
+            if ln.startswith(f"| {cls} |"):
+                if " | - | 0 |" in ln:
+                    break
+                report_fail(
+                    "test_per_class_summary_dominant_tribe: zero-verified dash",
+                    f"{cls} line={ln!r}",
+                )
+                return
+    report_pass(
+        "test_per_class_summary_dominant_tribe: zero-verified dash"
+    )
+    # Avoid an unused-variable warning when the body grows below.
+    _ = body
+
+
+def test_per_class_summary_spread_count(_tmp: str) -> None:
+    """spread = number of tribes with verified > 0 for the class."""
+    mod = _import_analyser()
+    stats = {
+        "tribe-alpha": {
+            "memory_corruption:format-pattern-default": {
+                "verified": 1, "falsepos": 0,
+            },
+        },
+        "tribe-beta": {
+            "memory_corruption:source-sink-call-graph": {
+                "verified": 1, "falsepos": 0,
+            },
+        },
+        "tribe-gamma": {
+            "memory_corruption:error-path-trait-dispatch": {
+                "verified": 0, "falsepos": 3,
+            },
+        },
+    }
+    lines = mod.render_per_class_summary(stats)
+    spread_line = ""
+    for ln in lines:
+        if ln.startswith("| memory_corruption |"):
+            spread_line = ln
+            break
+    # Trailing cell of memory_corruption row should be `| 2 |`.
+    if spread_line.rstrip().endswith("| 2 |"):
+        report_pass(
+            "test_per_class_summary_spread_count: spread=2"
+        )
+    else:
+        report_fail(
+            "test_per_class_summary_spread_count: spread=2",
+            f"line={spread_line!r}",
+        )
+
+
+def test_per_class_summary_unknown_class_handling(_tmp: str) -> None:
+    """Unknown classes (not in STAGE2_CLASSES) are appended sorted with
+    `unknown:` prefix."""
+    mod = _import_analyser()
+    stats = {
+        "tribe-alpha": {
+            "weird_class:foo": {"verified": 1, "falsepos": 0},
+            "other_weird:bar": {"verified": 0, "falsepos": 1},
+        },
+    }
+    lines = mod.render_per_class_summary(stats)
+    body = "\n".join(lines)
+    if "| unknown:weird_class |" not in body:
+        report_fail(
+            "test_per_class_summary_unknown_class_handling: weird_class row",
+            f"body tail={body[-300:]!r}",
+        )
+        return
+    report_pass(
+        "test_per_class_summary_unknown_class_handling: weird_class row"
+    )
+    if "| unknown:other_weird |" not in body:
+        report_fail(
+            "test_per_class_summary_unknown_class_handling: other_weird row"
+        )
+        return
+    report_pass(
+        "test_per_class_summary_unknown_class_handling: other_weird row"
+    )
+    # Unknown classes must appear AFTER the last STAGE2_CLASSES row.
+    last_known = max(
+        body.find(f"| {cls} |") for cls in mod.STAGE2_CLASSES
+    )
+    unknown_idx = body.find("| unknown:")
+    if last_known > 0 and unknown_idx > last_known:
+        report_pass(
+            "test_per_class_summary_unknown_class_handling: append after fixed rows"
+        )
+    else:
+        report_fail(
+            "test_per_class_summary_unknown_class_handling: append after fixed rows",
+            f"last_known={last_known} unknown_idx={unknown_idx}",
+        )
+    # Sorted: `other_weird` should come before `weird_class`.
+    o_idx = body.find("| unknown:other_weird |")
+    w_idx = body.find("| unknown:weird_class |")
+    if o_idx > 0 and w_idx > 0 and o_idx < w_idx:
+        report_pass(
+            "test_per_class_summary_unknown_class_handling: sorted append"
+        )
+    else:
+        report_fail(
+            "test_per_class_summary_unknown_class_handling: sorted append",
+            f"o_idx={o_idx} w_idx={w_idx}",
+        )
+
+
+def test_variant_trajectory_csv_schema(tmp: str) -> None:
+    """variant-trajectory.csv has the documented header + caveat
+    comment, and is emitted alongside the other artefacts."""
+    run_dir = os.path.join(tmp, "traj-schema")
+    os.makedirs(run_dir, exist_ok=True)
+    tribes = ["tribe-alpha"]
+    seed_ids = {t: f"seed-{t}" for t in tribes}
+    make_seed_node(run_dir, tribes, seed_ids)
+    write_text(os.path.join(run_dir, "bug-ledger.jsonl"), "")
+    write_text(
+        os.path.join(run_dir, "rotations.csv"),
+        "ts,target_dir,bugs_manifest\n",
+    )
+    write_text(
+        os.path.join(run_dir, "run-meta.json"),
+        json.dumps({
+            "started_at": "2026-05-10T12:00:00Z",
+            "wall_clock_s": 60,
+            "rotation_interval_s": 60,
+        }),
+    )
+    rc, _stdout, _stderr = run_analyser(run_dir)
+    assert_eq("test_variant_trajectory_csv_schema: analyser ok", 0, rc)
+    traj_path = os.path.join(run_dir, "variant-trajectory.csv")
+    assert_file_exists(
+        "test_variant_trajectory_csv_schema: csv emitted", traj_path,
+    )
+    with open(traj_path, encoding="utf-8") as f:
+        body = f.read()
+    if body.startswith("# trajectory: reconstructed from"):
+        report_pass(
+            "test_variant_trajectory_csv_schema: caveat comment leads"
+        )
+    else:
+        report_fail(
+            "test_variant_trajectory_csv_schema: caveat comment leads",
+            f"head={body[:120]!r}",
+        )
+    if "#513" in body:
+        report_pass(
+            "test_variant_trajectory_csv_schema: caveat references #513"
+        )
+    else:
+        report_fail(
+            "test_variant_trajectory_csv_schema: caveat references #513",
+        )
+    expected_header = (
+        "ts,tribe,class,phrasing,verified_cumul,falsepos_cumul,hit_rate"
+    )
+    if expected_header in body:
+        report_pass(
+            "test_variant_trajectory_csv_schema: column order"
+        )
+    else:
+        report_fail(
+            "test_variant_trajectory_csv_schema: column order",
+            f"missing header={expected_header!r}",
+        )
+
+
+def test_variant_trajectory_csv_reconstruction_proportional(_tmp: str) -> None:
+    """Proportional reconstruction: walking N events with end totals
+    (V, FP) emits rounded-cumulative rows; the final row matches the
+    end totals byte-for-byte."""
+    mod = _import_analyser()
+    out_dir = tempfile.mkdtemp(prefix="traj-proportional-")
+    try:
+        events = [
+            {
+                "ts": 1000, "tribe": "tribe-alpha",
+                "child_variant": "use_after_free:format-pattern-default",
+                "parent_variant": "", "source": "observed",
+                "parent_id": "p", "child_id": "c1",
+            },
+            {
+                "ts": 2000, "tribe": "tribe-alpha",
+                "child_variant": "use_after_free:format-pattern-default",
+                "parent_variant": "", "source": "observed",
+                "parent_id": "p", "child_id": "c2",
+            },
+            {
+                "ts": 3000, "tribe": "tribe-alpha",
+                "child_variant": "use_after_free:format-pattern-default",
+                "parent_variant": "", "source": "observed",
+                "parent_id": "p", "child_id": "c3",
+            },
+            {
+                "ts": 4000, "tribe": "tribe-alpha",
+                "child_variant": "use_after_free:format-pattern-default",
+                "parent_variant": "", "source": "observed",
+                "parent_id": "p", "child_id": "c4",
+            },
+        ]
+        stats = {
+            "tribe-alpha": {
+                "use_after_free:format-pattern-default": {
+                    "verified": 8, "falsepos": 4,
+                },
+            },
+        }
+        path = mod.emit_variant_trajectory(out_dir, events, stats)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        # Drop caveat + header rows.
+        data_rows = [
+            ln.split(",") for ln in lines
+            if ln and not ln.startswith("#") and not ln.startswith("ts,")
+        ]
+        if len(data_rows) != 4:
+            report_fail(
+                "test_variant_trajectory_csv_reconstruction_proportional: row count",
+                f"got {len(data_rows)} rows; lines={lines!r}",
+            )
+            return
+        report_pass(
+            "test_variant_trajectory_csv_reconstruction_proportional: row count"
+        )
+        # Expected cumulatives: V=8 across 4 events -> 2,4,6,8;
+        # FP=4 across 4 events -> 1,2,3,4.
+        expected_v = [2, 4, 6, 8]
+        expected_fp = [1, 2, 3, 4]
+        v_cumuls = [int(r[4]) for r in data_rows]
+        fp_cumuls = [int(r[5]) for r in data_rows]
+        if v_cumuls == expected_v and fp_cumuls == expected_fp:
+            report_pass(
+                "test_variant_trajectory_csv_reconstruction_proportional: cumulatives"
+            )
+        else:
+            report_fail(
+                "test_variant_trajectory_csv_reconstruction_proportional: cumulatives",
+                f"verified={v_cumuls} falsepos={fp_cumuls}",
+            )
+        # Final row must reach end totals byte-for-byte.
+        if v_cumuls[-1] == 8 and fp_cumuls[-1] == 4:
+            report_pass(
+                "test_variant_trajectory_csv_reconstruction_proportional: final row matches totals"
+            )
+        else:
+            report_fail(
+                "test_variant_trajectory_csv_reconstruction_proportional: final row matches totals",
+            )
+        # class + phrasing parsed from `class:phrasing`.
+        if all(r[2] == "use_after_free" and r[3] == "format-pattern-default" for r in data_rows):
+            report_pass(
+                "test_variant_trajectory_csv_reconstruction_proportional: class/phrasing split"
+            )
+        else:
+            report_fail(
+                "test_variant_trajectory_csv_reconstruction_proportional: class/phrasing split",
+                f"rows={data_rows!r}",
+            )
+    finally:
+        shutil.rmtree(out_dir, ignore_errors=True)
+
+
+# -------------------------------------------------------------------------
 # Snapshot test (#495): runs against a real archived stage3-docker run dir
 # when it is available, otherwise reports a [SKIP].
 # -------------------------------------------------------------------------
@@ -1010,6 +1396,17 @@ SNAPSHOT_DIR = os.environ.get(
     os.path.join(
         os.path.dirname(FED_ROOT), "tribes-bench",
         "runs", "stage3-docker-20260510T120610Z",
+    ),
+)
+
+# #513 snapshot: smoke #51 run dir. When present, asserts the per-class
+# summary actually shows multiple stage2 classes with verified > 0,
+# matching the cross-tribe activity captured by smoke #51.
+SNAPSHOT_DIR_513 = os.environ.get(
+    "AGENTIS_STAGE3_SNAPSHOT_DIR_513",
+    os.path.join(
+        os.path.dirname(FED_ROOT), "tribes-bench",
+        "runs", "stage3-docker-20260510T195436Z",
     ),
 )
 
@@ -1028,6 +1425,68 @@ def case_snapshot() -> None:
         report_fail("snapshot: comparison.md produced", f"missing {cmp_path}")
         return
     report_pass("snapshot: comparison.md produced")
+
+
+def case_snapshot_513() -> None:
+    """#513 smoke #51 snapshot: assert the per-class summary captures
+    >= 4 stage2 classes with verified > 0 (expected: heap_overflow,
+    use_after_free, memory_corruption, uninitialised_memory). Skips
+    cleanly when the reference run dir is absent."""
+    if not os.path.isdir(SNAPSHOT_DIR_513):
+        print(
+            f"[SKIP] snapshot 513: reference run dir absent ({SNAPSHOT_DIR_513})"
+        )
+        return
+    out_sub = os.path.join(SNAPSHOT_DIR_513, "_513-snapshot")
+    rc, _stdout, _stderr = run_analyser(
+        SNAPSHOT_DIR_513,
+        extra_args=["--out", out_sub],
+    )
+    assert_eq("snapshot 513: analyser exits 0", 0, rc)
+    cmp_path = os.path.join(out_sub, "comparison-stage3.md")
+    if not os.path.isfile(cmp_path):
+        report_fail(
+            "snapshot 513: comparison.md produced",
+            f"missing {cmp_path}",
+        )
+        return
+    report_pass("snapshot 513: comparison.md produced")
+    with open(cmp_path, encoding="utf-8") as f:
+        body = f.read()
+    if "### Per-class fitness summary" not in body:
+        report_fail(
+            "snapshot 513: per-class section present",
+            f"body tail={body[-400:]!r}",
+        )
+        return
+    report_pass("snapshot 513: per-class section present")
+    # Count stage2 classes with verified > 0 by scanning the table
+    # rows. Each row is `| <class> | <verified> | <falsepos> | ...`.
+    mod = _import_analyser()
+    classes_with_verified = 0
+    for cls in mod.STAGE2_CLASSES:
+        marker = f"| {cls} | "
+        idx = body.find(marker)
+        if idx < 0:
+            continue
+        row = body[idx:body.find("\n", idx)]
+        parts = [p.strip() for p in row.split("|")]
+        # parts: ['', class, verified, falsepos, hit_rate, dominant_tribe, spread, '']
+        if len(parts) >= 4:
+            try:
+                if int(parts[2]) > 0:
+                    classes_with_verified += 1
+            except ValueError:
+                pass
+    if classes_with_verified >= 4:
+        report_pass(
+            "snapshot 513: >= 4 stage2 classes with verified > 0"
+        )
+    else:
+        report_fail(
+            "snapshot 513: >= 4 stage2 classes with verified > 0",
+            f"got {classes_with_verified}",
+        )
 
 
 # -------------------------------------------------------------------------
@@ -1053,7 +1512,16 @@ def main() -> int:
         test_read_variant_stats_missing_binary_returns_empty(tmp)
         test_variant_outcomes_table_orders_by_verified_desc_falsepos_asc(tmp)
         test_mutation_diff_csv_has_observational_columns(tmp)
+        # #513 unit tests: per-class fitness summary + trajectory CSV.
+        test_per_class_summary_table_orders_by_stage2_class_order(tmp)
+        test_per_class_summary_aggregates_across_tribes(tmp)
+        test_per_class_summary_dominant_tribe(tmp)
+        test_per_class_summary_spread_count(tmp)
+        test_per_class_summary_unknown_class_handling(tmp)
+        test_variant_trajectory_csv_schema(tmp)
+        test_variant_trajectory_csv_reconstruction_proportional(tmp)
         case_snapshot()
+        case_snapshot_513()
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
     print("")


### PR DESCRIPTION
## Summary

Closes #513. Stage 3.5 observability follow-up — adds two new artifacts to `analyse-stage3.py` output so #459 Phase 1 commit decision can reference real per-class drift data.

## What changed

- **`variant-trajectory.csv`** (new) — per-(tribe, class, phrasing) cumulative counters reconstructed from `mutation-diff.csv` event timeline + end-of-run `variant_stats:*` totals via proportional distribution. Schema: `ts,tribe,class,phrasing,verified_cumul,falsepos_cumul,hit_rate`. CSV header carries explicit `# trajectory: reconstructed from end-of-run totals…` caveat — hunter-side write-through is the observed alternative, deferred (#513 mentions follow-up issue).

- **`### Per-class fitness summary`** section in `comparison-stage3.md` — 8 fixed rows in stage2-class canonical order: `class | verified | falsepos | hit_rate | dominant_tribe | spread`. `dominant_tribe` = tribe with most verified for that class (`-` when zero). `spread` = count of tribes with verified > 0 (0–5). Cross-tribe class drift from M98 mutation (#503/#505) is now directly visible.

## Why this matters

Stage 3.5 mechanics validated tonight (16-20 wire replicas per smoke, 80% mortality, 4+ classes scoring verified). #459 Phase 1 commit decision needs to see directional drift signal in current data, not synthesized post-hoc. This PR provides the visible artifact.

Reconstructed trajectory is a known compromise — real per-tick observability needs hunter-side write-through. Documented explicitly in the CSV header.

## Test plan

- [x] `colony-lint.sh`: 170 passed / 0 failed / 3 skipped (baseline preserved)
- [x] `test-analyse-stage3.py`: 76 passed / 0 failed (56 prior + 20 new assertion-level)
- [x] `check-learn-tags.sh`: 0 violations (no hunter.ag touched)
- [x] 7 new tests cover: stage2-class ordering, cross-tribe aggregation, dominant_tribe, spread, unknown-class handling, trajectory CSV schema, proportional reconstruction
- [x] Snapshot test against smoke #51 run dir: SKIP cleanly (run dir not in worktree, matches existing snapshot test pattern from #496)

## Out of scope

- Hunter-side write-through observability (real trajectory). Deferred — separate issue.
- Plotting / chart generation (CSV is sufficient input for external tools).
- Cross-run aggregation (per-run only, like #496).
- New observability for `market:rejected` outcome introduced by #493 — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)