### PR TITLE
auto-promote: fitness rule-hit bonus closes breeding-loop gap (d) (Fixes #823)

### DIFF
--- a/tools/auto-promote-config.yaml
+++ b/tools/auto-promote-config.yaml
@@ -6,6 +6,19 @@
 # All thresholds are per-agent: the script evaluates each running agent
 # independently against these rules.
 
+weights:
+  # Maximum additive contribution to the per-colony fitness scalar at
+  # 100% rule-hit ratio (#823). The sidecar computes
+  # `fitness_score_total = colony_fitness_score + (rule_hit_ratio * efficiency_bonus)`
+  # where rule_hit_ratio is acting-tick rule-hits / acting-tick total,
+  # gated by the `min_rule_hit_acting_ticks` floor below. Selection
+  # pressure favors LLM-efficient agents (rule-driven decisions) over
+  # LLM-heavy agents producing the same outcome quality. Bonus is
+  # additive on a 0..1 colony-fitness scalar so 0.15 is roughly a 15%
+  # boost at saturation. Promote prereq gates are NOT extended by this
+  # value — efficiency_bonus is a ranking signal only.
+  efficiency_bonus: 0.15
+
 promote:
   prerequisites:
     # Calibrated for finite-run research windows (75-tick × 60s ≈ 75 min)
@@ -25,6 +38,13 @@ promote:
     reject_rate_threshold: 0.05    # reject_rate on acting rows must be < 5%
     delta_slope_window: 20         # compute slope over last N acting rows
     delta_slope_min: 0             # average delta must be non-negative
+    # #823: floor on acting-tick count below which the rule-hit
+    # efficiency bonus collapses to zero. With 4 or fewer acting ticks
+    # `rule_hit_ratio` is one of {0/n, 1/n, ..., n/n} which is too coarse
+    # — a single rule-hit at n=2 reads as 50% rule-driven on near-zero
+    # evidence. Floor of 5 derives from rule-of-three at a 60% target
+    # rule-hit ratio: ceil(3 / 0.6) = 5.
+    min_rule_hit_acting_ticks: 5
   # Three-step ladder aligned with the four-tier confidence contract
   # (ADR-0001, issue #177). Each step promotes the agent across one
   # behavioural tier boundary: shadow -> propose -> review-gated ->
@@ -57,6 +77,16 @@ promote:
       # therefore still requires fewer total errors than the loose
       # propose→review-gated step).
       min_acting_entries_override: 30
+
+  # #823: tags in `learn()` rows that count as a rule-hit acting tick
+  # when computing the efficiency bonus. Canonical literals match the
+  # noticer distillation pilot schema (#820): `distilled` for the first
+  # rule-hit on a freshly distilled rule, `rule-hit` for subsequent hits
+  # against an already-cached rule. Operators can extend (e.g. add
+  # `rule-reinforced` from skeptic-agreement rows) without code change.
+  rule_hit_tag_allowlist:
+    - distilled
+    - rule-hit
 
 evolve:
   trigger:

--- a/tools/auto-promote-decisions.py
+++ b/tools/auto-promote-decisions.py
@@ -71,10 +71,12 @@ import agentis_memo_freshness as freshness  # noqa: E402
 
 def _load_config(path):
     """Load auto-promote-config.yaml into the same CFG_* shape the sh sidecar
-    receives via auto-promote-config-parser.py. Returns the 9 threshold values
-    as a tuple: (min_entries, min_acting_entries, min_runtime_hours,
+    receives via auto-promote-config-parser.py. Returns the 9 base threshold
+    values plus the 3 #823 efficiency-bonus params as a 12-tuple:
+    (min_entries, min_acting_entries, min_runtime_hours,
     reject_rate_threshold, delta_slope_window, delta_slope_min,
-    promote_steps_raw, evolve_slope_neg_for, evolve_reject_above)."""
+    promote_steps_raw, evolve_slope_neg_for, evolve_reject_above,
+    w_efficiency, min_rule_hit_acting_ticks, rule_hit_tag_allowlist)."""
     # Import the simple parser from the sibling helper so both entrypoints
     # share one YAML reader. PyYAML if available, fallback otherwise. The
     # sibling file has a hyphen in its name (not a legal Python identifier),
@@ -108,6 +110,15 @@ def _load_config(path):
     promote_steps_raw = ' '.join(t for t in (_fmt_step(s) for s in steps) if t is not None)
     e = cfg.get('evolve', {}).get('trigger', {})
 
+    # #823: rule-hit efficiency-bonus params. Additive to the per-colony
+    # fitness scalar, not a hard promote gate (selection-pressure signal).
+    # Defaults match the YAML so federations that omit the keys are
+    # behaviourally identical to those that paste in the defaults.
+    w_efficiency = float(cfg.get('weights', {}).get('efficiency_bonus', 0.15))
+    min_rule_hit_acting_ticks = int(p.get('min_rule_hit_acting_ticks', 5))
+    rule_hit_tag_allowlist = list(cfg.get('promote', {}).get(
+        'rule_hit_tag_allowlist', ['distilled', 'rule-hit']))
+
     return (
         int(p.get('min_entries', 200)),
         int(p.get('min_acting_entries', default_acting)),
@@ -118,6 +129,9 @@ def _load_config(path):
         promote_steps_raw,
         int(e.get('delta_slope_negative_for', 1000)),
         float(e.get('reject_rate_above', 0.20)),
+        w_efficiency,
+        min_rule_hit_acting_ticks,
+        rule_hit_tag_allowlist,
     )
 
 
@@ -199,7 +213,9 @@ def main():
         (min_entries, min_acting_entries, min_runtime_hours,
          reject_rate_threshold, delta_slope_window, delta_slope_min,
          promote_steps_raw, evolve_slope_neg_for,
-         evolve_reject_above) = _load_config(config_path)
+         evolve_reject_above, w_efficiency,
+         min_rule_hit_acting_ticks,
+         rule_hit_tag_allowlist) = _load_config(config_path)
     else:
         # Legacy positional mode used by auto-promote.sh sidecar. Keep byte-
         # identical contract — test-auto-promote.sh asserts it. The 12th arg
@@ -218,6 +234,15 @@ def main():
         evolve_reject_above = float(argv[10])
         if len(argv) >= 12:
             containerized = (argv[11].lower() == 'true')
+        # #823: legacy positional invocation (auto-promote.sh sidecar) does
+        # not pass the efficiency-bonus knobs — auto-promote-config-parser.py
+        # has not been extended for this PR. Fall back to the same defaults
+        # _load_config does, so a federation whose .ag agents emit zero
+        # rule-hit tags sees efficiency_bonus = 0 on every agent and the
+        # legacy → preview byte-identity contract (test 12) holds.
+        w_efficiency = 0.15
+        min_rule_hit_acting_ticks = 5
+        rule_hit_tag_allowlist = ['distilled', 'rule-hit']
 
     # Tags that mark a row as exercising a tier-gated acting branch (not observe).
     # See doc/auto-promote.md#classification — must match the tag strings emitted
@@ -236,6 +261,27 @@ def main():
         if tag_set & OBSERVE_TAGS:
             return 'observe'
         return 'legacy'
+
+    def _count_rule_hit_ticks(entries, allowlist):
+        """Count rows whose `tags` field contains any allowlisted rule-hit
+        tag (#823). Callers pass the already-classified acting-entries list,
+        so the result is a strict subset of acting_count and the ratio
+        rule_hit_ticks / acting_count is well-defined on [0, 1].
+
+        Canonical allowlist literals come from auto-promote-config.yaml and
+        match the noticer distillation pilot tag schema (#820): `distilled`
+        for the first rule-hit on a rule, `rule-hit` for subsequent hits.
+        Operators can extend the allowlist (e.g. with `rule-reinforced`)
+        without code change."""
+        allow = {str(t) for t in allowlist}
+        n = 0
+        for e in entries:
+            tags = e.get('tags') or []
+            if not isinstance(tags, list):
+                continue
+            if {str(t) for t in tags} & allow:
+                n += 1
+        return n
 
     # Parse promote steps ("from:to:override" triples; empty override = use global).
     promote_steps = []
@@ -668,6 +714,39 @@ def main():
                 legacy_count += 1
         acting_count = len(acting_entries_list)
 
+        # #823: rule-hit efficiency bonus. Additive selection-pressure
+        # signal layered on top of the per-colony fitness scalar so two
+        # agents producing identical outcome quality can still be ranked
+        # by how much LLM use the rule cache saved. Gated below the acting
+        # floor to suppress sub-statistical-sample noise (one rule-hit at
+        # n=2 reads as 50% rule-driven on near-zero evidence). The bonus
+        # is purely a ranking signal here; promote prereq gates downstream
+        # are unchanged so the binary promote/skip outcome is identical
+        # for federations whose .ag agents emit zero rule-hit tags
+        # (backward-compat — see #820 for the canonical tag schema).
+        rule_hit_ticks = _count_rule_hit_ticks(acting_entries_list, rule_hit_tag_allowlist)
+        efficiency_floor_met = acting_count >= min_rule_hit_acting_ticks
+        if efficiency_floor_met and acting_count > 0:
+            rule_hit_ratio = rule_hit_ticks / acting_count
+            efficiency_bonus = rule_hit_ratio * w_efficiency
+        else:
+            rule_hit_ratio = 0.0
+            efficiency_bonus = 0.0
+
+        # Enrich the per-colony fitness payload (if attached) with the new
+        # bonus so the dashboard and cross-run aggregator see one combined
+        # `fitness_score_total` = colony scalar + (rule_hit_ratio * w_efficiency).
+        # `colony_fitness_evidence` was populated earlier in this loop for
+        # agents in SIDE_BY_COLONY only; mutating in place propagates via
+        # the by-reference attach in _attach_explorer_evidence below.
+        if colony_fitness_evidence is not None:
+            base_score = float(colony_fitness_evidence.get('fitness_score', 0.0))
+            colony_fitness_evidence['rule_hit_ticks'] = rule_hit_ticks
+            colony_fitness_evidence['rule_hit_ratio'] = round(rule_hit_ratio, 6)
+            colony_fitness_evidence['efficiency_bonus'] = round(efficiency_bonus, 6)
+            colony_fitness_evidence['efficiency_floor_met'] = efficiency_floor_met
+            colony_fitness_evidence['fitness_score_total'] = round(base_score + efficiency_bonus, 6)
+
         def _linreg_slope(values):
             if len(values) < 2:
                 return 0.0
@@ -725,6 +804,15 @@ def main():
             'evolve_slope': round(evolve_slope, 6),
             'confidence': confidence,
             'pid': pid,
+            # #823: rule-hit efficiency-bonus fields. Surfaced on every
+            # decision record that builds an evidence dict so the dashboard
+            # can render the bonus alongside the other prereq stats. For
+            # agents whose .ag emits no `distilled` / `rule-hit` learn rows
+            # all four fields read as zero / false (backward compatible).
+            'rule_hit_ticks': rule_hit_ticks,
+            'rule_hit_ratio': round(rule_hit_ratio, 6),
+            'efficiency_bonus': round(efficiency_bonus, 6),
+            'efficiency_floor_met': efficiency_floor_met,
         }
 
         # --- Evolve check (takes priority if agent is degrading) ---

--- a/tools/test-auto-promote.sh
+++ b/tools/test-auto-promote.sh
@@ -755,6 +755,144 @@ else
     fail "fed-local priority" "expected entries_total=5, got <$ENTRIES_B> from <$OUT_B>"
 fi
 
+# --- Test 20: rule-hit efficiency bonus applies above acting floor (#823) ---
+# Plan body: `fitness_score_total = colony_fitness_score + (rule_hit_ratio
+# * w_efficiency)` where rule_hit_ratio = rule_hit_ticks / entries_acting,
+# gated by `entries_acting >= min_rule_hit_acting_ticks` (default 5). With
+# w_efficiency=0.15 (the YAML default) and a 6/10 fixture, expect
+# rule_hit_ratio=0.6 and efficiency_bonus=0.09.
+FED_EFF_A="$TMPDIR_TEST/fed-eff-a"
+mkdir -p "$FED_EFF_A/.agentis/experience"
+python3 -c "
+import json
+path = '$FED_EFF_A/.agentis/experience/eff-aaaa.jsonl'
+with open(path, 'w') as f:
+    # 6 acting rule-hit rows + 4 acting LLM-driven rows = 10 acting, 6 rule-hits
+    for _ in range(6):
+        f.write(json.dumps({'tags': ['acted', 'distilled', 'rule-hit', 'math-foundry'], 'outcome': 'success', 'delta': 0.05}) + '\n')
+    for _ in range(4):
+        f.write(json.dumps({'tags': ['acted', 'llm-driven', 'math-foundry'], 'outcome': 'success', 'delta': 0.05}) + '\n')
+"
+
+DAEMONS_EFF_A='[{"source":"/fake/eff-a.ag","pid":'"$$"',"agent_id":"eff-aaaa","colony":"c","started_at":'"$(date +%s)"',"confidence":0.4,"state":"running"}]'
+
+OUT_EFF_A=$(python3 "$SCRIPT_DIR/auto-promote-decisions.py" \
+    --preview --config "$SCRIPT_DIR/auto-promote-config.yaml" \
+    "$DAEMONS_EFF_A" "$FED_EFF_A")
+
+EFF_A_CHECK=$(python3 -c "
+import json, sys
+arr = json.loads(sys.argv[1])
+if len(arr) != 1:
+    print('arity:' + str(len(arr))); sys.exit(0)
+ev = arr[0].get('evidence') or {}
+hits = ev.get('rule_hit_ticks')
+ratio = ev.get('rule_hit_ratio')
+bonus = ev.get('efficiency_bonus')
+floor = ev.get('efficiency_floor_met')
+if hits != 6: print('rule_hit_ticks=' + str(hits) + ' (expected 6)'); sys.exit(0)
+if abs((ratio or 0) - 0.6) > 1e-9: print('rule_hit_ratio=' + str(ratio) + ' (expected 0.6)'); sys.exit(0)
+if abs((bonus or 0) - 0.09) > 1e-9: print('efficiency_bonus=' + str(bonus) + ' (expected 0.09)'); sys.exit(0)
+if floor is not True: print('efficiency_floor_met=' + str(floor) + ' (expected True)'); sys.exit(0)
+print('ok')
+" "$OUT_EFF_A" 2>&1 || true)
+
+if [ "$EFF_A_CHECK" = "ok" ]; then
+    pass "efficiency bonus: applies when acting floor met (#823)"
+else
+    fail "efficiency bonus above floor" "$EFF_A_CHECK from <$OUT_EFF_A>"
+fi
+
+# --- Test 21: rule-hit efficiency bonus is zero below acting floor (#823) ---
+# Floor justification (plan §4): at n=4 a single rule-hit reads as 25% on
+# near-zero evidence, biasing fitness on under-sampled agents. The bonus
+# must collapse to zero while rule_hit_ticks stays visible for operator
+# observability ("we counted the hits but suppressed the bonus").
+FED_EFF_B="$TMPDIR_TEST/fed-eff-b"
+mkdir -p "$FED_EFF_B/.agentis/experience"
+python3 -c "
+import json
+path = '$FED_EFF_B/.agentis/experience/eff-bbbb.jsonl'
+with open(path, 'w') as f:
+    # 4 acting rule-hit rows -- below min_rule_hit_acting_ticks=5
+    for _ in range(4):
+        f.write(json.dumps({'tags': ['acted', 'distilled', 'rule-hit', 'math-foundry'], 'outcome': 'success', 'delta': 0.05}) + '\n')
+"
+
+DAEMONS_EFF_B='[{"source":"/fake/eff-b.ag","pid":'"$$"',"agent_id":"eff-bbbb","colony":"c","started_at":'"$(date +%s)"',"confidence":0.4,"state":"running"}]'
+
+OUT_EFF_B=$(python3 "$SCRIPT_DIR/auto-promote-decisions.py" \
+    --preview --config "$SCRIPT_DIR/auto-promote-config.yaml" \
+    "$DAEMONS_EFF_B" "$FED_EFF_B")
+
+EFF_B_CHECK=$(python3 -c "
+import json, sys
+arr = json.loads(sys.argv[1])
+if len(arr) != 1:
+    print('arity:' + str(len(arr))); sys.exit(0)
+ev = arr[0].get('evidence') or {}
+hits = ev.get('rule_hit_ticks')
+ratio = ev.get('rule_hit_ratio')
+bonus = ev.get('efficiency_bonus')
+floor = ev.get('efficiency_floor_met')
+if hits != 4: print('rule_hit_ticks=' + str(hits) + ' (expected 4 -- still visible)'); sys.exit(0)
+if (ratio or 0) != 0.0: print('rule_hit_ratio=' + str(ratio) + ' (expected 0.0 below floor)'); sys.exit(0)
+if (bonus or 0) != 0.0: print('efficiency_bonus=' + str(bonus) + ' (expected 0.0 below floor)'); sys.exit(0)
+if floor is not False: print('efficiency_floor_met=' + str(floor) + ' (expected False)'); sys.exit(0)
+print('ok')
+" "$OUT_EFF_B" 2>&1 || true)
+
+if [ "$EFF_B_CHECK" = "ok" ]; then
+    pass "efficiency bonus: zero when below acting floor (#823)"
+else
+    fail "efficiency bonus below floor" "$EFF_B_CHECK from <$OUT_EFF_B>"
+fi
+
+# --- Test 22: efficiency bonus caps at w_efficiency on 100% rule-hit (#823) ---
+# Guards against accidental double-counting or denominator drift: at full
+# saturation rule_hit_ratio must equal exactly 1.0 (not >1.0) and
+# efficiency_bonus must equal w_efficiency exactly (the YAML default
+# 0.15).
+FED_EFF_C="$TMPDIR_TEST/fed-eff-c"
+mkdir -p "$FED_EFF_C/.agentis/experience"
+python3 -c "
+import json
+path = '$FED_EFF_C/.agentis/experience/eff-cccc.jsonl'
+with open(path, 'w') as f:
+    # 20 acting rule-hit rows, all carry both 'acted' and 'distilled'+'rule-hit'
+    for _ in range(20):
+        f.write(json.dumps({'tags': ['acted', 'distilled', 'rule-hit', 'math-foundry'], 'outcome': 'success', 'delta': 0.05}) + '\n')
+"
+
+DAEMONS_EFF_C='[{"source":"/fake/eff-c.ag","pid":'"$$"',"agent_id":"eff-cccc","colony":"c","started_at":'"$(date +%s)"',"confidence":0.4,"state":"running"}]'
+
+OUT_EFF_C=$(python3 "$SCRIPT_DIR/auto-promote-decisions.py" \
+    --preview --config "$SCRIPT_DIR/auto-promote-config.yaml" \
+    "$DAEMONS_EFF_C" "$FED_EFF_C")
+
+EFF_C_CHECK=$(python3 -c "
+import json, sys
+arr = json.loads(sys.argv[1])
+if len(arr) != 1:
+    print('arity:' + str(len(arr))); sys.exit(0)
+ev = arr[0].get('evidence') or {}
+hits = ev.get('rule_hit_ticks')
+ratio = ev.get('rule_hit_ratio')
+bonus = ev.get('efficiency_bonus')
+floor = ev.get('efficiency_floor_met')
+if hits != 20: print('rule_hit_ticks=' + str(hits) + ' (expected 20)'); sys.exit(0)
+if abs((ratio or 0) - 1.0) > 1e-9: print('rule_hit_ratio=' + str(ratio) + ' (expected 1.0)'); sys.exit(0)
+if abs((bonus or 0) - 0.15) > 1e-9: print('efficiency_bonus=' + str(bonus) + ' (expected 0.15 = w_efficiency)'); sys.exit(0)
+if floor is not True: print('efficiency_floor_met=' + str(floor) + ' (expected True)'); sys.exit(0)
+print('ok')
+" "$OUT_EFF_C" 2>&1 || true)
+
+if [ "$EFF_C_CHECK" = "ok" ]; then
+    pass "efficiency bonus: caps at w_efficiency on 100% rule-hit (#823)"
+else
+    fail "efficiency bonus saturation" "$EFF_C_CHECK from <$OUT_EFF_C>"
+fi
+
 # --- Test 18: containerized liveness — fresh memo overrides stale registry (#706) ---
 # Reproduces the lifecycle-blocked-after-reboot bug: the daemon registry's
 # `effective_state` stays at "zombie" across sleep/reboot cycles, but the in-


### PR DESCRIPTION
## Summary

Fixes #823. Closes breeding-loop completeness gap **(d)**: the auto-promote sidecar now reads each agent's rule-hit ratio and weights it as an additive efficiency bonus on top of the existing colony-fitness scalar. Selection pressure now favors LLM-efficient agents (rule-driven decisions) over LLM-heavy agents producing the same outcome quality.

Formula: `fitness_score_total = colony_fitness_score + (rule_hit_ratio * w_efficiency)` where `rule_hit_ratio = rule_hit_ticks / entries_acting`, gated by `entries_acting >= 5` floor.

## Changes

- `tools/auto-promote-decisions.py` — new `_count_rule_hit_ticks` helper + extension to `_load_config` for 3 new params + enriched `colony_fitness_evidence`
- `tools/auto-promote-config.yaml` — 3 new keys (`weights.efficiency_bonus`, `promote.prerequisites.min_rule_hit_acting_ticks`, `promote.rule_hit_tag_allowlist`)
- `tools/test-auto-promote.sh` — 3 new tests (Tests 20/21/22)

## Test plan

- [x] `bash tools/colony-lint.sh` baseline-equivalent (361 pass, 2 fail — both pre-existing on main, see #826)
- [x] `bash tools/test-auto-promote.sh` 39 → 42 passing (3 added, no regressions, Test 12 byte-identity holds). The single failure (Test 19 / no-memo containerized liveness) is pre-existing on main and tracked in #826.
- [ ] Field test: 75-tick claude-mathlib run post-merge measures rule-driven replicas reaching autonomous tier faster than LLM-only replicas

## Backward compat

Federations without `distilled` / `rule-hit` learn-row tags see `efficiency_bonus = 0` → identical behavior to current. Promote prereq gates are not extended (`efficiency_bonus` is a ranking signal only, not a hard gate). The cross-run aggregator continues to read `fitness_score` (not `fitness_score_total`), so existing run-history files are forward-compatible.