### PR TITLE
feat(auto-promote): sidecar plumbing for 3 research federations (PR-1 of #622)

### DIFF
--- a/claim-auditor/BUNDLE.manifest
+++ b/claim-auditor/BUNDLE.manifest
@@ -6,3 +6,13 @@ claim-auditor/oeis-search/
 claim-auditor/groupprops-search/
 claim-auditor/scholar-search/
 claim-auditor/auditor/
+
+# Auto-promote sidecar dependencies (#622). run-auditor.sh
+# `start_auto_promote_sidecar` shells out to tools/auto-promote.sh in
+# --containerized mode using the claim-auditor-tuned config.
+tools/auto-promote.sh
+tools/auto-promote-config.claim-auditor.yaml
+tools/auto-promote-config-parser.py
+tools/auto-promote-decisions.py
+tools/auto-promote-lock.py
+tools/parse-toml.sh

--- a/claim-auditor/tools/run-auditor.sh
+++ b/claim-auditor/tools/run-auditor.sh
@@ -295,9 +295,70 @@ spawn_container() {
 }
 
 # --- 4) Cleanup trap ---
+AUTO_PROMOTE_PID=""
 install_cleanup_trap() {
-    emit_step "installing cleanup trap (stop + rm container)"
-    emit_cmd "trap 'podman stop --time 5 claim-auditor-laptop 2>/dev/null || true; podman rm -f claim-auditor-laptop 2>/dev/null || true' EXIT INT TERM"
+    emit_step "installing cleanup trap (stop + rm container; kill sidecars)"
+    # shellcheck disable=SC2064  # Expand $AUTO_PROMOTE_PID at trigger time.
+    emit_cmd "trap '[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; podman stop --time 5 claim-auditor-laptop 2>/dev/null || true; podman rm -f claim-auditor-laptop 2>/dev/null || true' EXIT INT TERM"
+}
+
+# --- 4.5) Auto-promote sidecar (#622) ---
+# Spawns a background loop that invokes tools/auto-promote.sh in
+# --containerized mode every AP_INTERVAL seconds. Cwd is the host-side
+# bind-mount root ($LAPTOP_DIR == <run-dir>/laptop-node/) where the
+# container's .agentis/ state materialises. Self-terminates when no
+# daemons report `state="running"`. The cleanup trap installed above
+# kills it on orchestrator EXIT/INT/TERM.
+#
+# Env knobs:
+#   AUDITOR_AUTO_PROMOTE             1 enable (default), 0 disable
+#   AUDITOR_AUTO_PROMOTE_INTERVAL_S  seconds between sidecar ticks
+#                                    (default 300)
+start_auto_promote_sidecar() {
+    AP_ENABLED="${AUDITOR_AUTO_PROMOTE:-1}"
+    AP_INTERVAL="${AUDITOR_AUTO_PROMOTE_INTERVAL_S:-300}"
+    if [ "$AP_ENABLED" != "1" ]; then
+        emit_step "auto-promote sidecar: disabled via AUDITOR_AUTO_PROMOTE=$AP_ENABLED"
+        return 0
+    fi
+    AP_SCRIPT="$REPO_ROOT/tools/auto-promote.sh"
+    AP_CONFIG="$REPO_ROOT/tools/auto-promote-config.claim-auditor.yaml"
+    AP_LOG_DIR="$LAPTOP_DIR/.agentis/logs"
+    AP_LOG="$AP_LOG_DIR/auto-promote.log"
+    AP_STAMP="$AP_LOG_DIR/auto-promote.sidecar_started_at"
+    if [ ! -x "$AP_SCRIPT" ]; then
+        emit_step "auto-promote sidecar: $AP_SCRIPT not executable, skipping"
+        return 0
+    fi
+    if [ ! -f "$AP_CONFIG" ]; then
+        emit_step "auto-promote sidecar: $AP_CONFIG missing, skipping"
+        return 0
+    fi
+    emit_step "starting auto-promote sidecar (interval=${AP_INTERVAL}s, log=$AP_LOG)"
+    if [ "$DRY_RUN" = "1" ]; then
+        emit_cmd "auto-promote-sidecar placeholder: cwd=$LAPTOP_DIR config=$AP_CONFIG interval=${AP_INTERVAL}s"
+        return 0
+    fi
+    mkdir -p "$AP_LOG_DIR"
+    date +%s > "$AP_STAMP"
+    (
+        cd "$LAPTOP_DIR"
+        while :; do
+            if ! agentis daemon list --json 2>/dev/null | grep -Fq '"state":"running"'; then
+                printf '=== %s: no running daemons; sidecar exiting ===\n' \
+                    "$(date -Iseconds)" >> "$AP_LOG"
+                exit 0
+            fi
+            {
+                printf '=== %s: sidecar tick ===\n' "$(date -Iseconds)"
+                "$AP_SCRIPT" "$LAPTOP_DIR" --containerized --config "$AP_CONFIG" 2>&1 \
+                    || printf '[sidecar] auto-promote.sh exited %s\n' "$?"
+            } >> "$AP_LOG"
+            sleep "$AP_INTERVAL"
+        done
+    ) &
+    AUTO_PROMOTE_PID=$!
+    emit_step "auto-promote sidecar PID=$AUTO_PROMOTE_PID"
 }
 
 # --- 5) Tick stream (main audit loop) ---
@@ -482,6 +543,7 @@ build_image
 write_bootstrap
 write_run_meta
 spawn_container
+start_auto_promote_sidecar
 tick_stream
 
 if [ "$DRY_RUN" = "1" ]; then

--- a/math-foundry/BUNDLE.manifest
+++ b/math-foundry/BUNDLE.manifest
@@ -10,3 +10,13 @@ math-foundry/noticer/
 math-foundry/formulator/
 math-foundry/verifier/
 math-foundry/novelty/
+
+# Auto-promote sidecar dependencies (#622). run-foundry.sh
+# `start_auto_promote_sidecar` shells out to tools/auto-promote.sh in
+# --containerized mode using the math-foundry-tuned config.
+tools/auto-promote.sh
+tools/auto-promote-config.math-foundry.yaml
+tools/auto-promote-config-parser.py
+tools/auto-promote-decisions.py
+tools/auto-promote-lock.py
+tools/parse-toml.sh

--- a/math-foundry/tools/run-foundry.sh
+++ b/math-foundry/tools/run-foundry.sh
@@ -385,9 +385,73 @@ spawn_container() {
 }
 
 # --- 4) Cleanup trap ---
+AUTO_PROMOTE_PID=""
 install_cleanup_trap() {
-    emit_step "installing cleanup trap (stop + rm container)"
-    emit_cmd "trap 'podman stop --time 5 math-foundry-laptop 2>/dev/null || true; podman rm -f math-foundry-laptop 2>/dev/null || true' EXIT INT TERM"
+    emit_step "installing cleanup trap (stop + rm container; kill sidecars)"
+    # shellcheck disable=SC2064  # Expand $AUTO_PROMOTE_PID at trigger time.
+    emit_cmd "trap '[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; podman stop --time 5 math-foundry-laptop 2>/dev/null || true; podman rm -f math-foundry-laptop 2>/dev/null || true' EXIT INT TERM"
+}
+
+# --- 4.5) Auto-promote sidecar (#622) ---
+# Spawns a background loop that invokes tools/auto-promote.sh in
+# --containerized mode every AP_INTERVAL seconds. Cwd is the host-side
+# bind-mount root ($LAPTOP_DIR == <run-dir>/laptop-node/) where the
+# container's .agentis/ state materialises. Self-terminates when no
+# daemons report `state="running"` (e.g. after signal_shutdown drained
+# the container). The cleanup trap installed above kills it on
+# orchestrator EXIT/INT/TERM.
+#
+# Env knobs:
+#   FOUNDRY_AUTO_PROMOTE             1 enable (default), 0 disable
+#   FOUNDRY_AUTO_PROMOTE_INTERVAL_S  seconds between sidecar ticks
+#                                    (default 300; the dev-apprenticeship
+#                                    sidecar uses 1800 but math-foundry
+#                                    runs are 30-90min total — too coarse).
+start_auto_promote_sidecar() {
+    AP_ENABLED="${FOUNDRY_AUTO_PROMOTE:-1}"
+    AP_INTERVAL="${FOUNDRY_AUTO_PROMOTE_INTERVAL_S:-300}"
+    if [ "$AP_ENABLED" != "1" ]; then
+        emit_step "auto-promote sidecar: disabled via FOUNDRY_AUTO_PROMOTE=$AP_ENABLED"
+        return 0
+    fi
+    AP_SCRIPT="$REPO_ROOT/tools/auto-promote.sh"
+    AP_CONFIG="$REPO_ROOT/tools/auto-promote-config.math-foundry.yaml"
+    AP_LOG_DIR="$LAPTOP_DIR/.agentis/logs"
+    AP_LOG="$AP_LOG_DIR/auto-promote.log"
+    AP_STAMP="$AP_LOG_DIR/auto-promote.sidecar_started_at"
+    if [ ! -x "$AP_SCRIPT" ]; then
+        emit_step "auto-promote sidecar: $AP_SCRIPT not executable, skipping"
+        return 0
+    fi
+    if [ ! -f "$AP_CONFIG" ]; then
+        emit_step "auto-promote sidecar: $AP_CONFIG missing, skipping"
+        return 0
+    fi
+    emit_step "starting auto-promote sidecar (interval=${AP_INTERVAL}s, log=$AP_LOG)"
+    if [ "$DRY_RUN" = "1" ]; then
+        emit_cmd "auto-promote-sidecar placeholder: cwd=$LAPTOP_DIR config=$AP_CONFIG interval=${AP_INTERVAL}s"
+        return 0
+    fi
+    mkdir -p "$AP_LOG_DIR"
+    date +%s > "$AP_STAMP"
+    (
+        cd "$LAPTOP_DIR"
+        while :; do
+            if ! agentis daemon list --json 2>/dev/null | grep -Fq '"state":"running"'; then
+                printf '=== %s: no running daemons; sidecar exiting ===\n' \
+                    "$(date -Iseconds)" >> "$AP_LOG"
+                exit 0
+            fi
+            {
+                printf '=== %s: sidecar tick ===\n' "$(date -Iseconds)"
+                "$AP_SCRIPT" "$LAPTOP_DIR" --containerized --config "$AP_CONFIG" 2>&1 \
+                    || printf '[sidecar] auto-promote.sh exited %s\n' "$?"
+            } >> "$AP_LOG"
+            sleep "$AP_INTERVAL"
+        done
+    ) &
+    AUTO_PROMOTE_PID=$!
+    emit_step "auto-promote sidecar PID=$AUTO_PROMOTE_PID"
 }
 
 # --- 5) Tick stream (main foundry loop) ---
@@ -500,6 +564,7 @@ build_image
 write_bootstrap
 write_run_meta
 spawn_container
+start_auto_promote_sidecar
 tick_stream
 
 if [ "$DRY_RUN" = "1" ]; then

--- a/preprint-foundry/BUNDLE.manifest
+++ b/preprint-foundry/BUNDLE.manifest
@@ -9,3 +9,13 @@ preprint-foundry/theorist/
 preprint-foundry/computer/
 preprint-foundry/editor/
 preprint-foundry/submitter/
+
+# Auto-promote sidecar dependencies (#622). run-preprint.sh
+# `start_auto_promote_sidecar` shells out to tools/auto-promote.sh in
+# --containerized mode using the preprint-foundry-tuned config.
+tools/auto-promote.sh
+tools/auto-promote-config.preprint-foundry.yaml
+tools/auto-promote-config-parser.py
+tools/auto-promote-decisions.py
+tools/auto-promote-lock.py
+tools/parse-toml.sh

--- a/preprint-foundry/tools/run-preprint.sh
+++ b/preprint-foundry/tools/run-preprint.sh
@@ -358,9 +358,70 @@ spawn_container() {
 }
 
 # --- 4) Cleanup trap ---
+AUTO_PROMOTE_PID=""
 install_cleanup_trap() {
-    emit_step "installing cleanup trap (stop + rm container)"
-    emit_cmd "trap 'podman stop --time 5 preprint-foundry-laptop 2>/dev/null || true; podman rm -f preprint-foundry-laptop 2>/dev/null || true' EXIT INT TERM"
+    emit_step "installing cleanup trap (stop + rm container; kill sidecars)"
+    # shellcheck disable=SC2064  # Expand $AUTO_PROMOTE_PID at trigger time.
+    emit_cmd "trap '[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; podman stop --time 5 preprint-foundry-laptop 2>/dev/null || true; podman rm -f preprint-foundry-laptop 2>/dev/null || true' EXIT INT TERM"
+}
+
+# --- 4.5) Auto-promote sidecar (#622) ---
+# Spawns a background loop that invokes tools/auto-promote.sh in
+# --containerized mode every AP_INTERVAL seconds. Cwd is the host-side
+# bind-mount root ($LAPTOP_DIR == <run-dir>/laptop-node/) where the
+# container's .agentis/ state materialises. Self-terminates when no
+# daemons report `state="running"`. The cleanup trap installed above
+# kills it on orchestrator EXIT/INT/TERM.
+#
+# Env knobs:
+#   PREPRINT_AUTO_PROMOTE             1 enable (default), 0 disable
+#   PREPRINT_AUTO_PROMOTE_INTERVAL_S  seconds between sidecar ticks
+#                                     (default 300)
+start_auto_promote_sidecar() {
+    AP_ENABLED="${PREPRINT_AUTO_PROMOTE:-1}"
+    AP_INTERVAL="${PREPRINT_AUTO_PROMOTE_INTERVAL_S:-300}"
+    if [ "$AP_ENABLED" != "1" ]; then
+        emit_step "auto-promote sidecar: disabled via PREPRINT_AUTO_PROMOTE=$AP_ENABLED"
+        return 0
+    fi
+    AP_SCRIPT="$REPO_ROOT/tools/auto-promote.sh"
+    AP_CONFIG="$REPO_ROOT/tools/auto-promote-config.preprint-foundry.yaml"
+    AP_LOG_DIR="$LAPTOP_DIR/.agentis/logs"
+    AP_LOG="$AP_LOG_DIR/auto-promote.log"
+    AP_STAMP="$AP_LOG_DIR/auto-promote.sidecar_started_at"
+    if [ ! -x "$AP_SCRIPT" ]; then
+        emit_step "auto-promote sidecar: $AP_SCRIPT not executable, skipping"
+        return 0
+    fi
+    if [ ! -f "$AP_CONFIG" ]; then
+        emit_step "auto-promote sidecar: $AP_CONFIG missing, skipping"
+        return 0
+    fi
+    emit_step "starting auto-promote sidecar (interval=${AP_INTERVAL}s, log=$AP_LOG)"
+    if [ "$DRY_RUN" = "1" ]; then
+        emit_cmd "auto-promote-sidecar placeholder: cwd=$LAPTOP_DIR config=$AP_CONFIG interval=${AP_INTERVAL}s"
+        return 0
+    fi
+    mkdir -p "$AP_LOG_DIR"
+    date +%s > "$AP_STAMP"
+    (
+        cd "$LAPTOP_DIR"
+        while :; do
+            if ! agentis daemon list --json 2>/dev/null | grep -Fq '"state":"running"'; then
+                printf '=== %s: no running daemons; sidecar exiting ===\n' \
+                    "$(date -Iseconds)" >> "$AP_LOG"
+                exit 0
+            fi
+            {
+                printf '=== %s: sidecar tick ===\n' "$(date -Iseconds)"
+                "$AP_SCRIPT" "$LAPTOP_DIR" --containerized --config "$AP_CONFIG" 2>&1 \
+                    || printf '[sidecar] auto-promote.sh exited %s\n' "$?"
+            } >> "$AP_LOG"
+            sleep "$AP_INTERVAL"
+        done
+    ) &
+    AUTO_PROMOTE_PID=$!
+    emit_step "auto-promote sidecar PID=$AUTO_PROMOTE_PID"
 }
 
 # --- 5) Tick stream (main preprint loop) ---
@@ -652,6 +713,7 @@ build_image
 write_bootstrap
 write_run_meta
 spawn_container
+start_auto_promote_sidecar
 tick_stream
 
 if [ "$DRY_RUN" = "1" ]; then

--- a/tools/auto-promote-config.claim-auditor.yaml
+++ b/tools/auto-promote-config.claim-auditor.yaml
@@ -1,0 +1,37 @@
+# auto-promote-config.claim-auditor.yaml — Decision rules for the
+# claim-auditor research federation (#622).
+#
+# Mirrors tools/auto-promote-config.math-foundry.yaml. Auditor ticks
+# more slowly (HTTPS fetch to arXiv / OEIS / GroupProps / Scholar plus
+# the auditor's verdict step) so min_runtime_hours is doubled to 1.0:
+# the experience-row floor still requires 15 acting rows, which takes
+# ~25-45 min at the auditor cadence.
+
+promote:
+  prerequisites:
+    min_entries: 30
+    min_acting_entries: 15
+    min_runtime_hours: 1.0
+    reject_rate_threshold: 0.10
+    delta_slope_window: 20
+    delta_slope_min: 0
+  steps:
+    - from: 0.4
+      to: 0.6
+      min_acting_entries_override: 0
+    - from: 0.6
+      to: 0.8
+    - from: 0.8
+      to: 0.95
+      min_acting_entries_override: 30
+
+evolve:
+  trigger:
+    delta_slope_negative_for: 1000
+    reject_rate_above: 0.20
+  config:
+    generations: 3
+    population: 4
+    weights: "cb,val,exp"
+
+dry_run: true

--- a/tools/auto-promote-config.math-foundry.yaml
+++ b/tools/auto-promote-config.math-foundry.yaml
@@ -1,0 +1,54 @@
+# auto-promote-config.math-foundry.yaml — Decision rules for the
+# math-foundry research federation (#622).
+#
+# Mirrors the shape of tools/auto-promote-config.yaml (dev-apprenticeship
+# defaults) and inherits the same `promote.steps` ladder + `evolve` block,
+# but tunes prerequisite thresholds to the math-foundry tick cadence and
+# experience-row volume:
+#
+#   - min_entries: 30 — math-foundry ticks at 60s; a 30-min run accrues
+#     ~30 rows even with the observe-step gating, so 30 is enough to
+#     unblock the first promote evaluation without waiting hours.
+#   - min_acting_entries: 15 — explorer/formulator/noticer/verifier/novelty
+#     produce ~1 acting row per tick once propose tier is reached; 15
+#     gives roughly 15-30 min of acting-tier activity before the gate
+#     opens.
+#   - min_runtime_hours: 0.5 — research runs are short (30-90 min);
+#     48h dev-apprenticeship floor would never fire.
+#   - delta_slope_window: 20 — smaller window than the 100-row default
+#     because acting-row volume is correspondingly smaller.
+#   - reject_rate_threshold: 0.10 — math discovery is exploratory; 5%
+#     is too aggressive for early-tier behaviour where the verifier
+#     legitimately rejects half the proposals.
+#
+# `dry_run: true` is preserved — flip in a follow-up PR once the journal
+# shows the sidecar making sensible decisions on a real run.
+
+promote:
+  prerequisites:
+    min_entries: 30
+    min_acting_entries: 15
+    min_runtime_hours: 0.5
+    reject_rate_threshold: 0.10
+    delta_slope_window: 20
+    delta_slope_min: 0
+  steps:
+    - from: 0.4
+      to: 0.6
+      min_acting_entries_override: 0
+    - from: 0.6
+      to: 0.8
+    - from: 0.8
+      to: 0.95
+      min_acting_entries_override: 30
+
+evolve:
+  trigger:
+    delta_slope_negative_for: 1000
+    reject_rate_above: 0.20
+  config:
+    generations: 3
+    population: 4
+    weights: "cb,val,exp"
+
+dry_run: true

--- a/tools/auto-promote-config.preprint-foundry.yaml
+++ b/tools/auto-promote-config.preprint-foundry.yaml
@@ -1,0 +1,38 @@
+# auto-promote-config.preprint-foundry.yaml — Decision rules for the
+# preprint-foundry research federation (#622).
+#
+# Mirrors tools/auto-promote-config.math-foundry.yaml. Preprint-foundry
+# ticks more slowly (full preprint assembly: introducer + theorist +
+# computer + editor + submitter, with latexmk loops) and the submitter's
+# HITL gate at autonomous tier emits fewer acting rows than the
+# computational colonies upstream. Floor at 10 acting rows + 1.5h
+# runtime accordingly.
+
+promote:
+  prerequisites:
+    min_entries: 30
+    min_acting_entries: 10
+    min_runtime_hours: 1.5
+    reject_rate_threshold: 0.10
+    delta_slope_window: 20
+    delta_slope_min: 0
+  steps:
+    - from: 0.4
+      to: 0.6
+      min_acting_entries_override: 0
+    - from: 0.6
+      to: 0.8
+    - from: 0.8
+      to: 0.95
+      min_acting_entries_override: 30
+
+evolve:
+  trigger:
+    delta_slope_negative_for: 1000
+    reject_rate_above: 0.20
+  config:
+    generations: 3
+    population: 4
+    weights: "cb,val,exp"
+
+dry_run: true

--- a/tools/auto-promote-decisions.py
+++ b/tools/auto-promote-decisions.py
@@ -8,7 +8,7 @@
 #
 # Two invocation modes:
 #
-# Legacy (auto-promote.sh sidecar) — 11 positional args:
+# Legacy (auto-promote.sh sidecar) — 11 or 12 positional args:
 #   1  daemons JSON     (`agentis daemon list --json` output)
 #   2  fed_dir          federation directory (for .agentis/experience/ lookup)
 #   3  min_entries
@@ -20,9 +20,15 @@
 #   9  promote_steps    space-separated "from:to:override" triples
 #   10 evolve_slope_neg_for
 #   11 evolve_reject_above
+#   12 containerized    optional "true"/"false" (default false; #622).
+#                       When "true", the PID liveness probe falls back to
+#                       `effective_state == "running"` from the daemon-list
+#                       JSON because container PIDs are not visible from
+#                       the host PID namespace.
 #
 # Preview (dashboard, #248) — read-only, loads config itself:
-#   --preview --config <auto-promote-config.yaml> <daemons_json> <fed_dir>
+#   --preview --config <auto-promote-config.yaml> [--containerized] \
+#       <daemons_json> <fed_dir>
 #
 # Output: JSON array of decision records on stdout. Each record has at least
 # {agent, colony, decision} where decision is one of {promote, evolve, skip}.
@@ -93,25 +99,43 @@ def _load_config(path):
 def main():
     argv = sys.argv[1:]
 
+    containerized = False
     if argv and argv[0] == '--preview':
         # Preview mode: read-only call from federation-dashboard-collector.
-        # Syntax: --preview --config <yaml> <daemons_json> <fed_dir>
-        if len(argv) != 5 or argv[1] != '--config':
+        # Syntax:
+        #   --preview --config <yaml> [--containerized] <daemons_json> <fed_dir>
+        rest = argv[1:]
+        if not rest or rest[0] != '--config' or len(rest) < 2:
             sys.stderr.write(
-                'Usage: %s --preview --config <yaml> <daemons_json> <fed_dir>\n'
+                'Usage: %s --preview --config <yaml> '
+                '[--containerized] <daemons_json> <fed_dir>\n'
                 % os.path.basename(sys.argv[0])
             )
             return 2
-        config_path = argv[2]
-        daemons = json.loads(argv[3])
-        fed_dir = argv[4]
+        config_path = rest[1]
+        rest = rest[2:]
+        # Optional --containerized flag (#622).
+        if rest and rest[0] == '--containerized':
+            containerized = True
+            rest = rest[1:]
+        if len(rest) != 2:
+            sys.stderr.write(
+                'Usage: %s --preview --config <yaml> '
+                '[--containerized] <daemons_json> <fed_dir>\n'
+                % os.path.basename(sys.argv[0])
+            )
+            return 2
+        daemons = json.loads(rest[0])
+        fed_dir = rest[1]
         (min_entries, min_acting_entries, min_runtime_hours,
          reject_rate_threshold, delta_slope_window, delta_slope_min,
          promote_steps_raw, evolve_slope_neg_for,
          evolve_reject_above) = _load_config(config_path)
     else:
         # Legacy positional mode used by auto-promote.sh sidecar. Keep byte-
-        # identical contract — test-auto-promote.sh asserts it.
+        # identical contract — test-auto-promote.sh asserts it. The 12th arg
+        # ('true'/'false') is optional and toggles containerized liveness
+        # (#622); absence keeps the pre-#622 behaviour.
         daemons = json.loads(sys.argv[1])
         fed_dir = sys.argv[2]
         min_entries = int(sys.argv[3])
@@ -123,6 +147,8 @@ def main():
         promote_steps_raw = sys.argv[9]
         evolve_slope_neg_for = int(sys.argv[10])
         evolve_reject_above = float(sys.argv[11])
+        if len(sys.argv) >= 13:
+            containerized = (sys.argv[12].lower() == 'true')
 
     # Tags that mark a row as exercising a tier-gated acting branch (not observe).
     # See doc/auto-promote.md#classification — must match the tag strings emitted
@@ -183,30 +209,49 @@ def main():
             })
             continue
 
