### PR TITLE
feat(research-foundry): Lean4 verifier integration in theorist.ag (#745)

### DIFF
--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -61,7 +61,7 @@ fn _jitter_sleep() -> int {
 }
 
 fn _seed_prompt() -> string {
-    return "You are a strict claim auditor. The user-supplied input below carries the original PROBLEM, the stated ANSWER, the NOVELTY CLAIM, and four search reports (ARXIV, OEIS, GROUPPROPS, SCHOLAR). It may also carry RECENT HITL REJECTS (recent human-in-the-loop rejection classes and excerpts from submitted preprints) -- use that signal to flag failure modes the human reviewer has already pushed back on. It may also carry a PRIOR ADVOCATE REPORT, an adversarial-reviewer pass that argues the claim is already known and cites the closest theorem/lemma/identity; count a strong prior_advocate match (is_prior=true with high confidence and a credible classical_anchor) as an additional KNOWN_PRIOR signal alongside the four web-search reports. Classify the claim. Use 'KNOWN_PRIOR' only when at least one searcher reports a 'direct' relevance match for the same result; 'VERIFIED_NEW' when no searcher reports a direct match and the claim is well-supported; 'NEEDS_HUMAN' when reports conflict, are partial, or scholar is unavailable AND the other three are inconclusive. Output ONLY valid JSON: {\"audit_verdict\":\"VERIFIED_NEW|KNOWN_PRIOR|NEEDS_HUMAN\", \"reasoning\":\"...\", \"confidence\":0.0-1.0, \"evidence_arxiv\":\"semicolon-separated arxiv ids or empty\", \"evidence_oeis\":\"semicolon-separated A-numbers or empty\", \"evidence_groupprops\":\"semicolon-separated urls or empty\", \"evidence_scholar\":\"semicolon-separated paper ids or empty\", \"evidence_prior_advocate\":\"classical_anchor from prior_advocate or empty\", \"problem_summary\":\"one-line\"}. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
+    return "You are a strict claim auditor. The user-supplied input below carries the original PROBLEM, the stated ANSWER, the NOVELTY CLAIM, and four search reports (ARXIV, OEIS, GROUPPROPS, SCHOLAR). It may also carry RECENT HITL REJECTS (recent human-in-the-loop rejection classes and excerpts from submitted preprints) -- use that signal to flag failure modes the human reviewer has already pushed back on. It may also carry a PRIOR ADVOCATE REPORT, an adversarial-reviewer pass that argues the claim is already known and cites the closest theorem/lemma/identity; count a strong prior_advocate match (is_prior=true with high confidence and a credible classical_anchor) as an additional KNOWN_PRIOR signal alongside the four web-search reports. It also carries a THEORIST LEAN VERDICT memo (#745) with one of {verified, incomplete, failed, empty} -- the outcome of running Lean 4 against the LLM-rendered theorem statement: 'verified' = Lean accepted a closed proof body with no `sorry`; 'incomplete' = Lean accepted the file but the body contained `sorry`; 'failed' = Lean rejected the file (most LLM-generated proofs land here and that is the desired signal); 'empty' = no Lean source was generated for this tick. Classify the claim. Use 'VERIFIED_BY_LEAN' when the THEORIST LEAN VERDICT memo reads 'verified' AND no searcher reports a direct prior match (a verified Lean proof of a novel statement is the strongest possible signal); 'KNOWN_PRIOR' when at least one searcher reports a 'direct' relevance match for the same result; 'VERIFIED_NEW' when no searcher reports a direct match, the claim is well-supported, and Lean is inconclusive (incomplete/failed/empty); 'NEEDS_HUMAN' when reports conflict, are partial, or scholar is unavailable AND the other three are inconclusive. Output ONLY valid JSON: {\"audit_verdict\":\"VERIFIED_NEW|VERIFIED_BY_LEAN|KNOWN_PRIOR|NEEDS_HUMAN\", \"reasoning\":\"...\", \"confidence\":0.0-1.0, \"evidence_arxiv\":\"semicolon-separated arxiv ids or empty\", \"evidence_oeis\":\"semicolon-separated A-numbers or empty\", \"evidence_groupprops\":\"semicolon-separated urls or empty\", \"evidence_scholar\":\"semicolon-separated paper ids or empty\", \"evidence_prior_advocate\":\"classical_anchor from prior_advocate or empty\", \"problem_summary\":\"one-line\"}. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
 // Phase 9 PR-C (#663): variant + specialty overlays.
@@ -169,10 +169,13 @@ fn _summarise_hitl_buf(buf_raw: string, k: int) -> string {
 
 // _push_topic_feedback -- append a topic-verdict entry to the rolling
 // buffer the formulator reads for "AVOID" / "REPLICATE" priors (#623 A).
-// verdict_label is one of "KNOWN_PRIOR" / "VERIFIED_NEW"; the routing to
-// formulator:learned_known_topics vs formulator:learned_successful_topics
-// happens here. Window is env AUDITOR_FEEDBACK_WINDOW (default 50).
-// Modelled on explorer.ag::_push_settled_exploration.
+// verdict_label is one of "KNOWN_PRIOR" / "VERIFIED_NEW" / "VERIFIED_BY_LEAN";
+// the routing to formulator:learned_known_topics vs
+// formulator:learned_successful_topics happens here. VERIFIED_BY_LEAN
+// (#745) is treated as a successful-topic signal alongside VERIFIED_NEW
+// so a Lean-verified novel claim still biases formulator topic selection.
+// Window is env AUDITOR_FEEDBACK_WINDOW (default 50). Modelled on
+// explorer.ag::_push_settled_exploration.
 fn _push_topic_feedback(
     verdict_label: string,
     topic: string,
@@ -185,7 +188,11 @@ fn _push_topic_feedback(
         if verdict_label == "VERIFIED_NEW" {
             "formulator:learned_successful_topics";
         } else {
-            "";
+            if verdict_label == "VERIFIED_BY_LEAN" {
+                "formulator:learned_successful_topics";
+            } else {
+                "";
+            };
         };
     };
     if len(buf_key) == 0 { return; };
@@ -305,8 +312,15 @@ fn _publish_auditor(
         // probing claim-auditor's run dir (#638). tick_idx is the
         // current orchestrator tick where the auditor fires; the
         // preprint colonies consume `claim:*:tick-N` with N = their
-        // own current_tick at the next advance.
-        if verdict.audit_verdict == "VERIFIED_NEW" {
+        // own current_tick at the next advance. #745: VERIFIED_BY_LEAN
+        // is included as a downstream-eligible verdict so Lean-verified
+        // novel claims still reach the preprint pipeline.
+        let claim_seed_eligible = if verdict.audit_verdict == "VERIFIED_NEW" {
+            true;
+        } else {
+            verdict.audit_verdict == "VERIFIED_BY_LEAN";
+        };
+        if claim_seed_eligible {
             let tick_s = to_string(tick_idx);
             memo_write("claim:audit_reasoning:tick-" + tick_s, verdict.reasoning);
             memo_write("claim:audit_evidence_arxiv:tick-" + tick_s, verdict.evidence_arxiv);
@@ -320,12 +334,21 @@ fn _publish_auditor(
             memo_write("claim:report_prior_advocate:tick-" + tick_s, prior_advocate_report);
         };
 
-        // Audit -> formulator feedback (#623 A). For KNOWN_PRIOR and
-        // VERIFIED_NEW verdicts, append a rolling-buffer entry the
-        // formulator reads next tick to bias topic selection. Topic
-        // descriptor fallback chain: explorer:<pid>:topic:tick-<upstream>
+        // Audit -> formulator feedback (#623 A). For KNOWN_PRIOR,
+        // VERIFIED_NEW, and VERIFIED_BY_LEAN (#745) verdicts, append a
+        // rolling-buffer entry the formulator reads next tick to bias
+        // topic selection. Topic descriptor fallback chain:
+        // explorer:<pid>:topic:tick-<upstream>
         // -> replay:current_topic -> verdict.problem_summary.
-        let feedback_eligible = if verdict.audit_verdict == "KNOWN_PRIOR" { true; } else { verdict.audit_verdict == "VERIFIED_NEW"; };
+        let feedback_eligible = if verdict.audit_verdict == "KNOWN_PRIOR" {
+            true;
+        } else {
+            if verdict.audit_verdict == "VERIFIED_NEW" {
+                true;
+            } else {
+                verdict.audit_verdict == "VERIFIED_BY_LEAN";
+            };
+        };
         if feedback_eligible {
             // Phase 9 PR-A (#663): tick-keyed fan-in picker replaces the
             // replica-unsafe `recall_latest("replay:current_explorer_pid")`
@@ -467,6 +490,15 @@ fn tick(reason: string) -> void {
     let prior_advocate_report = _pick_upstream_by_confidence("prior_advocate", "report", "report", "confidence", upstream_tick);
     let prior_advocate_is_prior = _pick_upstream_by_confidence("prior_advocate", "report", "is_prior", "confidence", upstream_tick);
 
+    // #745: fan-in the theorist's Lean 4 formal-verification verdict.
+    // upstream_tick is `tick_idx - 2`; theorist runs on upstream_tick
+    // and persists its lean_verdict at the same key. Empty value when
+    // the theorist did not run (e.g. first 2 ticks of a run) -- fed
+    // verbatim to the prompt context so the LLM can treat it as "no
+    // Lean signal" rather than collapse it into VERIFIED_NEW.
+    let theorist_lean_verdict_raw = _pick_upstream_by_confidence("theorist", "lean_verdict", "lean_verdict", "", upstream_tick);
+    let theorist_lean_verdict = if len(theorist_lean_verdict_raw) > 0 { theorist_lean_verdict_raw; } else { "empty"; };
+
     let any_report = if len(arxiv_report) > 0 { true; } else { if len(oeis_report) > 0 { true; } else { if len(groupprops_report) > 0 { true; } else { if len(scholar_report) > 0 { true; } else { len(prior_advocate_report) > 0; }; }; }; };
     if !any_report {
         print("[auditor] no searcher reports for tick=", upstream_tick);
@@ -494,6 +526,7 @@ fn tick(reason: string) -> void {
             + "GROUPPROPS REPORT: " + groupprops_report + "\n"
             + "SCHOLAR REPORT: " + scholar_report + "\n"
             + "PRIOR ADVOCATE REPORT (is_prior=" + prior_advocate_is_prior + "): " + prior_advocate_report + "\n"
+            + "THEORIST LEAN VERDICT: " + theorist_lean_verdict + "\n"
             + "RECENT HITL REJECTS: " + hitl_summary + "\n";
 
     _dump_ctx_to_memo("auditor", _self_pid, tick_idx, ctx);

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -26,6 +26,16 @@ type Draft {
     rationale: string
 }
 
+// #745: Lean4 proof source emitted alongside main_tex. The LLM is
+// asked to render the same theorem in Lean 4 syntax; an empty body
+// (e.g. `:= by sorry`) is acceptable -- the checker reports
+// `incomplete` rather than `failed` so downstream auditors can
+// distinguish "no proof attempted" from "proof rejected by lean".
+type LeanDraft {
+    lean_source: string,
+    rationale: string
+}
+
 fn get_confidence() -> float {
     let raw = recall_latest("theorist:confidence");
     if len(raw) > 0 {
@@ -60,6 +70,66 @@ fn _jitter_sleep() -> int {
 
 fn _draft_prompt() -> string {
     return "You are a research mathematician drafting the body of a preprint. The user-supplied context carries PROBLEM, ANSWER, NOVELTY CLAIM, the upstream EXPLORER CODE and OUTPUT that produced the observation, and the AUDITOR REASONING. Produce: (1) Section 2 in LaTeX with `\\section{Preliminaries}` containing the definitions and notation needed to state the result precisely (use `amsthm` definition environment `\\begin{definition}...\\end{definition}` where appropriate). (2) Section 3 in LaTeX with `\\section{Main Result}` containing the precise statement inside `\\begin{theorem}...\\end{theorem}` or `\\begin{proposition}...\\end{proposition}` for observational claims, followed by either a `\\begin{proof}...\\end{proof}` block (proof_kind=\"sketch\" or \"full\") OR a description of the computational experiment (proof_kind=\"computational\"). Set hedge_required=true when the upstream evidence is purely computational and no analytic proof is being offered. Set proof_kind=\"computational\" in that case and use phrases like 'computational evidence suggests' rather than 'we prove'. Do NOT invent values not present in the explorer output. Output ONLY valid JSON: {\"definitions_tex\":\"...\",\"main_tex\":\"...\",\"proof_kind\":\"computational|sketch|full\",\"hedge_required\":true,\"rationale\":\"one-line\"}.";
+}
+
+// #745: Lean 4 verifier wiring. The theorist asks the LLM to translate
+// the LaTeX theorem statement (and proof body when proof_kind != "computational")
+// into Lean 4 source. The container's `lean` binary (installed via
+// elan in Containerfile.research) then runs the file. Output classes:
+//   - "verified"  : lean exited clean, no `sorry`, no `error:`
+//   - "incomplete": lean exited clean but body contained `sorry`
+//   - "failed"    : lean reported `error:` or timed out
+// Most LLM-generated proofs will land in "failed" -- that is the
+// desired signal; even a "failed" result is informative for auditor +
+// adaptive engine. The verifier is NEVER terminal -- theorist still
+// emits LaTeX even on lean failure.
+fn _lean_prompt() -> string {
+    return "You are translating a LaTeX theorem statement (and its proof body when an analytic proof is offered) into Lean 4 source. Produce a single self-contained Lean 4 file: import nothing beyond the core library (NO `import Mathlib`; the container ships stock Lean 4 without mathlib for image-size reasons). State the theorem with `theorem T : <prop> := <proof>` or `theorem T : <prop> := by <tactic_block>`. If the upstream proof body is a sketch / computational and you cannot produce a closed tactic proof from it, leave the body as `:= by sorry` -- that is acceptable and informative (it surfaces as `lean_verdict=incomplete`). Do NOT invent definitions; if the theorem references an undefined symbol, fall back to a Prop placeholder (`theorem T : True := trivial`). Output ONLY valid JSON: {\"lean_source\":\"<entire .lean file contents>\",\"rationale\":\"one-line description of what you translated\"}. Do NOT wrap output in markdown code fences.";
+}
+
+// _run_lean_check -- writes lean_source to a per-tick file under
+// $AGENTIS_ROOT/sandbox (mirrors computer.ag::_publish_computer
+// sandbox convention) and runs `lean` against it. Returns the
+// stringified verdict {verified, incomplete, failed}. 30s wall clock
+// cap via `timeout` keeps a runaway elaborator from blocking the tick.
+// Bypassable for tests via THEORIST_LEAN_DISABLED=1.
+fn _run_lean_check(self_pid: string, upstream_tick: int, lean_source: string) -> string {
+    let disabled = try { exec sh "printenv THEORIST_LEAN_DISABLED"; } catch e { ""; };
+    if disabled == "1" { return "failed"; };
+    if len(lean_source) == 0 { return "failed"; };
+
+    let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
+    let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
+    let lean_path = sandbox_eff + "/theorist-" + self_pid + "-tick-" + to_string(upstream_tick) + ".lean";
+
+    // colony-lint: safe-exec-concat
+    let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(lean_source) + " > " + shell_escape(lean_path);
+    let _wrote = try { exec sh write_cmd; } catch e { ""; };
+
+    let timeout_env = try { exec sh "printenv THEORIST_LEAN_TIMEOUT_SEC"; } catch e { ""; };
+    let timeout_s = if len(timeout_env) > 0 { timeout_env; } else { "30"; };
+
+    // colony-lint: safe-exec-concat
+    let run_cmd = "timeout " + shell_escape(timeout_s) + " lean " + shell_escape(lean_path) + " 2>&1; echo \"__lean_exit=$?__\"";
+    let run_output = try { exec sh run_cmd; } catch e { "__lean_exit=124__"; };
+
+    // colony-lint: safe-exec-concat
+    let has_error_cmd = "printf '%s' " + shell_escape(run_output) + " | grep -F 'error:' >/dev/null 2>&1 && printf yes || printf no";
+    let has_error = try { exec sh has_error_cmd; } catch e { "yes"; };
+
+    // colony-lint: safe-exec-concat
+    let timed_out_cmd = "printf '%s' " + shell_escape(run_output) + " | grep -F '__lean_exit=124__' >/dev/null 2>&1 && printf yes || printf no";
+    let timed_out = try { exec sh timed_out_cmd; } catch e { "no"; };
+
+    if has_error == "yes" { return "failed"; };
+    if timed_out == "yes" { return "failed"; };
+
+    // colony-lint: safe-exec-concat
+    let has_sorry_cmd = "printf '%s' " + shell_escape(lean_source) + " | grep -F 'sorry' >/dev/null 2>&1 && printf yes || printf no";
+    let has_sorry = try { exec sh has_sorry_cmd; } catch e { "yes"; };
+
+    if has_sorry == "yes" { return "incomplete"; };
+    return "verified";
 }
 
 // Phase 9 PR-C (#663): variant + specialty overlays.
@@ -145,11 +215,15 @@ fn select_replication_target() -> string {
 
 // _publish_theorist -- memo + emit (+ replicate when do_replicate=true).
 // Phase 9 PR-C (#663) added the M2-Malthusian replicate path; +1
-// fitness per successful draft (PR-D will refine).
+// fitness per successful draft (PR-D will refine). #745 added the
+// lean_verdict + lean_source memo writes alongside the existing
+// LaTeX outputs.
 fn _publish_theorist(
     final_write: bool,
     do_replicate: bool,
     draft: Draft,
+    lean_source: string,
+    lean_verdict: string,
     self_pid: string,
     _colony_name: string,
     upstream_tick: int,
@@ -163,6 +237,12 @@ fn _publish_theorist(
     memo_write("theorist:" + self_pid + ":proof_kind:tick-" + to_string(upstream_tick), draft.proof_kind);
     let hedge_str = if draft.hedge_required { "true"; } else { "false"; };
     memo_write("theorist:" + self_pid + ":hedge_required:tick-" + to_string(upstream_tick), hedge_str);
+    // #745: per-tick Lean verifier outcome fan-in keys consumed by
+    // auditor's _pick_upstream_by_confidence("theorist", "lean_verdict",
+    // ...). lean_source is persisted alongside for replay / debugging;
+    // never the terminal artefact (latexmk still consumes main_tex).
+    memo_write("theorist:" + self_pid + ":lean_source:tick-" + to_string(upstream_tick), lean_source);
+    memo_write("theorist:" + self_pid + ":lean_verdict:tick-" + to_string(upstream_tick), lean_verdict);
     memo_write("replay:current_theorist_pid", self_pid);
 
     emit("theorist:main_ready", draft);
@@ -320,25 +400,52 @@ fn tick(reason: string) -> void {
 
     let draft = prompt(_draft_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> Draft;
 
+    // #745: Lean 4 formal verification. The LLM is asked to render the
+    // theorem (and proof body for sketch/full kinds) in Lean 4; the
+    // container's lean binary then checks it. Non-terminal: even on
+    // failure the LaTeX body is still published below. Outcome
+    // {verified, incomplete, failed} is memo'd for the auditor's
+    // fan-in picker and is folded into the experience ledger via
+    // learn("lean_check", ...).
+    let lean_ctx = "PROOF KIND: " + draft.proof_kind + "\n"
+                 + "DEFINITIONS LATEX:\n" + draft.definitions_tex + "\n"
+                 + "MAIN LATEX:\n" + draft.main_tex + "\n";
+    let lean_draft = prompt(_lean_prompt(), lean_ctx) -> LeanDraft;
+    let lean_verdict = _run_lean_check(_self_pid, upstream_tick, lean_draft.lean_source);
+    print("[theorist] lean_verdict=", lean_verdict, " proof_kind=", draft.proof_kind);
+    // Branch on lean_verdict so check-learn-tags.sh sees a static
+    // outcome literal at each call site (lean_check:verified /
+    // lean_check:incomplete / lean_check:failed). One row per tick
+    // regardless of branch.
+    if lean_verdict == "verified" {
+        learn("lean_check", "tick " + to_string(tick_idx), "verified", "verified", ["lean", "verification"]);
+    } else {
+        if lean_verdict == "incomplete" {
+            learn("lean_check", "tick " + to_string(tick_idx), "incomplete", "incomplete", ["lean", "verification"]);
+        } else {
+            learn("lean_check", "tick " + to_string(tick_idx), "failed", "failed", ["lean", "verification"]);
+        };
+    };
+
     let my_tier = tier("theorist");
     if my_tier == "autonomous" {
         memo_write("theorist:" + _self_pid + ":review_gated", "true");
         learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["acted", "preprint-foundry"]);
         // #740: feed the AdaptiveEngine the chosen proof_kind on the same tier path.
         learn("proof_approach", draft.proof_kind, "tick " + to_string(tick_idx), "success", ["acted", "preprint-foundry"]);
-        _publish_theorist(true, true, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+        _publish_theorist(true, true, draft, lean_draft.lean_source, lean_verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
     } else {
         if my_tier == "review-gated" {
             memo_write("theorist:" + _self_pid + ":review_gated", "true");
             learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["review-gated", "preprint-foundry"]);
             // #740: feed the AdaptiveEngine the chosen proof_kind on the same tier path.
             learn("proof_approach", draft.proof_kind, "tick " + to_string(tick_idx), "partial", ["review-gated", "preprint-foundry"]);
-            _publish_theorist(true, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+            _publish_theorist(true, false, draft, lean_draft.lean_source, lean_verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
         } else {
             if my_tier == "propose" {
                 // #740: feed the AdaptiveEngine the chosen proof_kind on the same tier path.
                 learn("proof_approach", draft.proof_kind, "tick " + to_string(tick_idx), "partial", ["emitted", "preprint-foundry"]);
-                _publish_theorist(false, false, draft, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+                _publish_theorist(false, false, draft, lean_draft.lean_source, lean_verdict, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
             } else {
                 print("[theorist] observing (tier:", my_tier, ") rationale=", draft.rationale);
                 learn("theorise", "tick " + to_string(tick_idx), draft.rationale, "partial", ["observed", "preprint-foundry"]);

--- a/research-foundry/tools/Containerfile.research
+++ b/research-foundry/tools/Containerfile.research
@@ -81,6 +81,19 @@ RUN cd /tmp \
 RUN curl -fsSL https://claude.ai/install.sh | bash \
  && ln -s /root/.local/bin/claude /usr/local/bin/claude
 
+# Lean 4 toolchain for first-class proof verification in theorist.ag
+# (#745). Uses elan (Lean version manager) with a pinned toolchain so
+# the image is reproducible across rebuilds. Image bloat: ~1.5 GB per
+# the #745 forensic. Most LLM-generated proofs will FAIL the formal
+# check — that is the desired signal; verified / failed / incomplete
+# are all informative. theorist.ag treats the check as non-terminal
+# and still emits the LaTeX body regardless of outcome.
+ARG LEAN_TOOLCHAIN=leanprover/lean4:v4.13.0
+RUN curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+        | sh -s -- -y --default-toolchain "${LEAN_TOOLCHAIN}"
+ENV PATH="/root/.elan/bin:${PATH}"
+RUN lean --version
+
 WORKDIR /run-root
 
 ENTRYPOINT ["/bin/bash"]

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -411,6 +411,67 @@ assert_contains "28d. ed25519 identity key bootstrap line emitted" "$SRC" \
 assert_contains "28e. chmod 600 on identity private key emitted" "$SRC" \
     'chmod 600 /run-root/.agentis/identity/private.key'
 
+# ---------------------------------------------------------------------------
+# 29. #745: Lean 4 verifier integration.
+#   - Containerfile.research installs Lean via elan + pinned toolchain
+#   - theorist.ag emits .lean source and runs `lean` per tick
+#   - auditor.ag fans in lean_verdict and extends its verdict-label
+#     enum to include VERIFIED_BY_LEAN
+# ---------------------------------------------------------------------------
+CFILE_PATH="$(cd "$SCRIPT_DIR" && pwd)/Containerfile.research"
+THE_AG_PATH="$(cd "$SCRIPT_DIR/.." && pwd)/theorist/agents/theorist.ag"
+AUD_AG_PATH="$(cd "$SCRIPT_DIR/.." && pwd)/auditor/agents/auditor.ag"
+CFILE_SRC="$(cat "$CFILE_PATH")"
+THE_AG_SRC="$(cat "$THE_AG_PATH")"
+AUD_AG_SRC="$(cat "$AUD_AG_PATH")"
+
+assert_contains "29a. Containerfile.research declares LEAN_TOOLCHAIN ARG" "$CFILE_SRC" \
+    "ARG LEAN_TOOLCHAIN=leanprover/lean4:"
+assert_contains "29b. Containerfile.research installs elan via elan-init.sh" "$CFILE_SRC" \
+    "elan/master/elan-init.sh"
+assert_contains "29c. Containerfile.research exports /root/.elan/bin in PATH" "$CFILE_SRC" \
+    'ENV PATH="/root/.elan/bin:${PATH}"'
+assert_contains "29d. Containerfile.research runs lean --version smoke test" "$CFILE_SRC" \
+    "RUN lean --version"
+
+assert_contains "29e. theorist.ag declares LeanDraft type" "$THE_AG_SRC" \
+    "type LeanDraft"
+assert_contains "29f. theorist.ag has _lean_prompt helper" "$THE_AG_SRC" \
+    "fn _lean_prompt() -> string"
+assert_contains "29g. theorist.ag has _run_lean_check helper" "$THE_AG_SRC" \
+    "fn _run_lean_check"
+assert_contains "29h. theorist.ag invokes lean binary via exec sh" "$THE_AG_SRC" \
+    '"timeout " + shell_escape(timeout_s) + " lean "'
+assert_contains "29i. theorist.ag writes lean_verdict memo key" "$THE_AG_SRC" \
+    '":lean_verdict:tick-"'
+assert_contains "29j. theorist.ag writes lean_source memo key" "$THE_AG_SRC" \
+    '":lean_source:tick-"'
+assert_contains "29k. theorist.ag emits learn(lean_check, ...)" "$THE_AG_SRC" \
+    'learn("lean_check"'
+assert_contains "29l. theorist.ag honors THEORIST_LEAN_DISABLED bypass" "$THE_AG_SRC" \
+    "THEORIST_LEAN_DISABLED"
+assert_contains "29m. theorist.ag honors THEORIST_LEAN_TIMEOUT_SEC override" "$THE_AG_SRC" \
+    "THEORIST_LEAN_TIMEOUT_SEC"
+
+assert_contains "29n. auditor.ag _seed_prompt names VERIFIED_BY_LEAN" "$AUD_AG_SRC" \
+    "VERIFIED_BY_LEAN"
+assert_contains "29o. auditor.ag fans in theorist lean_verdict via picker" "$AUD_AG_SRC" \
+    '_pick_upstream_by_confidence("theorist", "lean_verdict", "lean_verdict", ""'
+assert_contains "29p. auditor.ag ctx names THEORIST LEAN VERDICT" "$AUD_AG_SRC" \
+    "THEORIST LEAN VERDICT:"
+
+# ---------------------------------------------------------------------------
+# 30. #745: check-learn-tags.sh schema extension for lean_check topic.
+# ---------------------------------------------------------------------------
+LEARN_TAGS_PATH="$(cd "$SCRIPT_DIR/../.." && pwd)/tools/check-learn-tags.sh"
+LEARN_TAGS_SRC="$(cat "$LEARN_TAGS_PATH")"
+assert_contains "30a. check-learn-tags.sh schema covers lean_check:verified" "$LEARN_TAGS_SRC" \
+    '"lean_check:verified")'
+assert_contains "30b. check-learn-tags.sh schema covers lean_check:incomplete" "$LEARN_TAGS_SRC" \
+    '"lean_check:incomplete")'
+assert_contains "30c. check-learn-tags.sh schema covers lean_check:failed" "$LEARN_TAGS_SRC" \
+    '"lean_check:failed")'
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/check-learn-tags.sh
+++ b/tools/check-learn-tags.sh
@@ -589,6 +589,30 @@ observed
 preprint-foundry"
             PAIR_KNOWN=1
             ;;
+        # #745: Lean 4 verifier activation in research-foundry/theorist.
+        # The theorist runs `lean <file>` against an LLM-rendered Lean
+        # source body and emits one of three learn() rows per tick:
+        #   verified  : closed proof accepted by lean, no `sorry`
+        #   incomplete: lean accepted file but body contained `sorry`
+        #   failed    : lean rejected file (timeout or `error:`)
+        # The outcome doubles as the fitness signal for the
+        # AdaptiveEngine + downstream auditor's VERIFIED_BY_LEAN
+        # verdict label.
+        "lean_check:verified")
+            ALLOWED_LITERALS="lean
+verification"
+            PAIR_KNOWN=1
+            ;;
+        "lean_check:incomplete")
+            ALLOWED_LITERALS="lean
+verification"
+            PAIR_KNOWN=1
+            ;;
+        "lean_check:failed")
+            ALLOWED_LITERALS="lean
+verification"
+            PAIR_KNOWN=1
+            ;;
         "compute:partial")
             ALLOWED_LITERALS="acted
 review-gated


### PR DESCRIPTION
## Summary
- Adds Lean 4 toolchain (elan + pinned `leanprover/lean4:v4.13.0`) to `research-foundry/tools/Containerfile.research` so theorist.ag can formally check generated proofs at tick time. Image bloat ~1.5 GB (1.24 GB -> ~2.7 GB acceptable).
- theorist.ag emits `.lean` alongside the existing `.tex` proof body, runs `lean <file>` with a 30s `timeout` cap, and writes `theorist:<pid>:lean_verdict:tick-N` memo with `{verified, incomplete, failed}`. Non-terminal -- even on lean failure the LaTeX is still published.
- auditor.ag fans in the lean_verdict via `_pick_upstream_by_confidence("theorist", "lean_verdict", ...)` and extends its verdict-label enum to `{VERIFIED_NEW, VERIFIED_BY_LEAN, KNOWN_PRIOR, NEEDS_HUMAN}`.

## Why
Epic #738 child P2. Supersedes deferred #627. Today the auditor relies on literature search alone — no formal proof check. This PR wires Lean 4 (via elan) into the container so theorist.ag emits `.lean` alongside `.tex` and verifies the proof body. Most LLM-generated proofs will FAIL the formal check — that is the desired signal, not a bug. `incomplete` (proof contains `sorry`) vs `failed` (real error) vs `verified` (closed proof accepted) gives the auditor and the AdaptiveEngine a richer signal than the current literature-only verdict.

## Scope
- Containerfile.research: +13 LOC (elan install + PATH + smoke test)
- theorist.ag: +110 LOC (`LeanDraft` type, `_lean_prompt`, `_run_lean_check`, per-tick lean call, branched `learn(lean_check, ...)`, plumbing into `_publish_theorist`)
- auditor.ag: +12 LOC (verdict-label enum extension, lean_verdict fan-in, ctx line)
- check-learn-tags.sh: +24 LOC (schema for `lean_check:verified|incomplete|failed`)
- test-run-research.sh: +61 LOC (19 new assertions covering all three .ag/Containerfile/schema layers)

Total: ~220 LOC inserted across 5 files.

## Out of scope (deferred follow-up)
- Item 4 of #745 acceptance (block autonomous submitter unless `lean_verdict == verified`). Submitter HITL gate is currently keyed on `reviewer:<claim>:approved`, NOT on `audit_verdict`. Flipping the submitter to gate on lean is a structural change worth its own SDLC cycle.
- Coq alternative.
- Full Lean colony with multiple verification agents.

## Image bloat
~1.5 GB added (elan + Lean 4 toolchain, no mathlib). Container size 1.24 GB -> ~2.7 GB. CI doesn't build the container — operator validates manually post-merge with `podman build`.

## Runtime knobs
- `LEAN_TOOLCHAIN` build arg (default `leanprover/lean4:v4.13.0`) — pin toolchain version at image build time.
- `THEORIST_LEAN_TIMEOUT_SEC` runtime env (default `30`) — wall-clock cap per lean invocation.
- `THEORIST_LEAN_DISABLED=1` runtime env — bypass lean (returns `failed` without invoking the binary; for tests and replays).

## Test plan
- [x] `tools/colony-lint.sh` clean (344 passed, 0 failed, 4 skipped — matches baseline)
- [x] `research-foundry/tools/test-run-research.sh` clean (162 passed, 0 failed — 19 new assertions for #745)
- [x] `tools/check-learn-tags.sh` clean (lean_check schema extended)
- [ ] CI green (note: CI doesn't build container — operator validates manually post-merge with `podman build`)
- [ ] Manual smoke: rebuild image, spawn 1-tick run, verify `lean --version` in container + see one `lean_check` learn() row in `events.jsonl`

Closes #745

Generated with [Claude Code](https://claude.com/claude-code)