### PR TITLE
feat(research-foundry): migrate submitter _encode_metadata_action (Wave 7s)

### DIFF
--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -1009,19 +1009,14 @@ fn _encode_metadata_action(
     ai_disclosure: string,
     rationale: string
 ) -> string {
-    // colony-lint: safe-exec-concat
-    let cmd = "python3 -c 'import sys,json\nm={\"title\":sys.argv[1],\"abstract_clean\":sys.argv[2],\"msc_codes_csv\":sys.argv[3],\"arxiv_category\":sys.argv[4],\"cross_list_csv\":sys.argv[5],\"cover_letter\":sys.argv[6],\"ai_disclosure\":sys.argv[7],\"rationale\":sys.argv[8]}\nsys.stdout.write(json.dumps(m,separators=(\",\",\":\")))' "
-        + shell_escape(title) + " "
-        + shell_escape(abstract_clean) + " "
-        + shell_escape(msc_codes_csv) + " "
-        + shell_escape(arxiv_category) + " "
-        + shell_escape(cross_list_csv) + " "
-        + shell_escape(cover_letter) + " "
-        + shell_escape(ai_disclosure) + " "
-        + shell_escape(rationale);
-    let out = try { exec sh cmd; } catch e { "{}"; };
-    if len(out) == 0 { return "{}"; };
-    return out;
+    return "{\"title\":\"" + json_escape_string(title)
+         + "\",\"abstract_clean\":\"" + json_escape_string(abstract_clean)
+         + "\",\"msc_codes_csv\":\"" + json_escape_string(msc_codes_csv)
+         + "\",\"arxiv_category\":\"" + json_escape_string(arxiv_category)
+         + "\",\"cross_list_csv\":\"" + json_escape_string(cross_list_csv)
+         + "\",\"cover_letter\":\"" + json_escape_string(cover_letter)
+         + "\",\"ai_disclosure\":\"" + json_escape_string(ai_disclosure)
+         + "\",\"rationale\":\"" + json_escape_string(rationale) + "\"}";
 }
 
 // _decode_action_field -- read one field out of the faithful Metadata

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -995,10 +995,10 @@ fn _submitter_canonical_ctx(
 // output into the rule action slot. Unlike the verdict colonies (which
 // pipe-encode only a discrete field), the submitter is generative, so the
 // rule action carries ALL eight Metadata fields as a JSON object the
-// Stage-1 path can losslessly reconstruct. Routed through python3
-// json.dumps so quotes / newlines / control characters in the LLM-emitted
-// title / abstract / cover letter cannot corrupt the action string. Total
-// on a serialize failure (returns "{}").
+// Stage-1 path can losslessly reconstruct. Built inline via
+// json_escape_string + concat so quotes / newlines / control characters
+// in the LLM-emitted title / abstract / cover letter cannot corrupt the
+// action string. Total on every input (json_escape_string is total).
 fn _encode_metadata_action(
     title: string,
     abstract_clean: string,


### PR DESCRIPTION
Wave 7s colonies migration. No new agentis builtin required — pure substrate-already-shipped migration.

## Migration

| File | Function | Old | New |
|------|----------|-----|-----|
| `research-foundry/submitter/agents/submitter.ag` | `_encode_metadata_action` (8 string fields) | `python3 -c 'json.dumps(...)'` via `exec sh` | `json_escape_string` + concat |

Same pattern as Wave 7q (`_script_action_json`, `_encode_draft_action`) and Wave 7p (`_encode_verdict_action`). Field order matches python dict insertion: title, abstract_clean, msc_codes_csv, arxiv_category, cross_list_csv, cover_letter, ai_disclosure, rationale.

Byte-identical to python for ASCII inputs; `json.loads`-equivalent for unicode (same drift documented in Wave 7p / 7q PRs).

## Stats

Real exec sh: **9 → 8**. Cumulative Waves 1-7s: 520 → 8 = **98.5%**.

**Requires agentis >= v1.18.20** (no new builtin in this PR; floor unchanged from current main pin v1.18.21).

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] real exec sh count drops by exactly 1 (9 → 8)
- [ ] CI green
- [ ] QA verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)