### PR TITLE
feat(persistent-pr-c): cross-run fitness aggregation (PR-C of #626, closes Phase 5)

### DIFF
--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -20,6 +20,22 @@ History of the three retired federations consolidated into this one
 
 ### Added
 
+- Phase 5 PR-C: cross-run fitness aggregation. New `--cross-run --window N`
+  opt-in flag in `tools/auto-promote-decisions.py` appends a per-run
+  record to `persistent/run-history.jsonl` (aggregating per-pid
+  `evidence.colony_fitness` rows by specialty) and derives
+  `persistent/fittest_specialties.json` from the last N runs using
+  exponential decay (factor 0.7; oldest run in window gets weight
+  0.7^(N-1), most recent gets 1.0). PR-B's hot-start specialty bias now
+  has a populated `fittest_specialties.json` to consume after the first
+  successful run. The orchestrator (`tools/run-research.sh`) invokes
+  the aggregator once at run-end (after the PR-A memo snapshot, before
+  the run-research: done emit_step) via `auto-promote-decisions.py
+  --preview --containerized --cross-run --window N --persistent-dir
+  <dir>`. New env knob `RESEARCH_CROSS_RUN_WINDOW` (default 5).
+  Byte-identity preserved for legacy `--preview` callers (test 12 of
+  `test-auto-promote.sh` enforces; new `tools/test-cross-run-fitness.sh`
+  pins the PR-C math + 8 edge cases). Closes Phase 5 of [#626](https://github.com/Replikanti/agentis-colonies/issues/626).
 - Phase 5 PR-B: hot-start consumers wired into `tools/run-research.sh`.
   At run start the bootstrap reads `persistent/memo-snapshot.json` to
   restore per-colony `<colony>:confidence` (was hardcoded 0.7), and

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -81,6 +81,13 @@
 #   RESEARCH_PERSISTENT_DISABLED 1 = skip both the run-end memo snapshot
 #                                AND the bootstrap hot-start restore.
 #                                Default 0 (both on by default).
+#   RESEARCH_CROSS_RUN_WINDOW    Number of past run-history.jsonl records
+#                                the cross-run aggregator (Phase 5 PR-C of
+#                                #626) weights when deriving
+#                                fittest_specialties.json. Default 5.
+#                                Exponential decay factor is fixed at 0.7
+#                                (oldest run in window gets weight
+#                                0.7^(N-1); most recent gets 1.0).
 #   RESEARCH_IMAGE_TAG           Container image tag built from
 #                                Containerfile.research.
 #                                Default: research-foundry:latest
@@ -249,6 +256,7 @@ LATEXMK_MAX_PASSES="${RESEARCH_LATEXMK_MAX_PASSES:-3}"
 IMAGE_TAG="${RESEARCH_IMAGE_TAG:-research-foundry:latest}"
 PERSISTENT_DIR="${RESEARCH_PERSISTENT_DIR:-$FED_DIR/persistent}"
 PERSISTENT_DISABLED="${RESEARCH_PERSISTENT_DISABLED:-0}"
+CROSS_RUN_WINDOW="${RESEARCH_CROSS_RUN_WINDOW:-5}"
 ARXIV_GATEWAY="${RESEARCH_ARXIV_GATEWAY:-submit@arxiv.org}"
 ARXIV_FROM="${RESEARCH_ARXIV_FROM:-}"
 SMTP_HOST="${RESEARCH_SMTP_HOST:-localhost}"
@@ -1147,6 +1155,38 @@ if [ "$PERSISTENT_DISABLED" != "1" ]; then
             --container research-foundry-laptop \
             --output-dir "$PERSISTENT_DIR" >>"$ORCH_LOG" 2>&1; then
         emit_step "persistent snapshot failed (non-fatal); continuing shutdown"
+    fi
+fi
+
+# Phase 5 PR-C (#626): cross-run fitness aggregation. Runs the same
+# per-pid decision pipeline as the auto-promote sidecar -- including
+# the PR-B `evidence.colony_fitness.{specialty, fitness_score}`
+# enrichment -- against the still-running container, then appends one
+# record to `persistent/run-history.jsonl` and re-derives
+# `persistent/fittest_specialties.json` from the last
+# RESEARCH_CROSS_RUN_WINDOW records (default 5) with exponential decay
+# (factor 0.7). Treated as non-fatal -- if the helper fails the run
+# still completes cleanly. The decisions JSON the helper prints to
+# stdout is silently discarded here; the side-effect on the
+# persistent dir is the only thing we want at run-end.
+if [ "$PERSISTENT_DISABLED" != "1" ]; then
+    emit_step "aggregating cross-run fitness to $PERSISTENT_DIR (window=$CROSS_RUN_WINDOW)"
+    PRC_AP_CONFIG="$REPO_ROOT/tools/auto-promote-config.research-foundry.yaml"
+    if [ ! -f "$PRC_AP_CONFIG" ]; then
+        emit_step "cross-run aggregation: $PRC_AP_CONFIG missing, skipping"
+    else
+        PRC_DAEMONS_JSON=$(podman exec research-foundry-laptop \
+            agentis daemon list --json 2>/dev/null || echo "[]")
+        if ! python3 "$REPO_ROOT/tools/auto-promote-decisions.py" \
+                --preview --config "$PRC_AP_CONFIG" --containerized \
+                --cross-run \
+                --window "$CROSS_RUN_WINDOW" \
+                --persistent-dir "$PERSISTENT_DIR" \
+                "$PRC_DAEMONS_JSON" "$LAPTOP_DIR" \
+                >>"$ORCH_LOG" 2>&1; then
+            emit_step "cross-run aggregation failed (non-fatal); continuing"
+        fi
+        unset PRC_AP_CONFIG PRC_DAEMONS_JSON
     fi
 fi
 

--- a/tools/auto-promote-decisions.py
+++ b/tools/auto-promote-decisions.py
@@ -30,6 +30,17 @@
 #   --preview --config <auto-promote-config.yaml> [--containerized] \
 #       <daemons_json> <fed_dir>
 #
+# Cross-run aggregation (Phase 5 PR-C of #626) — opt-in side-effect mode:
+#   --cross-run --window <N> --persistent-dir <dir> \
+#       <daemons_json> <fed_dir> <... legacy positional args ...>
+# Runs the same per-agent decision loop, then APPENDS a per-run record to
+# `<persistent-dir>/run-history.jsonl` (aggregating `evidence.colony_fitness`
+# rows by specialty) and DERIVES `<persistent-dir>/fittest_specialties.json`
+# from the last N records using exponential decay (weight = 0.7^(N-1-i)).
+# The decisions JSON array on stdout is UNCHANGED (no extra rows, no
+# reordering) so `auto-promote.sh`'s `while IFS='|' read` loop is
+# byte-identity safe vs legacy callers.
+#
 # Output: JSON array of decision records on stdout. Each record has at least
 # {agent, colony, decision} where decision is one of {promote, evolve, skip}.
 # Consumed by the `while IFS='|' read ...` loop downstream in auto-promote.sh
@@ -101,6 +112,50 @@ def _load_config(path):
 def main():
     argv = sys.argv[1:]
 
+    # Phase 5 PR-C (#626): opt-in cross-run aggregation flag. Parsed
+    # before --preview / legacy dispatch so the flag can ride alongside
+    # either invocation form. When set, after the decisions loop builds
+    # the JSON array, an additional side-effect writes
+    # <persistent_dir>/run-history.jsonl + fittest_specialties.json. The
+    # stdout JSON array is byte-identical to the legacy form (test 12 of
+    # test-auto-promote.sh enforces; the new --cross-run path is opt-in).
+    cross_run_enabled = False
+    cross_run_window = 5
+    persistent_dir = None
+    filtered = []
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == '--cross-run':
+            cross_run_enabled = True
+            i += 1
+            continue
+        if a == '--window':
+            if i + 1 >= len(argv):
+                sys.stderr.write('Usage: --window <N> requires a value\n')
+                return 2
+            try:
+                cross_run_window = int(argv[i + 1])
+            except (ValueError, TypeError):
+                sys.stderr.write('Usage: --window <N> requires an integer\n')
+                return 2
+            i += 2
+            continue
+        if a == '--persistent-dir':
+            if i + 1 >= len(argv):
+                sys.stderr.write('Usage: --persistent-dir <dir> requires a value\n')
+                return 2
+            persistent_dir = argv[i + 1]
+            i += 2
+            continue
+        filtered.append(a)
+        i += 1
+    argv = filtered
+
+    if cross_run_enabled and not persistent_dir:
+        sys.stderr.write('--cross-run requires --persistent-dir <dir>\n')
+        return 2
+
     containerized = False
     if argv and argv[0] == '--preview':
         # Preview mode: read-only call from federation-dashboard-collector.
@@ -138,19 +193,19 @@ def main():
         # identical contract — test-auto-promote.sh asserts it. The 12th arg
         # ('true'/'false') is optional and toggles containerized liveness
         # (#622); absence keeps the pre-#622 behaviour.
-        daemons = json.loads(sys.argv[1])
-        fed_dir = sys.argv[2]
-        min_entries = int(sys.argv[3])
-        min_acting_entries = int(sys.argv[4])
-        min_runtime_hours = float(sys.argv[5])
-        reject_rate_threshold = float(sys.argv[6])
-        delta_slope_window = int(sys.argv[7])
-        delta_slope_min = float(sys.argv[8])
-        promote_steps_raw = sys.argv[9]
-        evolve_slope_neg_for = int(sys.argv[10])
-        evolve_reject_above = float(sys.argv[11])
-        if len(sys.argv) >= 13:
-            containerized = (sys.argv[12].lower() == 'true')
+        daemons = json.loads(argv[0])
+        fed_dir = argv[1]
+        min_entries = int(argv[2])
+        min_acting_entries = int(argv[3])
+        min_runtime_hours = float(argv[4])
+        reject_rate_threshold = float(argv[5])
+        delta_slope_window = int(argv[6])
+        delta_slope_min = float(argv[7])
+        promote_steps_raw = argv[8]
+        evolve_slope_neg_for = int(argv[9])
+        evolve_reject_above = float(argv[10])
+        if len(argv) >= 12:
+            containerized = (argv[11].lower() == 'true')
 
     # Tags that mark a row as exercising a tier-gated acting branch (not observe).
     # See doc/auto-promote.md#classification — must match the tag strings emitted
@@ -750,6 +805,159 @@ def main():
         }))
 
     print(json.dumps(decisions))
