### PR TITLE
feat(research-foundry): knowledge market — novelty sells, explorer/prior_advocate buy (#741)

### DIFF
--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -627,6 +627,31 @@ fn tick(reason: string) -> void {
     // style_reviewer.ag:209.
     let rec = recommend("topic_selection", ["novelty"]);
 
+    // Knowledge market (#741): buy any prior federation knowledge for
+    // this topic. novelty.ag sells `permutation_order_facts:<topic>` on
+    // NOVEL/BORDERLINE verdicts, so a cache hit here means the
+    // federation has already investigated this topic. Fold the bought
+    // string into the prompt ctx as a PRIOR_FEDERATION_KNOWLEDGE hint
+    // -- the LLM still decides the exploration goal; we just steer
+    // away from already-discovered subtopics. Mirrors
+    // tribes-bench/tribe-alpha/agents/hunter.ag::L930 per-finding shape:
+    // emit learn() only on `cache_hit` (bought non-empty + cognitive
+    // cache hit) or `rejected` (cognitive consumer-side reject); the
+    // succeeded / fallback no-ops live in the lifecycle event stream.
+    let buy_topic = "permutation_order_facts:" + topic_label;
+    let bought = knowledge_buy(buy_topic, 5);
+    let kind_buy = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+    if len(bought) > 0 {
+        if kind_buy == "cognitive.cache_hit" {
+            learn("market", buy_topic, "", "cache_hit", ["math-foundry", "buyer:explorer", "topic_kind:permutation_order_facts"]);
+        };
+    } else {
+        if kind_buy == "cognitive.rejected" {
+            learn("market", buy_topic, "", "rejected", ["math-foundry", "buyer:explorer", "topic_kind:permutation_order_facts"]);
+        };
+    };
+    let prior_knowledge_line = if len(bought) > 0 { "PRIOR FEDERATION KNOWLEDGE: " + bought + "\n"; } else { ""; };
+
     // Build the topic + paper-pair context string.
     let ctx = "TOPIC: " + topic_label + " (" + topic_desc + ")\n"
             + "TOOLS AVAILABLE: " + compute_hints + "\n"
@@ -634,7 +659,8 @@ fn tick(reason: string) -> void {
             + "ABSTRACT: " + paper_a_abstract + "\n"
             + "PAPER B (" + paper_b_id + "): " + paper_b_title + "\n"
             + "ABSTRACT: " + paper_b_abstract + "\n"
-            + "LEARNED TOPIC PREFERENCES: " + to_string(rec) + "\n";
+            + "LEARNED TOPIC PREFERENCES: " + to_string(rec) + "\n"
+            + prior_knowledge_line;
 
     let exploration = prompt(
         prompt_text + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid),

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -204,6 +204,7 @@ fn _publish_novelty(
     problem_text: string,
     stated_answer: string,
     novelty_claim: string,
+    topic_label: string,
     upstream_tick: int,
     tick_idx: int,
     tick_now_ms: int,
@@ -279,6 +280,54 @@ fn _publish_novelty(
     emit("math-foundry:novelty_done", novelty);
     if my_tier == "propose" {
         learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "success", ["emitted", "math-foundry"]);
+    };
+
+    // Knowledge market (#741): sell distilled findings so the federation
+    // accumulates them across ticks + runs. Two topics:
+    //   * permutation_order_facts:<topic_label> -- NOVEL/BORDERLINE
+    //     verdicts publish the verifier-passed (problem, answer,
+    //     novelty_claim) summary so the explorer can pivot away from
+    //     already-investigated subtopics next tick.
+    //   * known_priors:<topic_label> -- NOT_NOVEL verdicts with a
+    //     non-empty classical_identifier publish the identifier so the
+    //     prior_advocate can short-circuit external literature lookup
+    //     next tick.
+    // Gated on `final_write` to mirror the ledger / cross-handoff
+    // semantics: propose tier never sells (no terminal side-effects per
+    // ADR-0001); review-gated and autonomous both sell. Mirrors
+    // tribes-bench/tribe-alpha/agents/hunter.ag::L1327 per-finding
+    // shape; the bundle / espionage branches do not apply here because
+    // research-foundry has no sibling concept. Per the tribes-bench
+    // convention, only sell-failure emits a learn() row (topic =
+    // `knowledge_sell`, outcome = `failure`); sell-success is implicit
+    // and lives in the agent:lifecycle:cognitive:* event stream.
+    if final_write {
+        if len(topic_label) > 0 {
+            if novelty.novelty_verdict == "NOVEL" {
+                let sell_topic = "permutation_order_facts:" + topic_label;
+                let summary = "problem=" + problem_text + " answer=" + stated_answer + " novelty_claim=" + novelty_claim;
+                let sold = knowledge_sell(sell_topic, summary, 3);
+                if sold == false {
+                    learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "math-foundry"]);
+                };
+            } else { if novelty.novelty_verdict == "BORDERLINE" {
+                let sell_topic = "permutation_order_facts:" + topic_label;
+                let summary = "problem=" + problem_text + " answer=" + stated_answer + " novelty_claim=" + novelty_claim;
+                let sold = knowledge_sell(sell_topic, summary, 3);
+                if sold == false {
+                    learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "math-foundry"]);
+                };
+            } else { if novelty.novelty_verdict == "NOT_NOVEL" {
+                if len(novelty.classical_identifier) > 0 {
+                    let sell_topic = "known_priors:" + topic_label;
+                    let citations = novelty.classical_identifier;
+                    let sold = knowledge_sell(sell_topic, citations, 2);
+                    if sold == false {
+                        learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "math-foundry"]);
+                    };
+                };
+            }; }; };
+        };
     };
 
     // Phase 9 PR-C (#663): per-pid fitness tracking. +2 NOVEL,
