### PR TITLE
fix(research-foundry): TOTAL_TICKS 30 -> 75 + min_runtime_hours 1.5 -> 1.0 (#718)

### DIFF
--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -27,7 +27,20 @@
 #   RESEARCH_TICK_INTERVAL_S     Seconds between orchestrator ticks.
 #                                Default 120 (median of the three
 #                                retired feds' 60/120/180s defaults).
-#   RESEARCH_TOTAL_TICKS         Number of ticks to drive. Default 30.
+#   RESEARCH_TOTAL_TICKS         Number of ticks to drive. Default 75
+#                                (#718: bumped from 30 so the default
+#                                run is long enough to clear the
+#                                auto-promote prereq gate). At the
+#                                default 120s tick interval that
+#                                yields a 2.5h budget. Auditor's
+#                                empirical 12 acting-rows/h rate in
+#                                Run #14 lands exactly at the
+#                                min_entries=30 threshold; verifier's
+#                                20/h clears it with margin. Editor's
+#                                9/h still falls short at 2.5h, which
+#                                is acceptable -- editor sits
+#                                downstream of theorist and promotes
+#                                on a slower cycle anyway.
 #   RESEARCH_DAEMONS_PER_COLONY  Per-colony daemon count for the math
 #                                pipeline (explorer/noticer/formulator/
 #                                verifier/novelty). Phase 1 = 1.
@@ -237,7 +250,7 @@ done
 TOPICS_RAW="${RESEARCH_TOPICS-number_theory,combinatorics,abstract_algebra,graph_theory}"
 PAPER_CORPUS_RAW="${RESEARCH_PAPER_CORPUS:-$FED_DIR/data/papers}"
 TICK_INTERVAL_S="${RESEARCH_TICK_INTERVAL_S:-120}"
-TOTAL_TICKS="${RESEARCH_TOTAL_TICKS:-30}"
+TOTAL_TICKS="${RESEARCH_TOTAL_TICKS:-75}"
 DAEMONS_PER_COLONY="${RESEARCH_DAEMONS_PER_COLONY:-1}"
 HOLD_PERIOD="${RESEARCH_HOLD_PERIOD:-4}"
 LLM_BACKEND="${RESEARCH_LLM_BACKEND:-claude}"

--- a/tools/auto-promote-config.research-foundry.yaml
+++ b/tools/auto-promote-config.research-foundry.yaml
@@ -41,7 +41,14 @@ promote:
   prerequisites:
     min_entries: 30
     min_acting_entries: 10
-    min_runtime_hours: 1.5
+    # min_runtime_hours relaxed from 1.5 to 1.0 (#718): the binding
+    # constraint is min_entries=30, which at the auditor's empirical
+    # 12 acting-rows/h needs 2.5h to clear. Paired with the
+    # RESEARCH_TOTAL_TICKS default bump from 30 to 75 (also #718), the
+    # default run now provides a 2.5h budget, so 1.0h is sufficient
+    # as a sanity guard against premature promotion without becoming
+    # the binding gate itself.
+    min_runtime_hours: 1.0
     reject_rate_threshold: 0.10
     delta_slope_window: 20
     delta_slope_min: 0


### PR DESCRIPTION
## Summary

- Bump `RESEARCH_TOTAL_TICKS` default `30` -> `75` in `research-foundry/tools/run-research.sh` (2.5h budget at the default 120s tick interval).
- Relax `min_runtime_hours` `1.5` -> `1.0` in `tools/auto-promote-config.research-foundry.yaml` (sanity guard only, no longer the binding gate).
- `min_entries=30` and `min_acting_entries=10` unchanged — preserve evidence robustness.

## Why

Run #14 forensic established the per-role acting-row rates: auditor 12/h, verifier 20/h, editor 9/h. Hitting `min_entries=30` therefore requires 2.5h for auditor, 1.5h for verifier, 3.3h for editor. The pre-fix default of 30 ticks at 120s/tick (1.0h) cleared none of them and also undershot the `min_runtime_hours: 1.5` gate, so every role stalled at the install seed of 0.7 (propose tier) with the prereq checklist permanently red.

Hybrid choice: extend the runway (75 ticks = 2.5h) rather than slash the 30-entry threshold. Auditor lands at exactly 30 entries, verifier clears with margin, editor falls short at 2.5h — acceptable because editor is downstream of theorist and promotes on a slower cycle anyway. Cost is ~2.5x more LLM spend per default run; reversible at any time via `RESEARCH_TOTAL_TICKS` env override.

`min_runtime_hours` moves down to 1.0 so it functions as a sanity guard (no promotes inside the first hour of a run) rather than the binding prereq gate, which is now properly the entry-count check.

## Test plan

- [x] `bash -n research-foundry/tools/run-research.sh` clean
- [x] `auto-promote-config-parser.py` emits `CFG_MIN_RUNTIME_HOURS=1.0` + `CFG_MIN_ENTRIES=30` + `CFG_MIN_ACTING_ENTRIES=10`
- [x] `tools/test-auto-promote.sh` — 37 passed, 0 failed
- [x] `tools/colony-lint.sh` — 344 passed, 0 failed, 4 skipped
- [ ] CI green
- [ ] After merge + #716 + #717: Run #15 (2.5h budget) should clear auditor + verifier past 30 entries; expect first promotes to the review-gated tier

Closes #718

Generated with [Claude Code](https://claude.com/claude-code)