### PR TITLE
fix(trading-binance): pnl_bps_x100 int field for precision-preserving parse (closes #589)

### DIFF
--- a/trading-binance/tools/test-verify-trade.sh
+++ b/trading-binance/tools/test-verify-trade.sh
@@ -225,9 +225,34 @@ rc=$?
 set -e
 assert_exit_code "12: malformed DECISION_JSON exits 4" "$rc" "4"
 
+# --- Test 13: pnl_bps_x100 field present and = int(pnl_bps * 100) ---
+# Closes #589: strategist.ag parse_int truncates float pnl_bps to 0,
+# so verify-trade.sh emits pnl_bps_x100 for precision-preserving int parse.
+PRICES_CSV13="$(mktemp --suffix=.csv)"
+{
+    printf 'open\n'
+    for i in $(seq 0 20); do printf '%s\n' "$(python3 -c "print(60000 + $i * 7)")"; done
+} > "$PRICES_CSV13"
+verdict13="$(DECISION_JSON='{"action":"LONG","size":1.0,"rationale":"r","setup":"s"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$PRICES_CSV13" \
+    SLIPPAGE_BPS=0 FUNDING_RATE_BPS=0 \
+    bash "$VERIFIER")"
+field_x100="$(python3 -c 'import sys,json; print(json.loads(sys.argv[1])["pnl_bps_x100"])' "$verdict13")"
+field_float="$(python3 -c 'import sys,json; print(json.loads(sys.argv[1])["pnl_bps"])' "$verdict13")"
+expected="$(python3 -c "print(int(round($field_float * 100)))")"
+if [ "$field_x100" = "$expected" ]; then
+    PASS=$((PASS+1))
+    echo "[PASS] 13b: pnl_bps_x100 = int(pnl_bps*100) (x100=$field_x100 float=$field_float)"
+else
+    FAIL=$((FAIL+1))
+    echo "[FAIL] 13b: pnl_bps_x100 expected $expected got $field_x100"
+fi
+rm -f "$PRICES_CSV13"
+
 # --- Summary ---
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then
     exit 1
 fi
+

