### PR TITLE
research-foundry: bump per-colony replica defaults to 3 for triage agents (Fixes #824)

### DIFF
--- a/research-foundry/CHANGELOG.md
+++ b/research-foundry/CHANGELOG.md
@@ -18,6 +18,10 @@ History of the three retired federations consolidated into this one
 
 ## [Unreleased]
 
+### Changed
+
+- `research-foundry/tools/run-research.sh` default `RESEARCH_<COLONY>_REPLICAS` for the four triage-role colonies (`noticer`, `skeptic`, `novelty`, `prior_advocate`) bumped `1` → `3` so the M2-Malthusian replicate gate and the `knowledge_market` `samples>1` density both have non-trivial cross-replica selection pressure on a default run ([#824](https://github.com/Replikanti/agentis-colonies/issues/824)). Pre-bump 17 of 18 colonies defaulted to 1 replica (only explorer ran at 5), so cross-replica diversity in the triage tier was empirically negligible despite the per-colony replicate-gate boilerplate shipped in [#663](https://github.com/Replikanti/agentis-colonies/pull/663). Explorer stays at 5 (already tuned). Sequential preprint pipeline (`formulator`, `verifier`, `introducer`, `theorist`, `computer`, `editor`, `reviewer`, `submitter`), rate-limited searchers (`arxiv-search`, `oeis-search`, `groupprops-search`, `scholar-search`), and the `auditor` stay at 1: extra replicas would either race on single-writer roles, burn shared API rate budget, or contend on `audit-ledger.jsonl`. Effective default daemon count is now 30 across 18 colonies (was 18). Operator override via the same `RESEARCH_<COLONY>_REPLICAS` env-var family is unchanged. `research-foundry/tools/test-replicate-gates.sh` extended with four new assertions (one per diversified colony) so the defaults cannot regress silently.
+
 ## [0.2.0] — 2026-05-28
 
 **Requires:** agentis >= `1.8.0`

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -429,17 +429,27 @@ unset _role _var _val
 : "${RESEARCH_EXPLORER_REPRODUCTIVE_FITNESS_THRESHOLD:=2}"
 
 # Phase 9 PR-B (#663): per-colony replica + pool seeds for the 17
-# non-explorer colonies. All default to 1 so PR-B does NOT change the
-# observable daemon count (still 5 explorers + 13 singletons; cull
-# cycle still only fires for explorer unless RESEARCH_CULL_COLONIES is
-# changed). PR-C will flip these to N>=3 where it lights up
-# replication per colony.
-: "${RESEARCH_NOTICER_REPLICAS:=1}"
+# non-explorer colonies.
+#
+# Default replica counts (#824): the four triage-role colonies (noticer,
+# skeptic, novelty, prior_advocate) ship at 3 replicas each so the
+# M2-Malthusian replicate gate and the knowledge_market `samples>1`
+# density both have non-trivial cross-replica selection pressure on a
+# default run. Explorer stays at 5 (already tuned). The sequential
+# preprint pipeline (formulator/verifier/introducer/theorist/computer/
+# editor/reviewer/submitter) and the rate-limited searchers
+# (arxiv/oeis/groupprops/scholar) stay at 1 because multiple replicas
+# would either race on single-writer roles or burn shared rate budget;
+# auditor stays at 1 because multiple replicas race on
+# `audit-ledger.jsonl`. Effective default daemon count is 30 across 18
+# colonies (was 18). Operator overrides via the same env-var family
+# (`RESEARCH_<COLONY>_REPLICAS`) are unchanged.
+: "${RESEARCH_NOTICER_REPLICAS:=3}"
 : "${RESEARCH_NOTICER_MAX_REPLICAS:=8}"
 : "${RESEARCH_NOTICER_POOL:=5000}"
 : "${RESEARCH_NOTICER_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
-: "${RESEARCH_SKEPTIC_REPLICAS:=1}"
+: "${RESEARCH_SKEPTIC_REPLICAS:=3}"
 : "${RESEARCH_SKEPTIC_MAX_REPLICAS:=8}"
 : "${RESEARCH_SKEPTIC_POOL:=5000}"
 : "${RESEARCH_SKEPTIC_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
@@ -454,7 +464,7 @@ unset _role _var _val
 : "${RESEARCH_VERIFIER_POOL:=5000}"
 : "${RESEARCH_VERIFIER_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
-: "${RESEARCH_NOVELTY_REPLICAS:=1}"
+: "${RESEARCH_NOVELTY_REPLICAS:=3}"
 : "${RESEARCH_NOVELTY_MAX_REPLICAS:=8}"
 : "${RESEARCH_NOVELTY_POOL:=5000}"
 : "${RESEARCH_NOVELTY_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
@@ -484,7 +494,7 @@ unset _role _var _val
 : "${RESEARCH_AUDITOR_POOL:=5000}"
 : "${RESEARCH_AUDITOR_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"
 
-: "${RESEARCH_PRIOR_ADVOCATE_REPLICAS:=1}"
+: "${RESEARCH_PRIOR_ADVOCATE_REPLICAS:=3}"
 : "${RESEARCH_PRIOR_ADVOCATE_MAX_REPLICAS:=8}"
 : "${RESEARCH_PRIOR_ADVOCATE_POOL:=5000}"
 : "${RESEARCH_PRIOR_ADVOCATE_REPRODUCTIVE_FITNESS_THRESHOLD:=3}"

--- a/research-foundry/tools/test-replicate-gates.sh
+++ b/research-foundry/tools/test-replicate-gates.sh
@@ -162,6 +162,31 @@ else
 fi
 unset RUN_RESEARCH_SH
 
+# (g) #824: run-research.sh ships per-colony replica defaults of 3 for
+# the four triage-role colonies (noticer, skeptic, novelty,
+# prior_advocate) so the M2-Malthusian replicate gate has non-trivial
+# selection pressure on a default run and knowledge_market samples
+# accumulate cross-replica density. Explorer stays at 5 (already tuned);
+# sequential pipeline / rate-limited searchers / auditor stay at 1
+# (architectural reasons documented in the env-knob comment block).
+RUN_RESEARCH_SH="$FED_DIR/tools/run-research.sh"
+if [ ! -f "$RUN_RESEARCH_SH" ]; then
+    fail "(g) run-research.sh ships #824 triage-colony replica defaults" \
+         "$RUN_RESEARCH_SH not found"
+else
+    TRIAGE_3=("NOTICER" "SKEPTIC" "NOVELTY" "PRIOR_ADVOCATE")
+    for tc in "${TRIAGE_3[@]}"; do
+        if grep -qE "^: \"\\\$\\{RESEARCH_${tc}_REPLICAS:=3\\}\"$" "$RUN_RESEARCH_SH"; then
+            pass "(g) RESEARCH_${tc}_REPLICAS default is 3"
+        else
+            fail "(g) RESEARCH_${tc}_REPLICAS default is 3" \
+                 "expected ': \"\${RESEARCH_${tc}_REPLICAS:=3}\"' line in $RUN_RESEARCH_SH"
+        fi
+    done
+    unset TRIAGE_3
+fi
+unset RUN_RESEARCH_SH
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes #824. Closes architectural-intent gap on population diversity: previously 17 of 18 colonies defaulted to 1 replica (only explorer ran at 5), so cross-replica selection pressure and knowledge_market sample density were both negligible empirically.

Bumps default `RESEARCH_<COLONY>_REPLICAS` for the four triage-role colonies (noticer, skeptic, novelty, prior_advocate) from 1 to 3 each. Explorer stays at 5 (already-tuned). Sequential preprint pipeline (introducer/theorist/computer/editor/submitter), rate-limited searchers (arxiv/oeis/groupprops/scholar), and the auditor stay at 1 (architectural reasons documented in the issue body).

Effective total: 30 daemons (was 18).

## Changes

- `research-foundry/tools/run-research.sh` -- 4 default bumps (1 -> 3) inside the existing `RESEARCH_<COLONY>_REPLICAS` env-knob pattern
- `research-foundry/tools/test-replicate-gates.sh` -- 4 new assertions for the new defaults
- `research-foundry/CHANGELOG.md` -- `[Unreleased]/### Changed` entry

## Out of scope

- Dashboard population-dynamics tile -- deferred to follow-up issue (per plan)
- Auto-tuning M2_CAP per colony -- deferred

## Test plan

- [x] `bash tools/colony-lint.sh` baseline-equivalent (39 pass / 1 fail; the 1 failing test-auto-promote.sh row pre-exists on main, unrelated to this PR)
- [x] `bash research-foundry/tools/test-replicate-gates.sh` extended tests pass (34/0/0; was 30/0/0)
- [ ] Field test: 75-tick claude-mathlib run shows cross-replica `knowledge_market` `samples > 1` density increases 2-3x