### PR TITLE
skeptic: distill verdicts into crystallizable rules (#845 Phase 1)

### DIFF
--- a/research-foundry/skeptic/agents/skeptic.ag
+++ b/research-foundry/skeptic/agents/skeptic.ag
@@ -311,6 +311,103 @@ fn _publish_skeptic(
     };
 }
 
+// _publish_skeptic_rule_hit -- mirror of _publish_skeptic but takes
+// primitive fields because the .ag grammar disallows inline
+// SkepticVerdict struct literals (confirmed: "expected Semicolon, got
+// LBrace"). The downstream still reads the same verdict JSON / memo
+// keys / emit payload, so the encoding is identical to the LLM path;
+// only the source differs (rule vs prompt). The fitness + replicate-gate
+// block is copied verbatim from _publish_skeptic so rule-hit ticks
+// contribute to replication fitness the same as LLM-driven ticks.
+fn _publish_skeptic_rule_hit(
+    final_write: bool,
+    do_replicate: bool,
+    verdict_label: string,
+    reasoning: string,
+    classical_reference: string,
+    confidence: float,
+    self_pid: string,
+    _colony_name: string,
+    noticer_pid: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int
+) -> void {
+    let _ = final_write;
+    let _ = tick_idx;
+    let conf_str = to_string(confidence);
+    let verdict_json = "{\"verdict\":\"" + verdict_label
+                     + "\",\"reasoning\":\"" + reasoning
+                     + "\",\"classical_reference\":\"" + classical_reference
+                     + "\",\"confidence\":" + conf_str + "}";
+    memo_write("skeptic:" + self_pid + ":verdict:tick-" + to_string(upstream_tick), verdict_json);
+    memo_write("skeptic:" + self_pid + ":verdict_label:tick-" + to_string(upstream_tick), verdict_label);
+    let upheld_str = if verdict_label == "dismissed" { "false"; } else { "true"; };
+    if len(noticer_pid) > 0 {
+        memo_write("skeptic:upheld:" + noticer_pid + ":tick-" + to_string(upstream_tick), upheld_str);
+    };
+    memo_write("replay:current_skeptic_pid", self_pid);
+    emit("math-foundry:skeptic_done", verdict_json);
+
+    if len(self_pid) > 0 {
+        let fit_pre = parse_int(recall_latest("skeptic:" + self_pid + ":fitness"));
+        let fit_delta = if verdict_label == "dismissed" { 0; } else { 1; };
+        memo_write("skeptic:" + self_pid + ":fitness", to_string(fit_pre + fit_delta));
+    };
+
+    if do_replicate {
+        let repr_thr = parse_int(recall_latest("skeptic:reproductive_fitness_threshold"));
+        if repr_thr > 0 {
+            let my_fit_r = parse_int(recall_latest("skeptic:" + self_pid + ":fitness"));
+            if my_fit_r > repr_thr {
+                let n_r = parse_int(recall_latest("colony-" + _colony_name + ":size"));
+                let max_repl_r = parse_int(recall_latest("colony-" + _colony_name + ":max_replicas"));
+                if n_r < max_repl_r {
+                    let pool_r = parse_int(recall_latest("colony-" + _colony_name + ":pool"));
+                    let base_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_base_cost"));
+                    let raw_k_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_k"));
+                    let k_r = if raw_k_r <= 0 { 3; } else { raw_k_r; };
+                    let cost_r = base_r + (base_r * n_r) / k_r;
+                    if pool_r >= cost_r {
+                        let variant_pick = pick_variant(n_r);
+                        memo_write("skeptic:prompt_variant", variant_pick);
+                        let target_r = select_replication_target();
+                        if len(target_r) > 0 {
+                            let variant_wrapped = _publish_prompt_body_and_wrap_variant(self_pid, variant_pick);
+                            let replica_id = try { replicate(target_r, my_fit_r, variant_wrapped); } catch e { "__replicate_error__"; };
+                            if replica_id != "__replicate_error__" {
+                                if len(replica_id) > 0 {
+                                    memo_write("colony-" + _colony_name + ":pool", to_string(pool_r - cost_r));
+                                    memo_write("colony-" + _colony_name + ":size", to_string(n_r + 1));
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "math-foundry", _colony_name]);
+
+                                    let lin_str = recall_latest("skeptic:" + self_pid + ":generation");
+                                    let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
+                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    if len(ledger_path_r) > 0 {
+                                        let parent_specialty = recall_latest("skeptic:" + self_pid + ":specialty");
+                                        let child_gen = lin + 1;
+                                        let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
+                                        // colony-lint: safe-exec-concat
+                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
+                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        memo_write("skeptic:" + replica_id + ":generation", to_string(child_gen));
+                                        if len(parent_specialty) > 0 {
+                                            memo_write("skeptic:" + replica_id + ":specialty", parent_specialty);
+                                        };
+                                    };
+                                } else {
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "math-foundry", _colony_name]);
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+}
+
 // Issue #767: aging-out gate (death pressure). Two-phase: this .ag
 // publishes `colony:cull_self_request:<pid>` when age_ticks crosses
 // `env:RESEARCH_AGING_THRESHOLD`; the cull-replicas.sh sidecar reads
@@ -336,6 +433,85 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
         memo_write("colony:cull_self_request:" + self_pid, "aging");
     };
     return next_age;
+}
+
+// #845: rule-first / distillation scaffolding ported from the noticer
+// (#819/#841/#843). The distillable decision here is the discrete
+// SkepticVerdict.verdict field ("dismissed|upheld|unsure"); reasoning
+// and classical_reference are free-form LLM prose and are NOT encoded
+// into the rule action (that was the #841 mistake). The crystallizer
+// distils repeat verdicts over the same canonical context into a rule
+// the next tick's Stage-1 lookup consumes without prompt().
+
+// _skeptic_canonical_ctx -- the rule key. Source of truth is the
+// upstream noticer's already-stable canonical context, written by the
+// noticer at `noticer:<pid>:canonical_ctx:tick-<N>` (shape
+// "topic=.. output_kind=.. bucket=.. seq=.. lines=.."). Reusing it
+// keeps the skeptic's rule key byte-identical to the noticer's so the
+// two colonies key off the same context class. Falls back to a coarse
+// self-built key from the surprise topic when the noticer wrote none.
+fn _skeptic_canonical_ctx(noticer_pid: string, upstream_tick: int) -> string {
+    if len(noticer_pid) > 0 {
+        let upstream = recall_latest("noticer:" + noticer_pid + ":canonical_ctx:tick-" + to_string(upstream_tick));
+        if len(upstream) > 0 {
+            return upstream;
+        };
+    };
+    let topic_a = recall_latest("replay:current_topic");
+    let topic = if len(topic_a) > 0 { topic_a; } else { "na"; };
+    return "topic=" + topic + " output_kind=na";
+}
+
+// _canonical_stable_desc -- deterministic detail string derived from
+// canonical_ctx (port of the noticer helper). Templates only the two
+// coarsest, stable fields (topic + output_kind) so the rule action is
+// identical across repeat observations of the same context class and
+// the distilled KnowledgeEntry id stays stable; bucket/seq/lines jitter
+// tick-to-tick and are intentionally excluded. Total on missing fields
+// ("na"). ASCII-only, single line.
+fn _canonical_stable_desc(canonical_ctx: string) -> string {
+    if len(canonical_ctx) == 0 { return "skeptic-class topic=na output_kind=na"; };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,re\ns=sys.argv[1]\ndef g(k):\n m=re.search(r\"(?:^| )\"+k+r\"=(\\S+)\", s)\n return m.group(1) if m else \"na\"\nprint(\"skeptic-class topic=\"+g(\"topic\")+\" output_kind=\"+g(\"output_kind\"))' " + shell_escape(canonical_ctx);
+    let out = try { exec sh cmd; } catch e { "skeptic-class topic=na output_kind=na"; };
+    if len(out) == 0 { return "skeptic-class topic=na output_kind=na"; };
+    return out;
+}
+
+// _parse_rule_action_verdict -- decoder for the pipe-delimited
+// `<verdict>|<canonical_detail>` encoding the LLM path writes into
+// learn("skeptic_verdict", ...). Analogous to the noticer's
+// _parse_rule_action_bool, but the discrete decision is a string
+// (the verdict) so it returns the portion before the first "|".
+// Total on missing pipe (returns the whole trimmed string).
+fn _parse_rule_action_verdict(action: string) -> string {
+    if len(action) == 0 { return ""; };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys; print(sys.argv[1].split(\"|\",1)[0].strip())' " + shell_escape(action);
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+// _skeptic_demotion_hook -- #819 demotion hook, extracted so both the
+// Stage-1 rule-hit path and the Stage-2 LLM path run it identically.
+// Reads the noticer's distilled rule_id and records skeptic agreement /
+// disagreement via crystallizer_record_use. No-op when the rule_id
+// memo is empty (noticer took its LLM path).
+fn _skeptic_demotion_hook(noticer_pid: string, upstream_tick: int, verdict_label: string) -> void {
+    if len(noticer_pid) == 0 { return; };
+    let noticer_rule_id = recall_latest("noticer:" + noticer_pid + ":rule_id:tick-" + to_string(upstream_tick));
+    if len(noticer_rule_id) == 0 { return; };
+    if verdict_label == "dismissed" {
+        crystallizer_record_use(noticer_rule_id, false, 0.0 - 0.15);
+        // colony-lint: learn-tags-ok
+        learn("noticer_surprise", "rule_demotion", "skeptic=dismissed rule_id=" + noticer_rule_id, "failure", ["rule-demoted", "skeptic-override", "math-foundry"]);
+    } else {
+        if verdict_label == "upheld" {
+            crystallizer_record_use(noticer_rule_id, true, 0.05);
+            // colony-lint: learn-tags-ok
+            learn("noticer_surprise", "rule_reinforce", "skeptic=upheld rule_id=" + noticer_rule_id, "success", ["rule-reinforced", "skeptic-agreement", "math-foundry"]);
+        };
+    };
 }
 
 fn tick(reason: string) -> void {
@@ -416,9 +592,110 @@ fn tick(reason: string) -> void {
             + "WHY SURPRISING: " + why_surprising + "\n";
 
     _dump_ctx_to_memo("skeptic", _self_pid, tick_idx, ctx);
-    let verdict = prompt(_seed_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> SkepticVerdict;
 
     let my_tier = tier("skeptic");
+
+    // ===== Stage 1: rule-first lookup (#845, mirrors noticer #819) =====
+    // The canonical context is the noticer's already-stable canonical_ctx
+    // for this upstream tick (or a coarse fallback). On a crystallized
+    // skeptic_verdict rule hit, reconstruct a SkepticVerdict from the
+    // rule's action slot and skip prompt(). Rollback knob:
+    // SKEPTIC_RULE_FIRST=0 short-circuits Stage 1 to the LLM path.
+    let canonical_ctx = _skeptic_canonical_ctx(noticer_pid, upstream_tick);
+
+    let rule_first_flag = try { exec sh "printenv SKEPTIC_RULE_FIRST"; } catch e { ""; };
+    let rule_first_enabled = rule_first_flag != "0";
+
+    let min_conf_str = try { exec sh "printenv SKEPTIC_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
+
+    if rule_first_enabled {
+        let rule = crystallizer_lookup_with_confidence("skeptic_verdict", canonical_ctx, min_conf);
+        if len(rule) > 0 {
+            // Rule hit -- synthesize a SkepticVerdict from the rule's
+            // action field without prompt(). The action slot carries
+            // "<verdict>|<canonical_detail>" (see Stage 2 learn() row).
+            // #843: crystallizer_lookup_with_confidence returns
+            // map<string,string> (Value::Map). Read fields with get()
+            // (the map accessor); json_get() expects a JSON string and
+            // raises "expected string, got map" on a map.
+            let rule_id = to_string(get(rule, "rule_id"));
+            let rule_action = to_string(get(rule, "action"));
+            let rule_conf_str = to_string(get(rule, "confidence"));
+            let rule_conf = if len(rule_conf_str) > 0 { parse_float(rule_conf_str); } else { min_conf; };
+            let rule_verdict_label = _parse_rule_action_verdict(rule_action);
+            let rule_reasoning = "rule-first: matched crystallized skeptic_verdict rule at confidence " + to_string(rule_conf) + ". Context: " + canonical_ctx;
+            // colony-lint: learn-tags-ok
+            learn("skeptic_verdict", canonical_ctx, rule_action, "success", ["distilled", "rule-hit", "math-foundry"]);
+            crystallizer_record_use(rule_id, true, 0.1);
+
+            // Tier branch -- mirrors the LLM path below. The rule-hit
+            // publisher takes primitive fields because the .ag grammar
+            // disallows inline SkepticVerdict struct literals. The
+            // skeptic_dismiss observability rows stay byte-identical to
+            // the LLM path so auto-promote sees the same tag stream.
+            if my_tier == "autonomous" {
+                memo_write("skeptic:" + _self_pid + ":review_gated", "true");
+                learn("skeptic_dismiss", "tick " + to_string(tick_idx) + " " + rule_verdict_label, rule_reasoning, "partial", ["acted", "math-foundry"]);
+                _publish_skeptic_rule_hit(true, true, rule_verdict_label, rule_reasoning, "", rule_conf, _self_pid, _colony_name, noticer_pid, upstream_tick, tick_idx, _tick_now_ms);
+            } else {
+                if my_tier == "review-gated" {
+                    memo_write("skeptic:" + _self_pid + ":review_gated", "true");
+                    learn("skeptic_dismiss", "tick " + to_string(tick_idx) + " " + rule_verdict_label, rule_reasoning, "partial", ["review-gated", "math-foundry"]);
+                    _publish_skeptic_rule_hit(true, false, rule_verdict_label, rule_reasoning, "", rule_conf, _self_pid, _colony_name, noticer_pid, upstream_tick, tick_idx, _tick_now_ms);
+                } else {
+                    if my_tier == "propose" {
+                        learn("skeptic_dismiss", "tick " + to_string(tick_idx) + " " + rule_verdict_label, rule_reasoning, "success", ["emitted", "math-foundry"]);
+                        _publish_skeptic_rule_hit(false, false, rule_verdict_label, rule_reasoning, "", rule_conf, _self_pid, _colony_name, noticer_pid, upstream_tick, tick_idx, _tick_now_ms);
+                    } else {
+                        print("[skeptic] observing rule-hit (tier:", my_tier, ") verdict=", rule_verdict_label);
+                        learn("skeptic_dismiss", "tick " + to_string(tick_idx) + " " + rule_verdict_label, rule_reasoning, "partial", ["observed", "math-foundry"]);
+                    };
+                };
+            };
+
+            _skeptic_demotion_hook(noticer_pid, upstream_tick, rule_verdict_label);
+
+            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_s1) > 0 { memo_write("skeptic:last_check", now_s1); };
+            return;
+        };
+    };
+
+    // ===== Stage 2: LLM fallback (historical path) =====
+    let verdict = prompt(_seed_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> SkepticVerdict;
+
+    // #845: distillation row. The rule action MUST be stable per context
+    // so the distilled KnowledgeEntry id is identical across repeat ticks
+    // and empirical_validations can accumulate. The action is
+    // "<verdict>|<canonical_detail>" -- the discrete verdict plus a
+    // deterministic detail derived from canonical_ctx (NOT the free-form
+    // reasoning / classical_reference prose, which would mint a fresh
+    // entry every tick -- the #841 mistake).
+    let canonical_action = verdict.verdict + "|" + _canonical_stable_desc(canonical_ctx);
+    // The distilled entry's CONDITION is a coarse, literal prefix of
+    // canonical_ctx (the leading topic= + output_kind= fields, before
+    // " bucket="). CrystallizedRule matches_context is
+    // context.starts_with(condition), so the coarse condition still
+    // prefix-matches the FULL canonical_ctx the Stage-1 lookup passes,
+    // and repeat observations of the same context CLASS map to one entry.
+    let _bucket_at = index_of(canonical_ctx, " bucket=");
+    let coarse_ctx = if _bucket_at > 0 { substring(canonical_ctx, 0, _bucket_at); } else { canonical_ctx; };
+    // colony-lint: learn-tags-ok
+    learn("skeptic_verdict", canonical_ctx, canonical_action, "success", ["distilled", "math-foundry"]);
+
+    // Complete the distillation loop: learn() above only writes the
+    // ExperienceStore; distill() promotes >=3 successful skeptic_verdict
+    // records into a KnowledgeEntry, and knowledge_validate() bumps
+    // empirical_validations toward crystallize_min_validations. distill()
+    // raises until there are >=3 successful records, so guard it; once the
+    // entry crystallizes the Stage-1 lookup starts hitting and this miss
+    // path stops running for that context.
+    let distilled_id = try { distill("skeptic_verdict", coarse_ctx, canonical_action, "heuristic"); } catch e { ""; };
+    if len(distilled_id) > 0 {
+        knowledge_validate(distilled_id);
+    };
+
     if my_tier == "autonomous" {
         memo_write("skeptic:" + _self_pid + ":review_gated", "true");
         learn("skeptic_dismiss", "tick " + to_string(tick_idx) + " " + verdict.verdict, verdict.reasoning, "partial", ["acted", "math-foundry"]);
@@ -446,29 +723,13 @@ fn tick(reason: string) -> void {
     // Class 1 terminal triage agent that decides upheld / dismissed /
     // unsure on noticer's surprise, so it reads the rule_id memo and
     // calls crystallizer_record_use(rule_id, agree?, ±delta) per its
-    // own verdict. Disagreement (dismissed) demotes by -0.15;
-    // agreement (upheld) reinforces by +0.05. `unsure` is treated as
-    // no signal -- the skeptic is itself uncertain.  noticer_pid is
-    // already resolved above via the Phase 9 PR-A picker
-    // (`_pick_upstream_pid_by_key`). The hook is a no-op when the
-    // rule_id memo is empty (noticer's Stage 1 missed and the tick
+    // own verdict (#845: extracted into _skeptic_demotion_hook so the
+    // Stage-1 rule-hit path runs it identically). Disagreement
+    // (dismissed) demotes by -0.15; agreement (upheld) reinforces by
+    // +0.05. `unsure` is treated as no signal. The hook is a no-op when
+    // the rule_id memo is empty (noticer's Stage 1 missed and the tick
     // took the LLM path).
-    if len(noticer_pid) > 0 {
-        let noticer_rule_id = recall_latest("noticer:" + noticer_pid + ":rule_id:tick-" + to_string(upstream_tick));
-        if len(noticer_rule_id) > 0 {
-            if verdict.verdict == "dismissed" {
-                crystallizer_record_use(noticer_rule_id, false, 0.0 - 0.15);
-                // colony-lint: learn-tags-ok
-                learn("noticer_surprise", "rule_demotion", "skeptic=dismissed rule_id=" + noticer_rule_id, "failure", ["rule-demoted", "skeptic-override", "math-foundry"]);
-            } else {
-                if verdict.verdict == "upheld" {
-                    crystallizer_record_use(noticer_rule_id, true, 0.05);
-                    // colony-lint: learn-tags-ok
-                    learn("noticer_surprise", "rule_reinforce", "skeptic=upheld rule_id=" + noticer_rule_id, "success", ["rule-reinforced", "skeptic-agreement", "math-foundry"]);
-                };
-            };
-        };
-    };
+    _skeptic_demotion_hook(noticer_pid, upstream_tick, verdict.verdict);
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
     if len(now) > 0 {


### PR DESCRIPTION
## Summary
Phase 1 of #845 — generalize the noticer breeding-loop pattern to the first **verdict colony**, the skeptic. It now:
- **Stage-1 rule-first:** keys on the upstream noticer's stable `canonical_ctx` memo, calls `crystallizer_lookup_with_confidence("skeptic_verdict", ctx, min)`, and on a hit reconstructs a `SkepticVerdict` from the rule map via `get()` (not `json_get` — #843), **skipping `prompt()`**.
- **Stage-2 miss:** records experience, then `distill()`s a stable `"<verdict>|<canonical_detail>"` action under a coarse `topic=… output_kind=…` condition and `knowledge_validate()`s it so the rule can crystallize.

Only the discrete `SkepticVerdict.verdict` is encoded into the rule action; `reasoning`/`classical_reference` (free LLM prose) stay out, so the entry id is stable and validations accumulate (the #841 lesson). The four-tier branch, `_publish_skeptic`, `skeptic_dismiss` observability rows, and the #819 demotion hook are preserved byte-identically on **both** paths.

## QA — ✅ ship-it (independent, deterministic get/json_get contrast)
| Area | Result | Notes |
|------|--------|-------|
| Map read with `get()`, no `json_get` on the map | ✅ | `get(rule,…)` at the rule-hit branch; the file's `json_get` calls are all on `surprise_json` (a JSON string), correct. |
| 4-tier branch + `_publish_skeptic`/`_publish_skeptic_rule_hit` + `skeptic_dismiss` rows + #819 demotion hook | ✅ | Preserved byte-identically on both rule-hit and prompt paths. |
| Daemon smoke: rule-hit branch via `get()` | ✅ | Rule crystallized; **128 rule-hit ticks, 0 `expected string, got map`**; `get()` decoded verdict/confidence. |
| json_get contrast | ✅ | Same map via `json_get` crashes every tick — proves the harness reaches the branch and `get()` is the fix. |
| colony-lint | ✅ | 345 passed / 0 failed / 5 skipped. |

## Test plan
- [x] colony-lint clean
- [x] daemon smoke: skeptic_verdict rule crystallizes → rule-hit branch reconstructs verdict via get(), 0 crashes
- [x] json_get contrast crashes on the same path
- [ ] Federation run: skeptic accumulates rule-hits alongside the noticer, federation prompt volume below noticer-only baseline (acceptance, #833)

Refs #845, #833. Builds on #819/#820/#841/#843.