### PR TITLE
feat(tribes-bench): containerize Claude Code CLI for Stage 3 docker federation (#535)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,33 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **Containerize Claude Code CLI in Stage 3 docker image (#535)**.
+  Unblocks full Stage 3 docker federation with claude backend — the
+  path to real population-scale emergence research. Tonight's marathon
+  shipped 5 architectural fixes to M98 v3 and validated cross-class
+  drift end-to-end via take-6 single-process smoke; the substrate
+  works. But replication never fires in single-process (M106 needs
+  peer workers), no multi-tribe competition, no real selection
+  pressure. The full Stage 3 docker orchestrator already wires all of
+  that — only blocker was that the container had no LLM client
+  installed (assumed OpenAI HTTP backend). This PR fixes that.
+  Containerfile changes: bump `AGENTIS_VERSION` v1.7.9 → v1.7.11
+  (picks up agentis-core #640 sticky-degraded fix) + install Claude
+  Code CLI via the Anthropic-published `claude.ai/install.sh`
+  installer + symlink `/root/.local/bin/claude` →
+  `/usr/local/bin/claude` so the agentis CLI backend resolves it via
+  PATH. Orchestrator changes (`run-stage3-docker.sh`): new env var
+  `STAGE3_HOST_CLAUDE_DIR` (default `$HOME/.claude`); when
+  `STAGE3_LLM_BACKEND=claude`, bind-mounts the host directory into
+  each container's `/root/.claude` (read-write so the Claude Code
+  CLI can refresh session tokens). OpenAI-backend code path unchanged
+  when `STAGE3_LLM_BACKEND=openai` (default). Build + smoke-verified:
+  `podman build` succeeds; `agentis --version` → `v1.7.11`,
+  `claude --version` → `2.1.139` inside the image. Operator security
+  note shipped in the script comments + header doc-block: mounting
+  ~/.claude exposes `.credentials.json` to the container; acceptable
+  on single-user dev machines; shared CI runners should provision a
+  dedicated session.
 - **hunter.ag: pass LLM `finding.class` directly to verifier (closes M98 v3 architectural hole)**
   ([#533](https://github.com/Replikanti/agentis-colonies/issues/533),
   follows the take-5 emergence smoke that exposed every prior M98 v3

--- a/tribes-bench/tools/Containerfile.stage3
+++ b/tribes-bench/tools/Containerfile.stage3
@@ -16,13 +16,20 @@
 # the key here (ARG OPENAI_API_KEY, ENV OPENAI_API_KEY, secret file COPY)
 # would leak into the image layers and `podman save` exports.
 #
+# WARNING: Claude Code session credentials (`~/.claude/.credentials.json`)
+# MUST NOT be baked in either. The orchestrator bind-mounts the host
+# operator's `$HOME/.claude` into the container at run time when
+# `STAGE3_LLM_BACKEND=claude` is set; never `COPY` the directory into
+# the image (#535).
+#
 # The agentis binary fetch is sha256-verified against the publisher's
 # detached signature so a compromised CDN can't substitute a backdoored
-# build mid-pull.
+# build mid-pull. The Claude Code installer is fetched from the
+# Anthropic-published canonical URL (claude.ai/install.sh).
 
 FROM ubuntu:24.04
 
-ARG AGENTIS_VERSION=v1.7.9
+ARG AGENTIS_VERSION=v1.7.11
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -43,6 +50,19 @@ RUN cd /tmp \
  && sha256sum -c agentis-linux-x86_64.sha256 \
  && install -m 0755 agentis-linux-x86_64 /usr/local/bin/agentis \
  && rm /tmp/agentis-linux-x86_64 /tmp/agentis-linux-x86_64.sha256
+
+# Install Claude Code CLI (#535). The standalone installer fetches a
+# statically-linked Linux x86_64 ELF binary into
+# /root/.local/share/claude/versions/<X.Y.Z> and symlinks /root/.local/bin/claude.
+# We then symlink to /usr/local/bin/claude so the agentis cli backend
+# (which spawns the `claude` subprocess) resolves it via PATH.
+#
+# The installer is fetched from the Anthropic-published canonical URL.
+# No version pin: Claude Code auto-updates frequently and the
+# orchestrator falls through to whatever the installer publishes today.
+# Operators who need reproducibility should rebuild the image periodically.
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+ && ln -s /root/.local/bin/claude /usr/local/bin/claude
 
 WORKDIR /run-root
 

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -121,6 +121,20 @@
 #   STAGE3_OPENAI_KEY_ENV      Name of the env var that carries the
 #                              OpenAI API key. Default: OPENAI_API_KEY.
 #   STAGE3_OPENAI_TIMEOUT_MS   Per-request timeout (ms). Default: 180000.
+#   STAGE3_HOST_CLAUDE_DIR     #535: when STAGE3_LLM_BACKEND=claude,
+#                              host directory bind-mounted into both
+#                              containers' `/root/.claude` (read-write
+#                              so the Claude Code CLI can refresh
+#                              session tokens). Default: $HOME/.claude
+#                              on the orchestrator host. Required when
+#                              backend=claude; orchestrator exits 1
+#                              when the directory does not exist.
+#                              SECURITY NOTE: mounting ~/.claude
+#                              exposes .credentials.json (the host
+#                              operator's Claude Code session token)
+#                              to the containers. Acceptable on a
+#                              single-user dev machine; on shared CI
+#                              runners, provision a dedicated session.
 #   STAGE3_LAPTOP_PORT         Host port for the laptop container's
 #                              agentis serve. Default: 9100.
 #   STAGE3_SERVER_PORT         Host port for the server container's
@@ -591,11 +605,33 @@ write_bootstraps() {
 # bridge under both rootful and rootless podman 4.x+. If a future host's
 # podman setup misses this alias (some legacy CNI configs), pass
 # --add-host host.containers.internal:<host-bridge-ip> to both runs.
+#
+# #535: when STAGE3_LLM_BACKEND=claude, the orchestrator bind-mounts the
+# host operator's $STAGE3_HOST_CLAUDE_DIR (default $HOME/.claude) into
+# each container's /root/.claude (read-write so the Claude Code CLI can
+# refresh session tokens). The OpenAI-backend code path is unchanged
+# when STAGE3_LLM_BACKEND=openai (default).
+#
+# Operator security note: mounting ~/.claude exposes the host's
+# .credentials.json (Claude Code session token) to the container. On a
+# single-user dev machine this is acceptable; on shared CI runners
+# operators should provision a dedicated Claude Code session.
 spawn_containers() {
+    local CLAUDE_MOUNT_FLAG=""
+    if [ "$LLM_BACKEND" = "claude" ]; then
+        local HOST_CLAUDE_DIR="${STAGE3_HOST_CLAUDE_DIR:-$HOME/.claude}"
+        if [ -d "$HOST_CLAUDE_DIR" ]; then
+            CLAUDE_MOUNT_FLAG="-v $HOST_CLAUDE_DIR:/root/.claude:rw"
+        else
+            echo "run-stage3-docker: STAGE3_HOST_CLAUDE_DIR=$HOST_CLAUDE_DIR does not exist" >&2
+            echo "                   set STAGE3_HOST_CLAUDE_DIR or install Claude Code first" >&2
+            exit 1
+        fi
+    fi
     emit_step "spawning stage3-laptop container (host port $LAPTOP_PORT, worker port $LAPTOP_WORKER_PORT)"
-    emit_cmd "podman run -d --name stage3-laptop -p $LAPTOP_PORT:$LAPTOP_PORT -p $LAPTOP_WORKER_PORT:$LAPTOP_WORKER_PORT -e $OPENAI_KEY_ENV=\"\${$OPENAI_KEY_ENV:-}\" -e WORKER_SECRET=\"$WORKER_SECRET\" -v $REPO_ROOT:/repo:ro -v $LAPTOP_DIR:/run-root:rw $IMAGE_TAG /run-root/bootstrap.sh"
+    emit_cmd "podman run -d --name stage3-laptop -p $LAPTOP_PORT:$LAPTOP_PORT -p $LAPTOP_WORKER_PORT:$LAPTOP_WORKER_PORT -e $OPENAI_KEY_ENV=\"\${$OPENAI_KEY_ENV:-}\" -e WORKER_SECRET=\"$WORKER_SECRET\" -v $REPO_ROOT:/repo:ro -v $LAPTOP_DIR:/run-root:rw $CLAUDE_MOUNT_FLAG $IMAGE_TAG /run-root/bootstrap.sh"
     emit_step "spawning stage3-server container (host port $SERVER_PORT, worker port $SERVER_WORKER_PORT)"
-    emit_cmd "podman run -d --name stage3-server -p $SERVER_PORT:$SERVER_PORT -p $SERVER_WORKER_PORT:$SERVER_WORKER_PORT -e $OPENAI_KEY_ENV=\"\${$OPENAI_KEY_ENV:-}\" -e WORKER_SECRET=\"$WORKER_SECRET\" -v $REPO_ROOT:/repo:ro -v $SERVER_DIR:/run-root:rw $IMAGE_TAG /run-root/bootstrap.sh"
+    emit_cmd "podman run -d --name stage3-server -p $SERVER_PORT:$SERVER_PORT -p $SERVER_WORKER_PORT:$SERVER_WORKER_PORT -e $OPENAI_KEY_ENV=\"\${$OPENAI_KEY_ENV:-}\" -e WORKER_SECRET=\"$WORKER_SECRET\" -v $REPO_ROOT:/repo:ro -v $SERVER_DIR:/run-root:rw $CLAUDE_MOUNT_FLAG $IMAGE_TAG /run-root/bootstrap.sh"
 }
 
 # --- 4) Target rotation timer (runs on the host, not inside containers) ---


### PR DESCRIPTION
## Summary

Closes #535.

Adds Claude Code CLI to `Containerfile.stage3` and threads `~/.claude` mount through `run-stage3-docker.sh` when `STAGE3_LLM_BACKEND=claude`. Unblocks full Stage 3 docker federation with claude backend.

## Why

After tonight's marathon (5 architectural emergence-blockers fixed: #527/#528/#640/#531/#533 + M98 v3 trilogy #523/#524/#526), the take-6 single-process smoke validated the cross-class drift mechanics end-to-end. But single-process can't trigger M106 replication (no peer workers) and can't exercise multi-tribe selection pressure. The full Stage 3 docker orchestrator already wires both — the only blocker was that the container had no LLM client installed (assumed OpenAI HTTP backend).

## What changes

**Containerfile.stage3:**

1. Bump `AGENTIS_VERSION` v1.7.9 → v1.7.11 (picks up agentis-core #640 sticky-degraded fix)
2. Install Claude Code CLI via Anthropic-published `claude.ai/install.sh`
3. Symlink `/root/.local/bin/claude` → `/usr/local/bin/claude` (PATH discoverable)

**run-stage3-docker.sh:**

1. New env var `STAGE3_HOST_CLAUDE_DIR` (default `$HOME/.claude`)
2. When `STAGE3_LLM_BACKEND=claude`: bind-mount host `~/.claude` into each container's `/root/.claude` read-write (Claude Code rotates session tokens)
3. Exits 1 with helpful message when claude backend is requested but the host directory does not exist
4. OpenAI-backend code path unchanged when `STAGE3_LLM_BACKEND=openai` (default)
5. Header doc-block describes new env var + security note

## Build + sanity verified

```
$ podman build -f tribes-bench/tools/Containerfile.stage3 -t test:535 .
Successfully tagged localhost/test:535

$ podman run --rm --entrypoint=/bin/bash test:535 -c "agentis --version && claude --version"
agentis v1.7.11
2.1.139 (Claude Code)
```

- `colony-lint.sh`: **170 / 0 / 3 skipped** (baseline preserved)
- `bash -n` on run-stage3-docker.sh: syntax clean

## Operator security note

Mounting `~/.claude` exposes `.credentials.json` (Claude Code session token) to the container. Acceptable on single-user dev machines (the only context where Stage 3 docker runs today). Shared CI runners should provision a dedicated Claude Code session before invoking the orchestrator. This is documented inline in the script + header doc-block.

## Files changed (3)

- `tribes-bench/tools/Containerfile.stage3` — agentis bump + claude install
- `tribes-bench/tools/run-stage3-docker.sh` — STAGE3_HOST_CLAUDE_DIR env var + mount flag wiring
- `tribes-bench/CHANGELOG.md` — Unreleased / Changed bullet

## Out of scope

- Take-7 multi-tribe federation smoke run — operator HItL after merge
- Bumping `AGENTIS_VERSION` further in future PRs (separate cadence)
- Containerfile multi-stage builds, runtime user, or other hardening — single-user dev machine is the only target today
- Tests for the new bind-mount semantics — script smoke is the validation path

## Test plan

- [x] Container builds successfully
- [x] Both binaries (agentis v1.7.11 + claude 2.1.139) executable inside image
- [x] colony-lint 170/0/3 baseline preserved
- [x] Bash syntax check passes on run-stage3-docker.sh
- [ ] CI green
- [ ] QA agent ship-it
- [ ] Take-7 smoke validates population-scale emergence (operator HItL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)