### PR TITLE
feat(research-foundry): migrate 73 date exec sh sites to now_ms/now_iso (Wave 2, companion to v1.18.2)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -65,11 +65,6 @@ fn _relevance_prompt() -> string {
     return "Given the PROBLEM, ANSWER, NOVELTY CLAIM, and a block of concatenated arXiv ATOM entries (multiple queries appended), pick up to 10 entries that look most relevant. Output ONLY valid JSON: {\"matches_found\": <int>, \"top_matches\": [{\"arxiv_id\":\"...\",\"title\":\"...\",\"relevance\":\"direct|partial|none\",\"reason\":\"...\"}], \"summary\":\"one-line\"}. Use 'direct' only when an abstract proves or states the same result; 'partial' for overlapping setup or weaker form; 'none' otherwise. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -496,9 +491,9 @@ fn _publish_arxiv_search_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("arxiv-search:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -623,7 +618,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("arxiv-search:last_check", now_s1); };
             return;
         };
@@ -678,7 +673,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("arxiv-search:last_check", now);
     };

--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -52,11 +52,6 @@ fn colony_name() -> string {
     return "auditor";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -749,9 +744,9 @@ fn _publish_auditor_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("auditor:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -947,7 +942,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("auditor:last_check", now_s1); };
             return;
         };
@@ -1022,7 +1017,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("auditor:last_check", now);
     };

--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -41,11 +41,6 @@ fn colony_name() -> string {
     return "computer";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -562,9 +557,9 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("computer:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -774,7 +769,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("computer:last_check", now_s1); };
             return;
         };
@@ -829,7 +824,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("computer:last_check", now);
     };

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -54,11 +54,6 @@ fn colony_name() -> string {
     return "editor";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -727,9 +722,9 @@ fn _publish_editor_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("editor:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -877,7 +872,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("editor:last_check", now_s1); };
             return;
         };
@@ -931,7 +926,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("editor:last_check", now);
     };

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -88,11 +88,6 @@ fn colony_name() -> string {
     return "explorer";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -937,9 +932,9 @@ fn _publish_explorer_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("explorer:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -1232,7 +1227,7 @@ fn tick(reason: string) -> void {
                     };
                 };
 
-                let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+                let now_s1 = now_iso();
                 if len(now_s1) > 0 { memo_write("explorer:last_check", now_s1); };
                 return;
             };
@@ -1340,7 +1335,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("explorer:last_check", now);
     };

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -42,11 +42,6 @@ fn colony_name() -> string {
     return "formulator";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -529,9 +524,9 @@ fn _publish_formulator_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("formulator:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -687,7 +682,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("formulator:last_check", now_s1); };
             return;
         };
@@ -739,7 +734,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("formulator:last_check", now);
     };

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -62,11 +62,6 @@ fn _relevance_prompt() -> string {
     return "Given the PROBLEM, ANSWER, NOVELTY CLAIM, and the raw groupprops opensearch JSON responses below (one per query), pick up to 5 entries that look most relevant. Output ONLY valid JSON: {\"matches_found\": <int>, \"top_matches\": [{\"url\":\"...\",\"title\":\"...\",\"relevance\":\"direct|partial|none\",\"reason\":\"...\"}], \"summary\":\"one-line\"}. Use 'direct' only when the page covers the exact claim; 'partial' for related results; 'none' otherwise. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -473,9 +468,9 @@ fn _publish_groupprops_search_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("groupprops-search:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -596,7 +591,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("groupprops-search:last_check", now_s1); };
             return;
         };
@@ -650,7 +645,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("groupprops-search:last_check", now);
     };

--- a/research-foundry/introducer/agents/introducer.ag
+++ b/research-foundry/introducer/agents/introducer.ag
@@ -47,11 +47,6 @@ fn colony_name() -> string {
     return "introducer";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -440,9 +435,9 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("introducer:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -577,7 +572,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("introducer:last_check", now_s1); };
             return;
         };
@@ -630,7 +625,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("introducer:last_check", now);
     };

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -285,11 +285,6 @@ fn _publish_noticer(
     };
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -548,9 +543,9 @@ fn _publish_noticer_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("noticer:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -671,7 +666,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("noticer:last_check", now_s1); };
             return;
         };
