### PR TITLE
feat(phase-4-prb): prior_advocate colony for claim-auditor synthesis (PR-B of #625)

### DIFF
--- a/research-foundry/BUNDLE.manifest
+++ b/research-foundry/BUNDLE.manifest
@@ -18,6 +18,7 @@ research-foundry/arxiv-search/
 research-foundry/oeis-search/
 research-foundry/groupprops-search/
 research-foundry/scholar-search/
+research-foundry/prior_advocate/
 research-foundry/auditor/
 research-foundry/introducer/
 research-foundry/theorist/

--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -28,6 +28,20 @@ History of the three retired federations consolidated into this one
   `upstream_tick` offsets bumped by one to absorb the new pipeline
   stage. New `(topic, outcome)` pairs in `tools/check-learn-tags.sh`
   for `skeptic_dismiss:partial` and `skeptic_dismiss:success`.
+- `prior_advocate/` colony (Phase 4 PR-B of #625). Reads the same
+  claim seed the four web searchers consume and runs an adversarial-
+  reviewer prompt that argues the claim is already known (cites the
+  closest theorem / lemma / identity). Verdict is folded into the
+  auditor's synthesis ctx as an additional KNOWN_PRIOR signal
+  alongside the four web-search reports; the auditor's seed prompt
+  is updated to count a strong prior_advocate match as a KNOWN_PRIOR
+  signal and the Verdict struct gains an `evidence_prior_advocate`
+  field. Pass-through default -- empty prior_advocate memo does not
+  block the auditor. New `(topic, outcome)` pairs in
+  `tools/check-learn-tags.sh` for `prior_match:partial` and
+  `prior_match:success`. The auditor persists
+  `claim:report_prior_advocate:tick-N` alongside the four searcher
+  reports on VERIFIED_NEW.
 
 ## [0.1.0] — 2026-05-18
 

--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -24,6 +24,7 @@ type Verdict {
     evidence_oeis: string,
     evidence_groupprops: string,
     evidence_scholar: string,
+    evidence_prior_advocate: string,
     problem_summary: string
 }
 
@@ -49,7 +50,7 @@ fn now_ms_via_shell() -> int {
 }
 
 fn _seed_prompt() -> string {
-    return "You are a strict claim auditor. The user-supplied input below carries the original PROBLEM, the stated ANSWER, the NOVELTY CLAIM, and four search reports (ARXIV, OEIS, GROUPPROPS, SCHOLAR). It may also carry RECENT HITL REJECTS (recent human-in-the-loop rejection classes and excerpts from submitted preprints) -- use that signal to flag failure modes the human reviewer has already pushed back on. Classify the claim. Use 'KNOWN_PRIOR' only when at least one searcher reports a 'direct' relevance match for the same result; 'VERIFIED_NEW' when no searcher reports a direct match and the claim is well-supported; 'NEEDS_HUMAN' when reports conflict, are partial, or scholar is unavailable AND the other three are inconclusive. Output ONLY valid JSON: {\"audit_verdict\":\"VERIFIED_NEW|KNOWN_PRIOR|NEEDS_HUMAN\", \"reasoning\":\"...\", \"confidence\":0.0-1.0, \"evidence_arxiv\":\"semicolon-separated arxiv ids or empty\", \"evidence_oeis\":\"semicolon-separated A-numbers or empty\", \"evidence_groupprops\":\"semicolon-separated urls or empty\", \"evidence_scholar\":\"semicolon-separated paper ids or empty\", \"problem_summary\":\"one-line\"}. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
+    return "You are a strict claim auditor. The user-supplied input below carries the original PROBLEM, the stated ANSWER, the NOVELTY CLAIM, and four search reports (ARXIV, OEIS, GROUPPROPS, SCHOLAR). It may also carry RECENT HITL REJECTS (recent human-in-the-loop rejection classes and excerpts from submitted preprints) -- use that signal to flag failure modes the human reviewer has already pushed back on. It may also carry a PRIOR ADVOCATE REPORT, an adversarial-reviewer pass that argues the claim is already known and cites the closest theorem/lemma/identity; count a strong prior_advocate match (is_prior=true with high confidence and a credible classical_anchor) as an additional KNOWN_PRIOR signal alongside the four web-search reports. Classify the claim. Use 'KNOWN_PRIOR' only when at least one searcher reports a 'direct' relevance match for the same result; 'VERIFIED_NEW' when no searcher reports a direct match and the claim is well-supported; 'NEEDS_HUMAN' when reports conflict, are partial, or scholar is unavailable AND the other three are inconclusive. Output ONLY valid JSON: {\"audit_verdict\":\"VERIFIED_NEW|KNOWN_PRIOR|NEEDS_HUMAN\", \"reasoning\":\"...\", \"confidence\":0.0-1.0, \"evidence_arxiv\":\"semicolon-separated arxiv ids or empty\", \"evidence_oeis\":\"semicolon-separated A-numbers or empty\", \"evidence_groupprops\":\"semicolon-separated urls or empty\", \"evidence_scholar\":\"semicolon-separated paper ids or empty\", \"evidence_prior_advocate\":\"classical_anchor from prior_advocate or empty\", \"problem_summary\":\"one-line\"}. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
 // _dump_ctx_to_memo -- write the assembled prompt context to a per-
@@ -124,7 +125,8 @@ fn _publish_auditor(
     arxiv_report: string,
     oeis_report: string,
     groupprops_report: string,
-    scholar_report: string
+    scholar_report: string,
+    prior_advocate_report: string
 ) -> void {
     let conf_str = to_string(verdict.confidence);
     let verdict_json = "{\"audit_verdict\":\"" + verdict.audit_verdict
@@ -178,6 +180,7 @@ fn _publish_auditor(
             memo_write("claim:report_oeis:tick-" + tick_s, oeis_report);
             memo_write("claim:report_groupprops:tick-" + tick_s, groupprops_report);
             memo_write("claim:report_scholar:tick-" + tick_s, scholar_report);
+            memo_write("claim:report_prior_advocate:tick-" + tick_s, prior_advocate_report);
         };
 
         // Audit -> formulator feedback (#623 A). For KNOWN_PRIOR and
@@ -229,7 +232,15 @@ fn tick(reason: string) -> void {
     let groupprops_report = if len(groupprops_pid) > 0 { recall_latest("groupprops_search:" + groupprops_pid + ":report:tick-" + to_string(upstream_tick)); } else { ""; };
     let scholar_report = if len(scholar_pid) > 0 { recall_latest("scholar_search:" + scholar_pid + ":report:tick-" + to_string(upstream_tick)); } else { ""; };
 
-    let any_report = if len(arxiv_report) > 0 { true; } else { if len(oeis_report) > 0 { true; } else { if len(groupprops_report) > 0 { true; } else { len(scholar_report) > 0; }; }; };
+    // Phase 4 PR-B (#625): prior_advocate is an additional adversarial-
+    // reviewer signal alongside the four web searchers. Pass-through
+    // default -- empty prior_advocate memo does not block the auditor;
+    // any_report still gates on the four searchers OR prior_advocate.
+    let prior_advocate_pid = recall_latest("replay:current_prior_advocate_pid");
+    let prior_advocate_report = if len(prior_advocate_pid) > 0 { recall_latest("prior_advocate:" + prior_advocate_pid + ":report:tick-" + to_string(upstream_tick)); } else { ""; };
+    let prior_advocate_is_prior = if len(prior_advocate_pid) > 0 { recall_latest("prior_advocate:" + prior_advocate_pid + ":is_prior:tick-" + to_string(upstream_tick)); } else { ""; };
+
+    let any_report = if len(arxiv_report) > 0 { true; } else { if len(oeis_report) > 0 { true; } else { if len(groupprops_report) > 0 { true; } else { if len(scholar_report) > 0 { true; } else { len(prior_advocate_report) > 0; }; }; }; };
     if !any_report {
         print("[auditor] no searcher reports for tick=", upstream_tick);
         return;
@@ -255,6 +266,7 @@ fn tick(reason: string) -> void {
             + "OEIS REPORT: " + oeis_report + "\n"
             + "GROUPPROPS REPORT: " + groupprops_report + "\n"
             + "SCHOLAR REPORT: " + scholar_report + "\n"
+            + "PRIOR ADVOCATE REPORT (is_prior=" + prior_advocate_is_prior + "): " + prior_advocate_report + "\n"
             + "RECENT HITL REJECTS: " + hitl_summary + "\n";
 
     _dump_ctx_to_memo("auditor", _self_pid, tick_idx, ctx);
@@ -268,14 +280,14 @@ fn tick(reason: string) -> void {
         // `autonomous_decision=true` for downstream observers (#622).
         memo_write("auditor:" + _self_pid + ":autonomous_decision", "true");
         learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "partial", ["acted", "claim-auditor"]);
-        _publish_auditor(true, true, verdict, _self_pid, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report);
+        _publish_auditor(true, true, verdict, _self_pid, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report, prior_advocate_report);
     } else {
         if my_tier == "review-gated" {
             learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "partial", ["review-gated", "claim-auditor"]);
-            _publish_auditor(true, false, verdict, _self_pid, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report);
+            _publish_auditor(true, false, verdict, _self_pid, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report, prior_advocate_report);
         } else {
             if my_tier == "propose" {
-                _publish_auditor(false, false, verdict, _self_pid, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report);
+                _publish_auditor(false, false, verdict, _self_pid, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report, prior_advocate_report);
             } else {
                 print("[auditor] observing (tier:", my_tier, ") verdict=", verdict.audit_verdict);
                 learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "partial", ["observed", "claim-auditor"]);

--- a/research-foundry/prior_advocate/README.md
+++ b/research-foundry/prior_advocate/README.md
@@ -1,0 +1,33 @@
+# Prior Advocate Colony
+
+> Part of the [Claim Auditor](../) research-foundry federation.
+
+The prior advocate colony reads the triggering claim row from memo
+(problem_text / answer / novelty_claim — the same seed the four web
+searchers consume) and runs an adversarial-reviewer LLM call that
+argues the claim is already known: it constructs the strongest
+possible case that the claim is a corollary or restatement of an
+existing result and cites the closest theorem / lemma / identity it
+can find. The structured Verdict is persisted to memo for the auditor
+to fold into its synthesis ctx as an additional KNOWN_PRIOR signal
+alongside the four web-search reports. The default is pass-through —
+an empty or missing prior_advocate memo does not block the auditor
+(Phase 4 PR-B #625).
+
+## Agents
+
+| Agent | File | Learns | Autonomy after |
+|-------|------|--------|----------------|
+| prior_advocate | `agents/prior_advocate.ag` | when a claim is plausibly a re-derivation of a classical result vs genuinely novel | ~10 acted ticks |
+
+## Setup
+
+1. Copy and edit the config:
+   ```bash
+   cp config/colony.example.toml config/colony.toml
+   ```
+
+2. Start the colony:
+   ```bash
+   ./scripts/start-colony.sh
+   ```

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -1,0 +1,148 @@
+// prior_advocate.ag -- Claim Auditor prior advocate: reads the
+// triggering claim row from memo (problem_text / answer /
+// novelty_claim, seeded the same way the four searchers consume it)
+// and runs an adversarial-reviewer prompt that argues the claim is
+// already known. The structured Verdict is persisted to memo for the
+// auditor to fold into its synthesis ctx as an additional KNOWN_PRIOR
+// signal alongside the four web-search reports (Phase 4 PR-B #625).
+//
+// Per-tick behaviour:
+//   1. Read claim seed memo (problem_text / answer / novelty_claim)
+//      for upstream_tick = tick_idx - 1 (mirrors searchers).
+//   2. Build the ADVOCATE_PROMPT and call prompt() -> Verdict JSON.
+//   3. Persist the verdict to memo
+//      (`prior_advocate:<pid>:report:tick-N`,
+//      `prior_advocate:<pid>:is_prior:tick-N`,
+//      `replay:current_prior_advocate_pid`) and emit
+//      "claim-auditor:prior_advocate_done".
+//
+// Run as daemon: agentis daemon agents/prior_advocate.ag --colony prior_advocate
+// Requires: exec capability, messaging capability.
+
+cb 2000;
+
+type Verdict {
+    is_prior: bool,
+    classical_anchor: string,
+    indirect_derivation: string,
+    confidence: float,
+    reasoning: string
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("prior_advocate:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    };
+    return 0.0;
+}
+
+fn colony_name() -> string {
+    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    if len(_cn) > 0 {
+        return _cn;
+    };
+    return "prior_advocate";
+}
+
+fn _seed_prompt() -> string {
+    return "You are an adversarial reviewer arguing this claim is already known. Construct the strongest possible case that the claim is a corollary of, or restatement of, an existing result. Cite the closest theorem/lemma/identity you can think of. Output JSON: `{is_prior: bool, classical_anchor: string, indirect_derivation: string, confidence: float, reasoning: string}`. Do NOT wrap output in markdown code fences.";
+}
+
+// _dump_ctx_to_memo -- write the assembled prompt context to a per-
+// tick memo key so #623-style validation (and any future audit) can
+// inspect what the LLM actually saw. Stable shape:
+// `<agent>:<pid>:ctx:tick-N`. Duplicated verbatim from auditor
+// because the .ag DSL has no shared-include mechanism (#642 pattern).
+fn _dump_ctx_to_memo(agent_name: string, pid: string, tick_idx: int, ctx: string) -> void {
+    if len(agent_name) == 0 { return; };
+    if len(pid) == 0 { return; };
+    memo_write(agent_name + ":" + pid + ":ctx:tick-" + to_string(tick_idx), ctx);
+}
+
+// _publish_prior_advocate -- memo + emit. Non-terminal agent collapses
+// autonomous -> review-gated per ADR-0001 (#622 PR-2 #632 pattern).
+// prior_advocate writes no ledger row today; final_write retained for
+// symmetry with the searchers.
+fn _publish_prior_advocate(
+    final_write: bool,
+    verdict: Verdict,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int
+) -> void {
+    let _ = final_write;
+    let conf_str = to_string(verdict.confidence);
+    let is_prior_str = if verdict.is_prior { "true"; } else { "false"; };
+    let verdict_json = "{\"is_prior\":" + is_prior_str
+                     + ",\"classical_anchor\":\"" + verdict.classical_anchor
+                     + "\",\"indirect_derivation\":\"" + verdict.indirect_derivation
+                     + "\",\"confidence\":" + conf_str
+                     + ",\"reasoning\":\"" + verdict.reasoning + "\"}";
+    memo_write("prior_advocate:" + self_pid + ":report:tick-" + to_string(upstream_tick), verdict_json);
+    memo_write("prior_advocate:" + self_pid + ":is_prior:tick-" + to_string(upstream_tick), is_prior_str);
+    memo_write("replay:current_prior_advocate_pid", self_pid);
+    emit("claim-auditor:prior_advocate_done", verdict);
+}
+
+fn tick(reason: string) -> void {
+    let _ = reason;
+    let _colony_name = colony_name();
+    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let conf = get_confidence();
+    print("[prior_advocate] tick conf=", conf);
+
+    let tick_idx_str = recall_latest("replay:current_tick");
+    let tick_idx = if len(tick_idx_str) > 0 { parse_int(tick_idx_str); } else { -1; };
+    if tick_idx < 0 {
+        print("[prior_advocate] no auditor tick yet");
+        return;
+    };
+    let upstream_tick = tick_idx - 1;
+    if upstream_tick < 0 {
+        print("[prior_advocate] waiting for first seed, current=", tick_idx);
+        return;
+    };
+
+    let problem_text = recall_latest("claim:problem_text:tick-" + to_string(upstream_tick));
+    let stated_answer = recall_latest("claim:answer:tick-" + to_string(upstream_tick));
+    let novelty_claim = recall_latest("claim:novelty_claim:tick-" + to_string(upstream_tick));
+    if len(problem_text) == 0 {
+        print("[prior_advocate] no claim seed for tick=", upstream_tick);
+        return;
+    };
+
+    let ctx = "PROBLEM: " + problem_text + "\n"
+            + "ANSWER: " + stated_answer + "\n"
+            + "NOVELTY CLAIM: " + novelty_claim + "\n";
+
+    _dump_ctx_to_memo("prior_advocate", _self_pid, tick_idx, ctx);
+    let verdict = prompt(_seed_prompt(), ctx) -> Verdict;
+
+    let my_tier = tier("prior_advocate");
+    if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("prior_advocate:" + _self_pid + ":review_gated", "true");
+        learn("prior_match", "tick " + to_string(tick_idx), verdict.reasoning, "partial", ["acted", "claim-auditor"]);
+        _publish_prior_advocate(true, verdict, _self_pid, upstream_tick, tick_idx);
+    } else {
+        if my_tier == "review-gated" {
+            memo_write("prior_advocate:" + _self_pid + ":review_gated", "true");
+            learn("prior_match", "tick " + to_string(tick_idx), verdict.reasoning, "partial", ["review-gated", "claim-auditor"]);
+            _publish_prior_advocate(true, verdict, _self_pid, upstream_tick, tick_idx);
+        } else {
+            if my_tier == "propose" {
+                learn("prior_match", "tick " + to_string(tick_idx), verdict.reasoning, "success", ["emitted", "claim-auditor"]);
+                _publish_prior_advocate(false, verdict, _self_pid, upstream_tick, tick_idx);
+            } else {
+                print("[prior_advocate] observing (tier:", my_tier, ") is_prior=", verdict.is_prior);
+                learn("prior_match", "tick " + to_string(tick_idx), verdict.reasoning, "partial", ["observed", "claim-auditor"]);
+            };
+        };
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("prior_advocate:last_check", now);
+    };
+}

--- a/research-foundry/prior_advocate/config/colony.example.toml
+++ b/research-foundry/prior_advocate/config/colony.example.toml
@@ -1,0 +1,30 @@
+# Prior Advocate Colony Configuration
+#
+# Part of the Claim Auditor federation. The prior advocate colony
+# reads the triggering claim row from memo (problem_text / answer /
+# novelty_claim, same seed the four web searchers consume) and runs
+# an adversarial-reviewer LLM call that argues the claim is already
+# known. The Verdict is persisted to memo for the auditor to fold
+# into its synthesis ctx as an additional KNOWN_PRIOR signal
+# alongside the four search reports. Does not touch any external API.
+#
+# Copy to colony.toml and edit for your environment.
+
+[colony]
+name = "prior_advocate"
+tick_interval_ms = 60000
+
+# Non-forge federation (#373, ADR-0003). The prior advocate writes
+# only to memo (no JSONL ledger row today); no agent in this colony
+# calls forge-api.sh.
+[forge]
+type = "none"
+
+[llm]
+backend = "cli"
+
+[[agents]]
+name = "prior_advocate"
+source = "agents/prior_advocate.ag"
+cb_budget = 2000
+tick_interval_ms = 60000

--- a/research-foundry/prior_advocate/scripts/start-colony.sh
+++ b/research-foundry/prior_advocate/scripts/start-colony.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Start the Prior Advocate colony (part of the Claim Auditor federation).
+#
+# The prior advocate reads the triggering claim row from memo and runs
+# an adversarial-reviewer LLM call that argues the claim is already
+# known. The Verdict is persisted to memo for the auditor to fold into
+# its synthesis ctx alongside the four web-search reports.
+#
+# Usage:
+#   ./scripts/start-colony.sh [path/to/colony.toml]
+#   ./scripts/start-colony.sh --restart-agent <name> [path/to/colony.toml]
+#   ./scripts/start-colony.sh --rate-limit-status
+#
+# ADR-0003 conformance: --restart-agent (#257) respawns one agent with full
+# colony env, skips memo seeding + log truncation; --rate-limit-status
+# (federation-dashboard 0.3.0) execs forge-api.sh rate-limit-status. Exit
+# codes: 0 ok, 2 unknown flag / missing arg, 3 unknown agent, 4 daemon
+# launch failure.
+
+set -e
+
+RESTART_AGENT=""
+RATE_LIMIT_STATUS=0
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --restart-agent)
+            if [ -z "${2:-}" ]; then
+                echo "start-colony.sh: --restart-agent requires an agent name" >&2
+                exit 2
+            fi
+            RESTART_AGENT="$2"
+            shift 2
+            ;;
+        --rate-limit-status)
+            RATE_LIMIT_STATUS=1
+            shift
+            ;;
+        --)
+            shift
+            POSITIONAL+=("$@")
+            break
+            ;;
+        -*)
+            echo "start-colony.sh: unknown flag: $1" >&2
+            exit 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+COLONY_DIR="$(dirname "$SCRIPT_DIR")"
+FED_DIR="$(dirname "$COLONY_DIR")"
+CONFIG="${1:-$COLONY_DIR/config/colony.toml}"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "Config not found: $CONFIG"
+    echo "Copy config/colony.example.toml to config/colony.toml and edit it."
+    exit 1
+fi
+
+PARSE_TOML=""
+for cand in "$FED_DIR/tools/parse-toml.sh" "$FED_DIR/../tools/parse-toml.sh"; do
+    if [ -f "$cand" ]; then
+        PARSE_TOML="$cand"
+        break
+    fi
+done
+if [ -z "$PARSE_TOML" ]; then
+    echo "Error: tools/parse-toml.sh not found in $FED_DIR/tools or $FED_DIR/../tools" >&2
+    exit 1
+fi
+# shellcheck source=/dev/null
+. "$PARSE_TOML"
+
+COLONY_NAME="prior_advocate"
+DISCOVERY_LEDGER="${DISCOVERY_LEDGER:-}"
+DAEMON_ID="${DAEMON_ID:-1}"
+export COLONY_DIR COLONY_NAME DISCOVERY_LEDGER DAEMON_ID
+
+AGENTS=(
+    prior_advocate
+)
+
+if [ ${#AGENTS[@]} -eq 0 ] && [ "$RATE_LIMIT_STATUS" = "0" ] && [ -z "$RESTART_AGENT" ]; then
+    echo "No agents defined yet." >&2
+    exit 1
+fi
+
+tick_interval_for() {
+    case "$1" in
+        prior_advocate) echo "${PRIOR_ADVOCATE_TICK_MS:-60000}" ;;
+        *) echo 60000 ;;
+    esac
+}
+
+if [ "$RATE_LIMIT_STATUS" = "1" ]; then
+    if [ -x "$COLONY_DIR/scripts/forge-api.sh" ]; then
+        exec "$COLONY_DIR/scripts/forge-api.sh" rate-limit-status
+    fi
+    echo '{"remaining": null, "limit": null, "reset_at": null, "error": "rate-limit-status not implemented for this colony"}'
+    exit 0
+fi
+
+if [ -n "$RESTART_AGENT" ]; then
+    valid=0
+    for a in "${AGENTS[@]}"; do
+        [ "$a" = "$RESTART_AGENT" ] && valid=1
+    done
+    if [ "$valid" = "0" ]; then
+        echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
+        exit 3
+    fi
+    tick=$(tick_interval_for "$RESTART_AGENT")
+    agentis daemon "$COLONY_DIR/agents/${RESTART_AGENT}.ag" \
+        --colony prior_advocate \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval "$tick" </dev/null >/dev/null 2>&1 &
+    agent_pid=$!
+    sleep 0.5
+    if ! kill -0 "$agent_pid" 2>/dev/null; then
+        echo "start-colony.sh: agentis daemon failed to launch $RESTART_AGENT" >&2
+        exit 4
+    fi
+    echo "started $RESTART_AGENT pid=$agent_pid tick=$tick"
+    exit 0
+fi
+
+# Seed propose-tier confidence.
+agentis memo set "prior_advocate:confidence" "0.7" >/dev/null 2>&1 || true
+
+echo "Starting Prior Advocate colony (${#AGENTS[@]} agents)..."
+
+for agent in "${AGENTS[@]}"; do
+    interval=$(tick_interval_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms)..."
+    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+        --colony prior_advocate \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval "$interval" &
+    sleep 2
+done
+
+echo "Colony started. Use 'agentis daemon list' to monitor."
+echo "Stop with: agentis daemon stop --all"
+
+wait

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -342,14 +342,14 @@ build_image() {
 }
 
 # --- 2) Per-node bootstrap script generator ---
-# Single bootstrap that spawns all 16 daemons under one .agentis/.
+# Single bootstrap that spawns all 17 daemons under one .agentis/.
 # Three pipeline groups:
 #   math      = explorer, noticer, skeptic, formulator, verifier, novelty
-#   searchers = arxiv-search, oeis-search, groupprops-search, scholar-search, auditor
+#   searchers = arxiv-search, oeis-search, groupprops-search, scholar-search, prior_advocate, auditor
 #   preprint  = introducer, theorist, computer, editor, submitter
 # Explorer keeps --enable-replication --allow-replica-replication so
 # the M2-Malthusian replicate gate inside explorer.ag can grow its
-# population. The remaining 15 colonies run with standard
+# population. The remaining 16 colonies run with standard
 # --enable-exec --enable-messaging flags. Per-daemon tick interval is
 # fixed at 30s (decoupled from the orchestrator's TICK_INTERVAL_S
 # `replay:current_tick` advance rate); same reason as the retired
@@ -357,10 +357,10 @@ build_image() {
 # the orchestrator tick to avoid missing state changes).
 write_bootstrap() {
     bootstrap_path="$LAPTOP_DIR/bootstrap.sh"
-    emit_step "generating bootstrap script at $bootstrap_path (colonies=16 daemons_per_colony=$DAEMONS_PER_COLONY)"
+    emit_step "generating bootstrap script at $bootstrap_path (colonies=17 daemons_per_colony=$DAEMONS_PER_COLONY)"
 
     if [ "$DRY_RUN" = "1" ]; then
-        emit_cmd "write-bootstrap path=$bootstrap_path colonies=explorer,noticer,skeptic,formulator,verifier,novelty,arxiv-search,oeis-search,groupprops-search,scholar-search,auditor,introducer,theorist,computer,editor,submitter"
+        emit_cmd "write-bootstrap path=$bootstrap_path colonies=explorer,noticer,skeptic,formulator,verifier,novelty,arxiv-search,oeis-search,groupprops-search,scholar-search,prior_advocate,auditor,introducer,theorist,computer,editor,submitter"
         return
     fi
 
@@ -399,9 +399,9 @@ write_bootstrap() {
             printf '  printf "llm.args = -p --output-format json --model %s --tools \\"\\" --system-prompt \\"You are a research mathematician drafting an arXiv preprint. Output only valid JSON.\\" --effort %s\\n"\n' "$CLAUDE_MODEL" "$CLAUDE_EFFORT"
         fi
         printf '} >> .agentis/config\n'
-        # Stage all 15 colonies + tools/ + config/ + data/ from the
+        # Stage all 17 colonies + tools/ + config/ + data/ from the
         # read-only /repo bind-mount.
-        printf 'for c in explorer noticer skeptic formulator verifier novelty arxiv-search oeis-search groupprops-search scholar-search auditor introducer theorist computer editor submitter; do\n'
+        printf 'for c in explorer noticer skeptic formulator verifier novelty arxiv-search oeis-search groupprops-search scholar-search prior_advocate auditor introducer theorist computer editor submitter; do\n'
         printf '    cp -r /repo/research-foundry/$c /run-root/$c\n'
         printf 'done\n'
         printf 'cp -r /repo/research-foundry/tools /run-root/tools\n'
@@ -416,7 +416,7 @@ write_bootstrap() {
         # claim-auditor / preprint-foundry searcher keys use underscored
         # forms (arxiv_search, oeis_search, etc.) because the .ag agents
         # call them that way internally; mirrors retired run-auditor.sh.
-        printf 'for c in explorer noticer skeptic formulator verifier novelty arxiv_search oeis_search groupprops_search scholar_search auditor introducer theorist computer editor submitter; do\n'
+        printf 'for c in explorer noticer skeptic formulator verifier novelty arxiv_search oeis_search groupprops_search scholar_search prior_advocate auditor introducer theorist computer editor submitter; do\n'
         printf '    (cd /run-root && agentis memo set $c:confidence 0.7 >/dev/null 2>&1 || true)\n'
         printf 'done\n'
         # Per-daemon tick interval is 30s (decoupled from orchestrator
@@ -498,6 +498,11 @@ write_bootstrap() {
         printf 'for c in arxiv-search oeis-search groupprops-search scholar-search; do\n'
         printf '    DAEMON_ID=1 COLONY_NAME=$c DISCOVERY_LEDGER=/run-root/audit-ledger.jsonl ARXIV_MAX_QUERY_RESULTS=10 AGENTIS_ROOT=/run-root/.agentis agentis daemon /run-root/$c/agents/$c.ag --colony $c --enable-exec --enable-messaging --tick-interval "$DAEMON_TICK_INTERVAL_MS" > /run-root/.agentis/logs/$c-1.log 2>&1 &\n'
         printf 'done\n'
+        # Phase 4 PR-B (#625): prior_advocate colony runs the adversarial
+        # reviewer prompt that argues the claim is already known. Single
+        # daemon mirroring the searchers' env shape; auditor.ag pass-
+        # through default so empty prior_advocate memo does not block.
+        printf 'DAEMON_ID=1 COLONY_NAME=prior_advocate DISCOVERY_LEDGER=/run-root/audit-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis agentis daemon /run-root/prior_advocate/agents/prior_advocate.ag --colony prior_advocate --enable-exec --enable-messaging --tick-interval "$DAEMON_TICK_INTERVAL_MS" > /run-root/.agentis/logs/prior_advocate-1.log 2>&1 &\n'
         printf 'DAEMON_ID=1 COLONY_NAME=auditor DISCOVERY_LEDGER=/run-root/audit-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis agentis daemon /run-root/auditor/agents/auditor.ag --colony auditor --enable-exec --enable-messaging --tick-interval "$DAEMON_TICK_INTERVAL_MS" > /run-root/.agentis/logs/auditor-1.log 2>&1 &\n'
         # preprint-foundry: introducer / theorist / computer / editor / submitter.
         # Audit-trail goes to preprint-ledger.jsonl.

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -15,7 +15,7 @@
 #   8. Invalid RESEARCH_TOTAL_TICKS=0 rejected with exit 2
 #   9. Empty RESEARCH_TOPICS rejected with exit 2
 #  10. Bootstrap-script generation step is emitted in dry-run output,
-#      and names all 16 colonies.
+#      and names all 17 colonies.
 #  11. Container spawn command is emitted in dry-run output using the
 #      `research-foundry-laptop` name (single sidecar block).
 #  12. Run-meta.json write step is emitted in dry-run output
@@ -128,12 +128,12 @@ assert_contains "9b. empty-topics stderr names the variable" "$EMPTY_OUT" \
     "RESEARCH_TOPICS must be a non-empty comma-separated list"
 
 # ---------------------------------------------------------------------------
-# 10. Bootstrap-script generation names all 16 colonies.
+# 10. Bootstrap-script generation names all 17 colonies.
 # ---------------------------------------------------------------------------
 assert_contains "10a. bootstrap-script generation step emitted" "$OUT" \
     "generating bootstrap script"
 assert_contains "10b. bootstrap names explorer/noticer/.../submitter" "$OUT" \
-    "colonies=explorer,noticer,skeptic,formulator,verifier,novelty,arxiv-search,oeis-search,groupprops-search,scholar-search,auditor,introducer,theorist,computer,editor,submitter"
+    "colonies=explorer,noticer,skeptic,formulator,verifier,novelty,arxiv-search,oeis-search,groupprops-search,scholar-search,prior_advocate,auditor,introducer,theorist,computer,editor,submitter"
 
 # ---------------------------------------------------------------------------
 # 11. Spawn command uses research-foundry-laptop name (single).

--- a/tools/check-learn-tags.sh
+++ b/tools/check-learn-tags.sh
@@ -459,6 +459,28 @@ observed
 claim-auditor"
             PAIR_KNOWN=1
             ;;
+        "prior_match:partial")
+            # Phase 4 PR-B (#625): prior_advocate runs an adversarial-
+            # reviewer prompt that argues the claim is already known.
+            # `partial` outcome covers acted / review-gated / observed
+            # branches.
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
+        "prior_match:success")
+            # Phase 4 PR-B (#625): prior_advocate `success` outcome
+            # covers the propose-tier emitted branch.
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+claim-auditor"
+            PAIR_KNOWN=1
+            ;;
 
         # ----------------------------------------------------------------
         # preprint-foundry research federation (#622 PR-3)


### PR DESCRIPTION
## Summary

Implements PR-B of three critic colonies per Phase 4 plan
(https://github.com/Replikanti/agentis-colonies/issues/625#issuecomment-4480642376).

The prior_advocate colony sits alongside the four web searchers
(arxiv / oeis / groupprops / scholar) and runs an adversarial-
reviewer LLM call that argues the triggering claim is already known
(cites the closest theorem / lemma / identity it can find). The
auditor folds the verdict into its synthesis ctx as an additional
KNOWN_PRIOR signal alongside the four web-search reports.

Failure-mode default: pass-through. Empty prior_advocate memo (LLM
unavailable or colony down) lets the auditor proceed on the four
searcher reports alone, so the new critic cannot strand the audit
pipeline on infrastructure issues. PR-A (skeptic) already merged via
#652; PR-C (reviewer) follows.

Two commits:
- `c25184d` — colony scaffold (4 files: `prior_advocate.ag`,
  `colony.example.toml`, `start-colony.sh`, `README.md`). Same
  `cb 2000`, tick interval, and 4-tier branch shape as the existing
  searchers; `upstream_tick = tick_idx - 1` mirrors the searcher
  offset. ADR-0003-conformant `start-colony.sh` with `--restart-agent`
  + `--rate-limit-status` flags. Tier branches from PR-2 (#632)
  preserved (autonomous collapses to review-gated; non-terminal).
- `65be9f9` — auditor + orchestrator wiring. `auditor.ag` Verdict
  struct gains `evidence_prior_advocate`; seed prompt instructs the
  LLM to count a strong prior_advocate match as a KNOWN_PRIOR
  signal; `_publish_auditor` persists
  `claim:report_prior_advocate:tick-N` alongside the four searcher
  reports on `VERIFIED_NEW`. `run-research.sh` bootstrap colony
  count 16 → 17 (cp/seed loops + dedicated daemon spawn line).
  `tools/check-learn-tags.sh` schema extended with
  `prior_match:partial` + `prior_match:success` pairs. CHANGELOG
  + BUNDLE.manifest updated.

## Test plan

- [x] `tools/colony-lint.sh` — 326 passed, 0 failed, 3 skipped
  (was 319 post-PR-A; +7 from new colony, plan expected ~326).
- [x] `tools/test-check-learn-tags.sh` — 16/0.
- [x] `tools/test-auto-promote.sh` — 35/0.
- [x] `tools/test-make-federation-bundle.sh` — 11/0.
- [x] `research-foundry/tools/test-run-research.sh` — 29/0 (colony
  list assertion updated to 17).
- [x] `bash -n` clean on all modified shell scripts.
- [x] `bash research-foundry/tools/run-research.sh --dry-run`
  surfaces `prior_advocate` in the colonies= placeholder and the
  bootstrap stage / confidence-seed loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)