### PR TITLE
fix(novelty): hoist claim:* memo seeding out of final_write gate (#687)

### DIFF
--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -191,6 +191,27 @@ History of the three retired federations consolidated into this one
   new smoke-test assertions in `tools/test-auto-evolve-ab.sh`
   (total 18/18).
 
+### Fixed
+
+- `novelty/agents/novelty.ag` seeded the `claim:problem_text` /
+  `claim:answer` / `claim:novelty_claim` / `claim:explorer_*`
+  `:tick-N` memos only when `_publish_novelty` was called with
+  `final_write=true`. Tier dispatch passes `final_write=true` only
+  on the `autonomous` branch — `review-gated` and `propose` both
+  passed `false` — so in the default `propose` tier the claim
+  handoff keys were never written, and the downstream audit +
+  preprint pipeline (4 searcher colonies + `auditor` reading
+  `claim:*:tick-N` at their next tick advance) never started. Fix
+  hoists the NOVEL / BORDERLINE `claim:*:tick-N` writes out of the
+  `final_write` gate so they fire on every NOVEL / BORDERLINE
+  verdict regardless of tier. The on-disk discovery-ledger.jsonl
+  append (the actual final-write side effect) stays inside the
+  `final_write` gate, matching ADR-0001 tier policy (autonomous +
+  review-gated emit ledger rows; propose skips). No tier semantics
+  changed; no fitness or replicate logic changed. Coverage:
+  existing `tools/test-replicate-gates.sh` stays 29/29,
+  `tools/test-jitter.sh` stays 72/72. (#687)
+
 ### Added
 
 - LLM-driven `.ag` mutator + real A/B harness in dry-run mode for

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -211,25 +211,32 @@ fn _publish_novelty(
         memo_write("novelty:final_verdict:" + explorer_pid + ":tick-" + to_string(upstream_tick), novelty.novelty_verdict);
     };
 
-    if final_write {
-        // Append to per-run discovery ledger.
-        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
-        if len(ledger_path) > 0 {
-            let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"event\":\"novelty_verdict\",\"verdict\":\"" + novelty.novelty_verdict + "\"}";
-            // colony-lint: safe-exec-concat
-            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-            let _ = try { exec sh append_cmd; } catch e { ""; };
+    // Seed `claim:*:tick-N` keys for the 4 searcher colonies +
+    // auditor so the downstream pipeline reads them at the NEXT
+    // tick (in-container, shared `.agentis/` memo). Replaces the
+    // cross-fed memo recall that the retired run-auditor.sh did
+    // by probing math-foundry's run dir (#638). tick_idx is the
+    // current orchestrator tick (where novelty fired); searchers
+    // read `claim:*:tick-N` with N = their own current_tick at
+    // the next tick advance. These are inter-colony handoff
+    // signals, not final-write side-effects: they fire on every
+    // NOVEL/BORDERLINE verdict regardless of tier so the audit +
+    // preprint pipeline unblocks in the default propose tier (#687).
+    if novelty.novelty_verdict == "NOVEL" {
+        let tick_s = to_string(tick_idx);
+        memo_write("claim:problem_text:tick-" + tick_s, problem_text);
+        memo_write("claim:answer:tick-" + tick_s, stated_answer);
+        memo_write("claim:novelty_claim:tick-" + tick_s, novelty_claim);
+        if len(explorer_pid) > 0 {
+            let explorer_code = recall_latest("explorer:" + explorer_pid + ":code:tick-" + to_string(upstream_tick));
+            let explorer_output = recall_latest("explorer:" + explorer_pid + ":output:tick-" + to_string(upstream_tick));
+            let explorer_goal = recall_latest("explorer:" + explorer_pid + ":goal:tick-" + to_string(upstream_tick));
+            memo_write("claim:explorer_code:tick-" + tick_s, explorer_code);
+            memo_write("claim:explorer_output:tick-" + tick_s, explorer_output);
+            memo_write("claim:explorer_goal:tick-" + tick_s, explorer_goal);
         };
-
-        // Seed `claim:*:tick-N` keys for the 4 searcher colonies +
-        // auditor so the downstream pipeline reads them at the NEXT
-        // tick (in-container, shared `.agentis/` memo). Replaces the
-        // cross-fed memo recall that the retired run-auditor.sh did
-        // by probing math-foundry's run dir (#638). tick_idx is the
-        // current orchestrator tick (where novelty fired); searchers
-        // read `claim:*:tick-N` with N = their own current_tick at
-        // the next tick advance.
-        if novelty.novelty_verdict == "NOVEL" {
+    } else {
+        if novelty.novelty_verdict == "BORDERLINE" {
             let tick_s = to_string(tick_idx);
             memo_write("claim:problem_text:tick-" + tick_s, problem_text);
             memo_write("claim:answer:tick-" + tick_s, stated_answer);
@@ -242,21 +249,21 @@ fn _publish_novelty(
                 memo_write("claim:explorer_output:tick-" + tick_s, explorer_output);
                 memo_write("claim:explorer_goal:tick-" + tick_s, explorer_goal);
             };
-        } else {
-            if novelty.novelty_verdict == "BORDERLINE" {
-                let tick_s = to_string(tick_idx);
-                memo_write("claim:problem_text:tick-" + tick_s, problem_text);
-                memo_write("claim:answer:tick-" + tick_s, stated_answer);
-                memo_write("claim:novelty_claim:tick-" + tick_s, novelty_claim);
-                if len(explorer_pid) > 0 {
-                    let explorer_code = recall_latest("explorer:" + explorer_pid + ":code:tick-" + to_string(upstream_tick));
-                    let explorer_output = recall_latest("explorer:" + explorer_pid + ":output:tick-" + to_string(upstream_tick));
-                    let explorer_goal = recall_latest("explorer:" + explorer_pid + ":goal:tick-" + to_string(upstream_tick));
-                    memo_write("claim:explorer_code:tick-" + tick_s, explorer_code);
-                    memo_write("claim:explorer_output:tick-" + tick_s, explorer_output);
-                    memo_write("claim:explorer_goal:tick-" + tick_s, explorer_goal);
-                };
-            };
+        };
+    };
+
+    if final_write {
+        // Append to per-run discovery ledger. This is the only
+        // remaining final_write-gated side effect: the on-disk
+        // discovery-ledger.jsonl row should reflect tier policy
+        // (autonomous + review-gated emit; propose skips per
+        // #622 ADR-0001).
+        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        if len(ledger_path) > 0 {
+            let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"event\":\"novelty_verdict\",\"verdict\":\"" + novelty.novelty_verdict + "\"}";
+            // colony-lint: safe-exec-concat
+            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
+            let _ = try { exec sh append_cmd; } catch e { ""; };
         };
     };
 


### PR DESCRIPTION
## Problem

`research-foundry/novelty/agents/novelty.ag` `_publish_novelty()` wrote the `claim:problem_text` / `claim:answer` / `claim:novelty_claim` / `claim:explorer_*` `:tick-N` memos inside an `if final_write { ... }` block. Tier dispatch in `tick()` invoked `_publish_novelty(final_write, do_replicate, ...)` as:

- `autonomous`   -> `_publish_novelty(true,  true,  ...)`  -> claim:* seeded
- `review-gated` -> `_publish_novelty(true,  false, ...)`  -> NO seed
- `propose`      -> `_publish_novelty(false, false, ...)`  -> NO seed

The default novelty confidence sits in `[0.6, 0.8)` -- the `propose` tier -- so on every default `run-research.sh` invocation the inter-colony `claim:*:tick-N` handoff never fired, and the downstream audit + preprint pipeline (4 searcher colonies + `auditor` consuming `claim:*:tick-N` at the next tick advance) stayed dormant.

## Fix

Hoist the `claim:*:tick-N` writes for both `NOVEL` and `BORDERLINE` verdicts out of the `final_write` gate in `_publish_novelty`. These are inter-colony handoff signals -- they should fire on every NOVEL / BORDERLINE verdict regardless of tier. The on-disk `discovery-ledger.jsonl` append (the actual final-write side effect) stays inside the `final_write` gate, matching ADR-0001 tier policy (`autonomous` + `review-gated` emit the ledger row, `propose` skips per #622).

## Impact

The audit + preprint pipeline now unblocks in the default `propose` tier instead of requiring the operator to manually promote `novelty` to `autonomous` first. No tier semantics changed, no fitness / replicate logic changed, no novelty prompt content changed.

## Verification

- `research-foundry/tools/test-replicate-gates.sh` -> 29 passed, 0 failed, 0 skipped (matches baseline).
- `research-foundry/tools/test-jitter.sh` -> 72 passed, 0 failed (matches baseline).
- `./tools/colony-lint.sh` -> 341 passed, 0 failed, 4 skipped.
- `agentis commit novelty.ag` parses cleanly in a scratch agentis repo.

## Diff shape

2 files, +61 / -33 (CHANGELOG +21, novelty.ag net +6 with comment + block reorder).

Closes #687