### PR TITLE
feat(lifecycle): birth + death enabled in default run-research.sh invocation (#679)

### DIFF
--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -20,6 +20,32 @@ History of the three retired federations consolidated into this one
 
 ### Changed
 
+- Lifecycle (birth + death + respawn) is now **on by default** in the
+  30-tick `run-research.sh --dry-run`/live invocation (#679). Four knobs
+  in `research-foundry/tools/run-research.sh` were flipped so the
+  M2-Malthusian replicate gate fires and the Phase 3 PR-3 cull cycle
+  engages without operator opt-in:
+  - `RESEARCH_CULL_ENABLED` default `0 -> 1` (cull cycle on).
+  - `RESEARCH_CULL_INTERVAL_TICKS` default `20 -> 5` (a 30-tick default
+    run now sees ~6 cull cycles instead of 1).
+  - `RESEARCH_<COLONY>_REPRODUCTIVE_FITNESS_THRESHOLD` default `10 -> 3`
+    across all 18 colonies (`explorer`, `noticer`, `skeptic`,
+    `formulator`, `verifier`, `novelty`, `arxiv-search`, `oeis-search`,
+    `groupprops-search`, `scholar-search`, `auditor`, `prior_advocate`,
+    `introducer`, `theorist`, `computer`, `editor`, `reviewer`,
+    `submitter`) so the per-pid fitness gate fires within a short run.
+  - `RESEARCH_CULL_MIN_ACTING` default `10 -> 3` so short default runs
+    accumulate enough acting rows to be eligible for cull.
+
+  `RESEARCH_CULL_MIN_EXPLORERS=3` (floor protection so the cull cycle
+  never empties the explorer pool) is unchanged. `MAX_REPLICAS`, `POOL`,
+  `TICK_INTERVAL_S`, and the per-colony fitness-scoring `.ag` formulas
+  are also unchanged — this PR is purely defaults. Operators who want
+  the previous opt-in behaviour can still set
+  `RESEARCH_CULL_ENABLED=0` and the previous thresholds via env.
+  Coverage added in `research-foundry/tools/test-run-research.sh`
+  (test 22a-22f); existing replicate-gate and jitter tests remain green.
+
 - Per-tick jitter + lowered replica default to keep
   research-foundry under the Claude API ~100 req/min ceiling (#670
   follow-up to Phase 9 PR-C of #663). Each of the 18 colony `.ag`

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -117,19 +117,27 @@
 #                                Per-pid fitness threshold above which the
 #                                replicate gate fires (memo key
 #                                explorer:reproductive_fitness_threshold).
-#                                Default 10.
+#                                Default 3 (#679: lowered from 10 so the
+#                                gate fires within the default 30-tick
+#                                run, engaging birth/death lifecycle
+#                                without operator opt-in).
 #   RESEARCH_CULL_ENABLED        1 enable Phase 3 PR 3 cull cycle, 0
-#                                disable (default 0; opt-in for long-run
-#                                experiments).
+#                                disable. Default 1 (#679: lifecycle on
+#                                by default so the 30-tick default run
+#                                produces at least one cull event).
 #   RESEARCH_CULL_INTERVAL_TICKS Sidecar ticks between cull invocations.
-#                                Default 20.
+#                                Default 5 (#679: lowered from 20 so a
+#                                30-tick default run sees ~6 cull
+#                                cycles instead of 1).
 #   RESEARCH_CULL_BOTTOM_PCT     Fraction of explorers culled per cycle.
 #                                Default 0.2 (bottom 20% by fitness).
 #   RESEARCH_CULL_MIN_EXPLORERS  Skip cull entirely when total explorer
 #                                count falls below this floor. Default 3.
 #   RESEARCH_CULL_MIN_ACTING     Skip per-row cull when explorer's
 #                                entries_acting is below this floor.
-#                                Default 10 (insufficient data).
+#                                Default 3 (#679: lowered from 10 so
+#                                short default runs accumulate enough
+#                                acting rows to be eligible for cull).
 #   RESEARCH_CULL_COLONIES       Comma-separated list of colony names
 #                                the cull cycle iterates over per
 #                                tick. Phase 9 PR-C (#663) expands the
@@ -241,7 +249,7 @@ SMTP_PORT="${RESEARCH_SMTP_PORT:-25}"
 : "${RESEARCH_EXPLORER_REPLICAS:=5}"
 : "${RESEARCH_EXPLORER_MAX_REPLICAS:=8}"
 : "${RESEARCH_EXPLORER_POOL:=5000}"
-: "${RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 # Phase 9 PR-B (#663): per-colony replica + pool seeds for the 17
 # non-explorer colonies. All default to 1 so PR-B does NOT change the
@@ -252,87 +260,87 @@ SMTP_PORT="${RESEARCH_SMTP_PORT:-25}"
 : "${RESEARCH_NOTICER_REPLICAS:=2}"
 : "${RESEARCH_NOTICER_MAX_REPLICAS:=8}"
 : "${RESEARCH_NOTICER_POOL:=5000}"
-: "${RESEARCH_NOTICER_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_NOTICER_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_SKEPTIC_REPLICAS:=2}"
 : "${RESEARCH_SKEPTIC_MAX_REPLICAS:=8}"
 : "${RESEARCH_SKEPTIC_POOL:=5000}"
-: "${RESEARCH_SKEPTIC_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_SKEPTIC_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_FORMULATOR_REPLICAS:=2}"
 : "${RESEARCH_FORMULATOR_MAX_REPLICAS:=8}"
 : "${RESEARCH_FORMULATOR_POOL:=5000}"
-: "${RESEARCH_FORMULATOR_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_FORMULATOR_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_VERIFIER_REPLICAS:=2}"
 : "${RESEARCH_VERIFIER_MAX_REPLICAS:=8}"
 : "${RESEARCH_VERIFIER_POOL:=5000}"
-: "${RESEARCH_VERIFIER_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_VERIFIER_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_NOVELTY_REPLICAS:=2}"
 : "${RESEARCH_NOVELTY_MAX_REPLICAS:=8}"
 : "${RESEARCH_NOVELTY_POOL:=5000}"
-: "${RESEARCH_NOVELTY_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_NOVELTY_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_ARXIV_SEARCH_REPLICAS:=2}"
 : "${RESEARCH_ARXIV_SEARCH_MAX_REPLICAS:=8}"
 : "${RESEARCH_ARXIV_SEARCH_POOL:=5000}"
-: "${RESEARCH_ARXIV_SEARCH_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_ARXIV_SEARCH_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_OEIS_SEARCH_REPLICAS:=2}"
 : "${RESEARCH_OEIS_SEARCH_MAX_REPLICAS:=8}"
 : "${RESEARCH_OEIS_SEARCH_POOL:=5000}"
-: "${RESEARCH_OEIS_SEARCH_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_OEIS_SEARCH_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_GROUPPROPS_SEARCH_REPLICAS:=2}"
 : "${RESEARCH_GROUPPROPS_SEARCH_MAX_REPLICAS:=8}"
 : "${RESEARCH_GROUPPROPS_SEARCH_POOL:=5000}"
-: "${RESEARCH_GROUPPROPS_SEARCH_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_GROUPPROPS_SEARCH_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_SCHOLAR_SEARCH_REPLICAS:=2}"
 : "${RESEARCH_SCHOLAR_SEARCH_MAX_REPLICAS:=8}"
 : "${RESEARCH_SCHOLAR_SEARCH_POOL:=5000}"
-: "${RESEARCH_SCHOLAR_SEARCH_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_SCHOLAR_SEARCH_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_AUDITOR_REPLICAS:=2}"
 : "${RESEARCH_AUDITOR_MAX_REPLICAS:=8}"
 : "${RESEARCH_AUDITOR_POOL:=5000}"
-: "${RESEARCH_AUDITOR_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_AUDITOR_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_PRIOR_ADVOCATE_REPLICAS:=2}"
 : "${RESEARCH_PRIOR_ADVOCATE_MAX_REPLICAS:=8}"
 : "${RESEARCH_PRIOR_ADVOCATE_POOL:=5000}"
-: "${RESEARCH_PRIOR_ADVOCATE_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_PRIOR_ADVOCATE_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_INTRODUCER_REPLICAS:=2}"
 : "${RESEARCH_INTRODUCER_MAX_REPLICAS:=8}"
 : "${RESEARCH_INTRODUCER_POOL:=5000}"
-: "${RESEARCH_INTRODUCER_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_INTRODUCER_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_THEORIST_REPLICAS:=2}"
 : "${RESEARCH_THEORIST_MAX_REPLICAS:=8}"
 : "${RESEARCH_THEORIST_POOL:=5000}"
-: "${RESEARCH_THEORIST_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_THEORIST_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_COMPUTER_REPLICAS:=2}"
 : "${RESEARCH_COMPUTER_MAX_REPLICAS:=8}"
 : "${RESEARCH_COMPUTER_POOL:=5000}"
-: "${RESEARCH_COMPUTER_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_COMPUTER_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_EDITOR_REPLICAS:=2}"
 : "${RESEARCH_EDITOR_MAX_REPLICAS:=8}"
 : "${RESEARCH_EDITOR_POOL:=5000}"
-: "${RESEARCH_EDITOR_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_EDITOR_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_REVIEWER_REPLICAS:=2}"
 : "${RESEARCH_REVIEWER_MAX_REPLICAS:=8}"
 : "${RESEARCH_REVIEWER_POOL:=5000}"
-: "${RESEARCH_REVIEWER_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_REVIEWER_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 : "${RESEARCH_SUBMITTER_REPLICAS:=2}"
 : "${RESEARCH_SUBMITTER_MAX_REPLICAS:=8}"
 : "${RESEARCH_SUBMITTER_POOL:=5000}"
-: "${RESEARCH_SUBMITTER_REPRODUCTIVE_FITNESS_THRESHOLD:=10}"
+: "${RESEARCH_SUBMITTER_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
 # Phase 9 PR-B (#663): comma-separated list of colony names eligible
 # for the cull cycle. PR-C expands the default to all 18 colonies
@@ -345,7 +353,7 @@ SMTP_PORT="${RESEARCH_SMTP_PORT:-25}"
 # `set -euo pipefail` (line 162) propagates the division-by-zero up
 # through the backgrounded subshell, killing both auto-promote AND cull
 # for the remainder of the run.
-: "${RESEARCH_CULL_INTERVAL_TICKS:=20}"
+: "${RESEARCH_CULL_INTERVAL_TICKS:=5}"
 
 # --- Validation ---
 if [ -z "$TOPICS_RAW" ]; then
@@ -847,15 +855,17 @@ start_auto_promote_sidecar() {
     AP_ENABLED="${RESEARCH_AUTO_PROMOTE:-1}"
     AP_INTERVAL="${RESEARCH_AUTO_PROMOTE_INTERVAL_S:-300}"
     # Phase 3 PR 3 (#624): optional cull cycle layered on top of the
-    # auto-promote sidecar tick. Defaults off so weekend long-runs opt in
-    # explicitly; the cull cycle kills the bottom-N explorer daemons by
-    # fitness_score and respawns replacements with demand-weighted
-    # specialty.
-    CULL_ENABLED="${RESEARCH_CULL_ENABLED:-0}"
-    CULL_INTERVAL_TICKS="${RESEARCH_CULL_INTERVAL_TICKS:-20}"
+    # auto-promote sidecar tick. Phase 10 (#679) flipped the defaults so
+    # birth/death engages in the default 30-tick run-research.sh
+    # invocation without operator opt-in: ENABLED=1, INTERVAL_TICKS=5,
+    # MIN_ACTING=3. The cull cycle kills the bottom-N explorer daemons
+    # by fitness_score and respawns replacements with demand-weighted
+    # specialty. CULL_MIN_EXPLORERS stays at 3 as a floor protection.
+    CULL_ENABLED="${RESEARCH_CULL_ENABLED:-1}"
+    CULL_INTERVAL_TICKS="${RESEARCH_CULL_INTERVAL_TICKS:-5}"
     CULL_BOTTOM_PCT="${RESEARCH_CULL_BOTTOM_PCT:-0.2}"
     CULL_MIN_EXPLORERS="${RESEARCH_CULL_MIN_EXPLORERS:-3}"
-    CULL_MIN_ACTING="${RESEARCH_CULL_MIN_ACTING:-10}"
+    CULL_MIN_ACTING="${RESEARCH_CULL_MIN_ACTING:-3}"
     # Phase 9 PR-B (#663): the generalised cull script supersedes the
     # legacy cull-explorers.sh wrapper; we drive it once per colony in
     # $RESEARCH_CULL_COLONIES (comma-separated, default `explorer`).

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -245,6 +245,35 @@ assert_contains "20c. RESEARCH_CULL_COLONIES includes submitter" "$SRC" \
 assert_contains "21. RESEARCH_JITTER_DISABLED in exec.env_passthrough" "$SRC" \
     "RESEARCH_JITTER_DISABLED"
 
+# ---------------------------------------------------------------------------
+# 22. #679: lifecycle-on-default. Birth/death/respawn must engage in the
+# default 30-tick run-research.sh run without operator opt-in. Four knobs
+# were flipped:
+#   - RESEARCH_CULL_ENABLED       :  0 -> 1   (function-scoped fallback)
+#   - RESEARCH_CULL_INTERVAL_TICKS: 20 -> 5   (both :=5 default + :-5 fallback)
+#   - RESEARCH_<COLONY>_REPRODUCTIVE_FITNESS_THRESHOLD: 10 -> 3 (all 18 colonies)
+#   - RESEARCH_CULL_MIN_ACTING    : 10 -> 3   (function-scoped fallback)
+# Explorer-specific RESEARCH_CULL_MIN_EXPLORERS=3 stays untouched as
+# floor protection.
+# ---------------------------------------------------------------------------
+assert_contains "22a. RESEARCH_CULL_ENABLED defaults to 1" "$SRC" \
+    "CULL_ENABLED=\"\${RESEARCH_CULL_ENABLED:-1}\""
+assert_contains "22b. RESEARCH_CULL_INTERVAL_TICKS top-level default is 5" "$SRC" \
+    ": \"\${RESEARCH_CULL_INTERVAL_TICKS:=5}\""
+assert_contains "22c. RESEARCH_CULL_INTERVAL_TICKS function-scoped fallback is 5" "$SRC" \
+    "CULL_INTERVAL_TICKS=\"\${RESEARCH_CULL_INTERVAL_TICKS:-5}\""
+assert_contains "22d. RESEARCH_CULL_MIN_ACTING defaults to 3" "$SRC" \
+    "CULL_MIN_ACTING=\"\${RESEARCH_CULL_MIN_ACTING:-3}\""
+assert_contains "22e. CULL_MIN_EXPLORERS floor protection unchanged at 3" "$SRC" \
+    "CULL_MIN_EXPLORERS=\"\${RESEARCH_CULL_MIN_EXPLORERS:-3}\""
+for c in EXPLORER NOTICER SKEPTIC FORMULATOR VERIFIER NOVELTY \
+         ARXIV_SEARCH OEIS_SEARCH GROUPPROPS_SEARCH SCHOLAR_SEARCH \
+         AUDITOR PRIOR_ADVOCATE INTRODUCER THEORIST COMPUTER \
+         EDITOR REVIEWER SUBMITTER; do
+    assert_contains "22f. RESEARCH_${c}_REPRODUCTIVE_FITNESS_THRESHOLD defaults to 3" "$SRC" \
+        "\"\${RESEARCH_${c}_REPRODUCTIVE_FITNESS_THRESHOLD:=3}\""
+done
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Flips four defaults in `research-foundry/tools/run-research.sh` so the
M2-Malthusian replicate gate fires and the Phase 3 PR-3 cull cycle
engages within the default 30-tick `run-research.sh` invocation,
**without** operator opt-in. Before this PR, the default demonstration
run produced zero birth and zero death events even though both code
paths were wired end-to-end (Phase 3 + Phase 9 PR-C #663).

closes #679

## Knob flips

| Knob | Old default | New default | Notes |
|------|-------------|-------------|-------|
| `RESEARCH_CULL_ENABLED` | `0` | `1` | Cull cycle on by default (function-scoped fallback at the auto-promote sidecar). |
| `RESEARCH_CULL_INTERVAL_TICKS` | `20` | `5` | Both the top-level `:=` default and the function-scoped `:-` fallback. A 30-tick default run now sees ~6 cull cycles instead of 1. |
| `RESEARCH_<COLONY>_REPRODUCTIVE_FITNESS_THRESHOLD` (x18) | `10` | `3` | All 18 colonies: `explorer`, `noticer`, `skeptic`, `formulator`, `verifier`, `novelty`, `arxiv-search`, `oeis-search`, `groupprops-search`, `scholar-search`, `auditor`, `prior_advocate`, `introducer`, `theorist`, `computer`, `editor`, `reviewer`, `submitter`. |
| `RESEARCH_CULL_MIN_ACTING` | `10` | `3` | Short default runs accumulate enough acting rows to be eligible for cull. |

`RESEARCH_CULL_MIN_EXPLORERS=3` (floor protection so the cull cycle
never empties the explorer pool) stays untouched. `MAX_REPLICAS`,
`POOL`, `TICK_INTERVAL_S`, and the per-colony fitness-scoring formulas
in the 18 `.ag` files are also unchanged — this PR is purely defaults.

## Math

- **Cull cycle**: With `INTERVAL_TICKS=5` and a 30-tick run, the cull
  cycle invokes ~6 times. With `MIN_ACTING=3` (down from 10), a colony
  with 3+ acting rows is eligible — well within reach for an explorer
  population running 30 ticks.
- **Replicate gate**: Per-pid fitness threshold dropping `10 -> 3` makes
  the gate fire on early productive ticks instead of waiting for a
  long-run accumulation that the 30-tick default never reaches.
- **Operator override**: Anyone wanting the previous opt-in behaviour
  can still set `RESEARCH_CULL_ENABLED=0` and the previous thresholds
  via env vars; this is purely the **default** that flipped.

## Test plan

- [x] `bash research-foundry/tools/test-run-research.sh` -> 91/0 (was 54/0; added 37 new assertions in test 22a-22f covering all four flipped knobs + the unchanged `CULL_MIN_EXPLORERS` floor).
- [x] `bash research-foundry/tools/test-replicate-gates.sh` -> 29/0.
- [x] `bash research-foundry/tools/test-jitter.sh` -> 72/0.
- [x] `./tools/colony-lint.sh` -> 340 passed, 0 failed, 4 skipped (baseline preserved).
- [x] Doc comments in `run-research.sh` header (lines 116-138) updated to call out the `#679` rationale per knob.
- [x] `research-foundry/CHANGELOG.md` under `[Unreleased]` -> `Changed` documents the four-knob flip + math.

## Out of scope (explicitly NOT in this PR)

- No changes to `CULL_MIN_EXPLORERS`, `MAX_REPLICAS`, `POOL`, or `TICK_INTERVAL_S`.
- No changes to any `.ag` file — fitness scoring formulas stay as-is.
- No Queen pattern, no caste split — those are Phase 10 ideas for follow-up PRs.