### PR TITLE
feat(phase-4-prc): reviewer colony for preprint-foundry anti-hallucination gate (PR-C of #625)

### DIFF
--- a/research-foundry/BUNDLE.manifest
+++ b/research-foundry/BUNDLE.manifest
@@ -24,6 +24,7 @@ research-foundry/introducer/
 research-foundry/theorist/
 research-foundry/computer/
 research-foundry/editor/
+research-foundry/reviewer/
 research-foundry/submitter/
 
 # Auto-promote sidecar dependencies (#622, #638). run-research.sh

--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -42,6 +42,21 @@ History of the three retired federations consolidated into this one
   `prior_match:success`. The auditor persists
   `claim:report_prior_advocate:tick-N` alongside the four searcher
   reports on VERIFIED_NEW.
+- `reviewer/` colony (Phase 4 PR-C of #625). Reads the editor's final
+  main.tex and the computer's reproducibility stdout, extracts every
+  numerical / symbolic claim from the .tex, and flags every claim
+  that lacks direct support in the reproducibility output. The
+  structured Verdict (`approved` / `rejected`) is persisted to memo
+  and -- on `approved` verdicts only -- the per-claim gate
+  `reviewer:<claim>:approved` is set to `"true"`. Reviewer enforces
+  block-by-default semantics -- submitter requires
+  `reviewer:<claim>:approved == "true"` before writing DRAFTED.
+  Operator override via
+  `agentis memo set reviewer:<claim>:approved true`. The submitter's
+  `upstream_tick` offset bumps from `tick_idx - 3` to `tick_idx - 4`
+  to absorb the new pipeline stage. New `(topic, outcome)` pairs in
+  `tools/check-learn-tags.sh` for `review:partial`, `review:success`,
+  and `review:failure`.
 
 ## [0.1.0] — 2026-05-18
 

--- a/research-foundry/reviewer/README.md
+++ b/research-foundry/reviewer/README.md
@@ -1,0 +1,35 @@
+# Reviewer Colony
+
+> Part of the [Preprint Foundry](../) research-foundry federation.
+
+The reviewer colony reads the editor's final `main.tex` and the
+computer's reproducibility stdout, extracts every numerical / symbolic
+claim from the .tex, and flags every claim that lacks direct support
+in the reproducibility output. The structured Verdict
+(`approved` / `rejected`) is persisted to memo and -- on `approved`
+verdicts only -- the per-claim gate `reviewer:<claim>:approved` is set
+to `"true"`. The submitter colony reads that gate before writing the
+DRAFTED row to `preprint-ledger.jsonl`: an empty / missing reviewer
+memo blocks the submission (block-by-default, since the reviewer is
+the highest-stakes critic in the Phase 4 pipeline). Operators can
+override the gate manually via
+`agentis memo set reviewer:<claim>:approved true` (Phase 4 PR-C of
+#625).
+
+## Agents
+
+| Agent | File | Learns | Autonomy after |
+|-------|------|--------|----------------|
+| reviewer | `agents/reviewer.ag` | which kinds of claim look supported by reproducibility stdout vs hallucinated | ~10 acted ticks |
+
+## Setup
+
+1. Copy and edit the config:
+   ```bash
+   cp config/colony.example.toml config/colony.toml
+   ```
+
+2. Start the colony:
+   ```bash
+   ./scripts/start-colony.sh
+   ```

--- a/research-foundry/reviewer/agents/reviewer.ag
+++ b/research-foundry/reviewer/agents/reviewer.ag
@@ -1,0 +1,186 @@
+// reviewer.ag -- Preprint Foundry reviewer: reads the editor's final
+// main.tex and the computer's reproducibility stdout, extracts every
+// numerical or symbolic claim in the .tex, and verifies each claim
+// against the reproducibility output. Emits an approved/rejected
+// verdict and writes the per-claim approval memo gate the submitter
+// reads BEFORE writing the DRAFTED row to preprint-ledger.jsonl. The
+// gate is block-by-default: an empty / missing reviewer memo blocks
+// the submitter; only an explicit `reviewer:<claim>:approved == "true"`
+// unblocks the DRAFTED write. Operators can override by setting the
+// memo manually (`agentis memo set reviewer:<claim>:approved true`).
+//
+// Per-tick behaviour:
+//   1. Read upstream artefacts at upstream_tick = tick_idx - 3:
+//      editor final_tex + claim_dir (via replay:current_editor_pid),
+//      computer reproducibility output (via replay:current_computer_pid),
+//      claim id (already seeded by novelty.ag -- Phase 1.5).
+//   2. Build REVIEW_CTX and produce a Verdict.
+//   3. Persist verdict + report to memo. On approved verdict, write
+//      `reviewer:<claim>:approved = "true"` (the gate the submitter
+//      reads). On rejected verdict, write
+//      `reviewer:<claim>:hallucinated_payload` for a future
+//      editor-repair cycle (memo channel reserved; repair loop is
+//      out of scope here). Emit "preprint-foundry:review_done".
+//
+// Run as daemon: agentis daemon agents/reviewer.ag --colony reviewer
+// Requires: exec capability, messaging capability.
+
+cb 2000;
+
+type Verdict {
+    verdict: string,
+    hallucinated_claims: string,
+    supported_claims_count: int,
+    total_claims_count: int,
+    reasoning: string
+}
+
+fn get_confidence() -> float {
+    let raw = recall_latest("reviewer:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    };
+    return 0.0;
+}
+
+fn colony_name() -> string {
+    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    if len(_cn) > 0 {
+        return _cn;
+    };
+    return "reviewer";
+}
+
+fn _seed_prompt() -> string {
+    return "You are a strict reproducibility reviewer. Extract every numerical or symbolic claim in the .tex (numbers, equations, specific values). For each claim, find the corresponding entry in the reproducibility stdout that supports it. Flag every claim WITHOUT direct stdout support. Output JSON: `{verdict: 'approved'|'rejected', hallucinated_claims: [{claim_text, line_or_section, why_unsupported}], supported_claims_count: int, total_claims_count: int, reasoning: string}`. Do NOT wrap output in markdown code fences.";
+}
+
+// _dump_ctx_to_memo -- write the assembled prompt context to a per-
+// tick memo key so #623-style validation (and any future audit) can
+// inspect what the LLM actually saw. Stable shape:
+// `<agent>:<pid>:ctx:tick-N`. Duplicated verbatim from editor because
+// the .ag DSL has no shared-include mechanism (Phase 2 #642 pattern).
+fn _dump_ctx_to_memo(agent_name: string, pid: string, tick_idx: int, ctx: string) -> void {
+    if len(agent_name) == 0 { return; };
+    if len(pid) == 0 { return; };
+    memo_write(agent_name + ":" + pid + ":ctx:tick-" + to_string(tick_idx), ctx);
+}
+
+// _publish_reviewer -- memo + emit. Non-terminal agent collapses
+// autonomous -> review-gated per ADR-0001 (#622 PR-2 #632 pattern).
+// reviewer writes no ledger row today; final_write retained for
+// symmetry with the other Phase 4 critic colonies (skeptic / prior_advocate).
+//
+// Block-by-default semantics: reviewer:<claim>:approved is written
+// ONLY when verdict == "approved". The submitter reads this key and
+// refuses to write the DRAFTED row when the value is not "true" (an
+// empty / missing memo blocks the submission, matching the highest-
+// stakes critic in the Phase 4 pipeline). On rejected verdict, also
+// stamp reviewer:<claim>:hallucinated_payload so a future editor-
+// repair cycle can consume it (the repair loop itself is out of scope
+// for PR-C).
+fn _publish_reviewer(
+    final_write: bool,
+    verdict: Verdict,
+    claim_id_eff: string,
+    self_pid: string,
+    upstream_tick: int,
+    tick_idx: int
+) -> void {
+    let _ = final_write;
+    let supported_str = to_string(verdict.supported_claims_count);
+    let total_str = to_string(verdict.total_claims_count);
+    let verdict_json = "{\"verdict\":\"" + verdict.verdict
+                     + "\",\"hallucinated_claims\":\"" + verdict.hallucinated_claims
+                     + "\",\"supported_claims_count\":" + supported_str
+                     + ",\"total_claims_count\":" + total_str
+                     + ",\"reasoning\":\"" + verdict.reasoning + "\"}";
+    memo_write("reviewer:" + self_pid + ":report:tick-" + to_string(upstream_tick), verdict_json);
+    memo_write("reviewer:" + self_pid + ":verdict:tick-" + to_string(upstream_tick), verdict.verdict);
+    memo_write("replay:current_reviewer_pid", self_pid);
+
+    if verdict.verdict == "approved" {
+        memo_write("reviewer:" + claim_id_eff + ":approved", "true");
+    } else {
+        let payload = "{\"verdict\":\"" + verdict.verdict
+                    + "\",\"hallucinated_claims\":\"" + verdict.hallucinated_claims
+                    + "\",\"reasoning\":\"" + verdict.reasoning + "\"}";
+        memo_write("reviewer:" + claim_id_eff + ":hallucinated_payload", payload);
+    };
+
+    emit("preprint-foundry:review_done", verdict);
+}
+
+fn tick(reason: string) -> void {
+    let _ = reason;
+    let _colony_name = colony_name();
+    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let conf = get_confidence();
+    print("[reviewer] tick conf=", conf);
+
+    let tick_idx_str = recall_latest("replay:current_tick");
+    let tick_idx = if len(tick_idx_str) > 0 { parse_int(tick_idx_str); } else { -1; };
+    if tick_idx < 0 {
+        print("[reviewer] no preprint tick yet");
+        return;
+    };
+    let upstream_tick = tick_idx - 3;
+    if upstream_tick < 0 {
+        print("[reviewer] waiting for editor pipeline, current=", tick_idx);
+        return;
+    };
+
+    let editor_pid = recall_latest("replay:current_editor_pid");
+    let computer_pid = recall_latest("replay:current_computer_pid");
+
+    let final_tex = if len(editor_pid) > 0 { recall_latest("editor:" + editor_pid + ":final_tex:tick-" + to_string(upstream_tick)); } else { ""; };
+    let claim_dir = if len(editor_pid) > 0 { recall_latest("editor:" + editor_pid + ":claim_dir:tick-" + to_string(upstream_tick)); } else { ""; };
+    let repro_output = if len(computer_pid) > 0 { recall_latest("computer:" + computer_pid + ":output:tick-" + to_string(upstream_tick)); } else { ""; };
+
+    let claim_id = recall_latest("claim:claim_id:tick-" + to_string(upstream_tick));
+    let claim_id_eff = if len(claim_id) > 0 { claim_id; } else { "claim-" + to_string(upstream_tick); };
+
+    if len(final_tex) == 0 {
+        print("[reviewer] no editor output for tick=", upstream_tick);
+        return;
+    };
+
+    let ctx = "CLAIM ID: " + claim_id_eff + "\n"
+            + "CLAIM DIR: " + claim_dir + "\n"
+            + "FINAL TEX:\n" + final_tex + "\n"
+            + "REPRODUCIBILITY STDOUT:\n" + repro_output + "\n";
+
+    _dump_ctx_to_memo("reviewer", _self_pid, tick_idx, ctx);
+    let verdict = prompt(_seed_prompt(), ctx) -> Verdict;
+
+    let my_tier = tier("reviewer");
+    if my_tier == "autonomous" {
+        // reason: tier N/A here; non-terminal agent -- collapses to review-gated.
+        memo_write("reviewer:" + _self_pid + ":review_gated", "true");
+        learn("review", "tick " + to_string(tick_idx), verdict.reasoning, "partial", ["acted", "preprint-foundry"]);
+        _publish_reviewer(true, verdict, claim_id_eff, _self_pid, upstream_tick, tick_idx);
+    } else {
+        if my_tier == "review-gated" {
+            memo_write("reviewer:" + _self_pid + ":review_gated", "true");
+            learn("review", "tick " + to_string(tick_idx), verdict.reasoning, "partial", ["review-gated", "preprint-foundry"]);
+            _publish_reviewer(true, verdict, claim_id_eff, _self_pid, upstream_tick, tick_idx);
+        } else {
+            if my_tier == "propose" {
+                if verdict.verdict == "approved" {
+                    learn("review", "tick " + to_string(tick_idx) + " approved " + claim_id_eff, verdict.reasoning, "success", ["emitted", "preprint-foundry"]);
+                } else {
+                    learn("review", "tick " + to_string(tick_idx) + " rejected " + claim_id_eff, verdict.reasoning, "failure", ["emitted", "preprint-foundry"]);
+                };
+                _publish_reviewer(false, verdict, claim_id_eff, _self_pid, upstream_tick, tick_idx);
+            } else {
+                print("[reviewer] observing (tier:", my_tier, ") verdict=", verdict.verdict);
+                learn("review", "tick " + to_string(tick_idx), verdict.reasoning, "partial", ["observed", "preprint-foundry"]);
+            };
+        };
+    };
+
+    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    if len(now) > 0 {
+        memo_write("reviewer:last_check", now);
+    };
+}

--- a/research-foundry/reviewer/config/colony.example.toml
+++ b/research-foundry/reviewer/config/colony.example.toml
@@ -1,0 +1,30 @@
+# Reviewer Colony Configuration
+#
+# Part of the Preprint Foundry federation. Single-agent colony that
+# extracts every numerical / symbolic claim from the editor's final
+# main.tex, cross-checks each claim against the computer's
+# reproducibility stdout, and writes a block-by-default approval gate
+# (`reviewer:<claim>:approved`) the submitter reads before drafting
+# the arXiv preprint package (Phase 4 PR-C of #625).
+#
+# Copy to colony.toml; the runtime knobs that actually drive a run
+# live in env vars consumed by tools/run-research.sh.
+
+[colony]
+name = "reviewer"
+tick_interval_ms = 60000
+
+# Non-forge federation (#373, ADR-0003). The reviewer writes only to
+# memo (no JSONL ledger row today); no agent in this colony calls
+# forge-api.sh.
+[forge]
+type = "none"
+
+[llm]
+backend = "cli"
+
+[[agents]]
+name = "reviewer"
+source = "agents/reviewer.ag"
+cb_budget = 2000
+tick_interval_ms = 60000

--- a/research-foundry/reviewer/scripts/start-colony.sh
+++ b/research-foundry/reviewer/scripts/start-colony.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Start the Reviewer colony (part of the Preprint Foundry federation).
+#
+# The reviewer extracts every numerical / symbolic claim from the
+# editor's final main.tex, cross-checks each claim against the
+# computer's reproducibility stdout, and writes the block-by-default
+# approval gate (`reviewer:<claim>:approved`) the submitter reads
+# before drafting the arXiv preprint package. Phase 4 PR-C of #625.
+#
+# Usage:
+#   ./scripts/start-colony.sh [path/to/colony.toml]
+#   ./scripts/start-colony.sh --restart-agent <name> [path/to/colony.toml]
+#   ./scripts/start-colony.sh --rate-limit-status
+#
+# ADR-0003 conformance: --restart-agent (#257) respawns one agent with full
+# colony env, skips memo seeding + log truncation; --rate-limit-status
+# (federation-dashboard 0.3.0) execs forge-api.sh rate-limit-status. Exit
+# codes: 0 ok, 2 unknown flag / missing arg, 3 unknown agent, 4 daemon
+# launch failure.
+
+set -e
+
+RESTART_AGENT=""
+RATE_LIMIT_STATUS=0
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --restart-agent)
+            if [ -z "${2:-}" ]; then
+                echo "start-colony.sh: --restart-agent requires an agent name" >&2
+                exit 2
+            fi
+            RESTART_AGENT="$2"
+            shift 2
+            ;;
+        --rate-limit-status)
+            RATE_LIMIT_STATUS=1
+            shift
+            ;;
+        --)
+            shift
+            POSITIONAL+=("$@")
+            break
+            ;;
+        -*)
+            echo "start-colony.sh: unknown flag: $1" >&2
+            exit 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+COLONY_DIR="$(dirname "$SCRIPT_DIR")"
+FED_DIR="$(dirname "$COLONY_DIR")"
+CONFIG="${1:-$COLONY_DIR/config/colony.toml}"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "Config not found: $CONFIG"
+    echo "Copy config/colony.example.toml to config/colony.toml and edit it."
+    exit 1
+fi
+
+PARSE_TOML=""
+for cand in "$FED_DIR/tools/parse-toml.sh" "$FED_DIR/../tools/parse-toml.sh"; do
+    if [ -f "$cand" ]; then
+        PARSE_TOML="$cand"
+        break
+    fi
+done
+if [ -z "$PARSE_TOML" ]; then
+    echo "Error: tools/parse-toml.sh not found in $FED_DIR/tools or $FED_DIR/../tools" >&2
+    exit 1
+fi
+# shellcheck source=/dev/null
+. "$PARSE_TOML"
+
+COLONY_NAME="reviewer"
+DISCOVERY_LEDGER="${DISCOVERY_LEDGER:-}"
+DAEMON_ID="${DAEMON_ID:-1}"
+export COLONY_DIR COLONY_NAME DISCOVERY_LEDGER DAEMON_ID
+
+AGENTS=(
+    reviewer
+)
+
+if [ ${#AGENTS[@]} -eq 0 ] && [ "$RATE_LIMIT_STATUS" = "0" ] && [ -z "$RESTART_AGENT" ]; then
+    echo "No agents defined yet." >&2
+    exit 1
+fi
+
+tick_interval_for() {
+    case "$1" in
+        reviewer) echo "${REVIEWER_TICK_MS:-60000}" ;;
+        *) echo 60000 ;;
+    esac
+}
+
+if [ "$RATE_LIMIT_STATUS" = "1" ]; then
+    if [ -x "$COLONY_DIR/scripts/forge-api.sh" ]; then
+        exec "$COLONY_DIR/scripts/forge-api.sh" rate-limit-status
+    fi
+    echo '{"remaining": null, "limit": null, "reset_at": null, "error": "rate-limit-status not implemented for this colony"}'
+    exit 0
+fi
+
+if [ -n "$RESTART_AGENT" ]; then
+    valid=0
+    for a in "${AGENTS[@]}"; do
+        [ "$a" = "$RESTART_AGENT" ] && valid=1
+    done
+    if [ "$valid" = "0" ]; then
+        echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
+        exit 3
+    fi
+    tick=$(tick_interval_for "$RESTART_AGENT")
+    agentis daemon "$COLONY_DIR/agents/${RESTART_AGENT}.ag" \
+        --colony reviewer \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval "$tick" </dev/null >/dev/null 2>&1 &
+    agent_pid=$!
+    sleep 0.5
+    if ! kill -0 "$agent_pid" 2>/dev/null; then
+        echo "start-colony.sh: agentis daemon failed to launch $RESTART_AGENT" >&2
+        exit 4
+    fi
+    echo "started $RESTART_AGENT pid=$agent_pid tick=$tick"
+    exit 0
+fi
+
+# Seed propose-tier confidence.
+agentis memo set "reviewer:confidence" "0.7" >/dev/null 2>&1 || true
+
+echo "Starting Reviewer colony (${#AGENTS[@]} agents)..."
+
+for agent in "${AGENTS[@]}"; do
+    interval=$(tick_interval_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms)..."
+    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+        --colony reviewer \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval "$interval" &
+    sleep 2
+done
+
+echo "Colony started. Use 'agentis daemon list' to monitor."
+echo "Stop with: agentis daemon stop --all"
+
+wait

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -318,7 +318,7 @@ fn tick(reason: string) -> void {
         print("[submitter] no preprint tick yet");
         return;
     };
