### PR TITLE
fix(tribes-bench): M98 v3 meta-prompt — diversification not exploitation (#527)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,33 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **M98 v3 meta-prompt rewritten to drive diversification (exploration), not exploitation**
+  ([#527](https://github.com/Replikanti/agentis-colonies/issues/527),
+  follows the plan-test-7 emergence smoke from #520 / [PR #526](https://github.com/Replikanti/agentis-colonies/pull/526).)
+  The pre-#527 meta-prompt template in `_evolve_hunting_prompt()` said
+  `"Focus on patterns that produced verified hits."` — which is an
+  explicit exploitation directive. Empirically (M98 v3 smoke at
+  `/tmp/m98v3-smoke-*`): 6/6 verified hits on the same `S2-SMVMEM-001`
+  uninitialised_memory bug, evolved prompt converged to hyper-target
+  `from_buf_and_len_unchecked` line 534. Zero cross-class drift —
+  exactly opposite of the plan-test-7 success criterion. The rewrite
+  in this PR replaces the convergence directive with an explicit
+  expansion directive: "if all (or most) verified findings are in one
+  bug class, the rewrite MUST explicitly probe for OTHER classes from
+  the stage2 verifier set (use_after_free, heap_overflow,
+  memory_corruption, data_race, send_violation, missing_lock,
+  dangling_borrow, uninitialised_memory) in the same target file. The
+  goal is a hunter that finds the NEXT class of bug, not more
+  instances of the same one." Identical text applied to all 5 tribes
+  (`tribe-{alpha,beta,gamma,delta,epsilon}/agents/hunter.ag`) since
+  every tribe's `_evolve_hunting_prompt()` body is byte-identical at
+  the meta-prompt site. Anti-gaming and #491/#493 guardrails are
+  unchanged (the meta-prompt rewrites the prompt body that the
+  hunter sends to the LLM; the verifier remains a deterministic
+  shell script with zero LLM in the path, and selection pressure
+  still flows only from real verified hits). No new env vars, no
+  new memo keys, no new helpers — purely a string rewrite at one
+  site per tribe.
 - **Bump `daemon.cb_per_tick` from agentis-core default 100 to 2000 in the Stage 3 docker orchestrator hermetic config**
   ([#528](https://github.com/Replikanti/agentis-colonies/issues/528)).
   Surfaced by the M98 v3 plan-test-7 emergence smoke: hunter daemons

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -323,9 +323,23 @@ fn _evolve_hunting_prompt(self_pid: string, prompt_text: string) -> string {
     // Always fire the meta-prompt call (whether or not we are at cap).
     // The schema-sanity ping below will dry-run it; the actual write
     // is gated on all guards passing.
+    // #527: meta-prompt drives diversification (exploration), not
+    // exploitation. Pre-#527 text said "Focus on patterns that produced
+    // verified hits" which made the LLM hyper-converge on the single
+    // highest-yielding bug it had already found — measured during the
+    // plan-test-7 emergence smoke (6/6 verified hits same UM bug). The
+    // rewrite below asks the LLM to PROBE OTHER CLASSES instead of
+    // amplifying the same one, restoring the cross-class drift signal
+    // M98 v3 was designed to enable.
     let meta = "Rewrite the hunting prompt below given these verified findings. "
              + "Keep the JSON output schema identical (return Finding{class, line, severity, rationale, signature_hint}). "
-             + "Focus on patterns that produced verified hits. Old prompt: <"
+             + "Focus on EXPANDING class coverage: if all (or most) verified findings are in one bug class, the "
+             + "rewrite MUST explicitly probe for OTHER classes from the stage2 verifier set "
+             + "(use_after_free, heap_overflow, memory_corruption, data_race, send_violation, "
+             + "missing_lock, dangling_borrow, uninitialised_memory) in the same target file. "
+             + "The goal is a hunter that finds the NEXT class of bug, not more instances of the same one. "
+             + "Only converge on a single class when the verified findings genuinely span multiple classes already. "
+             + "Old prompt: <"
              + prompt_text + ">. Verified findings: <" + buffer_json + ">.";
     let new_prompt_raw = try { prompt(meta, "") -> string; } catch e { ""; };
     let new_prompt = if len(new_prompt_raw) > max_bytes_eff { substring(new_prompt_raw, 0, max_bytes_eff); } else { new_prompt_raw; };

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -249,9 +249,17 @@ fn _evolve_hunting_prompt(self_pid: string, prompt_text: string) -> string {
     // Always fire the meta-prompt call (whether or not we are at cap).
     // The schema-sanity ping below will dry-run it; the actual write
     // is gated on all guards passing.
+    // #527: meta-prompt drives diversification, not exploitation. See
+    // tribe-alpha/agents/hunter.ag for full rationale.
     let meta = "Rewrite the hunting prompt below given these verified findings. "
              + "Keep the JSON output schema identical (return Finding{class, line, severity, rationale, signature_hint}). "
-             + "Focus on patterns that produced verified hits. Old prompt: <"
+             + "Focus on EXPANDING class coverage: if all (or most) verified findings are in one bug class, the "
+             + "rewrite MUST explicitly probe for OTHER classes from the stage2 verifier set "
+             + "(use_after_free, heap_overflow, memory_corruption, data_race, send_violation, "
+             + "missing_lock, dangling_borrow, uninitialised_memory) in the same target file. "
+             + "The goal is a hunter that finds the NEXT class of bug, not more instances of the same one. "
+             + "Only converge on a single class when the verified findings genuinely span multiple classes already. "
+             + "Old prompt: <"
              + prompt_text + ">. Verified findings: <" + buffer_json + ">.";
     let new_prompt_raw = try { prompt(meta, "") -> string; } catch e { ""; };
     let new_prompt = if len(new_prompt_raw) > max_bytes_eff { substring(new_prompt_raw, 0, max_bytes_eff); } else { new_prompt_raw; };

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -249,9 +249,17 @@ fn _evolve_hunting_prompt(self_pid: string, prompt_text: string) -> string {
     // Always fire the meta-prompt call (whether or not we are at cap).
     // The schema-sanity ping below will dry-run it; the actual write
     // is gated on all guards passing.
+    // #527: meta-prompt drives diversification, not exploitation. See
+    // tribe-alpha/agents/hunter.ag for full rationale.
     let meta = "Rewrite the hunting prompt below given these verified findings. "
              + "Keep the JSON output schema identical (return Finding{class, line, severity, rationale, signature_hint}). "
-             + "Focus on patterns that produced verified hits. Old prompt: <"
+             + "Focus on EXPANDING class coverage: if all (or most) verified findings are in one bug class, the "
+             + "rewrite MUST explicitly probe for OTHER classes from the stage2 verifier set "
+             + "(use_after_free, heap_overflow, memory_corruption, data_race, send_violation, "
+             + "missing_lock, dangling_borrow, uninitialised_memory) in the same target file. "
+             + "The goal is a hunter that finds the NEXT class of bug, not more instances of the same one. "
+             + "Only converge on a single class when the verified findings genuinely span multiple classes already. "
+             + "Old prompt: <"
              + prompt_text + ">. Verified findings: <" + buffer_json + ">.";
     let new_prompt_raw = try { prompt(meta, "") -> string; } catch e { ""; };
     let new_prompt = if len(new_prompt_raw) > max_bytes_eff { substring(new_prompt_raw, 0, max_bytes_eff); } else { new_prompt_raw; };

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -249,9 +249,17 @@ fn _evolve_hunting_prompt(self_pid: string, prompt_text: string) -> string {
     // Always fire the meta-prompt call (whether or not we are at cap).
     // The schema-sanity ping below will dry-run it; the actual write
     // is gated on all guards passing.
+    // #527: meta-prompt drives diversification, not exploitation. See
+    // tribe-alpha/agents/hunter.ag for full rationale.
     let meta = "Rewrite the hunting prompt below given these verified findings. "
              + "Keep the JSON output schema identical (return Finding{class, line, severity, rationale, signature_hint}). "
-             + "Focus on patterns that produced verified hits. Old prompt: <"
+             + "Focus on EXPANDING class coverage: if all (or most) verified findings are in one bug class, the "
+             + "rewrite MUST explicitly probe for OTHER classes from the stage2 verifier set "
+             + "(use_after_free, heap_overflow, memory_corruption, data_race, send_violation, "
+             + "missing_lock, dangling_borrow, uninitialised_memory) in the same target file. "
+             + "The goal is a hunter that finds the NEXT class of bug, not more instances of the same one. "
+             + "Only converge on a single class when the verified findings genuinely span multiple classes already. "
+             + "Old prompt: <"
              + prompt_text + ">. Verified findings: <" + buffer_json + ">.";
     let new_prompt_raw = try { prompt(meta, "") -> string; } catch e { ""; };
     let new_prompt = if len(new_prompt_raw) > max_bytes_eff { substring(new_prompt_raw, 0, max_bytes_eff); } else { new_prompt_raw; };

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -249,9 +249,17 @@ fn _evolve_hunting_prompt(self_pid: string, prompt_text: string) -> string {
     // Always fire the meta-prompt call (whether or not we are at cap).
     // The schema-sanity ping below will dry-run it; the actual write
     // is gated on all guards passing.
+    // #527: meta-prompt drives diversification, not exploitation. See
+    // tribe-alpha/agents/hunter.ag for full rationale.
     let meta = "Rewrite the hunting prompt below given these verified findings. "
              + "Keep the JSON output schema identical (return Finding{class, line, severity, rationale, signature_hint}). "
-             + "Focus on patterns that produced verified hits. Old prompt: <"
+             + "Focus on EXPANDING class coverage: if all (or most) verified findings are in one bug class, the "
+             + "rewrite MUST explicitly probe for OTHER classes from the stage2 verifier set "
+             + "(use_after_free, heap_overflow, memory_corruption, data_race, send_violation, "
+             + "missing_lock, dangling_borrow, uninitialised_memory) in the same target file. "
+             + "The goal is a hunter that finds the NEXT class of bug, not more instances of the same one. "
+             + "Only converge on a single class when the verified findings genuinely span multiple classes already. "
+             + "Old prompt: <"
              + prompt_text + ">. Verified findings: <" + buffer_json + ">.";
     let new_prompt_raw = try { prompt(meta, "") -> string; } catch e { ""; };
     let new_prompt = if len(new_prompt_raw) > max_bytes_eff { substring(new_prompt_raw, 0, max_bytes_eff); } else { new_prompt_raw; };


### PR DESCRIPTION
## Summary

Closes #527.

Text-only rewrite of the M98 v3 meta-prompt template in `_evolve_hunting_prompt()`. The pre-#527 version said `"Focus on patterns that produced verified hits"` — a convergence directive. The post-#527 version says probe OTHER classes when verified findings are dominated by one class — an expansion directive. This unblocks the cross-class drift signal that plan test 7 was designed to measure.

## Why

Empirical (M98 v3 plan-test-7 smoke at `/tmp/m98v3-smoke-20260511T203508Z`): tribe-alpha hunter found `S2-SMVMEM-001` (uninitialised_memory) on first tick, fired evolution after K=3 verified hits, evolved prompt hyper-targeted `from_buf_and_len_unchecked` line 534, then found the same bug 5 more times. Zero cross-class drift across 90 minutes wall clock.

Inspection of the evolved prompt revealed the LLM correctly identified the highest-signal pattern (the one bug it already found) and amplified it. Rational reward-maximizing behavior — and the exact opposite of cross-class drift. The cause was the meta-prompt text itself: "Focus on patterns that produced verified hits" is an exploitation directive with no exploration incentive.

## What changes

Single string in all 5 hunter.ag files (alpha/beta/gamma/delta/epsilon — `_evolve_hunting_prompt()` bodies are byte-identical at the meta-prompt site):

**Before:**
```
"Focus on patterns that produced verified hits."
```

**After:**
```
"Focus on EXPANDING class coverage: if all (or most) verified findings are in
 one bug class, the rewrite MUST explicitly probe for OTHER classes from the
 stage2 verifier set (use_after_free, heap_overflow, memory_corruption,
 data_race, send_violation, missing_lock, dangling_borrow, uninitialised_memory)
 in the same target file. The goal is a hunter that finds the NEXT class of
 bug, not more instances of the same one. Only converge on a single class
 when the verified findings genuinely span multiple classes already."
```

Plus a 2-line `// #527: meta-prompt drives diversification...` comment block above each site (alpha carries the full rationale comment; beta/gamma/delta/epsilon point to alpha for the full text).

CHANGELOG bullet under Unreleased / Changed with empirical evidence.

## Files changed (6)

- `tribes-bench/tribe-alpha/agents/hunter.ag` — meta-prompt + full rationale comment
- `tribes-bench/tribe-beta/agents/hunter.ag` — meta-prompt + brief comment pointing to alpha
- `tribes-bench/tribe-gamma/agents/hunter.ag` — same
- `tribes-bench/tribe-delta/agents/hunter.ag` — same
- `tribes-bench/tribe-epsilon/agents/hunter.ag` — same
- `tribes-bench/CHANGELOG.md` — Unreleased / Changed bullet

## Anti-gaming preserved

- Verifier remains deterministic shell script. No LLM in path
- Selection pressure flows only from real verified hits
- Hunter cannot influence verifier behavior through prompt content (#491 + #493 guardrails intact)
- The meta-prompt rewrites the LLM-facing hunting prompt body; this is the same surface PR 2/3 already exercised. No new external write, no new memo schema, no scope creep

## Validation

- `colony-lint.sh`: **170 / 0 / 3 skipped** (baseline preserved)
- All 5 hunter.ag parse + typecheck under agentis v1.7.10

## Out of scope

- Option B from #527 (independent variant.class mutation) — requires structural change to the M98 mutation loop, defer until we have empirical evidence the text-only fix doesn't suffice
- Tests for the actual diversification behavior — requires an LLM-in-the-loop smoke (next-level signal, operator-driven HItL)

## Test plan

- [x] colony-lint 170/0/3 baseline
- [x] All 5 hunter.ag pre-#527 → post-#527 text diff is the SAME byte string in each tribe
- [ ] CI green
- [ ] QA agent ship-it

🤖 Generated with [Claude Code](https://claude.com/claude-code)