### PR TITLE
fix(cull-replicas): env-knob isolation for test-cull-replicas live-container leak (#685)

### DIFF
--- a/tools/cull-replicas.sh
+++ b/tools/cull-replicas.sh
@@ -39,8 +39,14 @@
 #
 # This script only runs inside the host context that drives the
 # research-foundry container; it talks to the container exclusively via
-# `podman exec research-foundry-laptop ...`. The ledger path is the
-# host-side bind-mount root (<fed_dir>/replication-ledger.jsonl).
+# `podman exec "$CONTAINER" ...`, where $CONTAINER defaults to
+# `research-foundry-laptop` and can be overridden by exporting
+# `CULL_CONTAINER_NAME=<name>`. Test harnesses set this to a sentinel
+# value (`cull-test-noop`) so every `podman exec` fails fast and the
+# script's try/except blocks fall through to fixture-provided values
+# instead of leaking into a live federation's memo store (issue #685).
+# The ledger path is the host-side bind-mount root
+# (<fed_dir>/replication-ledger.jsonl).
 #
 # Net-zero on daemon count: kill 1, spawn 1. The M2-Malthusian
 # max_replicas cap from PR 1 still enforces the upper bound.
@@ -131,7 +137,7 @@ fi
 CONFIG_FILE="$REPO_ROOT/tools/auto-promote-config.research-foundry.yaml"
 DECISIONS_SCRIPT="$REPO_ROOT/tools/auto-promote-decisions.py"
 REPLICATION_LEDGER="$FED_DIR/replication-ledger.jsonl"
-CONTAINER="research-foundry-laptop"
+CONTAINER="${CULL_CONTAINER_NAME:-research-foundry-laptop}"
 VARIANTS_FILE="$REPO_ROOT/research-foundry/tools/colony-variants.json"
 
 log() {
@@ -251,6 +257,7 @@ read_specialty_counts() {
 import json, subprocess, sys
 daemons = json.loads(sys.argv[1])
 colony = sys.argv[2]
+container = sys.argv[3]
 counts = {}
 for d in daemons:
     pid = d.get('pid', 0)
@@ -258,7 +265,7 @@ for d in daemons:
         continue
     try:
         out = subprocess.run(
-            ['podman', 'exec', 'research-foundry-laptop',
+            ['podman', 'exec', container,
              'agentis', 'memo', 'get', '%s:%s:specialty' % (colony, pid)],
             capture_output=True, text=True, timeout=5,
         )
@@ -269,7 +276,7 @@ for d in daemons:
         continue
     counts[val] = counts.get(val, 0) + 1
 print(json.dumps(counts))
-" "$COLONY_DAEMONS_JSON" "$COLONY_NAME"
+" "$COLONY_DAEMONS_JSON" "$COLONY_NAME" "$CONTAINER"
 }
 
 SPECIALTY_COUNTS_JSON="$(read_specialty_counts)"
@@ -288,6 +295,7 @@ MAX_DAEMON_ID="$(python3 -c "
 import json, subprocess, sys
 daemons = json.loads(sys.argv[1])
 colony = sys.argv[2]
+container = sys.argv[3]
 max_id = 0
 for d in daemons:
     pid = d.get('pid', 0)
@@ -305,7 +313,7 @@ for d in daemons:
     # scanning the pool:specialty:<N> slot assignments for occupied ids.
     try:
         out = subprocess.run(
-            ['podman', 'exec', 'research-foundry-laptop',
+            ['podman', 'exec', container,
              'agentis', 'memo', 'get', '%s:%s:daemon_id' % (colony, pid)],
             capture_output=True, text=True, timeout=5,
         )
@@ -319,7 +327,7 @@ for d in daemons:
 # below.
 try:
     out = subprocess.run(
-        ['podman', 'exec', 'research-foundry-laptop',
+        ['podman', 'exec', container,
          'agentis', 'memo', 'list'],
         capture_output=True, text=True, timeout=5,
     )
@@ -341,7 +349,7 @@ except (OSError, subprocess.SubprocessError):
 if max_id == 0:
     max_id = len(daemons)
 print(max_id)
-" "$COLONY_DAEMONS_JSON" "$COLONY_NAME" 2>/dev/null || echo "$COLONY_COUNT")"
+" "$COLONY_DAEMONS_JSON" "$COLONY_NAME" "$CONTAINER" 2>/dev/null || echo "$COLONY_COUNT")"
 
 # Helper: demand-weighted specialty pick from colony-variants.json.
 # Invoked once per respawn so the picker re-evaluates after each prior

--- a/tools/test-cull-replicas.sh
+++ b/tools/test-cull-replicas.sh
@@ -30,6 +30,19 @@
 
 set -eu
 
+# Isolate this test harness from any live research-foundry container on
+# the host (#685). cull-replicas.sh resolves $CONTAINER from
+# CULL_CONTAINER_NAME (default research-foundry-laptop); pointing it at
+# a sentinel name that will never match a real podman container makes
+# every `podman exec` invocation fail fast, so the script's try/except
+# blocks fall through to the fixture-provided values
+# (CULL_DAEMONS_JSON_OVERRIDE, CULL_SPECIALTY_COUNTS_OVERRIDE) rather
+# than reading the live federation's memo store. Without this, tests 8
+# and 10 (which assert specific daemon_id allocations) fail whenever a
+# running research-foundry-laptop container has pool:specialty:<N>
+# slots claimed beyond the synthetic fixture's range.
+export CULL_CONTAINER_NAME=cull-test-noop
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CULL="$SCRIPT_DIR/cull-replicas.sh"
 WRAPPER="$SCRIPT_DIR/cull-explorers.sh"


### PR DESCRIPTION
## Summary

- `tools/cull-replicas.sh` hardcoded `research-foundry-laptop` in three `podman exec` invocations embedded in Python blocks (read_specialty_counts at line 261, MAX_DAEMON_ID daemon_id lookup at line 308, MAX_DAEMON_ID pool list at line 322) plus the top-level `$CONTAINER` assignment. The existing test fixture override knobs (`CULL_DAEMONS_JSON_OVERRIDE`, `CULL_SPECIALTY_COUNTS_OVERRIDE`) could not reach those Python paths, so `tools/test-cull-replicas.sh` tests 8 (#650 gap allocation) and 10 (#675 NEXT_ID per-respawn bump) silently leaked into a live `research-foundry-laptop` container's memo store whenever the federation was running on the same host. Symptom: daemon_id allocations drifted from the fixture's expected 5/6/7 range.
- Fix: introduce `CULL_CONTAINER_NAME` env knob, default `research-foundry-laptop`. Production semantics unchanged. Thread `$CONTAINER` through the three Python blocks via argv. Test harness exports `CULL_CONTAINER_NAME=cull-test-noop` (a name that never resolves to any podman container) so every `podman exec` invocation fails fast and the script's try/except blocks fall through to the fixture-provided values.
- No `.ag` changes, no production-path semantics changes, no new dependencies.

## Test plan

- [x] `bash tools/test-cull-replicas.sh` -- 13/13 PASS with no live container.
- [x] `bash tools/test-cull-replicas.sh` -- 13/13 PASS with a separately-named live podman container running (`cull-test-actual`, alpine sleep). This proves the env-knob redirects all queries away from anything live on the host, not just away from `research-foundry-laptop`.
- [x] `./tools/colony-lint.sh` -- 341 passed, 0 failed, 4 skipped (`test-cull-replicas.sh` row green).
- [x] Production path unchanged: `$CONTAINER` defaults to `research-foundry-laptop` when `CULL_CONTAINER_NAME` is unset.

Closes #685