### PR TITLE
feat(research-foundry): enable AdaptiveEngine + recommend/learn in 3 agents (#740)

### DIFF
--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -619,13 +619,22 @@ fn tick(reason: string) -> void {
         prompt_text_raw;
     };
 
+    // #740: AdaptiveEngine recommendation for topic selection. The
+    // engine ranks past topic_label outcomes by `novelty` fitness and
+    // folds the recommendation into the prompt context as a free-form
+    // hint. Empty KB on first tick returns Map() whose to_string is
+    // harmless. Pattern mirrors dev-apprenticeship/code-review/agents/
+    // style_reviewer.ag:209.
+    let rec = recommend("topic_selection", ["novelty"]);
+
     // Build the topic + paper-pair context string.
     let ctx = "TOPIC: " + topic_label + " (" + topic_desc + ")\n"
             + "TOOLS AVAILABLE: " + compute_hints + "\n"
             + "PAPER A (" + paper_a_id + "): " + paper_a_title + "\n"
             + "ABSTRACT: " + paper_a_abstract + "\n"
             + "PAPER B (" + paper_b_id + "): " + paper_b_title + "\n"
-            + "ABSTRACT: " + paper_b_abstract + "\n";
+            + "ABSTRACT: " + paper_b_abstract + "\n"
+            + "LEARNED TOPIC PREFERENCES: " + to_string(rec) + "\n";
 
     let exploration = prompt(
         prompt_text + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid),
@@ -639,6 +648,8 @@ fn tick(reason: string) -> void {
         // + fitness). Same settlement/fitness as propose, plus replicate.
         memo_write("explorer:" + _self_pid + ":review_gated", "true");
         learn("explore", "tick " + to_string(tick_idx) + " " + topic_label, exploration.exploration_goal, "partial", ["acted", "math-foundry"]);
+        // #740: feed the AdaptiveEngine the topic outcome on the same tier path.
+        learn("topic_selection", topic_label, "tick " + to_string(tick_idx), "success", ["acted", "math-foundry"]);
         _publish_explorer(true, true, exploration, _self_pid, _colony_name, tick_idx, _tick_now_ms, topic_label, prompt_text);
     } else {
         if my_tier == "review-gated" {
@@ -650,16 +661,22 @@ fn tick(reason: string) -> void {
             memo_write("explorer:" + _self_pid + ":goal:tick-" + to_string(tick_idx), exploration.exploration_goal);
             memo_write("explorer:" + _self_pid + ":topic:tick-" + to_string(tick_idx), topic_label);
             learn("explore", "tick " + to_string(tick_idx) + " " + topic_label, exploration.exploration_goal, "partial", ["review-gated", "math-foundry"]);
+            // #740: feed the AdaptiveEngine the topic outcome on the same tier path.
+            learn("topic_selection", topic_label, "tick " + to_string(tick_idx), "partial", ["review-gated", "math-foundry"]);
         } else {
             if my_tier == "propose" {
                 // Class 3 special case (#622): propose keeps settlement +
                 // fitness from today's body but loses the replicate gate
                 // (autonomous-only now).
+                // #740: feed the AdaptiveEngine the topic outcome on the same tier path.
+                learn("topic_selection", topic_label, "tick " + to_string(tick_idx), "partial", ["emitted", "math-foundry"]);
                 _publish_explorer(true, false, exploration, _self_pid, _colony_name, tick_idx, _tick_now_ms, topic_label, prompt_text);
             } else {
                 // shadow / dormant: observe-only.
                 print("[explorer] observing (tier:", my_tier, ") goal=", exploration.exploration_goal);
                 learn("explore", "tick " + to_string(tick_idx) + " " + topic_label, exploration.exploration_goal, "partial", ["observed", "math-foundry"]);
+                // #740: feed the AdaptiveEngine the topic outcome on the same tier path.
+                learn("topic_selection", topic_label, "tick " + to_string(tick_idx), "partial", ["observed", "math-foundry"]);
             };
         };
     };

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -231,13 +231,25 @@ fn _submitter_draft_phase(
     introducer_pid: string,
     my_tier: string
 ) -> void {
+    // #740: AdaptiveEngine recommendation for submission-decision
+    // metadata classification. Lands at the metadata-staging step --
+    // NOT a substitute for the #596 HITL gate (terminal arXiv send
+    // still requires reviewer-approved memo + autonomous tier; see
+    // tier dispatcher below). The engine ranks past metadata-quality
+    // outcomes (arxiv_category / msc_codes accuracy) and folds the
+    // recommendation into the prompt context. Empty KB on first tick
+    // returns Map() whose to_string is harmless. Pattern mirrors
+    // dev-apprenticeship/code-review/agents/style_reviewer.ag:209.
+    let rec = recommend("submission_decision", ["accuracy"]);
+
     let ctx = "FINAL TEX:\n" + final_tex + "\n"
             + "COMPILE LOG:\n" + compile_log + "\n"
             + "TITLE SEED: " + title_seed + "\n"
             + "MSC SEED: " + msc_seed + "\n"
             + "ARXIV CATEGORY SEED: " + cat_seed + "\n"
             + "REPRO SCRIPT (" + repro_lang + "):\n" + repro_script + "\n"
-            + "REPRO OUTPUT:\n" + repro_output + "\n";
+            + "REPRO OUTPUT:\n" + repro_output + "\n"
+            + "LEARNED METADATA-QUALITY PREFERENCES: " + to_string(rec) + "\n";
     let meta = prompt(_metadata_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(self_pid), ctx) -> Metadata;
 
     // Load authors.toml from $PREPRINT_AUTHOR_CONFIG (path threaded
@@ -333,6 +345,12 @@ fn _submitter_draft_phase(
     if my_tier == "propose" {
         learn("submit", "tick " + to_string(tick_idx) + " DRAFTED " + claim_id_eff, meta.rationale, "success", ["emitted", "preprint-foundry", "hitl-gated"]);
     };
+    // #740: feed the AdaptiveEngine the metadata-quality outcome
+    // (arxiv_category as the choice signal) on every tier path the
+    // draft phase touches. The terminal-send decision still belongs
+    // to the #596 HITL gate downstream. Tier semantics are already
+    // captured by the surrounding `submit:*` learn() rows.
+    learn("submission_decision", meta.arxiv_category, "tick " + to_string(tick_idx) + " DRAFTED " + claim_id_eff, "success", ["emitted", "preprint-foundry", "hitl-gated"]);
 
     // Phase 9 PR-C (#663): per-pid fitness tracking. +1 per DRAFTED
     // row (PR-D folds in the eventual HITL accept signal).

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -299,13 +299,24 @@ fn tick(reason: string) -> void {
         return;
     };
 
+    // #740: AdaptiveEngine recommendation for proof-style selection.
+    // The engine ranks past proof_kind outcomes (sketch / full /
+    // computational) by `accuracy` fitness and folds the recommendation
+    // into the prompt context as a free-form hint to nudge the LLM
+    // toward the historically successful style for the upstream
+    // evidence. Empty KB on first tick returns Map() whose to_string is
+    // harmless. Pattern mirrors dev-apprenticeship/code-review/agents/
+    // style_reviewer.ag:209.
+    let rec = recommend("proof_approach", ["accuracy"]);
+
     let ctx = "PROBLEM: " + problem_text + "\n"
             + "ANSWER: " + stated_answer + "\n"
             + "NOVELTY CLAIM: " + novelty_claim + "\n"
             + "AUDITOR REASONING: " + audit_reasoning + "\n"
             + "EXPLORER GOAL: " + explorer_goal + "\n"
             + "EXPLORER CODE:\n" + explorer_code + "\n"
-            + "EXPLORER OUTPUT:\n" + explorer_output + "\n";
+            + "EXPLORER OUTPUT:\n" + explorer_output + "\n"
+            + "LEARNED PROOF-STYLE PREFERENCES: " + to_string(rec) + "\n";
 
     let draft = prompt(_draft_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> Draft;
 
@@ -313,18 +324,26 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         memo_write("theorist:" + _self_pid + ":review_gated", "true");
         learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["acted", "preprint-foundry"]);
+        // #740: feed the AdaptiveEngine the chosen proof_kind on the same tier path.
+        learn("proof_approach", draft.proof_kind, "tick " + to_string(tick_idx), "success", ["acted", "preprint-foundry"]);
         _publish_theorist(true, true, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("theorist:" + _self_pid + ":review_gated", "true");
             learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["review-gated", "preprint-foundry"]);
+            // #740: feed the AdaptiveEngine the chosen proof_kind on the same tier path.
+            learn("proof_approach", draft.proof_kind, "tick " + to_string(tick_idx), "partial", ["review-gated", "preprint-foundry"]);
             _publish_theorist(true, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
         } else {
             if my_tier == "propose" {
+                // #740: feed the AdaptiveEngine the chosen proof_kind on the same tier path.
+                learn("proof_approach", draft.proof_kind, "tick " + to_string(tick_idx), "partial", ["emitted", "preprint-foundry"]);
                 _publish_theorist(false, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
             } else {
                 print("[theorist] observing (tier:", my_tier, ") rationale=", draft.rationale);
                 learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["observed", "preprint-foundry"]);
+                // #740: feed the AdaptiveEngine the chosen proof_kind on the same tier path.
+                learn("proof_approach", draft.proof_kind, "tick " + to_string(tick_idx), "partial", ["observed", "preprint-foundry"]);
             };
         };
     };

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -641,6 +641,12 @@ write_bootstrap() {
         printf '  printf "exec.env_passthrough = DAEMON_ID,COLONY_NAME,HOLD_PERIOD,DISCOVERY_LEDGER,AUDIT_LEDGER,PREPRINT_LEDGER,REPLICATION_LEDGER,EXPLORER_GENERATION,AGENTIS_ROOT,ARXIV_MAX_QUERY_RESULTS,PREPRINT_OUTPUT_ROOT,PREPRINT_AUTHOR_CONFIG,PREPRINT_LATEXMK_MAX_PASSES,PREPRINT_ARXIV_GATEWAY,PREPRINT_ARXIV_FROM,PREPRINT_SMTP_HOST,PREPRINT_SMTP_PORT,EXPLORER_PROMPT_EVOLUTION_THRESHOLD,EXPLORER_PROMPT_GEN_CAP,EXPLORER_PROMPT_MAX_BYTES,EXPLORER_PROMPT_LEVENSHTEIN_FLOOR,FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK,FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK,RESEARCH_JITTER_DISABLED,ANTHROPIC_MODEL\\n"\n'
         printf '  printf "experience.enabled = true\\n"\n'
         printf '  printf "telemetry.enabled = true\\n"\n'
+        # #740: AdaptiveEngine activation. Without this flag the
+        # recommend() / adapt() / score_options() builtins silently
+        # no-op even though the runtime ships them; learn() rows still
+        # land in the experience ledger but cannot feed back into
+        # strategy selection. Mirrors dev-apprenticeship/install.sh L707.
+        printf '  printf "learning.enabled = true\\n"\n'
         printf '  printf "llm.backend = %s\\n"\n' "$LLM_BACKEND"
         printf '  printf "daemon.cb_per_tick = %s\\n"\n' "$DAEMON_CB_PER_TICK"
         printf '  printf "daemon.heartbeat_interval_ms = %s\\n"\n' "$DAEMON_HEARTBEAT_MS"

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -353,6 +353,15 @@ assert_contains "25b. llm.args printf still carries --effort %s" "$SRC" \
 assert_contains "25c. ANTHROPIC_MODEL added to exec.env_passthrough allowlist" "$SRC" \
     "RESEARCH_JITTER_DISABLED,ANTHROPIC_MODEL"
 
+# ---------------------------------------------------------------------------
+# 26. #740: AdaptiveEngine activation. The hermetic .agentis/config block
+# in run-research.sh must write `learning.enabled = true` so the
+# recommend() / adapt() / score_options() builtins are live. Mirrors
+# dev-apprenticeship/install.sh L707.
+# ---------------------------------------------------------------------------
+assert_contains "26. run-research.sh writes learning.enabled = true" "$SRC" \
+    'printf "learning.enabled = true\\n"'
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/check-learn-tags.sh
+++ b/tools/check-learn-tags.sh
@@ -243,6 +243,23 @@ observed
 math-foundry"
             PAIR_KNOWN=1
             ;;
+        # #740: AdaptiveEngine activation in research-foundry/explorer.
+        # The explorer emits `learn("topic_selection", topic_label, ...,
+        # outcome, [tier, "math-foundry"])` alongside the existing
+        # `explore:*` rows so the AdaptiveEngine can rank topics by
+        # the `novelty` fitness signal.
+        "topic_selection:success")
+            ALLOWED_LITERALS="acted
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "topic_selection:partial")
+            ALLOWED_LITERALS="review-gated
+emitted
+observed
+math-foundry"
+            PAIR_KNOWN=1
+            ;;
         "settle:success")
             ALLOWED_LITERALS="acted
 math-foundry
@@ -525,6 +542,24 @@ observed
 preprint-foundry"
             PAIR_KNOWN=1
             ;;
+        # #740: AdaptiveEngine activation in research-foundry/theorist.
+        # The theorist emits `learn("proof_approach", draft.proof_kind,
+        # ..., outcome, [tier, "preprint-foundry"])` alongside the
+        # existing `theorise:*` rows so the AdaptiveEngine can rank
+        # proof styles (sketch / full / computational) by the
+        # `accuracy` fitness signal.
+        "proof_approach:success")
+            ALLOWED_LITERALS="acted
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
+        "proof_approach:partial")
+            ALLOWED_LITERALS="review-gated
+emitted
+observed
+preprint-foundry"
+            PAIR_KNOWN=1
+            ;;
         "compute:partial")
             ALLOWED_LITERALS="acted
 review-gated
