### PR TITLE
feat(tier-branches): autonomous + review-gated logic across 15 .ag agents (PR-2 of #622)

### DIFF
--- a/claim-auditor/arxiv-search/agents/arxiv-search.ag
+++ b/claim-auditor/arxiv-search/agents/arxiv-search.ag
@@ -65,6 +65,62 @@ fn _relevance_prompt() -> string {
     return "Given the PROBLEM, ANSWER, NOVELTY CLAIM, and a block of concatenated arXiv ATOM entries (multiple queries appended), pick up to 10 entries that look most relevant. Output ONLY valid JSON: {\"matches_found\": <int>, \"top_matches\": [{\"arxiv_id\":\"...\",\"title\":\"...\",\"relevance\":\"direct|partial|none\",\"reason\":\"...\"}], \"summary\":\"one-line\"}. Use 'direct' only when an abstract proves or states the same result; 'partial' for overlapping setup or weaker form; 'none' otherwise. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
+// _publish_arxiv_search -- fetch + judge + memo + emit. arxiv-search writes
+// no ledger row today; final_write retained for symmetry (#622 ADR-0001).
+fn _publish_arxiv_search(
+    final_write: bool,
+    queries: Queries,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int,
+    problem_text: string,
+    stated_answer: string,
+    novelty_claim: string
+) -> void {
+    let _ = final_write;
+    // Iteration over queries lives in Python because the .ag
+    // DSL has no for/while loop (precedent: tail-recursion
+    // pattern in dev-apprenticeship/triage/agents/router.ag
+    // tick_at). The helper accepts the queries JSON via
+    // QJSON env and prints the concatenated atom feed.
+    let queries_json = queries.queries_json;
+    let max_results_raw = try { exec sh "printenv ARXIV_MAX_QUERY_RESULTS"; } catch e { "10"; };
+    let max_results = if len(max_results_raw) > 0 { parse_int(max_results_raw); } else { 10; };
+    // colony-lint: safe-exec-concat
+    let fetch_cmd = "QJSON=" + shell_escape(queries_json) + " MAXR=" + to_string(max_results)
+        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
+        + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
+        + "if not isinstance(qs, list): qs=[]\n"
+        + "mx=int(os.environ.get(\"MAXR\",\"10\"))\n"
+        + "out=[]\n"
+        + "for q in qs[:5]:\n"
+        + "  url=\"http://export.arxiv.org/api/query?search_query=all:\"+urllib.parse.quote_plus(str(q))+\"&start=0&max_results=\"+str(mx)\n"
+        + "  try:\n"
+        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
+        + "  except Exception as e:\n"
+        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
+        + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
+        + "sys.stdout.write(\"\\n\".join(out))'";
+    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+
+    let judge_ctx = "PROBLEM: " + problem_text + "\n"
+                  + "ANSWER: " + stated_answer + "\n"
+                  + "NOVELTY CLAIM: " + novelty_claim + "\n"
+                  + "ARXIV FEEDS:\n" + combined_raw + "\n";
+    let report = prompt(_relevance_prompt(), judge_ctx) -> Report;
+
+    let report_json = "{\"matches_found\":" + to_string(report.matches_found)
+                    + ",\"summary\":\"" + report.summary
+                    + "\",\"top_match_count\":" + to_string(len(report.top_matches)) + "}";
+    memo_write("arxiv_search:" + self_pid + ":report:tick-" + to_string(upstream_tick), report_json);
+    memo_write("arxiv_search:" + self_pid + ":matches_found:tick-" + to_string(upstream_tick), to_string(report.matches_found));
+    memo_write("arxiv_search:" + self_pid + ":summary:tick-" + to_string(upstream_tick), report.summary);
+    memo_write("replay:current_arxiv_search_pid", self_pid);
+    emit("arxiv-search:report_ready", report);
+
+    learn("arxiv-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _colony_name = colony_name();
@@ -100,53 +156,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("arxiv_search");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("arxiv_search:" + _self_pid + ":review_gated", "true");
         learn("arxiv-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["acted", "claim-auditor"]);
+        _publish_arxiv_search(true, queries, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
     } else {
         if my_tier == "review-gated" {
+            memo_write("arxiv_search:" + _self_pid + ":review_gated", "true");
             learn("arxiv-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["review-gated", "claim-auditor"]);
+            _publish_arxiv_search(true, queries, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
         } else {
             if my_tier == "propose" {
-                // Iteration over queries lives in Python because the .ag
-                // DSL has no for/while loop (precedent: tail-recursion
-                // pattern in dev-apprenticeship/triage/agents/router.ag
-                // tick_at). The helper accepts the queries JSON via
-                // QJSON env and prints the concatenated atom feed.
-                let queries_json = queries.queries_json;
-                let max_results_raw = try { exec sh "printenv ARXIV_MAX_QUERY_RESULTS"; } catch e { "10"; };
-                let max_results = if len(max_results_raw) > 0 { parse_int(max_results_raw); } else { 10; };
-                // colony-lint: safe-exec-concat
-                let fetch_cmd = "QJSON=" + shell_escape(queries_json) + " MAXR=" + to_string(max_results)
-                    + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-                    + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
-                    + "if not isinstance(qs, list): qs=[]\n"
-                    + "mx=int(os.environ.get(\"MAXR\",\"10\"))\n"
-                    + "out=[]\n"
-                    + "for q in qs[:5]:\n"
-                    + "  url=\"http://export.arxiv.org/api/query?search_query=all:\"+urllib.parse.quote_plus(str(q))+\"&start=0&max_results=\"+str(mx)\n"
-                    + "  try:\n"
-                    + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-                    + "  except Exception as e:\n"
-                    + "    r=\"<error>\"+str(e)+\"</error>\"\n"
-                    + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
-                    + "sys.stdout.write(\"\\n\".join(out))'";
-                let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
-
-                let judge_ctx = "PROBLEM: " + problem_text + "\n"
-                              + "ANSWER: " + stated_answer + "\n"
-                              + "NOVELTY CLAIM: " + novelty_claim + "\n"
-                              + "ARXIV FEEDS:\n" + combined_raw + "\n";
-                let report = prompt(_relevance_prompt(), judge_ctx) -> Report;
-
-                let report_json = "{\"matches_found\":" + to_string(report.matches_found)
-                                + ",\"summary\":\"" + report.summary
-                                + "\",\"top_match_count\":" + to_string(len(report.top_matches)) + "}";
-                memo_write("arxiv_search:" + _self_pid + ":report:tick-" + to_string(upstream_tick), report_json);
-                memo_write("arxiv_search:" + _self_pid + ":matches_found:tick-" + to_string(upstream_tick), to_string(report.matches_found));
-                memo_write("arxiv_search:" + _self_pid + ":summary:tick-" + to_string(upstream_tick), report.summary);
-                memo_write("replay:current_arxiv_search_pid", _self_pid);
-                emit("arxiv-search:report_ready", report);
-
-                learn("arxiv-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+                _publish_arxiv_search(false, queries, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
             } else {
                 print("[arxiv-search] observing (tier:", my_tier, ") rationale=", queries.rationale);
                 learn("arxiv-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["observed", "claim-auditor"]);

--- a/claim-auditor/auditor/agents/auditor.ag
+++ b/claim-auditor/auditor/agents/auditor.ag
@@ -52,6 +52,59 @@ fn _seed_prompt() -> string {
     return "You are a strict claim auditor. The user-supplied input below carries the original PROBLEM, the stated ANSWER, the NOVELTY CLAIM, and four search reports (ARXIV, OEIS, GROUPPROPS, SCHOLAR). Classify the claim. Use 'KNOWN_PRIOR' only when at least one searcher reports a 'direct' relevance match for the same result; 'VERIFIED_NEW' when no searcher reports a direct match and the claim is well-supported; 'NEEDS_HUMAN' when reports conflict, are partial, or scholar is unavailable AND the other three are inconclusive. Output ONLY valid JSON: {\"audit_verdict\":\"VERIFIED_NEW|KNOWN_PRIOR|NEEDS_HUMAN\", \"reasoning\":\"...\", \"confidence\":0.0-1.0, \"evidence_arxiv\":\"semicolon-separated arxiv ids or empty\", \"evidence_oeis\":\"semicolon-separated A-numbers or empty\", \"evidence_groupprops\":\"semicolon-separated urls or empty\", \"evidence_scholar\":\"semicolon-separated paper ids or empty\", \"problem_summary\":\"one-line\"}. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
+// _publish_auditor -- TERMINAL agent (Class 1). memo + emit (+ ledger
+// row when final_write=true). Autonomous and review-gated both emit
+// the ledger row; only propose skips it (#622 ADR-0001). The ledger row
+// carries `terminal=true` when terminal=true (autonomous decision path).
+fn _publish_auditor(
+    final_write: bool,
+    terminal: bool,
+    verdict: Verdict,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int,
+    source_run: string,
+    source_tick: string,
+    source_pid: string
+) -> void {
+    let conf_str = to_string(verdict.confidence);
+    let verdict_json = "{\"audit_verdict\":\"" + verdict.audit_verdict
+                     + "\",\"reasoning\":\"" + verdict.reasoning
+                     + "\",\"confidence\":" + conf_str
+                     + ",\"problem_summary\":\"" + verdict.problem_summary + "\"}";
+    memo_write("auditor:" + self_pid + ":verdict:tick-" + to_string(upstream_tick), verdict_json);
+    memo_write("auditor:" + self_pid + ":verdict_label:tick-" + to_string(upstream_tick), verdict.audit_verdict);
+    memo_write("replay:current_auditor_pid", self_pid);
+
+    if final_write {
+        // Append to per-run audit ledger.
+        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        if len(ledger_path) > 0 {
+            let terminal_str = if terminal { "true"; } else { "false"; };
+            let ledger_row = "{\"ts\":" + to_string(tick_now_ms)
+                           + ",\"source_run\":\"" + source_run
+                           + "\",\"source_tick\":" + source_tick
+                           + ",\"source_pid\":\"" + source_pid
+                           + "\",\"problem_summary\":\"" + verdict.problem_summary
+                           + "\",\"audit_verdict\":\"" + verdict.audit_verdict
+                           + "\",\"evidence\":{\"arxiv\":\"" + verdict.evidence_arxiv
+                           + "\",\"oeis\":\"" + verdict.evidence_oeis
+                           + "\",\"groupprops\":\"" + verdict.evidence_groupprops
+                           + "\",\"scholar\":\"" + verdict.evidence_scholar
+                           + "\"},\"reasoning\":\"" + verdict.reasoning
+                           + "\",\"confidence\":" + conf_str
+                           + ",\"terminal\":" + terminal_str + "}";
+            // colony-lint: safe-exec-concat
+            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
+            let _ = try { exec sh append_cmd; } catch e { ""; };
+        };
+    };
+
+    emit("auditor:verdict_ready", verdict);
+    learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "success", ["emitted", "claim-auditor"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _tick_now_ms = now_ms_via_shell();
@@ -108,43 +161,20 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("auditor");
     if my_tier == "autonomous" {
+        // Terminal agent: autonomous emits the audit ledger row with
+        // terminal=true (no confidence floor; emit even when verdict.confidence
+        // would otherwise be below an internal floor) and stamps
+        // `autonomous_decision=true` for downstream observers (#622).
+        memo_write("auditor:" + _self_pid + ":autonomous_decision", "true");
         learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "partial", ["acted", "claim-auditor"]);
+        _publish_auditor(true, true, verdict, _self_pid, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid);
     } else {
         if my_tier == "review-gated" {
             learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "partial", ["review-gated", "claim-auditor"]);
+            _publish_auditor(true, false, verdict, _self_pid, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid);
         } else {
             if my_tier == "propose" {
-                let conf_str = to_string(verdict.confidence);
-                let verdict_json = "{\"audit_verdict\":\"" + verdict.audit_verdict
-                                 + "\",\"reasoning\":\"" + verdict.reasoning
-                                 + "\",\"confidence\":" + conf_str
-                                 + ",\"problem_summary\":\"" + verdict.problem_summary + "\"}";
-                memo_write("auditor:" + _self_pid + ":verdict:tick-" + to_string(upstream_tick), verdict_json);
-                memo_write("auditor:" + _self_pid + ":verdict_label:tick-" + to_string(upstream_tick), verdict.audit_verdict);
-                memo_write("replay:current_auditor_pid", _self_pid);
-
-                // Append to per-run audit ledger.
-                let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
-                if len(ledger_path) > 0 {
-                    let ledger_row = "{\"ts\":" + to_string(_tick_now_ms)
-                                   + ",\"source_run\":\"" + source_run
-                                   + "\",\"source_tick\":" + source_tick
-                                   + ",\"source_pid\":\"" + source_pid
-                                   + "\",\"problem_summary\":\"" + verdict.problem_summary
-                                   + "\",\"audit_verdict\":\"" + verdict.audit_verdict
-                                   + "\",\"evidence\":{\"arxiv\":\"" + verdict.evidence_arxiv
-                                   + "\",\"oeis\":\"" + verdict.evidence_oeis
-                                   + "\",\"groupprops\":\"" + verdict.evidence_groupprops
-                                   + "\",\"scholar\":\"" + verdict.evidence_scholar
-                                   + "\"},\"reasoning\":\"" + verdict.reasoning
-                                   + "\",\"confidence\":" + conf_str + "}";
-                    // colony-lint: safe-exec-concat
-                    let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-                    let _ = try { exec sh append_cmd; } catch e { ""; };
-                };
-
-                emit("auditor:verdict_ready", verdict);
-                learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "success", ["emitted", "claim-auditor"]);
+                _publish_auditor(false, false, verdict, _self_pid, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid);
             } else {
                 print("[auditor] observing (tier:", my_tier, ") verdict=", verdict.audit_verdict);
                 learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "partial", ["observed", "claim-auditor"]);

--- a/claim-auditor/groupprops-search/agents/groupprops-search.ag
+++ b/claim-auditor/groupprops-search/agents/groupprops-search.ag
@@ -62,6 +62,54 @@ fn _relevance_prompt() -> string {
     return "Given the PROBLEM, ANSWER, NOVELTY CLAIM, and the raw groupprops opensearch JSON responses below (one per query), pick up to 5 entries that look most relevant. Output ONLY valid JSON: {\"matches_found\": <int>, \"top_matches\": [{\"url\":\"...\",\"title\":\"...\",\"relevance\":\"direct|partial|none\",\"reason\":\"...\"}], \"summary\":\"one-line\"}. Use 'direct' only when the page covers the exact claim; 'partial' for related results; 'none' otherwise. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
+// _publish_groupprops_search -- fetch + judge + memo + emit. No ledger row
+// today; final_write retained for symmetry (#622 ADR-0001).
+fn _publish_groupprops_search(
+    final_write: bool,
+    queries: Queries,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int,
+    problem_text: string,
+    stated_answer: string,
+    novelty_claim: string
+) -> void {
+    let _ = final_write;
+    let queries_json = queries.queries_json;
+    // colony-lint: safe-exec-concat
+    let fetch_cmd = "QJSON=" + shell_escape(queries_json)
+        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
+        + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
+        + "if not isinstance(qs, list): qs=[]\n"
+        + "out=[]\n"
+        + "for q in qs[:5]:\n"
+        + "  url=\"https://groupprops.subwiki.org/w/api.php?action=opensearch&format=json&limit=10&search=\"+urllib.parse.quote_plus(str(q))\n"
+        + "  try:\n"
+        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
+        + "  except Exception as e:\n"
+        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
+        + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
+        + "sys.stdout.write(\"\\n\".join(out))'";
+    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+
+    let judge_ctx = "PROBLEM: " + problem_text + "\n"
+                  + "ANSWER: " + stated_answer + "\n"
+                  + "NOVELTY CLAIM: " + novelty_claim + "\n"
+                  + "GROUPPROPS FEEDS:\n" + combined_raw + "\n";
+    let report = prompt(_relevance_prompt(), judge_ctx) -> Report;
+
+    let report_json = "{\"matches_found\":" + to_string(report.matches_found)
+                    + ",\"summary\":\"" + report.summary
+                    + "\",\"top_match_count\":" + to_string(len(report.top_matches)) + "}";
+    memo_write("groupprops_search:" + self_pid + ":report:tick-" + to_string(upstream_tick), report_json);
+    memo_write("groupprops_search:" + self_pid + ":matches_found:tick-" + to_string(upstream_tick), to_string(report.matches_found));
+    memo_write("groupprops_search:" + self_pid + ":summary:tick-" + to_string(upstream_tick), report.summary);
+    memo_write("replay:current_groupprops_search_pid", self_pid);
+    emit("groupprops-search:report_ready", report);
+
+    learn("groupprops-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _colony_name = colony_name();
@@ -97,45 +145,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("groupprops_search");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("groupprops_search:" + _self_pid + ":review_gated", "true");
         learn("groupprops-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["acted", "claim-auditor"]);
+        _publish_groupprops_search(true, queries, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
     } else {
         if my_tier == "review-gated" {
+            memo_write("groupprops_search:" + _self_pid + ":review_gated", "true");
             learn("groupprops-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["review-gated", "claim-auditor"]);
+            _publish_groupprops_search(true, queries, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
         } else {
             if my_tier == "propose" {
-                let queries_json = queries.queries_json;
-                // colony-lint: safe-exec-concat
-                let fetch_cmd = "QJSON=" + shell_escape(queries_json)
-                    + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-                    + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
-                    + "if not isinstance(qs, list): qs=[]\n"
-                    + "out=[]\n"
-                    + "for q in qs[:5]:\n"
-                    + "  url=\"https://groupprops.subwiki.org/w/api.php?action=opensearch&format=json&limit=10&search=\"+urllib.parse.quote_plus(str(q))\n"
-                    + "  try:\n"
-                    + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-                    + "  except Exception as e:\n"
-                    + "    r=\"<error>\"+str(e)+\"</error>\"\n"
-                    + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
-                    + "sys.stdout.write(\"\\n\".join(out))'";
-                let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
-
-                let judge_ctx = "PROBLEM: " + problem_text + "\n"
-                              + "ANSWER: " + stated_answer + "\n"
-                              + "NOVELTY CLAIM: " + novelty_claim + "\n"
-                              + "GROUPPROPS FEEDS:\n" + combined_raw + "\n";
-                let report = prompt(_relevance_prompt(), judge_ctx) -> Report;
-
-                let report_json = "{\"matches_found\":" + to_string(report.matches_found)
-                                + ",\"summary\":\"" + report.summary
-                                + "\",\"top_match_count\":" + to_string(len(report.top_matches)) + "}";
-                memo_write("groupprops_search:" + _self_pid + ":report:tick-" + to_string(upstream_tick), report_json);
-                memo_write("groupprops_search:" + _self_pid + ":matches_found:tick-" + to_string(upstream_tick), to_string(report.matches_found));
-                memo_write("groupprops_search:" + _self_pid + ":summary:tick-" + to_string(upstream_tick), report.summary);
-                memo_write("replay:current_groupprops_search_pid", _self_pid);
-                emit("groupprops-search:report_ready", report);
-
-                learn("groupprops-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+                _publish_groupprops_search(false, queries, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
             } else {
                 print("[groupprops-search] observing (tier:", my_tier, ") rationale=", queries.rationale);
                 learn("groupprops-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["observed", "claim-auditor"]);

--- a/claim-auditor/oeis-search/agents/oeis-search.ag
+++ b/claim-auditor/oeis-search/agents/oeis-search.ag
@@ -62,6 +62,54 @@ fn _relevance_prompt() -> string {
     return "Given the PROBLEM, ANSWER, NOVELTY CLAIM, and the raw OEIS text-search responses below (each query's response concatenated), pick up to 5 A-numbers that look most relevant. Output ONLY valid JSON: {\"matches_found\": <int>, \"top_matches\": [{\"a_number\":\"A123456\",\"name\":\"...\",\"relevance\":\"direct|partial|none\",\"reason\":\"...\"}], \"summary\":\"one-line\"}. Use 'direct' only when the A-number is the same sequence; 'partial' if it overlaps but differs in offset or initial terms; 'none' otherwise. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
+// _publish_oeis_search -- fetch + judge + memo + emit. oeis-search writes
+// no ledger row today; final_write retained for symmetry (#622 ADR-0001).
+fn _publish_oeis_search(
+    final_write: bool,
+    sequences: Sequences,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int,
+    problem_text: string,
+    stated_answer: string,
+    novelty_claim: string
+) -> void {
+    let _ = final_write;
+    let sequences_json = sequences.sequences_json;
+    // colony-lint: safe-exec-concat
+    let fetch_cmd = "SJSON=" + shell_escape(sequences_json)
+        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
+        + "try:\n  seqs=json.loads(os.environ[\"SJSON\"])\nexcept Exception:\n  seqs=[]\n"
+        + "if not isinstance(seqs, list): seqs=[]\n"
+        + "out=[]\n"
+        + "for s in seqs[:5]:\n"
+        + "  url=\"https://oeis.org/search?fmt=text&q=\"+urllib.parse.quote_plus(str(s))\n"
+        + "  try:\n"
+        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
+        + "  except Exception as e:\n"
+        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
+        + "  out.append(\"--- seq: \"+str(s)+\" ---\\n\"+r)\n"
+        + "sys.stdout.write(\"\\n\".join(out))'";
+    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+
+    let judge_ctx = "PROBLEM: " + problem_text + "\n"
+                  + "ANSWER: " + stated_answer + "\n"
+                  + "NOVELTY CLAIM: " + novelty_claim + "\n"
+                  + "OEIS FEEDS:\n" + combined_raw + "\n";
+    let report = prompt(_relevance_prompt(), judge_ctx) -> Report;
+
+    let report_json = "{\"matches_found\":" + to_string(report.matches_found)
+                    + ",\"summary\":\"" + report.summary
+                    + "\",\"top_match_count\":" + to_string(len(report.top_matches)) + "}";
+    memo_write("oeis_search:" + self_pid + ":report:tick-" + to_string(upstream_tick), report_json);
+    memo_write("oeis_search:" + self_pid + ":matches_found:tick-" + to_string(upstream_tick), to_string(report.matches_found));
+    memo_write("oeis_search:" + self_pid + ":summary:tick-" + to_string(upstream_tick), report.summary);
+    memo_write("replay:current_oeis_search_pid", self_pid);
+    emit("oeis-search:report_ready", report);
+
+    learn("oeis-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _colony_name = colony_name();
@@ -97,45 +145,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("oeis_search");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("oeis_search:" + _self_pid + ":review_gated", "true");
         learn("oeis-search", "tick " + to_string(tick_idx), sequences.rationale, "partial", ["acted", "claim-auditor"]);
+        _publish_oeis_search(true, sequences, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
     } else {
         if my_tier == "review-gated" {
+            memo_write("oeis_search:" + _self_pid + ":review_gated", "true");
             learn("oeis-search", "tick " + to_string(tick_idx), sequences.rationale, "partial", ["review-gated", "claim-auditor"]);
+            _publish_oeis_search(true, sequences, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
         } else {
             if my_tier == "propose" {
-                let sequences_json = sequences.sequences_json;
-                // colony-lint: safe-exec-concat
-                let fetch_cmd = "SJSON=" + shell_escape(sequences_json)
-                    + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-                    + "try:\n  seqs=json.loads(os.environ[\"SJSON\"])\nexcept Exception:\n  seqs=[]\n"
-                    + "if not isinstance(seqs, list): seqs=[]\n"
-                    + "out=[]\n"
-                    + "for s in seqs[:5]:\n"
-                    + "  url=\"https://oeis.org/search?fmt=text&q=\"+urllib.parse.quote_plus(str(s))\n"
-                    + "  try:\n"
-                    + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-                    + "  except Exception as e:\n"
-                    + "    r=\"<error>\"+str(e)+\"</error>\"\n"
-                    + "  out.append(\"--- seq: \"+str(s)+\" ---\\n\"+r)\n"
-                    + "sys.stdout.write(\"\\n\".join(out))'";
-                let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
-
-                let judge_ctx = "PROBLEM: " + problem_text + "\n"
-                              + "ANSWER: " + stated_answer + "\n"
-                              + "NOVELTY CLAIM: " + novelty_claim + "\n"
-                              + "OEIS FEEDS:\n" + combined_raw + "\n";
-                let report = prompt(_relevance_prompt(), judge_ctx) -> Report;
-
-                let report_json = "{\"matches_found\":" + to_string(report.matches_found)
-                                + ",\"summary\":\"" + report.summary
-                                + "\",\"top_match_count\":" + to_string(len(report.top_matches)) + "}";
-                memo_write("oeis_search:" + _self_pid + ":report:tick-" + to_string(upstream_tick), report_json);
-                memo_write("oeis_search:" + _self_pid + ":matches_found:tick-" + to_string(upstream_tick), to_string(report.matches_found));
-                memo_write("oeis_search:" + _self_pid + ":summary:tick-" + to_string(upstream_tick), report.summary);
-                memo_write("replay:current_oeis_search_pid", _self_pid);
-                emit("oeis-search:report_ready", report);
-
-                learn("oeis-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+                _publish_oeis_search(false, sequences, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
             } else {
                 print("[oeis-search] observing (tier:", my_tier, ") rationale=", sequences.rationale);
                 learn("oeis-search", "tick " + to_string(tick_idx), sequences.rationale, "partial", ["observed", "claim-auditor"]);

--- a/claim-auditor/scholar-search/agents/scholar-search.ag
+++ b/claim-auditor/scholar-search/agents/scholar-search.ag
@@ -66,6 +66,56 @@ fn _relevance_prompt() -> string {
     return "Given the PROBLEM, ANSWER, NOVELTY CLAIM, and the raw Semantic Scholar JSON responses below (one per query, may contain 'unavailable' markers when the API rate-limited or errored), pick up to 5 papers that look most relevant. Output ONLY valid JSON: {\"status\": \"ok|unavailable|partial\", \"matches_found\": <int>, \"top_matches\": [{\"paper_id\":\"...\",\"title\":\"...\",\"relevance\":\"direct|partial|none\",\"reason\":\"...\"}], \"summary\":\"one-line\"}. status='unavailable' if every query failed; 'partial' if some failed; 'ok' otherwise. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
+// _publish_scholar_search -- fetch + judge + memo + emit. No ledger row
+// today; final_write retained for symmetry (#622 ADR-0001).
+fn _publish_scholar_search(
+    final_write: bool,
+    queries: Queries,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int,
+    problem_text: string,
+    stated_answer: string,
+    novelty_claim: string
+) -> void {
+    let _ = final_write;
+    let queries_json = queries.queries_json;
+    // colony-lint: safe-exec-concat
+    let fetch_cmd = "QJSON=" + shell_escape(queries_json)
+        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
+        + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
+        + "if not isinstance(qs, list): qs=[]\n"
+        + "out=[]\n"
+        + "for q in qs[:3]:\n"
+        + "  url=\"https://api.semanticscholar.org/graph/v1/paper/search?limit=10&fields=title,abstract,year,authors&query=\"+urllib.parse.quote_plus(str(q))\n"
+        + "  try:\n"
+        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
+        + "  except Exception as e:\n"
+        + "    r=\"<unavailable>\"+str(e)+\"</unavailable>\"\n"
+        + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
+        + "sys.stdout.write(\"\\n\".join(out))'";
+    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+
+    let judge_ctx = "PROBLEM: " + problem_text + "\n"
+                  + "ANSWER: " + stated_answer + "\n"
+                  + "NOVELTY CLAIM: " + novelty_claim + "\n"
+                  + "SEMANTIC SCHOLAR FEEDS:\n" + combined_raw + "\n";
+    let report = prompt(_relevance_prompt(), judge_ctx) -> Report;
+
+    let report_json = "{\"status\":\"" + report.status
+                    + "\",\"matches_found\":" + to_string(report.matches_found)
+                    + ",\"summary\":\"" + report.summary
+                    + "\",\"top_match_count\":" + to_string(len(report.top_matches)) + "}";
+    memo_write("scholar_search:" + self_pid + ":report:tick-" + to_string(upstream_tick), report_json);
+    memo_write("scholar_search:" + self_pid + ":status:tick-" + to_string(upstream_tick), report.status);
+    memo_write("scholar_search:" + self_pid + ":matches_found:tick-" + to_string(upstream_tick), to_string(report.matches_found));
+    memo_write("scholar_search:" + self_pid + ":summary:tick-" + to_string(upstream_tick), report.summary);
+    memo_write("replay:current_scholar_search_pid", self_pid);
+    emit("scholar-search:report_ready", report);
+
+    learn("scholar-search", "tick " + to_string(tick_idx), "status=" + report.status + " matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _colony_name = colony_name();
@@ -101,47 +151,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("scholar_search");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("scholar_search:" + _self_pid + ":review_gated", "true");
         learn("scholar-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["acted", "claim-auditor"]);
+        _publish_scholar_search(true, queries, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
     } else {
         if my_tier == "review-gated" {
+            memo_write("scholar_search:" + _self_pid + ":review_gated", "true");
             learn("scholar-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["review-gated", "claim-auditor"]);
+            _publish_scholar_search(true, queries, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
         } else {
             if my_tier == "propose" {
-                let queries_json = queries.queries_json;
-                // colony-lint: safe-exec-concat
-                let fetch_cmd = "QJSON=" + shell_escape(queries_json)
-                    + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-                    + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
-                    + "if not isinstance(qs, list): qs=[]\n"
-                    + "out=[]\n"
-                    + "for q in qs[:3]:\n"
-                    + "  url=\"https://api.semanticscholar.org/graph/v1/paper/search?limit=10&fields=title,abstract,year,authors&query=\"+urllib.parse.quote_plus(str(q))\n"
-                    + "  try:\n"
-                    + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-                    + "  except Exception as e:\n"
-                    + "    r=\"<unavailable>\"+str(e)+\"</unavailable>\"\n"
-                    + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
-                    + "sys.stdout.write(\"\\n\".join(out))'";
-                let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
-
-                let judge_ctx = "PROBLEM: " + problem_text + "\n"
-                              + "ANSWER: " + stated_answer + "\n"
-                              + "NOVELTY CLAIM: " + novelty_claim + "\n"
-                              + "SEMANTIC SCHOLAR FEEDS:\n" + combined_raw + "\n";
-                let report = prompt(_relevance_prompt(), judge_ctx) -> Report;
-
-                let report_json = "{\"status\":\"" + report.status
-                                + "\",\"matches_found\":" + to_string(report.matches_found)
-                                + ",\"summary\":\"" + report.summary
-                                + "\",\"top_match_count\":" + to_string(len(report.top_matches)) + "}";
-                memo_write("scholar_search:" + _self_pid + ":report:tick-" + to_string(upstream_tick), report_json);
-                memo_write("scholar_search:" + _self_pid + ":status:tick-" + to_string(upstream_tick), report.status);
-                memo_write("scholar_search:" + _self_pid + ":matches_found:tick-" + to_string(upstream_tick), to_string(report.matches_found));
-                memo_write("scholar_search:" + _self_pid + ":summary:tick-" + to_string(upstream_tick), report.summary);
-                memo_write("replay:current_scholar_search_pid", _self_pid);
-                emit("scholar-search:report_ready", report);
-
-                learn("scholar-search", "tick " + to_string(tick_idx), "status=" + report.status + " matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+                _publish_scholar_search(false, queries, _self_pid, upstream_tick, tick_idx, problem_text, stated_answer, novelty_claim);
             } else {
                 print("[scholar-search] observing (tier:", my_tier, ") rationale=", queries.rationale);
                 learn("scholar-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["observed", "claim-auditor"]);

--- a/math-foundry/explorer/agents/explorer.ag
+++ b/math-foundry/explorer/agents/explorer.ag
@@ -267,6 +267,143 @@ fn select_replication_target() -> string {
     return self_node_addr();
 }
 
+// _publish_explorer -- emit + exec + memo + (ledger + settlement + fitness
+// when final_write=true) + (replicate when do_replicate=true). Tier mapping
+// for explorer (Class 3 special case per #622 ADR-0001):
+//   * propose:     final_write=true,  do_replicate=false (keep settlement + fitness;
+//                                                         lose replicate vs today)
+//   * autonomous:  final_write=true,  do_replicate=true  (full body incl. replicate)
+//   * review-gated: handled inline as memo-only (no exec, no ledger, no
+//                  settlement, no fitness, no replicate). Does not call
+//                  this helper.
+fn _publish_explorer(
+    final_write: bool,
+    do_replicate: bool,
+    exploration: Exploration,
+    self_pid: string,
+    colony_name_str: string,
+    tick_idx: int,
+    tick_now_ms: int,
+    topic_label: string,
+    prompt_text: string
+) -> void {
+    emit("math-foundry:exploration_done", exploration);
+
+    // Execute the Python code in the sandbox via a temp file +
+    // python3 invocation. Pure compute only -- no file I/O,
+    // network, subprocess (enforced by prompt body, not by
+    // sandbox today).
+    let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
+    let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
+    // colony-lint: safe-exec-concat
+    let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(exploration.code) + " > " + shell_escape(sandbox_eff + "/explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py");
+    let _ = try { exec sh write_cmd; } catch e { ""; };
+    // colony-lint: safe-exec-concat
+    let run_cmd = "python3 " + shell_escape(sandbox_eff + "/explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py") + " 2>&1";
+    let output = try { exec sh run_cmd; } catch e { ""; };
+
+    memo_write("explorer:" + self_pid + ":code:tick-" + to_string(tick_idx), exploration.code);
+    memo_write("explorer:" + self_pid + ":output:tick-" + to_string(tick_idx), output);
+    memo_write("explorer:" + self_pid + ":goal:tick-" + to_string(tick_idx), exploration.exploration_goal);
+    memo_write("explorer:" + self_pid + ":topic:tick-" + to_string(tick_idx), topic_label);
+
+    if final_write {
+        // Append to per-run discovery ledger.
+        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        if len(ledger_path) > 0 {
+            let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"exploration_done\"}";
+            // colony-lint: safe-exec-concat
+            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
+            let _l = try { exec sh append_cmd; } catch e { ""; };
+        };
+
+        // Settlement: read the novelty verdict for tick - HOLD_PERIOD.
+        let hold_env = try { exec sh "printenv HOLD_PERIOD"; } catch e { ""; };
+        let hold = if len(hold_env) > 0 { parse_int(hold_env); } else { 4; };
+        let hold_eff = if hold <= 0 { 4; } else { hold; };
+        let settle_tick = tick_idx - hold_eff;
+        if settle_tick >= 0 {
+            let verdict_raw = recall_latest("novelty:final_verdict:" + self_pid + ":tick-" + to_string(settle_tick));
+            if len(verdict_raw) > 0 {
+                print("[explorer] settled tick=", settle_tick, " verdict=", verdict_raw);
+                learn("settle", "tick " + to_string(settle_tick) + " " + verdict_raw, "novelty=" + verdict_raw, "success", ["acted", "math-foundry", colony_name_str, "verdict:" + verdict_raw]);
+
+                // Fitness update: +2 NOVEL, +0.5 (mapped int 1)
+                // BORDERLINE, -1 NOT_NOVEL, -0.5 (mapped int 1)
+                // REJECT. Knob env vars are integer-scaled per-tick.
+                if len(self_pid) > 0 {
+                    let reward_novel_env = try { exec sh "printenv FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK"; } catch e { ""; };
+                    let reward_novel = if len(reward_novel_env) > 0 { parse_int(reward_novel_env); } else { 2; };
+                    let penalty_not_novel_env = try { exec sh "printenv FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK"; } catch e { ""; };
+                    let penalty_not_novel = if len(penalty_not_novel_env) > 0 { parse_int(penalty_not_novel_env); } else { 1; };
+                    let fit_pre = parse_int(recall_latest("explorer:" + self_pid + ":fitness"));
+                    let fit_delta = if verdict_raw == "NOVEL" {
+                        reward_novel;
+                    } else { if verdict_raw == "BORDERLINE" {
+                        1;
+                    } else { if verdict_raw == "NOT_NOVEL" {
+                        0 - penalty_not_novel;
+                    } else { if verdict_raw == "REJECT" {
+                        0 - 1;
+                    } else {
+                        0;
+                    }; }; }; };
+                    memo_write("explorer:" + self_pid + ":fitness", to_string(fit_pre + fit_delta));
+                };
+
+                // M98 v3 evolution trigger.
+                if len(self_pid) > 0 {
+                    let _buf_len = _push_settled_exploration(self_pid, verdict_raw);
+                    let _thr_env = try { exec sh "printenv EXPLORER_PROMPT_EVOLUTION_THRESHOLD"; } catch e { ""; };
+                    let _thr = if len(_thr_env) > 0 { parse_int(_thr_env); } else { 3; };
+                    let _thr_eff = if _thr <= 0 { 3; } else { _thr; };
+                    let _not_novel = _count_not_novel(self_pid);
+                    if _not_novel >= _thr_eff {
+                        let _ = _evolve_exploration_prompt(self_pid, prompt_text);
+                    };
+                };
+
+                // M2-Malthusian replicate gate -- autonomous tier only (#622).
+                if do_replicate {
+                    let repr_thr = parse_int(recall_latest("explorer:reproductive_fitness_threshold"));
+                    if repr_thr > 0 {
+                        let my_fit_r = parse_int(recall_latest("explorer:" + self_pid + ":fitness"));
+                        if my_fit_r > repr_thr {
+                            let n_r = parse_int(recall_latest("colony-" + colony_name_str + ":size"));
+                            let max_repl_r = parse_int(recall_latest("colony-" + colony_name_str + ":max_replicas"));
+                            if n_r < max_repl_r {
+                                let pool_r = parse_int(recall_latest("colony-" + colony_name_str + ":pool"));
+                                let base_r = parse_int(recall_latest("colony-" + colony_name_str + ":replication_base_cost"));
+                                let raw_k_r = parse_int(recall_latest("colony-" + colony_name_str + ":replication_k"));
+                                let k_r = if raw_k_r <= 0 { 3; } else { raw_k_r; };
+                                let cost_r = base_r + (base_r * n_r) / k_r;
+                                if pool_r >= cost_r {
+                                    let variant_pick = pick_variant(n_r);
+                                    memo_write("explorer:prompt_variant", variant_pick);
+                                    let target_r = select_replication_target();
+                                    if len(target_r) > 0 {
+                                        let variant_wrapped = _publish_prompt_body_and_wrap_variant(self_pid, variant_pick);
+                                        let replica_id = try { replicate(target_r, my_fit_r, variant_wrapped); } catch e { "__replicate_error__"; };
+                                        if replica_id != "__replicate_error__" {
+                                            if len(replica_id) > 0 {
+                                                memo_write("colony-" + colony_name_str + ":pool", to_string(pool_r - cost_r));
+                                                memo_write("colony-" + colony_name_str + ":size", to_string(n_r + 1));
+                                                learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "math-foundry", colony_name_str]);
+                                            } else {
+                                                learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "math-foundry", colony_name_str]);
+                                            };
+                                        };
+                                    };
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _tick_now_ms = now_ms_via_shell();
@@ -352,123 +489,28 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("explorer");
     if my_tier == "autonomous" {
+        // Class 3 special case (#622): autonomous adds the replicate gate
+        // on top of today's propose body (memo + exec + ledger + settlement
+        // + fitness). Same settlement/fitness as propose, plus replicate.
+        memo_write("explorer:" + _self_pid + ":review_gated", "true");
         learn("explore", "tick " + to_string(tick_idx) + " " + topic_label, exploration.exploration_goal, "partial", ["acted", "math-foundry"]);
+        _publish_explorer(true, true, exploration, _self_pid, _colony_name, tick_idx, _tick_now_ms, topic_label, prompt_text);
     } else {
         if my_tier == "review-gated" {
+            // Class 3 special case (#622): review-gated is memo-only --
+            // record the exploration intent without executing the Python,
+            // appending to the ledger, settling fitness, or replicating.
+            memo_write("explorer:" + _self_pid + ":review_gated", "true");
+            memo_write("explorer:" + _self_pid + ":code:tick-" + to_string(tick_idx), exploration.code);
+            memo_write("explorer:" + _self_pid + ":goal:tick-" + to_string(tick_idx), exploration.exploration_goal);
+            memo_write("explorer:" + _self_pid + ":topic:tick-" + to_string(tick_idx), topic_label);
             learn("explore", "tick " + to_string(tick_idx) + " " + topic_label, exploration.exploration_goal, "partial", ["review-gated", "math-foundry"]);
         } else {
             if my_tier == "propose" {
-                emit("math-foundry:exploration_done", exploration);
-
-                // Execute the Python code in the sandbox via a temp file +
-                // python3 invocation. Pure compute only -- no file I/O,
-                // network, subprocess (enforced by prompt body, not by
-                // sandbox today).
-                let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
-                let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
-                // colony-lint: safe-exec-concat
-                let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(exploration.code) + " > " + shell_escape(sandbox_eff + "/explore-" + _self_pid + "-tick-" + to_string(tick_idx) + ".py");
-                let _ = try { exec sh write_cmd; } catch e { ""; };
-                // colony-lint: safe-exec-concat
-                let run_cmd = "python3 " + shell_escape(sandbox_eff + "/explore-" + _self_pid + "-tick-" + to_string(tick_idx) + ".py") + " 2>&1";
-                let output = try { exec sh run_cmd; } catch e { ""; };
-
-                memo_write("explorer:" + _self_pid + ":code:tick-" + to_string(tick_idx), exploration.code);
-                memo_write("explorer:" + _self_pid + ":output:tick-" + to_string(tick_idx), output);
-                memo_write("explorer:" + _self_pid + ":goal:tick-" + to_string(tick_idx), exploration.exploration_goal);
-                memo_write("explorer:" + _self_pid + ":topic:tick-" + to_string(tick_idx), topic_label);
-
-                // Append to per-run discovery ledger.
-                let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
-                if len(ledger_path) > 0 {
-                    let ledger_row = "{\"ts\":" + to_string(_tick_now_ms) + ",\"colony\":\"" + _colony_name + "\",\"pid\":\"" + _self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"exploration_done\"}";
-                    // colony-lint: safe-exec-concat
-                    let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-                    let _ = try { exec sh append_cmd; } catch e { ""; };
-                };
-
-                // Settlement: read the novelty verdict for tick - HOLD_PERIOD.
-                let hold_env = try { exec sh "printenv HOLD_PERIOD"; } catch e { ""; };
-                let hold = if len(hold_env) > 0 { parse_int(hold_env); } else { 4; };
-                let hold_eff = if hold <= 0 { 4; } else { hold; };
-                let settle_tick = tick_idx - hold_eff;
-                if settle_tick >= 0 {
-                    let verdict_raw = recall_latest("novelty:final_verdict:" + _self_pid + ":tick-" + to_string(settle_tick));
-                    if len(verdict_raw) > 0 {
-                        print("[explorer] settled tick=", settle_tick, " verdict=", verdict_raw);
-                        learn("settle", "tick " + to_string(settle_tick) + " " + verdict_raw, "novelty=" + verdict_raw, "success", ["acted", "math-foundry", _colony_name, "verdict:" + verdict_raw]);
-
-                        // Fitness update: +2 NOVEL, +0.5 (mapped int 1)
-                        // BORDERLINE, -1 NOT_NOVEL, -0.5 (mapped int 1)
-                        // REJECT. Knob env vars are integer-scaled per-tick.
-                        if len(_self_pid) > 0 {
-                            let reward_novel_env = try { exec sh "printenv FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK"; } catch e { ""; };
-                            let reward_novel = if len(reward_novel_env) > 0 { parse_int(reward_novel_env); } else { 2; };
-                            let penalty_not_novel_env = try { exec sh "printenv FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK"; } catch e { ""; };
-                            let penalty_not_novel = if len(penalty_not_novel_env) > 0 { parse_int(penalty_not_novel_env); } else { 1; };
-                            let fit_pre = parse_int(recall_latest("explorer:" + _self_pid + ":fitness"));
-                            let fit_delta = if verdict_raw == "NOVEL" {
-                                reward_novel;
-                            } else { if verdict_raw == "BORDERLINE" {
-                                1;
-                            } else { if verdict_raw == "NOT_NOVEL" {
-                                0 - penalty_not_novel;
-                            } else { if verdict_raw == "REJECT" {
-                                0 - 1;
-                            } else {
-                                0;
-                            }; }; }; };
-                            memo_write("explorer:" + _self_pid + ":fitness", to_string(fit_pre + fit_delta));
-                        };
-
-                        // M98 v3 evolution trigger.
-                        if len(_self_pid) > 0 {
-                            let _buf_len = _push_settled_exploration(_self_pid, verdict_raw);
-                            let _thr_env = try { exec sh "printenv EXPLORER_PROMPT_EVOLUTION_THRESHOLD"; } catch e { ""; };
-                            let _thr = if len(_thr_env) > 0 { parse_int(_thr_env); } else { 3; };
-                            let _thr_eff = if _thr <= 0 { 3; } else { _thr; };
-                            let _not_novel = _count_not_novel(_self_pid);
-                            if _not_novel >= _thr_eff {
-                                let _ = _evolve_exploration_prompt(_self_pid, prompt_text);
-                            };
-                        };
-
-                        // M2-Malthusian replicate gate.
-                        let repr_thr = parse_int(recall_latest("explorer:reproductive_fitness_threshold"));
-                        if repr_thr > 0 {
-                            let my_fit_r = parse_int(recall_latest("explorer:" + _self_pid + ":fitness"));
-                            if my_fit_r > repr_thr {
-                                let n_r = parse_int(recall_latest("colony-" + _colony_name + ":size"));
-                                let max_repl_r = parse_int(recall_latest("colony-" + _colony_name + ":max_replicas"));
-                                if n_r < max_repl_r {
-                                    let pool_r = parse_int(recall_latest("colony-" + _colony_name + ":pool"));
-                                    let base_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_base_cost"));
-                                    let raw_k_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_k"));
-                                    let k_r = if raw_k_r <= 0 { 3; } else { raw_k_r; };
-                                    let cost_r = base_r + (base_r * n_r) / k_r;
-                                    if pool_r >= cost_r {
-                                        let variant_pick = pick_variant(n_r);
-                                        memo_write("explorer:prompt_variant", variant_pick);
-                                        let target_r = select_replication_target();
-                                        if len(target_r) > 0 {
-                                            let variant_wrapped = _publish_prompt_body_and_wrap_variant(_self_pid, variant_pick);
-                                            let replica_id = try { replicate(target_r, my_fit_r, variant_wrapped); } catch e { "__replicate_error__"; };
-                                            if replica_id != "__replicate_error__" {
-                                                if len(replica_id) > 0 {
-                                                    memo_write("colony-" + _colony_name + ":pool", to_string(pool_r - cost_r));
-                                                    memo_write("colony-" + _colony_name + ":size", to_string(n_r + 1));
-                                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "math-foundry", _colony_name]);
-                                                } else {
-                                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "math-foundry", _colony_name]);
-                                                };
-                                            };
-                                        };
-                                    };
-                                };
-                            };
-                        };
-                    };
-                };
+                // Class 3 special case (#622): propose keeps settlement +
+                // fitness from today's body but loses the replicate gate
+                // (autonomous-only now).
+                _publish_explorer(true, false, exploration, _self_pid, _colony_name, tick_idx, _tick_now_ms, topic_label, prompt_text);
             } else {
                 // shadow / dormant: observe-only.
                 print("[explorer] observing (tier:", my_tier, ") goal=", exploration.exploration_goal);

--- a/math-foundry/explorer/agents/explorer.ag
+++ b/math-foundry/explorer/agents/explorer.ag
@@ -281,7 +281,7 @@ fn _publish_explorer(
     do_replicate: bool,
     exploration: Exploration,
     self_pid: string,
-    colony_name_str: string,
+    _colony_name: string,
     tick_idx: int,
     tick_now_ms: int,
     topic_label: string,
@@ -311,7 +311,7 @@ fn _publish_explorer(
         // Append to per-run discovery ledger.
         let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
         if len(ledger_path) > 0 {
-            let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"exploration_done\"}";
+            let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + _colony_name + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"exploration_done\"}";
             // colony-lint: safe-exec-concat
             let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
             let _l = try { exec sh append_cmd; } catch e { ""; };
@@ -326,7 +326,7 @@ fn _publish_explorer(
             let verdict_raw = recall_latest("novelty:final_verdict:" + self_pid + ":tick-" + to_string(settle_tick));
             if len(verdict_raw) > 0 {
                 print("[explorer] settled tick=", settle_tick, " verdict=", verdict_raw);
-                learn("settle", "tick " + to_string(settle_tick) + " " + verdict_raw, "novelty=" + verdict_raw, "success", ["acted", "math-foundry", colony_name_str, "verdict:" + verdict_raw]);
+                learn("settle", "tick " + to_string(settle_tick) + " " + verdict_raw, "novelty=" + verdict_raw, "success", ["acted", "math-foundry", _colony_name, "verdict:" + verdict_raw]);
 
                 // Fitness update: +2 NOVEL, +0.5 (mapped int 1)
                 // BORDERLINE, -1 NOT_NOVEL, -0.5 (mapped int 1)
@@ -369,12 +369,12 @@ fn _publish_explorer(
                     if repr_thr > 0 {
                         let my_fit_r = parse_int(recall_latest("explorer:" + self_pid + ":fitness"));
                         if my_fit_r > repr_thr {
-                            let n_r = parse_int(recall_latest("colony-" + colony_name_str + ":size"));
-                            let max_repl_r = parse_int(recall_latest("colony-" + colony_name_str + ":max_replicas"));
+                            let n_r = parse_int(recall_latest("colony-" + _colony_name + ":size"));
+                            let max_repl_r = parse_int(recall_latest("colony-" + _colony_name + ":max_replicas"));
                             if n_r < max_repl_r {
-                                let pool_r = parse_int(recall_latest("colony-" + colony_name_str + ":pool"));
-                                let base_r = parse_int(recall_latest("colony-" + colony_name_str + ":replication_base_cost"));
-                                let raw_k_r = parse_int(recall_latest("colony-" + colony_name_str + ":replication_k"));
+                                let pool_r = parse_int(recall_latest("colony-" + _colony_name + ":pool"));
+                                let base_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_base_cost"));
+                                let raw_k_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_k"));
                                 let k_r = if raw_k_r <= 0 { 3; } else { raw_k_r; };
                                 let cost_r = base_r + (base_r * n_r) / k_r;
                                 if pool_r >= cost_r {
@@ -386,11 +386,11 @@ fn _publish_explorer(
                                         let replica_id = try { replicate(target_r, my_fit_r, variant_wrapped); } catch e { "__replicate_error__"; };
                                         if replica_id != "__replicate_error__" {
                                             if len(replica_id) > 0 {
-                                                memo_write("colony-" + colony_name_str + ":pool", to_string(pool_r - cost_r));
-                                                memo_write("colony-" + colony_name_str + ":size", to_string(n_r + 1));
-                                                learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "math-foundry", colony_name_str]);
+                                                memo_write("colony-" + _colony_name + ":pool", to_string(pool_r - cost_r));
+                                                memo_write("colony-" + _colony_name + ":size", to_string(n_r + 1));
+                                                learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "math-foundry", _colony_name]);
                                             } else {
-                                                learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "math-foundry", colony_name_str]);
+                                                learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "math-foundry", _colony_name]);
                                             };
                                         };
                                     };

--- a/math-foundry/formulator/agents/formulator.ag
+++ b/math-foundry/formulator/agents/formulator.ag
@@ -51,6 +51,46 @@ fn _seed_prompt() -> string {
     return "You discovered a surprising result through computation. Craft a competition-style problem whose answer IS this discovery. The user-supplied input below carries the TOPIC, the DISCOVERY description, the SPECIFIC VALUE, and the WHY SURPRISING reasoning. Craft a self-contained problem (no code, just math). The stated answer must be the specific value. Output ONLY valid JSON: {\"problem\": \"...\", \"answer\": \"...\", \"solution_full\": \"...\", \"novelty_claim\": \"...\", \"self_check_confidence\": 0.0-1.0}.";
 }
 
+// _publish_formulator -- emit + memo (+ ledger when final_write=true).
+// final_write=true: review-gated / autonomous, append ledger row.
+// final_write=false: propose, emit-only, skip ledger append (#622 ADR-0001).
+fn _publish_formulator(
+    final_write: bool,
+    problem: Problem,
+    self_pid: string,
+    colony_name_str: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int,
+    topic_label: string
+) -> void {
+    let self_conf_str = to_string(problem.self_check_confidence);
+    let problem_json = "{\"problem\":\"" + problem.problem
+                     + "\",\"answer\":\"" + problem.answer
+                     + "\",\"solution_full\":\"" + problem.solution_full
+                     + "\",\"novelty_claim\":\"" + problem.novelty_claim
+                     + "\",\"self_check_confidence\":" + self_conf_str + "}";
+    memo_write("formulator:" + self_pid + ":problem:tick-" + to_string(upstream_tick), problem_json);
+    memo_write("formulator:" + self_pid + ":problem_text:tick-" + to_string(upstream_tick), problem.problem);
+    memo_write("formulator:" + self_pid + ":answer:tick-" + to_string(upstream_tick), problem.answer);
+    memo_write("formulator:" + self_pid + ":novelty_claim:tick-" + to_string(upstream_tick), problem.novelty_claim);
+    memo_write("replay:current_formulator_pid", self_pid);
+    emit("math-foundry:problem_ready", problem);
+
+    if final_write {
+        // Append to per-run discovery ledger.
+        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        if len(ledger_path) > 0 {
+            let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"problem_ready\",\"answer\":\"" + problem.answer + "\"}";
+            // colony-lint: safe-exec-concat
+            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
+            let _ = try { exec sh append_cmd; } catch e { ""; };
+        };
+    };
+
+    learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, "answer=" + problem.answer, "success", ["emitted", "math-foundry"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _tick_now_ms = now_ms_via_shell();
@@ -101,35 +141,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("formulator");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("formulator:" + _self_pid + ":review_gated", "true");
         learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, problem.novelty_claim, "partial", ["acted", "math-foundry"]);
+        _publish_formulator(true, problem, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label);
     } else {
         if my_tier == "review-gated" {
+            memo_write("formulator:" + _self_pid + ":review_gated", "true");
             learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, problem.novelty_claim, "partial", ["review-gated", "math-foundry"]);
+            _publish_formulator(true, problem, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label);
         } else {
             if my_tier == "propose" {
-                let self_conf_str = to_string(problem.self_check_confidence);
-                let problem_json = "{\"problem\":\"" + problem.problem
-                                 + "\",\"answer\":\"" + problem.answer
-                                 + "\",\"solution_full\":\"" + problem.solution_full
-                                 + "\",\"novelty_claim\":\"" + problem.novelty_claim
-                                 + "\",\"self_check_confidence\":" + self_conf_str + "}";
-                memo_write("formulator:" + _self_pid + ":problem:tick-" + to_string(upstream_tick), problem_json);
-                memo_write("formulator:" + _self_pid + ":problem_text:tick-" + to_string(upstream_tick), problem.problem);
-                memo_write("formulator:" + _self_pid + ":answer:tick-" + to_string(upstream_tick), problem.answer);
-                memo_write("formulator:" + _self_pid + ":novelty_claim:tick-" + to_string(upstream_tick), problem.novelty_claim);
-                memo_write("replay:current_formulator_pid", _self_pid);
-                emit("math-foundry:problem_ready", problem);
-
-                // Append to per-run discovery ledger.
-                let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
-                if len(ledger_path) > 0 {
-                    let ledger_row = "{\"ts\":" + to_string(_tick_now_ms) + ",\"colony\":\"" + _colony_name + "\",\"pid\":\"" + _self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"problem_ready\",\"answer\":\"" + problem.answer + "\"}";
-                    // colony-lint: safe-exec-concat
-                    let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-                    let _ = try { exec sh append_cmd; } catch e { ""; };
-                };
-
-                learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, "answer=" + problem.answer, "success", ["emitted", "math-foundry"]);
+                _publish_formulator(false, problem, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label);
             } else {
                 print("[formulator] observing (tier:", my_tier, ") novelty_claim=", problem.novelty_claim);
                 learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, problem.novelty_claim, "partial", ["observed", "math-foundry"]);

--- a/math-foundry/noticer/agents/noticer.ag
+++ b/math-foundry/noticer/agents/noticer.ag
@@ -46,6 +46,38 @@ fn _seed_prompt() -> string {
     return "You ran a computational exploration. The user-supplied input below carries the exploration GOAL, the Python CODE that was run, and the OUTPUT printed to stdout. What is SURPRISING or NON-OBVIOUS? Look for specific small numbers that don't match closed form, pattern breaks, numerical coincidences. If the output just confirms a classical formula, mark boring (surprise_found=false). Output ONLY valid JSON: {\"surprise_found\": true|false, \"surprise_description\": \"...\", \"specific_value\": \"...\", \"why_surprising\": \"...\", \"confidence_in_surprise\": 0.0-1.0}.";
 }
 
+// _publish_noticer -- memo + emit + fitness (no ledger row today).
+// final_write parameter retained for symmetry with other non-terminal agents (#622 ADR-0001).
+fn _publish_noticer(
+    final_write: bool,
+    surprise: Surprise,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int
+) -> void {
+    let _ = final_write;
+    let conf_str = to_string(surprise.confidence_in_surprise);
+    let surprise_found_str = if surprise.surprise_found { "true"; } else { "false"; };
+    let surprise_json = "{\"surprise_found\":" + surprise_found_str
+                      + ",\"surprise_description\":\"" + surprise.surprise_description
+                      + "\",\"specific_value\":\"" + surprise.specific_value
+                      + "\",\"why_surprising\":\"" + surprise.why_surprising
+                      + "\",\"confidence_in_surprise\":" + conf_str + "}";
+    memo_write("noticer:" + self_pid + ":surprise:tick-" + to_string(upstream_tick), surprise_json);
+    memo_write("noticer:" + self_pid + ":surprise_found:tick-" + to_string(upstream_tick), surprise_found_str);
+    memo_write("replay:current_noticer_pid", self_pid);
+    emit("math-foundry:notice_done", surprise);
+
+    // Light fitness tracking: +1 if surprise found, 0 otherwise.
+    if len(self_pid) > 0 {
+        let fit_pre = parse_int(recall_latest("noticer:" + self_pid + ":fitness"));
+        let fit_delta = if surprise.surprise_found { 1; } else { 0; };
+        memo_write("noticer:" + self_pid + ":fitness", to_string(fit_pre + fit_delta));
+    };
+
+    learn("notice", "tick " + to_string(tick_idx), "surprise_found=" + surprise_found_str, "success", ["emitted", "math-foundry"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _colony_name = colony_name();
@@ -84,33 +116,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("noticer");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("noticer:" + _self_pid + ":review_gated", "true");
         learn("notice", "tick " + to_string(tick_idx), surprise.surprise_description, "partial", ["acted", "math-foundry"]);
+        _publish_noticer(true, surprise, _self_pid, upstream_tick, tick_idx);
     } else {
         if my_tier == "review-gated" {
+            memo_write("noticer:" + _self_pid + ":review_gated", "true");
             learn("notice", "tick " + to_string(tick_idx), surprise.surprise_description, "partial", ["review-gated", "math-foundry"]);
+            _publish_noticer(true, surprise, _self_pid, upstream_tick, tick_idx);
         } else {
             if my_tier == "propose" {
-                // Persist surprise verdict + downstream pointers.
-                let conf_str = to_string(surprise.confidence_in_surprise);
-                let surprise_found_str = if surprise.surprise_found { "true"; } else { "false"; };
-                let surprise_json = "{\"surprise_found\":" + surprise_found_str
-                                  + ",\"surprise_description\":\"" + surprise.surprise_description
-                                  + "\",\"specific_value\":\"" + surprise.specific_value
-                                  + "\",\"why_surprising\":\"" + surprise.why_surprising
-                                  + "\",\"confidence_in_surprise\":" + conf_str + "}";
-                memo_write("noticer:" + _self_pid + ":surprise:tick-" + to_string(upstream_tick), surprise_json);
-                memo_write("noticer:" + _self_pid + ":surprise_found:tick-" + to_string(upstream_tick), surprise_found_str);
-                memo_write("replay:current_noticer_pid", _self_pid);
-                emit("math-foundry:notice_done", surprise);
-
-                // Light fitness tracking: +1 if surprise found, 0 otherwise.
-                if len(_self_pid) > 0 {
-                    let fit_pre = parse_int(recall_latest("noticer:" + _self_pid + ":fitness"));
-                    let fit_delta = if surprise.surprise_found { 1; } else { 0; };
-                    memo_write("noticer:" + _self_pid + ":fitness", to_string(fit_pre + fit_delta));
-                };
-
-                learn("notice", "tick " + to_string(tick_idx), "surprise_found=" + surprise_found_str, "success", ["emitted", "math-foundry"]);
+                _publish_noticer(false, surprise, _self_pid, upstream_tick, tick_idx);
             } else {
                 print("[noticer] observing (tier:", my_tier, ") surprise_found=", surprise.surprise_found);
                 learn("notice", "tick " + to_string(tick_idx), surprise.surprise_description, "partial", ["observed", "math-foundry"]);

--- a/math-foundry/novelty/agents/novelty.ag
+++ b/math-foundry/novelty/agents/novelty.ag
@@ -50,6 +50,45 @@ fn _seed_prompt() -> string {
     return "You are a strict novelty referee. DEFAULT to NOT_NOVEL. The user-supplied input below carries the PROBLEM, the stated ANSWER, and the author's NOVELTY CLAIM. Mark NOT_NOVEL if the problem reduces to: Basel problem, Gauss sums, Galois group of x^n - 2, Milnor fiber formula, complete intersection Euler characteristic via Chern classes, classical Fourier or Mellin transform, or any other named famous result. Mark NOVEL only if the specific answer requires computation and is not a famous constant, and the reasoning requires genuine insight. Mark BORDERLINE if the problem is non-obvious but a known classical identifier is suspected. Output ONLY valid JSON: {\"is_classical_result\": true|false, \"classical_identifier\": \"...\", \"novelty_verdict\": \"NOVEL|BORDERLINE|NOT_NOVEL\", \"reasoning\": \"...\"}.";
 }
 
+// _publish_novelty -- TERMINAL agent (Class 1). memo + final_verdict +
+// emit (+ ledger row when final_write=true). Both autonomous and
+// review-gated emit the ledger row; only propose skips it (#622 ADR-0001).
+fn _publish_novelty(
+    final_write: bool,
+    novelty: NoveltyVerdict,
+    self_pid: string,
+    colony_name_str: string,
+    explorer_pid: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int
+) -> void {
+    let classical_str = if novelty.is_classical_result { "true"; } else { "false"; };
+    let novelty_json = "{\"is_classical_result\":" + classical_str
+                     + ",\"classical_identifier\":\"" + novelty.classical_identifier
+                     + "\",\"novelty_verdict\":\"" + novelty.novelty_verdict
+                     + "\",\"reasoning\":\"" + novelty.reasoning + "\"}";
+    memo_write("novelty:" + self_pid + ":verdict:tick-" + to_string(upstream_tick), novelty_json);
+
+    if len(explorer_pid) > 0 {
+        memo_write("novelty:final_verdict:" + explorer_pid + ":tick-" + to_string(upstream_tick), novelty.novelty_verdict);
+    };
+
+    if final_write {
+        // Append to per-run discovery ledger.
+        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        if len(ledger_path) > 0 {
+            let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"event\":\"novelty_verdict\",\"verdict\":\"" + novelty.novelty_verdict + "\"}";
+            // colony-lint: safe-exec-concat
+            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
+            let _ = try { exec sh append_cmd; } catch e { ""; };
+        };
+    };
+
+    emit("math-foundry:novelty_done", novelty);
+    learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "success", ["emitted", "math-foundry"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _tick_now_ms = now_ms_via_shell();
@@ -101,34 +140,19 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("novelty");
     if my_tier == "autonomous" {
+        // Terminal agent: autonomous emits the final verdict + ledger row
+        // unconditionally (no confidence floor) and stamps an
+        // `autonomous_decision=true` flag for downstream auditors (#622).
+        memo_write("novelty:" + _self_pid + ":autonomous_decision", "true");
         learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "partial", ["acted", "math-foundry"]);
+        _publish_novelty(true, novelty, _self_pid, _colony_name, explorer_pid, upstream_tick, tick_idx, _tick_now_ms);
     } else {
         if my_tier == "review-gated" {
             learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "partial", ["review-gated", "math-foundry"]);
+            _publish_novelty(true, novelty, _self_pid, _colony_name, explorer_pid, upstream_tick, tick_idx, _tick_now_ms);
         } else {
             if my_tier == "propose" {
-                let classical_str = if novelty.is_classical_result { "true"; } else { "false"; };
-                let novelty_json = "{\"is_classical_result\":" + classical_str
-                                 + ",\"classical_identifier\":\"" + novelty.classical_identifier
-                                 + "\",\"novelty_verdict\":\"" + novelty.novelty_verdict
-                                 + "\",\"reasoning\":\"" + novelty.reasoning + "\"}";
-                memo_write("novelty:" + _self_pid + ":verdict:tick-" + to_string(upstream_tick), novelty_json);
-
-                if len(explorer_pid) > 0 {
-                    memo_write("novelty:final_verdict:" + explorer_pid + ":tick-" + to_string(upstream_tick), novelty.novelty_verdict);
-                };
-
-                // Append to per-run discovery ledger.
-                let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
-                if len(ledger_path) > 0 {
-                    let ledger_row = "{\"ts\":" + to_string(_tick_now_ms) + ",\"colony\":\"" + _colony_name + "\",\"pid\":\"" + _self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"event\":\"novelty_verdict\",\"verdict\":\"" + novelty.novelty_verdict + "\"}";
-                    // colony-lint: safe-exec-concat
-                    let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-                    let _ = try { exec sh append_cmd; } catch e { ""; };
-                };
-
-                emit("math-foundry:novelty_done", novelty);
-                learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "success", ["emitted", "math-foundry"]);
+                _publish_novelty(false, novelty, _self_pid, _colony_name, explorer_pid, upstream_tick, tick_idx, _tick_now_ms);
             } else {
                 print("[novelty] observing (tier:", my_tier, ") verdict=", novelty.novelty_verdict);
                 learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "partial", ["observed", "math-foundry"]);

--- a/math-foundry/verifier/agents/verifier.ag
+++ b/math-foundry/verifier/agents/verifier.ag
@@ -55,6 +55,37 @@ fn _verifier_prompt() -> string {
     return "You are a problem-quality referee. The input below carries the PROBLEM and the STATED ANSWER from the author. Your sole job is to judge the PROBLEM ITSELF — not whether the stated answer is numerically correct. Set verdict=ACCEPT when the problem is well-defined (unambiguous statement, mathematically meaningful, has a determinable answer in principle). Set verdict=NEEDS_REVISION when the problem is mostly well-defined but has minor ambiguities that could be fixed with light editing. Set verdict=REJECT only when the problem itself is incoherent, ill-defined, or trivially malformed. Output ONLY valid JSON: {\"answers_agree\": false, \"solver_rigorous\": false, \"problem_well_defined\": true|false, \"verdict\": \"ACCEPT|REJECT|NEEDS_REVISION\", \"reasoning\": \"...\"}. Set answers_agree and solver_rigorous to false (they are deprecated metadata).";
 }
 
+// _publish_verifier -- memo + emit. Verifier writes no ledger row today,
+// so final_write is retained for symmetry but currently a no-op (#622 ADR-0001).
+fn _publish_verifier(
+    final_write: bool,
+    verdict: Verdict,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int
+) -> void {
+    let _ = final_write;
+    let agree_str = if verdict.answers_agree { "true"; } else { "false"; };
+    let rigorous_str = if verdict.solver_rigorous { "true"; } else { "false"; };
+    let well_defined_str = if verdict.problem_well_defined { "true"; } else { "false"; };
+    let verdict_json = "{\"answers_agree\":" + agree_str
+                     + ",\"solver_rigorous\":" + rigorous_str
+                     + ",\"problem_well_defined\":" + well_defined_str
+                     + ",\"verdict\":\"" + verdict.verdict
+                     + "\",\"reasoning\":\"" + verdict.reasoning + "\"}";
+    memo_write("verifier:" + self_pid + ":verdict:tick-" + to_string(upstream_tick), verdict_json);
+    memo_write("verifier:" + self_pid + ":verdict_label:tick-" + to_string(upstream_tick), verdict.verdict);
+    memo_write("replay:current_verifier_pid", self_pid);
+
+    if verdict.verdict == "ACCEPT" {
+        emit("math-foundry:verified", verdict);
+        learn("verify", "tick " + to_string(tick_idx) + " ACCEPT", verdict.reasoning, "success", ["emitted", "math-foundry"]);
+    } else {
+        emit("math-foundry:verifier_rejected", verdict);
+        learn("verify", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "failure", ["emitted", "math-foundry"]);
+    };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _colony_name = colony_name();
@@ -95,31 +126,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("verifier");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("verifier:" + _self_pid + ":review_gated", "true");
         learn("verify", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "partial", ["acted", "math-foundry"]);
+        _publish_verifier(true, verdict, _self_pid, upstream_tick, tick_idx);
     } else {
         if my_tier == "review-gated" {
+            memo_write("verifier:" + _self_pid + ":review_gated", "true");
             learn("verify", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "partial", ["review-gated", "math-foundry"]);
+            _publish_verifier(true, verdict, _self_pid, upstream_tick, tick_idx);
         } else {
             if my_tier == "propose" {
-                let agree_str = if verdict.answers_agree { "true"; } else { "false"; };
-                let rigorous_str = if verdict.solver_rigorous { "true"; } else { "false"; };
-                let well_defined_str = if verdict.problem_well_defined { "true"; } else { "false"; };
-                let verdict_json = "{\"answers_agree\":" + agree_str
-                                 + ",\"solver_rigorous\":" + rigorous_str
-                                 + ",\"problem_well_defined\":" + well_defined_str
-                                 + ",\"verdict\":\"" + verdict.verdict
-                                 + "\",\"reasoning\":\"" + verdict.reasoning + "\"}";
-                memo_write("verifier:" + _self_pid + ":verdict:tick-" + to_string(upstream_tick), verdict_json);
-                memo_write("verifier:" + _self_pid + ":verdict_label:tick-" + to_string(upstream_tick), verdict.verdict);
-                memo_write("replay:current_verifier_pid", _self_pid);
-
-                if verdict.verdict == "ACCEPT" {
-                    emit("math-foundry:verified", verdict);
-                    learn("verify", "tick " + to_string(tick_idx) + " ACCEPT", verdict.reasoning, "success", ["emitted", "math-foundry"]);
-                } else {
-                    emit("math-foundry:verifier_rejected", verdict);
-                    learn("verify", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "failure", ["emitted", "math-foundry"]);
-                };
+                _publish_verifier(false, verdict, _self_pid, upstream_tick, tick_idx);
             } else {
                 print("[verifier] observing (tier:", my_tier, ") verdict=", verdict.verdict);
                 learn("verify", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "partial", ["observed", "math-foundry"]);

--- a/preprint-foundry/computer/agents/computer.ag
+++ b/preprint-foundry/computer/agents/computer.ag
@@ -50,6 +50,57 @@ fn _script_prompt() -> string {
     return "You are writing a STANDALONE reproducibility script for a math preprint. The user-supplied context carries the PROBLEM, the verified ANSWER, the upstream EXPLORER CODE + OUTPUT that originally produced the observation, and the AUDITOR REASONING. Produce a self-contained script (NOT importing the explorer's code, NOT reading any external file) that re-derives the central claim by independent computation and prints the result with a clear label. Choose language=\"python\" (sympy/numpy/networkx/itertools/fractions are available) for arithmetic / combinatorial / sequence claims, language=\"gap\" for finite group theory claims (the container has the GAP interpreter on PATH). Use ONLY the standard library and listed third-party packages. NO file I/O, network, subprocess. Output ONLY valid JSON: {\"language\":\"python|gap\",\"script\":\"...full script body...\",\"expected_substring\":\"a substring that MUST appear in stdout when the script runs correctly (use the answer value)\",\"rationale\":\"one-line\"}.";
 }
 
+// _publish_computer -- sandbox write + run + memo + emit. computer writes
+// no ledger row today; final_write retained for symmetry (#622 ADR-0001).
+fn _publish_computer(
+    final_write: bool,
+    script: Script,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int
+) -> void {
+    let _ = final_write;
+    let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
+    let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
+    let lang = script.language;
+    let ext = if lang == "gap" { ".g"; } else { ".py"; };
+    let script_path = sandbox_eff + "/repro-" + self_pid + "-tick-" + to_string(upstream_tick) + ext;
+    // colony-lint: safe-exec-concat
+    let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(script.script) + " > " + shell_escape(script_path);
+    let _wrote = try { exec sh write_cmd; } catch e { ""; };
+
+    let run_cmd = if lang == "gap" {
+        // colony-lint: safe-exec-concat
+        "gap -q -b --norepl " + shell_escape(script_path) + " 2>&1";
+    } else {
+        // colony-lint: safe-exec-concat
+        "python3 " + shell_escape(script_path) + " 2>&1";
+    };
+    let output = try { exec sh run_cmd; } catch e { ""; };
+
+    let runs_ok = if len(script.expected_substring) > 0 {
+        // colony-lint: safe-exec-concat
+        let check_cmd = "printf '%s' " + shell_escape(output) + " | grep -F " + shell_escape(script.expected_substring) + " >/dev/null 2>&1 && printf yes || printf no";
+        let g = try { exec sh check_cmd; } catch e { "no"; };
+        g == "yes";
+    } else {
+        len(output) > 0;
+    };
+
+    memo_write("computer:" + self_pid + ":script:tick-" + to_string(upstream_tick), script.script);
+    memo_write("computer:" + self_pid + ":output:tick-" + to_string(upstream_tick), output);
+    memo_write("computer:" + self_pid + ":language:tick-" + to_string(upstream_tick), lang);
+    memo_write("computer:" + self_pid + ":expected_substring:tick-" + to_string(upstream_tick), script.expected_substring);
+    let runs_ok_str = if runs_ok { "true"; } else { "false"; };
+    memo_write("computer:" + self_pid + ":runs_ok:tick-" + to_string(upstream_tick), runs_ok_str);
+    memo_write("replay:current_computer_pid", self_pid);
+
+    emit("computer:script_ready", script);
+    emit("computer:output_ready", script);
+
+    learn("compute", "tick " + to_string(tick_idx), "runs_ok=" + runs_ok_str + " lang=" + lang, "success", ["emitted", "preprint-foundry"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _tick_now_ms = now_ms_via_shell();
@@ -92,51 +143,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("computer");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("computer:" + _self_pid + ":review_gated", "true");
         learn("compute", "tick " + to_string(tick_idx), script.rationale, "partial", ["acted", "preprint-foundry"]);
+        _publish_computer(true, script, _self_pid, upstream_tick, tick_idx);
     } else {
         if my_tier == "review-gated" {
+            memo_write("computer:" + _self_pid + ":review_gated", "true");
             learn("compute", "tick " + to_string(tick_idx), script.rationale, "partial", ["review-gated", "preprint-foundry"]);
+            _publish_computer(true, script, _self_pid, upstream_tick, tick_idx);
         } else {
             if my_tier == "propose" {
-                let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
-                let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
-                let lang = script.language;
-                let ext = if lang == "gap" { ".g"; } else { ".py"; };
-                let script_path = sandbox_eff + "/repro-" + _self_pid + "-tick-" + to_string(upstream_tick) + ext;
-                // colony-lint: safe-exec-concat
-                let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(script.script) + " > " + shell_escape(script_path);
-                let _wrote = try { exec sh write_cmd; } catch e { ""; };
-
-                let run_cmd = if lang == "gap" {
-                    // colony-lint: safe-exec-concat
-                    "gap -q -b --norepl " + shell_escape(script_path) + " 2>&1";
-                } else {
-                    // colony-lint: safe-exec-concat
-                    "python3 " + shell_escape(script_path) + " 2>&1";
-                };
-                let output = try { exec sh run_cmd; } catch e { ""; };
-
-                let runs_ok = if len(script.expected_substring) > 0 {
-                    // colony-lint: safe-exec-concat
-                    let check_cmd = "printf '%s' " + shell_escape(output) + " | grep -F " + shell_escape(script.expected_substring) + " >/dev/null 2>&1 && printf yes || printf no";
-                    let g = try { exec sh check_cmd; } catch e { "no"; };
-                    g == "yes";
-                } else {
-                    len(output) > 0;
-                };
-
-                memo_write("computer:" + _self_pid + ":script:tick-" + to_string(upstream_tick), script.script);
-                memo_write("computer:" + _self_pid + ":output:tick-" + to_string(upstream_tick), output);
-                memo_write("computer:" + _self_pid + ":language:tick-" + to_string(upstream_tick), lang);
-                memo_write("computer:" + _self_pid + ":expected_substring:tick-" + to_string(upstream_tick), script.expected_substring);
-                let runs_ok_str = if runs_ok { "true"; } else { "false"; };
-                memo_write("computer:" + _self_pid + ":runs_ok:tick-" + to_string(upstream_tick), runs_ok_str);
-                memo_write("replay:current_computer_pid", _self_pid);
-
-                emit("computer:script_ready", script);
-                emit("computer:output_ready", script);
-
-                learn("compute", "tick " + to_string(tick_idx), "runs_ok=" + runs_ok_str + " lang=" + lang, "success", ["emitted", "preprint-foundry"]);
+                _publish_computer(false, script, _self_pid, upstream_tick, tick_idx);
             } else {
                 print("[computer] observing (tier:", my_tier, ") rationale=", script.rationale);
                 learn("compute", "tick " + to_string(tick_idx), script.rationale, "partial", ["observed", "preprint-foundry"]);

--- a/preprint-foundry/editor/agents/editor.ag
+++ b/preprint-foundry/editor/agents/editor.ag
@@ -67,6 +67,105 @@ fn _repair_prompt() -> string {
     return "The previous LaTeX compile failed. The user-supplied input below carries the FAILING TEX and the latexmk LOG (last 80 lines). Produce a corrected `full_tex` that compiles with `latexmk -pdf -interaction=nonstopmode`. Common fixes: missing `\\usepackage{...}`, mis-matched `\\begin{...}` / `\\end{...}`, undefined `\\cite{...}` (replace with `\\cite{TBD}` and add a stub entry to refs.bib), runaway argument (close the brace), missing `$` for inline math. Do NOT change the scientific content -- only fix the compile error. Output ONLY valid JSON: {\"full_tex\":\"...corrected .tex...\",\"rationale\":\"what was fixed\"}.";
 }
 
+// _publish_editor -- write main.tex/refs.bib + latexmk + (optional repair) +
+// memo + emit. editor writes no ledger row today; final_write retained for
+// symmetry (#622 ADR-0001).
+fn _publish_editor(
+    final_write: bool,
+    edit: Edit,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int
+) -> void {
+    let _ = final_write;
+    let claim_id = recall_latest("claim:claim_id:tick-" + to_string(upstream_tick));
+    let claim_id_eff = if len(claim_id) > 0 { claim_id; } else { "claim-" + to_string(upstream_tick); };
+    let out_root = try { exec sh "printenv PREPRINT_OUTPUT_ROOT"; } catch e { ""; };
+    let out_root_eff = if len(out_root) > 0 { out_root; } else { "/run-root/preprints"; };
+    let claim_dir = out_root_eff + "/" + claim_id_eff;
+
+    let max_passes_env = try { exec sh "printenv PREPRINT_LATEXMK_MAX_PASSES"; } catch e { ""; };
+    let max_passes = if len(max_passes_env) > 0 { parse_int(max_passes_env); } else { 3; };
+    let max_passes_eff = if max_passes <= 0 { 1; } else { max_passes; };
+
+    // colony-lint: safe-exec-concat
+    let mkdir_cmd = "mkdir -p " + shell_escape(claim_dir);
+    let _mk = try { exec sh mkdir_cmd; } catch e { ""; };
+    // colony-lint: safe-exec-concat
+    let write_tex_cmd = "printf '%s' " + shell_escape(edit.full_tex) + " > " + shell_escape(claim_dir + "/main.tex");
+    let _wt = try { exec sh write_tex_cmd; } catch e { ""; };
+    // colony-lint: safe-exec-concat
+    let write_bib_cmd = "printf '%s' " + shell_escape(edit.refs_bib) + " > " + shell_escape(claim_dir + "/refs.bib");
+    let _wb = try { exec sh write_bib_cmd; } catch e { ""; };
+
+    // Substitute AUTHOR-PLACEHOLDER from authors.toml (#616).
+    // Idempotent helper exits 0 when TOML is missing /
+    // unparseable / empty, or when the .tex has no
+    // placeholder, so it is safe to run unconditionally.
+    let author_cfg_path = try { exec sh "printenv PREPRINT_AUTHOR_CONFIG"; } catch e { ""; };
+    let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };
+    // colony-lint: safe-exec-concat
+    let subst_cmd = "python3 /run-root/tools/substitute-author.py " + shell_escape(author_cfg_eff) + " " + shell_escape(claim_dir + "/main.tex");
+    let _subst = try { exec sh subst_cmd; } catch e { ""; };
+
+    // First compile pass.
+    // colony-lint: safe-exec-concat
+    let compile_cmd = "cd " + shell_escape(claim_dir) + " && latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex 2>&1 | tail -80";
+    let compile_log = try { exec sh compile_cmd; } catch e { ""; };
+    // colony-lint: safe-exec-concat
+    let pdf_check_cmd = "test -f " + shell_escape(claim_dir + "/main.pdf") + " && printf yes || printf no";
+    let pdf_ok_raw = try { exec sh pdf_check_cmd; } catch e { "no"; };
+    let compile_ok_initial = pdf_ok_raw == "yes";
+
+    let compile_ok_final = if compile_ok_initial {
+        true;
+    } else {
+        if max_passes_eff < 2 {
+            false;
+        } else {
+            // One repair pass.
+            let repair_ctx = "FAILING TEX:\n" + edit.full_tex + "\n"
+                           + "LATEXMK LOG (last 80 lines):\n" + compile_log + "\n";
+            let repair = prompt(_repair_prompt(), repair_ctx) -> Repair;
+            // colony-lint: safe-exec-concat
+            let rewrite_cmd = "printf '%s' " + shell_escape(repair.full_tex) + " > " + shell_escape(claim_dir + "/main.tex");
+            let _rw = try { exec sh rewrite_cmd; } catch e { ""; };
+            // Re-substitute AUTHOR-PLACEHOLDER in case the
+            // repair pass put it back (#616).
+            // colony-lint: safe-exec-concat
+            let subst_cmd_r = "python3 /run-root/tools/substitute-author.py " + shell_escape(author_cfg_eff) + " " + shell_escape(claim_dir + "/main.tex");
+            let _subst_r = try { exec sh subst_cmd_r; } catch e { ""; };
+            // colony-lint: safe-exec-concat
+            let recompile_cmd = "cd " + shell_escape(claim_dir) + " && latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex 2>&1 | tail -80";
+            let _recompile_log = try { exec sh recompile_cmd; } catch e { ""; };
+            // colony-lint: safe-exec-concat
+            let recheck_cmd = "test -f " + shell_escape(claim_dir + "/main.pdf") + " && printf yes || printf no";
+            let recheck = try { exec sh recheck_cmd; } catch e { "no"; };
+            recheck == "yes";
+        };
+    };
+
+    let final_tex_path = claim_dir + "/main.tex";
+    // colony-lint: safe-exec-concat
+    let read_tex_cmd = "cat " + shell_escape(final_tex_path);
+    let final_tex_body = try { exec sh read_tex_cmd; } catch e { edit.full_tex; };
+
+    memo_write("editor:" + self_pid + ":final_tex:tick-" + to_string(upstream_tick), final_tex_body);
+    memo_write("editor:" + self_pid + ":compile_log:tick-" + to_string(upstream_tick), compile_log);
+    memo_write("editor:" + self_pid + ":refs_bib:tick-" + to_string(upstream_tick), edit.refs_bib);
+    memo_write("editor:" + self_pid + ":claim_dir:tick-" + to_string(upstream_tick), claim_dir);
+    let compile_ok_str = if compile_ok_final { "true"; } else { "false"; };
+    memo_write("editor:" + self_pid + ":compile_ok:tick-" + to_string(upstream_tick), compile_ok_str);
+    let halluc_str = if edit.hallucinations_found { "true"; } else { "false"; };
+    memo_write("editor:" + self_pid + ":hallucinations_found:tick-" + to_string(upstream_tick), halluc_str);
+    memo_write("replay:current_editor_pid", self_pid);
+
+    emit("editor:final_tex_ready", edit);
+    emit("editor:compile_log_ready", edit);
+
+    learn("edit", "tick " + to_string(tick_idx), "compile_ok=" + compile_ok_str + " halluc=" + halluc_str, "success", ["emitted", "preprint-foundry"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _tick_now_ms = now_ms_via_shell();
@@ -119,98 +218,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("editor");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("editor:" + _self_pid + ":review_gated", "true");
         learn("edit", "tick " + to_string(tick_idx), edit.rationale, "partial", ["acted", "preprint-foundry"]);
+        _publish_editor(true, edit, _self_pid, upstream_tick, tick_idx);
     } else {
         if my_tier == "review-gated" {
+            memo_write("editor:" + _self_pid + ":review_gated", "true");
             learn("edit", "tick " + to_string(tick_idx), edit.rationale, "partial", ["review-gated", "preprint-foundry"]);
+            _publish_editor(true, edit, _self_pid, upstream_tick, tick_idx);
         } else {
             if my_tier == "propose" {
-                let claim_id = recall_latest("claim:claim_id:tick-" + to_string(upstream_tick));
-                let claim_id_eff = if len(claim_id) > 0 { claim_id; } else { "claim-" + to_string(upstream_tick); };
-                let out_root = try { exec sh "printenv PREPRINT_OUTPUT_ROOT"; } catch e { ""; };
-                let out_root_eff = if len(out_root) > 0 { out_root; } else { "/run-root/preprints"; };
-                let claim_dir = out_root_eff + "/" + claim_id_eff;
-
-                let max_passes_env = try { exec sh "printenv PREPRINT_LATEXMK_MAX_PASSES"; } catch e { ""; };
-                let max_passes = if len(max_passes_env) > 0 { parse_int(max_passes_env); } else { 3; };
-                let max_passes_eff = if max_passes <= 0 { 1; } else { max_passes; };
-
-                // colony-lint: safe-exec-concat
-                let mkdir_cmd = "mkdir -p " + shell_escape(claim_dir);
-                let _mk = try { exec sh mkdir_cmd; } catch e { ""; };
-                // colony-lint: safe-exec-concat
-                let write_tex_cmd = "printf '%s' " + shell_escape(edit.full_tex) + " > " + shell_escape(claim_dir + "/main.tex");
-                let _wt = try { exec sh write_tex_cmd; } catch e { ""; };
-                // colony-lint: safe-exec-concat
-                let write_bib_cmd = "printf '%s' " + shell_escape(edit.refs_bib) + " > " + shell_escape(claim_dir + "/refs.bib");
-                let _wb = try { exec sh write_bib_cmd; } catch e { ""; };
-
-                // Substitute AUTHOR-PLACEHOLDER from authors.toml (#616).
-                // Idempotent helper exits 0 when TOML is missing /
-                // unparseable / empty, or when the .tex has no
-                // placeholder, so it is safe to run unconditionally.
-                let author_cfg_path = try { exec sh "printenv PREPRINT_AUTHOR_CONFIG"; } catch e { ""; };
-                let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };
-                // colony-lint: safe-exec-concat
-                let subst_cmd = "python3 /run-root/tools/substitute-author.py " + shell_escape(author_cfg_eff) + " " + shell_escape(claim_dir + "/main.tex");
-                let _subst = try { exec sh subst_cmd; } catch e { ""; };
-
-                // First compile pass.
-                // colony-lint: safe-exec-concat
-                let compile_cmd = "cd " + shell_escape(claim_dir) + " && latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex 2>&1 | tail -80";
-                let compile_log = try { exec sh compile_cmd; } catch e { ""; };
-                // colony-lint: safe-exec-concat
-                let pdf_check_cmd = "test -f " + shell_escape(claim_dir + "/main.pdf") + " && printf yes || printf no";
-                let pdf_ok_raw = try { exec sh pdf_check_cmd; } catch e { "no"; };
-                let compile_ok_initial = pdf_ok_raw == "yes";
-
-                let compile_ok_final = if compile_ok_initial {
-                    true;
-                } else {
-                    if max_passes_eff < 2 {
-                        false;
-                    } else {
-                        // One repair pass.
-                        let repair_ctx = "FAILING TEX:\n" + edit.full_tex + "\n"
-                                       + "LATEXMK LOG (last 80 lines):\n" + compile_log + "\n";
-                        let repair = prompt(_repair_prompt(), repair_ctx) -> Repair;
-                        // colony-lint: safe-exec-concat
-                        let rewrite_cmd = "printf '%s' " + shell_escape(repair.full_tex) + " > " + shell_escape(claim_dir + "/main.tex");
-                        let _rw = try { exec sh rewrite_cmd; } catch e { ""; };
-                        // Re-substitute AUTHOR-PLACEHOLDER in case the
-                        // repair pass put it back (#616).
-                        // colony-lint: safe-exec-concat
-                        let subst_cmd_r = "python3 /run-root/tools/substitute-author.py " + shell_escape(author_cfg_eff) + " " + shell_escape(claim_dir + "/main.tex");
-                        let _subst_r = try { exec sh subst_cmd_r; } catch e { ""; };
-                        // colony-lint: safe-exec-concat
-                        let recompile_cmd = "cd " + shell_escape(claim_dir) + " && latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex 2>&1 | tail -80";
-                        let _recompile_log = try { exec sh recompile_cmd; } catch e { ""; };
-                        // colony-lint: safe-exec-concat
-                        let recheck_cmd = "test -f " + shell_escape(claim_dir + "/main.pdf") + " && printf yes || printf no";
-                        let recheck = try { exec sh recheck_cmd; } catch e { "no"; };
-                        recheck == "yes";
-                    };
-                };
-
-                let final_tex_path = claim_dir + "/main.tex";
-                // colony-lint: safe-exec-concat
-                let read_tex_cmd = "cat " + shell_escape(final_tex_path);
-                let final_tex_body = try { exec sh read_tex_cmd; } catch e { edit.full_tex; };
-
-                memo_write("editor:" + _self_pid + ":final_tex:tick-" + to_string(upstream_tick), final_tex_body);
-                memo_write("editor:" + _self_pid + ":compile_log:tick-" + to_string(upstream_tick), compile_log);
-                memo_write("editor:" + _self_pid + ":refs_bib:tick-" + to_string(upstream_tick), edit.refs_bib);
-                memo_write("editor:" + _self_pid + ":claim_dir:tick-" + to_string(upstream_tick), claim_dir);
-                let compile_ok_str = if compile_ok_final { "true"; } else { "false"; };
-                memo_write("editor:" + _self_pid + ":compile_ok:tick-" + to_string(upstream_tick), compile_ok_str);
-                let halluc_str = if edit.hallucinations_found { "true"; } else { "false"; };
-                memo_write("editor:" + _self_pid + ":hallucinations_found:tick-" + to_string(upstream_tick), halluc_str);
-                memo_write("replay:current_editor_pid", _self_pid);
-
-                emit("editor:final_tex_ready", edit);
-                emit("editor:compile_log_ready", edit);
-
-                learn("edit", "tick " + to_string(tick_idx), "compile_ok=" + compile_ok_str + " halluc=" + halluc_str, "success", ["emitted", "preprint-foundry"]);
+                _publish_editor(false, edit, _self_pid, upstream_tick, tick_idx);
             } else {
                 print("[editor] observing (tier:", my_tier, ") rationale=", edit.rationale);
                 learn("edit", "tick " + to_string(tick_idx), edit.rationale, "partial", ["observed", "preprint-foundry"]);

--- a/preprint-foundry/introducer/agents/introducer.ag
+++ b/preprint-foundry/introducer/agents/introducer.ag
@@ -56,6 +56,29 @@ fn _draft_prompt() -> string {
     return "You are an academic mathematician drafting a LaTeX preprint for arXiv. The user-supplied context carries the PROBLEM, the verified ANSWER, the NOVELTY CLAIM, the auditor REASONING, and four PRIOR-WORK SEARCH REPORTS (arxiv / oeis / groupprops / scholar). Produce: (1) a 100-180 word abstract in LaTeX (no math environments other than inline $...$), (2) a 400-800 word Section 1 Introduction in LaTeX with at least one citation placeholder `[CITATION-NEEDED: <topic>]` when no exact citation exists in the search reports, (3) 1-3 MSC2020 codes, (4) a single primary arXiv category (e.g. math.GR, math.CO, math.NT), (5) a paper title under 200 chars. Cite known prior work from the search reports inline using `\\cite{key}` with keys you invent (the bibliography is generated later). Do NOT claim a proof of an open conjecture; hedge with 'computational evidence' / 'we observe' when the upstream classification is COMPUTATIONAL. Output ONLY valid JSON: {\"abstract_tex\":\"...\",\"intro_tex\":\"...\",\"msc_codes_csv\":\"20D60,20E45\",\"arxiv_category\":\"math.GR\",\"title\":\"...\",\"rationale\":\"one-line\"}.";
 }
 
+// _publish_introducer -- memo + emit. introducer writes no ledger row
+// today; final_write retained for symmetry (#622 ADR-0001).
+fn _publish_introducer(
+    final_write: bool,
+    draft: Draft,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int
+) -> void {
+    let _ = final_write;
+    memo_write("introducer:" + self_pid + ":abstract:tick-" + to_string(upstream_tick), draft.abstract_tex);
+    memo_write("introducer:" + self_pid + ":intro:tick-" + to_string(upstream_tick), draft.intro_tex);
+    memo_write("introducer:" + self_pid + ":title:tick-" + to_string(upstream_tick), draft.title);
+    memo_write("introducer:" + self_pid + ":msc_codes:tick-" + to_string(upstream_tick), draft.msc_codes_csv);
+    memo_write("introducer:" + self_pid + ":arxiv_category:tick-" + to_string(upstream_tick), draft.arxiv_category);
+    memo_write("replay:current_introducer_pid", self_pid);
+
+    emit("introducer:abstract_ready", draft);
+    emit("introducer:intro_ready", draft);
+
+    learn("introduce", "tick " + to_string(tick_idx), "abstract+intro emitted", "success", ["emitted", "preprint-foundry"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _tick_now_ms = now_ms_via_shell();
@@ -110,23 +133,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("introducer");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("introducer:" + _self_pid + ":review_gated", "true");
         learn("introduce", "tick " + to_string(tick_idx), draft.rationale, "partial", ["acted", "preprint-foundry"]);
+        _publish_introducer(true, draft, _self_pid, upstream_tick, tick_idx);
     } else {
         if my_tier == "review-gated" {
+            memo_write("introducer:" + _self_pid + ":review_gated", "true");
             learn("introduce", "tick " + to_string(tick_idx), draft.rationale, "partial", ["review-gated", "preprint-foundry"]);
+            _publish_introducer(true, draft, _self_pid, upstream_tick, tick_idx);
         } else {
             if my_tier == "propose" {
-                memo_write("introducer:" + _self_pid + ":abstract:tick-" + to_string(upstream_tick), draft.abstract_tex);
-                memo_write("introducer:" + _self_pid + ":intro:tick-" + to_string(upstream_tick), draft.intro_tex);
-                memo_write("introducer:" + _self_pid + ":title:tick-" + to_string(upstream_tick), draft.title);
-                memo_write("introducer:" + _self_pid + ":msc_codes:tick-" + to_string(upstream_tick), draft.msc_codes_csv);
-                memo_write("introducer:" + _self_pid + ":arxiv_category:tick-" + to_string(upstream_tick), draft.arxiv_category);
-                memo_write("replay:current_introducer_pid", _self_pid);
-
-                emit("introducer:abstract_ready", draft);
-                emit("introducer:intro_ready", draft);
-
-                learn("introduce", "tick " + to_string(tick_idx), "abstract+intro emitted", "success", ["emitted", "preprint-foundry"]);
+                _publish_introducer(false, draft, _self_pid, upstream_tick, tick_idx);
             } else {
                 print("[introducer] observing (tier:", my_tier, ") rationale=", draft.rationale);
                 learn("introduce", "tick " + to_string(tick_idx), draft.rationale, "partial", ["observed", "preprint-foundry"]);

--- a/preprint-foundry/submitter/agents/submitter.ag
+++ b/preprint-foundry/submitter/agents/submitter.ag
@@ -67,6 +67,157 @@ fn _metadata_prompt() -> string {
     return "You are preparing an arXiv submission package for a math preprint. The user-supplied input below carries the FINAL TEX, the COMPILE LOG, the REPRODUCIBILITY SCRIPT and OUTPUT, and a candidate ARXIV_CATEGORY + MSC_CODES from the introducer. Produce: (1) the paper title (under 200 chars), (2) a clean ASCII abstract (under 1920 chars, no LaTeX environments, no `\\\\cite`, no `$...$` -- plain prose for the arXiv submission form), (3) MSC2020 codes (comma-separated), (4) the primary arXiv category (e.g. math.GR), (5) cross-list categories (comma-separated, may be empty), (6) a short cover letter (200-400 words) addressed to arXiv moderation that names the human author, summarises the contribution, notes that the proof is computational (when the reproducibility script is the evidence) and explicitly discloses AI assistance with drafting, (7) a single-paragraph AI disclosure that must be appended verbatim to the cover letter (arXiv 2024+ policy). Output ONLY valid JSON: {\"title\":\"...\",\"abstract_clean\":\"...\",\"msc_codes_csv\":\"...\",\"arxiv_category\":\"...\",\"cross_list_csv\":\"...\",\"cover_letter\":\"...\",\"ai_disclosure\":\"...\",\"rationale\":\"one-line\"}.";
 }
 
+// _submitter_draft_phase -- Phase A. Build arxiv-metadata.json + tarball
+// + cover letter, write DRAFTED row to ledger, persist memo. Used by
+// propose / review-gated / autonomous (Class 1 terminal, #622 ADR-0001).
+// When mark_awaiting=true (review-gated), also stamps an
+// `awaiting_approval` memo flag for the dashboard.
+fn _submitter_draft_phase(
+    mark_awaiting: bool,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int,
+    claim_id_eff: string,
+    claim_dir: string,
+    compile_ok: string,
+    source_audit_run: string,
+    final_tex: string,
+    compile_log: string,
+    title_seed: string,
+    msc_seed: string,
+    cat_seed: string,
+    repro_script: string,
+    repro_output: string,
+    repro_lang: string
+) -> void {
+    let ctx = "FINAL TEX:\n" + final_tex + "\n"
+            + "COMPILE LOG:\n" + compile_log + "\n"
+            + "TITLE SEED: " + title_seed + "\n"
+            + "MSC SEED: " + msc_seed + "\n"
+            + "ARXIV CATEGORY SEED: " + cat_seed + "\n"
+            + "REPRO SCRIPT (" + repro_lang + "):\n" + repro_script + "\n"
+            + "REPRO OUTPUT:\n" + repro_output + "\n";
+    let meta = prompt(_metadata_prompt(), ctx) -> Metadata;
+
+    // Load authors.toml from $PREPRINT_AUTHOR_CONFIG (path threaded
+    // through by run-preprint.sh). The file is parsed by a Python
+    // helper rather than the .ag DSL (no TOML in DSL).
+    let author_cfg_path = try { exec sh "printenv PREPRINT_AUTHOR_CONFIG"; } catch e { ""; };
+    let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };
+    // colony-lint: safe-exec-concat
+    let authors_cmd = "python3 -c 'import sys\ntry:\n import tomllib\nexcept Exception:\n import tomli as tomllib\ntry:\n with open(sys.argv[1],\"rb\") as f: d=tomllib.load(f)\nexcept Exception:\n print(\"AUTHOR-PLACEHOLDER <author@example.org>\"); sys.exit(0)\nauthors=d.get(\"authors\") or []\nout=[]\nfor a in authors:\n name=a.get(\"name\",\"AUTHOR-PLACEHOLDER\"); email=a.get(\"email\",\"\")\n if email: out.append(name+\" <\"+email+\">\")\n else: out.append(name)\nprint(\"; \".join(out) if out else \"AUTHOR-PLACEHOLDER\")' " + shell_escape(author_cfg_eff);
+    let authors_line = try { exec sh authors_cmd; } catch e { "AUTHOR-PLACEHOLDER"; };
+
+    // Build arxiv-metadata.json into the claim dir.
+    let cover_full = meta.cover_letter + "\n\n--- AI assistance disclosure ---\n" + meta.ai_disclosure + "\n";
+    // colony-lint: safe-exec-concat
+    let meta_cmd = "python3 -c 'import sys,json\nm={\"title\":sys.argv[1],\"abstract\":sys.argv[2],\"authors\":sys.argv[3],\"primary_category\":sys.argv[4],\"cross_list\":[s for s in sys.argv[5].split(\",\") if s],\"msc_codes\":[s for s in sys.argv[6].split(\",\") if s],\"cover_letter\":sys.argv[7]}\nwith open(sys.argv[8],\"w\") as f: json.dump(m,f,indent=2)\nprint(\"ok\")' "
+        + shell_escape(meta.title) + " "
+        + shell_escape(meta.abstract_clean) + " "
+        + shell_escape(authors_line) + " "
+        + shell_escape(meta.arxiv_category) + " "
+        + shell_escape(meta.cross_list_csv) + " "
+        + shell_escape(meta.msc_codes_csv) + " "
+        + shell_escape(cover_full) + " "
+        + shell_escape(claim_dir + "/arxiv-metadata.json");
+    let _meta_write = try { exec sh meta_cmd; } catch e { ""; };
+
+    // Stage reproducibility artefacts into the claim dir.
+    let ext = if repro_lang == "gap" { ".g"; } else { ".py"; };
+    // colony-lint: safe-exec-concat
+    let stage_script = "printf '%s' " + shell_escape(repro_script) + " > " + shell_escape(claim_dir + "/reproducibility" + ext);
+    let _ss = try { exec sh stage_script; } catch e { ""; };
+    // colony-lint: safe-exec-concat
+    let stage_output = "printf '%s' " + shell_escape(repro_output) + " > " + shell_escape(claim_dir + "/reproducibility-output.txt");
+    let _so = try { exec sh stage_output; } catch e { ""; };
+
+    // Package submission tarball.
+    // colony-lint: safe-exec-concat
+    let tar_cmd = "cd " + shell_escape(claim_dir) + " && tar -czf submission.tar.gz main.tex refs.bib reproducibility" + ext + " reproducibility-output.txt arxiv-metadata.json 2>&1 || true";
+    let _tar = try { exec sh tar_cmd; } catch e { ""; };
+
+    // Write DRAFTED row to preprint-ledger.jsonl.
+    let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+    if len(ledger_path) > 0 {
+        let ledger_row = "{\"ts\":" + to_string(tick_now_ms)
+                       + ",\"source_audit_run\":\"" + source_audit_run
+                       + "\",\"source_claim_id\":\"" + claim_id_eff
+                       + "\",\"preprint_path\":\"" + claim_dir
+                       + "\",\"title\":\"" + meta.title
+                       + "\",\"abstract\":\"" + meta.abstract_clean
+                       + "\",\"arxiv_category\":\"" + meta.arxiv_category
+                       + "\",\"msc_codes_csv\":\"" + meta.msc_codes_csv
+                       + "\",\"status\":\"DRAFTED\""
+                       + ",\"latex_compile_ok\":" + compile_ok
+                       + ",\"arxiv_id\":null"
+                       + ",\"submission_ts\":null}";
+        // colony-lint: safe-exec-concat
+        let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
+        let _ap = try { exec sh append_cmd; } catch e { ""; };
+    };
+
+    memo_write("submitter:" + self_pid + ":metadata:tick-" + to_string(upstream_tick), meta.title);
+    memo_write("submitter:" + self_pid + ":status:tick-" + to_string(upstream_tick), "DRAFTED");
+    memo_write("submitter:" + claim_id_eff + ":drafted", to_string(tick_now_ms));
+    memo_write("submitter:" + claim_id_eff + ":title", meta.title);
+    memo_write("submitter:" + claim_id_eff + ":arxiv_category", meta.arxiv_category);
+    memo_write("submitter:" + claim_id_eff + ":claim_dir", claim_dir);
+    memo_write("replay:current_submitter_pid", self_pid);
+
+    if mark_awaiting {
+        memo_write("submitter:" + claim_id_eff + ":awaiting_approval", "true");
+    };
+
+    emit("submitter:metadata_ready", meta);
+    emit("submitter:status_ready", meta);
+
+    learn("submit", "tick " + to_string(tick_idx) + " DRAFTED " + claim_id_eff, meta.rationale, "success", ["emitted", "preprint-foundry", "hitl-gated"]);
+}
+
+// _submitter_send_phase -- terminal SMTP send. Mails the tarball via
+// $PREPRINT_ARXIV_GATEWAY and writes the SUBMITTED row to the ledger.
+// Used by autonomous (unconditional, no HITL gate) and by the
+// human-approved branch of propose/review-gated.
+fn _submitter_send_phase(
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int,
+    claim_id_eff: string,
+    claim_dir: string
+) -> void {
+    let gateway = try { exec sh "printenv PREPRINT_ARXIV_GATEWAY"; } catch e { ""; };
+    let from_addr = try { exec sh "printenv PREPRINT_ARXIV_FROM"; } catch e { ""; };
+    let gateway_eff = if len(gateway) > 0 { gateway; } else { "submit@arxiv.org"; };
+    let from_eff = if len(from_addr) > 0 { from_addr; } else { "AUTHOR-PLACEHOLDER@example.org"; };
+    // colony-lint: safe-exec-concat
+    let send_cmd = "python3 -c 'import smtplib, ssl, sys, email.message, os\nm=email.message.EmailMessage()\nm[\"Subject\"]=\"arXiv submission: \"+sys.argv[1]\nm[\"From\"]=sys.argv[2]\nm[\"To\"]=sys.argv[3]\nwith open(sys.argv[4],\"r\") as f: cover=f.read()\nm.set_content(cover)\nwith open(sys.argv[5],\"rb\") as f: data=f.read()\nm.add_attachment(data, maintype=\"application\", subtype=\"gzip\", filename=\"submission.tar.gz\")\nhost=os.environ.get(\"PREPRINT_SMTP_HOST\",\"localhost\")\nport=int(os.environ.get(\"PREPRINT_SMTP_PORT\",\"25\"))\ntry:\n s=smtplib.SMTP(host,port,timeout=30); s.send_message(m); s.quit(); print(\"sent\")\nexcept Exception as e:\n print(\"smtp-error:\"+str(e))' "
+            + shell_escape(claim_id_eff) + " "
+            + shell_escape(from_eff) + " "
+            + shell_escape(gateway_eff) + " "
+            + shell_escape(claim_dir + "/arxiv-metadata.json") + " "
+            + shell_escape(claim_dir + "/submission.tar.gz");
+    let send_out = try { exec sh send_cmd; } catch e { "smtp-error:exec-failed"; };
+
+    let ledger_path2 = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+    if len(ledger_path2) > 0 {
+        let status_row = "{\"ts\":" + to_string(tick_now_ms)
+                       + ",\"source_claim_id\":\"" + claim_id_eff
+                       + "\",\"status\":\"SUBMITTED\""
+                       + ",\"submission_ts\":" + to_string(tick_now_ms)
+                       + ",\"smtp_result\":\"" + send_out + "\"}";
+        // colony-lint: safe-exec-concat
+        let append2 = "printf '%s\n' " + shell_escape(status_row) + " >> " + shell_escape(ledger_path2);
+        let _a2 = try { exec sh append2; } catch e { ""; };
+    };
+
+    memo_write("submitter:" + claim_id_eff + ":submitted", to_string(tick_now_ms));
+    memo_write("submitter:" + self_pid + ":status:tick-" + to_string(upstream_tick), "SUBMITTED");
+    emit("submitter:status_ready", send_out);
+    learn("submit", "tick " + to_string(tick_idx) + " SUBMITTED " + claim_id_eff, send_out, "success", ["emitted", "preprint-foundry", "hitl-gated"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _tick_now_ms = now_ms_via_shell();
@@ -123,92 +274,69 @@ fn tick(reason: string) -> void {
     let already_submitted = recall_latest("submitter:" + claim_id_eff + ":submitted");
 
     if my_tier == "autonomous" {
+        // Terminal agent (Class 1, #622 ADR-0001): autonomous skips the
+        // HITL gate. Phase A drafts if not already drafted; then we
+        // unconditionally enter the SMTP send path (the human_status
+        // check collapses to true). Records `autonomous_decision=true`
+        // for downstream observers.
+        memo_write("submitter:" + claim_id_eff + ":autonomous_decision", "true");
         learn("submit", "tick " + to_string(tick_idx), "tier=autonomous", "partial", ["acted", "preprint-foundry"]);
+        if len(already_drafted) == 0 {
+            _submitter_draft_phase(false, _self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, compile_ok, source_audit_run, final_tex, compile_log, title_seed, msc_seed, cat_seed, repro_script, repro_output, repro_lang);
+        };
+        if len(already_submitted) > 0 {
+            print("[submitter] already submitted claim=", claim_id_eff);
+            learn("submit", "tick " + to_string(tick_idx) + " noop " + claim_id_eff, "already submitted", "partial", ["observed", "preprint-foundry", "hitl-gated"]);
+        } else {
+            _submitter_send_phase(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir);
+        };
     } else {
         if my_tier == "review-gated" {
+            // Today's propose body, plus the `awaiting_approval` memo flag
+            // stamped during Phase A so the dashboard can surface that the
+            // submission is waiting on a human decision (#622).
             learn("submit", "tick " + to_string(tick_idx), "tier=review-gated", "partial", ["review-gated", "preprint-foundry"]);
+            if len(already_drafted) == 0 {
+                _submitter_draft_phase(true, _self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, compile_ok, source_audit_run, final_tex, compile_log, title_seed, msc_seed, cat_seed, repro_script, repro_output, repro_lang);
+            } else {
+                // Phase B: DRAFTED already exists -- observe HITL flag and act
+                // only on explicit human approval. NEVER auto-submit.
+                if human_status == "approved" {
+                    if len(already_submitted) > 0 {
+                        print("[submitter] already submitted claim=", claim_id_eff);
+                        learn("submit", "tick " + to_string(tick_idx) + " noop " + claim_id_eff, "already submitted", "partial", ["observed", "preprint-foundry", "hitl-gated"]);
+                    } else {
+                        _submitter_send_phase(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir);
+                    };
+                } else {
+                    if human_status == "rejected" {
+                        let ledger_path3 = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+                        if len(ledger_path3) > 0 {
+                            let reason_raw = recall_latest("submitter:" + claim_id_eff + ":human_reject_reason");
+                            let row = "{\"ts\":" + to_string(_tick_now_ms)
+                                    + ",\"source_claim_id\":\"" + claim_id_eff
+                                    + "\",\"status\":\"HUMAN_REJECTED\""
+                                    + ",\"reason\":\"" + reason_raw + "\"}";
+                            // colony-lint: safe-exec-concat
+                            let append3 = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path3);
+                            let _a3 = try { exec sh append3; } catch e { ""; };
+                        };
+                        memo_write("submitter:" + claim_id_eff + ":rejected", to_string(_tick_now_ms));
+                        memo_write("submitter:" + _self_pid + ":status:tick-" + to_string(upstream_tick), "HUMAN_REJECTED");
+                        emit("submitter:status_ready", "HUMAN_REJECTED");
+                        learn("submit", "tick " + to_string(tick_idx) + " HUMAN_REJECTED " + claim_id_eff, "human declined", "partial", ["emitted", "preprint-foundry", "hitl-gated"]);
+                    } else {
+                        // No human decision yet -- idle.
+                        print("[submitter] DRAFTED awaiting human approval claim=", claim_id_eff);
+                        learn("submit", "tick " + to_string(tick_idx) + " awaiting " + claim_id_eff, "human_status=" + human_status, "partial", ["observed", "preprint-foundry", "hitl-gated"]);
+                    };
+                };
+            };
         } else {
             if my_tier == "propose" {
                 // Phase A: produce DRAFTED row (idempotent: skip when already drafted).
                 if len(already_drafted) == 0 {
-                    let ctx = "FINAL TEX:\n" + final_tex + "\n"
-                            + "COMPILE LOG:\n" + compile_log + "\n"
-                            + "TITLE SEED: " + title_seed + "\n"
-                            + "MSC SEED: " + msc_seed + "\n"
-                            + "ARXIV CATEGORY SEED: " + cat_seed + "\n"
-                            + "REPRO SCRIPT (" + repro_lang + "):\n" + repro_script + "\n"
-                            + "REPRO OUTPUT:\n" + repro_output + "\n";
-                    let meta = prompt(_metadata_prompt(), ctx) -> Metadata;
-
-                    // Load authors.toml from $PREPRINT_AUTHOR_CONFIG (path threaded
-                    // through by run-preprint.sh). The file is parsed by a Python
-                    // helper rather than the .ag DSL (no TOML in DSL).
-                    let author_cfg_path = try { exec sh "printenv PREPRINT_AUTHOR_CONFIG"; } catch e { ""; };
-                    let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };
-                    // colony-lint: safe-exec-concat
-                    let authors_cmd = "python3 -c 'import sys\ntry:\n import tomllib\nexcept Exception:\n import tomli as tomllib\ntry:\n with open(sys.argv[1],\"rb\") as f: d=tomllib.load(f)\nexcept Exception:\n print(\"AUTHOR-PLACEHOLDER <author@example.org>\"); sys.exit(0)\nauthors=d.get(\"authors\") or []\nout=[]\nfor a in authors:\n name=a.get(\"name\",\"AUTHOR-PLACEHOLDER\"); email=a.get(\"email\",\"\")\n if email: out.append(name+\" <\"+email+\">\")\n else: out.append(name)\nprint(\"; \".join(out) if out else \"AUTHOR-PLACEHOLDER\")' " + shell_escape(author_cfg_eff);
-                    let authors_line = try { exec sh authors_cmd; } catch e { "AUTHOR-PLACEHOLDER"; };
-
-                    // Build arxiv-metadata.json into the claim dir.
-                    let cover_full = meta.cover_letter + "\n\n--- AI assistance disclosure ---\n" + meta.ai_disclosure + "\n";
-                    // colony-lint: safe-exec-concat
-                    let meta_cmd = "python3 -c 'import sys,json\nm={\"title\":sys.argv[1],\"abstract\":sys.argv[2],\"authors\":sys.argv[3],\"primary_category\":sys.argv[4],\"cross_list\":[s for s in sys.argv[5].split(\",\") if s],\"msc_codes\":[s for s in sys.argv[6].split(\",\") if s],\"cover_letter\":sys.argv[7]}\nwith open(sys.argv[8],\"w\") as f: json.dump(m,f,indent=2)\nprint(\"ok\")' "
-                        + shell_escape(meta.title) + " "
-                        + shell_escape(meta.abstract_clean) + " "
-                        + shell_escape(authors_line) + " "
-                        + shell_escape(meta.arxiv_category) + " "
-                        + shell_escape(meta.cross_list_csv) + " "
-                        + shell_escape(meta.msc_codes_csv) + " "
-                        + shell_escape(cover_full) + " "
-                        + shell_escape(claim_dir + "/arxiv-metadata.json");
-                    let _meta_write = try { exec sh meta_cmd; } catch e { ""; };
-
-                    // Stage reproducibility artefacts into the claim dir.
-                    let ext = if repro_lang == "gap" { ".g"; } else { ".py"; };
-                    // colony-lint: safe-exec-concat
-                    let stage_script = "printf '%s' " + shell_escape(repro_script) + " > " + shell_escape(claim_dir + "/reproducibility" + ext);
-                    let _ss = try { exec sh stage_script; } catch e { ""; };
-                    // colony-lint: safe-exec-concat
-                    let stage_output = "printf '%s' " + shell_escape(repro_output) + " > " + shell_escape(claim_dir + "/reproducibility-output.txt");
-                    let _so = try { exec sh stage_output; } catch e { ""; };
-
-                    // Package submission tarball.
-                    // colony-lint: safe-exec-concat
-                    let tar_cmd = "cd " + shell_escape(claim_dir) + " && tar -czf submission.tar.gz main.tex refs.bib reproducibility" + ext + " reproducibility-output.txt arxiv-metadata.json 2>&1 || true";
-                    let _tar = try { exec sh tar_cmd; } catch e { ""; };
-
-                    // Write DRAFTED row to preprint-ledger.jsonl.
-                    let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
-                    if len(ledger_path) > 0 {
-                        let ledger_row = "{\"ts\":" + to_string(_tick_now_ms)
-                                       + ",\"source_audit_run\":\"" + source_audit_run
-                                       + "\",\"source_claim_id\":\"" + claim_id_eff
-                                       + "\",\"preprint_path\":\"" + claim_dir
-                                       + "\",\"title\":\"" + meta.title
-                                       + "\",\"abstract\":\"" + meta.abstract_clean
-                                       + "\",\"arxiv_category\":\"" + meta.arxiv_category
-                                       + "\",\"msc_codes_csv\":\"" + meta.msc_codes_csv
-                                       + "\",\"status\":\"DRAFTED\""
-                                       + ",\"latex_compile_ok\":" + compile_ok
-                                       + ",\"arxiv_id\":null"
-                                       + ",\"submission_ts\":null}";
-                        // colony-lint: safe-exec-concat
-                        let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-                        let _ap = try { exec sh append_cmd; } catch e { ""; };
-                    };
-
-                    memo_write("submitter:" + _self_pid + ":metadata:tick-" + to_string(upstream_tick), meta.title);
-                    memo_write("submitter:" + _self_pid + ":status:tick-" + to_string(upstream_tick), "DRAFTED");
-                    memo_write("submitter:" + claim_id_eff + ":drafted", to_string(_tick_now_ms));
-                    memo_write("submitter:" + claim_id_eff + ":title", meta.title);
-                    memo_write("submitter:" + claim_id_eff + ":arxiv_category", meta.arxiv_category);
-                    memo_write("submitter:" + claim_id_eff + ":claim_dir", claim_dir);
-                    memo_write("replay:current_submitter_pid", _self_pid);
-
-                    emit("submitter:metadata_ready", meta);
-                    emit("submitter:status_ready", meta);
-
-                    learn("submit", "tick " + to_string(tick_idx) + " DRAFTED " + claim_id_eff, meta.rationale, "success", ["emitted", "preprint-foundry", "hitl-gated"]);
+                    _submitter_draft_phase(false, _self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, compile_ok, source_audit_run, final_tex, compile_log, title_seed, msc_seed, cat_seed, repro_script, repro_output, repro_lang);
                 } else {
                     // Phase B: DRAFTED already exists -- observe HITL flag and act
                     // only on explicit human approval. NEVER auto-submit.
@@ -217,35 +345,7 @@ fn tick(reason: string) -> void {
                             print("[submitter] already submitted claim=", claim_id_eff);
                             learn("submit", "tick " + to_string(tick_idx) + " noop " + claim_id_eff, "already submitted", "partial", ["observed", "preprint-foundry", "hitl-gated"]);
                         } else {
-                            let gateway = try { exec sh "printenv PREPRINT_ARXIV_GATEWAY"; } catch e { ""; };
-                            let from_addr = try { exec sh "printenv PREPRINT_ARXIV_FROM"; } catch e { ""; };
-                            let gateway_eff = if len(gateway) > 0 { gateway; } else { "submit@arxiv.org"; };
-                            let from_eff = if len(from_addr) > 0 { from_addr; } else { "AUTHOR-PLACEHOLDER@example.org"; };
-                            // colony-lint: safe-exec-concat
-                            let send_cmd = "python3 -c 'import smtplib, ssl, sys, email.message, os\nm=email.message.EmailMessage()\nm[\"Subject\"]=\"arXiv submission: \"+sys.argv[1]\nm[\"From\"]=sys.argv[2]\nm[\"To\"]=sys.argv[3]\nwith open(sys.argv[4],\"r\") as f: cover=f.read()\nm.set_content(cover)\nwith open(sys.argv[5],\"rb\") as f: data=f.read()\nm.add_attachment(data, maintype=\"application\", subtype=\"gzip\", filename=\"submission.tar.gz\")\nhost=os.environ.get(\"PREPRINT_SMTP_HOST\",\"localhost\")\nport=int(os.environ.get(\"PREPRINT_SMTP_PORT\",\"25\"))\ntry:\n s=smtplib.SMTP(host,port,timeout=30); s.send_message(m); s.quit(); print(\"sent\")\nexcept Exception as e:\n print(\"smtp-error:\"+str(e))' "
-                                + shell_escape(claim_id_eff) + " "
-                                + shell_escape(from_eff) + " "
-                                + shell_escape(gateway_eff) + " "
-                                + shell_escape(claim_dir + "/arxiv-metadata.json") + " "
-                                + shell_escape(claim_dir + "/submission.tar.gz");
-                            let send_out = try { exec sh send_cmd; } catch e { "smtp-error:exec-failed"; };
-
-                            let ledger_path2 = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
-                            if len(ledger_path2) > 0 {
-                                let status_row = "{\"ts\":" + to_string(_tick_now_ms)
-                                               + ",\"source_claim_id\":\"" + claim_id_eff
-                                               + "\",\"status\":\"SUBMITTED\""
-                                               + ",\"submission_ts\":" + to_string(_tick_now_ms)
-                                               + ",\"smtp_result\":\"" + send_out + "\"}";
-                                // colony-lint: safe-exec-concat
-                                let append2 = "printf '%s\n' " + shell_escape(status_row) + " >> " + shell_escape(ledger_path2);
-                                let _a2 = try { exec sh append2; } catch e { ""; };
-                            };
-
-                            memo_write("submitter:" + claim_id_eff + ":submitted", to_string(_tick_now_ms));
-                            memo_write("submitter:" + _self_pid + ":status:tick-" + to_string(upstream_tick), "SUBMITTED");
-                            emit("submitter:status_ready", send_out);
-                            learn("submit", "tick " + to_string(tick_idx) + " SUBMITTED " + claim_id_eff, send_out, "success", ["emitted", "preprint-foundry", "hitl-gated"]);
+                            _submitter_send_phase(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir);
                         };
                     } else {
                         if human_status == "rejected" {

--- a/preprint-foundry/theorist/agents/theorist.ag
+++ b/preprint-foundry/theorist/agents/theorist.ag
@@ -51,6 +51,28 @@ fn _draft_prompt() -> string {
     return "You are a research mathematician drafting the body of a preprint. The user-supplied context carries PROBLEM, ANSWER, NOVELTY CLAIM, the upstream EXPLORER CODE and OUTPUT that produced the observation, and the AUDITOR REASONING. Produce: (1) Section 2 in LaTeX with `\\section{Preliminaries}` containing the definitions and notation needed to state the result precisely (use `amsthm` definition environment `\\begin{definition}...\\end{definition}` where appropriate). (2) Section 3 in LaTeX with `\\section{Main Result}` containing the precise statement inside `\\begin{theorem}...\\end{theorem}` or `\\begin{proposition}...\\end{proposition}` for observational claims, followed by either a `\\begin{proof}...\\end{proof}` block (proof_kind=\"sketch\" or \"full\") OR a description of the computational experiment (proof_kind=\"computational\"). Set hedge_required=true when the upstream evidence is purely computational and no analytic proof is being offered. Set proof_kind=\"computational\" in that case and use phrases like 'computational evidence suggests' rather than 'we prove'. Do NOT invent values not present in the explorer output. Output ONLY valid JSON: {\"definitions_tex\":\"...\",\"main_tex\":\"...\",\"proof_kind\":\"computational|sketch|full\",\"hedge_required\":true,\"rationale\":\"one-line\"}.";
 }
 
+// _publish_theorist -- memo + emit. theorist writes no ledger row today;
+// final_write retained for symmetry (#622 ADR-0001).
+fn _publish_theorist(
+    final_write: bool,
+    draft: Draft,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int
+) -> void {
+    let _ = final_write;
+    memo_write("theorist:" + self_pid + ":definitions:tick-" + to_string(upstream_tick), draft.definitions_tex);
+    memo_write("theorist:" + self_pid + ":main:tick-" + to_string(upstream_tick), draft.main_tex);
+    memo_write("theorist:" + self_pid + ":proof_kind:tick-" + to_string(upstream_tick), draft.proof_kind);
+    let hedge_str = if draft.hedge_required { "true"; } else { "false"; };
+    memo_write("theorist:" + self_pid + ":hedge_required:tick-" + to_string(upstream_tick), hedge_str);
+    memo_write("replay:current_theorist_pid", self_pid);
+
+    emit("theorist:main_ready", draft);
+
+    learn("theorise", "tick " + to_string(tick_idx), "proof_kind=" + draft.proof_kind, "success", ["emitted", "preprint-foundry"]);
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _tick_now_ms = now_ms_via_shell();
@@ -95,22 +117,18 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("theorist");
     if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("theorist:" + _self_pid + ":review_gated", "true");
         learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["acted", "preprint-foundry"]);
+        _publish_theorist(true, draft, _self_pid, upstream_tick, tick_idx);
     } else {
         if my_tier == "review-gated" {
+            memo_write("theorist:" + _self_pid + ":review_gated", "true");
             learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["review-gated", "preprint-foundry"]);
+            _publish_theorist(true, draft, _self_pid, upstream_tick, tick_idx);
         } else {
             if my_tier == "propose" {
-                memo_write("theorist:" + _self_pid + ":definitions:tick-" + to_string(upstream_tick), draft.definitions_tex);
-                memo_write("theorist:" + _self_pid + ":main:tick-" + to_string(upstream_tick), draft.main_tex);
-                memo_write("theorist:" + _self_pid + ":proof_kind:tick-" + to_string(upstream_tick), draft.proof_kind);
-                let hedge_str = if draft.hedge_required { "true"; } else { "false"; };
-                memo_write("theorist:" + _self_pid + ":hedge_required:tick-" + to_string(upstream_tick), hedge_str);
-                memo_write("replay:current_theorist_pid", _self_pid);
-
-                emit("theorist:main_ready", draft);
-
-                learn("theorise", "tick " + to_string(tick_idx), "proof_kind=" + draft.proof_kind, "success", ["emitted", "preprint-foundry"]);
+                _publish_theorist(false, draft, _self_pid, upstream_tick, tick_idx);
             } else {
                 print("[theorist] observing (tier:", my_tier, ") rationale=", draft.rationale);
                 learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["observed", "preprint-foundry"]);


### PR DESCRIPTION
## Summary

PR-2 of the 3-part series for #622. Section B of the approved plan: fills in the `autonomous` and `review-gated` tier branches across all 15 `.ag` agents in the three research federations (math-foundry, claim-auditor, preprint-foundry).

Until this PR every autonomous and review-gated branch was a `learn(...)` stub and only `propose` did substantive work. This commit extracts the propose body into a helper function `_publish_<role>(final_write, ...)` and wires the higher tiers per the ADR-0001 contract.

PR-1 (sidecar plumbing, #630) already merged. PR-3 (lint extension) being implemented in parallel.

## Refactor pattern

For each of 15 `.ag` files:
- Extract today's propose body into `fn _publish_<role>(final_write, ...)` defined above `fn tick(...)`. The DSL helper-fn convention has precedent in `math-foundry/explorer/agents/explorer.ag` (`_push_settled_exploration`).
- Replace each tier branch with a thin dispatcher that calls the helper with `final_write=true` for autonomous + review-gated (ledger appended) or `final_write=false` for propose (emit-only).

## Per-class behavior

**Non-terminal agents (12)**: explorer, formulator, noticer, verifier, arxiv_search, oeis_search, groupprops_search, scholar_search, introducer, theorist, computer, editor.

- **autonomous** = same as review-gated; collapses with comment `// reason: tier N/A here; non-terminal agent -- collapses to review-gated`.
- **review-gated** = today's propose body (memo + emit + ledger) plus a `<agent>:<pid>:review_gated=true` memo flip so downstream agents can tell.
- **propose** = emit-only, skip ledger append (strict ADR-0001 "draft external writes" semantics, not "commit them").
- **shadow/observe** = unchanged.

**Terminal agents (3 special cases)**:

- **novelty**: autonomous emits `novelty:final_verdict` + ledger row regardless of confidence floor; stamps `novelty:<pid>:autonomous_decision=true`.
- **auditor**: autonomous emits the audit-ledger row with `terminal=true` and stamps `auditor:<pid>:autonomous_decision=true`. Review-gated emits the same row with `terminal=false`.
- **submitter**: autonomous bypasses the HITL gate -- drafts Phase A then auto-sends via SMTP. Review-gated keeps today's HITL gate but stamps `submitter:<claim_id>:awaiting_approval=true` at DRAFTED time.

**Explorer (Class 3 special case)**: autonomous adds the M2-Malthusian replicate gate (today's `repr_thr` check is propose-only). Move replication invocation under `autonomous` only; settlement + fitness retained for both autonomous + propose. Review-gated is memo-only (no exec, no ledger, no settlement/fitness, no replicate).

## Backward compatibility

Propose-branch behavior is either identical to today (terminal agents) or strictly less-writing (non-terminal agents lose the ledger append in propose; intentional per ADR-0001).

No orchestrator script edits. No lint script edits (those belong to PR-3). No new colonies. No new dependencies.

## Test plan

- [x] `tools/colony-lint.sh` -- 310 passed, 0 failed, 3 skipped (same as baseline on main)
- [x] All 15 `.ag` files compile cleanly via `agentis commit`
- [x] `bash -n` clean on `math-foundry/tools/run-foundry.sh`, `claim-auditor/tools/run-auditor.sh`, `preprint-foundry/tools/run-preprint.sh` (orchestrators untouched but verified)
- [ ] QA: short-run smoke on math-foundry to confirm `autonomous` and `review-gated` branches execute end-to-end without runtime errors when explicitly seeded (post-merge follow-up)
- [ ] QA: verify `submitter:<claim_id>:awaiting_approval` flag visible in dashboard at review-gated tier (post-merge follow-up, depends on PR-3 lint scope)

Refs #622. Does NOT close #622 (PR-3 still pending).