### PR TITLE
fix(submitter): word-boundary classifier + clear awaiting_approval on auto-promote (#643 #637)

### DIFF
--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -589,6 +589,15 @@ fn tick(reason: string) -> void {
         // check collapses to true). Records `autonomous_decision=true`
         // for downstream observers.
         memo_write("submitter:" + claim_id_eff + ":autonomous_decision", "true");
+        // #637: clear any stale `awaiting_approval=true` left over from
+        // a review-gated draft that auto-promoted to autonomous
+        // mid-flight (the sidecar bumped confidence past 0.95 between
+        // the draft tick and this send tick). Idempotent: a no-op when
+        // the claim was always-autonomous since the autonomous draft
+        // call below passes `mark_awaiting=false`. Must run BEFORE
+        // `_submitter_send_phase` so the dashboard never observes a
+        // sent+still-awaiting state during the SMTP gap.
+        memo_write("submitter:" + claim_id_eff + ":awaiting_approval", "false");
         learn("submit", "tick " + to_string(tick_idx), "tier=autonomous", "partial", ["acted", "preprint-foundry"]);
         if len(already_drafted) == 0 {
             _submitter_draft_phase(false, true, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, compile_ok, source_audit_run, final_tex, compile_log, title_seed, msc_seed, cat_seed, repro_script, repro_output, repro_lang);

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -371,7 +371,13 @@ fn _classify_hitl_reason(reason_raw: string) -> string {
         let _ = backend_eff;
     };
     // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,re\ns=sys.argv[1].lower()\nif re.search(r\"wrong|incorrect|error|proof.*fail\", s): print(\"math_wrong\")\nelif re.search(r\"unreadable|typo|grammar|prose\", s): print(\"writing_bad\")\nelif re.search(r\"uninteresting|trivial|not.*novel\", s): print(\"topic_boring\")\nelif re.search(r\"off.?topic|scope|wrong.*category\", s): print(\"scope_off\")\nelif re.search(r\"obviously|clearly|trivially|hedge|style\", s): print(\"style_violation\")\nelse: print(\"other\")' " + shell_escape(reason_raw);
+    // #643: word-boundary anchors on `trivial` (and friends) so the
+    // `topic_boring` regex does NOT shadow the word `trivially` --
+    // the latter is canonical math-style violation vocabulary that
+    // the editor's seed prompt explicitly forbids, so misclassifying
+    // it into `topic_boring` would pollute the rolling buffer the
+    // formulator + auditor read on their next tick.
+    let cmd = "python3 -c 'import sys,re\ns=sys.argv[1].lower()\nif re.search(r\"\\bwrong\\b|\\bincorrect\\b|\\berror\\b|proof.*fail\", s): print(\"math_wrong\")\nelif re.search(r\"\\bunreadable\\b|\\btypo\\b|\\bgrammar\\b|\\bprose\\b\", s): print(\"writing_bad\")\nelif re.search(r\"\\buninteresting\\b|\\btrivial\\b|not.*novel\", s): print(\"topic_boring\")\nelif re.search(r\"off.?topic|\\bscope\\b|wrong.*category\", s): print(\"scope_off\")\nelif re.search(r\"\\bobviously\\b|\\bclearly\\b|\\btrivially\\b|\\bhedge\\b|\\bstyle\\b\", s): print(\"style_violation\")\nelse: print(\"other\")' " + shell_escape(reason_raw);
     let out = try { exec sh cmd; } catch e { "other"; };
     return out;
 }

--- a/research-foundry/tools/test-submitter-classifier.sh
+++ b/research-foundry/tools/test-submitter-classifier.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 # research-foundry/tools/test-submitter-classifier.sh -- regression
-# test for the submitter's HITL-reject classifier.
+# test for the submitter's HITL-reject classifier and the
+# `awaiting_approval` memo flag lifecycle.
 #
 # Covers:
 #   (a) #643 -- the `topic_boring` regex no longer shadows `trivially`,
 #       which is a `style_violation` per the editor's seed prompt.
 #       Reproduces the classifier's Python one-liner inline so the
 #       test runs without `agentis` or a live federation.
+#   (b) #637 -- the autonomous-tier branch of `tick()` clears the
+#       `submitter:<claim>:awaiting_approval` memo flag, so a
+#       review-gated draft that auto-promotes to autonomous mid-flight
+#       does not leave a stuck "awaiting approval" indicator on the
+#       dashboard.
 #
 # Standard library only -- no pytest, no live federation. Python3 is
 # required for the regex reproduction (matches the .ag prod path).
@@ -89,6 +95,67 @@ if [ "$got" = "other" ]; then
 else
     fail "(a4) #643 'mirrored' does not shadow into math_wrong" \
          "got '$got'"
+fi
+
+# (b) #637 -- the autonomous-tier branch of tick() must clear the
+# `submitter:<claim_id_eff>:awaiting_approval` memo flag so a draft
+# that started at review-gated tier (which set the flag via
+# `_submitter_draft_phase(mark_awaiting=true, ...)`) and then was
+# auto-promoted to autonomous mid-flight does not leave the dashboard
+# stuck on "awaiting approval".
+#
+# Static check: assert the autonomous arm of tick() contains the
+# clear-flag memo_write *between* the `my_tier == "autonomous"` arm
+# opening and the call to `_submitter_send_phase` (where the SMTP
+# send happens). We grep for the explicit literal so the test fails
+# loudly if a later refactor renames the key shape.
+if grep -q "if my_tier == \"autonomous\"" "$SUBMITTER_AG" && \
+   awk '
+       /if my_tier == "autonomous"/ { in_auto = 1; next }
+       in_auto && /^    \} else \{/  { in_auto = 0 }
+       in_auto && /memo_write\("submitter:" \+ claim_id_eff \+ ":awaiting_approval", "false"\)/ { found = 1 }
+       END { exit found ? 0 : 1 }
+   ' "$SUBMITTER_AG"; then
+    pass "(b1) #637 autonomous branch clears awaiting_approval memo flag"
+else
+    fail "(b1) #637 autonomous branch clears awaiting_approval memo flag" \
+         "missing memo_write(\"submitter:\" + claim_id_eff + \":awaiting_approval\", \"false\") in autonomous arm"
+fi
+
+# (b2) Order check: the clear must come BEFORE _submitter_send_phase
+# so the dashboard never observes a sent+still-awaiting state during
+# the SMTP gap.
+if awk '
+    /if my_tier == "autonomous"/ { in_auto = 1; next }
+    in_auto && /^    \} else \{/  { in_auto = 0 }
+    in_auto && /memo_write\("submitter:" \+ claim_id_eff \+ ":awaiting_approval", "false"\)/ { cleared = NR }
+    in_auto && /_submitter_send_phase/ { sent = NR }
+    END { exit (cleared && sent && cleared < sent) ? 0 : 1 }
+' "$SUBMITTER_AG"; then
+    pass "(b2) #637 awaiting_approval cleared BEFORE _submitter_send_phase"
+else
+    fail "(b2) #637 awaiting_approval cleared BEFORE _submitter_send_phase" \
+         "clear must precede send_phase in the autonomous arm"
+fi
+
+# (b3) Idempotency: a second autonomous tick on a claim that is
+# already submitted must still keep the flag cleared (no re-set to
+# "true" sneaking in from a refactor). Static check: the autonomous
+# arm contains exactly one awaiting_approval write, and it is the
+# clear (value="false") rather than the set (value="true"). The
+# mark_awaiting=true call lives in `_submitter_draft_phase`, which
+# the autonomous arm invokes with `mark_awaiting=false`.
+if awk '
+    /if my_tier == "autonomous"/ { in_auto = 1; next }
+    in_auto && /^    \} else \{/  { in_auto = 0 }
+    in_auto && /memo_write\("submitter:" \+ claim_id_eff \+ ":awaiting_approval", "true"\)/ { bad++ }
+    in_auto && /_submitter_draft_phase\(false,/ { ok_draft_call = 1 }
+    END { exit (bad == 0 && ok_draft_call) ? 0 : 1 }
+' "$SUBMITTER_AG"; then
+    pass "(b3) #637 autonomous arm never sets awaiting_approval=true"
+else
+    fail "(b3) #637 autonomous arm never sets awaiting_approval=true" \
+         "found a stray awaiting_approval=true write or missing mark_awaiting=false in _submitter_draft_phase call"
 fi
 
 echo ""

--- a/research-foundry/tools/test-submitter-classifier.sh
+++ b/research-foundry/tools/test-submitter-classifier.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# research-foundry/tools/test-submitter-classifier.sh -- regression
+# test for the submitter's HITL-reject classifier.
+#
+# Covers:
+#   (a) #643 -- the `topic_boring` regex no longer shadows `trivially`,
+#       which is a `style_violation` per the editor's seed prompt.
+#       Reproduces the classifier's Python one-liner inline so the
+#       test runs without `agentis` or a live federation.
+#
+# Standard library only -- no pytest, no live federation. Python3 is
+# required for the regex reproduction (matches the .ag prod path).
+#
+# Usage: bash research-foundry/tools/test-submitter-classifier.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_DIR="$(dirname "$SCRIPT_DIR")"
+SUBMITTER_AG="$FED_DIR/submitter/agents/submitter.ag"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+skip() { echo "[SKIP] $1: $2"; SKIP=$((SKIP + 1)); }
+
+if [ ! -f "$SUBMITTER_AG" ]; then
+    echo "[FAIL] submitter.ag not found at $SUBMITTER_AG" >&2
+    exit 1
+fi
+
+# (a) #643 -- word-boundary regex sanity. Re-implement the
+# classifier's Python one-liner verbatim and assert the
+# misclassification reproducer from the issue body now lands in
+# `style_violation`, while the substring matches that legitimately
+# belong in `topic_boring` (the plain word `trivial`) are preserved.
+classify() {
+    python3 -c '
+import sys, re
+s = sys.argv[1].lower()
+if re.search(r"\bwrong\b|\bincorrect\b|\berror\b|proof.*fail", s): print("math_wrong")
+elif re.search(r"\bunreadable\b|\btypo\b|\bgrammar\b|\bprose\b", s): print("writing_bad")
+elif re.search(r"\buninteresting\b|\btrivial\b|not.*novel", s): print("topic_boring")
+elif re.search(r"off.?topic|\bscope\b|wrong.*category", s): print("scope_off")
+elif re.search(r"\bobviously\b|\bclearly\b|\btrivially\b|\bhedge\b|\bstyle\b", s): print("style_violation")
+else: print("other")
+' "$1"
+}
+
+# (a1) #643 reproducer: "argument trivially follows" -- the original
+# bug's seed input. Expected `style_violation`, NOT `topic_boring`.
+got="$(classify 'argument trivially follows')"
+if [ "$got" = "style_violation" ]; then
+    pass "(a1) #643 'argument trivially follows' classifies as style_violation"
+else
+    fail "(a1) #643 'argument trivially follows' classifies as style_violation" \
+         "got '$got'"
+fi
+
+# (a2) #643 follow-up phrasing from the issue body: a typical reviewer
+# remark "this trivially generalises to ..." MUST also resolve to
+# style_violation (the canonical math-style forbidden vocabulary).
+got="$(classify 'a trivially correct proof')"
+if [ "$got" = "style_violation" ]; then
+    pass "(a2) #643 'a trivially correct proof' classifies as style_violation"
+else
+    fail "(a2) #643 'a trivially correct proof' classifies as style_violation" \
+         "got '$got'"
+fi
+
+# (a3) Preserve original semantics: the bare word `trivial` (no -ly
+# suffix) is still legitimately a `topic_boring` signal.
+got="$(classify 'this result is trivial')"
+if [ "$got" = "topic_boring" ]; then
+    pass "(a3) #643 'this result is trivial' still classifies as topic_boring"
+else
+    fail "(a3) #643 'this result is trivial' still classifies as topic_boring" \
+         "got '$got'"
+fi
+
+# (a4) Word-boundary safety check: the substring `error` inside a
+# longer non-error word ("mirrored") must not shadow into math_wrong.
+got="$(classify 'the figure is mirrored along axis')"
+if [ "$got" = "other" ]; then
+    pass "(a4) #643 'mirrored' does not shadow into math_wrong"
+else
+    fail "(a4) #643 'mirrored' does not shadow into math_wrong" \
+         "got '$got'"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Two LOW follow-ups in `research-foundry/submitter/agents/submitter.ag`:

- **#643** — `_classify_hitl_reason`'s `topic_boring` regex matched the bare substring `trivial`, shadowing the legitimate math-style word `trivially` (canonical `style_violation` vocabulary per the editor's seed prompt). Switched every regex alternative to word-boundary anchors (`\b...\b`); substring patterns that legitimately span word boundaries (`proof.*fail`, `off.?topic`, `wrong.*category`, `not.*novel`) remain unchanged.
- **#637** — autonomous-tier branch of `tick()` never cleared the `submitter:<claim>:awaiting_approval=true` flag stamped by Phase A draft when `mark_awaiting=true`. A review-gated draft that auto-promoted to autonomous mid-flight left the dashboard stuck on "awaiting approval" for an already-sent claim. Added explicit `memo_write("submitter:<claim>:awaiting_approval", "false")` at the top of the autonomous arm, before `_submitter_send_phase`. Idempotent.

Closes #643
Closes #637

## Test plan

- [x] `./tools/colony-lint.sh` — 337 passed, 0 failed, 4 skipped.
- [x] `bash research-foundry/tools/test-submitter-classifier.sh` — 7 passed, 0 failed (new test file, 4 classifier assertions for #643 + 3 static-check assertions for #637).
- [x] `(a3)` preserves existing semantics: bare word `trivial` still classifies as `topic_boring`.
- [x] `(b3)` idempotency: autonomous arm contains no stray `awaiting_approval=true` write.

## Commits

- `a961dd0` — #643 word-boundary regex + 4 classifier reproducers
- `f7e3e21` — #637 clear awaiting_approval + 3 static-check assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)