### PR TITLE
feat(research-foundry): migrate 193 printenv exec sh sites to getenv() (companion to agentis-core v1.18.1)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -50,7 +50,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -75,7 +75,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -195,7 +195,7 @@ fn _publish_arxiv_search(
     // tick_at). The helper accepts the queries JSON via
     // QJSON env and prints the concatenated atom feed.
     let queries_json = queries.queries_json;
-    let max_results_raw = try { exec sh "printenv ARXIV_MAX_QUERY_RESULTS"; } catch e { "10"; };
+    let max_results_raw = getenv("ARXIV_MAX_QUERY_RESULTS");
     let max_results = if len(max_results_raw) > 0 { parse_int(max_results_raw); } else { 10; };
     // colony-lint: safe-exec-concat
     let fetch_cmd = "QJSON=" + shell_escape(queries_json) + " MAXR=" + to_string(max_results)
@@ -270,7 +270,7 @@ fn _publish_arxiv_search(
 
                                     let lin_str = recall_latest("arxiv-search:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("arxiv-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -396,7 +396,7 @@ fn _publish_arxiv_search_rule_hit(
     my_tier: string
 ) -> void {
     let _ = final_write;
-    let max_results_raw = try { exec sh "printenv ARXIV_MAX_QUERY_RESULTS"; } catch e { "10"; };
+    let max_results_raw = getenv("ARXIV_MAX_QUERY_RESULTS");
     let max_results = if len(max_results_raw) > 0 { parse_int(max_results_raw); } else { 10; };
     // colony-lint: safe-exec-concat
     let fetch_cmd = "QJSON=" + shell_escape(queries_json) + " MAXR=" + to_string(max_results)
@@ -468,7 +468,7 @@ fn _publish_arxiv_search_rule_hit(
 
                                     let lin_str = recall_latest("arxiv-search:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("arxiv-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -510,7 +510,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("arxiv-search:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("arxiv-search:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -519,7 +519,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("arxiv-search:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv ARXIV_SEARCH_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("ARXIV_SEARCH_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("arxiv-search:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -569,10 +569,10 @@ fn tick(reason: string) -> void {
     // the LLM path.
     let canonical_ctx = _arxiv_canonical_ctx(ctx);
 
-    let rule_first_flag = try { exec sh "printenv ARXIV_SEARCH_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("ARXIV_SEARCH_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv ARXIV_SEARCH_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("ARXIV_SEARCH_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -45,7 +45,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -62,7 +62,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -205,7 +205,7 @@ fn _push_topic_feedback(
     };
     if len(buf_key) == 0 { return; };
     let buf_raw = recall_latest(buf_key);
-    let win_env = try { exec sh "printenv AUDITOR_FEEDBACK_WINDOW"; } catch e { ""; };
+    let win_env = getenv("AUDITOR_FEEDBACK_WINDOW");
     let win = if len(win_env) > 0 { parse_int(win_env); } else { 50; };
     let win_eff = if win <= 0 { 50; } else { win; };
     // colony-lint: safe-exec-concat
@@ -339,7 +339,7 @@ fn _publish_auditor(
 
     if final_write {
         // Append to per-run audit ledger.
-        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let terminal_str = if terminal { "true"; } else { "false"; };
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms)
@@ -458,7 +458,7 @@ fn _publish_auditor(
 
                                     let lin_str = recall_latest("auditor:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("auditor:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -628,7 +628,7 @@ fn _publish_auditor_rule_hit(
     memo_write("replay:current_auditor_pid", self_pid);
 
     if final_write {
-        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let terminal_str = if terminal { "true"; } else { "false"; };
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms)
@@ -721,7 +721,7 @@ fn _publish_auditor_rule_hit(
 
                                     let lin_str = recall_latest("auditor:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("auditor:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -762,7 +762,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("auditor:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("auditor:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -771,7 +771,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("auditor:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv AUDITOR_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("AUDITOR_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("auditor:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -893,10 +893,10 @@ fn tick(reason: string) -> void {
     // pipeline's terminal verdict).
     let canonical_ctx = _auditor_canonical_ctx(upstream_tick, prior_advocate_is_prior, theorist_lean_verdict, theorist_proof_kind);
 
-    let rule_first_flag = try { exec sh "printenv AUDITOR_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("AUDITOR_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv AUDITOR_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("AUDITOR_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.9; };
 
     if rule_first_enabled {

--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -34,7 +34,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -51,7 +51,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -157,7 +157,7 @@ fn _publish_computer(
     my_tier: string
 ) -> void {
     let _ = final_write;
-    let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
+    let sandbox_dir = getenv("AGENTIS_ROOT");
     let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
     let lang = script.language;
     let ext = if lang == "gap" { ".g"; } else { ".py"; };
@@ -233,7 +233,7 @@ fn _publish_computer(
 
                                     let lin_str = recall_latest("computer:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("computer:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -300,7 +300,7 @@ fn _publish_computer_rule_hit(
 ) -> void {
     let _ = final_write;
     let _ = rationale;
-    let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
+    let sandbox_dir = getenv("AGENTIS_ROOT");
     let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
     let lang = lang_in;
     let ext = if lang == "gap" { ".g"; } else { ".py"; };
@@ -376,7 +376,7 @@ fn _publish_computer_rule_hit(
 
                                     let lin_str = recall_latest("computer:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("computer:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -574,7 +574,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("computer:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("computer:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -583,7 +583,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("computer:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv COMPUTER_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("COMPUTER_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("computer:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -720,10 +720,10 @@ fn tick(reason: string) -> void {
     // short-circuits Stage 1 to the LLM path.
     let canonical_ctx = _computer_canonical_ctx(ctx, upstream_tick);
 
-    let rule_first_flag = try { exec sh "printenv COMPUTER_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("COMPUTER_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv COMPUTER_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("COMPUTER_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -47,7 +47,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -64,7 +64,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -197,7 +197,7 @@ fn _push_pitfall(
     if len(tags) == 0 { return; };
     let buf_key = "editor:learned_pitfalls";
     let buf_raw = recall_latest(buf_key);
-    let win_env = try { exec sh "printenv EDITOR_PITFALL_WINDOW"; } catch e { ""; };
+    let win_env = getenv("EDITOR_PITFALL_WINDOW");
     let win = if len(win_env) > 0 { parse_int(win_env); } else { 20; };
     let win_eff = if win <= 0 { 20; } else { win; };
     let excerpt_eff = if len(log_excerpt) > 200 { substring(log_excerpt, 0, 200); } else { log_excerpt; };
@@ -280,11 +280,11 @@ fn _publish_editor(
     let _ = final_write;
     let claim_id = recall_latest("claim:claim_id:tick-" + to_string(upstream_tick));
     let claim_id_eff = if len(claim_id) > 0 { claim_id; } else { "claim-" + to_string(upstream_tick); };
-    let out_root = try { exec sh "printenv PREPRINT_OUTPUT_ROOT"; } catch e { ""; };
+    let out_root = getenv("PREPRINT_OUTPUT_ROOT");
     let out_root_eff = if len(out_root) > 0 { out_root; } else { "/run-root/preprints"; };
     let claim_dir = out_root_eff + "/" + claim_id_eff;
 
-    let max_passes_env = try { exec sh "printenv PREPRINT_LATEXMK_MAX_PASSES"; } catch e { ""; };
+    let max_passes_env = getenv("PREPRINT_LATEXMK_MAX_PASSES");
     let max_passes = if len(max_passes_env) > 0 { parse_int(max_passes_env); } else { 3; };
     let max_passes_eff = if max_passes <= 0 { 1; } else { max_passes; };
 
@@ -302,7 +302,7 @@ fn _publish_editor(
     // Idempotent helper exits 0 when TOML is missing /
     // unparseable / empty, or when the .tex has no
     // placeholder, so it is safe to run unconditionally.
-    let author_cfg_path = try { exec sh "printenv PREPRINT_AUTHOR_CONFIG"; } catch e { ""; };
+    let author_cfg_path = getenv("PREPRINT_AUTHOR_CONFIG");
     let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };
     // colony-lint: safe-exec-concat
     let subst_cmd = "python3 /run-root/tools/substitute-author.py " + shell_escape(author_cfg_eff) + " " + shell_escape(claim_dir + "/main.tex");
@@ -427,7 +427,7 @@ fn _publish_editor(
 
                                     let lin_str = recall_latest("editor:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("editor:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -565,11 +565,11 @@ fn _publish_editor_rule_hit(
     let _ = final_write;
     let claim_id = recall_latest("claim:claim_id:tick-" + to_string(upstream_tick));
     let claim_id_eff = if len(claim_id) > 0 { claim_id; } else { "claim-" + to_string(upstream_tick); };
-    let out_root = try { exec sh "printenv PREPRINT_OUTPUT_ROOT"; } catch e { ""; };
+    let out_root = getenv("PREPRINT_OUTPUT_ROOT");
     let out_root_eff = if len(out_root) > 0 { out_root; } else { "/run-root/preprints"; };
     let claim_dir = out_root_eff + "/" + claim_id_eff;
 
-    let max_passes_env = try { exec sh "printenv PREPRINT_LATEXMK_MAX_PASSES"; } catch e { ""; };
+    let max_passes_env = getenv("PREPRINT_LATEXMK_MAX_PASSES");
     let max_passes = if len(max_passes_env) > 0 { parse_int(max_passes_env); } else { 3; };
     let max_passes_eff = if max_passes <= 0 { 1; } else { max_passes; };
 
@@ -583,7 +583,7 @@ fn _publish_editor_rule_hit(
     let write_bib_cmd = "printf '%s' " + shell_escape(refs_bib) + " > " + shell_escape(claim_dir + "/refs.bib");
     let _wb = try { exec sh write_bib_cmd; } catch e { ""; };
 
-    let author_cfg_path = try { exec sh "printenv PREPRINT_AUTHOR_CONFIG"; } catch e { ""; };
+    let author_cfg_path = getenv("PREPRINT_AUTHOR_CONFIG");
     let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };
     // colony-lint: safe-exec-concat
     let subst_cmd = "python3 /run-root/tools/substitute-author.py " + shell_escape(author_cfg_eff) + " " + shell_escape(claim_dir + "/main.tex");
@@ -692,7 +692,7 @@ fn _publish_editor_rule_hit(
 
                                     let lin_str = recall_latest("editor:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("editor:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -739,7 +739,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("editor:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("editor:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -748,7 +748,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("editor:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv EDITOR_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("EDITOR_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("editor:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -825,10 +825,10 @@ fn tick(reason: string) -> void {
     // short-circuits Stage 1 to the LLM path.
     let canonical_ctx = _editor_canonical_ctx(ctx);
 
-    let rule_first_flag = try { exec sh "printenv EDITOR_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("EDITOR_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv EDITOR_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("EDITOR_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -81,7 +81,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -98,7 +98,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -181,7 +181,7 @@ fn _levenshtein_ratio_pct(a: string, b: string) -> int {
     };
     if len(b) == 0 { return 0; };
     if a == b { return 100; };
-    let max_bytes_env = try { exec sh "printenv EXPLORER_PROMPT_MAX_BYTES"; } catch e { ""; };
+    let max_bytes_env = getenv("EXPLORER_PROMPT_MAX_BYTES");
     let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
     let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
     let a_clamped = if len(a) > max_bytes_eff { substring(a, 0, max_bytes_eff); } else { a; };
@@ -199,7 +199,7 @@ fn _levenshtein_ratio_pct(a: string, b: string) -> int {
 fn _push_settled_exploration(self_pid: string, verdict: string) -> int {
     let buf_key = "explorer:" + self_pid + ":settled_explorations";
     let buf_raw = recall_latest(buf_key);
-    let thr_env = try { exec sh "printenv EXPLORER_PROMPT_EVOLUTION_THRESHOLD"; } catch e { ""; };
+    let thr_env = getenv("EXPLORER_PROMPT_EVOLUTION_THRESHOLD");
     let thr = if len(thr_env) > 0 { parse_int(thr_env); } else { 3; };
     let thr_eff = if thr <= 0 { 3; } else { thr; };
     // colony-lint: safe-exec-concat
@@ -245,13 +245,13 @@ fn _evolve_exploration_prompt(self_pid: string, prompt_text: string) -> string {
     let gen_key = "explorer:" + self_pid + ":exploration_generation";
     let gen_str = recall_latest(gen_key);
     let gen = if len(gen_str) > 0 { parse_int(gen_str); } else { 0; };
-    let gen_cap_env = try { exec sh "printenv EXPLORER_PROMPT_GEN_CAP"; } catch e { ""; };
+    let gen_cap_env = getenv("EXPLORER_PROMPT_GEN_CAP");
     let gen_cap = if len(gen_cap_env) > 0 { parse_int(gen_cap_env); } else { 10; };
     let gen_cap_eff = if gen_cap <= 0 { 10; } else { gen_cap; };
-    let max_bytes_env = try { exec sh "printenv EXPLORER_PROMPT_MAX_BYTES"; } catch e { ""; };
+    let max_bytes_env = getenv("EXPLORER_PROMPT_MAX_BYTES");
     let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
     let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
-    let lev_floor_env = try { exec sh "printenv EXPLORER_PROMPT_LEVENSHTEIN_FLOOR"; } catch e { ""; };
+    let lev_floor_env = getenv("EXPLORER_PROMPT_LEVENSHTEIN_FLOOR");
     let lev_floor = if len(lev_floor_env) > 0 { parse_int(lev_floor_env); } else { 5; };
     let lev_floor_eff = if lev_floor < 0 { 5; } else { lev_floor; };
     let prompt_key = "explorer:" + self_pid + ":exploration_prompt";
@@ -424,7 +424,7 @@ fn _publish_explorer(
 
     if final_write {
         // Append to per-run discovery ledger.
-        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + _colony_name + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"exploration_done\"}";
             // colony-lint: safe-exec-concat
@@ -433,7 +433,7 @@ fn _publish_explorer(
         };
 
         // Settlement: read the novelty verdict for tick - HOLD_PERIOD.
-        let hold_env = try { exec sh "printenv HOLD_PERIOD"; } catch e { ""; };
+        let hold_env = getenv("HOLD_PERIOD");
         let hold = if len(hold_env) > 0 { parse_int(hold_env); } else { 4; };
         let hold_eff = if hold <= 0 { 4; } else { hold; };
         let settle_tick = tick_idx - hold_eff;
@@ -447,9 +447,9 @@ fn _publish_explorer(
                 // BORDERLINE, -1 NOT_NOVEL, -0.5 (mapped int 1)
                 // REJECT. Knob env vars are integer-scaled per-tick.
                 if len(self_pid) > 0 {
-                    let reward_novel_env = try { exec sh "printenv FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK"; } catch e { ""; };
+                    let reward_novel_env = getenv("FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK");
                     let reward_novel = if len(reward_novel_env) > 0 { parse_int(reward_novel_env); } else { 2; };
-                    let penalty_not_novel_env = try { exec sh "printenv FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK"; } catch e { ""; };
+                    let penalty_not_novel_env = getenv("FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK");
                     let penalty_not_novel = if len(penalty_not_novel_env) > 0 { parse_int(penalty_not_novel_env); } else { 1; };
                     let fit_pre = parse_int(recall_latest("explorer:" + self_pid + ":fitness"));
                     let fit_delta = if verdict_raw == "NOVEL" {
@@ -469,7 +469,7 @@ fn _publish_explorer(
                 // M98 v3 evolution trigger.
                 if len(self_pid) > 0 {
                     let _buf_len = _push_settled_exploration(self_pid, verdict_raw);
-                    let _thr_env = try { exec sh "printenv EXPLORER_PROMPT_EVOLUTION_THRESHOLD"; } catch e { ""; };
+                    let _thr_env = getenv("EXPLORER_PROMPT_EVOLUTION_THRESHOLD");
                     let _thr = if len(_thr_env) > 0 { parse_int(_thr_env); } else { 3; };
                     let _thr_eff = if _thr <= 0 { 3; } else { _thr; };
                     let _not_novel = _count_not_novel(self_pid);
@@ -512,7 +512,7 @@ fn _publish_explorer(
                                                 // by specialty stay coherent on lineage chains.
                                                 let lin_str = recall_latest("explorer:" + self_pid + ":generation");
                                                 let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                                let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                                let ledger_path_r = getenv("REPLICATION_LEDGER");
                                                 if len(ledger_path_r) > 0 {
                                                     let parent_specialty = recall_latest("explorer:" + self_pid + ":specialty");
                                                     let child_gen = lin + 1;
@@ -558,7 +558,7 @@ fn _publish_explorer(
 //   - the hint memo is empty (novelty.ag has not published one yet)
 // Default behaviour with the env unset is byte-identical to pre-#765.
 fn _loss_shaping_enabled_explorer() -> bool {
-    let flag = try { exec sh "printenv NOVELTY_LOSS_SHAPING_ENABLED"; } catch e { ""; };
+    let flag = getenv("NOVELTY_LOSS_SHAPING_ENABLED");
     if len(flag) == 0 { return false; };
     if flag == "1" { return true; };
     return false;
@@ -794,7 +794,7 @@ fn _publish_explorer_rule_hit(
     let exploration_json = _build_faithful_exploration_action(exploration_goal, code, expected_output_format);
     emit("math-foundry:exploration_done", exploration_json);
 
-    let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
+    let sandbox_dir = getenv("AGENTIS_ROOT");
     let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
     // colony-lint: safe-exec-concat
     let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(code) + " > " + shell_escape(sandbox_eff + "/explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py");
@@ -829,7 +829,7 @@ fn _publish_explorer_rule_hit(
     memo_write("explorer:" + self_pid + ":topic:tick-" + to_string(tick_idx), topic_label);
 
     if final_write {
-        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + _colony_name + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"exploration_done\"}";
             // colony-lint: safe-exec-concat
@@ -837,7 +837,7 @@ fn _publish_explorer_rule_hit(
             let _l = try { exec sh append_cmd; } catch e { ""; };
         };
 
-        let hold_env = try { exec sh "printenv HOLD_PERIOD"; } catch e { ""; };
+        let hold_env = getenv("HOLD_PERIOD");
         let hold = if len(hold_env) > 0 { parse_int(hold_env); } else { 4; };
         let hold_eff = if hold <= 0 { 4; } else { hold; };
         let settle_tick = tick_idx - hold_eff;
@@ -848,9 +848,9 @@ fn _publish_explorer_rule_hit(
                 learn("settle", "tick " + to_string(settle_tick) + " " + verdict_raw, "novelty=" + verdict_raw, "success", ["acted", "math-foundry", _colony_name, "verdict:" + verdict_raw]);
 
                 if len(self_pid) > 0 {
-                    let reward_novel_env = try { exec sh "printenv FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK"; } catch e { ""; };
+                    let reward_novel_env = getenv("FOUNDRY_FITNESS_REWARD_NOVEL_PER_TICK");
                     let reward_novel = if len(reward_novel_env) > 0 { parse_int(reward_novel_env); } else { 2; };
-                    let penalty_not_novel_env = try { exec sh "printenv FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK"; } catch e { ""; };
+                    let penalty_not_novel_env = getenv("FOUNDRY_FITNESS_PENALTY_NOT_NOVEL_PER_TICK");
                     let penalty_not_novel = if len(penalty_not_novel_env) > 0 { parse_int(penalty_not_novel_env); } else { 1; };
                     let fit_pre = parse_int(recall_latest("explorer:" + self_pid + ":fitness"));
                     let fit_delta = if verdict_raw == "NOVEL" {
@@ -869,7 +869,7 @@ fn _publish_explorer_rule_hit(
 
                 if len(self_pid) > 0 {
                     let _buf_len = _push_settled_exploration(self_pid, verdict_raw);
-                    let _thr_env = try { exec sh "printenv EXPLORER_PROMPT_EVOLUTION_THRESHOLD"; } catch e { ""; };
+                    let _thr_env = getenv("EXPLORER_PROMPT_EVOLUTION_THRESHOLD");
                     let _thr = if len(_thr_env) > 0 { parse_int(_thr_env); } else { 3; };
                     let _thr_eff = if _thr <= 0 { 3; } else { _thr; };
                     let _not_novel = _count_not_novel(self_pid);
@@ -906,7 +906,7 @@ fn _publish_explorer_rule_hit(
 
                                                 let lin_str = recall_latest("explorer:" + self_pid + ":generation");
                                                 let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                                let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                                let ledger_path_r = getenv("REPLICATION_LEDGER");
                                                 if len(ledger_path_r) > 0 {
                                                     let parent_specialty = recall_latest("explorer:" + self_pid + ":specialty");
                                                     let child_gen = lin + 1;
@@ -956,7 +956,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("explorer:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("explorer:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -969,7 +969,7 @@ fn tick(reason: string) -> void {
                     // replicate-success path's parent.generation+1 lineage
                     // walk produces correct depths instead of always 1.
                     // Initial cohort: EXPLORER_GENERATION env (default 0).
-                    let _gen_env = try { exec sh "printenv EXPLORER_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("EXPLORER_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("explorer:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -992,7 +992,7 @@ fn tick(reason: string) -> void {
     // backward compat with pre-#719 orchestrators).
     let tick_idx_str = recall_latest("replay:current_tick");
     let tick_idx = if len(tick_idx_str) > 0 { parse_int(tick_idx_str); } else { -1; };
-    let _daemon_id_topic = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+    let _daemon_id_topic = getenv("DAEMON_ID");
     let _per_topic = if len(_daemon_id_topic) > 0 {
         recall_latest("replay:explorer_topic:daemon:" + _daemon_id_topic);
     } else { ""; };
@@ -1043,7 +1043,7 @@ fn tick(reason: string) -> void {
     // body via the M106 hash-pointer wire when _variant starts with `pp:`.
     let prompt_text_raw = recall_latest("explorer:" + _self_pid + ":exploration_prompt");
     let prompt_text = if len(prompt_text_raw) == 0 {
-        let max_bytes_env = try { exec sh "printenv EXPLORER_PROMPT_MAX_BYTES"; } catch e { ""; };
+        let max_bytes_env = getenv("EXPLORER_PROMPT_MAX_BYTES");
         let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
         let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
         let pp_hash = _extract_pp_hash(_variant);
@@ -1155,10 +1155,10 @@ fn tick(reason: string) -> void {
     // LLM path.
     let canonical_ctx = _explorer_canonical_ctx(_self_pid, topic_label, topic_desc, compute_hints, paper_a_id, paper_a_title, paper_a_abstract, paper_b_id, paper_b_title, paper_b_abstract);
 
-    let rule_first_flag = try { exec sh "printenv EXPLORER_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("EXPLORER_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv EXPLORER_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("EXPLORER_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -35,7 +35,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -52,7 +52,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -266,7 +266,7 @@ fn _publish_formulator(
 
     if final_write {
         // Append to per-run discovery ledger.
-        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"problem_ready\",\"answer\":\"" + problem.answer + "\"}";
             // colony-lint: safe-exec-concat
@@ -317,7 +317,7 @@ fn _publish_formulator(
 
                                     let lin_str = recall_latest("formulator:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("formulator:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -454,7 +454,7 @@ fn _publish_formulator_rule_hit(
 
     if final_write {
         // Append to per-run discovery ledger.
-        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"problem_ready\",\"answer\":\"" + answer + "\"}";
             // colony-lint: safe-exec-concat
@@ -501,7 +501,7 @@ fn _publish_formulator_rule_hit(
 
                                     let lin_str = recall_latest("formulator:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("formulator:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -542,7 +542,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("formulator:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("formulator:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -551,7 +551,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("formulator:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv FORMULATOR_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("FORMULATOR_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("formulator:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -639,10 +639,10 @@ fn tick(reason: string) -> void {
     // short-circuits Stage 1 to the LLM path.
     let canonical_ctx = _formulator_canonical_ctx(ctx, topic_label);
 
-    let rule_first_flag = try { exec sh "printenv FORMULATOR_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("FORMULATOR_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv FORMULATOR_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("FORMULATOR_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -47,7 +47,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -72,7 +72,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -247,7 +247,7 @@ fn _publish_groupprops_search(
 
                                     let lin_str = recall_latest("groupprops-search:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("groupprops-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -445,7 +445,7 @@ fn _publish_groupprops_search_rule_hit(
 
                                     let lin_str = recall_latest("groupprops-search:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("groupprops-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -486,7 +486,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("groupprops-search:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("groupprops-search:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -495,7 +495,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("groupprops-search:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv GROUPPROPS_SEARCH_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("GROUPPROPS_SEARCH_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("groupprops-search:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -547,10 +547,10 @@ fn tick(reason: string) -> void {
     // short-circuits Stage 1 to the LLM path.
     let canonical_ctx = _groupprops_search_canonical_ctx(ctx, upstream_tick);
 
-    let rule_first_flag = try { exec sh "printenv GROUPPROPS_SEARCH_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("GROUPPROPS_SEARCH_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv GROUPPROPS_SEARCH_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("GROUPPROPS_SEARCH_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/introducer/agents/introducer.ag
+++ b/research-foundry/introducer/agents/introducer.ag
@@ -40,7 +40,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -57,7 +57,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -213,7 +213,7 @@ fn _publish_introducer(
 
                                     let lin_str = recall_latest("introducer:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("introducer:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -378,7 +378,7 @@ fn _publish_introducer_rule_hit(
 
                                     let lin_str = recall_latest("introducer:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("introducer:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -452,7 +452,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("introducer:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("introducer:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -461,7 +461,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("introducer:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv INTRODUCER_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("INTRODUCER_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("introducer:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -528,10 +528,10 @@ fn tick(reason: string) -> void {
     let claim_id = recall_latest("claim:claim_id:tick-" + to_string(upstream_tick));
     let canonical_ctx = _introducer_canonical_ctx(ctx, claim_id);
 
-    let rule_first_flag = try { exec sh "printenv INTRODUCER_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("INTRODUCER_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv INTRODUCER_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("INTRODUCER_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -49,7 +49,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -260,7 +260,7 @@ fn _publish_noticer(
 
                                     let lin_str = recall_latest("noticer:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("noticer:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -295,7 +295,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -520,7 +520,7 @@ fn _publish_noticer_rule_hit(
 
                                     let lin_str = recall_latest("noticer:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("noticer:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -562,7 +562,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("noticer:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("noticer:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -571,7 +571,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("noticer:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv NOTICER_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("NOTICER_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("noticer:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -619,10 +619,10 @@ fn tick(reason: string) -> void {
     let canonical_ctx = build_canonical_context(output);
     memo_write("noticer:" + _self_pid + ":canonical_ctx:tick-" + to_string(upstream_tick), canonical_ctx);
 
-    let rule_first_flag = try { exec sh "printenv NOTICER_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("NOTICER_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv NOTICER_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("NOTICER_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -34,7 +34,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -51,7 +51,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -284,7 +284,7 @@ fn _publish_novelty(
         // discovery-ledger.jsonl row should reflect tier policy
         // (autonomous + review-gated emit; propose skips per
         // #622 ADR-0001).
-        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"event\":\"novelty_verdict\",\"verdict\":\"" + effective_label + "\"}";
             // colony-lint: safe-exec-concat
@@ -392,7 +392,7 @@ fn _publish_novelty(
 
                                     let lin_str = recall_latest("novelty:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("novelty:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -428,7 +428,7 @@ fn _publish_novelty(
 // Bucket vocabulary mirrors tools/colony-variants.json explorer specialties:
 //   group_theory, combinatorics, number_theory, probability, algebra.
 fn _loss_shaping_enabled() -> bool {
-    let flag = try { exec sh "printenv NOVELTY_LOSS_SHAPING_ENABLED"; } catch e { ""; };
+    let flag = getenv("NOVELTY_LOSS_SHAPING_ENABLED");
     if len(flag) == 0 { return false; };
     if flag == "1" { return true; };
     return false;
@@ -779,7 +779,7 @@ fn _publish_novelty_rule_hit(
     };
 
     if final_write {
-        let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+        let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"event\":\"novelty_verdict\",\"verdict\":\"" + effective_label + "\"}";
             // colony-lint: safe-exec-concat
@@ -862,7 +862,7 @@ fn _publish_novelty_rule_hit(
 
                                     let lin_str = recall_latest("novelty:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("novelty:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -903,7 +903,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("novelty:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("novelty:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -912,7 +912,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("novelty:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv NOVELTY_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("NOVELTY_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("novelty:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -988,10 +988,10 @@ fn tick(reason: string) -> void {
     // NOVELTY_RULE_FIRST=0 short-circuits Stage 1 to the LLM path.
     let canonical_ctx = _novelty_canonical_ctx(topic_label, stated_answer);
 
-    let rule_first_flag = try { exec sh "printenv NOVELTY_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("NOVELTY_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv NOVELTY_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("NOVELTY_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -47,7 +47,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -72,7 +72,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -256,7 +256,7 @@ fn _publish_oeis_search(
 
                                     let lin_str = recall_latest("oeis-search:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("oeis-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -381,7 +381,7 @@ fn _publish_oeis_search_rule_hit(
 
                                     let lin_str = recall_latest("oeis-search:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("oeis-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -500,7 +500,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("oeis-search:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("oeis-search:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -509,7 +509,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("oeis-search:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv OEIS_SEARCH_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("OEIS_SEARCH_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("oeis-search:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -566,10 +566,10 @@ fn tick(reason: string) -> void {
     let _topic_label = recall_latest("replay:current_topic");
     let canonical_ctx = _oeis_canonical_ctx(_topic_label, _input_blob);
 
-    let rule_first_flag = try { exec sh "printenv OEIS_SEARCH_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("OEIS_SEARCH_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv OEIS_SEARCH_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("OEIS_SEARCH_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -53,7 +53,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -74,7 +74,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -237,7 +237,7 @@ fn _publish_prior_advocate(
 
                                     let lin_str = recall_latest("prior_advocate:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("prior_advocate:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -427,7 +427,7 @@ fn _publish_prior_advocate_rule_hit(
 
                                     let lin_str = recall_latest("prior_advocate:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("prior_advocate:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -467,7 +467,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("prior_advocate:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("prior_advocate:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -476,7 +476,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("prior_advocate:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv PRIOR_ADVOCATE_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("PRIOR_ADVOCATE_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("prior_advocate:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -559,10 +559,10 @@ fn tick(reason: string) -> void {
     // PRIOR_ADVOCATE_RULE_FIRST=0 short-circuits Stage 1 to the LLM path.
     let canonical_ctx = _prior_advocate_canonical_ctx(upstream_tick);
 
-    let rule_first_flag = try { exec sh "printenv PRIOR_ADVOCATE_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("PRIOR_ADVOCATE_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv PRIOR_ADVOCATE_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("PRIOR_ADVOCATE_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/reviewer/agents/reviewer.ag
+++ b/research-foundry/reviewer/agents/reviewer.ag
@@ -44,7 +44,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -65,7 +65,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -294,7 +294,7 @@ fn _publish_reviewer(
 
                                     let lin_str = recall_latest("reviewer:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("reviewer:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -512,7 +512,7 @@ fn _publish_reviewer_rule_hit(
 
                                     let lin_str = recall_latest("reviewer:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("reviewer:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -559,7 +559,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("reviewer:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("reviewer:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -568,7 +568,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("reviewer:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv REVIEWER_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("REVIEWER_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("reviewer:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -628,10 +628,10 @@ fn tick(reason: string) -> void {
     // REVIEWER_RULE_CONFIDENCE defaults to 0.85.
     let canonical_ctx = _reviewer_canonical_ctx(claim_id_eff, final_tex, repro_output);
 
-    let rule_first_flag = try { exec sh "printenv REVIEWER_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("REVIEWER_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv REVIEWER_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("REVIEWER_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -51,7 +51,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -76,7 +76,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -253,7 +253,7 @@ fn _publish_scholar_search(
 
                                     let lin_str = recall_latest("scholar-search:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("scholar-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -375,7 +375,7 @@ fn _publish_scholar_search_rule_hit(
 
                                     let lin_str = recall_latest("scholar-search:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("scholar-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -496,7 +496,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("scholar-search:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("scholar-search:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -505,7 +505,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("scholar-search:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv SCHOLAR_SEARCH_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("SCHOLAR_SEARCH_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("scholar-search:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -559,10 +559,10 @@ fn tick(reason: string) -> void {
     let _topic_label = recall_latest("replay:current_topic");
     let canonical_ctx = _scholar_search_canonical_ctx(_topic_label, ctx);
 
-    let rule_first_flag = try { exec sh "printenv SCHOLAR_SEARCH_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("SCHOLAR_SEARCH_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv SCHOLAR_SEARCH_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("SCHOLAR_SEARCH_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/skeptic/agents/skeptic.ag
+++ b/research-foundry/skeptic/agents/skeptic.ag
@@ -44,7 +44,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -65,7 +65,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -286,7 +286,7 @@ fn _publish_skeptic(
 
                                     let lin_str = recall_latest("skeptic:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("skeptic:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -383,7 +383,7 @@ fn _publish_skeptic_rule_hit(
 
                                     let lin_str = recall_latest("skeptic:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("skeptic:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -530,7 +530,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("skeptic:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("skeptic:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -539,7 +539,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("skeptic:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv SKEPTIC_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("SKEPTIC_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("skeptic:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -603,10 +603,10 @@ fn tick(reason: string) -> void {
     // SKEPTIC_RULE_FIRST=0 short-circuits Stage 1 to the LLM path.
     let canonical_ctx = _skeptic_canonical_ctx(noticer_pid, upstream_tick);
 
-    let rule_first_flag = try { exec sh "printenv SKEPTIC_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("SKEPTIC_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv SKEPTIC_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("SKEPTIC_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -51,7 +51,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -68,7 +68,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -247,7 +247,7 @@ fn _submitter_stage_and_publish(
     // Load authors.toml from $PREPRINT_AUTHOR_CONFIG (path threaded
     // through by run-preprint.sh). The file is parsed by a Python
     // helper rather than the .ag DSL (no TOML in DSL).
-    let author_cfg_path = try { exec sh "printenv PREPRINT_AUTHOR_CONFIG"; } catch e { ""; };
+    let author_cfg_path = getenv("PREPRINT_AUTHOR_CONFIG");
     let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };
     // colony-lint: safe-exec-concat
     let authors_cmd = "python3 -c 'import sys\ntry:\n import tomllib\nexcept Exception:\n import tomli as tomllib\ntry:\n with open(sys.argv[1],\"rb\") as f: d=tomllib.load(f)\nexcept Exception:\n print(\"AUTHOR-PLACEHOLDER <author@example.org>\"); sys.exit(0)\nauthors=d.get(\"authors\") or []\nout=[]\nfor a in authors:\n name=a.get(\"name\",\"AUTHOR-PLACEHOLDER\"); email=a.get(\"email\",\"\")\n if email: out.append(name+\" <\"+email+\">\")\n else: out.append(name)\nprint(\"; \".join(out) if out else \"AUTHOR-PLACEHOLDER\")' " + shell_escape(author_cfg_eff);
@@ -291,7 +291,7 @@ fn _submitter_stage_and_publish(
     // computer's per-tick `runs_ok` memo (#596 spec, #600 sub-issue 1).
     // Provenance fields surface the editor / computer / introducer pid +
     // upstream_tick that produced this row (#600 sub-issue 2).
-    let ledger_path = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+    let ledger_path = getenv("DISCOVERY_LEDGER");
     if len(ledger_path) > 0 {
         let repro_runs_ok = if len(computer_pid) > 0 {
             recall_latest("computer:" + computer_pid + ":runs_ok:tick-" + to_string(upstream_tick));
@@ -386,7 +386,7 @@ fn _submitter_stage_and_publish(
 
                                     let lin_str = recall_latest("submitter:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("submitter:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -579,7 +579,7 @@ fn _submitter_draft_phase_rule_hit(
 //   other.
 fn _classify_hitl_reason(reason_raw: string) -> string {
     if len(reason_raw) == 0 { return "other"; };
-    let backend = try { exec sh "printenv HITL_CLASSIFIER_BACKEND"; } catch e { ""; };
+    let backend = getenv("HITL_CLASSIFIER_BACKEND");
     let backend_eff = if len(backend) > 0 { backend; } else { "regex"; };
     if backend_eff == "llm" {
         // TODO: replace with prompt(...) call once LLM-classifier
@@ -612,7 +612,7 @@ fn _push_hitl_reject(
 ) -> void {
     let buf_key = "feedback:hitl_rejects";
     let buf_raw = recall_latest(buf_key);
-    let win_env = try { exec sh "printenv HITL_REJECT_WINDOW"; } catch e { ""; };
+    let win_env = getenv("HITL_REJECT_WINDOW");
     let win = if len(win_env) > 0 { parse_int(win_env); } else { 20; };
     let win_eff = if win <= 0 { 20; } else { win; };
     let excerpt_eff = if len(reason_excerpt) > 200 { substring(reason_excerpt, 0, 200); } else { reason_excerpt; };
@@ -640,7 +640,7 @@ fn _handle_hitl_reject(
     my_tier: string
 ) -> void {
     let reason_raw = recall_latest("submitter:" + claim_id_eff + ":human_reject_reason");
-    let ledger_path3 = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+    let ledger_path3 = getenv("DISCOVERY_LEDGER");
     if len(ledger_path3) > 0 {
         // Route HUMAN_REJECTED row through python3 json.dumps so the
         // operator-supplied free-form rejection reason cannot break the
@@ -691,8 +691,8 @@ fn _submitter_send_phase(
     introducer_pid: string,
     my_tier: string
 ) -> void {
-    let gateway = try { exec sh "printenv PREPRINT_ARXIV_GATEWAY"; } catch e { ""; };
-    let from_addr = try { exec sh "printenv PREPRINT_ARXIV_FROM"; } catch e { ""; };
+    let gateway = getenv("PREPRINT_ARXIV_GATEWAY");
+    let from_addr = getenv("PREPRINT_ARXIV_FROM");
     let gateway_eff = if len(gateway) > 0 { gateway; } else { "submit@arxiv.org"; };
     let from_eff = if len(from_addr) > 0 { from_addr; } else { "AUTHOR-PLACEHOLDER@example.org"; };
     // colony-lint: safe-exec-concat
@@ -704,7 +704,7 @@ fn _submitter_send_phase(
             + shell_escape(claim_dir + "/submission.tar.gz");
     let send_out = try { exec sh send_cmd; } catch e { "smtp-error:exec-failed"; };
 
-    let ledger_path2 = try { exec sh "printenv DISCOVERY_LEDGER"; } catch e { ""; };
+    let ledger_path2 = getenv("DISCOVERY_LEDGER");
     if len(ledger_path2) > 0 {
         // Route SUBMITTED row through python3 json.dumps so the SMTP
         // result text (which may contain quotes / colons / newlines on
@@ -877,7 +877,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("submitter:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("submitter:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -886,7 +886,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("submitter:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv SUBMITTER_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("SUBMITTER_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("submitter:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -988,10 +988,10 @@ fn tick(reason: string) -> void {
     // overridable via SUBMITTER_RULE_CONFIDENCE.
     let canonical_ctx = _submitter_canonical_ctx(claim_id_eff, final_tex, title_seed, msc_seed, cat_seed, repro_script, repro_output);
 
-    let rule_first_flag = try { exec sh "printenv SUBMITTER_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("SUBMITTER_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv SUBMITTER_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("SUBMITTER_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     let rule_action = if rule_first_enabled {

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -45,7 +45,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -62,7 +62,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -94,11 +94,11 @@ fn _lean_prompt() -> string {
 // cap via `timeout` keeps a runaway elaborator from blocking the tick.
 // Bypassable for tests via THEORIST_LEAN_DISABLED=1.
 fn _run_lean_check(self_pid: string, upstream_tick: int, lean_source: string) -> string {
-    let disabled = try { exec sh "printenv THEORIST_LEAN_DISABLED"; } catch e { ""; };
+    let disabled = getenv("THEORIST_LEAN_DISABLED");
     if disabled == "1" { return "failed"; };
     if len(lean_source) == 0 { return "failed"; };
 
-    let sandbox_dir = try { exec sh "printenv AGENTIS_ROOT"; } catch e { ""; };
+    let sandbox_dir = getenv("AGENTIS_ROOT");
     let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
     let lean_path = sandbox_eff + "/theorist-" + self_pid + "-tick-" + to_string(upstream_tick) + ".lean";
 
@@ -106,7 +106,7 @@ fn _run_lean_check(self_pid: string, upstream_tick: int, lean_source: string) ->
     let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(lean_source) + " > " + shell_escape(lean_path);
     let _wrote = try { exec sh write_cmd; } catch e { ""; };
 
-    let timeout_env = try { exec sh "printenv THEORIST_LEAN_TIMEOUT_SEC"; } catch e { ""; };
+    let timeout_env = getenv("THEORIST_LEAN_TIMEOUT_SEC");
     let timeout_s = if len(timeout_env) > 0 { timeout_env; } else { "30"; };
 
     // Mathlib-aware lean invocation. The Containerfile prepares a Lake
@@ -117,7 +117,7 @@ fn _run_lean_check(self_pid: string, upstream_tick: int, lean_source: string) ->
     // The fallback `lean <file>` path (when MATHLIB_SHELL is unset)
     // matches the pre-mathlib container's contract so the agent still
     // works under stock Lean 4 if an operator strips the mathlib layer.
-    let mathlib_shell = try { exec sh "printenv MATHLIB_SHELL"; } catch e { ""; };
+    let mathlib_shell = getenv("MATHLIB_SHELL");
     // colony-lint: safe-exec-concat
     let run_cmd = if len(mathlib_shell) > 0 {
         "timeout " + shell_escape(timeout_s) + " lake env --dir=" + shell_escape(mathlib_shell) + " lean " + shell_escape(lean_path) + " 2>&1; echo \"__lean_exit=$?__\"";
@@ -311,7 +311,7 @@ fn _publish_theorist(
 
                                     let lin_str = recall_latest("theorist:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("theorist:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -562,7 +562,7 @@ fn _publish_theorist_rule_hit(
 
                                     let lin_str = recall_latest("theorist:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("theorist:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -609,7 +609,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("theorist:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("theorist:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -618,7 +618,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("theorist:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv THEORIST_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("THEORIST_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("theorist:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -742,10 +742,10 @@ fn tick(reason: string) -> void {
     let _topic_label = recall_latest("replay:current_topic");
     let canonical_ctx = _theorist_canonical_ctx(_topic_label, _input_blob);
 
-    let rule_first_flag = try { exec sh "printenv THEORIST_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("THEORIST_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv THEORIST_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("THEORIST_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {

--- a/research-foundry/verifier/agents/verifier.ag
+++ b/research-foundry/verifier/agents/verifier.ag
@@ -52,7 +52,7 @@ fn get_confidence() -> float {
 }
 
 fn colony_name() -> string {
-    let _cn = try { exec sh "printenv COLONY_NAME"; } catch e { ""; };
+    let _cn = getenv("COLONY_NAME");
     if len(_cn) > 0 {
         return _cn;
     };
@@ -77,7 +77,7 @@ fn now_ms_via_shell() -> int {
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
 // deterministic replays.
 fn _jitter_sleep() -> int {
-    let disabled = try { exec sh "printenv RESEARCH_JITTER_DISABLED"; } catch e { ""; };
+    let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
     let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
     return 0;
@@ -383,7 +383,7 @@ fn _publish_verifier(
 
                                     let lin_str = recall_latest("verifier:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("verifier:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -568,7 +568,7 @@ fn _publish_verifier_rule_hit(
 
                                     let lin_str = recall_latest("verifier:" + self_pid + ":generation");
                                     let lin = if len(lin_str) > 0 { parse_int(lin_str); } else { 0; };
-                                    let ledger_path_r = try { exec sh "printenv REPLICATION_LEDGER"; } catch e { ""; };
+                                    let ledger_path_r = getenv("REPLICATION_LEDGER");
                                     if len(ledger_path_r) > 0 {
                                         let parent_specialty = recall_latest("verifier:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
@@ -636,7 +636,7 @@ fn tick(reason: string) -> void {
     if len(_self_pid) > 0 {
         let _existing_specialty = recall_latest("verifier:" + _self_pid + ":specialty");
         if len(_existing_specialty) == 0 {
-            let _daemon_id = try { exec sh "printenv DAEMON_ID"; } catch e { ""; };
+            let _daemon_id = getenv("DAEMON_ID");
             if len(_daemon_id) > 0 {
                 let _pool_specialty = recall_latest("verifier:pool:specialty:" + _daemon_id);
                 if len(_pool_specialty) > 0 {
@@ -645,7 +645,7 @@ fn tick(reason: string) -> void {
                     if len(_pool_overlay) > 0 {
                         memo_write("verifier:" + _self_pid + ":specialty_overlay", _pool_overlay);
                     };
-                    let _gen_env = try { exec sh "printenv VERIFIER_GENERATION"; } catch e { "0"; };
+                    let _gen_env = getenv("VERIFIER_GENERATION");
                     let _gen_seed = if len(_gen_env) > 0 { _gen_env; } else { "0"; };
                     memo_write("verifier:" + _self_pid + ":generation", _gen_seed);
                     // colony-lint: learn-tags-ok
@@ -727,10 +727,10 @@ fn tick(reason: string) -> void {
     let topic_label = if len(topic_label_a) > 0 { topic_label_a; } else { recall_latest("replay:current_topic"); };
     let canonical_ctx = _verifier_canonical_ctx(topic_label, stated_answer);
 
-    let rule_first_flag = try { exec sh "printenv VERIFIER_RULE_FIRST"; } catch e { ""; };
+    let rule_first_flag = getenv("VERIFIER_RULE_FIRST");
     let rule_first_enabled = rule_first_flag != "0";
 
-    let min_conf_str = try { exec sh "printenv VERIFIER_RULE_CONFIDENCE"; } catch e { ""; };
+    let min_conf_str = getenv("VERIFIER_RULE_CONFIDENCE");
     let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
 
     if rule_first_enabled {


### PR DESCRIPTION
## Summary

Companion to `Replikanti/agentis-core` v1.18.1 (#742 — new \`getenv(name) -> string\` substrate builtin). Replaces all 193 occurrences of \`try { exec sh \"printenv X\"; } catch e { ... };\` across the 18 research-foundry agents with the substrate \`getenv(\"X\")\`.

| Metric | Pre | Post |
|---|---|---|
| exec sh sites in federation | 520 | 327 |
| printenv-via-exec-sh | 193 | 0 |
| getenv() calls | 0 | 193 |
| Files changed | — | 18 |

## Patterns migrated

| Count | Pattern (pre) | Result (post) |
|---|---|---|
| 173 | \`try { exec sh \"printenv X\"; } catch e { \"\"; };\` | \`getenv(\"X\");\` |
| 18 | \`try { exec sh \"printenv X_GENERATION\"; } catch e { \"0\"; };\` | \`getenv(\"X_GENERATION\");\` |
| 2 | \`try { exec sh \"printenv X\"; } catch e { \"10\"; };\` | \`getenv(\"X\");\` |

The fallback values (\`\"0\"\`, \`\"10\"\`) are dropped because every call site already wraps the result in \`if len(_raw) > 0 { ... } else { default; };\` — the catch handler was redundant with the empty-string check the subsequent line was already doing.

## Semantic equivalence

Pre-migration \`exec sh \"printenv X\"\` returned \`\"\"\` when X was unset OR when X was not in \`exec.env_passthrough\` (sandbox strip). Post-migration \`getenv(\"X\")\` returns \`\"\"\` on identical conditions (name not allowlisted, name substrate-reserved \`PATH\`/\`HOME\`/\`AGENTIS_*\`, or env var unset). The catch handler fires only on truly exceptional exec sh failures (no /usr/bin/printenv, sandbox denial, timeout) — all of which collapse to \`\"\"\` in operator-visible behaviour.

Operators with \`.agentis/config\` that pre-#742 set \`exec.env_passthrough = X,Y,Z\` continue to see byte-identical behaviour because getenv reuses that allowlist verbatim.

## Net effect

- Per-tick CB savings: ~75 CB per printenv call (exec sh wrapper + subprocess fork) → ~3.7k CB saved per 10-tick smoke run for the explorer alone
- Larger structural win: drops ExecForeign dependency on the printenv path (the agents still hold ExecForeign for the remaining 327 exec sh sites — sha256, http fetch, file writes, jitter sleep, jq, etc. — separate waves planned)
- Foundation for future federations that want to use \`getenv\` without granting ExecForeign at all

## Test plan
- [x] sed-based migration covers all 193 sites (193 insertions, 193 deletions)
- [x] tools/colony-lint.sh → 345 passed, 0 failed, 5 skipped
- [x] All 18 agents parse cleanly post-migration
- [ ] CI green