-    let upstream_tick = tick_idx - 3;
+    let upstream_tick = tick_idx - 4;
     if upstream_tick < 0 {
         print("[submitter] waiting for editor pipeline, current=", tick_idx);
         return;
@@ -351,6 +351,17 @@ fn tick(reason: string) -> void {
     };
     if len(claim_dir) == 0 {
         print("[submitter] no claim_dir for tick=", upstream_tick);
+        return;
+    };
+
+    // Phase 4 #625 PR-C: reviewer is the highest-stakes critic; block-by-default.
+    // Operator can override by `agentis memo set reviewer:<claim>:approved true`.
+    let reviewer_ok = recall_latest("reviewer:" + claim_id_eff + ":approved");
+    if reviewer_ok != "true" {
+        print("[submitter] reviewer gate not satisfied for claim=", claim_id_eff, " (key=reviewer:<claim>:approved)");
+        learn("submit", "tick " + to_string(tick_idx) + " gated " + claim_id_eff, "reviewer not approved", "partial", ["observed", "preprint-foundry", "hitl-gated"]);
+        let now0 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now0) > 0 { memo_write("submitter:last_check", now0); };
         return;
     };
 

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -357,10 +357,10 @@ build_image() {
 # the orchestrator tick to avoid missing state changes).
 write_bootstrap() {
     bootstrap_path="$LAPTOP_DIR/bootstrap.sh"
-    emit_step "generating bootstrap script at $bootstrap_path (colonies=17 daemons_per_colony=$DAEMONS_PER_COLONY)"
+    emit_step "generating bootstrap script at $bootstrap_path (colonies=18 daemons_per_colony=$DAEMONS_PER_COLONY)"
 
     if [ "$DRY_RUN" = "1" ]; then
-        emit_cmd "write-bootstrap path=$bootstrap_path colonies=explorer,noticer,skeptic,formulator,verifier,novelty,arxiv-search,oeis-search,groupprops-search,scholar-search,prior_advocate,auditor,introducer,theorist,computer,editor,submitter"
+        emit_cmd "write-bootstrap path=$bootstrap_path colonies=explorer,noticer,skeptic,formulator,verifier,novelty,arxiv-search,oeis-search,groupprops-search,scholar-search,prior_advocate,auditor,introducer,theorist,computer,editor,reviewer,submitter"
         return
     fi
 
@@ -399,9 +399,9 @@ write_bootstrap() {
             printf '  printf "llm.args = -p --output-format json --model %s --tools \\"\\" --system-prompt \\"You are a research mathematician drafting an arXiv preprint. Output only valid JSON.\\" --effort %s\\n"\n' "$CLAUDE_MODEL" "$CLAUDE_EFFORT"
         fi
         printf '} >> .agentis/config\n'
-        # Stage all 17 colonies + tools/ + config/ + data/ from the
+        # Stage all 18 colonies + tools/ + config/ + data/ from the
         # read-only /repo bind-mount.
-        printf 'for c in explorer noticer skeptic formulator verifier novelty arxiv-search oeis-search groupprops-search scholar-search prior_advocate auditor introducer theorist computer editor submitter; do\n'
+        printf 'for c in explorer noticer skeptic formulator verifier novelty arxiv-search oeis-search groupprops-search scholar-search prior_advocate auditor introducer theorist computer editor reviewer submitter; do\n'
         printf '    cp -r /repo/research-foundry/$c /run-root/$c\n'
         printf 'done\n'
         printf 'cp -r /repo/research-foundry/tools /run-root/tools\n'
@@ -416,7 +416,7 @@ write_bootstrap() {
         # claim-auditor / preprint-foundry searcher keys use underscored
         # forms (arxiv_search, oeis_search, etc.) because the .ag agents
         # call them that way internally; mirrors retired run-auditor.sh.
-        printf 'for c in explorer noticer skeptic formulator verifier novelty arxiv_search oeis_search groupprops_search scholar_search prior_advocate auditor introducer theorist computer editor submitter; do\n'
+        printf 'for c in explorer noticer skeptic formulator verifier novelty arxiv_search oeis_search groupprops_search scholar_search prior_advocate auditor introducer theorist computer editor reviewer submitter; do\n'
         printf '    (cd /run-root && agentis memo set $c:confidence 0.7 >/dev/null 2>&1 || true)\n'
         printf 'done\n'
         # Per-daemon tick interval is 30s (decoupled from orchestrator
@@ -510,6 +510,14 @@ write_bootstrap() {
         printf '    DAEMON_ID=1 COLONY_NAME=$c DISCOVERY_LEDGER=/run-root/preprint-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis PREPRINT_OUTPUT_ROOT=/run-root/preprints PREPRINT_AUTHOR_CONFIG=/run-root/config/authors.toml PREPRINT_LATEXMK_MAX_PASSES=%s agentis daemon /run-root/$c/agents/$c.ag --colony $c --enable-exec --enable-messaging --tick-interval "$DAEMON_TICK_INTERVAL_MS" > /run-root/.agentis/logs/$c-1.log 2>&1 &\n' "$LATEXMK_MAX_PASSES"
         printf 'done\n'
         printf 'DAEMON_ID=1 COLONY_NAME=editor DISCOVERY_LEDGER=/run-root/preprint-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis PREPRINT_OUTPUT_ROOT=/run-root/preprints PREPRINT_AUTHOR_CONFIG=/run-root/config/authors.toml PREPRINT_LATEXMK_MAX_PASSES=%s agentis daemon /run-root/editor/agents/editor.ag --colony editor --enable-exec --enable-messaging --tick-interval "$DAEMON_TICK_INTERVAL_MS" > /run-root/.agentis/logs/editor-1.log 2>&1 &\n' "$LATEXMK_MAX_PASSES"
+        # Phase 4 PR-C (#625): reviewer colony enforces a block-by-default
+        # gate before the submitter can write the DRAFTED row. Reads
+        # editor:<pid>:final_tex and computer:<pid>:output at
+        # upstream_tick = tick_idx - 3, extracts every numerical / symbolic
+        # claim in the .tex, flags unsupported claims, writes
+        # reviewer:<claim>:approved = "true" ONLY when verdict == approved.
+        # Operator override: `agentis memo set reviewer:<claim>:approved true`.
+        printf 'DAEMON_ID=1 COLONY_NAME=reviewer DISCOVERY_LEDGER=/run-root/preprint-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis agentis daemon /run-root/reviewer/agents/reviewer.ag --colony reviewer --enable-exec --enable-messaging --tick-interval "$DAEMON_TICK_INTERVAL_MS" > /run-root/.agentis/logs/reviewer-1.log 2>&1 &\n'
         printf 'DAEMON_ID=1 COLONY_NAME=submitter DISCOVERY_LEDGER=/run-root/preprint-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis PREPRINT_OUTPUT_ROOT=/run-root/preprints PREPRINT_AUTHOR_CONFIG=/run-root/config/authors.toml PREPRINT_ARXIV_GATEWAY=%s PREPRINT_ARXIV_FROM=%s PREPRINT_SMTP_HOST=%s PREPRINT_SMTP_PORT=%s agentis daemon /run-root/submitter/agents/submitter.ag --colony submitter --enable-exec --enable-messaging --tick-interval "$DAEMON_TICK_INTERVAL_MS" > /run-root/.agentis/logs/submitter-1.log 2>&1 &\n' \
             "$ARXIV_GATEWAY" "$ARXIV_FROM" "$SMTP_HOST" "$SMTP_PORT"
         printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -15,7 +15,7 @@
 #   8. Invalid RESEARCH_TOTAL_TICKS=0 rejected with exit 2
 #   9. Empty RESEARCH_TOPICS rejected with exit 2
 #  10. Bootstrap-script generation step is emitted in dry-run output,
-#      and names all 17 colonies.
+#      and names all 18 colonies.
 #  11. Container spawn command is emitted in dry-run output using the
 #      `research-foundry-laptop` name (single sidecar block).
 #  12. Run-meta.json write step is emitted in dry-run output
@@ -128,12 +128,12 @@ assert_contains "9b. empty-topics stderr names the variable" "$EMPTY_OUT" \
     "RESEARCH_TOPICS must be a non-empty comma-separated list"
 
 # ---------------------------------------------------------------------------
-# 10. Bootstrap-script generation names all 17 colonies.
+# 10. Bootstrap-script generation names all 18 colonies.
 # ---------------------------------------------------------------------------
 assert_contains "10a. bootstrap-script generation step emitted" "$OUT" \
     "generating bootstrap script"
 assert_contains "10b. bootstrap names explorer/noticer/.../submitter" "$OUT" \
-    "colonies=explorer,noticer,skeptic,formulator,verifier,novelty,arxiv-search,oeis-search,groupprops-search,scholar-search,prior_advocate,auditor,introducer,theorist,computer,editor,submitter"
+    "colonies=explorer,noticer,skeptic,formulator,verifier,novelty,arxiv-search,oeis-search,groupprops-search,scholar-search,prior_advocate,auditor,introducer,theorist,computer,editor,reviewer,submitter"
 
 # ---------------------------------------------------------------------------
 # 11. Spawn command uses research-foundry-laptop name (single).

--- a/tools/check-learn-tags.sh
+++ b/tools/check-learn-tags.sh
@@ -547,6 +547,41 @@ observed
 preprint-foundry"
             PAIR_KNOWN=1
             ;;
+        "review:partial")
+            # Phase 4 PR-C (#625): reviewer cross-checks every numerical /
+            # symbolic claim in the editor's final main.tex against the
+            # computer's reproducibility stdout. `partial` outcome covers
+            # acted / review-gated / observed branches.
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "review:success")
+            # Phase 4 PR-C (#625): reviewer `success` outcome covers the
+            # propose-tier approved branch (verdict == approved; writes
+            # reviewer:<claim>:approved = "true").
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "review:failure")
+            # Phase 4 PR-C (#625): reviewer `failure` outcome covers the
+            # propose-tier rejected branch (verdict != approved; writes
+            # reviewer:<claim>:hallucinated_payload for a future
+            # editor-repair cycle).
+            ALLOWED_LITERALS="acted
+review-gated
+emitted
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
         "submit:partial")
             ALLOWED_LITERALS="acted
 review-gated


### PR DESCRIPTION
## Summary

PR-C is the final critic of Phase 4 (#625), shipping the `reviewer` colony — a strict reproducibility reviewer for the preprint-foundry pipeline that **enforces a block-by-default gate** in front of the submitter. This complements:
- PR-A `skeptic` (#652) — gates the formulator on noticer surprises.
- PR-B `prior_advocate` (#655) — feeds an adversarial KNOWN_PRIOR signal into the auditor (pass-through default).

The reviewer reads the editor's final `main.tex` and the computer's reproducibility stdout, extracts every numerical / symbolic claim, and writes the per-claim memo gate `reviewer:<claim>:approved = "true"` **only on `approved` verdicts**. On `rejected` verdicts it also stamps `reviewer:<claim>:hallucinated_payload` for a future editor-repair cycle (memo channel reserved; repair loop is out of scope here). The submitter now reads that gate and refuses to write the DRAFTED row when the value is not `"true"` (an empty / missing reviewer memo blocks the submission). Operator override: `agentis memo set reviewer:<claim>:approved true`.

## Changes

- **New colony `research-foundry/reviewer/`** — `agents/reviewer.ag` (Phase 2 #642 ctx-dump pattern, 4-tier branch per #632, `cb 2000` matching editor/submitter), `config/colony.example.toml`, `scripts/start-colony.sh` (ADR-0003 conformant), `README.md`.
- **`research-foundry/submitter/agents/submitter.ag`** — insert the block-by-default reviewer gate before the tier branch; bump `upstream_tick` from `tick_idx - 3` to `tick_idx - 4` to absorb the new pipeline stage.
- **`research-foundry/tools/run-research.sh`** — spawn reviewer between editor and submitter in the preprint daemon block, add reviewer to the dry-run colony list, staging loop, and confidence seed loop; bootstrap-script emit_step narrative bumps from `colonies=17` to `colonies=18`.
- **`tools/check-learn-tags.sh`** — new `(review, partial)` / `(review, success)` / `(review, failure)` pairs in the preprint-foundry block.
- **`research-foundry/BUNDLE.manifest`** — add `research-foundry/reviewer/` ordered between editor and submitter (pipeline-stage convention).
- **`research-foundry/CHANGELOG.md`** — `[Unreleased] Added` entry documenting the new colony, block-by-default semantics, and the submitter offset bump.
- **`research-foundry/tools/test-run-research.sh`** — test 10b assertion updated to include reviewer in the canonical colony order.

## Test plan

- [x] `tools/colony-lint.sh` — 334 passed, 0 failed, 3 skipped (baseline was 326; +8 from new colony reviewer/ structure + config + shellcheck + daemon-flag + markdown + .ag syntax + tier-branch + submitter.ag re-validation).
- [x] `tools/check-learn-tags.sh` — exit 0 (new pairs registered).
- [x] `tools/test-auto-promote.sh` — 35 passed, 0 failed.
- [x] `tools/test-make-federation-bundle.sh` — 11 passed, 0 failed.
- [x] `research-foundry/tools/test-run-research.sh` — 29 passed, 0 failed.
- [x] `bash -n` clean on all modified `.sh`.
- [x] `bash research-foundry/tools/run-research.sh --dry-run` emits `colonies=18` and lists reviewer between editor and submitter in the colony order.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>