### PR TITLE
prior_advocate: distill verdicts into crystallizable rules (#845 Phase 3)

### DIFF
--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -9,12 +9,27 @@
 // Per-tick behaviour:
 //   1. Read claim seed memo (problem_text / answer / novelty_claim)
 //      for upstream_tick = tick_idx - 1 (mirrors searchers).
-//   2. Build the ADVOCATE_PROMPT and call prompt() -> Verdict JSON.
-//   3. Persist the verdict to memo
+//   2. Stage 1 (#845): build a coarse canonical context
+//      ("topic=.. output_kind=..") and consult the crystallizer via
+//      `crystallizer_lookup_with_confidence("prior_verdict",
+//      canonical_ctx, PRIOR_ADVOCATE_RULE_CONFIDENCE)`. On hit,
+//      synthesize a Verdict from the rule's `action` field and skip the
+//      LLM call.
+//   3. Stage 2: on miss, run the legacy LLM `prompt() -> Verdict` path.
+//      Trailing distillation row `learn("prior_verdict", canonical_ctx,
+//      "<is_prior-bool>|<desc>", ...)` + guarded distill() +
+//      knowledge_validate() let the crystallizer distil repeat verdicts
+//      into rules the next run's Stage 1 consumes.
+//   4. Persist the verdict to memo
 //      (`prior_advocate:<pid>:report:tick-N`,
 //      `prior_advocate:<pid>:is_prior:tick-N`,
 //      `replay:current_prior_advocate_pid`) and emit
 //      "claim-auditor:prior_advocate_done".
+//
+// Rollback knobs (#845):
+//   - `PRIOR_ADVOCATE_RULE_FIRST=0` short-circuits Stage 1 to the LLM path.
+//   - `PRIOR_ADVOCATE_RULE_CONFIDENCE=<float>` overrides the default 0.85
+//     confidence floor for Stage 1 rule acceptance.
 //
 // Run as daemon: agentis daemon agents/prior_advocate.ag --colony prior_advocate
 // Requires: exec capability, messaging capability.
@@ -274,6 +289,169 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
     return next_age;
 }
 
