### PR TITLE
chore(tribes-bench): add publish=false to all 5 vendored target Cargo.toml (#522)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,16 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **Retro-add `publish = false` to all 5 vendored target `Cargo.toml` files**
+  ([#522](https://github.com/Replikanti/agentis-colonies/issues/522)).
+  Defence-in-depth against accidental `cargo publish` of intentionally
+  vulnerable vendored code. Covers `tribes-bench/targets/stage2/smallvec-v0.6.13/`,
+  `targets/stage3/bumpalo-v3.2.0/`, `targets/stage4-crossbeam-deque-v0.7.2/`,
+  `targets/stage4-owning_ref-v0.4.1/`, `targets/stage4-generator-v0.6.25/`.
+  No production-leak path exists today (no top-level `Cargo.toml` workspace,
+  no `cargo publish` invocation anywhere in repo or CI) — this is a belt-and-braces
+  addition so crates.io would reject upload of duplicate-version-by-non-owner
+  even if someone runs `cargo publish` in a vendored target dir.
 - **M98 v3 PR 2/3 — verified-buffer + meta-prompt evolution + anti-degeneracy guards**
   ([#520](https://github.com/Replikanti/agentis-colonies/issues/520),
   PR 2/3 of three; depends on PR 1/3

--- a/tribes-bench/targets/stage2/smallvec-v0.6.13/Cargo.toml
+++ b/tribes-bench/targets/stage2/smallvec-v0.6.13/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "smallvec"
 version = "0.6.13"
+publish = false  # tribes-bench: intentionally vulnerable, never publish (#522)
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/servo/rust-smallvec"

--- a/tribes-bench/targets/stage3/bumpalo-v3.2.0/Cargo.toml
+++ b/tribes-bench/targets/stage3/bumpalo-v3.2.0/Cargo.toml
@@ -6,6 +6,7 @@ documentation = "https://docs.rs/bumpalo"
 edition = "2018"
 license = "MIT/Apache-2.0"
 name = "bumpalo"
+publish = false  # tribes-bench: intentionally vulnerable, never publish (#522)
 readme = "./README.md"
 repository = "https://github.com/fitzgen/bumpalo"
 version = "3.2.0"

--- a/tribes-bench/targets/stage4-crossbeam-deque-v0.7.2/Cargo.toml
+++ b/tribes-bench/targets/stage4-crossbeam-deque-v0.7.2/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "crossbeam-deque"
+publish = false  # tribes-bench: intentionally vulnerable, never publish (#522)
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Update README.md

--- a/tribes-bench/targets/stage4-generator-v0.6.25/Cargo.toml
+++ b/tribes-bench/targets/stage4-generator-v0.6.25/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "generator"
 version = "0.6.25"
+publish = false  # tribes-bench: intentionally vulnerable, never publish (#522)
 edition = "2018"
 authors = ["Xudong Huang <huangxu008@hotmail.com>"]
 license = "MIT/Apache-2.0"

--- a/tribes-bench/targets/stage4-owning_ref-v0.4.1/Cargo.toml
+++ b/tribes-bench/targets/stage4-owning_ref-v0.4.1/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "owning_ref"
 version = "0.4.1"
+publish = false  # tribes-bench: intentionally vulnerable, never publish (#522)
 authors = ["Marvin Löbel <loebel.marvin@gmail.com>"]
 license = "MIT"
 


### PR DESCRIPTION
## Summary

Closes #522.

Adds `publish = false` to the `[package]` section of all 5 vendored target `Cargo.toml` files. Defence-in-depth retro-add following the QA finding on #521.

## Files changed

- `tribes-bench/targets/stage2/smallvec-v0.6.13/Cargo.toml`
- `tribes-bench/targets/stage3/bumpalo-v3.2.0/Cargo.toml`
- `tribes-bench/targets/stage4-crossbeam-deque-v0.7.2/Cargo.toml`
- `tribes-bench/targets/stage4-owning_ref-v0.4.1/Cargo.toml`
- `tribes-bench/targets/stage4-generator-v0.6.25/Cargo.toml`
- `tribes-bench/CHANGELOG.md` (Unreleased / Changed bullet)

## Why this is low-risk today

1. No top-level `Cargo.toml` / workspace exists. `find . -name Cargo.toml` returns only the 5 vendored target dirs — no compile root, no `[workspace.dependencies]` anywhere.
2. No `cargo publish` invocation anywhere in repo or CI.
3. crates.io would reject duplicate-version upload by a non-owner regardless.

So this is defence-in-depth, not a live exploit closure.

## Why fix it anyway

If someone later adds a workspace or accidentally runs `cargo publish` to test something in a `stage4-*` dir, `publish = false` ensures the registry refuses intentionally-vulnerable code at upload time as well.

## Validation

- [x] colony-lint: 170 passed / 0 failed / 3 skipped (baseline preserved)
- [x] python3 tomllib parses all 5 Cargo.toml; `publish == False` for each
- [x] No other file changed (no behavior change beyond the publish flag)

## Test plan

- [ ] CI green
- [ ] QA agent ship-it
- [ ] Auto-merge on ship-it

🤖 Generated with [Claude Code](https://claude.com/claude-code)