### PR TITLE
fix(research-foundry/search): canonical dashed confidence key in 4 search colonies (#694)

### DIFF
--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -18,6 +18,10 @@ History of the three retired federations consolidated into this one
 
 ## [Unreleased]
 
+### Fixed
+
+- 4 search colonies (`arxiv-search`, `oeis-search`, `groupprops-search`, `scholar-search`) now use the canonical dashed `<basename>:confidence` memo key — matches on-disk basename per [CLAUDE.md Agent conventions](../CLAUDE.md) and is consistent with the [#688](https://github.com/Replikanti/agentis-colonies/issues/688) `last_check` rename. The bootstrap-loop colony list in `tools/run-research.sh` (3 occurrences) and the `recall_latest` call in each of the 4 `.ag` files were renamed in lockstep so the seeded confidence is now actually consumed by the agents (pre-fix the writers and the readers AGREED on the underscored form internally but Phase 5 PR-A's snapshot writer used the dashed form, so cross-run persistence silently dropped searcher confidence). `prior_advocate` already used its canonical form (matches `prior_advocate/` dir on disk). ([#694](https://github.com/Replikanti/agentis-colonies/issues/694))
+
 ### Added
 
 - Phase 5 PR-C: cross-run fitness aggregation. New `--cross-run --window N`

--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -42,7 +42,7 @@ type Report {
 }
 
 fn get_confidence() -> float {
-    let raw = recall_latest("arxiv_search:confidence");
+    let raw = recall_latest("arxiv-search:confidence");
     if len(raw) > 0 {
         return parse_float(raw);
     };

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -39,7 +39,7 @@ type Report {
 }
 
 fn get_confidence() -> float {
-    let raw = recall_latest("groupprops_search:confidence");
+    let raw = recall_latest("groupprops-search:confidence");
     if len(raw) > 0 {
         return parse_float(raw);
     };

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -39,7 +39,7 @@ type Report {
 }
 
 fn get_confidence() -> float {
-    let raw = recall_latest("oeis_search:confidence");
+    let raw = recall_latest("oeis-search:confidence");
     if len(raw) > 0 {
         return parse_float(raw);
     };

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -43,7 +43,7 @@ type Report {
 }
 
 fn get_confidence() -> float {
-    let raw = recall_latest("scholar_search:confidence");
+    let raw = recall_latest("scholar-search:confidence");
     if len(raw) > 0 {
         return parse_float(raw);
     };

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -571,10 +571,10 @@ write_bootstrap() {
         printf ': > /run-root/audit-ledger.jsonl\n'
         printf ': > /run-root/preprint-ledger.jsonl\n'
         printf ': > /run-root/replication-ledger.jsonl\n'
-        # Seed propose-tier confidence for each colony. Note the
-        # claim-auditor / preprint-foundry searcher keys use underscored
-        # forms (arxiv_search, oeis_search, etc.) because the .ag agents
-        # call them that way internally; mirrors retired run-auditor.sh.
+        # Seed propose-tier confidence for each colony. All keys use the
+        # canonical dashed `<basename>:confidence` form per CLAUDE.md Agent
+        # conventions; `prior_advocate` remains underscored because its disk
+        # basename is `prior_advocate` (the underscore IS its canonical form).
         #
         # Phase 5 PR-B (#626): hot-start restore. If
         # `<persistent-dir>/memo-snapshot.json` (written by PR-A at the

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -586,7 +586,7 @@ write_bootstrap() {
         # exactly as before.
         prb_snapshot_path="$PERSISTENT_DIR/memo-snapshot.json"
         if [ "$PERSISTENT_DISABLED" != "1" ] && [ -f "$prb_snapshot_path" ]; then
-            for prb_c in explorer noticer skeptic formulator verifier novelty arxiv_search oeis_search groupprops_search scholar_search prior_advocate auditor introducer theorist computer editor reviewer submitter; do
+            for prb_c in explorer noticer skeptic formulator verifier novelty arxiv-search oeis-search groupprops-search scholar-search prior_advocate auditor introducer theorist computer editor reviewer submitter; do
                 prb_val="$(python3 "$TOOLS_DIR/persistent-load.py" load-confidence "$PERSISTENT_DIR" "$prb_c" 2>/dev/null || true)"
                 if [ -n "$prb_val" ]; then
                     printf '(cd /run-root && agentis memo set %s:confidence %s >/dev/null 2>&1 || true)\n' "$prb_c" "$prb_val"
@@ -596,7 +596,7 @@ write_bootstrap() {
             done
             unset prb_c prb_val
         else
-            printf 'for c in explorer noticer skeptic formulator verifier novelty arxiv_search oeis_search groupprops_search scholar_search prior_advocate auditor introducer theorist computer editor reviewer submitter; do\n'
+            printf 'for c in explorer noticer skeptic formulator verifier novelty arxiv-search oeis-search groupprops-search scholar-search prior_advocate auditor introducer theorist computer editor reviewer submitter; do\n'
             printf '    (cd /run-root && agentis memo set $c:confidence 0.7 >/dev/null 2>&1 || true)\n'
             printf 'done\n'
         fi


### PR DESCRIPTION
## Summary

Same root pattern as #688 (last_check key) but for the `confidence` memo key. Renames 4 search colonies' underscored form (`arxiv_search:confidence` etc.) to canonical dashed form (`arxiv-search:confidence` matching on-disk basename per CLAUDE.md Agent conventions).

## Why this is a real fix, not just cosmetics

Pre-fix the writer (bootstrap loop) and the reader (.ag `recall_latest`) AGREED on the underscored form internally → single-run testing looked fine. But Phase 5 PR-A's snapshot writer used the dashed form (matching disk basename), so cross-run persistence silently dropped searcher confidence:

- Run N end: snapshot wrote `arxiv-search:confidence` (dashed) ✓ canonical
- Run N+1 bootstrap: reseeded `arxiv_search:confidence` (underscored) ✗ wrong namespace
- Run N+1 .ag: read `arxiv_search:confidence` ✓ matches reseed, but missed snapshot
- Dashboard load-confidence tooltip + Phase 5 hot-start saw nothing for these 4

## Diff

- 4 × `.ag` files: `recall_latest("<role>_<name>:confidence")` → `recall_latest("<role>-<name>:confidence")`
- 1 line in `research-foundry/tools/run-research.sh`: bootstrap colony list `arxiv_search oeis_search groupprops_search scholar_search` → dashed forms in 2 occurrences (hot-start hot path and legacy fallback)

`prior_advocate` untouched — its on-disk basename is `prior_advocate` (underscore), so its underscored memo key IS canonical.

## Tests

- `test-run-research.sh` — 91/91
- `test-replicate-gates.sh` — 29/29
- `test-jitter.sh` — 72/72
- `test-persistent-snapshot.sh` — 6/6
- `test-hot-start.sh` — 5/5
- `./tools/colony-lint.sh` — 342/0/4

Closes #694.