### PR TITLE
feat(research-foundry): final 3 submitter sites — 520 → 0 = 100% (Wave 7v)

### DIFF
--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -382,9 +382,8 @@ fn _submitter_stage_and_publish(
     // helper rather than the .ag DSL (no TOML in DSL).
     let author_cfg_path = getenv("PREPRINT_AUTHOR_CONFIG");
     let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };
-    // colony-lint: safe-exec-concat
-    let authors_cmd = "python3 -c 'import sys\ntry:\n import tomllib\nexcept Exception:\n import tomli as tomllib\ntry:\n with open(sys.argv[1],\"rb\") as f: d=tomllib.load(f)\nexcept Exception:\n print(\"AUTHOR-PLACEHOLDER <author@example.org>\"); sys.exit(0)\nauthors=d.get(\"authors\") or []\nout=[]\nfor a in authors:\n name=a.get(\"name\",\"AUTHOR-PLACEHOLDER\"); email=a.get(\"email\",\"\")\n if email: out.append(name+\" <\"+email+\">\")\n else: out.append(name)\nprint(\"; \".join(out) if out else \"AUTHOR-PLACEHOLDER\")' " + shell_escape(author_cfg_eff);
-    let authors_line = try { exec sh authors_cmd; } catch e { "AUTHOR-PLACEHOLDER"; };
+    let authors_result = compute_python_args("/run-root/tools/parse-authors.py", [author_cfg_eff], 30000);
+    let authors_line = to_string(get(authors_result, "output"));
 
     // Build arxiv-metadata.json into the claim dir.
     let cover_full = m_cover_letter + "\n\n--- AI assistance disclosure ---\n" + m_ai_disclosure + "\n";
