### PR TITLE
fix(cull-replicas): demand-weighted re-eval + bounds check + gap/no-op tests (#647 #649 #650 #651)

### DIFF
--- a/tools/cull-replicas.sh
+++ b/tools/cull-replicas.sh
@@ -106,6 +106,23 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# Validate --bottom-pct is a float in [0.0, 1.0]. Without this, a
+# misconfigured RESEARCH_CULL_BOTTOM_PCT > 1.0 mass-culls every replica
+# (the respawn phase is bounded by M2-Malthusian but the kill phase is
+# not). See issue #649.
+if ! python3 -c "
+import sys
+try:
+    v = float(sys.argv[1])
+except (ValueError, TypeError):
+    sys.exit(1)
+if not (0.0 <= v <= 1.0):
+    sys.exit(1)
+" "$BOTTOM_PCT" 2>/dev/null; then
+    echo "cull-replicas: --bottom-pct must be a float in [0.0, 1.0], got: $BOTTOM_PCT" >&2
+    exit 2
+fi
+
 if [ ! -d "$FED_DIR" ]; then
     echo "cull-replicas: fed_dir not found: $FED_DIR" >&2
     exit 2
@@ -318,11 +335,13 @@ if max_id == 0:
 print(max_id)
 " "$COLONY_DAEMONS_JSON" "$COLONY_NAME" 2>/dev/null || echo "$COLONY_COUNT")"
 
-# Compute the demand-weighted specialty pick once for this cull batch.
-# The pool + overlay table are looked up from colony-variants.json. For
-# the explorer colony in feds that ship no variants file (back-compat),
-# we fall back to the hardcoded 5-specialty pool the Phase 3 tool used.
-NEXT_SPECIALTY="$(python3 -c "
+# Helper: demand-weighted specialty pick from colony-variants.json.
+# Invoked once per respawn so the picker re-evaluates after each prior
+# respawn has bumped its variant's count (issue #647). For the explorer
+# colony in feds that ship no variants file (back-compat), we fall back
+# to the hardcoded 5-specialty pool the Phase 3 tool used.
+pick_next_specialty() {
+    python3 -c "
 import json, os, sys
 variants_path = sys.argv[1]
 colony = sys.argv[2]
@@ -360,17 +379,23 @@ for s in pool:
     elif c == min_count:
         mins.append(s)
 print(mins[now_ms % len(mins)])
-" "$VARIANTS_FILE" "$COLONY_NAME" "$SPECIALTY_COUNTS_JSON" "$NOW_MS")"
+" "$VARIANTS_FILE" "$COLONY_NAME" "$1" "$NOW_MS"
+}
 
-if [ -z "$NEXT_SPECIALTY" ]; then
+# Probe once up-front so we can early-exit when no variant pool is
+# defined for this colony. The actual per-respawn pick happens inside
+# the loop below.
+PROBE_SPECIALTY="$(pick_next_specialty "$SPECIALTY_COUNTS_JSON")"
+if [ -z "$PROBE_SPECIALTY" ]; then
     log "no variant pool resolved for colony=$COLONY_NAME (missing colony-variants.json entry)"
     exit 0
 fi
 
-log "picked $PICKED_COUNT cull candidate(s); respawn specialty=$NEXT_SPECIALTY (next daemon_id=$((MAX_DAEMON_ID + 1)))"
+log "picked $PICKED_COUNT cull candidate(s); first respawn specialty=$PROBE_SPECIALTY (next daemon_id=$((MAX_DAEMON_ID + 1)))"
 
 # Iterate picks. Each pick produces (cull, respawn) ledger rows.
 NEXT_ID="$MAX_DAEMON_ID"
+LIVE_COUNTS_JSON="$SPECIALTY_COUNTS_JSON"
 
 python3 -c "
 import json, sys
@@ -392,9 +417,25 @@ print('\n'.join(
         log "skip pid=$pid: $skip_reason"
         continue
     fi
+
+    # Re-evaluate the demand-weighted picker every respawn so multi-pick
+    # batches do not collide on the same specialty (issue #647). The
+    # LIVE_COUNTS_JSON map is bumped at the end of each iteration to
+    # reflect the just-respawned variant.
+    NEXT_SPECIALTY="$(pick_next_specialty "$LIVE_COUNTS_JSON")"
+
     if [ "$DRY_RUN" = "1" ]; then
         log "[dry-run] would cull pid=$pid agent_id=$agent_id specialty=$specialty fitness=$fitness"
         log "[dry-run] would respawn $COLONY_NAME with specialty=$NEXT_SPECIALTY daemon_id=$((NEXT_ID + 1))"
+        # Bump live counts so the next dry-run iteration's picker re-
+        # evaluates against the post-respawn distribution.
+        LIVE_COUNTS_JSON="$(python3 -c "
+import json, sys
+counts = json.loads(sys.argv[1])
+sp = sys.argv[2]
+counts[sp] = counts.get(sp, 0) + 1
+print(json.dumps(counts))
+" "$LIVE_COUNTS_JSON" "$NEXT_SPECIALTY")"
         continue
     fi
 
@@ -530,6 +571,16 @@ sys.stdout.write(json.dumps(row) + '\n')
 " "$NEW_ID" "$NEXT_SPECIALTY" "$pid" "$COLONY_NAME" "$VARIANTS_FILE" >> "$REPLICATION_LEDGER"
 
     log "respawned $COLONY_NAME daemon_id=$NEW_ID specialty=$NEXT_SPECIALTY (replaced pid=$pid)"
+
+    # Bump live counts so the next iteration's picker re-evaluates
+    # against the post-respawn distribution (issue #647).
+    LIVE_COUNTS_JSON="$(python3 -c "
+import json, sys
+counts = json.loads(sys.argv[1])
+sp = sys.argv[2]
+counts[sp] = counts.get(sp, 0) + 1
+print(json.dumps(counts))
+" "$LIVE_COUNTS_JSON" "$NEXT_SPECIALTY")"
 done
 
 log "done"

--- a/tools/cull-replicas.sh
+++ b/tools/cull-replicas.sh
@@ -293,6 +293,14 @@ for d in daemons:
     pid = d.get('pid', 0)
     if not pid:
         continue
+    # Prefer a daemon_id carried in the JSON itself (used by the test
+    # harness via CULL_DAEMONS_JSON_OVERRIDE to exercise the gap-
+    # allocation path without a live memo store, per issue #650).
+    raw = d.get('daemon_id')
+    if isinstance(raw, int) and raw > 0:
+        max_id = max(max_id, raw)
+    elif isinstance(raw, str) and raw.isdigit():
+        max_id = max(max_id, int(raw))
     # Read the DAEMON_ID memo if the agent published one. Fall back to
     # scanning the pool:specialty:<N> slot assignments for occupied ids.
     try:

--- a/tools/test-cull-replicas.sh
+++ b/tools/test-cull-replicas.sh
@@ -235,6 +235,67 @@ else
     fail "7. cull-explorers.sh wrapper forwards to cull-replicas explorer (PR-B)" "$WRAPPER_OUT"
 fi
 
+# --- Test 8 (#650): DAEMON_ID gap allocation -- when surviving replicas
+# carry daemon_id=1,2,4 the respawn must claim max(existing)+1 = 5, not
+# colliding with the surviving daemon_id=4 nor reusing the daemon_id=3
+# gap (the orchestrator reserves max+1 so pool slots never collide).
+GAP_JSON="$(python3 -c "
+import json
+daemons = []
+for did, pid_off in [(1, 1), (2, 2), (4, 4)]:
+    daemons.append({
+        'source': '/run-root/explorer/agents/explorer.ag',
+        'agent_id': 'agent-explorer-%d' % did,
+        'pid': 1000 + pid_off,
+        'daemon_id': did,
+        'state': 'running',
+        'effective_state': 'running',
+        'colony': 'explorer',
+        'started_at': 0,
+        'confidence': 0.7,
+    })
+print(json.dumps(daemons))
+")"
+
+GAP_OUT="$(CULL_DAEMONS_JSON_OVERRIDE="$GAP_JSON" \
+    CULL_SPECIALTY_COUNTS_OVERRIDE='{"group_theory":1,"combinatorics":1,"number_theory":1}' \
+    CULL_NOW_MS_OVERRIDE=0 \
+    bash "$CULL" "$WORK_DIR" explorer --dry-run --bottom-pct 0.34 --min-explorers 3 --min-acting 0 2>&1 || true)"
+
+if printf '%s' "$GAP_OUT" | grep -Fq 'next daemon_id=5'; then
+    pass "8. DAEMON_ID gap allocation -- alive=1,2,4 -> respawn=5 (#650)"
+else
+    fail "8. DAEMON_ID gap allocation -- alive=1,2,4 -> respawn=5 (#650)" "$GAP_OUT"
+fi
+
+# --- Test 9 (#651): all-below-min-acting batch is a no-op.
+# Inject decisions where every row has entries_acting below --min-acting
+# (here driven by --min-acting=10 with the synthetic fixture's implicit
+# zero acting count). Assert zero cull/respawn ledger rows are emitted
+# even outside dry-run. The script writes to <fed_dir>/replication-
+# ledger.jsonl so we truncate that canonical path first to isolate from
+# prior tests, then assert it stays empty after the invocation.
+NOOP_LEDGER_PATH="$WORK_DIR/replication-ledger.jsonl"
+: > "$NOOP_LEDGER_PATH"
+
+CULL_DAEMONS_JSON_OVERRIDE="$SYNTH_JSON" \
+    CULL_SPECIALTY_COUNTS_OVERRIDE='{"group_theory":1,"combinatorics":1,"number_theory":1,"probability":1,"algebra":1}' \
+    CULL_NOW_MS_OVERRIDE=0 \
+    bash "$CULL" "$WORK_DIR" explorer --bottom-pct 0.4 --min-explorers 3 --min-acting 10 \
+    > "$WORK_DIR/noop.stdout" 2>&1 || true
+
+CULL_ROWS="$(grep -c '"event": "cull"' "$NOOP_LEDGER_PATH" 2>/dev/null | head -n 1 || true)"
+RESPAWN_ROWS="$(grep -c '"event": "respawn"' "$NOOP_LEDGER_PATH" 2>/dev/null | head -n 1 || true)"
+CULL_ROWS="${CULL_ROWS:-0}"
+RESPAWN_ROWS="${RESPAWN_ROWS:-0}"
+
+if [ "$CULL_ROWS" -eq 0 ] && [ "$RESPAWN_ROWS" -eq 0 ]; then
+    pass "9. all-below-min-acting -> no cull/respawn rows emitted (#651)"
+else
+    fail "9. all-below-min-acting -> no cull/respawn rows emitted (#651)" \
+        "cull=$CULL_ROWS respawn=$RESPAWN_ROWS ledger=$(cat "$NOOP_LEDGER_PATH" 2>/dev/null)"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fixes four LOW/MEDIUM-severity follow-ups from #646 in `tools/cull-replicas.sh` and `tools/test-cull-replicas.sh`.

## Summary

- Closes #647 — demand-weighted picker is now re-evaluated per respawn within a batch. Previously `NEXT_SPECIALTY` was computed once before the loop, so multi-pick batches respawned every replacement with the same specialty.
- Closes #649 — `--bottom-pct` is now validated to be a float in `[0.0, 1.0]`; out-of-range or non-numeric values exit `2` with a clear error. Prevents a misconfigured `RESEARCH_CULL_BOTTOM_PCT > 1.0` from mass-culling every replica (the respawn phase is M2-Malthusian-bounded but the kill phase is not).
- Closes #650 — new test `8.` asserts DAEMON_ID gap allocation: with daemon_id=[1,2,4] alive the respawn claims `max(existing)+1=5`, not the gap=3 nor the surviving 4. The test drives the path via a `daemon_id` field on the synthetic daemon-list JSON (production `agentis daemon list` does not emit this field, so no real-world behavior changes — the field is exclusively a test-harness affordance, same shape as `CULL_DAEMONS_JSON_OVERRIDE`).
- Closes #651 — new test `9.` asserts an all-below-min-acting batch is a no-op: synthetic fed with `entries_acting=0` and `--min-acting=10` emits zero `cull`/`respawn` ledger rows.

## Layout

Two chunks:
- `de6a844 fix(cull-replicas): per-respawn demand-weighted re-eval + --bottom-pct bounds check (#647 #649)`
- `4f514a8 test(cull-replicas): assert DAEMON_ID gap allocation + all-below-min-acting no-op (#650 #651)`

## Test plan

- [x] `bash tools/test-cull-replicas.sh` — 12 passed, 0 failed (added 2 cases on top of existing 10).
- [x] `bash tools/colony-lint.sh` — 337 passed, 0 failed, 4 skipped. (Note: `test-llm-per-colony.sh` flaked once in cross-test runs but passes in isolation and on retry of the full lint — pre-existing intermittent, unrelated to this PR.)
- [x] Manual smoke: `--bottom-pct 1.5` / `-0.1` / `foo` → exit 2 with the right error; `--bottom-pct 0.5` valid.
- [x] Manual smoke: 5-explorer fed with `--bottom-pct 0.5` (3 respawns) confirms three distinct specialties picked across the batch (group_theory → combinatorics → number_theory), demonstrating per-respawn re-eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)