### PR TITLE
feat(phase-3-pr1): spawn 5 explorer specialties + seed M2-Malthusian replicate gate (PR 1 of #624)

### DIFF
--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -79,6 +79,24 @@ fn _variant_overlay_suffix() -> string {
     return "";
 }
 
+// Phase 3 PR 1 (#624): specialty overlay -- reads the per-pid specialty
+// overlay (claimed at first-tick from the bootstrap-seeded pool by
+// DAEMON_ID) and appends it after _variant_overlay_suffix() onto the
+// prompt() base body. Kept as a separate suffix outside the body that
+// M98 v3 prompt evolution rewrites, so specialty survives lineage.
+fn _specialty_overlay_suffix(self_pid: string) -> string {
+    if len(self_pid) == 0 {
+        return "";
+    };
+    let overlay = recall_latest("explorer:" + self_pid + ":specialty_overlay");
+    if len(overlay) > 0 {
+        let specialty = recall_latest("explorer:" + self_pid + ":specialty");
+        let label = if len(specialty) > 0 { specialty; } else { "unassigned"; };
+        return "\n\n[Specialty focus (" + label + "): " + overlay + "]";
+    };
+    return "";
+}
+
 // #520 M98 v3 PR 3/3: hash-pointer extraction over the M106 wire.
 fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
@@ -389,6 +407,22 @@ fn _publish_explorer(
                                                 memo_write("colony-" + _colony_name + ":pool", to_string(pool_r - cost_r));
                                                 memo_write("colony-" + _colony_name + ":size", to_string(n_r + 1));
                                                 learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "math-foundry", _colony_name]);
+
+                                                // Phase 3 PR 1 (#624): emit a `replicate` row
+                                                // into the per-run replication ledger. Generation
+                                                // marker = parent's generation + 1. Specialty
+                                                // mirrors the parent's claim so cross-pid joins
+                                                // by specialty stay coherent on lineage chains.
+                                                let lin_str = recall_latest("explorer:" + self_pid + ":generation");
+                                                let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
+                                                let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                                if len(ledger_path_r) > 0 {
+                                                    let parent_specialty = recall_latest("explorer:" + self_pid + ":specialty");
+                                                    let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(lin + 1) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
+                                                    // colony-lint: safe-exec-concat
+                                                    let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
+                                                    let _lr = try { exec sh append_r; } catch e { ""; };
+                                                };
                                             } else {
                                                 learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "math-foundry", _colony_name]);
                                             };
@@ -412,6 +446,31 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         memo_write("replay:current_explorer_pid", _self_pid);
     };
+
+    // Phase 3 PR 1 (#624): first-tick claim of a specialty from the
+    // bootstrap-seeded pool. Idempotent on subsequent ticks because
+    // the per-pid memo is non-empty after the first successful copy.
+    // DAEMON_ID env is set by tools/run-research.sh's explorer spawn
+    // loop and identifies which slot in pool:specialty:<N> to read.
+    if len(_self_pid) > 0 {
+        let _existing_specialty = recall_latest("explorer:" + _self_pid + ":specialty");
+        if len(_existing_specialty) == 0 {
+            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            if len(_daemon_id) > 0 {
+                let _pool_specialty = recall_latest("explorer:pool:specialty:" + _daemon_id);
+                if len(_pool_specialty) > 0 {
+                    memo_write("explorer:" + _self_pid + ":specialty", _pool_specialty);
+                    let _pool_overlay = recall_latest("explorer:pool:specialty_overlay:" + _daemon_id);
+                    if len(_pool_overlay) > 0 {
+                        memo_write("explorer:" + _self_pid + ":specialty_overlay", _pool_overlay);
+                    };
+                    // colony-lint: learn-tags-ok
+                    learn("explorer_specialty_claim", "daemon_id=" + _daemon_id, "specialty=" + _pool_specialty, "success", ["specialty-claim", "math-foundry"]);
+                };
+            };
+        };
+    };
+
     let _variant = recall_latest("explorer:prompt_variant");
     let conf = get_confidence();
     print("[explorer] tick conf=", conf);
