### PR TITLE
feat(research-foundry): migrate 36 echo+sleep sites to getpid+jitter_ms (Wave 4, companion to v1.18.4)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -72,7 +72,7 @@ fn _relevance_prompt() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -491,7 +491,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("arxiv-search:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -59,7 +59,7 @@ fn colony_name() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -746,7 +746,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("auditor:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -48,7 +48,7 @@ fn colony_name() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -557,7 +557,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("computer:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -61,7 +61,7 @@ fn colony_name() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -722,7 +722,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("editor:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -95,7 +95,7 @@ fn colony_name() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -934,7 +934,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("explorer:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
     if len(_self_pid) > 0 {

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -49,7 +49,7 @@ fn colony_name() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -531,7 +531,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("formulator:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -69,7 +69,7 @@ fn _relevance_prompt() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -468,7 +468,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("groupprops-search:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/introducer/agents/introducer.ag
+++ b/research-foundry/introducer/agents/introducer.ag
@@ -54,7 +54,7 @@ fn colony_name() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -435,7 +435,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("introducer:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -290,7 +290,7 @@ fn _publish_noticer(
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -545,7 +545,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("noticer:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -48,7 +48,7 @@ fn colony_name() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -887,7 +887,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("novelty:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -69,7 +69,7 @@ fn _relevance_prompt() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -482,7 +482,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("oeis-search:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -71,7 +71,7 @@ fn _seed_prompt() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -452,7 +452,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("prior_advocate:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/reviewer/agents/reviewer.ag
+++ b/research-foundry/reviewer/agents/reviewer.ag
@@ -62,7 +62,7 @@ fn _seed_prompt() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -542,7 +542,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("reviewer:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -73,7 +73,7 @@ fn _relevance_prompt() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -478,7 +478,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("scholar-search:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/skeptic/agents/skeptic.ag
+++ b/research-foundry/skeptic/agents/skeptic.ag
@@ -62,7 +62,7 @@ fn _seed_prompt() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -514,7 +514,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("skeptic:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -65,7 +65,7 @@ fn colony_name() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -860,7 +860,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("submitter:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -59,7 +59,7 @@ fn colony_name() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -592,7 +592,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("theorist:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 

--- a/research-foundry/verifier/agents/verifier.ag
+++ b/research-foundry/verifier/agents/verifier.ag
@@ -74,7 +74,7 @@ fn _verifier_prompt() -> string {
 fn _jitter_sleep() -> int {
     let disabled = getenv("RESEARCH_JITTER_DISABLED");
     if disabled == "1" { return 0; };
-    let _ = try { exec sh "sleep $(awk 'BEGIN{srand();print rand()*5}')"; } catch e { ""; };
+    jitter_ms(5000);
     return 0;
 }
 
@@ -620,7 +620,7 @@ fn tick(reason: string) -> void {
     if len(_last_check_now) > 0 { memo_write("verifier:last_check", _last_check_now); };
     let _tick_now_ms = now_ms();
     let _colony_name = colony_name();
-    let _self_pid = try { exec sh "echo $PPID"; } catch e { ""; };
+    let _self_pid = to_string(getpid());
     // Issue #767: aging tick + cull-self-request gate.
     let _ = _age_tick_and_check(_colony_name, _self_pid);
 


### PR DESCRIPTION
18 echo PPID -> to_string(getpid()), 18 sleep+awk -> jitter_ms(5000). exec sh: 227 -> 191. Cumulative Wave 1-4: 520 -> 191 = 63%. Lint 345/0/5.