### PR TITLE
fix(tribes-bench): :z SELinux relabel on claude bind-mount (#540)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,24 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **`run-stage3-docker.sh`: add `:z` SELinux relabel to claude bind-mount (#540)**.
+  Take-7 multi-tribe federation smoke surfaced that on SELinux-enforcing hosts
+  (Fedora, RHEL, openSUSE) the post-#536 mount `-v $HOST_CLAUDE_DIR:/root/.claude:rw`
+  is invisible to containers because `~/.claude` carries `user_home_t` SELinux
+  type which `container_t` processes cannot read — regardless of UID or
+  permission bits. Inside the container, `stat /root/.claude/.credentials.json`
+  returned `Permission denied` and `claude --print` returned `Not logged in`.
+  Take-7 was unblocked by a manual `chcon -t container_file_t /tmp/claude-dir
+  -R` workaround. Adding `,z` to the bind-mount tells podman to apply a shared
+  SELinux relabel automatically — the same approach used by other rootless
+  podman tooling. `:z` is a no-op on SELinux-disabled hosts (Ubuntu, Debian).
+  Operator security notes expanded in the script comment block: (1) existing
+  `.credentials.json` exposure warning preserved; (2) NEW warning not to debug
+  the credentials path with raw `cat`/`stat` (terminal scrollback leakage);
+  (3) NEW warning that `:z` mutates the SELinux type of the host source
+  directory permanently. test-run-stage3-docker.sh assertion count 149 → 150
+  with one new "claude mount includes :z SELinux relabel suffix" check.
+  colony-lint 170/0/3 baseline preserved.
 - **Re-apply #493 consumer-side `knowledge_buy` answer validation (Loose category c)**.
   PR #508 (commit aa21220) originally added a `_validate_bought_answer` gate
   to every `knowledge_buy` callsite in `hunter.ag`, cross-checking the

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -617,16 +617,31 @@ write_bootstraps() {
 # refresh session tokens). The OpenAI-backend code path is unchanged
 # when STAGE3_LLM_BACKEND=openai (default).
 #
-# Operator security note: mounting ~/.claude exposes the host's
-# .credentials.json (Claude Code session token) to the container. On a
-# single-user dev machine this is acceptable; on shared CI runners
-# operators should provision a dedicated Claude Code session.
+# Operator security notes:
+#   1. Mounting ~/.claude exposes the host's .credentials.json (Claude
+#      Code session token) to the container. On a single-user dev
+#      machine this is acceptable; on shared CI runners operators
+#      should provision a dedicated Claude Code session.
+#   2. Do NOT debug the credentials path with raw `cat` or `stat` —
+#      the token will end up in terminal scrollback. Use `test -r
+#      <file>` for existence checks.
+#   3. #540: the `:z` SELinux relabel option appended below mutates
+#      the SELinux type of $STAGE3_HOST_CLAUDE_DIR on the host
+#      (typically `user_home_t` → `container_file_t`). This is
+#      required on SELinux-enforcing distros (Fedora, RHEL, openSUSE)
+#      where `user_home_t` is denied to `container_t` processes —
+#      without `:z` the container sees `Permission denied` on every
+#      file under the mount despite UID/permission bits being correct.
+#      `:z` is a no-op on SELinux-disabled hosts (Ubuntu, Debian).
 spawn_containers() {
     local CLAUDE_MOUNT_FLAG=""
     if [ "$LLM_BACKEND" = "claude" ]; then
         local HOST_CLAUDE_DIR="${STAGE3_HOST_CLAUDE_DIR:-$HOME/.claude}"
         if [ -d "$HOST_CLAUDE_DIR" ]; then
-            CLAUDE_MOUNT_FLAG="-v $HOST_CLAUDE_DIR:/root/.claude:rw"
+            # #540: append `:z` so podman applies a shared SELinux
+            # relabel — required on SELinux-enforcing hosts. No-op
+            # on SELinux-disabled hosts.
+            CLAUDE_MOUNT_FLAG="-v $HOST_CLAUDE_DIR:/root/.claude:rw,z"
         else
             echo "run-stage3-docker: STAGE3_HOST_CLAUDE_DIR=$HOST_CLAUDE_DIR does not exist" >&2
             echo "                   set STAGE3_HOST_CLAUDE_DIR or install Claude Code first" >&2

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -376,17 +376,23 @@ CLAUDE_OUT="$(STAGE3_WALL_CLOCK_S=1800 \
               STAGE3_LLM_BACKEND=claude \
               STAGE3_HOST_CLAUDE_DIR=/tmp \
               bash "$ORCH" --dry-run 2>&1 || true)"
-assert_contains "claude backend mounts /tmp:/root/.claude:rw on laptop" \
+assert_contains "claude backend mounts /tmp:/root/.claude:rw,z on laptop" \
     "$CLAUDE_OUT" \
-    "-v /tmp:/root/.claude:rw"
-LAPTOP_CLAUDE_COUNT="$(printf '%s' "$CLAUDE_OUT" | grep -cF -- '-v /tmp:/root/.claude:rw' || true)"
+    "-v /tmp:/root/.claude:rw,z"
+LAPTOP_CLAUDE_COUNT="$(printf '%s' "$CLAUDE_OUT" | grep -cF -- '-v /tmp:/root/.claude:rw,z' || true)"
 if [ "$LAPTOP_CLAUDE_COUNT" -ge 2 ]; then
-    echo "[PASS] claude backend mounts /tmp:/root/.claude:rw on BOTH containers (found $LAPTOP_CLAUDE_COUNT instances)"
+    echo "[PASS] claude backend mounts /tmp:/root/.claude:rw,z on BOTH containers (found $LAPTOP_CLAUDE_COUNT instances)"
     PASS=$((PASS + 1))
 else
     echo "[FAIL] claude backend should mount /root/.claude on both containers (found only $LAPTOP_CLAUDE_COUNT instance(s))"
     FAIL=$((FAIL + 1))
 fi
+# #540: explicit `:z` SELinux relabel suffix presence assertion.
+# Distinct from the count assertion above so a regression that drops
+# `:z` while keeping the mount on both containers is still caught.
+assert_contains "claude mount includes :z SELinux relabel suffix" \
+    "$CLAUDE_OUT" \
+    ":rw,z"
 CLAUDE_MISSING_RC=0
 STAGE3_LLM_BACKEND=claude \
 STAGE3_HOST_CLAUDE_DIR=/nonexistent-path-$$ \


### PR DESCRIPTION
Take-7 surface: post-#536 mount invisible on SELinux-enforcing hosts. Adds ':z' to /root/.claude bind. No-op on SELinux-disabled hosts. test 149->150 + 3 expanded operator security notes. colony-lint 170/0/3.

Closes #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)