### PR TITLE
fix(tribes-bench): verifier class-alias map (#531)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,41 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **verify-finding-stage2.sh: class-alias map breaks false-positive local optimum in cross-class drift**
+  ([#531](https://github.com/Replikanti/agentis-colonies/issues/531),
+  follows the M98 v3 take-4 emergence smoke surfaced after #527
+  ([#530](https://github.com/Replikanti/agentis-colonies/pull/530))
+  and #528 ([#529](https://github.com/Replikanti/agentis-colonies/pull/529))
+  shipped. Take-4 confirmed cross-class drift behaviorally — hunter
+  drifted from line 534 (saturated UM) to line 827 (`insert_many`,
+  heap_overflow zone) — but 9/9 attempts were false positives because
+  the LLM labelled the described pattern `memory_corruption` while
+  the planted bug's `class` field is `heap_overflow`. The verifier
+  was strict on class equality, so the LLM-grammar ambiguity blocked
+  every verified hit, which in turn prevented the meta-prompt
+  evolution from firing again (PR #524 only triggers on K=3 verified
+  hits). The daemon ended stuck at a local optimum in false-positive
+  loop.) The verifier (`tribes-bench/tools/verify-finding-stage2.sh`)
+  now accepts class-alias matches when `STAGE3_VERIFIER_CLASS_ALIASES`
+  is `1` (default; set to `0` for strict matching). Alias groups
+  capture the LLM-naming ambiguities the smoke surfaced:
+  `{heap_overflow, memory_corruption, buffer_overflow}` (out-of-bounds
+  writes), `{use_after_free, dangling_borrow}` (references to invalid
+  memory), `{data_race, missing_lock}` (concurrent state mutation).
+  Singletons `{uninitialised_memory}` and `{send_violation}` stay
+  strict — they are unambiguous and aliasing them would dilute the
+  cross-class signal. Aliased matches emit one line to stderr so
+  post-mortems can distinguish strict vs aliased verifications
+  without changing the stdout verdict shape. 5 new tests added to
+  `test-verify-finding-stage2.sh` (4→9 cases): strict mode rejects
+  alias, alias mode accepts heap↔memcorr, alias mode accepts uaf↔
+  dangling, alias mode keeps UM strict (singleton), exact-class
+  match still works in alias mode. No new env vars beyond
+  `STAGE3_VERIFIER_CLASS_ALIASES`. No bugs.json edits. Anti-gaming
+  invariant unchanged — the alias map is in the verifier (the
+  ground-truth side); the hunter still cannot influence what counts
+  as a verified hit through prompt content. Option B from the issue
+  body; Option A (failure-driven mini-evolution) is deferred.
 - **M98 v3 meta-prompt rewritten to drive diversification (exploration), not exploitation**
   ([#527](https://github.com/Replikanti/agentis-colonies/issues/527),
   follows the plan-test-7 emergence smoke from #520 / [PR #526](https://github.com/Replikanti/agentis-colonies/pull/526).)

--- a/tribes-bench/tools/test-verify-finding-stage2.sh
+++ b/tribes-bench/tools/test-verify-finding-stage2.sh
@@ -209,6 +209,124 @@ case2
 case3
 case4
 
+# Cases 5-9: #531 class-alias map. Tests the new
+# STAGE3_VERIFIER_CLASS_ALIASES env var. Verifies that semantically-
+# equivalent class labels match (heap_overflow ↔ memory_corruption,
+# use_after_free ↔ dangling_borrow, data_race ↔ missing_lock) and
+# that unambiguous singleton classes (uninitialised_memory,
+# send_violation) stay strict.
+
+# Helper: invoke verifier with a finding at the given line + class
+# and return verified ("true" | "false").
+verifier_verdict() {
+    local line="$1"
+    local class="$2"
+    local alias_mode="${3:-1}"
+    local out
+    out="$(printf '{"line": %s, "class": "%s"}' "$line" "$class" | \
+        TARGET_DIR="$TARGET_DIR" \
+        BUGS_MANIFEST="$BUGS_MANIFEST" \
+        STAGE3_VERIFIER_CLASS_ALIASES="$alias_mode" \
+        bash "$VERIFIER" 2>/dev/null)"
+    printf '%s' "$out" | jq -r '.verified'
+}
+
+# Resolve a bug from the manifest by class predicate for fixture stability.
+bug_line_for_class() {
+    local cls="$1"
+    jq -r --arg c "$cls" 'first(.bugs[] | select(.class == $c)) | .line // "MISSING"' "$BUGS_MANIFEST"
+}
+
+case5_strict_mode_rejects_alias() {
+    # bug.class=heap_overflow + finding.class=memory_corruption.
+    # Strict mode (alias=0) must reject; the line is correct but the
+    # class doesn't strict-match.
+    local ho_line
+    ho_line="$(bug_line_for_class "heap_overflow")"
+    if [ "$ho_line" = "MISSING" ]; then
+        pass_with "case5: SKIPPED (no heap_overflow bug in manifest)"
+        return
+    fi
+    local v
+    v="$(verifier_verdict "$ho_line" "memory_corruption" "0")"
+    if [ "$v" = "false" ]; then
+        pass_with "case5: strict mode rejects heap_overflow ↔ memory_corruption alias"
+    else
+        fail_with "case5: strict mode incorrectly accepted alias (got verified=$v)"
+    fi
+}
+
+case6_alias_mode_accepts_heap_memcorr() {
+    # bug.class=heap_overflow + finding.class=memory_corruption.
+    # Alias mode (default) must accept.
+    local ho_line
+    ho_line="$(bug_line_for_class "heap_overflow")"
+    if [ "$ho_line" = "MISSING" ]; then
+        pass_with "case6: SKIPPED (no heap_overflow bug in manifest)"
+        return
+    fi
+    local v
+    v="$(verifier_verdict "$ho_line" "memory_corruption" "1")"
+    if [ "$v" = "true" ]; then
+        pass_with "case6: alias mode accepts heap_overflow ↔ memory_corruption"
+    else
+        fail_with "case6: alias mode rejected heap_overflow ↔ memory_corruption (got verified=$v)"
+    fi
+}
+
+case7_alias_mode_accepts_uaf_dangling() {
+    # bug.class=use_after_free + finding.class=dangling_borrow.
+    local uaf_line
+    uaf_line="$(bug_line_for_class "use_after_free")"
+    if [ "$uaf_line" = "MISSING" ]; then
+        pass_with "case7: SKIPPED (no use_after_free bug in manifest)"
+        return
+    fi
+    local v
+    v="$(verifier_verdict "$uaf_line" "dangling_borrow" "1")"
+    if [ "$v" = "true" ]; then
+        pass_with "case7: alias mode accepts use_after_free ↔ dangling_borrow"
+    else
+        fail_with "case7: alias mode rejected use_after_free ↔ dangling_borrow (got verified=$v)"
+    fi
+}
+
+case8_alias_mode_rejects_um_to_memcorr() {
+    # bug.class=uninitialised_memory + finding.class=memory_corruption.
+    # uninitialised_memory is a singleton (no alias group); even in
+    # alias mode it MUST stay strict.
+    local um_line
+    um_line="$(bug_line_for_class "uninitialised_memory")"
+    if [ "$um_line" = "MISSING" ]; then
+        pass_with "case8: SKIPPED (no uninitialised_memory bug in manifest)"
+        return
+    fi
+    local v
+    v="$(verifier_verdict "$um_line" "memory_corruption" "1")"
+    if [ "$v" = "false" ]; then
+        pass_with "case8: alias mode keeps uninitialised_memory strict (no cross-class accept)"
+    else
+        fail_with "case8: alias mode incorrectly aliased UM → memory_corruption (got verified=$v)"
+    fi
+}
+
+case9_exact_class_still_works() {
+    # Regression: exact-class match must always verify, alias mode or not.
+    local v
+    v="$(verifier_verdict "$FIRST_BUG_LINE" "$FIRST_BUG_CLASS" "1")"
+    if [ "$v" = "true" ]; then
+        pass_with "case9: exact-class match still verifies in alias mode"
+    else
+        fail_with "case9: exact-class match broken in alias mode (got verified=$v)"
+    fi
+}
+
+case5_strict_mode_rejects_alias
+case6_alias_mode_accepts_heap_memcorr
+case7_alias_mode_accepts_uaf_dangling
+case8_alias_mode_rejects_um_to_memcorr
+case9_exact_class_still_works
+
 echo ""
 echo "Summary: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tribes-bench/tools/verify-finding-stage2.sh
+++ b/tribes-bench/tools/verify-finding-stage2.sh
@@ -248,11 +248,44 @@ while [ "$i" -lt "$BUG_COUNT" ]; do
     BUG_SIG="$(jq -r ".bugs[$i].signature" "$BUGS_MANIFEST")"
 
     # Class predicate: only enforced when finding.class is set.
+    # #531: when STAGE3_VERIFIER_CLASS_ALIASES is "1" (default), a
+    # finding.class in the same alias group as bug.class also matches.
+    # Alias groups capture LLM-naming ambiguities the M98 v3 take-4
+    # smoke surfaced — heap_overflow described as memory_corruption,
+    # use_after_free as dangling_borrow, data_race as missing_lock.
+    # Set STAGE3_VERIFIER_CLASS_ALIASES=0 for strict matching.
     if [ -n "$FINDING_CLASS" ]; then
         BUG_CLASS="$(jq -r ".bugs[$i].class // \"\"" "$BUGS_MANIFEST")"
         if [ "$BUG_CLASS" != "$FINDING_CLASS" ]; then
-            i=$((i + 1))
-            continue
+            ALIAS_MODE="${STAGE3_VERIFIER_CLASS_ALIASES:-1}"
+            CLASS_MATCH=0
+            if [ "$ALIAS_MODE" = "1" ]; then
+                case "$BUG_CLASS" in
+                    heap_overflow|memory_corruption|buffer_overflow)
+                        case "$FINDING_CLASS" in
+                            heap_overflow|memory_corruption|buffer_overflow) CLASS_MATCH=1 ;;
+                        esac
+                        ;;
+                    use_after_free|dangling_borrow)
+                        case "$FINDING_CLASS" in
+                            use_after_free|dangling_borrow) CLASS_MATCH=1 ;;
+                        esac
+                        ;;
+                    data_race|missing_lock)
+                        case "$FINDING_CLASS" in
+                            data_race|missing_lock) CLASS_MATCH=1 ;;
+                        esac
+                        ;;
+                esac
+            fi
+            if [ "$CLASS_MATCH" -eq 0 ]; then
+                i=$((i + 1))
+                continue
+            fi
+            # Aliased match — log to stderr so post-mortems can
+            # distinguish strict vs aliased verifications without
+            # changing the JSON verdict shape on stdout.
+            echo "verify-finding-stage2: aliased class match: bug.class=$BUG_CLASS finding.class=$FINDING_CLASS bug_id=$(jq -r ".bugs[$i].id" "$BUGS_MANIFEST")" >&2
         fi
     fi
 


