### PR TITLE
feat(research-foundry): per-explorer topic pinning to specialty (#719)

### DIFF
--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -509,18 +509,51 @@ fn tick(reason: string) -> void {
     print("[explorer] tick conf=", conf);
 
     // Read foundry tick state seeded by the orchestrator
-    // (`tools/run-foundry.sh`) before each tick.
+    // (`tools/run-foundry.sh`) before each tick. #719: prefer per-daemon
+    // memos (`replay:explorer_*:daemon:<DAEMON_ID>`) seeded by the
+    // orchestrator from the specialty->topic mapping table; fall back
+    // to the global `replay:current_*` keys when the per-daemon memo
+    // is empty (unmapped specialty, missing DAEMON_ID env, or
+    // backward compat with pre-#719 orchestrators).
     let tick_idx_str = recall_latest("replay:current_tick");
     let tick_idx = if len(tick_idx_str) > 0 { parse_int(tick_idx_str); } else { -1; };
-    let topic_label = recall_latest("replay:current_topic");
-    let topic_desc = recall_latest("replay:current_topic_desc");
-    let compute_hints = recall_latest("replay:current_compute_hints");
-    let paper_a_id = recall_latest("replay:current_paper_a_id");
-    let paper_a_title = recall_latest("replay:current_paper_a_title");
-    let paper_a_abstract = recall_latest("replay:current_paper_a_abstract");
-    let paper_b_id = recall_latest("replay:current_paper_b_id");
-    let paper_b_title = recall_latest("replay:current_paper_b_title");
-    let paper_b_abstract = recall_latest("replay:current_paper_b_abstract");
+    let _daemon_id_topic = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+    let _per_topic = if len(_daemon_id_topic) > 0 {
+        recall_latest("replay:explorer_topic:daemon:" + _daemon_id_topic);
+    } else { ""; };
+    let topic_label = if len(_per_topic) > 0 { _per_topic; } else { recall_latest("replay:current_topic"); };
+    let topic_desc = if len(_daemon_id_topic) > 0 {
+        let _td = recall_latest("replay:explorer_topic_desc:daemon:" + _daemon_id_topic);
+        if len(_td) > 0 { _td; } else { recall_latest("replay:current_topic_desc"); };
+    } else { recall_latest("replay:current_topic_desc"); };
+    let compute_hints = if len(_daemon_id_topic) > 0 {
+        let _ch = recall_latest("replay:explorer_compute_hints:daemon:" + _daemon_id_topic);
+        if len(_ch) > 0 { _ch; } else { recall_latest("replay:current_compute_hints"); };
+    } else { recall_latest("replay:current_compute_hints"); };
+    let paper_a_id = if len(_daemon_id_topic) > 0 {
+        let _v = recall_latest("replay:explorer_paper_a_id:daemon:" + _daemon_id_topic);
+        if len(_v) > 0 { _v; } else { recall_latest("replay:current_paper_a_id"); };
+    } else { recall_latest("replay:current_paper_a_id"); };
+    let paper_a_title = if len(_daemon_id_topic) > 0 {
+        let _v = recall_latest("replay:explorer_paper_a_title:daemon:" + _daemon_id_topic);
+        if len(_v) > 0 { _v; } else { recall_latest("replay:current_paper_a_title"); };
+    } else { recall_latest("replay:current_paper_a_title"); };
+    let paper_a_abstract = if len(_daemon_id_topic) > 0 {
+        let _v = recall_latest("replay:explorer_paper_a_abstract:daemon:" + _daemon_id_topic);
+        if len(_v) > 0 { _v; } else { recall_latest("replay:current_paper_a_abstract"); };
+    } else { recall_latest("replay:current_paper_a_abstract"); };
+    let paper_b_id = if len(_daemon_id_topic) > 0 {
+        let _v = recall_latest("replay:explorer_paper_b_id:daemon:" + _daemon_id_topic);
+        if len(_v) > 0 { _v; } else { recall_latest("replay:current_paper_b_id"); };
+    } else { recall_latest("replay:current_paper_b_id"); };
+    let paper_b_title = if len(_daemon_id_topic) > 0 {
+        let _v = recall_latest("replay:explorer_paper_b_title:daemon:" + _daemon_id_topic);
+        if len(_v) > 0 { _v; } else { recall_latest("replay:current_paper_b_title"); };
+    } else { recall_latest("replay:current_paper_b_title"); };
+    let paper_b_abstract = if len(_daemon_id_topic) > 0 {
+        let _v = recall_latest("replay:explorer_paper_b_abstract:daemon:" + _daemon_id_topic);
+        if len(_v) > 0 { _v; } else { recall_latest("replay:current_paper_b_abstract"); };
+    } else { recall_latest("replay:current_paper_b_abstract"); };
     if tick_idx < 0 {
         print("[explorer] no foundry tick yet");
         return;

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -1101,20 +1101,55 @@ start_auto_promote_sidecar() {
 #   1. Pick the next topic (round-robin over RESEARCH_TOPICS).
 #   2. Sample two distinct papers from the topic's cached corpus.
 #   3. Seed `replay:current_*` memo keys read by explorer.ag.
-#   4. Sleep RESEARCH_TICK_INTERVAL_S seconds.
+#   4. For each explorer daemon_id 1..N, look up its specialty in the
+#      bootstrap-seeded `explorer:pool:specialty:<N>` memo, map specialty
+#      to topic via `_explorer_topic_for_specialty`, sample 2 papers
+#      from that topic's corpus, and write per-daemon memos:
+#        `replay:explorer_topic:daemon:<N>`
+#        `replay:explorer_topic_desc:daemon:<N>`
+#        `replay:explorer_compute_hints:daemon:<N>`
+#        `replay:explorer_paper_{a,b}_{id,title,abstract}:daemon:<N>`
+#      Explorer reads its per-daemon memo first (keyed by `$DAEMON_ID`),
+#      falls back to the global `replay:current_*` keys when empty.
+#   5. Sleep RESEARCH_TICK_INTERVAL_S seconds.
 # The 9-10-tick cascade through 14 downstream daemons (noticer -->
 # formulator --> verifier --> novelty --> 4 searchers --> auditor -->
 # introducer + theorist + computer --> editor --> submitter) happens
 # inside the merged container because all daemons share /run-root/
 # .agentis/. Each agent reads its upstream colleague's memo directly --
 # no cross-fed JSONL reconstruction.
+#
+# Per-explorer specialty -> topic mapping table (#719).
+# Aligns the 5 seeded explorer specialties with the 4 default
+# research topics; `algebra` intentionally overlaps with
+# `group_theory` (both abstract_algebra). Probability routes to
+# graph_theory rather than combinatorics so 4 distinct topics
+# are covered across 5 explorers per tick.
+#     group_theory   -> abstract_algebra
+#     combinatorics  -> combinatorics
+#     number_theory  -> number_theory
+#     probability    -> graph_theory
+#     algebra        -> abstract_algebra
+# Unmapped specialties (evolved variants with novel labels)
+# return empty -- per-daemon memo write is skipped and the
+# explorer falls back to the global `replay:current_topic`.
+_explorer_topic_for_specialty() {
+    case "$1" in
+        group_theory)   echo "abstract_algebra" ;;
+        combinatorics)  echo "combinatorics" ;;
+        number_theory)  echo "number_theory" ;;
+        probability)    echo "graph_theory" ;;
+        algebra)        echo "abstract_algebra" ;;
+        *)              echo "" ;;
+    esac
+}
 tick_stream() {
     emit_step "starting tick stream (interval=${TICK_INTERVAL_S}s total=${TOTAL_TICKS})"
     if [ "$DRY_RUN" = "1" ]; then
         emit_cmd "python3 -c 'research-loop placeholder: topics=$TOPICS_RAW total_ticks=$TOTAL_TICKS interval=$TICK_INTERVAL_S' # tick loop runs in real mode"
         return
     fi
-    python3 - "$TOPICS_RAW" "$PAPER_CORPUS" "$TOTAL_TICKS" "$TICK_INTERVAL_S" "$RUN_DIR" <<'PYRESEARCH'
+    python3 - "$TOPICS_RAW" "$PAPER_CORPUS" "$TOTAL_TICKS" "$TICK_INTERVAL_S" "$RUN_DIR" "$RESEARCH_EXPLORER_REPLICAS" <<'PYRESEARCH'
 import json
 import os
 import random
@@ -1122,14 +1157,26 @@ import subprocess
 import sys
 import time
 
-topics_raw, paper_corpus, total_ticks, interval, run_dir = (
+topics_raw, paper_corpus, total_ticks, interval, run_dir, explorer_replicas = (
     sys.argv[1], sys.argv[2], int(sys.argv[3]),
-    int(sys.argv[4]), sys.argv[5],
+    int(sys.argv[4]), sys.argv[5], int(sys.argv[6]),
 )
 topics = [t.strip() for t in topics_raw.split(",") if t.strip()]
 if not topics:
     sys.stderr.write("research-loop: no topics\n")
     sys.exit(2)
+
+# Per-explorer specialty -> topic mapping (#719). Keep in sync with
+# `_explorer_topic_for_specialty` (above) and the variants in
+# `tools/colony-variants.json`. Empty result -> per-daemon memo write
+# skipped; explorer falls back to global `replay:current_topic`.
+SPECIALTY_TOPIC_MAP = {
+    "group_theory": "abstract_algebra",
+    "combinatorics": "combinatorics",
+    "number_theory": "number_theory",
+    "probability": "graph_theory",
+    "algebra": "abstract_algebra",
+}
 
 corpora = {}
 for topic in topics:
@@ -1154,8 +1201,32 @@ for topic in topics:
         sys.exit(3)
     corpora[topic] = data
 
+
+def _memo_set(key, value):
+    subprocess.run(
+        ["podman", "exec", "research-foundry-laptop", "agentis", "memo", "set", key, value],
+        check=False,
+    )
+
+
+def _memo_get(key):
+    proc = subprocess.run(
+        ["podman", "exec", "research-foundry-laptop", "agentis", "memo", "get", key],
+        check=False, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return ""
+    out = (proc.stdout or "").strip()
+    # `agentis memo get` returns `<error>` style sentinel on miss in some builds.
+    if not out or out.startswith("<"):
+        return ""
+    return out
+
+
 log_path = os.path.join(run_dir, "orchestrator.log")
 rng = random.Random(0xF0FF)
+# Per-daemon paper-pair sampling uses a derived RNG so a given (tick,
+# daemon_id) draws a deterministic pair from its mapped topic.
 for idx in range(total_ticks):
     topic = topics[idx % len(topics)]
     data = corpora[topic]
@@ -1174,16 +1245,57 @@ for idx in range(total_ticks):
         ("replay:current_paper_b_abstract", str(b.get("abstract", ""))),
     ]
     for key, value in memo_pairs:
-        subprocess.run(
-            ["podman", "exec", "research-foundry-laptop", "agentis", "memo", "set", key, value],
-            check=False,
+        _memo_set(key, value)
+
+    # Per-explorer (per-DAEMON_ID) topic pinning (#719). Map each
+    # explorer's bootstrap-seeded specialty to a topic, sample 2 papers
+    # from that topic's corpus, and seed per-daemon memo keys. Explorers
+    # whose specialty has no mapping (evolved variants with novel
+    # labels) get no per-daemon write -- they fall back to the global
+    # `replay:current_*` keys above.
+    per_daemon_log = []
+    for daemon_id in range(1, max(0, explorer_replicas) + 1):
+        specialty = _memo_get("explorer:pool:specialty:" + str(daemon_id))
+        mapped_topic = SPECIALTY_TOPIC_MAP.get(specialty, "")
+        if not mapped_topic or mapped_topic not in corpora:
+            per_daemon_log.append(
+                "daemon=" + str(daemon_id) + " specialty=" + (specialty or "?") + " topic=<fallback>"
+            )
+            continue
+        topic_data = corpora[mapped_topic]
+        topic_papers = topic_data["papers"]
+        d_rng = random.Random(0xF0FF ^ (idx * 1009 + daemon_id))
+        if len(topic_papers) >= 2:
+            pa, pb = d_rng.sample(topic_papers, 2)
+        else:
+            pa = pb = topic_papers[0]
+        suffix = ":daemon:" + str(daemon_id)
+        per_daemon_pairs = [
+            ("replay:explorer_topic" + suffix, mapped_topic),
+            ("replay:explorer_topic_desc" + suffix, topic_data.get("description", "")),
+            ("replay:explorer_compute_hints" + suffix,
+             topic_data.get("compute_hints", "sympy, numpy, networkx")),
+            ("replay:explorer_paper_a_id" + suffix, str(pa.get("id", ""))),
+            ("replay:explorer_paper_a_title" + suffix, str(pa.get("title", ""))),
+            ("replay:explorer_paper_a_abstract" + suffix, str(pa.get("abstract", ""))),
+            ("replay:explorer_paper_b_id" + suffix, str(pb.get("id", ""))),
+            ("replay:explorer_paper_b_title" + suffix, str(pb.get("title", ""))),
+            ("replay:explorer_paper_b_abstract" + suffix, str(pb.get("abstract", ""))),
+        ]
+        for key, value in per_daemon_pairs:
+            _memo_set(key, value)
+        per_daemon_log.append(
+            "daemon=" + str(daemon_id) + " specialty=" + specialty + " topic=" + mapped_topic
         )
+
     with open(log_path, "a") as log:
         log.write(
             "# tick " + str(idx) + "/" + str(total_ticks)
             + " topic=" + topic + " papers=" + str(a.get("id"))
             + "," + str(b.get("id")) + "\n"
         )
+        if per_daemon_log:
+            log.write("#   per-explorer: " + "; ".join(per_daemon_log) + "\n")
     time.sleep(interval)
 PYRESEARCH
 }

--- a/research-foundry/tools/test-topic-pinning.sh
+++ b/research-foundry/tools/test-topic-pinning.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# research-foundry/tools/test-topic-pinning.sh -- regression test for
+# the #719 per-explorer topic pinning mapping in `tools/run-research.sh`.
+#
+# Asserts:
+#   (a) `_explorer_topic_for_specialty` returns the expected topic for
+#       each of the 5 bootstrap-seeded explorer specialties.
+#   (b) Unknown specialties return the empty string so the orchestrator
+#       skips per-daemon memo writes and the explorer falls back to the
+#       global `replay:current_topic`.
+#
+# Standard library only -- no live federation, no podman exec.
+#
+# Usage: bash research-foundry/tools/test-topic-pinning.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FED_DIR="$(dirname "$SCRIPT_DIR")"
+ORCH="$FED_DIR/tools/run-research.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# Extract the case-block function in isolation so sourcing the full
+# orchestrator (which does heavy bootstrap work at load time) is not
+# required. The 7-line block (`_explorer_topic_for_specialty()` { ... })
+# is grep'd out by anchor lines, then evaluated in this shell.
+extract_fn() {
+    awk '/^_explorer_topic_for_specialty\(\) \{$/,/^\}$/' "$ORCH"
+}
+
+fn_body="$(extract_fn)"
+if [ -z "$fn_body" ]; then
+    fail "extract_fn" "could not locate _explorer_topic_for_specialty in $ORCH"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+eval "$fn_body"
+
+assert_topic() {
+    local specialty="$1" expected="$2"
+    local got
+    got="$(_explorer_topic_for_specialty "$specialty")"
+    if [ "$got" = "$expected" ]; then
+        pass "mapping: $specialty -> $expected"
+    else
+        fail "mapping: $specialty" "expected '$expected', got '$got'"
+    fi
+}
+
+assert_topic group_theory   abstract_algebra
+assert_topic combinatorics  combinatorics
+assert_topic number_theory  number_theory
+assert_topic probability    graph_theory
+assert_topic algebra        abstract_algebra
+assert_topic ""             ""
+assert_topic unknown_spec   ""
+assert_topic evolved_x      ""
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds a `specialty -> topic` mapping in the orchestrator's per-tick loop; each explorer now reads a daemon-scoped `replay:explorer_topic:daemon:<DAEMON_ID>` memo (plus per-daemon topic_desc / compute_hints / paper_a / paper_b siblings) instead of all 5 explorers sharing the global `replay:current_topic`.
- Mapping: `group_theory -> abstract_algebra`, `combinatorics -> combinatorics`, `number_theory -> number_theory`, `probability -> graph_theory`, `algebra -> abstract_algebra`. Per-daemon paper pairs are sampled with an RNG seeded by `(tick_idx, daemon_id)` so each of the 5 explorers gets a deterministic, distinct paper pair from its mapped topic.
- Fallback path preserved: unmapped specialties (evolved variants with novel labels) get no per-daemon memo write, and `explorer.ag` falls back to the global `replay:current_*` keys -- which the orchestrator still writes unchanged so downstream agents (noticer, formulator, ...) keep their tick rotation.

## Why

Run #14 forensic: 6 generated PDF preprints all converged on the same subtopic (modal order in `S_n`) despite the rotation declaring 4 nominal topics (`number_theory, combinatorics, abstract_algebra, graph_theory`). Root cause: the per-tick orchestrator wrote one global topic + paper-pair, every explorer read the same memos, and the specialty overlay was only a prompt nudge (not a topic gate). Pinning each explorer to its specialty's topic restores corpus diversity across the cohort.

## Test plan

- [x] `bash -n research-foundry/tools/run-research.sh` clean
- [x] `tools/colony-lint.sh` clean (344 passed, 0 failed, 4 skipped) -- includes `research-foundry/explorer/explorer.ag syntax OK` + `tier-branch convention OK`
- [x] `bash research-foundry/tools/test-topic-pinning.sh` -- 8/8 PASS (5 mapped specialties + 3 fallback cases: empty / unknown / evolved-variant string)
- [ ] CI green
- [ ] After merge + a fresh foundry run: `discovery-ledger.jsonl` tick-0 explorer rows show >=3 distinct `topic` labels across the 5-explorer cohort, and `preprints/` no longer converges on a single subtopic across the run.

Closes #719

Generated with [Claude Code](https://claude.com/claude-code)