### PR TITLE
feat(research-foundry): migrate 3 sites — levenshtein + line count + split (Wave 7h)

### DIFF
--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -176,10 +176,7 @@ fn _levenshtein_ratio_pct(a: string, b: string) -> int {
     let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
     let a_clamped = if len(a) > max_bytes_eff { substring(a, 0, max_bytes_eff); } else { a; };
     let b_clamped = if len(b) > max_bytes_eff { substring(b, 0, max_bytes_eff); } else { b; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys\nA=sys.argv[1]\nB=sys.argv[2]\nif A==B:\n print(100); sys.exit(0)\nn=len(A); m=len(B)\nprev=list(range(m+1))\nfor i in range(1,n+1):\n cur=[i]+[0]*m\n for j in range(1,m+1):\n  c=0 if A[i-1]==B[j-1] else 1\n  cur[j]=min(prev[j]+1,cur[j-1]+1,prev[j-1]+c)\n prev=cur\nd=prev[m]\nmx=max(n,m)\nprint(int(round((1.0 - d/mx)*100)))' " + shell_escape(a_clamped) + " " + shell_escape(b_clamped);
-    let out = try { exec sh cmd; } catch e { "0"; };
-    let r = parse_int(out);
+    let r = levenshtein_similarity(a_clamped, b_clamped);
     if r < 0 { return 0; };
     if r > 100 { return 100; };
     return r;

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -490,13 +490,11 @@ fn _bucket_output_size(stdout: string) -> string {
 }
 
 // _count_lines -- newline-count tiebreaker for the canonical context.
+// Substrate-native: regex_find_all over "\n" markers + 1 for the
+// trailing line (matches python `str.count("\n") + 1`).
 fn _count_lines(stdout: string) -> string {
     if len(stdout) == 0 { return "0"; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys; sys.stdout.write(str(sys.argv[1].count(chr(10))+1))' " + shell_escape(stdout);
-    let out = try { exec sh cmd; } catch e { "0"; };
-    if len(out) == 0 { return "0"; };
-    return out;
+    return to_string(len(regex_find_all("\\n", stdout)) + 1);
 }
 
 // _parse_rule_action_bool / _parse_rule_action_desc -- decoders for
@@ -515,10 +513,9 @@ fn _parse_rule_action_bool(action: string) -> bool {
 
 fn _parse_rule_action_desc(action: string) -> string {
     if len(action) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys; s=sys.argv[1]; print(s.split(\"|\",1)[1] if \"|\" in s else \"\")' " + shell_escape(action);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let idx = index_of(action, "|");
+    if idx < 0 { return ""; };
+    return substring(action, idx + 1, len(action));
 }
 
 // #841: _canonical_stable_desc derives a DETERMINISTIC description from


### PR DESCRIPTION
Wave 7h colonies migration, companion to agentis v1.18.15.

## Migrations

3 sites migrated:

| File | Function | New call |
|------|----------|----------|
| explorer.ag | `_novelty_similarity_check` | `levenshtein_similarity(a_clamped, b_clamped)` (new builtin) |
| noticer.ag | `_count_lines` | `to_string(len(regex_find_all("\\n", stdout)) + 1)` |
| noticer.ag | `_parse_rule_action_desc` | `index_of` + `substring` |

The explorer Levenshtein DP was previously inlined as a 50-line `python3 -c` shell-out; v1.18.15's `levenshtein_similarity` substrate builtin replaces it with a single call returning 0..100 percent. Identical short-circuit + 1024-byte truncation preserved through the substrate.

The noticer `_count_lines` + `_parse_rule_action_desc` were 1-line python3 shell-outs trivially replaced inline using existing substrate primitives.

Final exec sh: 47 → **44**. Cumulative 520 → 44 = **92%**.

**Requires agentis v1.18.15.**

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] `grep -rE "exec sh " research-foundry/*/agents/*.ag | wc -l` → 44
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)