### PR TITLE
feat(research-foundry): enable Action audit chain with signed provenance (#743)

### DIFF
--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -655,6 +655,22 @@ write_bootstrap() {
         # immediately. Cross-run KB persistence requires a separate
         # persistent-snapshot.py extension (filed as follow-up).
         printf '  printf "knowledge.enabled = true\\n"\n'
+        # #743: ed25519-signed Action audit chain. Without
+        # `audit.persist_actions = true`, agentis-core treats the audit
+        # ledger as in-memory only and never flushes rows to
+        # <root>/audit/actions.jsonl. Without an explicit
+        # `audit.signing_key_path`, the runtime falls back to
+        # <root>/identity/private.key — but `agentis init` does not
+        # create that key, so signing degrades to unsigned chain rows.
+        # We bootstrap the ed25519 keypair explicitly below (mkdir +
+        # openssl/agentis identity init + chmod 600) so every Action
+        # row gets {seq, prev_hash, signer_pubkey, signature} and
+        # `agentis audit verify-actions` reports chained=N (N valid,
+        # 0 unsigned). Operator security note: <root>/audit/ and
+        # <root>/identity/ become credential-grade artifacts under
+        # this config — chmod 600 + restrict to forensic readers.
+        printf '  printf "audit.persist_actions = true\\n"\n'
+        printf '  printf "audit.signing_key_path = .agentis/identity/private.key\\n"\n'
         printf '  printf "llm.backend = %s\\n"\n' "$LLM_BACKEND"
         printf '  printf "daemon.cb_per_tick = %s\\n"\n' "$DAEMON_CB_PER_TICK"
         printf '  printf "daemon.heartbeat_interval_ms = %s\\n"\n' "$DAEMON_HEARTBEAT_MS"
@@ -687,7 +703,24 @@ write_bootstrap() {
         printf '    cp -r /repo/research-foundry/$c /run-root/$c\n'
         printf 'done\n'
         printf 'cp -r /repo/research-foundry/tools /run-root/tools\n'
-        printf 'mkdir -p /run-root/.agentis/sandbox /run-root/.agentis/logs /run-root/config /run-root/preprints /run-root/data\n'
+        # #743: extend mkdir with .agentis/audit and .agentis/identity.
+        # `agentis init` (L638 above) creates config/daemon/experience/
+        # logs/memo/objects/sandbox/spend/suspend but NOT audit/ or
+        # identity/, so audit.persist_actions would otherwise fail
+        # silently on first ledger flush. Identity dir holds the
+        # ed25519 private key bootstrapped immediately below.
+        printf 'mkdir -p /run-root/.agentis/sandbox /run-root/.agentis/logs /run-root/.agentis/audit /run-root/.agentis/identity /run-root/config /run-root/preprints /run-root/data\n'
+        # #743: bootstrap ed25519 keypair for audit-chain signing.
+        # Prefer `agentis identity init` when the pinned runtime ships
+        # it; fall back to `openssl genpkey -algorithm ed25519` (always
+        # available in the research container per Containerfile.research).
+        # chmod 600 because agentis-core #584 M2 release note flags the
+        # private key as credential-grade. The `|| true` after chmod is
+        # defensive in case `agentis identity init` writes to a
+        # different filename — the audit chain will simply fall back to
+        # unsigned rows in that case and the verify step will surface it.
+        printf 'if command -v agentis >/dev/null 2>&1 && agentis identity init >/dev/null 2>&1; then :; else openssl genpkey -algorithm ed25519 -out /run-root/.agentis/identity/private.key 2>/dev/null || true; fi\n'
+        printf 'chmod 600 /run-root/.agentis/identity/private.key 2>/dev/null || true\n'
         printf 'if [ -d /repo/research-foundry/data/papers ]; then cp -r /repo/research-foundry/data/papers /run-root/data/papers; fi\n'
         printf 'if [ -f /repo/research-foundry/config/authors.toml ]; then cp /repo/research-foundry/config/authors.toml /run-root/config/authors.toml; fi\n'
         printf ': > /run-root/discovery-ledger.jsonl\n'

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -389,6 +389,28 @@ assert_contains "27f. prior_advocate.ag binds known_priors buy topic" "$PRI_AG_S
 assert_contains "27g. prior_advocate.ag calls knowledge_buy" "$PRI_AG_SRC" \
     'knowledge_buy(buy_topic_pa, 2)'
 
+# ---------------------------------------------------------------------------
+# 28. #743: Action audit chain activation with ed25519 signing. The
+# hermetic .agentis/config block must enable `audit.persist_actions =
+# true` (otherwise rows never flush to <root>/audit/actions.jsonl) and
+# pin `audit.signing_key_path` to an explicit path under .agentis/
+# identity/. The bootstrap script must also create both .agentis/audit/
+# and .agentis/identity/ dirs (agentis init does not), bootstrap the
+# ed25519 keypair, and chmod 600 it. Together these wire the M2
+# tamper-evident chain (seq + prev_hash + signer_pubkey + signature)
+# verifiable via `agentis audit verify-actions`.
+# ---------------------------------------------------------------------------
+assert_contains "28a. run-research.sh writes audit.persist_actions = true" "$SRC" \
+    'printf "audit.persist_actions = true\\n"'
+assert_contains "28b. run-research.sh pins audit.signing_key_path" "$SRC" \
+    'printf "audit.signing_key_path = .agentis/identity/private.key\\n"'
+assert_contains "28c. bootstrap mkdir extends to .agentis/audit + .agentis/identity" "$SRC" \
+    '/run-root/.agentis/audit /run-root/.agentis/identity'
+assert_contains "28d. ed25519 identity key bootstrap line emitted" "$SRC" \
+    'openssl genpkey -algorithm ed25519 -out /run-root/.agentis/identity/private.key'
+assert_contains "28e. chmod 600 on identity private key emitted" "$SRC" \
+    'chmod 600 /run-root/.agentis/identity/private.key'
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- `.agentis/config` gains `audit.persist_actions = true` plus an explicit `audit.signing_key_path = .agentis/identity/private.key`, replacing the silent in-memory default.
- The hermetic bootstrap script now `mkdir -p`s `.agentis/audit/` and `.agentis/identity/` (neither created by `agentis init`) and bootstraps an ed25519 keypair (`agentis identity init` with `openssl genpkey -algorithm ed25519` fallback), `chmod 600`.
- Five new `test-run-research.sh` assertions pin the config emission, the extended mkdir, the keypair bootstrap, and the chmod (143 to 148 tests).

## Why
Epic #738 child P1. agentis-core #584 M2 tamper-evident action audit chain is silent substrate in research-foundry today (`audit.persist_actions` was unset, no identity key on disk). This PR activates it with explicit ed25519 signing so audit-ledger rows carry `seq` + `prev_hash` chain fields AND `signer_pubkey` + `signature`, verifiable post-run via `agentis audit verify-actions`.

## Operator security note
Per #584 M2 release note, `.agentis/audit/` becomes credential-grade after this — `chmod 600` is applied to the private key, and forensic readers should restrict read access to operators only. Identity key in `.agentis/identity/private.key` is also `chmod 600`.

## Test plan
- [x] `bash -n research-foundry/tools/run-research.sh`
- [x] `bash research-foundry/tools/test-run-research.sh`: 148 passed, 0 failed (5 new assertions in section 28a-e)
- [x] `bash tools/colony-lint.sh`: 344 passed, 0 failed, 4 skipped
- [ ] CI green
- [ ] After merge: rebuild image + real run, verify `<run_dir>/.agentis/audit/actions.jsonl` populated with chained+signed rows; `agentis audit verify-actions --verbose` reports `chained=N (N valid, 0 unsigned)`

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)