### PR TITLE
fix(noticer): rename idx → pos in _parse_rule_action_desc (Wave 8d)

### DIFF
--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -513,9 +513,9 @@ fn _parse_rule_action_bool(action: string) -> bool {
 
 fn _parse_rule_action_desc(action: string) -> string {
     if len(action) == 0 { return ""; };
-    let idx = index_of(action, "|");
-    if idx < 0 { return ""; };
-    return substring(action, idx + 1, len(action));
+    let pos = index_of(action, "|");
+    if pos < 0 { return ""; };
+    return substring(action, pos + 1, len(action));
 }
 
 // #841: _canonical_stable_desc derives a DETERMINISTIC description from


### PR DESCRIPTION
## Summary

One more instance of the Wave 8b (#936) idx-shadow pattern. `noticer.ag:514`'s `_parse_rule_action_desc` declares `let idx = index_of(action, "|")` and is called from the Stage-1 rule-hit body. When the call sits on a stack frame whose ancestor has parameter `idx: int`, the runtime overwrites the ancestor's `idx` — same root cause as Wave 8b.

20-tick verification run (post-Wave 8c) showed noticer was the only of 18 agents still emitting picker errors (53 occurrences). All other 17 agents are clean.

Fix: mechanical `idx → pos` rename inside the function body. 3 lines changed, no semantic change, no other call sites, no other agent files affected.

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [ ] CI green
- [ ] follow-up: 20-tick run shows noticer at 0 errors (full federation 18/18 clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)