### PR TITLE
feat(research-foundry): migrate 6 split+strip python3 sites to trim + to_lower (Wave 7d)

### DIFF
--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -658,10 +658,9 @@ fn _canonical_stable_desc(canonical_ctx: string) -> string {
 // Total on missing pipe (returns the whole trimmed string).
 fn _parse_rule_action_verdict(action: string) -> string {
     if len(action) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys; print(sys.argv[1].split(\"|\",1)[0].strip())' " + shell_escape(action);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let head_idx = index_of(action, "|");
+    let head = if head_idx < 0 { action; } else { substring(action, 0, head_idx); };
+    return trim(head);
 }
 
 // _publish_auditor_rule_hit -- mirror of _publish_auditor but takes

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -485,10 +485,9 @@ fn _count_lines(stdout: string) -> string {
 // total on missing pipe (returns false / empty).
 fn _parse_rule_action_bool(action: string) -> bool {
     if len(action) == 0 { return false; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys; print(\"1\" if sys.argv[1].split(\"|\",1)[0].strip().lower()==\"true\" else \"0\")' " + shell_escape(action);
-    let out = try { exec sh cmd; } catch e { "0"; };
-    return out == "1";
+    let head_idx = index_of(action, "|");
+    let head = if head_idx < 0 { action; } else { substring(action, 0, head_idx); };
+    return to_lower(trim(head)) == "true";
 }
 
 fn _parse_rule_action_desc(action: string) -> string {

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -782,10 +782,9 @@ fn _canonical_stable_desc(canonical_ctx: string) -> string {
 // Total on missing pipe (returns the whole trimmed string).
 fn _parse_rule_action_verdict(action: string) -> string {
     if len(action) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys; print(sys.argv[1].split(\"|\",1)[0].strip())' " + shell_escape(action);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let head_idx = index_of(action, "|");
+    let head = if head_idx < 0 { action; } else { substring(action, 0, head_idx); };
+    return trim(head);
 }
 
 // _publish_novelty_rule_hit -- mirror of _publish_novelty but takes

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -339,10 +339,9 @@ fn _canonical_stable_desc(canonical_ctx: string) -> string {
 // Total on missing pipe (returns false).
 fn _parse_rule_action_bool(action: string) -> bool {
     if len(action) == 0 { return false; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys; print(\"1\" if sys.argv[1].split(\"|\",1)[0].strip().lower()==\"true\" else \"0\")' " + shell_escape(action);
-    let out = try { exec sh cmd; } catch e { "0"; };
-    return out == "1";
+    let head_idx = index_of(action, "|");
+    let head = if head_idx < 0 { action; } else { substring(action, 0, head_idx); };
+    return to_lower(trim(head)) == "true";
 }
 
 // _publish_prior_advocate_rule_hit -- mirror of _publish_prior_advocate

--- a/research-foundry/skeptic/agents/skeptic.ag
+++ b/research-foundry/skeptic/agents/skeptic.ag
@@ -566,10 +566,9 @@ fn _canonical_stable_desc(canonical_ctx: string) -> string {
 // Total on missing pipe (returns the whole trimmed string).
 fn _parse_rule_action_verdict(action: string) -> string {
     if len(action) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys; print(sys.argv[1].split(\"|\",1)[0].strip())' " + shell_escape(action);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let head_idx = index_of(action, "|");
+    let head = if head_idx < 0 { action; } else { substring(action, 0, head_idx); };
+    return trim(head);
 }
 
 // _skeptic_demotion_hook -- #819 demotion hook, extracted so both the

--- a/research-foundry/verifier/agents/verifier.ag
+++ b/research-foundry/verifier/agents/verifier.ag
@@ -558,10 +558,9 @@ fn _canonical_stable_desc(canonical_ctx: string) -> string {
 // Total on missing pipe (returns the whole trimmed string).
 fn _parse_rule_action_verdict(action: string) -> string {
     if len(action) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys; print(sys.argv[1].split(\"|\",1)[0].strip())' " + shell_escape(action);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let head_idx = index_of(action, "|");
+    let head = if head_idx < 0 { action; } else { substring(action, 0, head_idx); };
+    return trim(head);
 }
 
 // _publish_verifier_rule_hit -- mirror of _publish_verifier but takes


### PR DESCRIPTION
Wave 7d colonies migration, companion to agentis-core v1.18.10.

Substrate purge across 6 agents (auditor, noticer, novelty, prior_advocate, skeptic, verifier). Two .ag functions migrated:

- `_parse_rule_action_verdict(action) -> string` (4 sites, A-shape)
- `_parse_rule_action_decision(action) -> bool` (2 sites, B-shape)

Both previously shell-out to python3 to decode the picker-result `action` field (`"<value>|<reason>"` shape from Wave 7c):

```ag
let cmd = "python3 -c 'print(sys.argv[1].split(\"|\",1)[0].strip())' "
        + shell_escape(action);                                      // A: extract
let cmd = "python3 -c 'print(\"1\" if sys.argv[1].split(\"|\",1)[0].strip().lower()==\"true\" else \"0\")' "
        + shell_escape(action);                                      // B: bool
```

v1.18.10 introduced `trim(s)` + `to_lower(s)` substrate builtins so both patterns collapse to a 3-line substring + trim:

```ag
let head_idx = index_of(action, "|");
let head = if head_idx < 0 { action; } else { substring(action, 0, head_idx); };
return trim(head);                                                  // A
return to_lower(trim(head)) == "true";                              // B
```

No shell-out, no LLM-tainted concat to harden, no `safe-exec-concat` lint suppression. Pure substrate compute, CB cost 12 (5 call + 1 `trim` + 5 call + 1 `to_lower`) on the bool path.

Final exec sh: 92 → 86. Cumulative 520 → 86 = **83%**.

**Requires agentis v1.18.10.**

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] `grep -rE "exec sh " research-foundry/*/agents/*.ag | wc -l` → 86
- [x] `grep -rE "sys.argv\[1\].split" research-foundry/*/agents/*.ag | wc -l` → 0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)