### PR TITLE
feat(research-foundry): migrate 29 sha_cmd sites to sha256_hex (Wave 3, companion to v1.18.3)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -117,9 +117,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("arxiv-search:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "arxiv-search:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -338,9 +336,7 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 // ("arxivctx=na").
 fn _arxiv_canonical_ctx(ctx: string) -> string {
     if len(ctx) == 0 { return "arxivctx=na"; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(ctx);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(ctx);
     if len(h) != 64 { return "arxivctx=na"; };
     return "arxivctx=" + h;
 }

--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -104,9 +104,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("auditor:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "auditor:prompt_body:" + h;
     let existing = recall_latest(body_key);

--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -93,9 +93,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("computer:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "computer:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -427,9 +425,7 @@ fn _publish_computer_rule_hit(
 fn _computer_canonical_ctx(prompt_ctx: string, upstream_tick: int) -> string {
     let topic_a = recall_latest("replay:current_topic");
     let topic = if len(topic_a) > 0 { topic_a; } else { "na"; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(prompt_ctx);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(prompt_ctx);
     if len(h) != 64 {
         return "topic=" + topic + " tick=" + to_string(upstream_tick) + " sha256=na";
     };

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -110,9 +110,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("editor:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "editor:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -507,9 +505,7 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 // empty / hash failure ("editorctx=na").
 fn _editor_canonical_ctx(ctx: string) -> string {
     if len(ctx) == 0 { return "editorctx=na"; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(ctx);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(ctx);
     if len(h) != 64 { return "editorctx=na"; };
     return "editorctx=" + h;
 }

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -158,9 +158,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("explorer:" + self_pid + ":exploration_prompt");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "explorer:prompt_body:" + h;
     let existing = recall_latest(body_key);

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -99,9 +99,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("formulator:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "formulator:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -387,9 +385,14 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 // aggregates. Falls back to a topic-only marker when hashing fails.
 fn _formulator_canonical_ctx(ctx: string, topic_label: string) -> string {
     let topic = if len(topic_label) > 0 { topic_label; } else { "na"; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256((sys.argv[1]+\"\\x1f\"+sys.argv[2]).encode(\"utf-8\")).hexdigest())' " + shell_escape(ctx) + " " + shell_escape(topic);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    // Wave 3 substrate migration (#907): replaced exec sh "python3 hashlib"
+    // with sha256_hex(). Previously joined ctx + 0x1f + topic via Python
+    // string concat; agentis substrate is single-arg so we use a printable
+    // separator instead. The hash is only used as an internal cache-key
+    // marker rendered into a metadata string ("input_sha=..."); not used
+    // cryptographically or compared against externally-computed digests,
+    // so changing the separator is semantically equivalent for the call site.
+    let h = sha256_hex(ctx + "\n--\n" + topic);
     if len(h) != 64 { return "topic=" + topic + " input_sha=na"; };
     return "topic=" + topic + " input_sha=" + h;
 }

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -110,9 +110,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("groupprops-search:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "groupprops-search:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -320,9 +318,7 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 fn _groupprops_search_canonical_ctx(ctx: string, upstream_tick: int) -> string {
     if len(ctx) == 0 { return "gpsctx=na"; };
     let salted = "tick=" + to_string(upstream_tick) + "\n" + ctx;
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(salted);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(salted);
     if len(h) != 64 { return "gpsctx=na"; };
     return "gpsctx=" + h;
 }

--- a/research-foundry/introducer/agents/introducer.ag
+++ b/research-foundry/introducer/agents/introducer.ag
@@ -99,9 +99,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("introducer:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "introducer:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -266,9 +264,7 @@ fn _publish_introducer(
 fn _introducer_canonical_ctx(input_ctx: string, claim_id: string) -> string {
     if len(input_ctx) == 0 { return "introducer-class empty"; };
     let keyed = if len(claim_id) > 0 { "claim_id=" + claim_id + "\n" + input_ctx; } else { input_ctx; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(keyed);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(keyed);
     if len(h) != 64 {
         let fallback = substring(input_ctx, 0, 64);
         return "introducer-sha-na " + fallback;

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -102,9 +102,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("noticer:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "noticer:prompt_body:" + h;
     let existing = recall_latest(body_key);

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -96,9 +96,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("novelty:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "novelty:prompt_body:" + h;
     let existing = recall_latest(body_key);

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -113,9 +113,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("oeis-search:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "oeis-search:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -454,9 +452,7 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 // most-discriminating-first to match the crystallizer's prefix matcher.
 fn _oeis_canonical_ctx(topic_label: string, input_blob: string) -> string {
     let topic = if len(topic_label) > 0 { topic_label; } else { "na"; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(input_blob);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(input_blob);
     let hash = if len(h) == 64 { h; } else { "na"; };
     return "topic=" + topic + " input_hash=" + hash;
 }

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -112,9 +112,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("prior_advocate:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "prior_advocate:prompt_body:" + h;
     let existing = recall_latest(body_key);

--- a/research-foundry/reviewer/agents/reviewer.ag
+++ b/research-foundry/reviewer/agents/reviewer.ag
@@ -103,9 +103,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("reviewer:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "reviewer:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -378,9 +376,7 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 // Total on hash failure (falls back to a coarse claim-only key).
 fn _reviewer_canonical_ctx(claim_id_eff: string, final_tex: string, repro_output: string) -> string {
     let joined = "claim=" + claim_id_eff + "||REVIEWER_SEP||tex=" + final_tex + "||REVIEWER_SEP||stdout=" + repro_output;
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(joined);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(joined);
     if len(h) != 64 { return "claim=" + claim_id_eff + " in=na"; };
     return "claim=" + claim_id_eff + " in=" + h;
 }

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -114,9 +114,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("scholar-search:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "scholar-search:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -449,9 +447,7 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 // most-discriminating-first to match the crystallizer's prefix matcher.
 fn _scholar_search_canonical_ctx(topic_label: string, input_blob: string) -> string {
     let topic = if len(topic_label) > 0 { topic_label; } else { "na"; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(input_blob);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(input_blob);
     let hash = if len(h) == 64 { h; } else { "na"; };
     return "topic=" + topic + " input_hash=" + hash;
 }

--- a/research-foundry/skeptic/agents/skeptic.ag
+++ b/research-foundry/skeptic/agents/skeptic.ag
@@ -108,9 +108,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("skeptic:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "skeptic:prompt_body:" + h;
     let existing = recall_latest(body_key);

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -110,9 +110,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("submitter:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "submitter:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -801,9 +799,7 @@ fn _submitter_canonical_ctx(
     let sep = "|@SUBMITTER_FIELD@|";
     let blob = final_tex + sep + title_seed + sep + msc_seed + sep
              + cat_seed + sep + repro_script + sep + repro_output;
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(blob);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(blob);
     let in_sha = if len(h) >= 16 { substring(h, 0, 16); } else { "na"; };
     let cat = if len(cat_seed) > 0 { cat_seed; } else { "na"; };
     return "claim=" + claim + " in_sha=" + in_sha + " cat_seed=" + cat;

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -191,9 +191,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("theorist:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "theorist:prompt_body:" + h;
     let existing = recall_latest(body_key);
@@ -446,9 +444,7 @@ fn _age_tick_and_check(colony: string, self_pid: string) -> int {
 // most-discriminating-first to match the crystallizer's prefix matcher.
 fn _theorist_canonical_ctx(topic_label: string, input_blob: string) -> string {
     let topic = if len(topic_label) > 0 { topic_label; } else { "na"; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(input_blob);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(input_blob);
     let hash = if len(h) == 64 { h; } else { "na"; };
     return "topic=" + topic + " input_hash=" + hash;
 }

--- a/research-foundry/verifier/agents/verifier.ag
+++ b/research-foundry/verifier/agents/verifier.ag
@@ -118,9 +118,7 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     if len(self_pid) == 0 { return variant_tag; };
     let body = recall_latest("verifier:" + self_pid + ":prompt_body");
     if len(body) == 0 { return variant_tag; };
-    // colony-lint: safe-exec-concat
-    let sha_cmd = "python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.sha256(sys.argv[1].encode(\"utf-8\")).hexdigest())' " + shell_escape(body);
-    let h = try { exec sh sha_cmd; } catch e { ""; };
+    let h = sha256_hex(body);
     if len(h) != 64 { return variant_tag; };
     let body_key = "verifier:prompt_body:" + h;
     let existing = recall_latest(body_key);


### PR DESCRIPTION
Wave 3 colonies migration. Drops 29 `exec sh` shell-outs to python3 hashlib.sha256. 28 mechanical + 1 manual edge case (formulator.ag uses 0x1f join; replaced with printable separator since digest is internal-only metadata). 18 files, +36 / -87. Final exec sh: 254 -> 227 (cumulative Waves 1-3: 520 -> 227 = 56% reduction). Lint 345/0/5.