### PR TITLE
chore(tribes-bench): STAGE3_CLAUDE_EFFORT knob (#557)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -32,6 +32,9 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **chore(rate-limit):** `STAGE3_CLAUDE_EFFORT` env knob (low|medium|high|xhigh|max, default
+  medium). Tunes claude CLI reasoning depth in caveman mode. Replaces PR #555's hardcoded
+  `--effort low` after take-12 showed 46% verified-hit regression at low ([#557](https://github.com/Replikanti/agentis-colonies/issues/557)).
 - **chore(rate-limit):** `STAGE3_CLAUDE_CAVEMAN` env knob (default off). When set to 1,
   orchestrator passes `--tools "" --system-prompt <minimal> --effort low` to claude CLI,
   stripping default Claude Code session overhead from ~38K to ~11K tokens per hunter call.

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -88,6 +88,9 @@
 #                              to ~11K tokens per hunter call. Stays
 #                              on flat-rate (does NOT use --bare which
 #                              would force API key auth). Default "0".
+#   STAGE3_CLAUDE_EFFORT       #557: claude CLI reasoning depth when
+#                              caveman mode is on. One of: low, medium,
+#                              high, xhigh, max. Default "medium".
 #   STAGE3_HUNTER_MAX_AGE      #487 follow-up: per-hunter age cap. Each
 #                              hunter increments its own age counter
 #                              (keyed on PPID, no shared-state RMW race)
@@ -339,6 +342,12 @@ STAGE3_HUNTER_TICK_MS_VAL="${STAGE3_HUNTER_TICK_MS:-240000}"
 # Default off to keep current behaviour as baseline until validation
 # smoke confirms quality parity.
 STAGE3_CLAUDE_CAVEMAN_VAL="${STAGE3_CLAUDE_CAVEMAN:-0}"
+# #557 quality-vs-burn tuning: claude CLI --effort flag. Gates chain-of-
+# thought reasoning depth. Default "medium" recovers most of take-11
+# quality at modest burn cost; "low" is most aggressive burn-reduction
+# but regressed verified hits 46% in take-12. Only consulted when
+# STAGE3_CLAUDE_CAVEMAN=1.
+STAGE3_CLAUDE_EFFORT_VAL="${STAGE3_CLAUDE_EFFORT:-medium}"
 # Minimal system prompt used in caveman mode. ~200 tokens (vs ~38K
 # default Claude Code system prompt). Single-line for shell-escape
 # simplicity through bootstrap.sh + .agentis/config layers.
@@ -458,6 +467,16 @@ case "$STAGE3_CLAUDE_CAVEMAN_VAL" in
         ;;
 esac
 
+# #557 quality-vs-burn tuning: validate STAGE3_CLAUDE_EFFORT always (not
+# conditional on caveman) so misconfigurations surface early.
+case "$STAGE3_CLAUDE_EFFORT_VAL" in
+    low|medium|high|xhigh|max) ;;
+    *)
+        echo "run-stage3-docker: STAGE3_CLAUDE_EFFORT must be one of low|medium|high|xhigh|max (got '$STAGE3_CLAUDE_EFFORT_VAL')" >&2
+        exit 2
+        ;;
+esac
+
 # Convert space-separated tribe lists into arrays (set -u + IFS-default
 # splitting cooperate as long as we don't quote the expansion here).
 # shellcheck disable=SC2206
@@ -532,7 +551,7 @@ emit_step "wall clock: ${WALL_CLOCK}s, rotation: ${ROTATION_INTERVAL}s, death th
 emit_step "max replicas per tribe: $STAGE3_MAX_REPLICAS_VAL"
 emit_step "hunter tick interval: ${STAGE3_HUNTER_TICK_MS_VAL} ms"
 if [ "$STAGE3_CLAUDE_CAVEMAN_VAL" = "1" ]; then
-    emit_step "caveman mode: enabled (--tools '' --system-prompt minimal --effort low)"
+    emit_step "caveman mode: enabled (--tools '' --system-prompt minimal --effort $STAGE3_CLAUDE_EFFORT_VAL)"
 else
     emit_step "caveman mode: disabled (default Claude CLI overhead)"
 fi
