### PR TITLE
fix(tribes-bench): rotation layer 4+5 — sandbox paths + stage4 cp (#567)

### DIFF
--- a/tribes-bench/CHANGELOG.md
+++ b/tribes-bench/CHANGELOG.md
@@ -16,6 +16,13 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Fixed
 
+- **Fix(rotation, layer 5):** orchestrator container bootstrap now copies stage4-*
+  crate dirs into sandbox alongside stage0/1/2/3, enabling cross-stage rotation
+  to stage4 RUSTSEC crates ([#567](https://github.com/Replikanti/agentis-colonies/issues/567)).
+- **Fix(rotation, layer 4):** rotation timer now writes sandbox-relative paths
+  (`targets-stage2/smallvec-v0.6.13`) instead of absolute filesystem paths
+  (`/run-root/targets/stage2/smallvec-v0.6.13`) which were rejected by agentis
+  file_read as 'outside sandbox' ([#567](https://github.com/Replikanti/agentis-colonies/issues/567)).
 - **Fix(rotation, layer 3):** stage3/bugs.json bug.file paths stripped of `bumpalo-v3.2.0/`
   prefix to match the convention used by stage2 and stage4 manifests (relative to target
   source root, not to stage dir). Unlocks cross-stage rotation for stage3 hunters which were

--- a/tribes-bench/tools/run-stage3-docker.sh
+++ b/tribes-bench/tools/run-stage3-docker.sh
@@ -731,6 +731,18 @@ write_bootstrap() {
         printf 'cp -r /run-root/targets/stage3 /run-root/.agentis/sandbox/targets-stage3 2>/dev/null || true\n'
         printf 'cp -r /run-root/targets/stage0 /run-root/.agentis/sandbox/targets-stage0 2>/dev/null || true\n'
         printf 'cp -r /run-root/targets/stage1 /run-root/.agentis/sandbox/targets-stage1 2>/dev/null || true\n'
+        # #567 layer 5: stage4-* crates (vendored #519/#545) are iterated and
+        # copied into the sandbox with their corresponding sandbox-relative
+        # name (targets-stage4-<crate>-v<version>). Without this loop the
+        # stage4 RUSTSEC crates are present under /run-root/targets/ but
+        # missing from /run-root/.agentis/sandbox/, so hunters hit
+        # 'path outside sandbox' on every stage4 rotation tick. The for-loop
+        # is emitted as 4 lines so the inner $d / $name expansions land in
+        # bootstrap.sh literally (rather than expanding here in the host).
+        printf 'for d in /run-root/targets/stage4-*; do\n'
+        printf '    name="$(basename "$d")"\n'
+        printf '    cp -r "$d" "/run-root/.agentis/sandbox/targets-$name" 2>/dev/null || true\n'
+        printf 'done\n'
         # Seed propose-tier confidence (default tier without seed is
         # dormant; tribes-bench Stage 2 convention is propose at 0.7,
         # mirrored from run-stage2.sh line 272). Without this seed the
@@ -891,7 +903,7 @@ rotation_timer() {
         extra_targets="$extra_targets J"
     fi
     if [ -z "$extra_targets" ]; then
-        emit_cmd "( phase=0; while true; do sleep $ROTATION_INTERVAL; phase=\$((1 - phase)); if [ \"\$phase\" = \"0\" ]; then td=/run-root/$TARGET_A_DIR_REL; bm=/run-root/$TARGET_A_BUGS_REL; else td=/run-root/$TARGET_B_DIR_REL; bm=/run-root/$TARGET_B_BUGS_REL; fi; tf=\$(podman exec stage3-laptop python3 -c \"import json,collections; j=json.load(open('\$bm')); fs=[b.get('file','') for b in j.get('bugs',[])]; c=collections.Counter(fs); print(c.most_common(1)[0][0] if c else 'lib.rs')\" 2>/dev/null || echo lib.rs); printf '%s,%s,%s\\n' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"\$td\" \"\$bm\" >>$ROTATIONS_CSV; podman exec stage3-laptop agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; done ) >>$RUN_DIR/rotation.log 2>&1 & echo \$! >$RUN_DIR/rotation.pid"
+        emit_cmd "( phase=0; while true; do sleep $ROTATION_INTERVAL; phase=\$((1 - phase)); if [ \"\$phase\" = \"0\" ]; then raw_td=$TARGET_A_DIR_REL; else raw_td=$TARGET_B_DIR_REL; fi; case \"\$raw_td\" in targets/stage[0-3]/*) td=\${raw_td/targets\\/stage/targets-stage} ;; targets/stage4-*) td=\${raw_td/targets\\//targets-} ;; *) td=\$raw_td ;; esac; bm=/run-root/.agentis/sandbox/\$td/bugs.json; tf=\$(podman exec stage3-laptop python3 -c \"import json,collections; j=json.load(open('\$bm')); fs=[b.get('file','') for b in j.get('bugs',[])]; c=collections.Counter(fs); print(c.most_common(1)[0][0] if c else 'lib.rs')\" 2>/dev/null || echo lib.rs); printf '%s,%s,%s\\n' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"\$td\" \"\$bm\" >>$ROTATIONS_CSV; podman exec stage3-laptop agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; done ) >>$RUN_DIR/rotation.log 2>&1 & echo \$! >$RUN_DIR/rotation.pid"
     else
         # Round-robin across A, B, plus whichever of C/D/E/F/G/H/I/J
         # were configured. Each iteration picks the next entry by integer
@@ -902,7 +914,7 @@ rotation_timer() {
         for k in $extra_targets; do
             targets_init="$targets_init; targets+=($k)"
         done
-        emit_cmd "( $targets_init; i=0; n=\${#targets[@]}; while true; do sleep $ROTATION_INTERVAL; k=\${targets[\$((i % n))]}; i=\$((i+1)); td_var=\"TARGET_\${k}_DIR_REL\"; bm_var=\"TARGET_\${k}_BUGS_REL\"; td=/run-root/\${!td_var}; bm=/run-root/\${!bm_var}; tf=\$(podman exec stage3-laptop python3 -c \"import json,collections; j=json.load(open('\$bm')); fs=[b.get('file','') for b in j.get('bugs',[])]; c=collections.Counter(fs); print(c.most_common(1)[0][0] if c else 'lib.rs')\" 2>/dev/null || echo lib.rs); printf '%s,%s,%s\\n' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"\$td\" \"\$bm\" >>$ROTATIONS_CSV; podman exec stage3-laptop agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; done ) >>$RUN_DIR/rotation.log 2>&1 & echo \$! >$RUN_DIR/rotation.pid"
+        emit_cmd "( $targets_init; i=0; n=\${#targets[@]}; while true; do sleep $ROTATION_INTERVAL; k=\${targets[\$((i % n))]}; i=\$((i+1)); td_var=\"TARGET_\${k}_DIR_REL\"; raw_td=\${!td_var}; case \"\$raw_td\" in targets/stage[0-3]/*) td=\${raw_td/targets\\/stage/targets-stage} ;; targets/stage4-*) td=\${raw_td/targets\\//targets-} ;; *) td=\$raw_td ;; esac; bm=/run-root/.agentis/sandbox/\$td/bugs.json; tf=\$(podman exec stage3-laptop python3 -c \"import json,collections; j=json.load(open('\$bm')); fs=[b.get('file','') for b in j.get('bugs',[])]; c=collections.Counter(fs); print(c.most_common(1)[0][0] if c else 'lib.rs')\" 2>/dev/null || echo lib.rs); printf '%s,%s,%s\\n' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"\$td\" \"\$bm\" >>$ROTATIONS_CSV; podman exec stage3-laptop agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-laptop agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_dir \"\$td\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:target_file \"\$tf\" >/dev/null 2>&1 || true; podman exec stage3-server agentis memo set hunter:bugs_manifest \"\$bm\" >/dev/null 2>&1 || true; done ) >>$RUN_DIR/rotation.log 2>&1 & echo \$! >$RUN_DIR/rotation.pid"
     fi
 }
 

--- a/tribes-bench/tools/test-run-stage3-docker.sh
+++ b/tribes-bench/tools/test-run-stage3-docker.sh
@@ -160,10 +160,20 @@ assert_contains "rotation timer cycles target_file" "$OUT" \
     "hunter:target_file"
 assert_contains "rotation timer cycles bugs_manifest" "$OUT" \
     "hunter:bugs_manifest"
-assert_contains "rotation toggles smallvec target" "$OUT" \
-    "/run-root/targets/stage2/smallvec-v0.6.13"
-assert_contains "rotation toggles bumpalo target" "$OUT" \
-    "/run-root/targets/stage3/bumpalo-v3.2.0"
+# #567 layer 4: rotation timer now writes sandbox-relative target_dir
+# (not absolute /run-root/... paths). The raw_td variable carries the
+# original `targets/stage2/...` rel-path and a bash case-statement maps
+# it to the sandbox-relative `targets-stage2/...` form before memo-set.
+assert_contains "rotation toggles smallvec target (raw_td)" "$OUT" \
+    "raw_td=targets/stage2/smallvec-v0.6.13"
+assert_contains "rotation toggles bumpalo target (raw_td)" "$OUT" \
+    "raw_td=targets/stage3/bumpalo-v3.2.0"
+assert_contains "rotation path-conversion case for stage0-3" "$OUT" \
+    'targets/stage[0-3]/*) td=${raw_td/targets\/stage/targets-stage}'
+assert_contains "rotation path-conversion case for stage4" "$OUT" \
+    'targets/stage4-*) td=${raw_td/targets\//targets-}'
+assert_contains "rotation bugs_manifest under sandbox root" "$OUT" \
+    'bm=/run-root/.agentis/sandbox/$td/bugs.json'
 assert_contains "rotation timer execs into laptop container" "$OUT" \
     "podman exec stage3-laptop agentis memo set"
 assert_contains "rotation timer execs into server container" "$OUT" \
@@ -278,9 +288,13 @@ assert_contains "5-target rotation uses modulo round-robin counter" \
 assert_contains "5-target rotation references TARGET_<K>_DIR_REL via indirect expansion" \
     "$OUT_5TARGET" \
     'td_var="TARGET_${k}_DIR_REL"'
-assert_contains "5-target rotation references TARGET_<K>_BUGS_REL via indirect expansion" \
+# #567 layer 4: bm is now derived from $td (sandbox-relative path) rather
+# than from a parallel TARGET_<K>_BUGS_REL env var, so the indirect bm_var
+# expansion is no longer emitted. The bugs.json filename is fixed by
+# convention (bootstrap copies stage*/bugs.json into the sandbox).
+assert_contains "5-target rotation derives bm from sandbox-rel td" \
     "$OUT_5TARGET" \
-    'bm_var="TARGET_${k}_BUGS_REL"'
+    'bm=/run-root/.agentis/sandbox/$td/bugs.json'
 # Concrete /run-root/targets/stage4-* paths only materialise at runtime:
 # the rotation timer's `${!td_var}` indirect expansion is interpreted
 # inside the backgrounded subshell, NOT when the dry-run echoes the


### PR DESCRIPTION
Fixes #567.

## Summary

Take-16 cross-stage rotation smoke (operator-local, all 3 prior rotation
fixes #547/#562/#566 merged) surfaced two more rotation-infrastructure
bugs blocking cross-stage end-to-end. Both are addressed in a single PR
because they are tightly coupled — layer 4 without layer 5 still fails
stage4 rotation, and layer 5 without layer 4 still fails all rotation.

- **Layer 4 (rotation timer):** rotation timer was writing absolute
  filesystem paths (`/run-root/targets/stage2/smallvec-v0.6.13`) into
  `hunter:target_dir`. `agentis file_read` rejects anything outside
  `<agentis-root>/sandbox/`, so every rotated target produced
  `target_read_failed`. The timer now keeps the raw rel-path in
  `$raw_td`, runs an inline bash `case` that maps `stage0..3` via
  `${raw_td/targets\/stage/targets-stage}` and `stage4-*` via
  `${raw_td/targets\//targets-}`, and writes the sandbox-relative
  form into `hunter:target_dir`. `hunter:bugs_manifest` is derived
  from `$td` as `/run-root/.agentis/sandbox/$td/bugs.json`, matching
  the bootstrap convention. Applied to both the 2-target A/B
  alternation and the N-target round-robin code paths.
- **Layer 5 (orchestrator container bootstrap):** bootstrap was
  hardcoding `cp -r` of stage0/1/2/3 into the sandbox but omitting
  the stage4-* crates (vendored under #519 + #545). Even with the
  layer-4 path conversion, hunters could not read stage4 files
  because the dirs did not exist under `.agentis/sandbox/`.
  Bootstrap now emits a `for`-loop over `/run-root/targets/stage4-*`
  that copies each to `/run-root/.agentis/sandbox/targets-<crate>-v<version>`.

## Take-16 evidence

- 39 `target_read_failed` errors
- 0 cross-stage verified hits
- $7.86 spent before the smoke was halted

## Test plan

- [x] `bash -n tribes-bench/tools/run-stage3-docker.sh` — clean
- [x] `bash tools/colony-lint.sh` — 170 passed, 0 failed, 3 skipped
- [x] `bash tribes-bench/tools/test-run-stage3-docker.sh` — **182 passed, 0 failed**
      (3 prior assertions updated to the new sandbox-relative convention,
      4 new assertions added covering the case-statement + the sandbox-
      rooted `bugs.json` derivation)
- [x] Dry-run inspection — emitted `bootstrap.sh` stage4 `for`-loop is
      syntactically valid (`bash -n` clean) and references the expected
      `/run-root/targets/stage4-*` glob with `$d` / `$name` preserved
      literally; rotation timer `emit_cmd` contains the case-based path
      conversion verbatim; trace for
      `STAGE3_TARGET_A_DIR=targets/stage4-lock_api-v0.3.4` resolves the
      `td` variable to `targets-stage4-lock_api-v0.3.4` (sandbox-relative,
      no `/run-root/` prefix) and `bm` to
      `/run-root/.agentis/sandbox/targets-stage4-lock_api-v0.3.4/bugs.json`.

## Acceptance criteria

Take-17 cross-stage smoke produces verified hits across all configured
stages — `S3-BP*`, `S4-LOCKAPI-*`, `S4-TKLO-*` rows in the bug-ledger
with `verified=true`, and `target_read_failed` count drops to 0.

## Out of scope

- `hunter.ag`, the verifier scripts, `start-colony.sh`, agentis-core
  itself, the `.ag` files. This PR is intentionally narrow to the two
  orchestrator-side bash bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)