### PR TITLE
fix(tribes-bench): rotation timer writes hunter:* memo keys (#546)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -14,6 +14,13 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fix(rotation):** orchestrator's rotation timer now writes the memo keys hunters
+  actually read (`hunter:target_dir`, `hunter:target_file`, `hunter:bugs_manifest`)
+  instead of unread `tribes-bench:*` variants — hunters now rotate in lockstep with
+  `STAGE3_ROTATION_INTERVAL_S` ([#546](https://github.com/Replikanti/agentis-colonies/issues/546)).
+
 ### Changed
 
 - **Stage 4 Phase 1 chunk 2: vendor 5 new RUSTSEC-anchored planted-bug crates + population-scaling knobs (#544)**.

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -720,6 +720,10 @@ spawn_containers() {
 # them into BOTH containers via `podman exec ... agentis memo set`.
 # Daemons re-read on each tick. Path values use container-side absolute
 # paths (/run-root/targets/...), since memos are read inside containers.
+# Memo key alignment: hunters read hunter:target_dir + hunter:target_file
+# (seeded by start-colony.sh at bootstrap). We overwrite those keys here
+# so rotation actually changes what hunters target. The bugs_manifest write
+# is a no-op stub for a future verifier-side change (see issue #546).
 rotation_timer() {
     emit_step "starting target-rotation timer (interval=${ROTATION_INTERVAL}s)"
     # Stage 4 Phase 1 chunk 1 (#519) + chunk 2 (#544): if any of
@@ -753,7 +757,7 @@ rotation_timer() {
         extra_targets="$extra_targets J"
     fi
     if [ -z "$extra_targets" ]; then
-        emit_cmd "( phase=0; while true; do sleep $ROTATION_INTERVAL; phase=\$((1 - phase)); if [ \"\$phase\" = \"0\" ]; then td=/run-root/$TARGET_A_DIR_REL; bm=/run-root/$TARGET_A_BUGS_REL; else td=/run-root/$TARGET_B_DIR_REL; bm=/run-root/$TARGET_B_BUGS_REL; fi; printf '%s,%s,%s\\n' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"\$td\" \"\$bm\" >>$ROTATIONS_CSV; podman exec stage3-laptop agentis memo set tribes-bench:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set tribes-bench:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set tribes-bench:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set tribes-bench:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; done ) >>$RUN_DIR/rotation.log 2>&1 & echo \$! >$RUN_DIR/rotation.pid"
+        emit_cmd "( phase=0; while true; do sleep $ROTATION_INTERVAL; phase=\$((1 - phase)); if [ \"\$phase\" = \"0\" ]; then td=/run-root/$TARGET_A_DIR_REL; bm=/run-root/$TARGET_A_BUGS_REL; else td=/run-root/$TARGET_B_DIR_REL; bm=/run-root/$TARGET_B_BUGS_REL; fi; tf=\$(podman exec stage3-laptop python3 -c \"import json,collections; j=json.load(open('\$bm')); fs=[b.get('file','') for b in j.get('bugs',[])]; c=collections.Counter(fs); print(c.most_common(1)[0][0] if c else 'lib.rs')\" 2>/dev/null || echo lib.rs); printf '%s,%s,%s\\n' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"\$td\" \"\$bm\" >>$ROTATIONS_CSV; podman exec stage3-laptop agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; done ) >>$RUN_DIR/rotation.log 2>&1 & echo \$! >$RUN_DIR/rotation.pid"
     else
         # Round-robin across A, B, plus whichever of C/D/E/F/G/H/I/J
         # were configured. Each iteration picks the next entry by integer
@@ -764,7 +768,7 @@ rotation_timer() {
         for k in $extra_targets; do
             targets_init="$targets_init; targets+=($k)"
         done
-        emit_cmd "( $targets_init; i=0; n=\${#targets[@]}; while true; do sleep $ROTATION_INTERVAL; k=\${targets[\$((i % n))]}; i=\$((i+1)); td_var=\"TARGET_\${k}_DIR_REL\"; bm_var=\"TARGET_\${k}_BUGS_REL\"; td=/run-root/\${!td_var}; bm=/run-root/\${!bm_var}; printf '%s,%s,%s\\n' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"\$td\" \"\$bm\" >>$ROTATIONS_CSV; podman exec stage3-laptop agentis memo set tribes-bench:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set tribes-bench:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set tribes-bench:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set tribes-bench:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; done ) >>$RUN_DIR/rotation.log 2>&1 & echo \$! >$RUN_DIR/rotation.pid"
+        emit_cmd "( $targets_init; i=0; n=\${#targets[@]}; while true; do sleep $ROTATION_INTERVAL; k=\${targets[\$((i % n))]}; i=\$((i+1)); td_var=\"TARGET_\${k}_DIR_REL\"; bm_var=\"TARGET_\${k}_BUGS_REL\"; td=/run-root/\${!td_var}; bm=/run-root/\${!bm_var}; tf=\$(podman exec stage3-laptop python3 -c \"import json,collections; j=json.load(open('\$bm')); fs=[b.get('file','') for b in j.get('bugs',[])]; c=collections.Counter(fs); print(c.most_common(1)[0][0] if c else 'lib.rs')\" 2>/dev/null || echo lib.rs); printf '%s,%s,%s\\n' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"\$td\" \"\$bm\" >>$ROTATIONS_CSV; podman exec stage3-laptop agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; done ) >>$RUN_DIR/rotation.log 2>&1 & echo \$! >$RUN_DIR/rotation.pid"
     fi
 }
 

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -155,9 +155,11 @@ assert_contains "bootstrap body writes colony.workers bound to peer worker IP:po
 assert_contains "rotation timer with configured interval" "$OUT" \
     "interval=120s"
 assert_contains "rotation timer cycles target_dir" "$OUT" \
-    "tribes-bench:target_dir"
+    "hunter:target_dir"
+assert_contains "rotation timer cycles target_file" "$OUT" \
+    "hunter:target_file"
 assert_contains "rotation timer cycles bugs_manifest" "$OUT" \
-    "tribes-bench:bugs_manifest"
+    "hunter:bugs_manifest"
 assert_contains "rotation toggles smallvec target" "$OUT" \
     "/run-root/targets/stage2/smallvec-v0.6.13"
 assert_contains "rotation toggles bumpalo target" "$OUT" \


### PR DESCRIPTION
## Summary

Fixes #546 (layer 1).

`tools/run-stage3-docker.sh` rotation timer was writing `tribes-bench:target_dir`
and `tribes-bench:bugs_manifest`, but `tribe-*/agents/hunter.ag` reads from
`hunter:target_dir` and `hunter:target_file` — different namespaces. So rotation
never affected hunter behaviour; hunters stayed locked on their bootstrap target
across an entire run. Diagnosed empirically in take-9 (93 verified hits all on
smallvec target A, zero on the stage3/stage4 substrate despite vendoring 8
RUSTSEC crates).

This PR:

- Replaces the four per-rotation memo writes with the `hunter:*` namespace
  (`hunter:target_dir`, `hunter:bugs_manifest`) in both rotation paths (legacy
  A/B alternation when no `STAGE3_TARGET_C..J` are configured, and the
  chunk-1/chunk-2 round-robin over A-J).
- Adds a new `hunter:target_file` memo write per rotation, derived from the
  rotated `bugs.json` via an in-container `python3 -c` one-liner that picks the
  most common `file` field across all bug entries (with a `lib.rs` fallback if
  the manifest is empty or unreadable).
- Total memo writes per rotation: 6 (was 4) — {target_dir, target_file, bugs_manifest} x {laptop, server}.
- `hunter:bugs_manifest` is a stub for layer 2 (cross-stage `BUGS_MANIFEST`
  env-var welding into daemon startup), which is **out of scope** here and
  deferred — see #546 for layer-2 tracking.
- Updates `test-run-stage3-docker.sh` assertions to pin the new keys
  (was: 165 assertions; now: 166, +1 for the `hunter:target_file` check).
- CHANGELOG entry under `[Unreleased]` -> `Fixed`.

## Test plan

- [x] `bash -n tribes-bench/tools/run-stage3-docker.sh` — syntax OK
- [x] `bash tribes-bench/tools/test-run-stage3-docker.sh` — 166 passed, 0 failed
- [x] `bash tools/colony-lint.sh` — 170 passed, 0 failed, 3 skipped (baseline preserved)
- [x] Dry-run emits `hunter:target_dir`, `hunter:target_file`, `hunter:bugs_manifest` in both A/B and round-robin loops; no `tribes-bench:*` rotation-key writes remain
- [x] Python3 one-liner validated standalone against `tribes-bench/targets/stage2/bugs.json` (prints `lib.rs`)
- [ ] End-to-end smoke: run a short tribes-bench federation with `STAGE3_ROTATION_INTERVAL_S=60` and verify hunter rotation by inspecting `hunter:target_dir` via `agentis memo get` inside each container after one rotation tick

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>