### PR TITLE
fix(tribes-bench): --help no longer truncates env-var docs + claude-backend test coverage (#537)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,26 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **run-stage3-docker.sh `--help` no longer truncates env-var docs + claude-backend test coverage (#537)**.
+  Two LOW-severity follow-ups from the #536 QA report. (1)
+  `run-stage3-docker.sh --help` used a fixed `sed -n '2,98p'` range
+  that truncated as the env-var docblock grew past line 98; new env
+  vars from #535 (`STAGE3_HOST_CLAUDE_DIR`), #528 (`STAGE3_DAEMON_CB_PER_TICK`),
+  the `STAGE3_OPENAI_*` family, and `STAGE3_LLM_BACKEND` itself were
+  all invisible to `--help`. Replaced the fixed range with an
+  `awk '/^#/ {sub(/^# ?/,""); print; next} {exit}'` extractor that
+  prints every leading comment line until the first non-comment line —
+  future env-var additions will surface automatically. (2)
+  `test-run-stage3-docker.sh` (145 → 149 assertions) now covers the
+  #535 claude-backend wiring: default-openai dry-run contains no
+  `/root/.claude` reference; claude-backend dry-run with a valid host
+  dir mounts `-v <host>:/root/.claude:rw` into BOTH containers (asserted
+  by count, not just presence); claude-backend with a missing host dir
+  exits 1. The two other LOW findings from the #536 QA report
+  (`/root/.claude.json` builder userID bake + claude installer not
+  version-pinned) are deferred — both documented inline in the
+  Containerfile and only relevant if/when the image is published to a
+  public registry. No behavior change for `--dry-run` or non-help paths.
 - **Containerize Claude Code CLI in Stage 3 docker image (#535)**.
   Unblocks full Stage 3 docker federation with claude backend — the
   path to real population-scale emergence research. Tonight's marathon

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -234,7 +234,12 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -h|--help)
-            sed -n '2,98p' "$SCRIPT_PATH" | sed 's/^# \{0,1\}//'
+            # #537: extract every leading comment line (from after the shebang
+            # until the first non-comment line). Pre-#537 used a fixed
+            # `sed -n '2,98p'` range that truncated as the env-var docblock
+            # grew past line 98 — STAGE3_HOST_CLAUDE_DIR (#535), STAGE3_LLM_BACKEND,
+            # STAGE3_OPENAI_*, STAGE3_DAEMON_CB_PER_TICK (#528) were all hidden.
+            awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "$SCRIPT_PATH"
             exit 0
             ;;
         *)

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -357,6 +357,56 @@ assert_contains "hermetic config emits daemon.cb_per_tick line" \
     "$(cat "$ORCH")" \
     'printf "daemon.cb_per_tick = %s'
 