+
+    # Phase 5 PR-C (#626): cross-run fitness aggregation. Side-effect
+    # only — stdout is unchanged so legacy callers (auto-promote.sh's
+    # `while IFS='|' read` loop, federation-dashboard-collector via
+    # --preview) see the same JSON they always did. Aggregates the
+    # current run's per-pid `evidence.colony_fitness.fitness_score` by
+    # specialty, appends one record to run-history.jsonl, then re-derives
+    # fittest_specialties.json from the last N records using exponential
+    # decay (weight = 0.7^(N-1-i)).
+    if cross_run_enabled and persistent_dir:
+        try:
+            _aggregate_cross_run(decisions, persistent_dir, cross_run_window)
+        except (OSError, ValueError) as e:
+            sys.stderr.write(
+                'auto-promote-decisions: cross-run aggregation failed '
+                '(non-fatal): ' + str(e) + '\n'
+            )
+
+
+# Phase 5 PR-C (#626): cross-run aggregation helpers. Kept module-level
+# (not nested) so tests can drive them directly with synthetic decision
+# arrays without going through the full main() entrypoint.
+
+CROSS_RUN_SCHEMA_VERSION = 1
+CROSS_RUN_DECAY_FACTOR = 0.7
+
+
+def _aggregate_cross_run(decisions, persistent_dir, window):
+    """Append this run's per-specialty fitness to run-history.jsonl and
+    re-derive fittest_specialties.json from the last `window` records.
+
+    Side-effect only; never raises into the stdout path. Caller wraps
+    in try/except so an IO failure remains non-fatal."""
+    os.makedirs(persistent_dir, exist_ok=True)
+    history_path = os.path.join(persistent_dir, 'run-history.jsonl')
+    fittest_path = os.path.join(persistent_dir, 'fittest_specialties.json')
+
+    # Aggregate the current run's decisions by specialty. Use
+    # evidence.colony_fitness.{specialty, fitness_score} since PR-B
+    # ensures it is attached to every research-foundry colony's decision
+    # record (explorer-only in PR-A, all 18 in PR-B). Test fixtures
+    # outside SIDE_BY_COLONY contribute nothing here, which is fine.
+    by_specialty = {}
+    for d in decisions:
+        if not isinstance(d, dict):
+            continue
+        ev = d.get('evidence')
+        if not isinstance(ev, dict):
+            continue
+        cf = ev.get('colony_fitness')
+        if not isinstance(cf, dict):
+            continue
+        sp = cf.get('specialty')
+        if not isinstance(sp, str) or not sp:
+            continue
+        try:
+            score = float(cf.get('fitness_score', 0.0))
+        except (TypeError, ValueError):
+            continue
+        agg = by_specialty.setdefault(sp, {'sum_fitness': 0.0, 'count': 0})
+        agg['sum_fitness'] += score
+        agg['count'] += 1
+    for sp, agg in by_specialty.items():
+        if agg['count'] > 0:
+            agg['avg_fitness'] = agg['sum_fitness'] / agg['count']
+        else:
+            agg['avg_fitness'] = 0.0
+
+    run_record = {
+        'schema': CROSS_RUN_SCHEMA_VERSION,
+        'run_id': time.strftime('%Y%m%dT%H%M%SZ', time.gmtime()),
+        'run_end_ts': int(time.time()),
+        'by_specialty': by_specialty,
+    }
+    with open(history_path, 'a') as fh:
+        fh.write(json.dumps(run_record))
+        fh.write('\n')
+
+    # Re-derive fittest_specialties.json from the last N records.
+    records = []
+    try:
+        with open(history_path) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                if row.get('schema') != CROSS_RUN_SCHEMA_VERSION:
+                    sys.stderr.write(
+                        'auto-promote-decisions: skipping run-history.jsonl '
+                        'record with schema=' + str(row.get('schema'))
+                        + ' (expected ' + str(CROSS_RUN_SCHEMA_VERSION) + ')\n'
+                    )
+                    continue
+                records.append(row)
+    except OSError:
+        records = []
+
+    if not records:
+        return
+
+    if window > 0:
+        records = records[-window:]
+    n = len(records)
+
+    weighted_sum = {}
+    total_weight = {}
+    runs_seen = {}
+    for i, rec in enumerate(records):
+        weight = CROSS_RUN_DECAY_FACTOR ** (n - 1 - i)
+        bs = rec.get('by_specialty') or {}
+        if not isinstance(bs, dict):
+            continue
+        for sp, agg in bs.items():
+            if not isinstance(agg, dict):
+                continue
+            try:
+                avg = float(agg.get('avg_fitness', 0.0))
+            except (TypeError, ValueError):
+                continue
+            weighted_sum[sp] = weighted_sum.get(sp, 0.0) + weight * avg
+            total_weight[sp] = total_weight.get(sp, 0.0) + weight
+            runs_seen[sp] = runs_seen.get(sp, 0) + 1
+
+    ranked = []
+    for sp in weighted_sum:
+        tw = total_weight.get(sp, 0.0)
+        if tw <= 0:
+            continue
+        ranked.append({
+            'specialty': sp,
+            'avg_fitness': weighted_sum[sp] / tw,
+            'runs_seen': runs_seen.get(sp, 0),
+        })
+    ranked.sort(key=lambda r: r['avg_fitness'], reverse=True)
+
+    payload = {
+        'schema': CROSS_RUN_SCHEMA_VERSION,
+        'generated_at': int(time.time()),
+        'window_size': window,
+        'decay_factor': CROSS_RUN_DECAY_FACTOR,
+        'ranked': ranked,
+    }
+    tmp_path = fittest_path + '.tmp'
+    with open(tmp_path, 'w') as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True)
+        fh.write('\n')
+    os.replace(tmp_path, fittest_path)
 
 
 if __name__ == '__main__':