-        # Safety guard 4: PID liveness check
+        # Safety guard 4: liveness check
         # If pid is missing (0) or dead, skip — we can't verify the daemon
         # is actually running, so acting on it is unsafe.
-        if not pid or pid <= 0:
-            decisions.append({
-                'agent': agent_name,
-                'colony': colony,
-                'decision': 'skip',
-                'reason': 'no pid reported by daemon list',
-                'confidence': confidence,
-            })
-            continue
-        try:
-            os.kill(pid, 0)
-        except OSError:
-            decisions.append({
-                'agent': agent_name,
-                'colony': colony,
-                'decision': 'skip',
-                'reason': f'pid {pid} not alive',
-                'pid': pid,
-                'confidence': confidence,
-            })
-            continue
+        #
+        # In containerized mode (#622) the host PID namespace can't see
+        # container PIDs, so os.kill(pid, 0) is a false-negative every
+        # tick. Fall back to `effective_state == "running"` from the
+        # daemon-list JSON (also valid for legacy mode; the runtime
+        # tracks zombie/running/etc. with a stale-heartbeat probe).
+        if containerized:
+            effective_state = d.get('effective_state') or state
+            if effective_state != 'running':
+                decisions.append({
+                    'agent': agent_name,
+                    'colony': colony,
+                    'decision': 'skip',
+                    'reason': f'effective_state={effective_state!r} not running',
+                    'pid': pid,
+                    'confidence': confidence,
+                })
+                continue
+        else:
+            if not pid or pid <= 0:
+                decisions.append({
+                    'agent': agent_name,
+                    'colony': colony,
+                    'decision': 'skip',
+                    'reason': 'no pid reported by daemon list',
+                    'confidence': confidence,
+                })
+                continue
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                decisions.append({
+                    'agent': agent_name,
+                    'colony': colony,
+                    'decision': 'skip',
+                    'reason': f'pid {pid} not alive',
+                    'pid': pid,
+                    'confidence': confidence,
+                })
+                continue
 
         # Compute runtime hours
         runtime_hours = (now - started_at) / 3600 if started_at else 0

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -26,9 +26,20 @@
 # See doc/auto-promote.md for the full DMN decision table and formula
 # derivation.
 #
