### PR TITLE
feat(research-foundry): bump cascade cb 200M → 2G for breeding-mode runs (#964)

### DIFF
--- a/research-foundry/arxiv-search/agents/arxiv-search.ag
+++ b/research-foundry/arxiv-search/agents/arxiv-search.ag
@@ -21,7 +21,7 @@
 // Run as daemon: agentis daemon agents/arxiv-search.ag --colony arxiv-search
 // Requires: exec capability (curl + python3), messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Queries {
     queries_json: string,

--- a/research-foundry/arxiv-search/config/colony.example.toml
+++ b/research-foundry/arxiv-search/config/colony.example.toml
@@ -30,5 +30,5 @@ max_query_results = 10
 [[agents]]
 name = "arxiv-search"
 source = "agents/arxiv-search.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 120000

--- a/research-foundry/auditor/agents/auditor.ag
+++ b/research-foundry/auditor/agents/auditor.ag
@@ -22,7 +22,7 @@
 // Run as daemon: agentis daemon agents/auditor.ag --colony auditor
 // Requires: exec capability, messaging capability, DISCOVERY_LEDGER env.
 
-cb 200000000;
+cb 2000000000;
 
 type Verdict {
     audit_verdict: string,

--- a/research-foundry/auditor/config/colony.example.toml
+++ b/research-foundry/auditor/config/colony.example.toml
@@ -28,5 +28,5 @@ confidence_floor = 0.7
 [[agents]]
 name = "auditor"
 source = "agents/auditor.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 90000

--- a/research-foundry/computer/agents/computer.ag
+++ b/research-foundry/computer/agents/computer.ag
@@ -16,7 +16,7 @@
 // Run as daemon: agentis daemon agents/computer.ag --colony computer
 // Requires: exec capability (python3 / gap), messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Script {
     language: string,

--- a/research-foundry/computer/config/colony.example.toml
+++ b/research-foundry/computer/config/colony.example.toml
@@ -28,5 +28,5 @@ expected_substring_required = true
 [[agents]]
 name = "computer"
 source = "agents/computer.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 180000

--- a/research-foundry/editor/agents/editor.ag
+++ b/research-foundry/editor/agents/editor.ag
@@ -23,7 +23,7 @@
 // Run as daemon: agentis daemon agents/editor.ag --colony editor
 // Requires: exec capability (latexmk + pdflatex), messaging.
 
-cb 200000000;
+cb 2000000000;
 
 type Edit {
     full_tex: string,

--- a/research-foundry/editor/config/colony.example.toml
+++ b/research-foundry/editor/config/colony.example.toml
@@ -29,5 +29,5 @@ latexmk_max_passes = 3
 [[agents]]
 name = "editor"
 source = "agents/editor.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 240000

--- a/research-foundry/explorer/agents/explorer.ag
+++ b/research-foundry/explorer/agents/explorer.ag
@@ -64,7 +64,7 @@
 // HOLD_PERIOD + DISCOVERY_LEDGER env (set by tools/run-foundry.sh
 // bootstrap).
 
-cb 200000000;
+cb 2000000000;
 
 type Exploration {
     exploration_goal: string,

--- a/research-foundry/explorer/config/colony.example.toml
+++ b/research-foundry/explorer/config/colony.example.toml
@@ -30,7 +30,7 @@ backend = "cli"
 [[agents]]
 name = "explorer"
 source = "agents/explorer.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 60000
 
 # Economy knobs. Operator override path: edit env vars before launching

--- a/research-foundry/formulator/agents/formulator.ag
+++ b/research-foundry/formulator/agents/formulator.ag
@@ -16,7 +16,7 @@
 // Run as daemon: agentis daemon agents/formulator.ag --colony formulator
 // Requires: exec capability, messaging capability, DISCOVERY_LEDGER env.
 
-cb 200000000;
+cb 2000000000;
 
 type Problem {
     problem: string,

--- a/research-foundry/formulator/config/colony.example.toml
+++ b/research-foundry/formulator/config/colony.example.toml
@@ -19,5 +19,5 @@ backend = "cli"
 [[agents]]
 name = "formulator"
 source = "agents/formulator.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 60000

--- a/research-foundry/groupprops-search/agents/groupprops-search.ag
+++ b/research-foundry/groupprops-search/agents/groupprops-search.ag
@@ -18,7 +18,7 @@
 //   agentis daemon agents/groupprops-search.ag --colony groupprops-search
 // Requires: exec capability (curl + python3), messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Queries {
     queries_json: string,

--- a/research-foundry/groupprops-search/config/colony.example.toml
+++ b/research-foundry/groupprops-search/config/colony.example.toml
@@ -26,5 +26,5 @@ max_queries = 5
 [[agents]]
 name = "groupprops-search"
 source = "agents/groupprops-search.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 120000

--- a/research-foundry/introducer/agents/introducer.ag
+++ b/research-foundry/introducer/agents/introducer.ag
@@ -20,7 +20,7 @@
 // Run as daemon: agentis daemon agents/introducer.ag --colony introducer
 // Requires: exec capability, messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Draft {
     abstract_tex: string,

--- a/research-foundry/introducer/config/colony.example.toml
+++ b/research-foundry/introducer/config/colony.example.toml
@@ -29,5 +29,5 @@ abstract_target_words = 150
 [[agents]]
 name = "introducer"
 source = "agents/introducer.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 180000

--- a/research-foundry/noticer/agents/noticer.ag
+++ b/research-foundry/noticer/agents/noticer.ag
@@ -30,7 +30,7 @@
 // Run as daemon: agentis daemon agents/noticer.ag --colony noticer
 // Requires: exec capability, messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Surprise {
     surprise_found: bool,

--- a/research-foundry/noticer/config/colony.example.toml
+++ b/research-foundry/noticer/config/colony.example.toml
@@ -19,5 +19,5 @@ backend = "cli"
 [[agents]]
 name = "noticer"
 source = "agents/noticer.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 60000

--- a/research-foundry/novelty/agents/novelty.ag
+++ b/research-foundry/novelty/agents/novelty.ag
@@ -16,7 +16,7 @@
 // Run as daemon: agentis daemon agents/novelty.ag --colony novelty
 // Requires: exec capability, messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type NoveltyVerdict {
     is_classical_result: bool,

--- a/research-foundry/novelty/config/colony.example.toml
+++ b/research-foundry/novelty/config/colony.example.toml
@@ -20,5 +20,5 @@ backend = "cli"
 [[agents]]
 name = "novelty"
 source = "agents/novelty.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 60000

--- a/research-foundry/oeis-search/agents/oeis-search.ag
+++ b/research-foundry/oeis-search/agents/oeis-search.ag
@@ -18,7 +18,7 @@
 // Run as daemon: agentis daemon agents/oeis-search.ag --colony oeis-search
 // Requires: exec capability (curl + python3), messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Sequences {
     sequences_json: string,

--- a/research-foundry/oeis-search/config/colony.example.toml
+++ b/research-foundry/oeis-search/config/colony.example.toml
@@ -26,5 +26,5 @@ max_sequences = 5
 [[agents]]
 name = "oeis-search"
 source = "agents/oeis-search.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 120000

--- a/research-foundry/prior_advocate/agents/prior_advocate.ag
+++ b/research-foundry/prior_advocate/agents/prior_advocate.ag
@@ -34,7 +34,7 @@
 // Run as daemon: agentis daemon agents/prior_advocate.ag --colony prior_advocate
 // Requires: exec capability, messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Verdict {
     is_prior: bool,

--- a/research-foundry/prior_advocate/config/colony.example.toml
+++ b/research-foundry/prior_advocate/config/colony.example.toml
@@ -26,5 +26,5 @@ backend = "cli"
 [[agents]]
 name = "prior_advocate"
 source = "agents/prior_advocate.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 60000

--- a/research-foundry/reviewer/agents/reviewer.ag
+++ b/research-foundry/reviewer/agents/reviewer.ag
@@ -25,7 +25,7 @@
 // Run as daemon: agentis daemon agents/reviewer.ag --colony reviewer
 // Requires: exec capability, messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Verdict {
     verdict: string,

--- a/research-foundry/reviewer/config/colony.example.toml
+++ b/research-foundry/reviewer/config/colony.example.toml
@@ -26,5 +26,5 @@ backend = "cli"
 [[agents]]
 name = "reviewer"
 source = "agents/reviewer.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 60000

--- a/research-foundry/scholar-search/agents/scholar-search.ag
+++ b/research-foundry/scholar-search/agents/scholar-search.ag
@@ -21,7 +21,7 @@
 //   agentis daemon agents/scholar-search.ag --colony scholar-search
 // Requires: exec capability (curl + python3), messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Queries {
     queries_json: string,

--- a/research-foundry/scholar-search/config/colony.example.toml
+++ b/research-foundry/scholar-search/config/colony.example.toml
@@ -26,5 +26,5 @@ max_queries = 3
 [[agents]]
 name = "scholar-search"
 source = "agents/scholar-search.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 120000

--- a/research-foundry/skeptic/agents/skeptic.ag
+++ b/research-foundry/skeptic/agents/skeptic.ag
@@ -18,7 +18,7 @@
 // Run as daemon: agentis daemon agents/skeptic.ag --colony skeptic
 // Requires: exec capability, messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Surprise {
     surprise_found: bool,

--- a/research-foundry/skeptic/config/colony.example.toml
+++ b/research-foundry/skeptic/config/colony.example.toml
@@ -20,5 +20,5 @@ backend = "cli"
 [[agents]]
 name = "skeptic"
 source = "agents/skeptic.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 60000

--- a/research-foundry/submitter/agents/submitter.ag
+++ b/research-foundry/submitter/agents/submitter.ag
@@ -29,7 +29,7 @@
 // Run as daemon: agentis daemon agents/submitter.ag --colony submitter
 // Requires: exec capability (tar / curl / sendmail), messaging.
 
-cb 200000000;
+cb 2000000000;
 
 type Metadata {
     title: string,

--- a/research-foundry/submitter/config/colony.example.toml
+++ b/research-foundry/submitter/config/colony.example.toml
@@ -37,5 +37,5 @@ arxiv_gateway = "submit@arxiv.org"
 [[agents]]
 name = "submitter"
 source = "agents/submitter.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 60000

--- a/research-foundry/theorist/agents/theorist.ag
+++ b/research-foundry/theorist/agents/theorist.ag
@@ -16,7 +16,7 @@
 // Run as daemon: agentis daemon agents/theorist.ag --colony theorist
 // Requires: exec capability, messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type Draft {
     definitions_tex: string,

--- a/research-foundry/theorist/config/colony.example.toml
+++ b/research-foundry/theorist/config/colony.example.toml
@@ -27,5 +27,5 @@ hedge_on_computational = true
 [[agents]]
 name = "theorist"
 source = "agents/theorist.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 180000

--- a/research-foundry/verifier/agents/verifier.ag
+++ b/research-foundry/verifier/agents/verifier.ag
@@ -27,7 +27,7 @@
 // Run as daemon: agentis daemon agents/verifier.ag --colony verifier
 // Requires: exec capability, messaging capability.
 
-cb 200000000;
+cb 2000000000;
 
 type SolverOutput {
     solution: string,

--- a/research-foundry/verifier/config/colony.example.toml
+++ b/research-foundry/verifier/config/colony.example.toml
@@ -19,5 +19,5 @@ backend = "cli"
 [[agents]]
 name = "verifier"
 source = "agents/verifier.ag"
-cb_budget = 200000000
+cb_budget = 2000000000
 tick_interval_ms = 60000


### PR DESCRIPTION
Persistent confidence (#959) carries autonomous-tier agents (0.95) into new runs. At autonomous, agent does LLM call every tick → 200M outer CB burns in ~25 min → CognitiveOverload halts cascade. 6h+ breeding runs need 4-8× this. 10× bump across 18 cascade .ag files + their colony.example.toml cb_budget mirrors. Lint clean.