### PR TITLE
feat: Binance USDT-M klines downloader (#573 PR-2)

### DIFF
--- a/trading-binance/BUNDLE.manifest
+++ b/trading-binance/BUNDLE.manifest
@@ -1,1 +1,2 @@
 trading-binance/
+trading-binance/tools/binance-feed-download.py

--- a/trading-binance/tools/binance-feed-download.py
+++ b/trading-binance/tools/binance-feed-download.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""binance-feed-download.py - Download Binance USDT-margined perpetual futures klines.
+
+Fetches historical kline (candlestick) data from the Binance USDT-margined
+perpetual futures public REST API (`/fapi/v1/klines`), paginates over
+multi-day windows with HTTP 429 / 5xx retry, and writes deterministic
+date-sharded CSV files under
+`<output-dir>/<symbol>/<timeframe>/<YYYY-MM-DD>.csv` for intraday timeframes
+(`30m`, `1h`) or `<output-dir>/<symbol>/<timeframe>/<YYYY>.csv` for daily.
+
+CSV columns (header on every file):
+    timestamp_ms,open,high,low,close,volume,quote_volume,trades,
+    taker_buy_volume,taker_buy_quote_volume
+
+Output is overwritten on re-run (deterministic). No live API calls in CI:
+`test-binance-feed-download.sh` serves a local fixture via http.server and
+passes `--binance-base-url http://localhost:<port>`.
+
+Standard library only — no `requests` / `pandas` dependency.
+
+Usage:
+    binance-feed-download.py --symbol BTCUSDT --timeframe 30m \\
+        --start 2026-02-15 --end 2026-05-15 \\
+        --output-dir trading-binance/data
+"""
+import argparse
+import json
+import pathlib
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+
+VALID_TIMEFRAMES = ("30m", "1h", "1d")
+INTERVAL_MS = {
+    "30m": 30 * 60 * 1000,
+    "1h": 60 * 60 * 1000,
+    "1d": 24 * 60 * 60 * 1000,
+}
+MAX_LIMIT = 1500
+DEFAULT_BASE_URL = "https://fapi.binance.com"
+KLINES_PATH = "/fapi/v1/klines"
+
+
+def _parse_args(argv):
+    p = argparse.ArgumentParser(
+        description="Download Binance USDT-M perpetual futures klines as CSV.",
+    )
+    p.add_argument("--symbol", required=True, help="Binance futures symbol (e.g. BTCUSDT).")
+    p.add_argument(
+        "--timeframe",
+        required=True,
+        choices=VALID_TIMEFRAMES,
+        help="Candle interval (30m, 1h, or 1d).",
+    )
+    p.add_argument("--start", required=True, help="UTC start date YYYY-MM-DD (inclusive).")
+    p.add_argument("--end", required=True, help="UTC end date YYYY-MM-DD (inclusive).")
+    p.add_argument(
+        "--output-dir",
+        default="trading-binance/data",
+        help="Output root directory (default: trading-binance/data).",
+    )
+    p.add_argument(
+        "--binance-base-url",
+        default=DEFAULT_BASE_URL,
+        help=argparse.SUPPRESS,
+    )
+    return p.parse_args(argv)
+
+
+def _parse_utc_date(s):
+    """Parse YYYY-MM-DD as midnight UTC. Raises ValueError on bad input."""
+    dt = datetime.strptime(s, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _date_to_ms(dt):
+    return int(dt.timestamp() * 1000)
+
+
+def _fetch_page(base_url, symbol, interval, start_ms, end_ms, limit):
+    """Fetch one klines page from Binance. Returns parsed JSON (list of lists).
+
+    Retries on 429 (once after Retry-After) and 5xx (3 attempts, 2s/4s/8s
+    backoff). Hard-fails on 418 / 451 (IP ban) and JSON parse errors.
+    """
+    params = {
+        "symbol": symbol,
+        "interval": interval,
+        "startTime": start_ms,
+        "endTime": end_ms,
+        "limit": limit,
+    }
+    qs = urllib.parse.urlencode(params)
+    url = base_url.rstrip("/") + KLINES_PATH + "?" + qs
+
+    retried_429 = False
+    backoff_attempts = 0
+    backoff_delays = [2, 4, 8]
+
+    while True:
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "agentis-binance-feed/0.1"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                body = resp.read()
+            try:
+                return json.loads(body.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as e:
+                sys.stderr.write("ERROR: JSON parse failed: " + str(e) + "\n")
+                sys.stderr.write("Raw response: " + repr(body[:1024]) + "\n")
+                sys.exit(1)
+
+        except urllib.error.HTTPError as e:
+            code = e.code
+            if code == 429:
+                if retried_429:
+                    sys.stderr.write("ERROR: HTTP 429 persisted after one retry — abort\n")
+                    sys.exit(1)
+                retry_after_hdr = e.headers.get("Retry-After") if e.headers else None
+                try:
+                    delay = int(retry_after_hdr) if retry_after_hdr else 60
+                except (TypeError, ValueError):
+                    delay = 60
+                sys.stderr.write(
+                    "WARN: HTTP 429 — sleeping " + str(delay) + "s before retry\n"
+                )
+                time.sleep(delay)
+                retried_429 = True
+                continue
+            if code in (418, 451):
+                sys.stderr.write("ERROR: Binance IP ban (HTTP " + str(code) + ") — abort\n")
+                sys.exit(1)
+            if 500 <= code < 600:
+                if backoff_attempts >= len(backoff_delays):
+                    sys.stderr.write(
+                        "ERROR: HTTP " + str(code) + " persisted after "
+                        + str(len(backoff_delays)) + " retries — abort\n"
+                    )
+                    sys.exit(1)
+                delay = backoff_delays[backoff_attempts]
+                sys.stderr.write(
+                    "WARN: HTTP " + str(code) + " — sleeping " + str(delay)
+                    + "s (attempt " + str(backoff_attempts + 1) + "/"
+                    + str(len(backoff_delays)) + ")\n"
+                )
+                time.sleep(delay)
+                backoff_attempts += 1
+                continue
+            sys.stderr.write("ERROR: HTTP " + str(code) + " " + str(e.reason) + "\n")
+            sys.exit(1)
+
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
+            if backoff_attempts >= len(backoff_delays):
+                sys.stderr.write(
+                    "ERROR: network error persisted after "
+                    + str(len(backoff_delays)) + " retries: " + str(e) + "\n"
+                )
+                sys.exit(1)
+            delay = backoff_delays[backoff_attempts]
+            sys.stderr.write(
+                "WARN: network error " + str(e) + " — sleeping " + str(delay)
+                + "s (attempt " + str(backoff_attempts + 1) + "/"
+                + str(len(backoff_delays)) + ")\n"
+            )
+            time.sleep(delay)
+            backoff_attempts += 1
+            continue
+
+
+def _fetch_all(base_url, symbol, interval, start_ms, end_ms):
+    """Page through Binance klines from start_ms to end_ms. De-dup by ts_ms."""
+    interval_ms = INTERVAL_MS[interval]
+    current_start = start_ms
+    all_rows = []
+
+    while current_start <= end_ms:
+        page = _fetch_page(
+            base_url, symbol, interval, current_start, end_ms, MAX_LIMIT
+        )
+        if not isinstance(page, list):
+            sys.stderr.write(
+                "ERROR: unexpected response shape (not a list): "
+                + repr(page)[:512] + "\n"
+            )
+            sys.exit(1)
+        if not page:
+            break
+        all_rows.extend(page)
+        last_ts = page[-1][0]
+        next_start = last_ts + interval_ms
+        if next_start <= current_start:
+            # Defensive: prevent infinite loop on degenerate response.
+            break
+        current_start = next_start
+        if len(page) < MAX_LIMIT:
+            break
+
+    seen = {}
+    for row in all_rows:
+        seen[row[0]] = row
+    return [seen[ts] for ts in sorted(seen.keys())]
+
+
+def _project_row(raw):
+    """Project Binance kline array to our CSV column ordering.
+
+    Binance returns:
+        [0]  ts_ms                     -> timestamp_ms
+        [1]  open                      -> open
+        [2]  high                      -> high
+        [3]  low                       -> low
+        [4]  close                     -> close
+        [5]  volume                    -> volume
+        [6]  close_ts_ms               (dropped: derivable from ts + interval)
+        [7]  quote_volume              -> quote_volume
+        [8]  trades                    -> trades
+        [9]  taker_buy_volume          -> taker_buy_volume
+        [10] taker_buy_quote_volume    -> taker_buy_quote_volume
+        [11] ignore                    (dropped)
+    """
+    return [
+        str(raw[0]),
+        str(raw[1]),
+        str(raw[2]),
+        str(raw[3]),
+        str(raw[4]),
+        str(raw[5]),
+        str(raw[7]),
+        str(raw[8]),
+        str(raw[9]),
+        str(raw[10]),
+    ]
+
+
+CSV_HEADER = (
+    "timestamp_ms,open,high,low,close,volume,quote_volume,trades,"
+    "taker_buy_volume,taker_buy_quote_volume"
+)
+
+
+def _shard_key(ts_ms, timeframe):
+    """Group rows into per-date (intraday) or per-year (daily) files."""
+    dt = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+    if timeframe == "1d":
+        return str(dt.year)
+    return dt.strftime("%Y-%m-%d")
+
+
+def _write_shards(rows, output_dir, symbol, timeframe):
+    """Group projected rows by shard key, write one CSV per group."""
+    by_shard = {}
+    for raw in rows:
+        ts_ms = int(raw[0])
+        key = _shard_key(ts_ms, timeframe)
+        by_shard.setdefault(key, []).append(_project_row(raw))
+
+    out_root = pathlib.Path(output_dir) / symbol / timeframe
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    written = []
+    for key in sorted(by_shard.keys()):
+        out_path = out_root / (key + ".csv")
+        with open(out_path, "w") as f:
+            f.write(CSV_HEADER + "\n")
+            for row in by_shard[key]:
+                f.write(",".join(row) + "\n")
+        written.append(out_path)
+    return written
+
+
+def main(argv=None):
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    try:
+        start_dt = _parse_utc_date(args.start)
+        end_dt = _parse_utc_date(args.end)
+    except ValueError as e:
+        sys.stderr.write("ERROR: invalid date format (expected YYYY-MM-DD): " + str(e) + "\n")
+        sys.exit(2)
+
+    if end_dt < start_dt:
+        sys.stderr.write("ERROR: --end is before --start\n")
+        sys.exit(2)
+
+    # End date is inclusive — extend to end-of-day UTC.
+    start_ms = _date_to_ms(start_dt)
+    end_ms = _date_to_ms(end_dt) + (24 * 60 * 60 * 1000) - 1
+
+    sys.stderr.write(
+        "Fetching " + args.symbol + " " + args.timeframe
+        + " from " + args.start + " to " + args.end
+        + " (" + args.binance_base_url + ")\n"
+    )
+
+    rows = _fetch_all(
+        args.binance_base_url, args.symbol, args.timeframe, start_ms, end_ms
+    )
+
+    sys.stderr.write("Fetched " + str(len(rows)) + " unique candles\n")
+
+    written = _write_shards(rows, args.output_dir, args.symbol, args.timeframe)
+    sys.stderr.write("Wrote " + str(len(written)) + " CSV file(s)\n")
+    for p in written:
+        sys.stderr.write("  " + str(p) + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading-binance/tools/test-binance-feed-download.sh
+++ b/trading-binance/tools/test-binance-feed-download.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# trading-binance/tools/test-binance-feed-download.sh
+#
+# Unit tests for `binance-feed-download.py` (#573 PR-2).
+#
+# Spawns a local python http.server that serves two-page klines fixture JSON
+# matching Binance `/fapi/v1/klines` shape, runs the downloader against
+# `--binance-base-url http://127.0.0.1:<port>`, and asserts:
+#
+#   Test 1: output CSV file exists at expected shard path
+#   Test 2: CSV header line matches the documented column ordering
+#   Test 3: row count = page-1 (1500) + page-2 (500) - 1 boundary duplicate = 1999
+#   Test 4: field projection — close_ts_ms (idx 6) dropped, ignore (idx 11) dropped,
+#           and column 7 of CSV (quote_volume) maps to Binance idx 7
+#   Test 5: pagination — fixture server received exactly 2 GET requests
+#   Test 6: rows are sorted by timestamp_ms ascending and unique (de-dup worked)
+#
+# Standard library only — no pytest, no requests. Self-contained: fixture
+# JSON is generated inline by a small python helper invoked from this shell
+# script; the fixture http server is plain `python3 -m http.server` shimmed
+# via a tiny subclass that returns the right JSON for /fapi/v1/klines and
+# logs hit count.
+#
+# Usage: bash trading-binance/tools/test-binance-feed-download.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOWNLOADER="$SCRIPT_DIR/binance-feed-download.py"
+
+PORT="${BINANCE_FIXTURE_PORT:-19340}"
+WORK_DIR="$(mktemp -d)"
+SERVER_LOG="$WORK_DIR/server.log"
+SERVER_PID_FILE="$WORK_DIR/server.pid"
+HIT_COUNT_FILE="$WORK_DIR/hit-count"
+OUTPUT_DIR="$WORK_DIR/data"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    if [ -f "$SERVER_PID_FILE" ]; then
+        local pid
+        pid="$(cat "$SERVER_PID_FILE" 2>/dev/null || true)"
+        if [ -n "$pid" ]; then
+            kill "$pid" 2>/dev/null || true
+            # Give it a brief moment to release the port.
+            sleep 0.2
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    fi
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Spawn fixture HTTP server
+# ---------------------------------------------------------------------------
+exit_setup_fail() {
+    fail "$1"
+    echo "--- server log ---"
+    cat "$SERVER_LOG" 2>/dev/null || true
+    echo "--- end server log ---"
+    exit 1
+}
+
+FIXTURE_SERVER="$WORK_DIR/fixture-server.py"
+cat > "$FIXTURE_SERVER" <<'PYFIXTURE'
+"""Local fixture HTTP server for Binance klines unit tests.
+
+Args:
+    1: bind port
+    2: hit-count file path (one integer, total requests to /fapi/v1/klines)
+    3: pid file (we don't write here — outer shell tracks the PID)
+
+Page 1: 1500 candles starting at FIRST_TS, ts step = 30 minutes.
+Page 2: 500 candles starting at FIRST_TS + 1499 * step.
+        -> page-2[0] timestamp == page-1[1499] timestamp (boundary overlap,
+        target of de-dup logic). Net unique count = 1500 + 500 - 1 = 1999.
+
+Fields produced match Binance contract exactly (12 fields, idx 6 = close_ts,
+idx 11 = ignore). Numerics emitted as strings (Binance does the same).
+"""
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+PORT = int(sys.argv[1])
+HIT_FILE = sys.argv[2]
+
+FIRST_TS = 1_700_000_000_000  # arbitrary anchor (2023-11-14 UTC-ish)
+STEP_MS = 30 * 60 * 1000  # 30m
+PAGE1_LEN = 1500
+PAGE2_LEN = 500
+BOUNDARY_TS = FIRST_TS + (PAGE1_LEN - 1) * STEP_MS  # page-1 last == page-2 first
+
+_lock = threading.Lock()
+_hits = {"n": 0}
+
+
+def _make_candle(idx):
+    ts = FIRST_TS + idx * STEP_MS
+    base = 30000.0 + idx
+    return [
+        ts,
+        f"{base:.2f}",
+        f"{base + 10:.2f}",
+        f"{base - 10:.2f}",
+        f"{base + 1:.2f}",
+        f"{100 + idx}.0",
+        ts + STEP_MS - 1,
+        f"{(100 + idx) * base:.2f}",
+        50 + idx,
+        f"{(50 + idx) / 2:.2f}",
+        f"{(50 + idx) * base / 2:.2f}",
+        "0",
+    ]
+
+
+def _page1():
+    return [_make_candle(i) for i in range(PAGE1_LEN)]
+
+
+def _page2():
+    # Index PAGE1_LEN-1 = boundary candle, then PAGE2_LEN-1 fresh.
+    return [_make_candle(PAGE1_LEN - 1 + i) for i in range(PAGE2_LEN)]
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        # Quiet by default.
+        pass
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/healthz":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"ok\n")
+            return
+        if parsed.path != "/fapi/v1/klines":
+            self.send_response(404)
+            self.end_headers()
+            return
+        with _lock:
+            _hits["n"] += 1
+            n = _hits["n"]
+            with open(HIT_FILE, "w") as f:
+                f.write(str(n))
+        q = parse_qs(parsed.query)
+        # Decide page by startTime: first call requests at FIRST_TS, second
+        # call advances past page-1 last + STEP_MS.
+        start_time = int(q.get("startTime", ["0"])[0])
+        if start_time <= FIRST_TS:
+            payload = _page1()
+        else:
+            payload = _page2()
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main():
+    with open(HIT_FILE, "w") as f:
+        f.write("0")
+    server = HTTPServer(("127.0.0.1", PORT), Handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()
+PYFIXTURE
+
+python3 "$FIXTURE_SERVER" "$PORT" "$HIT_COUNT_FILE" "$SERVER_PID_FILE" > "$SERVER_LOG" 2>&1 &
+SERVER_BG_PID=$!
+echo "$SERVER_BG_PID" > "$SERVER_PID_FILE"
+
+ready=0
+for _ in $(seq 1 50); do
+    if curl -s -o /dev/null "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
+        ready=1
+        break
+    fi
+    sleep 0.1
+done
+if [ "$ready" -ne 1 ]; then
+    exit_setup_fail "fixture server did not become ready on port $PORT"
+fi
+
+# ---------------------------------------------------------------------------
+# Run the downloader against the fixture
+# ---------------------------------------------------------------------------
+# Anchor TS is 2023-11-14 UTC; pick a date range that covers fixture span.
+# Page 1 = 1500 * 30m = 750 hours = 31.25 days starting at FIRST_TS.
+# Use a wide window so the downloader stops via "short read" on page 2.
+SYMBOL="BTCUSDT"
+TIMEFRAME="30m"
+START_DATE="2023-11-14"
+END_DATE="2024-01-31"
+
+if ! python3 "$DOWNLOADER" \
+    --symbol "$SYMBOL" \
+    --timeframe "$TIMEFRAME" \
+    --start "$START_DATE" \
+    --end "$END_DATE" \
+    --output-dir "$OUTPUT_DIR" \
+    --binance-base-url "http://127.0.0.1:$PORT" \
+    > "$WORK_DIR/downloader.stdout" 2> "$WORK_DIR/downloader.stderr"; then
+    echo "--- downloader stderr ---"
+    cat "$WORK_DIR/downloader.stderr"
+    echo "--- end downloader stderr ---"
+    fail "downloader exited non-zero"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test 1: output CSV file exists at expected shard path
+# ---------------------------------------------------------------------------
+SHARD_ROOT="$OUTPUT_DIR/$SYMBOL/$TIMEFRAME"
+shard_count=$(find "$SHARD_ROOT" -name '*.csv' -type f 2>/dev/null | wc -l | tr -d ' ')
+if [ "$shard_count" -gt 0 ]; then
+    pass "output CSV file(s) exist under $SHARD_ROOT (count=$shard_count)"
+else
+    fail "no output CSV files found under $SHARD_ROOT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: every CSV file has the documented header
+# ---------------------------------------------------------------------------
+EXPECTED_HEADER="timestamp_ms,open,high,low,close,volume,quote_volume,trades,taker_buy_volume,taker_buy_quote_volume"
+header_ok=1
+while IFS= read -r f; do
+    actual="$(head -n 1 "$f")"
+    if [ "$actual" != "$EXPECTED_HEADER" ]; then
+        header_ok=0
+        echo "  bad header in $f: $actual"
+    fi
+done < <(find "$SHARD_ROOT" -name '*.csv' -type f)
+if [ "$header_ok" -eq 1 ]; then
+    pass "every CSV file has the expected header"
+else
+    fail "at least one CSV file has wrong header"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: total row count (excluding headers) = 1999 (1500 + 500 - 1 dedup)
+# ---------------------------------------------------------------------------
+total_rows=0
+while IFS= read -r f; do
+    n=$(($(wc -l < "$f") - 1))
+    total_rows=$((total_rows + n))
+done < <(find "$SHARD_ROOT" -name '*.csv' -type f)
+if [ "$total_rows" -eq 1999 ]; then
+    pass "total row count = 1999 (de-dup at page boundary worked)"
+else
+    fail "total row count = $total_rows, expected 1999"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: field projection — column 7 (quote_volume) in CSV must equal
+# Binance fixture idx 7 (string formatted as `(100+i) * base`).
+# Use the first row of the first shard. Fixture idx 0 = FIRST_TS = 1700000000000,
+# base = 30000.0, so quote_volume = 100 * 30000.00 = "3000000.00".
+# ---------------------------------------------------------------------------
+first_shard="$(find "$SHARD_ROOT" -name '*.csv' -type f | sort | head -n 1)"
+first_row="$(sed -n '2p' "$first_shard")"
+IFS=',' read -r c_ts c_open c_high c_low c_close c_vol c_qv c_trades c_tbv c_tbqv <<< "$first_row"
+if [ "$c_ts" = "1700000000000" ] \
+    && [ "$c_open" = "30000.00" ] \
+    && [ "$c_qv" = "3000000.00" ] \
+    && [ "$c_trades" = "50" ]; then
+    pass "field projection — timestamp_ms, open, quote_volume, trades map to Binance idx 0/1/7/8"
+else
+    fail "field projection mismatch: ts=$c_ts open=$c_open qv=$c_qv trades=$c_trades"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: pagination — exactly 2 GET requests to /fapi/v1/klines
+# ---------------------------------------------------------------------------
+hits="$(cat "$HIT_COUNT_FILE" 2>/dev/null || echo 0)"
+if [ "$hits" = "2" ]; then
+    pass "pagination — fixture server received exactly 2 GET requests"
+else
+    fail "pagination — expected 2 GET requests, got $hits"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: rows monotonically increasing by timestamp_ms (sorted + unique)
+# ---------------------------------------------------------------------------
+sort_ok=$(python3 - "$SHARD_ROOT" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+all_ts = []
+for p in sorted(root.glob("*.csv")):
+    with open(p) as f:
+        next(f)  # skip header
+        for line in f:
+            ts = int(line.split(",", 1)[0])
+            all_ts.append(ts)
+if all_ts == sorted(set(all_ts)) and len(all_ts) == len(set(all_ts)):
+    print("1")
+else:
+    print("0")
+PY
+)
+if [ "$sort_ok" = "1" ]; then
+    pass "rows are sorted by timestamp_ms ascending and unique"
+else
+    fail "rows are not strictly sorted/unique by timestamp_ms"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

PR-2 of 5 for #573. Adds the Python CLI downloader that subsequent PRs
(replay harness, strategy daemon, A/B experiment) need to operate on.

- New tool `trading-binance/tools/binance-feed-download.py` — fetches
  Binance USDT-margined perpetual futures klines via the public
  `/fapi/v1/klines` REST endpoint, paginates over multi-day windows
  (max 1500 candles per request), handles HTTP 429 (Retry-After once),
  418 / 451 (hard-fail on IP ban), and 5xx / network errors (3-attempt
  exponential backoff 2s / 4s / 8s).
- Output is date-sharded CSV: one file per UTC date for `30m` / `1h`,
  one file per year for `1d`. Re-runs overwrite deterministically.
- New test `trading-binance/tools/test-binance-feed-download.sh` —
  spawns a local Python `http.server` fixture that serves a synthetic
  two-page klines payload (1500 + 500 candles with a one-row boundary
  overlap) and asserts 6 invariants: file presence, header, row count
  after de-dup (= 1999), field-projection mapping to Binance indices,
  pagination hit count, and per-timestamp ordering / uniqueness.
- `trading-binance/BUNDLE.manifest` appended with the new downloader so
  the release bundle stays install-ready.

CME BTC1! daily data (for gap analysis) is deferred to Phase 2. Yahoo
Finance `BTC=F` and Stooq CSV are candidate sources; neither is in scope
for this PR.

## Constraints honoured

- Python standard library only — no `requests`, no `pandas`.
- No `.ag` agent code, no orchestrator changes, no agentis-core changes.
- No live API calls in CI — the test uses a local fixture server on port
  `19340` (override via `BINANCE_FIXTURE_PORT`).
- `--binance-base-url` is a hidden CLI knob; default
  `https://fapi.binance.com`.

## Test plan

- [x] `python3 -m py_compile trading-binance/tools/binance-feed-download.py`
- [x] `bash -n trading-binance/tools/test-binance-feed-download.sh`
- [x] `bash trading-binance/tools/test-binance-feed-download.sh` — 6 / 6 assertions pass
- [x] `bash tools/colony-lint.sh` — 175 passed, 0 failed, 3 skipped (baseline preserved)
- [x] `python3 trading-binance/tools/binance-feed-download.py --help` renders cleanly; hidden `--binance-base-url` suppressed from help
- [ ] Operator-only follow-up: manual download of 1 day BTCUSDT 30m against live API to spot-check output format (not run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)