### PR TITLE
feat(lint): extend learn-tag schema to research feds + ACTING_TAGS replicated fix (PR-3 of #622)

### DIFF
--- a/tools/auto-promote-decisions.py
+++ b/tools/auto-promote-decisions.py
@@ -153,7 +153,7 @@ def main():
     # Tags that mark a row as exercising a tier-gated acting branch (not observe).
     # See doc/auto-promote.md#classification — must match the tag strings emitted
     # by .ag agents per the canonical pattern in CLAUDE.md.
-    ACTING_TAGS = {"acted", "review-gated", "emitted"}
+    ACTING_TAGS = {"acted", "review-gated", "emitted", "replicated"}
     OBSERVE_TAGS = {"observed"}
 
     def classify_entry(entry):

--- a/tools/check-learn-recommend-topic-match.sh
+++ b/tools/check-learn-recommend-topic-match.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# tools/check-learn-recommend-topic-match.sh: Enforce CLAUDE.md's
+# "learn() topic must match the topic in recommend() within the same
+# agent" rule statically (#622 PR-3).
+#
+# Background
+# ==========
+# Confidence-update plumbing in agentis-core ties a `recommend()` call's
+# topic to the `learn()` rows that scored that recommendation. When a
+# `recommend("foo", ...)` is paired with a `learn("bar", ...)` in the
+# same file, the recommend has no scored history — the agent's
+# confidence drifts at the runtime's default rate instead of being
+# steered by acted outcomes. This is silent: there is no syntax error,
+# no runtime panic, just stuck confidence.
+#
+# Rule
+# ----
+# For every `*.ag` file under `*/agents/*.ag` (excluding `*/runs/*`
+# per-tick snapshots), the set of topic strings appearing in
+# `recommend("<topic>", ...)` calls MUST be a subset of the set of topic
+# strings appearing in `learn("<topic>", ...)` calls in the same file.
+# A recommend with no matching learn is a hard violation.
+#
+# A `learn()` with no matching `recommend()` is allowed (an agent may
+# learn without recommending; this is the dominant pattern in
+# observe-only colonies). Asymmetry is one-directional.
+#
+# Scope
+# -----
+# Both topic-extraction operations use the literal first-arg shape
+# `learn("<topic>", ...)` / `recommend("<topic>", ...)` — dynamic /
+# variable-driven topics (e.g. `learn(topic_var, ...)`) are silently
+# skipped; this lint is a static guardrail, not an exhaustive runtime
+# check. The grep is `learn(` / `recommend(` at line scope; one call
+# per line is the federation-wide convention.
+#
+# Suppression
+# -----------
+# This rule has no per-line suppression because the failure mode (silent
+# confidence drift) is a correctness bug, not a stylistic call.
+# Authors who intentionally diverge topics must rename one of the
+# calls.
+#
+# Today (#622) 0 `recommend()` calls exist in the research federations
+# (math-foundry, claim-auditor, preprint-foundry), so the lint is
+# vacuously green for all three. tribes-bench hunters use raw memo
+# reads for confidence steering and have no `recommend()` calls
+# either. dev-apprenticeship colonies use the legacy
+# `recommend("<task-topic>", ...)` -> `learn("<gitlab-action-topic>", ...)`
+# split that predates this rule (multiple plumbing migrations not
+# done); they are out of scope for this lint until that migration
+# lands. The find glob is therefore the same per-federation set as
+# `check-learn-tags.sh` (#622 PR-3).
+#
+# Usage: ./tools/check-learn-recommend-topic-match.sh [path]
+# Exit 0 on clean, 1 on subset violation, 2 on usage error.
+
+set -euo pipefail
+
+SCAN_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+if [ ! -e "$SCAN_ROOT" ]; then
+    echo "check-learn-recommend-topic-match: scan root does not exist: $SCAN_ROOT" >&2
+    exit 2
+fi
+
+FAIL=0
+
+# Extract the literal first-arg topic from a single-line `<call>(` site.
+# Returns the topic via stdout, or empty string when the first arg is
+# not a string literal (variable / concat). The match is intentionally
+# strict: only `<call>("<topic>",` patterns are accepted.
+extract_first_arg_literal() {
+    local line="$1"
+    local call="$2"
+    # Strip `//` line comment if any.
+    case "$line" in
+        *"//"*) line="${line%%//*}" ;;
+    esac
+    # Find `<call>(` and everything after.
+    case "$line" in
+        *"$call("*) ;;
+        *) echo ""; return 0 ;;
+    esac
+    local body="${line#*"$call"\(}"
+    # Strip leading whitespace.
+    body="${body#"${body%%[![:space:]]*}"}"
+    # Require opening quote.
+    case "$body" in
+        \"*) ;;
+        *) echo ""; return 0 ;;
+    esac
+    body="${body#\"}"
+    # Capture up to the next `"`.
+    local close="${body%%\"*}"
+    if [ "$close" = "$body" ]; then
+        # No closing quote on this line.
+        echo ""
+        return 0
+    fi
+    # Reject embedded escape sequences or `+` continuation. A valid
+    # literal must be followed by `,` or `)` after optional whitespace.
+    local after="${body#"$close"\"}"
+    after="${after#"${after%%[![:space:]]*}"}"
+    case "$after" in
+        ","*|")"*) echo "$close"; return 0 ;;
+        *) echo ""; return 0 ;;
+    esac
+}
+
+check_file() {
+    local ag_file="$1"
+    local learn_topics=""
+    local recommend_topics=""
+
+    # First pass: collect learn topics.
+    while IFS= read -r line; do
+        # Strip `//` comment for grep purposes.
+        local clean="$line"
+        case "$clean" in
+            *"//"*) clean="${clean%%//*}" ;;
+        esac
+        case "$clean" in
+            *learn\(*)
+                local t
+                t="$(extract_first_arg_literal "$line" "learn")"
+                if [ -n "$t" ]; then
+                    learn_topics="$learn_topics
+$t"
+                fi
+                ;;
+        esac
+    done < "$ag_file"
+
+    # Second pass: collect recommend topics.
+    while IFS= read -r line; do
+        local clean="$line"
+        case "$clean" in
+            *"//"*) clean="${clean%%//*}" ;;
+        esac
+        case "$clean" in
+            *recommend\(*)
+                local t
+                t="$(extract_first_arg_literal "$line" "recommend")"
+                if [ -n "$t" ]; then
+                    recommend_topics="$recommend_topics
+$t"
+                fi
+                ;;
+        esac
+    done < "$ag_file"
+
+    # Empty recommend set → vacuously a subset.
+    [ -z "${recommend_topics// /}" ] && return 0
+
+    # For each unique recommend topic, ensure it appears in learn_topics.
+    local r_uniq
+    r_uniq="$(printf '%s\n' "$recommend_topics" | sort -u)"
+    local rt found
+    while IFS= read -r rt; do
+        [ -z "$rt" ] && continue
+        found=0
+        local lt
+        while IFS= read -r lt; do
+            [ -z "$lt" ] && continue
+            if [ "$lt" = "$rt" ]; then
+                found=1
+                break
+            fi
+        done <<EOF
+$learn_topics
+EOF
+        if [ "$found" = "0" ]; then
+            printf '%s — VIOLATION: recommend("%s", ...) has no matching learn("%s", ...) in the same file\n' "$ag_file" "$rt" "$rt"
+            FAIL=$((FAIL + 1))
+        fi
+    done <<EOF
+$r_uniq
+EOF
+}
+
+# Main: walk per-federation agent trees and skip per-run snapshots.
+# Same set as `check-learn-tags.sh`: tribes-bench + the three research
+# federations math-foundry / claim-auditor / preprint-foundry
+# (#622 PR-3). dev-apprenticeship is intentionally excluded — see
+# header for rationale.
+if [ -f "$SCAN_ROOT" ]; then
+    check_file "$SCAN_ROOT"
+else
+    while IFS= read -r -d '' f; do
+        case "$f" in
+            */runs/*) continue ;;
+        esac
+        check_file "$f"
+    done < <(find "$SCAN_ROOT" -type f \( \
+        -path '*/tribes-bench/tribe-*/agents/*.ag' -o \
+        -path '*/math-foundry/*/agents/*.ag' -o \
+        -path '*/claim-auditor/*/agents/*.ag' -o \
+        -path '*/preprint-foundry/*/agents/*.ag' \
+        \) -print0)
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "" >&2
+    echo "check-learn-recommend-topic-match: $FAIL violation(s)" >&2
+    exit 1
+fi
+
+exit 0

--- a/tools/check-learn-tags.sh
+++ b/tools/check-learn-tags.sh
@@ -88,17 +88,27 @@ tribes-bench"
             PAIR_KNOWN=1
             ;;
         "replicate:success")
+            # Shared between tribes-bench hunters and math-foundry
+            # explorer M2-Malthusian replicate (#622 PR-3). The
+            # federation-name literals (`tribes-bench` / `math-foundry`)
+            # disambiguate the call site at lint time.
             ALLOWED_LITERALS="replicated
 tribes-bench
-<tn>"
+math-foundry
+<tn>
+<cn>"
             PAIR_KNOWN=1
             ;;
         "replicate:failure")
+            # Shared between tribes-bench hunters and math-foundry
+            # explorer M2-Malthusian replicate (#622 PR-3).
             ALLOWED_LITERALS="replicate-skip
 replicate-error
 replicate-nak
 tribes-bench
-<tn>"
+math-foundry
+<tn>
+<cn>"
             PAIR_KNOWN=1
             ;;
         "reproductive_replicate:success")
@@ -207,6 +217,308 @@ miss
 tribes-bench"
             PAIR_KNOWN=1
             ;;
+
+        # ----------------------------------------------------------------
+        # math-foundry research federation (#622 PR-3)
+        # ----------------------------------------------------------------
+        # `<cn>` placeholder: math-foundry colony-name (literal one of
+        # explorer|formulator|noticer|novelty|verifier) or the bareword
+        # `_colony_name` variable reference. `verdict:<verdict>` allows
+        # the four ACCEPT-side verdict_raw literals (NOVEL, BORDERLINE,
+        # NOT_NOVEL, REJECT) and the parametric `verdict:` + bareword
+        # shape used at the call site.
+        "explore:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "settle:success")
+            ALLOWED_LITERALS="acted
+math-foundry
+<cn>"
+            ALLOWED_PARAMS="verdict:<verdict>"
+            PAIR_KNOWN=1
+            ;;
+        # NOTE: `replicate:success` and `replicate:failure` are shared
+        # between tribes-bench hunters and math-foundry explorer; see
+        # the tribes-bench entries above (case statement merges both).
+        "explorer_prompt_evolve:partial")
+            # Mirrors tribes-bench hunter_prompt_evolve:partial.
+            ALLOWED_LITERALS="prompt-evolution
+no-op
+lineage-reset
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "explorer_prompt_evolve:failure")
+            # Mirrors tribes-bench hunter_prompt_evolve:failure.
+            ALLOWED_LITERALS="prompt-evolution
+schema-revert
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "explorer_prompt_evolve:success")
+            # Mirrors tribes-bench hunter_prompt_evolve:success.
+            ALLOWED_LITERALS="prompt-evolution
+rewritten
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "explorer_prompt_inherit:success")
+            # Mirrors tribes-bench hunter_prompt_inherit:success.
+            ALLOWED_LITERALS="prompt-inheritance
+adopted
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "explorer_prompt_inherit:failure")
+            # Mirrors tribes-bench hunter_prompt_inherit:failure.
+            ALLOWED_LITERALS="prompt-inheritance
+miss
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "explorer_prompt_inherit:partial")
+            # Reserved for future parity with tribes-bench
+            # hunter_prompt_inherit:partial (no current emit site).
+            ALLOWED_LITERALS="prompt-inheritance
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "formulate:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "formulate:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "notice:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "notice:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "novelty:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "novelty:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "verify:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "verify:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "verify:failure")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+
+        # ----------------------------------------------------------------
+        # claim-auditor research federation (#622 PR-3)
+        # ----------------------------------------------------------------
+        "arxiv-search:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+        "arxiv-search:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+        "oeis-search:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+        "oeis-search:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+        "groupprops-search:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+        "groupprops-search:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+        "scholar-search:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+        "scholar-search:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+        "audit:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+        "audit:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+
+        # ----------------------------------------------------------------
+        # preprint-foundry research federation (#622 PR-3)
+        # ----------------------------------------------------------------
+        # `submit` is HITL-gated end-to-end; `hitl-gated` is a literal
+        # marker tag emitted by the HITL branches in submitter.ag.
+        "introduce:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "introduce:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "theorise:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "theorise:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "compute:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "compute:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "edit:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "edit:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "submit:partial")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+preprint-foundry
+hitl-gated"
+            PAIR_KNOWN=1
+            ;;
+        "submit:success")
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+preprint-foundry
+hitl-gated"
+            PAIR_KNOWN=1
+            ;;
     esac
 }
 
@@ -227,6 +539,16 @@ EOF
             # `<tn>` is only allowed when the schema explicitly lists it.
             case "$ALLOWED_LITERALS" in
                 *"<tn>"*) return 0 ;;
+            esac
+            ;;
+    esac
+    # Colony-name placeholder: math-foundry colony literals or the
+    # bareword `_colony_name` variable reference (#622 PR-3).
+    case "$tok" in
+        explorer|formulator|noticer|novelty|verifier|_colony_name)
+            # `<cn>` is only allowed when the schema explicitly lists it.
+            case "$ALLOWED_LITERALS" in
+                *"<cn>"*) return 0 ;;
             esac
             ;;
     esac
@@ -260,6 +582,23 @@ EOF
                 ;;
             "reason:unverifiable")
                 [ "$tok" = "reason:unverifiable" ] && return 0
+                ;;
+            "verdict:<verdict>")
+                # math-foundry explorer settle path emits
+                # `"verdict:" + verdict_raw`. Allowed verdicts at lint
+                # time: the four ACCEPT-side literals, the bareword
+                # variable reference `_verdict_raw`, and the literal
+                # placeholder `<verdict>` that `extract_token`
+                # collapses any `"verdict:" + <bareword>` shape to
+                # (#622 PR-3).
+                case "$tok" in
+                    verdict:NOVEL|verdict:BORDERLINE|verdict:NOT_NOVEL|verdict:REJECT)
+                        return 0
+                        ;;
+                    verdict:_verdict_raw|verdict:verdict_raw|verdict:_verdict|verdict:verdict|verdict:'<verdict>')
+                        return 0
+                        ;;
+                esac
                 ;;
         esac
     done <<EOF
@@ -353,6 +692,32 @@ extract_token() {
                             to_string\(*)
                                 echo "reward=0"
                                 return 0
+                                ;;
+                        esac
+                        ;;
+                    "verdict:")
+                        # math-foundry explorer emits
+                        # `"verdict:" + verdict_raw`. Collapse any
+                        # bareword tail to the parametric placeholder
+                        # so `token_allowed` matches via
+                        # `verdict:<verdict>` (#622 PR-3).
+                        case "$tail" in
+                            [a-zA-Z_]*)
+                                local tclean=1
+                                local tc
+                                local ti=0
+                                while [ "$ti" -lt "${#tail}" ]; do
+                                    tc="${tail:$ti:1}"
+                                    case "$tc" in
+                                        [a-zA-Z0-9_]) ;;
+                                        *) tclean=0; break ;;
+                                    esac
+                                    ti=$((ti + 1))
+                                done
+                                if [ "$tclean" = "1" ]; then
+                                    echo "verdict:$tail"
+                                    return 0
+                                fi
                                 ;;
                         esac
                         ;;
@@ -611,9 +976,11 @@ EOF
     done < "$ag_file"
 }
 
-# Main: walk tribes-bench/tribe-*/agents/*.ag (hunter agents today; the
-# glob is intentionally one level broader so a future scout.ag /
-# verifier.ag picks up coverage automatically). Skip `runs/` snapshots.
+# Main: walk per-federation agent trees and skip per-run snapshots.
+# Covers tribes-bench (hunter today; glob is one level broader so a
+# future scout.ag / verifier.ag picks up coverage automatically) plus
+# the three research federations math-foundry / claim-auditor /
+# preprint-foundry added in #622 PR-3.
 if [ -f "$SCAN_ROOT" ]; then
     check_file "$SCAN_ROOT"
 else
@@ -622,7 +989,12 @@ else
             */runs/*) continue ;;
         esac
         check_file "$f"
-    done < <(find "$SCAN_ROOT" -type f -path '*/tribes-bench/tribe-*/agents/*.ag' -print0)
+    done < <(find "$SCAN_ROOT" -type f \( \
+        -path '*/tribes-bench/tribe-*/agents/*.ag' -o \
+        -path '*/math-foundry/*/agents/*.ag' -o \
+        -path '*/claim-auditor/*/agents/*.ag' -o \
+        -path '*/preprint-foundry/*/agents/*.ag' \
+        \) -print0)
 fi
 
 if [ "$FAIL" -gt 0 ]; then

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -593,9 +593,26 @@ fi
 if [ -x "$REPO_ROOT/tools/check-learn-tags.sh" ]; then
     check_out="$("$REPO_ROOT/tools/check-learn-tags.sh" "$REPO_ROOT" 2>&1)" && check_rc=0 || check_rc=$?
     if [ "$check_rc" -eq 0 ]; then
-        pass "check-learn-tags: tribes-bench learn() tag streams match per-call-site schema (#492)"
+        pass "check-learn-tags: tribes-bench + research-fed learn() tag streams match per-call-site schema (#492, #622)"
     else
-        fail "check-learn-tags: schema violation in tribes-bench learn() tag stream (#492)"
+        fail "check-learn-tags: schema violation in learn() tag stream (#492, #622)"
+        printf '%s\n' "$check_out"
+    fi
+fi
+
+# --- learn() / recommend() topic-match guard (#622 PR-3) ---
+# `recommend("<topic>", ...)` topics in a `.ag` file must be a subset
+# of the `learn("<topic>", ...)` topics in the same file; otherwise
+# the recommend has no scored history and confidence drift is silent.
+# Scoped to tribes-bench + the three research feds (same per-call-site
+# set as check-learn-tags); dev-apprenticeship is excluded until its
+# pre-existing topic-split is migrated.
+if [ -x "$REPO_ROOT/tools/check-learn-recommend-topic-match.sh" ]; then
+    check_out="$("$REPO_ROOT/tools/check-learn-recommend-topic-match.sh" "$REPO_ROOT" 2>&1)" && check_rc=0 || check_rc=$?
+    if [ "$check_rc" -eq 0 ]; then
+        pass "check-learn-recommend-topic-match: recommend() topics are a subset of learn() topics per agent (#622)"
+    else
+        fail "check-learn-recommend-topic-match: recommend()/learn() topic mismatch (#622)"
         printf '%s\n' "$check_out"
     fi
 fi


### PR DESCRIPTION
## Summary

PR-3 of 3 for #622 — Section C of the approved plan. Companion PRs:
- PR-1 (sidecar plumbing): merged via #630.
- PR-2 (tier-branch fill-in across 15 `.ag`): in-flight on a sibling branch.

This PR is **lint-only + a 1-line classification fix** in `auto-promote-decisions.py`. No `.ag` files, orchestrator scripts, or runtime modules are touched.

## Changes

### 1. `tools/check-learn-tags.sh` — schema coverage for the three research feds

- Widened the `find` glob to also match `*/math-foundry/*/agents/*.ag`, `*/claim-auditor/*/agents/*.ag`, `*/preprint-foundry/*/agents/*.ag`. The `*/runs/*` exclusion continues to skip per-run snapshots.
- Extended `check_pair_schema()` with new `(topic, outcome)` pairs:
  - **math-foundry**: `explore:partial`, `settle:success`, `replicate:{success,failure}` (shared with tribes-bench), `explorer_prompt_{evolve,inherit}:{success,failure,partial}` (mirrored from `hunter_prompt_*`), `formulate:{partial,success}`, `notice:{partial,success}`, `novelty:{partial,success}`, `verify:{partial,success,failure}`.
  - **claim-auditor**: `arxiv-search:{partial,success}`, `oeis-search:{partial,success}`, `groupprops-search:{partial,success}`, `scholar-search:{partial,success}`, `audit:{partial,success}`.
  - **preprint-foundry**: `introduce:{partial,success}`, `theorise:{partial,success}`, `compute:{partial,success}`, `edit:{partial,success}`, `submit:{partial,success}` (with `hitl-gated` literal).
- Added a new `<cn>` (colony-name) placeholder covering `explorer|formulator|noticer|novelty|verifier|_colony_name`, parallel to the existing `<tn>` tribe-name placeholder.
- Added a `verdict:<verdict>` parametric token for the explorer `settle` call site (`"verdict:" + verdict_raw` -> `verdict:NOVEL|BORDERLINE|NOT_NOVEL|REJECT`).

### 2. `tools/check-learn-recommend-topic-match.sh` — new lint

Standalone shell script enforcing CLAUDE.md's rule "`learn()` topic must match the topic in `recommend()` within the same agent". For each `.ag` file, the set of `recommend("<topic>", ...)` topics must be a subset of the set of `learn("<topic>", ...)` topics. A `recommend` with no matching `learn` is a hard violation.

Scope is intentionally tribes-bench + the three research feds (same per-call-site set as `check-learn-tags`); dev-apprenticeship is excluded because four of its planning agents (`plan_reviewer`, `risk_assessor`, `scope_estimator`, `task_decomposer`) emit `learn()` calls in multi-line form (`learn(\n  "<topic>", ...)`) which the lint's single-line `extract_first_arg_literal()` parser silently skips, producing false-positive violations. Extending the parser to multi-line calls is out of scope here; tracked as a follow-up.

Wired into `tools/colony-lint.sh` immediately after the `check-learn-tags` block, mirroring its pattern.

### 3. `tools/auto-promote-decisions.py` — ACTING_TAGS fix (1 line)

```diff
- ACTING_TAGS = {"acted", "review-gated", "emitted"}
+ ACTING_TAGS = {"acted", "review-gated", "emitted", "replicated"}
```

tribes-bench hunters and the math-foundry explorer M2-Malthusian replicate path emit `learn(..., ["replicated", ...])` on successful replications. Today those acting rows silently drop from fitness compute (classify as `legacy`), so replicate-heavy agents look like they have no acting history. Adding `"replicated"` fixes the bug.

The constant is module-level and shared between the legacy positional-arg mode (used by `auto-promote.sh` sidecar) and the `--preview --config` mode (used by `federation-dashboard-collector.py`), so `test-auto-promote.sh` test 12 byte-identity holds. Verified dev-apprenticeship has zero replicate-tag agents — no regression there.

## Test plan

- [x] `tools/colony-lint.sh` — 311 passed, 0 failed, 3 skipped (was 310 on main; +1 new `check-learn-recommend-topic-match` lint row).
- [x] `tools/test-auto-promote.sh` — 35 passed, 0 failed (test 12 byte-identity between preview + legacy modes still green; `ACTING_TAGS` is module-level, both modes share it).
- [x] `tools/test-make-federation-bundle.sh` — 11 passed, 0 failed (no manifest changes; `check-*.sh` scripts are contributor-only per the test blacklist).
- [x] `tools/test-check-learn-tags.sh` — 16 passed, 0 failed (existing schema regression suite unchanged).
- [x] Manual run of `check-learn-tags.sh` against each new federation root passes (current `.ag` emitted tags match the new schema).
- [x] Manual run of `check-learn-recommend-topic-match.sh` against the full tree passes (vacuous: 0 `recommend()` calls in the in-scope federations today).
- [x] Negative tests: synthetic `.ag` with bogus tag rejected (exit 2), unknown `(topic, outcome)` pair rejected (exit 2), mismatched `recommend()`/`learn()` topic rejected (exit 1).
- [x] `bash -n` clean on both modified shell scripts; `shellcheck` clean.
- [x] `python3 -m ast` clean on `tools/auto-promote-decisions.py`.