-# Usage: ./tools/auto-promote.sh <federation-dir>
+# Usage: ./tools/auto-promote.sh <federation-dir> [--live]
+#        ./tools/auto-promote.sh <federation-dir> [--containerized] [--config <path>]
 #        ./tools/auto-promote.sh dev-apprenticeship
 #        ./tools/auto-promote.sh dev-apprenticeship --live   # override dry_run
+#        ./tools/auto-promote.sh /run-root/laptop-node --containerized \
+#            --config tools/auto-promote-config.math-foundry.yaml
+#
+# --containerized opts out of the dev-apprenticeship-specific
+# `[gitlab]`-in-colony.toml respawn path; forge-less research federations
+# (math-foundry / claim-auditor / preprint-foundry) need this because
+# their colonies have `forge.type = "none"` and the daemon must be
+# respawned without GITLAB_* env composition (#622).
+#
+# --config overrides the default tools/auto-promote-config.yaml path.
 #
 # Prerequisites: agentis, python3 (with PyYAML or a fallback parser)
 #
@@ -43,26 +54,66 @@ SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
 if [ $# -lt 1 ]; then
-    echo "Usage: $0 <federation-dir> [--live]"
+    echo "Usage: $0 <federation-dir> [--live] [--containerized] [--config <path>]"
     echo "Example: $0 dev-apprenticeship"
+    echo "Example: $0 /path/to/run/laptop-node --containerized --config tools/auto-promote-config.math-foundry.yaml"
     exit 1
 fi
 
-FED_DIR="$REPO_ROOT/$1"
+# First positional arg is always the federation dir (or run-dir/laptop-node in
+# containerized mode). Remaining args are parsed as flags below.
+FED_ARG="$1"
+shift
+
+FED_DIR="$REPO_ROOT/$FED_ARG"
 if [ ! -d "$FED_DIR" ]; then
-    FED_DIR="$1"  # try as absolute/relative path
+    FED_DIR="$FED_ARG"  # try as absolute/relative path
 fi
 if [ ! -d "$FED_DIR" ]; then
-    echo "Federation directory not found: $1"
+    echo "Federation directory not found: $FED_ARG"
     exit 1
 fi
 
 LIVE_OVERRIDE=false
-if [ "${2:-}" = "--live" ]; then
-    LIVE_OVERRIDE=true
-fi
+CONTAINERIZED=false
+CONFIG_OVERRIDE=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --live)
+            LIVE_OVERRIDE=true
+            shift
+            ;;
+        --containerized)
+            CONTAINERIZED=true
+            shift
+            ;;
+        --config)
+            if [ $# -lt 2 ]; then
+                echo "auto-promote: --config requires a path argument" >&2
+                exit 1
+            fi
+            CONFIG_OVERRIDE="$2"
+            shift 2
+            ;;
+        *)
+            echo "auto-promote: unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
 
