### PR TITLE
chore(tribes-bench): hunter tick interval env knob STAGE3_HUNTER_TICK_MS (#552)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -23,6 +23,9 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **chore(rate-limit):** hunter tick interval now overridable via `STAGE3_HUNTER_TICK_MS`
+  env, default 240000 ms (was hardcoded 60000). Extends wall-clock observation window
+  ~4x for emergence experiments within Claude Code flat-rate 5h ceiling ([#552](https://github.com/Replikanti/agentis-colonies/issues/552)).
 - **chore(rate-limit):** orchestrator now caps per-tribe replicas at 3 by default via
   `STAGE3_MAX_REPLICAS` env var. Keeps total concurrent daemon count predictable for
   Claude Code flat-rate budgets ([#549](https://github.com/Replikanti/agentis-colonies/issues/549)).

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -70,6 +70,17 @@
 #                              daemons across 5 tribes (5 source + 10
 #                              replicas) vs take-10's observed 26-daemon
 #                              peak that exhausted the budget at T+25min.
+#   STAGE3_HUNTER_TICK_MS      #552 burn-rate extension: hunter tick
+#                              interval (ms). Default 240000 (240s) is
+#                              4x the start-colony.sh hardcoded 60000;
+#                              preserves total LLM-call budget per smoke
+#                              but stretches wall clock 4x, giving
+#                              emergence observation a longer continuous
+#                              window within the Claude Code flat-rate
+#                              5h ceiling. Threaded into env_passthrough
+#                              as HUNTER_TICK_MS; each tribe's
+#                              start-colony.sh tick_interval_for()
+#                              hunter branch reads it (fallback 60000).
 #   STAGE3_HUNTER_MAX_AGE      #487 follow-up: per-hunter age cap. Each
 #                              hunter increments its own age counter
 #                              (keyed on PPID, no shared-state RMW race)
@@ -308,6 +319,12 @@ TRIBE_INITIAL_POOL="${STAGE3_TRIBE_INITIAL_POOL:-20000}"
 # ~15 concurrent daemons across 5 tribes (5 source + 10 replicas) vs
 # take-10's observed 26-daemon peak that exhausted the budget at T+25min.
 STAGE3_MAX_REPLICAS_VAL="${STAGE3_MAX_REPLICAS:-3}"
+# #552 burn-rate extension: hunter tick interval (ms). Default 240000
+# (240s) is 4x the start-colony.sh hardcoded 60000; preserves total
+# LLM-call budget per smoke but stretches wall clock 4x, giving
+# emergence observation longer continuous window within Claude Code
+# flat-rate 5h ceiling.
+STAGE3_HUNTER_TICK_MS_VAL="${STAGE3_HUNTER_TICK_MS:-240000}"
 # #487 follow-up: per-hunter age mortality. Each hunter has its own
 # monotonic age counter keyed on PPID; suicides via `agentis daemon stop`
 # when age > HUNTER_MAX_AGE. Eliminates the shared-state RMW race the
@@ -401,7 +418,8 @@ val=""
 for var_name in WALL_CLOCK ROTATION_INTERVAL DEATH_THRESHOLD \
                 OPENAI_TIMEOUT_MS LAPTOP_PORT SERVER_PORT \
                 LAPTOP_WORKER_PORT SERVER_WORKER_PORT \
-                STAGE3_MAX_REPLICAS_VAL; do
+                STAGE3_MAX_REPLICAS_VAL \
+                STAGE3_HUNTER_TICK_MS_VAL; do
     eval "val=\${$var_name}"
     case "$val" in
         ''|*[!0-9]*)
@@ -484,6 +502,7 @@ emit_step "run-stage3-docker: starting (dry_run=$DRY_RUN)"
 emit_step "run dir: $RUN_DIR"
 emit_step "wall clock: ${WALL_CLOCK}s, rotation: ${ROTATION_INTERVAL}s, death threshold: ${DEATH_THRESHOLD}"
 emit_step "max replicas per tribe: $STAGE3_MAX_REPLICAS_VAL"
+emit_step "hunter tick interval: ${STAGE3_HUNTER_TICK_MS_VAL} ms"
 emit_step "tribes: laptop=[${LAPTOP_TRIBES[*]}] server=[${SERVER_TRIBES[*]}]"
 emit_step "image tag: $IMAGE_TAG"
 emit_step "host ports: laptop=$LAPTOP_PORT server=$SERVER_PORT"
@@ -662,8 +681,8 @@ write_bootstrap() {
             # file to seed the tribe-<name>:bug_ledger memo from. Without
             # it, hunters verify findings but the JSONL ledger never
             # grows (visible in experience but missing from bug-ledger).
-            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s INITIAL_POOL=%s HUNTER_MAX_AGE=%s HUNTER_FITNESS_CREEP_PER_MINUTE=%s HUNTER_FITNESS_THRESHOLD_BASELINE=%s HUNTER_FITNESS_REWARD_VERIFIED=%s HUNTER_FITNESS_PENALTY_FALSEPOS=%s HUNTER_FITNESS_REWARD_REPLICATE=%s HUNTER_FITNESS_GRACE_MS=%s HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD=%s HUNTER_PROMPT_MAX_BYTES=%s HUNTER_PROMPT_EVOLUTION_THRESHOLD=%s HUNTER_PROMPT_GEN_CAP=%s HUNTER_PROMPT_LEVENSHTEIN_FLOOR=%s MAX_REPLICAS=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl LEDGER_REWARD_FULL=200 LEDGER_REWARD_SUBSEQUENT=50 bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
-                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$TRIBE_INITIAL_POOL" "$HUNTER_MAX_AGE" "$HUNTER_FITNESS_CREEP_PER_MINUTE" "$HUNTER_FITNESS_THRESHOLD_BASELINE" "$HUNTER_FITNESS_REWARD_VERIFIED" "$HUNTER_FITNESS_PENALTY_FALSEPOS" "$HUNTER_FITNESS_REWARD_REPLICATE" "$HUNTER_FITNESS_GRACE_MS" "$HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD" "$HUNTER_PROMPT_MAX_BYTES" "$HUNTER_PROMPT_EVOLUTION_THRESHOLD" "$HUNTER_PROMPT_GEN_CAP" "$HUNTER_PROMPT_LEVENSHTEIN_FLOOR" "$STAGE3_MAX_REPLICAS_VAL" "$tribe" "$tribe"
+            printf 'DEATH_THRESHOLD=%s POOL_CAP=%s METABOLIC_COST=%s INITIAL_POOL=%s HUNTER_MAX_AGE=%s HUNTER_FITNESS_CREEP_PER_MINUTE=%s HUNTER_FITNESS_THRESHOLD_BASELINE=%s HUNTER_FITNESS_REWARD_VERIFIED=%s HUNTER_FITNESS_PENALTY_FALSEPOS=%s HUNTER_FITNESS_REWARD_REPLICATE=%s HUNTER_FITNESS_GRACE_MS=%s HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD=%s HUNTER_PROMPT_MAX_BYTES=%s HUNTER_PROMPT_EVOLUTION_THRESHOLD=%s HUNTER_PROMPT_GEN_CAP=%s HUNTER_PROMPT_LEVENSHTEIN_FLOOR=%s MAX_REPLICAS=%s HUNTER_TICK_MS=%s AGENTIS_ROOT=/run-root/.agentis TARGET_DIR=targets-stage2/smallvec-v0.6.13 TARGET_FILE=lib.rs BUGS_MANIFEST=/run-root/.agentis/sandbox/targets-stage2/bugs.json VERIFIER_PATH=/run-root/tools/verify-finding-stage2.sh BUG_LEDGER_PATH=/run-root/bug-ledger.jsonl LEDGER_REWARD_FULL=200 LEDGER_REWARD_SUBSEQUENT=50 bash /run-root/%s/scripts/start-colony.sh > /run-root/%s.log 2>&1 &\n' \
+                "$DEATH_THRESHOLD" "$TRIBE_POOL_CAP" "$TRIBE_METABOLIC_COST" "$TRIBE_INITIAL_POOL" "$HUNTER_MAX_AGE" "$HUNTER_FITNESS_CREEP_PER_MINUTE" "$HUNTER_FITNESS_THRESHOLD_BASELINE" "$HUNTER_FITNESS_REWARD_VERIFIED" "$HUNTER_FITNESS_PENALTY_FALSEPOS" "$HUNTER_FITNESS_REWARD_REPLICATE" "$HUNTER_FITNESS_GRACE_MS" "$HUNTER_REPRODUCTIVE_FITNESS_THRESHOLD" "$HUNTER_PROMPT_MAX_BYTES" "$HUNTER_PROMPT_EVOLUTION_THRESHOLD" "$HUNTER_PROMPT_GEN_CAP" "$HUNTER_PROMPT_LEVENSHTEIN_FLOOR" "$STAGE3_MAX_REPLICAS_VAL" "$STAGE3_HUNTER_TICK_MS_VAL" "$tribe" "$tribe"
         done
         printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'
         printf 'exit 0\n'

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -450,6 +450,28 @@ assert_contains "STAGE3_MAX_REPLICAS=7 override surfaces in emit_step output (#5
     "$OUT_MAX_REPLICAS_OVERRIDE" \
     "max replicas per tribe: 7"
 
+# 9a-552. #552 burn-rate extension: STAGE3_HUNTER_TICK_MS overrides the
+# start-colony.sh hardcoded 60000 hunter tick (preserves total LLM-call
+# budget per smoke but stretches wall clock to fit emergence observation
+# inside Claude Code flat-rate 5h ceiling). Default 240000 must surface
+# in the emit_step transcript; an override of STAGE3_HUNTER_TICK_MS=600000
+# must propagate into the same emit_step line.
+assert_contains "STAGE3_HUNTER_TICK_MS default surfaces as 240000 ms (#552)" "$OUT" \
+    "hunter tick interval: 240000 ms"
+OUT_HUNTER_TICK_OVERRIDE="$(STAGE3_WALL_CLOCK_S=1800 \
+       STAGE3_ROTATION_INTERVAL_S=120 \
+       STAGE3_DEATH_THRESHOLD=300 \
+       STAGE3_LAPTOP_PORT=9100 \
+       STAGE3_SERVER_PORT=9101 \
+       STAGE3_LAPTOP_WORKER_PORT=9200 \
+       STAGE3_SERVER_WORKER_PORT=9201 \
+       STAGE3_WORKER_SECRET=testsecret \
+       STAGE3_HUNTER_TICK_MS=600000 \
+       bash "$ORCH" --dry-run 2>&1)"
+assert_contains "STAGE3_HUNTER_TICK_MS=600000 override surfaces in emit_step output (#552)" \
+    "$OUT_HUNTER_TICK_OVERRIDE" \
+    "hunter tick interval: 600000 ms"
+
 # 9b. #528: STAGE3_DAEMON_CB_PER_TICK env var is documented, has the
 # documented default of 2000, and its hermetic-config emit line is
 # present (so the spawned daemon's per-tick CB budget actually rises

--- a/tribes-bench/tribe-alpha/scripts/start-colony.sh
+++ b/tribes-bench/tribe-alpha/scripts/start-colony.sh
@@ -108,10 +108,13 @@ if [ ${#AGENTS[@]} -eq 0 ] && [ "$RATE_LIMIT_STATUS" = "0" ] && [ -z "$RESTART_A
 fi
 
 # Per-agent tick-interval override. Stage 0 hunter agents tick at 60s for
-# ~15 ticks per agent over the 900s wall-clock cap.
+# ~15 ticks per agent over the 900s wall-clock cap. HUNTER_TICK_MS env
+# (set by Stage 3 orchestrator via STAGE3_HUNTER_TICK_MS, default 240000
+# = 240s) extends wall-clock observation window within flat-rate LLM
+# budget (#552).
 tick_interval_for() {
     case "$1" in
-        hunter) echo 60000 ;;
+        hunter) echo "${HUNTER_TICK_MS:-60000}" ;;
         *) echo 60000 ;;
     esac
 }

--- a/tribes-bench/tribe-beta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-beta/scripts/start-colony.sh
@@ -108,10 +108,13 @@ if [ ${#AGENTS[@]} -eq 0 ] && [ "$RATE_LIMIT_STATUS" = "0" ] && [ -z "$RESTART_A
 fi
 
 # Per-agent tick-interval override. Stage 0 hunter agents tick at 60s for
-# ~15 ticks per agent over the 900s wall-clock cap.
+# ~15 ticks per agent over the 900s wall-clock cap. HUNTER_TICK_MS env
+# (set by Stage 3 orchestrator via STAGE3_HUNTER_TICK_MS, default 240000
+# = 240s) extends wall-clock observation window within flat-rate LLM
+# budget (#552).
 tick_interval_for() {
     case "$1" in
-        hunter) echo 60000 ;;
+        hunter) echo "${HUNTER_TICK_MS:-60000}" ;;
         *) echo 60000 ;;
     esac
 }

--- a/tribes-bench/tribe-delta/scripts/start-colony.sh
+++ b/tribes-bench/tribe-delta/scripts/start-colony.sh
@@ -108,10 +108,13 @@ if [ ${#AGENTS[@]} -eq 0 ] && [ "$RATE_LIMIT_STATUS" = "0" ] && [ -z "$RESTART_A
 fi
 
 # Per-agent tick-interval override. Stage 0 hunter agents tick at 60s for
-# ~15 ticks per agent over the 900s wall-clock cap.
+# ~15 ticks per agent over the 900s wall-clock cap. HUNTER_TICK_MS env
+# (set by Stage 3 orchestrator via STAGE3_HUNTER_TICK_MS, default 240000
+# = 240s) extends wall-clock observation window within flat-rate LLM
+# budget (#552).
 tick_interval_for() {
     case "$1" in
-        hunter) echo 60000 ;;
+        hunter) echo "${HUNTER_TICK_MS:-60000}" ;;
         *) echo 60000 ;;
     esac
 }

--- a/tribes-bench/tribe-epsilon/scripts/start-colony.sh
+++ b/tribes-bench/tribe-epsilon/scripts/start-colony.sh
@@ -108,10 +108,13 @@ if [ ${#AGENTS[@]} -eq 0 ] && [ "$RATE_LIMIT_STATUS" = "0" ] && [ -z "$RESTART_A
 fi
 
 # Per-agent tick-interval override. Stage 0 hunter agents tick at 60s for
-# ~15 ticks per agent over the 900s wall-clock cap.
+# ~15 ticks per agent over the 900s wall-clock cap. HUNTER_TICK_MS env
+# (set by Stage 3 orchestrator via STAGE3_HUNTER_TICK_MS, default 240000
+# = 240s) extends wall-clock observation window within flat-rate LLM
+# budget (#552).
 tick_interval_for() {
     case "$1" in
-        hunter) echo 60000 ;;
+        hunter) echo "${HUNTER_TICK_MS:-60000}" ;;
         *) echo 60000 ;;
     esac
 }

--- a/tribes-bench/tribe-gamma/scripts/start-colony.sh
+++ b/tribes-bench/tribe-gamma/scripts/start-colony.sh
@@ -108,10 +108,13 @@ if [ ${#AGENTS[@]} -eq 0 ] && [ "$RATE_LIMIT_STATUS" = "0" ] && [ -z "$RESTART_A
 fi
 
 # Per-agent tick-interval override. Stage 0 hunter agents tick at 60s for
-# ~15 ticks per agent over the 900s wall-clock cap.
+# ~15 ticks per agent over the 900s wall-clock cap. HUNTER_TICK_MS env
+# (set by Stage 3 orchestrator via STAGE3_HUNTER_TICK_MS, default 240000
+# = 240s) extends wall-clock observation window within flat-rate LLM
+# budget (#552).
 tick_interval_for() {
     case "$1" in
-        hunter) echo 60000 ;;
+        hunter) echo "${HUNTER_TICK_MS:-60000}" ;;
         *) echo 60000 ;;
     esac
 }


