### PR TITLE
fix(claim-auditor): cross-federation memo recall — probe laptop-node/.agentis (closes #601)

### DIFF
--- a/claim-auditor/tools/run-auditor.sh
+++ b/claim-auditor/tools/run-auditor.sh
@@ -370,7 +370,18 @@ log_path = os.path.join(run_dir, "orchestrator.log")
 # whatever the row itself carries.
 upstream_dir = os.path.dirname(source_ledger)
 upstream_agentis = os.path.join(upstream_dir, ".agentis")
-have_upstream_memo = os.path.isdir(upstream_agentis)
+upstream_laptop_agentis = os.path.join(upstream_dir, "laptop-node", ".agentis")
+# math-foundry writes its memo under <run-dir>/laptop-node/.agentis/, but
+# `os.path.dirname(source_ledger)` lands on <run-dir>. Probe both shapes
+# and pick whichever exists. Fall back to None when neither does so
+# subsequent recalls cleanly return empty.
+if os.path.isdir(upstream_agentis):
+    upstream_recall_cwd = upstream_dir
+elif os.path.isdir(upstream_laptop_agentis):
+    upstream_recall_cwd = os.path.join(upstream_dir, "laptop-node")
+else:
+    upstream_recall_cwd = None
+have_upstream_memo = upstream_recall_cwd is not None
 
 def upstream_recall(key):
     if not have_upstream_memo:
@@ -378,7 +389,7 @@ def upstream_recall(key):
     try:
         out = subprocess.check_output(
             ["agentis", "memo", "get", key],
-            cwd=upstream_dir,
+            cwd=upstream_recall_cwd,
             stderr=subprocess.DEVNULL,
         )
         return out.decode("utf-8", "replace").strip()


### PR DESCRIPTION
Closes #601.

## Summary

`claim-auditor/tools/run-auditor.sh` was unable to recover the original math-foundry problem context (formulator's `problem_text`, `answer`, `novelty_claim`) for any NOVEL/BORDERLINE row it processed. The orchestrator's `os.path.isdir(<run-dir>/.agentis)` probe always failed because math-foundry writes its memo store one level deeper at `<run-dir>/laptop-node/.agentis/`. The `have_upstream_memo` flag stayed False, no `agentis memo get` was ever invoked, and the orchestrator fell back to seeding the ledger row JSON as the "problem text".

End-to-end result on first smoke (12 min, 6 BORDERLINE rows audited): every verdict was `NEEDS_HUMAN` with confidence 0.4 and reasoning beginning "The problem input is a system event record (novelty verdict classification), not a mathematical claim" — the auditor was reasoning correctly given garbage input.

## Fix

Probe both directory shapes — `<run-dir>/.agentis/` and `<run-dir>/laptop-node/.agentis/` — and set the subprocess cwd to whichever exists. This is the same pattern already used (correctly) by `preprint-foundry/tools/run-preprint.sh`. ~15 line change, one file.

## Validation

- `bash -n claim-auditor/tools/run-auditor.sh`: PASS
- `tools/colony-lint.sh`: 310 passed, 0 failed, 3 skipped
- Manual probe: from a math-foundry run dir, the patched logic finds `laptop-node/.agentis/memo` and `agentis memo get formulator:36:problem_text:tick-5` returns the actual Schur Ramsey problem text.

## Test plan

- [ ] `tools/colony-lint.sh` passes
- [ ] Smoke run against big run #2 reconstructed ledger produces at least one `VERIFIED_NEW` verdict on the known-NOVEL P_2 find (tick 82) and at least one `KNOWN_PRIOR` on a classical BORDERLINE (e.g., Schur Ramsey, tick 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)