### PR TITLE
fix(claim-auditor): use replay:current_formulator_pid for memo recall (closes #603)

### DIFF
--- a/claim-auditor/tools/run-auditor.sh
+++ b/claim-auditor/tools/run-auditor.sh
@@ -398,6 +398,13 @@ def upstream_recall(key):
 
 source_run_id = os.path.basename(upstream_dir) or "unknown"
 
+# The ledger row's `pid` is the novelty daemon's pid (it emitted the
+# verdict event), not the formulator's. Formulator/explorer write memo
+# keys under their own daemon pids, so we look those up once from the
+# upstream's self-registered replay keys.
+upstream_formulator_pid = upstream_recall("replay:current_formulator_pid")
+upstream_explorer_pid = upstream_recall("replay:current_explorer_pid")
+
 for idx in range(total_ticks):
     if idx >= len(candidates):
         with open(log_path, "a") as log:
@@ -409,17 +416,20 @@ for idx in range(total_ticks):
         continue
     row = candidates[idx]
     source_tick = row.get("tick", 0)
+    # source_pid here is the novelty daemon pid recorded in the ledger
+    # row; we still pass it through to the searchers as
+    # `claim:source_pid` for audit-trail purposes.
     source_pid = str(row.get("pid", ""))
 
     problem_text = upstream_recall(
-        "formulator:" + source_pid + ":problem_text:tick-" + str(source_tick)
-    )
+        "formulator:" + upstream_formulator_pid + ":problem_text:tick-" + str(source_tick)
+    ) if upstream_formulator_pid else ""
     answer = upstream_recall(
-        "formulator:" + source_pid + ":answer:tick-" + str(source_tick)
-    )
+        "formulator:" + upstream_formulator_pid + ":answer:tick-" + str(source_tick)
+    ) if upstream_formulator_pid else ""
     novelty_claim = upstream_recall(
-        "formulator:" + source_pid + ":novelty_claim:tick-" + str(source_tick)
-    )
+        "formulator:" + upstream_formulator_pid + ":novelty_claim:tick-" + str(source_tick)
+    ) if upstream_formulator_pid else ""
     # Fallback: if the upstream memo is unreachable, hand the .ag
     # agents the row JSON so they at least know which verdict
     # triggered the audit. The .ag's early-exit on empty


### PR DESCRIPTION
Closes #603.

## Summary

Second bug in the same code path as #602. After fixing the laptop-node path probe, the orchestrator successfully reaches the upstream memo store but dereferences the wrong pid: it uses `row.get("pid")` (novelty daemon pid = 33) when querying formulator keys (which are written under formulator daemon pid = 36).

Result: all cross-federation memo recalls return empty, fallback seeds the ledger row JSON again, searchers and auditor produce another batch of `NEEDS_HUMAN`.

## Fix

Before the per-tick loop, recover formulator + explorer pids from `replay:current_formulator_pid` and `replay:current_explorer_pid` (math-foundry's self-registered keys per PR #594). Use those for all formulator/explorer-keyed lookups. The novelty pid is still passed through to the audit-trail as `claim:source_pid`.

## Validation

- `bash -n claim-auditor/tools/run-auditor.sh`: PASS
- `tools/colony-lint.sh`: 310 passed, 0 failed, 3 skipped
- Manual recall: `agentis memo get replay:current_formulator_pid` returns 36; `agentis memo get formulator:36:problem_text:tick-5` returns the Schur Ramsey problem text.

## Test plan

- [ ] After merge, smoke run against big run #2 ledger produces non-empty `claim:problem_text:tick-0` (= Schur Ramsey, not ledger JSON).
- [ ] At least one `VERIFIED_NEW` or `KNOWN_PRIOR` verdict in audit-ledger (not uniform `NEEDS_HUMAN`).

## Out of scope (= follow-ups if needed)

- `preprint-foundry/tools/run-preprint.sh` may have the same latent bug in its math-foundry recall path; check after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)