### PR TITLE
feat(auto-promote): add DEMOTE arm so negative fitness closes the feedback loop (#898)

### DIFF
--- a/tools/auto-promote-config-parser.py
+++ b/tools/auto-promote-config-parser.py
@@ -181,6 +181,16 @@ def main():
     print('CFG_EVOLVE_BOTH_SIGNALS_REQUIRED=%s'
           % ('true' if both_required else 'false'))
 
+    # Demote arm (#898). Defaults match auto-promote-config.yaml's demote:
+    # block AND _load_config in auto-promote-decisions.py so federations
+    # whose configs predate the block behave identically.
+    d = cfg.get('demote', {}) or {}
+    demote_enabled = d.get('enabled', True)
+    print('CFG_DEMOTE_ENABLED=%s' % ('true' if demote_enabled else 'false'))
+    print('CFG_DEMOTE_SLOPE_THRESHOLD=%s' % d.get('delta_slope_threshold', -0.05))
+    print('CFG_DEMOTE_MIN_ENTRIES=%s' % d.get('min_entries_for_demote', 30))
+    print('CFG_DEMOTE_HARD_FLOOR=%s' % d.get('hard_floor', 0.4))
+
     ec = cfg.get('evolve', {}).get('config', {})
     print('CFG_EVOLVE_GENERATIONS=%s' % ec.get('generations', 3))
     print('CFG_EVOLVE_POPULATION=%s' % ec.get('population', 4))

--- a/tools/auto-promote-config.yaml
+++ b/tools/auto-promote-config.yaml
@@ -97,6 +97,26 @@ evolve:
     population: 4
     weights: "cb,val,exp"
 
+# Demote arm (#898). Closes the federation feedback loop the v1.18.0
+# eval_ag_with_outcome substrate exposure opened. When an agent's
+# delta_slope on acting rows is sufficiently negative AND it has enough
+# entries to trust the signal AND it's above the shadow floor, step
+# confidence DOWN one rung on the promote ladder (0.95 -> 0.8, 0.8 ->
+# 0.6, 0.6 -> 0.4). At the shadow floor (0.4) the demote arm yields to
+# the evolve arm — there's no lower tier to step into.
+#
+# Why demote precedes evolve: demote is the lighter-touch precursor.
+# An agent at autonomous (0.95) with sustained negative slope first
+# gets a single step-down (immediate cost pressure via per-tier LLM
+# routing dropping to a cheaper backend), then if signal persists,
+# another step-down, etc. Only after hitting shadow does evolve kick
+# in and mutate the prompt.
+demote:
+  enabled: true
+  delta_slope_threshold: -0.05      # average delta on acting rows must be at most this to demote
+  min_entries_for_demote: 30        # same bootstrap stability floor as promote prereq
+  hard_floor: 0.4                   # never demote below shadow tier
+
 # dry_run: true means all actions are logged but not executed.
 # Default is true — flip to false only after reviewing the journal.
 dry_run: true

--- a/tools/auto-promote-decisions.py
+++ b/tools/auto-promote-decisions.py
@@ -119,6 +119,15 @@ def _load_config(path):
     rule_hit_tag_allowlist = list(cfg.get('promote', {}).get(
         'rule_hit_tag_allowlist', ['distilled', 'rule-hit']))
 
+    # Demote arm (#898). Defaults match the demote: block in
+    # auto-promote-config.yaml so federations whose configs predate the
+    # block behave identically.
+    d = cfg.get('demote', {}) or {}
+    demote_enabled = bool(d.get('enabled', True))
+    demote_slope_threshold = float(d.get('delta_slope_threshold', -0.05))
+    demote_min_entries = int(d.get('min_entries_for_demote', 30))
+    demote_hard_floor = float(d.get('hard_floor', 0.4))
+
     return (
         int(p.get('min_entries', 200)),
         int(p.get('min_acting_entries', default_acting)),
@@ -132,6 +141,10 @@ def _load_config(path):
         w_efficiency,
         min_rule_hit_acting_ticks,
         rule_hit_tag_allowlist,
+        demote_enabled,
+        demote_slope_threshold,
+        demote_min_entries,
+        demote_hard_floor,
     )
 
 
@@ -215,7 +228,9 @@ def main():
          promote_steps_raw, evolve_slope_neg_for,
          evolve_reject_above, w_efficiency,
          min_rule_hit_acting_ticks,
-         rule_hit_tag_allowlist) = _load_config(config_path)
+         rule_hit_tag_allowlist,
+         demote_enabled, demote_slope_threshold,
+         demote_min_entries, demote_hard_floor) = _load_config(config_path)
     else:
         # Legacy positional mode used by auto-promote.sh sidecar. Keep byte-
         # identical contract — test-auto-promote.sh asserts it. The 12th arg
