### PR TITLE
fix(tribes-bench): STAGE3_CLAUDE_MODEL knob, default sonnet (#563)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -28,6 +28,10 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- **chore(rate-limit):** `STAGE3_CLAUDE_MODEL` env knob (default `sonnet`). Adds explicit
+  `--model` flag to claude CLI invocation; without it, Claude Code defaults to subscription
+  tier model (Opus on Max 20x), burning ~5x more tokens than necessary. Restores agentis-core's
+  original Sonnet design intent. Operators can opt to Haiku/Opus via override ([#563](https://github.com/Replikanti/agentis-colonies/issues/563)).
 - **chore(rate-limit):** `STAGE3_CLAUDE_CAVEMAN` default flipped from 0 to 1 after take-13
   acceptance smoke confirmed caveman+medium effort is quality-equivalent to baseline (5/5
   stage2 bugs identified) at 52% native cost / 80% output tokens. Operators wanting default

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -92,6 +92,11 @@
 #   STAGE3_CLAUDE_EFFORT       #557: claude CLI reasoning depth when
 #                              caveman mode is on. One of: low, medium,
 #                              high, xhigh, max. Default "medium".
+#   STAGE3_CLAUDE_MODEL        #563: claude CLI --model flag value.
+#                              Accepts aliases (sonnet, haiku, opus) or
+#                              explicit model names (e.g. claude-sonnet-4-6).
+#                              Default "sonnet" cuts cost ~5x vs subscription-
+#                              tier default (Opus on Max 20x).
 #   STAGE3_HUNTER_MAX_AGE      #487 follow-up: per-hunter age cap. Each
 #                              hunter increments its own age counter
 #                              (keyed on PPID, no shared-state RMW race)
@@ -352,6 +357,11 @@ STAGE3_CLAUDE_CAVEMAN_VAL="${STAGE3_CLAUDE_CAVEMAN:-1}"
 # but regressed verified hits 46% in take-12. Only consulted when
 # STAGE3_CLAUDE_CAVEMAN=1.
 STAGE3_CLAUDE_EFFORT_VAL="${STAGE3_CLAUDE_EFFORT:-medium}"
+# #563 cost-reduction: explicit claude CLI --model flag. Without it
+# Claude Code defaults to subscription tier (Opus on Max 20x), burning
+# ~5x the tokens Sonnet would. Default "sonnet" matches agentis-core's
+# original llm.model = claude-sonnet-4-20250514 design intent.
+STAGE3_CLAUDE_MODEL_VAL="${STAGE3_CLAUDE_MODEL:-sonnet}"
 # Minimal system prompt used in caveman mode. ~200 tokens (vs ~38K
 # default Claude Code system prompt). Single-line for shell-escape
 # simplicity through bootstrap.sh + .agentis/config layers.
@@ -481,6 +491,19 @@ case "$STAGE3_CLAUDE_EFFORT_VAL" in
         ;;
 esac
 
+# #563 cost-reduction: validate STAGE3_CLAUDE_MODEL always so a typo
+# never silently falls through to subscription-tier default. Accept
+# both short aliases (sonnet|haiku|opus) and explicit Anthropic model
+# names (claude-<family>-<rest>).
+case "$STAGE3_CLAUDE_MODEL_VAL" in
+    sonnet|haiku|opus) ;;
+    claude-*-*) ;;
+    *)
+        echo "run-stage3-docker: STAGE3_CLAUDE_MODEL must be alias (sonnet|haiku|opus) or explicit model name like 'claude-sonnet-4-6' (got '$STAGE3_CLAUDE_MODEL_VAL')" >&2
+        exit 2
+        ;;
+esac
+
 # Convert space-separated tribe lists into arrays (set -u + IFS-default
 # splitting cooperate as long as we don't quote the expansion here).
 # shellcheck disable=SC2206
@@ -559,6 +582,7 @@ if [ "$STAGE3_CLAUDE_CAVEMAN_VAL" = "1" ]; then
 else
     emit_step "caveman mode: disabled (default Claude CLI overhead)"
 fi
+emit_step "claude model: $STAGE3_CLAUDE_MODEL_VAL"
 emit_step "tribes: laptop=[${LAPTOP_TRIBES[*]}] server=[${SERVER_TRIBES[*]}]"
 emit_step "image tag: $IMAGE_TAG"
 emit_step "host ports: laptop=$LAPTOP_PORT server=$SERVER_PORT"
