### PR TITLE
fix(persistent-snapshot): host-side memo file fallback when container exits early (#958)

### DIFF
--- a/research-foundry/tools/persistent-snapshot.py
+++ b/research-foundry/tools/persistent-snapshot.py
@@ -43,6 +43,13 @@ Per-call resilience:
 - A completely failed run (e.g. `podman` not on PATH or container
   unreachable) exits non-zero before any tmp/final file is created so
   the orchestrator never sees a half-formed JSON.
+- Host-side memo file fallback (#958): when `--laptop-dir <path>` is
+  supplied and `agentis memo get` returns empty for a key, the helper
+  reads `<laptop-dir>/.agentis/memo/<key>.jsonl` directly from the
+  bind-mount source and recovers the value (last line wins). This
+  guards against the common case where a daemon's worker exited before
+  the snapshot ran -- `podman exec` retries silently fail, but the
+  on-disk JSONL still carries the latest value.
 
 Pattern: this is a heredoc-free Python helper following the precedent
 of `tools/auto-promote-config-parser.py` and `tools/auto-promote-decisions.py`
@@ -51,6 +58,7 @@ parser bug).
 
 Usage:
     persistent-snapshot.py --container <name> --output-dir <dir>
+                           [--laptop-dir <path>]
     persistent-snapshot.py --help
 """
 import datetime
@@ -142,6 +150,7 @@ def _print_help_and_exit():
 def _parse_args(argv):
     container = None
     output_dir = None
+    laptop_dir = None
     i = 0
     while i < len(argv):
         a = argv[i]
@@ -161,6 +170,15 @@ def _parse_args(argv):
             output_dir = argv[i + 1]
             i += 2
             continue
+        elif a == "--laptop-dir":
+            # #958 host-side memo file fallback. Optional; older callers
+            # without the flag still work but lose the fallback.
+            if i + 1 >= len(argv):
+                sys.stderr.write("persistent-snapshot: --laptop-dir requires a value\n")
+                sys.exit(2)
+            laptop_dir = argv[i + 1]
+            i += 2
+            continue
         else:
             sys.stderr.write("persistent-snapshot: unknown argument: " + a + "\n")
             sys.exit(2)
@@ -170,7 +188,7 @@ def _parse_args(argv):
     if output_dir is None:
         sys.stderr.write("persistent-snapshot: --output-dir is required\n")
         sys.exit(2)
-    return container, output_dir
+    return container, output_dir, laptop_dir
 
 
 def _podman_exec(container, args):
@@ -361,27 +379,107 @@ def _knowledge_export(container, output_dir):
     return False
 
 
-def snapshot_keys(container, output_dir):
+def _list_memo_keys_on_host(laptop_dir):
+    """List `.jsonl` memo keys under `<laptop_dir>/.agentis/memo/` (#958).
+
+    Used as a fallback for `agentis memo list` when the container is
+    unreachable. Returns the set of bare key names (filename minus the
+    `.jsonl` suffix). Empty on any I/O failure or missing dir -- the
+    caller still emits the exact-key entries so a missing memo dir does
+    not blank the whole snapshot.
+    """
+    if not laptop_dir:
+        return []
+    memo_dir = os.path.join(laptop_dir, ".agentis", "memo")
+    if not os.path.isdir(memo_dir):
+        return []
+    try:
+        names = os.listdir(memo_dir)
+    except OSError:
+        return []
+    keys = []
+    for name in names:
+        if name.endswith(".jsonl"):
+            keys.append(name[: -len(".jsonl")])
+    return keys
+
+
+def _read_memo_from_host(laptop_dir, key):
+    """Read the latest value of `key` from the host-side memo file (#958).
+
+    Memo store layout: `<laptop_dir>/.agentis/memo/<key>.jsonl`, one JSON
+    line per write, last line wins. Returns the `.value` field as a string.
+    Returns "" on any failure (missing dir, missing file, malformed JSON,
+    missing field).
+
+    Used by the snapshot loop as a fallback when `podman exec agentis memo
+    get` returns empty -- typically because the daemon's worker already
+    exited and the in-container memo store is unreachable, even though the
+    JSONL file under the bind-mount source still carries the latest value.
+    """
+    if not laptop_dir:
+        return ""
+    path = os.path.join(laptop_dir, ".agentis", "memo", key + ".jsonl")
+    if not os.path.isfile(path):
+        return ""
+    try:
+        with open(path) as f:
+            last_line = ""
+            for line in f:
+                line = line.strip()
+                if line:
+                    last_line = line
+            if not last_line:
+                return ""
+            obj = json.loads(last_line)
+            v = obj.get("value", "")
+            return str(v) if v is not None else ""
+    except (OSError, ValueError):
+        # ValueError covers json.JSONDecodeError (subclass) on every
+        # supported Python without an explicit import.
+        return ""
+
+
+def snapshot_keys(container, output_dir, laptop_dir=None):
     """Snapshot the curated memo keys into <output_dir>/memo-snapshot.json.
 
     Pre-flight: ensure `podman exec <container> true` succeeds. Aborts
     before writing anything if podman is missing OR if the container is
     unreachable; that way the orchestrator never sees a half-formed
     JSON file.
+
+    When `laptop_dir` is supplied (#958), any key whose
+    `agentis memo get` returns empty is retried by reading the on-disk
+    `<laptop_dir>/.agentis/memo/<key>.jsonl` file directly. This
+    recovers values written by daemons whose workers exited before
+    the snapshot ran.
     """
     probe = _podman_exec(container, ["true"])
-    if probe is None:
+    container_live = probe is not None and probe.returncode == 0
+    if probe is None and not laptop_dir:
         sys.stderr.write(
             "persistent-snapshot: 'podman' binary not on PATH; aborting "
             + "(no snapshot written).\n"
         )
         return 3
-    if probe.returncode != 0:
+    if probe is not None and probe.returncode != 0 and not laptop_dir:
         sys.stderr.write(
             "persistent-snapshot: 'podman exec " + container + " true' failed "
             + "(rc=" + str(probe.returncode) + "); aborting (no snapshot written).\n"
         )
         return 3
+    if not container_live:
+        # #958: container is gone but --laptop-dir was supplied. Continue
+        # in host-only mode -- every per-key fetch will short-circuit to
+        # `_read_memo_from_host` because `_memo_get` returns "" on a
+        # dead container, and the host fallback recovers the on-disk
+        # value. This is the failure mode reported in #958 where the
+        # 6h40m run snapshotted empty values even though the underlying
+        # JSONL files had valid 0.7 entries.
+        sys.stderr.write(
+            "persistent-snapshot: container unreachable, falling back to "
+            + "host-only memo read from " + str(laptop_dir) + " (#958).\n"
+        )
 
     try:
         os.makedirs(output_dir, exist_ok=True)
@@ -398,7 +496,11 @@ def snapshot_keys(container, output_dir):
     keys_to_snapshot.extend(c + ":confidence" for c in CONFIDENCE_COLONIES)
 
     if PREFIX_GLOBS:
-        listed = _memo_list_keys(container)
+        if container_live:
+            listed = _memo_list_keys(container)
+        else:
+            # #958 host-only mode: enumerate from the bind-mount source.
+            listed = _list_memo_keys_on_host(laptop_dir)
         for prefix in PREFIX_GLOBS:
             for k in listed:
                 if not k.startswith(prefix):
@@ -421,7 +523,32 @@ def snapshot_keys(container, output_dir):
 
     snapshot = {}
     for key in deduped:
-        snapshot[key] = _memo_get(container, key)
+        if container_live:
+            value = _memo_get(container, key)
+        else:
+            # #958 host-only mode: skip the (always-failing) podman exec
+            # to keep shutdown latency bounded -- 100+ keys * 3s retry =
+            # 5+ minutes of dead waits otherwise.
+            value = ""
+        if not value and laptop_dir:
+            # #958 host-side fallback for the common case where the
+            # daemon's worker exited before the snapshot ran. Read the
+            # JSONL file directly from the bind-mount source.
+            host_value = _read_memo_from_host(laptop_dir, key)
+            if host_value:
+                if container_live:
+                    sys.stderr.write(
+                        "persistent-snapshot: " + key
+                        + " empty via container; host fallback recovered "
+                        + host_value + "\n"
+                    )
+                value = host_value
+            elif container_live:
+                sys.stderr.write(
+                    "persistent-snapshot: " + key
+                    + " missing on host AND container\n"
+                )
+        snapshot[key] = value
 
     payload = {
         "schema": SCHEMA_VERSION,
@@ -445,14 +572,18 @@ def snapshot_keys(container, output_dir):
     # knowledge-snapshot.json so run-research.sh's bootstrap can import
     # it back before colony daemons spawn. Failure-isolated: a missing or
     # corrupt KB export must not flip the memo-snapshot return code.
-    _knowledge_export(container, output_dir)
+    # Skip in host-only mode (#958) -- there is no live container to
+    # invoke `agentis knowledge export` against and the host-side KB
+    # rehydration path is out of scope for this fix.
+    if container_live:
+        _knowledge_export(container, output_dir)
 
     return 0
 
 
 def main(argv):
-    container, output_dir = _parse_args(argv)
-    return snapshot_keys(container, output_dir)
+    container, output_dir, laptop_dir = _parse_args(argv)
+    return snapshot_keys(container, output_dir, laptop_dir=laptop_dir)
 
 
 if __name__ == "__main__":

--- a/research-foundry/tools/run-research.sh
+++ b/research-foundry/tools/run-research.sh
@@ -2122,9 +2122,13 @@ signal_shutdown
 # snapshot must not break the shutdown path.
 if [ "$PERSISTENT_DISABLED" != "1" ]; then
     emit_step "snapshotting persistent memo to $PERSISTENT_DIR"
+    # #958: --laptop-dir wires the host-side memo file fallback so a
+    # daemon whose worker exited before the snapshot ran still
+    # contributes its on-disk JSONL value instead of "".
     if ! python3 "$TOOLS_DIR/persistent-snapshot.py" \
             --container research-foundry-laptop \
-            --output-dir "$PERSISTENT_DIR" >>"$ORCH_LOG" 2>&1; then
+            --output-dir "$PERSISTENT_DIR" \
+            --laptop-dir "$LAPTOP_DIR" >>"$ORCH_LOG" 2>&1; then
         emit_step "persistent snapshot failed (non-fatal); continuing shutdown"
     fi
 fi

--- a/research-foundry/tools/test-persistent-snapshot.sh
+++ b/research-foundry/tools/test-persistent-snapshot.sh
@@ -25,6 +25,10 @@
 #       materializes alongside memo-snapshot.json with byte-identical
 #       payload. Failure of the KB export must not flip the memo-only
 #       happy-path exit code.
+#   (8) Host-side memo file fallback (#958): with `--laptop-dir <fake>`
+#       and a dead container, assert the snapshot still writes
+#       memo-snapshot.json AND recovers `.value` fields from the
+#       on-disk `<laptop>/.agentis/memo/<key>.jsonl` files.
 #
 # Standard library only -- no pytest, no live federation.
 #
@@ -433,6 +437,75 @@ elif [ -f "$T7_DIR/knowledge-snapshot.json" ]; then
          "knowledge-snapshot.json was written"
 else
     pass "(7) kb-failure-isolated: memo lands, KB skipped, exit 0"
+fi
+
+# --- (8) Host-side memo file fallback (#958) ---
+# With --laptop-dir <fake> and a dead container (PODMAN_MODE=fail-all),
+# the helper must still write memo-snapshot.json AND populate
+# explorer:confidence from the on-disk JSONL file. Per-tick noise keys
+# under the bind-mount source must NOT bleed into the snapshot.
+T8_DIR="$WORK/t8-persistent"
+T8_LAPTOP="$WORK/t8-laptop"
+mkdir -p "$T8_LAPTOP/.agentis/memo"
+
+# Synthetic JSONL files: one valid confidence value, one exact-key, one
+# prefix-glob entry, one explorer:<pid>:specialty entry, plus a noise
+# per-tick key that the suffix filter must drop.
+printf '%s\n' \
+    '{"generation":0,"timestamp":1780778500,"value":"0.6"}' \
+    '{"generation":0,"timestamp":1780778527,"value":"0.7"}' \
+    >"$T8_LAPTOP/.agentis/memo/explorer:confidence.jsonl"
+printf '%s\n' \
+    '{"generation":0,"timestamp":1780778600,"value":"number_theory,combinatorics"}' \
+    >"$T8_LAPTOP/.agentis/memo/formulator:learned_known_topics.jsonl"
+printf '%s\n' \
+    '{"generation":0,"timestamp":1780778700,"value":"wrong-citation"}' \
+    >"$T8_LAPTOP/.agentis/memo/feedback:hitl_reject_reason:claim-99.jsonl"
+printf '%s\n' \
+    '{"generation":0,"timestamp":1780778800,"value":"group_theory"}' \
+    >"$T8_LAPTOP/.agentis/memo/explorer:912:specialty.jsonl"
+printf '%s\n' \
+    '{"generation":0,"timestamp":1780778900,"value":"tick-noise"}' \
+    >"$T8_LAPTOP/.agentis/memo/explorer:912:code:tick-3.jsonl"
+
+T8_RC=0
+PODMAN_MODE=fail-all python3 "$HELPER" \
+    --container research-foundry-laptop-DEAD \
+    --output-dir "$T8_DIR" \
+    --laptop-dir "$T8_LAPTOP" >"$WORK/t8.log" 2>&1 || T8_RC=$?
+
+if [ "$T8_RC" -ne 0 ]; then
+    fail "(8) host-fallback: helper exits 0 with dead container + --laptop-dir" \
+         "rc=$T8_RC; log: $(cat "$WORK/t8.log")"
+elif [ ! -f "$T8_DIR/memo-snapshot.json" ]; then
+    fail "(8) host-fallback: writes memo-snapshot.json" "file missing"
+else
+    if python3 -c '
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+keys = data["keys"]
+assert keys.get("explorer:confidence") == "0.7", \
+    "explorer:confidence = " + repr(keys.get("explorer:confidence"))
+assert keys.get("formulator:learned_known_topics") == "number_theory,combinatorics", \
+    "formulator:learned_known_topics = " + repr(keys.get("formulator:learned_known_topics"))
+assert keys.get("feedback:hitl_reject_reason:claim-99") == "wrong-citation", \
+    "feedback:hitl_reject_reason:claim-99 = " + repr(keys.get("feedback:hitl_reject_reason:claim-99"))
+assert keys.get("explorer:912:specialty") == "group_theory", \
+    "explorer:912:specialty = " + repr(keys.get("explorer:912:specialty"))
+# Suffix-filter must drop per-tick noise even via the host enumerator.
+assert "explorer:912:code:tick-3" not in keys, \
+    "tick noise leaked into snapshot"
+# Confidence colonies that have no JSONL file on disk must still be
+# present as empty strings (curated list semantics preserved).
+assert keys.get("noticer:confidence", None) == "", \
+    "noticer:confidence = " + repr(keys.get("noticer:confidence", None))
+' "$T8_DIR/memo-snapshot.json" >/dev/null 2>"$WORK/t8.assert.log"; then
+        pass "(8) host-fallback: dead container + --laptop-dir recovers on-disk values"
+    else
+        fail "(8) host-fallback: dead container + --laptop-dir recovers on-disk values" \
+             "$(cat "$WORK/t8.assert.log")"
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
Closes #958.

## Summary

Snapshot runs after \`signal_shutdown\`, when the container is draining. For agents whose worker already exited, \`podman exec agentis memo get <key>\` retries silently fail and the snapshot saves \"\" instead of the on-disk value.

In the 6h40m run on 2026-06-07, half the agents (computer/editor/introducer/reviewer/submitter/theorist) snapshotted empty even though their \`<key>.jsonl\` files on disk had valid 0.7 values.

## Changes

\`research-foundry/tools/persistent-snapshot.py\`:
- New \`--laptop-dir <path>\` arg (bind-mount source root).
- New \`_read_memo_from_host(laptop_dir, key)\` helper reading the last JSONL line + \`.value\` field.
- Snapshot loop: when \`agentis memo get\` returns empty, fall back to host-side read. Stderr log \`snapshot: <key> empty via container; host fallback recovered <value>\` on success.
- Container-down preflight degrades: when \`--laptop-dir\` is supplied and podman exec fails entirely, continues in host-only mode instead of aborting (catches container-already-dead case).

\`research-foundry/tools/run-research.sh\`: threads \`--laptop-dir \"\$LAPTOP_DIR\"\` into the snapshot call.

## Test plan

- [x] \`bash research-foundry/tools/test-persistent-snapshot.sh\` — 10 passed / 0 failed (was 9; +1 case 8 for host-fallback with synthetic JSONL fixtures)
- [x] \`bash tools/colony-lint.sh\` — 346 passed / 0 failed / 5 skipped
- [ ] Next federation run-end: snapshot captures non-empty values for editor/submitter/theorist regardless of container shutdown race

🤖 Generated with [Claude Code](https://claude.com/claude-code)