### PR TITLE
docs(research-foundry): scrub stale fed-path examples in colony READMEs + tool comments (closes #640)

### DIFF
--- a/research-foundry/computer/README.md
+++ b/research-foundry/computer/README.md
@@ -32,9 +32,7 @@ not present in stdout), the agent persists the artefacts but marks
    Host-side `gap` is optional but lets `tools/review-cli.sh --show`
    re-run the reproducibility script during human review.
 
-4. Start the colony as part of the federation:
-   ```bash
-   bash ../tools/run-preprint.sh \
-       --source-audit-run /path/to/claim-auditor/runs/<id> \
-       --source-foundry-run /path/to/math-foundry/runs/<id>
-   ```
+4. Start the colony as part of the federation. Cross-colony handoff is
+   now direct via the shared memo store; no `--source-*` flags. See
+   `research-foundry/tools/run-research.sh --help` for the current
+   invocation.

--- a/research-foundry/data/papers/README.md
+++ b/research-foundry/data/papers/README.md
@@ -50,8 +50,8 @@ with the same corpus is deterministic.
 Once, from a host that can reach arxiv:
 
 ```bash
-python3 math-foundry/tools/fetch-papers.py \
-    --output math-foundry/data/papers \
+python3 research-foundry/tools/fetch-papers.py \
+    --output research-foundry/data/papers \
     --topics number_theory combinatorics abstract_algebra graph_theory \
     --per-topic 25
 ```

--- a/research-foundry/editor/README.md
+++ b/research-foundry/editor/README.md
@@ -32,9 +32,7 @@ main result against the reproducibility output, marking
    `texlive-fonts-recommended`, `texlive-science`, and `latexmk`. The
    editor's `latexmk` invocations happen inside the container.
 
-4. Start the colony as part of the federation:
-   ```bash
-   bash ../tools/run-preprint.sh \
-       --source-audit-run /path/to/claim-auditor/runs/<id> \
-       --source-foundry-run /path/to/math-foundry/runs/<id>
-   ```
+4. Start the colony as part of the federation. Cross-colony handoff is
+   now direct via the shared memo store; no `--source-*` flags. See
+   `research-foundry/tools/run-research.sh --help` for the current
+   invocation.

--- a/research-foundry/introducer/README.md
+++ b/research-foundry/introducer/README.md
@@ -25,9 +25,7 @@ LLM-drafted block that the downstream editor colony stitches into
 2. Non-forge federation -- the only data sources are memo keys seeded
    by `tools/run-preprint.sh` (no GitLab/GitHub).
 
-3. Start the colony as part of the federation:
-   ```bash
-   bash ../tools/run-preprint.sh \
-       --source-audit-run /path/to/claim-auditor/runs/<id> \
-       --source-foundry-run /path/to/math-foundry/runs/<id>
-   ```
+3. Start the colony as part of the federation. Cross-colony handoff is
+   now direct via the shared memo store; no `--source-*` flags. See
+   `research-foundry/tools/run-research.sh --help` for the current
+   invocation.

--- a/research-foundry/submitter/README.md
+++ b/research-foundry/submitter/README.md
@@ -3,7 +3,7 @@
 > Part of the [Preprint Foundry](../) federation.
 
 Builds `arxiv-metadata.json` (title / abstract / MSC / categories /
-authors from `preprint-foundry/config/authors.toml`), packages
+authors from `research-foundry/config/authors.toml`), packages
 `submission.tar.gz` per arXiv submission format, drafts a cover letter
 with explicit AI-assistance disclosure (arXiv 2024+ policy), and
 writes a `status: DRAFTED` row to `preprint-ledger.jsonl`.
@@ -31,7 +31,7 @@ review helper.
    cp config/colony.example.toml config/colony.toml
    ```
 
-2. Edit `preprint-foundry/config/authors.toml` with real author
+2. Edit `research-foundry/config/authors.toml` with real author
    metadata (name, email, ORCID, endorsed categories) BEFORE the first
    real run. The submitter joins all `[[authors]]` entries with "; "
    into the metadata `authors` field; arXiv rejects submissions
@@ -44,12 +44,10 @@ review helper.
    `submit@arxiv.org`. The submitter picks up `$PREPRINT_SMTP_HOST` /
    `$PREPRINT_SMTP_PORT` from env (default: `localhost:25`).
 
-5. Start the colony as part of the federation:
-   ```bash
-   bash ../tools/run-preprint.sh \
-       --source-audit-run /path/to/claim-auditor/runs/<id> \
-       --source-foundry-run /path/to/math-foundry/runs/<id>
-   ```
+5. Start the colony as part of the federation. Cross-colony handoff is
+   now direct via the shared memo store; no `--source-*` flags. See
+   `research-foundry/tools/run-research.sh --help` for the current
+   invocation.
 
 6. Review DRAFTED rows and approve / reject:
    ```bash

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -1,7 +1,7 @@
 // submitter.ag -- Preprint Foundry submitter: reads the editor's
 // final main.tex + compile log + reproducibility artefacts, builds
 // `arxiv-metadata.json` (title / abstract / MSC / categories / authors
-// from preprint-foundry/config/authors.toml), packages
+// from research-foundry/config/authors.toml), packages
 // `submission.tar.gz` per arXiv format, drafts the cover letter with
 // AI-disclosure, and writes a `status: DRAFTED` row to
 // `preprint-ledger.jsonl`.

