### PR TITLE
fix(persistent-snapshot): carry explorer:*:exploration_prompt across runs (closes #739)

### DIFF
--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -18,6 +18,10 @@ History of the three retired federations consolidated into this one
 
 ## [Unreleased]
 
+### Fixed
+
+- `tools/persistent-snapshot.py` now carries the M98 v3 evolved-prompt state across runs by adding an `explorer:` prefix glob (filtered to four cross-run suffixes: `:exploration_prompt`, `:exploration_generation`, `:lineage_id`, `:specialty`). The `_evolve_exploration_prompt` loop in `research-foundry/explorer/agents/explorer.ag` (lines 204-263, mirroring `tribes-bench/*/agents/hunter.ag::_evolve_hunting_prompt`) was already shipped, but the evolved-prompt memo key `explorer:<pid>:exploration_prompt` was not in the snapshot writer's allowlist, so every container relaunch dropped the variant pool back to the `_seed_prompt()` baseline. Per-tick noise keys (`explorer:<pid>:code:tick-N`, `:output:tick-N`) are filtered out by an explicit suffix allowlist to bound snapshot size. New test (5) in `tools/test-persistent-snapshot.sh` pins the round-trip + noise-filter contract. The forensic correction (no `evolve_self()` runtime builtin -- it is a language keyword, M98 v3 is hand-rolled via `prompt(meta, "")`) is documented in the `explorer.ag` header. ([#739](https://github.com/Replikanti/agentis-colonies/issues/739))
+
 ### Changed
 
 - Lower default `RESEARCH_<COLONY>_REPLICAS` from 2 to 1 for all 17 non-explorer colonies, and split the claude model per colony (8 opus quality-critical: explorer, formulator, verifier, novelty, prior_advocate, auditor, theorist, editor; 10 sonnet mechanical: noticer, skeptic, 4 searchers, computer, introducer, reviewer, submitter). New per-colony env knob `RESEARCH_<COLONY>_CLAUDE_MODEL`. Wired via `ANTHROPIC_MODEL=` on each daemon spawn line (the claude CLI honors it natively); the shared `llm.args` config drops the `--model` slot. Drops federation peak request rate from ~78 -> ~44 calls/min and shifts ~55% of calls onto sonnet (~5x faster) so the 9-stage cascade clears within the 60-min default run window. Unblocks the zero-preprint stall observed in Run #9-12. ([#711](https://github.com/Replikanti/agentis-colonies/issues/711))

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -6,6 +6,26 @@
 // stdout, and writes the resulting (code, output) pair to memo for the
 // downstream noticer / formulator / verifier / novelty chain.
 //
+// M98 v3 prompt evolution (#739): the `_evolve_exploration_prompt`
+// helper below mirrors `tribes-bench/<tribe>/agents/hunter.ag`'s
+// `_evolve_hunting_prompt` pattern (Levenshtein floor, schema sanity,
+// gen-cap lineage reset, settled-explorations buffer, M106 hash-pointer
+// wrap for replicate-with-variant). There is no `evolve_self()`
+// runtime builtin -- the keyword `evolve_self` appears only in the
+// agentis-core grammar reservation; the actual evolution is hand-rolled
+// here via `prompt(meta, "")` + `memo_write`. The v1.7.10 agentis-core
+// `PromptExpr` non-literal relaxation (#638) was the enabler that let
+// this loop ship in research-foundry.
+//
+// Evolved-prompt memo key: `explorer:<pid>:exploration_prompt` (matches
+// the hunter's `hunting_prompt` convention, NOT the `evolved_prompt`
+// label some earlier specs used). Companion keys carried for the same
+// reason: `:exploration_generation`, `:lineage_id`, `:specialty`.
+// Cross-run persistence is provided by
+// `research-foundry/tools/persistent-snapshot.py` which snapshots
+// these four `explorer:*` suffixes at run end so the M98 v3 variant
+// pool survives container relaunch (added in #739).
+//
 // Per-tick behaviour:
 //   1. Read foundry tick state (`replay:current_tick`,
 //      `replay:current_topic`, `replay:current_paper_a/b`) seeded by

--- a/research-foundry/tools/persistent-snapshot.py
+++ b/research-foundry/tools/persistent-snapshot.py
@@ -65,7 +65,28 @@ EXACT_KEYS = [
 PREFIX_GLOBS = [
     "feedback:hitl_reject_reason:claim-",
     "feedback:hitl_reject_class:claim-",
+    # M98 v3 evolved-prompt state per explorer pid (#739). The
+    # _evolve_exploration_prompt loop in research-foundry/explorer/agents/
+    # explorer.ag writes `:exploration_prompt` (current variant body),
+    # `:exploration_generation` (lineage step within the gen-cap window),
+    # `:lineage_id` (bumped on gen-cap reset), and `:specialty` (claimed
+    # at first tick from the bootstrap-seeded pool). Carrying these four
+    # across runs lets the next bootstrap restore the variant pool so
+    # M98 v3 fitness pressure compounds run-over-run instead of
+    # restarting from the seed each container relaunch.
+    "explorer:",
 ]
+
+# Suffix filter for the `explorer:` prefix glob. The glob would otherwise
+# catch per-tick noise like `explorer:<pid>:code:tick-N` /
+# `explorer:<pid>:output:tick-N` (cb-budget bloat). Snapshot only the
+# specific suffixes that make up the cross-run evolved-prompt state.
+EXPLORER_PERSISTENT_SUFFIXES = (
+    ":exploration_prompt",
+    ":exploration_generation",
+    ":lineage_id",
+    ":specialty",
+)
 
 CONFIDENCE_COLONIES = [
     "explorer",
@@ -302,8 +323,15 @@ def snapshot_keys(container, output_dir):
         listed = _memo_list_keys(container)
         for prefix in PREFIX_GLOBS:
             for k in listed:
-                if k.startswith(prefix):
-                    keys_to_snapshot.append(k)
+                if not k.startswith(prefix):
+                    continue
+                # The `explorer:` prefix would otherwise catch noisy
+                # per-tick keys (e.g. `explorer:<pid>:code:tick-N`).
+                # Restrict it to the cross-run evolved-prompt state
+                # suffixes only (#739).
+                if prefix == "explorer:" and not k.endswith(EXPLORER_PERSISTENT_SUFFIXES):
+                    continue
+                keys_to_snapshot.append(k)
 
     seen = set()
     deduped = []

--- a/research-foundry/tools/test-persistent-snapshot.sh
+++ b/research-foundry/tools/test-persistent-snapshot.sh
@@ -2,7 +2,7 @@
 # research-foundry/tools/test-persistent-snapshot.sh -- regression test
 # for the Phase 5 PR-A (#626) persistent-snapshot.py helper.
 #
-# Four synthetic-fixture cases (no live container required):
+# Five synthetic-fixture cases (no live container required):
 #   (1) Happy path: stubbed `podman` emits canned `agentis memo get`
 #       output. Assert `memo-snapshot.json` contains the expected keys +
 #       values, schema=1, snapshot_ts present.
@@ -15,6 +15,11 @@
 #       Subsequent invocations with same version succeed. After
 #       manually editing the file to `99`, helper warns + refuses to
 #       overwrite (non-zero exit, memo-snapshot.json unchanged).
+#   (5) Explorer evolved-prompt round-trip (#739): the `explorer:`
+#       prefix glob carries `:exploration_prompt`, `:exploration_generation`,
+#       `:lineage_id`, and `:specialty` suffixes across runs while
+#       suppressing per-tick noise like `:code:tick-N` / `:output:tick-N`
+#       that would otherwise bloat the snapshot.
 #
 # Standard library only -- no pytest, no live federation.
 #
@@ -118,6 +123,22 @@ case "${1:-}" in
             feedback:hitl_reject_class:claim-42)
                 echo "factual"
                 ;;
+            explorer:476:exploration_prompt)
+                echo "Refined exploration prompt v3 -- compute coincidences in group orders."
+                ;;
+            explorer:476:exploration_generation)
+                echo "3"
+                ;;
+            explorer:476:lineage_id)
+                echo "1"
+                ;;
+            explorer:476:specialty)
+                echo "group_theory"
+                ;;
+            explorer:476:code:tick-7|explorer:476:output:tick-7)
+                # Noisy per-tick keys -- must NOT appear in the snapshot.
+                echo "noise"
+                ;;
             *:confidence)
                 echo "0.7"
                 ;;
