### PR TITLE
feat(dark-factory): operator entrypoint + human-gated submission package (V7)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,17 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Operator entrypoint + human-gated submission package (V7): `run-audit.sh` runs the auditor
+  end-to-end against an operator-chosen scope (`--target` program, optional `--harness` /
+  `--anchor-harness`, optional `--snapshot`, `--backend`, `--sandbox`) and, on a VERIFIED
+  finding, assembles a submission package on disk (`submission/`: the Immunefi-format
+  `report.md` embedding the PoC, the PoC source, the target, the snapshot, + a `MANIFEST.txt`
+  marked `PENDING HUMAN REVIEW — NOT SUBMITTED`). It NEVER contacts a bounty platform, NEVER
+  auto-submits, and NEVER auto-picks a scope — the operator supplies the target, and
+  submission is a separate, explicit human action. The colony has zero platform-egress
+  builtins (only host-side `prompt()` + sandboxed `exec`). Validated: a VERIFIED run stages a
+  complete human-gated package; a non-VERIFIED run stages nothing.
+
 - Real on-chain state snapshot (V4): `snapshot-rpc.sh` fetches accounts from a Solana RPC
   (`getAccountInfo`, base64) host-side and freezes them to a **content-addressed** snapshot
   (real `owner` / `lamports` / `data` — not a hand-written stub). The native vault harness

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -87,19 +87,49 @@ The report and PoC artifacts land under `<rundir>/.agentis/sandbox/`. See the
 [auditor colony README](./auditor/README.md) for the
 `SOLANA_HARNESS_DIR` / `BOUNTY_TARGET` / `BOUNTY_POC` env contract.
 
+## Run an audit (`run-audit.sh`)
+
+`run-audit.sh` is the operator entrypoint: it runs the full pipeline against a scope **you
+choose** and, on a VERIFIED finding, stages a **human-gated** submission package. Pass
+**absolute** paths (the colony runs in its own working dir).
+
+```bash
+# native solana-program target
+dark-factory/run-audit.sh --target "$PWD/path/to/program.rs" \
+    --harness "$PWD/dark-factory/solana-harness" --backend claude
+
+# Anchor target (+ optional frozen on-chain snapshot for state replay)
+dark-factory/run-audit.sh --target "$PWD/path/to/lib.rs" \
+    --anchor-harness "$PWD/dark-factory/solana-harness-anchor" \
+    --snapshot "$PWD/snap.txt" --backend claude --out "$PWD/audit-out"
+```
+
+On `Verdict: VERIFIED` the package lands at `<out>/submission/`: `report.md` (Immunefi-format,
+embeds the PoC), `poc.rs`, `target.rs`, `snapshot.txt` (if used), and `MANIFEST.txt` marked
+**PENDING HUMAN REVIEW — NOT SUBMITTED**. The colony never posts to a platform — submission is
+a manual human action. `run-audit.sh` requires `--target` and never auto-picks a scope.
+`--backend mock` runs offline-deterministically (structural heuristic, no LLM). Produce a
+frozen snapshot with `snapshot-rpc.sh --rpc <url> --out snap.txt <pubkey>`.
+
 ## Layout
 
 ```
 dark-factory/
   README.md                     # this file
   VERSION  CHANGELOG.md  BUNDLE.manifest  install.sh
+  run-audit.sh                  # operator entrypoint: run an audit -> human-gated package
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
+  snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
+  calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)
+  sealevel-scorecard.md         # calibration results (3/3 true-positive, 0 false-VERIFIED)
   auditor/                      # the single colony
     agents/auditor.ag           # the audit pipeline (reconn → guard → tracker → synthesis)
     config/colony.example.toml  # forge.type = "none"; cb_budget
     scripts/start-colony.sh     # thin `agentis go` launcher
     README.md
-  solana-harness/               # offline solana-program-test crate (real SVM)
+  solana-harness/               # offline solana-program-test crate (real SVM, native)
+  solana-harness-anchor/        # offline anchor-lang 0.31 harness (real SVM, Anchor) (V6)
+  sealevel/                     # modernized coral-xyz/sealevel-attacks lessons (corpus) (V6)
   fixtures/                     # detection fixtures (vuln + safe + rigged-harness cases)
 ```
 

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -49,6 +49,12 @@ fn ingest_target() -> string {
         if len(src) > 0 {
             return src;
         }
+        // BOUNTY_TARGET was requested but is unreadable. NEVER silently fall back to the
+        // embedded demo (a vulnerable vault) — that would audit a program the operator never
+        // supplied and could stage a false finding on an in-scope-safe target. Return empty
+        // so detection finds nothing (-> SAFE, no synthesis, no false-VERIFIED), and say so.
+        print("ingest: ERROR — BOUNTY_TARGET set but unreadable (", path, ") — auditing nothing; supply a readable absolute path. No embedded fallback when a target is requested.");
+        return "";
     }
     return embedded_target();
 }

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -26,18 +26,19 @@ AGENTIS="agentis"
 TARGET="" ; HARNESS="" ; ANCHOR_HARNESS="" ; SNAPSHOT="" ; POC=""
 BACKEND="claude" ; SANDBOX="hardened" ; OUT="$PWD/audit-out"
 
