### PR TITLE
feat(research-foundry): migrate 8 compute + grep-check sites (Wave 7k)

### DIFF
--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -155,19 +155,19 @@ fn _publish_computer(
     // Wave 5 #911: file_write auto-creates parent dirs (sandbox-resolved).
     file_write(script_path, script.script);
 
-    let run_cmd = if lang == "gap" {
+    let output = if lang == "gap" {
+        // GAP compute path retained — Wave 7L will ship a parallel
+        // `compute_gap` substrate primitive. The python3 branch was
+        // migrated to substrate in Wave 7k (#786).
         // colony-lint: safe-exec-concat
-        "gap -q -b --norepl " + shell_escape(script_path) + " 2>&1";
+        let gap_cmd = "gap -q -b --norepl " + shell_escape(script_path) + " 2>&1";
+        try { exec sh gap_cmd; } catch e { ""; };
     } else {
-        // colony-lint: safe-exec-concat
-        "python3 " + shell_escape(script_path) + " 2>&1";
+        to_string(get(compute_python(script_path, 300000), "output"));
     };
-    let output = try { exec sh run_cmd; } catch e { ""; };
 
     let runs_ok = if len(script.expected_substring) > 0 {
-        // colony-lint: safe-exec-concat
-        let check_cmd = "printf '%s' " + shell_escape(output) + " | grep -F " + shell_escape(script.expected_substring) + " >/dev/null 2>&1 && printf yes || printf no";
-        let g = try { exec sh check_cmd; } catch e { "no"; };
+        let g = if index_of(output, script.expected_substring) >= 0 { "yes"; } else { "no"; };
         g == "yes";
     } else {
         len(output) > 0;
@@ -297,19 +297,19 @@ fn _publish_computer_rule_hit(
     let script_path = sandbox_eff + "/repro-" + self_pid + "-tick-" + to_string(upstream_tick) + ext;
     file_write(script_path, script_body);
 
-    let run_cmd = if lang == "gap" {
+    let output = if lang == "gap" {
+        // GAP compute path retained — Wave 7L will ship a parallel
+        // `compute_gap` substrate primitive. The python3 branch was
+        // migrated to substrate in Wave 7k (#786).
         // colony-lint: safe-exec-concat
-        "gap -q -b --norepl " + shell_escape(script_path) + " 2>&1";
+        let gap_cmd = "gap -q -b --norepl " + shell_escape(script_path) + " 2>&1";
+        try { exec sh gap_cmd; } catch e { ""; };
     } else {
-        // colony-lint: safe-exec-concat
-        "python3 " + shell_escape(script_path) + " 2>&1";
+        to_string(get(compute_python(script_path, 300000), "output"));
     };
-    let output = try { exec sh run_cmd; } catch e { ""; };
 
     let runs_ok = if len(expected_substring) > 0 {
-        // colony-lint: safe-exec-concat
-        let check_cmd = "printf '%s' " + shell_escape(output) + " | grep -F " + shell_escape(expected_substring) + " >/dev/null 2>&1 && printf yes || printf no";
-        let g = try { exec sh check_cmd; } catch e { "no"; };
+        let g = if index_of(output, expected_substring) >= 0 { "yes"; } else { "no"; };
         g == "yes";
     } else {
         len(output) > 0;

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -797,7 +797,11 @@ fn _publish_explorer_rule_hit(
     let t1_ms = now_ms();
     let output = to_string(get(compute_result, "output"));
     let exit_code_str = to_string(get(compute_result, "exit_code"));
-    let wall_clock_str = to_string((t1_ms - t0_ms) / 1000);
+    let wall_clock_ms = t1_ms - t0_ms;
+    let wall_clock_int = wall_clock_ms / 1000;
+    let wall_clock_frac = mod(wall_clock_ms, 1000) / 10;
+    let wall_clock_frac_pad = if wall_clock_frac < 10 { "0" + to_string(wall_clock_frac); } else { to_string(wall_clock_frac); };
+    let wall_clock_str = to_string(wall_clock_int) + "." + wall_clock_frac_pad;
     let compute_dir = sandbox_dir + "/compute";
     let compute_path = compute_dir + "/" + self_pid + ".jsonl";
     let compute_row = "{\"ts_ms\":" + to_string(tick_now_ms) + ",\"agent\":\"" + self_pid + "\",\"colony\":\"" + _colony_name + "\",\"tick\":" + to_string(tick_idx) + ",\"script\":\"explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py\",\"wall_clock_s\":" + wall_clock_str + ",\"exit_code\":" + exit_code_str + ",\"source\":\"rule-hit\"}";

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -792,16 +792,12 @@ fn _publish_explorer_rule_hit(
     // compute-spend column. `timeout 300s` mirrors the LLM path
     // (#867) for symmetric containment of a runaway cached rule.
     let script_path = sandbox_eff + "/explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py";
-    let time_file = sandbox_eff + "/.time-" + self_pid + "-tick-" + to_string(tick_idx);
-    // colony-lint: safe-exec-concat
-    let run_cmd = "/usr/bin/time -f '%e,%x' -o " + shell_escape(time_file) + " timeout 300s python3 " + shell_escape(script_path) + " 2>&1";
-    let output = try { exec sh run_cmd; } catch e { ""; };
-    // colony-lint: safe-exec-concat
-    let stats_cmd = "tail -1 " + shell_escape(time_file) + " 2>/dev/null";
-    let stats = try { exec sh stats_cmd; } catch e { ""; };
-    let comma_idx = index_of(stats, ",");
-    let wall_clock_str = if comma_idx > 0 { substring(stats, 0, comma_idx); } else { "0"; };
-    let exit_code_str = if comma_idx > 0 { substring(stats, comma_idx + 1, len(stats)); } else { "0"; };
+    let t0_ms = now_ms();
+    let compute_result = compute_python(script_path, 300000);
+    let t1_ms = now_ms();
+    let output = to_string(get(compute_result, "output"));
+    let exit_code_str = to_string(get(compute_result, "exit_code"));
+    let wall_clock_str = to_string((t1_ms - t0_ms) / 1000);
     let compute_dir = sandbox_dir + "/compute";
     let compute_path = compute_dir + "/" + self_pid + ".jsonl";
     let compute_row = "{\"ts_ms\":" + to_string(tick_now_ms) + ",\"agent\":\"" + self_pid + "\",\"colony\":\"" + _colony_name + "\",\"tick\":" + to_string(tick_idx) + ",\"script\":\"explore-" + self_pid + "-tick-" + to_string(tick_idx) + ".py\",\"wall_clock_s\":" + wall_clock_str + ",\"exit_code\":" + exit_code_str + ",\"source\":\"rule-hit\"}";

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -119,20 +119,13 @@ fn _run_lean_check(self_pid: string, upstream_tick: int, lean_source: string) ->
     };
     let run_output = try { exec sh run_cmd; } catch e { "__lean_exit=124__"; };
 
-    // colony-lint: safe-exec-concat
-    let has_error_cmd = "printf '%s' " + shell_escape(run_output) + " | grep -F 'error:' >/dev/null 2>&1 && printf yes || printf no";
-    let has_error = try { exec sh has_error_cmd; } catch e { "yes"; };
-
-    // colony-lint: safe-exec-concat
-    let timed_out_cmd = "printf '%s' " + shell_escape(run_output) + " | grep -F '__lean_exit=124__' >/dev/null 2>&1 && printf yes || printf no";
-    let timed_out = try { exec sh timed_out_cmd; } catch e { "no"; };
+    let has_error = if index_of(run_output, "error:") >= 0 { "yes"; } else { "no"; };
+    let timed_out = if index_of(run_output, "__lean_exit=124__") >= 0 { "yes"; } else { "no"; };
 
     if has_error == "yes" { return "failed"; };
     if timed_out == "yes" { return "failed"; };
 
-    // colony-lint: safe-exec-concat
-    let has_sorry_cmd = "printf '%s' " + shell_escape(lean_source) + " | grep -F 'sorry' >/dev/null 2>&1 && printf yes || printf no";
-    let has_sorry = try { exec sh has_sorry_cmd; } catch e { "yes"; };
+    let has_sorry = if index_of(lean_source, "sorry") >= 0 { "yes"; } else { "no"; };
 
     if has_sorry == "yes" { return "incomplete"; };
 
@@ -144,9 +137,7 @@ fn _run_lean_check(self_pid: string, upstream_tick: int, lean_source: string) ->
     // `lean_source` whose proposition slot is the unit-true type
     // (`: True :=` / `: True := by`) and surface as `incomplete` so the
     // auditor never reaches VERIFIED_BY_LEAN on a vacuous certificate.
-    // colony-lint: safe-exec-concat
-    let trivial_prop_cmd = "printf '%s' " + shell_escape(lean_source) + " | grep -E ': *True *:=' >/dev/null 2>&1 && printf yes || printf no";
-    let is_trivial_prop = try { exec sh trivial_prop_cmd; } catch e { "no"; };
+    let is_trivial_prop = if regex_match(": *True *:=", lean_source) { "yes"; } else { "no"; };
     if is_trivial_prop == "yes" { return "incomplete"; };
 
     return "verified";


### PR DESCRIPTION
Wave 7k colonies migration, companion to agentis v1.18.18.

## Migrations

8 sites migrated:

| File | Sites | Pattern |
|------|-------|---------|
| explorer.ag (rule-hit) | 2 | `run_cmd` + `stats_cmd` → `compute_python(script_path, 300000)` + `now_ms()` wall-clock |
| computer.ag (× 2 `_publish_*`) | 2 | python branch → `compute_python`; GAP branch retained as `exec sh gap_cmd` (deferred to Wave 7L) |
| computer.ag (× 2 `check_cmd`) | 2 | `grep -F substring` → `index_of(output, substring) >= 0` |
| theorist.ag (`has_error`/`timed_out`/`has_sorry`) | 3 | `grep -F` → `index_of` |
| theorist.ag (`trivial_prop`) | 1 | `grep -E` → `regex_match` |

The federation's python compute path now goes through the substrate `ComputePython` capability. The interpreter itself still runs (parallel to TeX Live for `compile_latex`), but the spawn is sandbox-resolved, fixed-argv, pipe-drained, timeout-gated.

**GAP and Lean compute paths remain on exec sh** pending Wave 7L follow-up (`compute_gap` + `compute_lean` substrate primitives, or LLM-emission target rewrite to `.ag` `eval_ag`).

Final exec sh: 36 → **28**. Cumulative 520 → 28 = **95%**.

**Requires agentis v1.18.18.**

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] `grep -rE "exec sh " research-foundry/*/agents/*.ag | wc -l` → 28
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)