### PR TITLE
explorer: containment for runaway 'exec sh python3 explore-*.py' compute (#867)

### DIFF
--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -344,11 +344,29 @@ fn _publish_explorer(
     // sandbox today).
     let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
     let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
+    // #867: kill any leftover compute scripts from PRIOR ticks of THIS
+    // replica before launching a new one. Without this, runaway scripts
+    // accumulate -- seen in the #833 verification run when 7 stale
+    // scripts from ticks 2/4/12/14 were still spinning at tick 38,
+    // holding ~27 GB host RAM between them. The `[k]` regex class
+    // matches `k` against compute argv but pkill's own argv has the
+    // literal `[k]`, which doesn't satisfy the class, so pkill cannot
+    // self-match (process-list self-match avoidance trick).
+    // colony-lint: safe-exec-concat
+    let cleanup_cmd = "pkill -9 -f " + shell_escape("explore-" + self_pid + "-tic[k]-") + " 2>/dev/null; true";
+    let _c = try { exec sh cleanup_cmd; } catch e { ""; };
     // colony-lint: safe-exec-concat
     let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(exploration.code) + " > " + shell_escape(sandbox_eff + "/explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py");
     let _ = try { exec sh write_cmd; } catch e { ""; };
+    // #867: hard wall-clock cap. `timeout 300s` so a single runaway
+    // compute can't hold CPU/RAM indefinitely; SIGTERM at 300 s, then
+    // SIGKILL after the kernel's grace. The agent picks up an empty
+    // stdout for that tick (which the prompt and downstream cascade
+    // already tolerate as a null exploration). 300 s is generous for
+    // the polynomial / sequence-search work the explorer typically
+    // emits.
     // colony-lint: safe-exec-concat
-    let run_cmd = "python3 " + shell_escape(sandbox_eff + "/explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py") + " 2>&1";
+    let run_cmd = "timeout 300s python3 " + shell_escape(sandbox_eff + "/explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py") + " 2>&1";
     let output = try { exec sh run_cmd; } catch e { ""; };
 
     memo_write("explorer:" + self_pid + ":code:tick-" + to_string(tick_idx), exploration.code);


### PR DESCRIPTION
## Summary
Level-1 containment for [#867](https://github.com/Replikanti/agentis-colonies/issues/867). Two host-side guards before the `python3` exec:

1. **Pre-spawn cleanup** — kill any leftover `explore-<self_pid>-tick-*.py` from prior ticks of THIS replica via `pkill -9 -f`. Without this, scripts accumulate; the [#833](https://github.com/Replikanti/agentis-colonies/issues/833) verification run had 7 stale scripts from ticks 2/4/12/14 still spinning at tick 38, holding ~27 GB host RAM. Operator killed them mid-run to free memory; this prevents the situation from forming.
2. **Hard wall-clock cap** — wrap `python3` in `timeout 300s`. SIGTERM at 300 s, then SIGKILL after kernel grace. The agent picks up empty stdout for that tick (which the prompt + downstream cascade already tolerate as a null exploration). 300 s is generous for the polynomial / sequence-search shape the explorer typically emits.

## Per-replica scope
The `pkill` pattern includes `self_pid`, so other explorer replicas' running compute is not affected. The cleanup is "this replica's prior tick" only.

## Out of scope (separate issues)
- **Faithful tracking** of substrate-bypass compute spend (per-agent CPU-seconds + RSS-bytes alongside LLM spend, surfaced on the Analytics tab) — [#868](https://github.com/Replikanti/agentis-colonies/issues/868) level 2.
- **Substrate-native math** (replace `exec sh python3` with WASM-compiled `.ag` math libraries) — [#868](https://github.com/Replikanti/agentis-colonies/issues/868) level 3, research-track, gated on what level-2 measurements actually show.

## Verification
- `colony-lint`: **345 passed / 0 failed / 5 skipped** (matches baseline; `.ag` syntax + tier-branch + exec-sh safety + shellcheck + markdown all green for explorer).

## Files
- `research-foundry/explorer/agents/explorer.ag` (+25 LOC: two new `exec sh` lines + comments).

Closes [#867](https://github.com/Replikanti/agentis-colonies/issues/867).