### PR TITLE
feat(persistent-pr-a): research-foundry persistent dir + run-end snapshot (PR-A of #626)

### DIFF
--- a/research-foundry/BUNDLE.manifest
+++ b/research-foundry/BUNDLE.manifest
@@ -6,6 +6,10 @@ research-foundry/tools/fetch-papers.py
 research-foundry/tools/test-fetch-papers.py
 research-foundry/tools/review-cli.sh
 research-foundry/tools/substitute-author.py
+# Phase 5 PR-A (#626). Run-end snapshot of curated memo namespaces into
+# <fed-dir>/persistent/memo-snapshot.json. PR-B will consume the snapshot
+# at bootstrap; PR-C will aggregate cross-run fitness.
+research-foundry/tools/persistent-snapshot.py
 # Phase 9 PR-B (#663). Source-of-truth variant + overlay table read
 # by tools/cull-replicas.sh and the run-research.sh bootstrap loop.
 research-foundry/tools/colony-variants.json

--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -18,6 +18,20 @@ History of the three retired federations consolidated into this one
 
 ## [Unreleased]
 
+### Added
+
+- Phase 5 PR-A: `research-foundry/persistent/` directory scaffolding
+  with `SCHEMA_VERSION=1`. At run end the orchestrator snapshots curated
+  memo namespaces (`formulator:learned_*`, `editor:learned_pitfalls`,
+  `feedback:hitl_*`, `<colony>:confidence` for all 18 colonies) into
+  `persistent/memo-snapshot.json` via a new
+  `research-foundry/tools/persistent-snapshot.py` helper. Atomic write
+  (tmpfile + rename). No consumers yet -- PR-B will read the snapshot
+  at bootstrap to bias new replicas toward fit specialties, PR-C adds
+  cross-run fitness aggregation. New env knobs:
+  `RESEARCH_PERSISTENT_DIR` (default `<fed-dir>/persistent`),
+  `RESEARCH_PERSISTENT_DISABLED=1` opt-out. Reference: [#626](https://github.com/Replikanti/agentis-colonies/issues/626).
+
 ### Fixed
 
 - Four `research-foundry` search colonies (`arxiv-search`, `oeis-search`,

--- a/research-foundry/tools/persistent-snapshot.py
+++ b/research-foundry/tools/persistent-snapshot.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""persistent-snapshot.py - Snapshot curated memo namespaces to disk.
+
+Phase 5 PR-A of #626 (cross-run learning). Host-side helper invoked at
+run-end by `research-foundry/tools/run-research.sh` after `signal_shutdown`
+and before `emit_step "run-research: done"`. Reads a fixed, hardcoded set
+of memo keys from the merged research-foundry container via
+`podman exec <container> agentis memo get <key>` and writes the resulting
+dict to `<output_dir>/memo-snapshot.json` atomically (tmpfile + rename).
+
+This PR scaffolds the persistent dir + write path only. PR-B will read the
+snapshot at bootstrap to bias new replicas toward fit specialties; PR-C
+will aggregate cross-run fitness across snapshots. Nothing in-tree reads
+the snapshot yet.
+
+Schema:
+    {
+      "schema": 1,
+      "snapshot_ts": "<UTC ISO-8601>",
+      "container": "<container_name>",
+      "keys": { "<memo key>": "<value>", ... }
+    }
+
+Side-effects:
+- Writes `<output_dir>/SCHEMA_VERSION` (single line `1\n`) on first
+  invocation. If the file exists with a value != 1 the helper logs a
+  clear warning on stderr and exits non-zero without overwriting
+  memo-snapshot.json (run-research.sh treats the failure as non-fatal).
+
+Per-call resilience:
+- The container may already be shutting down. Each `podman exec` is
+  retried up to 3 times with a 1s sleep between attempts; non-zero
+  return on the final attempt yields an empty string for that key
+  (a missing or unreadable memo is not fatal).
+- A completely failed run (e.g. `podman` not on PATH or container
+  unreachable) exits non-zero before any tmp/final file is created so
+  the orchestrator never sees a half-formed JSON.
+
+Pattern: this is a heredoc-free Python helper following the precedent
+of `tools/auto-promote-config-parser.py` and `tools/auto-promote-decisions.py`
+(extracted from `auto-promote.sh` per #245 to avoid the macOS bash 3.2
+parser bug).
+
+Usage:
+    persistent-snapshot.py --container <name> --output-dir <dir>
+    persistent-snapshot.py --help
+"""
+import datetime
+import json
+import os
+import subprocess
+import sys
+import time
+
+
+SCHEMA_VERSION = 1
+
+EXACT_KEYS = [
+    "formulator:learned_known_topics",
+    "formulator:learned_successful_topics",
+    "editor:learned_pitfalls",
+    "feedback:hitl_rejects",
+]
+
+PREFIX_GLOBS = [
+    "feedback:hitl_reject_reason:claim-",
+    "feedback:hitl_reject_class:claim-",
+]
+
+CONFIDENCE_COLONIES = [
+    "explorer",
+    "noticer",
+    "skeptic",
+    "formulator",
+    "verifier",
+    "novelty",
+    "arxiv-search",
+    "oeis-search",
+    "groupprops-search",
+    "scholar-search",
+    "prior_advocate",
+    "auditor",
+    "introducer",
+    "theorist",
+    "computer",
+    "editor",
+    "reviewer",
+    "submitter",
+]
+
+RETRY_ATTEMPTS = 3
+RETRY_SLEEP_S = 1.0
+
+
+def _print_help_and_exit():
+    sys.stdout.write(__doc__ or "")
+    sys.stdout.write("\n")
+    sys.exit(0)
+
+
+def _parse_args(argv):
+    container = None
+    output_dir = None
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a in ("-h", "--help"):
+            _print_help_and_exit()
+        elif a == "--container":
+            if i + 1 >= len(argv):
+                sys.stderr.write("persistent-snapshot: --container requires a value\n")
+                sys.exit(2)
+            container = argv[i + 1]
+            i += 2
+            continue
+        elif a == "--output-dir":
+            if i + 1 >= len(argv):
+                sys.stderr.write("persistent-snapshot: --output-dir requires a value\n")
+                sys.exit(2)
+            output_dir = argv[i + 1]
+            i += 2
+            continue
+        else:
+            sys.stderr.write("persistent-snapshot: unknown argument: " + a + "\n")
+            sys.exit(2)
+    if container is None:
+        sys.stderr.write("persistent-snapshot: --container is required\n")
+        sys.exit(2)
+    if output_dir is None:
+        sys.stderr.write("persistent-snapshot: --output-dir is required\n")
+        sys.exit(2)
+    return container, output_dir
+
+
+def _podman_exec(container, args):
+    """Run `podman exec <container> <args>`. Returns CompletedProcess.
+
+    Returns None if podman itself is unreachable (FileNotFoundError),
+    which the caller treats as a fatal pre-flight failure (no JSON written).
+    """
+    cmd = ["podman", "exec", container] + list(args)
+    try:
+        return subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+
+
+def _memo_get(container, key):
+    """Run `agentis memo get <key>` inside the container with retry.
+
+    Returns the stdout string with trailing CR/LF stripped, or "" if all
+    attempts failed (missing memo or container shutdown).
+    """
+    last_rc = None
+    for attempt in range(RETRY_ATTEMPTS):
+        result = _podman_exec(container, ["agentis", "memo", "get", key])
+        if result is None:
+            return ""
+        if result.returncode == 0:
+            return result.stdout.decode("utf-8", errors="replace").rstrip("\r\n")
+        last_rc = result.returncode
+        if attempt < RETRY_ATTEMPTS - 1:
+            time.sleep(RETRY_SLEEP_S)
+    sys.stderr.write(
+        "persistent-snapshot: memo get '" + key + "' failed after "
+        + str(RETRY_ATTEMPTS) + " attempts (last rc=" + str(last_rc) + ")\n"
+    )
+    return ""
+
+
+def _memo_list_keys(container):
+    """Run `agentis memo list` and return the line-split key set.
+
+    Used to expand prefix-globs (`feedback:hitl_reject_reason:claim-*`).
+    Returns an empty list if the call fails on every attempt -- the
+    helper still writes the exact-key entries so a flaky list call
+    does not blank the whole snapshot.
+    """
+    for attempt in range(RETRY_ATTEMPTS):
+        result = _podman_exec(container, ["agentis", "memo", "list"])
+        if result is None:
+            return []
+        if result.returncode == 0:
+            raw = result.stdout.decode("utf-8", errors="replace")
+            keys = []
+            for line in raw.splitlines():
+                line = line.strip()
+                if line:
+                    keys.append(line)
+            return keys
+        if attempt < RETRY_ATTEMPTS - 1:
+            time.sleep(RETRY_SLEEP_S)
+    sys.stderr.write(
+        "persistent-snapshot: memo list failed after "
+        + str(RETRY_ATTEMPTS) + " attempts (prefix-globs will be empty)\n"
+    )
+    return []
+
+
+def _check_schema_version_file(output_dir):
+    """Validate SCHEMA_VERSION file. Write it if absent; return ok bool.
+
+    On version mismatch (file contents != "1"), log a clear warning and
+    return False. The caller exits non-zero in that case so the shell
+    wrapper can surface "persistent snapshot failed (non-fatal)".
+    """
+    sv_path = os.path.join(output_dir, "SCHEMA_VERSION")
+    if not os.path.exists(sv_path):
+        try:
+            with open(sv_path, "w") as f:
+                f.write(str(SCHEMA_VERSION) + "\n")
+        except OSError as e:
+            sys.stderr.write(
+                "persistent-snapshot: cannot write " + sv_path + ": " + str(e) + "\n"
+            )
+            return False
+        return True
+    try:
+        with open(sv_path, "r") as f:
+            existing = f.read().strip()
+    except OSError as e:
+        sys.stderr.write(
+            "persistent-snapshot: cannot read " + sv_path + ": " + str(e) + "\n"
+        )
+        return False
+    if existing != str(SCHEMA_VERSION):
+        sys.stderr.write(
+            "persistent-snapshot: SCHEMA_VERSION mismatch at " + sv_path
+            + " (found '" + existing + "', expected '" + str(SCHEMA_VERSION)
+            + "'). Refusing to overwrite memo-snapshot.json. Resolve manually "
+            + "(operator must reconcile schema before next run).\n"
+        )
+        return False
+    return True
+
+
+def _atomic_write_json(output_path, payload):
+    """Write payload as JSON via tmpfile + rename in the same dir."""
+    out_dir = os.path.dirname(output_path) or "."
+    tmp_path = output_path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+        f.flush()
+        try:
+            os.fsync(f.fileno())
+        except OSError:
+            pass
+    os.replace(tmp_path, output_path)
+    try:
+        dir_fd = os.open(out_dir, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass
+
+
+def snapshot_keys(container, output_dir):
+    """Snapshot the curated memo keys into <output_dir>/memo-snapshot.json.
+
+    Pre-flight: ensure `podman exec <container> true` succeeds. Aborts
+    before writing anything if podman is missing OR if the container is
+    unreachable; that way the orchestrator never sees a half-formed
+    JSON file.
+    """
+    probe = _podman_exec(container, ["true"])
+    if probe is None:
+        sys.stderr.write(
+            "persistent-snapshot: 'podman' binary not on PATH; aborting "
+            + "(no snapshot written).\n"
+        )
+        return 3
+    if probe.returncode != 0:
+        sys.stderr.write(
+            "persistent-snapshot: 'podman exec " + container + " true' failed "
+            + "(rc=" + str(probe.returncode) + "); aborting (no snapshot written).\n"
+        )
+        return 3
+
+    try:
+        os.makedirs(output_dir, exist_ok=True)
+    except OSError as e:
+        sys.stderr.write(
+            "persistent-snapshot: cannot create " + output_dir + ": " + str(e) + "\n"
+        )
+        return 4
+
+    if not _check_schema_version_file(output_dir):
+        return 5
+
+    keys_to_snapshot = list(EXACT_KEYS)
+    keys_to_snapshot.extend(c + ":confidence" for c in CONFIDENCE_COLONIES)
+
+    if PREFIX_GLOBS:
+        listed = _memo_list_keys(container)
+        for prefix in PREFIX_GLOBS:
+            for k in listed:
+                if k.startswith(prefix):
+                    keys_to_snapshot.append(k)
+
+    seen = set()
+    deduped = []
+    for k in keys_to_snapshot:
+        if k in seen:
+            continue
+        seen.add(k)
+        deduped.append(k)
+
+    snapshot = {}
+    for key in deduped:
+        snapshot[key] = _memo_get(container, key)
+
+    payload = {
+        "schema": SCHEMA_VERSION,
+        "snapshot_ts": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "container": container,
+        "keys": snapshot,
+    }
+
+    output_path = os.path.join(output_dir, "memo-snapshot.json")
+    try:
+        _atomic_write_json(output_path, payload)
+    except OSError as e:
+        sys.stderr.write(
+            "persistent-snapshot: cannot write " + output_path + ": " + str(e) + "\n"
+        )
+        return 6
+
+    sys.stdout.write("persistent-snapshot: wrote " + output_path + " (" + str(len(snapshot)) + " keys)\n")
+    return 0
+
+
+def main(argv):
+    container, output_dir = _parse_args(argv)
+    return snapshot_keys(container, output_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -66,6 +66,13 @@
 #                                Default: "" (real run).
 #   RESEARCH_RUN_DIR             Output dir override. Default: auto-
 #                                timestamped under research-foundry/runs/
+#   RESEARCH_PERSISTENT_DIR      Per-federation persistent dir written at
+#                                run-end (Phase 5 PR-A of #626). Default:
+#                                <fed-dir>/persistent. PR-B will read
+#                                memo-snapshot.json from here at bootstrap;
+#                                PR-C will aggregate cross-run fitness.
+#   RESEARCH_PERSISTENT_DISABLED 1 = skip the run-end memo snapshot.
+#                                Default 0 (snapshot is on by default).
 #   RESEARCH_IMAGE_TAG           Container image tag built from
 #                                Containerfile.research.
 #                                Default: research-foundry:latest
@@ -232,6 +239,8 @@ DAEMON_CB_PER_TICK="${RESEARCH_DAEMON_CB_PER_TICK:-2000}"
 DAEMON_HEARTBEAT_MS="${RESEARCH_DAEMON_HEARTBEAT_MS:-1800000}"
 LATEXMK_MAX_PASSES="${RESEARCH_LATEXMK_MAX_PASSES:-3}"
 IMAGE_TAG="${RESEARCH_IMAGE_TAG:-research-foundry:latest}"
+PERSISTENT_DIR="${RESEARCH_PERSISTENT_DIR:-$FED_DIR/persistent}"
+PERSISTENT_DISABLED="${RESEARCH_PERSISTENT_DISABLED:-0}"
 ARXIV_GATEWAY="${RESEARCH_ARXIV_GATEWAY:-submit@arxiv.org}"
 ARXIV_FROM="${RESEARCH_ARXIV_FROM:-}"
 SMTP_HOST="${RESEARCH_SMTP_HOST:-localhost}"
@@ -1068,6 +1077,20 @@ if [ "$DRY_RUN" = "1" ]; then
 fi
 
 signal_shutdown
+
+# Phase 5 PR-A (#626): snapshot curated memo namespaces into the
+# per-federation persistent dir so PR-B can read fittest-specialty +
+# learned-pitfall state at the next bootstrap. PR-C will aggregate
+# cross-run fitness across snapshots. Treated as non-fatal -- a failed
+# snapshot must not break the shutdown path.
+if [ "$PERSISTENT_DISABLED" != "1" ]; then
+    emit_step "snapshotting persistent memo to $PERSISTENT_DIR"
+    if ! python3 "$TOOLS_DIR/persistent-snapshot.py" \
+            --container research-foundry-laptop \
+            --output-dir "$PERSISTENT_DIR" >>"$ORCH_LOG" 2>&1; then
+        emit_step "persistent snapshot failed (non-fatal); continuing shutdown"
+    fi
+fi
 
 emit_step "run-research: done"
 echo "[run-research] run dir: $RUN_DIR"

--- a/research-foundry/tools/test-persistent-snapshot.sh
+++ b/research-foundry/tools/test-persistent-snapshot.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# research-foundry/tools/test-persistent-snapshot.sh -- regression test
+# for the Phase 5 PR-A (#626) persistent-snapshot.py helper.
+#
+# Four synthetic-fixture cases (no live container required):
+#   (1) Happy path: stubbed `podman` emits canned `agentis memo get`
+#       output. Assert `memo-snapshot.json` contains the expected keys +
+#       values, schema=1, snapshot_ts present.
+#   (2) Atomic write: invoke twice; assert no `.tmp` files left behind
+#       in the persistent dir.
+#   (3) Missing podman / failed exec: stub `podman` to exit non-zero on
+#       every call. Assert helper exits non-zero AND no half-formed
+#       memo-snapshot.json was written.
+#   (4) SCHEMA_VERSION: first invocation writes SCHEMA_VERSION=1.
+#       Subsequent invocations with same version succeed. After
+#       manually editing the file to `99`, helper warns + refuses to
+#       overwrite (non-zero exit, memo-snapshot.json unchanged).
+#
+# Standard library only -- no pytest, no live federation.
+#
+# Usage: bash research-foundry/tools/test-persistent-snapshot.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$SCRIPT_DIR/persistent-snapshot.py"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$HELPER" ]; then
+    fail "preflight" "$HELPER not found"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[SKIP] python3 not on PATH"
+    echo "Results: 0 passed, 0 failed (skipped)"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Build a fake `podman` script that the helper invokes via PATH lookup.
+# Behaviour switches on $PODMAN_MODE so each case can plug in different
+# canned outputs without rewriting the binary.
+mkdir -p "$WORK/bin"
+FAKE_PODMAN="$WORK/bin/podman"
+cat >"$FAKE_PODMAN" <<'FAKE_PODMAN_EOF'
+#!/usr/bin/env bash
+# Fake podman driven by $PODMAN_MODE. Recognises:
+#   exec <container> true               -> exit 0 (preflight)
+#   exec <container> agentis memo get <KEY>
+#   exec <container> agentis memo list
+set -eu
+
+mode="${PODMAN_MODE:-ok}"
+
+# Drop the leading `exec <container>` so $1 becomes the agentis subcmd.
+if [ "${1:-}" = "exec" ]; then
+    shift
+    shift
+fi
+
+if [ "$mode" = "fail-all" ]; then
+    echo "fake-podman: simulated failure" >&2
+    exit 1
+fi
+
+case "${1:-}" in
+    true)
+        exit 0
+        ;;
+    agentis)
+        shift
+        ;;
+    *)
+        # Unrecognised top-level command from the helper.
+        echo "fake-podman: unknown command: $*" >&2
+        exit 2
+        ;;
+esac
+
+case "${1:-}" in
+    memo)
+        shift
+        ;;
+    *)
+        echo "fake-podman: not memo subcmd: $*" >&2
+        exit 2
+        ;;
+esac
+
+case "${1:-}" in
+    get)
+        key="${2:-}"
+        case "$key" in
+            formulator:learned_known_topics)
+                echo "number_theory,combinatorics"
+                ;;
+            formulator:learned_successful_topics)
+                echo "graph_theory"
+                ;;
+            editor:learned_pitfalls)
+                echo "missing-bibtex"
+                ;;
+            feedback:hitl_rejects)
+                echo "claim-42,claim-43"
+                ;;
+            feedback:hitl_reject_reason:claim-42)
+                echo "wrong-citation"
+                ;;
+            feedback:hitl_reject_class:claim-42)
+                echo "factual"
+                ;;
+            *:confidence)
+                echo "0.7"
+                ;;
+            explorer:confidence|noticer:confidence|skeptic:confidence|\
+            formulator:confidence|verifier:confidence|novelty:confidence|\
+            arxiv-search:confidence|oeis-search:confidence|\
+            groupprops-search:confidence|scholar-search:confidence|\
+            prior_advocate:confidence|auditor:confidence|\
+            introducer:confidence|theorist:confidence|computer:confidence|\
+            editor:confidence|reviewer:confidence|submitter:confidence)
+                echo "0.7"
+                ;;
+            *)
+                # Missing memo: empty stdout, non-zero exit (mirrors
+                # real `agentis memo get` for absent keys).
+                exit 3
+                ;;
+        esac
+        ;;
+    list)
+        # Two synthetic prefix-glob expansions plus a noise key.
+        printf '%s\n' \
+            'formulator:learned_known_topics' \
+            'feedback:hitl_reject_reason:claim-42' \
+            'feedback:hitl_reject_class:claim-42' \
+            'unrelated:key'
+        ;;
+    *)
+        echo "fake-podman: not get/list subcmd: $*" >&2
+        exit 2
+        ;;
+esac
+FAKE_PODMAN_EOF
+chmod +x "$FAKE_PODMAN"
+
+export PATH="$WORK/bin:$PATH"
+
+# --- (1) Happy path ---
+T1_DIR="$WORK/t1-persistent"
+T1_RC=0
+PODMAN_MODE=ok python3 "$HELPER" --container research-foundry-laptop \
+    --output-dir "$T1_DIR" >"$WORK/t1.log" 2>&1 || T1_RC=$?
+
+if [ "$T1_RC" -ne 0 ]; then
+    fail "(1) happy-path: helper exits 0" "rc=$T1_RC; log: $(cat "$WORK/t1.log")"
+elif [ ! -f "$T1_DIR/memo-snapshot.json" ]; then
+    fail "(1) happy-path: writes memo-snapshot.json" "file missing"
+else
+    SNAPSHOT="$(cat "$T1_DIR/memo-snapshot.json")"
+
+    if printf '%s' "$SNAPSHOT" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+assert data["schema"] == 1, "schema not 1"
+assert "snapshot_ts" in data, "snapshot_ts missing"
+assert data["container"] == "research-foundry-laptop", "container wrong"
+keys = data["keys"]
+expected = {
+    "formulator:learned_known_topics": "number_theory,combinatorics",
+    "formulator:learned_successful_topics": "graph_theory",
+    "editor:learned_pitfalls": "missing-bibtex",
+    "feedback:hitl_rejects": "claim-42,claim-43",
+    "feedback:hitl_reject_reason:claim-42": "wrong-citation",
+    "feedback:hitl_reject_class:claim-42": "factual",
+}
+for k, v in expected.items():
+    assert k in keys, "missing key " + k
+    assert keys[k] == v, "key " + k + " = " + repr(keys[k]) + " not " + repr(v)
+for colony in ("explorer", "noticer", "skeptic", "formulator", "verifier",
+               "novelty", "arxiv-search", "oeis-search", "groupprops-search",
+               "scholar-search", "prior_advocate", "auditor", "introducer",
+               "theorist", "computer", "editor", "reviewer", "submitter"):
+    k = colony + ":confidence"
+    assert k in keys, "missing " + k
+    assert keys[k] == "0.7", k + " = " + repr(keys[k])
+' >/dev/null 2>"$WORK/t1.assert.log"; then
+        pass "(1) happy-path: snapshot keys + values + schema"
+    else
+        fail "(1) happy-path: snapshot keys + values + schema" "$(cat "$WORK/t1.assert.log")"
+    fi
+fi
+
+# --- (2) Atomic write ---
+T2_DIR="$WORK/t2-persistent"
+PODMAN_MODE=ok python3 "$HELPER" --container research-foundry-laptop \
+    --output-dir "$T2_DIR" >"$WORK/t2a.log" 2>&1
+PODMAN_MODE=ok python3 "$HELPER" --container research-foundry-laptop \
+    --output-dir "$T2_DIR" >"$WORK/t2b.log" 2>&1
+
+# After two successive invocations, no .tmp file may remain.
+T2_LEFTOVER=""
+for f in "$T2_DIR"/*.tmp; do
+    [ -e "$f" ] || continue
+    T2_LEFTOVER="$T2_LEFTOVER $f"
+done
+
+if [ -z "$T2_LEFTOVER" ]; then
+    pass "(2) atomic-write: no .tmp leftover after 2 invocations"
+else
+    fail "(2) atomic-write: no .tmp leftover after 2 invocations" "$T2_LEFTOVER"
+fi
+
+# --- (3) Missing podman / failed exec ---
+T3_DIR="$WORK/t3-persistent"
+T3_RC=0
+PODMAN_MODE=fail-all python3 "$HELPER" --container research-foundry-laptop \
+    --output-dir "$T3_DIR" >"$WORK/t3.log" 2>&1 || T3_RC=$?
+
+if [ "$T3_RC" -eq 0 ]; then
+    fail "(3) failed-exec: helper exits non-zero" "rc=0 (expected non-zero)"
+elif [ -f "$T3_DIR/memo-snapshot.json" ]; then
+    fail "(3) failed-exec: no half-formed memo-snapshot.json" "file was written"
+else
+    pass "(3) failed-exec: exits non-zero, no memo-snapshot.json written"
+fi
+
+# --- (4) SCHEMA_VERSION ---
+T4_DIR="$WORK/t4-persistent"
+PODMAN_MODE=ok python3 "$HELPER" --container research-foundry-laptop \
+    --output-dir "$T4_DIR" >"$WORK/t4a.log" 2>&1
+if [ "$(cat "$T4_DIR/SCHEMA_VERSION" 2>/dev/null || echo MISSING)" = "1" ]; then
+    pass "(4a) SCHEMA_VERSION: first invocation writes '1'"
+else
+    fail "(4a) SCHEMA_VERSION: first invocation writes '1'" \
+         "found: $(cat "$T4_DIR/SCHEMA_VERSION" 2>/dev/null || echo MISSING)"
+fi
+
+# Same version: must succeed and still produce a snapshot.
+T4B_RC=0
+PODMAN_MODE=ok python3 "$HELPER" --container research-foundry-laptop \
+    --output-dir "$T4_DIR" >"$WORK/t4b.log" 2>&1 || T4B_RC=$?
+if [ "$T4B_RC" -eq 0 ] && [ -f "$T4_DIR/memo-snapshot.json" ]; then
+    pass "(4b) SCHEMA_VERSION: same-version subsequent invocation succeeds"
+else
+    fail "(4b) SCHEMA_VERSION: same-version subsequent invocation succeeds" \
+         "rc=$T4B_RC; snapshot present: $([ -f "$T4_DIR/memo-snapshot.json" ] && echo yes || echo no)"
+fi
+
+# Mismatch: edit to 99, capture the snapshot mtime, helper must refuse.
+echo "99" >"$T4_DIR/SCHEMA_VERSION"
+SNAPSHOT_BEFORE_MTIME=""
+if [ -f "$T4_DIR/memo-snapshot.json" ]; then
+    SNAPSHOT_BEFORE_MTIME="$(stat -c %Y "$T4_DIR/memo-snapshot.json" 2>/dev/null || stat -f %m "$T4_DIR/memo-snapshot.json" 2>/dev/null || echo "")"
+fi
+sleep 1
+T4C_RC=0
+PODMAN_MODE=ok python3 "$HELPER" --container research-foundry-laptop \
+    --output-dir "$T4_DIR" >"$WORK/t4c.log" 2>&1 || T4C_RC=$?
+
+SNAPSHOT_AFTER_MTIME=""
+if [ -f "$T4_DIR/memo-snapshot.json" ]; then
+    SNAPSHOT_AFTER_MTIME="$(stat -c %Y "$T4_DIR/memo-snapshot.json" 2>/dev/null || stat -f %m "$T4_DIR/memo-snapshot.json" 2>/dev/null || echo "")"
+fi
+
+if [ "$T4C_RC" -ne 0 ] && [ "$SNAPSHOT_BEFORE_MTIME" = "$SNAPSHOT_AFTER_MTIME" ] \
+   && grep -q "SCHEMA_VERSION mismatch" "$WORK/t4c.log"; then
+    pass "(4c) SCHEMA_VERSION: mismatch warns + refuses to overwrite"
+else
+    fail "(4c) SCHEMA_VERSION: mismatch warns + refuses to overwrite" \
+         "rc=$T4C_RC; mtime-before=$SNAPSHOT_BEFORE_MTIME mtime-after=$SNAPSHOT_AFTER_MTIME; log: $(cat "$WORK/t4c.log")"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Phase 5 PR-A of cross-run learning (#626). Three-PR series; this is the
**scaffolding-only** step. The orchestrator now writes
`<fed-dir>/persistent/memo-snapshot.json` at run-end via a new
host-side Python helper. **Nothing in-tree reads the snapshot yet**;
PR-B + PR-C add the consumers.

- New helper: `research-foundry/tools/persistent-snapshot.py` (heredoc-
  free, follows the precedent of `tools/auto-promote-config-parser.py`
  / `auto-promote-decisions.py`). Reads memo via
  `podman exec <container> agentis memo get <key>` (bare form per
  #686), retries 3x on transient failure, atomic write via
  `<output_dir>/memo-snapshot.json.tmp` + `os.replace()`.
- Wired into `tools/run-research.sh` between `signal_shutdown` and the
  final `emit_step "run-research: done"`. Non-fatal: a failed snapshot
  logs `persistent snapshot failed (non-fatal); continuing shutdown`
  and the run still ends cleanly.
- New env knobs: `RESEARCH_PERSISTENT_DIR` (default `<fed-dir>/persistent`),
  `RESEARCH_PERSISTENT_DISABLED=1` to opt out.
- `SCHEMA_VERSION=1` written on first invocation; version mismatches
  warn and refuse to overwrite.

## Keys snapshotted (source-of-truth verified against main)

| Memo key | Writer | Line |
| --- | --- | --- |
| `formulator:learned_known_topics` | `auditor.ag` | 183 |
| `formulator:learned_successful_topics` | `auditor.ag` | 186 |
| `editor:learned_pitfalls` | `editor.ag` | 198 |
| `feedback:hitl_rejects` | `submitter.ag` | 442 |
| `feedback:hitl_reject_reason:claim-*` | `submitter.ag` | 497 |
| `feedback:hitl_reject_class:claim-*` | `submitter.ag` | 498 |
| `<colony>:confidence` (x18) | `run-research.sh` | 553-555 |

The 18 colonies covered: `explorer`, `noticer`, `skeptic`,
`formulator`, `verifier`, `novelty`, `arxiv-search`, `oeis-search`,
`groupprops-search`, `scholar-search`, `prior_advocate`, `auditor`,
`introducer`, `theorist`, `computer`, `editor`, `reviewer`, `submitter`.

## Scope (PR-A only)

What this PR ships:
- `persistent/` dir scaffolding (created lazily on first run-end).
- Atomic JSON write of the curated memo set.
- `SCHEMA_VERSION` file (written once, validated on every run).
- Two env knobs.
- `BUNDLE.manifest` entry for the new helper.

What this PR explicitly does **not** do (deferred to PR-B + PR-C):
- No bootstrap read of `memo-snapshot.json`. The container still
  starts cold-state (PR-B).
- No `--cross-run` flag for `tools/auto-promote-decisions.py` (PR-C).
- No specialty bias / confidence restore on respawn (PR-B).
- No `cross-run-fitness.json`, `fittest_specialties.json`, or
  `agent-confidence.json` writes (PR-B/C).
- No `.ag` changes at all.

This PR-A does NOT close #626. It will be closed by PR-C.

## Test plan

- [x] `bash research-foundry/tools/test-persistent-snapshot.sh` --
      6 assertions across 4 synthetic fixture cases (happy path,
      atomic write, failed podman, SCHEMA_VERSION mismatch): **6/6
      pass**.
- [x] `bash research-foundry/tools/test-run-research.sh` -- **91/91**
      (no regression on the orchestrator smoke test).
- [x] `bash research-foundry/tools/test-replicate-gates.sh` -- **29/29**.
- [x] `bash research-foundry/tools/test-jitter.sh` -- **72/72**.
- [x] `python3 -m ast research-foundry/tools/persistent-snapshot.py` --
      syntax clean.
- [x] `bash -n research-foundry/tools/run-research.sh` -- syntax clean.
- [x] `./tools/colony-lint.sh` -- 295 passed, 3 failed (pre-existing
      cull-replicas failures from `tools/test-cull-replicas.sh` test 8
      + test 10; same numbers on `main` HEAD), 2 skipped, 1 warn. No
      new failures introduced by this PR.

Refs #626.