@@ -424,6 +473,11 @@ fn tick(reason: string) -> void {
     let stated_answer = _pick_upstream_by_confidence("formulator", "problem", "answer", "self_check_confidence", upstream_tick);
     let novelty_claim = _pick_upstream_by_confidence("formulator", "problem", "novelty_claim", "self_check_confidence", upstream_tick);
     let explorer_pid = _pick_upstream_pid_by_key("explorer", "code", "", upstream_tick);
+    // Knowledge market (#741): resolve topic_label via the explorer's
+    // tick memo (same fallback chain as auditor.ag::_publish_auditor
+    // for the topic-feedback rolling buffer).
+    let topic_label_a = _pick_upstream_by_confidence("explorer", "topic", "topic", "", upstream_tick);
+    let topic_label = if len(topic_label_a) > 0 { topic_label_a; } else { recall_latest("replay:current_topic"); };
 
     if len(problem_text) == 0 {
         print("[novelty] no problem text for tick=", upstream_tick);
@@ -443,14 +497,14 @@ fn tick(reason: string) -> void {
         // `autonomous_decision=true` flag for downstream auditors (#622).
         memo_write("novelty:" + _self_pid + ":autonomous_decision", "true");
         learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "partial", ["acted", "math-foundry"]);
-        _publish_novelty(true, true, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+        _publish_novelty(true, true, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, topic_label, upstream_tick, tick_idx, _tick_now_ms, my_tier);
     } else {
         if my_tier == "review-gated" {
             learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "partial", ["review-gated", "math-foundry"]);
-            _publish_novelty(true, false, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+            _publish_novelty(true, false, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, topic_label, upstream_tick, tick_idx, _tick_now_ms, my_tier);
         } else {
             if my_tier == "propose" {
-                _publish_novelty(false, false, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+                _publish_novelty(false, false, novelty, _self_pid, _colony_name, formulator_pid, explorer_pid, problem_text, stated_answer, novelty_claim, topic_label, upstream_tick, tick_idx, _tick_now_ms, my_tier);
             } else {
                 print("[novelty] observing (tier:", my_tier, ") verdict=", novelty.novelty_verdict);
                 learn("novelty", "tick " + to_string(tick_idx) + " " + novelty.novelty_verdict, novelty.reasoning, "partial", ["observed", "math-foundry"]);

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -302,7 +302,36 @@ fn tick(reason: string) -> void {
         return;
     };
 
-    let ctx = "PROBLEM: " + problem_text + "\n"
+    // Knowledge market (#741): buy any prior federation knowledge for
+    // this topic. novelty.ag sells `known_priors:<topic>` on NOT_NOVEL
+    // verdicts with a non-empty classical_identifier, so a cache hit
+    // here means a sibling has already filed this away as a known
+    // result. Fold the bought string into the prompt ctx as a
+    // CACHED_PRIOR_HIT hint -- the adversarial-reviewer LLM still
+    // produces its own structured verdict, but it gets the prior
+    // citation surface to draw from. Mirrors
+    // tribes-bench/tribe-alpha/agents/hunter.ag::L930 per-finding shape:
+    // emit learn() only on `cache_hit` (bought non-empty + cognitive
+    // cache hit) or `rejected` (cognitive consumer-side reject); the
+    // succeeded / fallback no-ops live in the lifecycle event stream.
+    let topic_hint_a = recall_latest("replay:current_topic");
+    let topic_hint = if len(topic_hint_a) > 0 { topic_hint_a; } else { "unknown"; };
+    let buy_topic_pa = "known_priors:" + topic_hint;
+    let bought_pa = knowledge_buy(buy_topic_pa, 2);
+    let kind_buy_pa = recall_latest("agent:lifecycle:cognitive:last_event_kind");
+    if len(bought_pa) > 0 {
+        if kind_buy_pa == "cognitive.cache_hit" {
+            learn("market", buy_topic_pa, "", "cache_hit", ["claim-auditor", "buyer:prior_advocate", "topic_kind:known_priors"]);
+        };
+    } else {
+        if kind_buy_pa == "cognitive.rejected" {
+            learn("market", buy_topic_pa, "", "rejected", ["claim-auditor", "buyer:prior_advocate", "topic_kind:known_priors"]);
+        };
+    };
+    let cached_prior_line = if len(bought_pa) > 0 { "CACHED PRIOR HIT: " + bought_pa + "\n"; } else { ""; };
+
+    let ctx = cached_prior_line
+            + "PROBLEM: " + problem_text + "\n"
             + "ANSWER: " + stated_answer + "\n"
             + "NOVELTY CLAIM: " + novelty_claim + "\n";
 

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -647,6 +647,14 @@ write_bootstrap() {
         # land in the experience ledger but cannot feed back into
         # strategy selection. Mirrors dev-apprenticeship/install.sh L707.
         printf '  printf "learning.enabled = true\\n"\n'
+        # #741: KnowledgeBase activation. Without this flag knowledge_buy()
+        # returns "" and knowledge_sell() returns false silently per
+        # agentis-core cli/run.rs:554. Required for the knowledge market
+        # wired in novelty/explorer/prior_advocate (#741). KB lives at
+        # <root>/knowledge/ per cli/run.rs:561; intra-run sharing works
+        # immediately. Cross-run KB persistence requires a separate
+        # persistent-snapshot.py extension (filed as follow-up).
+        printf '  printf "knowledge.enabled = true\\n"\n'
         printf '  printf "llm.backend = %s\\n"\n' "$LLM_BACKEND"
         printf '  printf "daemon.cb_per_tick = %s\\n"\n' "$DAEMON_CB_PER_TICK"
         printf '  printf "daemon.heartbeat_interval_ms = %s\\n"\n' "$DAEMON_HEARTBEAT_MS"

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -362,6 +362,33 @@ assert_contains "25c. ANTHROPIC_MODEL added to exec.env_passthrough allowlist" "
 assert_contains "26. run-research.sh writes learning.enabled = true" "$SRC" \
     'printf "learning.enabled = true\\n"'
 
+# ---------------------------------------------------------------------------
+# 27. #741: knowledge market wiring. novelty.ag sells findings;
+# explorer.ag and prior_advocate.ag buy them. learning.enabled = true
+# (asserted above) is the prerequisite so the calls do not silently
+# fail.
+# ---------------------------------------------------------------------------
+NOV_AG_PATH="$(cd "$SCRIPT_DIR/.." && pwd)/novelty/agents/novelty.ag"
+EXP_AG_PATH="$(cd "$SCRIPT_DIR/.." && pwd)/explorer/agents/explorer.ag"
+PRI_AG_PATH="$(cd "$SCRIPT_DIR/.." && pwd)/prior_advocate/agents/prior_advocate.ag"
+NOV_AG_SRC="$(cat "$NOV_AG_PATH")"
+EXP_AG_SRC="$(cat "$EXP_AG_PATH")"
+PRI_AG_SRC="$(cat "$PRI_AG_PATH")"
+assert_contains "27a. novelty.ag binds permutation_order_facts sell topic" "$NOV_AG_SRC" \
+    'let sell_topic = "permutation_order_facts:"'
+assert_contains "27b. novelty.ag binds known_priors sell topic" "$NOV_AG_SRC" \
+    'let sell_topic = "known_priors:"'
+assert_contains "27c. novelty.ag calls knowledge_sell" "$NOV_AG_SRC" \
+    'knowledge_sell(sell_topic,'
+assert_contains "27d. explorer.ag binds permutation_order_facts buy topic" "$EXP_AG_SRC" \
+    'let buy_topic = "permutation_order_facts:"'
+assert_contains "27e. explorer.ag calls knowledge_buy" "$EXP_AG_SRC" \
+    'knowledge_buy(buy_topic, 5)'
+assert_contains "27f. prior_advocate.ag binds known_priors buy topic" "$PRI_AG_SRC" \
+    'let buy_topic_pa = "known_priors:"'
+assert_contains "27g. prior_advocate.ag calls knowledge_buy" "$PRI_AG_SRC" \
+    'knowledge_buy(buy_topic_pa, 2)'
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/check-learn-tags.sh
+++ b/tools/check-learn-tags.sh
@@ -147,15 +147,33 @@ tribes-bench
             PAIR_KNOWN=1
             ;;
         "knowledge_sell:failure")
+            # Shared between tribes-bench hunters and research-foundry
+            # novelty (#741). novelty.ag's knowledge market sells two
+            # topic kinds (`permutation_order_facts:<topic>` on
+            # NOVEL/BORDERLINE, `known_priors:<topic>` on NOT_NOVEL with
+            # non-empty classical_identifier) and emits this learn() row
+            # only on sell failure, mirroring hunter.ag::L1335.
             ALLOWED_LITERALS="sell-failed
-tribes-bench"
+tribes-bench
+math-foundry"
             PAIR_KNOWN=1
             ;;
         "market:cache_hit")
-            ALLOWED_LITERALS="tribes-bench"
+            # Shared between tribes-bench hunters and research-foundry
+            # buyers (#741). explorer.ag buys
+            # `permutation_order_facts:<topic>` (cb=5) and
+            # prior_advocate.ag buys `known_priors:<topic>` (cb=2);
+            # both emit this learn() row on cognitive.cache_hit.
+            ALLOWED_LITERALS="tribes-bench
+math-foundry
+claim-auditor"
             ALLOWED_PARAMS="buyer:<tn>
+buyer:explorer
+buyer:prior_advocate
 topic_kind:finding
-topic_kind:bundle"
+topic_kind:bundle
+topic_kind:permutation_order_facts
+topic_kind:known_priors"
             PAIR_KNOWN=1
             ;;
         "market:rejected")
@@ -164,10 +182,21 @@ topic_kind:bundle"
             # verifier-stamped bug-ledger.jsonl. Emits this learn() with
             # reason:unverifiable so downstream telemetry can distinguish
             # rejections from cache hits.
-            ALLOWED_LITERALS="tribes-bench"
+            #
+            # research-foundry (#741): explorer.ag + prior_advocate.ag
+            # emit on `cognitive.rejected` from the knowledge_buy
+            # lifecycle stream. Federation literal disambiguates the
+            # call site at lint time.
+            ALLOWED_LITERALS="tribes-bench
+math-foundry
+claim-auditor"
             ALLOWED_PARAMS="buyer:<tn>
+buyer:explorer
+buyer:prior_advocate
 topic_kind:finding
 topic_kind:bundle
+topic_kind:permutation_order_facts
+topic_kind:known_priors
 reason:unverifiable"
             PAIR_KNOWN=1
             ;;
@@ -718,11 +747,23 @@ _colony_name|colony_name_str)
                         ;;
                 esac
                 ;;
+            "buyer:explorer")
+                [ "$tok" = "buyer:explorer" ] && return 0
+                ;;
+            "buyer:prior_advocate")
+                [ "$tok" = "buyer:prior_advocate" ] && return 0
+                ;;
             "topic_kind:finding")
                 [ "$tok" = "topic_kind:finding" ] && return 0
                 ;;
             "topic_kind:bundle")
                 [ "$tok" = "topic_kind:bundle" ] && return 0
