### PR TITLE
feat(dark-factory): LLM-driven vulnerability detection (V3)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,19 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Added
+
+- Generalised detection (V3): an LLM-driven classifier (`classify_llm`) reads the
+  program source and returns a vulnerability class (`MissingSignerCheck` /
+  `MissingOwnerCheck` / `AccountDataMatching` / `ArbitraryCPI` / `IntegerOverflow`
+  / `Safe`), generalising past the structural heuristic to real Anchor shapes it
+  cannot see (e.g. an `authority: AccountInfo` field that should be a `Signer`).
+  It is primary when a real LLM backend is configured; the structural heuristic
+  remains the offline / `mock`-deterministic fallback (the mock backend yields no
+  class token, so detection falls through unchanged). A mis-classification only
+  routes to synthesis — the two-sided real-SVM gate stays the source of truth, so
+  it can never cause a false-VERIFIED.
+
 ## [0.1.0] — 2026-06-09
 
 **Requires:** agentis >= `1.18.0`

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -157,6 +157,41 @@ fn classify(code: string) -> string {
     return "none";
 }
 
+// V3 (#841): LLM-driven classification over the program source. Returns a canonical
+// vuln-class token, "Safe", or "" when the backend gives no usable answer (mock returns
+// the literal "mock", which matches no token) so the caller falls back to the structural
+// heuristic. prompt() is host-side (the one allowed egress), so this runs before the
+// network-closed sandbox compile. Generalises to real Anchor shapes the textual heuristic
+// cannot see (e.g. an `authority: AccountInfo` field that should be `Signer`).
+fn classify_llm(src: string) -> string {
+    let out = to_lower(prompt("You are a Solana/Anchor security auditor. Identify the SINGLE most likely access-control vulnerability in the program below and reply with EXACTLY ONE token, nothing else: MissingSignerCheck | MissingOwnerCheck | AccountDataMatching | ArbitraryCPI | IntegerOverflow | Safe. MissingSignerCheck = an account used as an authority is not required to sign (e.g. an Anchor field typed AccountInfo/UncheckedAccount instead of Signer, or a native handler that moves funds / mutates state without checking is_signer). Reply Safe when the authority is a Signer or the required access-control check is present.", src) -> string);
+    if index_of(out, "missingsignercheck") >= 0 { return "MissingSignerCheck"; }
+    if index_of(out, "missingownercheck") >= 0 { return "MissingOwnerCheck"; }
+    if index_of(out, "accountdatamatching") >= 0 { return "AccountDataMatching"; }
+    if index_of(out, "arbitrarycpi") >= 0 { return "ArbitraryCPI"; }
+    if index_of(out, "integeroverflow") >= 0 { return "IntegerOverflow"; }
+    if index_of(out, "safe") >= 0 { return "Safe"; }
+    return "";
+}
+
+// Resolve the final class from the V3 LLM verdict + the structural-heuristic verdict.
+// The LLM class wins when present (generalises to real Anchor/native programs); "Safe"
+// -> "none"; an empty LLM verdict (mock / no usable answer) falls back to the heuristic.
+// This is a SHALLOW string-only helper — it must NOT call classify() itself: the guard
+// runs classify() directly at its own depth (calling the deep structural fold through an
+// extra wrapper frame overflows the native stack the colony is tuned shallow for). A
+// mis-classification only ROUTES to synthesis; the #820 two-sided + real-SVM gate is the
+// truth, so a wrong class yields `inconclusive`, never a false-VERIFIED.
+fn resolve_cls(llm: string, heuristic: string) -> string {
+    if len(llm) > 0 {
+        if llm == "Safe" {
+            return "none";
+        }
+        return llm;
+    }
+    return heuristic;
+}
+
 // ---- helpers: DAG distillation -----------------------------------------------
 
 // Store each handler sub-graph in the content-addressed DAG (the dedup cache):
@@ -585,9 +620,14 @@ agent guard() -> void {
         emit("synth:hit", "hit");
         emit("synth:class", cached);
     } else {
-        // MISS: detect afresh. classify() is called directly (no wrapper frame) to keep
-        // the native call stack shallow inside the agent block.
-        let cls = classify(strip_comments(target));
+        // MISS: detect afresh. Run the structural detector at the agent's OWN depth
+        // (classify()'s fold overflows the native stack if called through an extra wrapper
+        // frame — the colony is tuned shallow). Then the V3 LLM classifier, then a shallow
+        // resolve: the LLM class wins (generalises to real Anchor), "Safe" -> none, an
+        // empty LLM verdict (mock / offline) falls back to the heuristic.
+        let heuristic = classify(strip_comments(target));
+        let llm = classify_llm(target);
+        let cls = resolve_cls(llm, heuristic);
         if cls == "MissingSignerCheck" {
             print("guard: MissingSignerCheck fired [Critical]");
         } else {


### PR DESCRIPTION
## V3 — generalised detection on real Anchor

Replaces the fixture-tuned structural `classify()` as the **primary** detector with an LLM classifier that reads the program source and returns a vulnerability class — generalising to real Anchor shapes the textual heuristic cannot see (e.g. an `authority: AccountInfo` field that should be a `Signer`).

### Changes (`auditor/agents/auditor.ag`)
- **`classify_llm(src)`** — host-side `prompt()` classification → one token of `MissingSignerCheck | MissingOwnerCheck | AccountDataMatching | ArbitraryCPI | IntegerOverflow | Safe`; returns `""` when the backend gives no usable answer (the `mock` backend returns `"mock"`, matching no token).
- **`resolve_cls(llm, heuristic)`** — the LLM class wins; `Safe` → `none`; an empty LLM verdict falls back to the structural heuristic, so **offline / `mock` determinism is preserved**.
- **guard** runs `classify()` at its own depth, then `classify_llm`, then the shallow resolve. (Calling the structural fold through an extra wrapper frame overflowed the native stack — the colony is tuned shallow — so the resolver must not re-enter `classify()`.)

### Safety
Detection only **routes** to synthesis. The two-sided real-SVM gate stays the source of truth, so a mis-classification yields `inconclusive`, **never a false-VERIFIED** — generalised LLM detection cannot, by construction, create a ban-list risk.

### Verified
On the real `coral-xyz/sealevel-attacks` 0-signer-authorization lessons (real Anchor):
- **insecure** (`authority: AccountInfo`) → `classify_llm` = `MissingSignerCheck` → guard fires → synthesis.
- **secure** (`authority: Signer`) → `classify_llm` = `Safe` → `guard: no rule fired` → `Verdict: SAFE` (no false fire).
- **mock / offline** (native vault) → empty LLM verdict → structural heuristic fires `MissingSignerCheck`, no crash (offline determinism preserved).

### Scope
V3 = vuln-class CLASSIFICATION. The per-class invariant the PoC asserts is V5; full sealevel-attacks calibration (≥3 TP, 0 false-VERIFIED) is V6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)