@@ -750,7 +745,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("noticer:last_check", now);
     };

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -41,11 +41,6 @@ fn colony_name() -> string {
     return "novelty";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -890,9 +885,9 @@ fn _publish_novelty_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("novelty:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -1040,7 +1035,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("novelty:last_check", now_s1); };
             return;
         };
@@ -1116,7 +1111,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("novelty:last_check", now);
     };

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -62,11 +62,6 @@ fn _relevance_prompt() -> string {
     return "Given the PROBLEM, ANSWER, NOVELTY CLAIM, and the raw OEIS text-search responses below (each query's response concatenated), pick up to 5 A-numbers that look most relevant. Output ONLY valid JSON: {\"matches_found\": <int>, \"top_matches\": [{\"a_number\":\"A123456\",\"name\":\"...\",\"relevance\":\"direct|partial|none\",\"reason\":\"...\"}], \"summary\":\"one-line\"}. Use 'direct' only when the A-number is the same sequence; 'partial' if it overlaps but differs in offset or initial terms; 'none' otherwise. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -487,9 +482,9 @@ fn _encode_sequences_action(sequences: Sequences) -> string {
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("oeis-search:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -622,7 +617,7 @@ fn tick(reason: string) -> void {
             };
 
             let _ = rule_rationale;
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("oeis-search:last_check", now_s1); };
             return;
         };
@@ -673,7 +668,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("oeis-search:last_check", now);
     };

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -64,11 +64,6 @@ fn _seed_prompt() -> string {
     return "You are an adversarial reviewer arguing this claim is already known. Construct the strongest possible case that the claim is a corollary of, or restatement of, an existing result. Cite the closest theorem/lemma/identity you can think of. Output JSON: `{is_prior: bool, classical_anchor: string, indirect_derivation: string, confidence: float, reasoning: string}`. Do NOT wrap output in markdown code fences.";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -455,9 +450,9 @@ fn _publish_prior_advocate_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("prior_advocate:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -611,7 +606,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("prior_advocate:last_check", now_s1); };
             return;
         };
@@ -673,7 +668,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("prior_advocate:last_check", now);
     };

--- a/research-foundry/reviewer/agents/reviewer.ag
+++ b/research-foundry/reviewer/agents/reviewer.ag
@@ -55,11 +55,6 @@ fn _seed_prompt() -> string {
     return "You are a CALIBRATED reproducibility reviewer -- your job is to triage, not gatekeep. False negatives (rejecting valid claims that are actually supported) block the submitter and drop the research; false positives (approving genuinely hallucinated claims) push unsupported content toward publication. Bias toward 'approved' when the central numerical or symbolic claim has a corresponding entry in the stdout (minor formatting differences, presentational rounding, or peripheral asides without direct stdout backing should NOT trigger rejection). Extract every numerical or symbolic claim in the .tex (numbers, equations, specific values). For each claim, find the corresponding entry in the reproducibility stdout that supports it. Flag a claim as hallucinated ONLY when it asserts a SPECIFIC value or equation that contradicts the stdout, or when the central result of the paper has no stdout support whatsoever (peripheral motivating remarks need not be supported). Output JSON: `{verdict: 'approved'|'rejected', hallucinated_claims: string (one claim per line, format: 'claim_text | line_or_section | why_unsupported'; empty string when verdict='approved'), supported_claims_count: int, total_claims_count: int, reasoning: string}`. Do NOT wrap output in markdown code fences. The hallucinated_claims field MUST be a plain string (not a JSON array or object); the agentis runtime enforces the Verdict.hallucinated_claims declaration as `string` and a list value triggers a fatal type error in the publish path.";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -547,9 +542,9 @@ fn _publish_reviewer_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("reviewer:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -687,7 +682,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("reviewer:last_check", now_s1); };
             return;
         };
@@ -748,7 +743,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("reviewer:last_check", now);
     };

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -66,11 +66,6 @@ fn _relevance_prompt() -> string {
     return "Given the PROBLEM, ANSWER, NOVELTY CLAIM, and the raw Semantic Scholar JSON responses below (one per query, may contain 'unavailable' markers when the API rate-limited or errored), pick up to 5 papers that look most relevant. Output ONLY valid JSON: {\"status\": \"ok|unavailable|partial\", \"matches_found\": <int>, \"top_matches\": [{\"paper_id\":\"...\",\"title\":\"...\",\"relevance\":\"direct|partial|none\",\"reason\":\"...\"}], \"summary\":\"one-line\"}. status='unavailable' if every query failed; 'partial' if some failed; 'ok' otherwise. Do NOT wrap output in markdown code fences (no triple backticks); return raw JSON only.";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -483,9 +478,9 @@ fn _encode_queries_action(queries: Queries) -> string {
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("scholar-search:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -617,7 +612,7 @@ fn tick(reason: string) -> void {
             };
 
             let _ = rule_rationale;
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("scholar-search:last_check", now_s1); };
             return;
         };
