### PR TITLE
fix(research-foundry): host-side sandbox path consistency (Wave 8f / closes #938)

### DIFF
--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -736,10 +736,10 @@ if [ "$DRY_RUN" = "0" ]; then
     # `laptop-node/`. `ln -sf` with relative targets keeps the run dir
     # relocatable. The container bootstrap at lines below truncates the
     # actual files inside /run-root, which is the symlink target.
-    ln -sf laptop-node/discovery-ledger.jsonl "$DISCOVERY_LEDGER"
-    ln -sf laptop-node/audit-ledger.jsonl "$AUDIT_LEDGER"
-    ln -sf laptop-node/preprint-ledger.jsonl "$PREPRINT_LEDGER"
-    ln -sf laptop-node/replication-ledger.jsonl "$REPLICATION_LEDGER"
+    ln -sf laptop-node/.agentis/sandbox/discovery-ledger.jsonl "$DISCOVERY_LEDGER"
+    ln -sf laptop-node/.agentis/sandbox/audit-ledger.jsonl "$AUDIT_LEDGER"
+    ln -sf laptop-node/.agentis/sandbox/preprint-ledger.jsonl "$PREPRINT_LEDGER"
+    ln -sf laptop-node/.agentis/sandbox/replication-ledger.jsonl "$REPLICATION_LEDGER"
 fi
 
 # #825 follow-up: under default LLM_BACKEND=claude with per-tier routing
@@ -1080,10 +1080,10 @@ write_bootstrap() {
         printf 'chmod 600 /run-root/.agentis/identity/private.key 2>/dev/null || true\n'
         printf 'if [ -d /repo/research-foundry/data/papers ]; then cp -r /repo/research-foundry/data/papers /run-root/data/papers; fi\n'
         printf 'if [ -f /repo/research-foundry/config/authors.toml ]; then cp /repo/research-foundry/config/authors.toml /run-root/config/authors.toml; fi\n'
-        printf ': > /run-root/discovery-ledger.jsonl\n'
-        printf ': > /run-root/audit-ledger.jsonl\n'
-        printf ': > /run-root/preprint-ledger.jsonl\n'
-        printf ': > /run-root/replication-ledger.jsonl\n'
+        printf ': > /run-root/.agentis/sandbox/discovery-ledger.jsonl\n'
+        printf ': > /run-root/.agentis/sandbox/audit-ledger.jsonl\n'
+        printf ': > /run-root/.agentis/sandbox/preprint-ledger.jsonl\n'
+        printf ': > /run-root/.agentis/sandbox/replication-ledger.jsonl\n'
         # Seed propose-tier confidence for each colony. All keys use the
         # canonical dashed `<basename>:confidence` form per CLAUDE.md Agent
         # conventions; `prior_advocate` remains underscored because its disk
@@ -1390,7 +1390,7 @@ write_bootstrap() {
         printf '        *) sp=unassigned ;;\n'
         printf '    esac\n'
         printf '    ts_ms=$(date +%%s%%3N)\n'
-        printf '    python3 -c '"'"'import json,sys; sys.stdout.write(json.dumps({"ts":int(sys.argv[1]),"event":"spawn","daemon_id":int(sys.argv[2]),"specialty":sys.argv[3],"generation":0,"reason":"initial"})+"\\n")'"'"' "$ts_ms" "$i" "$sp" >> /run-root/replication-ledger.jsonl\n'
+        printf '    python3 -c '"'"'import json,sys; sys.stdout.write(json.dumps({"ts":int(sys.argv[1]),"event":"spawn","daemon_id":int(sys.argv[2]),"specialty":sys.argv[3],"generation":0,"reason":"initial"})+"\\n")'"'"' "$ts_ms" "$i" "$sp" >> /run-root/.agentis/sandbox/replication-ledger.jsonl\n'
         printf 'done\n'
         unset prb_fittest_path
         # Phase 9 PR-C (#663): each of the 4 math downstream colonies

--- a/tools/cull-replicas.sh
+++ b/tools/cull-replicas.sh
@@ -676,7 +676,7 @@ print(overlay)
     # run-research.sh (DAEMON_ID + replication knobs read by <colony>.ag's
     # first-tick claim path). Background it so the cull tool can return
     # promptly.
-    podman exec "$CONTAINER" bash -c "DAEMON_ID=$NEW_ID COLONY_NAME=$COLONY_NAME EXPLORER_GENERATION=0 HOLD_PERIOD=\${HOLD_PERIOD:-4} DISCOVERY_LEDGER=/run-root/discovery-ledger.jsonl REPLICATION_LEDGER=/run-root/replication-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis agentis daemon /run-root/$COLONY_NAME/agents/$COLONY_NAME.ag --colony $COLONY_NAME --enable-exec --enable-messaging --enable-replication --allow-replica-replication --tick-interval 30000 > /run-root/.agentis/logs/$COLONY_NAME-$NEW_ID.log 2>&1 &" 2>/dev/null || true
+    podman exec "$CONTAINER" bash -c "DAEMON_ID=$NEW_ID COLONY_NAME=$COLONY_NAME EXPLORER_GENERATION=0 HOLD_PERIOD=\${HOLD_PERIOD:-4} DISCOVERY_LEDGER=discovery-ledger.jsonl REPLICATION_LEDGER=replication-ledger.jsonl AGENTIS_ROOT=/run-root/.agentis agentis daemon /run-root/$COLONY_NAME/agents/$COLONY_NAME.ag --colony $COLONY_NAME --enable-exec --enable-messaging --enable-replication --allow-replica-replication --tick-interval 30000 > /run-root/.agentis/logs/$COLONY_NAME-$NEW_ID.log 2>&1 &" 2>/dev/null || true
 
     # Issue #767 bug fix (load-bearing, NOT gated): re-increment
     # `colony-<colony>:size` to balance the post-stop decrement above


### PR DESCRIPTION
## Summary

Completes the Wave 8c (#937) ledger / preprint sandbox refactor by fixing the 4 host-side call sites that the daemons depend on. Closes #938.

| # | Site | Was | Now |
|---|------|-----|-----|
| 1 | `run-research.sh:1083-1086` pre-spawn truncates | `: > /run-root/<x>-ledger.jsonl` | `: > /run-root/.agentis/sandbox/<x>-ledger.jsonl` |
| 2 | `run-research.sh:1393` spawn-row replication append | `>> /run-root/replication-ledger.jsonl` | `>> /run-root/.agentis/sandbox/replication-ledger.jsonl` |
| 3 | `cull-replicas.sh:679` env vars on respawn | `DISCOVERY_LEDGER=/run-root/discovery-ledger.jsonl` | `DISCOVERY_LEDGER=discovery-ledger.jsonl` (relative → sandbox-resolved) |
| 4 | `run-research.sh:739-742` host symlinks | `ln -sf laptop-node/<x>-ledger.jsonl ...` | `ln -sf laptop-node/.agentis/sandbox/<x>-ledger.jsonl ...` |

Empirically verified on run `20260605T204238Z` (v1.18.24 verification, 20 ticks). All 18 daemons emit experience JSONLs, 45 discovery-ledger rows land in the sandbox, but the pre-patch `laptop-node/<x>-ledger.jsonl` symlink targets read 0 lines because they pointed at empty files. This patch restores end-to-end visibility: dashboard, `review-cli`, and external tooling see daemon-produced content again.

## Test plan
- [x] `tools/colony-lint.sh` → 345/0/5
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)