--- a/trading-binance/tools/verify-trade.sh
+++ b/trading-binance/tools/verify-trade.sh
@@ -135,6 +135,7 @@ if direction == 0:
     verdict = {
         "verified": True,
         "pnl_bps": 0.0,
+        "pnl_bps_x100": 0,
         "classification": "FLAT",
         "entry": None,
         "exit": None,
@@ -169,11 +170,14 @@ pnl_bps = raw_bps - slippage_cost - funding_cost
 
 classification = "WIN" if pnl_bps > 0 else "LOSS"
 
-# Round to 2 decimals (basis-point precision is plenty for telemetry;
-# avoids float-printing noise like 0.30000000000000004).
+# Emit pnl_bps as integer (bps × 100 = pnl_bps_x100) so the .ag side
+# can parse_int() without truncating sub-bp precision to zero. Keeps
+# legacy pnl_bps float field for human-readable telemetry / analyser.
+# Closes #589.
 verdict = {
     "verified": True,
     "pnl_bps": round(pnl_bps, 2),
+    "pnl_bps_x100": int(round(pnl_bps * 100)),
     "classification": classification,
     "entry": round(entry_price, 4),
     "exit": round(exit_price, 4),

--- a/trading-binance/tribe-alpha/agents/strategist.ag
+++ b/trading-binance/tribe-alpha/agents/strategist.ag
@@ -403,11 +403,12 @@ fn tick(reason: string) -> void {
                                 };
                                 let verified_str = to_string(json_get(verdict_raw, "verified"));
                                 let classification = to_string(json_get(verdict_raw, "classification"));
-                                let pnl_bps_str = to_string(json_get(verdict_raw, "pnl_bps"));
-                                let pnl_bps = parse_int(pnl_bps_str);
+                                let pnl_bps_x100_str = to_string(json_get(verdict_raw, "pnl_bps_x100"));
+                                let pnl_bps_x100 = parse_int(pnl_bps_x100_str);
+                                let pnl_bps = pnl_bps_x100 / 100;
                                 if verified_str == "true" {
                                     print("[strategist] settled tick=", settle_tick, " classification=", classification, " pnl_bps=", pnl_bps);
-                                    learn("settle", "tick " + to_string(settle_tick) + " " + classification, "pnl_bps=" + to_string(pnl_bps), "success", ["acted", "trading-binance", _tribe_name, "classification:" + classification]);
+                                    learn("settle", "tick " + to_string(settle_tick) + " " + classification, "pnl_bps=" + to_string(pnl_bps) + " pnl_bps_x100=" + to_string(pnl_bps_x100), "success", ["acted", "trading-binance", _tribe_name, "classification:" + classification]);
 
                                     // Fitness update: reward WIN, penalty
                                     // LOSS, neutral FLAT. Knob env vars are

--- a/trading-binance/tribe-beta/agents/strategist.ag
+++ b/trading-binance/tribe-beta/agents/strategist.ag
@@ -403,11 +403,12 @@ fn tick(reason: string) -> void {
                                 };
                                 let verified_str = to_string(json_get(verdict_raw, "verified"));
                                 let classification = to_string(json_get(verdict_raw, "classification"));
-                                let pnl_bps_str = to_string(json_get(verdict_raw, "pnl_bps"));
-                                let pnl_bps = parse_int(pnl_bps_str);
+                                let pnl_bps_x100_str = to_string(json_get(verdict_raw, "pnl_bps_x100"));
+                                let pnl_bps_x100 = parse_int(pnl_bps_x100_str);
+                                let pnl_bps = pnl_bps_x100 / 100;
                                 if verified_str == "true" {
                                     print("[strategist] settled tick=", settle_tick, " classification=", classification, " pnl_bps=", pnl_bps);
-                                    learn("settle", "tick " + to_string(settle_tick) + " " + classification, "pnl_bps=" + to_string(pnl_bps), "success", ["acted", "trading-binance", _tribe_name, "classification:" + classification]);
+                                    learn("settle", "tick " + to_string(settle_tick) + " " + classification, "pnl_bps=" + to_string(pnl_bps) + " pnl_bps_x100=" + to_string(pnl_bps_x100), "success", ["acted", "trading-binance", _tribe_name, "classification:" + classification]);
 
                                     // Fitness update: reward WIN, penalty
                                     // LOSS, neutral FLAT. Knob env vars are

--- a/trading-binance/tribe-delta/agents/strategist.ag
+++ b/trading-binance/tribe-delta/agents/strategist.ag
@@ -403,11 +403,12 @@ fn tick(reason: string) -> void {
                                 };
                                 let verified_str = to_string(json_get(verdict_raw, "verified"));
                                 let classification = to_string(json_get(verdict_raw, "classification"));
-                                let pnl_bps_str = to_string(json_get(verdict_raw, "pnl_bps"));
-                                let pnl_bps = parse_int(pnl_bps_str);
+                                let pnl_bps_x100_str = to_string(json_get(verdict_raw, "pnl_bps_x100"));
+                                let pnl_bps_x100 = parse_int(pnl_bps_x100_str);
+                                let pnl_bps = pnl_bps_x100 / 100;
                                 if verified_str == "true" {
                                     print("[strategist] settled tick=", settle_tick, " classification=", classification, " pnl_bps=", pnl_bps);
-                                    learn("settle", "tick " + to_string(settle_tick) + " " + classification, "pnl_bps=" + to_string(pnl_bps), "success", ["acted", "trading-binance", _tribe_name, "classification:" + classification]);
+                                    learn("settle", "tick " + to_string(settle_tick) + " " + classification, "pnl_bps=" + to_string(pnl_bps) + " pnl_bps_x100=" + to_string(pnl_bps_x100), "success", ["acted", "trading-binance", _tribe_name, "classification:" + classification]);
 
                                     // Fitness update: reward WIN, penalty
                                     // LOSS, neutral FLAT. Knob env vars are

--- a/trading-binance/tribe-epsilon/agents/strategist.ag
+++ b/trading-binance/tribe-epsilon/agents/strategist.ag
@@ -403,11 +403,12 @@ fn tick(reason: string) -> void {
                                 };
                                 let verified_str = to_string(json_get(verdict_raw, "verified"));
                                 let classification = to_string(json_get(verdict_raw, "classification"));
-                                let pnl_bps_str = to_string(json_get(verdict_raw, "pnl_bps"));
-                                let pnl_bps = parse_int(pnl_bps_str);
+                                let pnl_bps_x100_str = to_string(json_get(verdict_raw, "pnl_bps_x100"));
+                                let pnl_bps_x100 = parse_int(pnl_bps_x100_str);
+                                let pnl_bps = pnl_bps_x100 / 100;
                                 if verified_str == "true" {
                                     print("[strategist] settled tick=", settle_tick, " classification=", classification, " pnl_bps=", pnl_bps);
-                                    learn("settle", "tick " + to_string(settle_tick) + " " + classification, "pnl_bps=" + to_string(pnl_bps), "success", ["acted", "trading-binance", _tribe_name, "classification:" + classification]);
+                                    learn("settle", "tick " + to_string(settle_tick) + " " + classification, "pnl_bps=" + to_string(pnl_bps) + " pnl_bps_x100=" + to_string(pnl_bps_x100), "success", ["acted", "trading-binance", _tribe_name, "classification:" + classification]);
 
                                     // Fitness update: reward WIN, penalty
                                     // LOSS, neutral FLAT. Knob env vars are

--- a/trading-binance/tribe-gamma/agents/strategist.ag
+++ b/trading-binance/tribe-gamma/agents/strategist.ag
@@ -403,11 +403,12 @@ fn tick(reason: string) -> void {
                                 };
                                 let verified_str = to_string(json_get(verdict_raw, "verified"));
                                 let classification = to_string(json_get(verdict_raw, "classification"));
-                                let pnl_bps_str = to_string(json_get(verdict_raw, "pnl_bps"));
-                                let pnl_bps = parse_int(pnl_bps_str);
+                                let pnl_bps_x100_str = to_string(json_get(verdict_raw, "pnl_bps_x100"));
+                                let pnl_bps_x100 = parse_int(pnl_bps_x100_str);
+                                let pnl_bps = pnl_bps_x100 / 100;
                                 if verified_str == "true" {
                                     print("[strategist] settled tick=", settle_tick, " classification=", classification, " pnl_bps=", pnl_bps);
-                                    learn("settle", "tick " + to_string(settle_tick) + " " + classification, "pnl_bps=" + to_string(pnl_bps), "success", ["acted", "trading-binance", _tribe_name, "classification:" + classification]);
+                                    learn("settle", "tick " + to_string(settle_tick) + " " + classification, "pnl_bps=" + to_string(pnl_bps) + " pnl_bps_x100=" + to_string(pnl_bps_x100), "success", ["acted", "trading-binance", _tribe_name, "classification:" + classification]);
 
                                     // Fitness update: reward WIN, penalty
                                     // LOSS, neutral FLAT. Knob env vars are


### PR DESCRIPTION
## Summary

- verify-trade.sh emits `pnl_bps_x100` (int = round(pnl_bps * 100))
- strategist.ag reads `pnl_bps_x100` instead of float `pnl_bps`
- learn() "settle" out field includes both `pnl_bps=` and `pnl_bps_x100=` so analyzer recovers full precision

110 of 111 settled trades in the last experiment logged pnl_bps=0 because parse_int truncated float pnl_bps. BTC 1h × 8h hold × tier-gated size produces moves typically 0.2-0.5 bps net — all truncated to zero. Fitness math saw no signal; emergence would be undetectable.

Closes #589. Sixth follow-up fix unblocking PR-5 (#573).

## Test plan

- [x] `bash -n verify-trade.sh` clean
- [x] test-verify-trade.sh: 14/0 (+1 new test for x100 field)
- [x] test-run-replay.sh: 29/0
- [x] colony-lint: 205/0/3
- [ ] Runtime: settled trades log nonzero pnl_bps_x100 values