+need() { [ "$1" -ge 2 ] || { echo "run-audit.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
   case "$1" in
-    --target) TARGET="$2"; shift 2 ;;
-    --harness) HARNESS="$2"; shift 2 ;;
-    --anchor-harness) ANCHOR_HARNESS="$2"; shift 2 ;;
-    --snapshot) SNAPSHOT="$2"; shift 2 ;;
-    --poc) POC="$2"; shift 2 ;;
-    --backend) BACKEND="$2"; shift 2 ;;
-    --sandbox) SANDBOX="$2"; shift 2 ;;
-    --out) OUT="$2"; shift 2 ;;
-    --agentis) AGENTIS="$2"; shift 2 ;;
-    --help|-h) sed -n '2,28p' "$0"; exit 0 ;;
+    --target) need "$#"; TARGET="$2"; shift 2 ;;
+    --harness) need "$#"; HARNESS="$2"; shift 2 ;;
+    --anchor-harness) need "$#"; ANCHOR_HARNESS="$2"; shift 2 ;;
+    --snapshot) need "$#"; SNAPSHOT="$2"; shift 2 ;;
+    --poc) need "$#"; POC="$2"; shift 2 ;;
+    --backend) need "$#"; BACKEND="$2"; shift 2 ;;
+    --sandbox) need "$#"; SANDBOX="$2"; shift 2 ;;
+    --out) need "$#"; OUT="$2"; shift 2 ;;
+    --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
+    --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
     *) echo "run-audit.sh: unknown flag $1" >&2; exit 2 ;;
   esac
 done
@@ -46,10 +47,19 @@ done
 [ -f "$TARGET" ] || { echo "run-audit.sh: target not found: $TARGET" >&2; exit 2; }
 command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-audit.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
 
+# Resolve operator paths to ABSOLUTE — the colony runs with a different cwd, so a relative
+# path would silently miss; an unreadable BOUNTY_TARGET must NEVER fall back to a built-in
+# program (ingest_target() hard-fails on that, and we belt-and-suspenders it here).
+TARGET="$(cd "$(dirname "$TARGET")" && pwd)/$(basename "$TARGET")"
+if [ -n "$SNAPSHOT" ]; then [ -f "$SNAPSHOT" ] || { echo "run-audit.sh: snapshot not found: $SNAPSHOT" >&2; exit 2; }; SNAPSHOT="$(cd "$(dirname "$SNAPSHOT")" && pwd)/$(basename "$SNAPSHOT")"; fi
+if [ -n "$POC" ]; then [ -f "$POC" ] || { echo "run-audit.sh: poc not found: $POC" >&2; exit 2; }; POC="$(cd "$(dirname "$POC")" && pwd)/$(basename "$POC")"; fi
+if [ -n "$HARNESS" ]; then [ -d "$HARNESS" ] || { echo "run-audit.sh: harness dir not found: $HARNESS" >&2; exit 2; }; HARNESS="$(cd "$HARNESS" && pwd)"; fi
+if [ -n "$ANCHOR_HARNESS" ]; then [ -d "$ANCHOR_HARNESS" ] || { echo "run-audit.sh: anchor-harness dir not found: $ANCHOR_HARNESS" >&2; exit 2; }; ANCHOR_HARNESS="$(cd "$ANCHOR_HARNESS" && pwd)"; fi
+
 COLONY="$HERE/auditor/agents/auditor.ag"
 [ -f "$COLONY" ] || { echo "run-audit.sh: colony not found at $COLONY" >&2; exit 3; }
 
