### PR TITLE
fix(tier-branches): remove duplicate learn() in _publish_<role> helpers (#636)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -174,7 +174,8 @@ fn _publish_arxiv_search(
     tick_now_ms: int,
     problem_text: string,
     stated_answer: string,
-    novelty_claim: string
+    novelty_claim: string,
+    my_tier: string
 ) -> void {
     let _ = final_write;
     // Iteration over queries lives in Python because the .ag
@@ -217,7 +218,9 @@ fn _publish_arxiv_search(
     memo_write("replay:current_arxiv_search_pid", self_pid);
     emit("arxiv-search:report_ready", report);
 
-    learn("arxiv-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+    if my_tier == "propose" {
+        learn("arxiv-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+    };
 
     // Phase 9 PR-C (#663): per-pid fitness tracking. +1 when the
     // search returned hits, 0 otherwise. PR-D may refine.
@@ -345,15 +348,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("arxiv_search:" + _self_pid + ":review_gated", "true");
         learn("arxiv-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["acted", "claim-auditor"]);
-        _publish_arxiv_search(true, true, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+        _publish_arxiv_search(true, true, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("arxiv_search:" + _self_pid + ":review_gated", "true");
             learn("arxiv-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["review-gated", "claim-auditor"]);
-            _publish_arxiv_search(true, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+            _publish_arxiv_search(true, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_arxiv_search(false, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+                _publish_arxiv_search(false, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
             } else {
                 print("[arxiv-search] observing (tier:", my_tier, ") rationale=", queries.rationale);
                 learn("arxiv-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["observed", "claim-auditor"]);

--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -242,7 +242,8 @@ fn _publish_auditor(
     oeis_report: string,
     groupprops_report: string,
     scholar_report: string,
-    prior_advocate_report: string
+    prior_advocate_report: string,
+    my_tier: string
 ) -> void {
     let conf_str = to_string(verdict.confidence);
     let verdict_json = "{\"audit_verdict\":\"" + verdict.audit_verdict
@@ -317,7 +318,9 @@ fn _publish_auditor(
     };
 
     emit("auditor:verdict_ready", verdict);
-    learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "success", ["emitted", "claim-auditor"]);
+    if my_tier == "propose" {
+        learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "success", ["emitted", "claim-auditor"]);
+    };
 
     // Phase 9 PR-C (#663): per-pid fitness tracking. +1 on decisive
     // verdict (VERIFIED_NEW or KNOWN_PRIOR), 0 on NEEDS_HUMAN.
@@ -481,14 +484,14 @@ fn tick(reason: string) -> void {
         // `autonomous_decision=true` for downstream observers (#622).
         memo_write("auditor:" + _self_pid + ":autonomous_decision", "true");
         learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "partial", ["acted", "claim-auditor"]);
-        _publish_auditor(true, true, true, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report, prior_advocate_report);
+        _publish_auditor(true, true, true, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report, prior_advocate_report, my_tier);
     } else {
         if my_tier == "review-gated" {
             learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "partial", ["review-gated", "claim-auditor"]);
-            _publish_auditor(true, false, false, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report, prior_advocate_report);
+            _publish_auditor(true, false, false, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report, prior_advocate_report, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_auditor(false, false, false, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report, prior_advocate_report);
+                _publish_auditor(false, false, false, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, source_run, source_tick, source_pid, arxiv_report, oeis_report, groupprops_report, scholar_report, prior_advocate_report, my_tier);
             } else {
                 print("[auditor] observing (tier:", my_tier, ") verdict=", verdict.audit_verdict);
                 learn("audit", "tick " + to_string(tick_idx) + " " + verdict.audit_verdict, verdict.reasoning, "partial", ["observed", "claim-auditor"]);

--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -142,7 +142,8 @@ fn _publish_computer(
     _colony_name: string,
     upstream_tick: int,
     tick_idx: int,
-    tick_now_ms: int
+    tick_now_ms: int,
+    my_tier: string
 ) -> void {
     let _ = final_write;
     let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
@@ -183,7 +184,9 @@ fn _publish_computer(
     emit("computer:script_ready", script);
     emit("computer:output_ready", script);
 
-    learn("compute", "tick " + to_string(tick_idx), "runs_ok=" + runs_ok_str + " lang=" + lang, "success", ["emitted", "preprint-foundry"]);
+    if my_tier == "propose" {
+        learn("compute", "tick " + to_string(tick_idx), "runs_ok=" + runs_ok_str + " lang=" + lang, "success", ["emitted", "preprint-foundry"]);
+    };
 
     if len(self_pid) > 0 {
         let fit_pre = parse_int(recall_latest("computer:" + self_pid + ":fitness"));
@@ -312,15 +315,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("computer:" + _self_pid + ":review_gated", "true");
         learn("compute", "tick " + to_string(tick_idx), script.rationale, "partial", ["acted", "preprint-foundry"]);
-        _publish_computer(true, true, script, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+        _publish_computer(true, true, script, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("computer:" + _self_pid + ":review_gated", "true");
             learn("compute", "tick " + to_string(tick_idx), script.rationale, "partial", ["review-gated", "preprint-foundry"]);
-            _publish_computer(true, false, script, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+            _publish_computer(true, false, script, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_computer(false, false, script, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+                _publish_computer(false, false, script, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
             } else {
                 print("[computer] observing (tier:", my_tier, ") rationale=", script.rationale);
                 learn("compute", "tick " + to_string(tick_idx), script.rationale, "partial", ["observed", "preprint-foundry"]);

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -248,7 +248,8 @@ fn _publish_editor(
     _colony_name: string,
     upstream_tick: int,
     tick_idx: int,
-    tick_now_ms: int
+    tick_now_ms: int,
+    my_tier: string
 ) -> void {
     let _ = final_write;
     let claim_id = recall_latest("claim:claim_id:tick-" + to_string(upstream_tick));
@@ -357,7 +358,9 @@ fn _publish_editor(
     emit("editor:final_tex_ready", edit);
     emit("editor:compile_log_ready", edit);
 
-    learn("edit", "tick " + to_string(tick_idx), "compile_ok=" + compile_ok_str + " halluc=" + halluc_str, "success", ["emitted", "preprint-foundry"]);
+    if my_tier == "propose" {
+        learn("edit", "tick " + to_string(tick_idx), "compile_ok=" + compile_ok_str + " halluc=" + halluc_str, "success", ["emitted", "preprint-foundry"]);
+    };
 
     // Phase 9 PR-C (#663): per-pid fitness tracking. +1 on
     // compile_ok_final=true, 0 otherwise (matches the preprint-side
@@ -511,15 +514,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("editor:" + _self_pid + ":review_gated", "true");
         learn("edit", "tick " + to_string(tick_idx), edit.rationale, "partial", ["acted", "preprint-foundry"]);
-        _publish_editor(true, true, edit, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+        _publish_editor(true, true, edit, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("editor:" + _self_pid + ":review_gated", "true");
             learn("edit", "tick " + to_string(tick_idx), edit.rationale, "partial", ["review-gated", "preprint-foundry"]);
-            _publish_editor(true, false, edit, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+            _publish_editor(true, false, edit, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_editor(false, false, edit, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+                _publish_editor(false, false, edit, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
             } else {
                 print("[editor] observing (tier:", my_tier, ") rationale=", edit.rationale);
                 learn("edit", "tick " + to_string(tick_idx), edit.rationale, "partial", ["observed", "preprint-foundry"]);

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -222,7 +222,8 @@ fn _publish_formulator(
     upstream_tick: int,
     tick_idx: int,
     tick_now_ms: int,
-    topic_label: string
+    topic_label: string,
+    my_tier: string
 ) -> void {
     let self_conf_str = to_string(problem.self_check_confidence);
     let problem_json = "{\"problem\":\"" + problem.problem
@@ -248,7 +249,9 @@ fn _publish_formulator(
         };
     };
 
-    learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, "answer=" + problem.answer, "success", ["emitted", "math-foundry"]);
+    if my_tier == "propose" {
+        learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, "answer=" + problem.answer, "success", ["emitted", "math-foundry"]);
+    };
 
     // Phase 9 PR-C (#663): per-pid fitness tracking. +1 when the
     // self_check_confidence is above 0.5 (formulator believed in the
@@ -412,15 +415,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("formulator:" + _self_pid + ":review_gated", "true");
         learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, problem.novelty_claim, "partial", ["acted", "math-foundry"]);
-        _publish_formulator(true, true, problem, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label);
+        _publish_formulator(true, true, problem, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("formulator:" + _self_pid + ":review_gated", "true");
             learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, problem.novelty_claim, "partial", ["review-gated", "math-foundry"]);
-            _publish_formulator(true, false, problem, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label);
+            _publish_formulator(true, false, problem, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_formulator(false, false, problem, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label);
+                _publish_formulator(false, false, problem, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label, my_tier);
             } else {
                 print("[formulator] observing (tier:", my_tier, ") novelty_claim=", problem.novelty_claim);
                 learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, problem.novelty_claim, "partial", ["observed", "math-foundry"]);

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -162,7 +162,8 @@ fn _publish_groupprops_search(
     tick_now_ms: int,
     problem_text: string,
     stated_answer: string,
-    novelty_claim: string
+    novelty_claim: string,
+    my_tier: string
 ) -> void {
     let _ = final_write;
     let queries_json = queries.queries_json;
@@ -197,7 +198,9 @@ fn _publish_groupprops_search(
     memo_write("replay:current_groupprops_search_pid", self_pid);
     emit("groupprops-search:report_ready", report);
 
-    learn("groupprops-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+    if my_tier == "propose" {
+        learn("groupprops-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+    };
 
     if len(self_pid) > 0 {
         let fit_pre = parse_int(recall_latest("groupprops-search:" + self_pid + ":fitness"));
@@ -321,15 +324,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("groupprops_search:" + _self_pid + ":review_gated", "true");
         learn("groupprops-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["acted", "claim-auditor"]);
-        _publish_groupprops_search(true, true, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+        _publish_groupprops_search(true, true, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("groupprops_search:" + _self_pid + ":review_gated", "true");
             learn("groupprops-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["review-gated", "claim-auditor"]);
-            _publish_groupprops_search(true, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+            _publish_groupprops_search(true, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_groupprops_search(false, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+                _publish_groupprops_search(false, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
             } else {
                 print("[groupprops-search] observing (tier:", my_tier, ") rationale=", queries.rationale);
                 learn("groupprops-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["observed", "claim-auditor"]);

--- a/research-foundry/introducer/agents/introducer.ag
+++ b/research-foundry/introducer/agents/introducer.ag
@@ -151,7 +151,8 @@ fn _publish_introducer(
     _colony_name: string,
     upstream_tick: int,
     tick_idx: int,
-    tick_now_ms: int
+    tick_now_ms: int,
+    my_tier: string
 ) -> void {
     let _ = final_write;
     memo_write("introducer:" + self_pid + ":abstract:tick-" + to_string(upstream_tick), draft.abstract_tex);
@@ -164,7 +165,9 @@ fn _publish_introducer(
     emit("introducer:abstract_ready", draft);
     emit("introducer:intro_ready", draft);
 
-    learn("introduce", "tick " + to_string(tick_idx), "abstract+intro emitted", "success", ["emitted", "preprint-foundry"]);
+    if my_tier == "propose" {
+        learn("introduce", "tick " + to_string(tick_idx), "abstract+intro emitted", "success", ["emitted", "preprint-foundry"]);
+    };
 
     if len(self_pid) > 0 {
         let fit_pre = parse_int(recall_latest("introducer:" + self_pid + ":fitness"));
@@ -304,15 +307,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("introducer:" + _self_pid + ":review_gated", "true");
         learn("introduce", "tick " + to_string(tick_idx), draft.rationale, "partial", ["acted", "preprint-foundry"]);
-        _publish_introducer(true, true, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+        _publish_introducer(true, true, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("introducer:" + _self_pid + ":review_gated", "true");
             learn("introduce", "tick " + to_string(tick_idx), draft.rationale, "partial", ["review-gated", "preprint-foundry"]);
-            _publish_introducer(true, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+            _publish_introducer(true, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_introducer(false, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+                _publish_introducer(false, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
             } else {
                 print("[introducer] observing (tier:", my_tier, ") rationale=", draft.rationale);
                 learn("introduce", "tick " + to_string(tick_idx), draft.rationale, "partial", ["observed", "preprint-foundry"]);

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -175,7 +175,8 @@ fn _publish_noticer(
     _colony_name: string,
     upstream_tick: int,
     tick_idx: int,
-    tick_now_ms: int
+    tick_now_ms: int,
+    my_tier: string
 ) -> void {
     let _ = final_write;
     let conf_str = to_string(surprise.confidence_in_surprise);
@@ -197,7 +198,9 @@ fn _publish_noticer(
         memo_write("noticer:" + self_pid + ":fitness", to_string(fit_pre + fit_delta));
     };
 
-    learn("notice", "tick " + to_string(tick_idx), "surprise_found=" + surprise_found_str, "success", ["emitted", "math-foundry"]);
+    if my_tier == "propose" {
+        learn("notice", "tick " + to_string(tick_idx), "surprise_found=" + surprise_found_str, "success", ["emitted", "math-foundry"]);
+    };
 
     // Phase 9 PR-C (#663): M2-Malthusian replicate gate -- autonomous tier only.
     if do_replicate {
@@ -324,15 +327,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("noticer:" + _self_pid + ":review_gated", "true");
         learn("notice", "tick " + to_string(tick_idx), surprise.surprise_description, "partial", ["acted", "math-foundry"]);
-        _publish_noticer(true, true, surprise, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+        _publish_noticer(true, true, surprise, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("noticer:" + _self_pid + ":review_gated", "true");
             learn("notice", "tick " + to_string(tick_idx), surprise.surprise_description, "partial", ["review-gated", "math-foundry"]);
-            _publish_noticer(true, false, surprise, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+            _publish_noticer(true, false, surprise, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_noticer(false, false, surprise, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+                _publish_noticer(false, false, surprise, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
             } else {
                 print("[noticer] observing (tier:", my_tier, ") surprise_found=", surprise.surprise_found);
                 learn("notice", "tick " + to_string(tick_idx), surprise.surprise_description, "partial", ["observed", "math-foundry"]);

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -186,7 +186,8 @@ fn _publish_novelty(
     novelty_claim: string,
     upstream_tick: int,
     tick_idx: int,
-    tick_now_ms: int
+    tick_now_ms: int,
+    my_tier: string
 ) -> void {
     let classical_str = if novelty.is_classical_result { "true"; } else { "false"; };
     let novelty_json = "{\"is_classical_result\":" + classical_str
@@ -249,7 +250,9 @@ fn _publish_novelty(
     };
 
     emit("math-foundry:novelty_done", novelty);
-    learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "success", ["emitted", "math-foundry"]);
+    if my_tier == "propose" {
+        learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "success", ["emitted", "math-foundry"]);
+    };
 
     // Phase 9 PR-C (#663): per-pid fitness tracking. +2 NOVEL,
     // +1 BORDERLINE, -1 NOT_NOVEL.
@@ -410,14 +413,14 @@ fn tick(reason: string) -> void {
         // `autonomous_decision=true` flag for downstream auditors (#622).
         memo_write("novelty:" + _self_pid + ":autonomous_decision", "true");
         learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "partial", ["acted", "math-foundry"]);
-        _publish_novelty(true, true, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, upstream_tick, tick_idx, _tick_now_ms);
+        _publish_novelty(true, true, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, upstream_tick, tick_idx, _tick_now_ms, my_tier);
     } else {
         if my_tier == "review-gated" {
             learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "partial", ["review-gated", "math-foundry"]);
-            _publish_novelty(true, false, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, upstream_tick, tick_idx, _tick_now_ms);
+            _publish_novelty(true, false, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, upstream_tick, tick_idx, _tick_now_ms, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_novelty(false, false, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, upstream_tick, tick_idx, _tick_now_ms);
+                _publish_novelty(false, false, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, upstream_tick, tick_idx, _tick_now_ms, my_tier);
             } else {
                 print("[novelty] observing (tier:", my_tier, ") verdict=", novelty.novelty_verdict);
                 learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "partial", ["observed", "math-foundry"]);

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -169,7 +169,8 @@ fn _publish_oeis_search(
     tick_now_ms: int,
     problem_text: string,
     stated_answer: string,
-    novelty_claim: string
+    novelty_claim: string,
+    my_tier: string
 ) -> void {
     let _ = final_write;
     let sequences_json = sequences.sequences_json;
@@ -204,7 +205,9 @@ fn _publish_oeis_search(
     memo_write("replay:current_oeis_search_pid", self_pid);
     emit("oeis-search:report_ready", report);
 
-    learn("oeis-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+    if my_tier == "propose" {
+        learn("oeis-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+    };
 
     // Phase 9 PR-C (#663): per-pid fitness tracking.
     if len(self_pid) > 0 {
@@ -330,15 +333,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("oeis_search:" + _self_pid + ":review_gated", "true");
         learn("oeis-search", "tick " + to_string(tick_idx), sequences.rationale, "partial", ["acted", "claim-auditor"]);
-        _publish_oeis_search(true, true, sequences, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+        _publish_oeis_search(true, true, sequences, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("oeis_search:" + _self_pid + ":review_gated", "true");
             learn("oeis-search", "tick " + to_string(tick_idx), sequences.rationale, "partial", ["review-gated", "claim-auditor"]);
-            _publish_oeis_search(true, false, sequences, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+            _publish_oeis_search(true, false, sequences, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_oeis_search(false, false, sequences, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+                _publish_oeis_search(false, false, sequences, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
             } else {
                 print("[oeis-search] observing (tier:", my_tier, ") rationale=", sequences.rationale);
                 learn("oeis-search", "tick " + to_string(tick_idx), sequences.rationale, "partial", ["observed", "claim-auditor"]);

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -166,7 +166,8 @@ fn _publish_scholar_search(
     tick_now_ms: int,
     problem_text: string,
     stated_answer: string,
-    novelty_claim: string
+    novelty_claim: string,
+    my_tier: string
 ) -> void {
     let _ = final_write;
     let queries_json = queries.queries_json;
@@ -203,7 +204,9 @@ fn _publish_scholar_search(
     memo_write("replay:current_scholar_search_pid", self_pid);
     emit("scholar-search:report_ready", report);
 
-    learn("scholar-search", "tick " + to_string(tick_idx), "status=" + report.status + " matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+    if my_tier == "propose" {
+        learn("scholar-search", "tick " + to_string(tick_idx), "status=" + report.status + " matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+    };
 
     if len(self_pid) > 0 {
         let fit_pre = parse_int(recall_latest("scholar-search:" + self_pid + ":fitness"));
@@ -327,15 +330,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("scholar_search:" + _self_pid + ":review_gated", "true");
         learn("scholar-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["acted", "claim-auditor"]);
-        _publish_scholar_search(true, true, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+        _publish_scholar_search(true, true, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("scholar_search:" + _self_pid + ":review_gated", "true");
             learn("scholar-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["review-gated", "claim-auditor"]);
-            _publish_scholar_search(true, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+            _publish_scholar_search(true, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_scholar_search(false, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim);
+                _publish_scholar_search(false, false, queries, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
             } else {
                 print("[scholar-search] observing (tier:", my_tier, ") rationale=", queries.rationale);
                 learn("scholar-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["observed", "claim-auditor"]);

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -205,7 +205,8 @@ fn _submitter_draft_phase(
     cat_seed: string,
     repro_script: string,
     repro_output: string,
-    repro_lang: string
+    repro_lang: string,
+    my_tier: string
 ) -> void {
     let ctx = "FINAL TEX:\n" + final_tex + "\n"
             + "COMPILE LOG:\n" + compile_log + "\n"
@@ -288,7 +289,9 @@ fn _submitter_draft_phase(
     emit("submitter:metadata_ready", meta);
     emit("submitter:status_ready", meta);
 
-    learn("submit", "tick " + to_string(tick_idx) + " DRAFTED " + claim_id_eff, meta.rationale, "success", ["emitted", "preprint-foundry", "hitl-gated"]);
+    if my_tier == "propose" {
+        learn("submit", "tick " + to_string(tick_idx) + " DRAFTED " + claim_id_eff, meta.rationale, "success", ["emitted", "preprint-foundry", "hitl-gated"]);
+    };
 
     // Phase 9 PR-C (#663): per-pid fitness tracking. +1 per DRAFTED
     // row (PR-D folds in the eventual HITL accept signal).
@@ -409,7 +412,8 @@ fn _handle_hitl_reject(
     upstream_tick: int,
     tick_idx: int,
     tick_now_ms: int,
-    claim_id_eff: string
+    claim_id_eff: string,
+    my_tier: string
 ) -> void {
     let reason_raw = recall_latest("submitter:" + claim_id_eff + ":human_reject_reason");
     let ledger_path3 = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
@@ -434,7 +438,9 @@ fn _handle_hitl_reject(
     _push_hitl_reject(claim_id_eff, classification, reason_raw, tick_idx);
 
     emit("submitter:status_ready", "HUMAN_REJECTED");
-    learn("submit", "tick " + to_string(tick_idx) + " HUMAN_REJECTED " + claim_id_eff, "human declined", "partial", ["emitted", "preprint-foundry", "hitl-gated"]);
+    if my_tier == "propose" {
+        learn("submit", "tick " + to_string(tick_idx) + " HUMAN_REJECTED " + claim_id_eff, "human declined", "partial", ["emitted", "preprint-foundry", "hitl-gated"]);
+    };
 }
 
 // _submitter_send_phase -- terminal SMTP send. Mails the tarball via
@@ -447,7 +453,8 @@ fn _submitter_send_phase(
     tick_idx: int,
     tick_now_ms: int,
     claim_id_eff: string,
-    claim_dir: string
+    claim_dir: string,
+    my_tier: string
 ) -> void {
     let gateway = try { exec sh "printenv PREPRINT_ARXIV_GATEWAY"; } catch e { ""; };
     let from_addr = try { exec sh "printenv PREPRINT_ARXIV_FROM"; } catch e { ""; };
@@ -477,7 +484,9 @@ fn _submitter_send_phase(
     memo_write("submitter:" + claim_id_eff + ":submitted", to_string(tick_now_ms));
     memo_write("submitter:" + self_pid + ":status:tick-" + to_string(upstream_tick), "SUBMITTED");
     emit("submitter:status_ready", send_out);
-    learn("submit", "tick " + to_string(tick_idx) + " SUBMITTED " + claim_id_eff, send_out, "success", ["emitted", "preprint-foundry", "hitl-gated"]);
+    if my_tier == "propose" {
+        learn("submit", "tick " + to_string(tick_idx) + " SUBMITTED " + claim_id_eff, send_out, "success", ["emitted", "preprint-foundry", "hitl-gated"]);
+    };
 }
 
 fn tick(reason: string) -> void {
@@ -585,13 +594,13 @@ fn tick(reason: string) -> void {
         memo_write("submitter:" + claim_id_eff + ":autonomous_decision", "true");
         learn("submit", "tick " + to_string(tick_idx), "tier=autonomous", "partial", ["acted", "preprint-foundry"]);
         if len(already_drafted) == 0 {
-            _submitter_draft_phase(false, true, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, compile_ok, source_audit_run, final_tex, compile_log, title_seed, msc_seed, cat_seed, repro_script, repro_output, repro_lang);
+            _submitter_draft_phase(false, true, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, compile_ok, source_audit_run, final_tex, compile_log, title_seed, msc_seed, cat_seed, repro_script, repro_output, repro_lang, my_tier);
         };
         if len(already_submitted) > 0 {
             print("[submitter] already submitted claim=", claim_id_eff);
             learn("submit", "tick " + to_string(tick_idx) + " noop " + claim_id_eff, "already submitted", "partial", ["observed", "preprint-foundry", "hitl-gated"]);
         } else {
-            _submitter_send_phase(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir);
+            _submitter_send_phase(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, my_tier);
         };
     } else {
         if my_tier == "review-gated" {
@@ -600,7 +609,7 @@ fn tick(reason: string) -> void {
             // submission is waiting on a human decision (#622).
             learn("submit", "tick " + to_string(tick_idx), "tier=review-gated", "partial", ["review-gated", "preprint-foundry"]);
             if len(already_drafted) == 0 {
-                _submitter_draft_phase(true, false, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, compile_ok, source_audit_run, final_tex, compile_log, title_seed, msc_seed, cat_seed, repro_script, repro_output, repro_lang);
+                _submitter_draft_phase(true, false, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, compile_ok, source_audit_run, final_tex, compile_log, title_seed, msc_seed, cat_seed, repro_script, repro_output, repro_lang, my_tier);
             } else {
                 // Phase B: DRAFTED already exists -- observe HITL flag and act
                 // only on explicit human approval. NEVER auto-submit.
@@ -609,11 +618,11 @@ fn tick(reason: string) -> void {
                         print("[submitter] already submitted claim=", claim_id_eff);
                         learn("submit", "tick " + to_string(tick_idx) + " noop " + claim_id_eff, "already submitted", "partial", ["observed", "preprint-foundry", "hitl-gated"]);
                     } else {
-                        _submitter_send_phase(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir);
+                        _submitter_send_phase(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, my_tier);
                     };
                 } else {
                     if human_status == "rejected" {
-                        _handle_hitl_reject(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff);
+                        _handle_hitl_reject(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, my_tier);
                     } else {
                         // No human decision yet -- idle.
                         print("[submitter] DRAFTED awaiting human approval claim=", claim_id_eff);
@@ -625,7 +634,7 @@ fn tick(reason: string) -> void {
             if my_tier == "propose" {
                 // Phase A: produce DRAFTED row (idempotent: skip when already drafted).
                 if len(already_drafted) == 0 {
-                    _submitter_draft_phase(false, false, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, compile_ok, source_audit_run, final_tex, compile_log, title_seed, msc_seed, cat_seed, repro_script, repro_output, repro_lang);
+                    _submitter_draft_phase(false, false, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, compile_ok, source_audit_run, final_tex, compile_log, title_seed, msc_seed, cat_seed, repro_script, repro_output, repro_lang, my_tier);
                 } else {
                     // Phase B: DRAFTED already exists -- observe HITL flag and act
                     // only on explicit human approval. NEVER auto-submit.
@@ -634,11 +643,11 @@ fn tick(reason: string) -> void {
                             print("[submitter] already submitted claim=", claim_id_eff);
                             learn("submit", "tick " + to_string(tick_idx) + " noop " + claim_id_eff, "already submitted", "partial", ["observed", "preprint-foundry", "hitl-gated"]);
                         } else {
-                            _submitter_send_phase(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir);
+                            _submitter_send_phase(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, claim_dir, my_tier);
                         };
                     } else {
                         if human_status == "rejected" {
-                            _handle_hitl_reject(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff);
+                            _handle_hitl_reject(_self_pid, upstream_tick, tick_idx, _tick_now_ms, claim_id_eff, my_tier);
                         } else {
                             // No human decision yet -- idle.
                             print("[submitter] DRAFTED awaiting human approval claim=", claim_id_eff);

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -143,7 +143,8 @@ fn _publish_theorist(
     _colony_name: string,
     upstream_tick: int,
     tick_idx: int,
-    tick_now_ms: int
+    tick_now_ms: int,
+    my_tier: string
 ) -> void {
     let _ = final_write;
     memo_write("theorist:" + self_pid + ":definitions:tick-" + to_string(upstream_tick), draft.definitions_tex);
@@ -155,7 +156,9 @@ fn _publish_theorist(
 
     emit("theorist:main_ready", draft);
 
-    learn("theorise", "tick " + to_string(tick_idx), "proof_kind=" + draft.proof_kind, "success", ["emitted", "preprint-foundry"]);
+    if my_tier == "propose" {
+        learn("theorise", "tick " + to_string(tick_idx), "proof_kind=" + draft.proof_kind, "success", ["emitted", "preprint-foundry"]);
+    };
 
     if len(self_pid) > 0 {
         let fit_pre = parse_int(recall_latest("theorist:" + self_pid + ":fitness"));
@@ -285,15 +288,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("theorist:" + _self_pid + ":review_gated", "true");
         learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["acted", "preprint-foundry"]);
-        _publish_theorist(true, true, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+        _publish_theorist(true, true, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("theorist:" + _self_pid + ":review_gated", "true");
             learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["review-gated", "preprint-foundry"]);
-            _publish_theorist(true, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+            _publish_theorist(true, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_theorist(false, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+                _publish_theorist(false, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
             } else {
                 print("[theorist] observing (tier:", my_tier, ") rationale=", draft.rationale);
                 learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["observed", "preprint-foundry"]);

--- a/research-foundry/verifier/agents/verifier.ag
+++ b/research-foundry/verifier/agents/verifier.ag
@@ -190,7 +190,8 @@ fn _publish_verifier(
     _colony_name: string,
     upstream_tick: int,
     tick_idx: int,
-    tick_now_ms: int
+    tick_now_ms: int,
+    my_tier: string
 ) -> void {
     let _ = final_write;
     let agree_str = if verdict.answers_agree { "true"; } else { "false"; };
@@ -207,10 +208,14 @@ fn _publish_verifier(
 
     if verdict.verdict == "ACCEPT" {
         emit("math-foundry:verified", verdict);
-        learn("verify", "tick " + to_string(tick_idx) + " ACCEPT", verdict.reasoning, "success", ["emitted", "math-foundry"]);
+        if my_tier == "propose" {
+            learn("verify", "tick " + to_string(tick_idx) + " ACCEPT", verdict.reasoning, "success", ["emitted", "math-foundry"]);
+        };
     } else {
         emit("math-foundry:verifier_rejected", verdict);
-        learn("verify", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "failure", ["emitted", "math-foundry"]);
+        if my_tier == "propose" {
+            learn("verify", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "failure", ["emitted", "math-foundry"]);
+        };
     };
 
     // Phase 9 PR-C (#663): per-pid fitness tracking.
@@ -346,15 +351,15 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("verifier:" + _self_pid + ":review_gated", "true");
         learn("verify", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "partial", ["acted", "math-foundry"]);
-        _publish_verifier(true, true, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+        _publish_verifier(true, true, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("verifier:" + _self_pid + ":review_gated", "true");
             learn("verify", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "partial", ["review-gated", "math-foundry"]);
-            _publish_verifier(true, false, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+            _publish_verifier(true, false, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_verifier(false, false, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+                _publish_verifier(false, false, verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
             } else {
                 print("[verifier] observing (tier:", my_tier, ") verdict=", verdict.verdict);
                 learn("verify", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "partial", ["observed", "math-foundry"]);

--- a/tools/check-no-duplicate-learn.sh
+++ b/tools/check-no-duplicate-learn.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# check-no-duplicate-learn.sh: fail if any research-foundry .ag helper
+# (`fn _publish_<role>(...)` or `fn _submitter_*(...)`) emits an
+# unconditional top-level `learn(..., ["emitted", ...])` row.
+#
+# Background (#636): at the `autonomous` and `review-gated` tiers the
+# tick branch emits a `learn(..., ["acted" | "review-gated", ...])`
+# row, then calls `_publish_<role>(...)`. If that helper also emits
+# an unconditional `learn(..., ["emitted", ...])` row, ACTING-tagged
+# rows inflate 2x per tick because `acted`, `review-gated`, and
+# `emitted` all live in `ACTING_TAGS` in auto-promote-decisions.py.
+#
+# Fix pattern: gate the helper's `learn()` on `if my_tier == "propose"`.
+# This check enforces that every `learn(..., ["emitted", ...])` row
+# inside a `_publish_*` / `_submitter_*` helper body is wrapped in an
+# `if my_tier == "propose"` block.
+#
+# Usage: ./tools/check-no-duplicate-learn.sh [path-to-repo-root-or-file]
+# Exit 0 if clean, 1 if a violation is found.
+#
+# Accepts either a repo root (scans research-foundry/ recursively) or a
+# single .ag file path (single-file mode for unit-test fixtures).
+#
+# Runs on bash 3.2+ (stock macOS /bin/bash) and bash 4+.
+
+set -euo pipefail
+
+SCAN_ARG="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Single-file mode: target is a regular .ag file.
+if [ -f "$SCAN_ARG" ]; then
+    files=("$SCAN_ARG")
+else
+    TARGET_DIR="$SCAN_ARG/research-foundry"
+    if [ ! -d "$TARGET_DIR" ]; then
+        # No research-foundry tree to scan -- treat as clean.
+        exit 0
+    fi
+    files=()
+    while IFS= read -r -d '' ag_file; do
+        files+=("$ag_file")
+    done < <(find "$TARGET_DIR" -type f -name "*.ag" -print0 2>/dev/null)
+fi
+
+violations=0
+
+# scan_file <path>
+# For each `fn _publish_<role>(...) -> ... { ... }` or
+# `fn _submitter_<phase>(...) -> ... { ... }` block in the file,
+# verify that every `learn(..., ["emitted", ...])` call inside the
+# helper body is wrapped in an `if my_tier == "propose"` block.
+#
+# The body is defined as the lines between the `fn` opening brace
+# and the matching closing brace at column 1 (top-level `}`).
+scan_file() {
+    local ag_file="$1"
+    python3 - "$ag_file" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+with open(path, 'r', encoding='utf-8') as f:
+    lines = f.readlines()
+
+# Find every `fn _publish_<role>(` or `fn _submitter_<phase>(` line.
+fn_re = re.compile(r'^fn (_publish_[a-z_]+|_submitter_[a-z_]+)\s*\(')
+learn_re = re.compile(r'\blearn\s*\(')
+emitted_tag_re = re.compile(r'"emitted"')
+gate_re = re.compile(r'\bif\s+my_tier\s*==\s*"propose"')
+
+# A `_publish_prompt_body_and_wrap_variant` helper exists in every
+# .ag file but never calls learn() -- skip it.
+SKIP_HELPERS = {"_publish_prompt_body_and_wrap_variant"}
+
+violations = []
+
+i = 0
+n = len(lines)
+while i < n:
+    line = lines[i]
+    m = fn_re.match(line)
+    if not m:
+        i += 1
+        continue
+    helper = m.group(1)
+    if helper in SKIP_HELPERS:
+        i += 1
+        continue
+
+    # Walk forward to the opening `{` of the helper body.
+    body_start = None
+    j = i
+    while j < n:
+        if '{' in lines[j]:
+            body_start = j
+            break
+        j += 1
+    if body_start is None:
+        i += 1
+        continue
+
+    # Walk forward to the matching top-level `}` (column 1).
+    body_end = None
+    k = body_start + 1
+    while k < n:
+        if lines[k].startswith('}'):
+            body_end = k
+            break
+        k += 1
+    if body_end is None:
+        i += 1
+        continue
+
+    # Scan body for learn() rows that include an "emitted" tag. The
+    # tag list may span multiple lines (rare; not in today's codebase),
+    # so the per-line `learn(...` match is paired with a per-line
+    # `"emitted"` literal match -- both must be on the same line, since
+    # every `learn(..., ["emitted", ...])` row in research-foundry/
+    # today is single-line.
+    for li in range(body_start, body_end + 1):
+        text = lines[li]
+        if not learn_re.search(text):
+            continue
+        if not emitted_tag_re.search(text):
+            continue
+        # Walk upward to find an `if my_tier == "propose"` gate. If we
+        # hit the helper start without seeing one, the learn() is
+        # unconditional from the helper's perspective -- a #636
+        # violation. The walk does not try to track brace nesting; the
+        # canonical fix wraps the learn() in a one-line gate immediately
+        # preceding it, which this loop catches.
+        gated = False
+        for back in range(li, body_start - 1, -1):
+            if gate_re.search(lines[back]):
+                gated = True
+                break
+        if not gated:
+            violations.append((path, li + 1, helper, lines[li].rstrip()))
+
+    i = body_end + 1
+
+if violations:
+    for v in violations:
+        print(f"[FAIL] {v[0]}:{v[1]} helper={v[2]} unconditional emitted learn(): {v[3].strip()}")
+    sys.exit(1)
+PY
+}
+
+if [ ${#files[@]} -gt 0 ]; then
+    for ag_file in "${files[@]}"; do
+        if ! scan_file "$ag_file"; then
+            violations=$((violations + 1))
+        fi
+    done
+fi
+
+if [ "$violations" -eq 0 ]; then
+    exit 0
+fi
+
+echo ""
+echo 'Issue #636: tier-branch helpers must gate their learn(..., ["emitted", ...])'
+echo 'row on if my_tier == "propose". At autonomous / review-gated tiers, the'
+echo 'inline tier branch already emits an acted/review-gated row; an unconditional'
+echo 'helper-level emitted row inflates the ACTING_TAGS row count 2x per tick.'
+exit 1

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -636,6 +636,23 @@ if [ -x "$REPO_ROOT/tools/check-no-replay-current-pid.sh" ]; then
     fi
 fi
 
+# --- tier-branch double learn() guard (#636) ---
+# Every `_publish_<role>(...)` / `_submitter_<phase>(...)` helper in
+# research-foundry/ must gate its top-level `learn(..., ["emitted", ...])`
+# row on `if my_tier == "propose"`. At autonomous / review-gated tiers
+# the inline tier branch already emits an acted / review-gated row; an
+# unconditional helper-level emitted row inflates the ACTING_TAGS row
+# count 2x per tick once auto-promote starts firing.
+if [ -x "$REPO_ROOT/tools/check-no-duplicate-learn.sh" ]; then
+    check_out="$("$REPO_ROOT/tools/check-no-duplicate-learn.sh" "$REPO_ROOT" 2>&1)" && check_rc=0 || check_rc=$?
+    if [ "$check_rc" -eq 0 ]; then
+        pass "check-no-duplicate-learn: research-foundry helpers gate emitted learn() on propose tier (#636)"
+    else
+        fail "check-no-duplicate-learn: helper emits unconditional emitted learn() (#636)"
+        printf '%s\n' "$check_out"
+    fi
+fi
+
 # --- Plaintext token detection (#321) ---
 # Walks `[forge.*]` sections in every colony.toml / colony.example.toml
 # under the repo and flags `token` / `*api_key*` / `*secret*` values

--- a/tools/test-no-duplicate-learn.sh
+++ b/tools/test-no-duplicate-learn.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# tools/test-no-duplicate-learn.sh: unit tests for tools/check-no-duplicate-learn.sh.
+#
+# Self-contained. Creates temporary .ag fixture files, runs the checker
+# against them, asserts exit code + output pattern. Cleans up on exit.
+#
+# Usage: ./tools/test-no-duplicate-learn.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECKER="$SCRIPT_DIR/check-no-duplicate-learn.sh"
+
+if [ ! -x "$CHECKER" ]; then
+    echo "[FAIL] checker not found or not executable: $CHECKER"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+write_fixture() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name.ag"
+    printf '%s' "$content" > "$path"
+    printf '%s' "$path"
+}
+
+run_checker() {
+    set +e
+    out="$("$CHECKER" "$1" 2>&1)"
+    rc=$?
+    set -e
+}
+
+# --- Test 1: positive snapshot — repo root must pass clean ---
+# Post-#636 fix, all research-foundry helpers must gate their
+# emitted learn() on `if my_tier == "propose"`.
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+run_checker "$REPO_ROOT"
+if [ "$rc" -eq 0 ]; then
+    pass "snapshot repo root passes (0 violations, exit 0)"
+else
+    fail "snapshot repo root" "rc=$rc out=$out"
+fi
+
+# --- Test 2: violation — unconditional emitted learn() in _publish_<role> ---
+f="$(write_fixture "violation-unconditional" '
+fn _publish_foo(
+    final_write: bool,
+    self_pid: string,
+    tick_idx: int
+) -> void {
+    let _ = final_write;
+    memo_write("foo:" + self_pid, "ok");
+    learn("foo", "tick " + to_string(tick_idx), "x", "success", ["emitted", "math-foundry"]);
+}
+
+fn tick(rec: string) -> void {
+    let _ = rec;
+    _publish_foo(true, "p", 0);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 1 ] && (printf '%s' "$out" | grep -q "_publish_foo unconditional emitted learn"); then
+    pass "violation: _publish_foo with unconditional emitted learn() rejected"
+else
+    fail "violation-unconditional" "rc=$rc out=$out"
+fi
+
+# --- Test 3: clean — emitted learn() gated on `if my_tier == "propose"` ---
+f="$(write_fixture "clean-gated" '
+fn _publish_foo(
+    final_write: bool,
+    self_pid: string,
+    tick_idx: int,
+    my_tier: string
+) -> void {
+    let _ = final_write;
+    memo_write("foo:" + self_pid, "ok");
+    if my_tier == "propose" {
+        learn("foo", "tick " + to_string(tick_idx), "x", "success", ["emitted", "math-foundry"]);
+    };
+}
+
+fn tick(rec: string) -> void {
+    let _ = rec;
+    let my_tier = tier("foo");
+    _publish_foo(true, "p", 0, my_tier);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ]; then
+    pass "clean: emitted learn() gated on propose passes"
+else
+    fail "clean-gated" "rc=$rc out=$out"
+fi
+
+# --- Test 4: violation — _submitter_<phase> helper with unconditional emitted ---
+f="$(write_fixture "violation-submitter-phase" '
+fn _submitter_draft_phase(
+    self_pid: string,
+    tick_idx: int
+) -> void {
+    memo_write("submitter:" + self_pid, "drafted");
+    learn("submit", "tick " + to_string(tick_idx) + " DRAFTED", "x", "success", ["emitted", "preprint-foundry"]);
+}
+
+fn tick(rec: string) -> void {
+    let _ = rec;
+    _submitter_draft_phase("p", 0);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 1 ] && (printf '%s' "$out" | grep -q "_submitter_draft_phase unconditional emitted learn"); then
+    pass "violation: _submitter_draft_phase with unconditional emitted learn() rejected"
+else
+    fail "violation-submitter-phase" "rc=$rc out=$out"
+fi
+
+# --- Test 5: _publish_prompt_body_and_wrap_variant helper is skipped ---
+# This helper is a name-collision with the `fn _publish_<role>` pattern
+# but never calls learn(). Must not be flagged.
+f="$(write_fixture "skip-wrap-variant" '
+fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) -> string {
+    let _ = self_pid;
+    let _ = variant_tag;
+    return "ok";
+}
+
+fn tick(rec: string) -> void {
+    let _ = rec;
+    let _ = _publish_prompt_body_and_wrap_variant("p", "v");
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ]; then
+    pass "skip: _publish_prompt_body_and_wrap_variant is not flagged"
+else
+    fail "skip-wrap-variant" "rc=$rc out=$out"
+fi
+
+# --- Test 6: learn() without "emitted" tag is not flagged ---
+f="$(write_fixture "clean-non-emitted" '
+fn _publish_foo(self_pid: string, tick_idx: int) -> void {
+    memo_write("foo:" + self_pid, "ok");
+    learn("foo", "tick " + to_string(tick_idx), "x", "success", ["replicated", "math-foundry"]);
+}
+
+fn tick(rec: string) -> void {
+    let _ = rec;
+    _publish_foo("p", 0);
+}
+')"
+run_checker "$f"
+if [ "$rc" -eq 0 ]; then
+    pass "clean: learn() with replicated tag (not emitted) passes"
+else
+    fail "clean-non-emitted" "rc=$rc out=$out"
+fi
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #636.

## Summary

`_publish_<role>(...)` helpers in every Phase 4 research-foundry colony agent emit an unconditional top-level `learn(..., ["emitted", ...])` row inside their body. Because the inline `tick()` tier branches at `autonomous` and `review-gated` already emit a `learn(..., ["acted" | "review-gated", ...])` row before calling the helper, every promoted agent produces **two ACTING-tagged experience rows per tick** instead of one. All three tags (`acted`, `review-gated`, `emitted`) live in `auto-promote-decisions.py:158` `ACTING_TAGS`, so the fitness model double-counts.

No current effect because Phase 1 seeded every agent at confidence 0.7 (= `propose`, single-row path). The duplicate fires the moment auto-promote pushes any agent to `review-gated` or `autonomous` — which is the explicit Phase 1 goal of #622 and becomes load-bearing once Phase 7 PR-C lights up live evolve.

## Fix pattern

Approach (a) from #636: thread `my_tier: string` through to each `_publish_<role>` / `_submitter_<phase>` / `_handle_hitl_reject` helper, and wrap the helper's top-level `learn(..., ["emitted", ...])` row in `if my_tier == "propose" { ... }`. The other tier branches keep their inline `acted` / `review-gated` row — no behaviour change at `propose` or `observed`.

Per-tier acting-row counts after the fix:

| Tier | Inline branch | Helper | Total ACTING |
|---|---|---|---|
| `autonomous` | `["acted"]` | (gated off) | 1 |
| `review-gated` | `["review-gated"]` | (gated off) | 1 |
| `propose` | (none) | `["emitted"]` | 1 |
| `observed` | `["observed"]` | n/a | 0 (observe) |

## Audit results

Already-correct files (no change): `explorer.ag`, `skeptic.ag`, `prior_advocate.ag`, `reviewer.ag`. Their helpers never carried a top-level emitted `learn()`; the emitted row lives inside the inline `propose` tick branch.

Fixed in chunk 1 (discovery non-explorer): `noticer`, `formulator`, `verifier`, `novelty`.

Fixed in chunk 2 (audit): `arxiv-search`, `oeis-search`, `groupprops-search`, `scholar-search`, `auditor`.

Fixed in chunk 3 (preprint): `introducer`, `theorist`, `computer`, `editor`, `submitter` (three helpers: `_submitter_draft_phase`, `_handle_hitl_reject`, `_submitter_send_phase`).

## What this PR does NOT touch

* Phase 9 PR-C replicate gates inside each `_publish_<role>`. The `if do_replicate { ... }` body is correct as written; the duplicate is at the helper's top-level `learn()`, not inside the replicate path.
* `ACTING_TAGS` in `auto-promote-decisions.py`. The tag set is the right contract; the bug was the per-tick emission count, not the classifier.

## Tooling

* New `tools/check-no-duplicate-learn.sh` — grep-based static lint that walks every `.ag` in `research-foundry/` and fails when any `_publish_<role>` / `_submitter_<phase>` helper carries an emitted `learn()` row that is not gated on `if my_tier == "propose"`. Accepts either a repo root (recursive) or a single `.ag` file (single-file mode for fixtures).
* New `tools/test-no-duplicate-learn.sh` — 6 fixture-driven unit tests for the checker: positive snapshot on the repo, negative `_publish_<role>` fixture, gated positive fixture, negative `_submitter_<phase>` fixture, the `_publish_prompt_body_and_wrap_variant` skip, and a `replicated`-tag (not `emitted`) positive case.
* Both wired into `tools/colony-lint.sh`. Local lint now reports 339 passed, 0 failed, 4 skipped.

## Test plan

- [x] `./tools/check-no-duplicate-learn.sh` — exit 0, 0 violations.
- [x] `./tools/test-no-duplicate-learn.sh` — 6/6 passed.
- [x] `./tools/colony-lint.sh` — 339 passed, 0 failed, 4 skipped.