@@ -483,7 +542,7 @@ fn tick(reason: string) -> void {
             + "ABSTRACT: " + paper_b_abstract + "\n";
 
     let exploration = prompt(
-        prompt_text + _variant_overlay_suffix(),
+        prompt_text + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid),
         ctx
     ) -> Exploration;
 

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -418,10 +418,22 @@ fn _publish_explorer(
                                                 let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
                                                 if len(ledger_path_r) > 0 {
                                                     let parent_specialty = recall_latest("explorer:" + self_pid + ":specialty");
-                                                    let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(lin + 1) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
+                                                    let child_gen = lin + 1;
+                                                    let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
                                                     // colony-lint: safe-exec-concat
                                                     let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
                                                     let _lr = try { exec sh append_r; } catch e { ""; };
+                                                    // Phase 3 PR 1 QA finding: seed the child's
+                                                    // generation memo so the next replicate-success
+                                                    // produces parent_gen+2, not always 1.
+                                                    memo_write("explorer:" + replica_id + ":generation", to_string(child_gen));
+                                                    // Also inherit parent specialty so the child's
+                                                    // first tick (which won't run the pool-claim
+                                                    // because DAEMON_ID is set by replicate, not by
+                                                    // bootstrap) still has a specialty descriptor.
+                                                    if len(parent_specialty) > 0 {
+                                                        memo_write("explorer:" + replica_id + ":specialty", parent_specialty);
+                                                    };
                                                 };
                                             } else {
                                                 learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "math-foundry", _colony_name]);
@@ -464,6 +476,13 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("explorer:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
+                    // Phase 3 PR 1 QA finding: seed generation memo so the
+                    // replicate-success path's parent.generation+1 lineage
+                    // walk produces correct depths instead of always 1.
+                    // Initial cohort: EXPLORER_GENERATION env (default 0).
+                    let _gen_env = try { exec sh "printenv EXPLORER_GENERATION"; } catch e { "0"; };
+                    let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
+                    memo_write("explorer:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
                     learn("explorer_specialty_claim", "daemon_id=" + _daemon_id, "specialty=" + _pool_specialty, "success", ["specialty-claim", "math-foundry"]);
                 };

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -100,6 +100,24 @@
 #   RESEARCH_AUTO_PROMOTE_INTERVAL_S
 #                                Seconds between sidecar ticks.
 #                                Default 300.
+#   RESEARCH_EXPLORER_REPLICAS
+#                                Initial explorer replica count seeded by
+#                                the bootstrap script. Each replica claims
+#                                a distinct mathematical specialty from a
+#                                fixed pool. Default 5.
+#   RESEARCH_EXPLORER_MAX_REPLICAS
+#                                Hard cap on the explorer colony size used
+#                                by the M2-Malthusian replicate gate
+#                                (colony-explorer:max_replicas). Default 8.
+#   RESEARCH_EXPLORER_POOL
+#                                Initial colony-explorer:pool seeded for
+#                                the M2-Malthusian replicate gate.
+#                                Default 5000.
+#   RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD
+#                                Per-pid fitness threshold above which the
+#                                replicate gate fires (memo key
+#                                explorer:reproductive_fitness_threshold).
+#                                Default 10.
 #
 # Flags:
 #   --dry-run    Same as RESEARCH_DRY_RUN=1.
@@ -110,6 +128,8 @@
 #   discovery-ledger.jsonl        math pipeline rows (novelty.ag)
 #   audit-ledger.jsonl            claim-auditor rows (auditor.ag)
 #   preprint-ledger.jsonl         preprint pipeline rows (submitter.ag)
+#   replication-ledger.jsonl      explorer M2-Malthusian audit trail
+#                                 (spawn / replicate rows)
 #   laptop-node/
 #     bootstrap.sh                container bootstrap (real run only)
 #     .agentis/
@@ -187,6 +207,12 @@ SMTP_PORT="${RESEARCH_SMTP_PORT:-25}"
 : "${RESEARCH_FITNESS_REWARD_NOVEL_PER_TICK:=2}"
 : "${RESEARCH_FITNESS_PENALTY_NOT_NOVEL_PER_TICK:=1}"
 
+# Phase 3 PR 1 (#624): explorer specialty pool + M2-Malthusian replicate gate seeds.
+: "${RESEARCH_EXPLORER_REPLICAS:=5}"
+: "${RESEARCH_EXPLORER_MAX_REPLICAS:=8}"
+: "${RESEARCH_EXPLORER_POOL:=5000}"
+: "${RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+
 # --- Validation ---
 if [ -z "$TOPICS_RAW" ]; then
     echo "run-research: RESEARCH_TOPICS must be a non-empty comma-separated list" >&2
@@ -194,7 +220,7 @@ if [ -z "$TOPICS_RAW" ]; then
 fi
 
 val=""
-for var_name in TICK_INTERVAL_S TOTAL_TICKS DAEMONS_PER_COLONY HOLD_PERIOD OPENAI_TIMEOUT_MS LATEXMK_MAX_PASSES SMTP_PORT; do
+for var_name in TICK_INTERVAL_S TOTAL_TICKS DAEMONS_PER_COLONY HOLD_PERIOD OPENAI_TIMEOUT_MS LATEXMK_MAX_PASSES SMTP_PORT RESEARCH_EXPLORER_REPLICAS RESEARCH_EXPLORER_MAX_REPLICAS RESEARCH_EXPLORER_POOL RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD; do
     eval "val=\${$var_name}"
     case "$val" in
         ''|*[!0-9]*)
