### PR TITLE
fix(research-foundry): ed25519 audit key must be raw 32-byte seed not PEM (#757 smoke)

### DIFF
--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -761,15 +761,20 @@ write_bootstrap() {
         # ed25519 private key bootstrapped immediately below.
         printf 'mkdir -p /run-root/.agentis/sandbox /run-root/.agentis/logs /run-root/.agentis/audit /run-root/.agentis/identity /run-root/config /run-root/preprints /run-root/data\n'
         # #743: bootstrap ed25519 keypair for audit-chain signing.
-        # Prefer `agentis identity init` when the pinned runtime ships
-        # it; fall back to `openssl genpkey -algorithm ed25519` (always
-        # available in the research container per Containerfile.research).
+        # agentis-core expects a RAW 32-byte ed25519 seed at
+        # audit.signing_key_path. The original #743 wiring shelled out
+        # to `openssl genpkey -algorithm ed25519 -out <file>` which
+        # writes PEM-encoded PKCS8 (~119 bytes) — agentis-core rejects
+        # it with "expected 32 bytes, got 119" and every daemon crashes
+        # on boot (caught in smoke run #757 step 3).
+        #
+        # Fix: use `-outform DER` and `tail -c 32` to extract the raw
+        # seed. PKCS8 DER for ed25519 is a fixed 48-byte structure
+        # (16-byte header + 32-byte private key), so the last 32 bytes
+        # are exactly the raw seed the runtime needs.
         # chmod 600 because agentis-core #584 M2 release note flags the
-        # private key as credential-grade. The `|| true` after chmod is
-        # defensive in case `agentis identity init` writes to a
-        # different filename — the audit chain will simply fall back to
-        # unsigned rows in that case and the verify step will surface it.
-        printf 'if command -v agentis >/dev/null 2>&1 && agentis identity init >/dev/null 2>&1; then :; else openssl genpkey -algorithm ed25519 -out /run-root/.agentis/identity/private.key 2>/dev/null || true; fi\n'
+        # private key as credential-grade.
+        printf 'openssl genpkey -algorithm ed25519 -outform DER 2>/dev/null | tail -c 32 > /run-root/.agentis/identity/private.key 2>/dev/null || true\n'
         printf 'chmod 600 /run-root/.agentis/identity/private.key 2>/dev/null || true\n'
         printf 'if [ -d /repo/research-foundry/data/papers ]; then cp -r /repo/research-foundry/data/papers /run-root/data/papers; fi\n'
         printf 'if [ -f /repo/research-foundry/config/authors.toml ]; then cp /repo/research-foundry/config/authors.toml /run-root/config/authors.toml; fi\n'

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -441,8 +441,8 @@ assert_contains "28b. run-research.sh pins audit.signing_key_path" "$SRC" \
     'printf "audit.signing_key_path = .agentis/identity/private.key\\n"'
 assert_contains "28c. bootstrap mkdir extends to .agentis/audit + .agentis/identity" "$SRC" \
     '/run-root/.agentis/audit /run-root/.agentis/identity'
-assert_contains "28d. ed25519 identity key bootstrap line emitted" "$SRC" \
-    'openssl genpkey -algorithm ed25519 -out /run-root/.agentis/identity/private.key'
+assert_contains "28d. ed25519 identity key bootstrap line emits DER + tail -c 32" "$SRC" \
+    'openssl genpkey -algorithm ed25519 -outform DER 2>/dev/null | tail -c 32 > /run-root/.agentis/identity/private.key'
 assert_contains "28e. chmod 600 on identity private key emitted" "$SRC" \
     'chmod 600 /run-root/.agentis/identity/private.key'
 


### PR DESCRIPTION
## Summary
- `openssl genpkey -algorithm ed25519 -out <file>` writes PEM PKCS8 (119 bytes); agentis-core wants raw 32-byte seed → boot rejection
- Replace with `-outform DER | tail -c 32` to extract the raw seed (PKCS8 DER for ed25519 is fixed 48-byte: 16-byte header + 32-byte private key)

## Why
#757 step 3 smoke run (5 ticks × 1 daemon × 18 colonies) revealed all 18 daemons crash on boot with:
```
Error: audit.signing_key_path: Invalid signing key at .agentis/identity/private.key: expected 32 bytes, got 119
```
Watchdog retries 5×, every daemon enters failed state, no tick ever runs, no substrate call ever fires. The entire substrate-rewrite epic (#738) is silently dead in production despite all 8 child PRs landing green.

## Verification
Locally confirmed `openssl genpkey -algorithm ed25519 -outform DER | tail -c 32` produces a 32-byte file whose hex matches Python's `cryptography.Ed25519PrivateKey.private_bytes(Raw, Raw, NoEncryption())` output.

## Test plan
- [x] bash -n run-research.sh
- [x] test-run-research.sh 183/0
- [x] colony-lint 344/0/4
- [ ] CI green
- [ ] After merge + re-run #757 smoke: daemons boot OK, audit-ledger.jsonl has signed rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)