### PR TITLE
feat(research-foundry): migrate 2 inline JSON-build sites (Wave 7q)

### DIFF
--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -442,17 +442,10 @@ fn _computer_canonical_ctx(prompt_ctx: string, upstream_tick: int) -> string {
 // path. Total on failure (returns a minimal stub so distill() still
 // gets a non-empty action).
 fn _script_action_json(language: string, script_body: string, expected_substring: string, rationale: string) -> string {
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json; print(json.dumps({\"language\":sys.argv[1],\"script\":sys.argv[2],\"expected_substring\":sys.argv[3],\"rationale\":sys.argv[4]},separators=(\",\",\":\")))' "
-            + shell_escape(language) + " "
-            + shell_escape(script_body) + " "
-            + shell_escape(expected_substring) + " "
-            + shell_escape(rationale);
-    let out = try { exec sh cmd; } catch e { ""; };
-    if len(out) == 0 {
-        return "{\"language\":\"python\",\"script\":\"\",\"expected_substring\":\"\",\"rationale\":\"\"}";
-    };
-    return out;
+    return "{\"language\":\"" + json_escape_string(language)
+         + "\",\"script\":\"" + json_escape_string(script_body)
+         + "\",\"expected_substring\":\"" + json_escape_string(expected_substring)
+         + "\",\"rationale\":\"" + json_escape_string(rationale) + "\"}";
 }
 
 // #742 TaskBoard accept helper. Claims one open task on the

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -448,17 +448,13 @@ fn _theorist_canonical_ctx(topic_label: string, input_blob: string) -> string {
 // Map). Total on exec failure (returns "").
 fn _encode_draft_action(draft: Draft, lean_source: string, lean_verdict: string) -> string {
     let hedge_str = if draft.hedge_required { "true"; } else { "false"; };
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\no={\"definitions_tex\":sys.argv[1],\"main_tex\":sys.argv[2],\"proof_kind\":sys.argv[3],\"hedge_required\":(sys.argv[4]==\"true\"),\"rationale\":sys.argv[5],\"lean_source\":sys.argv[6],\"lean_verdict\":sys.argv[7]}\nsys.stdout.write(json.dumps(o,separators=(\",\",\":\")))' "
-            + shell_escape(draft.definitions_tex) + " "
-            + shell_escape(draft.main_tex) + " "
-            + shell_escape(draft.proof_kind) + " "
-            + shell_escape(hedge_str) + " "
-            + shell_escape(draft.rationale) + " "
-            + shell_escape(lean_source) + " "
-            + shell_escape(lean_verdict);
-    let out = try { exec sh cmd; } catch e { ""; };
-    return out;
+    return "{\"definitions_tex\":\"" + json_escape_string(draft.definitions_tex)
+         + "\",\"main_tex\":\"" + json_escape_string(draft.main_tex)
+         + "\",\"proof_kind\":\"" + json_escape_string(draft.proof_kind)
+         + "\",\"hedge_required\":" + hedge_str
+         + ",\"rationale\":\"" + json_escape_string(draft.rationale)
+         + "\",\"lean_source\":\"" + json_escape_string(lean_source)
+         + "\",\"lean_verdict\":\"" + json_escape_string(lean_verdict) + "\"}";
 }
 
 // _publish_theorist_rule_hit -- mirror of _publish_theorist but takes


### PR DESCRIPTION
Wave 7q colonies migration. No new agentis builtin required — pure substrate-already-shipped migration.

## Migrations

| File | Function | Old | New |
|------|----------|-----|-----|
| `research-foundry/computer/agents/computer.ag` | `_script_action_json` (4 fields) | `python3 -c 'json.dumps(...)'` via `exec sh` | `json_escape_string` + concat |
| `research-foundry/theorist/agents/theorist.ag` | `_encode_draft_action` (7 fields, bool `hedge_required`) | `python3 -c 'json.dumps(...)'` via `exec sh` | `json_escape_string` + concat + unquoted bool literal |

Same pattern as Wave 7p `_encode_verdict_action` in reviewer.ag. The `hedge_required` bool is preserved as an unquoted JSON literal (`true` / `false`) by inserting `hedge_str` between unquoted delimiters — matches python `json.dumps(bool)` output.

Field order matches the original python dict insertion order, so the crystallized rule action is byte-identical for ASCII inputs and `json.loads`-equivalent for unicode (same drift documented in Wave 7p).

## Stats

Real exec sh: **13 → 11**. Cumulative Waves 1-7q: 520 → 11 = **97.9%**.

**Requires agentis v1.18.20** (same floor as Wave 7p — `json_escape_string` shipped pre-v1.18.0, no new builtin in this PR).

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] real exec sh count drops by exactly 2 (13 → 11)
- [ ] CI green
- [ ] QA verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)