### PR TITLE
feat(phase-7-pra): auto-evolve plumbing + ledger + dry-run stubs (PR-A of #628)

### DIFF
--- a/tools/auto-evolve-ab-ledger.py
+++ b/tools/auto-evolve-ab-ledger.py
@@ -9,7 +9,7 @@
 # test-auto-promote.sh test 10.
 #
 # Usage:
-#   auto-evolve-ab-ledger.py <ledger_path> <event> <agent> <colony>
+#   auto-evolve-ab-ledger.py <event> <agent> <colony>
 #       <generation> <parent_sha> <ab_ticks> <dry_run> <extras_json>
 #
 # All positional args are strings (the calling shell already has them
@@ -17,8 +17,10 @@
 # keys are merged into the row; pass `{}` for "no extras".
 #
 # Output: a single JSON line on stdout. The caller redirects it into
-# the ledger file with `>>`. We don't open the ledger here so the
-# shell retains full control over file open / lock semantics.
+# the ledger file with `>>`. We deliberately do NOT take the ledger
+# path as an argument so shellcheck SC2094 ("read and write same file
+# in same pipeline") doesn't fire on the caller — the shell is the
+# sole owner of file open + redirect semantics.
 
 import json
 import os
@@ -27,29 +29,28 @@ import time
 
 
 def main():
-    if len(sys.argv) != 10:
+    if len(sys.argv) != 9:
         sys.stderr.write(
-            'Usage: %s <ledger_path> <event> <agent> <colony> '
+            'Usage: %s <event> <agent> <colony> '
             '<generation> <parent_sha> <ab_ticks> <dry_run> <extras_json>\n'
             % os.path.basename(sys.argv[0])
         )
         return 2
 
-    _ledger_path = sys.argv[1]  # consumed by caller for the redirect target
-    event = sys.argv[2]
-    agent = sys.argv[3]
-    colony = sys.argv[4]
+    event = sys.argv[1]
+    agent = sys.argv[2]
+    colony = sys.argv[3]
     try:
-        generation = int(sys.argv[5])
+        generation = int(sys.argv[4])
     except (ValueError, TypeError):
         generation = 0
-    parent_sha = sys.argv[6]
+    parent_sha = sys.argv[5]
     try:
-        ab_ticks = int(sys.argv[7])
+        ab_ticks = int(sys.argv[6])
     except (ValueError, TypeError):
         ab_ticks = 0
-    dry_run = sys.argv[8].lower() == 'true'
-    extras_raw = sys.argv[9]
+    dry_run = sys.argv[7].lower() == 'true'
+    extras_raw = sys.argv[8]
 
     try:
         extras = json.loads(extras_raw) if extras_raw else {}

--- a/tools/auto-evolve-ab-ledger.py
+++ b/tools/auto-evolve-ab-ledger.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# tools/auto-evolve-ab-ledger.py — Ledger row writer for
+# tools/auto-evolve-ab.sh (#628 PR-A).
+#
+# Emits one JSON object on stdout per invocation. Same extraction
+# pattern as the auto-promote-config-parser.py / auto-promote-decisions.py
+# pair: each Python block lives in its own helper file so the calling
+# shell never opens a heredoc — see CLAUDE.md no-heredoc invariant +
+# test-auto-promote.sh test 10.
+#
+# Usage:
+#   auto-evolve-ab-ledger.py <ledger_path> <event> <agent> <colony>
+#       <generation> <parent_sha> <ab_ticks> <dry_run> <extras_json>
+#
+# All positional args are strings (the calling shell already has them
+# in that form). `extras_json` is a JSON object literal whose top-level
+# keys are merged into the row; pass `{}` for "no extras".
+#
+# Output: a single JSON line on stdout. The caller redirects it into
+# the ledger file with `>>`. We don't open the ledger here so the
+# shell retains full control over file open / lock semantics.
+
+import json
+import os
+import sys
+import time
+
+
+def main():
+    if len(sys.argv) != 10:
+        sys.stderr.write(
+            'Usage: %s <ledger_path> <event> <agent> <colony> '
+            '<generation> <parent_sha> <ab_ticks> <dry_run> <extras_json>\n'
+            % os.path.basename(sys.argv[0])
+        )
+        return 2
+
+    _ledger_path = sys.argv[1]  # consumed by caller for the redirect target
+    event = sys.argv[2]
+    agent = sys.argv[3]
+    colony = sys.argv[4]
+    try:
+        generation = int(sys.argv[5])
+    except (ValueError, TypeError):
+        generation = 0
+    parent_sha = sys.argv[6]
+    try:
+        ab_ticks = int(sys.argv[7])
+    except (ValueError, TypeError):
+        ab_ticks = 0
+    dry_run = sys.argv[8].lower() == 'true'
+    extras_raw = sys.argv[9]
+
+    try:
+        extras = json.loads(extras_raw) if extras_raw else {}
+    except (json.JSONDecodeError, ValueError):
+        extras = {'_extras_parse_error': extras_raw[:200]}
+
+    row = {
+        'ts': int(time.time()),
+        'ts_iso': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+        'event': event,
+        'agent': agent,
+        'colony': colony,
+        'generation': generation,
+        'parent_sha': parent_sha,
+        'parent_sha8': parent_sha[:8] if parent_sha else '',
+        'ab_ticks': ab_ticks,
+        'dry_run': dry_run,
+    }
+    if isinstance(extras, dict):
+        for k, v in extras.items():
+            # Keep the base fields immutable so a malformed extras dict
+            # can't corrupt downstream parsers' assumptions.
+            if k not in row:
+                row[k] = v
+
+    print(json.dumps(row))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main() or 0)

