### PR TITLE
chore(tribes-bench): cap STAGE3_MAX_REPLICAS=3 default (#549)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -23,6 +23,9 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **chore(rate-limit):** orchestrator now caps per-tribe replicas at 3 by default via
+  `STAGE3_MAX_REPLICAS` env var. Keeps total concurrent daemon count predictable for
+  Claude Code flat-rate budgets ([#549](https://github.com/Replikanti/agentis-colonies/issues/549)).
 - **Stage 4 Phase 1 chunk 2: vendor 5 new RUSTSEC-anchored planted-bug crates + population-scaling knobs (#544)**.
   Brings the Stage 4 planted-bug substrate from 5 bugs / 3 classes
   (chunk 1: `crossbeam-deque`, `owning_ref`, `generator`) to 12 bugs /

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -63,6 +63,13 @@
 #                              smoke alive past the first burst phase.
 #                              Set to 0 to recover legacy cold-start
 #                              economy.
+#   STAGE3_MAX_REPLICAS        #549 burn-rate mitigation: cap replicas
+#                              per tribe so concurrent LLM-call traffic
+#                              stays under the Claude Code flat-rate
+#                              ceiling. Default 3 yields ~15 concurrent
+#                              daemons across 5 tribes (5 source + 10
+#                              replicas) vs take-10's observed 26-daemon
+#                              peak that exhausted the budget at T+25min.
 #   STAGE3_HUNTER_MAX_AGE      #487 follow-up: per-hunter age cap. Each
 #                              hunter increments its own age counter
 #                              (keyed on PPID, no shared-state RMW race)
@@ -296,6 +303,11 @@ DEATH_THRESHOLD="${STAGE3_DEATH_THRESHOLD:-300}"
 TRIBE_POOL_CAP="${STAGE3_TRIBE_POOL_CAP:-0}"
 TRIBE_METABOLIC_COST="${STAGE3_TRIBE_METABOLIC_COST:-0}"
 TRIBE_INITIAL_POOL="${STAGE3_TRIBE_INITIAL_POOL:-20000}"
+# #549 burn-rate mitigation: cap replicas per tribe to keep concurrent
+# LLM-call traffic under Claude Code flat-rate ceiling. Default 3 yields
+# ~15 concurrent daemons across 5 tribes (5 source + 10 replicas) vs
+# take-10's observed 26-daemon peak that exhausted the budget at T+25min.
+STAGE3_MAX_REPLICAS_VAL="${STAGE3_MAX_REPLICAS:-3}"
 # #487 follow-up: per-hunter age mortality. Each hunter has its own
 # monotonic age counter keyed on PPID; suicides via `agentis daemon stop`
 # when age > HUNTER_MAX_AGE. Eliminates the shared-state RMW race the
@@ -388,7 +400,8 @@ TARGET_J_BUGS_REL="${STAGE3_TARGET_J_BUGS:-}"
 val=""
 for var_name in WALL_CLOCK ROTATION_INTERVAL DEATH_THRESHOLD \
                 OPENAI_TIMEOUT_MS LAPTOP_PORT SERVER_PORT \
-                LAPTOP_WORKER_PORT SERVER_WORKER_PORT; do
+                LAPTOP_WORKER_PORT SERVER_WORKER_PORT \
+                STAGE3_MAX_REPLICAS_VAL; do
     eval "val=\${$var_name}"
     case "$val" in
         ''|*[!0-9]*)
@@ -470,6 +483,7 @@ fi
 emit_step "run-stage3-docker: starting (dry_run=$DRY_RUN)"
 emit_step "run dir: $RUN_DIR"
 emit_step "wall clock: ${WALL_CLOCK}s, rotation: ${ROTATION_INTERVAL}s, death threshold: ${DEATH_THRESHOLD}"
+emit_step "max replicas per tribe: $STAGE3_MAX_REPLICAS_VAL"
 emit_step "tribes: laptop=[${LAPTOP_TRIBES[*]}] server=[${SERVER_TRIBES[*]}]"
 emit_step "image tag: $IMAGE_TAG"
 emit_step "host ports: laptop=$LAPTOP_PORT server=$SERVER_PORT"
@@ -648,8 +662,8 @@ write_bootstrap() {
             # file to seed the tribe-<name>:bug_ledger memo from. Without
             # it, hunters verify findings but the JSONL ledger never
             # grows (visible in experience but missing from bug-ledger).
-            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s INITIAL_POOL=%s HUNTER_MAX_AGE=%s HUNTER_FITNESS_CREEP_PER_MINUTE=%s HUNTER_FITNESS_THRESHOLD_BASELINE=%s HUNTER_FITNESS_REWARD_VERIFIED=%s HUNTER_FITNESS_PENALTY_FALSEPOS=%s HUNTER_FITNESS_REWARD_REPLICATE=%s HUNTER_FITNESS_GRACE_MS=%s HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD=%s HUNTER_PROMPT_MAX_BYTES=%s HUNTER_PROMPT_EVOLUTION_THRESHOLD=%s HUNTER_PROMPT_GEN_CAP=%s HUNTER_PROMPT_LEVENSHTEIN_FLOOR=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl LEDGER_REWARD_FULL=200 LEDGER_REWARD_SUBSEQUENT=50 bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
-                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$TRIBE_INITIAL_POOL" "$HUNTER_MAX_AGE" "$HUNTER_FITNESS_CREEP_PER_MINUTE" "$HUNTER_FITNESS_THRESHOLD_BASELINE" "$HUNTER_FITNESS_REWARD_VERIFIED" "$HUNTER_FITNESS_PENALTY_FALSEPOS" "$HUNTER_FITNESS_REWARD_REPLICATE" "$HUNTER_FITNESS_GRACE_MS" "$HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD" "$HUNTER_PROMPT_MAX_BYTES" "$HUNTER_PROMPT_EVOLUTION_THRESHOLD" "$HUNTER_PROMPT_GEN_CAP" "$HUNTER_PROMPT_LEVENSHTEIN_FLOOR" "$tribe" "$tribe"
+            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s INITIAL_POOL=%s HUNTER_MAX_AGE=%s HUNTER_FITNESS_CREEP_PER_MINUTE=%s HUNTER_FITNESS_THRESHOLD_BASELINE=%s HUNTER_FITNESS_REWARD_VERIFIED=%s HUNTER_FITNESS_PENALTY_FALSEPOS=%s HUNTER_FITNESS_REWARD_REPLICATE=%s HUNTER_FITNESS_GRACE_MS=%s HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD=%s HUNTER_PROMPT_MAX_BYTES=%s HUNTER_PROMPT_EVOLUTION_THRESHOLD=%s HUNTER_PROMPT_GEN_CAP=%s HUNTER_PROMPT_LEVENSHTEIN_FLOOR=%s MAX_REPLICAS=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl LEDGER_REWARD_FULL=200 LEDGER_REWARD_SUBSEQUENT=50 bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
+                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$TRIBE_INITIAL_POOL" "$HUNTER_MAX_AGE" "$HUNTER_FITNESS_CREEP_PER_MINUTE" "$HUNTER_FITNESS_THRESHOLD_BASELINE" "$HUNTER_FITNESS_REWARD_VERIFIED" "$HUNTER_FITNESS_PENALTY_FALSEPOS" "$HUNTER_FITNESS_REWARD_REPLICATE" "$HUNTER_FITNESS_GRACE_MS" "$HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD" "$HUNTER_PROMPT_MAX_BYTES" "$HUNTER_PROMPT_EVOLUTION_THRESHOLD" "$HUNTER_PROMPT_GEN_CAP" "$HUNTER_PROMPT_LEVENSHTEIN_FLOOR" "$STAGE3_MAX_REPLICAS_VAL" "$tribe" "$tribe"
         done
         printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'
         printf 'exit 0\n'

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -427,6 +427,29 @@ assert_contains "per-tribe bootstrap line propagates HUNTER_PROMPT_EVOLUTION_THR
     "$(cat "$ORCH")" \
     "HUNTER_PROMPT_EVOLUTION_THRESHOLD=%s HUNTER_PROMPT_GEN_CAP=%s HUNTER_PROMPT_LEVENSHTEIN_FLOOR=%s"
 
+# 9a-549. #549 burn-rate mitigation: STAGE3_MAX_REPLICAS caps per-tribe
+# replicas so concurrent LLM-call traffic stays under Claude Code
+# flat-rate ceiling. Default 3 yields ~15 concurrent daemons across 5
+# tribes (5 source + 10 replicas) vs take-10's observed 26-daemon peak
+# that exhausted the budget at T+25min. Default dry-run must emit
+# `max replicas per tribe: 3`; an override of STAGE3_MAX_REPLICAS=7 must
+# propagate into the same emit_step line.
+assert_contains "STAGE3_MAX_REPLICAS default surfaces as 3 (#549)" "$OUT" \
+    "max replicas per tribe: 3"
+OUT_MAX_REPLICAS_OVERRIDE="$(STAGE3_WALL_CLOCK_S=1800 \
+       STAGE3_ROTATION_INTERVAL_S=120 \
+       STAGE3_DEATH_THRESHOLD=300 \
+       STAGE3_LAPTOP_PORT=9100 \
+       STAGE3_SERVER_PORT=9101 \
+       STAGE3_LAPTOP_WORKER_PORT=9200 \
+       STAGE3_SERVER_WORKER_PORT=9201 \
+       STAGE3_WORKER_SECRET=testsecret \
+       STAGE3_MAX_REPLICAS=7 \
+       bash "$ORCH" --dry-run 2>&1)"
+assert_contains "STAGE3_MAX_REPLICAS=7 override surfaces in emit_step output (#549)" \
+    "$OUT_MAX_REPLICAS_OVERRIDE" \
+    "max replicas per tribe: 7"
+
 # 9b. #528: STAGE3_DAEMON_CB_PER_TICK env var is documented, has the
 # documented default of 2000, and its hermetic-config emit line is
 # present (so the spawned daemon's per-tick CB budget actually rises


### PR DESCRIPTION
## Summary

Take-9 / take-10 1h smokes both exhausted the Claude Code flat-rate subscription at ~T+25min because peak concurrent daemons reached 26 (5 source + 21 replicas), driving ~1800-3000 LLM calls/h — well above the flat-rate ceiling. The Stage 3 docker orchestrator never overrode `MAX_REPLICAS` in its bootstrap env-injection printf, so tribes inherited start-colony.sh's effectively-unbounded default (999) and replicated until the pool drained.

This PR introduces `STAGE3_MAX_REPLICAS` (default 3) to the orchestrator. The new var is documented in the header docblock, validated as a positive integer, surfaced via `emit_step`, and threaded into the per-tribe bootstrap env line immediately before `AGENTIS_ROOT=`. Default 3 yields ~15 concurrent daemons across 5 tribes (5 source + 10 replicas), keeping total LLM-call traffic predictable for Claude Code flat-rate budgets.

## Changes

- `tribes-bench/tools/run-stage3-docker.sh`
  - Header docblock entry for `STAGE3_MAX_REPLICAS`.
  - `STAGE3_MAX_REPLICAS_VAL="${STAGE3_MAX_REPLICAS:-3}"` declaration co-located with the other tribe-economy vars (next to `TRIBE_INITIAL_POOL`).
  - Added to the positive-integer validation `for var_name in ...` loop.
  - `emit_step "max replicas per tribe: $STAGE3_MAX_REPLICAS_VAL"` next to the existing wall-clock / rotation / death-threshold step line.
  - Threaded into the per-tribe bootstrap `printf` (`MAX_REPLICAS=%s` immediately before `AGENTIS_ROOT=`).
- `tribes-bench/tools/test-run-stage3-docker.sh`
  - +2 dry-run assertions: default (`max replicas per tribe: 3`) and `STAGE3_MAX_REPLICAS=7` override surfaces in the same `emit_step` output.
- `tribes-bench/CHANGELOG.md`
  - New `### Changed` entry under `[Unreleased]`.

Out of scope: `hunter.ag`, `start-colony.sh`, verifier scripts, `.ag` files, `run-stage3-multinode.sh`, `VERSION`.

## Test plan

- [x] `bash -n tribes-bench/tools/run-stage3-docker.sh` — syntax clean.
- [x] `bash tools/colony-lint.sh` — 170 passed / 0 failed / 3 skipped.
- [x] `bash tribes-bench/tools/test-run-stage3-docker.sh` — 168 passed / 0 failed (+2 vs pre-#549 baseline of 166).
- [ ] Follow-up: 1h smoke run with `STAGE3_LLM_BACKEND=claude` and the default `STAGE3_MAX_REPLICAS=3` to confirm peak concurrent daemon count caps at ~15 and the flat-rate budget is not exhausted at T+25min.

Fixes #549