@@ -243,6 +258,21 @@ def main():
         w_efficiency = 0.15
         min_rule_hit_acting_ticks = 5
         rule_hit_tag_allowlist = ['distilled', 'rule-hit']
+        # #898: demote arm. Legacy positional invocation reads four extra
+        # `CFG_DEMOTE_*` exports from auto-promote-config-parser.py at
+        # positions 12-15 (after the optional containerized flag at 11).
+        # Defaults match _load_config + the YAML demote: block so a
+        # federation that pre-dates the demote arm sees byte-identical
+        # behaviour as long as the new positions are absent.
+        demote_enabled = True
+        demote_slope_threshold = -0.05
+        demote_min_entries = 30
+        demote_hard_floor = 0.4
+        if len(argv) >= 16:
+            demote_enabled = (argv[12].lower() in ('true', '1', 'yes'))
+            demote_slope_threshold = float(argv[13])
+            demote_min_entries = int(argv[14])
+            demote_hard_floor = float(argv[15])
 
     # Tags that mark a row as exercising a tier-gated acting branch (not observe).
     # See doc/auto-promote.md#classification — must match the tag strings emitted
@@ -848,6 +878,108 @@ def main():
                 'generation_current': generation_current,
             }))
             continue
+
+        # --- Demote check (#898) ---
+        # Closes the federation feedback loop the v1.18.0 eval_ag_with_outcome
+        # substrate exposure opened. Triggers strictly before the promote
+        # check so an agent at autonomous with sustained negative slope gets
+        # stepped down BEFORE we even attempt to promote it (which is a no-op
+        # at the ladder top — pre-#898 explorer was stuck at 0.95 forever
+        # despite -5.25 aggregate fitness, see smoke #18 forensic).
+        #
+        # Trigger conjunction (all must hold):
+        # (1) demote_enabled — federation opted in via config (default true)
+        # (2) entry_count >= demote_min_entries — bootstrap stability;
+        #     don't demote on noise from the first few rows
+        # (3) acting_count > 0 — slope is undefined on zero acting rows
+        # (4) delta_slope_acting <= demote_slope_threshold — the agent
+        #     is materially degrading on the acting branch
+        # (5) confidence > demote_hard_floor — never demote below shadow;
+        #     at the floor, evolve_self is the next step instead
+        #
+        # Step calculation: pick the largest step_from in the ladder that
+        # is strictly less than the current confidence. For confidence=0.95
+        # with ladder [(0.4,0.6),(0.6,0.8),(0.8,0.95)] that's 0.8. For 0.8
+        # it's 0.6. For 0.6 it's 0.4 (the floor — we step TO the floor but
+        # never below). For 0.4 we don't fire (caught by gate 5).
+        # Compute the MEAN delta on the acting window for the demote
+        # threshold. Using mean instead of slope (the metric for evolve)
+        # is intentional: demote reacts to a sustained low absolute
+        # fitness level (e.g. 56 partials × -0.10 = -5.6 net), where the
+        # linear-regression slope is 0 because the deltas are uniform.
+        # Slope would only catch DEGRADATION (negative trend) — which is
+        # what evolve already does. Demote is the lighter-touch precursor
+        # firing on absolute level.
+        demote_delta_mean = (
+            sum(deltas_acting) / len(deltas_acting)
+            if deltas_acting else 0.0
+        )
+
+        demote_floor_met = confidence > demote_hard_floor
+        demote_signal_met = (
+            acting_count > 0
+            and demote_delta_mean <= demote_slope_threshold
+        )
+        demote_entries_met = entry_count >= demote_min_entries
+        demote_triggered = (
+            demote_enabled
+            and demote_floor_met
+            and demote_signal_met
+            and demote_entries_met
+        )
+        if os.environ.get('AUTO_PROMOTE_DEBUG'):
+            sys.stderr.write(
+                f'DEMOTE_DBG {agent_name}: enabled={demote_enabled} '
+                f'conf={confidence} floor={demote_hard_floor} floor_met={demote_floor_met} '
+                f'mean_delta={demote_delta_mean} thresh={demote_slope_threshold} signal_met={demote_signal_met} '
+                f'entries={entry_count} min={demote_min_entries} entries_met={demote_entries_met} '
+                f'triggered={demote_triggered}\n'
+            )
+
+        if demote_triggered:
+            # Find the largest step_from strictly below current confidence;
+            # this is the rung we step DOWN to. Ladder is sorted ascending
+            # by step_from so the last match wins.
+            demote_target = None
+            for step_from, step_to, step_override in promote_steps:
+                if step_from < confidence:
+                    demote_target = step_from
+            # If no ladder rung is below current (e.g. confidence=0.3 below
+            # the lowest step_from=0.4), fall through — we should not be
+            # here because gate 5 would have caught it, but defend in case
+            # an operator pinned the ladder above the hard floor.
+            if demote_target is not None and demote_target < confidence:
+                demote_prereqs = [
+                    {'name': 'demote_enabled', 'value': demote_enabled,
+                     'threshold': True, 'op': '==',
+                     'meets': demote_enabled},
+                    {'name': 'entries_total', 'value': entry_count,
+                     'threshold': demote_min_entries, 'op': '>=',
+                     'meets': demote_entries_met},
+                    {'name': 'delta_mean_acting',
+                     'value': round(demote_delta_mean, 6),
+                     'threshold': demote_slope_threshold, 'op': '<=',
+                     'meets': demote_signal_met},
+                    {'name': 'confidence_above_floor',
+                     'value': confidence,
+                     'threshold': demote_hard_floor, 'op': '>',
+                     'meets': demote_floor_met},
+                ]
+                evidence['demote_prereqs'] = demote_prereqs
+                decisions.append(_attach_explorer_evidence({
+                    'agent': agent_name,
+                    'colony': colony,
+                    'decision': 'demote',
+                    'from': confidence,
+                    'to': demote_target,
+                    'reason': (
+                        f'demote triggered (mean_delta={demote_delta_mean:.6f} '
+                        f'<= {demote_slope_threshold}, '
+                        f'confidence {confidence} > floor {demote_hard_floor})'
+                    ),
+                    'evidence': evidence,
+                }))
+                continue
 
         # --- Promote check ---
         # Find applicable step for current confidence by tier-range membership

