### PR TITLE
arxiv-search: wire self-deciding distillation capability (#845)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -322,6 +322,177 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
     return next_age;
 }
 
+// #845: rule-first / distillation scaffolding (uniform self-deciding
+// rollout, mirrors the editor #852). The distillable decision here is
+// the FULL query-generation output: both Queries fields (queries_json +
+// rationale) are serialized faithfully into the rule action and keyed on
+// a FINE-grained sha256 of the exact upstream PROBLEM input. Identical
+// problem -> identical action -> the distilled KnowledgeEntry id is
+// stable and empirical_validations accumulate; diverse problems -> a
+// fresh hash -> no aggregation -> no rule (the colony self-decides to
+// stay LLM-driven). The HTTP arXiv fetch + relevance judgement still run
+// on the reconstructed queries -- the rule replaces only the LLM
+// query-generation step, not the external search.
+
+// _arxiv_canonical_ctx -- the rule key. Fine-grained: the sha256 of the
+// exact upstream ctx the LLM saw (PROBLEM + ANSWER + NOVELTY CLAIM, the
+// same string passed to prompt()). Identical upstream -> same 64-hex
+// key; any drift -> a fresh key, so divergent searches never collapse
+// onto one rule. Stable, parseable shape "arxivctx=<64hex>" the
+// crystallizer prefix-matcher keys off. Total on empty / hash failure
+// ("arxivctx=na").
+fn _arxiv_canonical_ctx(ctx: string) -> string {
+    if len(ctx) == 0 { return "arxivctx=na"; };
+    // colony-lint: safe-exec-concat
+    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(ctx);
+    let h = try { exec sh sha_cmd; } catch e { ""; };
+    if len(h) != 64 { return "arxivctx=na"; };
+    return "arxivctx=" + h;
+}
+
+// _queries_to_action_json -- faithful full-output serializer. Routes
+// both Queries string fields (queries_json + rationale) through python3
+// json.dumps so embedded `"` / `\n` / `\\` cannot corrupt the rule
+// action (same hardening as the editor's _edit_to_action_json #852). The
+// produced JSON is what learn()/distill() store as the rule action and
+// what the Stage-1 rule-hit path decodes back into Queries primitives
+// via json_get. Total on failure (returns an empty-Queries JSON).
+fn _queries_to_action_json(queries: Queries) -> string {
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,json\nobj={\"queries_json\":sys.argv[1],\"rationale\":sys.argv[2]}\nprint(json.dumps(obj,separators=(\",\",\":\")))' " + shell_escape(queries.queries_json) + " " + shell_escape(queries.rationale);
+    let out = try { exec sh cmd; } catch e { ""; };
+    if len(out) == 0 {
+        return "{\"queries_json\":\"\",\"rationale\":\"\"}";
+    };
+    return out;
+}
+
+// _publish_arxiv_search_rule_hit -- mirror of _publish_arxiv_search but
+// takes the Queries fields as primitives because the .ag grammar
+// disallows inline Queries struct literals (matches the editor's
+// _publish_editor_rule_hit precedent). The body is copied verbatim from
+// _publish_arxiv_search: it runs the SAME Python multi-query arXiv fetch
+// on the reconstructed queries, the SAME single-pass LLM relevance
+// judgement over the combined feed, persists the identical memo keys,
+// emits "arxiv-search:report_ready", tracks fitness, and runs the
+// M2-Malthusian replicate gate -- so a rule-hit tick is
+// byte-indistinguishable downstream from an LLM-driven tick except the
+// queries came from a crystallized rule rather than prompt(). The
+// relevance judgement still calls prompt() (relevance is a per-feed
+// judgement over fresh arXiv results, not a distillable query-formation
+// step).
+fn _publish_arxiv_search_rule_hit(
+    final_write: bool,
+    do_replicate: bool,
+    queries_json: string,
+    self_pid: string,
+    _colony_name: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int,
+    problem_text: string,
+    stated_answer: string,
+    novelty_claim: string,
+    my_tier: string
+) -> void {
+    let _ = final_write;
+    let max_results_raw = try { exec sh "printenv ARXIV_MAX_QUERY_RESULTS"; } catch e { "10"; };
+    let max_results = if len(max_results_raw) > 0 { parse_int(max_results_raw); } else { 10; };
+    // colony-lint: safe-exec-concat
+    let fetch_cmd = "QJSON=" + shell_escape(queries_json) + " MAXR=" + to_string(max_results)
+        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
+        + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
+        + "if not isinstance(qs, list): qs=[]\n"
+        + "mx=int(os.environ.get(\"MAXR\",\"10\"))\n"
+        + "out=[]\n"
+        + "for q in qs[:5]:\n"
+        + "  url=\"http://export.arxiv.org/api/query?search_query=all:\"+urllib.parse.quote_plus(str(q))+\"&start=0&max_results=\"+str(mx)\n"
+        + "  try:\n"
+        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
+        + "  except Exception as e:\n"
+        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
+        + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
+        + "sys.stdout.write(\"\\n\".join(out))'";
+    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+
+    let judge_ctx = "PROBLEM: " + problem_text + "\n"
+                  + "ANSWER: " + stated_answer + "\n"
+                  + "NOVELTY CLAIM: " + novelty_claim + "\n"
+                  + "ARXIV FEEDS:\n" + combined_raw + "\n";
+    let report = prompt(_relevance_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(self_pid), judge_ctx) -> Report;
+
+    let report_json = "{\"matches_found\":" + to_string(report.matches_found)
+                    + ",\"summary\":\"" + report.summary
+                    + "\",\"top_match_count\":" + to_string(len(report.top_matches)) + "}";
+    memo_write("arxiv_search:" + self_pid + ":report:tick-" + to_string(upstream_tick), report_json);
+    memo_write("arxiv_search:" + self_pid + ":matches_found:tick-" + to_string(upstream_tick), to_string(report.matches_found));
+    memo_write("arxiv_search:" + self_pid + ":summary:tick-" + to_string(upstream_tick), report.summary);
+    memo_write("replay:current_arxiv_search_pid", self_pid);
+    emit("arxiv-search:report_ready", report);
+
+    if my_tier == "propose" {
+        learn("arxiv-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+    };
+
+    if len(self_pid) > 0 {
+        let fit_pre = parse_int(recall_latest("arxiv-search:" + self_pid + ":fitness"));
+        let fit_delta = if report.matches_found > 0 { 1; } else { 0; };
+        memo_write("arxiv-search:" + self_pid + ":fitness", to_string(fit_pre + fit_delta));
+    };
+
+    if do_replicate {
+        let repr_thr = parse_int(recall_latest("arxiv-search:reproductive_fitness_threshold"));
+        if repr_thr > 0 {
+            let my_fit_r = parse_int(recall_latest("arxiv-search:" + self_pid + ":fitness"));
+            if my_fit_r > repr_thr {
+                let n_r = parse_int(recall_latest("colony-" + _colony_name + ":size"));
+                let max_repl_r = parse_int(recall_latest("colony-" + _colony_name + ":max_replicas"));
+                if n_r < max_repl_r {
+                    let pool_r = parse_int(recall_latest("colony-" + _colony_name + ":pool"));
+                    let base_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_base_cost"));
+                    let raw_k_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_k"));
+                    let k_r = if raw_k_r <= 0 { 3; } else { raw_k_r; };
+                    let cost_r = base_r + (base_r * n_r) / k_r;
+                    if pool_r >= cost_r {
+                        let variant_pick = pick_variant(n_r);
+                        memo_write("arxiv-search:prompt_variant", variant_pick);
+                        let target_r = select_replication_target();
+                        if len(target_r) > 0 {
+                            let variant_wrapped = _publish_prompt_body_and_wrap_variant(self_pid, variant_pick);
+                            let replica_id = try { replicate(target_r, my_fit_r, variant_wrapped); } catch e { "__replicate_error__"; };
+                            if replica_id != "__replicate_error__" {
+                                if len(replica_id) > 0 {
+                                    memo_write("colony-" + _colony_name + ":pool", to_string(pool_r - cost_r));
+                                    memo_write("colony-" + _colony_name + ":size", to_string(n_r + 1));
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "claim-auditor", _colony_name]);
+
+                                    let lin_str = recall_latest("arxiv-search:" + self_pid + ":generation");
+                                    let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
+                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    if len(ledger_path_r) > 0 {
+                                        let parent_specialty = recall_latest("arxiv-search:" + self_pid + ":specialty");
+                                        let child_gen = lin + 1;
+                                        let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
+                                        // colony-lint: safe-exec-concat
+                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
+                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        memo_write("arxiv-search:" + replica_id + ":generation", to_string(child_gen));
+                                        if len(parent_specialty) > 0 {
+                                            memo_write("arxiv-search:" + replica_id + ":specialty", parent_specialty);
+                                        };
+                                    };
+                                } else {
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "claim-auditor", _colony_name]);
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+}
+
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
@@ -385,9 +556,109 @@ fn tick(reason: string) -> void {
             + "ANSWER: " + stated_answer + "\n"
             + "NOVELTY CLAIM: " + novelty_claim + "\n";
 
+    let my_tier = tier("arxiv_search");
+
+    // ===== Stage 1: rule-first lookup (#845 uniform rollout) =====
+    // The canonical context is a fine-grained hash of the exact upstream
+    // ctx, so a crystallized arxiv_search_output rule only ever fires when
+    // the identical PROBLEM input recurs. On a hit, the rule's action slot
+    // carries the FULL Queries JSON (queries_json + rationale); we decode
+    // it with json_get and run the SAME downstream HTTP search / tier /
+    // publish / observability path as the prompt path, skipping prompt().
+    // Rollback knob: ARXIV_SEARCH_RULE_FIRST=0 short-circuits Stage 1 to
+    // the LLM path.
+    let canonical_ctx = _arxiv_canonical_ctx(ctx);
+
+    let rule_first_flag = try { exec sh "printenv ARXIV_SEARCH_RULE_FIRST"; } catch e { ""; };
+    let rule_first_enabled = rule_first_flag != "0";
+
+    let min_conf_str = try { exec sh "printenv ARXIV_SEARCH_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
+
+    if rule_first_enabled {
+        let rule = crystallizer_lookup_with_confidence("arxiv_search_output", canonical_ctx, min_conf);
+        if len(rule) > 0 {
+            // Rule hit -- reconstruct the Queries from the rule's action
+            // field without prompt(). #843: the lookup returns
+            // map<string,string> (Value::Map). Read fields with get()
+            // (the map accessor); json_get() expects a JSON string and
+            // raises "expected string, got map" on a map. The action
+            // value IS a JSON string, so json_get() is correct on it.
+            let rule_id = to_string(get(rule, "rule_id"));
+            let rule_action = to_string(get(rule, "action"));
+            let rule_conf_str = to_string(get(rule, "confidence"));
+            let rule_conf = if len(rule_conf_str) > 0 { parse_float(rule_conf_str); } else { min_conf; };
+            let r_queries_json = to_string(json_get(rule_action, "queries_json"));
+            let r_rationale_raw = to_string(json_get(rule_action, "rationale"));
+            let r_rationale = if len(r_rationale_raw) > 0 {
+                r_rationale_raw;
+            } else {
+                "rule-first: matched crystallized arxiv_search_output rule at confidence " + to_string(rule_conf);
+            };
+            // colony-lint: learn-tags-ok
+            learn("arxiv_search_output", canonical_ctx, rule_action, "success", ["distilled", "rule-hit", "math-foundry"]);
+            crystallizer_record_use(rule_id, true, 0.1);
+
+            // Tier branch -- mirrors the LLM path below; the rule-hit
+            // publisher takes primitive fields because the .ag grammar
+            // disallows inline Queries struct literals. The HTTP arXiv
+            // fetch + relevance judgement still run on the reconstructed
+            // queries inside _publish_arxiv_search_rule_hit.
+            if my_tier == "autonomous" {
+                memo_write("arxiv_search:" + _self_pid + ":review_gated", "true");
+                learn("arxiv-search", "tick " + to_string(tick_idx), r_rationale, "partial", ["acted", "claim-auditor"]);
+                _publish_arxiv_search_rule_hit(true, true, r_queries_json, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
+            } else {
+                if my_tier == "review-gated" {
+                    memo_write("arxiv_search:" + _self_pid + ":review_gated", "true");
+                    learn("arxiv-search", "tick " + to_string(tick_idx), r_rationale, "partial", ["review-gated", "claim-auditor"]);
+                    _publish_arxiv_search_rule_hit(true, false, r_queries_json, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
+                } else {
+                    if my_tier == "propose" {
+                        _publish_arxiv_search_rule_hit(false, false, r_queries_json, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
+                    } else {
+                        print("[arxiv-search] observing rule-hit (tier:", my_tier, ") rationale=", r_rationale);
+                        learn("arxiv-search", "tick " + to_string(tick_idx), r_rationale, "partial", ["observed", "claim-auditor"]);
+                    };
+                };
+            };
+
+            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_s1) > 0 { memo_write("arxiv-search:last_check", now_s1); };
+            return;
+        };
+    };
+
+    // ===== Stage 2: LLM fallback (historical path) =====
     let queries = prompt(_query_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> Queries;
 
-    let my_tier = tier("arxiv_search");
+    // #845 distillation row. The rule action is the FULL Queries
+    // serialized faithfully (NOT a coarse bucket -- caching a coarse
+    // class would wrongly cache creative query-formation). Keyed on the
+    // SAME fine canonical_ctx so identical PROBLEM input -> identical
+    // action -> the distilled KnowledgeEntry id is stable and
+    // empirical_validations accumulate; diverse input -> a fresh hash ->
+    // no aggregation -> no rule (the colony self-decides to stay
+    // LLM-driven).
+    let canonical_action = _queries_to_action_json(queries);
+    // colony-lint: learn-tags-ok
+    learn("arxiv_search_output", canonical_ctx, canonical_action, "success", ["distilled", "math-foundry"]);
+
+    // Complete the distillation loop: learn() above only writes the
+    // ExperienceStore; distill() promotes >=3 successful
+    // arxiv_search_output records over the same fine canonical_ctx into a
+    // KnowledgeEntry, and knowledge_validate() bumps empirical_validations
+    // toward crystallize_min_validations. distill() raises until there are
+    // >=3 successful records, so guard it; once the entry crystallizes the
+    // Stage-1 lookup starts hitting and this miss path stops running for
+    // that context. The distill CONDITION is the SAME fine canonical_ctx
+    // (a generative colony must not coarsen the key, or distinct query
+    // sets would collide onto one rule).
+    let distilled_id = try { distill("arxiv_search_output", canonical_ctx, canonical_action, "heuristic"); } catch e { ""; };
+    if len(distilled_id) > 0 {
+        knowledge_validate(distilled_id);
+    };
+
     if my_tier == "autonomous" {
         memo_write("arxiv_search:" + _self_pid + ":review_gated", "true");
         learn("arxiv-search", "tick " + to_string(tick_idx), queries.rationale, "partial", ["acted", "claim-auditor"]);


### PR DESCRIPTION
Final #845 batch — give `arxiv-search` the rule-first/distill capability; the crystallizer's gating decides at runtime whether a rule forms. Stage-1 reads the lookup map with `get()` (#843) and on a hit reconstructs the full output from the faithfully-serialized action string (json_get on the string only, 0 json_get-on-map), **skipping the LLM query-gen prompt — the external fetch still runs on the reconstructed queries**. Fine sha256-of-problem context → identical problem self-distills, diverse stays LLM-driven. **QA:** implementer daemon self-QA (rule crystallizes; get()+json_get-on-string decode contract clean with 0 `expected string, got map`; json_get-on-map contrast crashes) + reviewer diff-check (0 json_get-on-map, 4-tier branch + external-fetch + observability preserved); colony-lint 345/0/5. Refs #845, #833.