### PR TITLE
fix(tribes-bench): stage3/bugs.json bug.file paths drop bumpalo prefix (#565)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,11 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Fixed
 
+- **Fix(rotation, layer 3):** stage3/bugs.json bug.file paths stripped of `bumpalo-v3.2.0/`
+  prefix to match the convention used by stage2 and stage4 manifests (relative to target
+  source root, not to stage dir). Unlocks cross-stage rotation for stage3 hunters which were
+  previously hitting 'path outside sandbox' due to doubled prefix
+  ([#565](https://github.com/Replikanti/agentis-colonies/issues/565)).
 - **Fix(rotation, layer 2):** verifier scripts (`verify-finding.sh`, `verify-finding-stage2.sh`)
   now read `BUGS_MANIFEST` and `TARGET_DIR` from `hunter:bugs_manifest` / `hunter:target_dir`
   memos (set by orchestrator rotation timer per #546/#547), with env-var fallback. Enables

--- a/tribes-bench/targets/stage3/bugs.json
+++ b/tribes-bench/targets/stage3/bugs.json
@@ -2,7 +2,7 @@
   "stage": "stage3",
   "target_dir": "targets/stage3",
   "bugs": [
-    {"id": "S3-BPOFL-001", "class": "heap_overflow", "file": "bumpalo-v3.2.0/src/lib.rs", "line": 1093, "line_tolerance": 5, "signature": "unsafe fn realloc", "severity": "high", "verifier_test": "test_bp_ofl_001", "rationale": "RUSTSEC-2020-0006: Bump::realloc copied new_size bytes instead of old_size, reading past the source allocation into unknown memory (CVE-2020-35861)"},
-    {"id": "S3-BPUAF-001", "class": "use_after_free", "file": "bumpalo-v3.2.0/src/collections/vec.rs", "line": 1767, "line_tolerance": 5, "signature": "fn into_iter(mut self) -> IntoIter<T>", "severity": "high", "verifier_test": "test_bp_uaf_001", "rationale": "RUSTSEC-2022-0078: Vec::into_iter returns IntoIter<T> with no lifetime tied to the &Bump arena, allowing iteration after the Bump is dropped (use-after-free)"}
+    {"id": "S3-BPOFL-001", "class": "heap_overflow", "file": "src/lib.rs", "line": 1093, "line_tolerance": 5, "signature": "unsafe fn realloc", "severity": "high", "verifier_test": "test_bp_ofl_001", "rationale": "RUSTSEC-2020-0006: Bump::realloc copied new_size bytes instead of old_size, reading past the source allocation into unknown memory (CVE-2020-35861)"},
+    {"id": "S3-BPUAF-001", "class": "use_after_free", "file": "src/collections/vec.rs", "line": 1767, "line_tolerance": 5, "signature": "fn into_iter(mut self) -> IntoIter<T>", "severity": "high", "verifier_test": "test_bp_uaf_001", "rationale": "RUSTSEC-2022-0078: Vec::into_iter returns IntoIter<T> with no lifetime tied to the &Bump arena, allowing iteration after the Bump is dropped (use-after-free)"}
   ]
 }


### PR DESCRIPTION
Fixes #565.

## Summary

Take-15 cross-stage rotation smoke (operator-local) surfaced a layer-3 path mismatch in `tribes-bench/targets/stage3/bugs.json`. The `bug.file` field used the convention `bumpalo-v3.2.0/src/lib.rs` (relative to stage3/ dir), while stage2 and stage4 manifests use paths relative to **target source root** (`lib.rs`, `src/mutex.rs`, etc.).

After #547 (rotation memo writes) + #562 (verifier memo reads), the rotation timer's python3 one-liner derives `hunter:target_file` from bugs.json's most common `bug.file`. Combined with `hunter:target_dir = /run-root/targets/stage3/bumpalo-v3.2.0`, hunters resolved files at `/run-root/targets/stage3/bumpalo-v3.2.0/bumpalo-v3.2.0/src/lib.rs` (doubled prefix) → path outside sandbox.

## Fix

2-line data fix in `stage3/bugs.json`:
- `bumpalo-v3.2.0/src/lib.rs` → `src/lib.rs`
- `bumpalo-v3.2.0/src/collections/vec.rs` → `src/collections/vec.rs`

## Test plan

- [x] JSON syntactically valid: `python3 -c 'import json; json.load(open(...))'`
- [x] No hardcoded references to old path: `grep bumpalo-v3.2.0/src tribes-bench/tools/` returns nothing
- [ ] Operator's take-16 rotation smoke verifies S3-BP* hits appear in verified ledger

## Backward compatibility

Pre-PR direct invocations would have needed the prefix. None exist in tools/. New convention matches the other 3 manifest paths.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>