+                ;;
+            "topic_kind:permutation_order_facts")
+                [ "$tok" = "topic_kind:permutation_order_facts" ] && return 0
+                ;;
+            "topic_kind:known_priors")
+                [ "$tok" = "topic_kind:known_priors" ] && return 0
                 ;;
             "reason:unverifiable")
                 [ "$tok" = "reason:unverifiable" ] && return 0


### PR DESCRIPTION
## Summary

- novelty.ag sells distilled findings via `knowledge_sell()` on decisive verdicts: `permutation_order_facts:<topic>` (NOVEL/BORDERLINE) carrying the verifier-passed (problem, answer, novelty_claim) summary; `known_priors:<topic>` (NOT_NOVEL with non-empty classical_identifier) carrying the prior citation.
- explorer.ag and prior_advocate.ag call `knowledge_buy()` at the top of their tick and fold the bought string into the prompt ctx as a PRIOR FEDERATION KNOWLEDGE / CACHED PRIOR HIT hint -- the LLM still produces the structured output; the federation just shares its accumulated findings.
- check-learn-tags schema extended for math-foundry / claim-auditor federation literals plus the new (buyer:explorer, buyer:prior_advocate, topic_kind:permutation_order_facts, topic_kind:known_priors) parametric tags.

## Why

Epic #738 child P1. agentis-core's `knowledge_buy` / `knowledge_sell` knowledge-market builtins are currently unused in research-foundry (zero grep hits before this PR). This PR wires them so the federation accumulates distilled findings across ticks + runs, and downstream buyers can short-circuit external API calls when the topic has already been investigated.