@@ -647,7 +666,7 @@ write_bootstrap() {
         if [ "$STAGE3_CLAUDE_CAVEMAN_VAL" = "1" ]; then
             escaped_caveman_prompt=$(printf '%s' "$STAGE3_CAVEMAN_SYSTEM_PROMPT" | sed 's/"/\\"/g')
             printf '  printf "llm.command = claude\\n"\n'
-            printf '  printf "llm.args = -p --output-format json --tools \\"\\" --system-prompt \\"%s\\" --effort low\\n"\n' "$escaped_caveman_prompt"
+            printf '  printf "llm.args = -p --output-format json --tools \\"\\" --system-prompt \\"%s\\" --effort %s\\n"\n' "$escaped_caveman_prompt" "$STAGE3_CLAUDE_EFFORT_VAL"
         fi
         printf '  printf "colony.secret = %%s\\n" "$WORKER_SECRET"\n'
         printf '} >> .agentis/config\n'

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -490,7 +490,49 @@ OUT_CAVEMAN_ENABLED="$(STAGE3_WALL_CLOCK_S=1800 \
        bash "$ORCH" --dry-run 2>&1)"
 assert_contains "STAGE3_CLAUDE_CAVEMAN=1 override surfaces in emit_step output (#554)" \
     "$OUT_CAVEMAN_ENABLED" \
-    "caveman mode: enabled (--tools '' --system-prompt minimal --effort low)"
+    "caveman mode: enabled (--tools '' --system-prompt minimal --effort medium)"
+
+# 9a-557. #557 quality-vs-burn tuning: STAGE3_CLAUDE_EFFORT gates the
+# claude CLI --effort flag value when caveman mode is on. Default
+# "medium" must surface in the emit_step transcript; an override to
+# "high" must surface as `--effort high`; an invalid value must exit 2
+# with a helpful stderr message (validated unconditionally so operators
+# learn about misconfig regardless of caveman state).
+OUT_EFFORT_HIGH="$(STAGE3_WALL_CLOCK_S=1800 \
+       STAGE3_ROTATION_INTERVAL_S=120 \
+       STAGE3_DEATH_THRESHOLD=300 \
+       STAGE3_LAPTOP_PORT=9100 \
+       STAGE3_SERVER_PORT=9101 \
+       STAGE3_LAPTOP_WORKER_PORT=9200 \
+       STAGE3_SERVER_WORKER_PORT=9201 \
+       STAGE3_WORKER_SECRET=testsecret \
+       STAGE3_CLAUDE_CAVEMAN=1 \
+       STAGE3_CLAUDE_EFFORT=high \
+       bash "$ORCH" --dry-run 2>&1)"
+assert_contains "STAGE3_CLAUDE_EFFORT=high override surfaces in emit_step output (#557)" \
+    "$OUT_EFFORT_HIGH" \
+    "caveman mode: enabled (--tools '' --system-prompt minimal --effort high)"
+EFFORT_BAD_RC=0
+EFFORT_BAD_OUT="$(STAGE3_WALL_CLOCK_S=1800 \
+       STAGE3_ROTATION_INTERVAL_S=120 \
+       STAGE3_DEATH_THRESHOLD=300 \
+       STAGE3_LAPTOP_PORT=9100 \
+       STAGE3_SERVER_PORT=9101 \
+       STAGE3_LAPTOP_WORKER_PORT=9200 \
+       STAGE3_SERVER_WORKER_PORT=9201 \
+       STAGE3_WORKER_SECRET=testsecret \
+       STAGE3_CLAUDE_EFFORT=garbage \
+       bash "$ORCH" --dry-run 2>&1)" || EFFORT_BAD_RC=$?
+if [ "$EFFORT_BAD_RC" -eq 2 ]; then
+    echo "[PASS] STAGE3_CLAUDE_EFFORT=garbage exits 2 (#557)"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] STAGE3_CLAUDE_EFFORT=garbage should exit 2, got $EFFORT_BAD_RC (#557)"
+    FAIL=$((FAIL + 1))
+fi
+assert_contains "STAGE3_CLAUDE_EFFORT=garbage stderr names allowed values (#557)" \
+    "$EFFORT_BAD_OUT" \
+    "STAGE3_CLAUDE_EFFORT must be one of low|medium|high|xhigh|max"
 
 # 9b. #528: STAGE3_DAEMON_CB_PER_TICK env var is documented, has the
 # documented default of 2000, and its hermetic-config emit line is


### PR DESCRIPTION
Fixes #557.

## Summary

- New env knob `STAGE3_CLAUDE_EFFORT` accepting `low|medium|high|xhigh|max`, default `medium`. Parameterizes the `--effort` flag PR #555 introduced as a hardcoded `low`.
- Only consulted when `STAGE3_CLAUDE_CAVEMAN=1` (caveman-off path stays byte-identical to the post-#555 baseline). Effort value is validated unconditionally so misconfiguration surfaces early.
- Documented in the orchestrator header docstring, emitted into the `caveman mode: enabled (...)` `emit_step` line, and threaded into the bootstrap `llm.args` printf as a second `%s` slot alongside the system prompt.

## Motivation — take-12 evidence

PR #555 take-12 smoke (caveman=1, hardcoded `--effort low`) confirmed dramatic burn reduction: output tokens dropped 91% (915K -> 80K). BUT verified hits regressed 46% (67 -> 36), below the +/- 20% parity threshold. Hypothesis: `--effort low` strips too much chain-of-thought for subtle bugs requiring cross-function ownership tracking (e.g. the missed S2-SMVUAF-002).

`medium` is the new caveman baseline chosen to recover most of take-11's quality at modest burn cost; operators can still pick `low` for max burn savings or `high`/`xhigh`/`max` for parity-with-Claude-Code-defaults reasoning depth.

## Acceptance criteria

- [ ] Take-13 run (caveman=1, effort=medium) recovers >= 80% of take-11's verified-hit baseline.
- [ ] Burn rate remains materially below the take-11 (non-caveman) ~915K output-token level.

## Test plan

- [x] `bash -n tribes-bench/tools/run-stage3-docker.sh` — syntax clean
- [x] `bash tools/colony-lint.sh` — 170 passed, 0 failed, 3 skipped
- [x] `bash tribes-bench/tools/test-run-stage3-docker.sh` — **175** passed, 0 failed (was 172 after #555: +3 assertions)
- [x] Dry-run inspection — caveman=1 default emits `--effort medium`; `STAGE3_CLAUDE_EFFORT=high` emits `--effort high`; `STAGE3_CLAUDE_EFFORT=garbage` exits 2 with helpful stderr; caveman=0 path is byte-identical to post-#555 baseline (verified via stripped diff).