### PR TITLE
fix(dark-factory): gate supplied BOUNTY_POC against a target-agnostic forgery (agentis-core#852)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,23 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Security
+
+- Harden the supplied-`BOUNTY_POC` path so a target-agnostic forged PoC cannot mint a false
+  `VERIFIED` (agentis-core#852). The `assess()` two-sided gate is byte-for-byte unchanged; the
+  fix lives entirely in the `BOUNTY_POC` branch of `synth_via_prompt()`. A human-supplied PoC
+  must now (1) structurally reference the in-scope target/harness for the active mode
+  (`poc_exercises_target`) and (2) pass a per-run target-linkage challenge: a fresh nonce const
+  is appended to the target the PoC compiles against, the PoC is wrapped to echo it before its
+  own `main` runs, and the run output must surface the nonce — a PoC that never links this run's
+  target cannot. The documented "simply prints both markers without exercising the target"
+  forgery is now rejected (new negative-test fixture `fixtures/forged_marker_printer.rs`). The
+  autonomous LLM/template path is untouched, and `calibrate-sealevel.sh` (3/3 true-positive,
+  0 false-VERIFIED) still passes because the committed `sealevel/*/poc.rs` link the target and
+  surface the nonce. Residual (documented): a sophisticated operator-supplied PoC that links the
+  target but never invokes the vulnerable path cannot be distinguished from captured stdout — an
+  operator-trust assumption on the explicit override, not an autonomous gap.
+
 ### Added
 
 - Operator runbook (V8): `docs/RUNBOOK.md` — a one-page guide an operator follows to run a

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -411,8 +411,67 @@ fn compile_run(poc: string, target_src: string) -> string {
         // colony-lint: safe-exec-concat
         return exec sh "set -e; cp h_target.rs ${hd}/src/target.rs; cd ${hd}; cp src/bin/poc.rs.tmpl src/bin/poc.rs; set +e; export PATH=$HOME/.cargo/bin:$PATH; CARGO_NET_OFFLINE=1 cargo build --quiet --bin poc --offline > build.out 2>&1; BRC=$?; if [ $BRC -ne 0 ]; then cat build.out; echo __rc=$BRC; else RAYON_NUM_THREADS=4 ./target/debug/poc 2>&1; echo __rc=$?; fi";
     }
+    // std-only path: the PoC is `include!("target.rs")`, so write the (possibly
+    // challenge-augmented) target alongside it — keeps compile_run consistent with the
+    // harness branches and lets the #852 linkage challenge const resolve via the include.
+    file_write("target.rs", target_src);
     file_write("exploit.rs", poc);
     return exec sh "rm -f poc; rustc --edition 2021 exploit.rs -o poc 2>&1; ./poc 2>&1; echo __rc=$?";
+}
+
+// #852: a supplied BOUNTY_POC must demonstrably EXERCISE the in-scope target — a
+// target-agnostic PoC that merely prints the two markers (the documented forgery) must
+// not mint VERIFIED. This is the STRUCTURAL half of the gate: for the active harness mode
+// the PoC must reference the in-scope target/harness, exactly as the real PoCs do. Mode
+// detection mirrors harness_dir()/poc_instruction()/challenge_ref(). SHALLOW leaf
+// (getenv + index_of only) — safe at any agent depth.
+fn poc_exercises_target(poc: string) -> bool {
+    if len(getenv("SOLANA_ANCHOR_HARNESS_DIR")) > 0 {
+        if index_of(poc, "solana_harness_anchor") < 0 { return false; }
+        if index_of(poc, "processor!") >= 0 { return true; }
+        if index_of(poc, "entry(") >= 0 { return true; }
+        if index_of(poc, "::instruction") >= 0 { return true; }
+        return false;
+    }
+    if len(getenv("SOLANA_HARNESS_DIR")) > 0 {
+        if index_of(poc, "solana_harness") < 0 { return false; }
+        if index_of(poc, "process_instruction") >= 0 { return true; }
+        if index_of(poc, "processor!") >= 0 { return true; }
+        return false;
+    }
+    return index_of(poc, "target.rs") >= 0;
+}
+
+// #852: the Rust path to the per-run challenge const by harness mode. The const is
+// appended to the target the PoC is compiled against, so reading it back proves the PoC
+// linked THIS run's target (not a stale / target-free binary). SHALLOW leaf (getenv).
+fn challenge_ref() -> string {
+    if len(getenv("SOLANA_ANCHOR_HARNESS_DIR")) > 0 { return "solana_harness_anchor::POC_CHALLENGE"; }
+    if len(getenv("SOLANA_HARNESS_DIR")) > 0 { return "solana_harness::target::POC_CHALLENGE"; }
+    return "POC_CHALLENGE";
+}
+
+// #852: wrap a supplied PoC so it echoes the per-run challenge BEFORE its own main runs
+// (the user main may std::process::exit(101) on the violation path). Renames the first
+// `fn main(` to `__poc_user_main` and prepends a new `fn main` that prints
+// `POC_CHALLENGE=<nonce>` read from the target-linked const, then calls the user main. A
+// PoC that does not link the in-scope target cannot resolve the const → fails to compile
+// (std) or never surfaces the nonce, and is rejected. If no `fn main(` is present the PoC
+// is returned unchanged (the structural gate still applies). SHALLOW leaf (string surgery).
+fn wrap_with_challenge(poc: string, cref: string) -> string {
+    let p = index_of(poc, "fn main(");
+    if p < 0 { return poc; }
+    // Build with shallow (<=1 `+`) sequential concats: the colony's native call stack is
+    // tuned razor-thin (#820), and a long `((a+b)+c)+d` chain recurses one frame per `+`
+    // — enough, at this depth, to overflow. Sequential lets keep each expression shallow.
+    let head = substring(poc, 0, p);
+    let tail = substring(poc, p + 8, len(poc));
+    let renamed = head + "fn __poc_user_main(";
+    let body = renamed + tail;
+    let mhead = "\nfn main() { eprintln!(\"POC_CHALLENGE={}\", ";
+    let mmid = mhead + cref;
+    let mfn = mmid + "); __poc_user_main(); }\n";
+    return body + mfn;
 }
 
 // Generate the PoC and run it in the hardened sandbox. Resolution order:
@@ -427,8 +486,34 @@ fn synth_via_prompt(cls: string, target: string) -> string {
         // colony-lint: safe-exec-concat
         let supplied = exec sh "cat ${pocpath} 2>/dev/null || true";
         if index_of(supplied, "fn main") >= 0 {
-            print("synthesis: using BOUNTY_POC candidate (gated by assess)");
-            return compile_run(supplied, target);
+            // #852: do NOT trust a supplied PoC's markers blindly. (1) structural gate: it
+            // must reference the in-scope target/harness; (2) per-run target-linkage
+            // challenge (run_challenged_poc): a nonce const appended to the target, echoed
+            // by the wrapped PoC, proves it compiled against THIS run's target. Only then
+            // does the caller's two-sided assess() decide. Closes the target-agnostic
+            // marker-printer forgery; a sophisticated link-but-never-invoke PoC remains an
+            // operator-trust residual (indistinguishable from captured stdout) — the
+            // autonomous LLM/template path is unaffected.
+            if poc_exercises_target(supplied) {
+                // Inline (NOT a helper call — an extra frame here overflows the shallow
+                // native stack, #820) with shallow sequential concats. compile_run stays
+                // at this function's depth, exactly as the origin BOUNTY_POC path.
+                let nonce = substring(sha256_hex(target + now_iso()), 0, 16);
+                let cdef = "\npub const POC_CHALLENGE: &str = \"" + nonce;
+                let challenged = target + cdef + "\";\n";
+                let cref = challenge_ref();
+                let wrapped = wrap_with_challenge(supplied, cref);
+                let out = compile_run(wrapped, challenged);
+                let needle = "POC_CHALLENGE=" + nonce;
+                if index_of(out, needle) >= 0 {
+                    print("synthesis: BOUNTY_POC linked the in-scope target (challenge ok) — gating by two-sided assess");
+                    return out;
+                }
+                print("synthesis: REJECTED BOUNTY_POC — failed the per-run target-linkage challenge (did not link the in-scope target); not trusting it");
+                return "inconclusive: supplied BOUNTY_POC failed the target-linkage challenge";
+            }
+            print("synthesis: REJECTED BOUNTY_POC — it does not exercise the in-scope target (no target/harness reference); not trusting it");
+            return "inconclusive: supplied BOUNTY_POC does not exercise the in-scope target";
         }
         print("synthesis: BOUNTY_POC unreadable — falling back to generation");
     }

--- a/dark-factory/fixtures/forged_marker_printer.rs
+++ b/dark-factory/fixtures/forged_marker_printer.rs
@@ -1,0 +1,24 @@
+// Two-sided-gate negative-test fixture (#852): a target-AGNOSTIC forged PoC.
+//
+// It prints BOTH markers (`CONTROL OK:` + `INVARIANT VIOLATED:`) unconditionally and
+// never references or links the in-scope program under audit — the exact "simply prints
+// both markers without ever exercising the target" forgery from the #852 report. Under
+// the OLD gate (marker substrings only) this minted a false VERIFIED via the human
+// BOUNTY_POC override. The hardened gate MUST reject it: the structural check finds no
+// reference to the program/harness under audit, so the colony refuses to trust the
+// candidate and the verdict is INCONCLUSIVE for this PoC — never VERIFIED.
+//
+// (Note: deliberately contains no source reference to the audited program — not even in a
+// comment — so it exercises the STRUCTURAL half of the gate. A forgery that DID name the
+// program would instead be caught by the per-run linkage challenge.)
+//
+// Run it on the std path:  BOUNTY_POC=.../forged_marker_printer.rs agentis go ...
+// Expected: a "REJECTED BOUNTY_POC — it does not exercise the in-scope target" log line;
+// the supplied PoC never mints VERIFIED.
+
+fn main() {
+    // No program reference. No exercise of anything. Just both markers, unconditionally.
+    println!("CONTROL OK: fabricated control, nothing audited");
+    eprintln!("INVARIANT VIOLATED: fabricated violation, nothing audited");
+    std::process::exit(101);
+}


### PR DESCRIPTION
## Harden the supplied-`BOUNTY_POC` path against a target-agnostic forgery

Addresses **Replikanti/agentis-core#852** (cross-repo tracker; the auditor colony lives here).

### Problem
`synth_via_prompt()` trusted a human-supplied `BOUNTY_POC` on marker substrings alone: if the file printed both `CONTROL OK:` and `INVARIANT VIOLATED:`, `assess()` returned `verified` — even when the PoC never linked or invoked the in-scope target. Reachable only via the explicit `BOUNTY_POC=<path>` operator override (an operator-trust gap, not an autonomous false-VERIFIED), but a forged target-agnostic PoC could mint `VERIFIED` on any flagged class.

### Fix (scoped to the `BOUNTY_POC` branch; `assess()` byte-for-byte unchanged)
1. **`poc_exercises_target()`** — mode-aware structural gate. The supplied PoC must reference the in-scope target/harness: anchor → `solana_harness_anchor` + (`processor!`/`entry(`/`::instruction`); native → `solana_harness` + `process_instruction`; std → `include!("target.rs")`. A bare marker-printer references none → not trusted → `inconclusive`.
2. **Per-run target-linkage challenge** — a fresh nonce const `POC_CHALLENGE` is appended to the target the PoC compiles against; the PoC is wrapped (rename its `fn main` → `__poc_user_main`, prepend a `fn main` that echoes the nonce read from the target-linked const, then call the user main). The run output must surface `POC_CHALLENGE=<nonce>`. A PoC that never links this run's target cannot produce it.

Only when both pass does the existing two-sided `assess()` decide the verdict.

### What this closes vs. the documented residual
- **Closed:** the documented attack — a target-agnostic PoC that prints both markers without exercising the target. New negative-test fixture `fixtures/forged_marker_printer.rs` → `INCONCLUSIVE`.
- **Residual (documented):** a sophisticated operator-supplied PoC that *links* this run's target (so it can read the nonce) but never invokes the vulnerable path is indistinguishable from captured stdout. This stays an operator-trust assumption on the explicit `BOUNTY_POC` override; the autonomous LLM/template path is unaffected and remains the source of truth.

### Validation (offline, std path, mock backend)
| Case | Verdict |
|---|---|
| legit PoC referencing the target | `VERIFIED` (challenge ok) |
| `forged_marker_printer.rs` (no target reference) | `INCONCLUSIVE` |
| `rigged_harness.rs` (links target, no control) | `INCONCLUSIVE (inconclusive:no-control)` — contract preserved |

- `assess()` unchanged → `calibrate-sealevel.sh` (3/3 TP, 0 false-VERIFIED) preserved; the committed `sealevel/*/poc.rs` link the target and surface the nonce.
- The PoC-wrapper mechanism was pre-validated to compile for both the std (`rustc`) and anchor (`#[tokio::main]`) shapes.
- `tools/colony-lint.sh` 0 failures.

Note: the colony's native stack is tuned shallow; the challenge logic is inlined (no extra call frame) and uses shallow string concatenation to stay within the depth budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
