### PR TITLE
novelty: distill verdicts into crystallizable rules (#845 Phase 2)

### DIFF
--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -637,6 +637,256 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
     return next_age;
 }
 
+// #845: rule-first / distillation scaffolding ported from the skeptic
+// (#819/#841/#843). The distillable decision here is the discrete
+// NoveltyVerdict.novelty_verdict field ("NOVEL|BORDERLINE|NOT_NOVEL");
+// reasoning and classical_identifier are free-form LLM prose and are
+// NOT encoded into the rule action (that was the #841 mistake). The
+// crystallizer distils repeat verdicts over the same canonical context
+// into a rule the next tick's Stage-1 lookup consumes without prompt().
+
+// _classify_answer_kind -- six-way classifier of the stated answer's
+// shape. Mirrors the noticer's _classify_output_kind but reads the
+// formulator's stated ANSWER (the discrete, structural part of the
+// claim) so the canonical context is deterministic across repeat ticks
+// of the same context class. Total on every malformed input (falls
+// back to "scalar"). ASCII-only, single token.
+fn _classify_answer_kind(answer: string) -> string {
+    if len(answer) == 0 { return "empty"; };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,re\ntxt=sys.argv[1]\ns=txt.strip()\nif not s:\n print(\"empty\"); sys.exit(0)\nif s.startswith(\"[[\") or re.search(r\"\\[\\[[^]]+\\]\\]\", s):\n print(\"matrix\"); sys.exit(0)\nif re.search(r\"[A-Za-z]\\s*\\^\\s*\\d+\", s) or \"Poly(\" in s:\n print(\"polynomial\"); sys.exit(0)\nints=re.findall(r\"-?\\d+\", s)\nif len(ints)>=3:\n print(\"sequence\"); sys.exit(0)\nif re.search(r\"-?\\d+\\.\\d+\", s):\n print(\"float\"); sys.exit(0)\nif len(ints)==1:\n print(\"scalar\"); sys.exit(0)\nprint(\"symbolic\")' " + shell_escape(answer);
+    let out = try { exec sh cmd; } catch e { "scalar"; };
+    if len(out) == 0 { return "scalar"; };
+    return out;
+}
+
+// _novelty_canonical_ctx -- the rule key. The novelty referee's
+// upstream producers (verifier / formulator / explorer) do NOT write a
+// stable canonical_ctx memo the way the noticer does for the skeptic,
+// so we build a coarse self-key from the resolved topic_label plus a
+// deterministic classification of the stated answer's shape. Field
+// order is most-discriminating-first to match the crystallizer's prefix
+// matcher: "topic=<topic> output_kind=<kind> bucket=<size_bucket>".
+// topic + output_kind are the coarse, stable fields the distill
+// condition keys off; bucket jitters within a context class and is the
+// tiebreaker the Stage-1 full-ctx lookup prefix-matches against.
+// Missing / empty fields collapse to "na"; ASCII-only, single line.
+fn _novelty_canonical_ctx(topic_label: string, stated_answer: string) -> string {
+    let topic = if len(topic_label) > 0 { topic_label; } else { "na"; };
+    let kind = _classify_answer_kind(stated_answer);
+    let n = len(stated_answer);
+    let bucket = if n < 100 { "small"; } else { if n < 10000 { "medium"; } else { "large"; }; };
+    return "topic=" + topic + " output_kind=" + kind + " bucket=" + bucket;
+}
+
+// _canonical_stable_desc -- deterministic detail string derived from
+// canonical_ctx (port of the noticer / skeptic helper). Templates only
+// the two coarsest, stable fields (topic + output_kind) so the rule
+// action is identical across repeat observations of the same context
+// class and the distilled KnowledgeEntry id stays stable; bucket
+// jitters tick-to-tick and is intentionally excluded. Total on missing
+// fields ("na"). ASCII-only, single line.
+fn _canonical_stable_desc(canonical_ctx: string) -> string {
+    if len(canonical_ctx) == 0 { return "novelty-class topic=na output_kind=na"; };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,re\ns=sys.argv[1]\ndef g(k):\n m=re.search(r\"(?:^| )\"+k+r\"=(\\S+)\", s)\n return m.group(1) if m else \"na\"\nprint(\"novelty-class topic=\"+g(\"topic\")+\" output_kind=\"+g(\"output_kind\"))' " + shell_escape(canonical_ctx);
+    let out = try { exec sh cmd; } catch e { "novelty-class topic=na output_kind=na"; };
+    if len(out) == 0 { return "novelty-class topic=na output_kind=na"; };
+    return out;
+}
+
+// _parse_rule_action_verdict -- decoder for the pipe-delimited
+// `<novelty_verdict>|<canonical_detail>` encoding the LLM path writes
+// into learn("novelty_verdict", ...). The discrete decision is a string
+// (the verdict) so it returns the portion before the first "|".
+// Total on missing pipe (returns the whole trimmed string).
+fn _parse_rule_action_verdict(action: string) -> string {
+    if len(action) == 0 { return ""; };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys; print(sys.argv[1].split(\"|\",1)[0].strip())' " + shell_escape(action);
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+// _publish_novelty_rule_hit -- mirror of _publish_novelty but takes
+// primitive fields because the .ag grammar disallows inline
+// NoveltyVerdict struct literals (confirmed by the skeptic port:
+// "expected Semicolon, got LBrace"). The downstream still reads the
+// same verdict JSON / memo keys / claim handoff / knowledge_sell /
+// fitness signal, so the encoding is identical to the LLM path; only
+// the source differs (rule vs prompt). The claim-handoff,
+// knowledge-market, fitness, and replicate-gate blocks are copied from
+// _publish_novelty so rule-hit ticks behave identically to LLM ticks.
+fn _publish_novelty_rule_hit(
+    final_write: bool,
+    do_replicate: bool,
+    is_classical_result: bool,
+    classical_identifier: string,
+    novelty_verdict_label: string,
+    reasoning: string,
+    self_pid: string,
+    colony_name_str: string,
+    explorer_pid: string,
+    problem_text: string,
+    stated_answer: string,
+    novelty_claim: string,
+    topic_label: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int,
+    my_tier: string
+) -> void {
+    let effective_label = novelty_verdict_label;
+    let classical_str = if is_classical_result { "true"; } else { "false"; };
+    let novelty_json = "{\"is_classical_result\":" + classical_str
+                     + ",\"classical_identifier\":\"" + classical_identifier
+                     + "\",\"novelty_verdict\":\"" + effective_label
+                     + "\",\"reasoning\":\"" + reasoning + "\"}";
+    memo_write("novelty:" + self_pid + ":verdict:tick-" + to_string(upstream_tick), novelty_json);
+
+    if len(explorer_pid) > 0 {
+        memo_write("novelty:final_verdict:" + explorer_pid + ":tick-" + to_string(upstream_tick), effective_label);
+    };
+
+    if effective_label == "NOVEL" {
+        let tick_s = to_string(tick_idx);
+        memo_write("claim:problem_text:tick-" + tick_s, problem_text);
+        memo_write("claim:answer:tick-" + tick_s, stated_answer);
+        memo_write("claim:novelty_claim:tick-" + tick_s, novelty_claim);
+        if len(explorer_pid) > 0 {
+            let explorer_code = recall_latest("explorer:" + explorer_pid + ":code:tick-" + to_string(upstream_tick));
+            let explorer_output = recall_latest("explorer:" + explorer_pid + ":output:tick-" + to_string(upstream_tick));
+            let explorer_goal = recall_latest("explorer:" + explorer_pid + ":goal:tick-" + to_string(upstream_tick));
+            memo_write("claim:explorer_code:tick-" + tick_s, explorer_code);
+            memo_write("claim:explorer_output:tick-" + tick_s, explorer_output);
+            memo_write("claim:explorer_goal:tick-" + tick_s, explorer_goal);
+        };
+    } else {
+        if effective_label == "BORDERLINE" {
+            let tick_s = to_string(tick_idx);
+            memo_write("claim:problem_text:tick-" + tick_s, problem_text);
+            memo_write("claim:answer:tick-" + tick_s, stated_answer);
+            memo_write("claim:novelty_claim:tick-" + tick_s, novelty_claim);
+            if len(explorer_pid) > 0 {
+                let explorer_code = recall_latest("explorer:" + explorer_pid + ":code:tick-" + to_string(upstream_tick));
+                let explorer_output = recall_latest("explorer:" + explorer_pid + ":output:tick-" + to_string(upstream_tick));
+                let explorer_goal = recall_latest("explorer:" + explorer_pid + ":goal:tick-" + to_string(upstream_tick));
+                memo_write("claim:explorer_code:tick-" + tick_s, explorer_code);
+                memo_write("claim:explorer_output:tick-" + tick_s, explorer_output);
+                memo_write("claim:explorer_goal:tick-" + tick_s, explorer_goal);
+            };
+        };
+    };
+
+    if final_write {
+        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        if len(ledger_path) > 0 {
+            let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"event\":\"novelty_verdict\",\"verdict\":\"" + effective_label + "\"}";
+            // colony-lint: safe-exec-concat
+            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
+            let _ = try { exec sh append_cmd; } catch e { ""; };
+        };
+    };
+
+    emit("math-foundry:novelty_done", novelty_json);
+    if my_tier == "propose" {
+        learn("novelty", "tick " + to_string(tick_idx) + " " + effective_label, reasoning, "success", ["emitted", "math-foundry"]);
+    };
+
+    if len(topic_label) > 0 {
+        if effective_label == "NOVEL" {
+            let sell_topic = "permutation_order_facts:" + topic_label;
+            let summary = "problem=" + problem_text + " answer=" + stated_answer + " novelty_claim=" + novelty_claim;
+            let sold = knowledge_sell(sell_topic, summary, 3);
+            if sold == false {
+                learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "math-foundry"]);
+            };
+        } else { if effective_label == "BORDERLINE" {
+            let sell_topic = "permutation_order_facts:" + topic_label;
+            let summary = "problem=" + problem_text + " answer=" + stated_answer + " novelty_claim=" + novelty_claim;
+            let sold = knowledge_sell(sell_topic, summary, 3);
+            if sold == false {
+                learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "math-foundry"]);
+            };
+        } else { if effective_label == "NOT_NOVEL" {
+            if len(classical_identifier) > 0 {
+                let sell_topic = "known_priors:" + topic_label;
+                let citations = classical_identifier;
+                let sold = knowledge_sell(sell_topic, citations, 2);
+                if sold == false {
+                    learn("knowledge_sell", sell_topic, "", "failure", ["sell-failed", "math-foundry"]);
+                };
+            };
+        }; }; };
+    };
+
+    if len(self_pid) > 0 {
+        let fit_pre = parse_int(recall_latest("novelty:" + self_pid + ":fitness"));
+        let fit_delta = if effective_label == "NOVEL" {
+            2;
+        } else { if effective_label == "BORDERLINE" {
+            1;
+        } else { if effective_label == "NOT_NOVEL" {
+            0 - 1;
+        } else {
+            0;
+        }; }; };
+        memo_write("novelty:" + self_pid + ":fitness", to_string(fit_pre + fit_delta));
+    };
+
+    if do_replicate {
+        let repr_thr = parse_int(recall_latest("novelty:reproductive_fitness_threshold"));
+        if repr_thr > 0 {
+            let my_fit_r = parse_int(recall_latest("novelty:" + self_pid + ":fitness"));
+            if my_fit_r > repr_thr {
+                let n_r = parse_int(recall_latest("colony-" + colony_name_str + ":size"));
+                let max_repl_r = parse_int(recall_latest("colony-" + colony_name_str + ":max_replicas"));
+                if n_r < max_repl_r {
+                    let pool_r = parse_int(recall_latest("colony-" + colony_name_str + ":pool"));
+                    let base_r = parse_int(recall_latest("colony-" + colony_name_str + ":replication_base_cost"));
+                    let raw_k_r = parse_int(recall_latest("colony-" + colony_name_str + ":replication_k"));
+                    let k_r = if raw_k_r <= 0 { 3; } else { raw_k_r; };
+                    let cost_r = base_r + (base_r * n_r) / k_r;
+                    if pool_r >= cost_r {
+                        let variant_pick = pick_variant(n_r);
+                        memo_write("novelty:prompt_variant", variant_pick);
+                        let target_r = select_replication_target();
+                        if len(target_r) > 0 {
+                            let variant_wrapped = _publish_prompt_body_and_wrap_variant(self_pid, variant_pick);
+                            let replica_id = try { replicate(target_r, my_fit_r, variant_wrapped); } catch e { "__replicate_error__"; };
+                            if replica_id != "__replicate_error__" {
+                                if len(replica_id) > 0 {
+                                    memo_write("colony-" + colony_name_str + ":pool", to_string(pool_r - cost_r));
+                                    memo_write("colony-" + colony_name_str + ":size", to_string(n_r + 1));
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "math-foundry", colony_name_str]);
+
+                                    let lin_str = recall_latest("novelty:" + self_pid + ":generation");
+                                    let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
+                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    if len(ledger_path_r) > 0 {
+                                        let parent_specialty = recall_latest("novelty:" + self_pid + ":specialty");
+                                        let child_gen = lin + 1;
+                                        let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + colony_name_str + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
+                                        // colony-lint: safe-exec-concat
+                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
+                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        memo_write("novelty:" + replica_id + ":generation", to_string(child_gen));
+                                        if len(parent_specialty) > 0 {
+                                            memo_write("novelty:" + replica_id + ":specialty", parent_specialty);
+                                        };
+                                    };
+                                } else {
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "math-foundry", colony_name_str]);
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
@@ -727,6 +977,76 @@ fn tick(reason: string) -> void {
             + "ANSWER: " + stated_answer + "\n"
             + "NOVELTY CLAIM: " + novelty_claim + "\n";
 
+    let my_tier = tier("novelty");
+
+    // ===== Stage 1: rule-first lookup (#845, mirrors skeptic #819) =====
+    // The canonical context is a coarse self-built key (topic +
+    // output_kind + size bucket); novelty's upstreams write no stable
+    // canonical_ctx memo, so we synthesize one deterministically. On a
+    // crystallized novelty_verdict rule hit, reconstruct a NoveltyVerdict
+    // from the rule's action slot and skip prompt(). Rollback knob:
+    // NOVELTY_RULE_FIRST=0 short-circuits Stage 1 to the LLM path.
+    let canonical_ctx = _novelty_canonical_ctx(topic_label, stated_answer);
+
+    let rule_first_flag = try { exec sh "printenv NOVELTY_RULE_FIRST"; } catch e { ""; };
+    let rule_first_enabled = rule_first_flag != "0";
+
+    let min_conf_str = try { exec sh "printenv NOVELTY_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
+
+    if rule_first_enabled {
+        let rule = crystallizer_lookup_with_confidence("novelty_verdict", canonical_ctx, min_conf);
+        if len(rule) > 0 {
+            // Rule hit -- synthesize a NoveltyVerdict from the rule's
+            // action field without prompt(). The action slot carries
+            // "<novelty_verdict>|<canonical_detail>" (see Stage 2 learn()
+            // row). #843: crystallizer_lookup_with_confidence returns
+            // map<string,string> (Value::Map). Read fields with get()
+            // (the map accessor); json_get() expects a JSON string and
+            // raises "expected string, got map" on a map.
+            let rule_id = to_string(get(rule, "rule_id"));
+            let rule_action = to_string(get(rule, "action"));
+            let rule_verdict_label = _parse_rule_action_verdict(rule_action);
+            // Derive the struct fields the LLM would have set: NOT_NOVEL
+            // implies a classical match, NOVEL/BORDERLINE do not. The
+            // classical_identifier is free LLM prose and is intentionally
+            // NOT crystallized (#841), so it stays empty on the rule path.
+            let rule_is_classical = rule_verdict_label == "NOT_NOVEL";
+            let rule_reasoning = "rule-first: matched crystallized novelty_verdict rule. Context: " + canonical_ctx;
+            // colony-lint: learn-tags-ok
+            learn("novelty_verdict", canonical_ctx, rule_action, "success", ["distilled", "rule-hit", "math-foundry"]);
+            crystallizer_record_use(rule_id, true, 0.1);
+
+            // Tier branch -- mirrors the LLM path below. The rule-hit
+            // publisher takes primitive fields because the .ag grammar
+            // disallows inline NoveltyVerdict struct literals. The novelty
+            // observability rows stay byte-identical to the LLM path so
+            // auto-promote sees the same tag stream.
+            if my_tier == "autonomous" {
+                memo_write("novelty:" + _self_pid + ":autonomous_decision", "true");
+                learn("novelty", "tick " + to_string(tick_idx) + " " + rule_verdict_label, rule_reasoning, "partial", ["acted", "math-foundry"]);
+                _publish_novelty_rule_hit(true, true, rule_is_classical, "", rule_verdict_label, rule_reasoning, _self_pid, _colony_name, explorer_pid, problem_text, stated_answer, novelty_claim, topic_label, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+            } else {
+                if my_tier == "review-gated" {
+                    learn("novelty", "tick " + to_string(tick_idx) + " " + rule_verdict_label, rule_reasoning, "partial", ["review-gated", "math-foundry"]);
+                    _publish_novelty_rule_hit(true, false, rule_is_classical, "", rule_verdict_label, rule_reasoning, _self_pid, _colony_name, explorer_pid, problem_text, stated_answer, novelty_claim, topic_label, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+                } else {
+                    if my_tier == "propose" {
+                        _publish_novelty_rule_hit(false, false, rule_is_classical, "", rule_verdict_label, rule_reasoning, _self_pid, _colony_name, explorer_pid, problem_text, stated_answer, novelty_claim, topic_label, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+                    } else {
+                        print("[novelty] observing rule-hit (tier:", my_tier, ") verdict=", rule_verdict_label);
+                        learn("novelty", "tick " + to_string(tick_idx) + " " + rule_verdict_label, rule_reasoning, "partial", ["observed", "math-foundry"]);
+                    };
+                };
+            };
+
+            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_s1) > 0 { memo_write("novelty:last_check", now_s1); };
+            return;
+        };
+    };
+
+    // ===== Stage 2: LLM fallback (historical path) =====
     let novelty = prompt(_seed_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> NoveltyVerdict;
 
     // #765 novelty loss-function shaping (env-gated). On
@@ -742,7 +1062,39 @@ fn tick(reason: string) -> void {
     // and the observing print(). Empty `shaped_label` falls through to
     // the LLM's raw verdict (pre-#765 byte-identical).
     let effective_label_tick = if len(shaped_label) > 0 { shaped_label; } else { novelty.novelty_verdict; };
-    let my_tier = tier("novelty");
+
+    // #845: distillation row. The rule action MUST be stable per context
+    // so the distilled KnowledgeEntry id is identical across repeat ticks
+    // and empirical_validations can accumulate. The action is
+    // "<novelty_verdict>|<canonical_detail>" -- the discrete (shaping-
+    // aware) verdict plus a deterministic detail derived from
+    // canonical_ctx (NOT the free-form reasoning / classical_identifier
+    // prose, which would mint a fresh entry every tick -- the #841
+    // mistake).
+    let canonical_action = effective_label_tick + "|" + _canonical_stable_desc(canonical_ctx);
+    // The distilled entry's CONDITION is a coarse, literal prefix of
+    // canonical_ctx (the leading topic= + output_kind= fields, before
+    // " bucket="). CrystallizedRule matches_context is
+    // context.starts_with(condition), so the coarse condition still
+    // prefix-matches the FULL canonical_ctx the Stage-1 lookup passes,
+    // and repeat observations of the same context CLASS map to one entry.
+    let _bucket_at = index_of(canonical_ctx, " bucket=");
+    let coarse_ctx = if _bucket_at > 0 { substring(canonical_ctx, 0, _bucket_at); } else { canonical_ctx; };
+    // colony-lint: learn-tags-ok
+    learn("novelty_verdict", canonical_ctx, canonical_action, "success", ["distilled", "math-foundry"]);
+
+    // Complete the distillation loop: learn() above only writes the
+    // ExperienceStore; distill() promotes >=3 successful novelty_verdict
+    // records into a KnowledgeEntry, and knowledge_validate() bumps
+    // empirical_validations toward crystallize_min_validations. distill()
+    // raises until there are >=3 successful records, so guard it; once the
+    // entry crystallizes the Stage-1 lookup starts hitting and this miss
+    // path stops running for that context.
+    let distilled_id = try { distill("novelty_verdict", coarse_ctx, canonical_action, "heuristic"); } catch e { ""; };
+    if len(distilled_id) > 0 {
+        knowledge_validate(distilled_id);
+    };
+
     if my_tier == "autonomous" {
         // Terminal agent: autonomous emits the final verdict + ledger row
         // unconditionally (no confidence floor) and stamps an


### PR DESCRIPTION
Phase 2 of #845 — port the noticer/skeptic breeding-loop pattern to the novelty colony (class `novelty_verdict`, discrete `NoveltyVerdict.novelty_verdict` encoded; prose excluded). Stage-1 rule-first via `crystallizer_lookup_with_confidence` → reconstruct via `get()` (#843) → skip prompt; Stage-2 miss → learn + distill + knowledge_validate. **Independent QA ✅ ship-it:** 582 get-OK reconstructions, 0 `expected string, got map`, json_get contrast crashes, four-tier branch + `_publish_novelty`(_rule_hit) + observability preserved, colony-lint 345/0/5. Refs #845, #833.