### PR TITLE
chore(tribes-bench): promote STAGE3_CLAUDE_CAVEMAN default to 1 (#559)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -23,6 +23,10 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **chore(rate-limit):** `STAGE3_CLAUDE_CAVEMAN` default flipped from 0 to 1 after take-13
+  acceptance smoke confirmed caveman+medium effort is quality-equivalent to baseline (5/5
+  stage2 bugs identified) at 52% native cost / 80% output tokens. Operators wanting default
+  Claude Code session behavior can opt out via `STAGE3_CLAUDE_CAVEMAN=0` ([#559](https://github.com/Replikanti/agentis-colonies/issues/559)).
 - **chore(rate-limit):** hunter tick interval now overridable via `STAGE3_HUNTER_TICK_MS`
   env, default 240000 ms (was hardcoded 60000). Extends wall-clock observation window
   ~4x for emergence experiments within Claude Code flat-rate 5h ceiling ([#552](https://github.com/Replikanti/agentis-colonies/issues/552)).

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -87,7 +87,8 @@
 #                              Claude Code session overhead from ~38K
 #                              to ~11K tokens per hunter call. Stays
 #                              on flat-rate (does NOT use --bare which
-#                              would force API key auth). Default "0".
+#                              would force API key auth). Default "1"
+#                              since #559.
 #   STAGE3_CLAUDE_EFFORT       #557: claude CLI reasoning depth when
 #                              caveman mode is on. One of: low, medium,
 #                              high, xhigh, max. Default "medium".
@@ -339,9 +340,12 @@ STAGE3_HUNTER_TICK_MS_VAL="${STAGE3_HUNTER_TICK_MS:-240000}"
 # orchestrator passes --tools "" --system-prompt <minimal> --effort low
 # to claude CLI to strip default Claude Code session overhead from
 # ~38K to ~11K tokens per hunter call. Stays on flat-rate (no --bare).
-# Default off to keep current behaviour as baseline until validation
-# smoke confirms quality parity.
-STAGE3_CLAUDE_CAVEMAN_VAL="${STAGE3_CLAUDE_CAVEMAN:-0}"
+# Default on as of #559 — take-13 acceptance smoke validated caveman+medium
+# (STAGE3_CLAUDE_EFFORT=medium) as quality-equivalent to baseline (5/5 stage2
+# bugs found) at ~52% cost / ~80% output-token reduction. Operators wanting
+# the pre-#559 default Claude Code session behaviour can opt out via
+# STAGE3_CLAUDE_CAVEMAN=0.
+STAGE3_CLAUDE_CAVEMAN_VAL="${STAGE3_CLAUDE_CAVEMAN:-1}"
 # #557 quality-vs-burn tuning: claude CLI --effort flag. Gates chain-of-
 # thought reasoning depth. Default "medium" recovers most of take-11
 # quality at modest burn cost; "low" is most aggressive burn-reduction

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -473,12 +473,13 @@ assert_contains "STAGE3_HUNTER_TICK_MS=600000 override surfaces in emit_step out
     "hunter tick interval: 600000 ms"
 
 # 9a-554. #554 burn-rate mitigation: STAGE3_CLAUDE_CAVEMAN gates the
-# minimal-overhead claude CLI mode. Default 0 must surface as `caveman
-# mode: disabled`; an override of STAGE3_CLAUDE_CAVEMAN=1 must surface
-# as `caveman mode: enabled (...)`.
-assert_contains "STAGE3_CLAUDE_CAVEMAN default surfaces as disabled (#554)" "$OUT" \
-    "caveman mode: disabled"
-OUT_CAVEMAN_ENABLED="$(STAGE3_WALL_CLOCK_S=1800 \
+# minimal-overhead claude CLI mode. Post-#559 the default is "1", so the
+# default dry-run must surface as `caveman mode: enabled (...)`; an
+# override of STAGE3_CLAUDE_CAVEMAN=0 must surface as `caveman mode:
+# disabled`.
+assert_contains "STAGE3_CLAUDE_CAVEMAN default surfaces as enabled (#559)" "$OUT" \
+    "caveman mode: enabled (--tools '' --system-prompt minimal --effort medium)"
+OUT_CAVEMAN_DISABLED="$(STAGE3_WALL_CLOCK_S=1800 \
        STAGE3_ROTATION_INTERVAL_S=120 \
        STAGE3_DEATH_THRESHOLD=300 \
        STAGE3_LAPTOP_PORT=9100 \
@@ -486,11 +487,11 @@ OUT_CAVEMAN_ENABLED="$(STAGE3_WALL_CLOCK_S=1800 \
        STAGE3_LAPTOP_WORKER_PORT=9200 \
        STAGE3_SERVER_WORKER_PORT=9201 \
        STAGE3_WORKER_SECRET=testsecret \
-       STAGE3_CLAUDE_CAVEMAN=1 \
+       STAGE3_CLAUDE_CAVEMAN=0 \
        bash "$ORCH" --dry-run 2>&1)"
-assert_contains "STAGE3_CLAUDE_CAVEMAN=1 override surfaces in emit_step output (#554)" \
-    "$OUT_CAVEMAN_ENABLED" \
-    "caveman mode: enabled (--tools '' --system-prompt minimal --effort medium)"
+assert_contains "STAGE3_CLAUDE_CAVEMAN=0 override surfaces in emit_step output (#559)" \
+    "$OUT_CAVEMAN_DISABLED" \
+    "caveman mode: disabled"
 
 # 9a-557. #557 quality-vs-burn tuning: STAGE3_CLAUDE_EFFORT gates the
 # claude CLI --effort flag value when caveman mode is on. Default


### PR DESCRIPTION
## Summary

Fixes #559. Flips `STAGE3_CLAUDE_CAVEMAN` default from `0` to `1` in `tribes-bench/tools/run-stage3-docker.sh` so every operator gets the burn-rate savings by default. Effort default (`medium`) is unchanged.

## Validation evidence (take-13 acceptance smoke)

Operator-local 30-min smoke run with `STAGE3_CLAUDE_CAVEMAN=1` + `STAGE3_CLAUDE_EFFORT=medium`:

- **Quality:** 5/5 stage2 planted bugs identified, including UAF-002 that caveman+low missed in take-12.
- **Cost:** ~52% of take-11 baseline native cost.
- **Output tokens:** ~80% reduction vs baseline.

Caveman+medium is therefore quality-equivalent to the take-11 baseline (no regression) while shedding the bulk of the per-hunter session overhead Claude Code's default tools manifest + system prompt impose.

## Opt-out

Operators wanting the pre-#559 default Claude Code session behaviour can set `STAGE3_CLAUDE_CAVEMAN=0` in their orchestrator env; the disabled branch is byte-identical to the pre-#555 baseline.

## Files

- `tribes-bench/tools/run-stage3-docker.sh` — default flipped, header docstring + inline comment updated.
- `tribes-bench/tools/test-run-stage3-docker.sh` — default-vs-override assertion pair inverted (175/0, no count change).
- `tribes-bench/CHANGELOG.md` — `[Unreleased] / Changed` entry.

## Test plan

- [x] `bash -n tribes-bench/tools/run-stage3-docker.sh` clean
- [x] `tools/colony-lint.sh` green (170 passed, 0 failed, 3 skipped)
- [x] `tribes-bench/tools/test-run-stage3-docker.sh` 175/0 (test count unchanged)
- [x] Dry-run with no env override surfaces `caveman mode: enabled (--tools '' --system-prompt minimal --effort medium)`
- [x] Dry-run with `STAGE3_CLAUDE_CAVEMAN=0` surfaces `caveman mode: disabled (default Claude CLI overhead)`

Out of scope: this PR does NOT address hunter.ag, start-colony.sh, agentis-core, or the effort default.