@@ -138,11 +159,19 @@ case "${1:-}" in
         esac
         ;;
     list)
-        # Two synthetic prefix-glob expansions plus a noise key.
+        # Two synthetic prefix-glob expansions plus a noise key, and
+        # four explorer:<pid>:<suffix> keys for the #739 round-trip
+        # test plus two per-tick noise keys that must be filtered out.
         printf '%s\n' \
             'formulator:learned_known_topics' \
             'feedback:hitl_reject_reason:claim-42' \
             'feedback:hitl_reject_class:claim-42' \
+            'explorer:476:exploration_prompt' \
+            'explorer:476:exploration_generation' \
+            'explorer:476:lineage_id' \
+            'explorer:476:specialty' \
+            'explorer:476:code:tick-7' \
+            'explorer:476:output:tick-7' \
             'unrelated:key'
         ;;
     *)
@@ -278,6 +307,46 @@ if [ "$T4C_RC" -ne 0 ] && [ "$SNAPSHOT_BEFORE_MTIME" = "$SNAPSHOT_AFTER_MTIME" ]
 else
     fail "(4c) SCHEMA_VERSION: mismatch warns + refuses to overwrite" \
          "rc=$T4C_RC; mtime-before=$SNAPSHOT_BEFORE_MTIME mtime-after=$SNAPSHOT_AFTER_MTIME; log: $(cat "$WORK/t4c.log")"
