### PR TITLE
fix(research-foundry): permanent dashboard view — install file at FED_DIR + hybrid .agentis layout

### DIFF
--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -1552,12 +1552,38 @@ spawn_container() {
     unset persistent_mount
 }
 
+# --- 3.5) Dashboard view setup ---
+# Build a $FED_DIR/.agentis/ layout the host's `agentis daemon list` and
+# `federation-dashboard-collector.py` can walk. The container writes its
+# live state under $LAPTOP_DIR/.agentis/ (= /run-root/.agentis/ inside),
+# but the dashboard is launched against $FED_DIR/, and agentis-core's
+# `find_agentis_root_from()` (src/cli/util.rs) walks up looking for a
+# directory whose `.agentis/objects/` is a *real dir on disk*. The
+# container's objects symlink points at `/persistent/objects`, which
+# exists inside the container but is dangling on the host -- so a plain
+# `ln -snf $LAPTOP_DIR/.agentis $FED_DIR/.agentis` symlink fails the
+# is_dir() marker test and `agentis daemon list --json` returns `[]`,
+# which the dashboard renders as "Federation is stopped". The fix is a
+# hybrid: real $FED_DIR/.agentis/ directory containing a real (empty)
+# `objects/` subdir that satisfies the marker, plus per-subdir symlinks
+# into the container's live state for the dirs the dashboard actually
+# reads (daemon/, experience/, memo/, log/, logs/, audit/, config/,
+# identity/, sandbox/, spend/). The cleanup trap above wipes the whole
+# view on EXIT/INT/TERM so a re-run starts from a clean slate.
+setup_dashboard_view() {
+    emit_step "setting up dashboard view at $FED_DIR/.agentis (real dir + symlinks to $LAPTOP_DIR/.agentis subdirs + empty objects/)"
+    emit_cmd "rm -f $FED_DIR/.agentis 2>/dev/null"
+    emit_cmd "rm -rf $FED_DIR/.agentis 2>/dev/null"
+    emit_cmd "mkdir -p $FED_DIR/.agentis/objects"
+    emit_cmd "for sub in audit config daemon experience identity log logs memo sandbox spend; do [ -e \"$LAPTOP_DIR/.agentis/\$sub\" ] && ln -sfn \"$LAPTOP_DIR/.agentis/\$sub\" \"$FED_DIR/.agentis/\$sub\"; done"
+}
+
 # --- 4) Cleanup trap ---
 AUTO_PROMOTE_PID=""
 install_cleanup_trap() {
-    emit_step "installing cleanup trap (stop + rm container; kill sidecars; rm sidecar install file)"
+    emit_step "installing cleanup trap (stop + rm container; kill sidecars; rm sidecar install file + dashboard view)"
     # shellcheck disable=SC2064  # Expand $AUTO_PROMOTE_PID at trigger time.
-    emit_cmd "trap '[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; rm -f \"$LAPTOP_DIR/.auto-promote-install.toml\" 2>/dev/null; podman stop --time 5 research-foundry-laptop 2>/dev/null || true; podman rm -f research-foundry-laptop 2>/dev/null || true' EXIT INT TERM"
+    emit_cmd "trap '[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; rm -f \"$FED_DIR/.auto-promote-install.toml\" 2>/dev/null; rm -rf \"$FED_DIR/.agentis\" 2>/dev/null; podman stop --time 5 research-foundry-laptop 2>/dev/null || true; podman rm -f research-foundry-laptop 2>/dev/null || true' EXIT INT TERM"
 }
 
 # --- 4.5) Auto-promote sidecar (#622, consolidated #638) ---