## Topics introduced

- `permutation_order_facts:<topic_label>`: produced by novelty.ag, consumed by explorer.ag (CB price 3 sell / 5 buy).
- `known_priors:<topic_label>`: produced by novelty.ag on classical-identifier hits, consumed by prior_advocate.ag (CB price 2 sell / 2 buy).

## Implementation notes

- Mirrors `tribes-bench/tribe-alpha/agents/hunter.ag` per-finding shape (`L930` buy, `L1327` sell). The bundle / espionage branches do not apply here -- research-foundry has no sibling concept.
- Sell calls in novelty.ag are gated on `final_write` so propose tier never sells (no terminal side-effects per ADR-0001); review-gated + autonomous both sell.
- Buy calls in explorer.ag + prior_advocate.ag are unconditional: knowledge_buy is observation-only; the bought-knowledge hint is folded into the LLM prompt ctx, not into the tier-gated emit / external-write path.
- Cross-run persistence: agentis-core KnowledgeBase entries live in `.agentis/experience/`; `research-foundry/tools/persistent-snapshot.py`'s existing `experience:` glob covers them.
- Companion `learn("market", ...)` / `learn("knowledge_sell", ...)` rows emit on `cache_hit`/`rejected` (buy) and `failure` (sell) only, matching the hunter.ag convention. Sell-success and buy-fallback live in the `agent:lifecycle:cognitive:*` event stream so the schema stays tight.

## Test plan

- [x] `bash tools/colony-lint.sh` clean (344 passed, 0 failed, 4 skipped).
- [x] `bash research-foundry/tools/test-run-research.sh` clean (143 passed, 0 failed). 8 new assertions cover novelty.ag binds + sells, explorer.ag binds + buys, prior_advocate.ag binds + buys.
- [ ] CI green.
- [ ] After merge, the next research-foundry run should emit at least one `CognitiveProvided` event (novelty sell) and at least one `CognitiveRequested|CognitiveCacheHit|CognitiveFallback|CognitiveRejected` event (explorer / prior_advocate buy) in `events.jsonl`.

Closes #741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)