### PR TITLE
fix(test): make auto-promote Test 19 hermetic (Fixes #826)

### DIFF
--- a/tools/test-auto-promote.sh
+++ b/tools/test-auto-promote.sh
@@ -943,6 +943,19 @@ fi
 # promoted.
 FED_DEAD="$TMPDIR_TEST/fed-dead"
 mkdir -p "$FED_DEAD"
+# #826: seed an explicit STALE `<agent>:last_check` memo into the fixture so
+# the test is hermetic. Without a fed-local memo, `read_memo_raw` shells
+# `agentis memo get` (cwd=FED_DEAD), which falls back to the host operator's
+# GLOBAL memo store (~/.config/agentis) when the fed-local key is absent — and
+# that store carries a real, possibly-fresh `explorer:last_check` from any
+# actual federation run on the host. That made Test 19's outcome depend on
+# host state: a recent real run left a fresh memo → the containerized-liveness
+# gate fell through → the dead daemon was NOT skipped (promoted or prereq-
+# skipped instead), false-failing the assertion. A fed-local stale memo
+# shadows the global one (fed-local keys win, verified), so `fresh` is
+# deterministically False and the no-heartbeat + zombie-registry liveness gate
+# fires as intended. Mirrors Test 18's fresh-memo seeding (the live counterpart).
+(cd "$FED_DEAD" && agentis memo set "explorer:last_check" "2020-01-01T00:00:00Z" >/dev/null 2>&1)
 
 DAEMONS_DEAD='[{"pid":12345,"agent_id":"explorer-1","source":"explorer.ag","state":"zombie","effective_state":"zombie","colony":"discovery","confidence":0.4,"started_at":1}]'
 


### PR DESCRIPTION
## Summary

Fixes #826. `tools/test-auto-promote.sh` Test 19 (containerized liveness — dead daemon must skip) flaked on `main` depending purely on host state.

## Root cause (path A — test hermeticity, not a production bug)

Test 19 represented a "dead" daemon by the ABSENCE of a fed-local `<agent>:last_check` memo. But `read_memo_raw` shells `agentis memo get` with `cwd=fed_dir`, and the `agentis` binary falls back to the host operator's global memo store (`~/.config/agentis`) when the fed-local key is absent. That global store carries a real `explorer:last_check` from any actual federation run on the host — so:

- recent real run on host → fresh global memo → containerized-liveness gate falls through → dead daemon NOT skipped (promoted or prereq-skipped) → **test false-fails**
- no recent run → stale/absent global memo → gate fires → test passes

Confirmed via trace: `agentis memo set explorer:test_probe` lands fed-local and is read back correctly, but `agentis memo get explorer:last_check` (never set fed-local) returned a fresh `2026-05-28T06:05:40Z` from the host global store.

**This is test-only.** In production the federation directory always carries the real per-daemon `<agent>:last_check` memo (the container's `/run-root/.agentis/memo` bind-mount), so the global fallback never matters and the liveness gate works correctly.

## Fix

Seed an explicit STALE `explorer:last_check` (`2020-01-01T00:00:00Z`) into the FED_DEAD fixture via `agentis memo set` (cwd=FED_DEAD). Fed-local keys shadow the global store (verified), so `fresh` is deterministically `False`, and the no-heartbeat + zombie-registry liveness gate fires as the test intends. Mirrors Test 18's existing fresh-memo seeding (the live counterpart).

## Test plan

- [x] `bash tools/test-auto-promote.sh` — 43 passed / 0 failed (was 42/1)
- [x] Deterministic across 3 consecutive runs (no host-state dependence)
- [x] `bash tools/colony-lint.sh` — clean

## Possible follow-up (out of scope, benign in production)

The `agentis memo get` global fallback is a latent footgun for any host-side tool that reads a fed-local memo which happens to be absent. Production auto-promote is unaffected (fed dir always has the memo). Could file a separate hardening issue if desired (e.g. an `AGENTIS_NO_GLOBAL_MEMO` env for test isolation), but not needed for this fix.