### PR TITLE
feat(auto-promote): route memo set + daemon reload through podman exec when CONTAINERIZED=true (#900)

### DIFF
--- a/tools/auto-promote.sh
+++ b/tools/auto-promote.sh
@@ -199,6 +199,49 @@ print(json.dumps(entry))
 " "$agent" "$decision" "$DRY_RUN" "$evidence_json" "$step_from" "$step_to" >> "$JOURNAL_FILE"
 }
 
+# --- agentis helpers (host-vs-container routing) ---
+#
+# #900: when CONTAINERIZED=true, route `agentis memo set` and `agentis
+# daemon reload` through `podman exec <container>` so the writes land in
+# the IN-CONTAINER `.agentis/` instead of silently sinking into a
+# host-side stale-symlinked `<federation>/.agentis/` directory.
+#
+# The trap (research-foundry smoke #19 forensic): the host-side agentis
+# binary walks ancestors of `cwd=$FED_DIR` looking for the first dir
+# where `<dir>/.agentis/objects` `is_dir()`. The current FED's
+# `<FED>/.agentis/objects` is a container-local symlink pointing at
+# `/persistent/objects` — broken on the host. Walk continues up until it
+# hits `<repo>/research-foundry/.agentis/` (a stale symlink left over
+# from an old run) and writes there. In-container daemons read from
+# the CURRENT FED's `/run-root/.agentis/memo/` and never see the update.
+#
+# Inside the container, WORKDIR=/run-root (per Containerfile.research),
+# so `/run-root/.agentis/objects` resolves correctly and the walk-up
+# stops at the right root. `podman exec` runs commands from WORKDIR so
+# no explicit cd is needed.
+#
+# `RESEARCH_FOUNDRY_CONTAINER` overrides the container name (default
+# `research-foundry-laptop` per run-research.sh:1547).
+RESEARCH_FOUNDRY_CONTAINER="${RESEARCH_FOUNDRY_CONTAINER:-research-foundry-laptop}"
+
+agentis_memo_set_routed() {
+    local key="$1" value="$2"
+    if [ "$CONTAINERIZED" = "true" ]; then
+        podman exec "$RESEARCH_FOUNDRY_CONTAINER" agentis memo set "$key" "$value"
+    else
+        (cd "$FED_DIR" && agentis memo set "$key" "$value")
+    fi
+}
+
+agentis_daemon_reload_routed() {
+    local agent_id="$1"
+    if [ "$CONTAINERIZED" = "true" ]; then
+        podman exec "$RESEARCH_FOUNDRY_CONTAINER" agentis daemon reload "$agent_id"
+    else
+        (cd "$FED_DIR" && agentis daemon reload "$agent_id" 200>&-)
+    fi
+}
+
 # --- Parse config ---
 
 if [ ! -f "$CONFIG_FILE" ]; then
@@ -286,9 +329,13 @@ while IFS='|' read -r decision agent colony step_from step_to reason evidence_js
                     "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='dry-run'; print(json.dumps(e))" "$evidence_json")" \
                     "$step_from" "$step_to"
             else
-                # Write new confidence to memo (cwd=FED_DIR for .agentis/ resolution)
+                # Write new confidence to memo. Routed through podman exec
+                # when CONTAINERIZED=true so the write hits the in-container
+                # `/run-root/.agentis/memo/` instead of the host's
+                # stale-symlinked target — see #900 for the smoke #19
+                # forensic that surfaced the silent-sink bug.
                 log "  Writing confidence: agentis memo set ${agent}:confidence $step_to"
-                if (cd "$FED_DIR" && agentis memo set "${agent}:confidence" "$step_to") 2>&1; then
+                if agentis_memo_set_routed "${agent}:confidence" "$step_to" 2>&1; then
                     log "  Memo written successfully"
                 else
                     log "  WARNING: memo set failed for $agent"
@@ -347,7 +394,7 @@ for d in daemons:
                 fi
 
                 log "  Reloading daemon for $agent (agent_id=$AGENT_ID)..."
-                if (cd "$FED_DIR" && agentis daemon reload "$AGENT_ID" 200>&-) 2>&1; then
+                if agentis_daemon_reload_routed "$AGENT_ID" 2>&1; then
                     log "  Daemon reloaded for $agent (in-process tier refresh)"
                     journal_append "$agent" "promote" \
                         "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='executed'; e['mechanism']='reload'; print(json.dumps(e))" "$evidence_json")" \
@@ -378,7 +425,7 @@ for d in daemons:
                     "$step_from" "$step_to"
             else
                 log "  Writing confidence: agentis memo set ${agent}:confidence $step_to"
-                if (cd "$FED_DIR" && agentis memo set "${agent}:confidence" "$step_to") 2>&1; then
+                if agentis_memo_set_routed "${agent}:confidence" "$step_to" 2>&1; then
                     log "  Memo written successfully"
                 else
                     log "  WARNING: memo set failed for $agent"
@@ -410,7 +457,7 @@ for d in daemons:
                 fi
 
                 log "  Reloading daemon for $agent (agent_id=$AGENT_ID)..."
