### PR TITLE
feat(research-foundry): decide() audit-guard in auditor.ag (#761)

### DIFF
--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -246,6 +246,48 @@ fn _pick_upstream_by_confidence(role: string, ranking_key: string, output_key: s
     return recall_latest(role + ":" + pid + ":" + output_key + ":tick-" + ts);
 }
 
+// _decide_verdict_guard -- #761 audit-guard. After the rich-struct
+// `prompt() -> Verdict` returns its `audit_verdict` label, run a
+// second, signed `decide()` call over the same four-label set and
+// flag disagreement on the bus. Autonomous tier only (CB=50 per call;
+// would double the per-tick LLM cost if propose/review-gated/shadow
+// engaged it too -- those tiers do not emit a final ledger row anyway
+// so the second-opinion signal is wasted budget). `decide()`
+// auto-writes a signed MC3 row to `.agentis/decisions/chain.jsonl`,
+// giving every autonomous-tier verdict a tamper-evident audit trail
+// alongside the existing `audit/actions.jsonl` chain seeded by #743.
+// On disagreement: emit `auditor:verdict_disagreement`, downgrade the
+// per-pid confidence memo by 0.05 (floor 0.4 to stay above shadow),
+// and tag the experience row "disagreement". On agreement: tag the
+// row "agreement" so the AdaptiveEngine can correlate decide() match
+// rate with downstream HItL accept rate over time.
+fn _decide_verdict_guard(verdict_label: string, claim_text: string, ctx_str: string) -> void {
+    let my_tier = tier("auditor");
+    if my_tier != "autonomous" {
+        return;
+    };
+    let options = ["VERIFIED_NEW", "VERIFIED_BY_LEAN", "KNOWN_PRIOR", "NEEDS_HUMAN"];
+    let context = "Auditor verdict for claim: " + claim_text + " | context: " + ctx_str;
+    let decide_label = try { decide(options, context); } catch e { ""; };
+    if len(decide_label) == 0 {
+        return;
+    };
+    if verdict_label != decide_label {
+        emit("auditor:verdict_disagreement",
+             "prompt=" + verdict_label + " decide=" + decide_label);
+        let curr_raw = recall_latest("auditor:confidence");
+        if len(curr_raw) > 0 {
+            let curr = parse_float(curr_raw);
+            let lowered = curr - 0.05;
+            let floored = if lowered < 0.4 { 0.4; } else { lowered; };
+            memo_write("auditor:confidence", to_string(floored));
+        };
+        learn("audit", "verdict_disagreement", "prompt=" + verdict_label + " decide=" + decide_label, "partial", ["decide-guard", "disagreement", "claim-auditor"]);
+    } else {
+        learn("audit", "verdict_agreement", "prompt=" + verdict_label + " decide=" + decide_label, "success", ["decide-guard", "agreement", "claim-auditor"]);
+    };
+}
+
 // _publish_auditor -- TERMINAL agent (Class 1). memo + emit (+ ledger
 // row when final_write=true, + replicate when do_replicate=true).
 // Autonomous and review-gated both emit the ledger row; only propose
@@ -534,6 +576,16 @@ fn tick(reason: string) -> void {
 
     let my_tier = tier("auditor");
     if my_tier == "autonomous" {
+        // #761: audit-guard. Run decide() over the same four-label set
+        // before the terminal ledger write; on disagreement emit
+        // `auditor:verdict_disagreement`, downgrade auditor:confidence
+        // by 0.05 (floor 0.4), and tag the learn() row "disagreement".
+        // Side-effect: decide() writes a signed MC3 row to
+        // .agentis/decisions/chain.jsonl for every autonomous-tier
+        // verdict (whether agreement or disagreement), adding a
+        // tamper-evident audit trail alongside #743's actions chain.
+        let claim_for_guard = if len(novelty_claim) > 0 { novelty_claim; } else { problem_text; };
+        _decide_verdict_guard(verdict.audit_verdict, claim_for_guard, ctx);
         // Terminal agent: autonomous emits the audit ledger row with
         // terminal=true (no confidence floor; emit even when verdict.confidence
         // would otherwise be below an internal floor) and stamps

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -622,6 +622,43 @@ assert_contains "32a. KB import logs to knowledge-import.log (not /dev/null)" "$
 assert_contains "32b. KB import has || true tail (non-fatal on missing/corrupt)" "$SRC" \
     '|| true'
 
+# ---------------------------------------------------------------------------
+# 34. #761: decide() audit-guard in auditor.ag. After the rich-struct
+# `prompt() -> Verdict` returns its label, the autonomous-tier branch
+# runs a second `decide()` call over the same four-label set and emits
+# `auditor:verdict_disagreement` on mismatch. The guard is tier-gated
+# (autonomous only, CB=50/call) so propose/review-gated/shadow ticks
+# stay on their existing budget. `decide()` auto-writes a signed MC3
+# row to `.agentis/decisions/chain.jsonl` for every autonomous-tier
+# verdict, extending #743's audit-chain coverage to the verdict step.
+# ---------------------------------------------------------------------------
+DECIDE_COUNT="$(printf '%s\n' "$AUD_AG_SRC" | grep -cF -- 'decide(' || true)"
+if [ "$DECIDE_COUNT" -ge 1 ]; then
+    echo "[PASS] 34a. auditor.ag invokes decide() at least once (count=$DECIDE_COUNT)"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] 34a. auditor.ag invokes decide() at least once: got $DECIDE_COUNT"
+    FAIL=$((FAIL + 1))
+fi
+assert_contains "34b. auditor.ag defines _decide_verdict_guard helper" "$AUD_AG_SRC" \
+    "fn _decide_verdict_guard"
+assert_contains "34c. auditor.ag emits auditor:verdict_disagreement bus event" "$AUD_AG_SRC" \
+    'emit("auditor:verdict_disagreement"'
+assert_contains "34d. _decide_verdict_guard tier-gates on autonomous (CB=50 budget)" "$AUD_AG_SRC" \
+    'if my_tier != "autonomous"'
+assert_contains "34e. autonomous-tier branch wires _decide_verdict_guard before _publish_auditor" "$AUD_AG_SRC" \
+    "_decide_verdict_guard(verdict.audit_verdict"
+assert_contains "34f. disagreement path downgrades auditor:confidence by 0.05" "$AUD_AG_SRC" \
+    "curr - 0.05"
+assert_contains "34g. disagreement-path confidence downgrade floored at 0.4" "$AUD_AG_SRC" \
+    "if lowered < 0.4 { 0.4; }"
+assert_contains "34h. check-learn-tags.sh schema extends audit:partial with decide-guard tag" "$LEARN_TAGS_SRC" \
+    'decide-guard'
+assert_contains "34i. check-learn-tags.sh schema covers disagreement literal" "$LEARN_TAGS_SRC" \
+    'disagreement'
+assert_contains "34j. check-learn-tags.sh schema covers agreement literal" "$LEARN_TAGS_SRC" \
+    'agreement'
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/check-learn-tags.sh
+++ b/tools/check-learn-tags.sh
@@ -499,18 +499,30 @@ claim-auditor"
             PAIR_KNOWN=1
             ;;
         "audit:partial")
+            # #761: decide-guard tags ("decide-guard", "disagreement")
+            # join the existing tier-flag literals so the autonomous-
+            # tier `_decide_verdict_guard` disagreement path can emit
+            # a partial-outcome row alongside the verdict.
             ALLOWED_LITERALS="acted
 review-gated
 observed
-claim-auditor"
+claim-auditor
+decide-guard
+disagreement"
             PAIR_KNOWN=1
             ;;
         "audit:success")