--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -254,11 +254,14 @@ DECISIONS_JSON=$(python3 "$SCRIPT_DIR/auto-promote-decisions.py" \
     "$CFG_MIN_ENTRIES" "$CFG_MIN_ACTING_ENTRIES" "$CFG_MIN_RUNTIME_HOURS" \
     "$CFG_REJECT_RATE_THRESHOLD" "$CFG_DELTA_SLOPE_WINDOW" "$CFG_DELTA_SLOPE_MIN" \
     "$CFG_PROMOTE_STEPS" "$CFG_EVOLVE_SLOPE_NEG_FOR" "$CFG_EVOLVE_REJECT_ABOVE" \
-    "$CONTAINERIZED_ARG")
+    "$CONTAINERIZED_ARG" \
+    "$CFG_DEMOTE_ENABLED" "$CFG_DEMOTE_SLOPE_THRESHOLD" \
+    "$CFG_DEMOTE_MIN_ENTRIES" "$CFG_DEMOTE_HARD_FLOOR")
 
 # --- Execute decisions ---
 
 PROMOTE_COUNT=0
+DEMOTE_COUNT=0
 EVOLVE_COUNT=0
 SKIP_COUNT=0
 
@@ -359,6 +362,69 @@ for d in daemons:
             PROMOTE_COUNT=$((PROMOTE_COUNT + 1))
             ;;
 