@@ -236,6 +262,7 @@ LAPTOP_DIR="$RUN_DIR/laptop-node"
 DISCOVERY_LEDGER="$RUN_DIR/discovery-ledger.jsonl"
 AUDIT_LEDGER="$RUN_DIR/audit-ledger.jsonl"
 PREPRINT_LEDGER="$RUN_DIR/preprint-ledger.jsonl"
+REPLICATION_LEDGER="$RUN_DIR/replication-ledger.jsonl"
 
 # --- Dry-run / real-run dispatch helpers ---
 emit_cmd() {
@@ -277,6 +304,7 @@ if [ "$DRY_RUN" = "0" ]; then
     : >"$DISCOVERY_LEDGER"
     : >"$AUDIT_LEDGER"
     : >"$PREPRINT_LEDGER"
+    : >"$REPLICATION_LEDGER"
 fi
 
 emit_step "run-research: starting (dry_run=$DRY_RUN)"
@@ -332,7 +360,7 @@ write_bootstrap() {
         printf 'agentis init >/dev/null 2>&1 || true\n'
         printf '{\n'
         # Union of three retired feds' env_passthrough lists.
-        printf '  printf "exec.env_passthrough = DAEMON_ID,COLONY_NAME,HOLD_PERIOD,DISCOVERY_LEDGER,AUDIT_LEDGER,PREPRINT_LEDGER,AGENTIS_ROOT,ARXIV_MAX_QUERY_RESULTS,PREPRINT_OUTPUT_ROOT,PREPRINT_AUTHOR_CONFIG,PREPRINT_LATEXMK_MAX_PASSES,PREPRINT_ARXIV_GATEWAY,PREPRINT_ARXIV_FROM,PREPRINT_SMTP_HOST,PREPRINT_SMTP_PORT,EXPLORER_PROMPT_EVOLUTION_THRESHOLD,EXPLORER_PROMPT_GEN_CAP,EXPLORER_PROMPT_MAX_BYTES,EXPLORER_PROMPT_LEVENSHTEIN_FLOOR,FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK,FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK\\n"\n'
+        printf '  printf "exec.env_passthrough = DAEMON_ID,COLONY_NAME,HOLD_PERIOD,DISCOVERY_LEDGER,AUDIT_LEDGER,PREPRINT_LEDGER,REPLICATION_LEDGER,EXPLORER_GENERATION,AGENTIS_ROOT,ARXIV_MAX_QUERY_RESULTS,PREPRINT_OUTPUT_ROOT,PREPRINT_AUTHOR_CONFIG,PREPRINT_LATEXMK_MAX_PASSES,PREPRINT_ARXIV_GATEWAY,PREPRINT_ARXIV_FROM,PREPRINT_SMTP_HOST,PREPRINT_SMTP_PORT,EXPLORER_PROMPT_EVOLUTION_THRESHOLD,EXPLORER_PROMPT_GEN_CAP,EXPLORER_PROMPT_MAX_BYTES,EXPLORER_PROMPT_LEVENSHTEIN_FLOOR,FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK,FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK\\n"\n'
         printf '  printf "experience.enabled = true\\n"\n'
         printf '  printf "telemetry.enabled = true\\n"\n'
         printf '  printf "llm.backend = %s\\n"\n' "$LLM_BACKEND"
@@ -371,6 +399,7 @@ write_bootstrap() {
         printf ': > /run-root/discovery-ledger.jsonl\n'
         printf ': > /run-root/audit-ledger.jsonl\n'
         printf ': > /run-root/preprint-ledger.jsonl\n'
+        printf ': > /run-root/replication-ledger.jsonl\n'
         # Seed propose-tier confidence for each colony. Note the
         # claim-auditor / preprint-foundry searcher keys use underscored
         # forms (arxiv_search, oeis_search, etc.) because the .ag agents
@@ -382,9 +411,42 @@ write_bootstrap() {
         # tick); same lesson as the retired preprint-foundry bootstrap.
         printf 'DAEMON_TICK_INTERVAL_MS=30000\n'
         printf 'EXPLORER_TICK_INTERVAL_MS=30000\n'
+        # Phase 3 PR 1 (#624): seed the explorer specialty pool. Five
+        # mathematical specialties keyed by DAEMON_ID. The .ag agent's
+        # first-tick logic copies pool:specialty:<DAEMON_ID> ->
+        # <pid>:specialty and pool:specialty_overlay:<DAEMON_ID> ->
+        # <pid>:specialty_overlay, so each replica reads a distinct
+        # overlay appended to its prompt() body.
+        printf '(cd /run-root && agentis memo set explorer:pool:specialty:1 group_theory >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set explorer:pool:specialty_overlay:1 "Focus on finite group invariants: conjugacy classes, character tables, subgroup lattices, automorphism groups. Compute representations and quotients explicitly. Look for coincidences in character degrees, order divisibility, sporadic-vs-classical group behaviour." >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set explorer:pool:specialty:2 combinatorics >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set explorer:pool:specialty_overlay:2 "Focus on enumerative combinatorics: generating functions, bijective proofs, lattice paths, partition identities. Compute small-case counts and look for OEIS matches. Compare known sequences against derived ones for unexpected coincidence." >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set explorer:pool:specialty:3 number_theory >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set explorer:pool:specialty_overlay:3 "Focus on arithmetic functions and sieves: prime counting, Möbius, totient, divisor sums. Compute over small ranges, examine mod-p behaviour, look for unexpected density / equidistribution / sign-change patterns." >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set explorer:pool:specialty:4 probability >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set explorer:pool:specialty_overlay:4 "Focus on random structures: Erdős-Rényi graphs, random matrices, percolation thresholds, asymptotic distributions. Run small Monte Carlo and compare against predicted limits. Look for deviations from the expected scaling." >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set explorer:pool:specialty:5 algebra >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set explorer:pool:specialty_overlay:5 "Focus on representation theory + Lie algebras: irreducible representations, weight diagrams, Casimir invariants, Cartan classification. Compute decomposition of tensor products, dimensions, branching rules. Look for unexpected multiplicities or symmetries." >/dev/null 2>&1 || true)\n'
+        # Phase 3 PR 1 (#624): seed the M2-Malthusian replicate gate memos
+        # so the dormant logic in explorer.ag fires. colony-explorer:size
+        # tracks live population; max_replicas caps growth; pool funds
+        # replicate costs; replication_base_cost + replication_k drive the
+        # cost formula `base + base*n/k`. reproductive_fitness_threshold
+        # gates per-pid fitness above which a replica may spawn.
+        printf '(cd /run-root && agentis memo set colony-explorer:size %s >/dev/null 2>&1 || true)\n' "$RESEARCH_EXPLORER_REPLICAS"
+        printf '(cd /run-root && agentis memo set colony-explorer:max_replicas %s >/dev/null 2>&1 || true)\n' "$RESEARCH_EXPLORER_MAX_REPLICAS"
+        printf '(cd /run-root && agentis memo set colony-explorer:pool %s >/dev/null 2>&1 || true)\n' "$RESEARCH_EXPLORER_POOL"
+        printf '(cd /run-root && agentis memo set colony-explorer:replication_base_cost 100 >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set colony-explorer:replication_k 3 >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set explorer:reproductive_fitness_threshold %s >/dev/null 2>&1 || true)\n' "$RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD"
         # math pipeline: explorer (with replication) + noticer/formulator/verifier/novelty.
-        printf 'for i in $(seq 1 %s); do\n' "$DAEMONS_PER_COLONY"
-        printf '    DAEMON_ID=$i COLONY_NAME=explorer HOLD_PERIOD=%s DISCOVERY_LEDGER=/run-root/discovery-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis EXPLORER_PROMPT_EVOLUTION_THRESHOLD=%s EXPLORER_PROMPT_GEN_CAP=%s EXPLORER_PROMPT_MAX_BYTES=%s EXPLORER_PROMPT_LEVENSHTEIN_FLOOR=%s FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK=%s FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK=%s agentis daemon /run-root/explorer/agents/explorer.ag --colony explorer --enable-exec --enable-messaging --enable-replication --allow-replica-replication --tick-interval "$EXPLORER_TICK_INTERVAL_MS" > /run-root/.agentis/logs/explorer-$i.log 2>&1 &\n' \
+        # Phase 3 PR 1 (#624): spawn RESEARCH_EXPLORER_REPLICAS explorers
+        # (default 5) each carrying a distinct DAEMON_ID used by the .ag
+        # first-tick logic to claim a specialty from the pool. Generation 0
+        # for the initial cohort; child replicates increment generation
+        # in the replicate-success branch.
+        printf 'for i in $(seq 1 %s); do\n' "$RESEARCH_EXPLORER_REPLICAS"
+        printf '    DAEMON_ID=$i COLONY_NAME=explorer EXPLORER_GENERATION=0 HOLD_PERIOD=%s DISCOVERY_LEDGER=/run-root/discovery-ledger.jsonl REPLICATION_LEDGER=/run-root/replication-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis EXPLORER_PROMPT_EVOLUTION_THRESHOLD=%s EXPLORER_PROMPT_GEN_CAP=%s EXPLORER_PROMPT_MAX_BYTES=%s EXPLORER_PROMPT_LEVENSHTEIN_FLOOR=%s FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK=%s FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK=%s agentis daemon /run-root/explorer/agents/explorer.ag --colony explorer --enable-exec --enable-messaging --enable-replication --allow-replica-replication --tick-interval "$EXPLORER_TICK_INTERVAL_MS" > /run-root/.agentis/logs/explorer-$i.log 2>&1 &\n' \
             "$HOLD_PERIOD" \
             "$RESEARCH_EXPLORER_PROMPT_EVOLUTION_THRESHOLD" \
             "$RESEARCH_EXPLORER_PROMPT_GEN_CAP" \
@@ -392,6 +454,22 @@ write_bootstrap() {
             "$RESEARCH_EXPLORER_PROMPT_LEVENSHTEIN_FLOOR" \
             "$RESEARCH_FITNESS_REWARD_NOVEL_PER_TICK" \
             "$RESEARCH_FITNESS_PENALTY_NOT_NOVEL_PER_TICK"
+        printf 'done\n'
+        # Phase 3 PR 1 (#624): emit one `spawn` row per initial explorer
+        # into the replication ledger. The bootstrap already knows the
+        # loop iteration and the specialty assignment, so emit here
+        # rather than racing the .ag's first-tick claim path.
+        printf 'for i in $(seq 1 %s); do\n' "$RESEARCH_EXPLORER_REPLICAS"
+        printf '    case $i in\n'
+        printf '        1) sp=group_theory ;;\n'
+        printf '        2) sp=combinatorics ;;\n'
+        printf '        3) sp=number_theory ;;\n'
+        printf '        4) sp=probability ;;\n'
+        printf '        5) sp=algebra ;;\n'
+        printf '        *) sp=unassigned ;;\n'
+        printf '    esac\n'
+        printf '    ts_ms=$(date +%%s%%3N)\n'
+        printf '    python3 -c '"'"'import json,sys; sys.stdout.write(json.dumps({"ts":int(sys.argv[1]),"event":"spawn","daemon_id":int(sys.argv[2]),"specialty":sys.argv[3],"generation":0,"reason":"initial"})+"\\n")'"'"' "$ts_ms" "$i" "$sp" >> /run-root/replication-ledger.jsonl\n'
         printf 'done\n'
         printf 'for c in noticer formulator verifier novelty; do\n'
         printf '    for i in $(seq 1 %s); do\n' "$DAEMONS_PER_COLONY"


### PR DESCRIPTION
## Summary

PR 1 of 3 for Phase 3 (#624). Activates the dormant M2-Malthusian replicate gate inside `explorer.ag` by seeding the colony memos in the bootstrap script, and gives each initial replica a distinct mathematical specialty overlay so cohort-level diversity is captured at spawn time.

- `research-foundry/tools/run-research.sh`: 4 new env knobs, replication-ledger init, env_passthrough extension, 10 specialty pool memos, 6 M2-Malthusian gate memos, dedicated 1-to-N explorer spawn loop, 5 initial `spawn` rows emitted bootstrap-side.
- `research-foundry/explorer/agents/explorer.ag`: new `_specialty_overlay_suffix()`, first-tick claim-specialty logic keyed by `DAEMON_ID`, prompt() body now suffixes the specialty after the variant overlay (M98 v3 evolution still rewrites the base body, specialty survives), `replicate` row appended to the replication ledger on replicate-success.

Scope-limited to PR 1: no fitness scoring changes (PR 2), no cull tool (PR 3), no new colonies, no dashboard or auto-promote changes.

Plan reference: see issue thread on #624 for the full 3-PR breakdown (A + B + D-replicate-half landed here).

## Test plan

- [x] `tools/colony-lint.sh` — 311 passed, 0 failed, 3 skipped
- [x] `tools/test-auto-promote.sh` — 35 passed, 0 failed
- [x] `tools/test-make-federation-bundle.sh` — 11 passed, 0 failed
- [x] `research-foundry/tools/test-run-research.sh` — 29 passed, 0 failed
- [x] `bash -n research-foundry/tools/run-research.sh` clean
- [x] `agentis commit research-foundry/explorer/agents/explorer.ag` parses clean
- [x] Generated bootstrap inspected manually: 5 explorer spawn lines with `DAEMON_ID=$i` + `REPLICATION_LEDGER=` env; 5 `spawn` rows produced into `replication-ledger.jsonl` with `specialty in {group_theory, combinatorics, number_theory, probability, algebra}`.

## Follow-ups (out of scope)

- PR 2 of #624: per-pid fitness scoring + dashboard surfacing
- PR 3 of #624: cull cycle + cull-respawn sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)