@@ -665,12 +689,21 @@ write_bootstrap() {
         # session overhead (--tools "" --system-prompt <minimal> --effort
         # low). Strips Claude Code default system prompt + tools manifest
         # from each hunter call (~38K → ~11K tokens). Stays on flat-rate
-        # OAuth (no --bare). Default off keeps the emitted config
-        # byte-identical to the pre-#554 baseline.
+        # OAuth (no --bare).
+        # #563 cost-reduction: in BOTH caveman states, inject the
+        # explicit --model flag right after --output-format json so the
+        # claude CLI no longer silently falls back to subscription tier
+        # (Opus on Max 20x). The non-caveman branch also emits
+        # llm.command = claude + a minimal llm.args carrying just
+        # -p --output-format json --model <model> so the model knob
+        # applies even when operators opt out of caveman mode.
         if [ "$STAGE3_CLAUDE_CAVEMAN_VAL" = "1" ]; then
             escaped_caveman_prompt=$(printf '%s' "$STAGE3_CAVEMAN_SYSTEM_PROMPT" | sed 's/"/\\"/g')
             printf '  printf "llm.command = claude\\n"\n'
-            printf '  printf "llm.args = -p --output-format json --tools \\"\\" --system-prompt \\"%s\\" --effort %s\\n"\n' "$escaped_caveman_prompt" "$STAGE3_CLAUDE_EFFORT_VAL"
+            printf '  printf "llm.args = -p --output-format json --model %s --tools \\"\\" --system-prompt \\"%s\\" --effort %s\\n"\n' "$STAGE3_CLAUDE_MODEL_VAL" "$escaped_caveman_prompt" "$STAGE3_CLAUDE_EFFORT_VAL"
+        else
+            printf '  printf "llm.command = claude\\n"\n'
+            printf '  printf "llm.args = -p --output-format json --model %s\\n"\n' "$STAGE3_CLAUDE_MODEL_VAL"
         fi
         printf '  printf "colony.secret = %%s\\n" "$WORKER_SECRET"\n'
         printf '} >> .agentis/config\n'

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -535,6 +535,61 @@ assert_contains "STAGE3_CLAUDE_EFFORT=garbage stderr names allowed values (#557)
     "$EFFORT_BAD_OUT" \
     "STAGE3_CLAUDE_EFFORT must be one of low|medium|high|xhigh|max"
 
+# 9a-563. #563 cost-reduction: STAGE3_CLAUDE_MODEL injects an explicit
+# --model flag into the claude CLI invocation so Claude Code no longer
+# falls back to the subscription-tier default (Opus on Max 20x). Default
+# "sonnet" must surface in emit_step transcript; aliases (haiku) and
+# explicit model names (claude-sonnet-4-20250514) must round-trip; an
+# unrecognised value must exit 2 with a helpful stderr message.
+assert_contains "STAGE3_CLAUDE_MODEL default surfaces as sonnet (#563)" \
+    "$OUT" \
+    "claude model: sonnet"
+OUT_MODEL_HAIKU="$(STAGE3_WALL_CLOCK_S=1800 \
+       STAGE3_ROTATION_INTERVAL_S=120 \
+       STAGE3_DEATH_THRESHOLD=300 \
+       STAGE3_LAPTOP_PORT=9100 \
+       STAGE3_SERVER_PORT=9101 \
+       STAGE3_LAPTOP_WORKER_PORT=9200 \
+       STAGE3_SERVER_WORKER_PORT=9201 \
+       STAGE3_WORKER_SECRET=testsecret \
+       STAGE3_CLAUDE_MODEL=haiku \
+       bash "$ORCH" --dry-run 2>&1)"
+assert_contains "STAGE3_CLAUDE_MODEL=haiku alias override surfaces (#563)" \
+    "$OUT_MODEL_HAIKU" \
+    "claude model: haiku"
+OUT_MODEL_EXPLICIT="$(STAGE3_WALL_CLOCK_S=1800 \
+       STAGE3_ROTATION_INTERVAL_S=120 \
+       STAGE3_DEATH_THRESHOLD=300 \
+       STAGE3_LAPTOP_PORT=9100 \
+       STAGE3_SERVER_PORT=9101 \
+       STAGE3_LAPTOP_WORKER_PORT=9200 \
+       STAGE3_SERVER_WORKER_PORT=9201 \
+       STAGE3_WORKER_SECRET=testsecret \
+       STAGE3_CLAUDE_MODEL=claude-sonnet-4-20250514 \
+       bash "$ORCH" --dry-run 2>&1)"
+assert_contains "STAGE3_CLAUDE_MODEL explicit name override surfaces (#563)" \
+    "$OUT_MODEL_EXPLICIT" \
+    "claude model: claude-sonnet-4-20250514"
+MODEL_BAD_RC=0
+MODEL_BAD_OUT="$(STAGE3_WALL_CLOCK_S=1800 \
+       STAGE3_ROTATION_INTERVAL_S=120 \
+       STAGE3_DEATH_THRESHOLD=300 \
+       STAGE3_LAPTOP_PORT=9100 \
+       STAGE3_SERVER_PORT=9101 \
+       STAGE3_LAPTOP_WORKER_PORT=9200 \
+       STAGE3_SERVER_WORKER_PORT=9201 \
+       STAGE3_WORKER_SECRET=testsecret \
+       STAGE3_CLAUDE_MODEL=gpt-4 \
+       bash "$ORCH" --dry-run 2>&1)" || MODEL_BAD_RC=$?
+if [ "$MODEL_BAD_RC" -eq 2 ] && printf '%s' "$MODEL_BAD_OUT" | grep -Fq -- \
+    "STAGE3_CLAUDE_MODEL must be alias (sonnet|haiku|opus) or explicit model name"; then
+    echo "[PASS] STAGE3_CLAUDE_MODEL=gpt-4 exits 2 with helpful stderr (#563)"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] STAGE3_CLAUDE_MODEL=gpt-4 should exit 2 with helpful stderr, got rc=$MODEL_BAD_RC stderr=$MODEL_BAD_OUT (#563)"
+    FAIL=$((FAIL + 1))
+fi
+
 # 9b. #528: STAGE3_DAEMON_CB_PER_TICK env var is documented, has the
 # documented default of 2000, and its hermetic-config emit line is
 # present (so the spawned daemon's per-tick CB budget actually rises


### PR DESCRIPTION
Fixes #563

## Diagnosis

Take-14 spend telemetry showed Claude Code subprocess was burning **~$0.085/call** — matches Opus pricing ($15 / $75 per MTok), not Sonnet ($3 / $15 per MTok ≈ $0.017/call). Operator's Anthropic /usage UI showed Sonnet column at 0%, confirming Opus was the active model.

Root cause: orchestrator emitted `llm.args = -p --output-format json [...]` **without** a `--model` flag. Claude Code in `-p` mode without `--model` defaults to the user's subscription tier — on Max 20x that's Opus 4.7. Live host test confirmed `claude -p --output-format json --model sonnet` correctly switches the active model (modelUsage stanza includes `claude-sonnet-4-6`).

## Fix

Add `STAGE3_CLAUDE_MODEL` env knob (default `sonnet`) and inject `--model <value>` into the emitted `llm.args` line in **both** caveman ON and caveman OFF paths, so the model knob applies regardless of caveman state. Validator accepts short aliases (`sonnet | haiku | opus`) and explicit Anthropic model names (`claude-<family>-<rest>`) so future model versions don't require an orchestrator bump.

Expected impact: **~5x cost reduction** vs the previous Opus default. Operators can opt to opus/haiku via env override (`STAGE3_CLAUDE_MODEL=opus`).

This is a deliberate default-behavior change (Opus → Sonnet) — that is the point of the PR.

## Test plan

- [x] `bash -n tribes-bench/tools/run-stage3-docker.sh` clean
- [x] `bash tools/colony-lint.sh` 170 passed / 0 failed / 3 skipped
- [x] `bash tribes-bench/tools/test-run-stage3-docker.sh` 179 passed / 0 failed (was 175; +4 new assertions for #563)
- [x] Dry-run emit_step shows `claude model: sonnet` by default
- [x] Dry-run override `STAGE3_CLAUDE_MODEL=haiku` → `claude model: haiku`
- [x] Dry-run override `STAGE3_CLAUDE_MODEL=claude-sonnet-4-20250514` → `claude model: claude-sonnet-4-20250514`
- [x] Invalid `STAGE3_CLAUDE_MODEL=gpt-4` exits 2 with helpful stderr naming allowed shape
- [x] Manual bootstrap-emit inspection — caveman=1 produces `llm.args = -p --output-format json --model <model> --tools "" --system-prompt "<minimal>" --effort <effort>` with correct escaping; caveman=0 produces `llm.args = -p --output-format json --model <model>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)