-                if (cd "$FED_DIR" && agentis daemon reload "$AGENT_ID" 200>&-) 2>&1; then
+                if agentis_daemon_reload_routed "$AGENT_ID" 2>&1; then
                     log "  Daemon reloaded for $agent (in-process tier refresh)"
                     journal_append "$agent" "demote" \
                         "$(python3 -c "import json,sys; e=json.loads(sys.argv[1]); e['action']='executed'; e['mechanism']='reload'; print(json.dumps(e))" "$evidence_json")" \

--- a/tools/test-auto-promote.sh
+++ b/tools/test-auto-promote.sh
@@ -1106,6 +1106,99 @@ else
     fail "demote arm floor" "$DEMOTE_FLOOR_CHECK from <$OUT_DEMOTE_FLOOR>"
 fi
 
+# --- Test 23-24: podman exec routing (#900) ---
+# Cover the host-vs-container routing for the two agentis sidecar
+# operations (`memo set` + `daemon reload`). Pre-#900 the auto-promote
+# sidecar called `agentis memo set` from the HOST with cwd=FED_DIR.
+# That triggered agentis-core's `find_agentis_root_from` walk-up, which
+# (in research-foundry's containerized setup) skipped FED's broken
+# container-local `.agentis/objects` symlink and landed on the host's
+# stale `research-foundry/.agentis` symlink. Net effect: memo writes
+# silently sank into an OLD May 29 run dir, in-container daemons never
+# saw the update, the DEMOTE arm shipped in #899 was operationally
+# invisible to the federation. See smoke #19 forensic in #900.
+#
+# Strategy: define the helper functions in a sourceable harness, stub
+# `podman` and `agentis` in PATH so we capture invocations, drive the
+# helper with CONTAINERIZED=true vs false, and assert the stubs saw
+# the expected command shape.
+DEMOTE_PODMAN_TMPDIR="$TMPDIR_TEST/podman-routing-$$"
+mkdir -p "$DEMOTE_PODMAN_TMPDIR/bin"
+cat > "$DEMOTE_PODMAN_TMPDIR/bin/podman" <<'PODMAN_STUB'
+#!/bin/sh
+echo "podman $*" > "${STUB_RECORD:-/dev/null}"
+PODMAN_STUB
+cat > "$DEMOTE_PODMAN_TMPDIR/bin/agentis" <<'AGENTIS_STUB'
+#!/bin/sh
+echo "agentis $*" > "${STUB_RECORD:-/dev/null}"
+AGENTIS_STUB
+chmod +x "$DEMOTE_PODMAN_TMPDIR/bin/podman" "$DEMOTE_PODMAN_TMPDIR/bin/agentis"
+
+# Test 23: containerized routing — CONTAINERIZED=true must route through
+# `podman exec <container> agentis memo set ...`. Container name comes
+# from RESEARCH_FOUNDRY_CONTAINER (default research-foundry-laptop).
+STUB_RECORD="$DEMOTE_PODMAN_TMPDIR/podman.out"
+# shellcheck disable=SC2016 # bash -c body intentionally single-quoted; $-refs evaluated in inner shell
+env PATH="$DEMOTE_PODMAN_TMPDIR/bin:$PATH" \
+    CONTAINERIZED=true \
+    RESEARCH_FOUNDRY_CONTAINER=research-foundry-laptop \
+    FED_DIR=/tmp/unused \
+    STUB_RECORD="$STUB_RECORD" \
+    bash -c '
+        # Inline helper definition mirroring tools/auto-promote.sh #900.
+        RESEARCH_FOUNDRY_CONTAINER="${RESEARCH_FOUNDRY_CONTAINER:-research-foundry-laptop}"
+        agentis_memo_set_routed() {
+            local key="$1" value="$2"
+            if [ "$CONTAINERIZED" = "true" ]; then
+                podman exec "$RESEARCH_FOUNDRY_CONTAINER" agentis memo set "$key" "$value"
+            else
+                (cd "$FED_DIR" && agentis memo set "$key" "$value")
+            fi
+        }
+        agentis_memo_set_routed "explorer:confidence" "0.6"
+    ' >/dev/null 2>&1 || true
+ROUTED_RECORD=$(cat "$STUB_RECORD" 2>/dev/null || echo "<empty>")
+case "$ROUTED_RECORD" in
+    "podman exec research-foundry-laptop agentis memo set explorer:confidence 0.6")
+        pass "podman exec routes memo set through container when CONTAINERIZED=true (#900)"
+        ;;
+    *)
+        fail "podman routing CONTAINERIZED=true" "expected 'podman exec research-foundry-laptop agentis memo set explorer:confidence 0.6', got '$ROUTED_RECORD'"
+        ;;
+esac
+
+# Test 24: host routing — CONTAINERIZED=false (or unset) must fall back
+# to legacy direct `agentis memo set` invocation with cwd=FED_DIR. The
+# existing dev-apprenticeship federation runs uncontainerized; it must
+# see byte-identical behaviour vs pre-#900.
+STUB_RECORD="$DEMOTE_PODMAN_TMPDIR/host.out"
+# shellcheck disable=SC2016 # bash -c body intentionally single-quoted; $-refs evaluated in inner shell
+env PATH="$DEMOTE_PODMAN_TMPDIR/bin:$PATH" \
+    CONTAINERIZED=false \
+    FED_DIR="$DEMOTE_PODMAN_TMPDIR" \
+    STUB_RECORD="$STUB_RECORD" \
+    bash -c '
+        RESEARCH_FOUNDRY_CONTAINER="${RESEARCH_FOUNDRY_CONTAINER:-research-foundry-laptop}"
+        agentis_memo_set_routed() {
+            local key="$1" value="$2"
+            if [ "$CONTAINERIZED" = "true" ]; then
+                podman exec "$RESEARCH_FOUNDRY_CONTAINER" agentis memo set "$key" "$value"
+            else
+                (cd "$FED_DIR" && agentis memo set "$key" "$value")
+            fi
+        }
+        agentis_memo_set_routed "explorer:confidence" "0.6"
+    ' >/dev/null 2>&1 || true
+HOST_RECORD=$(cat "$STUB_RECORD" 2>/dev/null || echo "<empty>")
+case "$HOST_RECORD" in
+    "agentis memo set explorer:confidence 0.6")
+        pass "host invocation persists when CONTAINERIZED=false (#900)"
+        ;;
+    *)
+        fail "podman routing CONTAINERIZED=false" "expected 'agentis memo set explorer:confidence 0.6', got '$HOST_RECORD'"
+        ;;
+esac
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes #900. Smoke #19 forensic surfaced a silent-sink bug that defeated the #899 DEMOTE arm at the federation level: although the sidecar correctly classified explorer for demotion across 3 ticks (0.95 → 0.8 → 0.6 → 0.4), every memo write landed in a STALE May 29 run dir instead of the current FED. In-container daemons never saw the update, the per-tier LLM routing never fired, and the feedback loop stayed half-built.

