### PR TITLE
feat(research-foundry): migrate 4 _summarise_*_buf aggregation sites (Wave 7j)

### DIFF
--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -154,15 +154,48 @@ fn _dump_ctx_to_memo(agent_name: string, pid: string, tick_idx: int, ctx: string
     memo_write(agent_name + ":" + pid + ":ctx:tick-" + to_string(tick_idx), ctx);
 }
 
+// Tail-recursive helper: take the last `k` items of a list of strings.
+// Walks from `idx` to `len`, accumulating into `acc` once `idx >=
+// len - k` (or k <= 0 -> return original). Hard cap at 256 iterations
+// to keep CB bounded.
+fn _take_last_str(items: list<string>, k: int, idx: int, acc: list<string>) -> list<string> {
+    if idx >= len(items) { return acc; };
+    if idx >= 256 { return acc; };
+    let start = if k <= 0 { 0; } else { if len(items) <= k { 0; } else { len(items) - k; }; };
+    let next = if idx >= start { push(acc, get(items, idx)); } else { acc; };
+    return _take_last_str(items, k, idx + 1, next);
+}
+
+// Tail-recursive helper: append non-empty trimmed-and-truncated entries
+// from `items[idx..]` joined with " ;; ". Used by _summarise_hitl_buf to
+// build the "recent" suffix.
+fn _join_excerpts(items: list<string>, idx: int, max_len: int, acc: string) -> string {
+    if idx >= len(items) { return acc; };
+    if idx >= 256 { return acc; };
+    let raw = get(items, idx);
+    let trimmed = trim(raw);
+    let capped = if len(trimmed) > max_len { substring(trimmed, 0, max_len); } else { trimmed; };
+    let next = if len(capped) == 0 {
+        acc;
+    } else {
+        if len(acc) == 0 { capped; } else { acc + " ;; " + capped; };
+    };
+    return _join_excerpts(items, idx + 1, max_len, next);
+}
+
 // _summarise_hitl_buf -- collapse the rolling feedback:hitl_rejects
 // buffer to a tag-frequency table plus the last few raw excerpts.
 // Auditor and formulator both call this with the same buffer.
 fn _summarise_hitl_buf(buf_raw: string, k: int) -> string {
     if len(buf_raw) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\ntry: a=json.loads(sys.argv[1])\nexcept Exception: a=[]\nif not isinstance(a,list): a=[]\nk=int(sys.argv[2])\nif k>0 and len(a)>k: a=a[-k:]\nfreq={}\nfor r in a:\n if not isinstance(r,dict): continue\n c=str(r.get(\"class\",\"other\")) or \"other\"\n freq[c]=freq.get(c,0)+1\nitems=sorted(freq.items(), key=lambda kv:(-kv[1],kv[0]))\nfreq_s=\", \".join(\"%s:%d\" % (k,v) for k,v in items)\nlast=[]\nfor r in a[-3:]:\n if not isinstance(r,dict): continue\n ex=str(r.get(\"reason_excerpt\",\"\")).strip()\n if len(ex)>80: ex=ex[:80]\n if ex: last.append(ex)\nout=freq_s\nif last: out += \" | recent: \" + \" ;; \".join(last)\nprint(out)' " + shell_escape(buf_raw) + " " + shell_escape(to_string(k));
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let all_classes = json_array_object_field_values(buf_raw, "class");
+    let classes = _take_last_str(all_classes, k, 0, []);
+    let freq_s = string_list_freq_csv(classes, 0);
+    let all_excerpts = json_array_object_field_values(buf_raw, "reason_excerpt");
+    let recent_excerpts = _take_last_str(all_excerpts, 3, 0, []);
+    let recent_s = _join_excerpts(recent_excerpts, 0, 80, "");
+    if len(recent_s) == 0 { return freq_s; };
+    return freq_s + " | recent: " + recent_s;
 }
 
 // _push_topic_feedback -- append a topic-verdict entry to the rolling

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -156,12 +156,59 @@ fn _dump_ctx_to_memo(agent_name: string, pid: string, tick_idx: int, ctx: string
 // separated `<topic>:<problem_summary[:60]>` string the formulator
 // injects into the ctx. Same idiom as auditor::_push_topic_feedback
 // reader counterpart in spirit; matches explorer.ag::_count_not_novel.
+// Tail-recursive helper: take the last `k` items of a list of strings.
+fn _take_last_str(items: list<string>, k: int, idx: int, acc: list<string>) -> list<string> {
+    if idx >= len(items) { return acc; };
+    if idx >= 256 { return acc; };
+    let start = if k <= 0 { 0; } else { if len(items) <= k { 0; } else { len(items) - k; }; };
+    let next = if idx >= start { push(acc, get(items, idx)); } else { acc; };
+    return _take_last_str(items, k, idx + 1, next);
+}
+
+// Tail-recursive helper: append non-empty trimmed-and-truncated entries
+// from `items[idx..]` joined with " ;; ".
+fn _join_excerpts(items: list<string>, idx: int, max_len: int, acc: string) -> string {
+    if idx >= len(items) { return acc; };
+    if idx >= 256 { return acc; };
+    let raw = get(items, idx);
+    let trimmed = trim(raw);
+    let capped = if len(trimmed) > max_len { substring(trimmed, 0, max_len); } else { trimmed; };
+    let next = if len(capped) == 0 {
+        acc;
+    } else {
+        if len(acc) == 0 { capped; } else { acc + " ;; " + capped; };
+    };
+    return _join_excerpts(items, idx + 1, max_len, next);
+}
+
+// Tail-recursive helper: pair topic and problem_summary by index, trim
+// problem_summary, truncate to 60 chars, drop empty pairs, join with ", ".
+fn _join_topic_pairs(topics: list<string>, problems: list<string>, idx: int, acc: string) -> string {
+    if idx >= len(topics) { return acc; };
+    if idx >= 256 { return acc; };
+    let t = trim(get(topics, idx));
+    let p_raw = if idx < len(problems) { trim(get(problems, idx)); } else { ""; };
+    let p = if len(p_raw) > 60 { substring(p_raw, 0, 60); } else { p_raw; };
+    let pair = if len(t) > 0 {
+        t + ":" + p;
+    } else {
+        if len(p) > 0 { ":" + p; } else { ""; };
+    };
+    let next = if len(pair) == 0 {
+        acc;
+    } else {
+        if len(acc) == 0 { pair; } else { acc + ", " + pair; };
+    };
+    return _join_topic_pairs(topics, problems, idx + 1, next);
+}
+
 fn _summarise_topic_buf(buf_raw: string, k: int) -> string {
     if len(buf_raw) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\ntry: a=json.loads(sys.argv[1])\nexcept Exception: a=[]\nif not isinstance(a,list): a=[]\nk=int(sys.argv[2])\nif k>0 and len(a)>k: a=a[-k:]\nparts=[]\nfor r in a:\n if not isinstance(r,dict): continue\n t=str(r.get(\"topic\",\"\")).strip()\n p=str(r.get(\"problem_summary\",\"\")).strip()\n if len(p)>60: p=p[:60]\n if t or p: parts.append(t+\":\"+p)\nprint(\", \".join(parts))' " + shell_escape(buf_raw) + " " + shell_escape(to_string(k));
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let all_topics = json_array_object_field_values(buf_raw, "topic");
+    let all_problems = json_array_object_field_values(buf_raw, "problem_summary");
+    let topics = _take_last_str(all_topics, k, 0, []);
+    let problems = _take_last_str(all_problems, k, 0, []);
+    return _join_topic_pairs(topics, problems, 0, "");
 }
 
 // _summarise_hitl_buf -- collapse the rolling feedback:hitl_rejects
@@ -171,10 +218,14 @@ fn _summarise_topic_buf(buf_raw: string, k: int) -> string {
 // `feedback:hitl_rejects` (#623 C).
 fn _summarise_hitl_buf(buf_raw: string, k: int) -> string {
     if len(buf_raw) == 0 { return ""; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\ntry: a=json.loads(sys.argv[1])\nexcept Exception: a=[]\nif not isinstance(a,list): a=[]\nk=int(sys.argv[2])\nif k>0 and len(a)>k: a=a[-k:]\nfreq={}\nfor r in a:\n if not isinstance(r,dict): continue\n c=str(r.get(\"class\",\"other\")) or \"other\"\n freq[c]=freq.get(c,0)+1\nitems=sorted(freq.items(), key=lambda kv:(-kv[1],kv[0]))\nfreq_s=\", \".join(\"%s:%d\" % (k,v) for k,v in items)\nlast=[]\nfor r in a[-3:]:\n if not isinstance(r,dict): continue\n ex=str(r.get(\"reason_excerpt\",\"\")).strip()\n if len(ex)>80: ex=ex[:80]\n if ex: last.append(ex)\nout=freq_s\nif last: out += \" | recent: \" + \" ;; \".join(last)\nprint(out)' " + shell_escape(buf_raw) + " " + shell_escape(to_string(k));
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let all_classes = json_array_object_field_values(buf_raw, "class");
+    let classes = _take_last_str(all_classes, k, 0, []);
+    let freq_s = string_list_freq_csv(classes, 0);
+    let all_excerpts = json_array_object_field_values(buf_raw, "reason_excerpt");
+    let recent_excerpts = _take_last_str(all_excerpts, 3, 0, []);
+    let recent_s = _join_excerpts(recent_excerpts, 0, 80, "");
+    if len(recent_s) == 0 { return freq_s; };
+    return freq_s + " | recent: " + recent_s;
 }
 
 // _pick_upstream_pid_by_key -- Phase 9 PR-A (#663) replica-safe pick.

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -744,12 +744,31 @@ fn _push_topic_history(bucket: string) -> int {
 // explorer can read it on the next tick and steer toward the
 // under-represented area. Empty / parse failure returns "" (caller
 // skips the hint write).
+// Tail-recursive helper: count occurrences of `needle` in `arr`.
+fn _count_str_in(arr: list<string>, needle: string, idx: int, acc: int) -> int {
+    if idx >= len(arr) { return acc; };
+    if idx >= 256 { return acc; };
+    let next = if get(arr, idx) == needle { acc + 1; } else { acc; };
+    return _count_str_in(arr, needle, idx + 1, next);
+}
+
 fn _sparsest_bucket() -> string {
     let raw = recall_latest("novelty:topic_history");
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nraw=sys.argv[1]\ntry: arr=json.loads(raw) if raw else []\nexcept Exception: arr=[]\nif not isinstance(arr,list): arr=[]\nbuckets=[\"group_theory\",\"combinatorics\",\"number_theory\",\"probability\",\"algebra\"]\ncounts={b:0 for b in buckets}\nfor x in arr:\n if isinstance(x,str) and x in counts: counts[x]+=1\n# Pick deterministically: lowest count, alpha-first on tie.\nmn=min(counts.values()) if counts else 0\ncands=sorted(b for b,c in counts.items() if c==mn)\nprint(cands[0] if cands else \"\")' " + shell_escape(raw);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    let arr = json_array_to_strings(raw);
+    // Count the 5 known buckets in alpha-first order so the tie-break
+    // picks the earliest bucket name (matches python `sorted(b for ...)`
+    // contract byte-for-byte).
+    let c_algebra        = _count_str_in(arr, "algebra", 0, 0);
+    let c_combinatorics  = _count_str_in(arr, "combinatorics", 0, 0);
+    let c_group_theory   = _count_str_in(arr, "group_theory", 0, 0);
+    let c_number_theory  = _count_str_in(arr, "number_theory", 0, 0);
+    let c_probability    = _count_str_in(arr, "probability", 0, 0);
+    let m = min_int(min_int(min_int(min_int(c_algebra, c_combinatorics), c_group_theory), c_number_theory), c_probability);
+    if c_algebra == m { return "algebra"; };
+    if c_combinatorics == m { return "combinatorics"; };
+    if c_group_theory == m { return "group_theory"; };
+    if c_number_theory == m { return "number_theory"; };
+    return "probability";
 }
 
 // _downgrade_verdict -- one-step verdict downgrade per #765 anti-attractor


### PR DESCRIPTION
Wave 7j colonies migration, companion to agentis v1.18.17.

## Migrations

4 sites collapsed via the new `string_list_freq_csv` + v1.18.16's `json_array_object_field_values`:

| File | Function | Shape |
|------|----------|-------|
| auditor.ag | `_summarise_hitl_buf` | freq by `class` + last 3 `reason_excerpt` joined `" ;; "` |
| formulator.ag | `_summarise_hitl_buf` | identical to auditor |
| formulator.ag | `_summarise_topic_buf` | `"topic:problem_summary[:60], ..."` pairs |
| novelty.ag | `_sparsest_bucket` | fixed 5-bucket count + alpha tie-break |

The auditor + formulator `_summarise_hitl_buf` use composition: `json_array_object_field_values("class")` → `_take_last_str(k)` → `string_list_freq_csv` for the freq CSV; then `json_array_object_field_values("reason_excerpt")` → `_take_last_str(3)` → `_join_excerpts` for the "recent: " suffix.

The formulator `_summarise_topic_buf` has a different output shape (pairs not freq) — migrated via two parallel field projections + `_join_topic_pairs` helper.

The novelty `_sparsest_bucket` chains 5 `_count_str_in` calls (one per known bucket) + `min_int` + alpha-first if-chain.

**Editor `_summarise_pitfall_buf` deferred** — needs `"\n"` separator instead of `", "` which the current substrate primitive does not support. Will revisit in a follow-up.

Final exec sh: 40 → **36**. Cumulative 520 → 36 = **93%**.

**Requires agentis v1.18.17.**

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] `grep -rE "exec sh " research-foundry/*/agents/*.ag | wc -l` → 36
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)