### PR TITLE
fix(cross-fed-bridge): conflict policy doc + KIND_TO_DIR completion + sidecar merge-ledgers (#666)

### DIFF
--- a/doc/cross-fed-memo.md
+++ b/doc/cross-fed-memo.md
@@ -224,6 +224,26 @@ Both thresholds live in the source federation's
 auto-promote / auto-evolve config (PR-2 wires the exporter; PR-1 only
 specifies that the relationship MUST hold).
 
+## Write-conflict policy
+
+**Shared-key writes** — `cross-fed:applicable-to:<method-id>`,
+`cross-fed:export-suppress:<method-id>`, and any future operator-curated
+key that is not scoped to a single federation: **Last-Writer-Wins by
+mtime**. The bridge already runs sha256-by-content dedupe on each pass;
+when two federations write divergent content for the same shared key,
+the most recent host-side mtime wins on the next memo-to-memo
+round-trip. Operators reconciling intentional divergence must serialise
+edits — the bridge does not arbitrate semantic conflicts.
+
+**Per-fed-owned keys** — `cross-fed:method:<source-fed>:…`,
+`cross-fed:method-body:<source-fed>:…`,
+`cross-fed:fitness:<source-fed>:…`,
+`cross-fed:import-log:<target-fed>:…`: no conflict by design. The path
+embeds `<source-fed>` or `<target-fed>`, so no two federations ever
+target the same host file. A federation that writes outside its own
+namespace is misbehaving and the operator should treat such writes as a
+trust violation per the threat-model section below.
+
 ## Host dir layout
 
 The shared dir lives at `<repo-root>/cross-fed-memo/`. The bridge
@@ -264,6 +284,15 @@ per-fed ledger into the central `<host_dir>/pollination-ledger.jsonl`,
 preserving timestamp order. The central ledger is the audit trail
 the operator scans to see which federation published which method
 when.
+
+`pollination_ledger_merge` preserves every row from every source
+verbatim, sorted by `ts` then read-order. Two federations appending
+identical-timestamp rows produce two adjacent rows — this is
+intentional: the ledger is an audit log, not a set. Operators wanting a
+deduplicated view should post-process with
+`jq -s 'unique_by(.ts,.fed,.method_id)'` (or an equivalent
+projection); the bridge does not collapse rows on the operator's
+behalf because the choice of dedup key is policy-dependent.
 
 ## Threat model
 

--- a/tools/cross-fed-bridge.py
+++ b/tools/cross-fed-bridge.py
@@ -64,6 +64,9 @@ KIND_TO_DIR = {
     "fitness": "fitness",
     "applicable-to": "applicable-to",
     "import-log": "import-log",
+    "export-suppress": "export-suppress",
+    "opt-out": "opt-out",
+    "adopt-queue": "adopt-queue",
 }
 
 # File extension on the host side. `method-body` carries raw prompt
@@ -74,6 +77,9 @@ KIND_TO_EXT = {
     "fitness": ".json",
     "applicable-to": ".json",
     "import-log": ".json",
+    "export-suppress": ".json",
+    "opt-out": ".json",
+    "adopt-queue": ".json",
 }
 
 # Filenames written under <host_dir>/ that are NOT mirrored memo keys.

--- a/tools/cross-fed-bridge.sh
+++ b/tools/cross-fed-bridge.sh
@@ -129,8 +129,17 @@ log() {
 
 if [ "$MODE" = "sync" ]; then
     # One-shot bidirectional pass. The Python helper acquires the lock
-    # itself and exits 0 if another process holds it.
-    exec python3 "$PY_HELPER" sync "$FED_DIR" "$HOST_DIR" --lock-mode nonblocking
+    # itself and exits 0 if another process holds it. We do NOT `exec`
+    # here because we want to also run merge-ledgers in the same one-
+    # shot invocation so cron-style callers get the same end state as a
+    # sidecar tick.
+    if ! python3 "$PY_HELPER" sync "$FED_DIR" "$HOST_DIR" --lock-mode nonblocking; then
+        exit 1
+    fi
+    if ! python3 "$PY_HELPER" merge-ledgers "$HOST_DIR"; then
+        log "merge-ledgers pass failed; continuing"
+    fi
+    exit 0
 fi
 
 # --- Sidecar loop ---
@@ -162,5 +171,6 @@ while true; do
     if ! python3 "$PY_HELPER" sync "$FED_DIR" "$HOST_DIR" --lock-mode release >>"$LOG_FILE" 2>&1; then
         log "sync pass failed; continuing"
     fi
+    python3 "$PY_HELPER" merge-ledgers "$HOST_DIR" >>"$LOG_FILE" 2>&1 || log "merge-ledgers pass failed; continuing"
     sleep "$INTERVAL"
 done

--- a/tools/test-cross-fed-bridge.sh
+++ b/tools/test-cross-fed-bridge.sh
@@ -267,6 +267,95 @@ print(','.join(rows))
     fi
 fi
 
+# --- Test 8: KIND_TO_DIR / KIND_TO_EXT completeness ---
+# Phase 8 PR-2 prerequisites (#666): the helper must recognise the full
+# 8-kind set so operator-curated keys (export-suppress, opt-out) and the
+# adopt-queue seed can round-trip through the bridge without being
+# silently dropped by `_split_key`.
+KIND_OUT="$(python3 -c "
+import importlib.util
+spec = importlib.util.spec_from_file_location('cfb', '$BRIDGE_PY')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+expected = {'method','method-body','fitness','applicable-to','import-log','export-suppress','opt-out','adopt-queue'}
+got_dir = set(mod.KIND_TO_DIR)
+got_ext = set(mod.KIND_TO_EXT)
+miss_dir = expected - got_dir
+miss_ext = expected - got_ext
+extra_dir = got_dir - expected
+extra_ext = got_ext - expected
+mismatched_keys = got_dir.symmetric_difference(got_ext)
+print('miss_dir=%s miss_ext=%s extra_dir=%s extra_ext=%s sym=%s' % (
+    sorted(miss_dir), sorted(miss_ext), sorted(extra_dir), sorted(extra_ext), sorted(mismatched_keys),
+))
+" 2>&1)"
+if [ "$KIND_OUT" = "miss_dir=[] miss_ext=[] extra_dir=[] extra_ext=[] sym=[]" ]; then
+    pass "8. KIND_TO_DIR / KIND_TO_EXT cover the full 8-kind set"
+else
+    fail "8. KIND_TO_DIR / KIND_TO_EXT cover the full 8-kind set" \
+        "$KIND_OUT"
+fi
+
+# --- Test 9: sidecar invokes merge-ledgers each tick ---
+# Stage a per-fed pollination ledger, launch the sidecar with a 1s
+# interval, wait long enough for one full tick, then assert the central
+# ledger materialised under the host dir.
+MERGE_SIDECAR_HOST="$WORK_DIR/merge-sidecar-host"
+MERGE_SIDECAR_FED="$WORK_DIR/merge-sidecar-fed"
+mkdir -p "$MERGE_SIDECAR_HOST"
+mkdir -p "$MERGE_SIDECAR_FED/.agentis/memo"
+mkdir -p "$MERGE_SIDECAR_FED/.agentis"
+cat > "$MERGE_SIDECAR_FED/.agentis/pollination-ledger.jsonl" <<'EOF'
+{"ts": 1500, "event": "export", "fed": "merge-sidecar-fed", "method_id": "epsilon"}
+EOF
+
+CROSS_FED_HOST_DIR="$MERGE_SIDECAR_HOST" "$BRIDGE_SH" sidecar "$MERGE_SIDECAR_FED" --interval 1 \
+    >"$WORK_DIR/sidecar-merge.log" 2>&1 &
+PID_MERGE=$!
+
+# Give the loop enough time to complete a sync + merge-ledgers pass.
+sleep 3
+
+kill "$PID_MERGE" 2>/dev/null || true
+wait "$PID_MERGE" 2>/dev/null || true
+
+MERGE_CENTRAL="$MERGE_SIDECAR_HOST/pollination-ledger.jsonl"
+if [ -f "$MERGE_CENTRAL" ] && [ -s "$MERGE_CENTRAL" ] && grep -Fq 'epsilon' "$MERGE_CENTRAL"; then
+    pass "9. sidecar invokes merge-ledgers each tick"
+else
+    fail "9. sidecar invokes merge-ledgers each tick" \
+        "central=$(ls -la "$MERGE_CENTRAL" 2>&1) log=$(tail -5 "$WORK_DIR/sidecar-merge.log" 2>/dev/null)"
+fi
+
+# --- Test 10: round-trip for a new kind (opt-out) ---
+# Stage an opt-out memo on the fed side, sync to host, assert it lands
+# at <host>/opt-out/<fed>.json -- proves the new KIND_TO_DIR entries
+# survive _split_key + _memo_key_to_host_path.
+OPTOUT_FED="$WORK_DIR/optout-fed"
+OPTOUT_HOST="$WORK_DIR/optout-host"
+mkdir -p "$OPTOUT_FED/.agentis/memo" "$OPTOUT_HOST"
+echo '{"value":{"fed":"optout-fed","reason":"operator suppressed"}}' \
+    > "$OPTOUT_FED/.agentis/memo/cross-fed:opt-out:optout-fed.jsonl"
+
+python3 -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR')
+import importlib.util
+spec = importlib.util.spec_from_file_location('cfb', '$BRIDGE_PY')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+from pathlib import Path
+mod.sync_memo_to_host(Path('$OPTOUT_FED'), Path('$OPTOUT_HOST'))
+" >/dev/null 2>&1
+
+OPTOUT_FILE="$OPTOUT_HOST/opt-out/optout-fed.json"
+if [ -f "$OPTOUT_FILE" ] && grep -q 'operator suppressed' "$OPTOUT_FILE"; then
+    pass "10. round-trip for new kind (opt-out) lands at host/opt-out/<fed>.json"
+else
+    fail "10. round-trip for new kind (opt-out) lands at host/opt-out/<fed>.json" \
+        "expected $OPTOUT_FILE; got=$(cat "$OPTOUT_FILE" 2>/dev/null || echo MISSING)"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Phase 8 PR-2 prerequisites for the cross-fed bridge (#666). Four sub-fixes:

1. **Conflict-policy doc.** New `## Write-conflict policy` section in `doc/cross-fed-memo.md` between *Fitness gates* and *Host dir layout*. Documents Last-Writer-Wins-by-mtime for shared operator-curated keys (`cross-fed:applicable-to:<method-id>`, `cross-fed:export-suppress:<method-id>`, future operator-curated kinds) and the per-fed-owned paths that cannot conflict by design (`method`, `method-body`, `fitness`, `import-log` — path embeds `<source-fed>` or `<target-fed>`).

2. **Pollination-ledger dedupe note.** Appended paragraph to the existing `### Pollination ledger` subsection: `pollination_ledger_merge` preserves every row verbatim sorted by `ts` then read-order. Identical-timestamp rows from two feds produce two adjacent rows on purpose (audit log, not a set). Operators wanting a dedup'd view can post-process with `jq -s 'unique_by(.ts,.fed,.method_id)'`.

3. **`KIND_TO_DIR` / `KIND_TO_EXT` completion.** Adds the three remaining PR-2 kinds (`export-suppress`, `opt-out`, `adopt-queue`) to both dicts in `tools/cross-fed-bridge.py`. Subdirs materialise on first write via existing `_write_host_atomic`'s `mkdir(parents=True, exist_ok=True)`.

4. **Sidecar merge-ledgers wiring.** `tools/cross-fed-bridge.sh`:
   - Sidecar loop body now invokes `python3 "$PY_HELPER" merge-ledgers "$HOST_DIR"` after each `sync` pass (before `sleep`). Merge failure logs a warning but does not abort the loop, mirroring the existing sync-failure handling.
   - One-shot `sync` mode no longer `exec`s into the python helper; runs `sync` then `merge-ledgers` then `exit 0` so cron-style callers get the same end state as one sidecar tick.

CHANGELOG: cross-fed-bridge is platform-level tooling under `tools/` and not versioned via any per-federation CHANGELOG, so no CHANGELOG entry is needed (consistent with how earlier PR-1 work landed).

## Test plan

- [x] `bash tools/test-cross-fed-bridge.sh` — 11 passed, 0 failed (3 new tests: KIND_TO_DIR/EXT completeness, sidecar invokes merge-ledgers each tick, opt-out round-trip)
- [x] `./tools/colony-lint.sh` — 340 passed, 0 failed, 4 skipped
- [x] `bash -n tools/cross-fed-bridge.sh` — clean
- [x] `python3 -m ast tools/cross-fed-bridge.py` — clean
- [x] doc renders cleanly (no broken anchors, no orphaned headings)

Closes #666.