### PR TITLE
fix(research-foundry): bump 8 underbudgeted agent CB to 200M (Wave 8a)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -21,7 +21,7 @@
 // Run as daemon: agentis daemon agents/arxiv-search.ag --colony arxiv-search
 // Requires: exec capability (curl + python3), messaging capability.
 
-cb 2000;
+cb 200000000;
 
 type Queries {
     queries_json: string,

--- a/research-foundry/arxiv-search/config/colony.example.toml
+++ b/research-foundry/arxiv-search/config/colony.example.toml
@@ -30,5 +30,5 @@ max_query_results = 10
 [[agents]]
 name = "arxiv-search"
 source = "agents/arxiv-search.ag"
-cb_budget = 2000
+cb_budget = 200000000
 tick_interval_ms = 120000

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -23,7 +23,7 @@
 // Run as daemon: agentis daemon agents/editor.ag --colony editor
 // Requires: exec capability (latexmk + pdflatex), messaging.
 
-cb 2000;
+cb 200000000;
 
 type Edit {
     full_tex: string,

--- a/research-foundry/editor/config/colony.example.toml
+++ b/research-foundry/editor/config/colony.example.toml
@@ -29,5 +29,5 @@ latexmk_max_passes = 3
 [[agents]]
 name = "editor"
 source = "agents/editor.ag"
-cb_budget = 2000
+cb_budget = 200000000
 tick_interval_ms = 240000

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -18,7 +18,7 @@
 //   agentis daemon agents/groupprops-search.ag --colony groupprops-search
 // Requires: exec capability (curl + python3), messaging capability.
 
-cb 2000;
+cb 200000000;
 
 type Queries {
     queries_json: string,

--- a/research-foundry/groupprops-search/config/colony.example.toml
+++ b/research-foundry/groupprops-search/config/colony.example.toml
@@ -26,5 +26,5 @@ max_queries = 5
 [[agents]]
 name = "groupprops-search"
 source = "agents/groupprops-search.ag"
-cb_budget = 2000
+cb_budget = 200000000
 tick_interval_ms = 120000

--- a/research-foundry/introducer/agents/introducer.ag
+++ b/research-foundry/introducer/agents/introducer.ag
@@ -20,7 +20,7 @@
 // Run as daemon: agentis daemon agents/introducer.ag --colony introducer
 // Requires: exec capability, messaging capability.
 
-cb 2000;
+cb 200000000;
 
 type Draft {
     abstract_tex: string,

--- a/research-foundry/introducer/config/colony.example.toml
+++ b/research-foundry/introducer/config/colony.example.toml
@@ -29,5 +29,5 @@ abstract_target_words = 150
 [[agents]]
 name = "introducer"
 source = "agents/introducer.ag"
-cb_budget = 2000
+cb_budget = 200000000
 tick_interval_ms = 180000

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -18,7 +18,7 @@
 // Run as daemon: agentis daemon agents/oeis-search.ag --colony oeis-search
 // Requires: exec capability (curl + python3), messaging capability.
 
-cb 2000;
+cb 200000000;
 
 type Sequences {
     sequences_json: string,

--- a/research-foundry/oeis-search/config/colony.example.toml
+++ b/research-foundry/oeis-search/config/colony.example.toml
@@ -26,5 +26,5 @@ max_sequences = 5
 [[agents]]
 name = "oeis-search"
 source = "agents/oeis-search.ag"
-cb_budget = 2000
+cb_budget = 200000000
 tick_interval_ms = 120000

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -34,7 +34,7 @@
 // Run as daemon: agentis daemon agents/prior_advocate.ag --colony prior_advocate
 // Requires: exec capability, messaging capability.
 
-cb 2000;
+cb 200000000;
 
 type Verdict {
     is_prior: bool,

--- a/research-foundry/prior_advocate/config/colony.example.toml
+++ b/research-foundry/prior_advocate/config/colony.example.toml
@@ -26,5 +26,5 @@ backend = "cli"
 [[agents]]
 name = "prior_advocate"
 source = "agents/prior_advocate.ag"
-cb_budget = 2000
+cb_budget = 200000000
 tick_interval_ms = 60000

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -21,7 +21,7 @@
 //   agentis daemon agents/scholar-search.ag --colony scholar-search
 // Requires: exec capability (curl + python3), messaging capability.
 
-cb 2000;
+cb 200000000;
 
 type Queries {
     queries_json: string,

--- a/research-foundry/scholar-search/config/colony.example.toml
+++ b/research-foundry/scholar-search/config/colony.example.toml
@@ -26,5 +26,5 @@ max_queries = 3
 [[agents]]
 name = "scholar-search"
 source = "agents/scholar-search.ag"
-cb_budget = 2000
+cb_budget = 200000000
 tick_interval_ms = 120000

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -16,7 +16,7 @@
 // Run as daemon: agentis daemon agents/theorist.ag --colony theorist
 // Requires: exec capability, messaging capability.
 
-cb 2000;
+cb 200000000;
 
 type Draft {
     definitions_tex: string,

--- a/research-foundry/theorist/config/colony.example.toml
+++ b/research-foundry/theorist/config/colony.example.toml
@@ -27,5 +27,5 @@ hedge_on_computational = true
 [[agents]]
 name = "theorist"
 source = "agents/theorist.ag"
-cb_budget = 2000
+cb_budget = 200000000
 tick_interval_ms = 180000


### PR DESCRIPTION
## Summary

Companion to the Wave 7v finish line. 10-tick test run of agentis v1.18.23 with all exec-sh sites purged produced **0 preprints, 0 discoveries, 0 audits** despite agents ticking 5-50 times each. Per-agent log tail revealed editor (and 7 sibling agents) dying at the end of every tick with:

```
[tick:error] CognitiveOverload: budget 0, required 1
  at: operation costing 1 CB
  Hint: remaining budget: 0, initial: 2000
```

`initial: 2000` was the smoking gun — those 8 agents had their `cb` header at the scaffold-default 2000 from #639 (e421465) and were never bumped when the 10 production agents were raised to 200_000_000 in #861 (aa2b86d).

## Diagnosis

- In-process picker chain (`memo_list` + `_pick_max_tick_recurse` + `_pick_collect_mids_recurse`) alone costs ~4_000 CB at the 256-key cap. That's 2× the 2000 budget before any other work happens.
- `prompt()` LLM call costs thousands more.
- `compile_latex`, `recall_latest`, `memo_write`, `learn` each add hundreds.
- 2000 CB / tick was structurally impossible — the 8 affected agents were silently dying mid-tick the moment any non-trivial branch ran.

## Fix

Bump `cb <N>;` in `.ag` and matching `cb_budget = <N>` in `config/colony.example.toml` for all 8 agents from `2000` → `200_000_000`, matching the 10 sibling agents that have been working in production.

| Agent | Was | Now |
|-------|-----|-----|
| arxiv-search | 2000 | 200_000_000 |
| editor | 2000 | 200_000_000 |
| groupprops-search | 2000 | 200_000_000 |
| introducer | 2000 | 200_000_000 |
| oeis-search | 2000 | 200_000_000 |
| prior_advocate | 2000 | 200_000_000 |
| scholar-search | 2000 | 200_000_000 |
| theorist | 2000 | 200_000_000 |

The 10 untouched agents (auditor, computer, explorer, formulator, noticer, novelty, reviewer, skeptic, submitter, verifier) already run at 200_000_000.

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [ ] CI green
- [ ] Companion 10-tick run on the patched federation produces > 0 ledger rows in at least one of {preprint, audit, discovery}

🤖 Generated with [Claude Code](https://claude.com/claude-code)