### PR TITLE
fix(trading-binance): --replace on podman run for idempotent spawn (closes #585)

### DIFF
--- a/trading-binance/tools/run-replay.sh
+++ b/trading-binance/tools/run-replay.sh
@@ -403,7 +403,7 @@ write_bootstrap() {
 # --- 4) Spawn the container ---
 spawn_container() {
     emit_step "spawning replay-laptop container (image=$IMAGE_TAG)"
-    emit_cmd "podman run -d --name replay-laptop -e $OPENAI_KEY_ENV=\"\${$OPENAI_KEY_ENV:-}\" -v $REPO_ROOT:/repo:ro -v $LAPTOP_DIR:/run-root:rw $IMAGE_TAG /run-root/bootstrap.sh"
+    emit_cmd "podman run -d --replace --name replay-laptop -e $OPENAI_KEY_ENV=\"\${$OPENAI_KEY_ENV:-}\" -v $REPO_ROOT:/repo:ro -v $LAPTOP_DIR:/run-root:rw $IMAGE_TAG /run-root/bootstrap.sh"
 }
 
 # --- 5) Cleanup trap ---

--- a/trading-binance/tools/test-run-replay.sh
+++ b/trading-binance/tools/test-run-replay.sh
@@ -210,7 +210,7 @@ assert_eq "11. load-candles.py rejects continuity-gap fixture with exit 4" \
 assert_contains "12. bootstrap-script generation step emitted" "$OUT" \
     "generating bootstrap script"
 assert_contains "13. container spawn command emitted via echo prefix" "$OUT" \
-    "+ podman run -d --name replay-laptop"
+    "+ podman run -d --replace --name replay-laptop"
 assert_contains "14. run-meta.json write step emitted" "$OUT" \
     "writing run-meta.json"
 assert_contains "15. cleanup trap installed" "$OUT" \


### PR DESCRIPTION
## Summary

- \`podman run -d --replace --name replay-laptop ...\` (was \`-d --name ...\`)
- Bumps test-run-replay.sh assertion 13 to match (29/0)

Stale leftover container blocks new runs with 'name already in use'. With \`--replace\` podman cleans up first. Idempotent and safe.

Closes #585. Fourth follow-up fix on PR-3 unblocking PR-5 A/B (#573).

## Test plan

- [x] \`bash -n\` clean
- [x] \`test-run-replay.sh\` 29/0 (test 13 updated for new command)