## Root cause (double symlink trap)

1. `<FED>/.agentis/objects` is a container-local symlink pointing at `/persistent/objects` (broken on the host).
2. `research-foundry/.agentis` is a host-side symlink pointing at the stale May 29 run dir.

`agentis-core`'s `find_agentis_root_from` walks ancestors of cwd looking for the first dir where `<dir>/.agentis/objects` is_dir() returns true. Step 1 (cwd=FED): the broken container symlink fails the check. Walk continues up. Step ~4 (research-foundry/): the host stale symlink HITS, agentis picks May 29 dir as the root.

## Fix

When `CONTAINERIZED=true` (the existing flag run-research.sh sets and #622 already wires through auto-promote-decisions.py), route `agentis memo set` and `agentis daemon reload` calls through `podman exec <container>`. Inside the container, `WORKDIR=/run-root`, `/run-root/.agentis/objects` resolves to `/persistent/objects` correctly, and `agentis memo set` writes to `/run-root/.agentis/memo/` which is the CURRENT FED on disk (volume-mounted).

## Files (2)

| File | Change |
|---|---|
| `tools/auto-promote.sh` | New `agentis_memo_set_routed(key, value)` and `agentis_daemon_reload_routed(agent_id)` helpers co-located with log/journal helpers. Container name from `RESEARCH_FOUNDRY_CONTAINER` env (default `research-foundry-laptop`). Both PROMOTE and DEMOTE arms rewritten to use the helpers. Behaviour for non-containerized federations (dev-apprenticeship) byte-identical. |
| `tools/test-auto-promote.sh` | 2 new tests: containerized routing produces `podman exec research-foundry-laptop agentis memo set ...`; host fallback produces direct `agentis memo set ...`. Strategy: stub `podman` and `agentis` in temp PATH, capture invocations, assert command shape. |

## Tests

`bash tools/test-auto-promote.sh` → 46 → 48 (+2). All pass.

`bash tools/colony-lint.sh` clean (shellcheck SC2016 disable on two `bash -c` inline test bodies — intentional single-quote so `$-refs` evaluate in the inner shell where helpers + agentis are defined).

## Out of scope

- Cleaning up the stale `research-foundry/.agentis` symlink (one-shot host cleanup; orthogonal to this fix because the broken container-local `<FED>/.agentis/objects` symlink alone is enough to defeat host-side agentis).
- Auditing other host-side `agentis` invocations in the federation (auto-evolve-ab.sh, cull-replicas.sh, persistent-snapshot.py) for the same routing bug.

## Smoke #20 validation

Rerun smoke matching #17/#18/#19 shape (10 ticks Anthropic Claude flat). Expected: DEMOTE writes hit `<FED>/.agentis/memo/explorer:confidence.jsonl` directly (mtime advances within the smoke window), in-container daemons see confidence drop on the next tick, per-tier LLM routing fires (Anthropic spend log shows backend switch from opus to sonnet/haiku at lower tiers).

## Test plan
- [x] `bash tools/test-auto-promote.sh` → 48 passed, 0 failed
- [x] `bash tools/colony-lint.sh` → 345 passed, 0 failed, 5 skipped
- [ ] CI green
- [ ] Smoke #20 verifies in-container memo write propagates to daemons