@@ -604,6 +639,21 @@ hitl-gated"
 review-gated
 emitted
 observed
+preprint-foundry
+hitl-gated"
+            PAIR_KNOWN=1
+            ;;
+        # #740: AdaptiveEngine activation in research-foundry/submitter.
+        # The submitter emits `learn("submission_decision",
+        # meta.arxiv_category, ..., "success", ["emitted",
+        # "preprint-foundry", "hitl-gated"])` alongside the existing
+        # `submit:*` rows so the AdaptiveEngine can rank
+        # metadata-quality choices by the `accuracy` fitness signal.
+        # NOTE: this is a metadata-classification helper -- the
+        # terminal arXiv-send decision still belongs to the #596 HITL
+        # gate downstream.
+        "submission_decision:success")
+            ALLOWED_LITERALS="emitted
 preprint-foundry
 hitl-gated"
             PAIR_KNOWN=1


### PR DESCRIPTION
## Summary

- Adds `learning.enabled = true` to the hermetic `.agentis/config` written by `run-research.sh` so the agentis-core AdaptiveEngine activates for research-foundry. Before this flag the `recommend()` / `adapt()` / `score_options()` builtins silently no-op'd while `learn()` rows continued to land in the experience ledger.
- Wires `recommend()` + matching `learn()` pairs into three agents:
  - **explorer.ag**: `recommend("topic_selection", ["novelty"])` folded into the topic + paper-pair prompt context; matching `learn()` rows on every tier branch (acted / review-gated / emitted / observed).
  - **theorist.ag**: `recommend("proof_approach", ["accuracy"])` folded into the draft prompt context; matching `learn()` rows carry the chosen `draft.proof_kind` on every tier branch.
  - **submitter.ag**: `recommend("submission_decision", ["accuracy"])` folded into the metadata-staging prompt context; matching `learn()` row carries `meta.arxiv_category` as the choice signal. Lands at the metadata-classification step -- NOT a substitute for the #596 HITL gate (terminal arXiv send still requires reviewer-approved memo + autonomous tier).
