### PR TITLE
fix(preprint-foundry): substitute AUTHOR-PLACEHOLDER from authors.toml (closes #616)

### DIFF
--- a/preprint-foundry/BUNDLE.manifest
+++ b/preprint-foundry/BUNDLE.manifest
@@ -2,6 +2,7 @@ preprint-foundry/
 preprint-foundry/tools/run-preprint.sh
 preprint-foundry/tools/Containerfile.preprint
 preprint-foundry/tools/review-cli.sh
+preprint-foundry/tools/substitute-author.py
 preprint-foundry/config/authors.toml.example
 preprint-foundry/introducer/
 preprint-foundry/theorist/

--- a/preprint-foundry/CHANGELOG.md
+++ b/preprint-foundry/CHANGELOG.md
@@ -16,6 +16,12 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- `tools/substitute-author.py` helper that rewrites `AUTHOR-PLACEHOLDER`
+  in the editor colony's `main.tex` from `config/authors.toml` before
+  the latexmk compile pass, so the compiled PDF reflects the real
+  author byline + ORCID rather than just the `.tex` inside the
+  submission tarball (#616).
+
 ### Changed
 
 ### Deprecated
@@ -23,6 +29,12 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 ### Removed
 
 ### Fixed
+
+- Editor colony now invokes `substitute-author.py` after both the
+  initial LLM write and the repair-pass rewrite, closing #616 where
+  `main.tex` and `main.pdf` shipped with the literal token
+  `AUTHOR-PLACEHOLDER` even when `config/authors.toml` carried a real
+  author.
 
 ### Security
 

--- a/preprint-foundry/editor/agents/editor.ag
+++ b/preprint-foundry/editor/agents/editor.ag
@@ -145,6 +145,16 @@ fn tick(reason: string) -> void {
                 let write_bib_cmd = "printf '%s' " + shell_escape(edit.refs_bib) + " > " + shell_escape(claim_dir + "/refs.bib");
                 let _wb = try { exec sh write_bib_cmd; } catch e { ""; };
 
+                // Substitute AUTHOR-PLACEHOLDER from authors.toml (#616).
+                // Idempotent helper exits 0 when TOML is missing /
+                // unparseable / empty, or when the .tex has no
+                // placeholder, so it is safe to run unconditionally.
+                let author_cfg_path = try { exec sh "printenv PREPRINT_AUTHOR_CONFIG"; } catch e { ""; };
+                let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };
+                // colony-lint: safe-exec-concat
+                let subst_cmd = "python3 /run-root/tools/substitute-author.py " + shell_escape(author_cfg_eff) + " " + shell_escape(claim_dir + "/main.tex");
+                let _subst = try { exec sh subst_cmd; } catch e { ""; };
+
                 // First compile pass.
                 // colony-lint: safe-exec-concat
                 let compile_cmd = "cd " + shell_escape(claim_dir) + " && latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex 2>&1 | tail -80";
@@ -167,6 +177,11 @@ fn tick(reason: string) -> void {
                         // colony-lint: safe-exec-concat
                         let rewrite_cmd = "printf '%s' " + shell_escape(repair.full_tex) + " > " + shell_escape(claim_dir + "/main.tex");
                         let _rw = try { exec sh rewrite_cmd; } catch e { ""; };
+                        // Re-substitute AUTHOR-PLACEHOLDER in case the
+                        // repair pass put it back (#616).
+                        // colony-lint: safe-exec-concat
+                        let subst_cmd_r = "python3 /run-root/tools/substitute-author.py " + shell_escape(author_cfg_eff) + " " + shell_escape(claim_dir + "/main.tex");
+                        let _subst_r = try { exec sh subst_cmd_r; } catch e { ""; };
                         // colony-lint: safe-exec-concat
                         let recompile_cmd = "cd " + shell_escape(claim_dir) + " && latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex 2>&1 | tail -80";
                         let _recompile_log = try { exec sh recompile_cmd; } catch e { ""; };

--- a/preprint-foundry/tools/substitute-author.py
+++ b/preprint-foundry/tools/substitute-author.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Substitute AUTHOR-PLACEHOLDER in main.tex from authors.toml (#616).
+
+Usage: substitute-author.py <authors.toml> <main.tex>
+
+Reads authors.toml, builds a LaTeX author block ("<name>\\thanks{ORCID
+iD: <id>}", multi-author joined with " \\and "), and replaces the
+literal token AUTHOR-PLACEHOLDER in main.tex in place.
+
+Idempotent (exits 0 without rewriting) when:
+- the TOML path is missing or unparseable,
+- no [[authors]] entries are present or all are name-less,
+- the .tex file lacks the literal AUTHOR-PLACEHOLDER token.
+
+The editor colony invokes this helper after each LLM-produced tex
+write (initial draft + repair pass) and before the corresponding
+latexmk invocation, so the compiled PDF also reflects the real author
+rather than just the .tex inside the arXiv submission tarball.
+"""
+
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: substitute-author.py <authors.toml> <main.tex>",
+            file=sys.stderr,
+        )
+        return 2
+
+    toml_path, tex_path = sys.argv[1], sys.argv[2]
+
+    try:
+        import tomllib
+    except ImportError:
+        try:
+            import tomli as tomllib  # type: ignore
+        except ImportError:
+            return 0
+
+    try:
+        with open(toml_path, "rb") as f:
+            data = tomllib.load(f)
+    except Exception:
+        return 0
+
+    authors = data.get("authors") or []
+    parts = []
+    for a in authors:
+        name = (a.get("name") or "").strip()
+        if not name:
+            continue
+        orcid = (a.get("arxiv_orcid") or "").strip()
+        if orcid:
+            parts.append(name + "\\thanks{ORCID iD: " + orcid + "}")
+        else:
+            parts.append(name)
+
+    if not parts:
+        return 0
+
+    block = " \\and ".join(parts)
+
+    try:
+        with open(tex_path, "r", encoding="utf-8") as f:
+            tex = f.read()
+    except FileNotFoundError:
+        return 0
+
+    if "AUTHOR-PLACEHOLDER" not in tex:
+        return 0
+
+    with open(tex_path, "w", encoding="utf-8") as f:
+        f.write(tex.replace("AUTHOR-PLACEHOLDER", block))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- New `preprint-foundry/tools/substitute-author.py` helper rewrites `AUTHOR-PLACEHOLDER` in `main.tex` from `config/authors.toml` (builds `Name\thanks{ORCID iD: <id>}` per author, joins multi-author with ` \and `).
- `editor.ag` invokes the helper after the initial LLM-produced write and after the repair-pass rewrite, before each `latexmk` pass — so the compiled PDF reflects the real author, not just the `.tex` inside the arXiv tarball.
- `BUNDLE.manifest` + `CHANGELOG.md` updated.

## Why fix in editor.ag, not submitter.ag

The submitter already parses `authors.toml` for `arxiv-metadata.json` and the SMTP `From:` header, but it runs **after** the editor's `latexmk` compile. Substituting only there would leave `main.pdf` with the placeholder. The editor is the right gate because its `read_tex_cmd` (existing `cat main.tex` capture into memo) automatically picks up the substituted content, so the submitter still sees the real author downstream without code changes there.

## Plumbing

The bootstrap script already runs `cp -r /repo/preprint-foundry/tools /run-root/tools` (existing line in `run-preprint.sh`), so the new helper is available at `/run-root/tools/substitute-author.py` at runtime without a bootstrap change. No new env vars; the existing `PREPRINT_AUTHOR_CONFIG` is reused.

Idempotent: helper exits 0 (no rewrite) when the TOML is missing, unparseable, empty, or when the `.tex` lacks the placeholder — safe to run unconditionally on every tick.

## Test plan

- [x] `tools/colony-lint.sh` — 310 passed, 0 failed, 3 skipped
- [ ] CI green
- [ ] QA smoke: regenerate i^ord preprint from `runs/20260517T024932Z` and verify `main.pdf` byline + `arxiv-metadata.json` authors field
- [ ] Sanity: helper is idempotent (running twice produces identical output)

Closes #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)