### PR DESCRIPTION
## Summary

Fixes #552.

Adds `STAGE3_HUNTER_TICK_MS` to the Docker Stage 3 orchestrator, default `240000` ms,
threaded into each tribe's `start-colony.sh` `tick_interval_for()` hunter branch via the
`HUNTER_TICK_MS` env var. Only the `hunter)` branch is touched; the non-hunter (`*`)
branch keeps `60000` byte-for-byte. The 60000 fallback is preserved when `HUNTER_TICK_MS`
is unset so legacy callers and non-Stage-3 invocations are unaffected.

## Reframe (why scaling tick rather than count)

Tick scaling does **not** reduce total LLM-call budget per smoke. The same total spend
gets spread over a longer wall-clock window (4x over the previous hardcoded 60000 at
the new default of 240000). That's the requirement for emergence observation: the 5h
rolling message ceiling on Claude Code flat-rate was exhausting at ~T+25min from peak
concurrent daemon traffic, killing the smoke before prompt-evolution generations could
stabilise. Stretching the window to fit inside one 5h flat-rate ceiling gives lineage
drift / generation accumulation continuous observation room without changing per-smoke
spend.

## Files (8)

- `tribes-bench/tools/run-stage3-docker.sh` — env-var docstring + `STAGE3_HUNTER_TICK_MS_VAL` declaration + validation list entry + `emit_step` + threaded into bootstrap printf as `HUNTER_TICK_MS=%s` immediately before `AGENTIS_ROOT=`.
- `tribes-bench/tribe-{alpha,beta,gamma,delta,epsilon}/scripts/start-colony.sh` (5 files) — `tick_interval_for()` hunter branch reads `${HUNTER_TICK_MS:-60000}`. Identical 4-line change in all 5 tribes.
- `tribes-bench/tools/test-run-stage3-docker.sh` — +2 assertions (default 240000, override surfaces).
- `tribes-bench/CHANGELOG.md` — Changed entry under `[Unreleased]`.

## Test plan

- [x] `bash -n` on orchestrator + 5 `start-colony.sh` files — clean
- [x] `tools/colony-lint.sh` — 170 passed, 0 failed, 3 skipped
- [x] `tribes-bench/tools/test-run-stage3-docker.sh` — 170/0 (was 168 before #552, +2 for the new assertions)
- [x] Default dry-run emits `# hunter tick interval: 240000 ms`
- [x] Override `STAGE3_HUNTER_TICK_MS=600000` dry-run emits `# hunter tick interval: 600000 ms`
- [x] Orchestrator printf format-string `%s` count (20) matches arg count (20) after threading