- Schema for `tools/check-learn-tags.sh` extended with three new `(topic, outcome)` pairs so the new `learn()` rows pass the static guardrail. `test-run-research.sh` asserts the new config line is emitted by the generated bootstrap.

## Why

Epic #738 child P0. Currently research-foundry runs with `learning.enabled = false`, so AdaptiveEngine builtins (`recommend` / `adapt` / `score_options`) are dead substrate. This PR activates them and wires 3 representative agents to strategy selection. Reference pattern from `dev-apprenticeship/code-review/agents/style_reviewer.ag:209` (recommend/learn pair) and `dev-apprenticeship/install.sh` L707 (`learning.enabled` config write).

## Test plan

- [x] `bash -n research-foundry/tools/run-research.sh`
- [x] `bash research-foundry/tools/test-run-research.sh` -- 136 passed, 0 failed (new test 26 asserts `learning.enabled = true` line)
- [x] `bash tools/colony-lint.sh` -- 344 passed, 0 failed, 4 skipped (baseline was 343 PASS; schema additions register cleanly)
- [ ] CI green
- [ ] After merge + next run: KnowledgeBase grows; `recall_latest("<agent>:knowledge_base_summary")` returns non-empty after ~30 ticks

Closes #740

Generated with [Claude Code](https://claude.com/claude-code)