### PR TITLE
fix(trading-binance): grant pii_transmit for candle CSV prompts (closes #581)

### DIFF
--- a/trading-binance/tools/run-replay.sh
+++ b/trading-binance/tools/run-replay.sh
@@ -348,6 +348,11 @@ write_bootstrap() {
         printf '  printf "telemetry.enabled = true\\n"\n'
         printf '  printf "llm.backend = %s\\n"\n' "$LLM_BACKEND"
         printf '  printf "daemon.cb_per_tick = %s\\n"\n' "$DAEMON_CB_PER_TICK"
+        # Candle OHLCV strings trip agentis-core's PII heuristic
+        # (long numeric runs flagged as phone / credit_card / czech_birth_number).
+        # Without this allow, every prompt() returns 'capability denied: pii_transmit'
+        # and no decisions are ever produced. Closes #581.
+        printf '  printf "pii_transmit = allow\\n"\n'
         if [ "$LLM_BACKEND" = "openai" ]; then
             printf '  printf "llm.openai.endpoint = %s\\n"\n' "$OPENAI_ENDPOINT"
             printf '  printf "llm.openai.model = %s\\n"\n' "$OPENAI_MODEL"


### PR DESCRIPTION
## Summary

Adds \`pii_transmit = allow\` to the hermetic config emitted by \`run-replay.sh\`.

The 200-candle OHLCV CSV string used as \`prompt()\` context (~21KB of floats) triggers agentis-core's PII heuristic (phone / credit-card / Czech-birth-number patterns). Without the explicit allow, every \`prompt()\` call returns \`capability denied: pii_transmit\` and no decisions are produced.

Closes #581. Together with #579, unblocks PR-5 A/B emergence experiment (#573).

## Test plan

- [x] \`bash -n run-replay.sh\` clean
- [x] \`test-run-replay.sh\` 29/0
- [ ] Runtime verification on relaunched experiment