### PR TITLE
oeis-search: wire self-deciding distillation capability (#845)

### DIFF
--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -281,6 +281,131 @@ fn _publish_oeis_search(
     };
 }
 
+// _publish_oeis_search_rule_hit -- mirror of _publish_oeis_search but
+// takes primitive fields because the .ag grammar disallows inline
+// Sequences struct literals (confirmed across the skeptic / theorist
+// ports: "expected Semicolon, got LBrace"). The external OEIS fetch + the
+// relevance-judgement prompt STILL run on the reconstructed sequences --
+// the crystallized rule only replaces the LLM sequence-EXTRACTION call,
+// never the fetch or the per-A-number relevance judgement. The downstream
+// memo keys / emit payload / fitness signal / replicate gate are
+// byte-identical to _publish_oeis_search so a rule-hit tick behaves like
+// the LLM path; only the source of `sequences_json` / `rationale` differs
+// (rule vs prompt). The fetch + relevance + replicate blocks are copied
+// verbatim from _publish_oeis_search.
+fn _publish_oeis_search_rule_hit(
+    final_write: bool,
+    do_replicate: bool,
+    sequences_json: string,
+    rationale: string,
+    self_pid: string,
+    _colony_name: string,
+    upstream_tick: int,
+    tick_idx: int,
+    tick_now_ms: int,
+    problem_text: string,
+    stated_answer: string,
+    novelty_claim: string,
+    my_tier: string
+) -> void {
+    let _ = final_write;
+    let _ = rationale;
+    // External OEIS fetch on the reconstructed queries (NOT cached by the
+    // rule -- the rule replaced only LLM extraction).
+    // colony-lint: safe-exec-concat
+    let fetch_cmd = "SJSON=" + shell_escape(sequences_json)
+        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
+        + "try:\n  seqs=json.loads(os.environ[\"SJSON\"])\nexcept Exception:\n  seqs=[]\n"
+        + "if not isinstance(seqs, list): seqs=[]\n"
+        + "out=[]\n"
+        + "for s in seqs[:5]:\n"
+        + "  url=\"https://oeis.org/search?fmt=text&q=\"+urllib.parse.quote_plus(str(s))\n"
+        + "  try:\n"
+        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
+        + "  except Exception as e:\n"
+        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
+        + "  out.append(\"--- seq: \"+str(s)+\" ---\\n\"+r)\n"
+        + "sys.stdout.write(\"\\n\".join(out))'";
+    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+
+    let judge_ctx = "PROBLEM: " + problem_text + "\n"
+                  + "ANSWER: " + stated_answer + "\n"
+                  + "NOVELTY CLAIM: " + novelty_claim + "\n"
+                  + "OEIS FEEDS:\n" + combined_raw + "\n";
+    let report = prompt(_relevance_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(self_pid), judge_ctx) -> Report;
+
+    let report_json = "{\"matches_found\":" + to_string(report.matches_found)
+                    + ",\"summary\":\"" + report.summary
+                    + "\",\"top_match_count\":" + to_string(len(report.top_matches)) + "}";
+    memo_write("oeis_search:" + self_pid + ":report:tick-" + to_string(upstream_tick), report_json);
+    memo_write("oeis_search:" + self_pid + ":matches_found:tick-" + to_string(upstream_tick), to_string(report.matches_found));
+    memo_write("oeis_search:" + self_pid + ":summary:tick-" + to_string(upstream_tick), report.summary);
+    memo_write("replay:current_oeis_search_pid", self_pid);
+    emit("oeis-search:report_ready", report);
+
+    if my_tier == "propose" {
+        learn("oeis-search", "tick " + to_string(tick_idx), "matches=" + to_string(report.matches_found), "success", ["emitted", "claim-auditor"]);
+    };
+
+    if len(self_pid) > 0 {
+        let fit_pre = parse_int(recall_latest("oeis-search:" + self_pid + ":fitness"));
+        let fit_delta = if report.matches_found > 0 { 1; } else { 0; };
+        memo_write("oeis-search:" + self_pid + ":fitness", to_string(fit_pre + fit_delta));
+    };
+
+    if do_replicate {
+        let repr_thr = parse_int(recall_latest("oeis-search:reproductive_fitness_threshold"));
+        if repr_thr > 0 {
+            let my_fit_r = parse_int(recall_latest("oeis-search:" + self_pid + ":fitness"));
+            if my_fit_r > repr_thr {
+                let n_r = parse_int(recall_latest("colony-" + _colony_name + ":size"));
+                let max_repl_r = parse_int(recall_latest("colony-" + _colony_name + ":max_replicas"));
+                if n_r < max_repl_r {
+                    let pool_r = parse_int(recall_latest("colony-" + _colony_name + ":pool"));
+                    let base_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_base_cost"));
+                    let raw_k_r = parse_int(recall_latest("colony-" + _colony_name + ":replication_k"));
+                    let k_r = if raw_k_r <= 0 { 3; } else { raw_k_r; };
+                    let cost_r = base_r + (base_r * n_r) / k_r;
+                    if pool_r >= cost_r {
+                        let variant_pick = pick_variant(n_r);
+                        memo_write("oeis-search:prompt_variant", variant_pick);
+                        let target_r = select_replication_target();
+                        if len(target_r) > 0 {
+                            let variant_wrapped = _publish_prompt_body_and_wrap_variant(self_pid, variant_pick);
+                            let replica_id = try { replicate(target_r, my_fit_r, variant_wrapped); } catch e { "__replicate_error__"; };
+                            if replica_id != "__replicate_error__" {
+                                if len(replica_id) > 0 {
+                                    memo_write("colony-" + _colony_name + ":pool", to_string(pool_r - cost_r));
+                                    memo_write("colony-" + _colony_name + ":size", to_string(n_r + 1));
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "success", ["replicated", "claim-auditor", _colony_name]);
+
+                                    let lin_str = recall_latest("oeis-search:" + self_pid + ":generation");
+                                    let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
+                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    if len(ledger_path_r) > 0 {
+                                        let parent_specialty = recall_latest("oeis-search:" + self_pid + ":specialty");
+                                        let child_gen = lin + 1;
+                                        let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
+                                        // colony-lint: safe-exec-concat
+                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
+                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        memo_write("oeis-search:" + replica_id + ":generation", to_string(child_gen));
+                                        if len(parent_specialty) > 0 {
+                                            memo_write("oeis-search:" + replica_id + ":specialty", parent_specialty);
+                                        };
+                                    };
+                                } else {
+                                    learn("replicate", "n=" + to_string(n_r), "cost=" + to_string(cost_r), "failure", ["replicate-nak", "claim-auditor", _colony_name]);
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+}
+
 // Issue #767: aging-out gate (death pressure). Two-phase: this .ag
 // publishes `colony:cull_self_request:<pid>` when age_ticks crosses
 // `env:RESEARCH_AGING_THRESHOLD`; the cull-replicas.sh sidecar reads
@@ -306,6 +431,57 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
         memo_write("colony:cull_self_request:" + self_pid, "aging");
     };
     return next_age;
+}
+
+// #845 (uniform rollout): rule-first / distillation scaffolding ported
+// from the theorist (#851) / verifier (#850). oeis-search is a
+// GENERATIVE colony -- its primary LLM output is the extracted Sequences
+// (sequences_json + rationale), not a discrete verdict -- so the rule
+// action is the FULL, FAITHFUL serialization of that output, NOT a lossy
+// summary/bucket (the #841 mistake). Keyed on a FINE context (sha256 of
+// the exact upstream claim input + topic) so identical input -> identical
+// output crystallizes (self-distill) while diverse generation never
+// aggregates (self-stay-LLM). The crystallizer's confidence + validation
+// gating decides at runtime whether a rule actually forms; the .ag does
+// NOT pre-classify oeis-search as "should/should-not distill". The rule
+// replaces only the LLM sequence-extraction call: the external OEIS fetch
+// + relevance judgement still run on the reconstructed Sequences in
+// _publish_oeis_search_rule_hit (the rule never caches the fetch result).
+
+// _oeis_canonical_ctx -- the rule key. oeis-search's upstream producer
+// (the claim seed) writes no stable canonical_ctx memo, so we synthesize
+// a FINE key: topic plus a sha256 of the entire assembled upstream input
+// (problem + answer + novelty). The hash makes identical inputs share a
+// key and any input difference mint a distinct key, so diverse generation
+// self-no-ops (no rule forms) and only genuine input repeats crystallize.
+// Uses the existing python3 hashlib exec idiom (see
+// _publish_prompt_body_and_wrap_variant). Field order is
+// most-discriminating-first to match the crystallizer's prefix matcher.
+fn _oeis_canonical_ctx(topic_label: string, input_blob: string) -> string {
+    let topic = if len(topic_label) > 0 { topic_label; } else { "na"; };
+    // colony-lint: safe-exec-concat
+    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(input_blob);
+    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let hash = if len(h) == 64 { h; } else { "na"; };
+    return "topic=" + topic + " input_hash=" + hash;
+}
+
+// _encode_sequences_action -- faithful full serialization of the primary
+// LLM output (Sequences.sequences_json + Sequences.rationale) into a
+// single JSON string used as the crystallized rule action. BOTH output
+// fields are preserved so a rule hit reconstructs the byte-identical
+// Sequences without prompt(). Built via python3 json.dumps because the
+// sequences_json payload is itself a JSON-encoded string carrying quotes
+// and brackets that inline string concat cannot safely escape. The action
+// is a plain JSON STRING (decoded on the rule-hit path with json_get, NOT
+// get -- get is only for the lookup Map). Total on exec failure ("").
+fn _encode_sequences_action(sequences: Sequences) -> string {
+    // colony-lint: safe-exec-concat
+    let cmd = "python3 -c 'import sys,json\no={\"sequences_json\":sys.argv[1],\"rationale\":sys.argv[2]}\nsys.stdout.write(json.dumps(o,separators=(\",\",\":\")))' "
+            + shell_escape(sequences.sequences_json) + " "
+            + shell_escape(sequences.rationale);
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
 }
 
 fn tick(reason: string) -> void {
@@ -370,9 +546,114 @@ fn tick(reason: string) -> void {
             + "ANSWER: " + stated_answer + "\n"
             + "NOVELTY CLAIM: " + novelty_claim + "\n";
 
+    let my_tier = tier("oeis_search");
+
+    // ===== Stage 1: rule-first lookup (#845, mirrors theorist / verifier) =====
+    // The canonical context is a FINE self-built key (topic + sha256 of the
+    // exact upstream claim input: problem + answer + novelty). On a
+    // crystallized oeis_search_output rule hit, reconstruct the full
+    // Sequences output from the rule's action slot (a faithful JSON
+    // serialization) and skip the LLM extraction prompt(). Because the key
+    // is fine, this Stage-1 hit only ever fires when the identical input
+    // recurred enough times to crystallize -- i.e. oeis-search self-decided
+    // (via emergence) that its extraction for this input is stable. The
+    // external OEIS fetch + relevance judgement still run on the
+    // reconstructed sequences (in _publish_oeis_search_rule_hit). Rollback
+    // knob: OEIS_SEARCH_RULE_FIRST=0 short-circuits Stage 1 to the LLM path.
+    let _input_blob = "PROBLEM: " + problem_text + "\n"
+                    + "ANSWER: " + stated_answer + "\n"
+                    + "NOVELTY CLAIM: " + novelty_claim + "\n";
+    let _topic_label = recall_latest("replay:current_topic");
+    let canonical_ctx = _oeis_canonical_ctx(_topic_label, _input_blob);
+
+    let rule_first_flag = try { exec sh "printenv OEIS_SEARCH_RULE_FIRST"; } catch e { ""; };
+    let rule_first_enabled = rule_first_flag != "0";
+
+    let min_conf_str = try { exec sh "printenv OEIS_SEARCH_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
+
+    if rule_first_enabled {
+        let rule = crystallizer_lookup_with_confidence("oeis_search_output", canonical_ctx, min_conf);
+        if len(rule) > 0 {
+            // Rule hit -- reconstruct the FULL Sequences output from the
+            // rule's action field without prompt(). #843:
+            // crystallizer_lookup_with_confidence returns map<string,string>
+            // (Value::Map). Read the map fields with get() (the map
+            // accessor); json_get() expects a JSON string and raises
+            // "expected string, got map" on a Map. The action ITSELF is a
+            // JSON string (the faithful Sequences serialization), so its
+            // fields ARE read with json_get() -- get() is only for the
+            // outer Map.
+            let rule_id = to_string(get(rule, "rule_id"));
+            let rule_action = to_string(get(rule, "action"));
+            let rule_conf_str = to_string(get(rule, "confidence"));
+            let rule_conf = if len(rule_conf_str) > 0 { parse_float(rule_conf_str); } else { min_conf; };
+
+            let r_sequences_json = to_string(json_get(rule_action, "sequences_json"));
+            let r_rationale = to_string(json_get(rule_action, "rationale"));
+            let rule_rationale = "rule-first: matched crystallized oeis_search_output rule at confidence " + to_string(rule_conf) + ". Context: " + canonical_ctx;
+
+            // colony-lint: learn-tags-ok
+            learn("oeis_search_output", canonical_ctx, rule_action, "success", ["distilled", "rule-hit", "claim-auditor"]);
+            crystallizer_record_use(rule_id, true, 0.1);
+
+            // Tier branch -- mirrors the LLM path below. The rule-hit
+            // publisher takes primitive fields because the .ag grammar
+            // disallows inline Sequences struct literals. The oeis-search
+            // observability rows stay byte-identical to the LLM path so
+            // auto-promote sees the same tag stream.
+            if my_tier == "autonomous" {
+                memo_write("oeis_search:" + _self_pid + ":review_gated", "true");
+                learn("oeis-search", "tick " + to_string(tick_idx), r_rationale, "partial", ["acted", "claim-auditor"]);
+                _publish_oeis_search_rule_hit(true, true, r_sequences_json, r_rationale, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
+            } else {
+                if my_tier == "review-gated" {
+                    memo_write("oeis_search:" + _self_pid + ":review_gated", "true");
+                    learn("oeis-search", "tick " + to_string(tick_idx), r_rationale, "partial", ["review-gated", "claim-auditor"]);
+                    _publish_oeis_search_rule_hit(true, false, r_sequences_json, r_rationale, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
+                } else {
+                    if my_tier == "propose" {
+                        _publish_oeis_search_rule_hit(false, false, r_sequences_json, r_rationale, _self_pid, _colony_name, upstream_tick, tick_idx, _tick_now_ms, problem_text, stated_answer, novelty_claim, my_tier);
+                    } else {
+                        print("[oeis-search] observing rule-hit (tier:", my_tier, ") rationale=", r_rationale);
+                        learn("oeis-search", "tick " + to_string(tick_idx), r_rationale, "partial", ["observed", "claim-auditor"]);
+                    };
+                };
+            };
+
+            let _ = rule_rationale;
+            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_s1) > 0 { memo_write("oeis-search:last_check", now_s1); };
+            return;
+        };
+    };
+
+    // ===== Stage 2: LLM fallback (historical path) =====
     let sequences = prompt(_extract_prompt() + _variant_overlay_suffix() + _specialty_overlay_suffix(_self_pid), ctx) -> Sequences;
 
-    let my_tier = tier("oeis_search");
+    // #845: distillation row. The rule action is the FULL, FAITHFUL
+    // serialization of the primary LLM output (sequences_json + rationale)
+    // -- a generative colony must encode its whole output, NOT a lossy
+    // summary/bucket (the #841 mistake). The CONDITION is the SAME fine
+    // canonical_ctx the Stage-1 lookup passes (topic + sha256 of the
+    // upstream input), so a rule only forms when the IDENTICAL input recurs
+    // >= crystallize_min_validations times producing the identical output
+    // (self-distill). Diverse generation never aggregates (each tick mints
+    // a distinct action under a distinct context hash and no entry reaches
+    // the validation floor -- self-stay-LLM). distill() raises until there
+    // are >=3 successful oeis_search_output records, so guard it; once the
+    // entry crystallizes the Stage-1 lookup starts hitting and this miss
+    // path stops running for that context.
+    let canonical_action = _encode_sequences_action(sequences);
+    if len(canonical_action) > 0 {
+        // colony-lint: learn-tags-ok
+        learn("oeis_search_output", canonical_ctx, canonical_action, "success", ["distilled", "claim-auditor"]);
+        let distilled_id = try { distill("oeis_search_output", canonical_ctx, canonical_action, "heuristic"); } catch e { ""; };
+        if len(distilled_id) > 0 {
+            knowledge_validate(distilled_id);
+        };
+    };
+
     if my_tier == "autonomous" {
         memo_write("oeis_search:" + _self_pid + ":review_gated", "true");
         learn("oeis-search", "tick " + to_string(tick_idx), sequences.rationale, "partial", ["acted", "claim-auditor"]);


### PR DESCRIPTION
Final #845 batch — give `oeis-search` the rule-first/distill capability; the crystallizer's gating decides at runtime whether a rule forms. Stage-1 reads the lookup map with `get()` (#843) and on a hit reconstructs the full output from the faithfully-serialized action string (json_get on the string only, 0 json_get-on-map), **skipping the LLM query-gen prompt — the external fetch still runs on the reconstructed queries**. Fine sha256-of-problem context → identical problem self-distills, diverse stays LLM-driven. **QA:** implementer daemon self-QA (rule crystallizes; get()+json_get-on-string decode contract clean with 0 `expected string, got map`; json_get-on-map contrast crashes) + reviewer diff-check (0 json_get-on-map, 4-tier branch + external-fetch + observability preserved); colony-lint 345/0/5. Refs #845, #833.