-mkdir -p "$OUT"
+mkdir -p "$OUT"; OUT="$(cd "$OUT" && pwd)"
 RUN="$OUT/run"
 rm -rf "$RUN"; mkdir -p "$RUN"
 cp "$COLONY" "$RUN/auditor.ag"

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# V7 (#845) — operator entrypoint for a Dark Factory audit.
+#
+# Runs the .ag auditor colony end-to-end against an operator-chosen scope and, on a VERIFIED
+# finding, assembles a human-gated submission package on disk. It NEVER contacts a bounty
+# platform, NEVER auto-submits, and NEVER auto-picks a scope — the operator supplies the
+# in-scope program (and, for a live target, the RPC dump). Submission is always a separate,
+# explicit human action: a reviewer reads the package and submits it manually.
+#
+# Usage:
+#   run-audit.sh --target <program.rs> [options]
+# Options:
+#   --target <file>          REQUIRED. The in-scope program source to audit.
+#   --harness <dir>          Native solana-program-test harness dir (SOLANA_HARNESS_DIR).
+#   --anchor-harness <dir>   Anchor harness dir (SOLANA_ANCHOR_HARNESS_DIR).
+#   --snapshot <file>        Frozen on-chain account dump (BOUNTY_SNAPSHOT; see snapshot-rpc.sh).
+#   --poc <file>             Operator-supplied PoC candidate (BOUNTY_POC; still gated).
+#   --backend <mock|claude>  LLM backend (default: claude). mock = offline-deterministic.
+#   --sandbox <hardened|none> Sandbox profile (default: hardened).
+#   --out <dir>              Output dir for the run + submission package (default: ./audit-out).
+#   --agentis <bin>          agentis binary (default: `agentis` on PATH).
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+AGENTIS="agentis"
+TARGET="" ; HARNESS="" ; ANCHOR_HARNESS="" ; SNAPSHOT="" ; POC=""
+BACKEND="claude" ; SANDBOX="hardened" ; OUT="$PWD/audit-out"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target) TARGET="$2"; shift 2 ;;
+    --harness) HARNESS="$2"; shift 2 ;;
+    --anchor-harness) ANCHOR_HARNESS="$2"; shift 2 ;;
+    --snapshot) SNAPSHOT="$2"; shift 2 ;;
+    --poc) POC="$2"; shift 2 ;;
+    --backend) BACKEND="$2"; shift 2 ;;
+    --sandbox) SANDBOX="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --agentis) AGENTIS="$2"; shift 2 ;;
+    --help|-h) sed -n '2,28p' "$0"; exit 0 ;;
+    *) echo "run-audit.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$TARGET" ] || { echo "run-audit.sh: --target <program.rs> is required (the operator picks the in-scope program; this tool never auto-picks a scope)" >&2; exit 2; }
+[ -f "$TARGET" ] || { echo "run-audit.sh: target not found: $TARGET" >&2; exit 2; }
+command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-audit.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
+
+COLONY="$HERE/auditor/agents/auditor.ag"
+[ -f "$COLONY" ] || { echo "run-audit.sh: colony not found at $COLONY" >&2; exit 3; }
+
+mkdir -p "$OUT"
+RUN="$OUT/run"
+rm -rf "$RUN"; mkdir -p "$RUN"
+cp "$COLONY" "$RUN/auditor.ag"
+
+# init the agentis store FIRST (before any .agentis/ subdir exists), else HEAD is not set.
+( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
+{
+  echo "llm.backend = $BACKEND"
+  [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 180000"; }
+  echo "trace.level = normal"
+  echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,BOUNTY_SNAPSHOT"
+  echo "exec.default_timeout_ms = 180000"
+} > "$RUN/.agentis/config"
+
+# scope env — only what the operator supplied reaches the (env_clear'd) sandbox.
+ENV=(BOUNTY_TARGET="$TARGET")
+[ -n "$HARNESS" ]        && ENV+=(SOLANA_HARNESS_DIR="$HARNESS")
+[ -n "$ANCHOR_HARNESS" ] && ENV+=(SOLANA_ANCHOR_HARNESS_DIR="$ANCHOR_HARNESS")
+[ -n "$SNAPSHOT" ]       && ENV+=(BOUNTY_SNAPSHOT="$SNAPSHOT")
+[ -n "$POC" ]            && ENV+=(BOUNTY_POC="$POC")
+
+GO=(go auditor.ag --enable-exec --enable-messaging)
+[ "$SANDBOX" = "hardened" ] && GO+=(--sandbox-profile hardened)
+
+echo "run-audit.sh: auditing $(basename "$TARGET") (backend=$BACKEND, sandbox=$SANDBOX)" >&2
+( cd "$RUN" && env "${ENV[@]}" "$AGENTIS" "${GO[@]}" ) 2>&1 | tee "$RUN/audit.log"
+
+VERDICT="$(grep -oE 'Verdict: [A-Z()a-z: -]+' "$RUN/audit.log" | tail -1 | sed 's/^Verdict: //')"
+VERDICT="${VERDICT:-UNKNOWN}"
+SANDBOX_DIR="$RUN/.agentis/sandbox"
+echo >&2
+echo "================ VERDICT: $VERDICT ================" >&2
+
+case "$VERDICT" in
+  VERIFIED)
+    PKG="$OUT/submission"
+    rm -rf "$PKG"; mkdir -p "$PKG"
+    cp "$TARGET" "$PKG/target.rs" 2>/dev/null || true
+    [ -f "$SANDBOX_DIR/report.md" ] && cp "$SANDBOX_DIR/report.md" "$PKG/report.md"
+    # the harness-generated PoC (anchor or native) or the std-only standalone PoC
+    for p in "$SANDBOX_DIR/poc_standalone.rs"; do [ -f "$p" ] && cp "$p" "$PKG/poc.rs"; done
+    [ -n "$ANCHOR_HARNESS" ] && [ -f "$ANCHOR_HARNESS/src/bin/poc.rs" ] && cp "$ANCHOR_HARNESS/src/bin/poc.rs" "$PKG/poc.rs"
+    [ -z "$ANCHOR_HARNESS" ] && [ -n "$HARNESS" ] && [ -f "$HARNESS/src/bin/poc.rs" ] && cp "$HARNESS/src/bin/poc.rs" "$PKG/poc.rs"
+    [ -n "$SNAPSHOT" ] && [ -f "$SNAPSHOT" ] && cp "$SNAPSHOT" "$PKG/snapshot.txt"
+    {
+      echo "Dark Factory submission package"
+      echo "verdict: VERIFIED"
+      echo "target: $(basename "$TARGET")"
+      echo "backend: $BACKEND   sandbox: $SANDBOX"
+      echo "files: report.md (Immunefi-format finding, embeds the PoC), poc.rs, target.rs$( [ -n "$SNAPSHOT" ] && echo ", snapshot.txt")"
+      echo
+      echo "STATUS: PENDING HUMAN REVIEW — NOT SUBMITTED."
+      echo "This colony NEVER posts to a bounty platform. Submission to Immunefi /"
+      echo "Code4rena / Sherlock is a SEPARATE, explicit human action: a reviewer reads"
+      echo "report.md and submits it manually."
+    } > "$PKG/MANIFEST.txt"
+    echo "run-audit.sh: submission package staged at $PKG" >&2
+    echo "run-audit.sh: SUBMISSION IS HUMAN-GATED — review $PKG/report.md and submit manually. The colony never posts to a platform." >&2
+    ;;
+  *)
+    echo "run-audit.sh: no submission package (verdict is not VERIFIED). See $RUN/audit.log." >&2
+    ;;
+esac


