### PR TITLE
refactor(memo-freshness): extract helpers to shared tools/agentis_memo_freshness.py (#709)

### DIFF
--- a/dev-apprenticeship/BUNDLE.manifest
+++ b/dev-apprenticeship/BUNDLE.manifest
@@ -34,6 +34,10 @@ tools/auto-promote-config.yaml
 tools/auto-promote-config-parser.py
 tools/auto-promote-lock.py
 tools/auto-promote-decisions.py
+# #709: shared memo-freshness helpers (STALENESS_TICKS / read_memo_raw /
+# parse_last_check_epoch / resolve_tick_interval_ms) consumed by both
+# tools/auto-promote-decisions.py and federation-dashboard's collector.
+tools/agentis_memo_freshness.py
 tools/resolve-tick-interval.py
 tools/cost-cap.sh
 tools/cost-cap-sum.py

--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **dashboard**: memo-freshness helpers (`read_memo_raw`, `parse_last_check_epoch`, `resolve_tick_interval_ms`, `STALENESS_TICKS`) extracted from `federation-dashboard/lib/federation-dashboard-collector.py` into shared `tools/agentis_memo_freshness.py` so the dashboard and `tools/auto-promote-decisions.py` (#706) no longer keep a mirrored copy in sync via comment banners. Collector imports via the already-argv-routed `fed_tools_dir`. Graceful degradation preserved: missing helper module → all daemons `pid_alive=false`, matching the pre-existing missing-helper contract. ([#709](https://github.com/Replikanti/agentis-colonies/issues/709))
+
 ### Fixed
 
 - **dashboard**: auto-regen now runs as a Python daemon thread inside the server PID instead of an orphan-prone bash subshell. Pre-fix, `SIGKILL` on the wrapper left the bash regen subshell reparented to init, still writing `snapshot.json` with the pre-restart `STALENESS_TICKS` env value. Multiple operator restarts compounded — each spawned a fresh subshell on top of orphaned predecessors, racing on `snapshot.json` and flashing the dashboard banner between DEGRADED and HEALTHY. New design ties the regen loop to the server PID via a `threading.Thread(daemon=True)` whose env recipe is byte-identical to the existing `/refresh` POST handler. New env knob `FEDERATION_DASHBOARD_REGEN_S` (default 60, floor 10) for future tuning. ([#705](https://github.com/Replikanti/agentis-colonies/issues/705))

--- a/federation-dashboard/lib/federation-dashboard-collector.py
+++ b/federation-dashboard/lib/federation-dashboard-collector.py
@@ -70,68 +70,28 @@ colony_list_json = sys.argv[8]
 fed_tools_dir  = sys.argv[9]
 all_agents     = sys.argv[10:]
 
+# #709: memo-freshness helpers (read_memo_raw / parse_last_check_epoch /
+# resolve_tick_interval_ms / STALENESS_TICKS) live in the shared
+# tools/agentis_memo_freshness.py module so this collector and
+# tools/auto-promote-decisions.py consume the single source of truth
+# instead of mirroring the implementation (former drift documented in
+# #683/#697/#700/#705/#706/#708). The federation's shared-tools dir is
+# already passed as argv[9] -- we route the import via that path. If the
+# helper module is missing (older federation install), `freshness` stays
+# None and every daemon collapses to `pid_alive=false`, matching the
+# pre-existing missing-helper safe-default contract.
+if fed_tools_dir and fed_tools_dir not in sys.path:
+    sys.path.insert(0, fed_tools_dir)
+try:
+    import agentis_memo_freshness as freshness
+    STALENESS_TICKS = freshness.STALENESS_TICKS
+except ImportError:
+    freshness = None
+    STALENESS_TICKS = 3
+
 def safe_json(s, default):
     try: return json.loads(s or '[]')
     except (json.JSONDecodeError, TypeError, ValueError): return default
-
-# #683: helpers for memo-freshness liveness. `_read_memo_raw` shells out to
-# `agentis memo get <key>` (same idiom used for the per-repo confidence
-# overlay around lines 380-404) so the dashboard does not need to know
-# about the on-disk memo store layout. `_parse_last_check_epoch`
-# converts the canonical ISO-8601 UTC string the `.ag` agents write
-# (`exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"`) into epoch seconds; any
-# unexpected shape collapses to `None` so the caller treats the agent as
-# stale rather than crashing the whole collector regen.
-def _read_memo_raw(fed_dir, key):
-    try:
-        proc = subprocess.run(
-            ['agentis', 'memo', 'get', key],
-            cwd=fed_dir, capture_output=True, text=True, timeout=2,
-        )
-    except (subprocess.SubprocessError, OSError):
-        return None
-    if proc.returncode != 0:
-        return None
-    raw = (proc.stdout or '').strip()
-    return raw or None
-
-def _parse_last_check_epoch(raw):
-    if not raw:
-        return None
-    try:
-        dt = datetime.datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ")
-        return dt.replace(tzinfo=datetime.timezone.utc).timestamp()
-    except (TypeError, ValueError):
-        return None
-
-# Cache resolved tick intervals per (agent, colony) so the helper is not
-# re-spawned on every record when the same agent appears across multiple
-# repos (rare today, but cheap insurance against future fan-out).
-_tick_interval_cache = {}
-
-def _resolve_tick_interval_ms(agent, colony):
-    cache_key = (agent, colony)
-    if cache_key in _tick_interval_cache:
-        return _tick_interval_cache[cache_key]
-    interval = 60000
-    if fed_tools_dir and colony:
-        helper = os.path.join(fed_tools_dir, 'resolve-tick-interval.py')
-        colony_dir = os.path.join(fed_dir, colony)
-        if os.path.isfile(helper) and os.path.isdir(colony_dir):
-            try:
-                proc = subprocess.run(
-                    ['python3', helper, agent, colony_dir],
-                    capture_output=True, text=True, timeout=2,
-                )
-                if proc.returncode == 0:
-                    try:
-                        interval = int((proc.stdout or '').strip())
-                    except (TypeError, ValueError):
-                        interval = 60000
-            except (subprocess.SubprocessError, OSError):
-                interval = 60000
-    _tick_interval_cache[cache_key] = interval
-    return interval
 
 daemons    = safe_json(daemons_json, [])
 agent_map  = safe_json(agent_map_json, [])
@@ -324,22 +284,22 @@ for colony, agent in agent_pairs:
         # colony actually has repos. Field name `pid_alive` preserved so
         # the template + `is_running` derivation stay byte-identical.
         last_check_epoch = None
-        bare_raw = _read_memo_raw(fed_dir, agent + ':last_check')
-        last_check_epoch = _parse_last_check_epoch(bare_raw)
+        bare_raw = freshness.read_memo_raw(fed_dir, agent + ':last_check') if freshness else None
+        last_check_epoch = freshness.parse_last_check_epoch(bare_raw) if freshness else None
         if last_check_epoch is None:
             repos = repos_for_colony.get(colony, [])
             if repos:
                 per_repo_max = None
                 for owner, repo in repos:
                     pr_key = '%s__%s:%s:last_check' % (owner, repo, agent)
-                    pr_raw = _read_memo_raw(fed_dir, pr_key)
-                    pr_epoch = _parse_last_check_epoch(pr_raw)
+                    pr_raw = freshness.read_memo_raw(fed_dir, pr_key) if freshness else None
+                    pr_epoch = freshness.parse_last_check_epoch(pr_raw) if freshness else None
                     if pr_epoch is not None:
                         if per_repo_max is None or pr_epoch > per_repo_max:
                             per_repo_max = pr_epoch
                 last_check_epoch = per_repo_max
         if last_check_epoch is not None:
-            tick_interval_ms = _resolve_tick_interval_ms(agent, colony)
+            tick_interval_ms = freshness.resolve_tick_interval_ms(agent, colony, fed_dir=fed_dir, fed_tools_dir=fed_tools_dir) if freshness else 60000
             window_seconds = STALENESS_TICKS * (tick_interval_ms / 1000.0)
             rec['pid_alive'] = (epoch - last_check_epoch) < window_seconds
         else:

--- a/research-foundry/BUNDLE.manifest
+++ b/research-foundry/BUNDLE.manifest
@@ -47,6 +47,9 @@ tools/auto-promote.sh
 tools/auto-promote-config.research-foundry.yaml
 tools/auto-promote-config-parser.py
 tools/auto-promote-decisions.py
+# #709: shared memo-freshness helpers consumed by auto-promote-decisions.py
+# (and federation-dashboard's collector in environments that bundle it).
+tools/agentis_memo_freshness.py
 tools/auto-promote-lock.py
 tools/parse-toml.sh
 

--- a/tools/agentis_memo_freshness.py
+++ b/tools/agentis_memo_freshness.py
@@ -1,0 +1,90 @@
+"""
+Shared memo-freshness helpers used by federation-dashboard's collector
+and tools/auto-promote-decisions.py to derive containerized-daemon
+liveness from <agent>:last_check memo timestamps instead of the
+agentis daemon list state field (which lies for containerized
+federations -- see #683 / #686 / #697 / #700 / #705 / #706).
+
+Public API:
+  STALENESS_TICKS -- int (env-clamped, default 3)
+  read_memo_raw(fed_dir, key) -> Optional[str]
+  parse_last_check_epoch(raw) -> Optional[float]
+  resolve_tick_interval_ms(agent, colony, fed_dir, fed_tools_dir=None) -> int
+
+The fed_tools_dir kwarg of resolve_tick_interval_ms defaults to the
+directory containing this module (preserves the __file__-relative
+behaviour from auto-promote-decisions.py); pass an explicit dir to
+preserve the argv-routed behaviour from federation-dashboard-collector.py.
+Single source of truth extracted in #709 from prior mirrored copies in
+federation-dashboard/lib/federation-dashboard-collector.py (#683, #697,
+#700) and tools/auto-promote-decisions.py (#706, #708).
+"""
+import datetime
+import os
+import subprocess
+from typing import Optional
+
+
+try:
+    STALENESS_TICKS = max(1, int(os.environ.get("FEDERATION_DASHBOARD_STALENESS_TICKS", "3")))
+except (TypeError, ValueError):
+    STALENESS_TICKS = 3
+
+
+# Cache resolved tick intervals per (agent, colony) so the helper is not
+# re-spawned on every record when the same agent appears across multiple
+# repos (rare today, but cheap insurance against future fan-out).
+_tick_interval_cache: dict = {}
+
+
+def read_memo_raw(fed_dir: str, key: str) -> Optional[str]:
+    try:
+        proc = subprocess.run(
+            ['agentis', 'memo', 'get', key],
+            cwd=fed_dir, capture_output=True, text=True, timeout=2,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    raw = (proc.stdout or '').strip()
+    return raw or None
+
+
+def parse_last_check_epoch(raw: Optional[str]) -> Optional[float]:
+    if not raw:
+        return None
+    try:
+        dt = datetime.datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ")
+        return dt.replace(tzinfo=datetime.timezone.utc).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+def resolve_tick_interval_ms(agent: str, colony: str, fed_dir: str, fed_tools_dir: Optional[str] = None) -> int:
+    cache_key = (agent, colony)
+    if cache_key in _tick_interval_cache:
+        return _tick_interval_cache[cache_key]
+    interval = 60000
+    if fed_tools_dir is None:
+        fed_tools_dir = os.path.dirname(os.path.abspath(__file__))
+    if fed_tools_dir and colony:
+        helper = os.path.join(fed_tools_dir, 'resolve-tick-interval.py')
+        colony_dir = os.path.join(fed_dir, colony)
+        if os.path.isfile(helper) and os.path.isdir(colony_dir):
+            try:
+                proc = subprocess.run(
+                    ['python3', helper, agent, colony_dir],
+                    capture_output=True, text=True, timeout=2,
+                )
+                if proc.returncode == 0:
+                    try:
+                        interval = int((proc.stdout or '').strip())
+                        if interval <= 0:
+                            interval = 60000
+                    except (TypeError, ValueError):
+                        interval = 60000
+            except (subprocess.SubprocessError, OSError):
+                interval = 60000
+    _tick_interval_cache[cache_key] = interval
+    return interval

--- a/tools/auto-promote-decisions.py
+++ b/tools/auto-promote-decisions.py
@@ -58,69 +58,15 @@ import sys
 import time
 
 
-# Mirrored from federation-dashboard-collector.py:85-134; keep in sync with
-# #683/#697/#700/#705. #706 ports the same memo-freshness liveness predicate
-# from the dashboard to this sidecar so the containerized branch below no
-# longer trusts the daemon registry's stale `effective_state` field (the
-# in-process tick loop continues to write `<agent>:last_check` even when
-# the registry record is mis-flagged as `zombie` after sleep/reboot).
-try:
-    STALENESS_TICKS = max(1, int(os.environ.get("FEDERATION_DASHBOARD_STALENESS_TICKS", "3")))
-except (TypeError, ValueError):
-    STALENESS_TICKS = 3
-
-
-def _read_memo_raw(fed_dir, key):
-    try:
-        proc = subprocess.run(
-            ['agentis', 'memo', 'get', key],
-            cwd=fed_dir, capture_output=True, text=True, timeout=2,
-        )
-    except (subprocess.SubprocessError, OSError):
-        return None
-    if proc.returncode != 0:
-        return None
-    raw = (proc.stdout or '').strip()
-    return raw or None
-
-
-def _parse_last_check_epoch(raw):
-    if not raw:
-        return None
-    try:
-        dt = datetime.datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ")
-        return dt.replace(tzinfo=datetime.timezone.utc).timestamp()
-    except (TypeError, ValueError):
-        return None
-
-
-_tick_interval_cache = {}
-
-
-def _resolve_tick_interval_ms(agent, colony, fed_dir):
-    cache_key = (agent, colony)
-    if cache_key in _tick_interval_cache:
-        return _tick_interval_cache[cache_key]
-    interval = 60000
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    helper = os.path.join(script_dir, 'resolve-tick-interval.py')
-    if colony:
-        colony_dir = os.path.join(fed_dir, colony)
-        if os.path.isfile(helper) and os.path.isdir(colony_dir):
-            try:
-                proc = subprocess.run(
-                    ['python3', helper, agent, colony_dir],
-                    capture_output=True, text=True, timeout=2,
-                )
-                if proc.returncode == 0:
-                    try:
-                        interval = int((proc.stdout or '').strip())
-                    except (TypeError, ValueError):
-                        interval = 60000
-            except (subprocess.SubprocessError, OSError):
-                interval = 60000
-    _tick_interval_cache[cache_key] = interval
-    return interval
+# #709: memo-freshness helpers (read_memo_raw / parse_last_check_epoch /
+# resolve_tick_interval_ms / STALENESS_TICKS) extracted into the shared
+# tools/agentis_memo_freshness.py module so this sidecar and the dashboard
+# collector consume the single source of truth instead of mirroring the
+# implementation (former drift documented in #683/#697/#700/#705/#706/#708).
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+import agentis_memo_freshness as freshness  # noqa: E402
 
 
 def _load_config(path):
@@ -598,11 +544,11 @@ def main():
         # legacy callers; the memo path simply unblocks daemons whose
         # registry record lies.
         if containerized:
-            last_check_epoch = _parse_last_check_epoch(_read_memo_raw(fed_dir, agent_name + ':last_check'))
+            last_check_epoch = freshness.parse_last_check_epoch(freshness.read_memo_raw(fed_dir, agent_name + ':last_check'))
             fresh = False
             if last_check_epoch is not None:
-                tick_ms = _resolve_tick_interval_ms(agent_name, colony, fed_dir)
-                fresh = (time.time() - last_check_epoch) < STALENESS_TICKS * (tick_ms / 1000.0)
+                tick_ms = freshness.resolve_tick_interval_ms(agent_name, colony, fed_dir)
+                fresh = (time.time() - last_check_epoch) < freshness.STALENESS_TICKS * (tick_ms / 1000.0)
             effective_state = d.get('effective_state') or state
             if not fresh and effective_state != 'running':
                 decisions.append(_attach_explorer_evidence({

--- a/tools/test-agentis-memo-freshness.sh
+++ b/tools/test-agentis-memo-freshness.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# tools/test-agentis-memo-freshness.sh: unit tests for the shared
+# memo-freshness module extracted in #709 from
+# federation-dashboard/lib/federation-dashboard-collector.py and
+# tools/auto-promote-decisions.py. Covers:
+#
+#   1. STALENESS_TICKS default (no env) = 3.
+#   2. STALENESS_TICKS env=10 -> 10.
+#   3. STALENESS_TICKS env=0 clamps to 1.
+#   4. STALENESS_TICKS env=abc -> 3 (try/except fallback).
+#   5. parse_last_check_epoch("2026-05-19T12:34:56Z") matches the expected
+#      epoch derived from `date -d` / python fallback.
+#   6. parse_last_check_epoch(None) + bad-shape -> None.
+#   7. read_memo_raw against a seeded value (skipped if `agentis` not on
+#      PATH, mirroring test-dashboard-freshness-liveness.sh).
+#   8. resolve_tick_interval_ms with explicit fed_tools_dir + cache-hit on
+#      the 2nd call returns the same value without re-spawning the helper.
+#
+# Usage: ./tools/test-agentis-memo-freshness.sh
+# Exit 0 on full pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# Common Python prelude that adds the tools dir to sys.path so the
+# module loads under its real filename (hyphen-free).
+PYPATH_PRELUDE="import sys; sys.path.insert(0, '$SCRIPT_DIR')"
+
+# --- Test 1: default STALENESS_TICKS = 3 ---
+ACTUAL="$(unset FEDERATION_DASHBOARD_STALENESS_TICKS; python3 -c "$PYPATH_PRELUDE
+import agentis_memo_freshness as f
+print(f.STALENESS_TICKS)
+")"
+if [ "$ACTUAL" = "3" ]; then
+    pass "1: STALENESS_TICKS default = 3"
+else
+    fail "1: STALENESS_TICKS default" "expected 3, got $ACTUAL"
+fi
+
+# --- Test 2: env=10 -> 10 ---
+ACTUAL="$(FEDERATION_DASHBOARD_STALENESS_TICKS=10 python3 -c "$PYPATH_PRELUDE
+import agentis_memo_freshness as f
+print(f.STALENESS_TICKS)
+")"
+if [ "$ACTUAL" = "10" ]; then
+    pass "2: STALENESS_TICKS env=10 -> 10"
+else
+    fail "2: STALENESS_TICKS env=10" "expected 10, got $ACTUAL"
+fi
+
+# --- Test 3: env=0 clamps to 1 ---
+ACTUAL="$(FEDERATION_DASHBOARD_STALENESS_TICKS=0 python3 -c "$PYPATH_PRELUDE
+import agentis_memo_freshness as f
+print(f.STALENESS_TICKS)
+")"
+if [ "$ACTUAL" = "1" ]; then
+    pass "3: STALENESS_TICKS env=0 clamps to 1"
+else
+    fail "3: STALENESS_TICKS env=0 clamp" "expected 1, got $ACTUAL"
+fi
+
+# --- Test 4: env=abc -> 3 (fallback) ---
+ACTUAL="$(FEDERATION_DASHBOARD_STALENESS_TICKS=abc python3 -c "$PYPATH_PRELUDE
+import agentis_memo_freshness as f
+print(f.STALENESS_TICKS)
+")"
+if [ "$ACTUAL" = "3" ]; then
+    pass "4: STALENESS_TICKS env=abc -> 3 fallback"
+else
+    fail "4: STALENESS_TICKS env=abc fallback" "expected 3, got $ACTUAL"
+fi
+
+# --- Test 5: parse_last_check_epoch on a real ISO-8601 UTC string ---
+ISO_FIXTURE="2026-05-19T12:34:56Z"
+EXPECTED_EPOCH="$(date -u -d "$ISO_FIXTURE" '+%s' 2>/dev/null || \
+                  python3 -c "import datetime; print(int(datetime.datetime(2026,5,19,12,34,56,tzinfo=datetime.timezone.utc).timestamp()))")"
+ACTUAL="$(python3 -c "$PYPATH_PRELUDE
+import agentis_memo_freshness as f
+v = f.parse_last_check_epoch('$ISO_FIXTURE')
+print(int(v) if v is not None else 'None')
+")"
+if [ "$ACTUAL" = "$EXPECTED_EPOCH" ]; then
+    pass "5: parse_last_check_epoch($ISO_FIXTURE) = $EXPECTED_EPOCH"
+else
+    fail "5: parse_last_check_epoch ISO-8601" "expected $EXPECTED_EPOCH, got $ACTUAL"
+fi
+
+# --- Test 6: parse_last_check_epoch(None) + bad shape -> None ---
+ACTUAL="$(python3 -c "$PYPATH_PRELUDE
+import agentis_memo_freshness as f
+results = [f.parse_last_check_epoch(None), f.parse_last_check_epoch(''), f.parse_last_check_epoch('not-an-iso-date'), f.parse_last_check_epoch('2026-05-19')]
+print(','.join('None' if r is None else str(r) for r in results))
+")"
+if [ "$ACTUAL" = "None,None,None,None" ]; then
+    pass "6: parse_last_check_epoch(None / '' / bad-shape / date-only) all return None"
+else
+    fail "6: parse_last_check_epoch None/bad" "expected 'None,None,None,None', got '$ACTUAL'"
+fi
+
+# --- Test 7: read_memo_raw against seeded value ---
+if ! command -v agentis >/dev/null 2>&1; then
+    echo "[SKIP] 7: agentis binary not found on \$PATH (read_memo_raw end-to-end)"
+else
+    PROBE_DIR="$TMPDIR_TEST/probe"
+    mkdir -p "$PROBE_DIR"
+    (cd "$PROBE_DIR" && agentis memo set probe:key "probe-value-709" >/dev/null 2>&1) || true
+    PROBE_OUT="$(cd "$PROBE_DIR" && agentis memo get probe:key 2>/dev/null | tr -d '\r\n ')" || PROBE_OUT=""
+    if [ "$PROBE_OUT" != "probe-value-709" ]; then
+        echo "[SKIP] 7: installed agentis ($(agentis --version 2>&1)) memo get does not return a clean scalar"
+    else
+        ACTUAL="$(python3 -c "$PYPATH_PRELUDE
+import agentis_memo_freshness as f
+v = f.read_memo_raw('$PROBE_DIR', 'probe:key')
+print(v if v is not None else 'None')
+")"
+        if [ "$ACTUAL" = "probe-value-709" ]; then
+            pass "7: read_memo_raw(probe:key) returns seeded value"
+        else
+            fail "7: read_memo_raw seeded" "expected 'probe-value-709', got '$ACTUAL'"
+        fi
+    fi
+fi
+
+# --- Test 8: resolve_tick_interval_ms with explicit fed_tools_dir + cache hit ---
+# Build a tiny federation fixture: one colony with a start-colony.sh that
+# resolve-tick-interval.py can parse for a fixed tick_interval_for() value.
+T8_FED="$TMPDIR_TEST/t8/fed"
+mkdir -p "$T8_FED/stub-colony/scripts" "$T8_FED/stub-colony/agents"
+cat > "$T8_FED/stub-colony/scripts/start-colony.sh" <<'SH'
+#!/bin/bash
+tick_interval_for() {
+    case "$1" in
+        cached_agent) echo 90000 ;;
+        *) echo 60000 ;;
+    esac
+}
+SH
+chmod +x "$T8_FED/stub-colony/scripts/start-colony.sh"
+
+ACTUAL="$(python3 -c "$PYPATH_PRELUDE
+import agentis_memo_freshness as f
+# First call: spawns the helper subprocess; should resolve to 90000.
+v1 = f.resolve_tick_interval_ms('cached_agent', 'stub-colony', '$T8_FED', fed_tools_dir='$SCRIPT_DIR')
+# Sentinel: stash the cache contents so we can verify the 2nd call hits.
+cache_after_first = dict(f._tick_interval_cache)
+# Replace the cached value with a sentinel; the 2nd call should return
+# the sentinel, proving it consulted the cache (no fresh subprocess that
+# would have produced 90000 again).
+f._tick_interval_cache[('cached_agent', 'stub-colony')] = 12345
+v2 = f.resolve_tick_interval_ms('cached_agent', 'stub-colony', '$T8_FED', fed_tools_dir='$SCRIPT_DIR')
+print('%d|%d|%s' % (v1, v2, ('cached_agent', 'stub-colony') in cache_after_first))
+")"
+if [ "$ACTUAL" = "90000|12345|True" ]; then
+    pass "8: resolve_tick_interval_ms returns 90000 on first call and hits cache on second"
+else
+    fail "8: resolve_tick_interval_ms + cache" "expected '90000|12345|True', got '$ACTUAL'"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

`STALENESS_TICKS` + `read_memo_raw` / `parse_last_check_epoch` / `resolve_tick_interval_ms` lived in two places: `federation-dashboard/lib/federation-dashboard-collector.py` (added in #683, refined in #697 / #700) and `tools/auto-promote-decisions.py` (mirrored in #706 / #708). Six follow-up issues had to amend the same predicate twice and the in-file banner `# Mirrored from federation-dashboard-collector.py:85-134; keep in sync with #683/#697/#700/#705` was the only thing tying them together.

This PR makes `tools/agentis_memo_freshness.py` the single source of truth and rewires both consumers via the federation's shared-tools dir:

- `auto-promote-decisions.py` resolves the import via a `__file__`-relative `sys.path.insert` (no behaviour change vs the prior `script_dir = os.path.dirname(os.path.abspath(__file__))` block).
- `federation-dashboard-collector.py` resolves the import via the already-argv-routed `fed_tools_dir` (argv[9]). When the helper is unreachable (federation install predates the new file in `BUNDLE.manifest`), `freshness` stays `None` and every daemon collapses to `pid_alive=false`, byte-identical to the pre-existing missing-helper contract.

`BUNDLE.manifest` updates: append `tools/agentis_memo_freshness.py` to `dev-apprenticeship/` and `research-foundry/` next to `auto-promote-decisions.py`.

## Test plan

- [x] `bash tools/test-agentis-memo-freshness.sh` -- 8/8 new tests (STALENESS_TICKS env matrix incl. clamp + bad-value fallback, parse_last_check_epoch shapes, read_memo_raw end-to-end via real `agentis memo set`, resolve_tick_interval_ms cache-hit)
- [x] `bash tools/test-auto-promote.sh` -- 37/37 (incl. preview-mode byte-identity, containerized-liveness `#706` tests)
- [x] `bash tools/test-dashboard-freshness-liveness.sh` -- 5/5 (fresh / stale / missing / containerized / env-widened)
- [x] `bash research-foundry/tools/test-run-research.sh` -- 95/95
- [x] `bash research-foundry/tools/test-replicate-gates.sh` -- 29/29
- [x] `bash research-foundry/tools/test-jitter.sh` -- 72/72
- [x] `bash research-foundry/tools/test-last-check-early.sh` -- 72/72
- [x] `bash tools/test-make-federation-bundle.sh` -- 11/11 (new manifest entry validates)
- [x] `bash tools/test-make-dashboard-bundle.sh` -- 13/13
- [x] `./tools/colony-lint.sh` -- 344/0/4 (= 343 baseline + 1 new test discovered)
- [x] `python3 -m ast` clean on all three modules (shared helper, decisions, collector)

closes #709