### PR TITLE
feat(tribes-bench): M98 v3 PR 1/3 — memo-stored hunting prompts + per-tribe seed bootstrap (#520)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -14,6 +14,48 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Changed
+
+- **M98 v3 PR 1/3 — memo-stored hunting prompts + per-tribe seed bootstrap**
+  ([#520](https://github.com/Replikanti/agentis-colonies/issues/520),
+  PR 1/3 of three; PR 2/3 will add the verified-buffer + meta-prompt
+  evolution path, PR 3/3 will add the M106 hash-pointer inheritance
+  path. M98 v2 ([#505](https://github.com/Replikanti/agentis-colonies/issues/505))
+  stays reverted; M98 v3 supersedes both M98 v1 (hardcoded smallvec
+  prompts) and the M98 v2 generic class templates).
+  Each hunter's hunting prompt body now lives in
+  `hunter:<pid>:hunting_prompt` instead of a baked literal string at
+  the `prompt()` call site. On the first tick of a fresh hunter the
+  memo is empty, so the hunter falls back to `_seed_prompt_for_class(_tribe_default_class())`
+  — a per-tribe registry that restores the pre-#505 hardcoded prompt
+  verbatim — and writes it back to memo together with
+  `hunter:<pid>:hunting_prompt_generation = 0`. This preserves
+  byte-identical hunting behaviour on the first tick of a fresh colony
+  (seed equals pre-#505 prompt; no evolution yet). The hunting call
+  becomes `prompt(prompt_text + _variant_overlay_suffix(), src)` — the
+  #439 variant-prefix overlay is preserved verbatim, moved from a
+  prefix on the source to a suffix on the instruction. A new
+  `STAGE3_HUNTER_PROMPT_MAX_BYTES` env var (default 4096) clamps the
+  seed body length on bootstrap-read; it is threaded through
+  `exec.env_passthrough` so hunter.ag reads it via `printenv`.
+  **Depends on agentis-core v1.7.10 ([#638](https://github.com/Replikanti/agentis-core/issues/638))**:
+  the new `prompt(prompt_text + ..., src)` shape needs the v1.7.10
+  parser relaxation that accepts a non-literal first argument; pre-v1.7.10
+  builds will fail to parse hunter.ag with
+  `parse error: expected string literal for prompt instruction`.
+  **Anti-gaming invariant unchanged**: the verifier remains a
+  deterministic shell script with no LLM in the path. Hunters cannot
+  influence verifier behaviour through evolved prompt content;
+  selection pressure flows only from real verified hits. The
+  [#491](https://github.com/Replikanti/agentis-colonies/issues/491)
+  ledger-write monopoly and the
+  [#493](https://github.com/Replikanti/agentis-colonies/issues/493)
+  knowledge-sell answer-path guardrails are preserved verbatim. PR 1/3
+  introduces no new direct ledger writes, no new knowledge-market
+  answer paths, no evolution call, no inheritance call, no buffer
+  maintenance, and no anti-degeneracy guards beyond the length clamp
+  — those are PR 2/3 and PR 3/3 territory.
+
 ### Added
 
 - **Stage 4 Phase 1 chunk 1 — vendor 3 real RUSTSEC crates with 5 planted bugs covering 4 previously-missing stage2 classes**

--- a/tribes-bench/tools/check-agentis-version.sh
+++ b/tribes-bench/tools/check-agentis-version.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 # check-agentis-version.sh — refuses install or start when the agentis
-# runtime is older than v1.5.0 (the floor where knowledge_buy /
-# knowledge_sell ship as .ag builtins; pre-v1.5.0 hunters quarantine on
-# first tick — see #393 §9 risk 7).
+# runtime is older than v1.7.10 (the floor where prompt() accepts a
+# non-literal string expression as first argument — required by M98 v3
+# memo-stored hunting prompts in #520; agentis-core #638).
+#
+# Earlier floors:
+#   v1.5.0 — knowledge_buy / knowledge_sell ship as .ag builtins (#393)
+#   v1.7.10 — prompt() first-arg parser accepts non-literal expressions (#520, agentis-core #638)
 #
 # Usage: check-agentis-version.sh
 #
-# Exit 0  : version >= 1.5.0
+# Exit 0  : version >= 1.7.10
 # Exit 78 : EX_CONFIG, version too low or unparseable
 #
 # Bash 3.2 portable (no mapfile, no `${var,,}`, no GNU-only sed). The
@@ -15,8 +19,8 @@
 
 set -eu
 
-REQUIRED="1.5.0"
-RELEASE_URL="https://github.com/Replikanti/agentis/releases/tag/v1.5.0"
+REQUIRED="1.7.10"
+RELEASE_URL="https://github.com/Replikanti/agentis/releases/tag/v1.7.10"
 RUNTIME_DOWNLOAD_URL="https://github.com/Replikanti/agentis"
 
 if ! command -v agentis >/dev/null 2>&1; then

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -63,6 +63,15 @@
 #                              when age > MAX_AGE. Default 0 = OFF (no
 #                              per-hunter age mortality; tribe-wide
 #                              cascade still applies as before).
+#   STAGE3_HUNTER_PROMPT_MAX_BYTES
+#                              #520 M98 v3 PR 1/3: clamp on the per-pid
+#                              `hunter:<pid>:hunting_prompt` body length
+#                              at bootstrap-read. Default 4096 covers
+#                              every pre-#505 seed (~3 KB max) with
+#                              headroom for PR 2/3 evolution rewrites.
+#                              Threaded into env_passthrough so
+#                              hunter.ag reads it via
+#                              `exec sh "printenv HUNTER_PROMPT_MAX_BYTES"`.
 #   STAGE3_LLM_BACKEND         llm.backend value injected into both
 #                              hermetic configs. Default: openai (#445).
 #   STAGE3_OPENAI_MODEL        Model id when STAGE3_LLM_BACKEND=openai.
@@ -218,6 +227,14 @@ HUNTER_FITNESS_GRACE_MS="${STAGE3_HUNTER_FITNESS_GRACE_MS:-180000}"
 # Default 0 = OFF (byte-identical to v1.7.5 + #489 + #490 -- only the
 # existing M2-Malthusian finding-gated replicate path fires).
 HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD="${STAGE3_HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD:-0}"
+# #520 M98 v3 PR 1/3: per-hunter LLM-evolved hunting-prompt byte clamp.
+# Hunters read this on bootstrap and clamp the seed-prompt body length
+# (substring 0..N) before writing it to `hunter:<pid>:hunting_prompt`.
+# Default 4096 covers every pre-#505 seed (~3 KB max) with headroom for
+# the PR 2/3 evolution rewrites. Set via STAGE3_HUNTER_PROMPT_MAX_BYTES.
+# Surfaces via env_passthrough so hunter.ag reads it through
+# `exec sh "printenv HUNTER_PROMPT_MAX_BYTES"`.
+HUNTER_PROMPT_MAX_BYTES="${STAGE3_HUNTER_PROMPT_MAX_BYTES:-4096}"
 LLM_BACKEND="${STAGE3_LLM_BACKEND:-openai}"
 OPENAI_MODEL="${STAGE3_OPENAI_MODEL:-gpt-4o-mini}"
 OPENAI_ENDPOINT="${STAGE3_OPENAI_ENDPOINT:-https://api.openai.com/v1/chat/completions}"
@@ -401,7 +418,7 @@ write_bootstrap() {
         printf '{\n'
         printf '  printf "federation.enabled = true\\n"\n'
         printf '  printf "federation.peers = host.containers.internal:%s\\n"\n' "$peer_port"
-        printf '  printf "exec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,TARGET_FILE,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,LEDGER_REWARD_FULL,LEDGER_REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT,HUNTER_INITIAL_FITNESS,HUNTER_INITIAL_VARIANT\\n"\n'
+        printf '  printf "exec.env_passthrough = COLONY_DIR,TRIBE_NAME,TARGET_DIR,TARGET_FILE,BUGS_MANIFEST,VERIFIER_PATH,RUN_DIR,BUG_LEDGER_PATH,INITIAL_CB,BASE_COST,K_MALTHUSIAN,MAX_REPLICAS,REWARD_FULL,REWARD_SUBSEQUENT,LEDGER_REWARD_FULL,LEDGER_REWARD_SUBSEQUENT,DEATH_THRESHOLD,AGENTIS_ROOT,HUNTER_INITIAL_FITNESS,HUNTER_INITIAL_VARIANT,HUNTER_PROMPT_MAX_BYTES\\n"\n'
         printf '  printf "experience.enabled = true\\n"\n'
         printf '  printf "telemetry.enabled = true\\n"\n'
         printf '  printf "daemon.heartbeat_interval_ms = 600000\\n"\n'
@@ -496,8 +513,8 @@ write_bootstrap() {
             # file to seed the tribe-<name>:bug_ledger memo from. Without
             # it, hunters verify findings but the JSONL ledger never
             # grows (visible in experience but missing from bug-ledger).
-            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s INITIAL_POOL=%s HUNTER_MAX_AGE=%s HUNTER_FITNESS_CREEP_PER_MINUTE=%s HUNTER_FITNESS_THRESHOLD_BASELINE=%s HUNTER_FITNESS_REWARD_VERIFIED=%s HUNTER_FITNESS_PENALTY_FALSEPOS=%s HUNTER_FITNESS_REWARD_REPLICATE=%s HUNTER_FITNESS_GRACE_MS=%s HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl LEDGER_REWARD_FULL=200 LEDGER_REWARD_SUBSEQUENT=50 bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
-                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$TRIBE_INITIAL_POOL" "$HUNTER_MAX_AGE" "$HUNTER_FITNESS_CREEP_PER_MINUTE" "$HUNTER_FITNESS_THRESHOLD_BASELINE" "$HUNTER_FITNESS_REWARD_VERIFIED" "$HUNTER_FITNESS_PENALTY_FALSEPOS" "$HUNTER_FITNESS_REWARD_REPLICATE" "$HUNTER_FITNESS_GRACE_MS" "$HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD" "$tribe" "$tribe"
+            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s INITIAL_POOL=%s HUNTER_MAX_AGE=%s HUNTER_FITNESS_CREEP_PER_MINUTE=%s HUNTER_FITNESS_THRESHOLD_BASELINE=%s HUNTER_FITNESS_REWARD_VERIFIED=%s HUNTER_FITNESS_PENALTY_FALSEPOS=%s HUNTER_FITNESS_REWARD_REPLICATE=%s HUNTER_FITNESS_GRACE_MS=%s HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD=%s HUNTER_PROMPT_MAX_BYTES=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl LEDGER_REWARD_FULL=200 LEDGER_REWARD_SUBSEQUENT=50 bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
+                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$TRIBE_INITIAL_POOL" "$HUNTER_MAX_AGE" "$HUNTER_FITNESS_CREEP_PER_MINUTE" "$HUNTER_FITNESS_THRESHOLD_BASELINE" "$HUNTER_FITNESS_REWARD_VERIFIED" "$HUNTER_FITNESS_PENALTY_FALSEPOS" "$HUNTER_FITNESS_REWARD_REPLICATE" "$HUNTER_FITNESS_GRACE_MS" "$HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD" "$HUNTER_PROMPT_MAX_BYTES" "$tribe" "$tribe"
         done
         printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'
         printf 'exit 0\n'

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -66,6 +66,41 @@ fn _tribe_default_class() -> string {
     return "uninitialised_memory";
 }
 
+// #520 M98 v3 PR 1/3: per-class seed prompt registry. Returns the
+// pre-#505 hardcoded hunting prompt verbatim for the tribe's primary
+// class. Used by the bootstrap path in tick() to populate the
+// `hunter:<pid>:hunting_prompt` memo on a fresh hunter's first tick.
+// All five tribe-specific seed strings live next to their respective
+// `_tribe_default_class()` so the per-tribe diff stays bounded; the
+// shared evolution/clamp/inheritance scaffolding (PR 2/3, PR 3/3) is
+// out of scope here.
+fn _seed_prompt_for_class(class: string) -> string {
+    if class == "uninitialised_memory" {
+        return "Your specific target function is `from_buf_and_len_unchecked` -- it lives near line 534 of the file. The bug is INSIDE that function's signature: it takes a buffer + length but does NOT check that buf[0..len] is initialised. Find that EXACT function declaration line and report it. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for uninitialised memory exposure: a function that accepts a raw buffer plus a length parameter and constructs a SmallVec / Vec / array without verifying that buf[0..len] is fully initialised, or unsafe code that calls MaybeUninit::uninit().assume_init() before every byte of the inner type has been written. The classic example is: pub unsafe fn from_buf_and_len_unchecked(buf: A, len: usize) -> Self { /* no init check */ SmallVec { capacity: len, data: SmallVecData::from_inline(buf) } }. Pay attention to signatures with _unchecked suffixes, MaybeUninit, assume_init, mem::zeroed used on types that contain references, raw *const T pointers exposed to safe code, and any constructor whose len parameter is not bounded by an initialised-region check. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"uninitialised_memory\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.";
+    };
+    // Fallback: empty string. PR 1/3 only seeds the tribe's primary
+    // class; off-class seeds are PR 2/3 territory once evolution
+    // produces a non-primary lineage.
+    return "";
+}
+
+// #520 M98 v3 PR 1/3: variant-prefix overlay extracted into a helper.
+// Pre-#520 the overlay was prepended to `src` before being passed as
+// the second arg to prompt(). M98 v3 moves the overlay to a suffix on
+// the instruction (first arg), because v1.7.10 (#638) is the first
+// runtime that accepts a non-literal first arg, and the seed-then-
+// evolve loop needs the entire instruction body to live in memo. The
+// returned text is byte-identical to the pre-#520 prefix string, so
+// the LLM sees the same overlay content; only its position in the
+// composite prompt moves from "before source" to "after instruction".
+fn _variant_overlay_suffix() -> string {
+    let variant = recall_latest("hunter:prompt_variant");
+    if len(variant) > 0 {
+        return "\n\n[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]";
+    };
+    return "";
+}
+
 // #499: 8-class universe used by the class-flip mutation in
 // `pick_variant`. Indices 0..1 are the tribe's primary + sibling classes
 // (also seeded directly into the 14-literal pool below); 2..7 are
@@ -583,29 +618,41 @@ fn tick(reason: string) -> void {
         };
     };
 
-    // Tribe-alpha seed prompt (#421): retargeted from Stage 0
-    // command-injection heuristic to Stage 2 uninitialised_memory bug
-    // class. Smallvec-style `unsafe` libraries leak uninitialised heap
-    // bytes when a constructor accepts (raw_buffer, len) without
-    // verifying that `buf[0..len]` is initialised, or when
-    // `MaybeUninit::uninit().assume_init()` is called before the inner
-    // type is fully written. Stage 1+ will mutate this prompt across
-    // replicas.
+    // #520 M98 v3 PR 1/3: memo-stored hunting prompt + per-tribe seed
+    // bootstrap. Pre-#520 each tribe's hunting prompt was a baked
+    // literal string fed verbatim to prompt(). M98 v3 stores the prompt
+    // body in `hunter:<pid>:hunting_prompt` so PR 2/3 (evolution) and
+    // PR 3/3 (M106 hash-pointer inheritance) can mutate / propagate it.
+    // First tick on a fresh hunter populates the memo from
+    // `_seed_prompt_for_class(_tribe_default_class())`; the seed body
+    // is byte-identical to the pre-#505 hardcoded prompt this tribe
+    // had been using, so first-tick hunting behaviour is preserved.
+    // The #439 variant-prefix overlay is preserved via
+    // `_variant_overlay_suffix()`, now appended to the instruction
+    // instead of prepended to the source.
     //
-    // Stage 3 (#439): replicas inherit the parent's `hunter:prompt_variant`
-    // memo; appending it as a Focus: suffix lets sibling replicas lean
-    // into different interpretations of the same seed. Empty memo (Stage
-    // 2 single-tribe / no replication) is a no-op.
-    let variant = _variant;
-    let variant_prefix = if len(variant) > 0 {
-        "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
+    // STAGE3_HUNTER_PROMPT_MAX_BYTES (default 4096) clamps the seed
+    // body length on bootstrap-read so a future operator-overridden
+    // seed cannot blow up the prompt(). Read via printenv because
+    // env_passthrough exposes the var to the runtime; clamp is best-
+    // effort byte-count via len() (UTF-8 not character count -- the
+    // seed prompts are ASCII so this is the same value either way).
+    let prompt_text_raw = recall_latest("hunter:" + _self_pid + ":hunting_prompt");
+    let prompt_text = if len(prompt_text_raw) == 0 {
+        let seed = _seed_prompt_for_class(_tribe_default_class());
+        let max_bytes_env = try { exec sh "printenv HUNTER_PROMPT_MAX_BYTES"; } catch e { ""; };
+        let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
+        let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_clamped = if len(seed) > max_bytes_eff { substring(seed, 0, max_bytes_eff); } else { seed; };
+        memo_write("hunter:" + _self_pid + ":hunting_prompt", seed_clamped);
+        memo_write("hunter:" + _self_pid + ":hunting_prompt_generation", "0");
+        seed_clamped;
     } else {
-        "";
+        prompt_text_raw;
     };
-    let src_with_focus = variant_prefix + src;
     let finding = prompt(
-        "Your specific target function is `from_buf_and_len_unchecked` -- it lives near line 534 of the file. The bug is INSIDE that function's signature: it takes a buffer + length but does NOT check that buf[0..len] is initialised. Find that EXACT function declaration line and report it. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for uninitialised memory exposure: a function that accepts a raw buffer plus a length parameter and constructs a SmallVec / Vec / array without verifying that buf[0..len] is fully initialised, or unsafe code that calls MaybeUninit::uninit().assume_init() before every byte of the inner type has been written. The classic example is: pub unsafe fn from_buf_and_len_unchecked(buf: A, len: usize) -> Self { /* no init check */ SmallVec { capacity: len, data: SmallVecData::from_inline(buf) } }. Pay attention to signatures with _unchecked suffixes, MaybeUninit, assume_init, mem::zeroed used on types that contain references, raw *const T pointers exposed to safe code, and any constructor whose len parameter is not bounded by an initialised-region check. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"uninitialised_memory\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.",
-        src_with_focus
+        prompt_text + _variant_overlay_suffix(),
+        src
     ) -> Finding;
 
     let my_tier = tier("hunter");

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -67,6 +67,26 @@ fn _tribe_default_class() -> string {
     return "heap_overflow";
 }
 
+// #520 M98 v3 PR 1/3: per-class seed prompt registry. See alpha hunter
+// header comment for the architectural rationale. PR 1/3 only seeds
+// the tribe's primary class; off-class seeds are PR 2/3 territory.
+fn _seed_prompt_for_class(class: string) -> string {
+    if class == "heap_overflow" {
+        return "Your specific target function is `pub fn insert_many` -- it lives near line 827 of the file. The bug is the heap overflow inside this function: `iter.size_hint()` returns a lower bound that the function trusts to size the buffer, but a hostile iterator can lie (return lower=0 then yield N items) and the inner ptr::write loop blows past the allocation. Find `pub fn insert_many` (NOT `from_buf_and_len_unchecked`, NOT `grow`) and report THAT function's signature line. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for heap overflow: code that allocates capacity based on an externally-controllable iterator's size_hint() or len() and copies more elements than allocated when the iterator lies about its length. SmallVec / Vec methods named extend, insert_many, from_iter, append are the typical environment. The classic example is: let (lower, _) = iter.size_hint(); self.reserve(lower); for x in iter { unsafe { ptr::write(self.as_mut_ptr().add(idx), x); idx += 1; } } -- a hostile iterator returns lower=0 but yields N items, blowing past the buffer. Pay attention to size_hint, ptr::write, ptr::add, set_len without prior re-grow, missing capacity recheck inside the copy loop, and any unsafe block inside an iterator-driven extend / insert / append. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"heap_overflow\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.";
+    };
+    return "";
+}
+
+// #520 M98 v3 PR 1/3: variant-prefix overlay extracted into a helper.
+// See alpha hunter header comment for the architectural rationale.
+fn _variant_overlay_suffix() -> string {
+    let variant = recall_latest("hunter:prompt_variant");
+    if len(variant) > 0 {
+        return "\n\n[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]";
+    };
+    return "";
+}
+
 // #499: 8-class universe used by the class-flip mutation in
 // `pick_variant`. Indices 0..1 are the tribe's primary + sibling classes
 // (also seeded directly into the 14-literal pool below); 2..7 are
@@ -584,28 +604,24 @@ fn tick(reason: string) -> void {
         };
     };
 
-    // Tribe-beta seed prompt (#421): retargeted from Stage 0
-    // source-to-sink heuristic to Stage 2 heap_overflow bug class.
-    // Smallvec-style `unsafe` libraries overflow the heap when capacity
-    // is reserved from an externally-controllable iterator's
-    // size_hint() / len() and the loop body trusts that hint without
-    // re-checking, so a malicious iterator that returns a small lower
-    // bound but yields more elements writes past the allocated buffer.
-    //
-    // Stage 3 (#439): replicas inherit the parent's `hunter:prompt_variant`
-    // memo; appending it as a Focus: suffix lets sibling replicas lean
-    // into different interpretations of the same seed. Empty memo (Stage
-    // 2 single-tribe / no replication) is a no-op.
-    let variant = _variant;
-    let variant_prefix = if len(variant) > 0 {
-        "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
+    // #520 M98 v3 PR 1/3: memo-stored hunting prompt + per-tribe seed
+    // bootstrap. See alpha hunter for the architectural rationale.
+    let prompt_text_raw = recall_latest("hunter:" + _self_pid + ":hunting_prompt");
+    let prompt_text = if len(prompt_text_raw) == 0 {
+        let seed = _seed_prompt_for_class(_tribe_default_class());
+        let max_bytes_env = try { exec sh "printenv HUNTER_PROMPT_MAX_BYTES"; } catch e { ""; };
+        let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
+        let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_clamped = if len(seed) > max_bytes_eff { substring(seed, 0, max_bytes_eff); } else { seed; };
+        memo_write("hunter:" + _self_pid + ":hunting_prompt", seed_clamped);
+        memo_write("hunter:" + _self_pid + ":hunting_prompt_generation", "0");
+        seed_clamped;
     } else {
-        "";
+        prompt_text_raw;
     };
-    let src_with_focus = variant_prefix + src;
     let finding = prompt(
-        "Your specific target function is `pub fn insert_many` -- it lives near line 827 of the file. The bug is the heap overflow inside this function: `iter.size_hint()` returns a lower bound that the function trusts to size the buffer, but a hostile iterator can lie (return lower=0 then yield N items) and the inner ptr::write loop blows past the allocation. Find `pub fn insert_many` (NOT `from_buf_and_len_unchecked`, NOT `grow`) and report THAT function's signature line. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for heap overflow: code that allocates capacity based on an externally-controllable iterator's size_hint() or len() and copies more elements than allocated when the iterator lies about its length. SmallVec / Vec methods named extend, insert_many, from_iter, append are the typical environment. The classic example is: let (lower, _) = iter.size_hint(); self.reserve(lower); for x in iter { unsafe { ptr::write(self.as_mut_ptr().add(idx), x); idx += 1; } } -- a hostile iterator returns lower=0 but yields N items, blowing past the buffer. Pay attention to size_hint, ptr::write, ptr::add, set_len without prior re-grow, missing capacity recheck inside the copy loop, and any unsafe block inside an iterator-driven extend / insert / append. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"heap_overflow\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.",
-        src_with_focus
+        prompt_text + _variant_overlay_suffix(),
+        src
     ) -> Finding;
 
     let my_tier = tier("hunter");

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -67,6 +67,26 @@ fn _tribe_default_class() -> string {
     return "use_after_free";
 }
 
+// #520 M98 v3 PR 1/3: per-class seed prompt registry. See alpha hunter
+// header comment for the architectural rationale. PR 1/3 only seeds
+// the tribe's primary class; off-class seeds are PR 2/3 territory.
+fn _seed_prompt_for_class(class: string) -> string {
+    if class == "use_after_free" {
+        return "You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for use-after-free / double-free, with two related shapes: (1) a borrow outlives the value it points into -- Vec / SmallVec reallocation invalidating prior &/&mut slices, unsafe { ... } blocks that transmute lifetimes, raw pointers that survive past the safe Rust lifetime of their source, and (2) panic / unwind during insert_many / extend leaves the buffer in a transitionally-inconsistent state where Drop::drop re-frees pointers that were already moved or partially copied. The classic example is: pub fn insert_many<I: IntoIterator>(&mut self, idx: usize, iter: I) { ptr::copy(p.add(idx), p.add(idx + n), tail_len); for (i, x) in iter.enumerate() { ptr::write(p.add(idx + i), x); /* iter.next() panics here -> drop runs, double-frees moved-but-not-yet-shifted-back tail */ } }. Pay attention to ptr::copy / ptr::write through pointers obtained before a reallocation, set_len on a SmallVec / Vec while a derived raw pointer still aliases the old buffer, ManuallyDrop / mem::forget around partial moves, and RAII corner cases triggered by panics inside an unsafe block. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"use_after_free\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.";
+    };
+    return "";
+}
+
+// #520 M98 v3 PR 1/3: variant-prefix overlay extracted into a helper.
+// See alpha hunter header comment for the architectural rationale.
+fn _variant_overlay_suffix() -> string {
+    let variant = recall_latest("hunter:prompt_variant");
+    if len(variant) > 0 {
+        return "\n\n[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]";
+    };
+    return "";
+}
+
 // #499: 8-class universe used by the class-flip mutation in
 // `pick_variant`. Indices 0..1 are the tribe's primary + sibling classes
 // (also seeded directly into the 14-literal pool below); 2..7 are
@@ -585,27 +605,24 @@ fn tick(reason: string) -> void {
         };
     };
 
-    // Tribe-delta seed prompt: lifetime / aliasing reasoning heuristic.
-    // Orthogonal to alpha (format!()-pattern), beta (source-to-sink) and
-    // gamma (error-path) — those reason about data flow, delta reasons
-    // about temporal validity. The calibration check (M3) reruns the
-    // experiment with prompts swapped between tribes if TP rates differ
-    // by >2x.
-    //
-    // Stage 3 (#439): replicas inherit the parent's `hunter:prompt_variant`
-    // memo; appending it as a Focus: suffix lets sibling replicas lean
-    // into different interpretations of the same seed. Empty memo (Stage
-    // 2 single-tribe / no replication) is a no-op.
-    let variant = _variant;
-    let variant_prefix = if len(variant) > 0 {
-        "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
+    // #520 M98 v3 PR 1/3: memo-stored hunting prompt + per-tribe seed
+    // bootstrap. See alpha hunter for the architectural rationale.
+    let prompt_text_raw = recall_latest("hunter:" + _self_pid + ":hunting_prompt");
+    let prompt_text = if len(prompt_text_raw) == 0 {
+        let seed = _seed_prompt_for_class(_tribe_default_class());
+        let max_bytes_env = try { exec sh "printenv HUNTER_PROMPT_MAX_BYTES"; } catch e { ""; };
+        let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
+        let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_clamped = if len(seed) > max_bytes_eff { substring(seed, 0, max_bytes_eff); } else { seed; };
+        memo_write("hunter:" + _self_pid + ":hunting_prompt", seed_clamped);
+        memo_write("hunter:" + _self_pid + ":hunting_prompt_generation", "0");
+        seed_clamped;
     } else {
-        "";
+        prompt_text_raw;
     };
-    let src_with_focus = variant_prefix + src;
     let finding = prompt(
-        "You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for use-after-free / double-free, with two related shapes: (1) a borrow outlives the value it points into -- Vec / SmallVec reallocation invalidating prior &/&mut slices, unsafe { ... } blocks that transmute lifetimes, raw pointers that survive past the safe Rust lifetime of their source, and (2) panic / unwind during insert_many / extend leaves the buffer in a transitionally-inconsistent state where Drop::drop re-frees pointers that were already moved or partially copied. The classic example is: pub fn insert_many<I: IntoIterator>(&mut self, idx: usize, iter: I) { ptr::copy(p.add(idx), p.add(idx + n), tail_len); for (i, x) in iter.enumerate() { ptr::write(p.add(idx + i), x); /* iter.next() panics here -> drop runs, double-frees moved-but-not-yet-shifted-back tail */ } }. Pay attention to ptr::copy / ptr::write through pointers obtained before a reallocation, set_len on a SmallVec / Vec while a derived raw pointer still aliases the old buffer, ManuallyDrop / mem::forget around partial moves, and RAII corner cases triggered by panics inside an unsafe block. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"use_after_free\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.",
-        src_with_focus
+        prompt_text + _variant_overlay_suffix(),
+        src
     ) -> Finding;
 
     let my_tier = tier("hunter");

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -67,6 +67,26 @@ fn _tribe_default_class() -> string {
     return "use_after_free";
 }
 
+// #520 M98 v3 PR 1/3: per-class seed prompt registry. See alpha hunter
+// header comment for the architectural rationale. PR 1/3 only seeds
+// the tribe's primary class; off-class seeds are PR 2/3 territory.
+fn _seed_prompt_for_class(class: string) -> string {
+    if class == "use_after_free" {
+        return "Your specific target function is `pub fn insert_many` -- it lives near line 827 of the file. The bug shape you specialize in is the panic-unwind path: when `iter.next()` inside the insert loop panics, `Drop::drop` runs on a partially-moved buffer and double-frees pointers that were already shifted. Find `pub fn insert_many` (NOT `from_buf_and_len_unchecked`, NOT `grow`) and report that function's signature line. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for use-after-free / double-free triggered by panic / unwind on the early-exit path: code that takes ownership of a raw allocation, then panics or returns early via `?` without `mem::forget`-ing the original RAII guard, so when the stack unwinds both the original guard's Drop and the destination owner free the same pointer. The classic example is: let buf = unsafe { alloc::alloc(layout) }; let _guard = AllocGuard { ptr: buf, layout }; some_fallible_op()?; transfer_ownership(buf); mem::forget(_guard); -- if `?` triggers before the forget, _guard.drop() AND the eventual destination both dealloc(buf). Pay attention to `?` early-return inside an unsafe block, panic! / assert! between an alloc and a corresponding mem::forget, Drop::drop cascading on partially-moved values, ManuallyDrop wrappers that are forgotten on the happy path but not on the error path, and any sequence where a raw pointer is handed to a new owner without the source being defused first. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"use_after_free\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.";
+    };
+    return "";
+}
+
+// #520 M98 v3 PR 1/3: variant-prefix overlay extracted into a helper.
+// See alpha hunter header comment for the architectural rationale.
+fn _variant_overlay_suffix() -> string {
+    let variant = recall_latest("hunter:prompt_variant");
+    if len(variant) > 0 {
+        return "\n\n[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]";
+    };
+    return "";
+}
+
 // #499: 8-class universe used by the class-flip mutation in
 // `pick_variant`. Indices 0..1 are the tribe's primary + sibling classes
 // (also seeded directly into the 14-literal pool below); 2..7 are
@@ -585,28 +605,24 @@ fn tick(reason: string) -> void {
         };
     };
 
-    // Tribe-epsilon seed prompt: concurrency / Send+Sync reasoning
-    // heuristic. None of alpha (format!()-pattern), beta (source-to-sink),
-    // gamma (error-path), or delta (lifetime/aliasing) reasons about
-    // parallelism; concurrency bugs are the canonical category that
-    // *requires* whole-program reasoning. The calibration check (M3)
-    // reruns the experiment with prompts swapped between tribes if TP
-    // rates differ by >2x.
-    //
-    // Stage 3 (#439): replicas inherit the parent's `hunter:prompt_variant`
-    // memo; appending it as a Focus: suffix lets sibling replicas lean
-    // into different interpretations of the same seed. Empty memo (Stage
-    // 2 single-tribe / no replication) is a no-op.
-    let variant = _variant;
-    let variant_prefix = if len(variant) > 0 {
-        "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
+    // #520 M98 v3 PR 1/3: memo-stored hunting prompt + per-tribe seed
+    // bootstrap. See alpha hunter for the architectural rationale.
+    let prompt_text_raw = recall_latest("hunter:" + _self_pid + ":hunting_prompt");
+    let prompt_text = if len(prompt_text_raw) == 0 {
+        let seed = _seed_prompt_for_class(_tribe_default_class());
+        let max_bytes_env = try { exec sh "printenv HUNTER_PROMPT_MAX_BYTES"; } catch e { ""; };
+        let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
+        let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_clamped = if len(seed) > max_bytes_eff { substring(seed, 0, max_bytes_eff); } else { seed; };
+        memo_write("hunter:" + _self_pid + ":hunting_prompt", seed_clamped);
+        memo_write("hunter:" + _self_pid + ":hunting_prompt_generation", "0");
+        seed_clamped;
     } else {
-        "";
+        prompt_text_raw;
     };
-    let src_with_focus = variant_prefix + src;
     let finding = prompt(
-        "Your specific target function is `pub fn insert_many` -- it lives near line 827 of the file. The bug shape you specialize in is the panic-unwind path: when `iter.next()` inside the insert loop panics, `Drop::drop` runs on a partially-moved buffer and double-frees pointers that were already shifted. Find `pub fn insert_many` (NOT `from_buf_and_len_unchecked`, NOT `grow`) and report that function's signature line. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for use-after-free / double-free triggered by panic / unwind on the early-exit path: code that takes ownership of a raw allocation, then panics or returns early via `?` without `mem::forget`-ing the original RAII guard, so when the stack unwinds both the original guard's Drop and the destination owner free the same pointer. The classic example is: let buf = unsafe { alloc::alloc(layout) }; let _guard = AllocGuard { ptr: buf, layout }; some_fallible_op()?; transfer_ownership(buf); mem::forget(_guard); -- if `?` triggers before the forget, _guard.drop() AND the eventual destination both dealloc(buf). Pay attention to `?` early-return inside an unsafe block, panic! / assert! between an alloc and a corresponding mem::forget, Drop::drop cascading on partially-moved values, ManuallyDrop wrappers that are forgotten on the happy path but not on the error path, and any sequence where a raw pointer is handed to a new owner without the source being defused first. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"use_after_free\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.",
-        src_with_focus
+        prompt_text + _variant_overlay_suffix(),
+        src
     ) -> Finding;
 
     let my_tier = tier("hunter");

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -67,6 +67,26 @@ fn _tribe_default_class() -> string {
     return "memory_corruption";
 }
 
+// #520 M98 v3 PR 1/3: per-class seed prompt registry. See alpha hunter
+// header comment for the architectural rationale. PR 1/3 only seeds
+// the tribe's primary class; off-class seeds are PR 2/3 territory.
+fn _seed_prompt_for_class(class: string) -> string {
+    if class == "memory_corruption" {
+        return "Your specific target function is `pub fn grow` -- it lives near line 656 of the file. The bug is the capacity-shrink: `grow` accepts a `new_cap` smaller than the current `len`, leaving derived raw pointers overrunning the new (smaller) buffer. Do NOT report `insert_many` -- that's a different tribe's target. Find `pub fn grow` and report THAT function's signature line. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for memory corruption: arithmetic in grow / reserve / set_len / shrink_to_fit that accepts a smaller capacity than the current length, leading to derived raw pointers that overrun the new buffer, or to layout mismatches between alloc and dealloc. The classic example is: pub fn grow(&mut self, new_cap: usize) { /* no check that new_cap >= self.len */ let new_alloc = unsafe { alloc::alloc(Layout::array::<T>(new_cap).unwrap()) }; ptr::copy_nonoverlapping(self.as_ptr(), new_alloc as *mut T, self.len()); /* copies len() bytes into new_cap-sized buffer */ }. Pay attention to set_len, capacity assignments, alloc::dealloc, Layout::from_size_align, ptr::copy / ptr::copy_nonoverlapping with unchecked length parameters, and any path where new_cap < self.len() is reachable. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"memory_corruption\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.";
+    };
+    return "";
+}
+
+// #520 M98 v3 PR 1/3: variant-prefix overlay extracted into a helper.
+// See alpha hunter header comment for the architectural rationale.
+fn _variant_overlay_suffix() -> string {
+    let variant = recall_latest("hunter:prompt_variant");
+    if len(variant) > 0 {
+        return "\n\n[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]";
+    };
+    return "";
+}
+
 // #499: 8-class universe used by the class-flip mutation in
 // `pick_variant`. Indices 0..1 are the tribe's primary + sibling classes
 // (also seeded directly into the 14-literal pool below); 2..7 are
@@ -585,26 +605,24 @@ fn tick(reason: string) -> void {
         };
     };
 
-    // Tribe-gamma seed prompt: error-path data-flow heuristic. Plausibly
-    // equally good as tribe-alpha's format!()-pattern prompt and
-    // tribe-beta's source-to-sink prompt; the calibration check (M3)
-    // reruns the experiment with prompts swapped between tribes if TP
-    // rates differ by >2x.
-    //
-    // Stage 3 (#439): replicas inherit the parent's `hunter:prompt_variant`
-    // memo; appending it as a Focus: suffix lets sibling replicas lean
-    // into different interpretations of the same seed. Empty memo (Stage
-    // 2 single-tribe / no replication) is a no-op.
-    let variant = _variant;
-    let variant_prefix = if len(variant) > 0 {
-        "[Replica focus: prompt variant '" + variant + "' -- lean into that interpretation when scanning the source below.]\n\n";
+    // #520 M98 v3 PR 1/3: memo-stored hunting prompt + per-tribe seed
+    // bootstrap. See alpha hunter for the architectural rationale.
+    let prompt_text_raw = recall_latest("hunter:" + _self_pid + ":hunting_prompt");
+    let prompt_text = if len(prompt_text_raw) == 0 {
+        let seed = _seed_prompt_for_class(_tribe_default_class());
+        let max_bytes_env = try { exec sh "printenv HUNTER_PROMPT_MAX_BYTES"; } catch e { ""; };
+        let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
+        let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_clamped = if len(seed) > max_bytes_eff { substring(seed, 0, max_bytes_eff); } else { seed; };
+        memo_write("hunter:" + _self_pid + ":hunting_prompt", seed_clamped);
+        memo_write("hunter:" + _self_pid + ":hunting_prompt_generation", "0");
+        seed_clamped;
     } else {
-        "";
+        prompt_text_raw;
     };
-    let src_with_focus = variant_prefix + src;
     let finding = prompt(
-        "Your specific target function is `pub fn grow` -- it lives near line 656 of the file. The bug is the capacity-shrink: `grow` accepts a `new_cap` smaller than the current `len`, leaving derived raw pointers overrunning the new (smaller) buffer. Do NOT report `insert_many` -- that's a different tribe's target. Find `pub fn grow` and report THAT function's signature line. You are a Rust unsafe-code auditor scanning a smallvec-style library file. Look specifically for memory corruption: arithmetic in grow / reserve / set_len / shrink_to_fit that accepts a smaller capacity than the current length, leading to derived raw pointers that overrun the new buffer, or to layout mismatches between alloc and dealloc. The classic example is: pub fn grow(&mut self, new_cap: usize) { /* no check that new_cap >= self.len */ let new_alloc = unsafe { alloc::alloc(Layout::array::<T>(new_cap).unwrap()) }; ptr::copy_nonoverlapping(self.as_ptr(), new_alloc as *mut T, self.len()); /* copies len() bytes into new_cap-sized buffer */ }. Pay attention to set_len, capacity assignments, alloc::dealloc, Layout::from_size_align, ptr::copy / ptr::copy_nonoverlapping with unchecked length parameters, and any path where new_cap < self.len() is reachable. IMPORTANT — REPORT THE FUNCTION SIGNATURE LINE, NOT THE OPERATION LINE: when you spot a suspicious unsafe operation inside a function body, scroll up to find the function declaration line (e.g. `pub fn foo(...)` or `pub unsafe fn bar(...)`) and report THAT line number. The verifier matches at function-level granularity with ±5 line tolerance, anchored on the function signature. So if you find `ptr::write` at line 854 inside a function declared at line 827, report line=827, NOT line=854. Use signature_hint to record the function-name + parameter snippet (e.g. `pub fn insert_many` or `unsafe fn from_buf_and_len_unchecked`), NOT the operation. Return JSON with these fields: line: int -- 1-indexed source line where the bug is, OR 0 if you genuinely cannot find one. severity: string -- low | medium | high. rationale: string -- one sentence explaining why this line is suspicious. signature_hint: string -- short literal substring (5-30 chars) of the function signature that grep can find on that line, e.g. `pub fn foo` or `unsafe fn bar`. class: string -- must be exactly \"memory_corruption\". Do NOT return line=0 unless you have genuinely scanned the file and found nothing. Default to your best guess on a suspicious unsafe operation if you are unsure.",
-        src_with_focus
+        prompt_text + _variant_overlay_suffix(),
+        src
     ) -> Finding;
 
     let my_tier = tier("hunter");


### PR DESCRIPTION
## Summary

Sub-PR 1/3 of #520 (M98 v3 LLM-generated hunter prompts). Lands the **memo schema + bootstrap surface** without yet introducing evolution (PR 2/3) or M106 inheritance (PR 3/3). Preserves pre-#505 hunting behavior byte-identically on first tick — seeds are restored from the surgical-restore commit (9aacf65 / #517).

## What changes

For each of 5 hunter.ag files:
- New helper `_seed_prompt_for_class(class)` returning the tribe's pre-#505 hardcoded prompt for its `_tribe_default_class()` value.
- Bootstrap block at start of `tick()`: read `recall_latest("hunter:<pid>:hunting_prompt")`; if empty, write seed + initialize `:hunting_prompt_generation = "0"`.
- Hunting `prompt(...)` call switches from literal first-arg to `prompt(prompt_text + _variant_overlay_suffix(), src)` — non-literal expression unlocked by agentis-core v1.7.10 (#638 / PR #639).

Also:
- `tribes-bench/tools/run-stage3-docker.sh`: `STAGE3_HUNTER_PROMPT_MAX_BYTES` env var (default 4096) added to `exec.env_passthrough` for length-clamp on bootstrap.
- `tribes-bench/tools/check-agentis-version.sh`: runtime floor bumped 1.5.0 → 1.7.10 (#638 dependency).
- `tribes-bench/CHANGELOG.md` `## [Unreleased]` `### Changed` entry referencing #520 + v1.7.10 dependency + anti-gaming invariant restatement.

## Per-tribe seed → class mapping

Restored verbatim from `git show 9aacf65 -- tribes-bench/tribe-*/agents/hunter.ag` (pre-#505 baseline):

| Tribe | `_tribe_default_class()` |
|---|---|
| alpha | uninitialised_memory |
| beta | heap_overflow |
| gamma | memory_corruption |
| delta | use_after_free |
| epsilon | use_after_free |

Implementer reconciled mapping against codebase ground truth (the original prompt spec proposed gamma→uninitialised_memory + delta→memory_corruption — codebase says gamma→memory_corruption + delta→use_after_free; byte-identical-first-tick invariant requires codebase truth).

## Critical invariant preserved

First tick of a fresh colony hits the seed = pre-#505 prompt verbatim → byte-identical hunting LLM call (modulo the unchanged `_variant_overlay_suffix()` append). No evolution yet → no behavior drift in this PR. M98 v2's 0% LLM hit rate regression cannot recur from PR 1/3 alone.

## Out of scope (PR 2/3 + 3/3)

- Verified-buffer maintenance
- Evolution trigger / meta-prompt call
- Levenshtein floor + generation cap + JSON-schema sanity ping
- M106 hash-pointer inheritance across replicate()
- `STAGE3_HUNTER_PROMPT_{EVOLUTION_THRESHOLD,GEN_CAP,LEVENSHTEIN_FLOOR}` env vars
- `hunter:<pid>:verified_buffer` + `hunter:prompt_body:<sha256>` memo keys

## Anti-gaming

Hunter cannot influence verifier behavior through prompt content. Verifier is a deterministic shell script with no LLM in the path. Selection pressure flows only from real verified hits. PR-2/3 evolution will preserve this invariant.

## Validation

- Local colony-lint with **agentis v1.7.10 installed**: expected to pass 170/0/3 (matches #521 baseline post-vendor)
- Local colony-lint with **agentis < v1.7.10**: `check-agentis-version.sh` now exits 78 with clean upgrade message before .ag parse failures muddy the output
- CI (no agentis installed): unaffected by the .ag changes — runner already skips .ag syntax checks
- `tools/test-tribes-bench-run-stage3-docker.sh`: 65/0 unchanged (implementer-verified)
- run-stage3-docker.sh env_passthrough propagation: tested by implementer

## References

- #520 (parent M98 v3 issue + full plan)
- #515 (failure-mode analysis identifying LLM-evolved prompts as the only viable cross-class emergence route)
- #505 / #517 / #518 (M98 v2 hand-engineered generic prompts reverted)
- agentis-core #638 / tag v1.7.10 (prompt() non-literal first arg — unblocker)

## Test plan

- [x] All 5 hunter.ag files restored to pre-#505 seeds verbatim
- [x] Memo bootstrap + hunting call switch landed in all 5
- [x] Runtime floor bumped to v1.7.10
- [x] CHANGELOG entry under Unreleased / Changed
- [ ] CI green
- [ ] QA agent ship-it

🤖 Generated with [Claude Code](https://claude.com/claude-code)