### PR TITLE
fix(tribes-bench): verifier memo-aware rotation layer-2 (#561)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,11 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Fixed
 
+- **Fix(rotation, layer 2):** verifier scripts (`verify-finding.sh`, `verify-finding-stage2.sh`)
+  now read `BUGS_MANIFEST` and `TARGET_DIR` from `hunter:bugs_manifest` / `hunter:target_dir`
+  memos (set by orchestrator rotation timer per #546/#547), with env-var fallback. Enables
+  cross-stage rotation — hunters can now hunt stage4 crates and have findings verified
+  against the rotated manifest ([#561](https://github.com/Replikanti/agentis-colonies/issues/561)).
 - **Fix(rotation):** orchestrator's rotation timer now writes the memo keys hunters
   actually read (`hunter:target_dir`, `hunter:target_file`, `hunter:bugs_manifest`)
   instead of unread `tribes-bench:*` variants — hunters now rotate in lockstep with

--- a/tribes-bench/tools/verify-finding-stage2.sh
+++ b/tribes-bench/tools/verify-finding-stage2.sh
@@ -131,6 +131,20 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FED_DIR="$(dirname "$SCRIPT_DIR")"
 
 TARGET_DIR="${TARGET_DIR:-$FED_DIR/targets/stage2/smallvec-v0.6.13}"
+
+# #561 rotation layer-2: prefer hunter:bugs_manifest memo (set by orchestrator
+# rotation timer post-#547) over env var. Memo > env > stage2 hardcoded fallback.
+# Backward compatible: deployments without memo writes fall back to env behavior.
+ROTATED_MANIFEST=$(agentis memo get hunter:bugs_manifest 2>/dev/null | python3 -c 'import sys,json; data=sys.stdin.read().strip(); print(json.loads(data) if data.startswith(chr(34)) else data)' 2>/dev/null)
+ROTATED_DIR=$(agentis memo get hunter:target_dir 2>/dev/null | python3 -c 'import sys,json; data=sys.stdin.read().strip(); print(json.loads(data) if data.startswith(chr(34)) else data)' 2>/dev/null)
+
+if [ -n "$ROTATED_DIR" ] && [ -d "$ROTATED_DIR" ]; then
+    TARGET_DIR="$ROTATED_DIR"
+fi
+if [ -n "$ROTATED_MANIFEST" ] && [ -f "$ROTATED_MANIFEST" ]; then
+    BUGS_MANIFEST="$ROTATED_MANIFEST"
+fi
+
 BUGS_MANIFEST="${BUGS_MANIFEST:-$FED_DIR/targets/stage2/bugs.json}"
 BUG_LEDGER_PATH="${BUG_LEDGER_PATH:-}"
 TRIBE_NAME="${TRIBE_NAME:-}"

--- a/tribes-bench/tools/verify-finding.sh
+++ b/tribes-bench/tools/verify-finding.sh
@@ -101,6 +101,20 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FED_DIR="$(dirname "$SCRIPT_DIR")"
 
 TARGET_DIR="${TARGET_DIR:-$FED_DIR/targets/stage0}"
+
+# #561 rotation layer-2: prefer hunter:bugs_manifest memo (set by orchestrator
+# rotation timer post-#547) over env var. Memo > env > hardcoded default chain.
+# Backward compatible: deployments without memo writes fall back to env behavior.
+ROTATED_MANIFEST=$(agentis memo get hunter:bugs_manifest 2>/dev/null | python3 -c 'import sys,json; data=sys.stdin.read().strip(); print(json.loads(data) if data.startswith(chr(34)) else data)' 2>/dev/null)
+ROTATED_DIR=$(agentis memo get hunter:target_dir 2>/dev/null | python3 -c 'import sys,json; data=sys.stdin.read().strip(); print(json.loads(data) if data.startswith(chr(34)) else data)' 2>/dev/null)
+
+if [ -n "$ROTATED_DIR" ] && [ -d "$ROTATED_DIR" ]; then
+    TARGET_DIR="$ROTATED_DIR"
+fi
+if [ -n "$ROTATED_MANIFEST" ] && [ -f "$ROTATED_MANIFEST" ]; then
+    BUGS_MANIFEST="$ROTATED_MANIFEST"
+fi
+
 BUGS_MANIFEST="${BUGS_MANIFEST:-$TARGET_DIR/bugs.json}"
 
 emit_verdict() {


### PR DESCRIPTION
Fixes #561.

## Background

PR #547 (issue #546) landed layer-1 of cross-target rotation: the orchestrator's rotation timer in `run-stage3-docker.sh` now writes the three memo keys hunters actually read (`hunter:target_dir`, `hunter:target_file`, `hunter:bugs_manifest`). The hunter `.ag` agents already consume `hunter:target_dir` / `hunter:target_file` via `recall_latest()`, so hunters rotate in lockstep with `STAGE3_ROTATION_INTERVAL_S`.

The remaining blocker (this PR, **layer 2**): the verifier scripts (`verify-finding.sh:104`, `verify-finding-stage2.sh:134`) read `BUGS_MANIFEST` and `TARGET_DIR` exclusively from env vars. Env vars are welded at daemon startup, so after rotation the verifier kept checking findings against the original target's `bugs.json`, returning false-positive on cross-stage hits. With layer-2 fixed, hunters can now hunt stage4 crates and have findings verified against the rotated manifest — the bug-space diversity expected to unblock M98 v3 prompt evolution (~34 unique bugs across stage0/1/2/3/4 vs the current single-target ~5).

## Change

Both verifier scripts gain a memo-aware lookup block immediately after the `$TARGET_DIR` env default expansion. The lookup order is:

1. `agentis memo get hunter:bugs_manifest` / `hunter:target_dir` (set by orchestrator rotation timer per #547)
2. Existing `$BUGS_MANIFEST` / `$TARGET_DIR` env passthrough
3. Stage-specific hardcoded fallback (stage0 layout for `verify-finding.sh`, stage2 layout for `verify-finding-stage2.sh`)

The `python3 -c` unwrap on the memo output tolerates either a raw string (current `agentis memo get` behaviour) or a JSON-quoted string (defensive coding). When the memo is unset, both verifiers fall back to the previous env-var behaviour. Stage 0/1/2 unit tests pass unchanged.

## Backward compatibility

Deployments without memo writes see no behaviour change: `agentis memo get` on an unset key returns empty, and the if-guards (`-n` + `-d` / `-n` + `-f`) skip the override. Stage 0/1/2 callers and the existing `test-verify-finding.sh` / `test-verify-finding-stage2.sh` invocations (which set both env vars explicitly) keep producing byte-identical verdicts.

## Test plan

- [x] `bash -n` on both verifier scripts: clean
- [x] `tools/colony-lint.sh`: 170 passed, 0 failed, 3 skipped
- [x] `tribes-bench/tools/test-verify-finding.sh` (stage 0): 6/6 PASS
- [x] `STAGE1=1 tribes-bench/tools/test-verify-finding.sh` (stage 1): 6/6 PASS
- [x] `tribes-bench/tools/test-verify-finding-stage2.sh`: 9/9 PASS
- [x] `tribes-bench/tools/test-run-stage3-docker.sh`: 175/0
- [x] Manual smoke: memo → stage3 + `{line:1767, class:use_after_free}` matches `S3-BPUAF-001`; memo cleared + same finding falls through to stage2 default and returns no match; memo cleared + `{line:827, class:use_after_free}` matches stage2's `S2-SMVUAF-001`. Behaviour change confirmed end-to-end.

Unit-test coverage for the memo path itself is deferred to operator's take-15 rotation smoke (acceptance criteria from #561) since the existing test harness explicitly seeds env vars and therefore cannot observe memo override without restructuring.

## Acceptance

Take-15 rotation smoke (operator-driven): 2 h cross-stage run with `STAGE3_ROTATION_INTERVAL_S` non-zero across stage0..stage4 targets, verifying that hunters can land verified=true hits on bugs planted in non-startup targets.

## Scope

Tightly in scope. No changes to:
- `hunter.ag` (still reads `hunter:target_dir` only — unchanged from #547)
- `start-colony.sh` (per-tribe memo seeding unchanged)
- `run-stage3-docker.sh` (orchestrator rotation writes already correct from #547)
- agentis runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)