### PR TITLE
feat(research-foundry): migrate 24 append_r ledger writes to file_append (Wave 7a)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -284,9 +284,7 @@ fn _publish_arxiv_search(
                                         let parent_specialty = recall_latest("arxiv-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("arxiv-search:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("arxiv-search:" + replica_id + ":specialty", parent_specialty);
@@ -468,9 +466,7 @@ fn _publish_arxiv_search_rule_hit(
                                         let parent_specialty = recall_latest("arxiv-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("arxiv-search:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("arxiv-search:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -454,9 +454,7 @@ fn _publish_auditor(
                                         let parent_specialty = recall_latest("auditor:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("auditor:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("auditor:" + replica_id + ":specialty", parent_specialty);
@@ -715,9 +713,7 @@ fn _publish_auditor_rule_hit(
                                         let parent_specialty = recall_latest("auditor:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("auditor:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("auditor:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -508,9 +508,7 @@ fn _publish_explorer(
                                                     let parent_specialty = recall_latest("explorer:" + self_pid + ":specialty");
                                                     let child_gen = lin + 1;
                                                     let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                                    // colony-lint: safe-exec-concat
-                                                    let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                                    let _lr = try { exec sh append_r; } catch e { ""; };
+                                                    let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                                     // Phase 3 PR 1 QA finding: seed the child's
                                                     // generation memo so the next replicate-success
                                                     // produces parent_gen+2, not always 1.
@@ -901,9 +899,7 @@ fn _publish_explorer_rule_hit(
                                                     let parent_specialty = recall_latest("explorer:" + self_pid + ":specialty");
                                                     let child_gen = lin + 1;
                                                     let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                                    // colony-lint: safe-exec-concat
-                                                    let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                                    let _lr = try { exec sh append_r; } catch e { ""; };
+                                                    let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                                     memo_write("explorer:" + replica_id + ":generation", to_string(child_gen));
                                                     if len(parent_specialty) > 0 {
                                                         memo_write("explorer:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -313,9 +313,7 @@ fn _publish_formulator(
                                         let parent_specialty = recall_latest("formulator:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + colony_name_str + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("formulator:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("formulator:" + replica_id + ":specialty", parent_specialty);
@@ -500,9 +498,7 @@ fn _publish_formulator_rule_hit(
                                         let parent_specialty = recall_latest("formulator:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + colony_name_str + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("formulator:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("formulator:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -265,9 +265,7 @@ fn _publish_groupprops_search(
                                         let parent_specialty = recall_latest("groupprops-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("groupprops-search:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("groupprops-search:" + replica_id + ":specialty", parent_specialty);
@@ -450,9 +448,7 @@ fn _publish_groupprops_search_rule_hit(
                                         let parent_specialty = recall_latest("groupprops-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("groupprops-search:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("groupprops-search:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -263,9 +263,7 @@ fn _publish_noticer(
                                         let parent_specialty = recall_latest("noticer:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("noticer:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("noticer:" + replica_id + ":specialty", parent_specialty);
@@ -518,9 +516,7 @@ fn _publish_noticer_rule_hit(
                                         let parent_specialty = recall_latest("noticer:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("noticer:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("noticer:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -388,9 +388,7 @@ fn _publish_novelty(
                                         let parent_specialty = recall_latest("novelty:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + colony_name_str + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("novelty:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("novelty:" + replica_id + ":specialty", parent_specialty);
@@ -856,9 +854,7 @@ fn _publish_novelty_rule_hit(
                                         let parent_specialty = recall_latest("novelty:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + colony_name_str + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("novelty:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("novelty:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -272,9 +272,7 @@ fn _publish_oeis_search(
                                         let parent_specialty = recall_latest("oeis-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("oeis-search:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("oeis-search:" + replica_id + ":specialty", parent_specialty);
@@ -386,9 +384,7 @@ fn _publish_oeis_search_rule_hit(
                                         let parent_specialty = recall_latest("oeis-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("oeis-search:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("oeis-search:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -235,9 +235,7 @@ fn _publish_prior_advocate(
                                         let parent_specialty = recall_latest("prior_advocate:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("prior_advocate:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("prior_advocate:" + replica_id + ":specialty", parent_specialty);
@@ -425,9 +423,7 @@ fn _publish_prior_advocate_rule_hit(
                                         let parent_specialty = recall_latest("prior_advocate:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("prior_advocate:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("prior_advocate:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -270,9 +270,7 @@ fn _publish_scholar_search(
                                         let parent_specialty = recall_latest("scholar-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("scholar-search:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("scholar-search:" + replica_id + ":specialty", parent_specialty);
@@ -381,9 +379,7 @@ fn _publish_scholar_search_rule_hit(
                                         let parent_specialty = recall_latest("scholar-search:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"audit\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("scholar-search:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("scholar-search:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/skeptic/agents/skeptic.ag
+++ b/research-foundry/skeptic/agents/skeptic.ag
@@ -284,9 +284,7 @@ fn _publish_skeptic(
                                         let parent_specialty = recall_latest("skeptic:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("skeptic:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("skeptic:" + replica_id + ":specialty", parent_specialty);
@@ -381,9 +379,7 @@ fn _publish_skeptic_rule_hit(
                                         let parent_specialty = recall_latest("skeptic:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("skeptic:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("skeptic:" + replica_id + ":specialty", parent_specialty);

--- a/research-foundry/verifier/agents/verifier.ag
+++ b/research-foundry/verifier/agents/verifier.ag
@@ -381,9 +381,7 @@ fn _publish_verifier(
                                         let parent_specialty = recall_latest("verifier:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("verifier:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("verifier:" + replica_id + ":specialty", parent_specialty);
@@ -566,9 +564,7 @@ fn _publish_verifier_rule_hit(
                                         let parent_specialty = recall_latest("verifier:" + self_pid + ":specialty");
                                         let child_gen = lin + 1;
                                         let row = "{\"ts\":" + to_string(tick_now_ms) + ",\"event\":\"replicate\",\"colony\":\"" + _colony_name + "\",\"side\":\"discovery\",\"parent_pid\":\"" + self_pid + "\",\"child_replica_id\":\"" + replica_id + "\",\"specialty\":\"" + parent_specialty + "\",\"generation\":" + to_string(child_gen) + ",\"parent_fitness\":" + to_string(my_fit_r) + "}";
-                                        // colony-lint: safe-exec-concat
-                                        let append_r = "printf '%s\n' " + shell_escape(row) + " >> " + shell_escape(ledger_path_r);
-                                        let _lr = try { exec sh append_r; } catch e { ""; };
+                                        let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; } catch e { ""; };
                                         memo_write("verifier:" + replica_id + ":generation", to_string(child_gen));
                                         if len(parent_specialty) > 0 {
                                             memo_write("verifier:" + replica_id + ":specialty", parent_specialty);


### PR DESCRIPTION
Wave 7a substrate purge across 12 search/audit agents (arxiv-search, auditor, explorer, formulator, groupprops-search, noticer, novelty, oeis-search, prior_advocate, scholar-search, skeptic, verifier).

Each agent's replicate-event ledger row was previously appended via `exec sh "printf '%s\n' <row> >> <path>"`. v1.18.5 added the `file_append` builtin so all 24 sites collapse to a single substrate call:

```
let _lr = try { file_append(ledger_path_r, row + "\n"); "ok"; }
          catch e { ""; };
```

No new substrate primitives required. Drops the matching `// colony-lint: safe-exec-concat` suppression on each site.

Final exec sh: 152 → 128. Cumulative 520 → 128 = **75%**.

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] `grep -rE "exec sh " research-foundry/*/agents/*.ag | wc -l` → 128
- [ ] CI smoke (research-foundry replica path exercises this code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)