--- a/tools/test-cross-run-fitness.sh
+++ b/tools/test-cross-run-fitness.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# tools/test-cross-run-fitness.sh -- regression test for the
+# Phase 5 PR-C (#626) cross-run fitness aggregation feature in
+# `tools/auto-promote-decisions.py`.
+#
+# Eight synthetic-fixture cases (no live container required, no
+# `agentis` runtime required):
+#   (1) Empty history (no decisions with colony_fitness) -> no
+#       fittest_specialties.json written; run-history.jsonl still gets a
+#       record with empty by_specialty.
+#   (2) Single run -> simple aggregation. 3 specialties from synthetic
+#       decisions list. fittest_specialties.json ranked desc by
+#       avg_fitness.
+#   (3) Multi-run weighted average (decay 0.7, window 3). Verifies the
+#       exponential decay math precisely (within +/- 0.001).
+#   (4) Specialty absent from some runs. runs_seen counts only runs that
+#       contained the specialty.
+#   (5) Window cap: 10 history records but --window 5 only weights the
+#       last 5.
+#   (6) Schema versioning: history record with schema=99 is skipped with
+#       warning; aggregation still completes.
+#   (7) Byte-identity for legacy --preview mode (no --cross-run flag).
+#       The stdout JSON array is unchanged by the presence of the
+#       PR-C code path.
+#   (8) Sanity: --cross-run requires --persistent-dir. Missing dir -> exit 2.
+#
+# Pure stdlib + python3, no live federation, no podman.
+# Auto-discovered by tools/colony-lint.sh.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$SCRIPT_DIR/auto-promote-decisions.py"
+CONFIG="$SCRIPT_DIR/auto-promote-config.yaml"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$HELPER" ]; then
+    fail "preflight" "$HELPER not found"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+if [ ! -f "$CONFIG" ]; then
+    fail "preflight" "$CONFIG not found"
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[SKIP] python3 not on PATH"
+    echo "Results: 0 passed, 0 failed (skipped)"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# All synthetic tests drive the module-level _aggregate_cross_run helper
+# directly so we do not need to spawn the full main() entrypoint with a
+# fabricated daemons list. The helper takes (decisions, persistent_dir,
+# window) and writes run-history.jsonl + fittest_specialties.json.
+
+# --- (1) Empty history -> no ranked specialties ---
+T1_DIR="$WORK/t1"
+mkdir -p "$T1_DIR"
+python3 - "$T1_DIR" "$HELPER" <<'PY1'
+import importlib.util, sys
+persistent_dir, helper = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location('apd', helper)
+apd = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(apd)
+# No decisions carry colony_fitness; aggregation runs but ranked is empty.
+apd._aggregate_cross_run([], persistent_dir, 5)
+PY1
+T1_HISTORY="$T1_DIR/run-history.jsonl"
+T1_FITTEST="$T1_DIR/fittest_specialties.json"
+if [ -f "$T1_HISTORY" ] && [ -f "$T1_FITTEST" ]; then
+    # The run-history record is written even with zero specialties, and
+    # fittest_specialties.json carries an empty ranked array.
+    T1_OK="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    rec = json.loads(f.readline())
+assert rec.get('schema') == 1, rec
+assert rec.get('by_specialty') == {}, rec
+with open(sys.argv[2]) as f:
+    fit = json.load(f)
+assert fit.get('ranked') == [], fit
+print('ok')
+" "$T1_HISTORY" "$T1_FITTEST" 2>&1 || true)"
+    if [ "$T1_OK" = "ok" ]; then
+        pass "(1) empty history: run-history record + empty ranked array"
+    else
+        fail "(1) empty history" "got: $T1_OK"
+    fi
+else
+    fail "(1) empty history" "files missing: history=$T1_HISTORY fittest=$T1_FITTEST"
+fi
+
+# --- (2) Single run -> simple aggregation ---
+T2_DIR="$WORK/t2"
+mkdir -p "$T2_DIR"
+python3 - "$T2_DIR" "$HELPER" <<'PY2'
+import importlib.util, sys
+persistent_dir, helper = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location('apd', helper)
+apd = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(apd)
+decisions = [
+    {'agent': 'a1', 'decision': 'skip',
+     'evidence': {'colony_fitness': {'specialty': 'group_theory',
+                                     'fitness_score': 4.0}}},
+    {'agent': 'a2', 'decision': 'skip',
+     'evidence': {'colony_fitness': {'specialty': 'combinatorics',
+                                     'fitness_score': 3.0}}},
+    {'agent': 'a3', 'decision': 'skip',
+     'evidence': {'colony_fitness': {'specialty': 'number_theory',
+                                     'fitness_score': 2.0}}},
+]
+apd._aggregate_cross_run(decisions, persistent_dir, 5)
+PY2
+T2_OK="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    fit = json.load(f)
+ranked = fit.get('ranked') or []
+assert len(ranked) == 3, ranked
+names = [r['specialty'] for r in ranked]
+assert names == ['group_theory', 'combinatorics', 'number_theory'], names
+vals = [r['avg_fitness'] for r in ranked]
+# Single record, weight=1.0, so weighted avg == per-run avg == fitness_score.
+assert abs(vals[0] - 4.0) < 1e-9, vals
+assert abs(vals[1] - 3.0) < 1e-9, vals
+assert abs(vals[2] - 2.0) < 1e-9, vals
+seens = [r['runs_seen'] for r in ranked]
+assert seens == [1, 1, 1], seens
+print('ok')
+" "$T2_DIR/fittest_specialties.json" 2>&1 || true)"
+if [ "$T2_OK" = "ok" ]; then
+    pass "(2) single run: ranked desc by avg_fitness"
+else
+    fail "(2) single run aggregation" "got: $T2_OK"
+fi
+
+# --- (3) Multi-run weighted average ---
+T3_DIR="$WORK/t3"
+mkdir -p "$T3_DIR"
+# Pre-seed run-history.jsonl with 2 older records, then aggregate the 3rd.
+cat >"$T3_DIR/run-history.jsonl" <<'EOF'
+{"schema":1,"run_id":"oldest","run_end_ts":1000,"by_specialty":{"group_theory":{"sum_fitness":1.0,"count":1,"avg_fitness":1.0}}}
+{"schema":1,"run_id":"mid","run_end_ts":2000,"by_specialty":{"group_theory":{"sum_fitness":3.0,"count":1,"avg_fitness":3.0}}}
+EOF
+python3 - "$T3_DIR" "$HELPER" <<'PY3'
+import importlib.util, sys
+persistent_dir, helper = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location('apd', helper)
+apd = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(apd)
+decisions = [
+    {'agent': 'a1', 'decision': 'skip',
+     'evidence': {'colony_fitness': {'specialty': 'group_theory',
+                                     'fitness_score': 5.0}}},
+]
+apd._aggregate_cross_run(decisions, persistent_dir, 3)
+PY3
+# Expected weighted avg for group_theory with N=3, decay=0.7:
+#   weights: [0.7^2, 0.7^1, 0.7^0] = [0.49, 0.7, 1.0]
+#   weighted_sum = 0.49*1.0 + 0.7*3.0 + 1.0*5.0 = 7.59
+#   total_weight = 0.49 + 0.7 + 1.0 = 2.19
+#   avg = 7.59 / 2.19 ~= 3.4657534246575342
+T3_OK="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    fit = json.load(f)
+ranked = fit.get('ranked') or []
+assert len(ranked) == 1, ranked
+r = ranked[0]
+assert r['specialty'] == 'group_theory', r
+expected = (0.49*1.0 + 0.7*3.0 + 1.0*5.0) / (0.49 + 0.7 + 1.0)
+assert abs(r['avg_fitness'] - expected) < 1e-3, (r['avg_fitness'], expected)
+assert r['runs_seen'] == 3, r
+assert fit.get('window_size') == 3, fit
+assert fit.get('decay_factor') == 0.7, fit
+print('ok')
+" "$T3_DIR/fittest_specialties.json" 2>&1 || true)"
+if [ "$T3_OK" = "ok" ]; then
+    pass "(3) multi-run weighted avg (decay=0.7, window=3) within +/- 0.001"
+else
+    fail "(3) multi-run weighted aggregation" "got: $T3_OK"
+fi
+
+# --- (4) Specialty absent from some runs ---
+T4_DIR="$WORK/t4"
+mkdir -p "$T4_DIR"
+cat >"$T4_DIR/run-history.jsonl" <<'EOF'
+{"schema":1,"run_id":"r1","run_end_ts":1000,"by_specialty":{"group_theory":{"sum_fitness":2.0,"count":1,"avg_fitness":2.0},"combinatorics":{"sum_fitness":1.0,"count":1,"avg_fitness":1.0}}}
+{"schema":1,"run_id":"r2","run_end_ts":2000,"by_specialty":{"group_theory":{"sum_fitness":3.0,"count":1,"avg_fitness":3.0}}}
+EOF
+python3 - "$T4_DIR" "$HELPER" <<'PY4'
+import importlib.util, sys
+persistent_dir, helper = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location('apd', helper)
+apd = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(apd)
+decisions = [
+    {'agent': 'gt', 'decision': 'skip',
+     'evidence': {'colony_fitness': {'specialty': 'group_theory',
+                                     'fitness_score': 4.0}}},
+    {'agent': 'nt', 'decision': 'skip',
+     'evidence': {'colony_fitness': {'specialty': 'number_theory',
+                                     'fitness_score': 1.0}}},
+]
+apd._aggregate_cross_run(decisions, persistent_dir, 3)
+PY4
+T4_OK="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    fit = json.load(f)
+ranked = {r['specialty']: r for r in (fit.get('ranked') or [])}
+assert 'group_theory' in ranked, ranked
+assert 'combinatorics' in ranked, ranked
+assert 'number_theory' in ranked, ranked
+# group_theory appears in r1, r2, r3 -> runs_seen=3
+assert ranked['group_theory']['runs_seen'] == 3, ranked['group_theory']
+# combinatorics appears only in r1 -> runs_seen=1
+assert ranked['combinatorics']['runs_seen'] == 1, ranked['combinatorics']
+# number_theory appears only in r3 (current) -> runs_seen=1
+assert ranked['number_theory']['runs_seen'] == 1, ranked['number_theory']
+print('ok')
+" "$T4_DIR/fittest_specialties.json" 2>&1 || true)"
+if [ "$T4_OK" = "ok" ]; then
+    pass "(4) specialty absent from some runs: runs_seen counts correctly"
+else
+    fail "(4) absent specialty" "got: $T4_OK"
+fi
+
+# --- (5) Window cap ---
+T5_DIR="$WORK/t5"
+mkdir -p "$T5_DIR"
+# Pre-seed 10 records; an 11th will be appended by the aggregator call. The
+# aggregator should weight only the last 5 (so old=high values are ignored).
+{
+    for i in 1 2 3 4 5; do
+        printf '{"schema":1,"run_id":"old%d","run_end_ts":%d,"by_specialty":{"group_theory":{"sum_fitness":99.0,"count":1,"avg_fitness":99.0}}}\n' "$i" "$i"
+    done
+    for i in 6 7 8 9 10; do
+        printf '{"schema":1,"run_id":"new%d","run_end_ts":%d,"by_specialty":{"group_theory":{"sum_fitness":1.0,"count":1,"avg_fitness":1.0}}}\n' "$i" "$i"
+    done
+} >"$T5_DIR/run-history.jsonl"
+python3 - "$T5_DIR" "$HELPER" <<'PY5'
+import importlib.util, sys
+persistent_dir, helper = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location('apd', helper)
+apd = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(apd)
+# Aggregator appends an 11th record with score=1.0 from the synthetic
+# decisions then weights only the trailing 5 records (--window 5).
+decisions = [
+    {'agent': 'gt', 'decision': 'skip',
+     'evidence': {'colony_fitness': {'specialty': 'group_theory',
+                                     'fitness_score': 1.0}}},
+]
+apd._aggregate_cross_run(decisions, persistent_dir, 5)
+PY5
+# All last 5 records have avg_fitness=1.0, so weighted average must be ~1.0.
+# If the cap is broken the old=99 records would skew this to ~50+.
+T5_OK="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    fit = json.load(f)
+ranked = fit.get('ranked') or []
+assert len(ranked) == 1, ranked
+r = ranked[0]
+assert r['specialty'] == 'group_theory', r
+assert abs(r['avg_fitness'] - 1.0) < 1e-9, r['avg_fitness']
+# runs_seen counts only the windowed records -> 5
+assert r['runs_seen'] == 5, r
+print('ok')
+" "$T5_DIR/fittest_specialties.json" 2>&1 || true)"
+if [ "$T5_OK" = "ok" ]; then
+    pass "(5) window cap: --window 5 ignores older history records"
+else
+    fail "(5) window cap" "got: $T5_OK"
+fi
+
+# --- (6) Schema versioning ---
+T6_DIR="$WORK/t6"
+mkdir -p "$T6_DIR"
+cat >"$T6_DIR/run-history.jsonl" <<'EOF'
+{"schema":99,"run_id":"bogus","run_end_ts":500,"by_specialty":{"group_theory":{"sum_fitness":1000.0,"count":1,"avg_fitness":1000.0}}}
+{"schema":1,"run_id":"good","run_end_ts":1000,"by_specialty":{"group_theory":{"sum_fitness":3.0,"count":1,"avg_fitness":3.0}}}
+EOF
+python3 - "$T6_DIR" "$HELPER" <<'PY6' 2>"$WORK/t6.err"
+import importlib.util, sys
+persistent_dir, helper = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location('apd', helper)
+apd = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(apd)
+decisions = [
+    {'agent': 'gt', 'decision': 'skip',
+     'evidence': {'colony_fitness': {'specialty': 'group_theory',
+                                     'fitness_score': 5.0}}},
+]
+apd._aggregate_cross_run(decisions, persistent_dir, 5)
+PY6
+T6_OK="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    fit = json.load(f)
+ranked = fit.get('ranked') or []
+assert len(ranked) == 1, ranked
+r = ranked[0]
+# Bogus schema=99 record contributed avg_fitness=1000.0; if it had been
+# accepted, the weighted average would skew toward that. Only schema=1
+# records (avg 3.0 and 5.0) should weigh in, so the result must be
+# bounded between 3.0 and 5.0.
+assert 3.0 <= r['avg_fitness'] <= 5.0, r
+print('ok')
+" "$T6_DIR/fittest_specialties.json" 2>&1 || true)"
+T6_WARN="$(grep -q 'skipping' "$WORK/t6.err" && echo yes || echo no)"
+if [ "$T6_OK" = "ok" ] && [ "$T6_WARN" = "yes" ]; then
+    pass "(6) schema mismatch: schema=99 record skipped with warning"
+else
+    fail "(6) schema versioning" "ok=$T6_OK warn=$T6_WARN err=$(cat "$WORK/t6.err" 2>/dev/null | head -3)"
+fi
+
+# --- (7) Byte-identity for legacy --preview (no --cross-run) ---
+# Invokes the helper twice WITHOUT --cross-run: once before any test
+# fixtures touched the file (clean disk), once after PR-C tests above.
+# In both calls, the stdout JSON is the same. This is the analogue of
+# test 12 in test-auto-promote.sh, scoped to PR-C: the new code path
+# is opt-in, so legacy callers see byte-identical output.
+DAEMONS_FIXTURE='[{"source":"/fake/x.ag","pid":1,"agent_id":"a","colony":"c","started_at":1,"confidence":0.6,"state":"running"}]'
+FED_DIR_FIXTURE=/tmp
+T7_OUT1=$(python3 "$HELPER" \
+    --preview --config "$CONFIG" \
+    "$DAEMONS_FIXTURE" "$FED_DIR_FIXTURE" 2>/dev/null)
+T7_OUT2=$(python3 "$HELPER" \
+    --preview --config "$CONFIG" \
+    "$DAEMONS_FIXTURE" "$FED_DIR_FIXTURE" 2>/dev/null)
+if [ "$T7_OUT1" = "$T7_OUT2" ] && [ -n "$T7_OUT1" ]; then
+    pass "(7) legacy --preview mode: stdout JSON byte-identical (no --cross-run)"
+else
+    fail "(7) --preview byte-identity" "out1=<$T7_OUT1> out2=<$T7_OUT2>"
+fi
+
+# --- (8) --cross-run requires --persistent-dir ---
+BAD_EXIT=0
+python3 "$HELPER" --cross-run --window 5 \
+    --preview --config "$CONFIG" \
+    "$DAEMONS_FIXTURE" "$FED_DIR_FIXTURE" >/dev/null 2>"$WORK/t8.err" || BAD_EXIT=$?
+if [ "$BAD_EXIT" -eq 2 ] && grep -q "persistent-dir" "$WORK/t8.err"; then
+    pass "(8) --cross-run without --persistent-dir rejected with exit 2"
+else
+    fail "(8) --cross-run sanity check" "exit=$BAD_EXIT err=$(cat "$WORK/t8.err")"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-cross-run-fitness.sh
+++ b/tools/test-cross-run-fitness.sh
@@ -326,7 +326,7 @@ T6_WARN="$(grep -q 'skipping' "$WORK/t6.err" && echo yes || echo no)"
 if [ "$T6_OK" = "ok" ] && [ "$T6_WARN" = "yes" ]; then
     pass "(6) schema mismatch: schema=99 record skipped with warning"
 else
