### PR TITLE
fix(research-foundry/auto-promote): flip dry_run: true -> false (#717)

### DIFF
--- a/tools/auto-promote-config.research-foundry.yaml
+++ b/tools/auto-promote-config.research-foundry.yaml
@@ -19,8 +19,23 @@
 # `evolve.mutation.enabled` for the explorer agent only -- the
 # `evolve.mutation.allowed_agents: ["explorer"]` gate keeps the other
 # 14 agents in observe-only mode through the legacy `agentis evolve`
-# path. The top-level `dry_run: true` remains a safety belt for the
-# promotion ladder; evolve has its own per-block toggle now.
+# path. Explorer cull/evolve plus lifecycle-on-default (#663, #679)
+# are the maturity context for flipping the top-level gate next.
+#
+# Top-level `dry_run: false` (flipped per #717): Run #14 forensic
+# showed all 18 roles stuck at the install seed 0.7 (propose tier)
+# because the sidecar evaluated promote decisions every 5 minutes but
+# never applied them. Per ADR-0001 the propose tier silently disables
+# the auditor's audit-ledger writes, blocking the late-pipeline state
+# advance. The remaining safety net is layered downstream and is NOT
+# the top-level gate:
+#   - Auditor propose-tier guard (`final_write=false`) suppresses
+#     audit-ledger rows until a role is promoted past propose, so
+#     pre-promote auditors stay silent.
+#   - Submitter only acts terminally at the autonomous tier AND
+#     requires an operator-set `reviewer:<claim>:approved` memo key.
+#   - `RESEARCH_ARXIV_GATEWAY` is HItL-only per the orchestrator log;
+#     the terminal arXiv send is never auto-dispatched.
 
 promote:
   prerequisites:
@@ -65,4 +80,4 @@ evolve:
   ledger_path: "evolution-ledger.jsonl"
   dry_run: false                         # PR-C flips live for explorer (#628)
 
-dry_run: true
+dry_run: false


### PR DESCRIPTION
## Summary

- Flip top-level `dry_run: true` to `dry_run: false` in `tools/auto-promote-config.research-foundry.yaml` so the sidecar actually applies promote decisions for the research-foundry federation.
- Rewrite the surrounding comment block to document the rationale (Run #14 forensic) and the layered downstream safety net that replaces the now-removed top-level gate.
- Net change: 1 code line + 17 comment lines (18 LOC).

## Why

Run #14 forensic showed all 18 research-foundry roles stuck at the install-seed confidence 0.7 (propose tier) for the entire run. The sidecar was evaluating promote decisions every 5 minutes but never applying them because of the global `dry_run: true` gate. Per ADR-0001 the propose tier silently disables the auditor's audit-ledger writes (`final_write=false`), so the propose→review-gated barrier becomes a hard wall: no audit-ledger rows means no `claim:audit_*:tick-N` seeds, which means the preprint chain has nothing to consume and the late pipeline never advances.

The top-level gate is no longer the dominant safety belt. The layered downstream safety net (intentionally unchanged) is:

- Auditor `final_write=false` at propose tier suppresses audit-ledger rows for any role still below review-gated, so pre-promote auditors stay silent.
- Submitter only acts terminally at the autonomous tier AND requires an operator-set `reviewer:<claim>:approved` memo key.
- `RESEARCH_ARXIV_GATEWAY` is HItL-only per the orchestrator log; the terminal arXiv send is never auto-dispatched.

Maturity context: explorer cull/evolve (#663) and lifecycle-on-default (#679) have been live and stable, so flipping the top-level gate is the next step in the auto-promote rollout for this federation.

## Test plan

- [x] `tools/auto-promote-config-parser.py` emits `CFG_DRY_RUN=false`
- [x] `tools/test-auto-promote.sh` — 37 passed, 0 failed
- [x] `tools/colony-lint.sh` — 344 passed, 0 failed, 4 skipped
- [ ] CI green
- [ ] After merge + #716/#718/#719 chain: Run #15 should show confidence drift on auditor / editor / submitter after ~30 min runtime

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)