### PR TITLE
fix(research-foundry): topic-pinning loop reads live registry (#724)

### DIFF
--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -1150,9 +1150,11 @@ tick_stream() {
         return
     fi
     python3 - "$TOPICS_RAW" "$PAPER_CORPUS" "$TOTAL_TICKS" "$TICK_INTERVAL_S" "$RUN_DIR" "$RESEARCH_EXPLORER_REPLICAS" <<'PYRESEARCH'
+import glob
 import json
 import os
 import random
+import re
 import subprocess
 import sys
 import time
@@ -1247,14 +1249,30 @@ for idx in range(total_ticks):
     for key, value in memo_pairs:
         _memo_set(key, value)
 
-    # Per-explorer (per-DAEMON_ID) topic pinning (#719). Map each
+    # Per-explorer (per-DAEMON_ID) topic pinning (#719, #724). Map each
     # explorer's bootstrap-seeded specialty to a topic, sample 2 papers
     # from that topic's corpus, and seed per-daemon memo keys. Explorers
     # whose specialty has no mapping (evolved variants with novel
     # labels) get no per-daemon write -- they fall back to the global
     # `replay:current_*` keys above.
+    #
+    # #724: enumerate live daemon ids from the specialty-memo glob
+    # instead of a hardcoded range. `cull-replicas.sh` writes specialty
+    # memos for post-cull replica explorers (daemon_id > initial
+    # explorer_replicas), so the orchestrator must read whoever is
+    # actually present on disk. The regex filters out the sibling
+    # `explorer:pool:specialty_overlay:*.jsonl` files (decoys with a
+    # non-numeric suffix after the colon).
+    _memo_dir = os.path.join(run_dir, "laptop-node", ".agentis", "memo")
+    _spec_re = re.compile(r"^explorer:pool:specialty:(\d+)\.jsonl$")
+    daemon_ids = []
+    for _path in glob.glob(os.path.join(_memo_dir, "explorer:pool:specialty:*.jsonl")):
+        m = _spec_re.match(os.path.basename(_path))
+        if m:
+            daemon_ids.append(int(m.group(1)))
+    daemon_ids.sort()
     per_daemon_log = []
-    for daemon_id in range(1, max(0, explorer_replicas) + 1):
+    for daemon_id in daemon_ids:
         specialty = _memo_get("explorer:pool:specialty:" + str(daemon_id))
         mapped_topic = SPECIALTY_TOPIC_MAP.get(specialty, "")
         if not mapped_topic or mapped_topic not in corpora:

--- a/research-foundry/tools/test-topic-pinning.sh
+++ b/research-foundry/tools/test-topic-pinning.sh
@@ -62,6 +62,36 @@ assert_topic ""             ""
 assert_topic unknown_spec   ""
 assert_topic evolved_x      ""
 
+# Live-registry discovery test (#724). Mirrors the glob+regex block in
+# the orchestrator's `research_loop` Python heredoc. Fixture: an initial
+# explorer (daemon_id=1) plus a post-cull replica (daemon_id=7), with a
+# decoy `specialty_overlay` sibling file that must be rejected.
+tmp_memo_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_memo_dir"' EXIT
+: > "$tmp_memo_dir/explorer:pool:specialty:1.jsonl"
+: > "$tmp_memo_dir/explorer:pool:specialty:7.jsonl"
+: > "$tmp_memo_dir/explorer:pool:specialty_overlay:1.jsonl"
+
+discovered_ids="$(python3 - "$tmp_memo_dir" <<'PYDISCOVER'
+import glob, os, re, sys
+memo_dir = sys.argv[1]
+spec_re = re.compile(r"^explorer:pool:specialty:(\d+)\.jsonl$")
+ids = []
+for path in glob.glob(os.path.join(memo_dir, "explorer:pool:specialty:*.jsonl")):
+    m = spec_re.match(os.path.basename(path))
+    if m:
+        ids.append(int(m.group(1)))
+ids.sort()
+print(",".join(str(i) for i in ids))
+PYDISCOVER
+)"
+
+if [ "$discovered_ids" = "1,7" ]; then
+    pass "live-registry discovery: ids=[1,7], overlay rejected"
+else
+    fail "live-registry discovery" "expected '1,7', got '$discovered_ids'"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- Replace hardcoded `range(1, RESEARCH_EXPLORER_REPLICAS + 1)` in the orchestrator's per-tick topic-pinning block with a glob of live `explorer:pool:specialty:<N>.jsonl` memo files; integer-suffix regex rejects the `_overlay` decoy siblings.
- Post-cull replica explorers (daemon_id > initial REPLICAS) now get per-daemon topic memos written each tick — `cull-replicas.sh` writes their specialty assignments to the same dir, so the orchestrator picks them up automatically.
- New `test-topic-pinning.sh` fixture covers the live-registry path: ids `[1, 7]` discovered, `specialty_overlay:1.jsonl` rejected.

## Why
Follow-up to #719 / PR #723. Post-cull explorers silently fell back to the global `replay:current_topic` because the orchestrator only seeded per-daemon memos for `daemon_id` in `1..REPLICAS`. After the first cull cycle, any replica replacement at `daemon_id > REPLICAS` lost its specialty-pinned corpus and defeated the diversity gain for the remainder of the run.

The mapping table and per-daemon write logic from #719 are unchanged here; only the iteration source changes from a static range to a live filesystem glob.

## Test plan
- [x] `bash -n research-foundry/tools/run-research.sh`
- [x] `bash research-foundry/tools/test-topic-pinning.sh` — 9 passed, 0 failed (8 mapping + new live-registry case)
- [x] `bash tools/colony-lint.sh` — 344 passed, 0 failed, 4 skipped
- [ ] CI green
- [ ] Post-merge: a research-foundry run with `cull-replicas` active shows distinct per-explorer topics for daemon_id > 5 in `orchestrator.log` per-explorer line

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)