### PR TITLE
fix(cull-replicas): bump NEXT_ID per dry-run respawn (#675)

### DIFF
--- a/tools/cull-replicas.sh
+++ b/tools/cull-replicas.sh
@@ -433,8 +433,9 @@ print('\n'.join(
     NEXT_SPECIALTY="$(pick_next_specialty "$LIVE_COUNTS_JSON")"
 
     if [ "$DRY_RUN" = "1" ]; then
+        NEW_ID=$((NEXT_ID + 1))
         log "[dry-run] would cull pid=$pid agent_id=$agent_id specialty=$specialty fitness=$fitness"
-        log "[dry-run] would respawn $COLONY_NAME with specialty=$NEXT_SPECIALTY daemon_id=$((NEXT_ID + 1))"
+        log "[dry-run] would respawn $COLONY_NAME with specialty=$NEXT_SPECIALTY daemon_id=$NEW_ID"
         # Bump live counts so the next dry-run iteration's picker re-
         # evaluates against the post-respawn distribution.
         LIVE_COUNTS_JSON="$(python3 -c "
@@ -444,6 +445,10 @@ sp = sys.argv[2]
 counts[sp] = counts.get(sp, 0) + 1
 print(json.dumps(counts))
 " "$LIVE_COUNTS_JSON" "$NEXT_SPECIALTY")"
+        # Bump NEXT_ID so multi-pick dry-run batches allocate distinct
+        # daemon_ids — mirrors the live-path increment at lines below
+        # which is unreachable from the dry-run branch (#675).
+        NEXT_ID="$NEW_ID"
         continue
     fi
 

--- a/tools/test-cull-replicas.sh
+++ b/tools/test-cull-replicas.sh
@@ -296,6 +296,29 @@ else
         "cull=$CULL_ROWS respawn=$RESPAWN_ROWS ledger=$(cat "$NOOP_LEDGER_PATH" 2>/dev/null)"
 fi
 
+# --- Test 10 (#675): NEXT_ID must increment per dry-run respawn so a
+# multi-pick batch produces distinct daemon_ids. Reuses the alive=1,2,4
+# gap fixture from Test 8 but with --bottom-pct 0.67 to force the picker
+# to take all 3 surviving replicas (ceil(3 * 0.67) = 3). The expected
+# respawn allocation is daemon_id=5, 6, 7 on distinct dry-run lines.
+# Pre-fix, every line read daemon_id=5 because NEXT_ID was set once and
+# the dry-run branch never bumped it.
+MULTI_OUT="$(CULL_DAEMONS_JSON_OVERRIDE="$GAP_JSON" \
+    CULL_SPECIALTY_COUNTS_OVERRIDE='{"group_theory":1,"combinatorics":1,"number_theory":1}' \
+    CULL_NOW_MS_OVERRIDE=0 \
+    bash "$CULL" "$WORK_DIR" explorer --dry-run --bottom-pct 0.67 --min-explorers 3 --min-acting 0 2>&1 || true)"
+
+MULTI_ID5="$(printf '%s\n' "$MULTI_OUT" | grep -cF 'daemon_id=5' || true)"
+MULTI_ID6="$(printf '%s\n' "$MULTI_OUT" | grep -cF 'daemon_id=6' || true)"
+MULTI_ID7="$(printf '%s\n' "$MULTI_OUT" | grep -cF 'daemon_id=7' || true)"
+
+if [ "$MULTI_ID5" -ge 1 ] && [ "$MULTI_ID6" -ge 1 ] && [ "$MULTI_ID7" -ge 1 ]; then
+    pass "10. dry-run NEXT_ID bumps per respawn -> daemon_id=5,6,7 distinct (#675)"
+else
+    fail "10. dry-run NEXT_ID bumps per respawn -> daemon_id=5,6,7 distinct (#675)" \
+        "id5=$MULTI_ID5 id6=$MULTI_ID6 id7=$MULTI_ID7 out=$MULTI_OUT"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- `tools/cull-replicas.sh` initialised `NEXT_ID="$MAX_DAEMON_ID"` once before the per-pick loop, then logged `daemon_id=$((NEXT_ID + 1))` inside the dry-run branch without ever bumping `NEXT_ID`. The live path correctly increments via `NEW_ID=$((NEXT_ID + 1))` / `NEXT_ID="$NEW_ID"`, but those lines sit after the dry-run `continue` and were unreachable. Result: every dry-run respawn in a multi-pick batch printed the same `daemon_id=N+1`.
- Mirror the live-path two-step inside the dry-run branch so each respawn allocates a distinct id.
- Extend `tools/test-cull-replicas.sh` with Test 10: reuses the alive=1,2,4 gap fixture from Test 8 with `--bottom-pct 0.67` (forces `ceil(3 * 0.67) = 3` picks) and asserts `daemon_id=5`, `daemon_id=6`, `daemon_id=7` each appear in the dry-run output on distinct lines.

Closes #675.

## Test plan
- [x] `bash tools/test-cull-replicas.sh` — 13 passed, 0 failed (Test 10 added).
- [x] `./tools/colony-lint.sh` — 340 passed, 0 failed, 4 skipped.