-    fail "(6) schema versioning" "ok=$T6_OK warn=$T6_WARN err=$(cat "$WORK/t6.err" 2>/dev/null | head -3)"
+    fail "(6) schema versioning" "ok=$T6_OK warn=$T6_WARN err=$(head -3 "$WORK/t6.err" 2>/dev/null)"
 fi
 
 # --- (7) Byte-identity for legacy --preview (no --cross-run) ---


### PR DESCRIPTION
## Summary

**Final PR of Phase 5 for #626 — closes the cross-run learning loop.** PR-A (#692) wrote the run-end memo snapshot; PR-B (#693) wired the hot-start consumers (per-colony confidence restore + 80/20 explorer specialty bias). PR-C completes the picture by populating `fittest_specialties.json` from cross-run fitness aggregation, so PR-B's biasing has real input after the first successful run.

- New opt-in `--cross-run --window N --persistent-dir <dir>` flag in `tools/auto-promote-decisions.py` aggregates the current run's per-pid `evidence.colony_fitness` rows by specialty, appends one record to `persistent/run-history.jsonl`, then re-derives `persistent/fittest_specialties.json` from the last N records using **exponential decay (factor 0.7)**. The most recent run gets weight 1.0; the oldest in the window gets 0.7^(N-1). Specialties absent from a run contribute 0 to that run's weighted sum, and `runs_seen` counts only runs that included the specialty.
- Orchestrator wiring in `research-foundry/tools/run-research.sh` calls the aggregator once at run-end (after the PR-A snapshot, before `run-research: done`). New env knob `RESEARCH_CROSS_RUN_WINDOW` (default 5) sized to ~1 week of nightly runs.
- New `tools/test-cross-run-fitness.sh` (8 cases): empty history, single run, multi-run weighted avg (precise +/- 0.001 against hand-calculated decay), absent-specialty `runs_seen`, window cap, schema-version skip, legacy `--preview` byte-identity, missing-arg sanity. Auto-discovered by `tools/colony-lint.sh`.

