### PR TITLE
noticer: distill experience into crystallizable rules (Fixes #841)

### DIFF
--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -417,6 +417,28 @@ fn _parse_rule_action_desc(action: string) -> string {
     return out;
 }
 
+// #841: _canonical_stable_desc derives a DETERMINISTIC description from
+// canonical_ctx so the rule action recorded on the Stage-2 LLM path is
+// identical across repeat observations of the same context. The
+// KnowledgeEntry id is hashed from (category, action, condition,
+// recommendation); if the recommendation carried free-form LLM prose
+// (surprise.surprise_description) every tick minted a fresh entry and
+// empirical_validations could never accumulate. Here we template only
+// the two stable, coarsest canonical_ctx fields -- topic + output_kind
+// -- so the same context class maps to one entry the crystallizer can
+// validate toward crystallize_min_validations. The bucket/seq/lines
+// fields are intentionally excluded because they jitter tick-to-tick
+// within one context class. Total on missing fields ("na"). ASCII-only,
+// single line.
+fn _canonical_stable_desc(canonical_ctx: string) -> string {
+    if len(canonical_ctx) == 0 { return "surprise-class topic=na output_kind=na"; };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,re\ns=sys.argv[1]\ndef g(k):\n m=re.search(r\"(?:^| )\"+k+r\"=(\\S+)\", s)\n return m.group(1) if m else \"na\"\nprint(\"surprise-class topic=\"+g(\"topic\")+\" output_kind=\"+g(\"output_kind\"))' " + shell_escape(canonical_ctx);
+    let out = try { exec sh cmd; } catch e { "surprise-class topic=na output_kind=na"; };
+    if len(out) == 0 { return "surprise-class topic=na output_kind=na"; };
+    return out;
+}
+
 // _publish_noticer_rule_hit -- mirror of _publish_noticer but takes
 // primitive fields because the .ag grammar disallows inline Surprise
 // struct literals. The skeptic downstream still reads the JSON
@@ -666,9 +688,43 @@ fn tick(reason: string) -> void {
     // legacy "notice" learn() rows below stay in place for per-tier
     // observability (auto-promote consumes them).
     let surprise_found_str = if surprise.surprise_found { "true"; } else { "false"; };
-    let rule_action = surprise_found_str + "|" + surprise.surprise_description;
+    // #841: the recorded rule action MUST be stable per context so the
+    // distilled KnowledgeEntry id is identical across repeat ticks and
+    // empirical_validations can accumulate toward crystallization. The
+    // <desc> half is derived deterministically from canonical_ctx (NOT
+    // surprise.surprise_description, which is free-form LLM prose). Still
+    // pipe-delimited so _parse_rule_action_bool / _parse_rule_action_desc
+    // keep decoding it on the Stage 1 rule-hit path.
+    let canonical_action = surprise_found_str + "|" + _canonical_stable_desc(canonical_ctx);
+    // #841: the distilled entry's CONDITION must be a coarse, literal
+    // prefix of canonical_ctx (the leading topic= + output_kind= fields,
+    // dropping the tick-jittering bucket=/seq=/lines= tail). Two reasons:
+    // (1) the KnowledgeEntry id is hashed from (category, action,
+    // condition, recommendation) -- a stable coarse condition means repeat
+    // observations of the same context CLASS map to one entry, so
+    // empirical_validations accumulates toward crystallize_min_validations
+    // instead of minting a fresh entry every tick; (2) CrystallizedRule
+    // matches_context is `context.starts_with(condition)`, so a coarse
+    // condition still matches the FULL canonical_ctx the Stage-1 lookup
+    // passes. canonical_ctx is "topic=.. output_kind=.. bucket=.. ..", so
+    // the prefix ends just before " bucket=".
+    let _bucket_at = index_of(canonical_ctx, " bucket=");
+    let coarse_ctx = if _bucket_at > 0 { substring(canonical_ctx, 0, _bucket_at); } else { canonical_ctx; };
     // colony-lint: learn-tags-ok
-    learn("noticer_surprise", canonical_ctx, rule_action, "success", ["llm-driven", "math-foundry"]);
+    learn("noticer_surprise", canonical_ctx, canonical_action, "success", ["llm-driven", "math-foundry"]);
+
+    // #841: complete the distillation loop. learn() above only writes the
+    // ExperienceStore; distill() promotes >=3 successful noticer_surprise
+    // records into a KnowledgeEntry the crystallizer reads, and
+    // knowledge_validate() is the only runtime call that bumps
+    // empirical_validations toward crystallize_min_validations. distill()
+    // raises until there are >=3 successful records, so guard it; once the
+    // entry crystallizes the Stage 1 rule-first lookup starts hitting and
+    // this miss path stops running for that context.
+    let distilled_id = try { distill("noticer_surprise", coarse_ctx, canonical_action, "heuristic"); } catch e { ""; };
+    if len(distilled_id) > 0 {
+        knowledge_validate(distilled_id);
+    };
 
     if my_tier == "autonomous" {
         memo_write("noticer:" + _self_pid + ":review_gated", "true");


### PR DESCRIPTION
## Summary
Completes the federation breeding loop. The noticer recorded experience via `learn()` but never promoted it into the KnowledgeBase the crystallizer reads, so no domain `CrystallizedRule` ever formed (verified empirically in #833 — only `knowledge_market` entries existed despite 82 `noticer_surprise` experience rows). This wires the missing link on the Stage-2 LLM path:

- **Stable rule action** — `<bool>|surprise-class topic=.. output_kind=..` derived deterministically from the canonical context (not the free-form LLM `surprise_description`), so repeat observations hash to one `KnowledgeEntry` id.
- **`distill()` with a coarse condition** — the literal `topic=.. output_kind=..` prefix of `canonical_ctx` (dropping the per-tick `bucket=/seq=/lines=` jitter). A stable condition lets `empirical_validations` accumulate on one entry; and since `CrystallizedRule::matches_context` is `context.starts_with(condition)`, the coarse condition still prefix-matches the full `canonical_ctx` the Stage-1 `crystallizer_lookup` passes.
- **`knowledge_validate()`** — the only runtime path that bumps `empirical_validations` toward `crystallize_min_validations`.

Runtime chain now closed: `learn → distill → knowledge_validate ×N → M141 crystallize tick → crystallizer_lookup prefix-HIT`.

## QA — ✅ ship-it
Logic reviewed against the v1.10.0 runtime + a **deterministic standalone smoke** that proved the chain without the 150-min federation run: 16 jittering observations collapsed to **one** stable `KnowledgeEntry` (conf 0.80, samples 16), it crystallized into a persisted rule, and a lookup with a *different* full context HIT via coarse-prefix match.

| Area | Result | Mitigation | Notes |
|------|--------|------------|-------|
| Coarse condition prefix-match (`matches_context`) | ✅ | — | `full.starts_with(coarse)` confirmed in runtime source. |
| Stable entry id → validations accumulate | ✅ | — | 16 observations → 1 entry (empirically). |
| `distill` ≥3-record guard | ✅ | — | `try/catch` required; raises until ≥3 successful records. |
| `knowledge_validate` bumps `empirical_validations` | ✅ | — | Verdict-independent increment; validator wired in daemon. |
| Smoke: entry forms, crystallizes, lookup HIT | ✅ | — | Rule persisted to `_crystallizer_index`; lookup hit on a different full ctx. |
| Clean daemon (no tick errors) | ✅ | — | 37/0 ticks healthy. |
| Crystallize also gates on `confidence >= crystallize_min_confidence` (default 0.7) | ⚠️ | Verification-run config (#833) will lower `crystallize_min_confidence` so the loop fires reliably without needing ~14 records per context class. Not a defect in this change. | `distill` sets `confidence = min(1, records/20)`. |

## Test plan
- [x] `colony-lint.sh` — 345 passed / 0 failed / 5 skipped
- [x] `agentis` parses the noticer `.ag` (v1.10.0)
- [x] Deterministic distill→validate→crystallize→lookup smoke passes
- [ ] End-to-end confirmation in the #833 verification re-run (acceptance)

Fixes #841. Completes #819/#820. Refs #833.