@@ -668,7 +663,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("scholar-search:last_check", now);
     };

--- a/research-foundry/skeptic/agents/skeptic.ag
+++ b/research-foundry/skeptic/agents/skeptic.ag
@@ -55,11 +55,6 @@ fn _seed_prompt() -> string {
     return "You are a CALIBRATED skeptic -- your job is to triage, not gatekeep. False negatives (dismissing genuine novelty) starve downstream research; false positives (upholding trivia) waste compute. Bias toward \"unsure\" when uncertain. The user-supplied input below carries the noticer's SURPRISE DESCRIPTION, the SPECIFIC VALUE, and the WHY SURPRISING reasoning. Match the surprise against classical results: Basel-style sums, Gauss sums, named constants (pi, e, Euler-Mascheroni), classical generating functions, well-known group invariants, OEIS-famous sequences. Set verdict=\"dismissed\" ONLY when the surprise is a near-EXACT re-derivation of a specific classical identity you can name (cite the exact identity in classical_reference). Set verdict=\"upheld\" when the surprise has a novel structural angle, even if it touches classical territory. Set verdict=\"unsure\" by default when you see partial classical connection but cannot rule out genuine novelty -- this is the safe choice that keeps the pipeline flowing. Output ONLY valid JSON: {\"verdict\": \"dismissed|upheld|unsure\", \"reasoning\": \"...\", \"classical_reference\": \"...\", \"confidence\": 0.0-1.0}.";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -517,9 +512,9 @@ fn _skeptic_demotion_hook(noticer_pid: string, upstream_tick: int, verdict_label
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("skeptic:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -656,7 +651,7 @@ fn tick(reason: string) -> void {
 
             _skeptic_demotion_hook(noticer_pid, upstream_tick, rule_verdict_label);
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("skeptic:last_check", now_s1); };
             return;
         };
@@ -731,7 +726,7 @@ fn tick(reason: string) -> void {
     // took the LLM path).
     _skeptic_demotion_hook(noticer_pid, upstream_tick, verdict.verdict);
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("skeptic:last_check", now);
     };

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -58,11 +58,6 @@ fn colony_name() -> string {
     return "submitter";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -865,9 +860,9 @@ fn _decode_action_field(action: string, key: string) -> string {
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("submitter:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -961,7 +956,7 @@ fn tick(reason: string) -> void {
     if reviewer_ok != "true" {
         print("[submitter] reviewer gate not satisfied for claim=", claim_id_eff, " (key=reviewer:<claim>:approved)");
         learn("submit", "tick " + to_string(tick_idx) + " gated " + claim_id_eff, "reviewer not approved", "partial", ["observed", "preprint-foundry", "hitl-gated"]);
-        let now0 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        let now0 = now_iso();
         if len(now0) > 0 { memo_write("submitter:last_check", now0); };
         return;
     };
@@ -1117,7 +1112,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("submitter:last_check", now);
     };

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -52,11 +52,6 @@ fn colony_name() -> string {
     return "theorist";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -597,9 +592,9 @@ fn _publish_theorist_rule_hit(
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("theorist:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -821,7 +816,7 @@ fn tick(reason: string) -> void {
             };
 
             let _ = rule_rationale;
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("theorist:last_check", now_s1); };
             return;
         };
@@ -912,7 +907,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("theorist:last_check", now);
     };

--- a/research-foundry/tools/test-last-check-early.sh
+++ b/research-foundry/tools/test-last-check-early.sh
@@ -39,7 +39,7 @@ fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
 
 COLONIES="explorer noticer skeptic formulator verifier novelty arxiv-search oeis-search groupprops-search scholar-search prior_advocate auditor introducer theorist computer editor reviewer submitter"
 
-HEARTBEAT='let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };'
+HEARTBEAT='let _last_check_now = now_iso();'
 
 for c in $COLONIES; do
     ag_file="$FED_DIR/$c/agents/$c.ag"

--- a/research-foundry/verifier/agents/verifier.ag
+++ b/research-foundry/verifier/agents/verifier.ag
@@ -67,11 +67,6 @@ fn _verifier_prompt() -> string {
     return "You are a problem-quality referee. The input below carries the PROBLEM and the STATED ANSWER from the author. Your sole job is to judge the PROBLEM ITSELF — not whether the stated answer is numerically correct. Set verdict=ACCEPT when the problem is well-defined (unambiguous statement, mathematically meaningful, has a determinable answer in principle). Set verdict=NEEDS_REVISION when the problem is mostly well-defined but has minor ambiguities that could be fixed with light editing. Set verdict=REJECT only when the problem itself is incoherent, ill-defined, or trivially malformed. Output ONLY valid JSON: {\"answers_agree\": false, \"solver_rigorous\": false, \"problem_well_defined\": true|false, \"verdict\": \"ACCEPT|REJECT|NEEDS_REVISION\", \"reasoning\": \"...\"}. Set answers_agree and solver_rigorous to false (they are deprecated metadata).";
 }
 
-fn now_ms_via_shell() -> int {
-    let s = try { exec sh "date +%s%3N"; } catch e { "0"; };
-    return parse_int(s);
-}
-
 // Per-tick jitter (0-5s) to spread API requests across the 56-daemon
 // research-foundry container and stay under Claude's ~100 req/min ceiling
 // (#670). Bypassable via RESEARCH_JITTER_DISABLED=1 for tests and
@@ -623,9 +618,9 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 fn tick(reason: string) -> void {
     let _ = reason;
     let _ = _jitter_sleep();
-    let _last_check_now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let _last_check_now = now_iso();
     if len(_last_check_now) > 0 { memo_write("verifier:last_check", _last_check_now); };
-    let _tick_now_ms = now_ms_via_shell();
+    let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
     let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
     // Issue #767: aging tick + cull-self-request gate.
@@ -697,7 +692,7 @@ fn tick(reason: string) -> void {
     if len(_mech_falsify) > 0 {
         print("[verifier] mechanical falsification verdict=", _mech_falsify, " tick=", upstream_tick);
         _publish_falsified_verdict(_mech_falsify, _self_pid, _colony_name, upstream_tick, tick_idx);
-        let now_mech = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        let now_mech = now_iso();
         if len(now_mech) > 0 {
             memo_write("verifier:last_check", now_mech);
         };
@@ -777,7 +772,7 @@ fn tick(reason: string) -> void {
                 };
             };
 
-            let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            let now_s1 = now_iso();
             if len(now_s1) > 0 { memo_write("verifier:last_check", now_s1); };
             return;
         };
@@ -836,7 +831,7 @@ fn tick(reason: string) -> void {
         };
     };
 
-    let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+    let now = now_iso();
     if len(now) > 0 {
         memo_write("verifier:last_check", now);
     };


### PR DESCRIPTION
## Summary

Wave 2 of the exec sh purge. Companion to \`Replikanti/agentis-core\` v1.18.2 (#744 — \`now_ms\` + \`now_iso\` substrate builtins). Replaces all 73 \`exec sh \"date ...\"\` sites in research-foundry.

| Metric | Pre-Wave 1 | Post-Wave 1 | Post-Wave 2 |
|---|---|---|---|
| exec sh sites | 520 | 327 | **254** |
| Reduction | — | -37% | **-51% cumulative** |

## Changes (19 files, +74 / -164)

- 18 helper fn defs deleted (\`fn now_ms_via_shell() -> int\` + body)
- 36 helper callers replaced (\`now_ms_via_shell()\` → \`now_ms()\`)
- 55 inline ISO sites replaced (\`try { exec sh \"date -u +%Y-...\"; } catch e { \"\"; };\` → \`now_iso()\`)
- 1 test fix: \`research-foundry/tools/test-last-check-early.sh\` HEARTBEAT regex updated from old exec sh form to new substrate form

## Semantic equivalence

- now_ms() returns i64 directly (vs old `parse_int(exec sh "date +%s%3N")`)
- now_iso() never fails (no syscall, just SystemTime::now() + format), so the catch handlers (return "") are dead — dropping them is byte-equivalent
- No behaviour change

## Test plan
- [x] tools/colony-lint.sh → 345 passed, 0 failed, 5 skipped
- [x] test-last-check-early heartbeat invariant preserved (72 passed)
- [ ] CI green