### PR TITLE
ci: release.yml triggers on all federation tag patterns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
 # Tag-triggered bundle + asset upload for per-federation releases (#220).
-# Fires on pushes of tags shaped like `<federation>-v<X.Y.Z>`.
+# Fires on pushes of tags shaped like `<federation>-v<X.Y.Z>` for every
+# federation listed in the trigger pattern below.
 #
 # The workflow:
 #   1. Checks out the tagged commit (full history so the awk on CHANGELOG has
@@ -17,11 +18,25 @@ name: Release
 #   git tag <federation>-v<X.Y.Z> <merge-sha> -m "..."
 #   git push origin <federation>-v<X.Y.Z>
 # No manual `gh release create` / `gh release upload` needed.
+#
+# The trigger pattern lists every federation that ships from this repo.
+# Adding a new federation: append one line to the `tags:` list below AND
+# register the federation directory in `tools/check-changelog.sh`'s
+# `COMPONENTS` array (which is what governs the `[Unreleased]` CHANGELOG
+# soft-check on PRs).
+#
+# `federation-dashboard-v*` is deliberately NOT here -- the dashboard is a
+# federation-agnostic standalone component with a separate bundle builder
+# (`tools/make-dashboard-bundle.sh`) and its own workflow
+# (`.github/workflows/release-dashboard.yml`).
 
 on:
   push:
     tags:
       - 'dev-apprenticeship-v*'
+      - 'research-foundry-v*'
+      - 'tribes-bench-v*'
+      - 'trading-binance-v*'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Fixes the workflow trigger gap surfaced when pushing `research-foundry-v0.2.0` produced no release.yml run (the workflow only listened for `dev-apprenticeship-v*` tags).

## Background

Per the operator's clarification: `dev-apprenticeship-v*` was the original federation and the workflow trigger pattern frozen at it. Subsequent federations (`research-foundry/`, `tribes-bench/`, `trading-binance/`) shipped without their tag patterns being added to the workflow, so a tag push for any of them was a silent no-op for GitHub release creation. The manual `gh release create` for `research-foundry-v0.2.0` was a one-time recovery; this PR closes the gap so it does not happen again.

## Change

The workflow's `on.push.tags` list now includes all four federations:

```yaml
on:
  push:
    tags:
      - 'dev-apprenticeship-v*'
      - 'research-foundry-v*'
      - 'tribes-bench-v*'
      - 'trading-binance-v*'
```

Header comment expanded with the "adding a new federation" recipe (one line in this list + register in `tools/check-changelog.sh` `COMPONENTS`).

`federation-dashboard-v*` is intentionally absent — the dashboard has its own bundle builder (`tools/make-dashboard-bundle.sh`) and its own workflow (`.github/workflows/release-dashboard.yml`).

## Verification

The workflow body itself is unchanged (already federation-agnostic via `$GITHUB_REF_NAME` parsing). No CI run will fire for this PR since this is the workflow file itself; the smoke is on the next federation tag push.

## Test plan

- [x] `bash tools/colony-lint.sh` — 39 passed, 1 pre-existing flake (`no-memo liveness`), unrelated
- [ ] Post-merge sanity: next `<federation>-v*` tag push triggers release.yml

## Out of scope

- Backfilling `research-foundry-v0.2.0` (already manually published with bundle + sha256 via `gh release create`)
- Adding bundle support / BUNDLE.manifest for federations that don't have one yet (`tribes-bench`, `trading-binance` may need this work when they cut their first release — separate concern)