+            # #761: decide-guard agreement tags ("decide-guard",
+            # "agreement") share the success outcome with the existing
+            # propose-tier emitted path. AdaptiveEngine can correlate
+            # decide() match rate with downstream HItL accept rate.
             ALLOWED_LITERALS="acted
 review-gated
 emitted
 observed
-claim-auditor"
+claim-auditor
+decide-guard
+agreement"
             PAIR_KNOWN=1
             ;;
         "prior_match:partial")


### PR DESCRIPTION
## Summary

- Add `_decide_verdict_guard()` helper alongside `prompt() -> Verdict` in `research-foundry/auditor/agents/auditor.ag`. Tier-gated to autonomous (CB=50/call) so propose/review-gated/shadow ticks stay on their existing budget.
- On disagreement: emit `auditor:verdict_disagreement`, downgrade `auditor:confidence` by 0.05 (floor 0.4 to stay above shadow), tag the experience row "disagreement".
- `decide()` auto-writes a signed MC3 row to `.agentis/decisions/chain.jsonl` for every autonomous-tier verdict, extending #743's audit-chain coverage to the verdict step.

## Re-scoped per forensic in the issue

The original 3 migration sites in #761 did not fit `decide()` (auditor's `_pick_upstream_by_confidence` is deterministic plumbing, novelty's `final_write` is a bool from tier policy, explorer specialty is positional via `DAEMON_ID`). This PR implements the option B re-scope from the issue: the existing rich-struct `prompt() -> Verdict` (which downstream #622 / #687 / #745 consume) stays intact, and `decide()` rides alongside as a signed second-opinion guard.

## Test plan

- [x] `bash -n research-foundry/tools/run-research.sh` clean
- [x] `bash research-foundry/tools/test-run-research.sh` -> 193 passed, 0 failed (+10 new assertions in group 34)
- [x] `bash tools/colony-lint.sh` -> 344 passed, 0 failed, 4 skipped
- [x] `bash tools/check-learn-tags.sh` -> 0 violations (schema extended for the two new `audit:*` tag literals)
- [x] `grep -c "decide(" research-foundry/auditor/agents/auditor.ag` -> 6 (1 call + 5 comment refs)
- [x] `agentis commit` parses the modified auditor.ag clean

Closes #761