### PR TITLE
noticer: read crystallizer_lookup map with get(), not json_get() (Fixes #843)

### DIFF
--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -635,9 +635,14 @@ fn tick(reason: string) -> void {
             // downstream demotion hook reads the rule_id memo and calls
             // crystallizer_record_use(rule_id, agree?, ±delta) per its
             // own verdict.
-            let rule_id = to_string(json_get(rule, "rule_id"));
-            let rule_action = to_string(json_get(rule, "action"));
-            let rule_conf_str = to_string(json_get(rule, "confidence"));
+            // #843: crystallizer_lookup_with_confidence returns map<string,string>
+            // (Value::Map). Read fields with get() (the map accessor); json_get()
+            // expects a JSON string and raises "expected string, got map" on a map
+            // -- which crashed every rule-hit tick once #841 made crystallization
+            // fire and this branch was finally reached.
+            let rule_id = to_string(get(rule, "rule_id"));
+            let rule_action = to_string(get(rule, "action"));
+            let rule_conf_str = to_string(get(rule, "confidence"));
             let rule_conf = if len(rule_conf_str) > 0 { parse_float(rule_conf_str); } else { min_conf; };
             let rule_surprise_found = _parse_rule_action_bool(rule_action);
             let rule_description = _parse_rule_action_desc(rule_action);


### PR DESCRIPTION
## Summary
The noticer rule-hit branch read `crystallizer_lookup_with_confidence()`'s result — a `map<string,string>` (`Value::Map`) — with `json_get(rule, "...")`. `json_get` requires a JSON **string** first arg and raises `expected string, got map` on a `Value::Map`, crashing the tick before it writes `last_check` (the "noticer goes stale/dead on the dashboard" symptom; 49 crashes in run D, 457 in run C).

**Latent until #841.** Pre-#841 nothing crystallized → the lookup always returned an empty map → the rule-hit branch was never reached → the bug stayed dormant (0 errors in all pre-#841 runs). #841 made distillation work → rules crystallize → the lookup hits → the branch runs → it crashed every rule-hit tick. So the crash actually **confirms crystallization + rule-lookup work end-to-end**; the noticer just crashed while *consuming* a hit rule.

**Fix:** use `get(rule, "key")` (the `Value::Map` accessor) for `rule_id` / `action` / `confidence`.

## QA — ✅ ship-it (deterministic get/json_get contrast)
Mock-backend daemon smoke drove a `noticer_surprise` rule to crystallization and exercised the rule-hit branch (the branch the #842 QA never reached):

| Area | Result | Mitigation | Notes |
|------|--------|------------|-------|
| `get` handles `Value::Map`; `json_get` rejects it | ✅ | — | Confirmed in agentis-core v1.10.0 (`get` 5611, `json_get` 5806). |
| lookup returns `Value::Map`; keys rule_id/action/confidence present | ✅ | — | `eval_crystallizer_lookup_with_confidence` 2470, `crystallizer_rule_to_string_map` 17192. |
| **get() smoke reaches rule-hit branch + passes** | ✅ | — | Rule crystallized, lookup HIT 287×, `hit` memo populated (`rid=… act=true\|desc conf=0.2500`), **0** `expected string, got map` / tick:error. Daemon healthy. |
| **json_get() contrast still crashes** | ✅ | — | Same drive → `expected string, got map` ×294, hit memo never written, daemon quarantined (the stale/"dead" symptom). Proves the fix targets exactly this crash. |
| colony-lint | ✅ | — | 345 passed / 0 failed / 5 skipped. |

## Test plan
- [x] colony-lint clean
- [x] get() daemon smoke: rule-hit branch runs clean, rule_id/action/confidence extracted
- [x] json_get() contrast: reproduces `expected string, got map` on the same path
- [ ] End-to-end #833 re-run (acceptance): with #841 + this fix, breeding loop runs clean — distill → crystallize → rule-hit replaces `prompt()`

Fixes #843. Refs #833. Surfaced by #841.