### PR DESCRIPTION
## Summary

Closes #531.

Adds `STAGE3_VERIFIER_CLASS_ALIASES` env var (default `1`) to `verify-finding-stage2.sh`. When enabled, semantically-equivalent class labels match: `{heap_overflow, memory_corruption, buffer_overflow}`, `{use_after_free, dangling_borrow}`, `{data_race, missing_lock}`. Singletons `{uninitialised_memory}` and `{send_violation}` stay strict.

Unblocks the false-positive local optimum surfaced by the M98 v3 take-4 emergence smoke.

## Empirical motivation

Take-4 smoke (at `/tmp/m98v3-smoke-take4-*`, summarized in #531) confirmed M98 v3 cross-class drift works **behaviorally** — hunter saturated UM at line 534, evolution fired, evolved prompt explicitly diversified, hunter drifted to line 827 (`insert_many`, heap_overflow zone). But every attempt failed verification: 9/9 false positives because the LLM described "write past allocated buffer" pattern but labelled it `memory_corruption` while the planted bug `S2-SMVOFL-001` has `class=heap_overflow`. The evolution loop (#524 PR 2/3) only re-fires on K=3 verified hits, so the daemon got stuck.

## Why Option B (verifier-side alias map) over Option A (failure-driven evolution)

Option B is text-only in one verifier script, immediate emergence unblock, zero risk to the agent side. Option A (failure-driven mini-evolution in `_evolve_hunting_prompt`) is more principled but substantially larger scope — can ship as separate follow-up if Option B doesn't fully close the gap.

## Anti-gaming invariant unchanged

The alias map lives in the **verifier** (the ground-truth side). The hunter still cannot influence what counts as a verified hit through prompt content. Anti-gaming surfaces (#491 ledger-write monopoly + #493 knowledge_sell answer-validation) are intact.

## Files changed (3)

- `tribes-bench/tools/verify-finding-stage2.sh` — class-alias map + stderr aliased-match log
- `tribes-bench/tools/test-verify-finding-stage2.sh` — 5 new cases (4 → 9): strict mode rejects alias, alias mode accepts heap↔memcorr, alias mode accepts uaf↔dangling, alias mode keeps UM strict, exact-class match still works
- `tribes-bench/CHANGELOG.md` — Unreleased / Changed entry

## Validation

- `test-verify-finding-stage2.sh`: **9 / 0** (was 4, +5 new alias coverage cases)
- `colony-lint.sh`: **170 / 0 / 3 skipped** (baseline preserved)

## Out of scope

- Option A (failure-driven mini-evolution) — separate scope, file as follow-up if needed
- bugs.json edits — manifest stays canonical; matching becomes more forgiving on the verifier side only
- Adding more alias groups beyond the 3 surfaced by the smoke — keep the alias map minimal until empirical evidence demands more

## Test plan

- [x] All 9 verifier tests pass
- [x] colony-lint baseline preserved
- [ ] CI green
- [ ] QA agent ship-it

🤖 Generated with [Claude Code](https://claude.com/claude-code)