### PR TITLE
feat: replay harness orchestrator (#573 PR-3)

### DIFF
--- a/trading-binance/BUNDLE.manifest
+++ b/trading-binance/BUNDLE.manifest
@@ -1,2 +1,5 @@
 trading-binance/
 trading-binance/tools/binance-feed-download.py
+trading-binance/tools/run-replay.sh
+trading-binance/tools/load-candles.py
+trading-binance/tools/Containerfile.replay

--- a/trading-binance/tools/Containerfile.replay
+++ b/trading-binance/tools/Containerfile.replay
@@ -1,0 +1,70 @@
+# Containerfile.replay — base image for the offline historical-feed
+# replay orchestrator (#573 PR-3).
+#
+# WARNING: this image deliberately bakes ONLY the agentis runtime + base OS
+# tooling. The replay candle stream (trading-binance/data/<symbol>/<tf>/<date>.csv,
+# produced by PR-2), the per-tick context slices, the strategist agent
+# scaffolding, and the per-run hermetic .agentis/ state are mounted in at
+# run time via `-v $REPO_ROOT:/repo:ro` and `-v $RUN_DIR/<node>:/run-root:rw`.
+# Do NOT `COPY` any of the above into the image; doing so would (a) freeze
+# the historical candle surface to image-build time, defeating the offline
+# replay design, and (b) bake the public CSV feed into every image push.
+#
+# WARNING: OPENAI_API_KEY (and any other LLM-backend credential env var)
+# MUST NOT be baked in. The orchestrator passes it at run time via
+# `podman run -e OPENAI_API_KEY=...`. Any attempt to embed the key here
+# (ARG OPENAI_API_KEY, ENV OPENAI_API_KEY, secret file COPY) would leak
+# into the image layers and `podman save` exports.
+#
+# WARNING: Claude Code session credentials (`~/.claude/.credentials.json`)
+# MUST NOT be baked in either. Future replay-side claude backend support
+# will follow the tribes-bench pattern of bind-mounting the host
+# operator's `$HOME/.claude` at run time; never `COPY` the directory into
+# the image.
+#
+# The agentis binary fetch is sha256-verified against the publisher's
+# detached signature so a compromised CDN can't substitute a backdoored
+# build mid-pull. The Claude Code installer is fetched from the
+# Anthropic-published canonical URL (claude.ai/install.sh).
+
+FROM ubuntu:24.04
+
+ARG AGENTIS_VERSION=v1.7.12
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        python3 \
+        jq \
+        git \
+        curl \
+        ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN cd /tmp \
+ && curl -fsSL -o agentis-linux-x86_64 \
+        "https://github.com/Replikanti/agentis/releases/download/${AGENTIS_VERSION}/agentis-linux-x86_64" \
+ && curl -fsSL -o agentis-linux-x86_64.sha256 \
+        "https://github.com/Replikanti/agentis/releases/download/${AGENTIS_VERSION}/agentis-linux-x86_64.sha256" \
+ && sha256sum -c agentis-linux-x86_64.sha256 \
+ && install -m 0755 agentis-linux-x86_64 /usr/local/bin/agentis \
+ && rm /tmp/agentis-linux-x86_64 /tmp/agentis-linux-x86_64.sha256
+
+# Install Claude Code CLI for future replay claude-backend support. The
+# standalone installer fetches a statically-linked Linux x86_64 ELF
+# binary into /root/.local/share/claude/versions/<X.Y.Z> and symlinks
+# /root/.local/bin/claude. We then symlink to /usr/local/bin/claude so
+# the agentis cli backend (which spawns the `claude` subprocess) resolves
+# it via PATH.
+#
+# The installer is fetched from the Anthropic-published canonical URL.
+# No version pin: Claude Code auto-updates frequently and the
+# orchestrator falls through to whatever the installer publishes today.
+# Operators who need reproducibility should rebuild the image periodically.
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+ && ln -s /root/.local/bin/claude /usr/local/bin/claude
+
+WORKDIR /run-root
+
+ENTRYPOINT ["/bin/bash"]

--- a/trading-binance/tools/load-candles.py
+++ b/trading-binance/tools/load-candles.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""load-candles.py - Concatenate PR-2 CSV shards into a unified candle stream.
+
+Reads date-sharded CSV files produced by `binance-feed-download.py` under
+`<data-dir>/<symbol>/<timeframe>/<YYYY-MM-DD>.csv` (intraday) or
+`<data-dir>/<symbol>/<timeframe>/<YYYY>.csv` (daily), filters by optional
+inclusive [start, end] date range, concatenates them sorted by
+timestamp_ms, and prints the result to stdout with one header line.
+
+Validates row continuity: rejects any gap > 2x the timeframe interval.
+This catches silently-missing shards before they break the replay loop.
+
+Standard library only.
+
+Usage:
+    load-candles.py --data-dir trading-binance/data \\
+        --symbol BTCUSDT --timeframe 30m \\
+        [--start 2026-02-15] [--end 2026-05-13]
+
+Exit codes:
+    0  success — unified stream on stdout
+    2  invalid arguments / unknown timeframe
+    3  missing data dir or no shards in range
+    4  continuity violation (gap > 2x interval)
+"""
+import argparse
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+VALID_TIMEFRAMES = ("30m", "1h", "1d")
+INTERVAL_MS = {
+    "30m": 30 * 60 * 1000,
+    "1h": 60 * 60 * 1000,
+    "1d": 24 * 60 * 60 * 1000,
+}
+CSV_HEADER = (
+    "timestamp_ms,open,high,low,close,volume,quote_volume,trades,"
+    "taker_buy_volume,taker_buy_quote_volume"
+)
+
+
+def _parse_args(argv):
+    p = argparse.ArgumentParser(description="Concatenate Binance CSV shards.")
+    p.add_argument("--data-dir", required=True)
+    p.add_argument("--symbol", required=True)
+    p.add_argument("--timeframe", required=True, choices=VALID_TIMEFRAMES)
+    p.add_argument("--start", default="", help="UTC YYYY-MM-DD (inclusive).")
+    p.add_argument("--end", default="", help="UTC YYYY-MM-DD (inclusive).")
+    return p.parse_args(argv)
+
+
+def _shard_in_range(name, start, end):
+    """Return True iff the shard's date stem falls within [start, end].
+
+    Bare stems (no extension stripping done by caller) like 'YYYY-MM-DD' or
+    'YYYY' compare lexicographically against ISO date strings; an empty
+    bound is treated as open on that side.
+    """
+    if start and name < start:
+        return False
+    if end and name > end:
+        return False
+    return True
+
+
+def _read_shard(path):
+    """Yield raw CSV rows (excluding header) as strings, with trailing newlines stripped."""
+    with open(path, "r") as f:
+        header = f.readline().rstrip("\n")
+        if header != CSV_HEADER:
+            sys.stderr.write(
+                "ERROR: " + str(path) + " header mismatch:\n"
+                "  expected: " + CSV_HEADER + "\n"
+                "  got:      " + header + "\n"
+            )
+            sys.exit(3)
+        for line in f:
+            line = line.rstrip("\n")
+            if line:
+                yield line
+
+
+def main(argv=None):
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    shard_dir = pathlib.Path(args.data_dir) / args.symbol / args.timeframe
+    if not shard_dir.is_dir():
+        sys.stderr.write("ERROR: shard directory not found: " + str(shard_dir) + "\n")
+        sys.exit(3)
+
+    shards = sorted(shard_dir.glob("*.csv"))
+    if args.start or args.end:
+        shards = [
+            s for s in shards
+            if _shard_in_range(s.stem, args.start, args.end)
+        ]
+    if not shards:
+        sys.stderr.write(
+            "ERROR: no shards in range under " + str(shard_dir) + "\n"
+        )
+        sys.exit(3)
+
+    interval_ms = INTERVAL_MS[args.timeframe]
+    gap_cap = 2 * interval_ms
+    sys.stdout.write(CSV_HEADER + "\n")
+    last_ts = None
+    total = 0
+    for shard in shards:
+        for line in _read_shard(shard):
+            try:
+                ts = int(line.split(",", 1)[0])
+            except (ValueError, IndexError):
+                sys.stderr.write(
+                    "ERROR: malformed row in " + str(shard) + ": " + line + "\n"
+                )
+                sys.exit(3)
+            if last_ts is not None:
+                delta = ts - last_ts
+                if delta <= 0:
+                    sys.stderr.write(
+                        "ERROR: non-monotonic ts in " + str(shard)
+                        + " (prev=" + str(last_ts) + " cur=" + str(ts) + ")\n"
+                    )
+                    sys.exit(4)
+                if delta > gap_cap:
+                    sys.stderr.write(
+                        "ERROR: continuity gap " + str(delta) + " ms > "
+                        + str(gap_cap) + " ms (2x " + args.timeframe + ") "
+                        + "between ts=" + str(last_ts) + " and ts=" + str(ts) + "\n"
+                    )
+                    sys.exit(4)
+            sys.stdout.write(line + "\n")
+            last_ts = ts
+            total += 1
+
+    first_dt = datetime.fromtimestamp(
+        int(open(shards[0]).readlines()[1].split(",", 1)[0]) / 1000,
+        tz=timezone.utc,
+    )
+    sys.stderr.write(
+        "Loaded " + str(total) + " candles from " + str(len(shards))
+        + " shard(s) starting at " + first_dt.strftime("%Y-%m-%dT%H:%M:%SZ") + "\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/trading-binance/tools/run-replay.sh
+++ b/trading-binance/tools/run-replay.sh
@@ -1,0 +1,423 @@
+#!/bin/bash
+# run-replay.sh — offline historical-feed replay orchestrator for the
+# trading-binance federation (#573 PR-3).
+#
+# Streams PR-2 CSV candles from `trading-binance/data/<symbol>/<tf>/<date>.csv`
+# tick-by-tick to agentis daemons running inside a single podman container.
+# Mirrors tribes-bench/run-stage3-docker.sh architectural shape (emit_step
+# helper, run dir under <federation>/runs/<timestamp>/, sandbox cp idiom)
+# but adapts the rotation loop into a candle-tick loop instead of a
+# planted-bug-surface rotation.
+#
+# Daemons spawned in PR-3 will look for /run-root/market/agents/strategist.ag
+# which PR-4 ships. Until PR-4 lands the daemons will error out on missing
+# file; this is intentional — PR-3 validates orchestrator wiring + candle
+# loading + telemetry layout, not strategy decisions.
+#
+# Env vars (all optional; defaults shown):
+#   REPLAY_DATA_DIR              PR-2 CSV root.
+#                                Default: trading-binance/data
+#   REPLAY_SYMBOL                Binance futures symbol.
+#                                Default: BTCUSDT
+#   REPLAY_TIMEFRAME             Candle interval: 30m | 1h | 1d.
+#                                Default: 30m
+#   REPLAY_START                 UTC YYYY-MM-DD lower bound (inclusive).
+#                                Default: "" (first available shard)
+#   REPLAY_END                   UTC YYYY-MM-DD upper bound (inclusive).
+#                                Default: "" (last available shard)
+#   REPLAY_SPEED                 Replay multiplier. 100 = 1h market data
+#                                in 36s wall clock. Default: 100
+#   REPLAY_DAEMON_COUNT          Number of strategist daemons to spawn.
+#                                Default: 5
+#   REPLAY_LLM_BACKEND           llm.backend value injected into hermetic
+#                                config. Default: openai
+#   REPLAY_OPENAI_ENDPOINT       Chat-completions URL.
+#                                Default: https://openrouter.ai/api/v1/chat/completions
+#   REPLAY_OPENAI_MODEL          Model id when backend=openai.
+#                                Default: qwen/qwen3-coder-30b-a3b-instruct
+#   REPLAY_OPENAI_KEY_ENV        Env var carrying the LLM API key.
+#                                Default: OPENROUTER_API_KEY
+#   REPLAY_OPENAI_TIMEOUT_MS     Per-request timeout (ms). Default: 180000
+#   REPLAY_LOOKBACK_WINDOW       Past candles visible to daemon per tick.
+#                                Default: 200
+#   REPLAY_HOLD_PERIOD           Forward candles for PnL settlement.
+#                                Default: 8
+#   REPLAY_DRY_RUN               1 = emit_step the plan, skip podman.
+#                                Default: "" (real run)
+#   REPLAY_RUN_DIR               Output dir override. Default: auto-
+#                                timestamped under trading-binance/runs/
+#   REPLAY_IMAGE_TAG             Container image tag built from
+#                                Containerfile.replay.
+#                                Default: trading-binance-replay:latest
+#
+# Flags:
+#   --dry-run    Same as REPLAY_DRY_RUN=1.
+#
+# Output layout (under trading-binance/runs/<YYYYMMDDTHHMMSSZ>/):
+#   orchestrator.log              orchestrator's own log
+#   run-meta.json                 config dump (symbol, tf, range, knobs)
+#   candles.csv                   unified candle stream from load-candles.py
+#   laptop-node/
+#     bootstrap.sh                container bootstrap (real run only)
+#     .agentis/
+#       sandbox/context-stream/   per-tick context CSVs
+#       logs/
+#       spend/
+#   trade-ledger.jsonl            empty placeholder; PR-4 populates
+#   telemetry-combined.csv        empty placeholder; PR-5 analyser fills
+#
+# Exit codes:
+#   0   replay completed (or dry-run plan emitted)
+#   1   prerequisite missing (podman, python3 outside dry-run)
+#   2   invalid env (e.g. unknown timeframe)
+#   3   candle loading failed
+#   4   container spawn failed
+
+set -euo pipefail
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+TOOLS_DIR="$(dirname "$SCRIPT_PATH")"
+FED_DIR="$(dirname "$TOOLS_DIR")"
+REPO_ROOT="$(dirname "$FED_DIR")"
+
+# --- Argument parsing ---
+DRY_RUN="${REPLAY_DRY_RUN:-0}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "$SCRIPT_PATH"
+            exit 0
+            ;;
+        *)
+            echo "run-replay: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# --- Env-var defaults ---
+DATA_DIR_RAW="${REPLAY_DATA_DIR:-$FED_DIR/data}"
+SYMBOL="${REPLAY_SYMBOL:-BTCUSDT}"
+TIMEFRAME="${REPLAY_TIMEFRAME:-30m}"
+START="${REPLAY_START:-}"
+END="${REPLAY_END:-}"
+SPEED="${REPLAY_SPEED:-100}"
+DAEMON_COUNT="${REPLAY_DAEMON_COUNT:-5}"
+LLM_BACKEND="${REPLAY_LLM_BACKEND:-openai}"
+OPENAI_ENDPOINT="${REPLAY_OPENAI_ENDPOINT:-https://openrouter.ai/api/v1/chat/completions}"
+OPENAI_MODEL="${REPLAY_OPENAI_MODEL:-qwen/qwen3-coder-30b-a3b-instruct}"
+OPENAI_KEY_ENV="${REPLAY_OPENAI_KEY_ENV:-OPENROUTER_API_KEY}"
+OPENAI_TIMEOUT_MS="${REPLAY_OPENAI_TIMEOUT_MS:-180000}"
+LOOKBACK_WINDOW="${REPLAY_LOOKBACK_WINDOW:-200}"
+HOLD_PERIOD="${REPLAY_HOLD_PERIOD:-8}"
+IMAGE_TAG="${REPLAY_IMAGE_TAG:-trading-binance-replay:latest}"
+
+# --- Validation ---
+case "$TIMEFRAME" in
+    30m|1h|1d) ;;
+    *)
+        echo "run-replay: REPLAY_TIMEFRAME must be one of 30m|1h|1d (got '$TIMEFRAME')" >&2
+        exit 2
+        ;;
+esac
+
+case "$TIMEFRAME" in
+    30m) INTERVAL_SECONDS=1800 ;;
+    1h)  INTERVAL_SECONDS=3600 ;;
+    1d)  INTERVAL_SECONDS=86400 ;;
+esac
+
+val=""
+for var_name in SPEED DAEMON_COUNT LOOKBACK_WINDOW HOLD_PERIOD OPENAI_TIMEOUT_MS; do
+    eval "val=\${$var_name}"
+    case "$val" in
+        ''|*[!0-9]*)
+            echo "run-replay: $var_name must be a positive integer (got: $val)" >&2
+            exit 2
+            ;;
+    esac
+done
+unset val
+
+if [ "$SPEED" -lt 1 ]; then
+    echo "run-replay: REPLAY_SPEED must be >= 1 (got: $SPEED)" >&2
+    exit 2
+fi
+if [ "$DAEMON_COUNT" -lt 1 ]; then
+    echo "run-replay: REPLAY_DAEMON_COUNT must be >= 1 (got: $DAEMON_COUNT)" >&2
+    exit 2
+fi
+
+# Resolve DATA_DIR to absolute path (so we can pass it into containers /
+# helpers safely regardless of where the orchestrator is launched from).
+if [ -d "$DATA_DIR_RAW" ]; then
+    DATA_DIR="$(cd "$DATA_DIR_RAW" && pwd)"
+else
+    # Resolve later — load-candles.py is the single point of "data dir
+    # exists" enforcement so the dry-run path can still emit_step a plan
+    # without a populated data dir on disk.
+    DATA_DIR="$DATA_DIR_RAW"
+fi
+
+# --- Per-run hermetic dir ---
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="${REPLAY_RUN_DIR:-$FED_DIR/runs/$TS}"
+ORCH_LOG="$RUN_DIR/orchestrator.log"
+RUN_META="$RUN_DIR/run-meta.json"
+CANDLES_CSV="$RUN_DIR/candles.csv"
+LAPTOP_DIR="$RUN_DIR/laptop-node"
+SANDBOX_CTX="$LAPTOP_DIR/.agentis/sandbox/context-stream"
+TRADE_LEDGER="$RUN_DIR/trade-ledger.jsonl"
+TELEMETRY_CSV="$RUN_DIR/telemetry-combined.csv"
+
+# --- Dry-run / real-run dispatch helpers (mirrors tribes-bench idiom) ---
+emit_cmd() {
+    if [ "$DRY_RUN" = "1" ]; then
+        printf '+ %s\n' "$*"
+    else
+        printf '+ %s\n' "$*" >>"$ORCH_LOG"
+        # shellcheck disable=SC2294
+        eval "$@"
+    fi
+}
+
+emit_step() {
+    if [ "$DRY_RUN" = "1" ]; then
+        printf '# %s\n' "$*"
+    else
+        printf '# %s\n' "$*" >>"$ORCH_LOG"
+    fi
+}
+
+# --- Prerequisite checks (skipped in dry-run for portability) ---
+if [ "$DRY_RUN" = "0" ]; then
+    for bin in podman python3; do
+        if ! command -v "$bin" >/dev/null 2>&1; then
+            echo "run-replay: $bin not found on PATH" >&2
+            exit 1
+        fi
+    done
+    if [ "$LLM_BACKEND" = "openai" ]; then
+        eval "openai_key_value=\${$OPENAI_KEY_ENV:-}"
+        if [ -z "${openai_key_value:-}" ]; then
+            echo "run-replay: \$$OPENAI_KEY_ENV is empty (required for llm.backend=openai)" >&2
+            exit 1
+        fi
+        unset openai_key_value
+    fi
+    mkdir -p "$RUN_DIR" "$LAPTOP_DIR" "$SANDBOX_CTX" "$LAPTOP_DIR/.agentis/logs" "$LAPTOP_DIR/.agentis/spend"
+    : >"$ORCH_LOG"
+    : >"$TRADE_LEDGER"
+    : >"$TELEMETRY_CSV"
+fi
+
+emit_step "run-replay: starting (dry_run=$DRY_RUN)"
+emit_step "run dir: $RUN_DIR"
+emit_step "replay symbol: $SYMBOL"
+emit_step "timeframe: $TIMEFRAME (interval=${INTERVAL_SECONDS}s)"
+emit_step "date range: start=${START:-<first>} end=${END:-<last>}"
+emit_step "replay speed: $SPEED"
+emit_step "daemon count: $DAEMON_COUNT"
+emit_step "lookback window: $LOOKBACK_WINDOW"
+emit_step "hold period: $HOLD_PERIOD"
+emit_step "llm backend: $LLM_BACKEND"
+emit_step "image tag: $IMAGE_TAG"
+emit_step "data dir: $DATA_DIR"
+
+# --- 1) Load candles via helper (single point of file-existence enforcement) ---
+load_candles() {
+    emit_step "loading candle stream via load-candles.py"
+    if [ "$DRY_RUN" = "1" ]; then
+        emit_cmd "python3 $TOOLS_DIR/load-candles.py --data-dir $DATA_DIR --symbol $SYMBOL --timeframe $TIMEFRAME --start \"$START\" --end \"$END\" > $CANDLES_CSV"
+        return 0
+    fi
+    if ! python3 "$TOOLS_DIR/load-candles.py" \
+            --data-dir "$DATA_DIR" \
+            --symbol "$SYMBOL" \
+            --timeframe "$TIMEFRAME" \
+            --start "$START" \
+            --end "$END" >"$CANDLES_CSV" 2>>"$ORCH_LOG"; then
+        echo "run-replay: load-candles.py failed (see $ORCH_LOG)" >&2
+        exit 3
+    fi
+    candle_lines=$(($(wc -l <"$CANDLES_CSV") - 1))
+    emit_step "candles loaded: $candle_lines rows"
+}
+
+# --- 2) Build (or reuse) the container image ---
+build_image() {
+    emit_step "checking for existing image $IMAGE_TAG (build if missing)"
+    emit_cmd "podman image exists $IMAGE_TAG || podman build -t $IMAGE_TAG -f $TOOLS_DIR/Containerfile.replay $FED_DIR"
+}
+
+# --- 3) Per-node bootstrap script generator ---
+# write_bootstrap emits a self-contained bash script into <node-dir>/
+# bootstrap.sh that, when executed inside the container, performs:
+#   1. agentis init in /run-root (idempotent)
+#   2. Append llm config lines to .agentis/config
+#   3. Copy market/ agents + tools/ from the read-only /repo bind-mount
+#      into /run-root
+#   4. Spawn N strategist daemons (one per DAEMON_ID)
+#   5. Block until /run-root/.shutdown is touched by the host orchestrator
+write_bootstrap() {
+    bootstrap_path="$LAPTOP_DIR/bootstrap.sh"
+    emit_step "generating bootstrap script at $bootstrap_path (daemons=$DAEMON_COUNT)"
+
+    if [ "$DRY_RUN" = "1" ]; then
+        emit_cmd "write-bootstrap path=$bootstrap_path daemon_count=$DAEMON_COUNT symbol=$SYMBOL timeframe=$TIMEFRAME"
+        return
+    fi
+
+    {
+        printf '#!/bin/bash\n'
+        printf '# Auto-generated by run-replay.sh — runs inside the container.\n'
+        printf 'set -euo pipefail\n'
+        printf 'cd /run-root\n'
+        printf 'agentis init >/dev/null 2>&1 || true\n'
+        printf '{\n'
+        printf '  printf "exec.env_passthrough = DAEMON_ID,REPLAY_SYMBOL,REPLAY_TIMEFRAME,REPLAY_LOOKBACK_WINDOW,REPLAY_HOLD_PERIOD,AGENTIS_ROOT\\n"\n'
+        printf '  printf "experience.enabled = true\\n"\n'
+        printf '  printf "telemetry.enabled = true\\n"\n'
+        printf '  printf "llm.backend = %s\\n"\n' "$LLM_BACKEND"
+        if [ "$LLM_BACKEND" = "openai" ]; then
+            printf '  printf "llm.openai.endpoint = %s\\n"\n' "$OPENAI_ENDPOINT"
+            printf '  printf "llm.openai.model = %s\\n"\n' "$OPENAI_MODEL"
+            printf '  printf "llm.openai.api_key_env = %s\\n"\n' "$OPENAI_KEY_ENV"
+            printf '  printf "llm.openai.timeout_ms = %s\\n"\n' "$OPENAI_TIMEOUT_MS"
+        fi
+        printf '} >> .agentis/config\n'
+        printf 'cp -r /repo/trading-binance/market /run-root/market\n'
+        printf 'cp -r /repo/trading-binance/tools /run-root/tools\n'
+        printf 'mkdir -p /run-root/.agentis/sandbox\n'
+        # Seed propose-tier confidence so the strategist daemon ticks past
+        # dormant. PR-4 will own the actual seed convention; for now we
+        # seed a placeholder so PR-3 wiring is observable end-to-end.
+        printf '(cd /run-root && agentis memo set strategist:confidence 0.7 >/dev/null 2>&1 || true)\n'
+        # Spawn N strategist daemons. strategist.ag arrives in PR-4; in PR-3
+        # the daemons will fail to load the missing scenario file, which is
+        # the documented PR-3 outcome.
+        printf 'for i in $(seq 1 %s); do\n' "$DAEMON_COUNT"
+        printf '    DAEMON_ID=$i REPLAY_SYMBOL=%s REPLAY_TIMEFRAME=%s REPLAY_LOOKBACK_WINDOW=%s REPLAY_HOLD_PERIOD=%s AGENTIS_ROOT=/run-root/.agentis agentis daemon /run-root/market/agents/strategist.ag --colony market --tick-interval %s > /run-root/.agentis/logs/strategist-$i.log 2>&1 &\n' \
+            "$SYMBOL" "$TIMEFRAME" "$LOOKBACK_WINDOW" "$HOLD_PERIOD" "$((INTERVAL_SECONDS * 1000 / SPEED))"
+        printf 'done\n'
+        printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'
+        printf 'exit 0\n'
+    } >"$bootstrap_path"
+    chmod +x "$bootstrap_path"
+}
+
+# --- 4) Spawn the container ---
+spawn_container() {
+    emit_step "spawning replay-laptop container (image=$IMAGE_TAG)"
+    emit_cmd "podman run -d --name replay-laptop -e $OPENAI_KEY_ENV=\"\${$OPENAI_KEY_ENV:-}\" -v $REPO_ROOT:/repo:ro -v $LAPTOP_DIR:/run-root:rw $IMAGE_TAG /run-root/bootstrap.sh"
+}
+
+# --- 5) Cleanup trap ---
+install_cleanup_trap() {
+    emit_step "installing cleanup trap (stop + rm container)"
+    emit_cmd "trap 'podman stop --time 5 replay-laptop 2>/dev/null || true; podman rm -f replay-laptop 2>/dev/null || true' EXIT INT TERM"
+}
+
+# --- 6) Tick stream (main replay loop) ---
+# For each tick:
+#   1. Slice rows [idx-LOOKBACK_WINDOW .. idx] from candles.csv into
+#      <run-dir>/laptop-node/.agentis/sandbox/context-stream/tick-<idx>.csv
+#   2. Update memos so the strategist daemon picks up the new context path
+#   3. Sleep interval_seconds / SPEED so the daemon has a chance to react
+tick_stream() {
+    emit_step "starting tick stream (interval=${INTERVAL_SECONDS}s sped to $(( INTERVAL_SECONDS / SPEED ))s)"
+    if [ "$DRY_RUN" = "1" ]; then
+        emit_cmd "python3 -c 'replay-loop placeholder: lookback=$LOOKBACK_WINDOW hold=$HOLD_PERIOD speed=$SPEED' # tick loop runs in real mode"
+        return
+    fi
+    python3 - "$CANDLES_CSV" "$SANDBOX_CTX" "$LOOKBACK_WINDOW" "$HOLD_PERIOD" \
+            "$INTERVAL_SECONDS" "$SPEED" "$RUN_DIR" <<'PYREPLAY'
+import os
+import subprocess
+import sys
+import time
+
+candles_csv, ctx_dir, lookback, hold, interval, speed, run_dir = (
+    sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]),
+    int(sys.argv[5]), int(sys.argv[6]), sys.argv[7],
+)
+with open(candles_csv) as f:
+    header = f.readline().rstrip("\n")
+    rows = [line.rstrip("\n") for line in f if line.strip()]
+total = len(rows)
+if total <= lookback + hold:
+    sys.stderr.write(
+        "tick-stream: not enough candles ("
+        + str(total) + ") for lookback="
+        + str(lookback) + " + hold=" + str(hold) + "\n"
+    )
+    sys.exit(0)
+sleep_s = max(1, interval // max(1, speed))
+log_path = os.path.join(run_dir, "orchestrator.log")
+for idx in range(lookback, total - hold):
+    window = rows[idx - lookback:idx + 1]
+    out_path = os.path.join(ctx_dir, "tick-" + str(idx) + ".csv")
+    with open(out_path, "w") as out:
+        out.write(header + "\n")
+        out.write("\n".join(window) + "\n")
+    rel = "context-stream/tick-" + str(idx) + ".csv"
+    subprocess.run(
+        ["podman", "exec", "replay-laptop", "agentis", "memo", "set",
+         "replay:current_tick", str(idx)],
+        check=False,
+    )
+    subprocess.run(
+        ["podman", "exec", "replay-laptop", "agentis", "memo", "set",
+         "replay:context_path", rel],
+        check=False,
+    )
+    with open(log_path, "a") as log:
+        log.write("# tick " + str(idx) + "/" + str(total - hold) + " ctx=" + rel + "\n")
+    time.sleep(sleep_s)
+PYREPLAY
+}
+
+# --- 7) Shutdown signal ---
+signal_shutdown() {
+    emit_step "signalling shutdown (touch /run-root/.shutdown)"
+    emit_cmd "podman exec replay-laptop touch /run-root/.shutdown 2>/dev/null || true"
+}
+
+# --- 8) run-meta.json ---
+write_run_meta() {
+    emit_step "writing run-meta.json"
+    started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    emit_cmd "python3 -c 'import json; json.dump({\"started_at\":\"$started_at\",\"symbol\":\"$SYMBOL\",\"timeframe\":\"$TIMEFRAME\",\"start\":\"$START\",\"end\":\"$END\",\"speed\":$SPEED,\"daemon_count\":$DAEMON_COUNT,\"lookback_window\":$LOOKBACK_WINDOW,\"hold_period\":$HOLD_PERIOD,\"llm_backend\":\"$LLM_BACKEND\",\"image_tag\":\"$IMAGE_TAG\"}, open(\"$RUN_META\",\"w\"), indent=2)'"
+}
+
+# --- 9) Analyser placeholder ---
+# analyse-replay.py is the PR-5 deliverable; PR-3 just stubs the call so
+# the orchestrator wiring is observable. Failure is non-fatal.
+analyse_placeholder() {
+    emit_step "analyser placeholder (PR-5 will populate $TELEMETRY_CSV)"
+    emit_cmd "ls $LAPTOP_DIR/.agentis/spend 2>/dev/null || true"
+}
+
+# --- Orchestration body ---
+install_cleanup_trap
+load_candles
+build_image
+write_bootstrap
+write_run_meta
+spawn_container
+tick_stream
+
+if [ "$DRY_RUN" = "1" ]; then
+    emit_step "dry-run complete; no container spawned"
+    exit 0
+fi
+
+signal_shutdown
+analyse_placeholder
+
+emit_step "run-replay: done"
+echo "[run-replay] run dir: $RUN_DIR"

--- a/trading-binance/tools/test-run-replay.sh
+++ b/trading-binance/tools/test-run-replay.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# trading-binance/tools/test-run-replay.sh — smoke test for run-replay.sh
+# --dry-run mode + load-candles.py wiring (#573 PR-3).
+#
+# Assertions:
+#
+#   1. REPLAY_DRY_RUN=1 exits 0
+#   2. emit_step transcript names the configured symbol
+#   3. emit_step transcript names the configured timeframe
+#   4. emit_step transcript names the configured daemon count
+#   5. emit_step transcript names the configured lookback window
+#   6. emit_step transcript names the configured hold period
+#   7. emit_step transcript names the configured replay speed
+#   8. Invalid REPLAY_TIMEFRAME=15m rejected with exit 2 + helpful stderr
+#   9. Missing data dir rejected (real run: load-candles.py file-not-found)
+#  10. REPLAY_DATA_DIR with valid fixture CSV is processed end-to-end
+#      (load-candles.py invoked, candles.csv generated in RUN_DIR)
+#  11. load-candles.py rejects continuity-gap fixture
+#  12. Bootstrap-script generation step is emitted in dry-run output
+#  13. Container spawn command is emitted in dry-run output (echo-only)
+#  14. Run-meta.json write step is emitted in dry-run output
+#  15. Cleanup trap is installed in dry-run output
+#
+# Standard library only — no pytest, no requests, no live LLM, no podman.
+# Self-contained: fixture CSV is generated inline.
+#
+# Usage: bash trading-binance/tools/test-run-replay.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ORCH="$SCRIPT_DIR/run-replay.sh"
+LOADER="$SCRIPT_DIR/load-candles.py"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+    label="$1"; haystack="$2"; needle="$3"
+    if printf '%s' "$haystack" | grep -Fq -- "$needle"; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       needle not found: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_eq() {
+    label="$1"; expected="$2"; actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       expected: $expected"
+        echo "       actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+if [ ! -x "$ORCH" ]; then
+    echo "[FAIL] run-replay.sh not executable at $ORCH"
+    exit 1
+fi
+if [ ! -f "$LOADER" ]; then
+    echo "[FAIL] load-candles.py missing at $LOADER"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 1-7. Dry-run with explicit knobs surfaces every config line.
+# ---------------------------------------------------------------------------
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+DRY_RC=0
+OUT="$(REPLAY_DRY_RUN=1 \
+       REPLAY_SYMBOL=BTCUSDT \
+       REPLAY_TIMEFRAME=30m \
+       REPLAY_DAEMON_COUNT=5 \
+       REPLAY_LOOKBACK_WINDOW=200 \
+       REPLAY_HOLD_PERIOD=8 \
+       REPLAY_SPEED=100 \
+       REPLAY_RUN_DIR="$WORK_DIR/run-default" \
+       bash "$ORCH" 2>&1)" || DRY_RC=$?
+
+assert_eq "1. REPLAY_DRY_RUN=1 exits 0" "0" "$DRY_RC"
+assert_contains "2. emit_step names symbol" "$OUT" "replay symbol: BTCUSDT"
+assert_contains "3. emit_step names timeframe" "$OUT" "timeframe: 30m"
+assert_contains "4. emit_step names daemon count" "$OUT" "daemon count: 5"
+assert_contains "5. emit_step names lookback window" "$OUT" "lookback window: 200"
+assert_contains "6. emit_step names hold period" "$OUT" "hold period: 8"
+assert_contains "7. emit_step names replay speed" "$OUT" "replay speed: 100"
+
+# ---------------------------------------------------------------------------
+# 8. Invalid timeframe rejection.
+# ---------------------------------------------------------------------------
+INVALID_OUT="$(REPLAY_DRY_RUN=1 REPLAY_TIMEFRAME=15m \
+               bash "$ORCH" 2>&1 || true)"
+INVALID_RC=0
+REPLAY_DRY_RUN=1 REPLAY_TIMEFRAME=15m bash "$ORCH" >/dev/null 2>&1 || INVALID_RC=$?
+assert_eq "8a. REPLAY_TIMEFRAME=15m exits 2" "2" "$INVALID_RC"
+assert_contains "8b. invalid-timeframe stderr names accepted set" "$INVALID_OUT" \
+    "REPLAY_TIMEFRAME must be one of 30m|1h|1d"
+
+# ---------------------------------------------------------------------------
+# 9. Missing data dir rejected (real-run: load-candles.py file-not-found).
+# Dry-run intentionally does NOT validate the data dir so the plan can be
+# emitted without on-disk fixtures; the real-run path delegates to
+# load-candles.py which is the single point of "data dir exists" enforcement.
+# ---------------------------------------------------------------------------
+MISSING_DIR="$WORK_DIR/nonexistent-data"
+MISSING_RC=0
+REPLAY_DATA_DIR="$MISSING_DIR" REPLAY_SYMBOL=BTCUSDT REPLAY_TIMEFRAME=30m \
+    REPLAY_RUN_DIR="$WORK_DIR/run-missing" \
+    python3 "$LOADER" --data-dir "$MISSING_DIR" --symbol BTCUSDT \
+    --timeframe 30m >/dev/null 2>&1 || MISSING_RC=$?
+assert_eq "9. load-candles.py rejects missing data dir with exit 3" "3" "$MISSING_RC"
+
+# ---------------------------------------------------------------------------
+# 10. Valid fixture CSV is processed end-to-end: load-candles.py emits a
+# unified stream with the documented header and the expected row count.
+# Build a tiny 100-row 30m fixture under $WORK_DIR/data/BTCUSDT/30m/.
+# ---------------------------------------------------------------------------
+FIX_DIR="$WORK_DIR/data/BTCUSDT/30m"
+mkdir -p "$FIX_DIR"
+FIX_CSV="$FIX_DIR/2026-01-01.csv"
+python3 - "$FIX_CSV" 100 <<'PYFIX'
+import sys
+
+out_path = sys.argv[1]
+n = int(sys.argv[2])
+ANCHOR = 1735689600000  # 2025-01-01 00:00 UTC
+STEP = 30 * 60 * 1000
+header = (
+    "timestamp_ms,open,high,low,close,volume,quote_volume,trades,"
+    "taker_buy_volume,taker_buy_quote_volume"
+)
+with open(out_path, "w") as f:
+    f.write(header + "\n")
+    for i in range(n):
+        ts = ANCHOR + i * STEP
+        row = [str(ts), "100", "101", "99", "100", "10", "1000", "5", "5", "500"]
+        f.write(",".join(row) + "\n")
+PYFIX
+
+CANDLES_OUT="$WORK_DIR/candles-fixture.csv"
+LOADER_RC=0
+python3 "$LOADER" --data-dir "$WORK_DIR/data" --symbol BTCUSDT \
+    --timeframe 30m >"$CANDLES_OUT" 2>"$WORK_DIR/loader-stderr" || LOADER_RC=$?
+assert_eq "10a. load-candles.py exits 0 on valid fixture" "0" "$LOADER_RC"
+loader_header=$(head -1 "$CANDLES_OUT")
+assert_eq "10b. load-candles.py header matches contract" \
+    "timestamp_ms,open,high,low,close,volume,quote_volume,trades,taker_buy_volume,taker_buy_quote_volume" \
+    "$loader_header"
+loader_rows=$(( $(wc -l <"$CANDLES_OUT") - 1 ))
+assert_eq "10c. load-candles.py emits 100 data rows" "100" "$loader_rows"
+
+# 10d. End-to-end: REPLAY_DRY_RUN=1 against the fixture data dir surfaces
+# the fixture path in the plan transcript (validates data-dir threading).
+FIXTURE_OUT="$(REPLAY_DRY_RUN=1 \
+               REPLAY_DATA_DIR="$WORK_DIR/data" \
+               REPLAY_SYMBOL=BTCUSDT \
+               REPLAY_TIMEFRAME=30m \
+               REPLAY_RUN_DIR="$WORK_DIR/run-fixture" \
+               bash "$ORCH" 2>&1)"
+assert_contains "10d. fixture data-dir threaded into orchestrator output" \
+    "$FIXTURE_OUT" "data dir: $WORK_DIR/data"
+assert_contains "10e. load-candles.py invocation visible in dry-run" \
+    "$FIXTURE_OUT" "python3 $LOADER --data-dir $WORK_DIR/data --symbol BTCUSDT --timeframe 30m"
+
+# ---------------------------------------------------------------------------
+# 11. load-candles.py rejects a continuity gap > 2x interval.
+# Build a 30m fixture where row 50 jumps 4 hours forward (8x the step).
+# ---------------------------------------------------------------------------
+GAP_DIR="$WORK_DIR/gap-data/BTCUSDT/30m"
+mkdir -p "$GAP_DIR"
+GAP_CSV="$GAP_DIR/2026-01-01.csv"
+python3 - "$GAP_CSV" <<'PYGAP'
+import sys
+
+out_path = sys.argv[1]
+ANCHOR = 1735689600000  # 2025-01-01 00:00 UTC
+STEP = 30 * 60 * 1000
+JUMP = 8 * STEP  # 4h gap = 8x step, breaks the 2x cap
+header = (
+    "timestamp_ms,open,high,low,close,volume,quote_volume,trades,"
+    "taker_buy_volume,taker_buy_quote_volume"
+)
+with open(out_path, "w") as f:
+    f.write(header + "\n")
+    ts = ANCHOR
+    for i in range(60):
+        row = [str(ts), "100", "101", "99", "100", "10", "1000", "5", "5", "500"]
+        f.write(",".join(row) + "\n")
+        ts += JUMP if i == 50 else STEP
+PYGAP
+
+GAP_RC=0
+python3 "$LOADER" --data-dir "$WORK_DIR/gap-data" --symbol BTCUSDT \
+    --timeframe 30m >/dev/null 2>"$WORK_DIR/gap-stderr" || GAP_RC=$?
+assert_eq "11. load-candles.py rejects continuity-gap fixture with exit 4" \
+    "4" "$GAP_RC"
+
+# ---------------------------------------------------------------------------
+# 12-15. Bootstrap, spawn, run-meta, cleanup-trap steps are all emitted.
+# ---------------------------------------------------------------------------
+assert_contains "12. bootstrap-script generation step emitted" "$OUT" \
+    "generating bootstrap script"
+assert_contains "13. container spawn command emitted via echo prefix" "$OUT" \
+    "+ podman run -d --name replay-laptop"
+assert_contains "14. run-meta.json write step emitted" "$OUT" \
+    "writing run-meta.json"
+assert_contains "15. cleanup trap installed" "$OUT" \
+    "trap 'podman stop --time 5 replay-laptop"
+
+# Header-doc sanity (env vars documented).
+SRC="$(cat "$ORCH")"
+assert_contains "header documents REPLAY_DATA_DIR" "$SRC" "REPLAY_DATA_DIR"
+assert_contains "header documents REPLAY_SYMBOL" "$SRC" "REPLAY_SYMBOL"
+assert_contains "header documents REPLAY_TIMEFRAME" "$SRC" "REPLAY_TIMEFRAME"
+assert_contains "header documents REPLAY_SPEED" "$SRC" "REPLAY_SPEED"
+assert_contains "header documents REPLAY_DAEMON_COUNT" "$SRC" "REPLAY_DAEMON_COUNT"
+assert_contains "header documents REPLAY_LOOKBACK_WINDOW" "$SRC" "REPLAY_LOOKBACK_WINDOW"
+assert_contains "header documents REPLAY_HOLD_PERIOD" "$SRC" "REPLAY_HOLD_PERIOD"
+assert_contains "header documents REPLAY_DRY_RUN" "$SRC" "REPLAY_DRY_RUN"
+assert_contains "header documents REPLAY_RUN_DIR" "$SRC" "REPLAY_RUN_DIR"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
PR-3 of 5 for #573 Phase 1 (trading-binance federation).

## Summary

- `trading-binance/tools/run-replay.sh` — offline orchestrator that
  streams PR-2 historical CSV candles tick-by-tick to agentis daemons
  inside a single podman container. Mirrors tribes-bench
  `run-stage3-docker.sh` architectural shape (emit_step helper, run dir
  under federation/runs/, sandbox cp idiom, cleanup trap) but adapts the
  rotation loop into a per-candle tick stream with configurable lookback
  + hold + speed knobs.
- `trading-binance/tools/load-candles.py` — small stdlib-only helper
  that concatenates date-sharded PR-2 CSV shards, filters by optional
  [start, end] inclusive date range, validates continuity (rejects gaps
  > 2x interval), and prints the unified stream on stdout.
- `trading-binance/tools/Containerfile.replay` — base image identical
  to `tribes-bench/tools/Containerfile.stage3` (ubuntu:24.04 + agentis
  binary sha-verified + Claude Code CLI) with comments relabeled for
  the replay use case.
- `trading-binance/tools/test-run-replay.sh` — 29 assertions covering
  dry-run plan emission, invalid-timeframe rejection, missing-data-dir
  rejection, valid-fixture end-to-end loading, and continuity-gap
  detection. Runs without podman or live LLM.
- `trading-binance/BUNDLE.manifest` — appends the three runtime
  dependencies so the release bundle stays install-ready.

PR-3 deliberately does NOT add the strategist agent — that's PR-4. The
daemons spawned here will fail to load the missing `strategist.ag` file;
PR-3's contract is orchestrator wiring + candle loading + telemetry
layout, not strategy decisions. PR-3 also does NOT address the analyser
that consumes the replay output — that's PR-5.

## Test plan

- [x] `bash -n trading-binance/tools/run-replay.sh`
- [x] `python3 -m py_compile trading-binance/tools/load-candles.py`
- [x] `bash -n trading-binance/tools/test-run-replay.sh`
- [x] `bash trading-binance/tools/test-run-replay.sh` -> 29 passed, 0 failed
- [x] `bash tools/colony-lint.sh` -> 175 passed, 0 failed, 3 skipped (baseline preserved)
- [x] `REPLAY_DRY_RUN=1 bash trading-binance/tools/run-replay.sh` exits 0 and emits the full plan transcript with no podman invocation