-CONFIG_FILE="$SCRIPT_DIR/auto-promote-config.yaml"
+if [ -n "$CONFIG_OVERRIDE" ]; then
+    # Resolve --config against $REPO_ROOT first (so callers may pass a
+    # repo-relative path like `tools/auto-promote-config.math-foundry.yaml`),
+    # then fall back to treating it as an absolute/relative path verbatim.
+    if [ -f "$REPO_ROOT/$CONFIG_OVERRIDE" ]; then
+        CONFIG_FILE="$REPO_ROOT/$CONFIG_OVERRIDE"
+    else
+        CONFIG_FILE="$CONFIG_OVERRIDE"
+    fi
+else
+    CONFIG_FILE="$SCRIPT_DIR/auto-promote-config.yaml"
+fi
 JOURNAL_FILE="$SCRIPT_DIR/auto-promote-journal.jsonl"
 LOCK_FILE="$SCRIPT_DIR/.auto-promote.lock"
 
@@ -162,11 +213,17 @@ log "Found $DAEMON_COUNT daemon(s) running"
 # For each running daemon, collect: agent name, colony, pid, confidence,
 # experience entry count, reject rate, delta slope.
 
+if [ "$CONTAINERIZED" = "true" ]; then
+    CONTAINERIZED_ARG="true"
+else
+    CONTAINERIZED_ARG="false"
+fi
 DECISIONS_JSON=$(python3 "$SCRIPT_DIR/auto-promote-decisions.py" \
     "$DAEMONS_JSON" "$FED_DIR" \
     "$CFG_MIN_ENTRIES" "$CFG_MIN_ACTING_ENTRIES" "$CFG_MIN_RUNTIME_HOURS" \
     "$CFG_REJECT_RATE_THRESHOLD" "$CFG_DELTA_SLOPE_WINDOW" "$CFG_DELTA_SLOPE_MIN" \
-    "$CFG_PROMOTE_STEPS" "$CFG_EVOLVE_SLOPE_NEG_FOR" "$CFG_EVOLVE_REJECT_ABOVE")
+    "$CFG_PROMOTE_STEPS" "$CFG_EVOLVE_SLOPE_NEG_FOR" "$CFG_EVOLVE_REJECT_ABOVE" \
+    "$CONTAINERIZED_ARG")
 
 # --- Execute decisions ---
 