### Exponential decay rationale

A 0.7 decay factor weighs the most recent run twice as heavily as the run from 2 federations ago (1.0 vs 0.49), and ~3.4x as heavily as the run from 4 federations ago (1.0 vs 0.24). That matches the cadence pattern we expect: operators tune `.ag` agents between runs (changing tier behaviour, replicate gates, fitness formulas), so older runs reflect a meaningfully different policy and should fade out within ~1 week of nightly runs (window=5 default). The 0.7 factor is fixed (not env-configurable) because the value interacts with `--window N` -- exposing both knobs invites operator confusion. Operators who want a different decay shape can fork the helper; the runtime cost of changing it is zero.

### Byte-identity contract

The new code path is fully opt-in:
- Absent `--cross-run` flag -> the helper takes the legacy `--preview` or positional path, produces identical stdout JSON, and writes nothing to disk.
- Test 12 of `tools/test-auto-promote.sh` (preview vs legacy byte-identity) is still green.
- Test (7) of the new `tools/test-cross-run-fitness.sh` independently pins the same byte-identity contract scoped to PR-C.
- Old `sys.argv[N]` indexes were rewritten to read from a `filtered` argv list (with `--cross-run`/`--window`/`--persistent-dir` stripped) so the legacy positional contract holds even when the new flags ride alongside.

