### PR TITLE
chore(tribes-bench): STAGE3_CLAUDE_CAVEMAN env knob (#554)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -29,6 +29,13 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 - **chore(rate-limit):** orchestrator now caps per-tribe replicas at 3 by default via
   `STAGE3_MAX_REPLICAS` env var. Keeps total concurrent daemon count predictable for
   Claude Code flat-rate budgets ([#549](https://github.com/Replikanti/agentis-colonies/issues/549)).
+
+### Added
+
+- **chore(rate-limit):** `STAGE3_CLAUDE_CAVEMAN` env knob (default off). When set to 1,
+  orchestrator passes `--tools "" --system-prompt <minimal> --effort low` to claude CLI,
+  stripping default Claude Code session overhead from ~38K to ~11K tokens per hunter call.
+  Reduces flat-rate weekly burn ~50% per smoke ([#554](https://github.com/Replikanti/agentis-colonies/issues/554)).
 - **Stage 4 Phase 1 chunk 2: vendor 5 new RUSTSEC-anchored planted-bug crates + population-scaling knobs (#544)**.
   Brings the Stage 4 planted-bug substrate from 5 bugs / 3 classes
   (chunk 1: `crossbeam-deque`, `owning_ref`, `generator`) to 12 bugs /

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -81,6 +81,13 @@
 #                              as HUNTER_TICK_MS; each tribe's
 #                              start-colony.sh tick_interval_for()
 #                              hunter branch reads it (fallback 60000).
+#   STAGE3_CLAUDE_CAVEMAN      #554 burn-rate mitigation: when "1",
+#                              passes --tools "" --system-prompt <min>
+#                              --effort low to claude CLI. Strips
+#                              Claude Code session overhead from ~38K
+#                              to ~11K tokens per hunter call. Stays
+#                              on flat-rate (does NOT use --bare which
+#                              would force API key auth). Default "0".
 #   STAGE3_HUNTER_MAX_AGE      #487 follow-up: per-hunter age cap. Each
 #                              hunter increments its own age counter
 #                              (keyed on PPID, no shared-state RMW race)
@@ -325,6 +332,17 @@ STAGE3_MAX_REPLICAS_VAL="${STAGE3_MAX_REPLICAS:-3}"
 # emergence observation longer continuous window within Claude Code
 # flat-rate 5h ceiling.
 STAGE3_HUNTER_TICK_MS_VAL="${STAGE3_HUNTER_TICK_MS:-240000}"
+# #554 burn-rate mitigation: caveman Claude CLI mode. When on, the
+# orchestrator passes --tools "" --system-prompt <minimal> --effort low
+# to claude CLI to strip default Claude Code session overhead from
+# ~38K to ~11K tokens per hunter call. Stays on flat-rate (no --bare).
+# Default off to keep current behaviour as baseline until validation
+# smoke confirms quality parity.
+STAGE3_CLAUDE_CAVEMAN_VAL="${STAGE3_CLAUDE_CAVEMAN:-0}"
+# Minimal system prompt used in caveman mode. ~200 tokens (vs ~38K
+# default Claude Code system prompt). Single-line for shell-escape
+# simplicity through bootstrap.sh + .agentis/config layers.
+STAGE3_CAVEMAN_SYSTEM_PROMPT='You are a Rust unsafe-code static analyzer. Return ONLY valid JSON matching the requested schema. Do not explain or chain-of-thought outside the JSON.'
 # #487 follow-up: per-hunter age mortality. Each hunter has its own
 # monotonic age counter keyed on PPID; suicides via `agentis daemon stop`
 # when age > HUNTER_MAX_AGE. Eliminates the shared-state RMW race the
@@ -430,6 +448,16 @@ for var_name in WALL_CLOCK ROTATION_INTERVAL DEATH_THRESHOLD \
 done
 unset val
 
+# #554 burn-rate mitigation: STAGE3_CLAUDE_CAVEMAN is a boolean toggle
+# (0 or 1), not an integer; validate separately from the positive-int loop.
+case "$STAGE3_CLAUDE_CAVEMAN_VAL" in
+    0|1) ;;
+    *)
+        echo "run-stage3-docker: STAGE3_CLAUDE_CAVEMAN must be 0 or 1 (got '$STAGE3_CLAUDE_CAVEMAN_VAL')" >&2
+        exit 2
+        ;;
+esac
+
 # Convert space-separated tribe lists into arrays (set -u + IFS-default
 # splitting cooperate as long as we don't quote the expansion here).
 # shellcheck disable=SC2206
@@ -503,6 +531,11 @@ emit_step "run dir: $RUN_DIR"
 emit_step "wall clock: ${WALL_CLOCK}s, rotation: ${ROTATION_INTERVAL}s, death threshold: ${DEATH_THRESHOLD}"
 emit_step "max replicas per tribe: $STAGE3_MAX_REPLICAS_VAL"
 emit_step "hunter tick interval: ${STAGE3_HUNTER_TICK_MS_VAL} ms"
+if [ "$STAGE3_CLAUDE_CAVEMAN_VAL" = "1" ]; then
+    emit_step "caveman mode: enabled (--tools '' --system-prompt minimal --effort low)"
+else
+    emit_step "caveman mode: disabled (default Claude CLI overhead)"
+fi
 emit_step "tribes: laptop=[${LAPTOP_TRIBES[*]}] server=[${SERVER_TRIBES[*]}]"
 emit_step "image tag: $IMAGE_TAG"
 emit_step "host ports: laptop=$LAPTOP_PORT server=$SERVER_PORT"
@@ -603,6 +636,18 @@ write_bootstrap() {
             printf '  printf "llm.openai.model = %s\\n"\n' "$OPENAI_MODEL"
             printf '  printf "llm.openai.api_key_env = %s\\n"\n' "$OPENAI_KEY_ENV"
             printf '  printf "llm.openai.timeout_ms = %s\\n"\n' "$OPENAI_TIMEOUT_MS"
+        fi
+        # #554 burn-rate mitigation: when caveman mode is on, inject
+        # llm.command + llm.args to drive the claude CLI with minimal
+        # session overhead (--tools "" --system-prompt <minimal> --effort
+        # low). Strips Claude Code default system prompt + tools manifest
+        # from each hunter call (~38K → ~11K tokens). Stays on flat-rate
+        # OAuth (no --bare). Default off keeps the emitted config
+        # byte-identical to the pre-#554 baseline.
+        if [ "$STAGE3_CLAUDE_CAVEMAN_VAL" = "1" ]; then
+            escaped_caveman_prompt=$(printf '%s' "$STAGE3_CAVEMAN_SYSTEM_PROMPT" | sed 's/"/\\"/g')
+            printf '  printf "llm.command = claude\\n"\n'
+            printf '  printf "llm.args = -p --output-format json --tools \\"\\" --system-prompt \\"%s\\" --effort low\\n"\n' "$escaped_caveman_prompt"
         fi
         printf '  printf "colony.secret = %%s\\n" "$WORKER_SECRET"\n'
         printf '} >> .agentis/config\n'

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -472,6 +472,26 @@ assert_contains "STAGE3_HUNTER_TICK_MS=600000 override surfaces in emit_step out
     "$OUT_HUNTER_TICK_OVERRIDE" \
     "hunter tick interval: 600000 ms"
 
+# 9a-554. #554 burn-rate mitigation: STAGE3_CLAUDE_CAVEMAN gates the
+# minimal-overhead claude CLI mode. Default 0 must surface as `caveman
+# mode: disabled`; an override of STAGE3_CLAUDE_CAVEMAN=1 must surface
+# as `caveman mode: enabled (...)`.
+assert_contains "STAGE3_CLAUDE_CAVEMAN default surfaces as disabled (#554)" "$OUT" \
+    "caveman mode: disabled"
+OUT_CAVEMAN_ENABLED="$(STAGE3_WALL_CLOCK_S=1800 \
+       STAGE3_ROTATION_INTERVAL_S=120 \
+       STAGE3_DEATH_THRESHOLD=300 \
+       STAGE3_LAPTOP_PORT=9100 \
+       STAGE3_SERVER_PORT=9101 \
+       STAGE3_LAPTOP_WORKER_PORT=9200 \
+       STAGE3_SERVER_WORKER_PORT=9201 \
+       STAGE3_WORKER_SECRET=testsecret \
+       STAGE3_CLAUDE_CAVEMAN=1 \
+       bash "$ORCH" --dry-run 2>&1)"
+assert_contains "STAGE3_CLAUDE_CAVEMAN=1 override surfaces in emit_step output (#554)" \
+    "$OUT_CAVEMAN_ENABLED" \
+    "caveman mode: enabled (--tools '' --system-prompt minimal --effort low)"
+
 # 9b. #528: STAGE3_DAEMON_CB_PER_TICK env var is documented, has the
 # documented default of 2000, and its hermetic-config emit line is
 # present (so the spawned daemon's per-tick CB budget actually rises


### PR DESCRIPTION
## Summary

- Adds `STAGE3_CLAUDE_CAVEMAN` env knob (default `0` = off) to `run-stage3-docker.sh`. When `1`, orchestrator injects `llm.command = claude` plus `llm.args = -p --output-format json --tools "" --system-prompt <minimal> --effort low` into each container's hermetic `.agentis/config`.
- Strips default Claude Code session overhead (system prompt + tools manifest + memory framework) from `~38K` to `~11K` tokens per hunter call. Stays on flat-rate OAuth (does NOT use `--bare` which would force API key auth).
- Empirically observed reduction: take-11 30-min smoke burned ~20% of weekly token budget; this drops per-call cache_creation from ~28K to ~11K, projecting ~50% weekly burn reduction per smoke at parity tick budget.

Default-off keeps emitted config byte-identical to the pre-#554 baseline. Promotion to default is gated on a validation smoke confirming quality parity (verified findings rate per smoke unchanged).

Fixes #554.

## Test plan

- [x] `bash -n tribes-bench/tools/run-stage3-docker.sh` clean
- [x] `tools/colony-lint.sh` green (170/0/3 baseline preserved)
- [x] `tribes-bench/tools/test-run-stage3-docker.sh` 172/0 (was 170/0 after #553; +2 assertions for default disabled / override enabled)
- [x] Dry-run inspection (default): emitted bootstrap.sh contains no `llm.command` or `llm.args` lines (existing baseline)
- [x] Dry-run inspection (override `STAGE3_CLAUDE_CAVEMAN=1`): emitted `.agentis/config` shows `llm.command = claude` and `llm.args = -p --output-format json --tools "" --system-prompt "You are a Rust unsafe-code static analyzer. Return ONLY valid JSON matching the requested schema. Do not explain or chain-of-thought outside the JSON." --effort low` with both quote layers surviving the two-stage `printf` chain (orchestrator → bootstrap.sh → `.agentis/config`)
- [x] `STAGE3_CLAUDE_CAVEMAN=2` exits 2 with `must be 0 or 1 (got '2')` validation error
- [ ] Follow-up: validation smoke run under `STAGE3_CLAUDE_CAVEMAN=1` to confirm verified-findings rate parity before considering flipping default

Generated with Claude Code.