### PR TITLE
formulator: wire self-deciding distillation capability (#845)

### DIFF
--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -369,6 +369,163 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
     return next_age;
 }
 
+// #845: rule-first / distillation scaffolding ported from the noticer
+// (#819/#841/#843) and the verdict colonies (#846-#850), but with a
+// FAITHFUL FULL-OUTPUT encoding instead of the verdict colonies' lossy
+// `<verdict>|<detail>`. The formulator is GENERATIVE -- its primary
+// output is a `Problem` struct, not a discrete bucket -- so the rule
+// action must carry the ENTIRE Problem (all five fields) and the rule
+// key must be FINE-GRAINED (sha256 of the exact upstream input). This
+// is the #845 self-deciding design: identical input -> identical
+// Problem recurs >= min_validations -> self-distills; diverse input
+// never aggregates -> stays LLM-driven (the lookup self-no-ops). The
+// one thing never to do is coarsen the context or lossy-encode the
+// Problem to force caching -- that would wrongly cache creativity.
+
+// _formulator_canonical_ctx -- the rule key. FINE-GRAINED: sha256 of
+// the exact upstream input the LLM saw (the assembled `ctx`) plus the
+// topic label, via the python3 hashlib idiom already used by
+// _publish_prompt_body_and_wrap_variant. Identical upstream input ->
+// identical 64-hex key, so the distill condition and the Stage-1 lookup
+// key are byte-identical and the same input recurs onto one
+// KnowledgeEntry. Diverse input mints distinct keys and never
+// aggregates. Falls back to a topic-only marker when hashing fails.
+fn _formulator_canonical_ctx(ctx: string, topic_label: string) -> string {
+    let topic = if len(topic_label) > 0 { topic_label; } else { "na"; };
+    // colony-lint: safe-exec-concat
+    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256((sys.argv[1]+\"\\x1f\"+sys.argv[2]).encode(\"utf-8\")).hexdigest())' " + shell_escape(ctx) + " " + shell_escape(topic);
+    let h = try { exec sh sha_cmd; } catch e { ""; };
+    if len(h) != 64 { return "topic=" + topic + " input_sha=na"; };
+    return "topic=" + topic + " input_sha=" + h;
+}
+
+// _problem_json_action -- the FAITHFUL rule action. Serializes the full
+// Problem to the same JSON shape _publish_formulator writes to memo so
+// the Stage-1 rule-hit path reconstructs every field via json_get() on
+// this action string (NOT get() -- get() is the map accessor for the
+// lookup map; json_get() decodes a serialized JSON string per #843).
+// Byte-identical to the _publish_formulator problem_json so the action
+// the LLM path distils is exactly the payload the rule-hit path replays.
+fn _problem_json_action(problem: Problem) -> string {
+    let self_conf_str = to_string(problem.self_check_confidence);
+    return "{\"problem\":\"" + problem.problem
+         + "\",\"answer\":\"" + problem.answer
+         + "\",\"solution_full\":\"" + problem.solution_full
+         + "\",\"novelty_claim\":\"" + problem.novelty_claim
+         + "\",\"self_check_confidence\":" + self_conf_str + "}";
+}
+
+// _publish_formulator_rule_hit -- mirror of _publish_formulator but
+// takes primitive fields because the .ag grammar disallows inline
+// Problem struct literals. The downstream reads the same problem JSON /
+// memo keys / emit payload, so the encoding is identical to the LLM
+// path; only the source differs (rule vs prompt). The fitness +
+// replicate-gate block is copied verbatim from _publish_formulator so
+// rule-hit ticks contribute to replication fitness the same as
+// LLM-driven ticks.
+fn _publish_formulator_rule_hit(
+    final_write: bool,
+    do_replicate: bool,
+    problem_text: string,
+    answer: string,
+    solution_full: string,
+    novelty_claim: string,
+    self_check_confidence: float,
+    self_pid: string,
+    colony_name_str: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int,
+    topic_label: string,
+    my_tier: string
+) -> void {
+    let self_conf_str = to_string(self_check_confidence);
+    let problem_json = "{\"problem\":\"" + problem_text
+                     + "\",\"answer\":\"" + answer
+                     + "\",\"solution_full\":\"" + solution_full
+                     + "\",\"novelty_claim\":\"" + novelty_claim
+                     + "\",\"self_check_confidence\":" + self_conf_str + "}";
+    memo_write("formulator:" + self_pid + ":problem:tick-" + to_string(upstream_tick), problem_json);
+    memo_write("formulator:" + self_pid + ":problem_text:tick-" + to_string(upstream_tick), problem_text);
+    memo_write("formulator:" + self_pid + ":answer:tick-" + to_string(upstream_tick), answer);
+    memo_write("formulator:" + self_pid + ":novelty_claim:tick-" + to_string(upstream_tick), novelty_claim);
+    memo_write("replay:current_formulator_pid", self_pid);
+    emit("math-foundry:problem_ready", problem_json);
+
+    if final_write {
+        // Append to per-run discovery ledger.
+        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        if len(ledger_path) > 0 {
+            let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"problem_ready\",\"answer\":\"" + answer + "\"}";
+            // colony-lint: safe-exec-concat
+            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
+            let _ = try { exec sh append_cmd; } catch e { ""; };
+        };
+    };
+
+    if my_tier == "propose" {
+        learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, "answer=" + answer, "success", ["emitted", "math-foundry"]);
+    };
+
+    if len(self_pid) > 0 {
+        let fit_pre = parse_int(recall_latest("formulator:" + self_pid + ":fitness"));
+        let fit_delta = if self_check_confidence > 0.5 { 1; } else { 0; };
+        memo_write("formulator:" + self_pid + ":fitness", to_string(fit_pre + fit_delta));
+    };
+
+    if do_replicate {
+        let repr_thr = parse_int(recall_latest("formulator:reproductive_fitness_threshold"));
+        if repr_thr > 0 {
+            let my_fit_r = parse_int(recall_latest("formulator:" + self_pid + ":fitness"));
+            if my_fit_r > repr_thr {
+                let n_r = parse_int(recall_latest("colony-" + colony_name_str + ":size"));
+                let max_repl_r = parse_int(recall_latest("colony-" + colony_name_str + ":max_replicas"));
+                if n_r < max_repl_r {
+                    let pool_r = parse_int(recall_latest("colony-" + colony_name_str + ":pool"));
+                    let base_r = parse_int(recall_latest("colony-" + colony_name_str + ":replication_base_cost"));
+                    let raw_k_r = parse_int(recall_latest("colony-" + colony_name_str + ":replication_k"));
+                    let k_r = if raw_k_r <= 0 { 3; } else { raw_k_r; };
+                    let cost_r = base_r + (base_r * n_r) / k_r;
+                    if pool_r >= cost_r {
+                        let variant_pick = pick_variant(n_r);
+                        memo_write("formulator:prompt_variant", variant_pick);
+                        let target_r = select_replication_target();
+                        if len(target_r) > 0 {
+                            let variant_wrapped = _publish_prompt_body_and_wrap_variant(self_pid, variant_pick);
+                            let replica_id = try { replicate(target_r, my_fit_r, variant_wrapped); } catch e { "__replicate_error__"; };
+                            if replica_id != "__replicate_error__" {
+                                if len(replica_id) > 0 {
+                                    memo_write("colony-" + colony_name_str + ":pool", to_string(pool_r - cost_r));
+                                    memo_write("colony-" + colony_name_str + ":size", to_string(n_r + 1));
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "math-foundry", colony_name_str]);
+
+                                    let lin_str = recall_latest("formulator:" + self_pid + ":generation");
+                                    let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
+                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    if len(ledger_path_r) > 0 {
+                                        let parent_specialty = recall_latest("formulator:" + self_pid + ":specialty");
+                                        let child_gen = lin + 1;
+                                        let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + colony_name_str + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
+                                        // colony-lint: safe-exec-concat
+                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
+                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        memo_write("formulator:" + replica_id + ":generation", to_string(child_gen));
+                                        if len(parent_specialty) > 0 {
+                                            memo_write("formulator:" + replica_id + ":specialty", parent_specialty);
+                                        };
+                                    };
+                                } else {
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "math-foundry", colony_name_str]);
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
@@ -467,9 +624,102 @@ fn tick(reason: string) -> void {
             + "RECENT HITL REJECTS: " + hitl_summary + "\n";
 
     _dump_ctx_to_memo("formulator", _self_pid, tick_idx, ctx);
-    let problem = prompt(_seed_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> Problem;
 
     let my_tier = tier("formulator");
+
+    // ===== Stage 1: rule-first lookup (#845, faithful full-output) =====
+    // FINE-GRAINED key: sha256 of the exact upstream input (the assembled
+    // `ctx` + topic). On a crystallized formulator_output rule hit, the
+    // action slot carries the FULL Problem JSON, so we reconstruct every
+    // field via json_get() on the action string and skip prompt(). This
+    // self-no-ops on diverse input (distinct sha256 -> never aggregates)
+    // and only fires when an identical upstream input recurred >=
+    // min_validations times -- the crystallizer's gating decides, not a
+    // human pre-classification. Rollback knob: FORMULATOR_RULE_FIRST=0
+    // short-circuits Stage 1 to the LLM path.
+    let canonical_ctx = _formulator_canonical_ctx(ctx, topic_label);
+
+    let rule_first_flag = try { exec sh "printenv FORMULATOR_RULE_FIRST"; } catch e { ""; };
+    let rule_first_enabled = rule_first_flag != "0";
+
+    let min_conf_str = try { exec sh "printenv FORMULATOR_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
+
+    if rule_first_enabled {
+        let rule = crystallizer_lookup_with_confidence("formulator_output", canonical_ctx, min_conf);
+        if len(rule) > 0 {
+            // Rule hit -- reconstruct the full Problem from the rule's
+            // action field without prompt().
+            // #843: crystallizer_lookup_with_confidence returns
+            // map<string,string> (Value::Map). Read the MAP fields with
+            // get() (the map accessor); json_get() expects a JSON string
+            // and raises "expected string, got map" on a map. The action
+            // STRING, however, is faithful Problem JSON, so json_get() is
+            // the correct decoder for the fields inside it.
+            let rule_id = to_string(get(rule, "rule_id"));
+            let rule_action = to_string(get(rule, "action"));
+            let r_problem = to_string(json_get(rule_action, "problem"));
+            let r_answer = to_string(json_get(rule_action, "answer"));
+            let r_solution = to_string(json_get(rule_action, "solution_full"));
+            let r_novelty = to_string(json_get(rule_action, "novelty_claim"));
+            let r_conf_raw = to_string(json_get(rule_action, "self_check_confidence"));
+            let r_conf = if len(r_conf_raw) > 0 { parse_float(r_conf_raw); } else { 0.0; };
+            // colony-lint: learn-tags-ok
+            learn("formulator_output", canonical_ctx, rule_action, "success", ["distilled", "rule-hit", "preprint-foundry"]);
+            crystallizer_record_use(rule_id, true, 0.1);
+
+            if my_tier == "autonomous" {
+                memo_write("formulator:" + _self_pid + ":review_gated", "true");
+                learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, r_novelty, "partial", ["acted", "math-foundry"]);
+                _publish_formulator_rule_hit(true, true, r_problem, r_answer, r_solution, r_novelty, r_conf, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label, my_tier);
+            } else {
+                if my_tier == "review-gated" {
+                    memo_write("formulator:" + _self_pid + ":review_gated", "true");
+                    learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, r_novelty, "partial", ["review-gated", "math-foundry"]);
+                    _publish_formulator_rule_hit(true, false, r_problem, r_answer, r_solution, r_novelty, r_conf, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label, my_tier);
+                } else {
+                    if my_tier == "propose" {
+                        _publish_formulator_rule_hit(false, false, r_problem, r_answer, r_solution, r_novelty, r_conf, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, topic_label, my_tier);
+                    } else {
+                        print("[formulator] observing rule-hit (tier:", my_tier, ") novelty_claim=", r_novelty);
+                        learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, r_novelty, "partial", ["observed", "math-foundry"]);
+                    };
+                };
+            };
+
+            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_s1) > 0 { memo_write("formulator:last_check", now_s1); };
+            return;
+        };
+    };
+
+    // ===== Stage 2: LLM fallback (historical path) =====
+    let problem = prompt(_seed_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> Problem;
+
+    // #845: distillation row. FAITHFUL encoding -- the rule action is the
+    // FULL Problem JSON keyed on the FINE-GRAINED canonical_ctx (sha256 of
+    // the exact upstream input). Identical input -> identical action ->
+    // one KnowledgeEntry whose empirical_validations accumulate; diverse
+    // input mints distinct keys that never aggregate (self-stay-LLM). The
+    // distill CONDITION is the SAME fine canonical_ctx as the Stage-1
+    // lookup (no coarsening), so a recurring input prefix-matches its own
+    // crystallized rule.
+    let canonical_action = _problem_json_action(problem);
+    // colony-lint: learn-tags-ok
+    learn("formulator_output", canonical_ctx, canonical_action, "success", ["distilled", "preprint-foundry"]);
+
+    // Complete the distillation loop: learn() above only writes the
+    // ExperienceStore; distill() promotes >=3 successful formulator_output
+    // records into a KnowledgeEntry, and knowledge_validate() bumps
+    // empirical_validations toward crystallize_min_validations. distill()
+    // raises until there are >=3 successful records, so guard it; once the
+    // entry crystallizes the Stage-1 lookup starts hitting and this miss
+    // path stops running for that fine context.
+    let distilled_id = try { distill("formulator_output", canonical_ctx, canonical_action, "heuristic"); } catch e { ""; };
+    if len(distilled_id) > 0 {
+        knowledge_validate(distilled_id);
+    };
+
     if my_tier == "autonomous" {
         memo_write("formulator:" + _self_pid + ":review_gated", "true");
         learn("formulate", "tick " + to_string(tick_idx) + " " + topic_label, problem.novelty_claim, "partial", ["acted", "math-foundry"]);


### PR DESCRIPTION
Uniform #845 rollout — give `formulator` the rule-first/distill capability; the crystallizer's gating decides at runtime whether a rule forms (faithful full-output encoding + **fine** sha256-of-input context → identical input→output self-distills, diverse output stays LLM-driven; for formulator the diverse case is the norm so it self-no-ops — the correct emergent decision). Reads the lookup map with `get()` (#843); `json_get` only on the serialized action string (0 json_get-on-map). **QA:** implementer daemon self-QA (rule crystallizes → rule-hit reconstructs full output via get(), 0 `expected string, got map`; json_get-on-map contrast crashes) + reviewer diff-check (4-tier branch + publisher + observability preserved); colony-lint 345/0/5. Refs #845, #833.