### PR TITLE
fix(preprint-foundry): substitute-author.py matches \author{...} not literal token (closes #618)

### DIFF
--- a/preprint-foundry/CHANGELOG.md
+++ b/preprint-foundry/CHANGELOG.md
@@ -24,6 +24,15 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Changed
 
+- `tools/substitute-author.py` now rewrites the first `\author{...}`
+  macro found in `main.tex` (matched via a balanced-brace counter)
+  rather than the literal token `AUTHOR-PLACEHOLDER`. The upstream
+  LLM editor prompt asks for the placeholder but real-world output
+  is also `\author{Anonymous}`, `\author{}`, or any other LLM-invented
+  byline; the helper must work regardless of what the LLM emits.
+  Idempotency is preserved by short-circuiting when the existing
+  byline already matches the rendered block (#618).
+
 ### Deprecated
 
 ### Removed

--- a/preprint-foundry/tools/substitute-author.py
+++ b/preprint-foundry/tools/substitute-author.py
@@ -1,24 +1,58 @@
 #!/usr/bin/env python3
-"""Substitute AUTHOR-PLACEHOLDER in main.tex from authors.toml (#616).
+"""Substitute the LaTeX \\author{...} byline in main.tex from authors.toml.
 
 Usage: substitute-author.py <authors.toml> <main.tex>
 
 Reads authors.toml, builds a LaTeX author block ("<name>\\thanks{ORCID
-iD: <id>}", multi-author joined with " \\and "), and replaces the
-literal token AUTHOR-PLACEHOLDER in main.tex in place.
+iD: <id>}", multi-author joined with " \\and "), and rewrites the first
+`\\author{...}` macro in main.tex to that block.
+
+The match handles nested braces correctly via a depth counter, so
+running the helper twice on the same file is a byte-identical no-op
+even though the rendered block itself contains `\\thanks{...}` and
+therefore `{` `}` pairs inside the `\\author{...}` body.
+
+The choice to match `\\author{...}` rather than a literal token (e.g.
+`AUTHOR-PLACEHOLDER`) is deliberate: the upstream LLM editor prompt
+asks for the placeholder but real-world output is also
+`\\author{Anonymous}`, `\\author{}`, or any other LLM-invented byline.
+The helper must work regardless of what the LLM emits inside
+`\\author{...}` (#618; original literal-token-only version landed in
+#617 for #616).
 
 Idempotent (exits 0 without rewriting) when:
 - the TOML path is missing or unparseable,
 - no [[authors]] entries are present or all are name-less,
-- the .tex file lacks the literal AUTHOR-PLACEHOLDER token.
-
-The editor colony invokes this helper after each LLM-produced tex
-write (initial draft + repair pass) and before the corresponding
-latexmk invocation, so the compiled PDF also reflects the real author
-rather than just the .tex inside the arXiv submission tarball.
+- the .tex file has no `\\author{...}` macro at all,
+- the .tex file is missing,
+- the existing `\\author{...}` byline already matches the rendered
+  block (running the helper twice in succession).
 """
 
 import sys
+
+
+def _find_author_macro(tex: str) -> tuple[int, int] | None:
+    """Find the byte range of the first `\\author{...}` macro with
+    balanced braces. Returns (start, end_exclusive) or None.
+    """
+    head = "\\author{"
+    idx = tex.find(head)
+    if idx < 0:
+        return None
+    depth = 1
+    i = idx + len(head)
+    n = len(tex)
+    while i < n:
+        c = tex[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return (idx, i + 1)
+        i += 1
+    return None
 
 
 def main() -> int:
@@ -61,6 +95,7 @@ def main() -> int:
         return 0
 
     block = " \\and ".join(parts)
+    replacement = "\\author{" + block + "}"
 
     try:
         with open(tex_path, "r", encoding="utf-8") as f:
@@ -68,11 +103,18 @@ def main() -> int:
     except FileNotFoundError:
         return 0
 
-    if "AUTHOR-PLACEHOLDER" not in tex:
+    match = _find_author_macro(tex)
+    if match is None:
         return 0
 
+    start, end = match
+    if tex[start:end] == replacement:
+        return 0
+
+    new_tex = tex[:start] + replacement + tex[end:]
+
     with open(tex_path, "w", encoding="utf-8") as f:
-        f.write(tex.replace("AUTHOR-PLACEHOLDER", block))
+        f.write(new_tex)
 
     return 0
 


### PR DESCRIPTION
## Summary

Replace the literal `tex.replace("AUTHOR-PLACEHOLDER", block)` match in `tools/substitute-author.py` with a balanced-brace search for the first `\author{...}` macro. Closes #618 where post-#617 regen showed the LLM emitting `\author{Anonymous}` instead of `\author{AUTHOR-PLACEHOLDER}`, leaving the helper with no token to substitute.

## Why balanced-brace, not regex

A naive `re.sub(r'\\author\{[^}]*\}', ...)` breaks idempotency: after the first substitution the byline contains `\thanks{...}` and the next regex pass matches up to the inner `}` and leaves trailing brace garbage. A manual depth counter handles nested `{...}` correctly and the short-circuit when `tex[start:end] == replacement` keeps idempotency byte-identical.

## Verification

Tested locally against:

- `\author{Anonymous}` → rewritten correctly
- `\author{AUTHOR-PLACEHOLDER}` → rewritten correctly (back-compat with #617's literal-token expectation)
- `\author{}` (blank) → rewritten correctly
- No `\author{...}` macro at all → no-op
- Missing / unparseable / empty TOML → no-op
- Multi-author TOML → joined with ` \and `
- Author with `\thanks{...}` already present → second run is byte-identical
- Multiple `\author{...}` macros → only first one rewritten
- Empty `name = ""` entries → skipped cleanly

`tools/colony-lint.sh` clean (310 passed / 0 failed / 3 skipped).

## Test plan

- [x] colony-lint clean
- [ ] CI green
- [ ] Re-run i^ord preprint regen and verify the byline reflects Martin Holy + ORCID
- [ ] Sanity: helper still idempotent after the regex change

Closes #618. Follows from #617 / #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)