### PR TITLE
test(tools): refresh 39n/39o assertions for substrate impl (Wave 8g / closes #932)

### DIFF
--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -958,10 +958,10 @@ assert_contains "39l. novelty.ag writes novelty:bucket_tags memo" "$NOV_SRC_39" 
     'memo_write("novelty:bucket_tags:"'
 assert_contains "39m. novelty.ag calls _classify_buckets_all from loss shaping" "$NOV_SRC_39" \
     '_classify_buckets_all(topic_label)'
-assert_contains "39n. _classify_bucket lowercases haystack (case-insensitive)" "$NOV_SRC_39" \
-    'argv[1].lower()'
-assert_contains "39o. _sparsest_bucket still pins the 5 canonical buckets" "$NOV_SRC_39" \
-    'buckets=[\"group_theory\",\"combinatorics\",\"number_theory\",\"probability\",\"algebra\"]'
+assert_contains "39n. _classify_bucket lowercases haystack (case-insensitive via to_lower)" "$NOV_SRC_39" \
+    'to_lower(condition)'
+assert_contains "39o. _sparsest_bucket counts the 5 canonical buckets" "$NOV_SRC_39" \
+    '_count_str_in(arr, "algebra"'
 
 # Live acceptance: run the inventory and verify unclassified < 30% on
 # the current 24-paper corpus. Skips if python3 is missing (also covered


### PR DESCRIPTION
## Summary

Wave 7g (#769) migrated novelty.ag's bucket classifier away from inline `python3 -c 'argv[1].lower() ...'` to a substrate impl using `to_lower(condition)` + 5× `regex_match(...)` for each bucket. The `test-run-research.sh` 39n / 39o assertions kept the legacy python needles and have been failing on every run since.

| # | Was | Now |
|---|-----|-----|
| 39n | \`argv[1].lower()\` | \`to_lower(condition)\` |
| 39o | \`buckets=[...]\` python list | \`_count_str_in(arr, "algebra"\` (first of 5 alpha-first sentinel calls) |

## Verification
- [x] `bash test-run-research.sh` → 307 passed, 0 failed (was 305 / 2 pre-patch)
- [x] `tools/colony-lint.sh` → 345 / 0 / 5
- [ ] CI green

Closes #932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)