### PR TITLE
fix(auto-promote): memo-freshness liveness check unblocks lifecycle for containerized federations (#706)

### DIFF
--- a/tools/auto-promote-decisions.py
+++ b/tools/auto-promote-decisions.py
@@ -48,6 +48,7 @@
 #
 # Contract is frozen by doc/auto-promote.md and test-auto-promote.sh.
 
+import datetime
 import hashlib
 import json
 import math
@@ -55,6 +56,71 @@ import os
 import subprocess
 import sys
 import time
+
+
+# Mirrored from federation-dashboard-collector.py:85-134; keep in sync with
+# #683/#697/#700/#705. #706 ports the same memo-freshness liveness predicate
+# from the dashboard to this sidecar so the containerized branch below no
+# longer trusts the daemon registry's stale `effective_state` field (the
+# in-process tick loop continues to write `<agent>:last_check` even when
+# the registry record is mis-flagged as `zombie` after sleep/reboot).
+try:
+    STALENESS_TICKS = max(1, int(os.environ.get("FEDERATION_DASHBOARD_STALENESS_TICKS", "3")))
+except (TypeError, ValueError):
+    STALENESS_TICKS = 3
+
+
+def _read_memo_raw(fed_dir, key):
+    try:
+        proc = subprocess.run(
+            ['agentis', 'memo', 'get', key],
+            cwd=fed_dir, capture_output=True, text=True, timeout=2,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    raw = (proc.stdout or '').strip()
+    return raw or None
+
+
+def _parse_last_check_epoch(raw):
+    if not raw:
+        return None
+    try:
+        dt = datetime.datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ")
+        return dt.replace(tzinfo=datetime.timezone.utc).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+_tick_interval_cache = {}
+
+
+def _resolve_tick_interval_ms(agent, colony, fed_dir):
+    cache_key = (agent, colony)
+    if cache_key in _tick_interval_cache:
+        return _tick_interval_cache[cache_key]
+    interval = 60000
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    helper = os.path.join(script_dir, 'resolve-tick-interval.py')
+    if colony:
+        colony_dir = os.path.join(fed_dir, colony)
+        if os.path.isfile(helper) and os.path.isdir(colony_dir):
+            try:
+                proc = subprocess.run(
+                    ['python3', helper, agent, colony_dir],
+                    capture_output=True, text=True, timeout=2,
+                )
+                if proc.returncode == 0:
+                    try:
+                        interval = int((proc.stdout or '').strip())
+                    except (TypeError, ValueError):
+                        interval = 60000
+            except (subprocess.SubprocessError, OSError):
+                interval = 60000
+    _tick_interval_cache[cache_key] = interval
+    return interval
 
 
 def _load_config(path):
@@ -524,17 +590,26 @@ def main():
         #
         # In containerized mode (#622) the host PID namespace can't see
         # container PIDs, so os.kill(pid, 0) is a false-negative every
-        # tick. Fall back to `effective_state == "running"` from the
-        # daemon-list JSON (also valid for legacy mode; the runtime
-        # tracks zombie/running/etc. with a stale-heartbeat probe).
+        # tick. #706: trust memo freshness (`<agent>:last_check` within
+        # STALENESS_TICKS * tick_interval) over `effective_state`, since
+        # the daemon registry's state field stays stale across sleep/reboot
+        # cycles even when the in-process tick loop keeps writing the memo.
+        # `effective_state == "running"` remains a valid fall-through for
+        # legacy callers; the memo path simply unblocks daemons whose
+        # registry record lies.
         if containerized:
+            last_check_epoch = _parse_last_check_epoch(_read_memo_raw(fed_dir, agent_name + ':last_check'))
+            fresh = False
+            if last_check_epoch is not None:
+                tick_ms = _resolve_tick_interval_ms(agent_name, colony, fed_dir)
+                fresh = (time.time() - last_check_epoch) < STALENESS_TICKS * (tick_ms / 1000.0)
             effective_state = d.get('effective_state') or state
-            if effective_state != 'running':
+            if not fresh and effective_state != 'running':
                 decisions.append(_attach_explorer_evidence({
                     'agent': agent_name,
                     'colony': colony,
                     'decision': 'skip',
-                    'reason': f'effective_state={effective_state!r} not running',
+                    'reason': f'memo last_check stale and effective_state={effective_state!r} not running',
                     'pid': pid,
                     'confidence': confidence,
                 }))

--- a/tools/test-auto-promote.sh
+++ b/tools/test-auto-promote.sh
@@ -644,6 +644,81 @@ else
     fail "fed-local priority" "expected entries_total=5, got <$ENTRIES_B> from <$OUT_B>"
 fi
 
+# --- Test 18: containerized liveness — fresh memo overrides stale registry (#706) ---
+# Reproduces the lifecycle-blocked-after-reboot bug: the daemon registry's
+# `effective_state` stays at "zombie" across sleep/reboot cycles, but the in-
+# process tick loop keeps writing `<agent>:last_check`. Pre-#706 the
+# containerized branch trusted `effective_state` and skipped every such agent
+# with "effective_state='zombie' not running" — promotions, evolves, and
+# (downstream) cull-replicas inputs all stalled. Post-#706 a fresh memo
+# (within STALENESS_TICKS * tick_interval) carries the agent past the
+# containerized gate so the rest of the prereq pipeline runs normally.
+FED_LIVE="$TMPDIR_TEST/fed-live"
+mkdir -p "$FED_LIVE"
+ISO_NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+(cd "$FED_LIVE" && agentis memo set "explorer:last_check" "$ISO_NOW" >/dev/null 2>&1)
+
+DAEMONS_LIVE='[{"pid":12345,"agent_id":"explorer-1","source":"explorer.ag","state":"zombie","effective_state":"zombie","colony":"discovery","confidence":0.4,"started_at":1}]'
+
+OUT_LIVE=$(python3 "$SCRIPT_DIR/auto-promote-decisions.py" \
+    --preview --config "$SCRIPT_DIR/auto-promote-config.yaml" --containerized \
+    "$DAEMONS_LIVE" "$FED_LIVE")
+
+LIVE_CHECK=$(python3 -c "
+import json, re, sys
+arr = json.loads(sys.argv[1])
+if len(arr) != 1:
+    print('arity:' + str(len(arr))); sys.exit(0)
+d = arr[0]
+reason = d.get('reason', '')
+if re.search(r\"effective_state=.*not running\", reason):
+    print('regression: got <' + reason + '>')
+else:
+    print('ok')
+" "$OUT_LIVE" 2>&1 || true)
+
+if [ "$LIVE_CHECK" = "ok" ]; then
+    pass "containerized liveness: fresh memo overrides stale registry (#706)"
+else
+    fail "fresh-memo liveness" "$LIVE_CHECK from <$OUT_LIVE>"
+fi
+
+# --- Test 19: containerized liveness — no memo + stale registry skips (#706) ---
+# Counterpart to test 18: with NO `<agent>:last_check` memo present and the
+# registry's `effective_state` still "zombie", the sidecar must skip with
+# the new memo-aware reason string. This guards against the inverse
+# regression — relaxing the gate too far would let truly dead daemons get
+# promoted.
+FED_DEAD="$TMPDIR_TEST/fed-dead"
+mkdir -p "$FED_DEAD"
+
+DAEMONS_DEAD='[{"pid":12345,"agent_id":"explorer-1","source":"explorer.ag","state":"zombie","effective_state":"zombie","colony":"discovery","confidence":0.4,"started_at":1}]'
+
+OUT_DEAD=$(python3 "$SCRIPT_DIR/auto-promote-decisions.py" \
+    --preview --config "$SCRIPT_DIR/auto-promote-config.yaml" --containerized \
+    "$DAEMONS_DEAD" "$FED_DEAD")
+
+DEAD_CHECK=$(python3 -c "
+import json, re, sys
+arr = json.loads(sys.argv[1])
+if len(arr) != 1:
+    print('arity:' + str(len(arr))); sys.exit(0)
+d = arr[0]
+if d.get('decision') != 'skip':
+    print('decision:' + d.get('decision', '')); sys.exit(0)
+reason = d.get('reason', '')
+if re.search(r\"memo last_check stale and effective_state='zombie' not running\", reason):
+    print('ok')
+else:
+    print('reason:' + reason)
+" "$OUT_DEAD" 2>&1 || true)
+
+if [ "$DEAD_CHECK" = "ok" ]; then
+    pass "containerized liveness: no memo + stale registry skips with new reason (#706)"
+else
+    fail "no-memo liveness" "$DEAD_CHECK from <$OUT_DEAD>"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-auto-promote.sh
+++ b/tools/test-auto-promote.sh
@@ -653,6 +653,9 @@ fi
 # (downstream) cull-replicas inputs all stalled. Post-#706 a fresh memo
 # (within STALENESS_TICKS * tick_interval) carries the agent past the
 # containerized gate so the rest of the prereq pipeline runs normally.
+if ! command -v agentis >/dev/null 2>&1; then
+    echo "[SKIP] Test 18 + 19: agentis binary not available — memo seeding would be a no-op and the new memo-aware reason would false-fail the assertion (#706)"
+else
 FED_LIVE="$TMPDIR_TEST/fed-live"
 mkdir -p "$FED_LIVE"
 ISO_NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -718,6 +721,8 @@ if [ "$DEAD_CHECK" = "ok" ]; then
 else
     fail "no-memo liveness" "$DEAD_CHECK from <$OUT_DEAD>"
 fi
+
+fi  # end agentis-available guard for Test 18 + 19
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

- `tools/auto-promote-decisions.py` containerized branch now trusts `<agent>:last_check` memo freshness over `effective_state`, mirroring the dashboard's #683 logic.
- Daemon registry `effective_state` lies after sleep/reboot — the field stays `zombie` even when the in-process tick loop keeps writing the memo. Pre-#706 every containerized agent fell into the `effective_state='zombie' not running` skip branch, blocking promotions, evolves, and (downstream) cull-replicas inputs.
- Memo freshness is PID-namespace independent: the predicate works whether the dashboard / sidecar runs inside or outside the container.

## Background

This continues the registry-liveness fix chain: #683 (dashboard PID liveness → memo freshness), #697 (per-repo fallback), #700 (env-configurable `FEDERATION_DASHBOARD_STALENESS_TICKS`), #705 (banner alignment). The dashboard was correct after #683, but `auto-promote-decisions.py` still consumed the stale registry field — so the dashboard rendered HEALTHY while the sidecar refused to promote anything.

## Implementation

The three helpers (`_read_memo_raw`, `_parse_last_check_epoch`, `_resolve_tick_interval_ms`) are mirrored verbatim from `federation-dashboard/lib/federation-dashboard-collector.py:85-134` with a `keep in sync with #683/#697/#700/#705` banner. `STALENESS_TICKS` reuses the same `FEDERATION_DASHBOARD_STALENESS_TICKS` env knob so a single setting controls both the dashboard and the sidecar.

The containerized gate is now:

```python
if containerized:
    last_check_epoch = _parse_last_check_epoch(_read_memo_raw(fed_dir, agent_name + ':last_check'))
    fresh = False
    if last_check_epoch is not None:
        tick_ms = _resolve_tick_interval_ms(agent_name, colony, fed_dir)
        fresh = (time.time() - last_check_epoch) < STALENESS_TICKS * (tick_ms / 1000.0)
    effective_state = d.get('effective_state') or state
    if not fresh and effective_state != 'running':
        # skip with reason "memo last_check stale and effective_state=... not running"
```

Host-side (`containerized=False`) path is untouched — `dev-apprenticeship/` still uses `os.kill(pid, 0)`.

## Test plan

- [x] `bash tools/test-auto-promote.sh` — 37/0 (35 baseline + 2 new tests for #706)
  - Test 18: fresh memo + stale registry → decision does NOT carry `effective_state=... not running` reason
  - Test 19: no memo + stale registry → decision IS skipped with the new memo-aware reason
- [x] `bash research-foundry/tools/test-run-research.sh` — 95/0
- [x] `bash research-foundry/tools/test-replicate-gates.sh` — 29/0
- [x] `bash research-foundry/tools/test-jitter.sh` — 72/0
- [x] `bash research-foundry/tools/test-last-check-early.sh` — 72/0
- [x] `bash tools/colony-lint.sh` — 343/0/4 (baseline)
- [x] `python3 -m ast tools/auto-promote-decisions.py` — syntax clean

## Out of scope

- `tools/cull-replicas.sh` — inherits the fix transitively via `auto-promote-decisions.py` JSON output.
- `federation-dashboard/` — already memo-freshness-driven since #683.

---
Closes #706