### PR TITLE
fix(tribes-bench): re-apply #493 Loose category c — consumer-side knowledge_buy answer validation

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,24 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **Re-apply #493 consumer-side `knowledge_buy` answer validation (Loose category c)**.
+  PR #508 (commit aa21220) originally added a `_validate_bought_answer` gate
+  to every `knowledge_buy` callsite in `hunter.ag`, cross-checking the
+  returned answer's claimed `bug_id` against the seller-tribe's
+  verifier-stamped `bug-ledger.jsonl` before trusting it. The surgical
+  restore PR #517 reverted to the pre-#493 baseline (9aacf65) to recover
+  from an unrelated regression; PR #518 brought back #491 (verifier-only
+  ledger writes) but not #493. This re-applies #493 byte-identically
+  across all 5 hunter.ag files: same helper body, same two-callsite gate
+  (single-finding buy + bundle/espionage buy), same `rejected_unverified`
+  outcome on the per-tick `emit_market_csv` column, same
+  `learn("market", ..., "rejected", [..., "reason:unverifiable"])` tag
+  schema (already covered by `tools/check-learn-tags.sh`). Rejection is
+  non-punitive (no reputation hit, just discard the answer + suppress
+  the `hunter:bought_context` memo write so downstream prompts never see
+  an unverifiable bought answer); fail-safe defaults collapse every
+  parse / exec / lookup failure to `false` (reject), never to accept.
+  Closes the Loose category (c) gap re-opened by PR #517.
 - **run-stage3-docker.sh `--help` no longer truncates env-var docs + claude-backend test coverage (#537)**.
   Two LOW-severity follow-ups from the #536 QA report. (1)
   `run-stage3-docker.sh --help` used a fixed `sed -n '2,98p'` range

--- a/tribes-bench/tribe-alpha/agents/hunter.ag
+++ b/tribes-bench/tribe-alpha/agents/hunter.ag
@@ -59,6 +59,73 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #493: consumer-side `knowledge_buy` answer validator (Loose category c).
+// Every `knowledge_buy` callsite cross-checks the returned answer's
+// claimed `bug_id` against the seller-tribe's verifier-stamped
+// `bug-ledger.jsonl` before trusting it. Fail-safe: any parse failure,
+// missing seller-ledger memo, or non-matching grep => return `false`
+// (reject the answer). Never falsely accept.
+//
+// `topic_kind == "finding"`: answer format produced by the single-finding
+// sell at hunter.ag L903 is `line=<N> bug=<ID> rationale=<...>`. Parse
+// the `bug=` token (space-delimited) and require one verifier-stamped
+// row in the seller's ledger.
+//
+// `topic_kind == "bundle"`: answer format produced by the bundle sell at
+// hunter.ag L933 is a `;`-separated list of bug_ids. Require *all* listed
+// ids to resolve to verifier-stamped rows. Empty list => `false`.
+//
+// Limitation (deferred): the gate only catches sells whose claimed
+// `bug_id` does not exist in the seller's ledger. A sell that quotes a
+// bug_id that *did* happen but whose `rationale=<...>` substring is
+// fabricated is NOT caught — the verifier never inspects free-text
+// rationale. Tracked separately as Loose's rationale-string anchoring
+// follow-up.
+//
+// Re-applied after PR #517 surgical restore dropped the original #508
+// patch (commit aa21220); #518 brought back #491 but not #493.
+fn _validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool {
+    if len(answer) == 0 { return false; };
+    let seller_ledger = recall_latest("tribe-" + seller_tribe + ":bug_ledger");
+    if len(seller_ledger) == 0 { return false; };
+
+    if topic_kind == "finding" {
+        // Parse `bug=<ID>` from the answer. Producer guarantees the
+        // token is preceded by " bug=" (single space) per L903.
+        let bug_marker = " bug=";
+        let bm_idx = index_of(answer, bug_marker);
+        if bm_idx < 0 { return false; };
+        let bug_start = bm_idx + len(bug_marker);
+        let after = substring(answer, bug_start, len(answer));
+        let space_idx = index_of(after, " ");
+        let bug_id = if space_idx >= 0 {
+            substring(after, 0, space_idx);
+        } else {
+            after;
+        };
+        if len(bug_id) == 0 { return false; };
+        // colony-lint: safe-exec-concat
+        let grep_cmd = "grep -F " + shell_escape("\"bug_id\": \"" + bug_id + "\"") + " " + shell_escape(seller_ledger) + " 2>/dev/null | head -1";
+        let hit = try { exec sh grep_cmd; } catch e { ""; };
+        return len(hit) > 0;
+    };
+
+    if topic_kind == "bundle" {
+        // Bundle producer emits `bug_id1;bug_id2;…;` (trailing `;`).
+        // One `exec sh` splits on `;`, counts non-empty ids (denom), and
+        // counts how many resolve to a verifier-stamped row (numer).
+        // Validation passes iff denom > 0 AND numer == denom. The pipeline
+        // is total: empty answer => denom=0 => reject. shell_escape on the
+        // dynamic args keeps user-controlled string substitution safe.
+        // colony-lint: safe-exec-concat
+        let bundle_cmd = "answer=" + shell_escape(answer) + "; ledger=" + shell_escape(seller_ledger) + "; denom=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -cv '^$'); if [ \"$denom\" -eq 0 ]; then exit 0; fi; numer=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -v '^$' | while read id; do grep -F \"\\\"bug_id\\\": \\\"$id\\\"\" \"$ledger\" >/dev/null 2>&1 && echo 1; done | wc -l); if [ \"$numer\" = \"$denom\" ]; then echo OK; fi";
+        let res = try { exec sh bundle_cmd; } catch e { ""; };
+        return len(res) > 0;
+    };
+
+    return false;
+}
+
 // #499: per-tribe primary class — used as fallback when a variant string
 // lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
 // pre-#499 builds where pick_variant emitted phrasing-only strings).
@@ -862,17 +929,38 @@ fn tick(reason: string) -> void {
                     let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
                     let bought = knowledge_buy(buy_topic, max_cb_buy);
                     let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_buy = if len(bought) > 0 {
+                    let lifecycle_outcome_buy = if len(bought) > 0 {
                         if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): semantic-validation gate. Runs
+                    // *after* the lifecycle-event switch so cache_hit /
+                    // succeeded / rejected / fallback stay attributable to
+                    // the memo-store layer; a failed validation collapses to
+                    // a distinct `rejected_unverified` outcome and suppresses
+                    // the bought_context memo write so downstream prompts
+                    // never see an unverifiable answer.
+                    let validated_buy = if len(bought) > 0 {
+                        _validate_bought_answer(bought, sibling, "finding");
+                    } else {
+                        false;
+                    };
+                    let outcome_buy = if len(bought) > 0 {
+                        if validated_buy { lifecycle_outcome_buy; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_buy;
+                    };
                     let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
                     if len(bought) > 0 {
-                        if outcome_buy == "cache_hit" {
-                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                        if validated_buy {
+                            if outcome_buy == "cache_hit" {
+                                learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                            };
+                            memo_write("hunter:bought_context", bought);
+                        } else {
+                            learn("market", buy_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought);
                     };
                     emit_market_csv(_tick_now_ms, "buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
                 };
@@ -896,17 +984,36 @@ fn tick(reason: string) -> void {
                     let prem_max_cb = premium_factor_for_rep(best_s);
                     let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
                     let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_eb = if len(bought_b) > 0 {
+                    let lifecycle_outcome_eb = if len(bought_b) > 0 {
                         if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): bundle semantic-validation
+                    // gate. Every `;`-separated bug_id in the bundle must
+                    // resolve to a verifier-stamped row in the seller's
+                    // ledger; first miss => `rejected_unverified` + suppress
+                    // memo write.
+                    let validated_eb = if len(bought_b) > 0 {
+                        _validate_bought_answer(bought_b, best_t, "bundle");
+                    } else {
+                        false;
+                    };
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if validated_eb { lifecycle_outcome_eb; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_eb;
+                    };
                     let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
                     if len(bought_b) > 0 {
-                        if outcome_eb == "cache_hit" {
-                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                        if validated_eb {
+                            if outcome_eb == "cache_hit" {
+                                learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                            };
+                            memo_write("hunter:bought_context", bought_b);
+                        } else {
+                            learn("market", espionage_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought_b);
                     };
                     emit_market_csv(_tick_now_ms, "buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
                 };

--- a/tribes-bench/tribe-beta/agents/hunter.ag
+++ b/tribes-bench/tribe-beta/agents/hunter.ag
@@ -60,6 +60,73 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #493: consumer-side `knowledge_buy` answer validator (Loose category c).
+// Every `knowledge_buy` callsite cross-checks the returned answer's
+// claimed `bug_id` against the seller-tribe's verifier-stamped
+// `bug-ledger.jsonl` before trusting it. Fail-safe: any parse failure,
+// missing seller-ledger memo, or non-matching grep => return `false`
+// (reject the answer). Never falsely accept.
+//
+// `topic_kind == "finding"`: answer format produced by the single-finding
+// sell at hunter.ag L903 is `line=<N> bug=<ID> rationale=<...>`. Parse
+// the `bug=` token (space-delimited) and require one verifier-stamped
+// row in the seller's ledger.
+//
+// `topic_kind == "bundle"`: answer format produced by the bundle sell at
+// hunter.ag L933 is a `;`-separated list of bug_ids. Require *all* listed
+// ids to resolve to verifier-stamped rows. Empty list => `false`.
+//
+// Limitation (deferred): the gate only catches sells whose claimed
+// `bug_id` does not exist in the seller's ledger. A sell that quotes a
+// bug_id that *did* happen but whose `rationale=<...>` substring is
+// fabricated is NOT caught — the verifier never inspects free-text
+// rationale. Tracked separately as Loose's rationale-string anchoring
+// follow-up.
+//
+// Re-applied after PR #517 surgical restore dropped the original #508
+// patch (commit aa21220); #518 brought back #491 but not #493.
+fn _validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool {
+    if len(answer) == 0 { return false; };
+    let seller_ledger = recall_latest("tribe-" + seller_tribe + ":bug_ledger");
+    if len(seller_ledger) == 0 { return false; };
+
+    if topic_kind == "finding" {
+        // Parse `bug=<ID>` from the answer. Producer guarantees the
+        // token is preceded by " bug=" (single space) per L903.
+        let bug_marker = " bug=";
+        let bm_idx = index_of(answer, bug_marker);
+        if bm_idx < 0 { return false; };
+        let bug_start = bm_idx + len(bug_marker);
+        let after = substring(answer, bug_start, len(answer));
+        let space_idx = index_of(after, " ");
+        let bug_id = if space_idx >= 0 {
+            substring(after, 0, space_idx);
+        } else {
+            after;
+        };
+        if len(bug_id) == 0 { return false; };
+        // colony-lint: safe-exec-concat
+        let grep_cmd = "grep -F " + shell_escape("\"bug_id\": \"" + bug_id + "\"") + " " + shell_escape(seller_ledger) + " 2>/dev/null | head -1";
+        let hit = try { exec sh grep_cmd; } catch e { ""; };
+        return len(hit) > 0;
+    };
+
+    if topic_kind == "bundle" {
+        // Bundle producer emits `bug_id1;bug_id2;…;` (trailing `;`).
+        // One `exec sh` splits on `;`, counts non-empty ids (denom), and
+        // counts how many resolve to a verifier-stamped row (numer).
+        // Validation passes iff denom > 0 AND numer == denom. The pipeline
+        // is total: empty answer => denom=0 => reject. shell_escape on the
+        // dynamic args keeps user-controlled string substitution safe.
+        // colony-lint: safe-exec-concat
+        let bundle_cmd = "answer=" + shell_escape(answer) + "; ledger=" + shell_escape(seller_ledger) + "; denom=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -cv '^$'); if [ \"$denom\" -eq 0 ]; then exit 0; fi; numer=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -v '^$' | while read id; do grep -F \"\\\"bug_id\\\": \\\"$id\\\"\" \"$ledger\" >/dev/null 2>&1 && echo 1; done | wc -l); if [ \"$numer\" = \"$denom\" ]; then echo OK; fi";
+        let res = try { exec sh bundle_cmd; } catch e { ""; };
+        return len(res) > 0;
+    };
+
+    return false;
+}
+
 // #499: per-tribe primary class — used as fallback when a variant string
 // lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
 // pre-#499 builds where pick_variant emitted phrasing-only strings).
@@ -779,17 +846,38 @@ fn tick(reason: string) -> void {
                     let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
                     let bought = knowledge_buy(buy_topic, max_cb_buy);
                     let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_buy = if len(bought) > 0 {
+                    let lifecycle_outcome_buy = if len(bought) > 0 {
                         if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): semantic-validation gate. Runs
+                    // *after* the lifecycle-event switch so cache_hit /
+                    // succeeded / rejected / fallback stay attributable to
+                    // the memo-store layer; a failed validation collapses to
+                    // a distinct `rejected_unverified` outcome and suppresses
+                    // the bought_context memo write so downstream prompts
+                    // never see an unverifiable answer.
+                    let validated_buy = if len(bought) > 0 {
+                        _validate_bought_answer(bought, sibling, "finding");
+                    } else {
+                        false;
+                    };
+                    let outcome_buy = if len(bought) > 0 {
+                        if validated_buy { lifecycle_outcome_buy; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_buy;
+                    };
                     let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
                     if len(bought) > 0 {
-                        if outcome_buy == "cache_hit" {
-                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                        if validated_buy {
+                            if outcome_buy == "cache_hit" {
+                                learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                            };
+                            memo_write("hunter:bought_context", bought);
+                        } else {
+                            learn("market", buy_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought);
                     };
                     emit_market_csv(_tick_now_ms, "buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
                 };
@@ -813,17 +901,36 @@ fn tick(reason: string) -> void {
                     let prem_max_cb = premium_factor_for_rep(best_s);
                     let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
                     let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_eb = if len(bought_b) > 0 {
+                    let lifecycle_outcome_eb = if len(bought_b) > 0 {
                         if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): bundle semantic-validation
+                    // gate. Every `;`-separated bug_id in the bundle must
+                    // resolve to a verifier-stamped row in the seller's
+                    // ledger; first miss => `rejected_unverified` + suppress
+                    // memo write.
+                    let validated_eb = if len(bought_b) > 0 {
+                        _validate_bought_answer(bought_b, best_t, "bundle");
+                    } else {
+                        false;
+                    };
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if validated_eb { lifecycle_outcome_eb; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_eb;
+                    };
                     let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
                     if len(bought_b) > 0 {
-                        if outcome_eb == "cache_hit" {
-                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                        if validated_eb {
+                            if outcome_eb == "cache_hit" {
+                                learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                            };
+                            memo_write("hunter:bought_context", bought_b);
+                        } else {
+                            learn("market", espionage_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought_b);
                     };
                     emit_market_csv(_tick_now_ms, "buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
                 };

--- a/tribes-bench/tribe-delta/agents/hunter.ag
+++ b/tribes-bench/tribe-delta/agents/hunter.ag
@@ -60,6 +60,73 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #493: consumer-side `knowledge_buy` answer validator (Loose category c).
+// Every `knowledge_buy` callsite cross-checks the returned answer's
+// claimed `bug_id` against the seller-tribe's verifier-stamped
+// `bug-ledger.jsonl` before trusting it. Fail-safe: any parse failure,
+// missing seller-ledger memo, or non-matching grep => return `false`
+// (reject the answer). Never falsely accept.
+//
+// `topic_kind == "finding"`: answer format produced by the single-finding
+// sell at hunter.ag L903 is `line=<N> bug=<ID> rationale=<...>`. Parse
+// the `bug=` token (space-delimited) and require one verifier-stamped
+// row in the seller's ledger.
+//
+// `topic_kind == "bundle"`: answer format produced by the bundle sell at
+// hunter.ag L933 is a `;`-separated list of bug_ids. Require *all* listed
+// ids to resolve to verifier-stamped rows. Empty list => `false`.
+//
+// Limitation (deferred): the gate only catches sells whose claimed
+// `bug_id` does not exist in the seller's ledger. A sell that quotes a
+// bug_id that *did* happen but whose `rationale=<...>` substring is
+// fabricated is NOT caught — the verifier never inspects free-text
+// rationale. Tracked separately as Loose's rationale-string anchoring
+// follow-up.
+//
+// Re-applied after PR #517 surgical restore dropped the original #508
+// patch (commit aa21220); #518 brought back #491 but not #493.
+fn _validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool {
+    if len(answer) == 0 { return false; };
+    let seller_ledger = recall_latest("tribe-" + seller_tribe + ":bug_ledger");
+    if len(seller_ledger) == 0 { return false; };
+
+    if topic_kind == "finding" {
+        // Parse `bug=<ID>` from the answer. Producer guarantees the
+        // token is preceded by " bug=" (single space) per L903.
+        let bug_marker = " bug=";
+        let bm_idx = index_of(answer, bug_marker);
+        if bm_idx < 0 { return false; };
+        let bug_start = bm_idx + len(bug_marker);
+        let after = substring(answer, bug_start, len(answer));
+        let space_idx = index_of(after, " ");
+        let bug_id = if space_idx >= 0 {
+            substring(after, 0, space_idx);
+        } else {
+            after;
+        };
+        if len(bug_id) == 0 { return false; };
+        // colony-lint: safe-exec-concat
+        let grep_cmd = "grep -F " + shell_escape("\"bug_id\": \"" + bug_id + "\"") + " " + shell_escape(seller_ledger) + " 2>/dev/null | head -1";
+        let hit = try { exec sh grep_cmd; } catch e { ""; };
+        return len(hit) > 0;
+    };
+
+    if topic_kind == "bundle" {
+        // Bundle producer emits `bug_id1;bug_id2;…;` (trailing `;`).
+        // One `exec sh` splits on `;`, counts non-empty ids (denom), and
+        // counts how many resolve to a verifier-stamped row (numer).
+        // Validation passes iff denom > 0 AND numer == denom. The pipeline
+        // is total: empty answer => denom=0 => reject. shell_escape on the
+        // dynamic args keeps user-controlled string substitution safe.
+        // colony-lint: safe-exec-concat
+        let bundle_cmd = "answer=" + shell_escape(answer) + "; ledger=" + shell_escape(seller_ledger) + "; denom=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -cv '^$'); if [ \"$denom\" -eq 0 ]; then exit 0; fi; numer=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -v '^$' | while read id; do grep -F \"\\\"bug_id\\\": \\\"$id\\\"\" \"$ledger\" >/dev/null 2>&1 && echo 1; done | wc -l); if [ \"$numer\" = \"$denom\" ]; then echo OK; fi";
+        let res = try { exec sh bundle_cmd; } catch e { ""; };
+        return len(res) > 0;
+    };
+
+    return false;
+}
+
 // #499: per-tribe primary class — used as fallback when a variant string
 // lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
 // pre-#499 builds where pick_variant emitted phrasing-only strings).
@@ -780,17 +847,38 @@ fn tick(reason: string) -> void {
                     let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
                     let bought = knowledge_buy(buy_topic, max_cb_buy);
                     let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_buy = if len(bought) > 0 {
+                    let lifecycle_outcome_buy = if len(bought) > 0 {
                         if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): semantic-validation gate. Runs
+                    // *after* the lifecycle-event switch so cache_hit /
+                    // succeeded / rejected / fallback stay attributable to
+                    // the memo-store layer; a failed validation collapses to
+                    // a distinct `rejected_unverified` outcome and suppresses
+                    // the bought_context memo write so downstream prompts
+                    // never see an unverifiable answer.
+                    let validated_buy = if len(bought) > 0 {
+                        _validate_bought_answer(bought, sibling, "finding");
+                    } else {
+                        false;
+                    };
+                    let outcome_buy = if len(bought) > 0 {
+                        if validated_buy { lifecycle_outcome_buy; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_buy;
+                    };
                     let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
                     if len(bought) > 0 {
-                        if outcome_buy == "cache_hit" {
-                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                        if validated_buy {
+                            if outcome_buy == "cache_hit" {
+                                learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                            };
+                            memo_write("hunter:bought_context", bought);
+                        } else {
+                            learn("market", buy_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought);
                     };
                     emit_market_csv(_tick_now_ms, "buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
                 };
@@ -814,17 +902,36 @@ fn tick(reason: string) -> void {
                     let prem_max_cb = premium_factor_for_rep(best_s);
                     let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
                     let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_eb = if len(bought_b) > 0 {
+                    let lifecycle_outcome_eb = if len(bought_b) > 0 {
                         if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): bundle semantic-validation
+                    // gate. Every `;`-separated bug_id in the bundle must
+                    // resolve to a verifier-stamped row in the seller's
+                    // ledger; first miss => `rejected_unverified` + suppress
+                    // memo write.
+                    let validated_eb = if len(bought_b) > 0 {
+                        _validate_bought_answer(bought_b, best_t, "bundle");
+                    } else {
+                        false;
+                    };
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if validated_eb { lifecycle_outcome_eb; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_eb;
+                    };
                     let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
                     if len(bought_b) > 0 {
-                        if outcome_eb == "cache_hit" {
-                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                        if validated_eb {
+                            if outcome_eb == "cache_hit" {
+                                learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                            };
+                            memo_write("hunter:bought_context", bought_b);
+                        } else {
+                            learn("market", espionage_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought_b);
                     };
                     emit_market_csv(_tick_now_ms, "buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
                 };

--- a/tribes-bench/tribe-epsilon/agents/hunter.ag
+++ b/tribes-bench/tribe-epsilon/agents/hunter.ag
@@ -60,6 +60,73 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #493: consumer-side `knowledge_buy` answer validator (Loose category c).
+// Every `knowledge_buy` callsite cross-checks the returned answer's
+// claimed `bug_id` against the seller-tribe's verifier-stamped
+// `bug-ledger.jsonl` before trusting it. Fail-safe: any parse failure,
+// missing seller-ledger memo, or non-matching grep => return `false`
+// (reject the answer). Never falsely accept.
+//
+// `topic_kind == "finding"`: answer format produced by the single-finding
+// sell at hunter.ag L903 is `line=<N> bug=<ID> rationale=<...>`. Parse
+// the `bug=` token (space-delimited) and require one verifier-stamped
+// row in the seller's ledger.
+//
+// `topic_kind == "bundle"`: answer format produced by the bundle sell at
+// hunter.ag L933 is a `;`-separated list of bug_ids. Require *all* listed
+// ids to resolve to verifier-stamped rows. Empty list => `false`.
+//
+// Limitation (deferred): the gate only catches sells whose claimed
+// `bug_id` does not exist in the seller's ledger. A sell that quotes a
+// bug_id that *did* happen but whose `rationale=<...>` substring is
+// fabricated is NOT caught — the verifier never inspects free-text
+// rationale. Tracked separately as Loose's rationale-string anchoring
+// follow-up.
+//
+// Re-applied after PR #517 surgical restore dropped the original #508
+// patch (commit aa21220); #518 brought back #491 but not #493.
+fn _validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool {
+    if len(answer) == 0 { return false; };
+    let seller_ledger = recall_latest("tribe-" + seller_tribe + ":bug_ledger");
+    if len(seller_ledger) == 0 { return false; };
+
+    if topic_kind == "finding" {
+        // Parse `bug=<ID>` from the answer. Producer guarantees the
+        // token is preceded by " bug=" (single space) per L903.
+        let bug_marker = " bug=";
+        let bm_idx = index_of(answer, bug_marker);
+        if bm_idx < 0 { return false; };
+        let bug_start = bm_idx + len(bug_marker);
+        let after = substring(answer, bug_start, len(answer));
+        let space_idx = index_of(after, " ");
+        let bug_id = if space_idx >= 0 {
+            substring(after, 0, space_idx);
+        } else {
+            after;
+        };
+        if len(bug_id) == 0 { return false; };
+        // colony-lint: safe-exec-concat
+        let grep_cmd = "grep -F " + shell_escape("\"bug_id\": \"" + bug_id + "\"") + " " + shell_escape(seller_ledger) + " 2>/dev/null | head -1";
+        let hit = try { exec sh grep_cmd; } catch e { ""; };
+        return len(hit) > 0;
+    };
+
+    if topic_kind == "bundle" {
+        // Bundle producer emits `bug_id1;bug_id2;…;` (trailing `;`).
+        // One `exec sh` splits on `;`, counts non-empty ids (denom), and
+        // counts how many resolve to a verifier-stamped row (numer).
+        // Validation passes iff denom > 0 AND numer == denom. The pipeline
+        // is total: empty answer => denom=0 => reject. shell_escape on the
+        // dynamic args keeps user-controlled string substitution safe.
+        // colony-lint: safe-exec-concat
+        let bundle_cmd = "answer=" + shell_escape(answer) + "; ledger=" + shell_escape(seller_ledger) + "; denom=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -cv '^$'); if [ \"$denom\" -eq 0 ]; then exit 0; fi; numer=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -v '^$' | while read id; do grep -F \"\\\"bug_id\\\": \\\"$id\\\"\" \"$ledger\" >/dev/null 2>&1 && echo 1; done | wc -l); if [ \"$numer\" = \"$denom\" ]; then echo OK; fi";
+        let res = try { exec sh bundle_cmd; } catch e { ""; };
+        return len(res) > 0;
+    };
+
+    return false;
+}
+
 // #499: per-tribe primary class — used as fallback when a variant string
 // lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
 // pre-#499 builds where pick_variant emitted phrasing-only strings).
@@ -780,17 +847,38 @@ fn tick(reason: string) -> void {
                     let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
                     let bought = knowledge_buy(buy_topic, max_cb_buy);
                     let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_buy = if len(bought) > 0 {
+                    let lifecycle_outcome_buy = if len(bought) > 0 {
                         if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): semantic-validation gate. Runs
+                    // *after* the lifecycle-event switch so cache_hit /
+                    // succeeded / rejected / fallback stay attributable to
+                    // the memo-store layer; a failed validation collapses to
+                    // a distinct `rejected_unverified` outcome and suppresses
+                    // the bought_context memo write so downstream prompts
+                    // never see an unverifiable answer.
+                    let validated_buy = if len(bought) > 0 {
+                        _validate_bought_answer(bought, sibling, "finding");
+                    } else {
+                        false;
+                    };
+                    let outcome_buy = if len(bought) > 0 {
+                        if validated_buy { lifecycle_outcome_buy; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_buy;
+                    };
                     let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
                     if len(bought) > 0 {
-                        if outcome_buy == "cache_hit" {
-                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                        if validated_buy {
+                            if outcome_buy == "cache_hit" {
+                                learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                            };
+                            memo_write("hunter:bought_context", bought);
+                        } else {
+                            learn("market", buy_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought);
                     };
                     emit_market_csv(_tick_now_ms, "buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
                 };
@@ -814,17 +902,36 @@ fn tick(reason: string) -> void {
                     let prem_max_cb = premium_factor_for_rep(best_s);
                     let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
                     let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_eb = if len(bought_b) > 0 {
+                    let lifecycle_outcome_eb = if len(bought_b) > 0 {
                         if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): bundle semantic-validation
+                    // gate. Every `;`-separated bug_id in the bundle must
+                    // resolve to a verifier-stamped row in the seller's
+                    // ledger; first miss => `rejected_unverified` + suppress
+                    // memo write.
+                    let validated_eb = if len(bought_b) > 0 {
+                        _validate_bought_answer(bought_b, best_t, "bundle");
+                    } else {
+                        false;
+                    };
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if validated_eb { lifecycle_outcome_eb; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_eb;
+                    };
                     let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
                     if len(bought_b) > 0 {
-                        if outcome_eb == "cache_hit" {
-                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                        if validated_eb {
+                            if outcome_eb == "cache_hit" {
+                                learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                            };
+                            memo_write("hunter:bought_context", bought_b);
+                        } else {
+                            learn("market", espionage_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought_b);
                     };
                     emit_market_csv(_tick_now_ms, "buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
                 };

--- a/tribes-bench/tribe-gamma/agents/hunter.ag
+++ b/tribes-bench/tribe-gamma/agents/hunter.ag
@@ -60,6 +60,73 @@ fn target_file() -> string {
     return recall_latest("hunter:target_file");
 }
 
+// #493: consumer-side `knowledge_buy` answer validator (Loose category c).
+// Every `knowledge_buy` callsite cross-checks the returned answer's
+// claimed `bug_id` against the seller-tribe's verifier-stamped
+// `bug-ledger.jsonl` before trusting it. Fail-safe: any parse failure,
+// missing seller-ledger memo, or non-matching grep => return `false`
+// (reject the answer). Never falsely accept.
+//
+// `topic_kind == "finding"`: answer format produced by the single-finding
+// sell at hunter.ag L903 is `line=<N> bug=<ID> rationale=<...>`. Parse
+// the `bug=` token (space-delimited) and require one verifier-stamped
+// row in the seller's ledger.
+//
+// `topic_kind == "bundle"`: answer format produced by the bundle sell at
+// hunter.ag L933 is a `;`-separated list of bug_ids. Require *all* listed
+// ids to resolve to verifier-stamped rows. Empty list => `false`.
+//
+// Limitation (deferred): the gate only catches sells whose claimed
+// `bug_id` does not exist in the seller's ledger. A sell that quotes a
+// bug_id that *did* happen but whose `rationale=<...>` substring is
+// fabricated is NOT caught — the verifier never inspects free-text
+// rationale. Tracked separately as Loose's rationale-string anchoring
+// follow-up.
+//
+// Re-applied after PR #517 surgical restore dropped the original #508
+// patch (commit aa21220); #518 brought back #491 but not #493.
+fn _validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool {
+    if len(answer) == 0 { return false; };
+    let seller_ledger = recall_latest("tribe-" + seller_tribe + ":bug_ledger");
+    if len(seller_ledger) == 0 { return false; };
+
+    if topic_kind == "finding" {
+        // Parse `bug=<ID>` from the answer. Producer guarantees the
+        // token is preceded by " bug=" (single space) per L903.
+        let bug_marker = " bug=";
+        let bm_idx = index_of(answer, bug_marker);
+        if bm_idx < 0 { return false; };
+        let bug_start = bm_idx + len(bug_marker);
+        let after = substring(answer, bug_start, len(answer));
+        let space_idx = index_of(after, " ");
+        let bug_id = if space_idx >= 0 {
+            substring(after, 0, space_idx);
+        } else {
+            after;
+        };
+        if len(bug_id) == 0 { return false; };
+        // colony-lint: safe-exec-concat
+        let grep_cmd = "grep -F " + shell_escape("\"bug_id\": \"" + bug_id + "\"") + " " + shell_escape(seller_ledger) + " 2>/dev/null | head -1";
+        let hit = try { exec sh grep_cmd; } catch e { ""; };
+        return len(hit) > 0;
+    };
+
+    if topic_kind == "bundle" {
+        // Bundle producer emits `bug_id1;bug_id2;…;` (trailing `;`).
+        // One `exec sh` splits on `;`, counts non-empty ids (denom), and
+        // counts how many resolve to a verifier-stamped row (numer).
+        // Validation passes iff denom > 0 AND numer == denom. The pipeline
+        // is total: empty answer => denom=0 => reject. shell_escape on the
+        // dynamic args keeps user-controlled string substitution safe.
+        // colony-lint: safe-exec-concat
+        let bundle_cmd = "answer=" + shell_escape(answer) + "; ledger=" + shell_escape(seller_ledger) + "; denom=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -cv '^$'); if [ \"$denom\" -eq 0 ]; then exit 0; fi; numer=$(printf '%s' \"$answer\" | tr ';' '\\n' | grep -v '^$' | while read id; do grep -F \"\\\"bug_id\\\": \\\"$id\\\"\" \"$ledger\" >/dev/null 2>&1 && echo 1; done | wc -l); if [ \"$numer\" = \"$denom\" ]; then echo OK; fi";
+        let res = try { exec sh bundle_cmd; } catch e { ""; };
+        return len(res) > 0;
+    };
+
+    return false;
+}
+
 // #499: per-tribe primary class — used as fallback when a variant string
 // lacks the `<class>:<phrasing>` colon separator (legacy memo replay from
 // pre-#499 builds where pick_variant emitted phrasing-only strings).
@@ -780,17 +847,38 @@ fn tick(reason: string) -> void {
                     let max_cb_buy = max_cb_for_rep(cur_rep_buy_str);
                     let bought = knowledge_buy(buy_topic, max_cb_buy);
                     let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_buy = if len(bought) > 0 {
+                    let lifecycle_outcome_buy = if len(bought) > 0 {
                         if kind_buy == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_buy == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): semantic-validation gate. Runs
+                    // *after* the lifecycle-event switch so cache_hit /
+                    // succeeded / rejected / fallback stay attributable to
+                    // the memo-store layer; a failed validation collapses to
+                    // a distinct `rejected_unverified` outcome and suppresses
+                    // the bought_context memo write so downstream prompts
+                    // never see an unverifiable answer.
+                    let validated_buy = if len(bought) > 0 {
+                        _validate_bought_answer(bought, sibling, "finding");
+                    } else {
+                        false;
+                    };
+                    let outcome_buy = if len(bought) > 0 {
+                        if validated_buy { lifecycle_outcome_buy; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_buy;
+                    };
                     let cache_buy_s = if outcome_buy == "cache_hit" { "1"; } else { "0"; };
                     if len(bought) > 0 {
-                        if outcome_buy == "cache_hit" {
-                            learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                        if validated_buy {
+                            if outcome_buy == "cache_hit" {
+                                learn("market", buy_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding"]);
+                            };
+                            memo_write("hunter:bought_context", bought);
+                        } else {
+                            learn("market", buy_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:finding", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought);
                     };
                     emit_market_csv(_tick_now_ms, "buy", buy_topic, "finding", "", to_string(max_cb_buy), "", cache_buy_s, outcome_buy);
                 };
@@ -814,17 +902,36 @@ fn tick(reason: string) -> void {
                     let prem_max_cb = premium_factor_for_rep(best_s);
                     let bought_b = knowledge_buy(espionage_topic, prem_max_cb);
                     let kind_eb = recall_latest("agent:lifecycle:cognitive:last_event_kind");
-                    let outcome_eb = if len(bought_b) > 0 {
+                    let lifecycle_outcome_eb = if len(bought_b) > 0 {
                         if kind_eb == "cognitive.cache_hit" { "cache_hit"; } else { "succeeded"; };
                     } else {
                         if kind_eb == "cognitive.rejected" { "rejected"; } else { "fallback"; };
                     };
+                    // #493 (Loose category c): bundle semantic-validation
+                    // gate. Every `;`-separated bug_id in the bundle must
+                    // resolve to a verifier-stamped row in the seller's
+                    // ledger; first miss => `rejected_unverified` + suppress
+                    // memo write.
+                    let validated_eb = if len(bought_b) > 0 {
+                        _validate_bought_answer(bought_b, best_t, "bundle");
+                    } else {
+                        false;
+                    };
+                    let outcome_eb = if len(bought_b) > 0 {
+                        if validated_eb { lifecycle_outcome_eb; } else { "rejected_unverified"; };
+                    } else {
+                        lifecycle_outcome_eb;
+                    };
                     let cache_eb_s = if outcome_eb == "cache_hit" { "1"; } else { "0"; };
                     if len(bought_b) > 0 {
-                        if outcome_eb == "cache_hit" {
-                            learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                        if validated_eb {
+                            if outcome_eb == "cache_hit" {
+                                learn("market", espionage_topic, "", "cache_hit", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle"]);
+                            };
+                            memo_write("hunter:bought_context", bought_b);
+                        } else {
+                            learn("market", espionage_topic, "", "rejected", ["tribes-bench", "buyer:" + _tribe_name, "topic_kind:bundle", "reason:unverifiable"]);
                         };
-                        memo_write("hunter:bought_context", bought_b);
                     };
                     emit_market_csv(_tick_now_ms, "buy", espionage_topic, "bundle", "", to_string(prem_max_cb), "", cache_eb_s, outcome_eb);
                 };


### PR DESCRIPTION
## Summary

Re-applies the consumer-side `knowledge_buy` answer validation guardrails (Loose category c, originally PR #508 commit aa21220) lost during surgical restore PR #517. #518 brought back #491 ledger-monopoly guards but #493 was never re-applied — this PR closes that gap.

## Why this matters

Without #493 guards, any hunter agent can purchase a knowledge entry via `knowledge_buy`, receive a "plausible-sounding" rationale string, and act on it (or propagate it via subsequent `learn()` events) with **no verifier anchor**. The Loose recipe specifically calls this out as a self-evolving-system failure mode: agents adopt peer "working" code without checking whether it works.

Today the LLM prompts don't suggest selling fake answers because hunters are cooperative-by-default. But once Stage 4 evolution produces fitness-pressured lineages (see take-7 multi-tribe federation, unlocked by #535/#536), sellers gain reward by selling regardless of answer quality. The gate stops noise from propagating as authoritative.

## What changes

For each of 5 hunter.ag (byte-identical block — `_validate_bought_answer` body sha256 = `27ce8ca9d1924b8ee10d19aa57320046df82a96fc7c4821d7fe9ff8964f1f186` across all 5 tribes):

1. **New helper** `_validate_bought_answer(answer: string, seller_tribe: string, topic_kind: string) -> bool` placed between `target_file()` and `_tribe_default_class()` (same position as aa21220).
2. **Single-finding gate** at the `let bought = knowledge_buy(buy_topic, max_cb_buy)` callsite — parses `bug=<ID>` token from the producer's `line=N bug=ID rationale=...` format, requires one verifier-stamped row in seller's `tribe-<sibling>:bug_ledger`.
3. **Bundle gate** at the `let bought_b = knowledge_buy(espionage_topic, prem_max_cb)` callsite — every `;`-separated bug_id in the bundle must resolve to a verifier-stamped row; first miss → reject whole bundle.

Failed validation collapses to a distinct `rejected_unverified` outcome on `learn("market", ..., "rejected", [..., "reason:unverifiable"])`. The `memo_write("hunter:bought_context", ...)` is suppressed on rejection so downstream prompts never see an unverifiable answer.

## Fail-safe defaults

- Empty answer → reject
- Missing seller-ledger memo → reject
- Parse failure → reject
- Non-zero exec sh exit → reject
- Never falsely accept

Rejection is **non-punitive** (no reputation hit, just discard) per the original PR rationale — punishment-on-rejection is itself a gaming vector that needs adversarial-reputation analysis before it lands.

## Files changed (6, +593 / -40)

- 5 × `tribes-bench/tribe-*/agents/hunter.ag` (+107 each — helper + 2 callsite rewrites)
- `tribes-bench/CHANGELOG.md` (+18 — Unreleased / Changed bullet)

## Validation

- `colony-lint.sh`: **170 / 0 / 3 skipped** (baseline preserved)
- `tools/check-learn-tags.sh`: exit 0 (the `market:rejected:reason:unverifiable` schema entry survived #517 — the only #493 artifact that didn't revert)
- `tools/check-exec-sh.sh`: exit 0 (both new exec sh sites have `// colony-lint: safe-exec-concat` + `shell_escape()` on user-controlled strings)
- `_validate_bought_answer` body byte-identical across all 5 hunters (sha256 above)

## Original commit reference

`git show aa21220 -- tribes-bench/tribe-alpha/agents/hunter.ag` — the diff this PR re-applies, modulo a 2-line docblock trailer that records the #517 → #518 → #493 restoration history.

## Out of scope

- Rationale-string anchoring to measurements (the gate only catches sells whose claimed bug_id is absent from the seller's ledger; sells that quote a real bug_id but fabricate the `rationale=<...>` substring are not caught — explicit Loose follow-up tracked separately)
- Adversarial-reputation analysis for punishment-on-rejection — keep rejection non-punitive until that lands

## References

- #493 (parent issue, Loose category c)
- #508 / aa21220 (original PR)
- #517 (surgical restore that dropped this)
- #518 (re-applied #491 but not #493)
- Loose recipe writeup on self-evolving agent failure modes

## Test plan

- [x] colony-lint 170/0/3 baseline preserved
- [x] check-learn-tags + check-exec-sh clean
- [x] All 5 hunter.ag byte-identical at helper site (sha256 verified)
- [ ] CI green
- [ ] QA agent ship-it

🤖 Generated with [Claude Code](https://claude.com/claude-code)