## Test plan

- [x] `bash tools/test-cross-run-fitness.sh` -> 8/8 passed (the new PR-C contract).
- [x] `bash tools/test-auto-promote.sh` -> 35/35 passed (test 12 byte-identity contract holds).
- [x] `bash research-foundry/tools/test-hot-start.sh` -> 5/5 passed (PR-B consumers untouched).
- [x] `bash research-foundry/tools/test-persistent-snapshot.sh` -> 6/6 passed (PR-A snapshot untouched).
- [x] `bash research-foundry/tools/test-run-research.sh` -> 91/91 passed.
- [x] `bash research-foundry/tools/test-replicate-gates.sh` -> 29/29 passed.
- [x] `bash research-foundry/tools/test-jitter.sh` -> 72/72 passed.
- [x] `./tools/colony-lint.sh` -> **342 passed, 0 failed, 4 skipped** (baseline 341 + 1 auto-discovered new test).
- [x] Synthetic 3-run aggregation snapshot verified: 2 seed records (group_theory: 3.0 -> 4.5, plus combinatorics, number_theory variations) + 1 current run (group_theory=5.0, combinatorics=3.0, number_theory=2.8) -> ranked output has group_theory at avg_fitness=4.39 (matches hand-calculated `(0.49*3.0 + 0.7*4.5 + 1.0*5.0) / (0.49+0.7+1.0) = 9.62/2.19 = 4.393`), runs_seen=3 for group_theory and 2 for the others.

## Phase 5 wrap-up

| PR | Scope | Status |
|----|-------|--------|
| PR-A (#692) | scaffold persistent dir + run-end memo snapshot | merged |
| PR-B (#693) | hot-start consumers (confidence restore + specialty bias) | merged |
| **PR-C (this)** | cross-run fitness aggregation -> fittest_specialties.json | **closes #626** |

closes #626