### PR TITLE
feat(phase-7-prc): flip live for explorer + #660/#661 + allowlist (PR-C of #628)

### DIFF
--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -18,6 +18,28 @@ History of the three retired federations consolidated into this one
 
 ## [Unreleased]
 
+### Changed
+
+- Flipped `evolve.dry_run` and `evolve.mutation.enabled` for
+  research-foundry (Phase 7 PR-C of #628). The explorer agent now
+  runs in live evolve mode: the LLM mutator proposes candidates, the
+  A/B harness spawns a sibling daemon under a synthetic agent_id,
+  scoring goes through `tools/explorer-fitness.py` (PR 2 of #624),
+  and a winning candidate atomically replaces the parent `.ag` with
+  a respawn of the canonical daemon. The other 14 agents stay in
+  observe-only mode behind a new `evolve.mutation.allowed_agents`
+  list (`["explorer"]`). Configs that omit the key (dev-apprenticeship,
+  tribes-bench) keep the legacy `*` fallback so flipping
+  `mutation.enabled` later does not trip the gate. Fixes two PR-B
+  blockers along the way: the candidate daemon SPAWN_CMD now uses
+  the container-side `/run-root/...` path instead of the host fed-dir
+  prefix (#660), and the mutator-stderr clipper strips the
+  double-quote byte so `mutation_rejected` rows always have a
+  parseable JSON `reason` field (#661). Header docs on
+  `tools/auto-evolve-ab.sh` updated to match the implementation; 3
+  new smoke-test assertions in `tools/test-auto-evolve-ab.sh`
+  (total 18/18).
+
 ### Added
 
 - LLM-driven `.ag` mutator + real A/B harness in dry-run mode for

--- a/tools/auto-evolve-ab.sh
+++ b/tools/auto-evolve-ab.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
-# auto-evolve-ab.sh — Phase 7 PR-B harness for self-improving .ag
-# mutation + A/B comparison (#628).
+# auto-evolve-ab.sh — Phase 7 harness for self-improving .ag mutation
+# + A/B comparison (#628).
 #
 # Invoked by `tools/auto-promote.sh` when
 # `evolve.mutation.enabled = true` in the active auto-promote-config.
 # When the flag is false (the default) the legacy `agentis evolve`
 # path runs instead — see auto-promote.sh evolve handler.
 #
-# Pipeline (PR-B):
+# Pipeline:
+#   0a. Generation cap check: abort with `evolve_throttled` when
+#       `generation_next > evolve.mutation.max_generations`.
+#   0b. Per-agent allowlist gate (PR-C): when
+#       `evolve.mutation.allowed_agents` is set and does not contain
+#       the agent name (or `*`), emit `evolve_skipped_not_in_allowlist`
+#       and exit 0. The default `*` (or missing key) preserves the
+#       legacy behaviour for dev-apprenticeship / tribes-bench configs.
 #   1. Pre-flight throttle: count open candidate files in
 #      `<colony>/agents/.evolve/`; abort with `evolve_throttled` ledger
 #      row when the cap is hit.
@@ -23,14 +30,18 @@
 #      daemon under a synthetic agent_id `<agent>-cand-gen-<N>` so its
 #      experience writes go to an isolated .jsonl. Wait K ticks
 #      bounded by `ab.absolute_max_wait_s`. Score candidate vs
-#      canonical via `auto-promote-decisions.py --preview` +
-#      `explorer-fitness.py` (or fallback proxy
-#      `(acting - reject) / max(acting, 1)`). Compare with
-#      `ab.min_delta`. Emit `evolve_cycle` (winner candidate /
-#      canonical) or `ab_inconclusive` ledger row.
+#      canonical:
+#        - explorer agents go through `tools/explorer-fitness.py`
+#          (PR-C wires it in; PR 2 of #624 added the helper);
+#        - non-explorer agents use the inline proxy
+#          `(acting - reject) / max(acting, 1)`;
+#        - both paths fall back to the proxy if their preferred
+#          signal returns empty / errors.
+#      Compare with `ab.min_delta`. Emit `evolve_cycle` (winner
+#      candidate / canonical) or `ab_inconclusive` ledger row.
 #   5. Promote winner (DRY-RUN AWARE): when `evolve.dry_run=true`, log
-#      and stop. When false (PR-C), if candidate wins: stop candidate,
-#      archive parent to
+#      and stop. When false (PR-C, research-foundry only), if
+#      candidate wins: stop candidate, archive parent to
 #      `<fed-dir>/<archive_dir>/<agent>-gen-N-<sha8>.ag`, `mv -f`
 #      candidate over canonical, respawn canonical daemon. Cleanup
 #      always removes the .evolve/ candidate + synthetic experience.
@@ -43,10 +54,6 @@
 #   0 — success (ledger written, regardless of decision)
 #   1 — usage / arg error
 #   2 — config / parser error
-#
-# Out of scope for PR-B:
-#   - flipping `evolve.dry_run=false` for explorer (deferred to PR-C)
-#   - bundle-manifest wiring (deferred to PR-C alongside the flip)
 
 set -euo pipefail
 
@@ -474,12 +481,17 @@ fi
 # the synthetic .jsonl; the canonical keeps its existing path.
 sleep "$WAIT_S"
 
-# Score both daemons. The fallback proxy is
-#   (acting_count - reject_count) / max(acting_count, 1)
-# computed straight off the .jsonl tail. For explorers we additionally
-# try `explorer-fitness.py` for the empirical signal, but the proxy is
-# the canonical scalar the A/B comparison runs on -- one path, no
-# divergence between explorer / non-explorer agents on this PR.
+# Score both daemons. Two paths:
+#   - Explorer agents go through `tools/explorer-fitness.py`, which
+#     blends NOVEL count, auditor confidence, and HITL accept ratio
+#     into a single scalar (Phase 3 PR 2 of #624). PR-C (#628) wires
+#     it in for the live evolve flip.
+#   - Non-explorer agents (when the allowlist gate is eventually
+#     widened) use the inline proxy:
+#       (acting_count - reject_count) / max(acting_count, 1)
+#     computed straight off the .jsonl tail.
+# Both paths fall back to the proxy if their preferred signal returns
+# empty / errors -- the A/B comparison always has a defined scalar.
 score_jsonl() {
     local jsonl_path="$1"
     local window="$2"
@@ -522,8 +534,38 @@ else:
 " "$jsonl_path" "$window"
 }
 
-CANDIDATE_SCORE=$(score_jsonl "$SYNTH_EXP" "$AB_TICKS")
-CANONICAL_SCORE=$(score_jsonl "$EXPERIENCE_PATH" "$AB_TICKS")
+# Pull the explorer fitness scalar via the helper. Empty pid is OK --
+# explorer-fitness.py only uses it as a heuristic for HITL reject
+# attribution and falls back to a window-clamped global count when the
+# pid is unmatched. Returns "" on any error so the caller can fall
+# through to the proxy.
+score_explorer() {
+    local agent_id="$1"
+    local pid="$2"
+    python3 "$REPO_ROOT/tools/explorer-fitness.py" \
+        "$FED_DIR" "$pid" "$agent_id" 2>/dev/null \
+        | python3 -c "
+import json, sys
+try:
+    obj = json.loads(sys.stdin.read())
+    print('%.6f' % float(obj.get('fitness_score', 0.0)))
+except (json.JSONDecodeError, ValueError, TypeError):
+    print('')
+"
+}
+
+if [ "$AGENT_NAME" = "explorer" ]; then
+    CANDIDATE_SCORE=$(score_explorer "$SYNTHETIC_ID" "")
+    CANONICAL_SCORE=$(score_explorer "$AGENT_NAME" "")
+    if [ -z "$CANDIDATE_SCORE" ] || [ -z "$CANONICAL_SCORE" ]; then
+        log "  explorer-fitness returned empty; falling back to proxy"
+        CANDIDATE_SCORE=$(score_jsonl "$SYNTH_EXP" "$AB_TICKS")
+        CANONICAL_SCORE=$(score_jsonl "$EXPERIENCE_PATH" "$AB_TICKS")
+    fi
+else
+    CANDIDATE_SCORE=$(score_jsonl "$SYNTH_EXP" "$AB_TICKS")
+    CANONICAL_SCORE=$(score_jsonl "$EXPERIENCE_PATH" "$AB_TICKS")
+fi
 
 log "  scores: candidate=$CANDIDATE_SCORE canonical=$CANONICAL_SCORE min_delta=$CFG_EVOLVE_AB_MIN_DELTA"
 

--- a/tools/auto-evolve-ab.sh
+++ b/tools/auto-evolve-ab.sh
@@ -420,9 +420,17 @@ fi
 # cull-explorers.sh:410 pattern (podman exec bash -c "... agentis daemon ... &").
 # Container name is fixed to `research-foundry-laptop` -- the only
 # containerized federation today.
+#
+# Path translation (fixes #660): $CANDIDATE_PATH is host-side
+# `<fed-dir>/<colony>/agents/.evolve/<agent>.ag.candidate-gen-N`. The
+# container mounts the federation root at `/run-root/`, so strip the
+# host fed-dir prefix and prepend `/run-root/` before handing the path
+# to the daemon. Mirrors the respawn block below + cull-explorers.sh:410
+# pattern (`/run-root/<colony>/agents/<agent>.ag`).
 CONTAINER_NAME="${RESEARCH_CONTAINER_NAME:-research-foundry-laptop}"
+CANDIDATE_CONTAINER_PATH="/run-root/${COLONY}/agents/.evolve/${AGENT_NAME}.ag.candidate-gen-${GENERATION_NEXT}"
 CANDIDATE_LOG="/run-root/.agentis/logs/${SYNTHETIC_ID}.log"
-SPAWN_CMD="agentis daemon $CANDIDATE_PATH --colony $COLONY --enable-exec --enable-messaging --tick-interval $TICK_INTERVAL_MS > $CANDIDATE_LOG 2>&1 &"
+SPAWN_CMD="agentis daemon $CANDIDATE_CONTAINER_PATH --colony $COLONY --enable-exec --enable-messaging --tick-interval $TICK_INTERVAL_MS > $CANDIDATE_LOG 2>&1 &"
 
 log "  spawning candidate daemon: synthetic_id=$SYNTHETIC_ID wait_s=$WAIT_S"
 if ! podman exec "$CONTAINER_NAME" bash -c "$SPAWN_CMD" 2>/dev/null; then
@@ -514,8 +522,9 @@ log "  A/B verdict: winner=$WINNER delta=$DELTA"
 
 # Stop the candidate daemon regardless of verdict. It served its A/B
 # purpose; whether we then archive + replace canonical depends on the
-# dry-run flag below.
-podman exec "$CONTAINER_NAME" bash -c "pkill -f 'agentis daemon $CANDIDATE_PATH' 2>/dev/null || true" >/dev/null 2>&1 || true
+# dry-run flag below. Uses the container-side path (#660) so pkill -f
+# matches the daemon's actual argv.
+podman exec "$CONTAINER_NAME" bash -c "pkill -f 'agentis daemon $CANDIDATE_CONTAINER_PATH' 2>/dev/null || true" >/dev/null 2>&1 || true
 
 if [ "$WINNER" = "inconclusive" ]; then
     ledger_append "ab_inconclusive" \

--- a/tools/auto-evolve-ab.sh
+++ b/tools/auto-evolve-ab.sh
@@ -288,13 +288,15 @@ if [ "$MUT_RC" -ne 0 ]; then
         MUT_REASON="mutator_failed"
     fi
     log "  mutator rc=$MUT_RC reason=$MUT_REASON"
-    # Strip control characters and clip stderr so the ledger row stays
-    # one JSON line. We deliberately use python3 here, not sed/tr, so the
-    # macOS bash 3.2 quoting story stays compatible.
+    # Strip control characters, drop the double-quote byte (34) so the
+    # JSON ledger row doesn't fracture mid-string (#661), and clip stderr
+    # to 500 chars so the row stays single-line. We deliberately use
+    # python3 here, not sed/tr, so the macOS bash 3.2 quoting story stays
+    # compatible.
     MUT_STDERR_CLIP=$(python3 -c "
 import sys
 buf = sys.argv[1].replace('\n', ' ')[:500]
-print(''.join(c for c in buf if c == ' ' or 32 <= ord(c) < 127))
+print(''.join(c for c in buf if c == ' ' or (32 <= ord(c) < 127 and ord(c) != 34)))
 " "$MUT_OUTPUT")
     ledger_append "mutation_rejected" \
         "{\"reason\":\"$MUT_REASON\",\"mutator_stderr\":\"$MUT_STDERR_CLIP\"}"

--- a/tools/auto-evolve-ab.sh
+++ b/tools/auto-evolve-ab.sh
@@ -235,6 +235,32 @@ if [ "$GENERATION_NEXT" -gt "$CFG_EVOLVE_MUTATION_MAX_GENERATIONS" ]; then
 fi
 
 # ------------------------------------------------------------------
+# 0b. Per-agent allowlist gate (PR-C, #628)
+# ------------------------------------------------------------------
+#
+# `evolve.mutation.allowed_agents` is a comma-separated list emitted by
+# the config parser. `*` is the legacy-compat sentinel meaning "all
+# agents allowed" -- dev-apprenticeship + tribes-bench configs that
+# omit the key fall through to that path. research-foundry pins it to
+# `explorer` only; every other agent invocation short-circuits here.
+ALLOWED_AGENTS_CSV="${CFG_EVOLVE_MUTATION_ALLOWED_AGENTS:-*}"
+if [ "$ALLOWED_AGENTS_CSV" != "*" ]; then
+    AGENT_ALLOWED=$(python3 -c "
+import sys
+csv = sys.argv[1]
+agent = sys.argv[2]
+items = [s.strip() for s in csv.split(',') if s.strip()]
+print('true' if (agent in items or '*' in items) else 'false')
+" "$ALLOWED_AGENTS_CSV" "$AGENT_NAME")
+    if [ "$AGENT_ALLOWED" != "true" ]; then
+        log "  agent not in allowlist: $AGENT_NAME (allowed=$ALLOWED_AGENTS_CSV)"
+        ledger_append "evolve_skipped_not_in_allowlist" \
+            "{\"reason\":\"agent_not_in_allowlist\",\"allowed_agents\":\"$ALLOWED_AGENTS_CSV\"}"
+        exit 0
+    fi
+fi
+
+# ------------------------------------------------------------------
 # 1. Pre-flight throttle: count open candidate files
 # ------------------------------------------------------------------
 

--- a/tools/auto-promote-config-parser.py
+++ b/tools/auto-promote-config-parser.py
@@ -202,6 +202,16 @@ def main():
         skip_tiers = [skip_tiers]
     skip_tiers_csv = ','.join(str(t) for t in skip_tiers)
     print("CFG_EVOLVE_MUTATION_SKIP_TIERS='%s'" % skip_tiers_csv)
+    # Phase 7 PR-C (#628): per-agent allowlist for the live evolve path.
+    # When the key is absent, default to the legacy-compat sentinel `*`
+    # so dev-apprenticeship + tribes-bench configs that flip
+    # `mutation.enabled` later don't trip the new gate. PR-C ships
+    # research-foundry with `["explorer"]` only.
+    allowed_agents = em.get('allowed_agents', ['*'])
+    if not isinstance(allowed_agents, list):
+        allowed_agents = [allowed_agents]
+    allowed_agents_csv = ','.join(str(a) for a in allowed_agents)
+    print("CFG_EVOLVE_MUTATION_ALLOWED_AGENTS='%s'" % allowed_agents_csv)
 
     ab = cfg.get('evolve', {}).get('ab', {})
     print('CFG_EVOLVE_AB_TICKS=%s' % ab.get('ticks', 50))

--- a/tools/auto-promote-config.research-foundry.yaml
+++ b/tools/auto-promote-config.research-foundry.yaml
@@ -15,8 +15,12 @@
 # exchange for a single sidecar pass. Per-colony prereq variation is
 # deferred as a Phase 2 chore.
 #
-# `dry_run: true` is preserved — flip in a follow-up PR once the
-# journal shows the sidecar making sensible decisions on a real run.
+# Phase 7 PR-C (#628) flips `evolve.dry_run` and
+# `evolve.mutation.enabled` for the explorer agent only -- the
+# `evolve.mutation.allowed_agents: ["explorer"]` gate keeps the other
+# 14 agents in observe-only mode through the legacy `agentis evolve`
+# path. The top-level `dry_run: true` remains a safety belt for the
+# promotion ladder; evolve has its own per-block toggle now.
 
 promote:
   prerequisites:
@@ -46,7 +50,8 @@ evolve:
     population: 4
     weights: "cb,val,exp"
   mutation:
-    enabled: false                       # PR-A default OFF — PR-C flips for explorer
+    enabled: true                        # PR-C flips ON — gated per agent below
+    allowed_agents: ["explorer"]         # PR-C: explorer is the only agent in live evolve mode
     max_concurrent_per_colony: 1         # throttle: max open candidates per colony
     max_generations: 10                  # 10-gen cap per #628 acceptance
     skip_tiers: ["autonomous"]           # do not evolve autonomous-tier agents
@@ -58,6 +63,6 @@ evolve:
     absolute_max_wait_s: 1800            # PR-B (#628): hard cap on A/B wait
   archive_dir: "evolution-archive"
   ledger_path: "evolution-ledger.jsonl"
-  dry_run: true                          # PR-A + PR-B ship dry-run; PR-C flips
+  dry_run: false                         # PR-C flips live for explorer (#628)
 
 dry_run: true

--- a/tools/test-auto-evolve-ab.sh
+++ b/tools/test-auto-evolve-ab.sh
@@ -28,9 +28,15 @@
 #       by introspecting the script's archive-path interpolation; the
 #       archive is only written on live-mode candidate-winner runs).
 #
-# Out of scope (deferred to PR-C):
-#   - live evolve with dry_run=false + actual respawn
-#   - bundle-manifest inclusion
+# PR-C (#628) added 3 new assertions:
+#   16. SPAWN_CMD path translation (#660): the generated container
+#       command uses `/run-root/...` paths, never `<run-dir>/.../.evolve/`.
+#   17. Mutator-stderr quote escaping (#661): a mutator stub that
+#       writes quotes to stderr produces a ledger row whose JSON parses
+#       cleanly (no `_extras_parse_error`).
+#   18. Allowlist enforcement: invoking the harness with an agent name
+#       not in `evolve.mutation.allowed_agents` emits an
+#       `evolve_skipped_not_in_allowlist` row and exits 0.
 #
 # Usage: ./tools/test-auto-evolve-ab.sh
 # Exit code 0 if all tests pass, 1 otherwise.
@@ -482,6 +488,138 @@ if [ "$ARCHIVE_PATTERN" = "    $EXPECTED_SHAPE" ]; then
     pass "archive path: filename matches <agent>-gen-N-<sha8>.ag shape"
 else
     fail "archive path shape" "expected '$EXPECTED_SHAPE' got '$ARCHIVE_PATTERN'"
+fi
+
+# ------------------------------------------------------------------
+# PR-C (#628) new tests
+# ------------------------------------------------------------------
+
+# ----- Test 16: SPAWN_CMD path translation (#660) -----
+# auto-evolve-ab.sh used to feed $CANDIDATE_PATH (host-side) into
+# SPAWN_CMD inside the container. The container mounts the fed-dir at
+# /run-root/, so the host path resolved to a non-existent file. Verify
+# by introspection: the SPAWN_CMD line must reference
+# $CANDIDATE_CONTAINER_PATH (declared above it) and the
+# $CANDIDATE_CONTAINER_PATH declaration must start with /run-root/.
+
+SPAWN_LINE=$(grep -nE '^SPAWN_CMD=' "$SCRIPT_DIR/auto-evolve-ab.sh" | head -1)
+CONTAINER_DECL_LINE=$(grep -nE '^CANDIDATE_CONTAINER_PATH=' "$SCRIPT_DIR/auto-evolve-ab.sh" | head -1)
+# shellcheck disable=SC2016
+# Intentional: matching the literal `$CANDIDATE_` text as it appears
+# verbatim in auto-evolve-ab.sh (the regex is consumed by grep, not the
+# shell). We are NOT expanding the variable here.
+PKILL_LINE=$(grep -nE 'pkill -f .agentis daemon \$CANDIDATE_' "$SCRIPT_DIR/auto-evolve-ab.sh" | head -1)
+
+# shellcheck disable=SC2016
+# Same intent as above: `\$CANDIDATE_PATH` is a grep regex literal.
+if echo "$SPAWN_LINE" | grep -q 'CANDIDATE_CONTAINER_PATH' \
+    && echo "$CONTAINER_DECL_LINE" | grep -q '"/run-root/' \
+    && ! echo "$SPAWN_LINE" | grep -qE '\$CANDIDATE_PATH\b' \
+    && echo "$PKILL_LINE" | grep -q 'CANDIDATE_CONTAINER_PATH' \
+    && ! echo "$PKILL_LINE" | grep -qE '\$CANDIDATE_PATH\b'; then
+    pass "path translation: SPAWN_CMD + pkill use container path (#660)"
+else
+    fail "path translation" "spawn=$SPAWN_LINE decl=$CONTAINER_DECL_LINE pkill=$PKILL_LINE"
+fi
+
+# ----- Test 17: mutator-stderr quote escaping (#661) -----
+# The harness's stderr clipper used to allow byte 34 (double quote),
+# which fractured the JSON ledger row when mutator stderr embedded
+# quotes. Verify the clipper now strips byte 34 by replaying the exact
+# Python snippet from auto-evolve-ab.sh against a quoted input and
+# round-tripping the resulting JSON.
+
+QUOTE_INPUT='mutator failed: backend returned "<bad>" shape'
+CLIPPED=$(python3 -c "
+import sys
+buf = sys.argv[1].replace('\n', ' ')[:500]
+print(''.join(c for c in buf if c == ' ' or (32 <= ord(c) < 127 and ord(c) != 34)))
+" "$QUOTE_INPUT")
+
+# Build the exact ledger extras JSON the harness would write, and parse
+# it to verify validity.
+LEDGER_JSON='{"reason":"mutator_failed","mutator_stderr":"'"$CLIPPED"'"}'
+JSON_OK=$(python3 -c "
+import json, sys
+try:
+    obj = json.loads(sys.argv[1])
+    print('ok' if obj.get('reason') == 'mutator_failed' else 'bad_reason')
+except (json.JSONDecodeError, ValueError):
+    print('parse_error')
+" "$LEDGER_JSON")
+
+if [ "$JSON_OK" = "ok" ] && ! echo "$CLIPPED" | grep -q '"'; then
+    pass "quote escaping: clipped stderr keeps JSON ledger row valid (#661)"
+else
+    fail "quote escaping" "json_ok=$JSON_OK clipped=$CLIPPED"
+fi
+
+# ----- Test 18: allowlist enforcement -----
+# A config with `evolve.mutation.allowed_agents: ["explorer"]` must
+# short-circuit when invoked with a non-explorer agent. The harness
+# emits an `evolve_skipped_not_in_allowlist` ledger row and exits 0
+# without producing a candidate.
+
+ALLOWLIST_CONFIG="$TMPDIR_TEST/allowlist-config.yaml"
+cat > "$ALLOWLIST_CONFIG" <<'ALLOWLISTEOF'
+promote:
+  prerequisites:
+    min_entries: 30
+    min_acting_entries: 10
+    min_runtime_hours: 1.5
+    reject_rate_threshold: 0.10
+    delta_slope_window: 20
+    delta_slope_min: 0
+  steps:
+    - from: 0.4
+      to: 0.6
+      min_acting_entries_override: 0
+
+evolve:
+  trigger:
+    delta_slope_negative_for: 1000
+    reject_rate_above: 0.20
+    both_signals_required: false
+  mutation:
+    enabled: true
+    allowed_agents: ["explorer"]
+    max_concurrent_per_colony: 1
+    max_generations: 10
+    skip_tiers: ["autonomous"]
+  ab:
+    ticks: 50
+    min_acting_for_decision: 10
+    min_delta: 0.05
+    fast_mode_ticks: 10
+  archive_dir: "evolution-archive"
+  ledger_path: "evolution-ledger.jsonl"
+  dry_run: true
+
+dry_run: true
+ALLOWLISTEOF
+
+# Set up a noticer agent under the same fake fed.
+NOTICER_DIR="$FAKE_FED/noticer/agents"
+mkdir -p "$NOTICER_DIR"
+NOTICER_AG="$NOTICER_DIR/noticer.ag"
+cp "$PARENT_AG" "$NOTICER_AG"
+
+rm -f "$LEDGER"
+ALLOW_OUT=$(MUTATE_LLM_STUB="$GOOD_STUB" \
+    "$SCRIPT_DIR/auto-evolve-ab.sh" "$FAKE_FED" noticer noticer "$NOTICER_AG" \
+    --ticks 10 --config "$ALLOWLIST_CONFIG" 2>&1) || true
+ALLOW_RC=$?
+
+# Verify a) ledger row is evolve_skipped_not_in_allowlist, b) exit 0,
+# c) no candidate file was created (the gate runs before mutator step).
+ALLOW_CANDS=$(find "$NOTICER_DIR/.evolve" -name "*.candidate-gen-*" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+if grep -q '"event":"evolve_skipped_not_in_allowlist"\|"event": "evolve_skipped_not_in_allowlist"' "$LEDGER" 2>/dev/null \
+    && [ "$ALLOW_RC" = "0" ] \
+    && [ "$ALLOW_CANDS" = "0" ]; then
+    pass "allowlist: non-explorer agent short-circuits + ledger row + exit 0"
+else
+    fail "allowlist enforcement" "rc=$ALLOW_RC cands=$ALLOW_CANDS ledger=$(cat "$LEDGER" 2>/dev/null) out: $ALLOW_OUT"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Phase 7 PR-C of #628 — flips `evolve.dry_run` and `evolve.mutation.enabled` to `true` for `tools/auto-promote-config.research-foundry.yaml`, wires `tools/explorer-fitness.py` (PR 2 of #624) into the A/B scoring path, and gates live mutation behind a new per-agent allowlist (`evolve.mutation.allowed_agents: ["explorer"]`). The other 14 agents stay in observe-only mode behind the same flag. Configs that omit the allowlist (dev-apprenticeship, tribes-bench) keep `*` as fallback so flipping `mutation.enabled` later does not trip the gate.

Inline fixes for two PR-B blockers carried forward as commits:
- #660 — SPAWN_CMD + pkill path translation, candidate daemon now references `/run-root/...` container path instead of host fed-dir prefix.
- #661 — mutator-stderr clipper strips the double-quote byte so `mutation_rejected` rows always have a parseable JSON `reason` field.

## Test plan

- [x] `tools/test-auto-evolve-ab.sh` — 18/18 pass (3 new assertions: SPAWN_CMD path translation, quote escape, allowlist enforcement).
- [x] `bash -n` clean on `tools/auto-evolve-ab.sh` + `tools/test-auto-evolve-ab.sh`.
- [x] CHANGELOG entry for `research-foundry` describes the flip + allowlist + #660/#661.
- [ ] QA agent verifies end-to-end live-evolve flow against a fresh research-foundry run.
- [ ] CI green.

Closes #628 once PR-D follow-up issues are filed for remaining LOW-severity items (per PR-B QA report).
Fixes #660, #661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)