### PR TITLE
feat(research-foundry): migrate 9 sites — FIFO buffer + bucket categorize (Wave 7g)

### DIFF
--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -198,9 +198,10 @@ fn _push_topic_feedback(
     let win_env = getenv("AUDITOR_FEEDBACK_WINDOW");
     let win = if len(win_env) > 0 { parse_int(win_env); } else { 50; };
     let win_eff = if win <= 0 { 50; } else { win; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nraw=sys.argv[1]\ntopic=sys.argv[2]\nps=sys.argv[3]\nt=int(sys.argv[4])\nk=int(sys.argv[5])\ntry:\n arr=json.loads(raw) if raw else []\n if not isinstance(arr,list): arr=[]\nexcept Exception:\n arr=[]\narr.append({\"topic\":topic,\"problem_summary\":ps,\"tick\":t})\nif len(arr)>k: arr=arr[-k:]\nprint(json.dumps(arr,separators=(\",\",\":\")))' " + shell_escape(buf_raw) + " " + shell_escape(topic) + " " + shell_escape(problem_summary) + " " + shell_escape(to_string(tick_idx)) + " " + shell_escape(to_string(win_eff));
-    let new_buf = try { exec sh cmd; } catch e { "[]"; };
+    let entry = "{\"topic\":\"" + json_escape_string(topic) + "\""
+              + ",\"problem_summary\":\"" + json_escape_string(problem_summary) + "\""
+              + ",\"tick\":" + to_string(tick_idx) + "}";
+    let new_buf = json_array_append_truncate(buf_raw, entry, win_eff);
     memo_write(buf_key, new_buf);
 }
 

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -213,9 +213,12 @@ fn _push_pitfall(
     let win = if len(win_env) > 0 { parse_int(win_env); } else { 20; };
     let win_eff = if win <= 0 { 20; } else { win; };
     let excerpt_eff = if len(log_excerpt) > 200 { substring(log_excerpt, 0, 200); } else { log_excerpt; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nraw=sys.argv[1]\nt=int(sys.argv[2])\ncid=sys.argv[3]\np=sys.argv[4]\ntags=sys.argv[5]\nex=sys.argv[6]\nk=int(sys.argv[7])\ntry:\n arr=json.loads(raw) if raw else []\n if not isinstance(arr,list): arr=[]\nexcept Exception:\n arr=[]\narr.append({\"tick\":t,\"claim_id\":cid,\"pass\":p,\"tags\":tags,\"excerpt\":ex})\nif len(arr)>k: arr=arr[-k:]\nprint(json.dumps(arr,separators=(\",\",\":\")))' " + shell_escape(buf_raw) + " " + shell_escape(to_string(tick_idx)) + " " + shell_escape(claim_id) + " " + shell_escape(pass_label) + " " + shell_escape(tags) + " " + shell_escape(excerpt_eff) + " " + shell_escape(to_string(win_eff));
-    let new_buf = try { exec sh cmd; } catch e { "[]"; };
+    let entry = "{\"tick\":" + to_string(tick_idx)
+              + ",\"claim_id\":\"" + json_escape_string(claim_id) + "\""
+              + ",\"pass\":\"" + json_escape_string(pass_label) + "\""
+              + ",\"tags\":\"" + json_escape_string(tags) + "\""
+              + ",\"excerpt\":\"" + json_escape_string(excerpt_eff) + "\"}";
+    let new_buf = json_array_append_truncate(buf_raw, entry, win_eff);
     memo_write(buf_key, new_buf);
 }
 

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -192,13 +192,13 @@ fn _push_settled_exploration(self_pid: string, verdict: string) -> int {
     let thr_env = getenv("EXPLORER_PROMPT_EVOLUTION_THRESHOLD");
     let thr = if len(thr_env) > 0 { parse_int(thr_env); } else { 3; };
     let thr_eff = if thr <= 0 { 3; } else { thr; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nraw=sys.argv[1]\nv=sys.argv[2]\nk=int(sys.argv[3])\ntry:\n arr=json.loads(raw) if raw else []\n if not isinstance(arr,list): arr=[]\nexcept Exception:\n arr=[]\narr.append({\"verdict\":v})\nif len(arr)>k: arr=arr[-k:]\nprint(json.dumps(arr,separators=(\",\",\":\")))' " + shell_escape(buf_raw) + " " + shell_escape(verdict) + " " + shell_escape(to_string(thr_eff));
-    let new_buf = try { exec sh cmd; } catch e { "[]"; };
+    let entry = "{\"verdict\":\"" + json_escape_string(verdict) + "\"}";
+    let new_buf = json_array_append_truncate(buf_raw, entry, thr_eff);
     memo_write(buf_key, new_buf);
-    // colony-lint: safe-exec-concat
-    let count_cmd = "python3 -c 'import sys,json\ntry: a=json.loads(sys.argv[1])\nexcept Exception: a=[]\nprint(len(a) if isinstance(a,list) else 0)' " + shell_escape(new_buf);
-    let n = try { exec sh count_cmd; } catch e { "0"; };
+    // Substrate-native entry count: parse via json_array_to_strings of
+    // verdicts (we just stored objects, but the count is what matters,
+    // so we use regex_find_all on the same "verdict" key marker).
+    let n = to_string(len(regex_find_all("\"verdict\"\\s*:", new_buf)));
     return parse_int(n);
 }
 
@@ -558,10 +558,13 @@ fn _loss_shaping_enabled_explorer() -> bool {
 // on a bucket label.
 fn _classify_bucket_explorer(s: string) -> string {
     if len(s) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys\ntxt=sys.argv[1].lower()\nbuckets=[(\"group_theory\",[\"group_theory\",\"sylow\",\"cayley\",\"monoid\",\"semigroup\",\"permutation\",\"symmetric_group\",\"sym_n\",\"schur\",\"lattice\",\"coset\",\"conjugacy\",\"abelian\",\"nilpotent\",\"solvable\",\"simple group\",\"presentation\",\"free group\"]),(\"combinatorics\",[\"combinatorics\",\"hamiltonicity\",\"hamilton cycle\",\"latin square\",\"hypergraph\",\"catalan\",\"partition\",\"generating function\",\"matroid\",\"turan\",\"ramsey\",\"enumeration\",\"bijection\",\"set system\",\"design theory\"]),(\"number_theory\",[\"number_theory\",\"hecke\",\"l-function\",\"zeta\",\"modular form\",\"diophantine\",\"frobenius\",\"p-adic\",\"elliptic curve\",\"galois\",\"class field\",\"automorphic\",\"prime\",\"sieve\",\"riemann\"]),(\"probability\",[\"probability\",\"martingale\",\"random walk\",\"mixing time\",\"stationary distribution\",\"markov chain\",\"percolation\",\"branching process\",\"brownian\",\"stochastic\",\"renyi\",\"entropy\"]),(\"algebra\",[\"algebra\",\"cohomology\",\"sheaf\",\"ring spectrum\",\"module\",\"derived category\",\"witt\",\"lie algebra\",\"hopf\",\"tensor\",\"homotopy\",\"scheme\",\"variety\",\"ideal\",\"polynomial ring\"])]\nfor name,kws in buckets:\n for kw in kws:\n  if kw in txt:\n   print(name); sys.exit(0)\nprint(\"\")' " + shell_escape(s);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let txt = to_lower(s);
+    if regex_match("group_theory|sylow|cayley|monoid|semigroup|permutation|symmetric_group|sym_n|schur|lattice|coset|conjugacy|abelian|nilpotent|solvable|simple group|presentation|free group", txt) { return "group_theory"; };
+    if regex_match("combinatorics|hamiltonicity|hamilton cycle|latin square|hypergraph|catalan|partition|generating function|matroid|turan|ramsey|enumeration|bijection|set system|design theory", txt) { return "combinatorics"; };
+    if regex_match("number_theory|hecke|l-function|zeta|modular form|diophantine|frobenius|p-adic|elliptic curve|galois|class field|automorphic|prime|sieve|riemann", txt) { return "number_theory"; };
+    if regex_match("probability|martingale|random walk|mixing time|stationary distribution|markov chain|percolation|branching process|brownian|stochastic|renyi|entropy", txt) { return "probability"; };
+    if regex_match("algebra|cohomology|sheaf|ring spectrum|module|derived category|witt|lie algebra|hopf|tensor|homotopy|scheme|variety|ideal|polynomial ring", txt) { return "algebra"; };
+    return "";
 }
 
 fn _loss_shaping_hint(self_pid: string, topic_label: string) -> string {

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -532,10 +532,13 @@ fn _loss_shaping_enabled() -> bool {
 // probability > algebra`) so saturation downgrades remain stable.
 fn _classify_bucket(condition: string) -> string {
     if len(condition) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys\ntxt=sys.argv[1].lower()\nbuckets=[(\"group_theory\",[\"group_theory\",\"sylow\",\"cayley\",\"monoid\",\"semigroup\",\"permutation\",\"symmetric_group\",\"sym_n\",\"schur\",\"lattice\",\"coset\",\"conjugacy\",\"abelian\",\"nilpotent\",\"solvable\",\"simple group\",\"presentation\",\"free group\"]),(\"combinatorics\",[\"combinatorics\",\"hamiltonicity\",\"hamilton cycle\",\"latin square\",\"hypergraph\",\"catalan\",\"partition\",\"generating function\",\"matroid\",\"turan\",\"ramsey\",\"enumeration\",\"bijection\",\"set system\",\"design theory\"]),(\"number_theory\",[\"number_theory\",\"hecke\",\"l-function\",\"zeta\",\"modular form\",\"diophantine\",\"frobenius\",\"p-adic\",\"elliptic curve\",\"galois\",\"class field\",\"automorphic\",\"prime\",\"sieve\",\"riemann\"]),(\"probability\",[\"probability\",\"martingale\",\"random walk\",\"mixing time\",\"stationary distribution\",\"markov chain\",\"percolation\",\"branching process\",\"brownian\",\"stochastic\",\"renyi\",\"entropy\"]),(\"algebra\",[\"algebra\",\"cohomology\",\"sheaf\",\"ring spectrum\",\"module\",\"derived category\",\"witt\",\"lie algebra\",\"hopf\",\"tensor\",\"homotopy\",\"scheme\",\"variety\",\"ideal\",\"polynomial ring\"])]\nfor name,kws in buckets:\n for kw in kws:\n  if kw in txt:\n   print(name); sys.exit(0)\nprint(\"\")' " + shell_escape(condition);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let txt = to_lower(condition);
+    if regex_match("group_theory|sylow|cayley|monoid|semigroup|permutation|symmetric_group|sym_n|schur|lattice|coset|conjugacy|abelian|nilpotent|solvable|simple group|presentation|free group", txt) { return "group_theory"; };
+    if regex_match("combinatorics|hamiltonicity|hamilton cycle|latin square|hypergraph|catalan|partition|generating function|matroid|turan|ramsey|enumeration|bijection|set system|design theory", txt) { return "combinatorics"; };
+    if regex_match("number_theory|hecke|l-function|zeta|modular form|diophantine|frobenius|p-adic|elliptic curve|galois|class field|automorphic|prime|sieve|riemann", txt) { return "number_theory"; };
+    if regex_match("probability|martingale|random walk|mixing time|stationary distribution|markov chain|percolation|branching process|brownian|stochastic|renyi|entropy", txt) { return "probability"; };
+    if regex_match("algebra|cohomology|sheaf|ring spectrum|module|derived category|witt|lie algebra|hopf|tensor|homotopy|scheme|variety|ideal|polynomial ring", txt) { return "algebra"; };
+    return "";
 }
 
 // _classify_buckets_all -- like `_classify_bucket` but returns a CSV of
@@ -546,10 +549,18 @@ fn _classify_bucket(condition: string) -> string {
 // single-bucket dispatch. Returns "" on empty input or zero matches.
 fn _classify_buckets_all(condition: string) -> string {
     if len(condition) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys\ntxt=sys.argv[1].lower()\nbuckets=[(\"group_theory\",[\"group_theory\",\"sylow\",\"cayley\",\"monoid\",\"semigroup\",\"permutation\",\"symmetric_group\",\"sym_n\",\"schur\",\"lattice\",\"coset\",\"conjugacy\",\"abelian\",\"nilpotent\",\"solvable\",\"simple group\",\"presentation\",\"free group\"]),(\"combinatorics\",[\"combinatorics\",\"hamiltonicity\",\"hamilton cycle\",\"latin square\",\"hypergraph\",\"catalan\",\"partition\",\"generating function\",\"matroid\",\"turan\",\"ramsey\",\"enumeration\",\"bijection\",\"set system\",\"design theory\"]),(\"number_theory\",[\"number_theory\",\"hecke\",\"l-function\",\"zeta\",\"modular form\",\"diophantine\",\"frobenius\",\"p-adic\",\"elliptic curve\",\"galois\",\"class field\",\"automorphic\",\"prime\",\"sieve\",\"riemann\"]),(\"probability\",[\"probability\",\"martingale\",\"random walk\",\"mixing time\",\"stationary distribution\",\"markov chain\",\"percolation\",\"branching process\",\"brownian\",\"stochastic\",\"renyi\",\"entropy\"]),(\"algebra\",[\"algebra\",\"cohomology\",\"sheaf\",\"ring spectrum\",\"module\",\"derived category\",\"witt\",\"lie algebra\",\"hopf\",\"tensor\",\"homotopy\",\"scheme\",\"variety\",\"ideal\",\"polynomial ring\"])]\nhits=[]\nfor name,kws in buckets:\n for kw in kws:\n  if kw in txt:\n   hits.append(name); break\nprint(\",\".join(hits))' " + shell_escape(condition);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let txt = to_lower(condition);
+    let h1 = if regex_match("group_theory|sylow|cayley|monoid|semigroup|permutation|symmetric_group|sym_n|schur|lattice|coset|conjugacy|abelian|nilpotent|solvable|simple group|presentation|free group", txt) { "group_theory"; } else { ""; };
+    let h2 = if regex_match("combinatorics|hamiltonicity|hamilton cycle|latin square|hypergraph|catalan|partition|generating function|matroid|turan|ramsey|enumeration|bijection|set system|design theory", txt) { "combinatorics"; } else { ""; };
+    let h3 = if regex_match("number_theory|hecke|l-function|zeta|modular form|diophantine|frobenius|p-adic|elliptic curve|galois|class field|automorphic|prime|sieve|riemann", txt) { "number_theory"; } else { ""; };
+    let h4 = if regex_match("probability|martingale|random walk|mixing time|stationary distribution|markov chain|percolation|branching process|brownian|stochastic|renyi|entropy", txt) { "probability"; } else { ""; };
+    let h5 = if regex_match("algebra|cohomology|sheaf|ring spectrum|module|derived category|witt|lie algebra|hopf|tensor|homotopy|scheme|variety|ideal|polynomial ring", txt) { "algebra"; } else { ""; };
+    let c1 = h1;
+    let c2 = if len(c1) == 0 { h2; } else { if len(h2) == 0 { c1; } else { c1 + "," + h2; }; };
+    let c3 = if len(c2) == 0 { h3; } else { if len(h3) == 0 { c2; } else { c2 + "," + h3; }; };
+    let c4 = if len(c3) == 0 { h4; } else { if len(h4) == 0 { c3; } else { c3 + "," + h4; }; };
+    let c5 = if len(c4) == 0 { h5; } else { if len(h5) == 0 { c4; } else { c4 + "," + h5; }; };
+    return c5;
 }
 
 // _novelty_score -- bag-of-words Jaccard distance from the incoming claim
@@ -721,9 +732,8 @@ fn _topic_history_check(bucket: string) -> bool {
 fn _push_topic_history(bucket: string) -> int {
     if len(bucket) == 0 { return 0; };
     let raw = recall_latest("novelty:topic_history");
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nraw=sys.argv[1]\nbk=sys.argv[2]\ntry: arr=json.loads(raw) if raw else []\nexcept Exception: arr=[]\nif not isinstance(arr,list): arr=[]\narr.append(bk)\nif len(arr)>50: arr=arr[-50:]\nprint(json.dumps(arr,separators=(\",\",\":\")))' " + shell_escape(raw) + " " + shell_escape(bucket);
-    let new_buf = try { exec sh cmd; } catch e { "[]"; };
+    let entry = "\"" + json_escape_string(bucket) + "\"";
+    let new_buf = json_array_append_truncate(raw, entry, 50);
     memo_write("novelty:topic_history", new_buf);
     return len(new_buf);
 }

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -764,9 +764,11 @@ fn _push_hitl_reject(
     let win = if len(win_env) > 0 { parse_int(win_env); } else { 20; };
     let win_eff = if win <= 0 { 20; } else { win; };
     let excerpt_eff = if len(reason_excerpt) > 200 { substring(reason_excerpt, 0, 200); } else { reason_excerpt; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nraw=sys.argv[1]\ncid=sys.argv[2]\nc=sys.argv[3]\nex=sys.argv[4]\nt=int(sys.argv[5])\nk=int(sys.argv[6])\ntry:\n arr=json.loads(raw) if raw else []\n if not isinstance(arr,list): arr=[]\nexcept Exception:\n arr=[]\narr.append({\"ts\":t,\"claim_id\":cid,\"class\":c,\"reason_excerpt\":ex})\nif len(arr)>k: arr=arr[-k:]\nprint(json.dumps(arr,separators=(\",\",\":\")))' " + shell_escape(buf_raw) + " " + shell_escape(claim_id) + " " + shell_escape(classification) + " " + shell_escape(excerpt_eff) + " " + shell_escape(to_string(tick_idx)) + " " + shell_escape(to_string(win_eff));
-    let new_buf = try { exec sh cmd; } catch e { "[]"; };
+    let entry = "{\"ts\":" + to_string(tick_idx)
+              + ",\"claim_id\":\"" + json_escape_string(claim_id) + "\""
+              + ",\"class\":\"" + json_escape_string(classification) + "\""
+              + ",\"reason_excerpt\":\"" + json_escape_string(excerpt_eff) + "\"}";
+    let new_buf = json_array_append_truncate(buf_raw, entry, win_eff);
     memo_write(buf_key, new_buf);
 }
 


### PR DESCRIPTION
Wave 7g colonies migration, companion to agentis v1.18.14.

## Migrations

**5 rolling-FIFO buffer sites** — collapsed to `json_array_append_truncate(buf, entry, k)` + `json_escape_string`-built entry strings:

| File | Function | Entry shape |
|------|----------|-------------|
| editor.ag | `_push_pitfall` | `{tick,claim_id,pass,tags,excerpt}` |
| auditor.ag | `_push_topic_recap` | `{topic,problem_summary,tick}` |
| novelty.ag | `_push_topic_history` | bucket (bare string) |
| explorer.ag | `_push_settled_exploration` | `{verdict}` |
| submitter.ag | `_push_hitl_reject` | `{ts,claim_id,class,reason_excerpt}` |

**4 inline-substrate migrations** — no new builtins:

- `novelty._classify_bucket(condition)` — 5-bucket alternation regex (`regex_match`) preserving python `if kw in txt` substring contract.
- `novelty._classify_buckets_all(condition)` — same alternation but CSV-collect via chained concat.
- `explorer._classify_bucket_explorer(s)` — same as novelty single-variant.
- `explorer.count_cmd` — `regex_find_all` over `"verdict":` marker (no second python invocation needed).

Final exec sh: 56 → **47**. Cumulative 520 → 47 = **91%**.

**Requires agentis v1.18.14.**

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] `grep -rE "exec sh " research-foundry/*/agents/*.ag | wc -l` → 47
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)