### PR TITLE
feat(phase-9-pra): replica-safe handoff via winner-by-confidence picker (PR-A of #663)

### DIFF
--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -20,6 +20,27 @@ History of the three retired federations consolidated into this one
 
 ### Changed
 
+- Replica-safe handoff via winner-by-confidence picker across 9
+  downstream `.ag` files (Phase 9 PR-A of #663, pre-blocker for the
+  entire phase). Every `recall_latest("replay:current_<role>_pid")` +
+  pid-keyed memo read is replaced with
+  `_pick_upstream_by_confidence(role, output_key, tick)` — the picker
+  enumerates `<role>:*:<decision_key>:tick-<N>` memos via `agentis
+  memo list`, ranks by the embedded confidence field
+  (`confidence_in_surprise` / `confidence` / `self_check_confidence`
+  depending on role), and returns the value of the picked output_key.
+  With N=1 the picker collapses to a single match identical to the v1
+  LWW behaviour; with N>1 it stops the last-writer-wins stomp that
+  blocked replicating any role beyond explorer. Files touched:
+  noticer, skeptic, formulator, verifier, novelty, auditor, editor,
+  reviewer, submitter. New colony-lint check
+  `tools/check-no-replay-current-pid.sh` fails any future regression
+  to the `replay:current_<role>_pid` consumer pattern. The two
+  pre-existing replica-safe sites (`reviewer:<claim>:approved` claim-
+  keyed, auditor's `claim:audit_*:tick-N` tick-keyed writes) are
+  preserved. PR-B (tooling generalisation) and PR-C (per-`.ag`
+  replicate machinery) ride on this wire change.
+
 - Flipped `evolve.dry_run` and `evolve.mutation.enabled` for
   research-foundry (Phase 7 PR-C of #628). The explorer agent now
   runs in live evolve mode: the LLM mutator proposes candidates, the

--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -107,6 +107,37 @@ fn _push_topic_feedback(
     memo_write(buf_key, new_buf);
 }
 
+// _pick_upstream_pid_by_key -- Phase 9 PR-A (#663) replica-safe pick.
+// Enumerates `<role>:*:<decision_key>:tick-<N>` memo keys via
+// `agentis memo list`, ranks by an embedded confidence field when one
+// is known for the role, and returns the picked PID (empty string when
+// no match). For known roles the meta map below selects the canonical
+// decision_key + confidence_field regardless of `fallback_key`; for
+// unknown roles `fallback_key` is used as the discovery suffix and the
+// picker falls back to alphabetical-first PID (deterministic for N=1,
+// undefined ordering for N>1 -- PR-B/PR-C tightens that).
+fn _pick_upstream_pid_by_key(role: string, fallback_key: string, tick: int) -> string {
+    let tick_s = to_string(tick);
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,subprocess,json\nrole=sys.argv[1]\nout_key=sys.argv[2]\ntick=sys.argv[3]\nmeta={\"noticer\":(\"surprise\",\"confidence_in_surprise\"),\"skeptic\":(\"verdict\",\"confidence\"),\"formulator\":(\"problem\",\"self_check_confidence\"),\"verifier\":(\"verdict\",\"confidence\"),\"auditor\":(\"verdict\",\"confidence\"),\"reviewer\":(\"report\",\"confidence\"),\"prior_advocate\":(\"report\",\"confidence\")}\ndk,cf=meta.get(role,(out_key,\"\"))\nsuf=\":\"+dk+\":tick-\"+tick\npre=role+\":\"\ntry: out=subprocess.run([\"agentis\",\"memo\",\"list\"],capture_output=True,text=True,check=False).stdout\nexcept Exception: out=\"\"\nbest_pid=\"\"\nbest_conf=-1.0\npids=[]\nfor line in out.splitlines():\n line=line.strip()\n if not line or not line.startswith(pre): continue\n key=line.split()[0]\n if not key.endswith(suf): continue\n mid=key[len(pre):-len(suf)]\n if \":\" in mid or not mid: continue\n pids.append(mid)\nif not cf:\n pids.sort()\n if pids: best_pid=pids[0]\nelse:\n for mid in pids:\n  try: v=subprocess.run([\"agentis\",\"memo\",\"get\",pre+mid+suf],capture_output=True,text=True,check=False).stdout\n  except Exception: v=\"\"\n  try: obj=json.loads(v)\n  except Exception: obj=None\n  if not isinstance(obj,dict): continue\n  try: conf=float(obj.get(cf,0.0))\n  except Exception: conf=0.0\n  if conf>best_conf:\n   best_conf=conf\n   best_pid=mid\nprint(best_pid)' " + shell_escape(role) + " " + shell_escape(fallback_key) + " " + shell_escape(tick_s);
+    let pid = try { exec sh cmd; } catch e { ""; };
+    return pid;
+}
+
+// _pick_upstream_by_confidence -- Phase 9 PR-A (#663) value-returning
+// wrapper around `_pick_upstream_pid_by_key`. Returns the value of
+// `<role>:<picked_pid>:<output_key>:tick-<N>` (empty when no upstream
+// row matches). For N=1 this collapses to a single match identical to
+// the v1 `recall_latest("replay:current_<role>_pid")` + per-key read.
+// Duplicated verbatim across the 9 downstream .ag files because the
+// .ag DSL has no shared-include mechanism (matches the #623 E pattern
+// for _dump_ctx_to_memo / _summarise_*_buf).
+fn _pick_upstream_by_confidence(role: string, output_key: string, tick: int) -> string {
+    let pid = _pick_upstream_pid_by_key(role, output_key, tick);
+    if len(pid) == 0 { return ""; };
+    return recall_latest(role + ":" + pid + ":" + output_key + ":tick-" + to_string(tick));
+}
+
 // _publish_auditor -- TERMINAL agent (Class 1). memo + emit (+ ledger
 // row when final_write=true). Autonomous and review-gated both emit
 // the ledger row; only propose skips it (#622 ADR-0001). The ledger row
@@ -190,8 +221,10 @@ fn _publish_auditor(
         // -> replay:current_topic -> verdict.problem_summary.
         let feedback_eligible = if verdict.audit_verdict == "KNOWN_PRIOR" { true; } else { verdict.audit_verdict == "VERIFIED_NEW"; };
         if feedback_eligible {
-            let explorer_pid_fb = recall_latest("replay:current_explorer_pid");
-            let topic_fb_a = if len(explorer_pid_fb) > 0 { recall_latest("explorer:" + explorer_pid_fb + ":topic:tick-" + to_string(upstream_tick)); } else { ""; };
+            // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces the
+            // replica-unsafe `recall_latest("replay:current_explorer_pid")`
+            // LWW fallback for the topic descriptor lookup.
+            let topic_fb_a = _pick_upstream_by_confidence("explorer", "topic", upstream_tick);
             let topic_fb_b = if len(topic_fb_a) > 0 { topic_fb_a; } else { recall_latest("replay:current_topic"); };
             let topic_fb = if len(topic_fb_b) > 0 { topic_fb_b; } else { verdict.problem_summary; };
             _push_topic_feedback(verdict.audit_verdict, topic_fb, verdict.problem_summary, tick_idx);
@@ -222,23 +255,20 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    let arxiv_pid = recall_latest("replay:current_arxiv_search_pid");
-    let oeis_pid = recall_latest("replay:current_oeis_search_pid");
-    let groupprops_pid = recall_latest("replay:current_groupprops_search_pid");
-    let scholar_pid = recall_latest("replay:current_scholar_search_pid");
-
-    let arxiv_report = if len(arxiv_pid) > 0 { recall_latest("arxiv_search:" + arxiv_pid + ":report:tick-" + to_string(upstream_tick)); } else { ""; };
-    let oeis_report = if len(oeis_pid) > 0 { recall_latest("oeis_search:" + oeis_pid + ":report:tick-" + to_string(upstream_tick)); } else { ""; };
-    let groupprops_report = if len(groupprops_pid) > 0 { recall_latest("groupprops_search:" + groupprops_pid + ":report:tick-" + to_string(upstream_tick)); } else { ""; };
-    let scholar_report = if len(scholar_pid) > 0 { recall_latest("scholar_search:" + scholar_pid + ":report:tick-" + to_string(upstream_tick)); } else { ""; };
+    // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces the five
+    // replica-unsafe `recall_latest("replay:current_<role>_pid")` LWW
+    // handoffs. With N=1 each call collapses to a single match.
+    let arxiv_report = _pick_upstream_by_confidence("arxiv_search", "report", upstream_tick);
+    let oeis_report = _pick_upstream_by_confidence("oeis_search", "report", upstream_tick);
+    let groupprops_report = _pick_upstream_by_confidence("groupprops_search", "report", upstream_tick);
+    let scholar_report = _pick_upstream_by_confidence("scholar_search", "report", upstream_tick);
 
     // Phase 4 PR-B (#625): prior_advocate is an additional adversarial-
     // reviewer signal alongside the four web searchers. Pass-through
     // default -- empty prior_advocate memo does not block the auditor;
     // any_report still gates on the four searchers OR prior_advocate.
-    let prior_advocate_pid = recall_latest("replay:current_prior_advocate_pid");
-    let prior_advocate_report = if len(prior_advocate_pid) > 0 { recall_latest("prior_advocate:" + prior_advocate_pid + ":report:tick-" + to_string(upstream_tick)); } else { ""; };
-    let prior_advocate_is_prior = if len(prior_advocate_pid) > 0 { recall_latest("prior_advocate:" + prior_advocate_pid + ":is_prior:tick-" + to_string(upstream_tick)); } else { ""; };
+    let prior_advocate_report = _pick_upstream_by_confidence("prior_advocate", "report", upstream_tick);
+    let prior_advocate_is_prior = _pick_upstream_by_confidence("prior_advocate", "is_prior", upstream_tick);
 
     let any_report = if len(arxiv_report) > 0 { true; } else { if len(oeis_report) > 0 { true; } else { if len(groupprops_report) > 0 { true; } else { if len(scholar_report) > 0 { true; } else { len(prior_advocate_report) > 0; }; }; }; };
     if !any_report {

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -128,6 +128,37 @@ fn _summarise_pitfall_buf(buf_raw: string, k: int) -> string {
 // _publish_editor -- write main.tex/refs.bib + latexmk + (optional repair) +
 // memo + emit. editor writes no ledger row today; final_write retained for
 // symmetry (#622 ADR-0001).
+// _pick_upstream_pid_by_key -- Phase 9 PR-A (#663) replica-safe pick.
+// Enumerates `<role>:*:<decision_key>:tick-<N>` memo keys via
+// `agentis memo list`, ranks by an embedded confidence field when one
+// is known for the role, and returns the picked PID (empty string when
+// no match). For known roles the meta map below selects the canonical
+// decision_key + confidence_field regardless of `fallback_key`; for
+// unknown roles `fallback_key` is used as the discovery suffix and the
+// picker falls back to alphabetical-first PID (deterministic for N=1,
+// undefined ordering for N>1 -- PR-B/PR-C tightens that).
+fn _pick_upstream_pid_by_key(role: string, fallback_key: string, tick: int) -> string {
+    let tick_s = to_string(tick);
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,subprocess,json\nrole=sys.argv[1]\nout_key=sys.argv[2]\ntick=sys.argv[3]\nmeta={\"noticer\":(\"surprise\",\"confidence_in_surprise\"),\"skeptic\":(\"verdict\",\"confidence\"),\"formulator\":(\"problem\",\"self_check_confidence\"),\"verifier\":(\"verdict\",\"confidence\"),\"auditor\":(\"verdict\",\"confidence\"),\"reviewer\":(\"report\",\"confidence\"),\"prior_advocate\":(\"report\",\"confidence\")}\ndk,cf=meta.get(role,(out_key,\"\"))\nsuf=\":\"+dk+\":tick-\"+tick\npre=role+\":\"\ntry: out=subprocess.run([\"agentis\",\"memo\",\"list\"],capture_output=True,text=True,check=False).stdout\nexcept Exception: out=\"\"\nbest_pid=\"\"\nbest_conf=-1.0\npids=[]\nfor line in out.splitlines():\n line=line.strip()\n if not line or not line.startswith(pre): continue\n key=line.split()[0]\n if not key.endswith(suf): continue\n mid=key[len(pre):-len(suf)]\n if \":\" in mid or not mid: continue\n pids.append(mid)\nif not cf:\n pids.sort()\n if pids: best_pid=pids[0]\nelse:\n for mid in pids:\n  try: v=subprocess.run([\"agentis\",\"memo\",\"get\",pre+mid+suf],capture_output=True,text=True,check=False).stdout\n  except Exception: v=\"\"\n  try: obj=json.loads(v)\n  except Exception: obj=None\n  if not isinstance(obj,dict): continue\n  try: conf=float(obj.get(cf,0.0))\n  except Exception: conf=0.0\n  if conf>best_conf:\n   best_conf=conf\n   best_pid=mid\nprint(best_pid)' " + shell_escape(role) + " " + shell_escape(fallback_key) + " " + shell_escape(tick_s);
+    let pid = try { exec sh cmd; } catch e { ""; };
+    return pid;
+}
+
+// _pick_upstream_by_confidence -- Phase 9 PR-A (#663) value-returning
+// wrapper around `_pick_upstream_pid_by_key`. Returns the value of
+// `<role>:<picked_pid>:<output_key>:tick-<N>` (empty when no upstream
+// row matches). For N=1 this collapses to a single match identical to
+// the v1 `recall_latest("replay:current_<role>_pid")` + per-key read.
+// Duplicated verbatim across the 9 downstream .ag files because the
+// .ag DSL has no shared-include mechanism (matches the #623 E pattern
+// for _dump_ctx_to_memo / _summarise_*_buf).
+fn _pick_upstream_by_confidence(role: string, output_key: string, tick: int) -> string {
+    let pid = _pick_upstream_pid_by_key(role, output_key, tick);
+    if len(pid) == 0 { return ""; };
+    return recall_latest(role + ":" + pid + ":" + output_key + ":tick-" + to_string(tick));
+}
+
 fn _publish_editor(
     final_write: bool,
     edit: Edit,
@@ -265,19 +296,21 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    let introducer_pid = recall_latest("replay:current_introducer_pid");
-    let theorist_pid = recall_latest("replay:current_theorist_pid");
-    let computer_pid = recall_latest("replay:current_computer_pid");
-
-    let abstract_tex = if len(introducer_pid) > 0 { recall_latest("introducer:" + introducer_pid + ":abstract:tick-" + to_string(upstream_tick)); } else { ""; };
-    let intro_tex = if len(introducer_pid) > 0 { recall_latest("introducer:" + introducer_pid + ":intro:tick-" + to_string(upstream_tick)); } else { ""; };
-    let title = if len(introducer_pid) > 0 { recall_latest("introducer:" + introducer_pid + ":title:tick-" + to_string(upstream_tick)); } else { ""; };
-    let definitions_tex = if len(theorist_pid) > 0 { recall_latest("theorist:" + theorist_pid + ":definitions:tick-" + to_string(upstream_tick)); } else { ""; };
-    let main_tex = if len(theorist_pid) > 0 { recall_latest("theorist:" + theorist_pid + ":main:tick-" + to_string(upstream_tick)); } else { ""; };
-    let proof_kind = if len(theorist_pid) > 0 { recall_latest("theorist:" + theorist_pid + ":proof_kind:tick-" + to_string(upstream_tick)); } else { ""; };
-    let repro_script = if len(computer_pid) > 0 { recall_latest("computer:" + computer_pid + ":script:tick-" + to_string(upstream_tick)); } else { ""; };
-    let repro_output = if len(computer_pid) > 0 { recall_latest("computer:" + computer_pid + ":output:tick-" + to_string(upstream_tick)); } else { ""; };
-    let repro_lang = if len(computer_pid) > 0 { recall_latest("computer:" + computer_pid + ":language:tick-" + to_string(upstream_tick)); } else { "python"; };
+    // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces three
+    // replica-unsafe `recall_latest("replay:current_<role>_pid")` LWW
+    // handoffs. introducer/theorist/computer have no JSON-confidence
+    // memo so the picker falls back to alphabetical-first PID; with
+    // N=1 (today) this collapses to a single match identical to v1.
+    let abstract_tex = _pick_upstream_by_confidence("introducer", "abstract", upstream_tick);
+    let intro_tex = _pick_upstream_by_confidence("introducer", "intro", upstream_tick);
+    let title = _pick_upstream_by_confidence("introducer", "title", upstream_tick);
+    let definitions_tex = _pick_upstream_by_confidence("theorist", "definitions", upstream_tick);
+    let main_tex = _pick_upstream_by_confidence("theorist", "main", upstream_tick);
+    let proof_kind = _pick_upstream_by_confidence("theorist", "proof_kind", upstream_tick);
+    let repro_script = _pick_upstream_by_confidence("computer", "script", upstream_tick);
+    let repro_output = _pick_upstream_by_confidence("computer", "output", upstream_tick);
+    let repro_lang_raw = _pick_upstream_by_confidence("computer", "language", upstream_tick);
+    let repro_lang = if len(repro_lang_raw) > 0 { repro_lang_raw; } else { "python"; };
 
     let any_section = if len(abstract_tex) > 0 { true; } else { if len(main_tex) > 0 { true; } else { len(repro_script) > 0; }; };
     if !any_section {

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -88,6 +88,37 @@ fn _summarise_hitl_buf(buf_raw: string, k: int) -> string {
     return out;
 }
 
+// _pick_upstream_pid_by_key -- Phase 9 PR-A (#663) replica-safe pick.
+// Enumerates `<role>:*:<decision_key>:tick-<N>` memo keys via
+// `agentis memo list`, ranks by an embedded confidence field when one
+// is known for the role, and returns the picked PID (empty string when
+// no match). For known roles the meta map below selects the canonical
+// decision_key + confidence_field regardless of `fallback_key`; for
+// unknown roles `fallback_key` is used as the discovery suffix and the
+// picker falls back to alphabetical-first PID (deterministic for N=1,
+// undefined ordering for N>1 -- PR-B/PR-C tightens that).
+fn _pick_upstream_pid_by_key(role: string, fallback_key: string, tick: int) -> string {
+    let tick_s = to_string(tick);
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,subprocess,json\nrole=sys.argv[1]\nout_key=sys.argv[2]\ntick=sys.argv[3]\nmeta={\"noticer\":(\"surprise\",\"confidence_in_surprise\"),\"skeptic\":(\"verdict\",\"confidence\"),\"formulator\":(\"problem\",\"self_check_confidence\"),\"verifier\":(\"verdict\",\"confidence\"),\"auditor\":(\"verdict\",\"confidence\"),\"reviewer\":(\"report\",\"confidence\"),\"prior_advocate\":(\"report\",\"confidence\")}\ndk,cf=meta.get(role,(out_key,\"\"))\nsuf=\":\"+dk+\":tick-\"+tick\npre=role+\":\"\ntry: out=subprocess.run([\"agentis\",\"memo\",\"list\"],capture_output=True,text=True,check=False).stdout\nexcept Exception: out=\"\"\nbest_pid=\"\"\nbest_conf=-1.0\npids=[]\nfor line in out.splitlines():\n line=line.strip()\n if not line or not line.startswith(pre): continue\n key=line.split()[0]\n if not key.endswith(suf): continue\n mid=key[len(pre):-len(suf)]\n if \":\" in mid or not mid: continue\n pids.append(mid)\nif not cf:\n pids.sort()\n if pids: best_pid=pids[0]\nelse:\n for mid in pids:\n  try: v=subprocess.run([\"agentis\",\"memo\",\"get\",pre+mid+suf],capture_output=True,text=True,check=False).stdout\n  except Exception: v=\"\"\n  try: obj=json.loads(v)\n  except Exception: obj=None\n  if not isinstance(obj,dict): continue\n  try: conf=float(obj.get(cf,0.0))\n  except Exception: conf=0.0\n  if conf>best_conf:\n   best_conf=conf\n   best_pid=mid\nprint(best_pid)' " + shell_escape(role) + " " + shell_escape(fallback_key) + " " + shell_escape(tick_s);
+    let pid = try { exec sh cmd; } catch e { ""; };
+    return pid;
+}
+
+// _pick_upstream_by_confidence -- Phase 9 PR-A (#663) value-returning
+// wrapper around `_pick_upstream_pid_by_key`. Returns the value of
+// `<role>:<picked_pid>:<output_key>:tick-<N>` (empty when no upstream
+// row matches). For N=1 this collapses to a single match identical to
+// the v1 `recall_latest("replay:current_<role>_pid")` + per-key read.
+// Duplicated verbatim across the 9 downstream .ag files because the
+// .ag DSL has no shared-include mechanism (matches the #623 E pattern
+// for _dump_ctx_to_memo / _summarise_*_buf).
+fn _pick_upstream_by_confidence(role: string, output_key: string, tick: int) -> string {
+    let pid = _pick_upstream_pid_by_key(role, output_key, tick);
+    if len(pid) == 0 { return ""; };
+    return recall_latest(role + ":" + pid + ":" + output_key + ":tick-" + to_string(tick));
+}
+
 // _publish_formulator -- emit + memo (+ ledger when final_write=true).
 // final_write=true: review-gated / autonomous, append ledger row.
 // final_write=false: propose, emit-only, skip ledger append (#622 ADR-0001).
@@ -148,12 +179,12 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    let noticer_pid = recall_latest("replay:current_noticer_pid");
-    if len(noticer_pid) == 0 {
-        print("[formulator] no noticer pid for tick=", upstream_tick);
-        return;
-    };
-    let surprise_found = recall_latest("noticer:" + noticer_pid + ":surprise_found:tick-" + to_string(upstream_tick));
+    // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces the
+    // replica-unsafe `recall_latest("replay:current_<role>_pid")` LWW
+    // handoff. With N=1 the picker collapses to a single match identical
+    // to the v1 behaviour; with N>1 it ranks upstream replicas by an
+    // embedded confidence field instead of last-writer-wins.
+    let surprise_found = _pick_upstream_by_confidence("noticer", "surprise_found", upstream_tick);
     if surprise_found != "true" {
         print("[formulator] surprise not found (or noticer unset) for tick=", upstream_tick);
         return;
@@ -161,13 +192,12 @@ fn tick(reason: string) -> void {
     // #625 Phase 4 PR-A: skeptic gate. Pass-through default -- empty
     // skeptic memo does not block. Only an explicit `dismissed` label
     // skips the tick.
-    let skeptic_pid = recall_latest("replay:current_skeptic_pid");
-    let skeptic_label = if len(skeptic_pid) > 0 { recall_latest("skeptic:" + skeptic_pid + ":verdict_label:tick-" + to_string(upstream_tick)); } else { ""; };
+    let skeptic_label = _pick_upstream_by_confidence("skeptic", "verdict_label", upstream_tick);
     if skeptic_label == "dismissed" {
         print("[formulator] skeptic dismissed surprise for tick=", upstream_tick);
         return;
     };
-    let surprise_json = recall_latest("noticer:" + noticer_pid + ":surprise:tick-" + to_string(upstream_tick));
+    let surprise_json = _pick_upstream_by_confidence("noticer", "surprise", upstream_tick);
     if len(surprise_json) == 0 {
         print("[formulator] no surprise json for tick=", upstream_tick);
         return;
@@ -175,8 +205,7 @@ fn tick(reason: string) -> void {
     let surprise_description = to_string(json_get(surprise_json, "surprise_description"));
     let specific_value = to_string(json_get(surprise_json, "specific_value"));
     let why_surprising = to_string(json_get(surprise_json, "why_surprising"));
-    let explorer_pid = recall_latest("replay:current_explorer_pid");
-    let topic_label = recall_latest("explorer:" + explorer_pid + ":topic:tick-" + to_string(upstream_tick));
+    let topic_label = _pick_upstream_by_confidence("explorer", "topic", upstream_tick);
 
     // #623 A: read the auditor-written rolling buffers and inject the
     // recent verdict context. Stable keys, no :pid, no :tick.

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -46,6 +46,37 @@ fn _seed_prompt() -> string {
     return "You ran a computational exploration. The user-supplied input below carries the exploration GOAL, the Python CODE that was run, and the OUTPUT printed to stdout. What is SURPRISING or NON-OBVIOUS? Look for specific small numbers that don't match closed form, pattern breaks, numerical coincidences. If the output just confirms a classical formula, mark boring (surprise_found=false). Output ONLY valid JSON: {\"surprise_found\": true|false, \"surprise_description\": \"...\", \"specific_value\": \"...\", \"why_surprising\": \"...\", \"confidence_in_surprise\": 0.0-1.0}.";
 }
 
+// _pick_upstream_pid_by_key -- Phase 9 PR-A (#663) replica-safe pick.
+// Enumerates `<role>:*:<decision_key>:tick-<N>` memo keys via
+// `agentis memo list`, ranks by an embedded confidence field when one
+// is known for the role, and returns the picked PID (empty string when
+// no match). For known roles the meta map below selects the canonical
+// decision_key + confidence_field regardless of `fallback_key`; for
+// unknown roles `fallback_key` is used as the discovery suffix and the
+// picker falls back to alphabetical-first PID (deterministic for N=1,
+// undefined ordering for N>1 -- PR-B/PR-C tightens that).
+fn _pick_upstream_pid_by_key(role: string, fallback_key: string, tick: int) -> string {
+    let tick_s = to_string(tick);
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,subprocess,json\nrole=sys.argv[1]\nout_key=sys.argv[2]\ntick=sys.argv[3]\nmeta={\"noticer\":(\"surprise\",\"confidence_in_surprise\"),\"skeptic\":(\"verdict\",\"confidence\"),\"formulator\":(\"problem\",\"self_check_confidence\"),\"verifier\":(\"verdict\",\"confidence\"),\"auditor\":(\"verdict\",\"confidence\"),\"reviewer\":(\"report\",\"confidence\"),\"prior_advocate\":(\"report\",\"confidence\")}\ndk,cf=meta.get(role,(out_key,\"\"))\nsuf=\":\"+dk+\":tick-\"+tick\npre=role+\":\"\ntry: out=subprocess.run([\"agentis\",\"memo\",\"list\"],capture_output=True,text=True,check=False).stdout\nexcept Exception: out=\"\"\nbest_pid=\"\"\nbest_conf=-1.0\npids=[]\nfor line in out.splitlines():\n line=line.strip()\n if not line or not line.startswith(pre): continue\n key=line.split()[0]\n if not key.endswith(suf): continue\n mid=key[len(pre):-len(suf)]\n if \":\" in mid or not mid: continue\n pids.append(mid)\nif not cf:\n pids.sort()\n if pids: best_pid=pids[0]\nelse:\n for mid in pids:\n  try: v=subprocess.run([\"agentis\",\"memo\",\"get\",pre+mid+suf],capture_output=True,text=True,check=False).stdout\n  except Exception: v=\"\"\n  try: obj=json.loads(v)\n  except Exception: obj=None\n  if not isinstance(obj,dict): continue\n  try: conf=float(obj.get(cf,0.0))\n  except Exception: conf=0.0\n  if conf>best_conf:\n   best_conf=conf\n   best_pid=mid\nprint(best_pid)' " + shell_escape(role) + " " + shell_escape(fallback_key) + " " + shell_escape(tick_s);
+    let pid = try { exec sh cmd; } catch e { ""; };
+    return pid;
+}
+
+// _pick_upstream_by_confidence -- Phase 9 PR-A (#663) value-returning
+// wrapper around `_pick_upstream_pid_by_key`. Returns the value of
+// `<role>:<picked_pid>:<output_key>:tick-<N>` (empty when no upstream
+// row matches). For N=1 this collapses to a single match identical to
+// the v1 `recall_latest("replay:current_<role>_pid")` + per-key read.
+// Duplicated verbatim across the 9 downstream .ag files because the
+// .ag DSL has no shared-include mechanism (matches the #623 E pattern
+// for _dump_ctx_to_memo / _summarise_*_buf).
+fn _pick_upstream_by_confidence(role: string, output_key: string, tick: int) -> string {
+    let pid = _pick_upstream_pid_by_key(role, output_key, tick);
+    if len(pid) == 0 { return ""; };
+    return recall_latest(role + ":" + pid + ":" + output_key + ":tick-" + to_string(tick));
+}
+
 // _publish_noticer -- memo + emit + fitness (no ledger row today).
 // final_write parameter retained for symmetry with other non-terminal agents (#622 ADR-0001).
 fn _publish_noticer(
@@ -97,14 +128,13 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    let explorer_pid = recall_latest("replay:current_explorer_pid");
-    if len(explorer_pid) == 0 {
-        print("[noticer] no explorer pid for tick=", upstream_tick);
-        return;
-    };
-    let code = recall_latest("explorer:" + explorer_pid + ":code:tick-" + to_string(upstream_tick));
-    let output = recall_latest("explorer:" + explorer_pid + ":output:tick-" + to_string(upstream_tick));
-    let expl_goal = recall_latest("explorer:" + explorer_pid + ":goal:tick-" + to_string(upstream_tick));
+    // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces the
+    // replica-unsafe `recall_latest("replay:current_explorer_pid")` LWW
+    // handoff. With N=1 the picker collapses to a single match identical
+    // to the v1 behaviour.
+    let code = _pick_upstream_by_confidence("explorer", "code", upstream_tick);
+    let output = _pick_upstream_by_confidence("explorer", "output", upstream_tick);
+    let expl_goal = _pick_upstream_by_confidence("explorer", "goal", upstream_tick);
     if len(output) == 0 {
         print("[noticer] no explorer output for tick=", upstream_tick);
         return;

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -50,6 +50,37 @@ fn _seed_prompt() -> string {
     return "You are a strict novelty referee. DEFAULT to NOT_NOVEL. The user-supplied input below carries the PROBLEM, the stated ANSWER, and the author's NOVELTY CLAIM. Mark NOT_NOVEL if the problem reduces to: Basel problem, Gauss sums, Galois group of x^n - 2, Milnor fiber formula, complete intersection Euler characteristic via Chern classes, classical Fourier or Mellin transform, or any other named famous result. Mark NOVEL only if the specific answer requires computation and is not a famous constant, and the reasoning requires genuine insight. Mark BORDERLINE if the problem is non-obvious but a known classical identifier is suspected. Output ONLY valid JSON: {\"is_classical_result\": true|false, \"classical_identifier\": \"...\", \"novelty_verdict\": \"NOVEL|BORDERLINE|NOT_NOVEL\", \"reasoning\": \"...\"}.";
 }
 
+// _pick_upstream_pid_by_key -- Phase 9 PR-A (#663) replica-safe pick.
+// Enumerates `<role>:*:<decision_key>:tick-<N>` memo keys via
+// `agentis memo list`, ranks by an embedded confidence field when one
+// is known for the role, and returns the picked PID (empty string when
+// no match). For known roles the meta map below selects the canonical
+// decision_key + confidence_field regardless of `fallback_key`; for
+// unknown roles `fallback_key` is used as the discovery suffix and the
+// picker falls back to alphabetical-first PID (deterministic for N=1,
+// undefined ordering for N>1 -- PR-B/PR-C tightens that).
+fn _pick_upstream_pid_by_key(role: string, fallback_key: string, tick: int) -> string {
+    let tick_s = to_string(tick);
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,subprocess,json\nrole=sys.argv[1]\nout_key=sys.argv[2]\ntick=sys.argv[3]\nmeta={\"noticer\":(\"surprise\",\"confidence_in_surprise\"),\"skeptic\":(\"verdict\",\"confidence\"),\"formulator\":(\"problem\",\"self_check_confidence\"),\"verifier\":(\"verdict\",\"confidence\"),\"auditor\":(\"verdict\",\"confidence\"),\"reviewer\":(\"report\",\"confidence\"),\"prior_advocate\":(\"report\",\"confidence\")}\ndk,cf=meta.get(role,(out_key,\"\"))\nsuf=\":\"+dk+\":tick-\"+tick\npre=role+\":\"\ntry: out=subprocess.run([\"agentis\",\"memo\",\"list\"],capture_output=True,text=True,check=False).stdout\nexcept Exception: out=\"\"\nbest_pid=\"\"\nbest_conf=-1.0\npids=[]\nfor line in out.splitlines():\n line=line.strip()\n if not line or not line.startswith(pre): continue\n key=line.split()[0]\n if not key.endswith(suf): continue\n mid=key[len(pre):-len(suf)]\n if \":\" in mid or not mid: continue\n pids.append(mid)\nif not cf:\n pids.sort()\n if pids: best_pid=pids[0]\nelse:\n for mid in pids:\n  try: v=subprocess.run([\"agentis\",\"memo\",\"get\",pre+mid+suf],capture_output=True,text=True,check=False).stdout\n  except Exception: v=\"\"\n  try: obj=json.loads(v)\n  except Exception: obj=None\n  if not isinstance(obj,dict): continue\n  try: conf=float(obj.get(cf,0.0))\n  except Exception: conf=0.0\n  if conf>best_conf:\n   best_conf=conf\n   best_pid=mid\nprint(best_pid)' " + shell_escape(role) + " " + shell_escape(fallback_key) + " " + shell_escape(tick_s);
+    let pid = try { exec sh cmd; } catch e { ""; };
+    return pid;
+}
+
+// _pick_upstream_by_confidence -- Phase 9 PR-A (#663) value-returning
+// wrapper around `_pick_upstream_pid_by_key`. Returns the value of
+// `<role>:<picked_pid>:<output_key>:tick-<N>` (empty when no upstream
+// row matches). For N=1 this collapses to a single match identical to
+// the v1 `recall_latest("replay:current_<role>_pid")` + per-key read.
+// Duplicated verbatim across the 9 downstream .ag files because the
+// .ag DSL has no shared-include mechanism (matches the #623 E pattern
+// for _dump_ctx_to_memo / _summarise_*_buf).
+fn _pick_upstream_by_confidence(role: string, output_key: string, tick: int) -> string {
+    let pid = _pick_upstream_pid_by_key(role, output_key, tick);
+    if len(pid) == 0 { return ""; };
+    return recall_latest(role + ":" + pid + ":" + output_key + ":tick-" + to_string(tick));
+}
+
 // _publish_novelty -- TERMINAL agent (Class 1). memo + final_verdict +
 // emit (+ ledger row when final_write=true). Both autonomous and
 // review-gated emit the ledger row; only propose skips it (#622 ADR-0001).
@@ -151,23 +182,31 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    let verifier_pid = recall_latest("replay:current_verifier_pid");
-    if len(verifier_pid) == 0 {
+    // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces the
+    // replica-unsafe `recall_latest("replay:current_<role>_pid")` LWW
+    // handoff. `formulator_pid` is passed to `_publish_novelty` but is
+    // unused inside the function body, so an empty string is fine; the
+    // value-side reads (problem_text/answer/novelty_claim) go through
+    // the picker. `explorer_pid` is still surfaced because the publish
+    // function writes the cross-reference key
+    // `novelty:final_verdict:<explorer_pid>:tick-N` and reads explorer
+    // code/output/goal by that pid.
+    let verdict_label = _pick_upstream_by_confidence("verifier", "verdict_label", upstream_tick);
+    if len(verdict_label) == 0 {
         print("[novelty] no verifier pid for tick=", upstream_tick);
         return;
     };
-    let verdict_label = recall_latest("verifier:" + verifier_pid + ":verdict_label:tick-" + to_string(upstream_tick));
     let verifier_passed = if verdict_label == "ACCEPT" { true; } else { if verdict_label == "NEEDS_REVISION" { true; } else { false; }; };
     if !verifier_passed {
         print("[novelty] verifier rejected (verdict=", verdict_label, ") for tick=", upstream_tick);
         return;
     };
 
-    let formulator_pid = recall_latest("replay:current_formulator_pid");
-    let problem_text = recall_latest("formulator:" + formulator_pid + ":problem_text:tick-" + to_string(upstream_tick));
-    let stated_answer = recall_latest("formulator:" + formulator_pid + ":answer:tick-" + to_string(upstream_tick));
-    let novelty_claim = recall_latest("formulator:" + formulator_pid + ":novelty_claim:tick-" + to_string(upstream_tick));
-    let explorer_pid = recall_latest("replay:current_explorer_pid");
+    let formulator_pid = "";
+    let problem_text = _pick_upstream_by_confidence("formulator", "problem_text", upstream_tick);
+    let stated_answer = _pick_upstream_by_confidence("formulator", "answer", upstream_tick);
+    let novelty_claim = _pick_upstream_by_confidence("formulator", "novelty_claim", upstream_tick);
+    let explorer_pid = _pick_upstream_pid_by_key("explorer", "code", upstream_tick);
 
     if len(problem_text) == 0 {
         print("[novelty] no problem text for tick=", upstream_tick);

--- a/research-foundry/reviewer/agents/reviewer.ag
+++ b/research-foundry/reviewer/agents/reviewer.ag
@@ -66,6 +66,37 @@ fn _dump_ctx_to_memo(agent_name: string, pid: string, tick_idx: int, ctx: string
     memo_write(agent_name + ":" + pid + ":ctx:tick-" + to_string(tick_idx), ctx);
 }
 
+// _pick_upstream_pid_by_key -- Phase 9 PR-A (#663) replica-safe pick.
+// Enumerates `<role>:*:<decision_key>:tick-<N>` memo keys via
+// `agentis memo list`, ranks by an embedded confidence field when one
+// is known for the role, and returns the picked PID (empty string when
+// no match). For known roles the meta map below selects the canonical
+// decision_key + confidence_field regardless of `fallback_key`; for
+// unknown roles `fallback_key` is used as the discovery suffix and the
+// picker falls back to alphabetical-first PID (deterministic for N=1,
+// undefined ordering for N>1 -- PR-B/PR-C tightens that).
+fn _pick_upstream_pid_by_key(role: string, fallback_key: string, tick: int) -> string {
+    let tick_s = to_string(tick);
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,subprocess,json\nrole=sys.argv[1]\nout_key=sys.argv[2]\ntick=sys.argv[3]\nmeta={\"noticer\":(\"surprise\",\"confidence_in_surprise\"),\"skeptic\":(\"verdict\",\"confidence\"),\"formulator\":(\"problem\",\"self_check_confidence\"),\"verifier\":(\"verdict\",\"confidence\"),\"auditor\":(\"verdict\",\"confidence\"),\"reviewer\":(\"report\",\"confidence\"),\"prior_advocate\":(\"report\",\"confidence\")}\ndk,cf=meta.get(role,(out_key,\"\"))\nsuf=\":\"+dk+\":tick-\"+tick\npre=role+\":\"\ntry: out=subprocess.run([\"agentis\",\"memo\",\"list\"],capture_output=True,text=True,check=False).stdout\nexcept Exception: out=\"\"\nbest_pid=\"\"\nbest_conf=-1.0\npids=[]\nfor line in out.splitlines():\n line=line.strip()\n if not line or not line.startswith(pre): continue\n key=line.split()[0]\n if not key.endswith(suf): continue\n mid=key[len(pre):-len(suf)]\n if \":\" in mid or not mid: continue\n pids.append(mid)\nif not cf:\n pids.sort()\n if pids: best_pid=pids[0]\nelse:\n for mid in pids:\n  try: v=subprocess.run([\"agentis\",\"memo\",\"get\",pre+mid+suf],capture_output=True,text=True,check=False).stdout\n  except Exception: v=\"\"\n  try: obj=json.loads(v)\n  except Exception: obj=None\n  if not isinstance(obj,dict): continue\n  try: conf=float(obj.get(cf,0.0))\n  except Exception: conf=0.0\n  if conf>best_conf:\n   best_conf=conf\n   best_pid=mid\nprint(best_pid)' " + shell_escape(role) + " " + shell_escape(fallback_key) + " " + shell_escape(tick_s);
+    let pid = try { exec sh cmd; } catch e { ""; };
+    return pid;
+}
+
+// _pick_upstream_by_confidence -- Phase 9 PR-A (#663) value-returning
+// wrapper around `_pick_upstream_pid_by_key`. Returns the value of
+// `<role>:<picked_pid>:<output_key>:tick-<N>` (empty when no upstream
+// row matches). For N=1 this collapses to a single match identical to
+// the v1 `recall_latest("replay:current_<role>_pid")` + per-key read.
+// Duplicated verbatim across the 9 downstream .ag files because the
+// .ag DSL has no shared-include mechanism (matches the #623 E pattern
+// for _dump_ctx_to_memo / _summarise_*_buf).
+fn _pick_upstream_by_confidence(role: string, output_key: string, tick: int) -> string {
+    let pid = _pick_upstream_pid_by_key(role, output_key, tick);
+    if len(pid) == 0 { return ""; };
+    return recall_latest(role + ":" + pid + ":" + output_key + ":tick-" + to_string(tick));
+}
+
 // _publish_reviewer -- memo + emit. Non-terminal agent collapses
 // autonomous -> review-gated per ADR-0001 (#622 PR-2 #632 pattern).
 // reviewer writes no ledger row today; final_write retained for
@@ -130,12 +161,14 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    let editor_pid = recall_latest("replay:current_editor_pid");
-    let computer_pid = recall_latest("replay:current_computer_pid");
-
-    let final_tex = if len(editor_pid) > 0 { recall_latest("editor:" + editor_pid + ":final_tex:tick-" + to_string(upstream_tick)); } else { ""; };
-    let claim_dir = if len(editor_pid) > 0 { recall_latest("editor:" + editor_pid + ":claim_dir:tick-" + to_string(upstream_tick)); } else { ""; };
-    let repro_output = if len(computer_pid) > 0 { recall_latest("computer:" + computer_pid + ":output:tick-" + to_string(upstream_tick)); } else { ""; };
+    // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces two
+    // replica-unsafe `recall_latest("replay:current_<role>_pid")` LWW
+    // handoffs. editor/computer have no JSON-confidence memo so the
+    // picker falls back to alphabetical-first PID; with N=1 (today)
+    // this collapses to a single match identical to v1.
+    let final_tex = _pick_upstream_by_confidence("editor", "final_tex", upstream_tick);
+    let claim_dir = _pick_upstream_by_confidence("editor", "claim_dir", upstream_tick);
+    let repro_output = _pick_upstream_by_confidence("computer", "output", upstream_tick);
 
     let claim_id = recall_latest("claim:claim_id:tick-" + to_string(upstream_tick));
     let claim_id_eff = if len(claim_id) > 0 { claim_id; } else { "claim-" + to_string(upstream_tick); };

--- a/research-foundry/skeptic/agents/skeptic.ag
+++ b/research-foundry/skeptic/agents/skeptic.ag
@@ -66,6 +66,37 @@ fn _dump_ctx_to_memo(agent_name: string, pid: string, tick_idx: int, ctx: string
     memo_write(agent_name + ":" + pid + ":ctx:tick-" + to_string(tick_idx), ctx);
 }
 
+// _pick_upstream_pid_by_key -- Phase 9 PR-A (#663) replica-safe pick.
+// Enumerates `<role>:*:<decision_key>:tick-<N>` memo keys via
+// `agentis memo list`, ranks by an embedded confidence field when one
+// is known for the role, and returns the picked PID (empty string when
+// no match). For known roles the meta map below selects the canonical
+// decision_key + confidence_field regardless of `fallback_key`; for
+// unknown roles `fallback_key` is used as the discovery suffix and the
+// picker falls back to alphabetical-first PID (deterministic for N=1,
+// undefined ordering for N>1 -- PR-B/PR-C tightens that).
+fn _pick_upstream_pid_by_key(role: string, fallback_key: string, tick: int) -> string {
+    let tick_s = to_string(tick);
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,subprocess,json\nrole=sys.argv[1]\nout_key=sys.argv[2]\ntick=sys.argv[3]\nmeta={\"noticer\":(\"surprise\",\"confidence_in_surprise\"),\"skeptic\":(\"verdict\",\"confidence\"),\"formulator\":(\"problem\",\"self_check_confidence\"),\"verifier\":(\"verdict\",\"confidence\"),\"auditor\":(\"verdict\",\"confidence\"),\"reviewer\":(\"report\",\"confidence\"),\"prior_advocate\":(\"report\",\"confidence\")}\ndk,cf=meta.get(role,(out_key,\"\"))\nsuf=\":\"+dk+\":tick-\"+tick\npre=role+\":\"\ntry: out=subprocess.run([\"agentis\",\"memo\",\"list\"],capture_output=True,text=True,check=False).stdout\nexcept Exception: out=\"\"\nbest_pid=\"\"\nbest_conf=-1.0\npids=[]\nfor line in out.splitlines():\n line=line.strip()\n if not line or not line.startswith(pre): continue\n key=line.split()[0]\n if not key.endswith(suf): continue\n mid=key[len(pre):-len(suf)]\n if \":\" in mid or not mid: continue\n pids.append(mid)\nif not cf:\n pids.sort()\n if pids: best_pid=pids[0]\nelse:\n for mid in pids:\n  try: v=subprocess.run([\"agentis\",\"memo\",\"get\",pre+mid+suf],capture_output=True,text=True,check=False).stdout\n  except Exception: v=\"\"\n  try: obj=json.loads(v)\n  except Exception: obj=None\n  if not isinstance(obj,dict): continue\n  try: conf=float(obj.get(cf,0.0))\n  except Exception: conf=0.0\n  if conf>best_conf:\n   best_conf=conf\n   best_pid=mid\nprint(best_pid)' " + shell_escape(role) + " " + shell_escape(fallback_key) + " " + shell_escape(tick_s);
+    let pid = try { exec sh cmd; } catch e { ""; };
+    return pid;
+}
+
+// _pick_upstream_by_confidence -- Phase 9 PR-A (#663) value-returning
+// wrapper around `_pick_upstream_pid_by_key`. Returns the value of
+// `<role>:<picked_pid>:<output_key>:tick-<N>` (empty when no upstream
+// row matches). For N=1 this collapses to a single match identical to
+// the v1 `recall_latest("replay:current_<role>_pid")` + per-key read.
+// Duplicated verbatim across the 9 downstream .ag files because the
+// .ag DSL has no shared-include mechanism (matches the #623 E pattern
+// for _dump_ctx_to_memo / _summarise_*_buf).
+fn _pick_upstream_by_confidence(role: string, output_key: string, tick: int) -> string {
+    let pid = _pick_upstream_pid_by_key(role, output_key, tick);
+    if len(pid) == 0 { return ""; };
+    return recall_latest(role + ":" + pid + ":" + output_key + ":tick-" + to_string(tick));
+}
+
 // _publish_skeptic -- memo + emit. Skeptic writes no ledger row today,
 // so final_write is retained for symmetry but currently a no-op.
 // Non-terminal agent collapses autonomous -> review-gated per ADR-0001
@@ -113,17 +144,21 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    let noticer_pid = recall_latest("replay:current_noticer_pid");
+    // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces the
+    // replica-unsafe `recall_latest("replay:current_noticer_pid")` LWW
+    // handoff. `noticer_pid` is still surfaced because `_publish_skeptic`
+    // writes the cross-reference key `skeptic:upheld:<noticer_pid>:tick-N`.
+    let noticer_pid = _pick_upstream_pid_by_key("noticer", "surprise", upstream_tick);
     if len(noticer_pid) == 0 {
         print("[skeptic] no noticer pid for tick=", upstream_tick);
         return;
     };
-    let surprise_found = recall_latest("noticer:" + noticer_pid + ":surprise_found:tick-" + to_string(upstream_tick));
+    let surprise_found = _pick_upstream_by_confidence("noticer", "surprise_found", upstream_tick);
     if surprise_found != "true" {
         print("[skeptic] surprise not found (or noticer unset) for tick=", upstream_tick);
         return;
     };
-    let surprise_json = recall_latest("noticer:" + noticer_pid + ":surprise:tick-" + to_string(upstream_tick));
+    let surprise_json = _pick_upstream_by_confidence("noticer", "surprise", upstream_tick);
     if len(surprise_json) == 0 {
         print("[skeptic] no surprise json for tick=", upstream_tick);
         return;

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -67,6 +67,37 @@ fn _metadata_prompt() -> string {
     return "You are preparing an arXiv submission package for a math preprint. The user-supplied input below carries the FINAL TEX, the COMPILE LOG, the REPRODUCIBILITY SCRIPT and OUTPUT, and a candidate ARXIV_CATEGORY + MSC_CODES from the introducer. Produce: (1) the paper title (under 200 chars), (2) a clean ASCII abstract (under 1920 chars, no LaTeX environments, no `\\\\cite`, no `$...$` -- plain prose for the arXiv submission form), (3) MSC2020 codes (comma-separated), (4) the primary arXiv category (e.g. math.GR), (5) cross-list categories (comma-separated, may be empty), (6) a short cover letter (200-400 words) addressed to arXiv moderation that names the human author, summarises the contribution, notes that the proof is computational (when the reproducibility script is the evidence) and explicitly discloses AI assistance with drafting, (7) a single-paragraph AI disclosure that must be appended verbatim to the cover letter (arXiv 2024+ policy). Output ONLY valid JSON: {\"title\":\"...\",\"abstract_clean\":\"...\",\"msc_codes_csv\":\"...\",\"arxiv_category\":\"...\",\"cross_list_csv\":\"...\",\"cover_letter\":\"...\",\"ai_disclosure\":\"...\",\"rationale\":\"one-line\"}.";
 }
 
+// _pick_upstream_pid_by_key -- Phase 9 PR-A (#663) replica-safe pick.
+// Enumerates `<role>:*:<decision_key>:tick-<N>` memo keys via
+// `agentis memo list`, ranks by an embedded confidence field when one
+// is known for the role, and returns the picked PID (empty string when
+// no match). For known roles the meta map below selects the canonical
+// decision_key + confidence_field regardless of `fallback_key`; for
+// unknown roles `fallback_key` is used as the discovery suffix and the
+// picker falls back to alphabetical-first PID (deterministic for N=1,
+// undefined ordering for N>1 -- PR-B/PR-C tightens that).
+fn _pick_upstream_pid_by_key(role: string, fallback_key: string, tick: int) -> string {
+    let tick_s = to_string(tick);
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,subprocess,json\nrole=sys.argv[1]\nout_key=sys.argv[2]\ntick=sys.argv[3]\nmeta={\"noticer\":(\"surprise\",\"confidence_in_surprise\"),\"skeptic\":(\"verdict\",\"confidence\"),\"formulator\":(\"problem\",\"self_check_confidence\"),\"verifier\":(\"verdict\",\"confidence\"),\"auditor\":(\"verdict\",\"confidence\"),\"reviewer\":(\"report\",\"confidence\"),\"prior_advocate\":(\"report\",\"confidence\")}\ndk,cf=meta.get(role,(out_key,\"\"))\nsuf=\":\"+dk+\":tick-\"+tick\npre=role+\":\"\ntry: out=subprocess.run([\"agentis\",\"memo\",\"list\"],capture_output=True,text=True,check=False).stdout\nexcept Exception: out=\"\"\nbest_pid=\"\"\nbest_conf=-1.0\npids=[]\nfor line in out.splitlines():\n line=line.strip()\n if not line or not line.startswith(pre): continue\n key=line.split()[0]\n if not key.endswith(suf): continue\n mid=key[len(pre):-len(suf)]\n if \":\" in mid or not mid: continue\n pids.append(mid)\nif not cf:\n pids.sort()\n if pids: best_pid=pids[0]\nelse:\n for mid in pids:\n  try: v=subprocess.run([\"agentis\",\"memo\",\"get\",pre+mid+suf],capture_output=True,text=True,check=False).stdout\n  except Exception: v=\"\"\n  try: obj=json.loads(v)\n  except Exception: obj=None\n  if not isinstance(obj,dict): continue\n  try: conf=float(obj.get(cf,0.0))\n  except Exception: conf=0.0\n  if conf>best_conf:\n   best_conf=conf\n   best_pid=mid\nprint(best_pid)' " + shell_escape(role) + " " + shell_escape(fallback_key) + " " + shell_escape(tick_s);
+    let pid = try { exec sh cmd; } catch e { ""; };
+    return pid;
+}
+
+// _pick_upstream_by_confidence -- Phase 9 PR-A (#663) value-returning
+// wrapper around `_pick_upstream_pid_by_key`. Returns the value of
+// `<role>:<picked_pid>:<output_key>:tick-<N>` (empty when no upstream
+// row matches). For N=1 this collapses to a single match identical to
+// the v1 `recall_latest("replay:current_<role>_pid")` + per-key read.
+// Duplicated verbatim across the 9 downstream .ag files because the
+// .ag DSL has no shared-include mechanism (matches the #623 E pattern
+// for _dump_ctx_to_memo / _summarise_*_buf).
+fn _pick_upstream_by_confidence(role: string, output_key: string, tick: int) -> string {
+    let pid = _pick_upstream_pid_by_key(role, output_key, tick);
+    if len(pid) == 0 { return ""; };
+    return recall_latest(role + ":" + pid + ":" + output_key + ":tick-" + to_string(tick));
+}
+
 // _submitter_draft_phase -- Phase A. Build arxiv-metadata.json + tarball
 // + cover letter, write DRAFTED row to ledger, persist memo. Used by
 // propose / review-gated / autonomous (Class 1 terminal, #622 ADR-0001).
@@ -324,22 +355,28 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    let editor_pid = recall_latest("replay:current_editor_pid");
-    let final_tex = if len(editor_pid) > 0 { recall_latest("editor:" + editor_pid + ":final_tex:tick-" + to_string(upstream_tick)); } else { ""; };
-    let compile_log = if len(editor_pid) > 0 { recall_latest("editor:" + editor_pid + ":compile_log:tick-" + to_string(upstream_tick)); } else { ""; };
-    let refs_bib = if len(editor_pid) > 0 { recall_latest("editor:" + editor_pid + ":refs_bib:tick-" + to_string(upstream_tick)); } else { ""; };
-    let claim_dir = if len(editor_pid) > 0 { recall_latest("editor:" + editor_pid + ":claim_dir:tick-" + to_string(upstream_tick)); } else { ""; };
-    let compile_ok = if len(editor_pid) > 0 { recall_latest("editor:" + editor_pid + ":compile_ok:tick-" + to_string(upstream_tick)); } else { "false"; };
+    // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces three
+    // replica-unsafe `recall_latest("replay:current_<role>_pid")` LWW
+    // handoffs. editor/introducer/computer have no JSON-confidence memo
+    // so the picker falls back to alphabetical-first PID; with N=1
+    // (today) this collapses to a single match identical to v1. The
+    // default fallbacks ("false" for compile_ok, "python" for repro_lang)
+    // are preserved when the picker returns an empty string.
+    let final_tex = _pick_upstream_by_confidence("editor", "final_tex", upstream_tick);
+    let compile_log = _pick_upstream_by_confidence("editor", "compile_log", upstream_tick);
+    let refs_bib = _pick_upstream_by_confidence("editor", "refs_bib", upstream_tick);
+    let claim_dir = _pick_upstream_by_confidence("editor", "claim_dir", upstream_tick);
+    let compile_ok_raw = _pick_upstream_by_confidence("editor", "compile_ok", upstream_tick);
+    let compile_ok = if len(compile_ok_raw) > 0 { compile_ok_raw; } else { "false"; };
 
-    let introducer_pid = recall_latest("replay:current_introducer_pid");
-    let title_seed = if len(introducer_pid) > 0 { recall_latest("introducer:" + introducer_pid + ":title:tick-" + to_string(upstream_tick)); } else { ""; };
-    let msc_seed = if len(introducer_pid) > 0 { recall_latest("introducer:" + introducer_pid + ":msc_codes:tick-" + to_string(upstream_tick)); } else { ""; };
-    let cat_seed = if len(introducer_pid) > 0 { recall_latest("introducer:" + introducer_pid + ":arxiv_category:tick-" + to_string(upstream_tick)); } else { ""; };
+    let title_seed = _pick_upstream_by_confidence("introducer", "title", upstream_tick);
+    let msc_seed = _pick_upstream_by_confidence("introducer", "msc_codes", upstream_tick);
+    let cat_seed = _pick_upstream_by_confidence("introducer", "arxiv_category", upstream_tick);
 
-    let computer_pid = recall_latest("replay:current_computer_pid");
-    let repro_script = if len(computer_pid) > 0 { recall_latest("computer:" + computer_pid + ":script:tick-" + to_string(upstream_tick)); } else { ""; };
-    let repro_output = if len(computer_pid) > 0 { recall_latest("computer:" + computer_pid + ":output:tick-" + to_string(upstream_tick)); } else { ""; };
-    let repro_lang = if len(computer_pid) > 0 { recall_latest("computer:" + computer_pid + ":language:tick-" + to_string(upstream_tick)); } else { "python"; };
+    let repro_script = _pick_upstream_by_confidence("computer", "script", upstream_tick);
+    let repro_output = _pick_upstream_by_confidence("computer", "output", upstream_tick);
+    let repro_lang_raw = _pick_upstream_by_confidence("computer", "language", upstream_tick);
+    let repro_lang = if len(repro_lang_raw) > 0 { repro_lang_raw; } else { "python"; };
 
     let source_audit_run = recall_latest("claim:source_audit_run:tick-" + to_string(upstream_tick));
     let source_claim_id = recall_latest("claim:claim_id:tick-" + to_string(upstream_tick));

--- a/research-foundry/tools/test-pick-upstream-by-confidence.sh
+++ b/research-foundry/tools/test-pick-upstream-by-confidence.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# test-pick-upstream-by-confidence.sh: regression test for the Phase 9
+# PR-A picker (#663) -- synthesise 2 upstream memo rows with different
+# confidence and assert the picker selects the higher-confidence PID.
+#
+# The picker logic lives inline inside every downstream .ag as the helper
+# `_pick_upstream_by_confidence(role, output_key, tick)`. The python
+# scoring core is duplicated boilerplate across 9 .ag files. This test
+# exercises the same python pipeline standalone so a regression in any
+# copy can be caught without spawning a daemon.
+#
+# Usage: ./research-foundry/tools/test-pick-upstream-by-confidence.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+export AGENTIS_ROOT="$TMPDIR_TEST/.agentis"
+mkdir -p "$AGENTIS_ROOT"
+
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+if ! command -v agentis >/dev/null 2>&1; then
+    echo "[SKIP] agentis binary not on PATH; cannot exercise memo store"
+    exit 0
+fi
+
+# Initialise the temp agentis root.
+(cd "$TMPDIR_TEST" && agentis init >/dev/null 2>&1) || true
+
+# pick_winner_pid <role> <decision_key> <conf_field> <tick>
+# Echoes the winning PID on stdout. Mirrors the python pipeline embedded
+# in `_pick_upstream_by_confidence` across the 9 downstream .ag files.
+pick_winner_pid() {
+    local role="$1"
+    local decision_key="$2"
+    local conf_field="$3"
+    local tick="$4"
+    AGENTIS_ROOT="$AGENTIS_ROOT" python3 -c '
+import os, sys, subprocess, json, re
+role = sys.argv[1]
+decision_key = sys.argv[2]
+conf_field = sys.argv[3]
+tick = sys.argv[4]
+suffix = ":" + decision_key + ":tick-" + tick
+prefix = role + ":"
+try:
+    out = subprocess.run(["agentis", "memo", "list"], capture_output=True, text=True, check=False).stdout
+except Exception:
+    out = ""
+best_pid = ""
+best_conf = -1.0
+for line in out.splitlines():
+    line = line.strip()
+    if not line or not line.startswith(prefix):
+        continue
+    key = line.split()[0]
+    if not key.endswith(suffix):
+        continue
+    mid = key[len(prefix):-len(suffix)]
+    if ":" in mid or not mid:
+        continue
+    try:
+        v = subprocess.run(["agentis", "memo", "get", key], capture_output=True, text=True, check=False).stdout
+    except Exception:
+        v = ""
+    try:
+        obj = json.loads(v)
+    except Exception:
+        obj = None
+    if not isinstance(obj, dict):
+        continue
+    try:
+        conf = float(obj.get(conf_field, 0.0))
+    except Exception:
+        conf = 0.0
+    if conf > best_conf:
+        best_conf = conf
+        best_pid = mid
+print(best_pid)
+' "$role" "$decision_key" "$conf_field" "$tick"
+}
+
+# --- Test 1: noticer picker selects higher-confidence surprise row ---
+agentis memo set "noticer:pid-aaaa:surprise:tick-7" '{"surprise_found":true,"specific_value":"x","why_surprising":"y","confidence_in_surprise":0.42}' >/dev/null
+agentis memo set "noticer:pid-bbbb:surprise:tick-7" '{"surprise_found":true,"specific_value":"u","why_surprising":"v","confidence_in_surprise":0.91}' >/dev/null
+got="$(pick_winner_pid noticer surprise confidence_in_surprise 7)"
+if [ "$got" = "pid-bbbb" ]; then
+    pass "noticer: picker selects PID with confidence_in_surprise=0.91 over 0.42"
+else
+    fail "noticer pick" "expected pid-bbbb, got '$got'"
+fi
+
+# --- Test 2: picker returns empty string when no rows match the tick ---
+got2="$(pick_winner_pid noticer surprise confidence_in_surprise 99)"
+if [ -z "$got2" ]; then
+    pass "noticer: picker returns empty when no rows for tick=99"
+else
+    fail "noticer empty pick" "expected empty, got '$got2'"
+fi
+
+# --- Test 3: auditor picker uses 'confidence' field name ---
+agentis memo set "auditor:pid-cccc:verdict:tick-3" '{"audit_verdict":"VERIFIED_NEW","reasoning":"r","confidence":0.55,"problem_summary":"p"}' >/dev/null
+agentis memo set "auditor:pid-dddd:verdict:tick-3" '{"audit_verdict":"KNOWN_PRIOR","reasoning":"r","confidence":0.83,"problem_summary":"p"}' >/dev/null
+got3="$(pick_winner_pid auditor verdict confidence 3)"
+if [ "$got3" = "pid-dddd" ]; then
+    pass "auditor: picker selects PID with confidence=0.83 over 0.55"
+else
+    fail "auditor pick" "expected pid-dddd, got '$got3'"
+fi
+
+# --- Test 4: tie-breaking is deterministic (first-encountered wins on equal confidence) ---
+# Two equal confidences should not crash; either PID is acceptable but
+# the picker must return non-empty.
+agentis memo set "noticer:pid-eeee:surprise:tick-11" '{"surprise_found":true,"specific_value":"x","why_surprising":"y","confidence_in_surprise":0.5}' >/dev/null
+agentis memo set "noticer:pid-ffff:surprise:tick-11" '{"surprise_found":true,"specific_value":"u","why_surprising":"v","confidence_in_surprise":0.5}' >/dev/null
+got4="$(pick_winner_pid noticer surprise confidence_in_surprise 11)"
+if [ "$got4" = "pid-eeee" ] || [ "$got4" = "pid-ffff" ]; then
+    pass "noticer: picker resolves ties without crashing"
+else
+    fail "noticer tie pick" "expected pid-eeee or pid-ffff, got '$got4'"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/research-foundry/verifier/agents/verifier.ag
+++ b/research-foundry/verifier/agents/verifier.ag
@@ -55,6 +55,37 @@ fn _verifier_prompt() -> string {
     return "You are a problem-quality referee. The input below carries the PROBLEM and the STATED ANSWER from the author. Your sole job is to judge the PROBLEM ITSELF — not whether the stated answer is numerically correct. Set verdict=ACCEPT when the problem is well-defined (unambiguous statement, mathematically meaningful, has a determinable answer in principle). Set verdict=NEEDS_REVISION when the problem is mostly well-defined but has minor ambiguities that could be fixed with light editing. Set verdict=REJECT only when the problem itself is incoherent, ill-defined, or trivially malformed. Output ONLY valid JSON: {\"answers_agree\": false, \"solver_rigorous\": false, \"problem_well_defined\": true|false, \"verdict\": \"ACCEPT|REJECT|NEEDS_REVISION\", \"reasoning\": \"...\"}. Set answers_agree and solver_rigorous to false (they are deprecated metadata).";
 }
 
+// _pick_upstream_pid_by_key -- Phase 9 PR-A (#663) replica-safe pick.
+// Enumerates `<role>:*:<decision_key>:tick-<N>` memo keys via
+// `agentis memo list`, ranks by an embedded confidence field when one
+// is known for the role, and returns the picked PID (empty string when
+// no match). For known roles the meta map below selects the canonical
+// decision_key + confidence_field regardless of `fallback_key`; for
+// unknown roles `fallback_key` is used as the discovery suffix and the
+// picker falls back to alphabetical-first PID (deterministic for N=1,
+// undefined ordering for N>1 -- PR-B/PR-C tightens that).
+fn _pick_upstream_pid_by_key(role: string, fallback_key: string, tick: int) -> string {
+    let tick_s = to_string(tick);
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,subprocess,json\nrole=sys.argv[1]\nout_key=sys.argv[2]\ntick=sys.argv[3]\nmeta={\"noticer\":(\"surprise\",\"confidence_in_surprise\"),\"skeptic\":(\"verdict\",\"confidence\"),\"formulator\":(\"problem\",\"self_check_confidence\"),\"verifier\":(\"verdict\",\"confidence\"),\"auditor\":(\"verdict\",\"confidence\"),\"reviewer\":(\"report\",\"confidence\"),\"prior_advocate\":(\"report\",\"confidence\")}\ndk,cf=meta.get(role,(out_key,\"\"))\nsuf=\":\"+dk+\":tick-\"+tick\npre=role+\":\"\ntry: out=subprocess.run([\"agentis\",\"memo\",\"list\"],capture_output=True,text=True,check=False).stdout\nexcept Exception: out=\"\"\nbest_pid=\"\"\nbest_conf=-1.0\npids=[]\nfor line in out.splitlines():\n line=line.strip()\n if not line or not line.startswith(pre): continue\n key=line.split()[0]\n if not key.endswith(suf): continue\n mid=key[len(pre):-len(suf)]\n if \":\" in mid or not mid: continue\n pids.append(mid)\nif not cf:\n pids.sort()\n if pids: best_pid=pids[0]\nelse:\n for mid in pids:\n  try: v=subprocess.run([\"agentis\",\"memo\",\"get\",pre+mid+suf],capture_output=True,text=True,check=False).stdout\n  except Exception: v=\"\"\n  try: obj=json.loads(v)\n  except Exception: obj=None\n  if not isinstance(obj,dict): continue\n  try: conf=float(obj.get(cf,0.0))\n  except Exception: conf=0.0\n  if conf>best_conf:\n   best_conf=conf\n   best_pid=mid\nprint(best_pid)' " + shell_escape(role) + " " + shell_escape(fallback_key) + " " + shell_escape(tick_s);
+    let pid = try { exec sh cmd; } catch e { ""; };
+    return pid;
+}
+
+// _pick_upstream_by_confidence -- Phase 9 PR-A (#663) value-returning
+// wrapper around `_pick_upstream_pid_by_key`. Returns the value of
+// `<role>:<picked_pid>:<output_key>:tick-<N>` (empty when no upstream
+// row matches). For N=1 this collapses to a single match identical to
+// the v1 `recall_latest("replay:current_<role>_pid")` + per-key read.
+// Duplicated verbatim across the 9 downstream .ag files because the
+// .ag DSL has no shared-include mechanism (matches the #623 E pattern
+// for _dump_ctx_to_memo / _summarise_*_buf).
+fn _pick_upstream_by_confidence(role: string, output_key: string, tick: int) -> string {
+    let pid = _pick_upstream_pid_by_key(role, output_key, tick);
+    if len(pid) == 0 { return ""; };
+    return recall_latest(role + ":" + pid + ":" + output_key + ":tick-" + to_string(tick));
+}
+
 // _publish_verifier -- memo + emit. Verifier writes no ledger row today,
 // so final_write is retained for symmetry but currently a no-op (#622 ADR-0001).
 fn _publish_verifier(
@@ -105,13 +136,11 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    let formulator_pid = recall_latest("replay:current_formulator_pid");
-    if len(formulator_pid) == 0 {
-        print("[verifier] no formulator pid for tick=", upstream_tick);
-        return;
-    };
-    let problem_text = recall_latest("formulator:" + formulator_pid + ":problem_text:tick-" + to_string(upstream_tick));
-    let stated_answer = recall_latest("formulator:" + formulator_pid + ":answer:tick-" + to_string(upstream_tick));
+    // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces the
+    // replica-unsafe `recall_latest("replay:current_formulator_pid")`
+    // LWW handoff. With N=1 the picker collapses to a single match.
+    let problem_text = _pick_upstream_by_confidence("formulator", "problem_text", upstream_tick);
+    let stated_answer = _pick_upstream_by_confidence("formulator", "answer", upstream_tick);
     if len(problem_text) == 0 {
         print("[verifier] no problem text for tick=", upstream_tick);
         return;

--- a/tools/check-no-replay-current-pid.sh
+++ b/tools/check-no-replay-current-pid.sh
@@ -31,9 +31,14 @@ while IFS= read -r -d '' ag_file; do
     # are out of scope for PR-A and left in place so any external probes
     # the orchestrator might keep continue to work; PR-B/PR-C may retire
     # them once the broader replica machinery lands.
-    if grep -nE 'recall_latest\("replay:current_[a-z_]+_pid"\)' "$ag_file" >/dev/null 2>&1; then
+    #
+    # The leading-`//` strip excludes comment lines that document the
+    # historical pattern (this PR's own changelog-style comments mention
+    # the literal). Scan operates on uncommented source only.
+    cleaned="$(sed -e 's|^[[:space:]]*//.*||' "$ag_file")"
+    if printf '%s\n' "$cleaned" | grep -nE 'recall_latest\("replay:current_[a-z_]+_pid"\)' >/dev/null 2>&1; then
         echo "[FAIL] $ag_file reads replay:current_<role>_pid (Phase 9 PR-A regression)"
-        grep -nE 'recall_latest\("replay:current_[a-z_]+_pid"\)' "$ag_file"
+        printf '%s\n' "$cleaned" | grep -nE 'recall_latest\("replay:current_[a-z_]+_pid"\)'
         violations=$((violations + 1))
     fi
 done < <(find "$TARGET_DIR" -type f -name "*.ag" -print0 2>/dev/null)

--- a/tools/check-no-replay-current-pid.sh
+++ b/tools/check-no-replay-current-pid.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# check-no-replay-current-pid.sh: fail if any research-foundry .ag file
+# reads or writes `replay:current_<role>_pid` after Phase 9 PR-A landed.
+#
+# Phase 9 PR-A (#663) replaced the replica-unsafe `replay:current_<role>_pid`
+# LWW handoff with a tick-keyed fan-in + winner-by-confidence picker
+# (`_pick_upstream_by_confidence(role, output_key, tick)`). The picker
+# enumerates `<role>:*:<decision_key>:tick-<N>` memos, ranks by an embedded
+# `confidence*` field, and returns the chosen PID. Downstream agents must
+# NOT regress to the LWW pattern; this check enforces that invariant.
+#
+# Usage: ./tools/check-no-replay-current-pid.sh [path-to-repo-root]
+# Exit 0 if clean, 1 if a violation is found.
+#
+# Runs on bash 3.2+ (stock macOS /bin/bash) and bash 4+.
+
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TARGET_DIR="$REPO_ROOT/research-foundry"
+
+if [ ! -d "$TARGET_DIR" ]; then
+    # No research-foundry tree to scan -- treat as clean.
+    exit 0
+fi
+
+violations=0
+while IFS= read -r -d '' ag_file; do
+    # Match only `recall_latest("replay:current_<role>_pid")` (consumer side).
+    # Producer-side `memo_write("replay:current_<role>_pid", self_pid)` writes
+    # are out of scope for PR-A and left in place so any external probes
+    # the orchestrator might keep continue to work; PR-B/PR-C may retire
+    # them once the broader replica machinery lands.
+    if grep -nE 'recall_latest\("replay:current_[a-z_]+_pid"\)' "$ag_file" >/dev/null 2>&1; then
+        echo "[FAIL] $ag_file reads replay:current_<role>_pid (Phase 9 PR-A regression)"
+        grep -nE 'recall_latest\("replay:current_[a-z_]+_pid"\)' "$ag_file"
+        violations=$((violations + 1))
+    fi
+done < <(find "$TARGET_DIR" -type f -name "*.ag" -print0 2>/dev/null)
+
+if [ "$violations" -eq 0 ]; then
+    exit 0
+fi
+
+echo ""
+echo "Phase 9 PR-A (#663) removed all replay:current_<role>_pid reads in"
+echo "research-foundry/. Use _pick_upstream_by_confidence(role, output_key,"
+echo "tick) instead. See research-foundry/CHANGELOG.md for the rationale."
+exit 1

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -622,6 +622,20 @@ if [ -x "$REPO_ROOT/tools/check-learn-recommend-topic-match.sh" ]; then
     fi
 fi
 
+# --- replay:current_<role>_pid regression guard (#663 Phase 9 PR-A) ---
+# Phase 9 PR-A replaced the replica-unsafe `replay:current_<role>_pid`
+# LWW handoff with `_pick_upstream_by_confidence(role, output_key, tick)`.
+# Downstream `.ag` files must NOT regress to the LWW pattern.
+if [ -x "$REPO_ROOT/tools/check-no-replay-current-pid.sh" ]; then
+    check_out="$("$REPO_ROOT/tools/check-no-replay-current-pid.sh" "$REPO_ROOT" 2>&1)" && check_rc=0 || check_rc=$?
+    if [ "$check_rc" -eq 0 ]; then
+        pass "check-no-replay-current-pid: no replay:current_<role>_pid references in research-foundry/ (#663)"
+    else
+        fail "check-no-replay-current-pid: replay:current_<role>_pid regression (#663 Phase 9 PR-A)"
+        printf '%s\n' "$check_out"
+    fi
+fi
+
 # --- Plaintext token detection (#321) ---
 # Walks `[forge.*]` sections in every colony.toml / colony.example.toml
 # under the repo and flags `token` / `*api_key*` / `*secret*` values


### PR DESCRIPTION
## Summary

Phase 9 PR-A of #663 — wire-level pre-blocker for the entire phase.

Replaces the replica-unsafe `replay:current_<role>_pid` LWW handoff with a tick-keyed fan-in + winner-by-confidence picker across **9 downstream `.ag` files** in `research-foundry/`. Every `recall_latest("replay:current_<role>_pid")` + pid-keyed memo read becomes:

```
let foo = _pick_upstream_by_confidence("<role>", "<output_key>", tick);
```

The picker enumerates `<role>:*:<decision_key>:tick-<N>` memos via `agentis memo list`, ranks by an embedded confidence field (`confidence_in_surprise` / `confidence` / `self_check_confidence` depending on role), and returns the chosen output value. With **N=1 (today) the picker collapses to a single match identical to the v1 LWW behaviour**; with N>1 it stops the last-writer-wins stomp that prevents replicating any role beyond explorer.

## Why this is a Phase 9 pre-blocker

Phase 3 (#624) replicated the explorer with the M2-Malthusian gate. Phase 9 (#663) generalises this to all 18 colonies. Today every downstream agent reads `replay:current_<role>_pid` and joins on that single PID. With N>1 replicas for an upstream role, the next replica writer overwrites the key — downstream consumers see only one upstream's output per tick. The other N-1 daemons are wasted. PR-B (tooling generalisation: cull-replicas.sh + colony-fitness.py + colony-variants.json) and PR-C (per-`.ag` replicate machinery + spawn loops) ride on this wire change.

## Files touched

**9 downstream `.ag` files** (consumer side of the LWW handoff):

- `research-foundry/noticer/agents/noticer.ag` — fans in explorer
- `research-foundry/skeptic/agents/skeptic.ag` — fans in noticer (preserves noticer_pid for cross-ref write)
- `research-foundry/formulator/agents/formulator.ag` — fans in noticer / skeptic / explorer
- `research-foundry/verifier/agents/verifier.ag` — fans in formulator
- `research-foundry/novelty/agents/novelty.ag` — fans in verifier / formulator / explorer
- `research-foundry/auditor/agents/auditor.ag` — fans in 4 searchers + prior_advocate (+ explorer fallback in feedback path)
- `research-foundry/editor/agents/editor.ag` — fans in introducer / theorist / computer
- `research-foundry/reviewer/agents/reviewer.ag` — fans in editor / computer
- `research-foundry/submitter/agents/submitter.ag` — fans in editor / introducer / computer

**4 supporting files:**

- `research-foundry/CHANGELOG.md` — Unreleased entry describing the wire change + Phase 9 pre-blocker rationale.
- `research-foundry/tools/test-pick-upstream-by-confidence.sh` — regression test for the python picker pipeline (4 cases: max-confidence pick, no-match returns empty, role-specific conf_field, tie-breaking).
- `tools/check-no-replay-current-pid.sh` — colony-lint check that fails any future regression to the `recall_latest("replay:current_<role>_pid")` consumer pattern. Producer-side `memo_write(...)` writes are out of scope for PR-A.
- `tools/colony-lint.sh` — wires the new check.

## Preserved replica-safe patterns

- `research-foundry/reviewer/agents/reviewer.ag` line 103: claim-keyed `reviewer:<claim_id>:approved` — unchanged.
- `research-foundry/auditor/agents/auditor.ag` lines 173-183: tick-keyed `claim:audit_*:tick-<N>` write side — unchanged.

## Out of scope

- Explorer agent (already Phase 7 PR-C live-flipped; no upstream pid reads).
- The 4 search engines (only read `replay:current_tick`, no upstream pid reads).
- Producer-side `memo_write("replay:current_<role>_pid", self_pid)` writes — left in place so any external probes the orchestrator might keep continue to work.
- No spawn-loop changes, no flag flips, no replication knobs — PR-B + PR-C scope.

## Test plan

- [x] `tools/colony-lint.sh` passes (335 passed, 0 failed, 3 skipped locally).
- [x] New `research-foundry/tools/test-pick-upstream-by-confidence.sh` passes (4/4).
- [x] Existing `research-foundry/tools/test-run-research.sh` still passes (29/29).
- [x] All 9 `.ag` files smoke-tested via `agentis commit` (parse + typecheck).
- [x] `tools/check-no-replay-current-pid.sh` exits 0 against the post-fix tree.

**No behavioural change for N=1; PR-B + PR-C ride on this.**