### PR TITLE
feat: A/B emergence experiment harness (#573 PR-5)

### DIFF
--- a/trading-binance/BUNDLE.manifest
+++ b/trading-binance/BUNDLE.manifest
@@ -4,6 +4,11 @@ trading-binance/tools/run-replay.sh
 trading-binance/tools/load-candles.py
 trading-binance/tools/Containerfile.replay
 trading-binance/tools/verify-trade.sh
+trading-binance/tools/run-ab-experiment.sh
+trading-binance/tools/analyze-ab-results.py
+trading-binance/tools/test-run-ab-experiment.sh
+trading-binance/tools/test-analyze-ab-results.py
+trading-binance/data/
 trading-binance/tribe-alpha/
 trading-binance/tribe-beta/
 trading-binance/tribe-gamma/

--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,38 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- `tools/run-ab-experiment.sh` A/B emergence experiment harness:
+  runs N paired replicates x 2 arms (control =
+  `REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999` / evolution off,
+  treatment = `=3` / evolution on) against
+  `tools/run-replay.sh`, writes a per-experiment
+  `experiment-manifest.json` mapping every run dir to its arm, then
+  invokes the analyser. Knobs: `AB_N_REPLICATES`, `AB_SYMBOL`,
+  `AB_TIMEFRAME`, `AB_START`, `AB_END`, `AB_SPEED`, `AB_DRY_RUN`
+  (#573 PR-5).
+- `tools/analyze-ab-results.py` stdlib analyser: walks the experiment
+  dir, parses per-run `trade-ledger.jsonl` + `.agentis/experience/*.jsonl`
+  + `.agentis/memo*.jsonl`, computes per-(arm, tribe) PnL bps, win
+  rate, total trades, max drawdown, per-trade Sharpe, and two mutation
+  surrogates (distinct prompt-body SHAs + `strategist_prompt_evolve`
+  rewrite rows). Emits `comparison.md` with run -> arm header table,
+  per-tribe arm-vs-arm tables, a federation aggregate, and the
+  honest-caveats section. Refuses to emit when any run dir cannot be
+  unambiguously mapped via `experiment-manifest.json` (#573 PR-5).
+- `tools/test-run-ab-experiment.sh` 8-assertion dry-run smoke test
+  covering `--help`, replicate count, per-arm threshold, dir naming,
+  manifest path, analyser invocation, and unknown-flag exit code
+  (#573 PR-5).
+- `tools/test-analyze-ab-results.py` 6-case `unittest` suite covering
+  PnL aggregation, win-rate FLAT exclusion, chronological max
+  drawdown, mutation-rate control/treatment asymmetry, missing
+  experience dir graceful, and run -> arm header table presence
+  (#573 PR-5).
+- `data/.gitkeep` placeholder: the Binance candle data tree is NOT
+  committed (~tens of MB per symbol/timeframe). Operator must run
+  `tools/binance-feed-download.py --symbol BTCUSDT --timeframe 1h
+  --start <YYYY-MM-DD> --end <YYYY-MM-DD>` before invoking the A/B
+  harness (#573 PR-5).
 - Five tribe colonies under `tribe-{alpha,beta,gamma,delta,epsilon}/`,
   each shipping a `strategist.ag` agent encoding one Ludvik Turek style
   trading setup (volume profile / fibonacci retracement / market
@@ -40,6 +72,17 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   `load-candles.py` is now mirrored into the container's bind-mounted
   `/run-root/candles.csv` so the verifier resolves it without
   host-path translation (#573 PR-4).
+- `tools/run-replay.sh` env passthrough: now threads
+  `STRATEGIST_PROMPT_EVOLUTION_THRESHOLD` (the A/B emergence
+  experiment's primary lever) plus five forward-compat strategist
+  knobs (`STRATEGIST_PROMPT_GEN_CAP`, `STRATEGIST_PROMPT_MAX_BYTES`,
+  `STRATEGIST_PROMPT_LEVENSHTEIN_FLOOR`,
+  `STRATEGIST_FITNESS_REWARD_WIN_PER_BPS`,
+  `STRATEGIST_FITNESS_PENALTY_LOSS_PER_BPS`) into the per-tribe daemon
+  env via `exec.env_passthrough` + the daemon-spawn `printf` block.
+  Defaults match the strategist.ag in-agent defaults so existing
+  PR-3 / PR-4 behaviour is preserved when the new knobs are unset
+  (#573 PR-5).
 
 ### Deprecated
 

--- a/trading-binance/tools/analyze-ab-results.py
+++ b/trading-binance/tools/analyze-ab-results.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+# analyze-ab-results.py -- A/B emergence experiment analyser for the
+# trading-binance federation (#573 PR-5).
+#
+# Walks an experiment directory produced by run-ab-experiment.sh:
+#
+#   <experiment-dir>/
+#     experiment-manifest.json
+#     ab-trading-<ts>-control-run-1/
+#       trade-ledger.jsonl
+#       laptop-node/.agentis/experience/*.jsonl
+#       laptop-node/.agentis/memo*.jsonl
+#     ab-trading-<ts>-treatment-run-1/
+#       ...
+#
+# Per-(arm, tribe) metrics:
+#   - pnl_bps_total
+#   - win_rate (excludes FLAT)
+#   - total_trades
+#   - max_drawdown_bps (chronological)
+#   - sharpe = mean(pnl) / stdev(pnl)   (no annualisation; caveat)
+#   - mutation_rate surrogates: distinct prompt-body SHAs +
+#     `strategist_prompt_evolve` learn rows tagged `rewritten`
+#
+# Aggregates per (arm, tribe) across the N replicates: mean + stdev.
+#
+# Output: <experiment-dir>/comparison.md
+#
+# Stdlib only. Refuses to emit the report if any run dir cannot be
+# unambiguously mapped to one arm via experiment-manifest.json.
+#
+# Usage: analyze-ab-results.py <experiment-dir>
+
+import argparse
+import json
+import math
+import os
+import re
+import statistics
+import sys
+from pathlib import Path
+
+
+TRIBES = ["tribe-alpha", "tribe-beta", "tribe-gamma", "tribe-delta", "tribe-epsilon"]
+
+# Tag-list classifications we count from experience rows.
+_PNL_BPS_RE = re.compile(r"pnl_bps=(-?\d+(?:\.\d+)?)")
+
+
+def read_jsonl(path):
+    """Return a list of decoded JSON objects from a .jsonl file. Returns
+    an empty list when the file is missing or unreadable (per-line
+    JSONDecodeError tolerated)."""
+    out = []
+    if not os.path.isfile(path):
+        return out
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    out.append(json.loads(line))
+                except (json.JSONDecodeError, ValueError):
+                    continue
+    except OSError:
+        return []
+    return out
+
+
+def _classification_from_tags(tags):
+    """Return WIN / LOSS / FLAT from a tag list, or empty string."""
+    if not isinstance(tags, list):
+        return ""
+    for t in tags:
+        if not isinstance(t, str):
+            continue
+        if t.startswith("classification:"):
+            return t.split(":", 1)[1]
+    return ""
+
+
+def _pnl_bps_from_row(row):
+    """Extract pnl_bps from a learn() row's `details` string. The
+    strategist emits `details = "pnl_bps=<int_or_float>"`. Returns 0.0
+    when the field is absent or unparseable."""
+    details = row.get("details") if isinstance(row, dict) else None
+    if not isinstance(details, str):
+        return 0.0
+    m = _PNL_BPS_RE.search(details)
+    if not m:
+        return 0.0
+    try:
+        return float(m.group(1))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _ts_from_row(row):
+    """Best-effort chronological key. Falls back to 0 when the row
+    carries no timestamp."""
+    if not isinstance(row, dict):
+        return 0
+    ts = row.get("ts")
+    if isinstance(ts, (int, float)):
+        return int(ts)
+    when = row.get("when")
+    if isinstance(when, (int, float)):
+        return int(when)
+    return 0
+
+
+def _collect_settle_rows(experience_dir, tribe):
+    """Return chronologically-sorted settle rows for one tribe. Looks
+    at every .jsonl file under experience_dir (one per daemon id) and
+    keeps rows whose topic == 'settle' AND tags contain the tribe name
+    AND a classification tag. Missing dir returns []."""
+    out = []
+    if not os.path.isdir(experience_dir):
+        return out
+    try:
+        names = sorted(os.listdir(experience_dir))
+    except OSError:
+        return out
+    for name in names:
+        if not name.endswith(".jsonl"):
+            continue
+        rows = read_jsonl(os.path.join(experience_dir, name))
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            if row.get("topic") != "settle":
+                continue
+            tags = row.get("tags") or []
+            if not isinstance(tags, list):
+                continue
+            if tribe not in tags:
+                continue
+            cls = _classification_from_tags(tags)
+            if not cls:
+                continue
+            out.append(row)
+    out.sort(key=_ts_from_row)
+    return out
+
+
+def _max_drawdown(pnls):
+    """Chronological max drawdown over the running equity curve.
+    pnls already sorted by ts ascending. Returns a non-negative bps
+    value (0 when no trades or curve monotonically non-decreasing)."""
+    if not pnls:
+        return 0.0
+    running = 0.0
+    peak = 0.0
+    max_dd = 0.0
+    for p in pnls:
+        running += p
+        if running > peak:
+            peak = running
+        dd = peak - running
+        if dd > max_dd:
+            max_dd = dd
+    return max_dd
+
+
+def _sharpe_like(pnls):
+    """mean / stdev across per-trade returns; no annualisation. Returns
+    0.0 when fewer than 2 trades (stdev undefined) or stdev == 0."""
+    if len(pnls) < 2:
+        return 0.0
+    try:
+        sd = statistics.stdev(pnls)
+    except statistics.StatisticsError:
+        return 0.0
+    if sd == 0:
+        return 0.0
+    return statistics.mean(pnls) / sd
+
+
+def _mutation_surrogates(run_dir, tribe):
+    """Return (distinct_prompt_body_shas, rewrite_event_count) for one
+    (run, tribe). Sources:
+      - distinct `strategist:prompt_body:<sha>` memo keys recorded in
+        any .jsonl under .agentis/memo* (best-effort -- the runtime
+        layout may vary).
+      - `learn("strategist_prompt_evolve", ..., tags=[..., "rewritten"])`
+        rows in .agentis/experience/."""
+    agentis_dir = os.path.join(run_dir, "laptop-node", ".agentis")
+    sha_set = set()
+    if os.path.isdir(agentis_dir):
+        for root, _dirs, files in os.walk(agentis_dir):
+            base = os.path.basename(root)
+            if not (base.startswith("memo") or base == "memo"):
+                # Only descend through memo* directories; avoid
+                # over-walking the entire .agentis tree.
+                continue
+            for f in files:
+                if not f.endswith(".jsonl"):
+                    continue
+                for row in read_jsonl(os.path.join(root, f)):
+                    if not isinstance(row, dict):
+                        continue
+                    key = row.get("key")
+                    if isinstance(key, str) and key.startswith("strategist:prompt_body:"):
+                        sha_set.add(key.split(":", 2)[2])
+        # Also probe top-level memo*.jsonl in case the runtime keeps a
+        # single flat file rather than per-key dirs.
+        for entry in os.listdir(agentis_dir):
+            full = os.path.join(agentis_dir, entry)
+            if not os.path.isfile(full):
+                continue
+            if not entry.startswith("memo"):
+                continue
+            if not entry.endswith(".jsonl"):
+                continue
+            for row in read_jsonl(full):
+                if not isinstance(row, dict):
+                    continue
+                key = row.get("key")
+                if isinstance(key, str) and key.startswith("strategist:prompt_body:"):
+                    sha_set.add(key.split(":", 2)[2])
+
+    rewrite_count = 0
+    exp_dir = os.path.join(run_dir, "laptop-node", ".agentis", "experience")
+    if os.path.isdir(exp_dir):
+        for name in os.listdir(exp_dir):
+            if not name.endswith(".jsonl"):
+                continue
+            for row in read_jsonl(os.path.join(exp_dir, name)):
+                if not isinstance(row, dict):
+                    continue
+                if row.get("topic") != "strategist_prompt_evolve":
+                    continue
+                tags = row.get("tags") or []
+                if not isinstance(tags, list):
+                    continue
+                if "rewritten" not in tags:
+                    continue
+                if tribe and tribe not in tags:
+                    # Best-effort tribe filter; strategist tags rewrite
+                    # rows with `trading-binance` but not always the
+                    # tribe name -- so unfiltered fall-through is the
+                    # safe default.
+                    pass
+                rewrite_count += 1
+    return len(sha_set), rewrite_count
+
+
+def compute_run_tribe_metrics(run_dir, tribe):
+    """All metrics for one (run, tribe). Missing experience dir => zero
+    row, no crash."""
+    exp_dir = os.path.join(run_dir, "laptop-node", ".agentis", "experience")
+    rows = _collect_settle_rows(exp_dir, tribe)
+    pnls = []
+    wins = 0
+    losses = 0
+    flats = 0
+    for row in rows:
+        cls = _classification_from_tags(row.get("tags") or [])
+        bps = _pnl_bps_from_row(row)
+        pnls.append(bps)
+        if cls == "WIN":
+            wins += 1
+        elif cls == "LOSS":
+            losses += 1
+        elif cls == "FLAT":
+            flats += 1
+    total = len(rows)
+    decided = wins + losses
+    win_rate = (wins / decided) if decided > 0 else 0.0
+    pnl_total = sum(pnls)
+    max_dd = _max_drawdown(pnls)
+    sharpe = _sharpe_like(pnls)
+    distinct_shas, rewrite_events = _mutation_surrogates(run_dir, tribe)
+    return {
+        "tribe": tribe,
+        "total_trades": total,
+        "wins": wins,
+        "losses": losses,
+        "flats": flats,
+        "win_rate": win_rate,
+        "pnl_bps_total": pnl_total,
+        "max_drawdown_bps": max_dd,
+        "sharpe": sharpe,
+        "distinct_prompt_shas": distinct_shas,
+        "rewrite_events": rewrite_events,
+    }
+
+
+def _agg(values):
+    """(mean, stdev) tuple; stdev=0 when n<2."""
+    if not values:
+        return (0.0, 0.0)
+    mean = statistics.mean(values)
+    if len(values) < 2:
+        return (mean, 0.0)
+    try:
+        sd = statistics.stdev(values)
+    except statistics.StatisticsError:
+        sd = 0.0
+    return (mean, sd)
+
+
+def aggregate_arm_tribe(per_run_metrics):
+    """List of metric dicts (one per replicate) -> aggregated dict."""
+    if not per_run_metrics:
+        return {
+            "n": 0,
+            "pnl_bps_mean": 0.0, "pnl_bps_stdev": 0.0,
+            "win_rate_mean": 0.0, "win_rate_stdev": 0.0,
+            "trades_mean": 0.0, "trades_stdev": 0.0,
+            "max_dd_mean": 0.0, "max_dd_stdev": 0.0,
+            "sharpe_mean": 0.0, "sharpe_stdev": 0.0,
+            "distinct_shas_mean": 0.0, "distinct_shas_stdev": 0.0,
+            "rewrite_events_mean": 0.0, "rewrite_events_stdev": 0.0,
+        }
+    pnl = [m["pnl_bps_total"] for m in per_run_metrics]
+    wr = [m["win_rate"] for m in per_run_metrics]
+    tr = [m["total_trades"] for m in per_run_metrics]
+    dd = [m["max_drawdown_bps"] for m in per_run_metrics]
+    sh = [m["sharpe"] for m in per_run_metrics]
+    ds = [m["distinct_prompt_shas"] for m in per_run_metrics]
+    re_ = [m["rewrite_events"] for m in per_run_metrics]
+    pnl_m, pnl_s = _agg(pnl)
+    wr_m, wr_s = _agg(wr)
+    tr_m, tr_s = _agg(tr)
+    dd_m, dd_s = _agg(dd)
+    sh_m, sh_s = _agg(sh)
+    ds_m, ds_s = _agg(ds)
+    re_m, re_s = _agg(re_)
+    return {
+        "n": len(per_run_metrics),
+        "pnl_bps_mean": pnl_m, "pnl_bps_stdev": pnl_s,
+        "win_rate_mean": wr_m, "win_rate_stdev": wr_s,
+        "trades_mean": tr_m, "trades_stdev": tr_s,
+        "max_dd_mean": dd_m, "max_dd_stdev": dd_s,
+        "sharpe_mean": sh_m, "sharpe_stdev": sh_s,
+        "distinct_shas_mean": ds_m, "distinct_shas_stdev": ds_s,
+        "rewrite_events_mean": re_m, "rewrite_events_stdev": re_s,
+    }
+
+
+def _fmt(x, places=2):
+    if isinstance(x, float):
+        if math.isnan(x) or math.isinf(x):
+            return "n/a"
+        return f"{x:.{places}f}"
+    return str(x)
+
+
+HONEST_CAVEATS = """## Honest caveats
+
+- Single symbol (BTCUSDT).
+- Single timeframe (1h).
+- No live or paper trading — offline replay only; alpha-decay from
+  adversaries not exercised.
+- No multi-tribe knowledge-market.
+- N=3 replicates per arm is a direction-of-effect probe, not a
+  publishable result. ~70% power to detect a 50bps mean difference. A
+  null result here means "evolution is not obviously winning"; it does
+  NOT prove "evolution adds no value."
+- Same LLM model both arms — testing the meta-prompt evolution
+  mechanism, not the underlying model.
+- 90 days is short — evolved strategies may overfit. Out-of-sample
+  validation is Phase 2.
+- No multiple-comparison correction across the 5 tribes; tribe-level
+  tables are exploratory.
+"""
+
+
+def load_manifest(experiment_dir):
+    """Read experiment-manifest.json and return (manifest_dict,
+    run_dir -> arm map). Raises FileNotFoundError if missing."""
+    mpath = os.path.join(experiment_dir, "experiment-manifest.json")
+    if not os.path.isfile(mpath):
+        raise FileNotFoundError(mpath)
+    with open(mpath, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+    run_to_arm = {}
+    for run in manifest.get("runs", []):
+        rd = run.get("run_dir")
+        arm = run.get("arm")
+        if not rd or not arm:
+            continue
+        run_to_arm[os.path.basename(rd.rstrip("/"))] = arm
+    return manifest, run_to_arm
+
+
+def discover_run_dirs(experiment_dir, run_to_arm):
+    """List every direct subdir of experiment_dir matching the
+    ab-trading-*-{control,treatment}-run-* pattern. Returns
+    (arm -> [absolute run_dir]) mapping. Refuses to map any subdir
+    whose basename is not unambiguously found in run_to_arm."""
+    arms = {"control": [], "treatment": []}
+    if not os.path.isdir(experiment_dir):
+        return arms, []
+    unmapped = []
+    for entry in sorted(os.listdir(experiment_dir)):
+        full = os.path.join(experiment_dir, entry)
+        if not os.path.isdir(full):
+            continue
+        if "-control-run-" not in entry and "-treatment-run-" not in entry:
+            continue
+        arm = run_to_arm.get(entry)
+        if arm in ("control", "treatment"):
+            arms[arm].append(full)
+        else:
+            unmapped.append(entry)
+    return arms, unmapped
+
+
+def render_report(manifest, arm_run_metrics, federation_agg):
+    """Build the comparison.md text body."""
+    lines = []
+    lines.append("# A/B emergence experiment — comparison report")
+    lines.append("")
+    lines.append("## Manifest")
+    lines.append("")
+    lines.append("| Field | Value |")
+    lines.append("|---|---|")
+    lines.append("| experiment_ts | " + str(manifest.get("experiment_ts", "")) + " |")
+    lines.append("| symbol | " + str(manifest.get("symbol", "")) + " |")
+    lines.append("| timeframe | " + str(manifest.get("timeframe", "")) + " |")
+    lines.append("| start | " + str(manifest.get("start", "")) + " |")
+    lines.append("| end | " + str(manifest.get("end", "")) + " |")
+    lines.append("| replay_speed | " + str(manifest.get("replay_speed", "")) + " |")
+    lines.append("| n_replicates_per_arm | " + str(manifest.get("n_replicates_per_arm", "")) + " |")
+    lines.append("| llm_model | " + str(manifest.get("llm_model", "")) + " |")
+    lines.append("")
+    lines.append("Arms:")
+    lines.append("")
+    lines.append("- **control** = REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999 (prompt evolution off)")
+    lines.append("- **treatment** = REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=3 (prompt evolution on)")
+    lines.append("")
+    lines.append("### Run -> arm mapping")
+    lines.append("")
+    lines.append("| run_idx | arm | run_dir | threshold | exit_code |")
+    lines.append("|---|---|---|---|---|")
+    for run in manifest.get("runs", []):
+        lines.append(
+            "| " + str(run.get("run_idx", "")) + " | "
+            + str(run.get("arm", "")) + " | "
+            + os.path.basename(str(run.get("run_dir", ""))) + " | "
+            + str(run.get("strategist_prompt_evolution_threshold", "")) + " | "
+            + str(run.get("exit_code", "")) + " |"
+        )
+    lines.append("")
+
+    # Per-tribe tables.
+    lines.append("## Per-tribe arm-vs-arm (mean +/- stdev across replicates)")
+    lines.append("")
+    for tribe in TRIBES:
+        lines.append("### " + tribe)
+        lines.append("")
+        lines.append("| Metric | control | treatment |")
+        lines.append("|---|---|---|")
+        c = arm_run_metrics["control"]["per_tribe_agg"][tribe]
+        t = arm_run_metrics["treatment"]["per_tribe_agg"][tribe]
+        lines.append("| n (replicates) | " + _fmt(c["n"], 0) + " | " + _fmt(t["n"], 0) + " |")
+        lines.append("| pnl_bps_total | " + _fmt(c["pnl_bps_mean"]) + " +/- " + _fmt(c["pnl_bps_stdev"]) + " | " + _fmt(t["pnl_bps_mean"]) + " +/- " + _fmt(t["pnl_bps_stdev"]) + " |")
+        lines.append("| win_rate | " + _fmt(c["win_rate_mean"], 4) + " +/- " + _fmt(c["win_rate_stdev"], 4) + " | " + _fmt(t["win_rate_mean"], 4) + " +/- " + _fmt(t["win_rate_stdev"], 4) + " |")
+        lines.append("| total_trades | " + _fmt(c["trades_mean"]) + " +/- " + _fmt(c["trades_stdev"]) + " | " + _fmt(t["trades_mean"]) + " +/- " + _fmt(t["trades_stdev"]) + " |")
+        lines.append("| max_drawdown_bps | " + _fmt(c["max_dd_mean"]) + " +/- " + _fmt(c["max_dd_stdev"]) + " | " + _fmt(t["max_dd_mean"]) + " +/- " + _fmt(t["max_dd_stdev"]) + " |")
+        lines.append("| sharpe (per-trade, no annualisation) | " + _fmt(c["sharpe_mean"], 4) + " +/- " + _fmt(c["sharpe_stdev"], 4) + " | " + _fmt(t["sharpe_mean"], 4) + " +/- " + _fmt(t["sharpe_stdev"], 4) + " |")
+        lines.append("| distinct prompt-body SHAs | " + _fmt(c["distinct_shas_mean"]) + " +/- " + _fmt(c["distinct_shas_stdev"]) + " | " + _fmt(t["distinct_shas_mean"]) + " +/- " + _fmt(t["distinct_shas_stdev"]) + " |")
+        lines.append("| `strategist_prompt_evolve` rewrite rows | " + _fmt(c["rewrite_events_mean"]) + " +/- " + _fmt(c["rewrite_events_stdev"]) + " | " + _fmt(t["rewrite_events_mean"]) + " +/- " + _fmt(t["rewrite_events_stdev"]) + " |")
+        lines.append("")
+
+    # Federation aggregate.
+    lines.append("## Federation aggregate (all tribes combined)")
+    lines.append("")
+    lines.append("| Metric | control | treatment |")
+    lines.append("|---|---|---|")
+    fc = federation_agg["control"]
+    ft = federation_agg["treatment"]
+    lines.append("| n (replicate x tribe rows) | " + _fmt(fc["n"], 0) + " | " + _fmt(ft["n"], 0) + " |")
+    lines.append("| pnl_bps_total | " + _fmt(fc["pnl_bps_mean"]) + " +/- " + _fmt(fc["pnl_bps_stdev"]) + " | " + _fmt(ft["pnl_bps_mean"]) + " +/- " + _fmt(ft["pnl_bps_stdev"]) + " |")
+    lines.append("| win_rate | " + _fmt(fc["win_rate_mean"], 4) + " +/- " + _fmt(fc["win_rate_stdev"], 4) + " | " + _fmt(ft["win_rate_mean"], 4) + " +/- " + _fmt(ft["win_rate_stdev"], 4) + " |")
+    lines.append("| total_trades | " + _fmt(fc["trades_mean"]) + " +/- " + _fmt(fc["trades_stdev"]) + " | " + _fmt(ft["trades_mean"]) + " +/- " + _fmt(ft["trades_stdev"]) + " |")
+    lines.append("| max_drawdown_bps | " + _fmt(fc["max_dd_mean"]) + " +/- " + _fmt(fc["max_dd_stdev"]) + " | " + _fmt(ft["max_dd_mean"]) + " +/- " + _fmt(ft["max_dd_stdev"]) + " |")
+    lines.append("| sharpe (per-trade, no annualisation) | " + _fmt(fc["sharpe_mean"], 4) + " +/- " + _fmt(fc["sharpe_stdev"], 4) + " | " + _fmt(ft["sharpe_mean"], 4) + " +/- " + _fmt(ft["sharpe_stdev"], 4) + " |")
+    lines.append("| distinct prompt-body SHAs | " + _fmt(fc["distinct_shas_mean"]) + " +/- " + _fmt(fc["distinct_shas_stdev"]) + " | " + _fmt(ft["distinct_shas_mean"]) + " +/- " + _fmt(ft["distinct_shas_stdev"]) + " |")
+    lines.append("| `strategist_prompt_evolve` rewrite rows | " + _fmt(fc["rewrite_events_mean"]) + " +/- " + _fmt(fc["rewrite_events_stdev"]) + " | " + _fmt(ft["rewrite_events_mean"]) + " +/- " + _fmt(ft["rewrite_events_stdev"]) + " |")
+    lines.append("")
+
+    lines.append(HONEST_CAVEATS)
+    return "\n".join(lines) + "\n"
+
+
+def analyze(experiment_dir):
+    """End-to-end driver. Returns (comparison_md_path, report_text).
+    Raises SystemExit(non-zero) on unmappable run dirs or missing
+    manifest."""
+    experiment_dir = os.path.abspath(experiment_dir)
+    try:
+        manifest, run_to_arm = load_manifest(experiment_dir)
+    except FileNotFoundError as e:
+        sys.stderr.write("analyze-ab-results: missing experiment-manifest.json at " + str(e) + "\n")
+        raise SystemExit(3)
+
+    arms, unmapped = discover_run_dirs(experiment_dir, run_to_arm)
+    if unmapped:
+        sys.stderr.write(
+            "analyze-ab-results: refusing to emit comparison.md -- the following "
+            "run dirs cannot be mapped to an arm via experiment-manifest.json: "
+            + ", ".join(unmapped) + "\n"
+        )
+        raise SystemExit(2)
+
+    # Walk each arm x run x tribe.
+    arm_run_metrics = {
+        "control": {"runs": [], "per_tribe_agg": {}},
+        "treatment": {"runs": [], "per_tribe_agg": {}},
+    }
+    for arm in ("control", "treatment"):
+        for run_dir in arms[arm]:
+            per_tribe = {}
+            for tribe in TRIBES:
+                per_tribe[tribe] = compute_run_tribe_metrics(run_dir, tribe)
+            arm_run_metrics[arm]["runs"].append({
+                "run_dir": run_dir,
+                "per_tribe": per_tribe,
+            })
+        # Per-tribe aggregate across replicates.
+        for tribe in TRIBES:
+            per_run = [r["per_tribe"][tribe] for r in arm_run_metrics[arm]["runs"]]
+            arm_run_metrics[arm]["per_tribe_agg"][tribe] = aggregate_arm_tribe(per_run)
+
+    # Federation-level aggregate (every replicate x tribe row pooled).
+    federation_agg = {}
+    for arm in ("control", "treatment"):
+        pooled = []
+        for r in arm_run_metrics[arm]["runs"]:
+            for tribe in TRIBES:
+                pooled.append(r["per_tribe"][tribe])
+        federation_agg[arm] = aggregate_arm_tribe(pooled)
+
+    report = render_report(manifest, arm_run_metrics, federation_agg)
+    out_path = os.path.join(experiment_dir, "comparison.md")
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(report)
+    return out_path, report
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="A/B emergence experiment analyser (trading-binance #573 PR-5).",
+    )
+    parser.add_argument("experiment_dir", help="Path produced by run-ab-experiment.sh")
+    args = parser.parse_args(argv)
+    out_path, _report = analyze(args.experiment_dir)
+    sys.stdout.write("[analyze-ab-results] wrote " + out_path + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/trading-binance/tools/run-ab-experiment.sh
+++ b/trading-binance/tools/run-ab-experiment.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+# run-ab-experiment.sh — A/B emergence experiment harness for the
+# trading-binance federation (#573 PR-5).
+#
+# Runs N paired replicates x 2 arms:
+#   control    REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999
+#              prompt evolution effectively off — seed prompts stay
+#              frozen for the entire run. Baseline arm.
+#   treatment  REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=3
+#              prompt evolution armed at the strategist.ag default —
+#              after every 3 verified trades the meta-prompt rewrites
+#              the body. Emergence arm.
+#
+# Each replicate invokes `tools/run-replay.sh` with a fresh hermetic
+# run dir under <federation>/runs/ab-trading-<ts>/ and writes a single
+# `experiment-manifest.json` mapping every run dir back to its arm.
+# After all replicates finish, `tools/analyze-ab-results.py` walks the
+# manifest, parses per-run trade ledgers + experience rows, and emits
+# `comparison.md` with per-tribe arm-vs-arm tables and a federation
+# aggregate.
+#
+# Prerequisite: a populated `trading-binance/data/<symbol>/<tf>/` tree
+# must already exist on disk. Run
+# `tools/binance-feed-download.py --symbol BTCUSDT --timeframe 1h \
+#     --start <YYYY-MM-DD> --end <YYYY-MM-DD>` before invoking this
+# script. The data dir is NOT committed to the repo (see `data/.gitkeep`).
+#
+# Env vars (all optional; defaults shown):
+#   AB_N_REPLICATES    Replicates per arm. Default: 3
+#   AB_SYMBOL          Binance futures symbol. Default: BTCUSDT
+#   AB_TIMEFRAME       Candle interval: 30m | 1h | 1d. Default: 1h
+#   AB_START           UTC YYYY-MM-DD lower bound. Default: "" (first
+#                      available shard)
+#   AB_END             UTC YYYY-MM-DD upper bound. Default: "" (last
+#                      available shard)
+#   AB_SPEED           Replay multiplier. Default: 720
+#   AB_DRY_RUN         1 = emit_step the plan, do not invoke
+#                      run-replay.sh or analyse. Default: 0
+#   REPLAY_*           Anything that run-replay.sh consumes is
+#                      forwarded as-is (e.g. REPLAY_OPENAI_MODEL,
+#                      REPLAY_LOOKBACK_WINDOW, REPLAY_HOLD_PERIOD).
+#
+# Flags:
+#   --dry-run    Same as AB_DRY_RUN=1.
+#   -h|--help    Print this header.
+#
+# Output layout (under trading-binance/runs/ab-trading-<TS>/):
+#   experiment-manifest.json
+#   ab-trading-<TS>-control-run-1/      (run-replay.sh output)
+#   ab-trading-<TS>-control-run-2/
+#   ...
+#   ab-trading-<TS>-treatment-run-1/
+#   ...
+#   comparison.md                       (written by analyse step)
+#
+# Exit codes:
+#   0   harness completed (or dry-run plan emitted)
+#   2   unknown flag or invalid env value
+#   3   missing required input (data dir / dependent script)
+#   4   one or more replicate runs failed in real-run mode
+#   5   reserved — budget cap exceeded (currently warns + continues)
+
+set -euo pipefail
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+TOOLS_DIR="$(dirname "$SCRIPT_PATH")"
+FED_DIR="$(dirname "$TOOLS_DIR")"
+FED_ROOT="${FED_ROOT:-$FED_DIR}"
+
+# --- Argument parsing ---
+DRY_RUN="${AB_DRY_RUN:-0}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "$SCRIPT_PATH"
+            exit 0
+            ;;
+        *)
+            echo "run-ab-experiment: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# --- Env defaults ---
+N_REPLICATES="${AB_N_REPLICATES:-3}"
+SYMBOL="${AB_SYMBOL:-BTCUSDT}"
+TIMEFRAME="${AB_TIMEFRAME:-1h}"
+START="${AB_START:-}"
+END="${AB_END:-}"
+SPEED="${AB_SPEED:-720}"
+
+# --- Validation ---
+case "$N_REPLICATES" in
+    ''|*[!0-9]*)
+        echo "run-ab-experiment: AB_N_REPLICATES must be a positive integer (got '$N_REPLICATES')" >&2
+        exit 2
+        ;;
+esac
+if [ "$N_REPLICATES" -lt 1 ]; then
+    echo "run-ab-experiment: AB_N_REPLICATES must be >= 1 (got '$N_REPLICATES')" >&2
+    exit 2
+fi
+case "$TIMEFRAME" in
+    30m|1h|1d) ;;
+    *)
+        echo "run-ab-experiment: AB_TIMEFRAME must be one of 30m|1h|1d (got '$TIMEFRAME')" >&2
+        exit 2
+        ;;
+esac
+case "$SPEED" in
+    ''|*[!0-9]*)
+        echo "run-ab-experiment: AB_SPEED must be a positive integer (got '$SPEED')" >&2
+        exit 2
+        ;;
+esac
+
+# --- Per-experiment hermetic dir ---
+EXP_TS="$(date -u +%Y%m%dT%H%M%SZ)"
+EXP_DIR="$FED_ROOT/runs/ab-trading-$EXP_TS"
+MANIFEST="$EXP_DIR/experiment-manifest.json"
+
+# --- Dry-run / real-run dispatch helpers (mirrors run-replay.sh idiom) ---
+emit_cmd() {
+    if [ "$DRY_RUN" = "1" ]; then
+        printf '+ %s\n' "$*"
+    else
+        printf '+ %s\n' "$*"
+    fi
+}
+
+emit_step() {
+    printf '# %s\n' "$*"
+}
+
+# --- Banner ---
+emit_step "run-ab-experiment: starting (dry_run=$DRY_RUN)"
+emit_step "experiment ts: $EXP_TS"
+emit_step "experiment dir: $EXP_DIR"
+emit_step "symbol: $SYMBOL timeframe: $TIMEFRAME range: ${START:-<first>}..${END:-<last>}"
+emit_step "speed: $SPEED replicates/arm: $N_REPLICATES"
+emit_step "control arm: REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999 (evolution off)"
+emit_step "treatment arm: REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=3 (evolution on)"
+
+if [ "$DRY_RUN" = "0" ]; then
+    mkdir -p "$EXP_DIR"
+fi
+
+# --- Replicate loop ---
+# RUNS_RECORD captures 5-tuples per run flattened into a single array:
+# (arm, run_idx, run_dir, threshold, exit_code) for manifest assembly.
+RUNS_RECORD=()
+FAIL_COUNT=0
+
+for arm in control treatment; do
+    if [ "$arm" = "control" ]; then
+        THR=999
+    else
+        THR=3
+    fi
+    run=1
+    while [ "$run" -le "$N_REPLICATES" ]; do
+        RUN_NAME="ab-trading-$EXP_TS-$arm-run-$run"
+        RUN_DIR="$EXP_DIR/$RUN_NAME"
+        emit_step "[arm=$arm run=$run/$N_REPLICATES] run_dir=$RUN_DIR threshold=$THR"
+
+        if [ "$DRY_RUN" = "0" ]; then
+            mkdir -p "$RUN_DIR"
+        fi
+
+        # Build env block for this replicate. REPLAY_RUN_DIR pins the
+        # per-replicate output dir; the strategist threshold env is the
+        # only thing that differs between control and treatment.
+        REPLICATE_ENV=(
+            "REPLAY_RUN_DIR=$RUN_DIR"
+            "REPLAY_SYMBOL=$SYMBOL"
+            "REPLAY_TIMEFRAME=$TIMEFRAME"
+            "REPLAY_START=$START"
+            "REPLAY_END=$END"
+            "REPLAY_SPEED=$SPEED"
+            "REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=$THR"
+        )
+
+        EXIT_CODE=0
+        if [ "$DRY_RUN" = "1" ]; then
+            # In dry-run mode we emit a placeholder that test-run-ab-experiment.sh
+            # can grep for. The actual run-replay.sh invocation is NOT made.
+            emit_cmd "${REPLICATE_ENV[*]} bash $FED_ROOT/tools/run-replay.sh"
+        else
+            (
+                # shellcheck disable=SC2068
+                for kv in ${REPLICATE_ENV[@]}; do
+                    export "${kv?}"
+                done
+                bash "$FED_ROOT/tools/run-replay.sh"
+            ) || EXIT_CODE=$?
+            if [ "$EXIT_CODE" -ne 0 ]; then
+                FAIL_COUNT=$((FAIL_COUNT + 1))
+                emit_step "[arm=$arm run=$run] replicate failed (exit=$EXIT_CODE) — continuing"
+            fi
+        fi
+
+        RUNS_RECORD+=("$arm" "$run" "$RUN_DIR" "$THR" "$EXIT_CODE")
+        run=$((run + 1))
+    done
+done
+
+# --- Manifest assembly ---
+emit_step "writing experiment-manifest.json"
+emit_cmd "python3 -c 'write_manifest($MANIFEST)'"
+
+if [ "$DRY_RUN" = "0" ]; then
+    # Pipe the 5-tuple stream into a Python helper that emits the
+    # JSON manifest. Use NUL-separation so run-dir paths with spaces
+    # do not corrupt the stream.
+    {
+        rec_i=0
+        rec_len=${#RUNS_RECORD[@]}
+        while [ "$rec_i" -lt "$rec_len" ]; do
+            printf '%s\0%s\0%s\0%s\0%s\0' \
+                "${RUNS_RECORD[$rec_i]}" \
+                "${RUNS_RECORD[$((rec_i + 1))]}" \
+                "${RUNS_RECORD[$((rec_i + 2))]}" \
+                "${RUNS_RECORD[$((rec_i + 3))]}" \
+                "${RUNS_RECORD[$((rec_i + 4))]}"
+            rec_i=$((rec_i + 5))
+        done
+    } | python3 - "$MANIFEST" "$EXP_TS" "$SYMBOL" "$TIMEFRAME" "$START" "$END" "$SPEED" "$N_REPLICATES" "${REPLAY_OPENAI_MODEL:-}" <<'PYMANIFEST'
+import json
+import os
+import sys
+
+out_path = sys.argv[1]
+manifest = {
+    "experiment_ts": sys.argv[2],
+    "symbol": sys.argv[3],
+    "timeframe": sys.argv[4],
+    "start": sys.argv[5],
+    "end": sys.argv[6],
+    "replay_speed": int(sys.argv[7]),
+    "n_replicates_per_arm": int(sys.argv[8]),
+    "llm_model": sys.argv[9],
+    "arms": {
+        "control": {
+            "strategist_prompt_evolution_threshold": 999,
+            "description": "prompt evolution effectively off (baseline)",
+        },
+        "treatment": {
+            "strategist_prompt_evolution_threshold": 3,
+            "description": "prompt evolution armed (emergence)",
+        },
+    },
+    "runs": [],
+}
+data = sys.stdin.buffer.read()
+if data:
+    parts = data.split(b"\x00")
+    # Trailing empty element from final NUL.
+    if parts and parts[-1] == b"":
+        parts = parts[:-1]
+    if len(parts) % 5 != 0:
+        sys.stderr.write(
+            "run-ab-experiment: malformed RUNS_RECORD stream "
+            "(len=" + str(len(parts)) + ", expected multiple of 5)\n"
+        )
+        sys.exit(1)
+    for i in range(0, len(parts), 5):
+        arm = parts[i].decode("utf-8")
+        run_idx = int(parts[i + 1])
+        run_dir = parts[i + 2].decode("utf-8")
+        threshold = int(parts[i + 3])
+        exit_code = int(parts[i + 4])
+        manifest["runs"].append({
+            "arm": arm,
+            "run_idx": run_idx,
+            "run_dir": run_dir,
+            "strategist_prompt_evolution_threshold": threshold,
+            "exit_code": exit_code,
+        })
+os.makedirs(os.path.dirname(out_path), exist_ok=True)
+with open(out_path, "w", encoding="utf-8") as f:
+    json.dump(manifest, f, indent=2)
+    f.write("\n")
+PYMANIFEST
+fi
+
+emit_step "manifest path: $MANIFEST"
+
+# --- Analyser invocation ---
+emit_step "invoking analyse-ab-results.py against $EXP_DIR"
+if [ "$DRY_RUN" = "1" ]; then
+    emit_cmd "python3 $FED_ROOT/tools/analyze-ab-results.py $EXP_DIR"
+else
+    python3 "$FED_ROOT/tools/analyze-ab-results.py" "$EXP_DIR" || {
+        echo "run-ab-experiment: analyse step failed" >&2
+        exit 4
+    }
+fi
+
+if [ "$DRY_RUN" = "0" ] && [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "run-ab-experiment: $FAIL_COUNT replicate(s) failed; see manifest exit_code fields" >&2
+    exit 4
+fi
+
+emit_step "run-ab-experiment: done"
+echo "[run-ab-experiment] experiment dir: $EXP_DIR"
+echo "[run-ab-experiment] comparison.md: $EXP_DIR/comparison.md"

--- a/trading-binance/tools/run-replay.sh
+++ b/trading-binance/tools/run-replay.sh
@@ -50,6 +50,30 @@
 #   REPLAY_IMAGE_TAG             Container image tag built from
 #                                Containerfile.replay.
 #                                Default: trading-binance-replay:latest
+#   REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD
+#                                Verified-trade count required before
+#                                strategist.ag rewrites its prompt body
+#                                (M98 v3). Set to a large number (e.g.
+#                                999) to disable prompt evolution for
+#                                the A/B control arm. Default: 3
+#   REPLAY_STRATEGIST_PROMPT_GEN_CAP
+#                                Per-lineage generation cap before
+#                                reset; forward-compat knob threaded
+#                                into the daemon env so the A/B harness
+#                                can pin it. Default: 10
+#   REPLAY_STRATEGIST_PROMPT_MAX_BYTES
+#                                Hard byte cap on rewritten prompt
+#                                bodies; forward-compat. Default: 8192
+#   REPLAY_STRATEGIST_PROMPT_LEVENSHTEIN_FLOOR
+#                                Minimum dissimilarity percent for a
+#                                rewrite to be accepted (else no-op);
+#                                forward-compat. Default: 20
+#   REPLAY_STRATEGIST_FITNESS_REWARD_WIN_PER_BPS
+#                                Fitness reward multiplier per bps of
+#                                positive PnL; forward-compat. Default: 1
+#   REPLAY_STRATEGIST_FITNESS_PENALTY_LOSS_PER_BPS
+#                                Fitness penalty multiplier per bps of
+#                                negative PnL; forward-compat. Default: 1
 #
 # Flags:
 #   --dry-run    Same as REPLAY_DRY_RUN=1.
@@ -116,6 +140,19 @@ OPENAI_TIMEOUT_MS="${REPLAY_OPENAI_TIMEOUT_MS:-180000}"
 LOOKBACK_WINDOW="${REPLAY_LOOKBACK_WINDOW:-200}"
 HOLD_PERIOD="${REPLAY_HOLD_PERIOD:-8}"
 IMAGE_TAG="${REPLAY_IMAGE_TAG:-trading-binance-replay:latest}"
+
+# Strategist M98 v3 prompt-evolution + fitness knobs. The first one
+# (THRESHOLD) is the A/B emergence experiment's primary lever:
+#   control arm  = 999  (evolution effectively off)
+#   treatment arm = 3   (evolution armed, matches strategist.ag default)
+# The rest are forward-compat knobs threaded through to the per-tribe
+# daemon env so the A/B harness has a single surface to pin them on.
+: "${REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD:=3}"
+: "${REPLAY_STRATEGIST_PROMPT_GEN_CAP:=10}"
+: "${REPLAY_STRATEGIST_PROMPT_MAX_BYTES:=8192}"
+: "${REPLAY_STRATEGIST_PROMPT_LEVENSHTEIN_FLOOR:=20}"
+: "${REPLAY_STRATEGIST_FITNESS_REWARD_WIN_PER_BPS:=1}"
+: "${REPLAY_STRATEGIST_FITNESS_PENALTY_LOSS_PER_BPS:=1}"
 
 # --- Validation ---
 case "$TIMEFRAME" in
@@ -297,7 +334,7 @@ write_bootstrap() {
         printf 'cd /run-root\n'
         printf 'agentis init >/dev/null 2>&1 || true\n'
         printf '{\n'
-        printf '  printf "exec.env_passthrough = DAEMON_ID,TRIBE_NAME,REPLAY_SYMBOL,REPLAY_TIMEFRAME,REPLAY_LOOKBACK_WINDOW,REPLAY_HOLD_PERIOD,HOLD_PERIOD,VERIFIER_PATH,CANDLES_CSV,TRADE_LEDGER,AGENTIS_ROOT\\n"\n'
+        printf '  printf "exec.env_passthrough = DAEMON_ID,TRIBE_NAME,REPLAY_SYMBOL,REPLAY_TIMEFRAME,REPLAY_LOOKBACK_WINDOW,REPLAY_HOLD_PERIOD,HOLD_PERIOD,VERIFIER_PATH,CANDLES_CSV,TRADE_LEDGER,AGENTIS_ROOT,STRATEGIST_PROMPT_EVOLUTION_THRESHOLD,STRATEGIST_PROMPT_GEN_CAP,STRATEGIST_PROMPT_MAX_BYTES,STRATEGIST_PROMPT_LEVENSHTEIN_FLOOR,STRATEGIST_FITNESS_REWARD_WIN_PER_BPS,STRATEGIST_FITNESS_PENALTY_LOSS_PER_BPS\\n"\n'
         printf '  printf "experience.enabled = true\\n"\n'
         printf '  printf "telemetry.enabled = true\\n"\n'
         printf '  printf "llm.backend = %s\\n"\n' "$LLM_BACKEND"
@@ -320,8 +357,15 @@ write_bootstrap() {
         # Spawn one source strategist daemon per tribe. Each tribe's
         # M2-Malthusian replicate path grows the population from there.
         printf 'for t in alpha beta gamma delta epsilon; do\n'
-        printf '    DAEMON_ID=1 TRIBE_NAME=tribe-$t REPLAY_SYMBOL=%s REPLAY_TIMEFRAME=%s REPLAY_LOOKBACK_WINDOW=%s REPLAY_HOLD_PERIOD=%s HOLD_PERIOD=%s VERIFIER_PATH=/run-root/tools/verify-trade.sh CANDLES_CSV=/run-root/candles.csv TRADE_LEDGER=/run-root/trade-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis agentis daemon /run-root/tribe-$t/agents/strategist.ag --colony tribe-$t --enable-exec --enable-messaging --enable-replication --allow-replica-replication --tick-interval %s > /run-root/.agentis/logs/strategist-$t.log 2>&1 &\n' \
-            "$SYMBOL" "$TIMEFRAME" "$LOOKBACK_WINDOW" "$HOLD_PERIOD" "$HOLD_PERIOD" "$((INTERVAL_SECONDS * 1000 / SPEED))"
+        printf '    DAEMON_ID=1 TRIBE_NAME=tribe-$t REPLAY_SYMBOL=%s REPLAY_TIMEFRAME=%s REPLAY_LOOKBACK_WINDOW=%s REPLAY_HOLD_PERIOD=%s HOLD_PERIOD=%s VERIFIER_PATH=/run-root/tools/verify-trade.sh CANDLES_CSV=/run-root/candles.csv TRADE_LEDGER=/run-root/trade-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=%s STRATEGIST_PROMPT_GEN_CAP=%s STRATEGIST_PROMPT_MAX_BYTES=%s STRATEGIST_PROMPT_LEVENSHTEIN_FLOOR=%s STRATEGIST_FITNESS_REWARD_WIN_PER_BPS=%s STRATEGIST_FITNESS_PENALTY_LOSS_PER_BPS=%s agentis daemon /run-root/tribe-$t/agents/strategist.ag --colony tribe-$t --enable-exec --enable-messaging --enable-replication --allow-replica-replication --tick-interval %s > /run-root/.agentis/logs/strategist-$t.log 2>&1 &\n' \
+            "$SYMBOL" "$TIMEFRAME" "$LOOKBACK_WINDOW" "$HOLD_PERIOD" "$HOLD_PERIOD" \
+            "$REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD" \
+            "$REPLAY_STRATEGIST_PROMPT_GEN_CAP" \
+            "$REPLAY_STRATEGIST_PROMPT_MAX_BYTES" \
+            "$REPLAY_STRATEGIST_PROMPT_LEVENSHTEIN_FLOOR" \
+            "$REPLAY_STRATEGIST_FITNESS_REWARD_WIN_PER_BPS" \
+            "$REPLAY_STRATEGIST_FITNESS_PENALTY_LOSS_PER_BPS" \
+            "$((INTERVAL_SECONDS * 1000 / SPEED))"
         printf 'done\n'
         printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'
         printf 'exit 0\n'

--- a/trading-binance/tools/test-analyze-ab-results.py
+++ b/trading-binance/tools/test-analyze-ab-results.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+# test-analyze-ab-results.py -- unit tests for analyze-ab-results.py
+# (#573 PR-5).
+#
+# 6 unittest cases covering:
+#   1. PnL bps aggregation matches a hand-computed total.
+#   2. Win rate excludes FLAT.
+#   3. Max drawdown is chronological regardless of input file order.
+#   4. Mutation rate is 0 on control fixture, N on treatment fixture
+#      with N rewrite rows.
+#   5. Missing .agentis/experience/ directory yields a zero-trade row,
+#      no crash.
+#   6. comparison.md is written with the run -> arm header table.
+#
+# All cases build hermetic fixtures under tempfile.TemporaryDirectory().
+# Stdlib only.
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "analyze_ab_results",
+    os.path.join(SCRIPT_DIR, "analyze-ab-results.py"),
+)
+analyzer = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(analyzer)
+
+
+TS = "20260101T000000Z"
+
+
+def _write_jsonl(path, rows):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def _settle_row(tribe, classification, pnl_bps, ts):
+    """Build a settle learn() row matching strategist.ag's emit shape."""
+    return {
+        "topic": "settle",
+        "summary": "tick X " + classification,
+        "details": "pnl_bps=" + str(pnl_bps),
+        "outcome": "success",
+        "tags": ["acted", "trading-binance", tribe, "classification:" + classification],
+        "ts": ts,
+    }
+
+
+def _rewrite_row(tribe, gen, ts):
+    """Build a `strategist_prompt_evolve` rewrite row."""
+    return {
+        "topic": "strategist_prompt_evolve",
+        "summary": "rewrite",
+        "details": "gen=" + str(gen),
+        "outcome": "success",
+        "tags": ["prompt-evolution", "rewritten", "trading-binance", tribe],
+        "ts": ts,
+    }
+
+
+def _memo_row(key, value):
+    return {"key": key, "value": value}
+
+
+def _build_run_dir(exp_dir, ts, arm, run_idx):
+    """Create the on-disk skeleton for one run, returns the run_dir
+    path. Caller fills .agentis/experience/ + .agentis/memo*.jsonl."""
+    name = "ab-trading-" + ts + "-" + arm + "-run-" + str(run_idx)
+    run_dir = os.path.join(exp_dir, name)
+    os.makedirs(os.path.join(run_dir, "laptop-node", ".agentis", "experience"), exist_ok=True)
+    return run_dir
+
+
+def _write_manifest(exp_dir, ts, runs):
+    """runs: list of (arm, run_idx, run_dir, threshold, exit_code)"""
+    manifest = {
+        "experiment_ts": ts,
+        "symbol": "BTCUSDT",
+        "timeframe": "1h",
+        "start": "2026-01-01",
+        "end": "2026-03-31",
+        "replay_speed": 720,
+        "n_replicates_per_arm": max(r[1] for r in runs) if runs else 0,
+        "llm_model": "qwen/qwen3-coder-30b-a3b-instruct",
+        "arms": {
+            "control": {"strategist_prompt_evolution_threshold": 999, "description": "off"},
+            "treatment": {"strategist_prompt_evolution_threshold": 3, "description": "on"},
+        },
+        "runs": [
+            {
+                "arm": arm,
+                "run_idx": run_idx,
+                "run_dir": run_dir,
+                "strategist_prompt_evolution_threshold": threshold,
+                "exit_code": exit_code,
+            }
+            for (arm, run_idx, run_dir, threshold, exit_code) in runs
+        ],
+    }
+    with open(os.path.join(exp_dir, "experiment-manifest.json"), "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+
+
+class PnlAggregationTest(unittest.TestCase):
+    """Test 1 -- PnL bps aggregation matches hand-computed total."""
+
+    def test_pnl_total_matches_hand_computed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp_dir = os.path.join(tmp, "ab-trading-" + TS)
+            run_dir = _build_run_dir(exp_dir, TS, "control", 1)
+            exp_jsonl = os.path.join(run_dir, "laptop-node", ".agentis", "experience", "1.jsonl")
+            rows = [
+                _settle_row("tribe-alpha", "WIN", 25.0, 1000),
+                _settle_row("tribe-alpha", "LOSS", -15.0, 2000),
+                _settle_row("tribe-alpha", "WIN", 40.0, 3000),
+                # different tribe, not counted for alpha
+                _settle_row("tribe-beta", "WIN", 100.0, 1500),
+            ]
+            _write_jsonl(exp_jsonl, rows)
+            m = analyzer.compute_run_tribe_metrics(run_dir, "tribe-alpha")
+            self.assertEqual(m["total_trades"], 3)
+            self.assertAlmostEqual(m["pnl_bps_total"], 50.0, places=6)
+            # tribe-beta isolated correctly
+            mb = analyzer.compute_run_tribe_metrics(run_dir, "tribe-beta")
+            self.assertEqual(mb["total_trades"], 1)
+            self.assertAlmostEqual(mb["pnl_bps_total"], 100.0, places=6)
+
+
+class WinRateExcludesFlatTest(unittest.TestCase):
+    """Test 2 -- win rate denominator excludes FLAT rows."""
+
+    def test_win_rate_excludes_flat(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp_dir = os.path.join(tmp, "ab-trading-" + TS)
+            run_dir = _build_run_dir(exp_dir, TS, "control", 1)
+            exp_jsonl = os.path.join(run_dir, "laptop-node", ".agentis", "experience", "1.jsonl")
+            rows = [
+                _settle_row("tribe-alpha", "WIN", 10.0, 1000),
+                _settle_row("tribe-alpha", "LOSS", -5.0, 2000),
+                _settle_row("tribe-alpha", "FLAT", 0.0, 3000),
+                _settle_row("tribe-alpha", "FLAT", 0.0, 4000),
+                _settle_row("tribe-alpha", "WIN", 8.0, 5000),
+            ]
+            _write_jsonl(exp_jsonl, rows)
+            m = analyzer.compute_run_tribe_metrics(run_dir, "tribe-alpha")
+            # 2 WIN, 1 LOSS, 2 FLAT -> win_rate = 2/3
+            self.assertEqual(m["wins"], 2)
+            self.assertEqual(m["losses"], 1)
+            self.assertEqual(m["flats"], 2)
+            self.assertAlmostEqual(m["win_rate"], 2.0 / 3.0, places=6)
+            self.assertEqual(m["total_trades"], 5)
+
+
+class MaxDrawdownChronologicalTest(unittest.TestCase):
+    """Test 3 -- max drawdown is computed in chronological order
+    regardless of input row order on disk."""
+
+    def test_drawdown_chronological(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp_dir = os.path.join(tmp, "ab-trading-" + TS)
+            run_dir = _build_run_dir(exp_dir, TS, "control", 1)
+            exp_jsonl = os.path.join(run_dir, "laptop-node", ".agentis", "experience", "1.jsonl")
+            # Chronological pnls: +100, -30, -50, +200 -> equity curve:
+            # 100, 70, 20, 220 -> running max 100 at ts=1000, dip to 20
+            # at ts=3000 -> max_dd = 100 - 20 = 80.
+            # Write rows OUT OF ORDER on disk:
+            rows = [
+                _settle_row("tribe-alpha", "WIN", 200.0, 4000),
+                _settle_row("tribe-alpha", "WIN", 100.0, 1000),
+                _settle_row("tribe-alpha", "LOSS", -50.0, 3000),
+                _settle_row("tribe-alpha", "LOSS", -30.0, 2000),
+            ]
+            _write_jsonl(exp_jsonl, rows)
+            m = analyzer.compute_run_tribe_metrics(run_dir, "tribe-alpha")
+            self.assertAlmostEqual(m["max_drawdown_bps"], 80.0, places=6)
+            self.assertAlmostEqual(m["pnl_bps_total"], 220.0, places=6)
+
+
+class MutationRateTest(unittest.TestCase):
+    """Test 4 -- mutation surrogates are 0 on control fixture,
+    N on treatment fixture with N rewrite rows + N distinct prompt-body
+    memo SHAs."""
+
+    def test_mutation_rate_control_zero_treatment_n(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp_dir = os.path.join(tmp, "ab-trading-" + TS)
+            control_dir = _build_run_dir(exp_dir, TS, "control", 1)
+            # Control: only WIN/LOSS settle rows, no rewrite, no memo
+            # dump rows.
+            _write_jsonl(
+                os.path.join(control_dir, "laptop-node", ".agentis", "experience", "1.jsonl"),
+                [
+                    _settle_row("tribe-alpha", "WIN", 10.0, 1000),
+                    _settle_row("tribe-alpha", "LOSS", -5.0, 2000),
+                ],
+            )
+            c = analyzer.compute_run_tribe_metrics(control_dir, "tribe-alpha")
+            self.assertEqual(c["distinct_prompt_shas"], 0)
+            self.assertEqual(c["rewrite_events"], 0)
+
+            # Treatment: 3 rewrite rows + 3 distinct prompt-body SHAs.
+            treat_dir = _build_run_dir(exp_dir, TS, "treatment", 1)
+            _write_jsonl(
+                os.path.join(treat_dir, "laptop-node", ".agentis", "experience", "1.jsonl"),
+                [
+                    _settle_row("tribe-alpha", "WIN", 10.0, 1000),
+                    _rewrite_row("tribe-alpha", 1, 1100),
+                    _rewrite_row("tribe-alpha", 2, 2100),
+                    _rewrite_row("tribe-alpha", 3, 3100),
+                ],
+            )
+            # Memo dump: 3 distinct prompt-body SHAs.
+            memo_path = os.path.join(treat_dir, "laptop-node", ".agentis", "memo.jsonl")
+            _write_jsonl(memo_path, [
+                _memo_row("strategist:prompt_body:" + "a" * 64, "body1"),
+                _memo_row("strategist:prompt_body:" + "b" * 64, "body2"),
+                _memo_row("strategist:prompt_body:" + "c" * 64, "body3"),
+                _memo_row("unrelated:key", "junk"),
+            ])
+            t = analyzer.compute_run_tribe_metrics(treat_dir, "tribe-alpha")
+            self.assertEqual(t["distinct_prompt_shas"], 3)
+            self.assertEqual(t["rewrite_events"], 3)
+
+
+class MissingExperienceDirTest(unittest.TestCase):
+    """Test 5 -- missing .agentis/experience/ dir yields a 0-metric row
+    with no crash (e.g. run aborted before any learn() fired)."""
+
+    def test_missing_experience_dir_yields_zero_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp_dir = os.path.join(tmp, "ab-trading-" + TS)
+            os.makedirs(exp_dir, exist_ok=True)
+            run_dir = os.path.join(exp_dir, "ab-trading-" + TS + "-control-run-1")
+            # Create the run dir but NOT the .agentis tree.
+            os.makedirs(run_dir, exist_ok=True)
+            m = analyzer.compute_run_tribe_metrics(run_dir, "tribe-alpha")
+            self.assertEqual(m["total_trades"], 0)
+            self.assertEqual(m["wins"], 0)
+            self.assertEqual(m["losses"], 0)
+            self.assertEqual(m["flats"], 0)
+            self.assertEqual(m["win_rate"], 0.0)
+            self.assertEqual(m["pnl_bps_total"], 0.0)
+            self.assertEqual(m["max_drawdown_bps"], 0.0)
+            self.assertEqual(m["sharpe"], 0.0)
+            self.assertEqual(m["distinct_prompt_shas"], 0)
+            self.assertEqual(m["rewrite_events"], 0)
+
+
+class ReportRendersHeaderTableTest(unittest.TestCase):
+    """Test 6 -- end-to-end analyze() writes comparison.md with the
+    arm-labelled run -> arm header table."""
+
+    def test_comparison_md_has_run_to_arm_header(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exp_dir = os.path.join(tmp, "ab-trading-" + TS)
+            os.makedirs(exp_dir, exist_ok=True)
+            # 2 control runs + 2 treatment runs (small to keep test fast).
+            run_dirs = []
+            for arm in ("control", "treatment"):
+                for run_idx in (1, 2):
+                    rd = _build_run_dir(exp_dir, TS, arm, run_idx)
+                    # Single settle row so the metrics block is non-empty.
+                    _write_jsonl(
+                        os.path.join(rd, "laptop-node", ".agentis", "experience", "1.jsonl"),
+                        [_settle_row("tribe-alpha", "WIN", 7.5, 1000)],
+                    )
+                    threshold = 999 if arm == "control" else 3
+                    run_dirs.append((arm, run_idx, rd, threshold, 0))
+            _write_manifest(exp_dir, TS, run_dirs)
+            out_path, report = analyzer.analyze(exp_dir)
+            self.assertTrue(os.path.isfile(out_path))
+            self.assertEqual(os.path.basename(out_path), "comparison.md")
+            # Manifest fields surface.
+            self.assertIn("BTCUSDT", report)
+            self.assertIn("control", report)
+            self.assertIn("treatment", report)
+            self.assertIn("REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999", report)
+            self.assertIn("REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=3", report)
+            # Run -> arm header table.
+            self.assertIn("Run -> arm mapping", report)
+            self.assertIn("ab-trading-" + TS + "-control-run-1", report)
+            self.assertIn("ab-trading-" + TS + "-treatment-run-2", report)
+            # Per-tribe table for tribe-alpha at minimum.
+            self.assertIn("tribe-alpha", report)
+            self.assertIn("pnl_bps_total", report)
+            # Federation aggregate exists.
+            self.assertIn("Federation aggregate", report)
+            # Honest caveats section verbatim per plan H.
+            self.assertIn("Honest caveats", report)
+
+    def test_analyse_refuses_unmapped_run_dir(self):
+        """Bonus assertion (still under test 6 class) -- the analyser
+        must refuse to emit when a control-/treatment-named run dir is
+        not in the manifest."""
+        with tempfile.TemporaryDirectory() as tmp:
+            exp_dir = os.path.join(tmp, "ab-trading-" + TS)
+            os.makedirs(exp_dir, exist_ok=True)
+            # Manifest only mentions run 1 control; physical disk has
+            # an extra unmapped control-run-99.
+            mapped = _build_run_dir(exp_dir, TS, "control", 1)
+            _build_run_dir(exp_dir, TS, "control", 99)  # unmapped
+            _write_manifest(exp_dir, TS, [("control", 1, mapped, 999, 0)])
+            with self.assertRaises(SystemExit) as cm:
+                analyzer.analyze(exp_dir)
+            self.assertEqual(cm.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trading-binance/tools/test-run-ab-experiment.sh
+++ b/trading-binance/tools/test-run-ab-experiment.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# test-run-ab-experiment.sh -- smoke test for run-ab-experiment.sh
+# --dry-run mode (#573 PR-5).
+#
+# 8 assertions covering the harness control surface:
+#   1. --help works (returns 0, prints usage).
+#   2. AB_DRY_RUN=1 AB_N_REPLICATES=2 emits exactly 4 run-replay.sh
+#      lines (2 arms * 2 replicates).
+#   3. Control replicates carry
+#      REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999.
+#   4. Treatment replicates carry
+#      REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=3.
+#   5. Per-run dirs follow ab-trading-*-{control,treatment}-run-*
+#      naming.
+#   6. experiment-manifest.json path is emitted in the plan.
+#   7. analyze-ab-results.py invocation emitted after the runs.
+#   8. Unknown flag exits non-zero (2).
+#
+# Standard library only -- no pytest, no live LLM, no podman.
+#
+# Usage: bash trading-binance/tools/test-run-ab-experiment.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HARNESS="$SCRIPT_DIR/run-ab-experiment.sh"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+    label="$1"; haystack="$2"; needle="$3"
+    if printf '%s' "$haystack" | grep -Fq -- "$needle"; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       needle not found: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_eq() {
+    label="$1"; expected="$2"; actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "[PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label"
+        echo "       expected: $expected"
+        echo "       actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+if [ ! -x "$HARNESS" ]; then
+    echo "[FAIL] run-ab-experiment.sh not executable at $HARNESS"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 1. --help works.
+# ---------------------------------------------------------------------------
+HELP_RC=0
+HELP_OUT="$(bash "$HARNESS" --help 2>&1)" || HELP_RC=$?
+assert_eq "1a. --help exits 0" "0" "$HELP_RC"
+assert_contains "1b. --help prints harness summary" "$HELP_OUT" \
+    "A/B emergence experiment harness"
+assert_contains "1c. --help documents AB_N_REPLICATES" "$HELP_OUT" \
+    "AB_N_REPLICATES"
+
+# ---------------------------------------------------------------------------
+# 2-7. AB_DRY_RUN=1 AB_N_REPLICATES=2 -> 4 run-replay invocations + manifest
+#      + analyser invocation.
+# ---------------------------------------------------------------------------
+DRY_RC=0
+DRY_OUT="$(AB_DRY_RUN=1 AB_N_REPLICATES=2 \
+           AB_SYMBOL=BTCUSDT AB_TIMEFRAME=1h \
+           bash "$HARNESS" 2>&1)" || DRY_RC=$?
+assert_eq "2a. AB_DRY_RUN=1 exits 0" "0" "$DRY_RC"
+
+run_replay_lines=$(printf '%s\n' "$DRY_OUT" | grep -c 'bash .*run-replay.sh' || true)
+assert_eq "2b. exactly 4 run-replay.sh invocations emitted (2 arms x 2 reps)" \
+    "4" "$run_replay_lines"
+
+# 3. Control threshold (999) appears in dry-run.
+control_999_lines=$(printf '%s\n' "$DRY_OUT" \
+    | grep -F 'REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999' \
+    | grep -c 'bash .*run-replay.sh' || true)
+assert_eq "3. control replicates carry threshold=999" "2" "$control_999_lines"
+
+# 4. Treatment threshold (3) appears in dry-run.
+treatment_3_lines=$(printf '%s\n' "$DRY_OUT" \
+    | grep -F 'REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=3 ' \
+    | grep -c 'bash .*run-replay.sh' || true)
+assert_eq "4. treatment replicates carry threshold=3" "2" "$treatment_3_lines"
+
+# 5. Per-run dir naming convention.
+assert_contains "5a. control-run-1 dir name emitted" "$DRY_OUT" \
+    "control-run-1"
+assert_contains "5b. control-run-2 dir name emitted" "$DRY_OUT" \
+    "control-run-2"
+assert_contains "5c. treatment-run-1 dir name emitted" "$DRY_OUT" \
+    "treatment-run-1"
+assert_contains "5d. treatment-run-2 dir name emitted" "$DRY_OUT" \
+    "treatment-run-2"
+
+# 6. experiment-manifest.json path emitted.
+assert_contains "6. experiment-manifest.json path emitted" "$DRY_OUT" \
+    "experiment-manifest.json"
+
+# 7. analyser invocation emitted (after the runs).
+assert_contains "7. analyze-ab-results.py invocation emitted" "$DRY_OUT" \
+    "analyze-ab-results.py"
+
+# Verify ordering: analyser line appears AFTER the last run-replay line.
+analyser_pos=$(printf '%s\n' "$DRY_OUT" | grep -n 'analyze-ab-results.py' | tail -1 | cut -d: -f1)
+last_replay_pos=$(printf '%s\n' "$DRY_OUT" | grep -n 'bash .*run-replay.sh' | tail -1 | cut -d: -f1)
+if [ -n "$analyser_pos" ] && [ -n "$last_replay_pos" ] && [ "$analyser_pos" -gt "$last_replay_pos" ]; then
+    echo "[PASS] 7b. analyser invocation strictly after last replicate"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] 7b. analyser invocation ordering wrong (analyser_pos=$analyser_pos last_replay_pos=$last_replay_pos)"
+    FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Unknown flag exits 2.
+# ---------------------------------------------------------------------------
+UNK_RC=0
+bash "$HARNESS" --no-such-flag >/dev/null 2>&1 || UNK_RC=$?
+assert_eq "8. unknown flag exits 2" "2" "$UNK_RC"
+
+# Header-doc sanity.
+SRC="$(cat "$HARNESS")"
+assert_contains "header documents AB_N_REPLICATES" "$SRC" "AB_N_REPLICATES"
+assert_contains "header documents AB_SYMBOL" "$SRC" "AB_SYMBOL"
+assert_contains "header documents AB_TIMEFRAME" "$SRC" "AB_TIMEFRAME"
+assert_contains "header documents AB_SPEED" "$SRC" "AB_SPEED"
+assert_contains "header documents AB_DRY_RUN" "$SRC" "AB_DRY_RUN"
+assert_contains "header documents binance-feed-download prerequisite" "$SRC" \
+    "binance-feed-download.py"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

#573 PR-5 of 5 -- closes Phase 1 scaffolding for the trading-binance federation. **Harness only; actual experiment execution is gated on user budget approval (~\$20 LLM spend, ~18h wall clock).**

- Adds `tools/run-ab-experiment.sh` shell wrapper that runs N paired replicates x 2 arms (control = evolution OFF via `REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999`, treatment = evolution ON via `=3`) against `tools/run-replay.sh`, writes `experiment-manifest.json` mapping every run dir to its arm, then invokes the analyser.
- Adds `tools/analyze-ab-results.py` stdlib analyser that parses per-run `trade-ledger.jsonl` + `.agentis/experience/*.jsonl` + `.agentis/memo*.jsonl`, computes per-(arm, tribe) PnL bps + win rate + total trades + max drawdown + per-trade Sharpe + two mutation surrogates (distinct prompt-body SHAs + `strategist_prompt_evolve` rewrite rows), and emits `comparison.md` with run->arm header table, per-tribe arm-vs-arm tables, federation aggregate, and honest caveats. Refuses to emit when any run dir is unmappable via the manifest.
- Patches `tools/run-replay.sh` env passthrough to thread the new `STRATEGIST_PROMPT_EVOLUTION_THRESHOLD` knob (primary A/B lever) plus 5 forward-compat strategist knobs (`*_GEN_CAP`, `*_MAX_BYTES`, `*_LEVENSHTEIN_FLOOR`, `*_FITNESS_REWARD_WIN_PER_BPS`, `*_FITNESS_PENALTY_LOSS_PER_BPS`) through `exec.env_passthrough` + the per-tribe daemon-spawn `printf` block. No strategist.ag changes (the threshold env var was already read at strategist.ag L137 + L438 per the PR-4 design).
- Adds `data/.gitkeep` placeholder; operator must run `tools/binance-feed-download.py --symbol BTCUSDT --timeframe 1h --start <YYYY-MM-DD> --end <YYYY-MM-DD>` before invoking the harness (data tree not committed).

Files touched (all stdlib Python, all bash 3.2-compatible):
- new: `trading-binance/tools/run-ab-experiment.sh` (~265 lines)
- new: `trading-binance/tools/analyze-ab-results.py` (~400 lines)
- new: `trading-binance/tools/test-run-ab-experiment.sh` (8 plan-spec assertions + sub-checks = 21 total)
- new: `trading-binance/tools/test-analyze-ab-results.py` (6 plan-spec unittest cases + 1 bonus refuse-unmapped case = 7 total)
- new: `trading-binance/data/.gitkeep`
- modified: `trading-binance/tools/run-replay.sh` (env-defaults + env_passthrough + daemon-spawn `printf` patch + header doc)
- modified: `trading-binance/BUNDLE.manifest` (4 new tool entries + data/ dir)
- modified: `trading-binance/CHANGELOG.md` (Added + Changed entries under `[Unreleased]`)

## Test plan

- [x] `bash -n trading-binance/tools/run-ab-experiment.sh` clean
- [x] `bash -n trading-binance/tools/test-run-ab-experiment.sh` clean
- [x] `bash -n trading-binance/tools/run-replay.sh` clean (post-patch)
- [x] `python3 -m py_compile trading-binance/tools/analyze-ab-results.py` clean
- [x] `python3 -m py_compile trading-binance/tools/test-analyze-ab-results.py` clean
- [x] `python3 trading-binance/tools/test-analyze-ab-results.py` -> 7/0 pass
- [x] `bash trading-binance/tools/test-run-ab-experiment.sh` -> 21/0 pass (8 plan assertions + sub-checks + header-doc sanity)
- [x] `bash trading-binance/tools/test-verify-trade.sh` -> 13/0 pass (PR-4 regression)
- [x] `bash trading-binance/tools/test-run-replay.sh` -> 29/0 pass (PR-3 regression, env-passthrough patch did not break)
- [x] `bash trading-binance/tools/test-binance-feed-download.sh` -> 6/0 pass (PR-2 regression)
- [x] `bash tools/colony-lint.sh` -> 205/0 pass, 3 skipped (no regressions)

## Out of scope (Phase 2+)

- Live / paper trading
- ETHUSDT or any second symbol
- Walk-forward / out-of-sample validation
- Multi-tribe knowledge market
- Cross-symbol correlation
- Capacity / slippage-vs-size modelling

Experiment execution itself is **not** part of this PR -- pending user nod on the ~\$20 budget and ~18h wall clock estimate documented in the plan.

Closes Phase 1 of #573.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>