### PR TITLE
fix(tribes-bench): bump daemon.cb_per_tick 100 -> 2000 (#528)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,25 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **Bump `daemon.cb_per_tick` from agentis-core default 100 to 2000 in the Stage 3 docker orchestrator hermetic config**
+  ([#528](https://github.com/Replikanti/agentis-colonies/issues/528)).
+  Surfaced by the M98 v3 plan-test-7 emergence smoke: hunter daemons
+  CB-exhausted after ~10 LLM-heavy ticks, became zombies (alive,
+  ticking, watchdog-happy) that consumed wall clock + LLM API spend
+  without producing any verified findings. M98 v3 evolution-path ticks
+  spend ~250-300 CB on prompt + meta-prompt + schema-sanity ping +
+  exec-sh helpers; the agentis-core default of 100 CB/tick refill is
+  net-negative against this workload and drains the `cb 200000000;`
+  lifetime budget within ~10 ticks. New env var
+  `STAGE3_DAEMON_CB_PER_TICK` (default 2000) is written into both
+  hermetic `.agentis/config` files as `daemon.cb_per_tick = <value>`.
+  2000 gives ~7× safety headroom on evolution ticks and sustained
+  operation across the full 6-hour wall clock. Lower the value only
+  when intentionally reproducing CB-exhaustion behaviour. Affects only
+  the docker orchestrator; the non-orchestrator entry points
+  (`start-colony.sh` direct invocations) still inherit the
+  agentis-core default unless the operator overrides in their own
+  `.agentis/config`.
 - **M98 v3 PR 3/3 — M106 hash-pointer inheritance across replicate() — M98 v3 COMPLETE**
   ([#520](https://github.com/Replikanti/agentis-colonies/issues/520),
   PR 3/3 of three and the FINAL piece of M98 v3; depends on PR 1/3

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -100,6 +100,18 @@
 #                              (5%). A rewrite below the floor is
 #                              treated as no-op: old prompt retained,
 #                              generation not bumped, buffer untouched.
+#   STAGE3_DAEMON_CB_PER_TICK  Per-tick CB replenishment written into
+#                              hermetic .agentis/config as
+#                              `daemon.cb_per_tick` (#528). Default 2000
+#                              — well above the agentis-core default of
+#                              100 which empirically bricks LLM-heavy
+#                              tribes-bench daemons after ~10 ticks once
+#                              the `cb 200000000;` lifetime budget
+#                              drains (M98 v3 evolution-path ticks spend
+#                              ~250-300 CB on prompt + meta-prompt +
+#                              schema-sanity ping + exec-sh helpers).
+#                              Lower this only when intentionally
+#                              reproducing CB-exhaustion behaviour.
 #   STAGE3_LLM_BACKEND         llm.backend value injected into both
 #                              hermetic configs. Default: openai (#445).
 #   STAGE3_OPENAI_MODEL        Model id when STAGE3_LLM_BACKEND=openai.
@@ -273,6 +285,7 @@ HUNTER_PROMPT_GEN_CAP="${STAGE3_HUNTER_PROMPT_GEN_CAP:-10}"
 # #520 M98 v3 PR 2/3: minimum dissimilarity (integer percent, 0..100)
 # for an LLM-proposed prompt rewrite to be accepted. Default 5 (5%).
 HUNTER_PROMPT_LEVENSHTEIN_FLOOR="${STAGE3_HUNTER_PROMPT_LEVENSHTEIN_FLOOR:-5}"
+DAEMON_CB_PER_TICK="${STAGE3_DAEMON_CB_PER_TICK:-2000}"
 LLM_BACKEND="${STAGE3_LLM_BACKEND:-openai}"
 OPENAI_MODEL="${STAGE3_OPENAI_MODEL:-gpt-4o-mini}"
 OPENAI_ENDPOINT="${STAGE3_OPENAI_ENDPOINT:-https://api.openai.com/v1/chat/completions}"
@@ -468,6 +481,11 @@ write_bootstrap() {
         printf '  printf "messaging.distributed = true\\n"\n'
         printf '  printf "colony.workers = %%s:%%s\\n" "$PEER_HOST_IP" "%s"\n' "$peer_worker_port"
         printf '  printf "llm.backend = %s\\n"\n' "$LLM_BACKEND"
+        # #528: bump daemon.cb_per_tick well above the agentis-core default (100)
+        # so M98 v3 evolution-path ticks (which can spend 250-300 CB on prompt
+        # + meta-prompt + schema-sanity ping + exec-sh helpers) don't drain
+        # the daemon's 200M lifetime budget within ~10 ticks.
+        printf '  printf "daemon.cb_per_tick = %s\\n"\n' "$DAEMON_CB_PER_TICK"
         if [ "$LLM_BACKEND" = "openai" ]; then
             printf '  printf "llm.openai.endpoint = %s\\n"\n' "$OPENAI_ENDPOINT"
             printf '  printf "llm.openai.model = %s\\n"\n' "$OPENAI_MODEL"

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -342,6 +342,21 @@ assert_contains "per-tribe bootstrap line propagates HUNTER_PROMPT_EVOLUTION_THR
     "$(cat "$ORCH")" \
     "HUNTER_PROMPT_EVOLUTION_THRESHOLD=%s HUNTER_PROMPT_GEN_CAP=%s HUNTER_PROMPT_LEVENSHTEIN_FLOOR=%s"
 
+# 9b. #528: STAGE3_DAEMON_CB_PER_TICK env var is documented, has the
+# documented default of 2000, and its hermetic-config emit line is
+# present (so the spawned daemon's per-tick CB budget actually rises
+# above the agentis-core default of 100 which empirically bricks
+# LLM-heavy tribes-bench daemons after ~10 ticks).
+assert_contains "header documents STAGE3_DAEMON_CB_PER_TICK" \
+    "$(cat "$ORCH")" \
+    "STAGE3_DAEMON_CB_PER_TICK"
+assert_contains "STAGE3_DAEMON_CB_PER_TICK default is 2000" \
+    "$(cat "$ORCH")" \
+    'DAEMON_CB_PER_TICK="${STAGE3_DAEMON_CB_PER_TICK:-2000}"'
+assert_contains "hermetic config emits daemon.cb_per_tick line" \
+    "$(cat "$ORCH")" \
+    'printf "daemon.cb_per_tick = %s'
+
 # 10. #520 M98 v3 PR 3/3: M106 hash-pointer inheritance — assert each
 # hunter.ag carries the new helpers, the bootstrap inheritance branch,
 # and that both replicate() sites call the parent-wrap helper. Source-


### PR DESCRIPTION
## Summary

Closes #528.

Single env-var addition (`STAGE3_DAEMON_CB_PER_TICK`, default 2000) that emits `daemon.cb_per_tick = <value>` into both hermetic `.agentis/config` files written by `run-stage3-docker.sh`. Fixes the CB exhaustion regression surfaced by the M98 v3 plan-test-7 emergence smoke.

## Why

Empirical: hunter daemon at `/tmp/m98v3-smoke-*` produced 6 verified hits in the first ~10 minutes, then zero new hits in the remaining 35 minutes. 24 CognitiveOverload errors. Daemon-inner ALIVE, watchdog happy, registry says `running` — but functionally bricked.

Root cause: agentis-core daemon runner replenishes CB each tick at `cb_per_tick * priority_multiplier` (`src/daemon/runner.rs:1357`). Default `daemon.cb_per_tick = 100` (`src/daemon/config.rs:367`). M98 v3 evolution-path ticks spend ~250-300 CB. Net drain of 150-200 CB per tick exhausts the `cb 200000000;` lifetime budget within ~10 ticks for any hunter that hits a meta-prompt evolution.

`grep -rE 'cb_per_tick|CB_PER_TICK' tribes-bench/` returns ZERO matches pre-PR — every Stage 3 docker smoke ever run has used the default 100 and bricked daemons mid-flight.

## What changes

| File | Change |
|---|---|
| `tribes-bench/tools/run-stage3-docker.sh` | Adds `STAGE3_DAEMON_CB_PER_TICK` env var (default 2000), threaded into hermetic config emit between the `llm.backend` line and the conditional OpenAI block |
| `tribes-bench/tools/test-run-stage3-docker.sh` | +3 assertions: header docs STAGE3_DAEMON_CB_PER_TICK, default is 2000, hermetic config emits `daemon.cb_per_tick = %s` line |
| `tribes-bench/CHANGELOG.md` | New `## [Unreleased]` / `### Changed` bullet with the empirical-evidence write-up |

## Default value rationale

- Worst-case observed per-tick spend: ~300 CB (evolution tick = hunting prompt + meta-prompt + schema-sanity ping + ~5 exec-sh helpers + ~20 memo R/W)
- 2000 CB / tick → ~6.7× safety headroom on the worst case
- Sustainable across 6h × 60s ticks = 360 ticks × 2000 CB = 720k CB refilled. Initial `cb 200000000;` consumed and refilled freely.
- Lower the value via `STAGE3_DAEMON_CB_PER_TICK=100` env override when reproducing CB-exhaustion behaviour for testing.

## Validation

- `test-run-stage3-docker.sh`: **145 / 0** (was 142, +3 new assertions)
- `colony-lint.sh`: **170 / 0 / 3 skipped** (baseline preserved)

## Out of scope

- Per-tribe `colony.example.toml` seeding — orchestrator wins via hermetic config emit, no need to seed in two places. Non-orchestrator entry points (`start-colony.sh` direct invocations from operator scripts) still inherit agentis-core default unless operator overrides locally
- agentis-core upstream change to make CB per-tick replenishment more generous by default — separate concern; file as agentis-core follow-up if desired

## References

- M98 v3 plan-test-7 smoke at `/tmp/m98v3-smoke-20260511T203508Z` (operator-local)
- agentis-core CB replenish site `src/daemon/runner.rs:1355-1357`
- agentis-core config default `src/daemon/config.rs:367`

## Test plan

- [x] test-run-stage3-docker.sh 145/0
- [x] colony-lint.sh 170/0/3 baseline
- [ ] CI green
- [ ] QA agent ship-it

🤖 Generated with [Claude Code](https://claude.com/claude-code)