### PR TITLE
fix(research-foundry/search): dashed last_check key in 4 search colonies (#688)

### DIFF
--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -18,6 +18,19 @@ History of the three retired federations consolidated into this one
 
 ## [Unreleased]
 
+### Fixed
+
+- Four `research-foundry` search colonies (`arxiv-search`, `oeis-search`,
+  `scholar-search`, `groupprops-search`) wrote their per-tick liveness memo
+  to the underscored key `<agent>_search:last_check` instead of the
+  canonical dashed `<agent>-search:last_check`. The
+  `federation-dashboard` freshness probe and any operator tooling that
+  follows the `<basename>:last_check` convention (CLAUDE.md "Agent
+  conventions") therefore reported these four agents as stale or missing
+  even when they ticked normally. Rename is mechanical (one `memo_write`
+  call per file) and matches the basename of each `.ag` file. No reader
+  of the underscored form existed in-tree (#688).
+
 ### Changed
 
 - Lifecycle (birth + death + respawn) is now **on by default** in the

--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -378,6 +378,6 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("arxiv_search:last_check", now);
+        memo_write("arxiv-search:last_check", now);
     };
 }

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -354,6 +354,6 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("groupprops_search:last_check", now);
+        memo_write("groupprops-search:last_check", now);
     };
 }

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -363,6 +363,6 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("oeis_search:last_check", now);
+        memo_write("oeis-search:last_check", now);
     };
 }

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -360,6 +360,6 @@ fn tick(reason: string) -> void {
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {
-        memo_write("scholar_search:last_check", now);
+        memo_write("scholar-search:last_check", now);
     };
 }


### PR DESCRIPTION
## Summary

Mechanical 4-line rename. Four `research-foundry` search colonies wrote their per-tick liveness memo to the underscored key `<agent>_search:last_check` instead of the canonical dashed `<agent>-search:last_check`. The `federation-dashboard` freshness probe (#683 / #686) reads the dashed form per the `<basename>:last_check` convention documented in CLAUDE.md "Agent conventions", so these four agents looked stale or missing on the dashboard even when they ticked normally.

Renames (one `memo_write` call per file, basename matches the `.ag` filename):

| File | Was | Now |
|------|-----|-----|
| `research-foundry/arxiv-search/agents/arxiv-search.ag:381` | `arxiv_search:last_check` | `arxiv-search:last_check` |
| `research-foundry/oeis-search/agents/oeis-search.ag:366` | `oeis_search:last_check` | `oeis-search:last_check` |
| `research-foundry/scholar-search/agents/scholar-search.ag:363` | `scholar_search:last_check` | `scholar-search:last_check` |
| `research-foundry/groupprops-search/agents/groupprops-search.ag:357` | `groupprops_search:last_check` | `groupprops-search:last_check` |

No reader of the underscored form existed in-tree — confirmed via `grep -rnE '(arxiv_search|oeis_search|scholar_search|groupprops_search):last_check' research-foundry/` (only the 4 producers matched, all flipped in this PR). The dashed form is the canonical shape used by the other 14 `research-foundry` agents (`explorer`, `editor`, `auditor`, `noticer`, `computer`, `introducer`, `formulator`, `novelty`, `skeptic`, `reviewer`, `theorist`, `submitter`, `verifier`, `prior_advocate`).

CHANGELOG: `research-foundry/CHANGELOG.md` `[Unreleased] / Fixed`.

## Out of scope

- Colony-lint rule that enforces `memo_write("<basename>:last_check", ...)` shape. Issue mentions this as optional; opening as a follow-up rather than expanding scope here.

## Test plan

- [x] `bash research-foundry/tools/test-replicate-gates.sh` — 29 passed, 0 failed, 0 skipped.
- [x] `bash research-foundry/tools/test-jitter.sh` — 72 passed, 0 failed.
- [x] `./tools/colony-lint.sh` — 341 passed, 0 failed, 4 skipped.
- [x] `grep -rnE '(arxiv_search|oeis_search|scholar_search|groupprops_search):last_check' research-foundry/` returns no matches.

closes #688

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>