### PR TITLE
fix(tribes-bench): re-apply #491 Loose category a — restore verifier-only ledger gate after #517

### DIFF
--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -676,13 +676,12 @@ fn tick(reason: string) -> void {
                         parse_int(recall_latest("tribe-" + _tribe_name + ":reward_subsequent"));
                     };
 
+                    // #491 (Loose category a): ledger writes are now done
+                    // exclusively by verify-finding-stage2.sh on the
+                    // verified=true path. ledger_path is still read here
+                    // because the bundle-sell tail summary below
+                    // grep-reads the same file.
                     let ledger_path = recall_latest("tribe-" + _tribe_name + ":bug_ledger");
-                    if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(_tick_now_ms) + ", \"tribe\": \"" + _tribe_name + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
-                        // colony-lint: safe-exec-concat
-                        let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
-                        let _ = try { exec sh append_cmd; } catch e { ""; };
-                    };
 
                     // #485 finite-pool: cap-aware reward credit. When
                     // tribe-X:pool_cap is set, reward is bounded so pool

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -676,13 +676,12 @@ fn tick(reason: string) -> void {
                         parse_int(recall_latest("tribe-" + _tribe_name + ":reward_subsequent"));
                     };
 
+                    // #491 (Loose category a): ledger writes are now done
+                    // exclusively by verify-finding-stage2.sh on the
+                    // verified=true path. ledger_path is still read here
+                    // because the bundle-sell tail summary below
+                    // grep-reads the same file.
                     let ledger_path = recall_latest("tribe-" + _tribe_name + ":bug_ledger");
-                    if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(_tick_now_ms) + ", \"tribe\": \"" + _tribe_name + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
-                        // colony-lint: safe-exec-concat
-                        let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
-                        let _ = try { exec sh append_cmd; } catch e { ""; };
-                    };
 
                     // #485 finite-pool: cap-aware reward credit. When
                     // tribe-X:pool_cap is set, reward is bounded so pool

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -677,13 +677,12 @@ fn tick(reason: string) -> void {
                         parse_int(recall_latest("tribe-" + _tribe_name + ":reward_subsequent"));
                     };
 
+                    // #491 (Loose category a): ledger writes are now done
+                    // exclusively by verify-finding-stage2.sh on the
+                    // verified=true path. ledger_path is still read here
+                    // because the bundle-sell tail summary below
+                    // grep-reads the same file.
                     let ledger_path = recall_latest("tribe-" + _tribe_name + ":bug_ledger");
-                    if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(_tick_now_ms) + ", \"tribe\": \"" + _tribe_name + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
-                        // colony-lint: safe-exec-concat
-                        let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
-                        let _ = try { exec sh append_cmd; } catch e { ""; };
-                    };
 
                     // #485 finite-pool: cap-aware reward credit. When
                     // tribe-X:pool_cap is set, reward is bounded so pool

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -678,13 +678,12 @@ fn tick(reason: string) -> void {
                         parse_int(recall_latest("tribe-" + _tribe_name + ":reward_subsequent"));
                     };
 
+                    // #491 (Loose category a): ledger writes are now done
+                    // exclusively by verify-finding-stage2.sh on the
+                    // verified=true path. ledger_path is still read here
+                    // because the bundle-sell tail summary below
+                    // grep-reads the same file.
                     let ledger_path = recall_latest("tribe-" + _tribe_name + ":bug_ledger");
-                    if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(_tick_now_ms) + ", \"tribe\": \"" + _tribe_name + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
-                        // colony-lint: safe-exec-concat
-                        let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
-                        let _ = try { exec sh append_cmd; } catch e { ""; };
-                    };
 
                     // #485 finite-pool: cap-aware reward credit. When
                     // tribe-X:pool_cap is set, reward is bounded so pool

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -676,13 +676,12 @@ fn tick(reason: string) -> void {
                         parse_int(recall_latest("tribe-" + _tribe_name + ":reward_subsequent"));
                     };
 
+                    // #491 (Loose category a): ledger writes are now done
+                    // exclusively by verify-finding-stage2.sh on the
+                    // verified=true path. ledger_path is still read here
+                    // because the bundle-sell tail summary below
+                    // grep-reads the same file.
                     let ledger_path = recall_latest("tribe-" + _tribe_name + ":bug_ledger");
-                    if len(ledger_path) > 0 {
-                        let row = "{\"ts\": " + to_string(_tick_now_ms) + ", \"tribe\": \"" + _tribe_name + "\", \"bug_id\": \"" + bug_id + "\", \"reward\": " + to_string(reward) + "}";
-                        // colony-lint: safe-exec-concat
-                        let append_cmd = "printf '%s\\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path);
-                        let _ = try { exec sh append_cmd; } catch e { ""; };
-                    };
 
                     // #485 finite-pool: cap-aware reward credit. When
                     // tribe-X:pool_cap is set, reward is bounded so pool


### PR DESCRIPTION
## Summary

PR #517 surgically restored hunter.ag from pre-#505 commit 9aacf65 (smoke #51 reference state). 9aacf65 pre-dates #491 (verifier-only ledger writer), so the hunter.ag-side hunks of #491 were lost — pre-#491 hunter.ag wrote bug-ledger.jsonl rows directly via `exec sh "printf >> ledger"`.

This PR re-applies the #491 hunter.ag hunks on top of the restored baseline.

## What changed

- Removed the direct `printf '%s\n' <row> >> <ledger_path>` exec sh append block from the verified-finding success branch in all 5 hunter.ag files
- Kept `recall_latest("tribe-<name>:bug_ledger")` read — bundle-sell tail summary downstream grep-reads the same path
- Added `// #491 (Loose category a): ledger writes are now done exclusively by verify-finding-stage2.sh` comment marker at the recall site

## What stayed (unaffected by #517)

- `verify-finding-stage2.sh` ledger-write logic (env-gated on BUG_LEDGER_PATH + TRIBE_NAME + LEDGER_REWARD_FULL/SUBSEQUENT)
- `run-stage3-docker.sh` env_passthrough + daemon spawn env

## Known gap

**Loose category c (#493 knowledge_sell answer validation) hunter.ag hunks remain LOST.** The #493 patch diff does not apply against the post-#517 hunter.ag because of structural shifts (different surrounding lines). Separate follow-up PR needed to re-apply `_validate_bought_answer` helper + gates at both `knowledge_buy` call sites.

## Validation

- [x] `colony-lint.sh`: 170 passed / 0 failed / 3 skipped (baseline match)
- [x] `grep -rn '>>.*bug-ledger\|>>.*ledger_path' tribes-bench/tribe-*/agents/`: 0 matches
- [ ] Smoke against smallvec baseline: expect ~14-16 verified / 30min preserved + no ledger drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)