### PR DESCRIPTION
## V7 — operator entrypoint + human-gated submission package

`run-audit.sh` runs the auditor end-to-end against an **operator-chosen** scope and, on a VERIFIED finding, assembles a human-gated submission package on disk. It never contacts a bounty platform, never auto-submits, and never auto-picks a scope.

### `run-audit.sh`
- `--target <program.rs>` (required) + optional `--harness` / `--anchor-harness` / `--snapshot` / `--poc` / `--backend mock|claude` / `--sandbox hardened|none` / `--out`.
- Sets up the agentis store (init first → HEAD), writes the config (backend + `exec.env_passthrough` + timeout), runs the colony with the scope env + the hardened sandbox, and on `Verdict: VERIFIED` stages `<out>/submission/`: `report.md` (Immunefi-format, embeds the PoC), `poc.rs`, `target.rs`, `snapshot.txt` (if used), + `MANIFEST.txt` marked **PENDING HUMAN REVIEW — NOT SUBMITTED**.

### Safety (the STOP gates)
- **Never auto-picks a scope** — `--target` is required; the operator chooses the in-scope program (and, for a live target, dumps its accounts via `snapshot-rpc.sh`).
- **Never auto-submits / never contacts a platform** — the colony has zero platform-egress builtins (only host-side `prompt()` + sandboxed `exec`); submission is a separate, explicit human action.

### Verification
- Dry run on the signer fixture (mock, std path) → `Verdict: VERIFIED` → `audit-out/submission/` staged with `report.md` + `poc.rs` + `target.rs` + `MANIFEST.txt` ("PENDING HUMAN REVIEW — NOT SUBMITTED"). A non-VERIFIED run stages nothing.
- The same command runs a real Anchor lesson with `--anchor-harness ./solana-harness-anchor --backend claude` (the V6 pipeline).
- `colony-lint`: 353 passed, 0 failed (shellcheck OK).