### PR TITLE
feat(phase-8-pr1): cross-fed memo bridge sidecar (PR-1 of #629)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,11 @@ __pycache__/
 # Sidecar lock files (created next to the script via fcntl.flock; #245 / #318)
 tools/.auto-promote.lock
 tools/.cost-cap.lock
+
+# Cross-fed memo host-dir content (#629 Phase 8 PR-1). The bridge sidecar
+# regenerates everything under /cross-fed-memo/ on every tick from each
+# federation's `.agentis/memo/cross-fed:*` keys -- only the .gitkeep + README
+# are tracked.
+/cross-fed-memo/*
+!/cross-fed-memo/.gitkeep
+!/cross-fed-memo/README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,16 @@ Releasing: bump `federation-dashboard/VERSION`, move `[Unreleased]` into a dated
 
 `tools/new-federation.sh <federation-name> [<starter-colony-name>]` generates a directory shape that conforms to [ADR-0003](./doc/adr/ADR-0003-federation-portability-contract.md) and passes `colony-lint.sh` clean. Output: `<fed>/VERSION` (`0.1.0`), `<fed>/CHANGELOG.md` (Keep-a-Changelog with empty `[Unreleased]` + dated `[0.1.0]`), `<fed>/BUNDLE.manifest`, `<fed>/README.md`, `<fed>/install.sh`, plus one starter colony with an ADR-0003-conformant `start-colony.sh` (supports `--restart-agent` and `--rate-limit-status`). Colony name defaults to `core`. After scaffolding: add the federation to the `COMPONENTS` array in `tools/check-changelog.sh` and add a row to the top-level `README.md` Federations table. See also [`doc/federation-patterns.md`](./doc/federation-patterns.md) for non-coder federation sketches and [`tools/new-colony.sh`](./tools/new-colony.sh) for adding additional colonies to an existing federation.
 
+## Cross-federation memo (`cross-fed:*`)
+
+A shared memo namespace readable + writable by all federations on the same host. Methods that prove productive in one federation can cross-pollinate to others via this channel.
+
+- Conventions documented in `doc/cross-fed-memo.md`.
+- Storage: `<repo-root>/cross-fed-memo/` host dir, file-per-key. Mirrored to each fed's `.agentis/memo/cross-fed:*` by `tools/cross-fed-bridge.sh sidecar`.
+- Export from a fed happens at `_publish_<role>` autonomous-tier paths when a method clears both replicate threshold AND export-fitness threshold.
+- Import into a fed happens at bootstrap via `cross-fed:adopt-queue:<target-fed>` memo seed.
+- Operator curates `cross-fed:applicable-to:<method-id>` to control which feds adopt which methods.
+
 # dev-apprenticeship specifics
 
 Everything below this line is true for the `dev-apprenticeship/` federation only. Other federations choose their own colony decomposition, bus events, confidence keys, and operator scripts.

--- a/cross-fed-memo/README.md
+++ b/cross-fed-memo/README.md
@@ -1,0 +1,19 @@
+# cross-fed-memo/ (host-local state, do not commit content)
+
+Shared scratch directory for the `cross-fed:*` memo namespace defined
+in [`../doc/cross-fed-memo.md`](../doc/cross-fed-memo.md). The contents
+of this directory are regenerated on every tick by
+`tools/cross-fed-bridge.sh` from each federation's
+`<fed_dir>/.agentis/memo/cross-fed:*` keys.
+
+**Only `.gitkeep` (and this README) are tracked.** Every file written
+here by the bridge -- `method/<fed>/<id>.json`,
+`method-body/<fed>/<id>.txt`, `fitness/...`, `applicable-to/...`,
+`import-log/...`, `pollination-ledger.jsonl` -- is host-local state.
+The `.gitignore` at the repo root ensures git ignores the rest of the
+tree.
+
+Part of Phase 8 PR-1 of
+[#629](https://github.com/Replikanti/agentis-colonies/issues/629). PR-1
+is the foundation only: no federation reads or writes the namespace
+yet. PR-2, PR-3, PR-4 wire the agent paths.

--- a/doc/cross-fed-memo.md
+++ b/doc/cross-fed-memo.md
@@ -265,6 +265,65 @@ preserving timestamp order. The central ledger is the audit trail
 the operator scans to see which federation published which method
 when.
 
+## Threat model
+
+The `cross-fed:*` namespace is a *trusted-host, untrusted-fed* surface.
+All federations on the same host share `<repo-root>/cross-fed-memo/`
+through the bridge sidecar; any federation can read every other
+federation's exported method record + body + fitness scalar.
+
+Assumed threats:
+
+1. **Malicious cross-fed write.** A compromised federation A writes a
+   method record claiming a fitness score of `999.0` so the operator
+   prioritises adopting it into federation B. *Mitigation:* the operator
+   curates `cross-fed:applicable-to:<method-id>` before any adoption.
+   The bridge does not authorise on fitness alone; the export-fitness
+   threshold is a pre-filter, not a trust signal. PR-2/3 will add
+   `cross-fed:export-suppress:<source-fed>:<method-id>` (operator-only
+   write) for explicit blocklisting.
+
+2. **External tampering of `<repo-root>/cross-fed-memo/`.** A process
+   outside any federation rewrites a method body file between two
+   sidecar ticks. *Mitigation:* sha256-by-content dedupe causes the
+   bridge to overwrite the federation's `.agentis/memo/cross-fed:*` on
+   the next tick if the host file changes, but the federation's own
+   memo store treats the new content as just another remote method.
+   The operator-curated `applicable-to` gate is the last line of
+   defence. This is the same trust model as any
+   `<fed_dir>/.agentis/memo/*` file, since both are operator-writable.
+
+3. **Out-of-band federation that bypasses the bridge.** Any process
+   with write access to a federation's `.agentis/memo/cross-fed:*` keys
+   can plant a method without going through `pollination-ledger.jsonl`.
+   *Mitigation:* the central ledger only captures bridge-mediated
+   activity; out-of-band entries are visible in per-fed memo dumps but
+   not in the audit trail. Recommend operator audits by `diff`ing
+   `<host_dir>/methods/*` against per-fed memo dumps when paranoid.
+
+4. **Export-fitness threshold spoofing.** A method's
+   `cross-fed:fitness:<source-fed>:<method-id>` is written by the
+   federation that owns it; nothing cryptographically binds the score
+   to actual measured fitness. *Mitigation:* the operator sees the
+   source federation in the key. Future hardening (out of Phase 8
+   scope) could anchor scores to a signed `replication-ledger.jsonl`
+   entry.
+
+Not threats:
+
+- **Method body executes during import.** Import is operator-mediated;
+  no automatic execution path. The `.ag` file lands in the target
+  federation's colony only after the operator approves.
+- **Cross-fed write storms.** Bridge holds a flock on
+  `<host_dir>/.lock`; only one sidecar tick runs at a time across
+  *all* federations.
+
+Out of Phase 8 scope (track separately):
+
+- Cryptographic signing of method bodies + fitness scores.
+- Operator audit log of `applicable-to` curation decisions.
+- Per-fed network segmentation (cross-fed is single-host only).
+
 ## Related
 
 - [#629](https://github.com/Replikanti/agentis-colonies/issues/629) —

--- a/doc/cross-fed-memo.md
+++ b/doc/cross-fed-memo.md
@@ -1,0 +1,277 @@
+# Cross-federation memo reference
+
+`cross-fed:*` is a shared memo namespace readable + writable by every
+federation running on the same host. A method that proves productive
+in one federation (clears its replicate threshold AND an export-fitness
+gate) can publish itself into this channel; a separate federation that
+has been marked as `applicable-to` can then adopt the same method at
+bootstrap and verify-or-discard it under its own fitness signal.
+
+The channel is a thin file-per-key bridge on top of the existing
+per-federation memo stores: each federation writes to its own
+`.agentis/memo/cross-fed:*` keys, a sidecar mirrors those keys to a
+host-level shared directory, and the same sidecar mirrors keys from
+the shared directory back into every other federation's memo store.
+Federations never read each other's memo stores directly. See the
+Storage section below.
+
+This document is the reference for the namespace conventions, key
+shapes, export/import rules, fitness gates, applicable-to curation,
+and the host-dir layout. It does not cover the agent-side code that
+emits or consumes the keys — that lives in PR-2 (export from
+research-foundry) and PR-3 (target-fed import scaffold) of
+[#629](https://github.com/Replikanti/agentis-colonies/issues/629).
+
+## Scope
+
+- **Included:** the `cross-fed:*` key namespace, the method-record JSON
+  shape, export rules, import rules, applicable-to curation, fitness
+  gates, and the host-dir layout consumed by
+  `tools/cross-fed-bridge.sh`.
+- **Excluded:** how a federation produces a method (PR-2: export from
+  research-foundry's `_publish_<role>` autonomous-tier paths), how a
+  federation consumes one (PR-3: target-fed import + test scaffold),
+  and the cooperative search loop that closes the feedback loop (PR-4).
+
+## When the bridge fires
+
+The sidecar is a long-running loop spawned alongside (but separate
+from) a federation. On each tick (default 60s) it does two passes:
+
+1. **memo -> host.** Read every `cross-fed:*` key from
+   `<fed_dir>/.agentis/memo/` and mirror each key into a file under
+   `<host_dir>/`, content-addressed to skip no-op writes.
+2. **host -> memo.** Read every file under `<host_dir>/` and mirror
+   each one back into the federation's `.agentis/memo/cross-fed:*`
+   keys.
+
+The two passes run under a single host-level `flock` so only one
+sidecar instance touches the shared dir at a time. With multiple
+federations on one host each federation runs its own sidecar; the
+first to acquire the lock wins the tick, the others log
+`lock held by other process; no-op` and exit 0. The next tick will
+retry.
+
+## Key shapes
+
+All keys are flat `cross-fed:<kind>:<...>` strings. The `<source-fed>`
+component is the federation's directory name as it appears under
+`<repo-root>/`. The `<method-id>` component is a short content-derived
+identifier (the `body_sha` first 16 hex chars in PR-2's exporter).
+
+### `cross-fed:method:<source-fed>:<method-id>`
+
+The productive-method record itself, as JSON. Carries every field the
+target federation needs to decide whether to adopt and, after adopting,
+to verify under its own fitness signal. Example:
+
+```json
+{
+  "id": "a1b2c3d4e5f60718",
+  "source_fed": "research-foundry",
+  "source_agent": "explorer",
+  "source_pid": 1042,
+  "source_tick": 5731,
+  "specialty": "group_theory",
+  "variant": "character-table-sieve",
+  "verdict_chain": ["formulator:novel", "verifier:verified_new"],
+  "fitness_at_export": 0.82,
+  "body_sha": "a1b2c3d4e5f60718...",
+  "abstract": "Sieve conjugacy classes by character-degree gcd to surface sporadic-vs-classical anomalies.",
+  "created_at": 1747584000
+}
+```
+
+### `cross-fed:method-body:<source-fed>:<method-id>`
+
+The raw prompt body, content-addressed. Split from the record so the
+record stays cheap to scan and the body can be fetched on demand. The
+bridge mirrors both as separate files.
+
+### `cross-fed:fitness:<source-fed>:<method-id>`
+
+Fitness scalar at export time, as a JSON number (e.g. `0.82`). Stored
+separately so a future curation tool can re-scan all exported methods
+and prune the floor without rewriting the method record.
+
+### `cross-fed:applicable-to:<method-id>`
+
+JSON array of federation names the method is eligible to be adopted
+into. Operator-edited at MVP; future PRs may derive it from a
+similarity score across federation specialties.
+
+```json
+["trading-binance", "tribes-bench"]
+```
+
+A method whose `applicable-to` array does NOT contain the target
+federation's name is **not** imported by that federation's adoption
+loop.
+
+### `cross-fed:import-log:<target-fed>:<method-id>`
+
+Adoption record written by the target federation when it first picks
+up the method. JSON with timestamp + the adopter agent's pid:
+
+```json
+{
+  "imported_at": 1747600000,
+  "target_fed": "trading-binance",
+  "adopter_pid": 4096,
+  "adopter_agent": "strategy_explorer"
+}
+```
+
+PR-3 wires this; PR-1 only sets up the storage.
+
+## Method record JSON shape
+
+The `cross-fed:method:*` record carries:
+
+| Field | Type | Source |
+|---|---|---|
+| `id` | string | first 16 hex chars of `body_sha` |
+| `source_fed` | string | federation directory name |
+| `source_agent` | string | `.ag` file basename without extension |
+| `source_pid` | int | daemon pid that produced the method |
+| `source_tick` | int | daemon tick at export time |
+| `specialty` | string | producing agent's specialty (`group_theory`, `combinatorics`, …) |
+| `variant` | string | short label distinguishing variants of the same specialty |
+| `verdict_chain` | array of strings | ordered verdict trail (`formulator:novel`, `verifier:verified_new`) |
+| `fitness_at_export` | float | fitness score at the moment of export |
+| `body_sha` | string | sha256 of `cross-fed:method-body:…` payload, 64 hex chars |
+| `abstract` | string | one-sentence operator-facing description |
+| `created_at` | int | unix-seconds export timestamp |
+
+## Export rules
+
+A method becomes exportable when **both** gates fire:
+
+1. **Verdict gate.** The method's `verdict_chain` advances from
+   `NOVEL` to `VERIFIED_NEW` (or the federation's equivalent
+   accept-verdict for novel productive output). This is the same
+   gate that controls the source federation's internal replicate
+   path.
+2. **Fitness gate.** The method's producer agent's `fitness_score` at
+   the moment the accept verdict fires meets the federation's
+   `export_fitness_threshold`. The threshold MUST be **>= the
+   replicate threshold** — see _Fitness gates_ below.
+
+When both fire, the source federation's `_publish_<role>`
+autonomous-tier path writes the four `cross-fed:*` keys above to its
+own memo store. The bridge sidecar picks them up on the next tick and
+mirrors them into the host dir.
+
+Operator override: writing a `cross-fed:export-suppress:<method-id>`
+key blocks an export retroactively. The bridge leaves any already-
+mirrored copy in place but does not re-publish the keys if they are
+deleted from the host dir.
+
+## Import rules
+
+At target-federation bootstrap (PR-3 wires this; PR-1 only specifies
+the contract), the target federation's adoption loop:
+
+1. Lists every `cross-fed:method:*` key in its own memo store
+   (mirrored by the bridge from the host dir).
+2. Filters to records whose `cross-fed:applicable-to:<method-id>`
+   array contains the target federation's directory name.
+3. For each remaining record, fetches the `cross-fed:method-body:*`
+   key, hands the body to a fresh adopter agent on its first tick,
+   and writes a `cross-fed:import-log:<target-fed>:<method-id>` record.
+4. The adopter agent runs the method under the target federation's
+   own fitness signal. The signal is local; PR-1 makes no claim
+   about cross-federation fitness equivalence.
+
+First-tick adoption is intentional: the target federation's adopter
+must verify or discard the imported method before its own
+`evolve`/`auto-evolve` loop can prune the genealogy. Letting it sit
+in memo unverified would create stale `cross-fed:import-log:*` rows
+the operator has no easy way to age out.
+
+## Applicable-to curation
+
+MVP (PR-1, PR-2, PR-3) keeps `cross-fed:applicable-to:*` operator-
+edited. The bridge sidecar mirrors whatever value the operator
+writes; no automated curation runs against it.
+
+A federation that wants to opt out of being a target writes
+`cross-fed:opt-out: true` to its own memo at bootstrap; PR-3's
+import scaffold respects the flag.
+
+Future work (post-PR-4): derive `applicable-to` from a per-method
+specialty similarity score against each federation's declared
+specialties. The MVP shape lets that scoring service write the same
+key without changing the bridge contract.
+
+## Fitness gates
+
+Two scalar thresholds govern the cross-federation publish path:
+
+- **`replicate_threshold`** — the source federation's internal
+  threshold above which a method's producer agent replicates inside
+  the same federation (existing behaviour, unchanged).
+- **`export_fitness_threshold`** — the threshold above which the same
+  method publishes to the cross-federation channel. **Must be
+  `>= replicate_threshold`.**
+
+The ordering invariant matters: a method that is not productive
+enough to replicate inside its own federation is, by definition, not
+productive enough to publish to others. Inverting the relationship
+would publish methods the source federation does not itself trust.
+
+Both thresholds live in the source federation's
+auto-promote / auto-evolve config (PR-2 wires the exporter; PR-1 only
+specifies that the relationship MUST hold).
+
+## Host dir layout
+
+The shared dir lives at `<repo-root>/cross-fed-memo/`. The bridge
+mirrors one file per memo key, with the colons in the key replaced
+by path separators:
+
+```
+cross-fed-memo/
+  .lock                       # flock(2) target for the sidecar
+  pollination-ledger.jsonl    # merged from per-fed ledgers (see below)
+  method/
+    <source-fed>/
+      <method-id>.json        # cross-fed:method:<source-fed>:<method-id>
+  method-body/
+    <source-fed>/
+      <method-id>.txt         # cross-fed:method-body:<source-fed>:<method-id>
+  fitness/
+    <source-fed>/
+      <method-id>.json        # cross-fed:fitness:<source-fed>:<method-id>
+  applicable-to/
+    <method-id>.json          # cross-fed:applicable-to:<method-id>
+  import-log/
+    <target-fed>/
+      <method-id>.json        # cross-fed:import-log:<target-fed>:<method-id>
+```
+
+Only `.gitkeep` is tracked in git. Every other path is regenerated by
+the bridge from per-federation memo content. **Never commit
+`cross-fed:*` payloads.** The host dir is host-local state, not source
+code.
+
+### Pollination ledger
+
+Each federation that exports a method also appends a row to its own
+`<fed_dir>/.agentis/pollination-ledger.jsonl` (one JSON object per
+line). The bridge's `merge-ledgers` command concatenates every
+per-fed ledger into the central `<host_dir>/pollination-ledger.jsonl`,
+preserving timestamp order. The central ledger is the audit trail
+the operator scans to see which federation published which method
+when.
+
+## Related
+
+- [#629](https://github.com/Replikanti/agentis-colonies/issues/629) —
+  Phase 8 design issue (cooperative inter-federation search).
+- `tools/cross-fed-bridge.sh` — the bridge sidecar entry point.
+- `tools/cross-fed-bridge.py` — the Python helper that does the
+  actual file/key sync.
+- `tools/test-cross-fed-bridge.sh` — smoke tests.
+- [`doc/auto-promote.md`](./auto-promote.md) — adjacent reference for
+  the internal replicate path that this channel layers on top of.

--- a/tools/cross-fed-bridge.py
+++ b/tools/cross-fed-bridge.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""tools/cross-fed-bridge.py -- Bidirectional memo <-> host-dir sync for
+the `cross-fed:*` namespace defined in doc/cross-fed-memo.md.
+
+Phase 8 PR-1 of #629. PR-1 is the foundation layer: no federation reads
+or writes `cross-fed:*` keys yet -- that's PR-2 (exporter from
+research-foundry) and PR-3 (importer scaffold). The sidecar this script
+backs is therefore a no-op against an empty host dir and against every
+existing federation. PR-1 only ships the contract + storage.
+
+Commands:
+
+    cross-fed-bridge.py sync <fed_dir> <host_dir> [--lock-mode MODE]
+        Run one bidirectional sync pass between a federation's memo
+        store and the shared host dir. --lock-mode is one of:
+            acquire       -- block until the .lock is held (default)
+            nonblocking   -- try once; exit 0 if held by another process
+            release       -- no-op placeholder for symmetry; the lock is
+                             released when the process exits
+        sync exits 0 on a clean pass, non-zero only on an unrecoverable
+        I/O error (the wrapper shell script treats both fed_dir and
+        host_dir as creatable on demand).
+
+    cross-fed-bridge.py merge-ledgers <host_dir>
+        Concatenate every <host_dir>/../<fed>/.agentis/pollination-ledger.jsonl
+        into <host_dir>/pollination-ledger.jsonl, preserving timestamp
+        order. Per-fed ledger paths are passed via stdin (one path per
+        line) for testability; if stdin is a tty the helper falls back
+        to globbing <host_dir>'s parent for `*/.agentis/pollination-ledger.jsonl`.
+
+The script is pure stdlib: no PyYAML, no third-party deps. Targets the
+same Python floor as the rest of `tools/` (3.9+).
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+# --- Constants -------------------------------------------------------
+
+# Memo files in `.agentis/memo/` carry a `.jsonl` suffix in the agentis
+# runtime layout. The bridge mirrors one host file per memo key; the
+# memo-side filename always ends in `.jsonl`, the host-side filename
+# uses a kind-specific extension (`.json` for structured records,
+# `.txt` for raw bodies).
+MEMO_SUFFIX = ".jsonl"
+KEY_PREFIX = "cross-fed:"
+
+# Memo subdir under `<fed_dir>/.agentis/memo/`.
+MEMO_SUBDIR = Path(".agentis") / "memo"
+
+# Host-dir subdir per kind. Keys flatten `cross-fed:<kind>:...` into
+# `<host_dir>/<kind>/...`.
+KIND_TO_DIR = {
+    "method": "method",
+    "method-body": "method-body",
+    "fitness": "fitness",
+    "applicable-to": "applicable-to",
+    "import-log": "import-log",
+}
+
+# File extension on the host side. `method-body` carries raw prompt
+# text; everything else is structured JSON.
+KIND_TO_EXT = {
+    "method": ".json",
+    "method-body": ".txt",
+    "fitness": ".json",
+    "applicable-to": ".json",
+    "import-log": ".json",
+}
+
+# Filenames written under <host_dir>/ that are NOT mirrored memo keys.
+HOST_DIR_RESERVED = frozenset({".lock", ".gitkeep", "README.md", "pollination-ledger.jsonl"})
+
+
+# --- Lock ------------------------------------------------------------
+
+
+def acquire_lock(host_dir: Path, mode: str = "acquire"):
+    """Acquire an advisory flock on <host_dir>/.lock.
+
+    Returns the open file handle on success (caller MUST keep it alive
+    for the duration of the work to hold the lock). Returns None when
+    mode='nonblocking' and the lock is held by another process.
+
+    The lock is per open-file-description: when the caller process
+    exits, the kernel releases the lock automatically. No explicit
+    release path is required (and the 'release' mode is a no-op
+    placeholder for shell symmetry).
+    """
+    host_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = host_dir / ".lock"
+    handle = open(lock_path, "w")
+    flags = fcntl.LOCK_EX
+    if mode == "nonblocking":
+        flags |= fcntl.LOCK_NB
+    try:
+        fcntl.flock(handle.fileno(), flags)
+    except BlockingIOError:
+        handle.close()
+        return None
+    return handle
+
+
+# --- Key/path helpers -----------------------------------------------
+
+
+def _split_key(key: str) -> tuple[str, list[str]] | None:
+    """Parse a cross-fed:<kind>:<...> memo key into (kind, parts).
+
+    Returns None when the key shape is unrecognised. The bridge skips
+    unrecognised keys rather than crashing so an operator can stage
+    experimental kinds without taking the sidecar down.
+    """
+    if not key.startswith(KEY_PREFIX):
+        return None
+    rest = key[len(KEY_PREFIX):]
+    parts = rest.split(":")
+    if len(parts) < 2:
+        return None
+    kind = parts[0]
+    if kind not in KIND_TO_DIR:
+        return None
+    return kind, parts[1:]
+
+
+def _memo_key_to_host_path(host_dir: Path, key: str) -> Path | None:
+    parsed = _split_key(key)
+    if parsed is None:
+        return None
+    kind, parts = parsed
+    ext = KIND_TO_EXT[kind]
+    sub = KIND_TO_DIR[kind]
+    # Last component carries the file basename; everything before it is
+    # a nested directory path. `cross-fed:method:<source-fed>:<method-id>`
+    # therefore maps to `<host_dir>/method/<source-fed>/<method-id>.json`.
+    *dirs, leaf = parts
+    target_dir = host_dir / sub
+    for d in dirs:
+        target_dir = target_dir / d
+    return target_dir / (leaf + ext)
+
+
+def _host_path_to_memo_key(host_dir: Path, host_path: Path) -> str | None:
+    try:
+        rel = host_path.relative_to(host_dir)
+    except ValueError:
+        return None
+    parts = rel.parts
+    if not parts:
+        return None
+    if parts[0] in HOST_DIR_RESERVED:
+        return None
+    if parts[0] not in KIND_TO_DIR.values():
+        return None
+    # Strip the extension off the leaf component.
+    leaf = parts[-1]
+    stem = leaf
+    for ext in (".json", ".txt", ".jsonl"):
+        if leaf.endswith(ext):
+            stem = leaf[: -len(ext)]
+            break
+    components = [parts[0], *parts[1:-1], stem]
+    return KEY_PREFIX + ":".join(components)
+
+
+def _memo_path_to_key(memo_path: Path) -> str | None:
+    name = memo_path.name
+    if not name.endswith(MEMO_SUFFIX):
+        return None
+    key = name[: -len(MEMO_SUFFIX)]
+    if not key.startswith(KEY_PREFIX):
+        return None
+    return key
+
+
+def _key_to_memo_path(memo_dir: Path, key: str) -> Path:
+    return memo_dir / (key + MEMO_SUFFIX)
+
+
+# --- Read / write primitives ----------------------------------------
+
+
+def _read_memo_value(memo_path: Path) -> str:
+    """Return the latest value for a memo key.
+
+    agentis memo store appends one JSON record per write to
+    `<key>.jsonl`. The bridge reads the last non-empty line; its
+    `value` field holds the payload. Falls back to the raw file
+    content when the line shape is not the expected
+    `{"value": ..., ...}` record.
+    """
+    try:
+        raw = memo_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    last = ""
+    for line in raw.splitlines():
+        if line.strip():
+            last = line
+    if not last:
+        return ""
+    try:
+        rec = json.loads(last)
+        if isinstance(rec, dict) and "value" in rec:
+            v = rec["value"]
+            if isinstance(v, str):
+                return v
+            return json.dumps(v, sort_keys=True, separators=(",", ":"))
+    except json.JSONDecodeError:
+        pass
+    return last
+
+
+def _write_memo_value(memo_path: Path, value: str) -> None:
+    """Append a new JSON record to a memo key's `.jsonl` file.
+
+    The format mirrors what `agentis memo set` writes: a single-line
+    `{"value": <payload>}` object. PR-1 uses the bridge as a
+    file-level data channel and never runs `agentis memo set`
+    from inside the sidecar -- that would require the agentis CLI on
+    every host, which is not a contract this script can enforce.
+    Direct append keeps the bridge self-contained.
+    """
+    memo_path.parent.mkdir(parents=True, exist_ok=True)
+    # Try to parse the incoming value as structured JSON so the memo
+    # record carries the native type the writer intended; fall back to
+    # a string value.
+    parsed_value: object
+    try:
+        parsed_value = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        parsed_value = value
+    record = {"value": parsed_value}
+    serialised = json.dumps(record, sort_keys=True, separators=(",", ":"))
+    with memo_path.open("a", encoding="utf-8") as f:
+        f.write(serialised + "\n")
+
+
+def _read_host_value(host_path: Path) -> str:
+    try:
+        return host_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _write_host_atomic(host_path: Path, value: str) -> bool:
+    """Write `value` to `host_path` if the on-disk content differs.
+
+    Returns True when a write happened, False when the file already
+    matched (sha256 dedupe). The dedupe keeps a re-sync no-op on the
+    host filesystem so cron-style invocations do not churn mtimes.
+    """
+    host_path.parent.mkdir(parents=True, exist_ok=True)
+    new_bytes = value.encode("utf-8")
+    new_sha = hashlib.sha256(new_bytes).hexdigest()
+    if host_path.exists():
+        try:
+            existing = host_path.read_bytes()
+            if hashlib.sha256(existing).hexdigest() == new_sha:
+                return False
+        except OSError:
+            pass
+    tmp = host_path.with_suffix(host_path.suffix + ".tmp")
+    tmp.write_bytes(new_bytes)
+    os.replace(tmp, host_path)
+    return True
+
+
+# --- Sync passes -----------------------------------------------------
+
+
+def _iter_memo_keys(memo_dir: Path) -> Iterable[Path]:
+    if not memo_dir.is_dir():
+        return []
+    out = []
+    for entry in memo_dir.iterdir():
+        if not entry.is_file():
+            continue
+        if not entry.name.endswith(MEMO_SUFFIX):
+            continue
+        if not entry.name.startswith(KEY_PREFIX):
+            continue
+        out.append(entry)
+    out.sort()
+    return out
+
+
+def _iter_host_files(host_dir: Path) -> Iterable[Path]:
+    if not host_dir.is_dir():
+        return []
+    out = []
+    for kind_dir_name in sorted(KIND_TO_DIR.values()):
+        kind_dir = host_dir / kind_dir_name
+        if not kind_dir.is_dir():
+            continue
+        for path in sorted(kind_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            if path.name in HOST_DIR_RESERVED:
+                continue
+            out.append(path)
+    return out
+
+
+def sync_memo_to_host(fed_dir: Path, host_dir: Path) -> int:
+    """Mirror every cross-fed:* memo key in fed_dir to host_dir.
+
+    Returns the number of host files written (excluding dedupe no-ops).
+    """
+    memo_dir = fed_dir / MEMO_SUBDIR
+    written = 0
+    for memo_path in _iter_memo_keys(memo_dir):
+        key = _memo_path_to_key(memo_path)
+        if key is None:
+            continue
+        host_path = _memo_key_to_host_path(host_dir, key)
+        if host_path is None:
+            continue
+        value = _read_memo_value(memo_path)
+        if _write_host_atomic(host_path, value):
+            written += 1
+    return written
+
+
+def sync_host_to_memo(host_dir: Path, fed_dir: Path) -> int:
+    """Mirror every file under host_dir into fed_dir's memo store.
+
+    Returns the number of memo records appended (one per changed
+    host file).
+    """
+    memo_dir = fed_dir / MEMO_SUBDIR
+    appended = 0
+    for host_path in _iter_host_files(host_dir):
+        key = _host_path_to_memo_key(host_dir, host_path)
+        if key is None:
+            continue
+        memo_path = _key_to_memo_path(memo_dir, key)
+        host_value = _read_host_value(host_path)
+        existing_value = _read_memo_value(memo_path) if memo_path.exists() else None
+        # Dedupe by comparing the canonical-JSON form of both sides so
+        # whitespace + key ordering differences in the host file don't
+        # trigger redundant appends.
+        if existing_value is not None:
+            try:
+                left = json.loads(existing_value)
+                right = json.loads(host_value)
+                if json.dumps(left, sort_keys=True) == json.dumps(right, sort_keys=True):
+                    continue
+            except (json.JSONDecodeError, TypeError):
+                if existing_value == host_value:
+                    continue
+        _write_memo_value(memo_path, host_value)
+        appended += 1
+    return appended
+
+
+# --- Pollination ledger merge ---------------------------------------
+
+
+def _ledger_sources_from_stdin() -> list[Path]:
+    paths: list[Path] = []
+    if sys.stdin.isatty():
+        return paths
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        p = Path(line)
+        if p.is_file():
+            paths.append(p)
+    return paths
+
+
+def _ledger_sources_from_disk(host_dir: Path) -> list[Path]:
+    parent = host_dir.parent
+    sources: list[Path] = []
+    if not parent.is_dir():
+        return sources
+    for fed_root in sorted(parent.iterdir()):
+        if not fed_root.is_dir():
+            continue
+        if fed_root == host_dir:
+            continue
+        candidate = fed_root / ".agentis" / "pollination-ledger.jsonl"
+        if candidate.is_file():
+            sources.append(candidate)
+    return sources
+
+
+def pollination_ledger_merge(host_dir: Path) -> int:
+    """Concatenate per-fed pollination ledgers into the central one.
+
+    Rows are ordered by their `ts` (or `timestamp`) field when present,
+    falling back to the order in which they were read. The central
+    ledger is rewritten on every merge -- the source rows are the
+    authoritative copy.
+
+    Returns the number of rows written to the central ledger.
+    """
+    host_dir.mkdir(parents=True, exist_ok=True)
+    sources = _ledger_sources_from_stdin()
+    if not sources:
+        sources = _ledger_sources_from_disk(host_dir)
+    rows: list[tuple[float, int, str]] = []
+    seq = 0
+    for src in sources:
+        try:
+            with src.open("r", encoding="utf-8", errors="replace") as f:
+                for raw_line in f:
+                    line = raw_line.rstrip("\n").rstrip("\r")
+                    if not line.strip():
+                        continue
+                    ts_val: float = 0.0
+                    try:
+                        rec = json.loads(line)
+                        if isinstance(rec, dict):
+                            for k in ("ts", "timestamp", "created_at"):
+                                v = rec.get(k)
+                                if isinstance(v, (int, float)):
+                                    ts_val = float(v)
+                                    break
+                    except json.JSONDecodeError:
+                        pass
+                    rows.append((ts_val, seq, line))
+                    seq += 1
+        except OSError:
+            continue
+    rows.sort(key=lambda r: (r[0], r[1]))
+    central = host_dir / "pollination-ledger.jsonl"
+    tmp = central.with_suffix(central.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as out:
+        for _ts, _seq, line in rows:
+            out.write(line + "\n")
+    os.replace(tmp, central)
+    return len(rows)
+
+
+# --- CLI -------------------------------------------------------------
+
+
+def _cmd_sync(args: argparse.Namespace) -> int:
+    fed_dir = Path(args.fed_dir).resolve()
+    host_dir = Path(args.host_dir).resolve()
+    if not fed_dir.is_dir():
+        print(f"cross-fed-bridge: fed_dir not a directory: {fed_dir}", file=sys.stderr)
+        return 2
+    lock_mode = args.lock_mode or "acquire"
+    if lock_mode == "release":
+        return 0
+    handle = acquire_lock(host_dir, mode=lock_mode)
+    if handle is None:
+        print("cross-fed-bridge: lock held by other process; no-op")
+        return 0
+    try:
+        written = sync_memo_to_host(fed_dir, host_dir)
+        appended = sync_host_to_memo(host_dir, fed_dir)
+        print(
+            f"cross-fed-bridge: sync ok fed={fed_dir.name} host={host_dir} "
+            f"memo_to_host={written} host_to_memo={appended}"
+        )
+        return 0
+    finally:
+        handle.close()
+
+
+def _cmd_merge_ledgers(args: argparse.Namespace) -> int:
+    host_dir = Path(args.host_dir).resolve()
+    rows = pollination_ledger_merge(host_dir)
+    print(f"cross-fed-bridge: merge-ledgers ok host={host_dir} rows={rows}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="cross-fed-bridge.py",
+        description="Bidirectional cross-fed:* memo <-> host-dir sync.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_sync = sub.add_parser("sync", help="Run one bidirectional sync pass.")
+    p_sync.add_argument("fed_dir")
+    p_sync.add_argument("host_dir")
+    p_sync.add_argument(
+        "--lock-mode",
+        choices=("acquire", "nonblocking", "release"),
+        default="acquire",
+    )
+    p_sync.set_defaults(func=_cmd_sync)
+
+    p_merge = sub.add_parser("merge-ledgers", help="Merge per-fed pollination ledgers.")
+    p_merge.add_argument("host_dir")
+    p_merge.set_defaults(func=_cmd_merge_ledgers)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/cross-fed-bridge.sh
+++ b/tools/cross-fed-bridge.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# tools/cross-fed-bridge.sh -- Bidirectional cross-fed:* memo <-> host-dir
+# sync sidecar (Phase 8 PR-1 of #629).
+#
+# Thin shell wrapper around tools/cross-fed-bridge.py. PR-1 ships the
+# bridge as a no-op against every existing federation; no agent reads
+# or writes `cross-fed:*` keys yet. PR-2 wires the source-side export
+# from research-foundry, PR-3 wires the target-side import, PR-4 closes
+# the cooperative search loop. See doc/cross-fed-memo.md for the
+# namespace contract.
+#
+# Invocation forms:
+#
+#   tools/cross-fed-bridge.sh sync <fed_dir>
+#       Run one bidirectional sync pass between <fed_dir>'s memo store
+#       and the host-level shared dir at <repo-root>/cross-fed-memo/.
+#       Suitable for cron-style invocation.
+#
+#   tools/cross-fed-bridge.sh sidecar <fed_dir> [--interval N]
+#       Long-running sidecar loop. Holds a non-blocking flock on the
+#       host dir's .lock file; if the lock is held by another sidecar
+#       on the same host, logs `lock held by other process; no-op`
+#       and exits 0 (only one bridge can own the shared dir at a time).
+#       Defaults to a 60s sync cadence.
+#
+# Exit codes:
+#   0 -- clean pass (or lock held by another sidecar -- the existing
+#        owner is doing the work)
+#   1 -- missing fed_dir, unknown flag, helper crashed
+#
+# The host dir lives at <repo-root>/cross-fed-memo/ by default. Override
+# via CROSS_FED_HOST_DIR for ad-hoc tests; the wrapper resolves it to an
+# absolute path before passing it to the Python helper.
+#
+# This script intentionally does NOT touch the agentis CLI: every memo
+# read/write goes through the Python helper's direct .jsonl file
+# manipulation. The bridge therefore runs on any host with python3 +
+# flock(2), regardless of whether `agentis` is on PATH.
+
+set -euo pipefail
+
+# --- Path resolution ---
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+PY_HELPER="$SCRIPT_DIR/cross-fed-bridge.py"
+
+if [ ! -f "$PY_HELPER" ]; then
+    echo "cross-fed-bridge: missing helper at $PY_HELPER" >&2
+    exit 1
+fi
+
+usage() {
+    cat >&2 <<'EOF'
+Usage:
+  tools/cross-fed-bridge.sh sync <fed_dir>
+  tools/cross-fed-bridge.sh sidecar <fed_dir> [--interval N]
+
+Mirrors `cross-fed:*` memo keys between <fed_dir>/.agentis/memo/ and
+the host-level shared dir at <repo-root>/cross-fed-memo/. PR-1 of #629.
+EOF
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+MODE="$1"
+shift
+
+if [ "$MODE" != "sync" ] && [ "$MODE" != "sidecar" ]; then
+    usage
+    exit 1
+fi
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+FED_ARG="$1"
+shift
+
+# Resolve fed_dir against $REPO_ROOT first (so callers may pass a
+# repo-relative name like `research-foundry`), then fall back to
+# treating it as an absolute/relative path verbatim.
+if [ -d "$REPO_ROOT/$FED_ARG" ]; then
+    FED_DIR="$REPO_ROOT/$FED_ARG"
+else
+    FED_DIR="$FED_ARG"
+fi
+if [ ! -d "$FED_DIR" ]; then
+    echo "cross-fed-bridge: fed_dir not found: $FED_ARG" >&2
+    exit 1
+fi
+# Canonicalise so subsequent operations don't trip over `./` and `..`.
+FED_DIR="$(cd "$FED_DIR" && pwd)"
+
+INTERVAL=60
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --interval)
+            if [ $# -lt 2 ]; then
+                echo "cross-fed-bridge: --interval requires a value" >&2
+                exit 1
+            fi
+            INTERVAL="$2"
+            shift 2
+            ;;
+        *)
+            echo "cross-fed-bridge: unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+HOST_DIR="${CROSS_FED_HOST_DIR:-$REPO_ROOT/cross-fed-memo}"
+mkdir -p "$HOST_DIR"
+
+LOG_DIR="$FED_DIR/.agentis/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/cross-fed-bridge.log"
+
+log() {
+    echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] cross-fed-bridge: $*" | tee -a "$LOG_FILE"
+}
+
+if [ "$MODE" = "sync" ]; then
+    # One-shot bidirectional pass. The Python helper acquires the lock
+    # itself and exits 0 if another process holds it.
+    exec python3 "$PY_HELPER" sync "$FED_DIR" "$HOST_DIR" --lock-mode nonblocking
+fi
+
+# --- Sidecar loop ---
+#
+# We acquire the lock once at the wrapper level via fd 200, then the
+# inner Python sync call runs with --lock-mode release so it does not
+# try to re-acquire the same file lock. Only one sidecar per host.
+LOCK_FILE="$HOST_DIR/.lock"
+exec 200>"$LOCK_FILE"
+if ! python3 -c '
+import fcntl, sys
+try:
+    fcntl.flock(int(sys.argv[1]), fcntl.LOCK_EX | fcntl.LOCK_NB)
+except BlockingIOError:
+    sys.exit(1)
+' 200 2>/dev/null; then
+    log "lock held by other process; no-op"
+    exit 0
+fi
+
+log "sidecar started (fed_dir=$FED_DIR host_dir=$HOST_DIR interval=${INTERVAL}s)"
+
+# Sidecar loop. Each iteration runs one bidirectional pass; the lock
+# stays held on fd 200 for the lifetime of this process so concurrent
+# sidecar starts on the same host bail out at the gate above. Sleep
+# happens via a foreground call so SIGTERM at any point terminates the
+# loop cleanly.
+while true; do
+    if ! python3 "$PY_HELPER" sync "$FED_DIR" "$HOST_DIR" --lock-mode release >>"$LOG_FILE" 2>&1; then
+        log "sync pass failed; continuing"
+    fi
+    sleep "$INTERVAL"
+done

--- a/tools/test-cross-fed-bridge.sh
+++ b/tools/test-cross-fed-bridge.sh
@@ -149,7 +149,7 @@ if grep -Fq "lock held by other process" "$WORK_DIR/sidecar-b.log"; then
     pass "4. second sidecar logs lock-held and exits 0"
 else
     fail "4. second sidecar logs lock-held and exits 0" \
-        "$(cat "$WORK_DIR/sidecar-b.log" 2>/dev/null | head -5)"
+        "$(head -5 "$WORK_DIR/sidecar-b.log" 2>/dev/null)"
 fi
 
 # --- Test 5: empty host dir -> no-op ---

--- a/tools/test-cross-fed-bridge.sh
+++ b/tools/test-cross-fed-bridge.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+# tools/test-cross-fed-bridge.sh -- smoke tests for the cross-fed:* bridge
+# sidecar (Phase 8 PR-1 of #629).
+#
+# Exercises the bidirectional sync, lock acquisition, sha256 dedupe,
+# and pollination-ledger merge paths without spawning agents. The
+# Python helper is invoked directly for the unit-level assertions
+# (sync_host_to_memo / sync_memo_to_host) and the shell wrapper is
+# invoked for the lock + sidecar paths.
+#
+# Standard library only -- no pytest, no third-party deps.
+#
+# Usage: bash tools/test-cross-fed-bridge.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BRIDGE_SH="$SCRIPT_DIR/cross-fed-bridge.sh"
+BRIDGE_PY="$SCRIPT_DIR/cross-fed-bridge.py"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+if [ ! -x "$BRIDGE_SH" ]; then
+    fail "cross-fed-bridge.sh executable" "$BRIDGE_SH not executable"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+if [ ! -f "$BRIDGE_PY" ]; then
+    fail "cross-fed-bridge.py present" "$BRIDGE_PY missing"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# --- Test 1: bash -n on the shell wrapper ---
+if bash -n "$BRIDGE_SH" 2>/dev/null; then
+    pass "1. bash -n clean on cross-fed-bridge.sh"
+else
+    fail "1. bash -n clean on cross-fed-bridge.sh" "$(bash -n "$BRIDGE_SH" 2>&1)"
+fi
+
+# --- Test 2: python3 -m ast clean on the helper ---
+if python3 -m ast "$BRIDGE_PY" >/dev/null 2>&1; then
+    pass "2. python3 -m ast clean on cross-fed-bridge.py"
+else
+    fail "2. python3 -m ast clean on cross-fed-bridge.py" \
+        "$(python3 -m ast "$BRIDGE_PY" 2>&1 | head -3)"
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# --- Test 3a: bidirectional sync, host -> memo ---
+# Stage a method file in the host dir, run sync_host_to_memo via the
+# helper, then assert the fed memo store has the expected key.
+HOST_DIR="$WORK_DIR/host"
+FED_DIR="$WORK_DIR/fed-target"
+mkdir -p "$HOST_DIR/method/test-fed"
+mkdir -p "$FED_DIR/.agentis/memo"
+
+cat > "$HOST_DIR/method/test-fed/abc.json" <<'EOF'
+{"id":"abc","source_fed":"test-fed","abstract":"demo method"}
+EOF
+
+H2M_OUT="$(python3 -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR')
+import importlib.util
+spec = importlib.util.spec_from_file_location('cfb', '$BRIDGE_PY')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+from pathlib import Path
+n = mod.sync_host_to_memo(Path('$HOST_DIR'), Path('$FED_DIR'))
+print('appended=%d' % n)
+" 2>&1)" || true
+
+MEMO_FILE="$FED_DIR/.agentis/memo/cross-fed:method:test-fed:abc.jsonl"
+if [ -f "$MEMO_FILE" ] && [ -s "$MEMO_FILE" ]; then
+    pass "3a. sync_host_to_memo creates expected memo key"
+else
+    fail "3a. sync_host_to_memo creates expected memo key" \
+        "expected $MEMO_FILE; out=$H2M_OUT"
+fi
+
+# --- Test 3b: bidirectional sync, memo -> host ---
+# Write a different method record to the fed memo, then sync to host.
+SOURCE_FED_DIR="$WORK_DIR/fed-source"
+mkdir -p "$SOURCE_FED_DIR/.agentis/memo"
+DEF_RECORD='{"value":{"id":"def","source_fed":"test-fed","abstract":"another method"}}'
+echo "$DEF_RECORD" > "$SOURCE_FED_DIR/.agentis/memo/cross-fed:method:test-fed:def.jsonl"
+
+M2H_OUT="$(python3 -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR')
+import importlib.util
+spec = importlib.util.spec_from_file_location('cfb', '$BRIDGE_PY')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+from pathlib import Path
+n = mod.sync_memo_to_host(Path('$SOURCE_FED_DIR'), Path('$HOST_DIR'))
+print('written=%d' % n)
+" 2>&1)" || true
+
+HOST_FILE="$HOST_DIR/method/test-fed/def.json"
+if [ -f "$HOST_FILE" ] && grep -q 'def' "$HOST_FILE"; then
+    pass "3b. sync_memo_to_host creates expected host file"
+else
+    fail "3b. sync_memo_to_host creates expected host file" \
+        "expected $HOST_FILE with payload; out=$M2H_OUT; got=$(cat "$HOST_FILE" 2>/dev/null || echo MISSING)"
+fi
+
+# --- Test 4: lock acquisition (only one sidecar at a time) ---
+# Spawn two parallel `cross-fed-bridge.sh sidecar` invocations against
+# the same host dir; the first holds the lock indefinitely (we cap it
+# at 5s via a kill), the second must log `lock held` and exit 0.
+LOCK_FED_A="$WORK_DIR/fed-locker-a"
+LOCK_FED_B="$WORK_DIR/fed-locker-b"
+LOCK_HOST="$WORK_DIR/lock-host"
+mkdir -p "$LOCK_FED_A/.agentis/memo" "$LOCK_FED_B/.agentis/memo" "$LOCK_HOST"
+
+# Start first sidecar in background; it owns the lock.
+CROSS_FED_HOST_DIR="$LOCK_HOST" "$BRIDGE_SH" sidecar "$LOCK_FED_A" --interval 60 \
+    >"$WORK_DIR/sidecar-a.log" 2>&1 &
+PID_A=$!
+
+# Wait briefly so PID_A has time to take the lock before PID_B starts.
+sleep 1
+
+# Second sidecar must observe the lock is held and bail out.
+CROSS_FED_HOST_DIR="$LOCK_HOST" "$BRIDGE_SH" sidecar "$LOCK_FED_B" --interval 60 \
+    >"$WORK_DIR/sidecar-b.log" 2>&1 &
+PID_B=$!
+
+# Give PID_B time to attempt the lock then exit.
+sleep 1
+
+# Reap PID_B (should already be gone); PID_A is still looping, kill it.
+wait "$PID_B" 2>/dev/null || true
+kill "$PID_A" 2>/dev/null || true
+wait "$PID_A" 2>/dev/null || true
+
+if grep -Fq "lock held by other process" "$WORK_DIR/sidecar-b.log"; then
+    pass "4. second sidecar logs lock-held and exits 0"
+else
+    fail "4. second sidecar logs lock-held and exits 0" \
+        "$(cat "$WORK_DIR/sidecar-b.log" 2>/dev/null | head -5)"
+fi
+
+# --- Test 5: empty host dir -> no-op ---
+EMPTY_HOST="$WORK_DIR/empty-host"
+EMPTY_FED="$WORK_DIR/empty-fed"
+mkdir -p "$EMPTY_HOST" "$EMPTY_FED/.agentis/memo"
+
+EMPTY_OUT="$(python3 -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR')
+import importlib.util
+spec = importlib.util.spec_from_file_location('cfb', '$BRIDGE_PY')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+from pathlib import Path
+n = mod.sync_host_to_memo(Path('$EMPTY_HOST'), Path('$EMPTY_FED'))
+print('appended=%d' % n)
+" 2>&1)"
+
+# Memo dir must remain empty (no `.jsonl` files).
+WROTE="$(find "$EMPTY_FED/.agentis/memo" -name '*.jsonl' 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$EMPTY_OUT" = "appended=0" ] && [ "$WROTE" = "0" ]; then
+    pass "5. empty host dir -> no-op (no memo writes)"
+else
+    fail "5. empty host dir -> no-op (no memo writes)" \
+        "out=$EMPTY_OUT wrote=$WROTE"
+fi
+
+# --- Test 6: sha256 dedupe on re-sync ---
+# Run sync_memo_to_host twice with identical fed memo content. After
+# the first call the host file mtime is recorded; after the second
+# call (no source change) the mtime must not advance.
+DEDUPE_FED="$WORK_DIR/dedupe-fed"
+DEDUPE_HOST="$WORK_DIR/dedupe-host"
+mkdir -p "$DEDUPE_FED/.agentis/memo" "$DEDUPE_HOST"
+echo '{"value":{"id":"xyz","x":1}}' > "$DEDUPE_FED/.agentis/memo/cross-fed:method:dedupe-fed:xyz.jsonl"
+
+python3 -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR')
+import importlib.util
+spec = importlib.util.spec_from_file_location('cfb', '$BRIDGE_PY')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+from pathlib import Path
+mod.sync_memo_to_host(Path('$DEDUPE_FED'), Path('$DEDUPE_HOST'))
+" >/dev/null 2>&1
+
+DEDUPE_FILE="$DEDUPE_HOST/method/dedupe-fed/xyz.json"
+if [ ! -f "$DEDUPE_FILE" ]; then
+    fail "6. sha256 dedupe on re-sync" "first sync did not produce $DEDUPE_FILE"
+else
+    MTIME_BEFORE="$(stat -c %Y "$DEDUPE_FILE" 2>/dev/null || stat -f %m "$DEDUPE_FILE" 2>/dev/null)"
+    # Sleep so any mtime advance would be observable.
+    sleep 1
+    SECOND_OUT="$(python3 -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR')
+import importlib.util
+spec = importlib.util.spec_from_file_location('cfb', '$BRIDGE_PY')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+from pathlib import Path
+n = mod.sync_memo_to_host(Path('$DEDUPE_FED'), Path('$DEDUPE_HOST'))
+print('written=%d' % n)
+")"
+    MTIME_AFTER="$(stat -c %Y "$DEDUPE_FILE" 2>/dev/null || stat -f %m "$DEDUPE_FILE" 2>/dev/null)"
+    if [ "$SECOND_OUT" = "written=0" ] && [ "$MTIME_BEFORE" = "$MTIME_AFTER" ]; then
+        pass "6. sha256 dedupe on re-sync (no write, no mtime change)"
+    else
+        fail "6. sha256 dedupe on re-sync (no write, no mtime change)" \
+            "second-out=$SECOND_OUT mtime_before=$MTIME_BEFORE mtime_after=$MTIME_AFTER"
+    fi
+fi
+
+# --- Test 7: pollination-ledger merge ---
+# Stage per-fed ledgers, invoke merge-ledgers with paths on stdin,
+# assert the central ledger holds every row in timestamp order.
+MERGE_HOST="$WORK_DIR/merge-host"
+mkdir -p "$MERGE_HOST"
+LEDGER_A="$WORK_DIR/fed-ledger-a.jsonl"
+LEDGER_B="$WORK_DIR/fed-ledger-b.jsonl"
+cat > "$LEDGER_A" <<'EOF'
+{"ts": 1000, "event": "export", "fed": "a", "method_id": "alpha"}
+{"ts": 3000, "event": "export", "fed": "a", "method_id": "gamma"}
+EOF
+cat > "$LEDGER_B" <<'EOF'
+{"ts": 2000, "event": "export", "fed": "b", "method_id": "beta"}
+{"ts": 4000, "event": "export", "fed": "b", "method_id": "delta"}
+EOF
+
+printf '%s\n%s\n' "$LEDGER_A" "$LEDGER_B" | python3 "$BRIDGE_PY" merge-ledgers "$MERGE_HOST" >/dev/null 2>&1 || true
+
+CENTRAL="$MERGE_HOST/pollination-ledger.jsonl"
+if [ ! -f "$CENTRAL" ]; then
+    fail "7. pollination-ledger merge" "central ledger not at $CENTRAL"
+else
+    # Validate exact ordering on the `ts` field (alpha, beta, gamma, delta).
+    MERGED_ORDER="$(python3 -c "
+import json, sys
+rows = []
+with open('$CENTRAL') as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(json.loads(line)['method_id'])
+print(','.join(rows))
+" 2>/dev/null)"
+    if [ "$MERGED_ORDER" = "alpha,beta,gamma,delta" ]; then
+        pass "7. pollination-ledger merge (correct timestamp order)"
+    else
+        fail "7. pollination-ledger merge (correct timestamp order)" \
+            "got order: $MERGED_ORDER"
+    fi
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Phase 8 PR-1 of #629 — introduces a host-side cross-federation memo namespace + a bidirectional bridge sidecar. Any federation running on the same host can read+write `cross-fed:*` memo keys; the bridge mirrors content between each fed's `.agentis/memo/cross-fed:*` and `<repo-root>/cross-fed-memo/` (file-per-key). Sha256 dedupe avoids unnecessary writes; flock prevents concurrent sidecars stomping each other.

This is plumbing only — today nothing reads or writes `cross-fed:*`. PRs 2-4 will wire research-foundry export, target-fed import, and cooperative-search ledger merging onto this foundation.

Components:
- `doc/cross-fed-memo.md` (277 lines) — conventions, key shapes, ledger merge semantics, threat model.
- `tools/cross-fed-bridge.sh` (166 lines) — `sync` / `sidecar` subcommands, flock at top.
- `tools/cross-fed-bridge.py` (507 lines) — bidirectional sync, sha256 dedupe, `merge-ledgers` for pollination-ledger consolidation.
- `tools/test-cross-fed-bridge.sh` (272 lines) — 8 assertions.
- `cross-fed-memo/{.gitkeep, README.md}` — host dir.
- `.gitignore` + `CLAUDE.md` — ignore generated content + 10-line namespace doc.

## Test plan

- [x] 8/8 pass on `tools/test-cross-fed-bridge.sh` (syntax + sync directions + lock contention + dedupe + empty-dir + ledger merge order).
- [x] `bash -n` clean on both shell scripts.
- [x] `python3 -m ast` clean on `cross-fed-bridge.py`.
- [ ] QA agent verifies sidecar runs cleanly against two real federations.
- [ ] CI green.

Closes #629 PR-1 of 4 — Phase 8 #629 itself stays open until PR-4 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
