### PR TITLE
feat(research-foundry): wire in-container agentis worker for replicate() (#744)

### DIFF
--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -191,10 +191,11 @@
 #                                Per-pid fitness threshold above which the
 #                                replicate gate fires (memo key
 #                                explorer:reproductive_fitness_threshold).
-#                                Default 3 (#679: lowered from 10 so the
-#                                gate fires within the default 30-tick
-#                                run, engaging birth/death lifecycle
-#                                without operator opt-in).
+#                                Default 2 (#744: lowered from 3 so the
+#                                autonomous-tier gate is reachable in the
+#                                75-tick research run; #679 had already
+#                                lowered it from 10 so the gate fires
+#                                within the default tick budget).
 #   RESEARCH_CULL_ENABLED        1 enable Phase 3 PR 3 cull cycle, 0
 #                                disable. Default 1 (#679: lifecycle on
 #                                by default so the 30-tick default run
@@ -381,7 +382,7 @@ SMTP_PORT="${RESEARCH_SMTP_PORT:-25}"
 : "${RESEARCH_EXPLORER_REPLICAS:=5}"
 : "${RESEARCH_EXPLORER_MAX_REPLICAS:=8}"
 : "${RESEARCH_EXPLORER_POOL:=5000}"
-: "${RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
+: "${RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD:=2}"
 
 # Phase 9 PR-B (#663): per-colony replica + pool seeds for the 17
 # non-explorer colonies. All default to 1 so PR-B does NOT change the
@@ -600,6 +601,16 @@ emit_step "latexmk max passes: $LATEXMK_MAX_PASSES"
 emit_step "image tag: $IMAGE_TAG"
 emit_step "arxiv gateway: $ARXIV_GATEWAY (HITL-gated; never auto-sent)"
 emit_step "author config: $AUTHOR_CONFIG"
+# Phase 9 M106 (#744): the in-container agentis worker is the MSG_REPLICATE
+# target for replicate(target_r, my_fit_r, variant_wrapped). Without a
+# listener on 127.0.0.1:9100 every replicate() call NAKs (returns ""), the
+# replication ledger stays empty, and the M106 variant inheritance feature
+# never engages. The worker launches inside bootstrap.sh after `agentis init`
+# and before the daemons spawn; math-foundry:worker_addr +
+# math-foundry:peer_worker_count are seeded so select_replication_target()
+# resolves instead of falling back to the unreachable self_node_addr().
+emit_step "launching agentis worker on 127.0.0.1:9100 for in-container replication"
+emit_step "seeding math-foundry:worker_addr + peer_worker_count for replicate() targets"
 
 # --- 1) Build (or reuse) the container image ---
 build_image() {
@@ -924,6 +935,33 @@ write_bootstrap() {
         printf '(cd /run-root && agentis memo set colony-submitter:replication_base_cost 100 >/dev/null 2>&1 || true)\n'
         printf '(cd /run-root && agentis memo set colony-submitter:replication_k 3 >/dev/null 2>&1 || true)\n'
         printf '(cd /run-root && agentis memo set submitter:reproductive_fitness_threshold %s >/dev/null 2>&1 || true)\n' "$RESEARCH_SUBMITTER_REPRODUCTIVE_FITNESS_THRESHOLD"
+        # Phase 9 M106 (#744): launch the in-container agentis worker and
+        # seed math-foundry:worker_addr + peer_worker_count so the
+        # M2-Malthusian replicate() target pointer resolves. Before this
+        # block landed, explorer.ag (and the 17 other colonies with the
+        # M2-Malthusian replicate gate) called
+        # replicate(target_r, my_fit_r, variant_wrapped) on every
+        # autonomous-tier tick that cleared the fitness + colony-size +
+        # pool gates -- but the call returned "" because
+        # select_replication_target() resolved to the unreachable
+        # self_node_addr() (127.0.0.1:9100 with no listener), so every
+        # call NAK'd and the M106 variant inheritance feature never
+        # engaged. Pattern mirrors tribes-bench/start-federation.sh
+        # L65-94 (setsid + readiness probe + memo seeds). The container
+        # tears down the worker via `podman stop` (the orchestrator
+        # cleanup trap), so no separate kill is needed.
+        printf '# --- agentis worker (in-container MSG_REPLICATE target) ---\n'
+        printf 'mkdir -p /run-root/.agentis/log\n'
+        printf 'setsid agentis worker 127.0.0.1:9100 --max-concurrent 8 > /run-root/.agentis/log/worker.log 2>&1 &\n'
+        printf 'WORKER_PID=$!\n'
+        printf 'for i in 1 2 3 4 5 6 7 8 9 10; do\n'
+        printf '    if (echo > /dev/tcp/127.0.0.1/9100) 2>/dev/null; then break; fi\n'
+        printf '    sleep 0.5\n'
+        printf 'done\n'
+        printf 'echo "agentis worker pid=$WORKER_PID listening on 127.0.0.1:9100"\n'
+        printf '(cd /run-root && agentis memo set math-foundry:worker_addr 127.0.0.1:9100 >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set math-foundry:peer_worker_count 1 >/dev/null 2>&1 || true)\n'
+        printf '(cd /run-root && agentis memo set math-foundry:peer_worker_addr:0 127.0.0.1:9100 >/dev/null 2>&1 || true)\n'
         # math pipeline: explorer (with replication) + noticer/formulator/verifier/novelty.
         # Phase 3 PR 1 (#624): spawn RESEARCH_EXPLORER_REPLICAS explorers
         # (default 5) each carrying a distinct DAEMON_ID used by the .ag
@@ -1078,6 +1116,12 @@ write_bootstrap() {
             "$RESEARCH_SUBMITTER_CLAUDE_MODEL" "$ARXIV_GATEWAY" "$ARXIV_FROM" "$SMTP_HOST" "$SMTP_PORT"
         printf 'done\n'
         printf 'while [ ! -e /run-root/.shutdown ]; do sleep 5; done\n'
+        # M106 (#744): kill the in-container agentis worker so the
+        # container exits cleanly. `podman stop --time 5` from the host
+        # trap covers the SIGKILL fallback, but a clean SIGTERM ordering
+        # avoids racing pending MSG_REPLICATE handshakes against a
+        # half-shutdown daemon set.
+        printf 'if [ -n "${WORKER_PID:-}" ]; then kill "$WORKER_PID" 2>/dev/null || true; fi\n'
         printf 'exit 0\n'
     } >"$bootstrap_path"
     chmod +x "$bootstrap_path"

--- a/research-foundry/tools/test-replicate-gates.sh
+++ b/research-foundry/tools/test-replicate-gates.sh
@@ -130,6 +130,38 @@ for c in "${NON_EXPLORER[@]}"; do
     fi
 done
 
+# (f) #744: run-research.sh wires the in-container agentis worker +
+# math-foundry:worker_addr memo seed so the M2-Malthusian replicate()
+# call site has a valid MSG_REPLICATE target. Without this wiring,
+# select_replication_target() falls back to the unreachable
+# self_node_addr() (127.0.0.1:9100 with no listener), every replicate()
+# call NAKs (returns ""), and the M106 variant inheritance feature
+# never engages -- so the .ag-level replicate path tested by (b/e)
+# above is dead code in production. Guard the orchestrator wiring
+# here so the .ag and orchestrator assertions evolve together.
+RUN_RESEARCH_SH="$FED_DIR/tools/run-research.sh"
+if [ ! -f "$RUN_RESEARCH_SH" ]; then
+    fail "(f) run-research.sh wires worker_addr memo for replicate() targets" \
+         "$RUN_RESEARCH_SH not found"
+else
+    RUN_RESEARCH_SRC="$(cat "$RUN_RESEARCH_SH")"
+    missing=""
+    printf '%s' "$RUN_RESEARCH_SRC" | grep -Fq -- "setsid agentis worker 127.0.0.1:9100" || \
+        missing="$missing worker-launch"
+    printf '%s' "$RUN_RESEARCH_SRC" | grep -Fq -- "agentis memo set math-foundry:worker_addr 127.0.0.1:9100" || \
+        missing="$missing worker_addr-memo-seed"
+    printf '%s' "$RUN_RESEARCH_SRC" | grep -Fq -- "agentis memo set math-foundry:peer_worker_count 1" || \
+        missing="$missing peer_worker_count-memo-seed"
+    if [ -z "$missing" ]; then
+        pass "(f) run-research.sh wires worker_addr memo for replicate() targets"
+    else
+        fail "(f) run-research.sh wires worker_addr memo for replicate() targets" \
+             "missing:$missing"
+    fi
+    unset RUN_RESEARCH_SRC missing
+fi
+unset RUN_RESEARCH_SH
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
 [ "$FAIL" -eq 0 ]

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -272,7 +272,9 @@ assert_contains "22d. RESEARCH_CULL_MIN_ACTING defaults to 3" "$SRC" \
     "CULL_MIN_ACTING=\"\${RESEARCH_CULL_MIN_ACTING:-3}\""
 assert_contains "22e. CULL_MIN_EXPLORERS floor protection unchanged at 3" "$SRC" \
     "CULL_MIN_EXPLORERS=\"\${RESEARCH_CULL_MIN_EXPLORERS:-3}\""
-for c in EXPLORER NOTICER SKEPTIC FORMULATOR VERIFIER NOVELTY \
+# #744: EXPLORER threshold default lowered 3 -> 2 (asserted by 32f below).
+# The remaining 17 colonies keep default 3 until follow-up tuning lowers them.
+for c in NOTICER SKEPTIC FORMULATOR VERIFIER NOVELTY \
          ARXIV_SEARCH OEIS_SEARCH GROUPPROPS_SEARCH SCHOLAR_SEARCH \
          AUDITOR PRIOR_ADVOCATE INTRODUCER THEORIST COMPUTER \
          EDITOR REVIEWER SUBMITTER; do
@@ -526,6 +528,33 @@ assert_contains "31o. theorist.ag emits learn(\"taskboard\", ..., \"success\") f
     'learn("taskboard", "accept prove_modular_identity"'
 assert_contains "31p. theorist.ag emits learn(\"taskboard\", ..., \"success\") for completed tag" "$TB_THE_AG_SRC" \
     'learn("taskboard", "complete prove_modular_identity"'
+
+# ---------------------------------------------------------------------------
+# 32. #744: in-container agentis worker wiring for M106 replicate() targets.
+#
+# explorer.ag (and 17 other colonies with the M2-Malthusian replicate gate)
+# already call replicate(target_r, my_fit_r, variant_wrapped) on every
+# autonomous-tier tick that clears the fitness + colony-size + pool gates.
+# But before this patch landed, every call NAK'd because run-research.sh
+# never launched an `agentis worker` listener and never seeded
+# math-foundry:worker_addr -- select_replication_target() fell back to the
+# unreachable self_node_addr() (127.0.0.1:9100 with no listener), so the
+# M106 variant inheritance feature never engaged. These four assertions
+# guard the wiring (emit_step at the orchestrator layer + the printf lines
+# that emit the worker launch + memo seeds into the bootstrap script).
+# ---------------------------------------------------------------------------
+assert_contains "32a. emit_step names worker launch on 127.0.0.1:9100" "$OUT" \
+    "launching agentis worker on 127.0.0.1:9100 for in-container replication"
+assert_contains "32b. emit_step names worker_addr + peer_worker_count memo seed" "$OUT" \
+    "seeding math-foundry:worker_addr + peer_worker_count for replicate() targets"
+assert_contains "32c. bootstrap emits setsid agentis worker launch" "$SRC" \
+    "setsid agentis worker 127.0.0.1:9100"
+assert_contains "32d. bootstrap emits math-foundry:worker_addr memo seed" "$SRC" \
+    "agentis memo set math-foundry:worker_addr 127.0.0.1:9100"
+assert_contains "32e. bootstrap emits math-foundry:peer_worker_count memo seed" "$SRC" \
+    "agentis memo set math-foundry:peer_worker_count 1"
+assert_contains "32f. RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD default lowered 3 -> 2" "$SRC" \
+    ': "${RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD:=2}"'
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- Launches agentis worker on 127.0.0.1:9100 inside the container so replicate() has a valid target
- Seeds math-foundry:worker_addr + peer_worker_count=1 memos so select_replication_target() resolves
- Lowers RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD default 3 -> 2 to make the gate reachable in 75-tick runs

## Why
Epic #738 child P1. The M106 variant inheritance feature has shipped in agentis-core since v1.7.8 and explorer.ag has called replicate() since then. But across 18+ runs zero replicate events recorded -- every call NAK'd because no worker listened on the fallback address and no worker_addr memo seeded.

## Zero .ag changes
- replicate() call site: explorer.ag (unchanged)
- M106 hash-pointer variant wrap: explorer.ag (unchanged)
- Child-side adoption path: explorer.ag (unchanged)
- Replication-ledger.jsonl writes: explorer.ag (unchanged)
- Malthusian gate (autonomous tier + fitness + size + pool): explorer.ag (unchanged)

Only `tools/run-research.sh` changes: worker launch, memo seeds, threshold default.

## Test plan
- [x] `bash -n run-research.sh`
- [x] `test-run-research.sh` (6 new assertions: 32a-32f)
- [x] `test-replicate-gates.sh` (1 new assertion: f -- worker_addr presence)
- [x] `colony-lint.sh` clean (344 passed, 0 failed, 4 skipped)
- [ ] CI green
- [ ] After merge + Run #19: `replication-ledger.jsonl` has at least one `event=replicate` row

Closes #744

Generated with [Claude Code](https://claude.com/claude-code)