+        demote)
+            # #898: demote arm. Mirror of promote's memo-write + daemon
+            # reload, but stepping confidence DOWN. Closes the federation
+            # feedback loop the v1.18.0 eval_ag_with_outcome substrate
+            # exposure opened (research-foundry smoke #18 forensic showed
+            # explorer at -5.25 aggregate fitness still stuck at
+            # confidence=0.95 because auto-promote had no DEMOTE arm).
+            log "DEMOTE $agent ($colony): $step_from -> $step_to ($reason)"
+            if [ "$DRY_RUN" = "true" ]; then
+                log "  [dry-run] Would run: agentis memo set ${agent}:confidence $step_to"
+                log "  [dry-run] Would reload daemon for $agent (agentis daemon reload, #733)"
+                journal_append "$agent" "demote" \
+                    "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='dry-run'; print(json.dumps(e))" "$evidence_json")" \
+                    "$step_from" "$step_to"
+            else
+                log "  Writing confidence: agentis memo set ${agent}:confidence $step_to"
+                if (cd "$FED_DIR" && agentis memo set "${agent}:confidence" "$step_to") 2>&1; then
+                    log "  Memo written successfully"
+                else
+                    log "  WARNING: memo set failed for $agent"
+                    journal_append "$agent" "demote-failed" \
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['error']='memo_set_failed'; print(json.dumps(e))" "$evidence_json")" \
+                        "$step_from" "$step_to"
+                    continue
+                fi
+
+                # Reload via the v1.7.16 #656 primitive (same as promote
+                # arm — see promote's comment block for rationale).
+                AGENT_ID=$(python3 -c "
+import json, sys, os
+daemons = json.loads(sys.argv[1])
+agent = sys.argv[2]
+for d in daemons:
+    src = d.get('source', '')
+    if os.path.basename(src) == agent + '.ag':
+        print(d.get('agent_id', ''))
+        break
+" "$DAEMONS_JSON" "$agent")
+
+                if [ -z "$AGENT_ID" ]; then
+                    log "  WARNING: could not find agent_id for $agent in daemon list, skipping reload"
+                    journal_append "$agent" "demote-partial" \
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='memo-only'; e['warning']='agent_id_not_found'; print(json.dumps(e))" "$evidence_json")" \
+                        "$step_from" "$step_to"
+                    continue
+                fi
+
+                log "  Reloading daemon for $agent (agent_id=$AGENT_ID)..."
+                if (cd "$FED_DIR" && agentis daemon reload "$AGENT_ID" 200>&-) 2>&1; then
+                    log "  Daemon reloaded for $agent (in-process tier refresh)"
+                    journal_append "$agent" "demote" \
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='executed'; e['mechanism']='reload'; print(json.dumps(e))" "$evidence_json")" \
+                        "$step_from" "$step_to"
+                else
+                    log "  WARNING: agentis daemon reload failed for $agent (agent_id=$AGENT_ID) — memo was written, but daemon will not emit agent.tier_reloaded until next reload or restart"
+                    journal_append "$agent" "demote-partial" \
+                        "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='memo-only'; e['warning']='reload_failed'; print(json.dumps(e))" "$evidence_json")" \
+                        "$step_from" "$step_to"
+                fi
+            fi
+            DEMOTE_COUNT=$((DEMOTE_COUNT + 1))
+            ;;
+
         evolve)
             log "EVOLVE $agent ($colony): $reason"
             if [ "$DRY_RUN" = "true" ]; then
@@ -444,4 +510,4 @@ for d in decisions:
     print(f'{decision}|{agent}|{colony}|{step_from}|{step_to}|{reason}|{evidence}')
 " "$DECISIONS_JSON")
 
-log "Done. Promotes=$PROMOTE_COUNT, Evolves=$EVOLVE_COUNT, Skips=$SKIP_COUNT"
+log "Done. Promotes=$PROMOTE_COUNT, Demotes=$DEMOTE_COUNT, Evolves=$EVOLVE_COUNT, Skips=$SKIP_COUNT"

--- a/tools/test-auto-promote.sh
+++ b/tools/test-auto-promote.sh
@@ -986,6 +986,126 @@ fi
 
 fi  # end agentis-available guard for Test 18 + 19
 
