### PR TITLE
feat(research-foundry): migrate 18 hex-validity sites to is_hex_lower (Wave 7b)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -105,10 +105,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -93,10 +93,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -82,10 +82,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -99,10 +99,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -146,10 +146,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -87,10 +87,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -99,10 +99,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/introducer/agents/introducer.ag
+++ b/research-foundry/introducer/agents/introducer.ag
@@ -88,10 +88,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -90,10 +90,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -84,10 +84,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -101,10 +101,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -101,10 +101,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/reviewer/agents/reviewer.ag
+++ b/research-foundry/reviewer/agents/reviewer.ag
@@ -92,10 +92,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -103,10 +103,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/skeptic/agents/skeptic.ag
+++ b/research-foundry/skeptic/agents/skeptic.ag
@@ -96,10 +96,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -148,10 +148,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -178,10 +178,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 

--- a/research-foundry/verifier/agents/verifier.ag
+++ b/research-foundry/verifier/agents/verifier.ag
@@ -106,10 +106,7 @@ fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
     if substring(variant_tag, 0, 3) != "pp:" { return ""; };
     let hex = substring(variant_tag, 3, 67);
-    // colony-lint: safe-exec-concat
-    let cmd = "printf '%s' " + shell_escape(hex) + " | tr -d '0-9a-f' | wc -c";
-    let leftover = try { exec sh cmd; } catch e { "1"; };
-    if parse_int(leftover) != 0 { return ""; };
+    if !is_hex_lower(hex) { return ""; };
     return hex;
 }
 


### PR DESCRIPTION
Wave 7b colonies migration, companion to agentis-core v1.18.8 release.

Substrate purge across 18 research-foundry agents (arxiv-search, auditor, computer, editor, explorer, formulator, groupprops-search, introducer, noticer, novelty, oeis-search, prior_advocate, reviewer, scholar-search, skeptic, submitter, theorist, verifier).

Each agent's `_extract_pp_hash` helper previously validated a content-addressed pp-hash by shelling out:

```ag
let cmd = "printf '%s' " + shell_escape(hex)
        + " | tr -d '0-9a-f' | wc -c";
let leftover = try { exec sh cmd; } catch e { "1"; };
if parse_int(leftover) != 0 { return ""; };
```

agentis v1.18.8 introduced `is_hex_lower(s) -> bool` substrate builtin so all 18 sites collapse to a single semantic check:

```ag
if !is_hex_lower(hex) { return ""; };
```

No shell-out, no LLM-tainted concat to harden, no `safe-exec-concat` lint suppression. Pure substrate compute, CB cost 8 (5 call + 3).

Final exec sh: 128 → 110. Cumulative 520 → 110 = **79%**.

**Requires agentis v1.18.8.**

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] `grep -rE "exec sh " research-foundry/*/agents/*.ag | wc -l` → 110
- [x] `grep -rE "tr -d .0-9a-f" research-foundry/*/agents/*.ag | wc -l` → 0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)