### PR TITLE
computer: wire self-deciding distillation capability (#845)

### DIFF
--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -269,6 +269,201 @@ fn _publish_computer(
     };
 }
 
+// _publish_computer_rule_hit -- mirror of _publish_computer but takes
+// the four Script fields as primitives because the .ag grammar
+// disallows inline Script struct literals ("expected Semicolon, got
+// LBrace"). The cached rule action carries the FULL primary output
+// (the LLM-generated script), so the rule replaces only the LLM
+// GENERATION step -- the determinism (sandbox write + run + runs_ok
+// check) still executes here exactly as in _publish_computer, so the
+// reconstructed output drives the same downstream emits / memo writes
+// the executed LLM path produces (#845 "rule hit must reproduce
+// downstream effects"). The emit payload is the serialized Script JSON
+// string rather than a Script struct (skeptic #845 rule-hit pattern),
+// and the fitness + replicate-gate block is copied verbatim from
+// _publish_computer so rule-hit ticks contribute to replication fitness
+// the same as LLM-driven ticks.
+fn _publish_computer_rule_hit(
+    final_write: bool,
+    do_replicate: bool,
+    lang_in: string,
+    script_body: string,
+    expected_substring: string,
+    rationale: string,
+    script_json: string,
+    self_pid: string,
+    _colony_name: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int,
+    my_tier: string
+) -> void {
+    let _ = final_write;
+    let _ = rationale;
+    let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
+    let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
+    let lang = lang_in;
+    let ext = if lang == "gap" { ".g"; } else { ".py"; };
+    let script_path = sandbox_eff + "/repro-" + self_pid + "-tick-" + to_string(upstream_tick) + ext;
+    // colony-lint: safe-exec-concat
+    let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(script_body) + " > " + shell_escape(script_path);
+    let _wrote = try { exec sh write_cmd; } catch e { ""; };
+
+    let run_cmd = if lang == "gap" {
+        // colony-lint: safe-exec-concat
+        "gap -q -b --norepl " + shell_escape(script_path) + " 2>&1";
+    } else {
+        // colony-lint: safe-exec-concat
+        "python3 " + shell_escape(script_path) + " 2>&1";
+    };
+    let output = try { exec sh run_cmd; } catch e { ""; };
+
+    let runs_ok = if len(expected_substring) > 0 {
+        // colony-lint: safe-exec-concat
+        let check_cmd = "printf '%s' " + shell_escape(output) + " | grep -F " + shell_escape(expected_substring) + " >/dev/null 2>&1 && printf yes || printf no";
+        let g = try { exec sh check_cmd; } catch e { "no"; };
+        g == "yes";
+    } else {
+        len(output) > 0;
+    };
+
+    memo_write("computer:" + self_pid + ":script:tick-" + to_string(upstream_tick), script_body);
+    memo_write("computer:" + self_pid + ":output:tick-" + to_string(upstream_tick), output);
+    memo_write("computer:" + self_pid + ":language:tick-" + to_string(upstream_tick), lang);
+    memo_write("computer:" + self_pid + ":expected_substring:tick-" + to_string(upstream_tick), expected_substring);
+    let runs_ok_str = if runs_ok { "true"; } else { "false"; };
+    memo_write("computer:" + self_pid + ":runs_ok:tick-" + to_string(upstream_tick), runs_ok_str);
+    memo_write("replay:current_computer_pid", self_pid);
+
+    emit("computer:script_ready", script_json);
+    emit("computer:output_ready", script_json);
+
+    if my_tier == "propose" {
+        learn("compute", "tick " + to_string(tick_idx), "runs_ok=" + runs_ok_str + " lang=" + lang, "success", ["emitted", "preprint-foundry"]);
+    };
+
+    if len(self_pid) > 0 {
+        let fit_pre = parse_int(recall_latest("computer:" + self_pid + ":fitness"));
+        let fit_delta = if runs_ok { 1; } else { 0; };
+        memo_write("computer:" + self_pid + ":fitness", to_string(fit_pre + fit_delta));
+    };
+
+    if do_replicate {
+        let repr_thr = parse_int(recall_latest("computer:reproductive_fitness_threshold"));
+        if repr_thr > 0 {
+            let my_fit_r = parse_int(recall_latest("computer:" + self_pid + ":fitness"));
+            if my_fit_r > repr_thr {
+                let n_r = parse_int(recall_latest("colony-" + _colony_name + ":size"));
+                let max_repl_r = parse_int(recall_latest("colony-" + _colony_name + ":max_replicas"));
+                if n_r < max_repl_r {
+                    let pool_r = parse_int(recall_latest("colony-" + _colony_name + ":pool"));
+                    let base_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_base_cost"));
+                    let raw_k_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_k"));
+                    let k_r = if raw_k_r <= 0 { 3; } else { raw_k_r; };
+                    let cost_r = base_r + (base_r * n_r) / k_r;
+                    if pool_r >= cost_r {
+                        let variant_pick = pick_variant(n_r);
+                        memo_write("computer:prompt_variant", variant_pick);
+                        let target_r = select_replication_target();
+                        if len(target_r) > 0 {
+                            let variant_wrapped = _publish_prompt_body_and_wrap_variant(self_pid, variant_pick);
+                            let replica_id = try { replicate(target_r, my_fit_r, variant_wrapped); } catch e { "__replicate_error__"; };
+                            if replica_id != "__replicate_error__" {
+                                if len(replica_id) > 0 {
+                                    memo_write("colony-" + _colony_name + ":pool", to_string(pool_r - cost_r));
+                                    memo_write("colony-" + _colony_name + ":size", to_string(n_r + 1));
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "preprint-foundry", _colony_name]);
+
+                                    let lin_str = recall_latest("computer:" + self_pid + ":generation");
+                                    let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
+                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    if len(ledger_path_r) > 0 {
+                                        let parent_specialty = recall_latest("computer:" + self_pid + ":specialty");
+                                        let child_gen = lin + 1;
+                                        // colony-lint: safe-exec-concat
+                                        let row_cmd = "python3 -c 'import sys,json\nts=int(sys.argv[1])\nrow={\"ts\":ts,\"event\":\"replicate\",\"colony\":sys.argv[2],\"side\":\"preprint\",\"parent_pid\":sys.argv[3],\"child_replica_id\":sys.argv[4],\"specialty\":sys.argv[5],\"generation\":int(sys.argv[6]),\"parent_fitness\":int(sys.argv[7])}\nwith open(sys.argv[8],\"a\") as f: f.write(json.dumps(row,separators=(\",\",\":\"))+\"\\n\")\nprint(\"ok\")' "
+                                            + shell_escape(to_string(tick_now_ms)) + " "
+                                            + shell_escape(_colony_name) + " "
+                                            + shell_escape(self_pid) + " "
+                                            + shell_escape(replica_id) + " "
+                                            + shell_escape(parent_specialty) + " "
+                                            + shell_escape(to_string(child_gen)) + " "
+                                            + shell_escape(to_string(my_fit_r)) + " "
+                                            + shell_escape(ledger_path_r);
+                                        let _lr = try { exec sh row_cmd; } catch e { ""; };
+                                        memo_write("computer:" + replica_id + ":generation", to_string(child_gen));
+                                        if len(parent_specialty) > 0 {
+                                            memo_write("computer:" + replica_id + ":specialty", parent_specialty);
+                                        };
+                                    };
+                                } else {
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "preprint-foundry", _colony_name]);
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+}
+
+// #845: rule-first / distillation scaffolding ported from the skeptic /
+// auditor (#819/#841/#843) but adapted for a GENERATIVE colony per the
+// #845 reframe ("wire the capability into EVERY colony; the runtime
+// self-decides"). Unlike the verdict colonies, the computer's primary
+// output is a creative payload (the reproducibility Script), so the rule
+// action is the FULL primary output encoded FAITHFULLY (the entire
+// Script serialized as JSON), keyed on a FINE canonical context (sha256
+// of the exact upstream input). Identical input -> identical script
+// recurs >= min_validations -> self-distill; diverse input mints a fresh
+// fine ctx every tick -> no rule ever forms -> the colony stays
+// LLM-driven by emergence (NOT a human pre-classification). The fine ctx
+// is the only over-suppression guard: a creative payload is never keyed
+// on a coarse class.
+
+// _computer_canonical_ctx -- the rule key, FINE-grained. sha256 of the
+// exact upstream prompt input (the assembled ctx the LLM sees) prefixed
+// with the upstream tick and topic so two structurally-identical claims
+// on different topics never collide. Uses the python3 hashlib idiom
+// already in this file (_publish_prompt_body_and_wrap_variant). Total on
+// hash failure (falls back to a tick+topic coarse key, which is still
+// fine enough that distinct ticks do not collapse).
+fn _computer_canonical_ctx(prompt_ctx: string, upstream_tick: int) -> string {
+    let topic_a = recall_latest("replay:current_topic");
+    let topic = if len(topic_a) > 0 { topic_a; } else { "na"; };
+    // colony-lint: safe-exec-concat
+    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(prompt_ctx);
+    let h = try { exec sh sha_cmd; } catch e { ""; };
+    if len(h) != 64 {
+        return "topic=" + topic + " tick=" + to_string(upstream_tick) + " sha256=na";
+    };
+    return "topic=" + topic + " tick=" + to_string(upstream_tick) + " sha256=" + h;
+}
+
+// _script_action_json -- FAITHFUL full-output encoding. Serializes the
+// whole Script struct (language + script + expected_substring +
+// rationale) to a compact JSON string via python3 json.dumps so the
+// rule action carries the COMPLETE primary output verbatim (NOT a lossy
+// verdict bucket -- the #845 generative-colony requirement). Routing
+// through json.dumps guarantees the script body's quotes / newlines /
+// backslashes round-trip safely back through json_get on the rule-hit
+// path. Total on failure (returns a minimal stub so distill() still
+// gets a non-empty action).
+fn _script_action_json(language: string, script_body: string, expected_substring: string, rationale: string) -> string {
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,json; print(json.dumps({\"language\":sys.argv[1],\"script\":sys.argv[2],\"expected_substring\":sys.argv[3],\"rationale\":sys.argv[4]},separators=(\",\",\":\")))' "
+            + shell_escape(language) + " "
+            + shell_escape(script_body) + " "
+            + shell_escape(expected_substring) + " "
+            + shell_escape(rationale);
+    let out = try { exec sh cmd; } catch e { ""; };
+    if len(out) == 0 {
+        return "{\"language\":\"python\",\"script\":\"\",\"expected_substring\":\"\",\"rationale\":\"\"}";
+    };
+    return out;
+}
+
 // #742 TaskBoard accept helper. Claims one open task on the
 // `research-foundry:compute` channel posted by explorer's
 // `_offer_compute_task`. Returns the task_id (as a string) on a
@@ -512,9 +707,109 @@ fn tick(reason: string) -> void {
             + "EXPLORER CODE:\n" + explorer_code + "\n"
             + "EXPLORER OUTPUT:\n" + explorer_output + "\n";
 
+    let my_tier = tier("computer");
+
+    // ===== Stage 1: rule-first lookup (#845, generative faithful encoding) =====
+    // The canonical context is a FINE sha256 of the exact prompt input
+    // (ctx) so only a byte-identical upstream claim shares a key. On a
+    // crystallized computer_output rule hit, reconstruct the FULL Script
+    // from the rule's action slot (a faithful JSON string) and skip
+    // prompt(); the cached script still RUNS in the sandbox so the
+    // downstream emits / memo writes / runs_ok flag are byte-equivalent
+    // to the executed LLM path. Rollback knob: COMPUTER_RULE_FIRST=0
+    // short-circuits Stage 1 to the LLM path.
+    let canonical_ctx = _computer_canonical_ctx(ctx, upstream_tick);
+
+    let rule_first_flag = try { exec sh "printenv COMPUTER_RULE_FIRST"; } catch e { ""; };
+    let rule_first_enabled = rule_first_flag != "0";
+
+    let min_conf_str = try { exec sh "printenv COMPUTER_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
+
+    if rule_first_enabled {
+        let rule = crystallizer_lookup_with_confidence("computer_output", canonical_ctx, min_conf);
+        if len(rule) > 0 {
+            // Rule hit -- reconstruct the full Script from the rule's
+            // action field without prompt(). #843: the lookup returns
+            // map<string,string> (Value::Map). Read the map fields with
+            // get() (the map accessor); json_get() expects a JSON STRING
+            // and raises "expected string, got map" on a map. The action
+            // SLOT, however, is itself a JSON string (the faithful Script
+            // serialization), so we json_get() ON THAT STRING to recover
+            // each Script field.
+            let rule_id = to_string(get(rule, "rule_id"));
+            let rule_action = to_string(get(rule, "action"));
+            let rule_conf_str = to_string(get(rule, "confidence"));
+            let rule_conf = if len(rule_conf_str) > 0 { parse_float(rule_conf_str); } else { min_conf; };
+            let rule_language = to_string(json_get(rule_action, "language"));
+            let rule_script = to_string(json_get(rule_action, "script"));
+            let rule_expected = to_string(json_get(rule_action, "expected_substring"));
+            let rule_rationale = to_string(json_get(rule_action, "rationale"));
+            let rule_lang_eff = if len(rule_language) > 0 { rule_language; } else { "python"; };
+            // colony-lint: learn-tags-ok
+            learn("computer_output", canonical_ctx, rule_action, "success", ["distilled", "rule-hit", "preprint-foundry"]);
+            crystallizer_record_use(rule_id, true, 0.1);
+
+            // Tier branch -- mirrors the LLM path below. The rule-hit
+            // publisher takes primitive fields because the .ag grammar
+            // disallows inline Script struct literals; it re-runs the
+            // cached script so the observability rows + emits stay
+            // byte-identical to the executed LLM path.
+            if my_tier == "autonomous" {
+                memo_write("computer:" + _self_pid + ":review_gated", "true");
+                learn("compute", "tick " + to_string(tick_idx), rule_rationale, "partial", ["acted", "preprint-foundry"]);
+                _publish_computer_rule_hit(true, true, rule_lang_eff, rule_script, rule_expected, rule_rationale, rule_action, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+            } else {
+                if my_tier == "review-gated" {
+                    memo_write("computer:" + _self_pid + ":review_gated", "true");
+                    learn("compute", "tick " + to_string(tick_idx), rule_rationale, "partial", ["review-gated", "preprint-foundry"]);
+                    _publish_computer_rule_hit(true, false, rule_lang_eff, rule_script, rule_expected, rule_rationale, rule_action, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+                } else {
+                    if my_tier == "propose" {
+                        _publish_computer_rule_hit(false, false, rule_lang_eff, rule_script, rule_expected, rule_rationale, rule_action, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, my_tier);
+                    } else {
+                        print("[computer] observing rule-hit (tier:", my_tier, ") rationale=", rule_rationale);
+                        learn("compute", "tick " + to_string(tick_idx), rule_rationale, "partial", ["observed", "preprint-foundry"]);
+                    };
+                };
+            };
+
+            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_s1) > 0 { memo_write("computer:last_check", now_s1); };
+            return;
+        };
+    };
+
+    // ===== Stage 2: LLM fallback (historical path) =====
     let script = prompt(_script_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> Script;
 
-    let my_tier = tier("computer");
+    // #845: distillation row. The rule action is the FULL primary output
+    // encoded FAITHFULLY (the whole Script serialized as JSON), keyed on
+    // the FINE canonical_ctx (sha256 of the exact prompt input). Because
+    // the action carries the complete script verbatim, a rule only ever
+    // forms when a byte-identical upstream claim produces a byte-identical
+    // script >= crystallize_min_validations times -- diverse claims mint a
+    // fresh fine ctx every tick and never aggregate, so the colony stays
+    // LLM-driven by emergence. The condition AND the action use the SAME
+    // fine ctx (no coarsening) -- coarsening a creative payload is the one
+    // #845 over-suppression hazard.
+    let canonical_action = _script_action_json(script.language, script.script, script.expected_substring, script.rationale);
+    // colony-lint: learn-tags-ok
+    learn("computer_output", canonical_ctx, canonical_action, "success", ["distilled", "preprint-foundry"]);
+
+    // Complete the distillation loop: learn() above only writes the
+    // ExperienceStore; distill() promotes >=3 successful computer_output
+    // records over the same fine ctx into a KnowledgeEntry, and
+    // knowledge_validate() bumps empirical_validations toward
+    // crystallize_min_validations. distill() raises until there are >=3
+    // successful records, so guard it; once the entry crystallizes the
+    // Stage-1 lookup starts hitting and this miss path stops running for
+    // that exact-input context.
+    let distilled_id = try { distill("computer_output", canonical_ctx, canonical_action, "heuristic"); } catch e { ""; };
+    if len(distilled_id) > 0 {
+        knowledge_validate(distilled_id);
+    };
+
     if my_tier == "autonomous" {
         memo_write("computer:" + _self_pid + ":review_gated", "true");
         learn("compute", "tick " + to_string(tick_idx), script.rationale, "partial", ["acted", "preprint-foundry"]);


### PR DESCRIPTION
Uniform #845 rollout — give `computer` the rule-first/distill capability; the crystallizer's gating decides at runtime whether a rule forms (faithful full-output encoding + **fine** sha256-of-input context → identical input→output self-distills, diverse output stays LLM-driven; for computer the diverse case is the norm so it self-no-ops — the correct emergent decision). Reads the lookup map with `get()` (#843); `json_get` only on the serialized action string (0 json_get-on-map). **QA:** implementer daemon self-QA (rule crystallizes → rule-hit reconstructs full output via get(), 0 `expected string, got map`; json_get-on-map contrast crashes) + reviewer diff-check (4-tier branch + publisher + observability preserved); colony-lint 345/0/5. Refs #845, #833.