### PR TITLE
feat(memo-freshness): per-role STALENESS_TICKS table (#736)

### DIFF
--- a/federation-dashboard/lib/federation-dashboard-collector.py
+++ b/federation-dashboard/lib/federation-dashboard-collector.py
@@ -50,6 +50,12 @@ import sys, os, json, time, re, datetime, subprocess
 # wanting tighter classification keep the env override.
 # Clamped to >= 1 so a misconfigured `0` cannot turn every agent
 # permanently stale.
+#
+# #736: per-role staleness window now lives in the shared
+# tools/agentis_memo_freshness.py module (STALENESS_TICKS_BY_ROLE +
+# staleness_ticks_for()). The global STALENESS_TICKS below is retained
+# only as a safe-default fallback for the missing-helper case (older
+# federation install without the shared module).
 try:
     STALENESS_TICKS = max(1, int(os.environ.get("FEDERATION_DASHBOARD_STALENESS_TICKS", "15")))
 except (TypeError, ValueError):
@@ -87,10 +93,8 @@ if fed_tools_dir and fed_tools_dir not in sys.path:
     sys.path.insert(0, fed_tools_dir)
 try:
     import agentis_memo_freshness as freshness
-    STALENESS_TICKS = freshness.STALENESS_TICKS
 except ImportError:
     freshness = None
-    STALENESS_TICKS = 15
 
 def safe_json(s, default):
     try: return json.loads(s or '[]')
@@ -303,7 +307,11 @@ for colony, agent in agent_pairs:
                 last_check_epoch = per_repo_max
         if last_check_epoch is not None:
             tick_interval_ms = freshness.resolve_tick_interval_ms(agent, colony, fed_dir=fed_dir, fed_tools_dir=fed_tools_dir) if freshness else 60000
-            window_seconds = STALENESS_TICKS * (tick_interval_ms / 1000.0)
+            # #736: per-role staleness window (tick-driven 5, listen-driven 60,
+            # dev-apprenticeship 30, unknown roles fall back to global 15).
+            # Missing-helper fallback keeps the global STALENESS_TICKS=15.
+            role_ticks = freshness.staleness_ticks_for(agent) if freshness else STALENESS_TICKS
+            window_seconds = role_ticks * (tick_interval_ms / 1000.0)
             rec['pid_alive'] = (epoch - last_check_epoch) < window_seconds
         else:
             rec['pid_alive'] = False

--- a/tools/agentis_memo_freshness.py
+++ b/tools/agentis_memo_freshness.py
@@ -6,21 +6,36 @@ agentis daemon list state field (which lies for containerized
 federations -- see #683 / #686 / #697 / #700 / #705 / #706).
 
 Public API:
-  STALENESS_TICKS -- int (env-clamped, default 15)
+  STALENESS_TICKS -- int (env-clamped, default 15) -- global fallback
+  STALENESS_TICKS_BY_ROLE -- dict[str, int] -- per-role override table
+  staleness_ticks_for(role) -> int -- per-role lookup with global fallback
   read_memo_raw(fed_dir, key) -> Optional[str]
   parse_last_check_epoch(raw) -> Optional[float]
   resolve_tick_interval_ms(agent, colony, fed_dir, fed_tools_dir=None) -> int
 
-Default rationale (#716): listen-driven roles (long-poll `listen()` cadence,
-e.g. `research-foundry` explorers) can legitimately go quiet for the
-documented ~10-minute window between events while healthy. At the prior
-default of 3, every quiet listener flipped to `pid_alive=false` and the
-promote-tier cascade SKIPped the affected roles. `15` covers the
-10-minute quiet window on both the 60s dev-apprenticeship tick (15 min)
-and the 120s research-foundry tick (30 min) while still flagging genuinely
-dead daemons within one operator pulse. Tick-driven federations that want
-tighter classification keep the `FEDERATION_DASHBOARD_STALENESS_TICKS` env
-override (clamped to >= 1).
+Per-role staleness rationale (#736): a single global window cannot fit
+all role types. Tick-driven roles (research-foundry explorer/noticer/
+skeptic/verifier/formulator/novelty) write `last_check` every tick, so a
+5-tick window is the right liveness signal. Listen-driven research-foundry
+roles (auditor, editor, submitter, theorist, computer, prior_advocate,
+introducer, reviewer + the 4 search colonies) only wake on bus events
+and routinely go quiet for 30+ minutes when no work matches their topic
+filter; a 60-tick window (2h at 120s/tick) covers normal quiet stretches
+without flagging healthy daemons. dev-apprenticeship roles (reactive
+GitLab-bound colonies) use a 30-tick window (30 min at 60s/tick or 2.5h
+at 300s/tick). Unknown roles (evolved variants, new federations, test
+fixtures) fall through to the global STALENESS_TICKS (#716 default 15).
+
+Global rationale (#716): at the prior default of 3, every quiet listener
+flipped to `pid_alive=false` and the promote-tier cascade SKIPped the
+affected roles. `15` covered the 10-minute quiet window on both the 60s
+dev-apprenticeship tick (15 min) and the 120s research-foundry tick
+(30 min) while still flagging genuinely dead daemons within one operator
+pulse. #736 keeps `15` as the fallback for unknown roles. Tick-driven
+federations that want tighter classification keep the
+`FEDERATION_DASHBOARD_STALENESS_TICKS` env override (clamped to >= 1),
+which applies to the global fallback only -- per-role table values are
+intentional defaults baked in for known roles.
 
 The fed_tools_dir kwarg of resolve_tick_interval_ms defaults to the
 directory containing this module (preserves the __file__-relative
@@ -40,6 +55,67 @@ try:
     STALENESS_TICKS = max(1, int(os.environ.get("FEDERATION_DASHBOARD_STALENESS_TICKS", "15")))
 except (TypeError, ValueError):
     STALENESS_TICKS = 15
+
+
+# #736: per-role staleness windows. See module docstring for rationale.
+# Unknown roles fall back to STALENESS_TICKS (15) via staleness_ticks_for().
+STALENESS_TICKS_BY_ROLE = {
+    # Tick-driven research-foundry roles (busy every tick, ~5-tick liveness)
+    "explorer": 5,
+    "noticer": 5,
+    "skeptic": 5,
+    "verifier": 5,
+    "formulator": 5,
+    "novelty": 5,
+    # Listen-driven research-foundry roles (60 ticks = 2h at 120s/tick)
+    "auditor": 60,
+    "editor": 60,
+    "submitter": 60,
+    "theorist": 60,
+    "computer": 60,
+    "prior_advocate": 60,
+    "introducer": 60,
+    "reviewer": 60,
+    # Search colonies (HTTP-bound, intermittent)
+    "arxiv-search": 60,
+    "oeis-search": 60,
+    "scholar-search": 60,
+    "groupprops-search": 60,
+    # dev-apprenticeship roles (GitLab-bound; 30 ticks = 30 min at 60s/tick
+    # or 2.5h at 300s/tick for reactive colonies)
+    "router": 30,
+    "prioritizer": 30,
+    "labeler": 30,
+    "issue_creator": 30,
+    "logic_reviewer": 30,
+    "style_reviewer": 30,
+    "security_reviewer": 30,
+    "test_reviewer": 30,
+    "approval_decider": 30,
+    "scope_estimator": 30,
+    "risk_assessor": 30,
+    "task_decomposer": 30,
+    "plan_reviewer": 30,
+    "code_writer": 30,
+    "test_writer": 30,
+    "refactorer": 30,
+    "commit_composer": 30,
+    "ship_decider": 30,
+    "changelog_writer": 30,
+    "version_bumper": 30,
+    "release_checker": 30,
+}
+
+
+def staleness_ticks_for(role: str) -> int:
+    """Look up the staleness window (ticks) for a role.
+
+    Returns the per-role value from STALENESS_TICKS_BY_ROLE when the role
+    is known, otherwise falls back to the global STALENESS_TICKS (#716,
+    env-clamped, default 15). Unknown roles cover evolved variants,
+    new federations, and test fixtures.
+    """
+    return STALENESS_TICKS_BY_ROLE.get(role, STALENESS_TICKS)
 
 
 # Cache resolved tick intervals per (agent, colony) so the helper is not

--- a/tools/auto-promote-decisions.py
+++ b/tools/auto-promote-decisions.py
@@ -542,13 +542,16 @@ def main():
         # cycles even when the in-process tick loop keeps writing the memo.
         # `effective_state == "running"` remains a valid fall-through for
         # legacy callers; the memo path simply unblocks daemons whose
-        # registry record lies.
+        # registry record lies. #736: per-role staleness window via
+        # staleness_ticks_for() -- tick-driven roles (5), listen-driven
+        # research-foundry roles (60), dev-apprenticeship roles (30),
+        # unknown roles fall back to the global STALENESS_TICKS (15).
         if containerized:
             last_check_epoch = freshness.parse_last_check_epoch(freshness.read_memo_raw(fed_dir, agent_name + ':last_check'))
             fresh = False
             if last_check_epoch is not None:
                 tick_ms = freshness.resolve_tick_interval_ms(agent_name, colony, fed_dir)
-                fresh = (time.time() - last_check_epoch) < freshness.STALENESS_TICKS * (tick_ms / 1000.0)
+                fresh = (time.time() - last_check_epoch) < freshness.staleness_ticks_for(agent_name) * (tick_ms / 1000.0)
             effective_state = d.get('effective_state') or state
             if not fresh and effective_state != 'running':
                 decisions.append(_attach_explorer_evidence({

--- a/tools/test-agentis-memo-freshness.sh
+++ b/tools/test-agentis-memo-freshness.sh
@@ -15,6 +15,10 @@
 #      PATH, mirroring test-dashboard-freshness-liveness.sh).
 #   8. resolve_tick_interval_ms with explicit fed_tools_dir + cache-hit on
 #      the 2nd call returns the same value without re-spawning the helper.
+#   9. staleness_ticks_for(role) returns the per-role table value for
+#      known roles (#736).
+#  10. staleness_ticks_for(role) falls back to the global STALENESS_TICKS
+#      for unknown roles (#736).
 #
 # Usage: ./tools/test-agentis-memo-freshness.sh
 # Exit 0 on full pass, 1 otherwise.
@@ -163,6 +167,31 @@ if [ "$ACTUAL" = "90000|12345|True" ]; then
     pass "8: resolve_tick_interval_ms returns 90000 on first call and hits cache on second"
 else
     fail "8: resolve_tick_interval_ms + cache" "expected '90000|12345|True', got '$ACTUAL'"
+fi
+
+# --- Test 9: staleness_ticks_for(role) returns table value for known roles (#736) ---
+ACTUAL="$(unset FEDERATION_DASHBOARD_STALENESS_TICKS; python3 -c "$PYPATH_PRELUDE
+import agentis_memo_freshness as f
+# auditor is listen-driven (60), explorer is tick-driven (5), router is
+# dev-apprenticeship (30). Three rows cover the three distinct table tiers.
+print('%d|%d|%d' % (f.staleness_ticks_for('auditor'), f.staleness_ticks_for('explorer'), f.staleness_ticks_for('router')))
+")"
+if [ "$ACTUAL" = "60|5|30" ]; then
+    pass "9: staleness_ticks_for(known role) returns table value (auditor=60, explorer=5, router=30)"
+else
+    fail "9: staleness_ticks_for known roles" "expected '60|5|30', got '$ACTUAL'"
+fi
+
+# --- Test 10: staleness_ticks_for(unknown role) falls back to global STALENESS_TICKS (#736) ---
+ACTUAL="$(unset FEDERATION_DASHBOARD_STALENESS_TICKS; python3 -c "$PYPATH_PRELUDE
+import agentis_memo_freshness as f
+# Unknown role (evolved variant / test fixture) falls back to STALENESS_TICKS.
+print(f.staleness_ticks_for('xyz_evolve_variant_does_not_exist'))
+")"
+if [ "$ACTUAL" = "15" ]; then
+    pass "10: staleness_ticks_for(unknown role) falls back to global STALENESS_TICKS=15"
+else
+    fail "10: staleness_ticks_for unknown fallback" "expected 15, got $ACTUAL"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- Adds `STALENESS_TICKS_BY_ROLE` table + `staleness_ticks_for(role)` helper in `tools/agentis_memo_freshness.py`. Tick-driven research-foundry roles get a 5-tick window, listen-driven research-foundry roles + search colonies get 60 ticks (2h at 120s tick), dev-apprenticeship roles get 30 ticks. Unknown roles fall back to the global `STALENESS_TICKS` (15) from #716.
- Two callers updated: `tools/auto-promote-decisions.py` (sidecar promote evaluation, line 551) and `federation-dashboard/lib/federation-dashboard-collector.py` (HEALTHY/DEGRADED banner, line 306 + dead alias at 90/93 dropped).
- Two new tests in `tools/test-agentis-memo-freshness.sh` covering the table-hit path (auditor=60, explorer=5, router=30) and the unknown-role fallback path (returns 15).

## Why

Run #17 forensic on the research-foundry federation showed P1 fix #716 (global `STALENESS_TICKS` 3 -> 15) still mis-classified 15 of 18 research-foundry roles as `zombie` at tick 49. Listen-driven roles (auditor, editor, submitter, theorist, computer, prior_advocate, introducer, reviewer + the 4 search colonies) have legitimate 30+ min quiet stretches between bus events that exceed the 15-tick (~30 min at 120s tick) global window. A single global value cannot serve both tick-driven and listen-driven role types -- the table encodes the per-role intent directly.

Per-role env override (`FEDERATION_DASHBOARD_STALENESS_TICKS_<ROLE>=N`) skipped for v1 per YAGNI. Operator can edit the dict directly until real demand surfaces.

## Test plan

- [x] `python3 -c` import + helper invocations return expected values (auditor=60, explorer=5, router=30, unknown=15, global=15).
- [x] `bash tools/test-agentis-memo-freshness.sh` passes 10/10 (8 pre-existing + 2 new).
- [x] `bash tools/test-auto-promote.sh` passes 40/40 (includes containerized-liveness regression coverage from #706).
- [x] `bash tools/test-dashboard-freshness-liveness.sh` passes 5/5 (1 opt-in skip).
- [x] `bash tools/colony-lint.sh` clean: 344 passed, 0 failed, 4 skipped.
- [ ] CI green.
- [ ] After merge: Run #18 should show 0 zombie misclassifications for listen-driven roles, allowing real promote evaluation past 1h runtime.

Closes #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)