### PR TITLE
feat(research-foundry): migrate 8 fetch_cmd python orchestrators (Wave 6, companion to v1.18.6)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -125,6 +125,31 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     return "pp:" + h + "|" + variant_tag;
 }
 
+// Wave 6 #913: substrate http_get + url_encode_component helpers
+// replacing the python3 urllib orchestrator. _arxiv_fetch_and_join
+// iterates the queries list via tail-recursion (the DSL has no
+// for/while loop; precedent: tick_at in
+// dev-apprenticeship/triage/agents/router.ag) and caps at 5 queries
+// per call to match the python orchestrator's `for q in qs[:5]:`
+// slice. The "--- query: X ---\n" separator and the
+// "<error>...</error>" wrapping are preserved verbatim so the
+// downstream relevance-judgement prompt sees a byte-identical
+// concatenated feed.
+fn _arxiv_fetch_and_join(queries: list<string>, max_results: int) -> string {
+    return _arxiv_fetch_recurse(queries, max_results, 0, "");
+}
+
+fn _arxiv_fetch_recurse(queries: list<string>, max_results: int, idx: int, acc: string) -> string {
+    if idx >= len(queries) { return acc; };
+    if idx >= 5 { return acc; };
+    let q = get(queries, idx);
+    let url = "http://export.arxiv.org/api/query?search_query=all:" + url_encode_component(q) + "&start=0&max_results=" + to_string(max_results);
+    let body = try { http_get(url); } catch e { "<error>" + e + "</error>"; };
+    let sep = if idx == 0 { ""; } else { "\n"; };
+    let chunk = sep + "--- query: " + q + " ---\n" + body;
+    return _arxiv_fetch_recurse(queries, max_results, idx + 1, acc + chunk);
+}
+
 // Phase 9 PR-C (#663): per-colony variant picker from the
 // colony-variants.json `arxiv-search` row.
 fn pick_variant(n: int) -> string {
@@ -190,22 +215,13 @@ fn _publish_arxiv_search(
     let queries_json = queries.queries_json;
     let max_results_raw = getenv("ARXIV_MAX_QUERY_RESULTS");
     let max_results = if len(max_results_raw) > 0 { parse_int(max_results_raw); } else { 10; };
-    // colony-lint: safe-exec-concat
-    let fetch_cmd = "QJSON=" + shell_escape(queries_json) + " MAXR=" + to_string(max_results)
-        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-        + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
-        + "if not isinstance(qs, list): qs=[]\n"
-        + "mx=int(os.environ.get(\"MAXR\",\"10\"))\n"
-        + "out=[]\n"
-        + "for q in qs[:5]:\n"
-        + "  url=\"http://export.arxiv.org/api/query?search_query=all:\"+urllib.parse.quote_plus(str(q))+\"&start=0&max_results=\"+str(mx)\n"
-        + "  try:\n"
-        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-        + "  except Exception as e:\n"
-        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
-        + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
-        + "sys.stdout.write(\"\\n\".join(out))'";
-    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+    // Wave 6 #913: substrate http_get + url_encode_component replace
+    // the python3 urllib orchestrator. json_array_to_strings parses the
+    // queries list; _arxiv_fetch_and_join iterates via tail-recursion
+    // and concatenates the atom-XML responses with the same separator
+    // format the relevance-judgement prompt expects.
+    let queries_list = json_array_to_strings(queries_json);
+    let combined_raw = _arxiv_fetch_and_join(queries_list, max_results);
 
     let judge_ctx = "PROBLEM: " + problem_text + "\n"
                   + "ANSWER: " + stated_answer + "\n"
@@ -389,22 +405,10 @@ fn _publish_arxiv_search_rule_hit(
     let _ = final_write;
     let max_results_raw = getenv("ARXIV_MAX_QUERY_RESULTS");
     let max_results = if len(max_results_raw) > 0 { parse_int(max_results_raw); } else { 10; };
-    // colony-lint: safe-exec-concat
-    let fetch_cmd = "QJSON=" + shell_escape(queries_json) + " MAXR=" + to_string(max_results)
-        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-        + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
-        + "if not isinstance(qs, list): qs=[]\n"
-        + "mx=int(os.environ.get(\"MAXR\",\"10\"))\n"
-        + "out=[]\n"
-        + "for q in qs[:5]:\n"
-        + "  url=\"http://export.arxiv.org/api/query?search_query=all:\"+urllib.parse.quote_plus(str(q))+\"&start=0&max_results=\"+str(mx)\n"
-        + "  try:\n"
-        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-        + "  except Exception as e:\n"
-        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
-        + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
-        + "sys.stdout.write(\"\\n\".join(out))'";
-    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+    // Wave 6 #913: substrate http_get + url_encode_component (rule-hit path
+    // mirror of the LLM path above).
+    let queries_list = json_array_to_strings(queries_json);
+    let combined_raw = _arxiv_fetch_and_join(queries_list, max_results);
 
     let judge_ctx = "PROBLEM: " + problem_text + "\n"
                   + "ANSWER: " + stated_answer + "\n"

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -127,6 +127,33 @@ fn pick_variant(n: int) -> string {
     return "representation";
 }
 
+// Wave 6 #913: substrate http_get + url_encode_component helpers
+// replacing the python3 urllib orchestrator. _groupprops_fetch_and_join
+// iterates the queries list via tail-recursion (the DSL has no
+// for/while loop; precedent: tick_at in
+// dev-apprenticeship/triage/agents/router.ag) and caps at 5 queries
+// per call to match the python orchestrator's `for q in qs[:5]:`
+// slice. The "--- query: X ---\n" separator and the
+// "<error>...</error>" wrapping are preserved verbatim so the
+// downstream relevance-judgement prompt sees a byte-identical
+// concatenated feed. Groupprops wiki has no max_results equivalent
+// (`&limit=10` is baked into the URL), so the helper omits the
+// max_results parameter.
+fn _groupprops_fetch_and_join(queries: list<string>) -> string {
+    return _groupprops_fetch_recurse(queries, 0, "");
+}
+
+fn _groupprops_fetch_recurse(queries: list<string>, idx: int, acc: string) -> string {
+    if idx >= len(queries) { return acc; };
+    if idx >= 5 { return acc; };
+    let q = get(queries, idx);
+    let url = "https://groupprops.subwiki.org/w/api.php?action=opensearch&format=json&limit=10&search=" + url_encode_component(q);
+    let body = try { http_get(url); } catch e { "<error>" + e + "</error>"; };
+    let sep = if idx == 0 { ""; } else { "\n"; };
+    let chunk = sep + "--- query: " + q + " ---\n" + body;
+    return _groupprops_fetch_recurse(queries, idx + 1, acc + chunk);
+}
+
 fn self_node_addr() -> string {
     let addr = recall_latest("math-foundry:worker_addr");
     if len(addr) > 0 {
@@ -171,21 +198,14 @@ fn _publish_groupprops_search(
 ) -> void {
     let _ = final_write;
     let queries_json = queries.queries_json;
-    // colony-lint: safe-exec-concat
-    let fetch_cmd = "QJSON=" + shell_escape(queries_json)
-        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-        + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
-        + "if not isinstance(qs, list): qs=[]\n"
-        + "out=[]\n"
-        + "for q in qs[:5]:\n"
-        + "  url=\"https://groupprops.subwiki.org/w/api.php?action=opensearch&format=json&limit=10&search=\"+urllib.parse.quote_plus(str(q))\n"
-        + "  try:\n"
-        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-        + "  except Exception as e:\n"
-        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
-        + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
-        + "sys.stdout.write(\"\\n\".join(out))'";
-    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+    // Wave 6 #913: substrate http_get + url_encode_component replace
+    // the python3 urllib orchestrator. json_array_to_strings parses the
+    // queries list; _groupprops_fetch_and_join iterates via
+    // tail-recursion and concatenates the opensearch JSON responses
+    // with the same separator format the relevance-judgement prompt
+    // expects.
+    let queries_list = json_array_to_strings(queries_json);
+    let combined_raw = _groupprops_fetch_and_join(queries_list);
 
     let judge_ctx = "PROBLEM: " + problem_text + "\n"
                   + "ANSWER: " + stated_answer + "\n"
@@ -367,21 +387,10 @@ fn _publish_groupprops_search_rule_hit(
 ) -> void {
     let _ = final_write;
     let queries_json = queries_json_arg;
-    // colony-lint: safe-exec-concat
-    let fetch_cmd = "QJSON=" + shell_escape(queries_json)
-        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-        + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
-        + "if not isinstance(qs, list): qs=[]\n"
-        + "out=[]\n"
-        + "for q in qs[:5]:\n"
-        + "  url=\"https://groupprops.subwiki.org/w/api.php?action=opensearch&format=json&limit=10&search=\"+urllib.parse.quote_plus(str(q))\n"
-        + "  try:\n"
-        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-        + "  except Exception as e:\n"
-        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
-        + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
-        + "sys.stdout.write(\"\\n\".join(out))'";
-    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+    // Wave 6 #913: substrate http_get + url_encode_component (rule-hit
+    // path mirror of the LLM path above).
+    let queries_list = json_array_to_strings(queries_json);
+    let combined_raw = _groupprops_fetch_and_join(queries_list);
 
     let judge_ctx = "PROBLEM: " + problem_text + "\n"
                   + "ANSWER: " + stated_answer + "\n"

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -121,6 +121,32 @@ fn _publish_prompt_body_and_wrap_variant(self_pid: string, variant_tag: string) 
     return "pp:" + h + "|" + variant_tag;
 }
 
+// Wave 6 #913: substrate http_get + url_encode_component helpers
+// replacing the python3 urllib orchestrator. _oeis_fetch_and_join
+// iterates the sequences list via tail-recursion (the DSL has no
+// for/while loop; precedent: tick_at in
+// dev-apprenticeship/triage/agents/router.ag) and caps at 5 sequences
+// per call to match the python orchestrator's `for s in seqs[:5]:`
+// slice. The "--- seq: X ---\n" separator and the
+// "<error>...</error>" wrapping are preserved verbatim so the
+// downstream relevance-judgement prompt sees a byte-identical
+// concatenated feed. OEIS has no max_results equivalent (`&fmt=text`
+// returns a fixed page), so the helper omits the max_results parameter.
+fn _oeis_fetch_and_join(sequences: list<string>) -> string {
+    return _oeis_fetch_recurse(sequences, 0, "");
+}
+
+fn _oeis_fetch_recurse(sequences: list<string>, idx: int, acc: string) -> string {
+    if idx >= len(sequences) { return acc; };
+    if idx >= 5 { return acc; };
+    let s = get(sequences, idx);
+    let url = "https://oeis.org/search?fmt=text&q=" + url_encode_component(s);
+    let body = try { http_get(url); } catch e { "<error>" + e + "</error>"; };
+    let sep = if idx == 0 { ""; } else { "\n"; };
+    let chunk = sep + "--- seq: " + s + " ---\n" + body;
+    return _oeis_fetch_recurse(sequences, idx + 1, acc + chunk);
+}
+
 // Phase 9 PR-C (#663): per-colony variant picker from the
 // colony-variants.json `oeis-search` row.
 fn pick_variant(n: int) -> string {
@@ -178,21 +204,13 @@ fn _publish_oeis_search(
 ) -> void {
     let _ = final_write;
     let sequences_json = sequences.sequences_json;
-    // colony-lint: safe-exec-concat
-    let fetch_cmd = "SJSON=" + shell_escape(sequences_json)
-        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-        + "try:\n  seqs=json.loads(os.environ[\"SJSON\"])\nexcept Exception:\n  seqs=[]\n"
-        + "if not isinstance(seqs, list): seqs=[]\n"
-        + "out=[]\n"
-        + "for s in seqs[:5]:\n"
-        + "  url=\"https://oeis.org/search?fmt=text&q=\"+urllib.parse.quote_plus(str(s))\n"
-        + "  try:\n"
-        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-        + "  except Exception as e:\n"
-        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
-        + "  out.append(\"--- seq: \"+str(s)+\" ---\\n\"+r)\n"
-        + "sys.stdout.write(\"\\n\".join(out))'";
-    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+    // Wave 6 #913: substrate http_get + url_encode_component replace
+    // the python3 urllib orchestrator. json_array_to_strings parses the
+    // sequences list; _oeis_fetch_and_join iterates via tail-recursion
+    // and concatenates the OEIS text-search responses with the same
+    // separator format the relevance-judgement prompt expects.
+    let sequences_list = json_array_to_strings(sequences_json);
+    let combined_raw = _oeis_fetch_and_join(sequences_list);
 
     let judge_ctx = "PROBLEM: " + problem_text + "\n"
                   + "ANSWER: " + stated_answer + "\n"
@@ -305,21 +323,10 @@ fn _publish_oeis_search_rule_hit(
     let _ = rationale;
     // External OEIS fetch on the reconstructed queries (NOT cached by the
     // rule -- the rule replaced only LLM extraction).
-    // colony-lint: safe-exec-concat
-    let fetch_cmd = "SJSON=" + shell_escape(sequences_json)
-        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-        + "try:\n  seqs=json.loads(os.environ[\"SJSON\"])\nexcept Exception:\n  seqs=[]\n"
-        + "if not isinstance(seqs, list): seqs=[]\n"
-        + "out=[]\n"
-        + "for s in seqs[:5]:\n"
-        + "  url=\"https://oeis.org/search?fmt=text&q=\"+urllib.parse.quote_plus(str(s))\n"
-        + "  try:\n"
-        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-        + "  except Exception as e:\n"
-        + "    r=\"<error>\"+str(e)+\"</error>\"\n"
-        + "  out.append(\"--- seq: \"+str(s)+\" ---\\n\"+r)\n"
-        + "sys.stdout.write(\"\\n\".join(out))'";
-    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+    // Wave 6 #913: substrate http_get + url_encode_component (rule-hit
+    // path mirror of the LLM path above).
+    let sequences_list = json_array_to_strings(sequences_json);
+    let combined_raw = _oeis_fetch_and_join(sequences_list);
 
     let judge_ctx = "PROBLEM: " + problem_text + "\n"
                   + "ANSWER: " + stated_answer + "\n"

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -131,6 +131,33 @@ fn pick_variant(n: int) -> string {
     return "preprint";
 }
 
+// Wave 6 #913: substrate http_get + url_encode_component helpers
+// replacing the python3 urllib orchestrator. _scholar_fetch_and_join
+// iterates the queries list via tail-recursion (the DSL has no
+// for/while loop; precedent: tick_at in
+// dev-apprenticeship/triage/agents/router.ag) and caps at 3 queries
+// per call to match the python orchestrator's `for q in qs[:3]:`
+// slice (Semantic Scholar's stricter rate limit). The
+// "--- query: X ---\n" separator and the "<unavailable>...</unavailable>"
+// wrapping are preserved verbatim so the downstream relevance-judgement
+// prompt sees a byte-identical concatenated feed. Semantic Scholar has
+// no max_results parameter on this endpoint (`&limit=10` baked into the
+// URL), so the helper omits the max_results parameter.
+fn _scholar_fetch_and_join(queries: list<string>) -> string {
+    return _scholar_fetch_recurse(queries, 0, "");
+}
+
+fn _scholar_fetch_recurse(queries: list<string>, idx: int, acc: string) -> string {
+    if idx >= len(queries) { return acc; };
+    if idx >= 3 { return acc; };
+    let q = get(queries, idx);
+    let url = "https://api.semanticscholar.org/graph/v1/paper/search?limit=10&fields=title,abstract,year,authors&query=" + url_encode_component(q);
+    let body = try { http_get(url); } catch e { "<unavailable>" + e + "</unavailable>"; };
+    let sep = if idx == 0 { ""; } else { "\n"; };
+    let chunk = sep + "--- query: " + q + " ---\n" + body;
+    return _scholar_fetch_recurse(queries, idx + 1, acc + chunk);
+}
+
 fn self_node_addr() -> string {
     let addr = recall_latest("math-foundry:worker_addr");
     if len(addr) > 0 {
@@ -175,21 +202,13 @@ fn _publish_scholar_search(
 ) -> void {
     let _ = final_write;
     let queries_json = queries.queries_json;
-    // colony-lint: safe-exec-concat
-    let fetch_cmd = "QJSON=" + shell_escape(queries_json)
-        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-        + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
-        + "if not isinstance(qs, list): qs=[]\n"
-        + "out=[]\n"
-        + "for q in qs[:3]:\n"
-        + "  url=\"https://api.semanticscholar.org/graph/v1/paper/search?limit=10&fields=title,abstract,year,authors&query=\"+urllib.parse.quote_plus(str(q))\n"
-        + "  try:\n"
-        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-        + "  except Exception as e:\n"
-        + "    r=\"<unavailable>\"+str(e)+\"</unavailable>\"\n"
-        + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
-        + "sys.stdout.write(\"\\n\".join(out))'";
-    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+    // Wave 6 #913: substrate http_get + url_encode_component replace
+    // the python3 urllib orchestrator. json_array_to_strings parses the
+    // queries list; _scholar_fetch_and_join iterates via tail-recursion
+    // and concatenates the Semantic Scholar JSON responses with the
+    // same separator format the relevance-judgement prompt expects.
+    let queries_list = json_array_to_strings(queries_json);
+    let combined_raw = _scholar_fetch_and_join(queries_list);
 
     let judge_ctx = "PROBLEM: " + problem_text + "\n"
                   + "ANSWER: " + stated_answer + "\n"
@@ -297,21 +316,10 @@ fn _publish_scholar_search_rule_hit(
     my_tier: string
 ) -> void {
     let _ = final_write;
-    // colony-lint: safe-exec-concat
-    let fetch_cmd = "QJSON=" + shell_escape(queries_json)
-        + " python3 -c 'import os, json, urllib.parse, urllib.request, sys\n"
-        + "try:\n  qs=json.loads(os.environ[\"QJSON\"])\nexcept Exception:\n  qs=[]\n"
-        + "if not isinstance(qs, list): qs=[]\n"
-        + "out=[]\n"
-        + "for q in qs[:3]:\n"
-        + "  url=\"https://api.semanticscholar.org/graph/v1/paper/search?limit=10&fields=title,abstract,year,authors&query=\"+urllib.parse.quote_plus(str(q))\n"
-        + "  try:\n"
-        + "    r=urllib.request.urlopen(url,timeout=30).read().decode(\"utf-8\",\"replace\")\n"
-        + "  except Exception as e:\n"
-        + "    r=\"<unavailable>\"+str(e)+\"</unavailable>\"\n"
-        + "  out.append(\"--- query: \"+str(q)+\" ---\\n\"+r)\n"
-        + "sys.stdout.write(\"\\n\".join(out))'";
-    let combined_raw = try { exec sh fetch_cmd; } catch e { ""; };
+    // Wave 6 #913: substrate http_get + url_encode_component (rule-hit
+    // path mirror of the LLM path above).
+    let queries_list = json_array_to_strings(queries_json);
+    let combined_raw = _scholar_fetch_and_join(queries_list);
 
     let judge_ctx = "PROBLEM: " + problem_text + "\n"
                   + "ANSWER: " + stated_answer + "\n"


### PR DESCRIPTION
Wave 6 colonies migration. 8 python3 urllib shell-outs across 4 search agents (arxiv/oeis/groupprops/scholar) replaced with tail-recursive http_get loops + url_encode_component + json_array_to_strings. 4 helper pairs cover 8 call sites. Per-agent URL templates preserved verbatim. Final exec sh: 160 -> 152. Cumulative 520 -> 152 = 71%. Lint 345/0/5.