@@ -231,9 +288,15 @@ while IFS='|' read -r decision agent colony step_from step_to reason evidence_js
                     continue
                 fi
 
-                # Read gitlab config from colony.toml (mirrors dashboard restart_daemon)
-                COLONY_TOML="${AGENT_COLONY_DIR}config/colony.toml"
-                SPAWN_ENV=$(python3 -c "
+                # Read gitlab config from colony.toml (mirrors dashboard restart_daemon).
+                # Skipped in --containerized mode: research federations use
+                # `forge.type = "none"` and the daemon respawns without
+                # GITLAB_* env composition (#622).
+                if [ "$CONTAINERIZED" = "true" ]; then
+                    SPAWN_ENV="export COLONY_DIR=$(python3 -c 'import shlex,sys; print(shlex.quote(sys.argv[1]))' "$AGENT_COLONY_DIR")"
+                else
+                    COLONY_TOML="${AGENT_COLONY_DIR}config/colony.toml"
+                    SPAWN_ENV=$(python3 -c "
 import sys, os
 toml_path = sys.argv[1]
 colony_dir = sys.argv[2]
@@ -274,12 +337,13 @@ else:
     print(f'export COLONY_DIR={shlex.quote(colony_dir)}')
 " "$COLONY_TOML" "$AGENT_COLONY_DIR" 2>/dev/null)
 
-                if [ "$SPAWN_ENV" = "__INCOMPLETE__" ] || [ -z "$SPAWN_ENV" ]; then
-                    log "  WARNING: incomplete [gitlab] in $COLONY_TOML, skipping restart"
-                    journal_append "$agent" "promote-partial" \
-                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='memo-only'; e['warning']='incomplete_colony_toml'; print(json.dumps(e))" "$evidence_json")" \
-                        "$step_from" "$step_to"
-                    continue
+                    if [ "$SPAWN_ENV" = "__INCOMPLETE__" ] || [ -z "$SPAWN_ENV" ]; then
+                        log "  WARNING: incomplete [gitlab] in $COLONY_TOML, skipping restart"
+                        journal_append "$agent" "promote-partial" \
+                            "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='memo-only'; e['warning']='incomplete_colony_toml'; print(json.dumps(e))" "$evidence_json")" \
+                            "$step_from" "$step_to"
+                        continue
+                    fi
                 fi
 
                 # Find agent_id from daemon list


### PR DESCRIPTION
## Summary

PR-1 of three for #622 (Phase 1: activate dormant Agentis primitives). Wires the auto-promote sidecar into the three containerized research federations so the promote/evolve scheduler that already ships for `dev-apprenticeship/` starts running against research runs too.

Three logical pieces:

- **`tools/auto-promote.sh`**: new `--containerized` flag that skips the dev-apprenticeship-specific `[gitlab]` read + `__INCOMPLETE__` refusal in the promote-restart path. Research feds use `forge.type = "none"` and need to respawn daemons without `GITLAB_*` env composition. New `--config <path>` override resolves against `$REPO_ROOT` first so callers can pass a repo-relative path.
- **`tools/auto-promote-decisions.py`**: in containerized mode, the host-PID liveness probe (`os.kill(pid, 0)`) is replaced with `effective_state == "running"` from the daemon-list JSON. Container PIDs aren't visible from the host PID namespace, so the legacy probe is a false-negative every tick. Threaded through both legacy positional mode (optional 12th arg) and `--preview` mode (optional flag); byte-identity contract preserved.
- **Per-federation sidecar wiring**: each of `math-foundry/tools/run-foundry.sh`, `claim-auditor/tools/run-auditor.sh`, `preprint-foundry/tools/run-preprint.sh` gains a `start_auto_promote_sidecar` function inserted after `spawn_container`. Env-gated (`<FED>_AUTO_PROMOTE` default `1`, interval default `300s`). cwd is `<RUN_DIR>/laptop-node/` (the bind-mount host path where the container's `.agentis/` materialises). Cleanup trap extended to kill the sidecar PID on `EXIT/INT/TERM`. Sidecar self-terminates when no daemons report `state="running"`.
- **Three new config files** (`tools/auto-promote-config.{math-foundry,claim-auditor,preprint-foundry}.yaml`) with per-fed prereq thresholds tuned to shorter (30-90min) run durations. All default to `dry_run: true` — flip in a follow-up PR after the journal shows sensible decisions.
- **`BUNDLE.manifest` updates** for each of the three federations: shared `tools/auto-promote*` family + `tools/parse-toml.sh`.

PR-2 (tier-branch fill-in across 15 `.ag` files) and PR-3 (lint extension + `ACTING_TAGS` fix) follow. Until PR-2 lands, sidecar promote decisions will mostly skip because the `.ag` autonomous/review-gated tier branches are stubs; expected and out of scope here.

## Test plan

- [x] `tools/test-auto-promote.sh` — 35 passed, 0 failed. Test 12 (byte-identity between legacy positional mode and `--preview` mode) intact.
- [x] `tools/test-make-federation-bundle.sh` — 11 passed, 0 failed. New shared-tools manifest entries resolve.
- [x] `tools/colony-lint.sh` — 310 passed, 0 failed, 3 skipped.
- [x] `bash -n` clean on `tools/auto-promote.sh`, `math-foundry/tools/run-foundry.sh`, `claim-auditor/tools/run-auditor.sh`, `preprint-foundry/tools/run-preprint.sh`.
- [x] `--dry-run` on each of `run-foundry.sh` / `run-auditor.sh` / `run-preprint.sh` emits `# starting auto-promote sidecar` and the placeholder cwd+config+interval line.
- [x] `--preview --containerized` smoke: a fake daemon with `effective_state="zombie"` is correctly skipped; with `effective_state="running"` the call proceeds to prereq evaluation.
- [x] Byte-identity verified with `--containerized` set on both sides (legacy 12th arg `true` vs `--preview --containerized`).

Plan: posted to #622 before implementation.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)