--- a/tools/auto-evolve-ab.sh
+++ b/tools/auto-evolve-ab.sh
@@ -158,7 +158,7 @@ ledger_append() {
     local extras_json="$2"
     mkdir -p "$(dirname "$LEDGER_PATH")"
     python3 "$SCRIPT_DIR/auto-evolve-ab-ledger.py" \
-        "$LEDGER_PATH" "$event" \
+        "$event" \
         "$AGENT_NAME" "$COLONY" \
         "$GENERATION_NEXT" "$PARENT_SHA" \
         "$AB_TICKS" "$EVOLVE_DRY_RUN" \

--- a/tools/auto-evolve-ab.sh
+++ b/tools/auto-evolve-ab.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# auto-evolve-ab.sh — Phase 7 PR-A plumbing for self-improving .ag
+# mutation harness (#628).
+#
+# Invoked by `tools/auto-promote.sh` when
+# `evolve.mutation.enabled = true` in the active auto-promote-config.
+# When the flag is false (the default) the legacy `agentis evolve`
+# path runs instead — see auto-promote.sh evolve handler.
+#
+# Pipeline (PR-A, mutator stubbed):
+#   1. Pre-flight throttle: count open candidate files in
+#      `<colony>/agents/.evolve/`; abort with `evolve_throttled` ledger
+#      row when the cap is hit.
+#   2. Generate stub candidate: copy parent .ag to
+#      `<colony>/agents/.evolve/<agent>.ag.candidate-gen-N` with a
+#      trivial cosmetic comment. PR-B replaces this with the real
+#      LLM-driven mutator (`auto-evolve-mutate.py`).
+#   3. Validity gate (3 checks): `agentis commit` succeeds, tier
+#      coverage regex passes (mirroring colony-lint.sh §475-490), and
+#      a `cb <N>;` budget line is present. On failure, write a
+#      `mutation_rejected` ledger row + exit.
+#   4. PR-A skip: do NOT actually run A/B (no daemon spawn / score
+#      comparison yet). Log `ab_skipped_pr_a_stub` ledger row to mark
+#      the placeholder. PR-B fills this in.
+#   5. Cleanup: remove the stub candidate. When `evolve.dry_run=true`,
+#      do NOT archive the parent or respawn. When false (PR-C scope),
+#      archive parent to `<fed-dir>/<archive_dir>/<agent>-gen-N-<sha8>.ag`.
+#
+# Usage:
+#   tools/auto-evolve-ab.sh <fed-dir> <agent-name> <colony> <parent-ag-path>
+#       [--ticks K] [--config <yaml>] [--dry-run]
+#
+# Exit codes:
+#   0 — success (ledger written, regardless of decision)
+#   1 — usage / arg error
+#   2 — config / parser error
+#
+# Out of scope for PR-A:
+#   - real LLM mutation (deferred to PR-B `auto-evolve-mutate.py`)
+#   - A/B daemon spawn + score comparison (PR-B)
+#   - flipping `evolve.dry_run=false` (PR-C)
+
+set -euo pipefail
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+usage() {
+    echo "Usage: $0 <fed-dir> <agent-name> <colony> <parent-ag-path>"
+    echo "          [--ticks K] [--config <yaml>] [--dry-run]"
+    exit 1
+}
+
+if [ $# -lt 4 ]; then
+    usage
+fi
+
+FED_DIR="$1"
+AGENT_NAME="$2"
+COLONY="$3"
+PARENT_AG="$4"
+shift 4
+
+AB_TICKS_OVERRIDE=""
+CONFIG_OVERRIDE=""
+DRY_RUN_FORCE=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ticks)
+            if [ $# -lt 2 ]; then
+                echo "auto-evolve-ab: --ticks requires a value" >&2
+                exit 1
+            fi
+            AB_TICKS_OVERRIDE="$2"
+            shift 2
+            ;;
+        --config)
+            if [ $# -lt 2 ]; then
+                echo "auto-evolve-ab: --config requires a path argument" >&2
+                exit 1
+            fi
+            CONFIG_OVERRIDE="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN_FORCE=true
+            shift
+            ;;
+        *)
+            echo "auto-evolve-ab: unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ ! -d "$FED_DIR" ]; then
+    echo "auto-evolve-ab: federation dir not found: $FED_DIR" >&2
+    exit 1
+fi
+if [ ! -f "$PARENT_AG" ]; then
+    echo "auto-evolve-ab: parent .ag file not found: $PARENT_AG" >&2
+    exit 1
+fi
+
+# Resolve config path: --config wins; otherwise default to the
+# adjacent default config. Same resolution rule as auto-promote.sh
+# (#622): try repo-root-relative first, then verbatim.
+if [ -n "$CONFIG_OVERRIDE" ]; then
+    if [ -f "$REPO_ROOT/$CONFIG_OVERRIDE" ]; then
+        CONFIG_FILE="$REPO_ROOT/$CONFIG_OVERRIDE"
+    else
+        CONFIG_FILE="$CONFIG_OVERRIDE"
+    fi
+else
+    CONFIG_FILE="$SCRIPT_DIR/auto-promote-config.yaml"
+fi
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "auto-evolve-ab: config not found: $CONFIG_FILE" >&2
+    exit 2
+fi
+
+# Parse config — same parser as auto-promote.sh sidecar. Pulls the
+# `CFG_EVOLVE_*` set added in PR-A's parser update.
+eval "$(python3 "$SCRIPT_DIR/auto-promote-config-parser.py" "$CONFIG_FILE")"
+
+# CLI --dry-run forces dry-run regardless of config.
+if [ "$DRY_RUN_FORCE" = "true" ]; then
+    EVOLVE_DRY_RUN="true"
+else
+    EVOLVE_DRY_RUN="$CFG_EVOLVE_DRY_RUN"
+fi
+
+# --ticks overrides config-driven AB ticks; otherwise fall back.
+if [ -n "$AB_TICKS_OVERRIDE" ]; then
+    AB_TICKS="$AB_TICKS_OVERRIDE"
+else
+    AB_TICKS="$CFG_EVOLVE_AB_TICKS"
+fi
+
+LEDGER_PATH="$FED_DIR/$CFG_EVOLVE_LEDGER_PATH"
+ARCHIVE_DIR="$FED_DIR/$CFG_EVOLVE_ARCHIVE_DIR"
+EVOLVE_DIR="$FED_DIR/$COLONY/agents/.evolve"
+
+log() {
+    echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] auto-evolve-ab: $*"
+}
+
+# Append a ledger row. Args:
+#   1: event name (evolve_cycle | mutation_rejected | evolve_throttled |
+#      ab_inconclusive | ab_skipped_pr_a_stub)
+#   2: extras JSON (object literal merged into the base record)
+# The base record always carries ts, event, agent, colony, generation,
+# parent_sha8, ab_ticks, dry_run so downstream tooling can rely on
+# those fields being present on every row.
+ledger_append() {
+    local event="$1"
+    local extras_json="$2"
+    mkdir -p "$(dirname "$LEDGER_PATH")"
+    python3 "$SCRIPT_DIR/auto-evolve-ab-ledger.py" \
+        "$LEDGER_PATH" "$event" \
+        "$AGENT_NAME" "$COLONY" \
+        "$GENERATION_NEXT" "$PARENT_SHA" \
+        "$AB_TICKS" "$EVOLVE_DRY_RUN" \
+        "$extras_json" >> "$LEDGER_PATH"
+}
+
+# ------------------------------------------------------------------
+# 0. Resolve parent_sha + generation_current
+# ------------------------------------------------------------------
+
+PARENT_SHA=$(python3 -c "
+import hashlib, sys
+with open(sys.argv[1], 'rb') as f:
+    print(hashlib.sha256(f.read()).hexdigest())
+" "$PARENT_AG")
+PARENT_SHA8="${PARENT_SHA:0:8}"
+
+# Read current generation from the ledger if it exists. Mirrors the
+# scan in auto-promote-decisions.py so the two agree on `generation_current`.
+GENERATION_CURRENT=$(python3 -c "
+import json, os, sys
+ledger = sys.argv[1]
+sha = sys.argv[2]
+sha8 = sha[:8]
+max_gen = 0
+if os.path.isfile(ledger):
+    with open(ledger) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(row, dict):
+                continue
+            if row.get('parent_sha8') != sha8 and row.get('parent_sha') != sha:
+                continue
+            g = row.get('generation')
+            try:
+                gi = int(g) if g is not None else 0
+            except (ValueError, TypeError):
+                gi = 0
+            if gi > max_gen:
+                max_gen = gi
+print(max_gen)
+" "$LEDGER_PATH" "$PARENT_SHA")
+GENERATION_NEXT=$((GENERATION_CURRENT + 1))
+
+log "Starting (agent=$AGENT_NAME colony=$COLONY parent_sha8=$PARENT_SHA8 gen_next=$GENERATION_NEXT dry_run=$EVOLVE_DRY_RUN)"
+
+# ------------------------------------------------------------------
+# 0a. Generation cap check
+# ------------------------------------------------------------------
+
+if [ "$GENERATION_NEXT" -gt "$CFG_EVOLVE_MUTATION_MAX_GENERATIONS" ]; then
+    log "  generation cap reached: next=$GENERATION_NEXT > max=$CFG_EVOLVE_MUTATION_MAX_GENERATIONS"
+    ledger_append "evolve_throttled" "{\"reason\":\"max_generations_reached\",\"max_generations\":$CFG_EVOLVE_MUTATION_MAX_GENERATIONS}"
+    exit 0
+fi
+
+# ------------------------------------------------------------------
+# 1. Pre-flight throttle: count open candidate files
+# ------------------------------------------------------------------
+
+mkdir -p "$EVOLVE_DIR"
+OPEN_COUNT=$(find "$EVOLVE_DIR" -maxdepth 1 -name "*.candidate-gen-*" -type f 2>/dev/null | wc -l)
+OPEN_COUNT=$((OPEN_COUNT + 0))
+
+if [ "$OPEN_COUNT" -ge "$CFG_EVOLVE_MUTATION_MAX_CONCURRENT_PER_COLONY" ]; then
+    log "  throttle: $OPEN_COUNT open candidates >= max=$CFG_EVOLVE_MUTATION_MAX_CONCURRENT_PER_COLONY"
+    ledger_append "evolve_throttled" "{\"open_candidates\":$OPEN_COUNT,\"max_concurrent_per_colony\":$CFG_EVOLVE_MUTATION_MAX_CONCURRENT_PER_COLONY}"
+    exit 0
+fi
+
+# ------------------------------------------------------------------
+# 2. Generate stub candidate (PR-A placeholder for LLM mutator)
+# ------------------------------------------------------------------
+
+CANDIDATE_PATH="$EVOLVE_DIR/${AGENT_NAME}.ag.candidate-gen-${GENERATION_NEXT}"
+# Stub mutation: copy parent + append a cosmetic comment. PR-B replaces
+# this block with the real `tools/auto-evolve-mutate.py` LLM call.
+cp "$PARENT_AG" "$CANDIDATE_PATH"
+printf '\n// Stub mutation generated by PR-A (#628) — replaced by LLM mutator in PR-B\n' >> "$CANDIDATE_PATH"
+
+CANDIDATE_SHA=$(python3 -c "
+import hashlib, sys
+with open(sys.argv[1], 'rb') as f:
+    print(hashlib.sha256(f.read()).hexdigest())
+" "$CANDIDATE_PATH")
+CANDIDATE_SHA8="${CANDIDATE_SHA:0:8}"
+
+log "  stub candidate written: $CANDIDATE_PATH (sha8=$CANDIDATE_SHA8)"
+
+# ------------------------------------------------------------------
+# 3. Validity gate (3 checks)
+# ------------------------------------------------------------------
+
+VALIDITY_FAILS=""
+
+# 3a. `agentis commit <candidate>` succeeds. Mirrors the colony-lint
+# pattern (#177): bootstrap a temp .agentis/ once via `agentis init`
+# so `agentis commit` doesn't error out with "Not an Agentis repository".
+VALIDITY_TMP="$(mktemp -d)"
+if command -v agentis >/dev/null 2>&1; then
+    (cd "$VALIDITY_TMP" && agentis init >/dev/null 2>&1) || true
+    if ! (cd "$VALIDITY_TMP" && agentis commit "$CANDIDATE_PATH") >/dev/null 2>&1; then
+        VALIDITY_FAILS="$VALIDITY_FAILS agentis_commit_failed"
+    fi
+else
+    # agentis not on PATH — record but don't hard-fail. The smoke test
+    # exercises this branch and downstream pipelines must still write
+    # a ledger row for visibility.
+    VALIDITY_FAILS="$VALIDITY_FAILS agentis_binary_missing"
+fi
+rm -rf "$VALIDITY_TMP"
+
+# 3b. Tier-coverage regex (mirrors colony-lint.sh:475-490). The
+# canonical pattern collapses shadow into the else-fallthrough, so we
+# require the three explicit tier literals (propose / review-gated /
+# autonomous) plus at least one tier(...) call.
+TIER_OK=true
+if ! grep -qE '\btier\s*\(\s*"[^"]+"\s*\)' "$CANDIDATE_PATH" \
+    && ! grep -qE '\brepo_tier\s*\(\s*"[^"]+"\s*,' "$CANDIDATE_PATH"; then
+    TIER_OK=false
+fi
+for tier_name in propose review-gated autonomous; do
+    if ! grep -qE "\"$tier_name\"" "$CANDIDATE_PATH"; then
+        TIER_OK=false
+    fi
+done
+if ! $TIER_OK; then
+    VALIDITY_FAILS="$VALIDITY_FAILS tier_coverage_missing"
+fi
+
+# 3c. `cb <N>;` budget line present at the top.
+if ! grep -qE '^\s*cb\s+[0-9]+\s*;' "$CANDIDATE_PATH"; then
+    VALIDITY_FAILS="$VALIDITY_FAILS cb_budget_missing"
+fi
+
+if [ -n "$VALIDITY_FAILS" ]; then
+    # Normalise leading space for the ledger extras JSON.
+    VALIDITY_FAILS_CSV=$(echo "$VALIDITY_FAILS" | sed 's/^ //;s/ /,/g')
+    log "  validity gate failed: $VALIDITY_FAILS_CSV"
+    ledger_append "mutation_rejected" \
+        "{\"candidate_sha8\":\"$CANDIDATE_SHA8\",\"reason\":\"validity_gate\",\"failed_checks\":\"$VALIDITY_FAILS_CSV\"}"
+    rm -f "$CANDIDATE_PATH"
+    exit 0
+fi
+
+log "  validity gate passed"
+
+# ------------------------------------------------------------------
+# 4. A/B spawn (PR-A stub: log placeholder + skip)
+# ------------------------------------------------------------------
+
+log "  A/B run skipped in PR-A (placeholder); PR-B wires real spawn + scoring"
+ledger_append "ab_skipped_pr_a_stub" \
+    "{\"candidate_sha8\":\"$CANDIDATE_SHA8\",\"note\":\"PR-A plumbing only; A/B harness lives in PR-B\"}"
+
+# ------------------------------------------------------------------
+# 5. Cleanup
+# ------------------------------------------------------------------
+
+if [ "$EVOLVE_DRY_RUN" = "true" ]; then
+    log "  dry-run: removing stub candidate, no archive, no respawn"
+    rm -f "$CANDIDATE_PATH"
+else
+    # PR-C scope: archive parent + respawn daemon. Plumbed here so the
+    # interface is stable but unreachable until PR-C flips dry_run off.
+    mkdir -p "$ARCHIVE_DIR"
+    ARCHIVE_PATH="$ARCHIVE_DIR/${AGENT_NAME}-gen-${GENERATION_NEXT}-${PARENT_SHA8}.ag"
+    cp "$PARENT_AG" "$ARCHIVE_PATH"
+    log "  archived parent to $ARCHIVE_PATH"
+    rm -f "$CANDIDATE_PATH"
+fi
+
+log "Done."

--- a/tools/auto-promote-config-parser.py
+++ b/tools/auto-promote-config-parser.py
@@ -177,11 +177,50 @@ def main():
     e = cfg.get('evolve', {}).get('trigger', {})
     print('CFG_EVOLVE_SLOPE_NEG_FOR=%s' % e.get('delta_slope_negative_for', 1000))
     print('CFG_EVOLVE_REJECT_ABOVE=%s' % e.get('reject_rate_above', 0.20))
+    both_required = e.get('both_signals_required', False)
+    print('CFG_EVOLVE_BOTH_SIGNALS_REQUIRED=%s'
+          % ('true' if both_required else 'false'))
 
     ec = cfg.get('evolve', {}).get('config', {})
     print('CFG_EVOLVE_GENERATIONS=%s' % ec.get('generations', 3))
     print('CFG_EVOLVE_POPULATION=%s' % ec.get('population', 4))
     print("CFG_EVOLVE_WEIGHTS='%s'" % ec.get('weights', 'cb,val,exp'))
+
+    # Phase 7 PR-A (#628): mutation + A/B + archive + ledger plumbing.
+    # All fields default to legacy-compat values so dev-apprenticeship
+    # configs (which omit them) keep the pre-#628 `agentis evolve` path.
+    em = cfg.get('evolve', {}).get('mutation', {})
+    mutation_enabled = em.get('enabled', False)
+    print('CFG_EVOLVE_MUTATION_ENABLED=%s'
+          % ('true' if mutation_enabled else 'false'))
+    print('CFG_EVOLVE_MUTATION_MAX_CONCURRENT_PER_COLONY=%s'
+          % em.get('max_concurrent_per_colony', 1))
+    print('CFG_EVOLVE_MUTATION_MAX_GENERATIONS=%s'
+          % em.get('max_generations', 10))
+    skip_tiers = em.get('skip_tiers', ['autonomous'])
+    if not isinstance(skip_tiers, list):
+        skip_tiers = [skip_tiers]
+    skip_tiers_csv = ','.join(str(t) for t in skip_tiers)
+    print("CFG_EVOLVE_MUTATION_SKIP_TIERS='%s'" % skip_tiers_csv)
+
+    ab = cfg.get('evolve', {}).get('ab', {})
+    print('CFG_EVOLVE_AB_TICKS=%s' % ab.get('ticks', 50))
+    print('CFG_EVOLVE_AB_MIN_ACTING_FOR_DECISION=%s'
+          % ab.get('min_acting_for_decision', 10))
+    print('CFG_EVOLVE_AB_MIN_DELTA=%s' % ab.get('min_delta', 0.05))
+    print('CFG_EVOLVE_AB_FAST_MODE_TICKS=%s' % ab.get('fast_mode_ticks', 10))
+
+    archive_dir = cfg.get('evolve', {}).get('archive_dir', 'evolution-archive')
+    print("CFG_EVOLVE_ARCHIVE_DIR='%s'" % archive_dir)
+    ledger_path = cfg.get('evolve', {}).get('ledger_path', 'evolution-ledger.jsonl')
+    print("CFG_EVOLVE_LEDGER_PATH='%s'" % ledger_path)
+
+    # Per-block `evolve.dry_run` controls whether auto-evolve-ab.sh
+    # mutates files. Defaults to true so PR-A and PR-B never touch any
+    # .ag file even after `mutation.enabled` is later flipped on. PR-C
+    # is the only PR that toggles this to false.
+    evolve_dry_run = cfg.get('evolve', {}).get('dry_run', True)
+    print('CFG_EVOLVE_DRY_RUN=%s' % ('true' if evolve_dry_run else 'false'))
 
     dr = cfg.get('dry_run', True)
     print('CFG_DRY_RUN=%s' % ('true' if dr else 'false'))

--- a/tools/auto-promote-config.research-foundry.yaml
+++ b/tools/auto-promote-config.research-foundry.yaml
@@ -40,9 +40,23 @@ evolve:
   trigger:
     delta_slope_negative_for: 1000
     reject_rate_above: 0.20
+    both_signals_required: false        # false=OR (legacy), true=AND
   config:
     generations: 3
     population: 4
     weights: "cb,val,exp"
+  mutation:
+    enabled: false                       # PR-A default OFF — PR-C flips for explorer
+    max_concurrent_per_colony: 1         # throttle: max open candidates per colony
+    max_generations: 10                  # 10-gen cap per #628 acceptance
+    skip_tiers: ["autonomous"]           # do not evolve autonomous-tier agents
+  ab:
+    ticks: 50                            # K-tick A/B window
+    min_acting_for_decision: 10
+    min_delta: 0.05                      # candidate must beat parent by this fraction
+    fast_mode_ticks: 10                  # for smoke tests
+  archive_dir: "evolution-archive"
+  ledger_path: "evolution-ledger.jsonl"
+  dry_run: true                          # PR-A + PR-B ship dry-run; PR-C flips
 
 dry_run: true

--- a/tools/auto-promote-decisions.py
+++ b/tools/auto-promote-decisions.py
@@ -37,6 +37,7 @@
 #
 # Contract is frozen by doc/auto-promote.md and test-auto-promote.sh.
 
+import hashlib
 import json
 import math
 import os
@@ -255,6 +256,75 @@ def main():
             score = 0.0
         breakdown = payload.get('breakdown')
         return (score, breakdown if isinstance(breakdown, dict) else None)
+
+    # Phase 7 PR-A (#628): cache `<colony>/agents/<agent>.ag` sha256
+    # per agent inside this loop so the same hash is reused across the
+    # evolve decision and the ledger row writer downstream. Returns ''
+    # when the .ag file is unreachable so the caller can omit the field
+    # cleanly.
+    _parent_sha_cache = {}
+
+    def _resolve_parent_sha(_fed_dir, _colony, _agent_name):
+        cache_key = (_colony, _agent_name)
+        if cache_key in _parent_sha_cache:
+            return _parent_sha_cache[cache_key]
+        candidate = os.path.join(_fed_dir, _colony, 'agents', _agent_name + '.ag')
+        result = ''
+        try:
+            with open(candidate, 'rb') as fh:
+                result = hashlib.sha256(fh.read()).hexdigest()
+        except OSError:
+            result = ''
+        _parent_sha_cache[cache_key] = result
+        return result
+
+    # Phase 7 PR-A (#628): scan `<fed_dir>/evolution-ledger.jsonl` for
+    # the max recorded generation matching the resolved parent_sha for
+    # this agent. Returns 0 when the ledger is absent or no row matches.
+    # The ledger path is the auto-evolve-ab.sh default — overridable via
+    # `evolve.ledger_path` config but auto-promote-decisions.py reads the
+    # default location for legacy-mode positional invocation parity.
+    _ledger_rows_cache = None
+
+    def _load_ledger_rows(_fed_dir):
+        nonlocal _ledger_rows_cache
+        if _ledger_rows_cache is not None:
+            return _ledger_rows_cache
+        ledger_path = os.path.join(_fed_dir, 'evolution-ledger.jsonl')
+        rows = []
+        try:
+            with open(ledger_path) as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rows.append(json.loads(line))
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+        except OSError:
+            pass
+        _ledger_rows_cache = rows
+        return rows
+
+    def _resolve_generation_current(_fed_dir, _parent_sha):
+        if not _parent_sha:
+            return 0
+        sha8 = _parent_sha[:8]
+        max_gen = 0
+        for row in _load_ledger_rows(_fed_dir):
+            if not isinstance(row, dict):
+                continue
+            if row.get('parent_sha8') != sha8 and row.get('parent_sha') != _parent_sha:
+                continue
+            gen = row.get('generation')
+            try:
+                gen_int = int(gen) if gen is not None else 0
+            except (ValueError, TypeError):
+                gen_int = 0
+            if gen_int > max_gen:
+                max_gen = gen_int
+        return max_gen
 
     for d in daemons:
         source = d.get('source', '')
@@ -489,19 +559,33 @@ def main():
         # Evolve signals are computed from acting rows only: observe-step rows
         # carry a structural "success" outcome and zero delta, so including
         # them would mask degradation on the tier-gated acting path.
-        evolve_triggered = False
-        if len(acting_entries_list) >= evolve_slope_neg_for and evolve_slope < 0:
-            evolve_triggered = True
-        if acting_count > 0 and reject_rate_acting > evolve_reject_above:
-            evolve_triggered = True
+        slope_signal = (
+            len(acting_entries_list) >= evolve_slope_neg_for
+            and evolve_slope < 0
+        )
+        reject_signal = (
+            acting_count > 0 and reject_rate_acting > evolve_reject_above
+        )
+        evolve_triggered = slope_signal or reject_signal
 
         if evolve_triggered:
+            # Phase 7 PR-A (#628): emit `evolve_window_stagnant`,
+            # `parent_sha`, and `generation_current` on every evolve
+            # decision so the downstream auto-evolve-ab.sh harness has
+            # the full context to write its ledger row without having
+            # to recompute the same values.
+            evolve_window_stagnant = slope_signal and reject_signal
+            parent_sha = _resolve_parent_sha(fed_dir, colony, agent_name)
+            generation_current = _resolve_generation_current(fed_dir, parent_sha)
             decisions.append(_attach_explorer_evidence({
                 'agent': agent_name,
                 'colony': colony,
                 'decision': 'evolve',
                 'reason': f'evolve triggered (slope={evolve_slope:.6f}, reject_rate_acting={reject_rate_acting:.4f})',
                 'evidence': evidence,
+                'evolve_window_stagnant': evolve_window_stagnant,
+                'parent_sha': parent_sha,
+                'generation_current': generation_current,
             }))
             continue
 

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -411,15 +411,34 @@ for d in daemons:
                     continue
                 fi
 
-                log "  Running: agentis evolve $AGENT_AG_FILE"
-                EVOLVE_OUTPUT=$(cd "$FED_DIR" && agentis evolve "$AGENT_AG_FILE" \
-                    --generations "$CFG_EVOLVE_GENERATIONS" \
-                    --population "$CFG_EVOLVE_POPULATION" \
-                    --weights "$CFG_EVOLVE_WEIGHTS" 2>&1) || true
-                log "  Evolve output: $EVOLVE_OUTPUT"
+                # Phase 7 PR-A (#628): when `evolve.mutation.enabled=true`
+                # in the active config, route to the new auto-evolve-ab
+                # harness (mutator + validity gate + A/B + ledger). The
+                # legacy `agentis evolve` path is preserved unchanged
+                # when the flag is false (default), so dev-apprenticeship
+                # and every pre-#628 federation keeps its existing
+                # behaviour.
+                if [ "${CFG_EVOLVE_MUTATION_ENABLED:-false}" = "true" ]; then
+                    log "  Routing to auto-evolve-ab.sh (mutation.enabled=true)"
+                    EVOLVE_OUTPUT=$("$SCRIPT_DIR/auto-evolve-ab.sh" \
+                        "$FED_DIR" "$agent" "$colony" "$AGENT_AG_FILE" \
+                        --ticks "$CFG_EVOLVE_AB_TICKS" \
+                        --config "$CONFIG_FILE" 2>&1) || true
+                    log "  Auto-evolve-ab output: $EVOLVE_OUTPUT"
 
-                journal_append "$agent" "evolve" \
-                    "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='executed'; e['evolve_output']=sys.argv[2][:500]; print(json.dumps(e))" "$evidence_json" "$EVOLVE_OUTPUT")"
+                    journal_append "$agent" "evolve" \
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='auto-evolve-ab'; e['evolve_output']=sys.argv[2][:500]; print(json.dumps(e))" "$evidence_json" "$EVOLVE_OUTPUT")"
+                else
+                    log "  Running: agentis evolve $AGENT_AG_FILE"
+                    EVOLVE_OUTPUT=$(cd "$FED_DIR" && agentis evolve "$AGENT_AG_FILE" \
+                        --generations "$CFG_EVOLVE_GENERATIONS" \
+                        --population "$CFG_EVOLVE_POPULATION" \
+                        --weights "$CFG_EVOLVE_WEIGHTS" 2>&1) || true
+                    log "  Evolve output: $EVOLVE_OUTPUT"
+
+                    journal_append "$agent" "evolve" \
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='executed'; e['evolve_output']=sys.argv[2][:500]; print(json.dumps(e))" "$evidence_json" "$EVOLVE_OUTPUT")"
+                fi
             fi
             EVOLVE_COUNT=$((EVOLVE_COUNT + 1))
             ;;

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -420,9 +420,14 @@ if command -v agentis &>/dev/null; then
             [ -d "$dir/config" ] || continue
             colony="$(basename "$dir")"
             ag_files=()
+            # Phase 7 PR-A (#628): exclude `<colony>/agents/.evolve/`
+            # candidate-gen-N files from the per-agent .ag glob. The
+            # auto-evolve-ab.sh harness lifecycle owns those files;
+            # treating them as production agents here would fail the
+            # tier-coverage lint mid-mutation.
             while IFS= read -r -d '' f; do
                 ag_files+=("$f")
-            done < <(find "$dir/agents" -name "*.ag" -print0 2>/dev/null)
+            done < <(find "$dir/agents" -maxdepth 1 -name "*.ag" -print0 2>/dev/null)
 
             if [ ${#ag_files[@]} -gt 0 ]; then
                 for ag in "${ag_files[@]}"; do

--- a/tools/test-auto-evolve-ab.sh
+++ b/tools/test-auto-evolve-ab.sh
@@ -26,7 +26,6 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMPDIR_TEST="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_TEST"' EXIT
 

--- a/tools/test-auto-evolve-ab.sh
+++ b/tools/test-auto-evolve-ab.sh
@@ -1,0 +1,343 @@
+#!/bin/bash
+# tools/test-auto-evolve-ab.sh — Smoke tests for the Phase 7 PR-A
+# auto-evolve plumbing harness (#628).
+#
+# Covered:
+#   1. bash -n on auto-evolve-ab.sh
+#   2. bash -n on self
+#   3. throttle gate fires when .evolve/ has >= max_concurrent_per_colony
+#      candidates
+#   4. validity gate rejects a candidate with missing cb / missing tiers
+#   5. ledger row written for `evolve_throttled`
+#   6. ledger row written for `ab_skipped_pr_a_stub`
+#   7. dry-run mode does NOT modify any non-ledger files
+#   8. stub candidate (the cosmetic-comment placeholder PR-A generates)
+#      is parseable by `agentis commit` when called against a clean
+#      parent — verifies the appended comment doesn't break syntax.
+#
+# Out of scope (deferred to PR-B / PR-C tests):
+#   - real LLM mutation (PR-B `auto-evolve-mutate.py`)
+#   - A/B score comparison (PR-B)
+#   - live evolve with dry_run=false (PR-C)
+#
+# Usage: ./tools/test-auto-evolve-ab.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# ----- Test 1: bash -n on auto-evolve-ab.sh -----
+if bash -n "$SCRIPT_DIR/auto-evolve-ab.sh"; then
+    pass "bash -n: tools/auto-evolve-ab.sh"
+else
+    fail "bash -n auto-evolve-ab.sh" "syntax error"
+fi
+
+# ----- Test 2: bash -n on self -----
+if bash -n "$SCRIPT_DIR/test-auto-evolve-ab.sh"; then
+    pass "bash -n: tools/test-auto-evolve-ab.sh (self)"
+else
+    fail "bash -n self" "syntax error"
+fi
+
+# ----- Setup: synthetic federation tree -----
+# Mirror the shape the script consumes: <fed>/<colony>/agents/<agent>.ag.
+# Use a research-foundry style config so `evolve.mutation.enabled=true`
+# kicks in even when the default config keeps mutation off.
+FAKE_FED="$TMPDIR_TEST/fake-fed"
+FAKE_COLONY="explorer"
+mkdir -p "$FAKE_FED/$FAKE_COLONY/agents"
+PARENT_AG="$FAKE_FED/$FAKE_COLONY/agents/probe.ag"
+
+cat > "$PARENT_AG" <<'AGEOF'
+// probe.ag -- Synthetic fixture for tools/test-auto-evolve-ab.sh.
+// Hand-written to pass the harness's three validity-gate checks:
+// cb budget present, tier(...) call present, all three non-shadow
+// tier literals ("propose", "review-gated", "autonomous") present.
+
+cb 200;
+
+fn tick(_rec: string) -> void {
+    let my_tier = tier("probe");
+    if my_tier == "autonomous" {
+        // direct external write
+    } else {
+        if my_tier == "review-gated" {
+            // draft external write
+        } else {
+            if my_tier == "propose" {
+                // emit on bus
+            } else {
+                // shadow / dormant: observe only
+            };
+        };
+    };
+}
+AGEOF
+
+# Write a minimal config that flips mutation on so the harness actually
+# runs through the pipeline. Defaults to dry_run=true so no files are
+# mutated outside the ledger.
+FAKE_CONFIG="$TMPDIR_TEST/fake-config.yaml"
+cat > "$FAKE_CONFIG" <<'YAMLEOF'
+promote:
+  prerequisites:
+    min_entries: 30
+    min_acting_entries: 10
+    min_runtime_hours: 1.5
+    reject_rate_threshold: 0.10
+    delta_slope_window: 20
+    delta_slope_min: 0
+  steps:
+    - from: 0.4
+      to: 0.6
+      min_acting_entries_override: 0
+    - from: 0.6
+      to: 0.8
+    - from: 0.8
+      to: 0.95
+
+evolve:
+  trigger:
+    delta_slope_negative_for: 1000
+    reject_rate_above: 0.20
+    both_signals_required: false
+  mutation:
+    enabled: true
+    max_concurrent_per_colony: 1
+    max_generations: 10
+    skip_tiers: ["autonomous"]
+  ab:
+    ticks: 50
+    min_acting_for_decision: 10
+    min_delta: 0.05
+    fast_mode_ticks: 10
+  archive_dir: "evolution-archive"
+  ledger_path: "evolution-ledger.jsonl"
+  dry_run: true
+
+dry_run: true
+YAMLEOF
+
+LEDGER="$FAKE_FED/evolution-ledger.jsonl"
+
+# ----- Test 3: happy path → ab_skipped_pr_a_stub row -----
+# Clean run with no .evolve/ pre-existing — must pass throttle, pass
+# validity (parent template above is hand-written to satisfy all
+# 3 checks, modulo `agentis commit` which we tolerate failing when
+# the binary is missing), and write an `ab_skipped_pr_a_stub` row.
+
+rm -f "$LEDGER"
+OUT=$("$SCRIPT_DIR/auto-evolve-ab.sh" "$FAKE_FED" probe "$FAKE_COLONY" "$PARENT_AG" \
+    --ticks 10 --config "$FAKE_CONFIG" 2>&1) || true
+
+if [ -f "$LEDGER" ]; then
+    pass "happy path: ledger file created"
+else
+    fail "happy path ledger" "ledger missing after run; output: $OUT"
+fi
+
+# ----- Test 4: ab_skipped_pr_a_stub event written -----
+# When `agentis` is on PATH and the parent passes commit + tier
+# coverage + cb budget, the run must reach the PR-A stub skip step.
+# When `agentis` is missing, the validity gate fails on
+# `agentis_binary_missing` instead — still a valid PR-A pipeline
+# exit, but emits `mutation_rejected` not `ab_skipped_pr_a_stub`.
+
+if command -v agentis >/dev/null 2>&1; then
+    if grep -q '"event":"ab_skipped_pr_a_stub"\|"event": "ab_skipped_pr_a_stub"' "$LEDGER" 2>/dev/null; then
+        pass "ledger contains ab_skipped_pr_a_stub event"
+    else
+        fail "ab_skipped_pr_a_stub event" "not found in ledger: $(cat "$LEDGER" 2>/dev/null)"
+    fi
+else
+    # Without agentis the validity gate rejects on missing binary;
+    # the mutation_rejected row is the expected outcome here.
+    if grep -q '"event":"mutation_rejected"\|"event": "mutation_rejected"' "$LEDGER" 2>/dev/null; then
+        pass "ledger contains mutation_rejected event (agentis missing on PATH)"
+    else
+        fail "ledger event" "no ab_skipped_pr_a_stub or mutation_rejected: $(cat "$LEDGER" 2>/dev/null)"
+    fi
+fi
+
+# ----- Test 5: throttle gate fires when .evolve/ is full -----
+# Pre-create one candidate file in .evolve/ to hit the cap (config sets
+# max_concurrent_per_colony: 1). A second invocation MUST exit early
+# with an `evolve_throttled` row and MUST NOT touch a new candidate.
+
+EVOLVE_DIR="$FAKE_FED/$FAKE_COLONY/agents/.evolve"
+mkdir -p "$EVOLVE_DIR"
+touch "$EVOLVE_DIR/probe.ag.candidate-gen-99"
+
+# Reset ledger to isolate this event.
+rm -f "$LEDGER"
+THROTTLE_OUT=$("$SCRIPT_DIR/auto-evolve-ab.sh" "$FAKE_FED" probe "$FAKE_COLONY" "$PARENT_AG" \
+    --ticks 10 --config "$FAKE_CONFIG" 2>&1) || true
+
+if grep -q '"event":"evolve_throttled"\|"event": "evolve_throttled"' "$LEDGER" 2>/dev/null; then
+    pass "throttle gate: ledger row written when cap hit"
+else
+    fail "throttle gate ledger" "no evolve_throttled row; ledger: $(cat "$LEDGER" 2>/dev/null) out: $THROTTLE_OUT"
+fi
+
+# Confirm no new candidate-gen-N file (other than the pre-seeded one)
+# was created — the throttle must short-circuit before stub generation.
+NEW_CANDIDATES=$(find "$EVOLVE_DIR" -name "*.candidate-gen-*" -type f | wc -l | tr -d ' ')
+if [ "$NEW_CANDIDATES" = "1" ]; then
+    pass "throttle gate: no new candidate generated"
+else
+    fail "throttle gate side effect" "expected 1 candidate (the seed), found $NEW_CANDIDATES"
+fi
+
+# Cleanup throttle seed.
+rm -f "$EVOLVE_DIR/probe.ag.candidate-gen-99"
+
+# ----- Test 6: validity gate rejection -----
+# Mutate the parent so it lacks `cb <N>;` AND lacks tier literals — the
+# stub-mutation step copies the parent verbatim (plus an appended
+# cosmetic comment), so an invalid parent produces an invalid
+# candidate. The harness must emit `mutation_rejected`.
+
+BAD_PARENT="$FAKE_FED/$FAKE_COLONY/agents/bad.ag"
+cat > "$BAD_PARENT" <<'BADEOF'
+// no cb line, no tier() call, no tier literals
+agent bad {
+    fn tick(_rec: string) -> void {
+    }
+}
+BADEOF
+
+rm -f "$LEDGER"
+BAD_OUT=$("$SCRIPT_DIR/auto-evolve-ab.sh" "$FAKE_FED" bad "$FAKE_COLONY" "$BAD_PARENT" \
+    --ticks 10 --config "$FAKE_CONFIG" 2>&1) || true
+
+if grep -q '"event":"mutation_rejected"\|"event": "mutation_rejected"' "$LEDGER" 2>/dev/null; then
+    pass "validity gate: mutation_rejected row written on bad candidate"
+else
+    fail "validity gate ledger" "no mutation_rejected row; ledger: $(cat "$LEDGER" 2>/dev/null) out: $BAD_OUT"
+fi
+
+# The rejected candidate must be cleaned up so a re-run doesn't see
+# itself in the .evolve/ throttle count.
+REMAINING_CANDS=$(find "$EVOLVE_DIR" -name "bad.ag.candidate-gen-*" -type f | wc -l | tr -d ' ')
+if [ "$REMAINING_CANDS" = "0" ]; then
+    pass "validity gate: rejected candidate cleaned up"
+else
+    fail "validity gate cleanup" "expected 0 remaining bad candidates, found $REMAINING_CANDS"
+fi
+
+# ----- Test 7: dry-run mode does NOT mutate non-ledger files -----
+# Snapshot the parent + the colony before a dry-run pass, run, and
+# compare. The ledger is excluded from the comparison (that's the one
+# file the harness IS allowed to write under dry-run).
+
+SNAPSHOT_DIR="$TMPDIR_TEST/snapshot"
+rm -rf "$SNAPSHOT_DIR"
+mkdir -p "$SNAPSHOT_DIR"
+cp -R "$FAKE_FED" "$SNAPSHOT_DIR/before"
+rm -f "$SNAPSHOT_DIR/before/evolution-ledger.jsonl"
+
+rm -f "$LEDGER"
+DRY_OUT=$("$SCRIPT_DIR/auto-evolve-ab.sh" "$FAKE_FED" probe "$FAKE_COLONY" "$PARENT_AG" \
+    --ticks 10 --config "$FAKE_CONFIG" --dry-run 2>&1) || true
+
+cp -R "$FAKE_FED" "$SNAPSHOT_DIR/after"
+rm -f "$SNAPSHOT_DIR/after/evolution-ledger.jsonl"
+# .evolve/ may be created (and emptied) but should be empty at end.
+# Compare directory contents excluding ledger and .evolve/.
+DIFF_OUT=$(diff -r "$SNAPSHOT_DIR/before" "$SNAPSHOT_DIR/after" 2>&1 | grep -v '\.evolve' || true)
+# Allow .evolve/ to exist as long as no candidates remain inside.
+LINGERING=$(find "$EVOLVE_DIR" -name "*.candidate-gen-*" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+if [ -z "$DIFF_OUT" ] && [ "$LINGERING" = "0" ]; then
+    pass "dry-run: no non-ledger file changes (LINGERING=0)"
+else
+    fail "dry-run side effects" "diff: $DIFF_OUT lingering candidates: $LINGERING out: $DRY_OUT"
+fi
+
+# ----- Test 8: stub candidate parseable by agentis commit -----
+# Generate a stub manually (same logic as the script) and verify
+# `agentis commit` on it succeeds. Skipped when agentis is not on PATH.
+
+if command -v agentis >/dev/null 2>&1; then
+    STUB_DIR="$TMPDIR_TEST/stub-parse"
+    mkdir -p "$STUB_DIR"
+    # `agentis commit` requires an .agentis/ in CWD — same bootstrap
+    # pattern as colony-lint.sh:387-396 and the validity gate in
+    # tools/auto-evolve-ab.sh.
+    (cd "$STUB_DIR" && agentis init >/dev/null 2>&1) || true
+    STUB_PATH="$STUB_DIR/probe.ag.candidate-gen-1"
+    cp "$PARENT_AG" "$STUB_PATH"
+    printf '\n// Stub mutation generated by PR-A (#628)\n' >> "$STUB_PATH"
+    if (cd "$STUB_DIR" && agentis commit "$STUB_PATH") >/dev/null 2>&1; then
+        pass "stub candidate parseable by agentis commit"
+    else
+        fail "stub parseability" "agentis commit failed on stub candidate"
+    fi
+else
+    pass "stub candidate parseability (skipped: agentis not on PATH)"
+fi
+
+# ----- Test 9: ledger schema sanity -----
+# Every row must carry the base fields (ts, event, agent, colony,
+# generation, parent_sha, parent_sha8, ab_ticks, dry_run). Verifies
+# the ledger writer helper isn't drifting from the schema downstream
+# tooling will consume.
+
+rm -f "$LEDGER"
+"$SCRIPT_DIR/auto-evolve-ab.sh" "$FAKE_FED" probe "$FAKE_COLONY" "$PARENT_AG" \
+    --ticks 10 --config "$FAKE_CONFIG" --dry-run >/dev/null 2>&1 || true
+
+if [ -s "$LEDGER" ]; then
+    SCHEMA_OK=$(python3 -c "
+import json, sys
+required = {'ts', 'event', 'agent', 'colony', 'generation', 'parent_sha',
+            'parent_sha8', 'ab_ticks', 'dry_run'}
+rows = 0
+bad = []
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        rows += 1
+        try:
+            r = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            bad.append('parse_error')
+            continue
+        missing = required - set(r.keys())
+        if missing:
+            bad.append(','.join(sorted(missing)))
+if rows == 0:
+    print('no_rows')
+elif bad:
+    print('bad:' + ';'.join(bad))
+else:
+    print('ok:%d' % rows)
+" "$LEDGER")
+    case "$SCHEMA_OK" in
+        ok:*)
+            pass "ledger schema: required fields present on every row"
+            ;;
+        *)
+            fail "ledger schema" "$SCHEMA_OK (ledger: $(cat "$LEDGER"))"
+            ;;
+    esac
+else
+    fail "ledger schema setup" "ledger empty after dry-run pass"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Phase 7 PR-A — plumbing for the self-improving `.ag` mutation harness
(#628). Zero `.ag` files mutated; the mutator is stubbed (PR-B fills
it in); the A/B step is stubbed (PR-B); `dry_run` ships at `true` so
even after `mutation.enabled` is flipped on later, no file mutations
happen until PR-C explicitly toggles it.

- Three new `CFG_EVOLVE_MUTATION_*`, four new `CFG_EVOLVE_AB_*`, and
  three new `CFG_EVOLVE_{ARCHIVE_DIR,LEDGER_PATH,DRY_RUN}` knobs
  threaded through `auto-promote-config-parser.py` with legacy-safe
  defaults so dev-apprenticeship and pre-#628 federations keep their
  existing `agentis evolve` path.
- `auto-promote.sh` evolve handler routes to the new harness when
  `evolve.mutation.enabled=true`, else falls through to the legacy
  path verbatim.
- `auto-promote-decisions.py` emits three new fields on every evolve
  decision: `evolve_window_stagnant`, `parent_sha`, `generation_current`.
  Test 12 byte-identity preserved (the new helpers fire only on the
  evolve emit path, which test 12's fixture never reaches).
- `auto-evolve-ab.sh` (new) — five-step pipeline (throttle → stub
  mutator → validity gate → A/B stub → cleanup) with a ledger row
  per outcome.
- `auto-evolve-ab-ledger.py` (new) — single-row JSONL writer with
  required base schema `{ts, event, agent, colony, generation,
  parent_sha, parent_sha8, ab_ticks, dry_run}` plus arbitrary extras.
- `colony-lint.sh` adds `-maxdepth 1` to the per-agent `.ag` glob so
  in-flight candidates under `.evolve/` don't fail tier-coverage.
- `test-auto-evolve-ab.sh` (new) — 11 smoke-test assertions.

Out of scope (deferred):
- Real LLM mutator (PR-B `auto-evolve-mutate.py`)
- A/B daemon spawn + score comparison (PR-B)
- Flip `evolve.dry_run=false` (PR-C)

## Test plan

- [x] `tools/colony-lint.sh`: 320 passed, 0 failed (baseline 319 + new smoke test)
- [x] `tools/test-auto-promote.sh`: 35 passed, 0 failed (test 12 byte-identity preserved)
- [x] `tools/test-make-federation-bundle.sh`: 11 passed, 0 failed
- [x] `tools/test-auto-evolve-ab.sh`: 11 passed, 0 failed (new)
- [x] `bash -n` clean on every modified shell script
- [x] `python3 -m ast` clean on every modified `.py`
- [x] `shellcheck` clean on every modified `.sh`

Refs #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)