+// #845: rule-first / distillation scaffolding ported from the skeptic
+// (#846) / noticer (#819/#841/#843). The distillable decision here is
+// the discrete Verdict.is_prior bool; classical_anchor /
+// indirect_derivation / reasoning are free-form LLM prose and are NOT
+// encoded into the rule action (that was the #841 mistake). The
+// crystallizer distils repeat is_prior verdicts over the same canonical
+// context into a rule the next tick's Stage-1 lookup consumes without
+// prompt().
+
+// _prior_advocate_canonical_ctx -- the rule key. The claim/audit side
+// has no upstream producer that writes a stable canonical_ctx memo (only
+// the discovery-side noticer does), so build a coarse, deterministic
+// key from the current topic plus the output_kind classified from the
+// claim's explorer_output seed for the same upstream tick. Shape
+// "topic=.. output_kind=..", matching the leading two fields the noticer
+// emits so the coarse condition stays in the same family. Falls back to
+// "na" fields when the topic / output is empty.
+fn _prior_advocate_canonical_ctx(upstream_tick: int) -> string {
+    let topic_a = recall_latest("replay:current_topic");
+    let topic = if len(topic_a) > 0 { topic_a; } else { "na"; };
+    let explorer_output = recall_latest("claim:explorer_output:tick-" + to_string(upstream_tick));
+    let kind = _classify_output_kind(explorer_output);
+    return "topic=" + topic + " output_kind=" + kind;
+}
+
+// _classify_output_kind -- six-way classifier of explorer stdout shape.
+// Ported verbatim from the noticer so the prior_advocate's output_kind
+// field is byte-identical to the discovery-side classification for the
+// same explorer output. Total on every malformed input (falls back to
+// "sequence").
+fn _classify_output_kind(stdout: string) -> string {
+    if len(stdout) == 0 { return "empty"; };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,re\ntxt=sys.argv[1]\ns=txt.strip()\nif not s:\n print(\"empty\"); sys.exit(0)\nif re.search(r\"^(Traceback|Error|SyntaxError|NameError|TypeError|ValueError)\", s, re.M):\n print(\"error\"); sys.exit(0)\nif s.startswith(\"[[\") or re.search(r\"\\[\\[[^]]+\\]\\]\", s):\n print(\"matrix\"); sys.exit(0)\nif (\"(\" in s and \")\" in s) and len(re.findall(r\"\\(\\s*\\d+\\s*,\\s*\\d+\\s*\\)\", s))>=4:\n print(\"graph_adjacency\"); sys.exit(0)\nif re.search(r\"[A-Za-z]\\s*\\^\\s*\\d+\", s) or \"Poly(\" in s:\n print(\"polynomial\"); sys.exit(0)\nints=re.findall(r\"-?\\d+\", s)\nif len(ints)>=3:\n print(\"sequence\"); sys.exit(0)\nif len(ints)==1 or re.search(r\"-?\\d+\\.\\d+\", s):\n print(\"scalar\"); sys.exit(0)\nprint(\"sequence\")' " + shell_escape(stdout);
+    let out = try { exec sh cmd; } catch e { "sequence"; };
+    if len(out) == 0 { return "sequence"; };
+    return out;
+}
+
+// _canonical_stable_desc -- deterministic detail string derived from
+// canonical_ctx (port of the noticer/skeptic helper). Templates only the
+// two coarsest, stable fields (topic + output_kind) so the rule action is
+// identical across repeat observations of the same context class and the
+// distilled KnowledgeEntry id stays stable. Total on missing fields
+// ("na"). ASCII-only, single line.
+fn _canonical_stable_desc(canonical_ctx: string) -> string {
+    if len(canonical_ctx) == 0 { return "prior-class topic=na output_kind=na"; };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,re\ns=sys.argv[1]\ndef g(k):\n m=re.search(r\"(?:^| )\"+k+r\"=(\\S+)\", s)\n return m.group(1) if m else \"na\"\nprint(\"prior-class topic=\"+g(\"topic\")+\" output_kind=\"+g(\"output_kind\"))' " + shell_escape(canonical_ctx);
+    let out = try { exec sh cmd; } catch e { "prior-class topic=na output_kind=na"; };
+    if len(out) == 0 { return "prior-class topic=na output_kind=na"; };
+    return out;
+}
+
+// _parse_rule_action_bool -- decoder for the pipe-delimited
+// `<is_prior-bool>|<canonical_detail>` encoding the LLM path writes into
+// learn("prior_verdict", ...). Ported verbatim from the noticer: the
+// crystallizer stores the action in the rule's `action` slot; Stage 1
+// reads it back and reconstructs the boolean without a prompt() call.
+// Total on missing pipe (returns false).
+fn _parse_rule_action_bool(action: string) -> bool {
+    if len(action) == 0 { return false; };
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys; print(\"1\" if sys.argv[1].split(\"|\",1)[0].strip().lower()==\"true\" else \"0\")' " + shell_escape(action);
+    let out = try { exec sh cmd; } catch e { "0"; };
+    return out == "1";
+}
+
+// _publish_prior_advocate_rule_hit -- mirror of _publish_prior_advocate
+// but takes primitive fields because the .ag grammar disallows inline
+// Verdict struct literals. The auditor downstream still reads the same
+// verdict JSON / memo keys / emit payload, so the encoding is identical
+// to the LLM path; only the source differs (rule vs prompt). The fitness
+// + replicate-gate block is copied verbatim from _publish_prior_advocate
+// so rule-hit ticks contribute to replication fitness the same as
+// LLM-driven ticks.
+fn _publish_prior_advocate_rule_hit(
+    final_write: bool,
+    do_replicate: bool,
+    is_prior: bool,
+    classical_anchor: string,
+    indirect_derivation: string,
+    confidence: float,
+    reasoning: string,
+    self_pid: string,
+    _colony_name: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int
+) -> void {
+    let _ = final_write;
+    let _ = tick_idx;
+    let conf_str = to_string(confidence);
+    let is_prior_str = if is_prior { "true"; } else { "false"; };
+    let verdict_json = "{\"is_prior\":" + is_prior_str
+                     + ",\"classical_anchor\":\"" + classical_anchor
+                     + "\",\"indirect_derivation\":\"" + indirect_derivation
+                     + "\",\"confidence\":" + conf_str
+                     + ",\"reasoning\":\"" + reasoning + "\"}";
+    memo_write("prior_advocate:" + self_pid + ":report:tick-" + to_string(upstream_tick), verdict_json);
+    memo_write("prior_advocate:" + self_pid + ":is_prior:tick-" + to_string(upstream_tick), is_prior_str);
+    memo_write("replay:current_prior_advocate_pid", self_pid);
+    emit("claim-auditor:prior_advocate_done", verdict_json);
+
+    if len(self_pid) > 0 {
+        let fit_pre = parse_int(recall_latest("prior_advocate:" + self_pid + ":fitness"));
+        let fit_delta = if is_prior { 1; } else { 0; };
+        memo_write("prior_advocate:" + self_pid + ":fitness", to_string(fit_pre + fit_delta));
+    };
+
+    if do_replicate {
+        let repr_thr = parse_int(recall_latest("prior_advocate:reproductive_fitness_threshold"));
+        if repr_thr > 0 {
+            let my_fit_r = parse_int(recall_latest("prior_advocate:" + self_pid + ":fitness"));
+            if my_fit_r > repr_thr {
+                let n_r = parse_int(recall_latest("colony-" + _colony_name + ":size"));
+                let max_repl_r = parse_int(recall_latest("colony-" + _colony_name + ":max_replicas"));
+                if n_r < max_repl_r {
+                    let pool_r = parse_int(recall_latest("colony-" + _colony_name + ":pool"));
+                    let base_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_base_cost"));
+                    let raw_k_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_k"));
+                    let k_r = if raw_k_r <= 0 { 3; } else { raw_k_r; };
+                    let cost_r = base_r + (base_r * n_r) / k_r;
+                    if pool_r >= cost_r {
+                        let variant_pick = pick_variant(n_r);
+                        memo_write("prior_advocate:prompt_variant", variant_pick);
+                        let target_r = select_replication_target();
+                        if len(target_r) > 0 {
+                            let variant_wrapped = _publish_prompt_body_and_wrap_variant(self_pid, variant_pick);
+                            let replica_id = try { replicate(target_r, my_fit_r, variant_wrapped); } catch e { "__replicate_error__"; };
+                            if replica_id != "__replicate_error__" {
+                                if len(replica_id) > 0 {
+                                    memo_write("colony-" + _colony_name + ":pool", to_string(pool_r - cost_r));
+                                    memo_write("colony-" + _colony_name + ":size", to_string(n_r + 1));
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "claim-auditor", _colony_name]);
+
+                                    let lin_str = recall_latest("prior_advocate:" + self_pid + ":generation");
+                                    let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
+                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    if len(ledger_path_r) > 0 {
+                                        let parent_specialty = recall_latest("prior_advocate:" + self_pid + ":specialty");
+                                        let child_gen = lin + 1;
+                                        let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
+                                        // colony-lint: safe-exec-concat
+                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
+                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        memo_write("prior_advocate:" + replica_id + ":generation", to_string(child_gen));
+                                        if len(parent_specialty) > 0 {
+                                            memo_write("prior_advocate:" + replica_id + ":specialty", parent_specialty);
+                                        };
+                                    };
+                                } else {
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "claim-auditor", _colony_name]);
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
@@ -370,9 +548,111 @@ fn tick(reason: string) -> void {
             + "NOVELTY CLAIM: " + novelty_claim + "\n";
 
     _dump_ctx_to_memo("prior_advocate", _self_pid, tick_idx, ctx);
-    let verdict = prompt(_seed_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> Verdict;
 
     let my_tier = tier("prior_advocate");
+
+    // ===== Stage 1: rule-first lookup (#845, mirrors skeptic #846) =====
+    // The canonical context is a coarse, deterministic "topic=.. output_kind=.."
+    // key (the claim/audit side has no upstream canonical_ctx producer). On a
+    // crystallized prior_verdict rule hit, reconstruct a Verdict from the
+    // rule's action slot and skip prompt(). Rollback knob:
+    // PRIOR_ADVOCATE_RULE_FIRST=0 short-circuits Stage 1 to the LLM path.
+    let canonical_ctx = _prior_advocate_canonical_ctx(upstream_tick);
+
+    let rule_first_flag = try { exec sh "printenv PRIOR_ADVOCATE_RULE_FIRST"; } catch e { ""; };
+    let rule_first_enabled = rule_first_flag != "0";
+
+    let min_conf_str = try { exec sh "printenv PRIOR_ADVOCATE_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
+
+    if rule_first_enabled {
+        let rule = crystallizer_lookup_with_confidence("prior_verdict", canonical_ctx, min_conf);
+        if len(rule) > 0 {
+            // Rule hit -- synthesize a Verdict from the rule's action
+            // field without prompt(). The action slot carries
+            // "<is_prior-bool>|<canonical_detail>" (see Stage 2 learn() row).
+            // #843: crystallizer_lookup_with_confidence returns
+            // map<string,string> (Value::Map). Read fields with get()
+            // (the map accessor); json_get() expects a JSON string and
+            // raises "expected string, got map" on a map.
+            let rule_id = to_string(get(rule, "rule_id"));
+            let rule_action = to_string(get(rule, "action"));
+            let rule_conf_str = to_string(get(rule, "confidence"));
+            let rule_conf = if len(rule_conf_str) > 0 { parse_float(rule_conf_str); } else { min_conf; };
+            let rule_is_prior = _parse_rule_action_bool(rule_action);
+            let rule_reasoning = "rule-first: matched crystallized prior_verdict rule at confidence " + to_string(rule_conf) + ". Context: " + canonical_ctx;
+            // colony-lint: learn-tags-ok
+            learn("prior_verdict", canonical_ctx, rule_action, "success", ["distilled", "rule-hit", "math-foundry"]);
+            crystallizer_record_use(rule_id, true, 0.1);
+
+            // Tier branch -- mirrors the LLM path below. The rule-hit
+            // publisher takes primitive fields because the .ag grammar
+            // disallows inline Verdict struct literals. classical_anchor /
+            // indirect_derivation are empty (free LLM prose, not encoded);
+            // the prior_match observability rows stay byte-identical to the
+            // LLM path so auto-promote sees the same tag stream.
+            if my_tier == "autonomous" {
+                memo_write("prior_advocate:" + _self_pid + ":review_gated", "true");
+                learn("prior_match", "tick " + to_string(tick_idx), rule_reasoning, "partial", ["acted", "claim-auditor"]);
+                _publish_prior_advocate_rule_hit(true, true, rule_is_prior, "", "", rule_conf, rule_reasoning, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+            } else {
+                if my_tier == "review-gated" {
+                    memo_write("prior_advocate:" + _self_pid + ":review_gated", "true");
+                    learn("prior_match", "tick " + to_string(tick_idx), rule_reasoning, "partial", ["review-gated", "claim-auditor"]);
+                    _publish_prior_advocate_rule_hit(true, false, rule_is_prior, "", "", rule_conf, rule_reasoning, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+                } else {
+                    if my_tier == "propose" {
+                        learn("prior_match", "tick " + to_string(tick_idx), rule_reasoning, "success", ["emitted", "claim-auditor"]);
+                        _publish_prior_advocate_rule_hit(false, false, rule_is_prior, "", "", rule_conf, rule_reasoning, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms);
+                    } else {
+                        print("[prior_advocate] observing rule-hit (tier:", my_tier, ") is_prior=", rule_is_prior);
+                        learn("prior_match", "tick " + to_string(tick_idx), rule_reasoning, "partial", ["observed", "claim-auditor"]);
+                    };
+                };
+            };
+
+            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_s1) > 0 { memo_write("prior_advocate:last_check", now_s1); };
+            return;
+        };
+    };
+
+    // ===== Stage 2: LLM fallback (historical path) =====
+    let verdict = prompt(_seed_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> Verdict;
+
+    // #845: distillation row. The rule action MUST be stable per context
+    // so the distilled KnowledgeEntry id is identical across repeat ticks
+    // and empirical_validations can accumulate. The action is
+    // "<is_prior-bool>|<canonical_detail>" -- the discrete is_prior bool
+    // plus a deterministic detail derived from canonical_ctx (NOT the
+    // free-form reasoning / classical_anchor / indirect_derivation prose,
+    // which would mint a fresh entry every tick -- the #841 mistake).
+    let is_prior_str = if verdict.is_prior { "true"; } else { "false"; };
+    let canonical_action = is_prior_str + "|" + _canonical_stable_desc(canonical_ctx);
+    // The distilled entry's CONDITION is a coarse, literal prefix of
+    // canonical_ctx (the leading topic= + output_kind= fields, before
+    // " bucket="). CrystallizedRule matches_context is
+    // context.starts_with(condition); the coarse condition prefix-matches
+    // the FULL canonical_ctx the Stage-1 lookup passes, and repeat
+    // observations of the same context CLASS map to one entry. canonical_ctx
+    // here carries no " bucket=" tail, so the prefix is the whole string.
+    let _bucket_at = index_of(canonical_ctx, " bucket=");
+    let coarse_ctx = if _bucket_at > 0 { substring(canonical_ctx, 0, _bucket_at); } else { canonical_ctx; };
+    // colony-lint: learn-tags-ok
+    learn("prior_verdict", canonical_ctx, canonical_action, "success", ["distilled", "math-foundry"]);
+
+    // Complete the distillation loop: learn() above only writes the
+    // ExperienceStore; distill() promotes >=3 successful prior_verdict
+    // records into a KnowledgeEntry, and knowledge_validate() bumps
+    // empirical_validations toward crystallize_min_validations. distill()
+    // raises until there are >=3 successful records, so guard it; once the
+    // entry crystallizes the Stage-1 lookup starts hitting and this miss
+    // path stops running for that context.
+    let distilled_id = try { distill("prior_verdict", coarse_ctx, canonical_action, "heuristic"); } catch e { ""; };
+    if len(distilled_id) > 0 {
+        knowledge_validate(distilled_id);
+    };
+
     if my_tier == "autonomous" {
         memo_write("prior_advocate:" + _self_pid + ":review_gated", "true");
         learn("prior_match", "tick " + to_string(tick_idx), verdict.reasoning, "partial", ["acted", "claim-auditor"]);


### PR DESCRIPTION
Phase 3 of #845 — port the breeding-loop pattern to prior_advocate (class `prior_verdict`, discrete `Verdict.is_prior` bool encoded; prose excluded). Stage-1 rule-first → reconstruct via `get()` (#843) → skip prompt; Stage-2 miss → learn + distill + knowledge_validate. **Independent QA ✅ ship-it:** get() rule-hit branch clean (0 `expected string, got map`), json_get contrast crashes, four-tier branch + `_publish_prior_advocate`(_rule_hit) + `prior_match` observability preserved, colony-lint 345/0/5. Refs #845, #833.