@@ -405,9 +404,7 @@ fn _submitter_stage_and_publish(
     let _so = try { file_write(claim_dir + "/reproducibility-output.txt", repro_output); "ok"; } catch e { ""; };
 
     // Package submission tarball.
-    // colony-lint: safe-exec-concat
-    let tar_cmd = "cd " + shell_escape(claim_dir) + " && tar -czf submission.tar.gz main.tex refs.bib reproducibility" + ext + " reproducibility-output.txt arxiv-metadata.json 2>&1 || true";
-    let _tar = try { exec sh tar_cmd; } catch e { ""; };
+    let _tar = compute_python_args("/run-root/tools/make-submission-tarball.py", [claim_dir, ext], 30000);
 
     // Write DRAFTED row to preprint-ledger.jsonl. Row construction is
     // routed through python3 json.dumps so quotes / newlines / control
@@ -870,14 +867,11 @@ fn _submitter_send_phase(
     let from_addr = getenv("PREPRINT_ARXIV_FROM");
     let gateway_eff = if len(gateway) > 0 { gateway; } else { "submit@arxiv.org"; };
     let from_eff = if len(from_addr) > 0 { from_addr; } else { "AUTHOR-PLACEHOLDER@example.org"; };
-    // colony-lint: safe-exec-concat
-    let send_cmd = "python3 -c 'import smtplib, ssl, sys, email.message, os\nm=email.message.EmailMessage()\nm[\"Subject\"]=\"arXiv submission: \"+sys.argv[1]\nm[\"From\"]=sys.argv[2]\nm[\"To\"]=sys.argv[3]\nwith open(sys.argv[4],\"r\") as f: cover=f.read()\nm.set_content(cover)\nwith open(sys.argv[5],\"rb\") as f: data=f.read()\nm.add_attachment(data, maintype=\"application\", subtype=\"gzip\", filename=\"submission.tar.gz\")\nhost=os.environ.get(\"PREPRINT_SMTP_HOST\",\"localhost\")\nport=int(os.environ.get(\"PREPRINT_SMTP_PORT\",\"25\"))\ntry:\n s=smtplib.SMTP(host,port,timeout=30); s.send_message(m); s.quit(); print(\"sent\")\nexcept Exception as e:\n print(\"smtp-error:\"+str(e))' "
-            + shell_escape(claim_id_eff) + " "
-            + shell_escape(from_eff) + " "
-            + shell_escape(gateway_eff) + " "
-            + shell_escape(claim_dir + "/arxiv-metadata.json") + " "
-            + shell_escape(claim_dir + "/submission.tar.gz");
-    let send_out = try { exec sh send_cmd; } catch e { "smtp-error:exec-failed"; };
+    let send_result = compute_python_args("/run-root/tools/send-arxiv-email.py",
+        [claim_id_eff, from_eff, gateway_eff,
+         claim_dir + "/arxiv-metadata.json",
+         claim_dir + "/submission.tar.gz"], 60000);
+    let send_out = to_string(get(send_result, "output"));
 
     let ledger_path2 = getenv("DISCOVERY_LEDGER");
     if len(ledger_path2) > 0 {

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -383,7 +383,7 @@ fn _submitter_stage_and_publish(
     let author_cfg_path = getenv("PREPRINT_AUTHOR_CONFIG");
     let author_cfg_eff = if len(author_cfg_path) > 0 { author_cfg_path; } else { "/run-root/config/authors.toml"; };
     let authors_result = compute_python_args("/run-root/tools/parse-authors.py", [author_cfg_eff], 30000);
-    let authors_line = to_string(get(authors_result, "output"));
+    let authors_line = trim(to_string(get(authors_result, "output")));
 
     // Build arxiv-metadata.json into the claim dir.
     let cover_full = m_cover_letter + "\n\n--- AI assistance disclosure ---\n" + m_ai_disclosure + "\n";
@@ -871,7 +871,7 @@ fn _submitter_send_phase(
         [claim_id_eff, from_eff, gateway_eff,
          claim_dir + "/arxiv-metadata.json",
          claim_dir + "/submission.tar.gz"], 60000);
-    let send_out = to_string(get(send_result, "output"));
+    let send_out = trim(to_string(get(send_result, "output")));
 
     let ledger_path2 = getenv("DISCOVERY_LEDGER");
     if len(ledger_path2) > 0 {

--- a/research-foundry/tools/make-submission-tarball.py
+++ b/research-foundry/tools/make-submission-tarball.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Build the arXiv submission tarball from a claim directory.
+
+Usage: make-submission-tarball.py <claim_dir> <reproducibility_ext>
+
+Creates `<claim_dir>/submission.tar.gz` containing the canonical
+arXiv submission file set, with all paths flattened to the basename
+inside the archive (no `<claim_dir>/` prefix in the entries — matches
+the legacy `cd <claim_dir> && tar -czf ...` shell-out contract).
+
+`reproducibility_ext` is the .ag-side extension chooser — either `.py`
+(compute_python runs) or `.g` (compute_gap runs) — so the entry is
+named `reproducibility.py` or `reproducibility.g` to match the
+upstream language.
+
+Total: missing files are silently skipped (the legacy `tar ... || true`
+swallowed any tar error). Returns exit_code 0 on success or partial
+success, non-zero only on catastrophic OS failure (claim_dir absent).
+
+Extracted from inline `tar -czf ...` shell command in submitter.ag for
+Wave 7v of the exec-sh purge — substrate has no tar primitive, but
+python stdlib `tarfile` covers the use case without a new builtin.
+"""
+
+import os
+import sys
+import tarfile
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        sys.stderr.write("usage: make-submission-tarball.py <claim_dir> <repro_ext>\n")
+        return 2
+    claim_dir = argv[1]
+    repro_ext = argv[2]
+    if not os.path.isdir(claim_dir):
+        sys.stderr.write(f"claim_dir not a directory: {claim_dir}\n")
+        return 1
+    members = [
+        "main.tex",
+        "refs.bib",
+        f"reproducibility{repro_ext}",
+        "reproducibility-output.txt",
+        "arxiv-metadata.json",
+    ]
+    archive_path = os.path.join(claim_dir, "submission.tar.gz")
+    with tarfile.open(archive_path, "w:gz") as tar:
+        for name in members:
+            src = os.path.join(claim_dir, name)
+            if os.path.isfile(src):
+                tar.add(src, arcname=name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/research-foundry/tools/parse-authors.py
+++ b/research-foundry/tools/parse-authors.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Parse authors.toml and print an arXiv-metadata "authors" line.
+
+Usage: parse-authors.py <authors.toml>
+
+Reads the [[authors]] array from the supplied TOML file and emits a
+single semicolon-separated line of `Name <email>` entries (email
+omitted when absent). On missing / unparseable / empty TOML, prints
+the placeholder `AUTHOR-PLACEHOLDER <author@example.org>` and exits 0
+so the submitter pipeline never crashes on operator-side config
+mistakes — same idempotent contract as substitute-author.py.
+
+Extracted from inline `python3 -c '...'` in submitter.ag for Wave 7v
+of the exec-sh purge (agentis substrate `compute_python_args` cannot
+take an inline -c string; it requires a script path on disk).
+"""
+
+import sys
+
+try:
+    import tomllib
+except Exception:  # pragma: no cover - py < 3.11 fallback
+    try:
+        import tomli as tomllib
+    except Exception:
+        print("AUTHOR-PLACEHOLDER <author@example.org>")
+        sys.exit(0)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("AUTHOR-PLACEHOLDER <author@example.org>")
+        return 0
+    try:
+        with open(argv[1], "rb") as f:
+            d = tomllib.load(f)
+    except Exception:
+        print("AUTHOR-PLACEHOLDER <author@example.org>")
+        return 0
+    authors = d.get("authors") or []
+    out: list[str] = []
+    for a in authors:
+        name = a.get("name", "AUTHOR-PLACEHOLDER")
+        email = a.get("email", "")
+        if email:
+            out.append(f"{name} <{email}>")
+        else:
+            out.append(name)
+    print("; ".join(out) if out else "AUTHOR-PLACEHOLDER")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/research-foundry/tools/send-arxiv-email.py
+++ b/research-foundry/tools/send-arxiv-email.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Email the arXiv submission tarball + cover letter via SMTP.
+
+Usage: send-arxiv-email.py <claim_id> <from_addr> <to_addr> <cover_path> <tarball_path>
+
+Reads the cover letter from `cover_path` and the tarball from
+`tarball_path`, constructs a single `email.message.EmailMessage` with
+Subject `"arXiv submission: <claim_id>"`, attaches the tarball as
+`application/gzip` named `submission.tar.gz`, and sends via SMTP to
+the host/port from `PREPRINT_SMTP_HOST` (default `localhost`) and
+`PREPRINT_SMTP_PORT` (default `25`).
+
+On success prints `sent` to stdout; on any failure prints
+`smtp-error:<exception>` to stdout. Always exits 0 so the submitter
+pipeline can read the result line and persist it to the ledger
+verbatim — matches the legacy contract: the shell-out's `catch e {
+"smtp-error:exec-failed"; }` and the inline python's `print("smtp-
+error:"+str(e))` are interchangeable from the caller's perspective.
+
+Extracted from inline `python3 -c '...'` in submitter.ag for Wave 7v
+of the exec-sh purge (agentis substrate `compute_python_args` cannot
+take an inline -c string; it requires a script path on disk).
+"""
+
+import email.message
+import os
+import smtplib
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 6:
+        print("smtp-error:usage")
+        return 0
+    claim_id = argv[1]
+    from_addr = argv[2]
+    to_addr = argv[3]
+    cover_path = argv[4]
+    tarball_path = argv[5]
+    m = email.message.EmailMessage()
+    m["Subject"] = f"arXiv submission: {claim_id}"
+    m["From"] = from_addr
+    m["To"] = to_addr
+    try:
+        with open(cover_path, "r") as f:
+            cover = f.read()
+        m.set_content(cover)
+        with open(tarball_path, "rb") as f:
+            data = f.read()
+        m.add_attachment(
+            data,
+            maintype="application",
+            subtype="gzip",
+            filename="submission.tar.gz",
+        )
+        host = os.environ.get("PREPRINT_SMTP_HOST", "localhost")
+        port = int(os.environ.get("PREPRINT_SMTP_PORT", "25"))
+        s = smtplib.SMTP(host, port, timeout=30)
+        s.send_message(m)
+        s.quit()
+        print("sent")
+    except Exception as e:
+        print(f"smtp-error:{e}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
🎯 **The final wave.** Pure colonies migration — no new agentis builtin required.

## Summary

The last 3 `exec sh` sites in the federation are all in submitter.ag and all wrap an inline `python3 -c '<multi-line script>'` invocation. `compute_python_args` (shipped Wave 7u in agentis v1.18.23) cannot take an inline `-c` string — it requires a script path on disk. So this PR extracts the 3 inline scripts to standalone tool files and migrates the call sites.

## New tools

| File | Purpose |
|------|---------|
| `research-foundry/tools/parse-authors.py` | Parse `authors.toml` → emit `"Name <email>; ..."` line. Idempotent on missing/unparseable config (prints `AUTHOR-PLACEHOLDER <author@example.org>` and exits 0). |
| `research-foundry/tools/make-submission-tarball.py` | Build `<claim_dir>/submission.tar.gz` containing the 5 arXiv submission files. Uses python stdlib `tarfile.open("w:gz")` (same gzip POSIX tar output as the legacy `tar -czf` shell — no operator-visible delta). |
| `research-foundry/tools/send-arxiv-email.py` | Assemble `email.message.EmailMessage` with cover letter body + gzipped tarball attachment; send via `smtplib.SMTP(host, port)` from `PREPRINT_SMTP_HOST` / `PREPRINT_SMTP_PORT` env. Prints `sent` on success or `smtp-error:<exc>` on failure. |

All 3 preserve the legacy contracts: idempotent, total, print result line to stdout, never crash the pipeline. `tools/run-research.sh:1052` already `cp -r`'s the full `tools/` tree into `/run-root/tools/` at container startup, so the new scripts are picked up automatically.

## Migrations

| Site (submitter.ag) | Old | New |
|---------------------|-----|-----|
| Line 387 `authors_cmd` | `python3 -c '...tomllib...' <cfg>` via `exec sh` | `compute_python_args("/run-root/tools/parse-authors.py", [author_cfg_eff], 30000)` |
| Line 410 `tar_cmd` | `cd <dir> && tar -czf ...` via `exec sh` | `compute_python_args("/run-root/tools/make-submission-tarball.py", [claim_dir, ext], 30000)` |
| Line 880 `send_cmd` | `python3 -c '...smtplib...' <args...>` via `exec sh` | `compute_python_args("/run-root/tools/send-arxiv-email.py", [claim_id_eff, from_eff, gateway_eff, ..., ...], 60000)` |

The `try { exec sh ... } catch e { "fallback"; }` wrappers drop away because `compute_python_args` is total — errors surface as `{exit_code, output}` map entries and the callers read `output` directly (matches the legacy stdout-capture contract).

## Containerfile

No bump needed. Pin remains at v1.18.23 (from Wave 7u). This PR adds no new substrate primitives.

## Stats

Real exec sh: **3 → 0**. Cumulative Waves 1-7v: **520 → 0 = 100%**.

🏁 **Goal achieved**: `dotahni ten ukol zbaveni se pythonu do konce!` — every `exec sh` site in the federation that previously shelled out to python3 (or any other binary) is now either substrate-managed (`compute_python_args`, `compute_python`, `compute_gap`, `compute_lean`, `compile_latex`) or inlined as pure `.ag` (`json_escape_string` + concat, `sha256_hex`, `base64_encode`/`base64_decode`, `string_list_freq_csv`, `levenshtein_similarity`, `json_array_object_field_values`, `json_array_append_truncate`, `regex_*`, `trim` / `to_lower`, `memo_list`, `factorial`, `knowledge_export`, `mkdir` / `file_exists`).

The python3 interpreter still runs (the substrate wraps it via `compute_python_args` for fixed pre-installed tools), but no `.ag` agent shells out to it anymore. Capability gating (`CapKind::ComputePython` byte 0x13) and CB economy (50 per call) now control the full surface.

**Requires agentis v1.18.23.**

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [x] real exec sh count drops by exactly 3 (3 → 0)
- [x] python syntax check on 3 new tool scripts (`python3 -m py_compile`)
- [x] Containerfile pin unchanged (v1.18.23 already shipped compute_python_args)
- [ ] CI green
- [ ] QA verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)