+fi
+
+# --- (5) Explorer evolved-prompt round-trip (#739) ---
+# The four `explorer:<pid>:{exploration_prompt,exploration_generation,
+# lineage_id,specialty}` suffixes must round-trip through snapshot so
+# the M98 v3 variant pool survives cross-run bootstrap. The two
+# `:code:tick-N` / `:output:tick-N` noise keys must be filtered out.
+T5_DIR="$WORK/t5-persistent"
+T5_RC=0
+PODMAN_MODE=ok python3 "$HELPER" --container research-foundry-laptop \
+    --output-dir "$T5_DIR" >"$WORK/t5.log" 2>&1 || T5_RC=$?
+
+if [ "$T5_RC" -ne 0 ]; then
+    fail "(5) explorer-prompt round-trip: helper exits 0" "rc=$T5_RC; log: $(cat "$WORK/t5.log")"
+elif [ ! -f "$T5_DIR/memo-snapshot.json" ]; then
+    fail "(5) explorer-prompt round-trip: writes memo-snapshot.json" "file missing"
+else
+    T5_SNAPSHOT="$(cat "$T5_DIR/memo-snapshot.json")"
+    if printf '%s' "$T5_SNAPSHOT" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+keys = data["keys"]
+expected = {
+    "explorer:476:exploration_prompt":
+        "Refined exploration prompt v3 -- compute coincidences in group orders.",
+    "explorer:476:exploration_generation": "3",
+    "explorer:476:lineage_id": "1",
+    "explorer:476:specialty": "group_theory",
+}
+for k, v in expected.items():
+    assert k in keys, "missing key " + k
+    assert keys[k] == v, "key " + k + " = " + repr(keys[k]) + " not " + repr(v)
+# Per-tick noise keys must be filtered out (snapshot bloat guard).
+for noise in ("explorer:476:code:tick-7", "explorer:476:output:tick-7"):
+    assert noise not in keys, "noise key leaked into snapshot: " + noise
+' >/dev/null 2>"$WORK/t5.assert.log"; then
+        pass "(5) explorer-prompt round-trip: four suffixes carry, noise filtered"
+    else
+        fail "(5) explorer-prompt round-trip: four suffixes carry, noise filtered" "$(cat "$WORK/t5.assert.log")"
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Issue #739 was originally framed as "implement M98 v3 `evolve_self` loop in `explorer.ag`." Forensic check (plan agent) showed the loop is already shipped — `research-foundry/explorer/agents/explorer.ag` lines 204-263 (`_evolve_exploration_prompt`) mirrors `tribes-bench/*/agents/hunter.ag::_evolve_hunting_prompt` with Levenshtein floor, schema sanity, gen-cap lineage reset, settled-explorations buffer, and the M106 hash-pointer wrap for replicate-with-variant. There is no `evolve_self()` runtime builtin — the keyword exists only in the agentis-core grammar reservation; the actual evolution is hand-rolled via `prompt(meta, "")` + `memo_write`. The agentis-core v1.7.10 `PromptExpr` non-literal relaxation (#638) was the enabler.

The real gap was persistence. The evolved-prompt memo key `explorer:<pid>:exploration_prompt` (matching hunter's `hunting_prompt` convention) was not in the `tools/persistent-snapshot.py` `PREFIX_GLOBS` allowlist, so every container relaunch dropped the M98 v3 variant pool back to the `_seed_prompt()` baseline (Phase 5 cross-run contract was unsatisfied for explorer).

## Changes

- **`research-foundry/tools/persistent-snapshot.py`** (+32 / -1): add `"explorer:"` to `PREFIX_GLOBS` plus a new `EXPLORER_PERSISTENT_SUFFIXES = (":exploration_prompt", ":exploration_generation", ":lineage_id", ":specialty")` allowlist. The snapshot loop carries only those four suffixes for the `explorer:` prefix so per-tick noise (`:code:tick-N`, `:output:tick-N`) is filtered out and snapshot size stays bounded.
- **`research-foundry/tools/test-persistent-snapshot.sh`** (+73 / -2): new test (5) seeds the four explorer suffixes + two noise keys in the fake-podman `memo list` output, runs the snapshot, asserts all four round-trip with expected values AND both noise keys are absent.
- **`research-foundry/explorer/agents/explorer.ag`** (+20 / -0): header comment block documenting the M98 v3 pattern, the keyword-vs-builtin clarification, the `:exploration_prompt` memo key convention, and the persistent-snapshot.py wiring added in this PR. No functional `.ag` change.
- **`research-foundry/CHANGELOG.md`** (+4 / -0): `[Unreleased]` `### Fixed` entry covering the persistence-layer fix and the forensic correction.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` parses `persistent-snapshot.py` clean
- [x] `bash -n test-persistent-snapshot.sh` parses clean
- [x] `bash research-foundry/tools/test-persistent-snapshot.sh` -> 7 passed, 0 failed (4 pre-existing + the new explorer-prompt round-trip + noise-filter assertion)
- [x] `tools/colony-lint.sh` -> 344 passed, 0 failed, 4 skipped
- [ ] Runtime verification across two consecutive `tools/run-research.sh` invocations: confirm `persistent/memo-snapshot.json` contains evolved explorer prompts after run N and that run N+1 bootstrap restores them (out of scope for this PR; left for the operator's next live run since it requires the full federation container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #739