@@ -1597,13 +1623,16 @@ start_auto_promote_sidecar() {
     CULL_COLONIES="${RESEARCH_CULL_COLONIES:-explorer}"
     if [ "$AP_ENABLED" != "1" ]; then
         emit_step "auto-promote sidecar: disabled via RESEARCH_AUTO_PROMOTE=$AP_ENABLED"
-        # Write .auto-promote-install.toml so the dashboard's sidecar
-        # liveness probe (#248 / #378 / #699) sees installed=true,
+        # Write .auto-promote-install.toml at $FED_DIR so the dashboard's
+        # sidecar liveness probe (#248 / #378 / #699) sees installed=true,
         # enabled=false instead of treating a healthy disable as orphan
-        # state. Schema matches dev-apprenticeship/install.sh:864-899
+        # state. Path must be FED_DIR (not LAPTOP_DIR) because the
+        # dashboard reads $FED_DIR/.auto-promote-install.toml --
+        # writing it under LAPTOP_DIR makes the file invisible to the
+        # collector. Schema matches dev-apprenticeship/install.sh:864-899
         # for parser compatibility (federation-dashboard-collector.py
         # parses [auto_promote] with underscore).
-        emit_cmd "printf '# Auto-promote scheduler settings (#148 / #216 / #699).\n#\n# Written by research-foundry/tools/run-research.sh at sidecar spawn.\n# Read by federation-dashboard to derive HEALTHY / DEGRADED banner.\n[auto_promote]\nenabled = false\ninterval_s = $AP_INTERVAL\n' > $LAPTOP_DIR/.auto-promote-install.toml"
+        emit_cmd "printf '# Auto-promote scheduler settings (#148 / #216 / #699).\n#\n# Written by research-foundry/tools/run-research.sh at sidecar spawn.\n# Read by federation-dashboard to derive HEALTHY / DEGRADED banner.\n[auto_promote]\nenabled = false\ninterval_s = $AP_INTERVAL\n' > $FED_DIR/.auto-promote-install.toml"
         return 0
     fi
     AP_SCRIPT="$REPO_ROOT/tools/auto-promote.sh"
@@ -1630,16 +1659,19 @@ start_auto_promote_sidecar() {
     else
         emit_step "cull-replicas cycle: disabled (RESEARCH_CULL_ENABLED=$CULL_ENABLED)"
     fi
-    # Write .auto-promote-install.toml so the dashboard's sidecar
-    # liveness probe (#248 / #378 / #699) sees installed=true and the
-    # configured interval instead of reporting running_orphan=true /
-    # status="orphan". Schema matches dev-apprenticeship/install.sh:864-899
-    # for parser compatibility (federation-dashboard-collector.py parses
+    # Write .auto-promote-install.toml at $FED_DIR so the dashboard's
+    # sidecar liveness probe (#248 / #378 / #699) sees installed=true and
+    # the configured interval instead of reporting running_orphan=true /
+    # status="orphan". Path must be FED_DIR (not LAPTOP_DIR) because the
+    # collector reads $FED_DIR/.auto-promote-install.toml -- writing it
+    # under LAPTOP_DIR makes the file invisible to the dashboard.
+    # Schema matches dev-apprenticeship/install.sh:864-899 for parser
+    # compatibility (federation-dashboard-collector.py parses
     # [auto_promote] with underscore at line 906). Emitted via emit_cmd
     # so the write surfaces in both the dry-run transcript and the real
     # orchestrator log; the cleanup trap installed above removes the
     # file on EXIT/INT/TERM.
-    emit_cmd "printf '# Auto-promote scheduler settings (#148 / #216 / #699).\n#\n# Written by research-foundry/tools/run-research.sh at sidecar spawn.\n# Read by federation-dashboard to derive HEALTHY / DEGRADED banner.\n[auto_promote]\nenabled = true\ninterval_s = $AP_INTERVAL\n' > $LAPTOP_DIR/.auto-promote-install.toml"
+    emit_cmd "printf '# Auto-promote scheduler settings (#148 / #216 / #699).\n#\n# Written by research-foundry/tools/run-research.sh at sidecar spawn.\n# Read by federation-dashboard to derive HEALTHY / DEGRADED banner.\n[auto_promote]\nenabled = true\ninterval_s = $AP_INTERVAL\n' > $FED_DIR/.auto-promote-install.toml"
     if [ "$DRY_RUN" = "1" ]; then
         emit_cmd "auto-promote-sidecar placeholder: cwd=$LAPTOP_DIR config=$AP_CONFIG interval=${AP_INTERVAL}s"
         if [ "$CULL_ENABLED" = "1" ]; then
@@ -1957,6 +1989,7 @@ install_cleanup_trap
 build_image
 write_bootstrap
 write_run_meta
+setup_dashboard_view
 spawn_container
 start_auto_promote_sidecar
 tick_stream

--- a/research-foundry/tools/test-run-research.sh
+++ b/research-foundry/tools/test-run-research.sh
@@ -306,14 +306,19 @@ done
 
 # ---------------------------------------------------------------------------
 # 18a-d (#699): start_auto_promote_sidecar writes .auto-promote-install.toml
-# at $LAPTOP_DIR so the dashboard's sidecar liveness probe (#248 / #378)
+# at $FED_DIR so the dashboard's sidecar liveness probe (#248 / #378)
 # reports installed=true, status="ok" instead of running_orphan=true,
-# status="orphan". Schema must byte-match dev-apprenticeship/install.sh
+# status="orphan". Path was LAPTOP_DIR pre-fix but the dashboard reads
+# FED_DIR/.auto-promote-install.toml -- writing it under LAPTOP_DIR made
+# the file invisible to the collector and surfaced as
+# "sidecar running but install file missing" in the banner.
+# Schema must byte-match dev-apprenticeship/install.sh
 # (federation-dashboard-collector.py:906 parses [auto_promote] with
 # underscore). Cleanup trap removes the file on EXIT/INT/TERM.
 # ---------------------------------------------------------------------------
-assert_contains "18a. dry-run emits .auto-promote-install.toml write" "$OUT" \
-    "> $WORK_DIR/run-default/laptop-node/.auto-promote-install.toml"
+FED_DIR_DERIVED="$(dirname "$SCRIPT_DIR")"
+assert_contains "18a. dry-run emits .auto-promote-install.toml write at FED_DIR" "$OUT" \
+    "> $FED_DIR_DERIVED/.auto-promote-install.toml"
 assert_contains "18b. emitted file content carries the [auto_promote] section header" "$OUT" \
     '[auto_promote]\nenabled = true\ninterval_s = 300\n'
 
@@ -324,7 +329,31 @@ assert_contains "18c. RESEARCH_AUTO_PROMOTE=0 emits enabled = false write" "$DIS
     '[auto_promote]\nenabled = false\n'
 
 assert_contains "18d. cleanup trap removes .auto-promote-install.toml on EXIT/INT/TERM" "$OUT" \
-    "rm -f \"$WORK_DIR/run-default/laptop-node/.auto-promote-install.toml\""
+    "rm -f \"$FED_DIR_DERIVED/.auto-promote-install.toml\""
+
+# ---------------------------------------------------------------------------
+# 18e-i (this PR): setup_dashboard_view materialises $FED_DIR/.agentis as a
+# real directory with an empty objects/ subdir + per-subdir symlinks into
+# $LAPTOP_DIR/.agentis. Pre-fix the dashboard saw a missing or stale
+# .agentis at FED_DIR and `agentis daemon list --json` returned [],
+# surfacing as "Federation is stopped" in the banner. The fix satisfies
+# agentis-core's find_agentis_root_from() marker test
+# (.agentis/objects/.is_dir()) which the container-only `/persistent/objects`
+# symlink target cannot. Cleanup trap removes $FED_DIR/.agentis on
+# EXIT/INT/TERM so a re-run starts from a clean slate.
+# ---------------------------------------------------------------------------
+assert_contains "18e. setup_dashboard_view step emitted" "$OUT" \
+    "setting up dashboard view at $FED_DIR_DERIVED/.agentis"
+assert_contains "18f. removes stale FED_DIR/.agentis symlink before mkdir" "$OUT" \
+    "rm -f $FED_DIR_DERIVED/.agentis 2>/dev/null"
+assert_contains "18g. removes stale FED_DIR/.agentis directory before mkdir" "$OUT" \
+    "rm -rf $FED_DIR_DERIVED/.agentis 2>/dev/null"
+assert_contains "18h. creates real FED_DIR/.agentis/objects dir" "$OUT" \
+    "mkdir -p $FED_DIR_DERIVED/.agentis/objects"
+assert_contains "18i. emits per-subdir symlink loop into LAPTOP_DIR/.agentis" "$OUT" \
+    "for sub in audit config daemon experience identity log logs memo sandbox spend; do [ -e \"$WORK_DIR/run-default/laptop-node/.agentis/\$sub\" ] && ln -sfn \"$WORK_DIR/run-default/laptop-node/.agentis/\$sub\" \"$FED_DIR_DERIVED/.agentis/\$sub\"; done"
+assert_contains "18j. cleanup trap removes FED_DIR/.agentis on EXIT/INT/TERM" "$OUT" \
+    "rm -rf \"$FED_DIR_DERIVED/.agentis\""
 
 # ---------------------------------------------------------------------------
 # 23. #711 / #746: per-colony RESEARCH_<COLONY>_CLAUDE_MODEL env defaults


### PR DESCRIPTION
## Summary

Two dashboard surface bugs in `run-research.sh` permanently fixed:

1. **Install file at wrong path.** Script wrote `.auto-promote-install.toml` to `\$LAPTOP_DIR/` but \`federation-dashboard-collector.py\` reads from `\$FED_DIR/`. Dashboard banner read: \"sidecar running but install file missing\".

2. **\`agentis daemon list\` returns []** when run from \`\$FED_DIR\` because \`find_agentis_root_from()\` walks up looking for \`.agentis/objects/.is_dir()\`. The run dir's \`objects\` is a symlink to \`/persistent/objects\` (container-only mount) — broken on host → marker test fails → daemon registry never found → dashboard banner: \"Federation is stopped\".

## Changes

- \`research-foundry/tools/run-research.sh\`:
  - **3× install-file path swap** \$LAPTOP_DIR → \$FED_DIR (cleanup trap + both \`start_auto_promote_sidecar\` branches)
  - **New helper \`setup_dashboard_view\`**: builds \`\$FED_DIR/.agentis/\` as real dir with empty \`objects/\` (satisfies the marker) + per-subdir symlinks to \`\$LAPTOP_DIR/.agentis/{audit,config,daemon,experience,identity,log,logs,memo,sandbox,spend}\`
  - Wired into orchestration body between \`write_run_meta\` and \`spawn_container\`
  - EXIT trap removes the hybrid view too — clean slate per run
- \`research-foundry/tools/test-run-research.sh\`: 18a/18d retargeted to \$FED_DIR + 6 new tests 18e-18j for \`setup_dashboard_view\`

## Validation

- [x] \`colony-lint.sh\`: 346 passed / 0 failed / 5 skipped
- [x] \`test-run-research.sh\`: 313 passed / 0 failed (was 307; +6 new)
- [x] Empirically verified during live run \`runs/20260606T073043Z\` — dashboard banner went from \"Federation is stopped\" + \"sidecar running but install file missing\" to clean healthy state once both fixes applied manually

## Test plan

- [x] Lint clean
- [x] All run-research dry-run assertions pass
- [ ] Reviewer dry-runs \`bash research-foundry/tools/run-research.sh --dry-run\` and confirms emitted transcript shows install file at FED_DIR + setup_dashboard_view block + EXIT trap covers both

🤖 Generated with [Claude Code](https://claude.com/claude-code)