### PR TITLE
fix(cross-fed-memo): canonicalize export-suppress 2-segment + enumerate opt-out/adopt-queue (#681)

### DIFF
--- a/doc/cross-fed-memo.md
+++ b/doc/cross-fed-memo.md
@@ -244,6 +244,14 @@ target the same host file. A federation that writes outside its own
 namespace is misbehaving and the operator should treat such writes as a
 trust violation per the threat-model section below.
 
+The remaining cross-fed kinds also fall under the per-fed-owned rule —
+`cross-fed:opt-out:<fed>` (each federation opts itself out; the `<fed>`
+segment scopes ownership) and
+`cross-fed:adopt-queue:<target-fed>:<method-id>` (queued at the target
+federation's bootstrap; the `<target-fed>` segment scopes ownership).
+Both are per-fed by construction, so no two federations target the same
+host file and no conflict-policy arbitration is required.
+
 ## Host dir layout
 
 The shared dir lives at `<repo-root>/cross-fed-memo/`. The bridge
@@ -309,8 +317,10 @@ Assumed threats:
    curates `cross-fed:applicable-to:<method-id>` before any adoption.
    The bridge does not authorise on fitness alone; the export-fitness
    threshold is a pre-filter, not a trust signal. PR-2/3 will add
-   `cross-fed:export-suppress:<source-fed>:<method-id>` (operator-only
-   write) for explicit blocklisting.
+   `cross-fed:export-suppress:<method-id>` as an operator-only,
+   federation-agnostic blocklist entry. Last-Writer-Wins by mtime per
+   the conflict-policy section; operators reconciling intentional
+   divergence must serialise edits.
 
 2. **External tampering of `<repo-root>/cross-fed-memo/`.** A process
    outside any federation rewrites a method body file between two


### PR DESCRIPTION
## Summary

Doc-only fix for the `cross-fed:export-suppress` key-shape inconsistency flagged in #681. Picks **option A (2-segment shared)** as canonical and brings the threat-model section in line with the operator-override paragraph + write-conflict policy.

Two changes to `doc/cross-fed-memo.md`:

1. **Line ~312 (threat-model #1 mitigation)** — rewrite `cross-fed:export-suppress:<source-fed>:<method-id>` to `cross-fed:export-suppress:<method-id>`; reword surrounding sentence so the operator-only blocklist intent reads naturally and reference the conflict-policy section for the LWW-by-mtime rule.
2. **Conflict-policy section (after the per-fed-owned bullet)** — add a short paragraph enumerating the remaining cross-fed kinds (`cross-fed:opt-out:<fed>` and `cross-fed:adopt-queue:<target-fed>:<method-id>`) so the audit-trail catalogue is complete. Both are per-fed by construction.

No code change required — `tools/cross-fed-bridge.py` `_split_key` / `_memo_key_to_host_path` already parse arbitrary segment counts (`len(parts) < 2` is the only floor); `KIND_TO_DIR["export-suppress"] = "export-suppress"` is unchanged.

## Verification

- `./tools/colony-lint.sh` — green for everything related to this change. The 2 `test-cull-replicas.sh` FAILs (tests 8 + 10) are pre-existing on `main` at parity-sha `cb94e50` and not regressions from this PR (no `.ag` / shell files touched). They post-date the close of #675 (which fixed a different respawn-loop bug); a follow-up issue may be warranted but is out of scope here.
- No `.ag` files touched.

closes #681