+# 9c. #535 + #537: claude-backend wiring. Default OpenAI dry-run must
+# NOT emit any /root/.claude reference; claude-backend dry-run with a
+# valid host dir must inject -v <host>:/root/.claude:rw into BOTH
+# containers; claude-backend dry-run with a missing host dir must
+# exit 1 with the helpful message.
+assert_not_contains "default openai dry-run has no /root/.claude mount" \
+    "$OUT" \
+    "/root/.claude"
+CLAUDE_OUT="$(STAGE3_WALL_CLOCK_S=1800 \
+              STAGE3_ROTATION_INTERVAL_S=120 \
+              STAGE3_DEATH_THRESHOLD=300 \
+              STAGE3_LAPTOP_PORT=9100 \
+              STAGE3_SERVER_PORT=9101 \
+              STAGE3_LAPTOP_WORKER_PORT=9200 \
+              STAGE3_SERVER_WORKER_PORT=9201 \
+              STAGE3_WORKER_SECRET=testsecret \
+              STAGE3_LLM_BACKEND=claude \
+              STAGE3_HOST_CLAUDE_DIR=/tmp \
+              bash "$ORCH" --dry-run 2>&1 || true)"
+assert_contains "claude backend mounts /tmp:/root/.claude:rw on laptop" \
+    "$CLAUDE_OUT" \
+    "-v /tmp:/root/.claude:rw"
+LAPTOP_CLAUDE_COUNT="$(printf '%s' "$CLAUDE_OUT" | grep -cF -- '-v /tmp:/root/.claude:rw' || true)"
+if [ "$LAPTOP_CLAUDE_COUNT" -ge 2 ]; then
+    echo "[PASS] claude backend mounts /tmp:/root/.claude:rw on BOTH containers (found $LAPTOP_CLAUDE_COUNT instances)"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] claude backend should mount /root/.claude on both containers (found only $LAPTOP_CLAUDE_COUNT instance(s))"
+    FAIL=$((FAIL + 1))
+fi
+CLAUDE_MISSING_RC=0
+STAGE3_LLM_BACKEND=claude \
+STAGE3_HOST_CLAUDE_DIR=/nonexistent-path-$$ \
+STAGE3_WALL_CLOCK_S=1800 \
+STAGE3_ROTATION_INTERVAL_S=120 \
+STAGE3_DEATH_THRESHOLD=300 \
+STAGE3_LAPTOP_PORT=9100 \
+STAGE3_SERVER_PORT=9101 \
+STAGE3_LAPTOP_WORKER_PORT=9200 \
+STAGE3_SERVER_WORKER_PORT=9201 \
+STAGE3_WORKER_SECRET=testsecret \
+bash "$ORCH" --dry-run >/dev/null 2>&1 || CLAUDE_MISSING_RC=$?
+if [ "$CLAUDE_MISSING_RC" -eq 1 ]; then
+    echo "[PASS] claude backend with missing STAGE3_HOST_CLAUDE_DIR exits 1"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] claude backend with missing STAGE3_HOST_CLAUDE_DIR should exit 1 (got $CLAUDE_MISSING_RC)"
+    FAIL=$((FAIL + 1))
+fi
+
 # 10. #520 M98 v3 PR 3/3: M106 hash-pointer inheritance — assert each
 # hunter.ag carries the new helpers, the bootstrap inheritance branch,
 # and that both replicate() sites call the parent-wrap helper. Source-


### PR DESCRIPTION
## Summary

Closes #537. Two LOW-severity follow-ups from the #536 QA report.

## What changes

**1. `run-stage3-docker.sh --help` extractor**

Replaced fixed `sed -n '2,98p'` range with `awk` extractor that prints every leading comment line until the first non-comment line. Fixes silent truncation of `STAGE3_HOST_CLAUDE_DIR` (#535), `STAGE3_DAEMON_CB_PER_TICK` (#528), `STAGE3_OPENAI_*`, and `STAGE3_LLM_BACKEND` itself — all were past line 98 and invisible via `--help`. Future env-var additions surface automatically.

**2. `test-run-stage3-docker.sh` claude-backend coverage**

Added 4 new assertions (145 → 149 total):

1. Default openai dry-run contains NO `/root/.claude` reference (regression sentinel for the OpenAI codepath)
2. Claude-backend dry-run with `STAGE3_HOST_CLAUDE_DIR=/tmp`: `-v /tmp:/root/.claude:rw` appears in dry-run output
3. Same: mount appears in BOTH containers (laptop + server) — count assertion, not just presence
4. Claude-backend dry-run with missing `STAGE3_HOST_CLAUDE_DIR=/nonexistent-path-$$`: orchestrator exits 1

Without these, a regression that flipped `rw → ro` or that leaked `-v ...:/root/.claude` into the openai codepath would not fail any test.

## Out of scope

The two other LOW findings from #536 QA (`/root/.claude.json` builder userID bake + claude installer not version-pinned) are deferred — both documented inline in the Containerfile and only relevant if/when the image is published to a public registry.

## Files changed (3)

- `tribes-bench/tools/run-stage3-docker.sh` — `--help` awk extractor
- `tribes-bench/tools/test-run-stage3-docker.sh` — 4 new claude-backend assertions
- `tribes-bench/CHANGELOG.md` — Unreleased / Changed bullet

## Validation

- `test-run-stage3-docker.sh`: **149 / 0** (was 145, +4 new)
- `colony-lint.sh`: **170 / 0 / 3 skipped** (baseline preserved)
- `bash -n` on run-stage3-docker.sh: clean
- `--help` smoke verified: STAGE3_HOST_CLAUDE_DIR + STAGE3_DAEMON_CB_PER_TICK + STAGE3_LLM_BACKEND all now visible (218 lines total output, up from previous truncated 97)

## Test plan

- [x] test-run-stage3-docker.sh 149/0
- [x] colony-lint baseline preserved
- [x] --help shows all env vars
- [ ] CI green
- [ ] QA agent ship-it

🤖 Generated with [Claude Code](https://claude.com/claude-code)