### PR TITLE
feat(research-foundry): migrate 4 JSON object construction sites (Wave 7i)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -360,13 +360,8 @@ fn _arxiv_canonical_ctx(ctx: string) -> string {
 // what the Stage-1 rule-hit path decodes back into Queries primitives
 // via json_get. Total on failure (returns an empty-Queries JSON).
 fn _queries_to_action_json(queries: Queries) -> string {
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nobj={\"queries_json\":sys.argv[1],\"rationale\":sys.argv[2]}\nprint(json.dumps(obj,separators=(\",\",\":\")))' " + shell_escape(queries.queries_json) + " " + shell_escape(queries.rationale);
-    let out = try { exec sh cmd; } catch e { ""; };
-    if len(out) == 0 {
-        return "{\"queries_json\":\"\",\"rationale\":\"\"}";
-    };
-    return out;
+    return "{\"queries_json\":\"" + json_escape_string(queries.queries_json)
+         + "\",\"rationale\":\"" + json_escape_string(queries.rationale) + "\"}";
 }
 
 // _publish_arxiv_search_rule_hit -- mirror of _publish_arxiv_search but

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -617,14 +617,12 @@ fn _editor_canonical_ctx(ctx: string) -> string {
 // what the Stage-1 rule-hit path decodes back into Edit primitives via
 // json_get. Total on failure (returns an empty-Edit JSON).
 fn _edit_to_action_json(edit: Edit) -> string {
-    let halluc_str = if edit.hallucinations_found { "true"; } else { "false"; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nobj={\"full_tex\":sys.argv[1],\"refs_bib\":sys.argv[2],\"fingerprint_csv\":sys.argv[3],\"hallucinations_found\":(sys.argv[4]==\"true\"),\"rationale\":sys.argv[5]}\nprint(json.dumps(obj,separators=(\",\",\":\")))' " + shell_escape(edit.full_tex) + " " + shell_escape(edit.refs_bib) + " " + shell_escape(edit.fingerprint_csv) + " " + shell_escape(halluc_str) + " " + shell_escape(edit.rationale);
-    let out = try { exec sh cmd; } catch e { ""; };
-    if len(out) == 0 {
-        return "{\"full_tex\":\"\",\"refs_bib\":\"\",\"fingerprint_csv\":\"\",\"hallucinations_found\":false,\"rationale\":\"\"}";
-    };
-    return out;
+    let halluc_lit = if edit.hallucinations_found { "true"; } else { "false"; };
+    return "{\"full_tex\":\"" + json_escape_string(edit.full_tex)
+         + "\",\"refs_bib\":\"" + json_escape_string(edit.refs_bib)
+         + "\",\"fingerprint_csv\":\"" + json_escape_string(edit.fingerprint_csv)
+         + "\",\"hallucinations_found\":" + halluc_lit
+         + ",\"rationale\":\"" + json_escape_string(edit.rationale) + "\"}";
 }
 
 // _publish_editor_rule_hit -- mirror of _publish_editor but takes the

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -346,13 +346,8 @@ fn _groupprops_search_canonical_ctx(ctx: string, upstream_tick: int) -> string {
 // rule-hit path decodes back into Queries primitives via json_get. Total
 // on failure (returns an empty-Queries JSON).
 fn _queries_to_action_json(queries: Queries) -> string {
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nobj={\"queries_json\":sys.argv[1],\"rationale\":sys.argv[2]}\nprint(json.dumps(obj,separators=(\",\",\":\")))' " + shell_escape(queries.queries_json) + " " + shell_escape(queries.rationale);
-    let out = try { exec sh cmd; } catch e { ""; };
-    if len(out) == 0 {
-        return "{\"queries_json\":\"\",\"rationale\":\"\"}";
-    };
-    return out;
+    return "{\"queries_json\":\"" + json_escape_string(queries.queries_json)
+         + "\",\"rationale\":\"" + json_escape_string(queries.rationale) + "\"}";
 }
 
 // _publish_groupprops_search_rule_hit -- mirror of _publish_groupprops_search

--- a/research-foundry/introducer/agents/introducer.ag
+++ b/research-foundry/introducer/agents/introducer.ag
@@ -278,16 +278,12 @@ fn _introducer_canonical_ctx(input_ctx: string, claim_id: string) -> string {
 // never on the lookup map -- #843). Faithful: every Draft field round-trips
 // byte-for-byte, so a rule-hit reconstruction is identical to the LLM draft.
 fn _encode_draft_action(draft: Draft) -> string {
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nobj={\"abstract_tex\":sys.argv[1],\"intro_tex\":sys.argv[2],\"msc_codes_csv\":sys.argv[3],\"arxiv_category\":sys.argv[4],\"title\":sys.argv[5],\"rationale\":sys.argv[6]}\nsys.stdout.write(json.dumps(obj,separators=(\",\",\":\")))' "
-        + shell_escape(draft.abstract_tex) + " "
-        + shell_escape(draft.intro_tex) + " "
-        + shell_escape(draft.msc_codes_csv) + " "
-        + shell_escape(draft.arxiv_category) + " "
-        + shell_escape(draft.title) + " "
-        + shell_escape(draft.rationale);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    return "{\"abstract_tex\":\"" + json_escape_string(draft.abstract_tex)
+         + "\",\"intro_tex\":\"" + json_escape_string(draft.intro_tex)
+         + "\",\"msc_codes_csv\":\"" + json_escape_string(draft.msc_codes_csv)
+         + "\",\"arxiv_category\":\"" + json_escape_string(draft.arxiv_category)
+         + "\",\"title\":\"" + json_escape_string(draft.title)
+         + "\",\"rationale\":\"" + json_escape_string(draft.rationale) + "\"}";
 }
 
 // _publish_introducer_rule_hit -- mirror of _publish_introducer but takes


### PR DESCRIPTION
Wave 7i colonies migration, companion to agentis v1.18.16.

## Migrations

4 sites where action-encoder helpers built JSON strings via `python3 -c json.dumps` shell-out — collapsed to inline `json_escape_string` + concat:

| File | Function | Shape |
|------|----------|-------|
| arxiv-search.ag | `_queries_to_action_json` | `{queries_json, rationale}` |
| groupprops-search.ag | `_queries_to_action_json` | identical to arxiv-search |
| introducer.ag | `_encode_draft_action` | 6-field Draft |
| editor.ag | `_edit_to_action_json` | 5-field Edit (incl. bool) |

The Edit shape inlines the boolean `hallucinations_found` as a raw JSON literal (`"true"` / `"false"` — NOT escaped) so `json_get(action, "hallucinations_found")` downstream deserializes back to a boolean rather than the string `"true"`.

v1.18.16 substrate addition `json_array_object_field_values` is **NOT** consumed by this PR — it's reserved for the next-wave JSON freq aggregator (`auditor` / `formulator` `_summarise_hitl_buf`).

Final exec sh: 44 → **40**. Cumulative 520 → 40 = **92%**.

**Requires agentis v1.18.16.**

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] `grep -rE "exec sh " research-foundry/*/agents/*.ag | wc -l` → 40
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)