### PR TITLE
feat(research-foundry): migrate 3 inline sites — novelty + scholar + oeis (Wave 7m)

### DIFF
--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -719,11 +719,15 @@ fn _topic_history_check(bucket: string) -> bool {
     if len(bucket) == 0 { return false; };
     let raw = recall_latest("novelty:topic_history");
     if len(raw) == 0 { return false; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nraw=sys.argv[1]\nbk=sys.argv[2]\ntry: arr=json.loads(raw) if raw else []\nexcept Exception: arr=[]\nif not isinstance(arr,list) or not arr:\n print(\"0\"); sys.exit(0)\nhits=sum(1 for x in arr if isinstance(x,str) and x==bk)\nshare=hits/len(arr)\nprint(\"1\" if share>0.4 else \"0\")' " + shell_escape(raw) + " " + shell_escape(bucket);
-    let out = try { exec sh cmd; } catch e { "0"; };
-    if out == "1" { return true; };
-    return false;
+    let arr = json_array_to_strings(raw);
+    let total = len(arr);
+    if total == 0 { return false; };
+    let hits = _count_str_in(arr, bucket, 0, 0);
+    // share = hits / total > 0.4 iff hits * 10 > total * 4 (integer math
+    // preserves the python threshold byte-for-byte for total <= 25; for
+    // larger buffers the integer round error is < 1 / total which is far
+    // below the 0.4 sensitivity).
+    return hits * 10 > total * 4;
 }
 
 // _push_topic_history -- append `bucket` to `novelty:topic_history` and

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -467,12 +467,8 @@ fn _oeis_canonical_ctx(topic_label: string, input_blob: string) -> string {
 // is a plain JSON STRING (decoded on the rule-hit path with json_get, NOT
 // get -- get is only for the lookup Map). Total on exec failure ("").
 fn _encode_sequences_action(sequences: Sequences) -> string {
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\no={\"sequences_json\":sys.argv[1],\"rationale\":sys.argv[2]}\nsys.stdout.write(json.dumps(o,separators=(\",\",\":\")))' "
-            + shell_escape(sequences.sequences_json) + " "
-            + shell_escape(sequences.rationale);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    return "{\"sequences_json\":\"" + json_escape_string(sequences.sequences_json)
+         + "\",\"rationale\":\"" + json_escape_string(sequences.rationale) + "\"}";
 }
 
 fn tick(reason: string) -> void {

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -464,12 +464,8 @@ fn _scholar_search_canonical_ctx(topic_label: string, input_blob: string) -> str
 // get -- get is only for the lookup Map). Total on exec failure
 // (returns "").
 fn _encode_queries_action(queries: Queries) -> string {
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\no={\"queries_json\":sys.argv[1],\"rationale\":sys.argv[2]}\nsys.stdout.write(json.dumps(o,separators=(\",\",\":\")))' "
-            + shell_escape(queries.queries_json) + " "
-            + shell_escape(queries.rationale);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    return "{\"queries_json\":\"" + json_escape_string(queries.queries_json)
+         + "\",\"rationale\":\"" + json_escape_string(queries.rationale) + "\"}";
 }
 
 fn tick(reason: string) -> void {


### PR DESCRIPTION
Wave 7m colonies migration, no substrate change required.

## Migrations

| File | Function | Migration |
|------|----------|-----------|
| novelty.ag | `_topic_history_check` | `json_array_to_strings` + `_count_str_in` + integer-math threshold (`hits * 10 > total * 4` iff `share > 0.4`) |
| scholar-search.ag | `_encode_queries_action` | `json_escape_string` + concat (2-field JSON) |
| oeis-search.ag | `_encode_sequences_action` | `json_escape_string` + concat (2-field JSON) |

The novelty integer-math threshold (`hits * 10 > total * 4`) is byte-equivalent to python `hits / len(arr) > 0.4` for `total <= 25` (the buffer caps at 50 entries; worst-case integer-divide round error < 0.02, well below the 0.4 sensitivity floor).

The scholar-search + oeis-search action encoders match the Wave 7i arxiv-search + groupprops-search pattern.

Final exec sh: 24 → **21**. Cumulative 520 → 21 = **96%**.

No new agentis-core dep — uses v1.18.16+ existing primitives.

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] `grep -rE "exec sh " research-foundry/*/agents/*.ag | wc -l` → 21
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)