--- a/research-foundry/theorist/README.md
+++ b/research-foundry/theorist/README.md
@@ -25,9 +25,7 @@ experiment ("computational evidence suggests" framing).
 2. Non-forge federation -- the only data sources are memo keys seeded
    by `tools/run-preprint.sh` (no GitLab/GitHub).
 
-3. Start the colony as part of the federation:
-   ```bash
-   bash ../tools/run-preprint.sh \
-       --source-audit-run /path/to/claim-auditor/runs/<id> \
-       --source-foundry-run /path/to/math-foundry/runs/<id>
-   ```
+3. Start the colony as part of the federation. Cross-colony handoff is
+   now direct via the shared memo store; no `--source-*` flags. See
+   `research-foundry/tools/run-research.sh --help` for the current
+   invocation.

--- a/research-foundry/tools/fetch-papers.py
+++ b/research-foundry/tools/fetch-papers.py
@@ -4,7 +4,7 @@ arxiv paper corpus consumed by `tools/run-foundry.sh` (#592).
 
 Live arxiv calls are rate-limited and would add latency to every
 foundry tick, so the orchestrator never hits arxiv at runtime. This
-script populates `math-foundry/data/papers/<topic>.json` once; the
+script populates `research-foundry/data/papers/<topic>.json` once; the
 orchestrator then serves from disk.
 
 The script uses the `arxiv` Python package (install via pip). If the

--- a/research-foundry/tools/review-cli.sh
+++ b/research-foundry/tools/review-cli.sh
@@ -3,7 +3,7 @@
 # federation (#596).
 #
 # Lists DRAFTED rows in the latest preprint-ledger.jsonl under
-# preprint-foundry/runs/, optionally renders the per-claim main.pdf via
+# research-foundry/runs/, optionally renders the per-claim main.pdf via
 # `xdg-open`, and writes the per-claim HITL approval memo key that the
 # submitter colony reads on its next tick.
 #

--- a/research-foundry/tools/test-fetch-papers.py
+++ b/research-foundry/tools/test-fetch-papers.py
@@ -6,7 +6,7 @@ Validates the JSON output structure with synthetic arxiv responses
 injected via a fake arxiv module placed on sys.modules. No network,
 no `arxiv` install required.
 
-Run: python3 math-foundry/tools/test-fetch-papers.py
+Run: python3 research-foundry/tools/test-fetch-papers.py
 """
 
 import json


### PR DESCRIPTION
## Summary

Follow-up to #639 (Phase 1.5 consolidation of `math-foundry/` + `claim-auditor/` + `preprint-foundry/` into `research-foundry/`). 19 stale path references survived in 10 doc / tool-comment locations across the consolidated federation. An operator copying these snippets would invoke flags (`--source-audit-run` / `--source-foundry-run`) that no longer exist in `run-research.sh`, or edit configs under directories that no longer exist.

Pure search-and-replace housekeeping; no runtime impact.

## Changes

- **4 colony READMEs** (`computer/`, `editor/`, `introducer/`, `theorist/`): removed the `--source-audit-run` / `--source-foundry-run` snippets from the `run-preprint.sh` example. Replaced each with a sentence pointing operators at `research-foundry/tools/run-research.sh --help` since cross-colony handoff is now direct via the shared memo store.
- **`submitter/README.md`**: same `--source-*` snippet removal, plus two `preprint-foundry/config/authors.toml` -> `research-foundry/config/authors.toml` path corrections.
- **`submitter/agents/submitter.ag`**: one comment-line path correction (line 4). No `tick()` / logic changes — this is the only `.ag` edit in the PR.
- **`tools/review-cli.sh`**: `preprint-foundry/runs/` -> `research-foundry/runs/` in a header comment.
- **`tools/fetch-papers.py`**: `math-foundry/data/papers/<topic>.json` -> `research-foundry/...` in a docstring.
- **`tools/test-fetch-papers.py`**: usage example path corrected.
- **`data/papers/README.md`**: `math-foundry/tools/fetch-papers.py` + `math-foundry/data/papers` in a `python3 ...` invocation -> consolidated paths.

## Preserved as-is (legitimate historical refs)

- `research-foundry/README.md` consolidation paragraph (history of the merge).
- `research-foundry/docs/archive/*-CHANGELOG.md` (frozen CHANGELOGs of the three retired federations).
- `tools/test-run-research.sh:4` ("Replaces the retired ..." supersession comment — explicit historical pointer).
- `.ag` `learn()` / `emit()` / `listen()` event-name / tag identifiers (runtime semantic IDs of the consolidated colonies, not path examples).

## Test plan

- [x] `tools/colony-lint.sh` clean (311 passed, 0 failed, 3 skipped — unchanged baseline).
- [x] `bash -n research-foundry/tools/review-cli.sh` clean.
- [x] `bash -n research-foundry/tools/test-run-research.sh` clean.
- [x] Re-audit grep: all remaining `math-foundry|claim-auditor|preprint-foundry` hits in `research-foundry/` (outside `docs/archive/`) are runtime event identifiers, `.ag` learn-tags, or explicit consolidation-history comments — none are stale path-example invocations.

Closes #640.