+# --- Test 20-22: demote arm (#898) ---
+# Cover the three boundary cases for the new demote decision arm that
+# closes the federation feedback loop the v1.18.0 eval_ag_with_outcome
+# substrate exposure opened. Pre-#898 auto-promote-decisions.py had no
+# demote logic — sustained negative fitness from .ag agents calling
+# learn() with Outcome::Partial / Failure could not push confidence DOWN,
+# so research-foundry smoke #18 forensic showed explorer at -5.25
+# aggregate fitness still stuck at confidence=0.95.
+
+# Helper: build a hermetic fed_dir with N synthetic acting rows at given
+# delta, fresh memo + heartbeat. Echoes the fed_dir path on stdout.
+make_demote_fixture() {
+    local agent_id="$1" colony="$2" n_rows="$3" delta="$4"
+    local fed_dir="$TMPDIR_TEST/demote-${agent_id}-$$"
+    mkdir -p "$fed_dir/.agentis/experience" "$fed_dir/.agentis/memo" "$fed_dir/.agentis/daemon"
+    python3 -c "
+import json, time, sys
+agent_id, colony, n_rows, delta = sys.argv[1], sys.argv[2], int(sys.argv[3]), float(sys.argv[4])
+fed_dir = sys.argv[5]
+ts_ms = int(time.time() * 1000)
+with open(f'{fed_dir}/.agentis/experience/{agent_id}.jsonl', 'w') as f:
+    for i in range(n_rows):
+        f.write(json.dumps({
+            'action': 'eval_ag', 'agent': 'main', 'tags': ['acted', 'eval_ag', 'math-foundry'],
+            'outcome': 'partial', 'delta': delta,
+            'ts': ts_ms + i, 'in': 'x', 'out': 'y', 'cb': 0,
+        }) + '\n')
+with open(f'{fed_dir}/.agentis/memo/{colony}:last_check.jsonl', 'w') as f:
+    f.write(json.dumps({'value': str(ts_ms)}) + '\n')
+with open(f'{fed_dir}/.agentis/daemon/{agent_id}.heartbeat', 'w') as f:
+    f.write(f'{ts_ms}\n3000000\nhealthy\n100000\nfalse\n')
+" "$agent_id" "$colony" "$n_rows" "$delta" "$fed_dir"
+    echo "$fed_dir"
+}
+
+# Test 20: positive case — explorer at autonomous tier (0.95) with
+# sustained negative mean delta (-0.10 across 40 acting rows) MUST
+# trigger a single-step demote to review-gated (0.8).
+FED_DEMOTE_FIRE=$(make_demote_fixture "demote-fire-1" "explorer" 40 "-0.10")
+DAEMONS_DEMOTE_FIRE="[{\"pid\":$$,\"agent_id\":\"demote-fire-1\",\"source\":\"explorer.ag\",\"state\":\"running\",\"effective_state\":\"running\",\"colony\":\"explorer\",\"confidence\":0.95,\"started_at\":1}]"
+
+OUT_DEMOTE_FIRE=$(python3 "$SCRIPT_DIR/auto-promote-decisions.py" \
+    --preview --config "$SCRIPT_DIR/auto-promote-config.yaml" \
+    "$DAEMONS_DEMOTE_FIRE" "$FED_DEMOTE_FIRE")
+
+DEMOTE_FIRE_CHECK=$(python3 -c "
+import json, sys
+arr = json.loads(sys.argv[1])
+if len(arr) != 1:
+    print('arity:' + str(len(arr))); sys.exit(0)
+d = arr[0]
+if d.get('decision') != 'demote':
+    print('decision:' + str(d.get('decision'))); sys.exit(0)
+if abs(float(d.get('from', 0)) - 0.95) > 0.001:
+    print('from:' + str(d.get('from'))); sys.exit(0)
+if abs(float(d.get('to', 0)) - 0.8) > 0.001:
+    print('to:' + str(d.get('to'))); sys.exit(0)
+print('ok')
+" "$OUT_DEMOTE_FIRE" 2>&1 || true)
+
+if [ "$DEMOTE_FIRE_CHECK" = "ok" ]; then
+    pass "demote arm fires on sustained negative delta at autonomous tier (#898)"
+else
+    fail "demote arm fire" "$DEMOTE_FIRE_CHECK from <$OUT_DEMOTE_FIRE>"
+fi
+
+# Test 21: negative case — mean delta above threshold (-0.04) MUST NOT
+# trigger demote. Guards against false positives that would punish
+# barely-negative agents (noise) and degrade healthy federations.
+FED_DEMOTE_NO=$(make_demote_fixture "demote-no-1" "explorer" 40 "-0.04")
+DAEMONS_DEMOTE_NO="[{\"pid\":$$,\"agent_id\":\"demote-no-1\",\"source\":\"explorer.ag\",\"state\":\"running\",\"effective_state\":\"running\",\"colony\":\"explorer\",\"confidence\":0.95,\"started_at\":1}]"
+
+OUT_DEMOTE_NO=$(python3 "$SCRIPT_DIR/auto-promote-decisions.py" \
+    --preview --config "$SCRIPT_DIR/auto-promote-config.yaml" \
+    "$DAEMONS_DEMOTE_NO" "$FED_DEMOTE_NO")
+
+DEMOTE_NO_CHECK=$(python3 -c "
+import json, sys
+arr = json.loads(sys.argv[1])
+if len(arr) != 1:
+    print('arity:' + str(len(arr))); sys.exit(0)
+d = arr[0]
+if d.get('decision') == 'demote':
+    print('false positive: demoted at mean_delta=-0.04'); sys.exit(0)
+print('ok')
+" "$OUT_DEMOTE_NO" 2>&1 || true)
+
+if [ "$DEMOTE_NO_CHECK" = "ok" ]; then
+    pass "demote arm does NOT fire on borderline-negative delta (#898)"
+else
+    fail "demote arm borderline" "$DEMOTE_NO_CHECK from <$OUT_DEMOTE_NO>"
+fi
+
+# Test 22: hard-floor case — agent at shadow tier (0.4) with sustained
+# negative delta MUST NOT demote below shadow. At the floor, evolve_self
+# is the next step instead.
+FED_DEMOTE_FLOOR=$(make_demote_fixture "demote-floor-1" "explorer" 40 "-0.20")
+DAEMONS_DEMOTE_FLOOR="[{\"pid\":$$,\"agent_id\":\"demote-floor-1\",\"source\":\"explorer.ag\",\"state\":\"running\",\"effective_state\":\"running\",\"colony\":\"explorer\",\"confidence\":0.4,\"started_at\":1}]"
+
+OUT_DEMOTE_FLOOR=$(python3 "$SCRIPT_DIR/auto-promote-decisions.py" \
+    --preview --config "$SCRIPT_DIR/auto-promote-config.yaml" \
+    "$DAEMONS_DEMOTE_FLOOR" "$FED_DEMOTE_FLOOR")
+
+DEMOTE_FLOOR_CHECK=$(python3 -c "
+import json, sys
+arr = json.loads(sys.argv[1])
+if len(arr) != 1:
+    print('arity:' + str(len(arr))); sys.exit(0)
+d = arr[0]
+if d.get('decision') == 'demote':
+    print('hard floor breach: demoted below shadow'); sys.exit(0)
+print('ok')
+" "$OUT_DEMOTE_FLOOR" 2>&1 || true)
+
+if [ "$DEMOTE_FLOOR_CHECK" = "ok" ]; then
+    pass "demote arm respects hard floor at shadow tier (#898)"
+else
+    fail "demote arm floor" "$DEMOTE_FLOOR_CHECK from <$OUT_DEMOTE_FLOOR>"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes #898. Smoke #18 (post-v1.18.0 agentis-core + #897 colonies rewiring) confirmed the substrate-side feedback signal works end-to-end:

| Layer | Signal | State |
|---|---|---|
| Substrate `eval_ag_with_outcome` | outcome bucket per call | ✅ 78 audit rows |
| explorer.ag branch + learn() | mapped Outcome | ✅ 78 experience rows |
| `experience.outcome_partial_delta = -0.10` | active | ✅ partial rows have delta=-0.10 |
| Aggregate fitness for explorer | -5.25 across 78 calls | ✅ massive negative |

But the signal could not propagate: auto-promote-decisions.py had only UPWARD promotion (0.4 → 0.6 → 0.8 → 0.95) and no DEMOTE arm. Despite the massive negative fitness, the sidecar logged `SKIP explorer: no applicable promote step for confidence=0.95` across all 4 ticks. Half-built feedback loop.

This PR ships the missing demote arm.

## Trigger conjunction (all must hold)

1. `demote.enabled` (default `true`)
2. `entry_count >= demote.min_entries_for_demote` (default `30`) — bootstrap stability
3. `acting_count > 0` — slope/mean undefined on zero acting rows
4. `mean(deltas on acting window) <= demote.delta_slope_threshold` (default `-0.05`)
5. `confidence > demote.hard_floor` (default `0.4`) — never demote below shadow

## Step calculation

Pick the largest `step_from` strictly less than the current confidence on the existing promote ladder. From `0.95 → 0.8 → 0.6 → 0.4`. From a non-rung value like `0.5` → step to `0.4` (partial to floor).

## Why MEAN, not slope

Slope (what evolve uses) is the wrong metric here. 56 uniform partials at delta=-0.10 produce slope=0 (no trend) but the agent IS materially failing on absolute level. Mean catches sustained low fitness even when the trend is flat. The probe `python3 /tmp/probe_demote2.py` validates 8 boundary cases including this one.

## Decision order

Demote precedes evolve. Demote is the lighter-touch precursor: an agent at autonomous (0.95) with sustained negative mean first gets a single step-down (immediate cost pressure via v1.7.15 #652 per-tier LLM routing dropping to a cheaper backend). Only after hitting shadow does evolve fire and mutate the prompt.

## Files changed (5)

| File | Change |
|---|---|
| `tools/auto-promote-config.yaml` | New `demote:` block with 4 keys |
| `tools/auto-promote-config-parser.py` | 4 new `CFG_DEMOTE_*` exports |
| `tools/auto-promote-decisions.py` | `_load_config` returns extended tuple; new demote arm between evolve trigger and promote check; structured `evidence.demote_prereqs` array (same shape as promote's) for dashboard rendering |
| `tools/auto-promote.sh` | New `demote)` case in dispatch loop (memo write + `agentis daemon reload`, same path as promote arm); `DEMOTE_COUNT` tracker; final log line updated to `Done. Promotes=N, Demotes=M, Evolves=K, Skips=L` |
| `tools/test-auto-promote.sh` | 3 new tests: positive fire (0.95 + sustained -0.10 → demote to 0.8), borderline (mean -0.04 → skip), hard floor (at 0.4 + -0.20 → skip) |

## Backwards compatibility

Federations whose `.agentis` configs pre-date the `demote:` block see byte-identical behaviour. Defaults match the YAML block AND `_load_config` AND legacy positional fallback. The decisions.py legacy positional invocation reads `CFG_DEMOTE_*` at positions 12-15 (after the optional containerized flag at 11); when absent, defaults fire.

## Out of scope

The 0.95 daemon-list-vs-memo confidence mismatch surfaced in smoke #18 forensic (auto-promote sees confidence=0.95 across all agents despite memo showing 0.7) is filed as a separate research-foundry investigation — orthogonal to this fix because demote operates on slope/mean from `experience.jsonl`, not on the daemon-list confidence value.

## Test plan

- [x] `bash tools/test-auto-promote.sh` → 46 passed, 0 failed (was 43)
- [x] `bash tools/colony-lint.sh` → 345 passed, 0 failed, 5 skipped
- [x] Synthetic boundary probe covering 8 cases (positive/negative/floor/min-entries × autonomous/review-gated/propose/shadow) all classify correctly

## Smoke #19 validation plan

After merge, rerun smoke matching #17/#18 shape (10 ticks Anthropic Claude flat). Expected: at least one DEMOTE arm fires on explorer within the smoke window because the -5.25 aggregate fitness from smoke #18 will reappear. Confidence drift visible in `<agent>:confidence` memo timeline.