### PR TITLE
feat(research-foundry): migrate 17 ledger-write sites to file_write/file_append (Wave 5a, companion to v1.18.5)

### DIFF
--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -348,9 +348,7 @@ fn _publish_auditor(
                            + "\"},\"reasoning\":\"" + verdict.reasoning
                            + "\",\"confidence\":" + conf_str
                            + ",\"terminal\":" + terminal_str + "}";
-            // colony-lint: safe-exec-concat
-            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-            let _ = try { exec sh append_cmd; } catch e { ""; };
+            file_append(ledger_path, ledger_row + "\n");
         };
 
         // Seed `claim:audit_*:tick-N` + `claim:report_*:tick-N` keys
@@ -634,9 +632,7 @@ fn _publish_auditor_rule_hit(
                            + ",\"reasoning\":\"" + reasoning
                            + "\",\"confidence\":" + conf_str
                            + ",\"terminal\":" + terminal_str + "}";
-            // colony-lint: safe-exec-concat
-            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-            let _ = try { exec sh append_cmd; } catch e { ""; };
+            file_append(ledger_path, ledger_row + "\n");
         };
 
         let claim_seed_eligible = if audit_verdict == "VERIFIED_NEW" {

--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -155,9 +155,8 @@ fn _publish_computer(
     let lang = script.language;
     let ext = if lang == "gap" { ".g"; } else { ".py"; };
     let script_path = sandbox_eff + "/repro-" + self_pid + "-tick-" + to_string(upstream_tick) + ext;
-    // colony-lint: safe-exec-concat
-    let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(script.script) + " > " + shell_escape(script_path);
-    let _wrote = try { exec sh write_cmd; } catch e { ""; };
+    // Wave 5 #911: file_write auto-creates parent dirs (sandbox-resolved).
+    file_write(script_path, script.script);
 
     let run_cmd = if lang == "gap" {
         // colony-lint: safe-exec-concat
@@ -298,9 +297,7 @@ fn _publish_computer_rule_hit(
     let lang = lang_in;
     let ext = if lang == "gap" { ".g"; } else { ".py"; };
     let script_path = sandbox_eff + "/repro-" + self_pid + "-tick-" + to_string(upstream_tick) + ext;
-    // colony-lint: safe-exec-concat
-    let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(script_body) + " > " + shell_escape(script_path);
-    let _wrote = try { exec sh write_cmd; } catch e { ""; };
+    file_write(script_path, script_body);
 
     let run_cmd = if lang == "gap" {
         // colony-lint: safe-exec-concat

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -284,12 +284,8 @@ fn _publish_editor(
     // colony-lint: safe-exec-concat
     let mkdir_cmd = "mkdir -p " + shell_escape(claim_dir);
     let _mk = try { exec sh mkdir_cmd; } catch e { ""; };
-    // colony-lint: safe-exec-concat
-    let write_tex_cmd = "printf '%s' " + shell_escape(edit.full_tex) + " > " + shell_escape(claim_dir + "/main.tex");
-    let _wt = try { exec sh write_tex_cmd; } catch e { ""; };
-    // colony-lint: safe-exec-concat
-    let write_bib_cmd = "printf '%s' " + shell_escape(edit.refs_bib) + " > " + shell_escape(claim_dir + "/refs.bib");
-    let _wb = try { exec sh write_bib_cmd; } catch e { ""; };
+    file_write(claim_dir + "/main.tex", edit.full_tex);
+    file_write(claim_dir + "/refs.bib", edit.refs_bib);
 
     // Substitute AUTHOR-PLACEHOLDER from authors.toml (#616).
     // Idempotent helper exits 0 when TOML is missing /
@@ -567,12 +563,8 @@ fn _publish_editor_rule_hit(
     // colony-lint: safe-exec-concat
     let mkdir_cmd = "mkdir -p " + shell_escape(claim_dir);
     let _mk = try { exec sh mkdir_cmd; } catch e { ""; };
-    // colony-lint: safe-exec-concat
-    let write_tex_cmd = "printf '%s' " + shell_escape(full_tex) + " > " + shell_escape(claim_dir + "/main.tex");
-    let _wt = try { exec sh write_tex_cmd; } catch e { ""; };
-    // colony-lint: safe-exec-concat
-    let write_bib_cmd = "printf '%s' " + shell_escape(refs_bib) + " > " + shell_escape(claim_dir + "/refs.bib");
-    let _wb = try { exec sh write_bib_cmd; } catch e { ""; };
+    file_write(claim_dir + "/main.tex", full_tex);
+    file_write(claim_dir + "/refs.bib", refs_bib);
 
     let author_cfg_path = getenv("PREPRINT_AUTHOR_CONFIG");
     let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -420,9 +420,7 @@ fn _publish_explorer(
         let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + _colony_name + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"exploration_done\"}";
-            // colony-lint: safe-exec-concat
-            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-            let _l = try { exec sh append_cmd; } catch e { ""; };
+            file_append(ledger_path, ledger_row + "\n");
         };
 
         // Settlement: read the novelty verdict for tick - HOLD_PERIOD.
@@ -789,9 +787,9 @@ fn _publish_explorer_rule_hit(
 
     let sandbox_dir = getenv("AGENTIS_ROOT");
     let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
-    // colony-lint: safe-exec-concat
-    let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(code) + " > " + shell_escape(sandbox_eff + "/explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py");
-    let _ = try { exec sh write_cmd; } catch e { ""; };
+    // Wave 5 #911: file_write auto-creates parent dirs.
+    let _script_path = sandbox_eff + "/explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py";
+    file_write(_script_path, code);
     // #868 L2: same `/usr/bin/time` wrapper + JSONL emit as the
     // LLM-driven path above. Rule-hit replays are *also* substrate-
     // bypass compute and must show up in the dashboard so a colony
@@ -812,9 +810,10 @@ fn _publish_explorer_rule_hit(
     let compute_dir = sandbox_dir + "/compute";
     let compute_path = compute_dir + "/" + self_pid + ".jsonl";
     let compute_row = "{\"ts_ms\":" + to_string(tick_now_ms) + ",\"agent\":\"" + self_pid + "\",\"colony\":\"" + _colony_name + "\",\"tick\":" + to_string(tick_idx) + ",\"script\":\"explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py\",\"wall_clock_s\":" + wall_clock_str + ",\"exit_code\":" + exit_code_str + ",\"source\":\"rule-hit\"}";
-    // colony-lint: safe-exec-concat
-    let append_cmd = "mkdir -p " + shell_escape(compute_dir) + " && printf '%s\n' " + shell_escape(compute_row) + " >> " + shell_escape(compute_path);
-    let _t = try { exec sh append_cmd; } catch e { ""; };
+    // Wave 5 #911: file_append's resolve_sandbox_path auto-creates
+    // parent dirs (matches the file_write contract), so the explicit
+    // `mkdir -p $compute_dir` step is redundant.
+    file_append(compute_path, compute_row + "\n");
 
     memo_write("explorer:" + self_pid + ":code:tick-" + to_string(tick_idx), code);
     memo_write("explorer:" + self_pid + ":output:tick-" + to_string(tick_idx), output);
@@ -825,9 +824,7 @@ fn _publish_explorer_rule_hit(
         let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + _colony_name + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"exploration_done\"}";
-            // colony-lint: safe-exec-concat
-            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-            let _l = try { exec sh append_cmd; } catch e { ""; };
+            file_append(ledger_path, ledger_row + "\n");
         };
 
         let hold_env = getenv("HOLD_PERIOD");

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -262,9 +262,7 @@ fn _publish_formulator(
         let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"problem_ready\",\"answer\":\"" + problem.answer + "\"}";
-            // colony-lint: safe-exec-concat
-            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-            let _ = try { exec sh append_cmd; } catch e { ""; };
+            file_append(ledger_path, ledger_row + "\n");
         };
     };
 
@@ -455,9 +453,7 @@ fn _publish_formulator_rule_hit(
         let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"topic\":\"" + topic_label + "\",\"event\":\"problem_ready\",\"answer\":\"" + answer + "\"}";
-            // colony-lint: safe-exec-concat
-            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-            let _ = try { exec sh append_cmd; } catch e { ""; };
+            file_append(ledger_path, ledger_row + "\n");
         };
     };
 

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -280,9 +280,7 @@ fn _publish_novelty(
         let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"event\":\"novelty_verdict\",\"verdict\":\"" + effective_label + "\"}";
-            // colony-lint: safe-exec-concat
-            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-            let _ = try { exec sh append_cmd; } catch e { ""; };
+            file_append(ledger_path, ledger_row + "\n");
         };
     };
 
@@ -775,9 +773,7 @@ fn _publish_novelty_rule_hit(
         let ledger_path = getenv("DISCOVERY_LEDGER");
         if len(ledger_path) > 0 {
             let ledger_row = "{\"ts\":" + to_string(tick_now_ms) + ",\"colony\":\"" + colony_name_str + "\",\"pid\":\"" + self_pid + "\",\"tick\":" + to_string(tick_idx) + ",\"event\":\"novelty_verdict\",\"verdict\":\"" + effective_label + "\"}";
-            // colony-lint: safe-exec-concat
-            let append_cmd = "printf '%s\n' " + shell_escape(ledger_row) + " >> " + shell_escape(ledger_path);
-            let _ = try { exec sh append_cmd; } catch e { ""; };
+            file_append(ledger_path, ledger_row + "\n");
         };
     };
 

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -97,9 +97,7 @@ fn _run_lean_check(self_pid: string, upstream_tick: int, lean_source: string) ->
     let sandbox_eff = if len(sandbox_dir) > 0 { sandbox_dir + "/sandbox"; } else { "/run-root/.agentis/sandbox"; };
     let lean_path = sandbox_eff + "/theorist-" + self_pid + "-tick-" + to_string(upstream_tick) + ".lean";
 
-    // colony-lint: safe-exec-concat
-    let write_cmd = "mkdir -p " + shell_escape(sandbox_eff) + " && printf '%s' " + shell_escape(lean_source) + " > " + shell_escape(lean_path);
-    let _wrote = try { exec sh write_cmd; } catch e { ""; };
+    file_write(lean_path, lean_source);
 
     let timeout_env = getenv("THEORIST_LEAN_TIMEOUT_SEC");
     let timeout_s = if len(timeout_env) > 0 { timeout_env; } else { "30"; };


### PR DESCRIPTION
Wave 5a colonies migration. 9 append_cmd -> file_append, 4 write_tex/bib_cmd -> file_write, 4 write_cmd -> file_write. 7 files, +23 / -51. Final exec sh: 191 -> 174. Cumulative 520 -> 174 = 67%. Wave 5b (14 row_cmd python3 json.dumps) + Wave 6 (8 fetch_cmd) follow. Lint 345/0/5.