### PR TITLE
dark-factory: EVM/Solidity dispatch in the colony — M1 (#858)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,19 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Added
+
+- EVM/Solidity auditing in the colony — M1 (agentis-core#858). `auditor.ag` now dispatches on
+  `EVM_HARNESS_DIR` / a `.sol` target: the LLM writes a self-contained `revm` PoC, the target +
+  a generic reentrancy attacker are solc-compiled host-side (`evm-harness/compile.js`, solc 0.8.26
+  pinned via `package.json`), and the PoC runs the unchanged two-sided gate (`CONTROL OK:` +
+  `INVARIANT VIOLATED:` + `exit 101`) through the real EVM (revm). `run-audit.sh` gains
+  `--evm-harness` and accepts `.sol` targets; the submission package preserves the EVM PoC +
+  attacker. Validated end-to-end on the live runtime: the reentrancy vault → `VERIFIED` +
+  human-gated package; the secure variant → `SAFE` (no false-VERIFY). Scope is the reentrancy
+  class with a `.sol` reconn bypass; Solidity reconn ingest (M2) and the broader EVM class set
+  (M3) follow.
+
 ### Security
 
 - Harden the supplied-`BOUNTY_POC` path so a target-agnostic forged PoC cannot mint a false

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -105,6 +105,11 @@ dark-factory/run-audit.sh --target "$PWD/path/to/program.rs" \
 dark-factory/run-audit.sh --target "$PWD/path/to/lib.rs" \
     --anchor-harness "$PWD/dark-factory/solana-harness-anchor" \
     --snapshot "$PWD/snap.txt" --backend claude --out "$PWD/audit-out"
+
+# EVM/Solidity target (M1: Reentrancy) — verified through the real EVM (revm).
+# One-time host-side: (cd dark-factory/evm-harness && npm i solc)   # pins solc 0.8.26 for compile.js
+dark-factory/run-audit.sh --target "$PWD/path/to/Contract.sol" \
+    --evm-harness "$PWD/dark-factory/evm-harness" --backend claude --out "$PWD/audit-out"
 ```
 
 On `Verdict: VERIFIED` the package lands at `<out>/submission/`: `report.md` (Immunefi-format,
@@ -139,7 +144,8 @@ dark-factory/
 
 ## Status
 
-Experimental, research scaffold. The detection set is intentionally narrow
-(MissingSignerCheck / IntegerOverflow) and the real-SVM path requires the
-one-time toolchain build. Submission to Immunefi / Code4rena / Sherlock is
-always a separate, explicit human action — the colony never auto-posts.
+Experimental, research scaffold. The Solana detection set is intentionally narrow
+(MissingSignerCheck / IntegerOverflow) and the real-SVM path requires the one-time
+toolchain build; an EVM/Solidity path (M1: Reentrancy, agentis-core#858) audits `.sol`
+targets through the real EVM (revm) via `--evm-harness`. Submission to Immunefi /
+Code4rena / Sherlock is always a separate, explicit human action — the colony never auto-posts.

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -198,6 +198,79 @@ fn resolve_cls(llm: string, heuristic: string) -> string {
     return heuristic;
 }
 
+// ---- helpers: EVM/Solidity detection (M1: reentrancy) ------------------------
+
+// Is the active audit an EVM/Solidity one? True when the operator selected the EVM harness
+// (EVM_HARNESS_DIR), or the source is clearly Solidity. The harness flag is authoritative;
+// the source sniff covers a Solidity target supplied without the flag. SHALLOW leaf
+// (getenv + index_of). M1 scopes EVM detection to reentrancy; M3 broadens the class set.
+fn is_evm_target(src: string) -> bool {
+    if len(getenv("EVM_HARNESS_DIR")) > 0 {
+        return true;
+    }
+    if index_of(src, "pragma solidity") >= 0 {
+        return true;
+    }
+    if index_of(src, "function ") >= 0 {
+        if index_of(src, "msg.sender") >= 0 {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Structural reentrancy heuristic (checks-effects-interactions violation): an external
+// value-bearing call (`.call{value:`) that is NOT dominated by zeroing the caller's recorded
+// balance (`balanceOf[...] = 0` / a `-=` effect). Insecure = the external call precedes the
+// effect (interaction-before-effect); secure = the effect precedes the call. -1 sentinels mean
+// the construct is absent. SHALLOW leaf (index_of only). This is the structural fallback when
+// the LLM classifier gives no usable answer (mock / offline).
+fn detect_reentrancy(src: string) -> bool {
+    let call = index_of(src, ".call{value:");
+    if call < 0 {
+        return false;
+    }
+    let zero = index_of(src, "] = 0");
+    let dec = index_of(src, "] -=");
+    let effect = min_present(zero, dec);
+    if effect < 0 {
+        return true;
+    }
+    if call < effect {
+        return true;
+    }
+    return false;
+}
+
+// V3-style LLM classification for an EVM/Solidity target (M1: reentrancy vs safe). Returns
+// "Reentrancy", "Safe", or "" when the backend gives no usable answer (mock -> "mock", which
+// matches no token) so the caller falls back to the structural heuristic. prompt() is host-side
+// (the one allowed egress) and runs before the network-closed sandbox build. M3 broadens this to
+// the full EVM class set (access-control, unchecked-call, oracle, overflow).
+fn classify_evm_llm(src: string) -> string {
+    let out = to_lower(prompt("You are an EVM/Solidity security auditor. Decide whether the contract below is exploitable by REENTRANCY (a checks-effects-interactions violation: an external value-bearing call such as `msg.sender.call{value: ...}` is made BEFORE the caller's recorded balance is zeroed, so a malicious receiver can re-enter and drain funds). Reply with EXACTLY ONE token, nothing else: Reentrancy | Safe. Reply Reentrancy only when the external call precedes the state update (the funds can be re-entered); reply Safe when the balance is zeroed before the external call, or there is no reentrancy.", src) -> string);
+    if index_of(out, "reentrancy") >= 0 { return "Reentrancy"; }
+    if index_of(out, "safe") >= 0 { return "Safe"; }
+    return "";
+}
+
+// Resolve the EVM class from the LLM verdict + the structural reentrancy heuristic. The LLM
+// wins when present ("Safe" -> "none"); an empty verdict falls back to the heuristic. SHALLOW
+// leaf — a mis-route only reaches synthesis, where the two-sided real-EVM gate is the truth
+// (a wrong route yields `inconclusive`, never a false-VERIFIED).
+fn resolve_evm_cls(llm: string, heuristic: bool) -> string {
+    if len(llm) > 0 {
+        if llm == "Safe" {
+            return "none";
+        }
+        return llm;
+    }
+    if heuristic {
+        return "Reentrancy";
+    }
+    return "none";
+}
+
 // ---- helpers: DAG distillation -----------------------------------------------
 
 // Store each handler sub-graph in the content-addressed DAG (the dedup cache):
@@ -278,6 +351,7 @@ fn is_vuln_class(cls: string) -> bool {
     if cls == "AccountDataMatching" { return true; }
     if cls == "ArbitraryCPI" { return true; }
     if cls == "IntegerOverflow" { return true; }
+    if cls == "Reentrancy" { return true; }
     return false;
 }
 
@@ -319,6 +393,10 @@ fn invariant_for(cls: string) -> string {
 // SOLANA_ANCHOR_HARNESS_DIR is set, else the native harness (SOLANA_HARNESS_DIR).
 // Leaf (getenv only) — safe at any agent depth.
 fn harness_dir() -> string {
+    let e = getenv("EVM_HARNESS_DIR");
+    if len(e) > 0 {
+        return e;
+    }
     let a = getenv("SOLANA_ANCHOR_HARNESS_DIR");
     if len(a) > 0 {
         return a;
@@ -328,6 +406,43 @@ fn harness_dir() -> string {
 
 fn poc_instruction(cls: string) -> string {
     let inv = invariant_for(cls);
+    if len(getenv("EVM_HARNESS_DIR")) > 0 {
+        return "You are given a Solidity smart contract (the in-scope target). Write the FULL contents of " +
+            "src/bin/poc.rs: a self-contained `fn main()` that drives the target through the REAL EVM (the " +
+            "`revm` crate, version 14) as a TWO-SIDED proof. Do NOT link or import the target as Rust — the " +
+            "target (and a provided generic reentrancy attacker) are compiled to EVM creation-bytecode " +
+            "HOST-SIDE and passed to your binary as file paths on argv: argv[1] = the target's creation-" +
+            "bytecode (.bin, a hex string), argv[2] = a provided attacker contract's creation-bytecode (.bin) " +
+            "exposing `attack()` payable (it deposits msg.value into the target then calls the target's " +
+            "withdraw(), and re-enters withdraw() from its receive() while the target still holds funds); its " +
+            "constructor takes the target address. PROVE THIS INVARIANT " +
+            "(conservation of funds): an attacker MUST NOT be able to end holding more ETH than it staked, and " +
+            "the honest flow MUST conserve. Imports (revm 14): `use revm::db::{CacheDB, EmptyDB}; use " +
+            "revm::primitives::{keccak256, AccountInfo, Address, Bytes, ExecutionResult, Output, TxKind, " +
+            "U256}; use revm::Evm; use std::process::exit;`. Build the EVM with `let mut evm = " +
+            "Evm::builder().with_db(CacheDB::new(EmptyDB::default())).build();`. Fund an account via " +
+            "`evm.db_mut().insert_account_info(addr, AccountInfo { balance: wei, ..Default::default() });`. " +
+            "Read a balance via `evm.db_mut().accounts.get(&addr).map(|a| a.info.balance).unwrap_or(U256::ZERO)`. " +
+            "Send a tx by setting `tx.caller / tx.transact_to (TxKind::Create or TxKind::Call(addr)) / tx.value " +
+            "/ tx.data = Bytes::from(bytes) / tx.gas_limit = 30_000_000 / tx.gas_price = U256::ZERO / tx.nonce = " +
+            "None` on `evm.tx_mut()`, then `evm.transact_commit()`. A successful CREATE returns " +
+            "`ExecutionResult::Success { output: Output::Create(_, Some(addr)), .. }`. Compute a function " +
+            "selector with `keccak256(sig.as_bytes())[..4].to_vec()` (e.g. \"deposit()\", \"withdraw()\", " +
+            "\"attack()\"). Load a .bin with `hex::decode(std::fs::read_to_string(path).unwrap().trim()).unwrap()`. " +
+            "For a constructor(address) argument, append the 32-byte left-padded address (12 zero bytes + the " +
+            "20 address bytes) to the attacker creation-bytecode before deploying. STEPS: (1) read argv[1] " +
+            "(target bytecode) and argv[2] (attacker bytecode); (2) CONTROL — deploy a FRESH target, have an " +
+            "honest account deposit then withdraw, and assert the honest flow conserves (the user is restored " +
+            "and the vault returns to 0); if it conserves print exactly `CONTROL OK: <detail>`; if the honest " +
+            "flow does NOT conserve, print a HARNESS ERROR to stderr and `exit(2)` (NOT a verdict). (3) EXPLOIT " +
+            "— deploy a FRESH target, seed honest TVL (e.g. another account deposits 5 ETH), deploy the " +
+            "attacker with the target address as its constructor arg, call the attacker's `attack()` with some " +
+            "stake (e.g. 1 ETH), then read the attacker's final balance; if the attacker holds MORE than it " +
+            "staked print exactly `INVARIANT VIOLATED: <detail>` to stderr and call `std::process::exit(101)`; " +
+            "otherwise print `invariant held: <detail>`. Both `CONTROL OK:` and `INVARIANT VIOLATED:` markers " +
+            "are REQUIRED on a vulnerable target. Reserve exit code 101 EXCLUSIVELY for a genuine INVARIANT " +
+            "VIOLATED. Output only the Rust source of src/bin/poc.rs.";
+    }
     if len(getenv("SOLANA_ANCHOR_HARNESS_DIR")) > 0 {
         return "You are given an ANCHOR Solana program — the contents of the harness crate " +
             "`solana_harness_anchor`'s src/lib.rs (an `#[program]` module with `declare_id!`). Write the FULL " +
@@ -388,6 +503,22 @@ fn poc_instruction(cls: string) -> string {
 // (the deterministic template-fallback). `target_src` is written to src/target.rs so the
 // PoC links against the in-scope program. All leaf calls — the native call stack stays shallow.
 fn compile_run(poc: string, target_src: string) -> string {
+    let ed = getenv("EVM_HARNESS_DIR");
+    if len(ed) > 0 {
+        // EVM harness: the target is a Solidity .sol. It does NOT link the PoC — solc compiles
+        // the target + the committed generic reentrancy Attacker host-side (node compile.js), the
+        // revm poc.rs loads the creation-bytecode at runtime via argv. The in-sandbox build stays
+        // offline (cargo + revm only); solc/node runs host-side. revm is slow in debug, so build +
+        // run --release (the warmed profile). An empty poc keeps the harness's committed poc.rs.
+        file_write("h_target.sol", target_src);
+        if len(poc) > 0 {
+            file_write("h_poc.rs", poc);
+            // colony-lint: safe-exec-concat
+            return exec sh "set -e; cp h_target.sol ${ed}/contracts/Target.sol; cp h_poc.rs ${ed}/src/bin/poc.rs; cd ${ed}; set +e; node compile.js > solc.out 2>&1; SRC=$?; if [ $SRC -ne 0 ]; then cat solc.out; echo __rc=$SRC; else export PATH=$HOME/.cargo/bin:$PATH; CARGO_NET_OFFLINE=1 cargo build --quiet --release --bin poc --offline > build.out 2>&1; BRC=$?; if [ $BRC -ne 0 ]; then cat build.out; echo __rc=$BRC; else RAYON_NUM_THREADS=4 ./target/release/poc contracts/bin/Target.bin contracts/bin/Attacker.bin 2>&1; echo __rc=$?; fi; fi";
+        }
+        // colony-lint: safe-exec-concat
+        return exec sh "set -e; cp h_target.sol ${ed}/contracts/Target.sol; cd ${ed}; set +e; node compile.js > solc.out 2>&1; SRC=$?; if [ $SRC -ne 0 ]; then cat solc.out; echo __rc=$SRC; else export PATH=$HOME/.cargo/bin:$PATH; CARGO_NET_OFFLINE=1 cargo build --quiet --release --bin poc --offline > build.out 2>&1; BRC=$?; if [ $BRC -ne 0 ]; then cat build.out; echo __rc=$BRC; else RAYON_NUM_THREADS=4 ./target/release/poc contracts/bin/Target.bin contracts/bin/Attacker.bin 2>&1; echo __rc=$?; fi; fi";
+    }
     let ad = getenv("SOLANA_ANCHOR_HARNESS_DIR");
     if len(ad) > 0 {
         // Anchor harness: the target IS the whole crate src/lib.rs (an #[program] module).
@@ -572,6 +703,7 @@ fn severity_for(cls: string) -> string {
     if cls == "MissingOwnerCheck" { return "Critical"; }
     if cls == "ArbitraryCPI" { return "Critical"; }
     if cls == "AccountDataMatching" { return "High"; }
+    if cls == "Reentrancy" { return "High"; }
     if cls == "IntegerOverflow" { return "Medium"; }
     return "Informational";
 }
@@ -595,6 +727,9 @@ fn summary_for(cls: string, node: string) -> string {
     if cls == "IntegerOverflow" {
         return "The `" + node + "` handler performs unchecked arithmetic on caller-influenced amounts, so a crafted amount can wrap or underflow and corrupt the conserved value (balance / supply).";
     }
+    if cls == "Reentrancy" {
+        return "The `" + node + "` function makes an external value-bearing call before zeroing the caller's recorded balance (a checks-effects-interactions violation), so a malicious receiver can re-enter and withdraw repeatedly, draining funds far beyond its own deposit.";
+    }
     return "The `" + node + "` handler exposes a privileged action to an unauthorized caller, breaking its access-control invariant.";
 }
 
@@ -604,6 +739,9 @@ fn impact_for(cls: string) -> string {
     }
     if cls == "ArbitraryCPI" {
         return "An attacker redirects a trusted cross-program call to a malicious program, enabling arbitrary effects executed under the victim program's authority.";
+    }
+    if cls == "Reentrancy" {
+        return "Direct theft of funds: an attacker re-enters the vulnerable function during its external call and withdraws repeatedly, draining the entire pooled balance (every depositor's funds), not just its own.";
     }
     return "Unauthorized control over a privileged action: an attacker performs it without the required authorization, typically draining funds or seizing state.";
 }
@@ -624,13 +762,26 @@ fn remediation_for(cls: string) -> string {
     if cls == "IntegerOverflow" {
         return "Use checked arithmetic (`checked_add` / `checked_sub` / `checked_mul`) and reject on overflow, or saturating ops where a clamp is the intended behaviour.";
     }
+    if cls == "Reentrancy" {
+        return "Apply checks-effects-interactions: update state (zero the caller's balance) BEFORE the external call, and/or guard the function with a reentrancy lock (e.g. OpenZeppelin `nonReentrant`).";
+    }
     return "Add the missing access-control check so only the authorized party can perform the privileged action.";
 }
 
-// Best-effort implicated-node extraction: the handler fn name from the target (structural detection).
+// Best-effort implicated-node extraction: the handler fn name from the target (structural
+// detection). Handles both Rust (`fn `) and Solidity (`function `) targets; for a Solidity
+// reentrancy target the vulnerable function is `withdraw`, so prefer it when present.
 fn first_fn_name(src: string) -> string {
     let p = index_of(src, "fn ");
-    if p < 0 { return "(handler)"; }
+    if p < 0 {
+        if index_of(src, "function withdraw") >= 0 { return "withdraw"; }
+        let fp = index_of(src, "function ");
+        if fp < 0 { return "(handler)"; }
+        let frest = substring(src, fp + 9, len(src));
+        let fparen = index_of(frest, "(");
+        if fparen < 0 { return "(handler)"; }
+        return substring(frest, 0, fparen);
+    }
     let rest = substring(src, p + 3, len(src));
     let paren = index_of(rest, "(");
     if paren < 0 { return "(handler)"; }
@@ -834,6 +985,24 @@ fn ingest_nodes(target: string) -> string {
 
 agent reconn() -> void {
     let target = listen("audit:target");
+    // M1 (#858): EVM/Solidity targets BYPASS the Rust-shaped ingest. `cargo tree` needs a
+    // Cargo crate and the reference node-extractor parses Rust `fn`/`struct`/`impl`, neither of
+    // which applies to a `.sol`. Skip both and emit a trivial DAG node so the pipeline still
+    // flows to guard/synthesis/verify; the content-addressed target hash (verdict cache + dedup)
+    // is taken over the source text, which is language-agnostic. Full Solidity ingest (solc AST
+    // -> function/call/sink node stream) is M2.
+    if is_evm_target(target) {
+        let ecode = strip_comments(target);
+        let eth = dag_put(ecode);
+        let enode = dag_put("{\"kind\":\"solidity-target\",\"lang\":\"evm\"}");
+        print("reconn: EVM/Solidity target — Rust ingest bypassed (M1); target hash", substring(eth, 0, 12), "node", substring(enode, 0, 12));
+        let eprior = pick_prior(recall_latest("bounty:verdict:" + eth), recall_latest("bounty:blacklist:" + eth));
+        emit("guard:target", target);
+        emit("guard:th", eth);
+        emit("guard:cached", eprior);
+        emit("tracker:target", target);
+        return;
+    }
     file_write("Cargo.toml", "[package]\nname = \"bounty-target\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[lib]\n");
     file_write("src/lib.rs", target);
     let tree = exec sh "cargo tree --offline 2>&1; echo __rc=$?";
@@ -891,21 +1060,39 @@ agent guard() -> void {
         emit("synth:hit", "hit");
         emit("synth:class", cached);
     } else {
-        // MISS: detect afresh. Run the structural detector at the agent's OWN depth
-        // (classify()'s fold overflows the native stack if called through an extra wrapper
-        // frame — the colony is tuned shallow). Then the V3 LLM classifier, then a shallow
-        // resolve: the LLM class wins (generalises to real Anchor), "Safe" -> none, an
-        // empty LLM verdict (mock / offline) falls back to the heuristic.
-        let heuristic = classify(strip_comments(target));
-        let llm = classify_llm(target);
-        let cls = resolve_cls(llm, heuristic);
-        if is_vuln_class(cls) {
-            print("guard: " + cls + " fired [" + severity_for(cls) + "]");
+        if is_evm_target(target) {
+            // M1 (#858): EVM/Solidity detection. The Rust heuristic + Solana-token LLM classifier
+            // do not apply, so route through the EVM pair: the structural reentrancy heuristic
+            // (CEI violation) + an EVM LLM classifier (Reentrancy vs Safe). The LLM wins when
+            // present, "Safe" -> none, an empty verdict falls back to the heuristic. M3 broadens
+            // this to the full EVM class set; the two-sided real-EVM gate stays the source of truth.
+            let evm_heur = detect_reentrancy(strip_comments(target));
+            let evm_llm = classify_evm_llm(target);
+            let evm_cls = resolve_evm_cls(evm_llm, evm_heur);
+            if is_vuln_class(evm_cls) {
+                print("guard: " + evm_cls + " fired [" + severity_for(evm_cls) + "] (EVM)");
+            } else {
+                print("guard: no EVM rule fired — target looks safe");
+            }
+            emit("synth:hit", "miss");
+            emit("synth:class", evm_cls);
         } else {
-            print("guard: no rule fired — target looks safe");
+            // MISS: detect afresh. Run the structural detector at the agent's OWN depth
+            // (classify()'s fold overflows the native stack if called through an extra wrapper
+            // frame — the colony is tuned shallow). Then the V3 LLM classifier, then a shallow
+            // resolve: the LLM class wins (generalises to real Anchor), "Safe" -> none, an
+            // empty LLM verdict (mock / offline) falls back to the heuristic.
+            let heuristic = classify(strip_comments(target));
+            let llm = classify_llm(target);
+            let cls = resolve_cls(llm, heuristic);
+            if is_vuln_class(cls) {
+                print("guard: " + cls + " fired [" + severity_for(cls) + "]");
+            } else {
+                print("guard: no rule fired — target looks safe");
+            }
+            emit("synth:hit", "miss");
+            emit("synth:class", cls);
         }
-        emit("synth:hit", "miss");
-        emit("synth:class", cls);
     }
 }
 
@@ -945,7 +1132,20 @@ agent synthesis() -> void {
                 let node = first_fn_name(target);
                 let gate = submission_gate(th);
                 let hd = harness_dir();
-                if len(hd) > 0 {
+                if is_evm_target(target) {
+                    // M1 (#858): EVM harness mode. The PoC was verified through the REAL EVM
+                    // (revm) by synth_via_prompt — solc compiled the target host-side, the revm
+                    // poc.rs loaded the creation-bytecode and ran the two-sided gate. Ship the
+                    // revm PoC + its actual run output. The Solana frozen-snapshot replay does
+                    // not apply to an EVM target.
+                    // colony-lint: safe-exec-concat
+                    let epoc_src = exec sh "cat ${hd}/src/bin/poc.rs 2>/dev/null || true";
+                    file_write("report.md", submission_report(cls, th, node, trace, epoc_src, "yes (real EVM via revm)", run_out, "## On-chain state snapshot replay\n\nn/a — verified through the real EVM (revm): solc compiles the in-scope target to creation bytecode host-side, the revm PoC deploys it and runs the two-sided gate. The honest CONTROL flow conserves on this exact target and the EXPLOIT breaks the conservation invariant.\n\n"));
+                    print("synthesis: VERIFIED — real-EVM two-sided PoC (revm)");
+                    print("report: wrote standardized Immunefi report.md  (sub-graph", substring(th, 0, 12), ")");
+                    print("submission:", gate, "— human-gated, never auto-posted");
+                    print("Verdict: VERIFIED");
+                } else { if len(hd) > 0 {
                     // Harness mode: the PoC was already verified through the REAL Solana SVM
                     // (solana-program-test + BanksClient) by synth_via_prompt. The std-only
                     // standalone re-compile + frozen-snapshot replay assume a std-stub target
@@ -976,6 +1176,7 @@ agent synthesis() -> void {
                     print("report: wrote standardized Immunefi report.md  (sub-graph", substring(th, 0, 12), ")");
                     print("submission:", gate, "— human-gated, never auto-posted");
                     print("Verdict: VERIFIED");
+                }
                 }
             } else {
                 print("synthesis: Inconclusive — " + verdict);

--- a/dark-factory/evm-harness/.gitignore
+++ b/dark-factory/evm-harness/.gitignore
@@ -1,2 +1,10 @@
 target/
 node_modules/
+
+# colony runtime scratch — compile_run writes the in-scope target + build logs here per run;
+# the committed contracts/bin/{ReentrancyVault*,Attacker}.bin are the calibration artifacts.
+build.out
+solc.out
+contracts/Target.sol
+contracts/bin/Target.bin
+contracts/bin/IVault.bin

--- a/dark-factory/evm-harness/compile.js
+++ b/dark-factory/evm-harness/compile.js
@@ -1,3 +1,8 @@
+// Host-side solc compiler for the EVM PoC harness (pinned solc 0.8.26, see package.json).
+// Compiles EVERY .sol file under ./contracts to creation bytecode, one ./contracts/bin/<Contract>.bin
+// per top-level contract. Generic so an arbitrary in-scope target written into ./contracts by the
+// colony's compile_run compiles without editing this file (mirrors the Solana RPC-snapshot host-side
+// split: the in-sandbox build stays offline = cargo + revm only; solc runs host-side here).
 const solc = require('solc');
 const fs = require('fs');
 const path = require('path');
@@ -6,9 +11,10 @@ const SRC = './contracts';
 const OUT = './contracts/bin';
 fs.mkdirSync(OUT, { recursive: true });
 
-const files = ['ReentrancyVaultInsecure.sol', 'ReentrancyVaultSecure.sol', 'Attacker.sol'];
 const sources = {};
-for (const f of files) sources[f] = { content: fs.readFileSync(path.join(SRC, f), 'utf8') };
+for (const f of fs.readdirSync(SRC)) {
+  if (f.endsWith('.sol')) sources[f] = { content: fs.readFileSync(path.join(SRC, f), 'utf8') };
+}
 
 const input = {
   language: 'Solidity',
@@ -29,14 +35,25 @@ if (out.errors) {
   if (fatal) process.exit(1);
 }
 
-const want = {
-  'ReentrancyVaultInsecure.sol': 'ReentrancyVaultInsecure',
-  'ReentrancyVaultSecure.sol': 'ReentrancyVaultSecure',
-  'Attacker.sol': 'Attacker',
-};
-for (const [file, name] of Object.entries(want)) {
-  const bc = out.contracts[file][name].evm.bytecode.object;
-  fs.writeFileSync(path.join(OUT, name + '.bin'), bc);
-  console.log(`${name}: ${bc.length / 2} bytes creation bytecode`);
+let n = 0;
+for (const file of Object.keys(out.contracts || {})) {
+  // Per-contract bin (by contract name) ...
+  let primary = null;
+  for (const [name, c] of Object.entries(out.contracts[file])) {
+    const bc = c.evm.bytecode.object;
+    fs.writeFileSync(path.join(OUT, name + '.bin'), bc);
+    console.log(`${name}: ${bc.length / 2} bytes creation bytecode (${file})`);
+    n++;
+    // ... plus a per-file primary alias = the largest deployable contract in this file,
+    // so callers can load <filebasename>.bin without knowing the internal contract name
+    // (interfaces / abstract contracts compile to empty bytecode and are skipped).
+    if (bc.length > 0 && (primary === null || bc.length > primary.bc.length)) {
+      primary = { bc };
+    }
+  }
+  if (primary) {
+    const base = file.replace(/\.sol$/, '');
+    fs.writeFileSync(path.join(OUT, base + '.bin'), primary.bc);
+  }
 }
-console.log('solc version: ' + solc.version());
+console.log(`compiled ${n} contract(s); solc version: ` + solc.version());

--- a/dark-factory/evm-harness/package-lock.json
+++ b/dark-factory/evm-harness/package-lock.json
@@ -1,0 +1,112 @@
+{
+  "name": "evm-harness",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "solc": "^0.8.26"
+      }
+    },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "license": "MIT"
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/solc": {
+      "version": "0.8.26",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.26.tgz",
+      "integrity": "sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==",
+      "license": "MIT",
+      "dependencies": {
+        "command-exists": "^1.2.8",
+        "commander": "^8.1.0",
+        "follow-redirects": "^1.12.1",
+        "js-sha3": "0.8.0",
+        "memorystream": "^0.3.1",
+        "semver": "^5.5.0",
+        "tmp": "0.0.33"
+      },
+      "bin": {
+        "solcjs": "solc.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    }
+  }
+}

--- a/dark-factory/evm-harness/package.json
+++ b/dark-factory/evm-harness/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "evm-harness-solc",
+  "private": true,
+  "description": "Host-side solc pin for the Dark Factory EVM PoC harness (compile.js).",
+  "dependencies": {
+    "solc": "0.8.26"
+  }
+}

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -45,7 +45,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-[ -n "$TARGET" ] || { echo "run-audit.sh: --target <program.rs> is required (the operator picks the in-scope program; this tool never auto-picks a scope)" >&2; exit 2; }
+[ -n "$TARGET" ] || { echo "run-audit.sh: --target <program.rs|target.sol> is required (the operator picks the in-scope program; this tool never auto-picks a scope)" >&2; exit 2; }
 [ -f "$TARGET" ] || { echo "run-audit.sh: target not found: $TARGET" >&2; exit 2; }
 command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-audit.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
 

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -8,11 +8,12 @@
 # explicit human action: a reviewer reads the package and submits it manually.
 #
 # Usage:
-#   run-audit.sh --target <program.rs> [options]
+#   run-audit.sh --target <program.rs|target.sol> [options]
 # Options:
-#   --target <file>          REQUIRED. The in-scope program source to audit.
+#   --target <file>          REQUIRED. The in-scope program source to audit (.rs or .sol).
 #   --harness <dir>          Native solana-program-test harness dir (SOLANA_HARNESS_DIR).
 #   --anchor-harness <dir>   Anchor harness dir (SOLANA_ANCHOR_HARNESS_DIR).
+#   --evm-harness <dir>      EVM revm harness dir (EVM_HARNESS_DIR) for a Solidity target.
 #   --snapshot <file>        Frozen on-chain account dump (BOUNTY_SNAPSHOT; see snapshot-rpc.sh).
 #   --poc <file>             Operator-supplied PoC candidate (BOUNTY_POC; still gated).
 #   --backend <mock|claude>  LLM backend (default: claude). mock = offline-deterministic.
@@ -23,7 +24,7 @@ set -eu
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
-TARGET="" ; HARNESS="" ; ANCHOR_HARNESS="" ; SNAPSHOT="" ; POC=""
+TARGET="" ; HARNESS="" ; ANCHOR_HARNESS="" ; EVM_HARNESS="" ; SNAPSHOT="" ; POC=""
 BACKEND="claude" ; SANDBOX="hardened" ; OUT="$PWD/audit-out"
 
 need() { [ "$1" -ge 2 ] || { echo "run-audit.sh: missing value for the preceding flag" >&2; exit 2; }; }
@@ -32,6 +33,7 @@ while [ $# -gt 0 ]; do
     --target) need "$#"; TARGET="$2"; shift 2 ;;
     --harness) need "$#"; HARNESS="$2"; shift 2 ;;
     --anchor-harness) need "$#"; ANCHOR_HARNESS="$2"; shift 2 ;;
+    --evm-harness) need "$#"; EVM_HARNESS="$2"; shift 2 ;;
     --snapshot) need "$#"; SNAPSHOT="$2"; shift 2 ;;
     --poc) need "$#"; POC="$2"; shift 2 ;;
     --backend) need "$#"; BACKEND="$2"; shift 2 ;;
@@ -55,6 +57,7 @@ if [ -n "$SNAPSHOT" ]; then [ -f "$SNAPSHOT" ] || { echo "run-audit.sh: snapshot
 if [ -n "$POC" ]; then [ -f "$POC" ] || { echo "run-audit.sh: poc not found: $POC" >&2; exit 2; }; POC="$(cd "$(dirname "$POC")" && pwd)/$(basename "$POC")"; fi
 if [ -n "$HARNESS" ]; then [ -d "$HARNESS" ] || { echo "run-audit.sh: harness dir not found: $HARNESS" >&2; exit 2; }; HARNESS="$(cd "$HARNESS" && pwd)"; fi
 if [ -n "$ANCHOR_HARNESS" ]; then [ -d "$ANCHOR_HARNESS" ] || { echo "run-audit.sh: anchor-harness dir not found: $ANCHOR_HARNESS" >&2; exit 2; }; ANCHOR_HARNESS="$(cd "$ANCHOR_HARNESS" && pwd)"; fi
+if [ -n "$EVM_HARNESS" ]; then [ -d "$EVM_HARNESS" ] || { echo "run-audit.sh: evm-harness dir not found: $EVM_HARNESS" >&2; exit 2; }; EVM_HARNESS="$(cd "$EVM_HARNESS" && pwd)"; fi
 
 COLONY="$HERE/auditor/agents/auditor.ag"
 [ -f "$COLONY" ] || { echo "run-audit.sh: colony not found at $COLONY" >&2; exit 3; }
@@ -70,7 +73,7 @@ cp "$COLONY" "$RUN/auditor.ag"
   echo "llm.backend = $BACKEND"
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 180000"; }
   echo "trace.level = normal"
-  echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,BOUNTY_SNAPSHOT"
+  echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,EVM_HARNESS_DIR,BOUNTY_SNAPSHOT"
   echo "exec.default_timeout_ms = 180000"
 } > "$RUN/.agentis/config"
 
@@ -78,6 +81,7 @@ cp "$COLONY" "$RUN/auditor.ag"
 ENV=(BOUNTY_TARGET="$TARGET")
 [ -n "$HARNESS" ]        && ENV+=(SOLANA_HARNESS_DIR="$HARNESS")
 [ -n "$ANCHOR_HARNESS" ] && ENV+=(SOLANA_ANCHOR_HARNESS_DIR="$ANCHOR_HARNESS")
+[ -n "$EVM_HARNESS" ]    && ENV+=(EVM_HARNESS_DIR="$EVM_HARNESS")
 [ -n "$SNAPSHOT" ]       && ENV+=(BOUNTY_SNAPSHOT="$SNAPSHOT")
 [ -n "$POC" ]            && ENV+=(BOUNTY_POC="$POC")
 
@@ -97,19 +101,27 @@ case "$VERDICT" in
   VERIFIED)
     PKG="$OUT/submission"
     rm -rf "$PKG"; mkdir -p "$PKG"
-    cp "$TARGET" "$PKG/target.rs" 2>/dev/null || true
+    # Preserve the target's extension in the package (.sol for an EVM target, .rs otherwise).
+    case "$TARGET" in *.sol) TGT_NAME="target.sol" ;; *) TGT_NAME="target.rs" ;; esac
+    cp "$TARGET" "$PKG/$TGT_NAME" 2>/dev/null || true
     [ -f "$SANDBOX_DIR/report.md" ] && cp "$SANDBOX_DIR/report.md" "$PKG/report.md"
     # the harness-generated PoC (anchor or native) or the std-only standalone PoC
     for p in "$SANDBOX_DIR/poc_standalone.rs"; do [ -f "$p" ] && cp "$p" "$PKG/poc.rs"; done
     [ -n "$ANCHOR_HARNESS" ] && [ -f "$ANCHOR_HARNESS/src/bin/poc.rs" ] && cp "$ANCHOR_HARNESS/src/bin/poc.rs" "$PKG/poc.rs"
     [ -z "$ANCHOR_HARNESS" ] && [ -n "$HARNESS" ] && [ -f "$HARNESS/src/bin/poc.rs" ] && cp "$HARNESS/src/bin/poc.rs" "$PKG/poc.rs"
+    # EVM: the revm PoC the LLM wrote + the generic reentrancy attacker it was compiled against,
+    # so the package reproduces against the in-scope target's bytecode.
+    if [ -n "$EVM_HARNESS" ]; then
+      [ -f "$EVM_HARNESS/src/bin/poc.rs" ] && cp "$EVM_HARNESS/src/bin/poc.rs" "$PKG/poc.rs"
+      [ -f "$EVM_HARNESS/contracts/Attacker.sol" ] && cp "$EVM_HARNESS/contracts/Attacker.sol" "$PKG/Attacker.sol"
+    fi
     [ -n "$SNAPSHOT" ] && [ -f "$SNAPSHOT" ] && cp "$SNAPSHOT" "$PKG/snapshot.txt"
     {
       echo "Dark Factory submission package"
       echo "verdict: VERIFIED"
       echo "target: $(basename "$TARGET")"
       echo "backend: $BACKEND   sandbox: $SANDBOX"
-      echo "files: report.md (Immunefi-format finding, embeds the PoC), poc.rs, target.rs$( [ -n "$SNAPSHOT" ] && echo ", snapshot.txt")"
+      echo "files: report.md (Immunefi-format finding, embeds the PoC), poc.rs, $TGT_NAME$( [ -n "$EVM_HARNESS" ] && echo ", Attacker.sol")$( [ -n "$SNAPSHOT" ] && echo ", snapshot.txt")"
       echo
       echo "STATUS: PENDING HUMAN REVIEW — NOT SUBMITTED."
       echo "This colony NEVER posts to a bounty platform. Submission to Immunefi /"


### PR DESCRIPTION
## Why

M1 of agentis-core#858 — the EVM peer of the calibrated Solana audit path. Code4rena is winding down → Immunefi (first-valid-PoC-wins, **no dup dilution**, PoC required), and the EVM funnel is ~5-10× the Solana one. The `evm-harness` (revm, two-sided gate) merged in #974; this wires it into the colony so the federation can run real EVM audits end-to-end.

## What

`auditor/agents/auditor.ag` now audits EVM/Solidity targets:
- **Dispatch** — `is_evm_target` / `classify_evm_llm` / `resolve_evm_cls` (selects on `EVM_HARNESS_DIR` or a `.sol` source).
- **Synthesis** — an EVM prompt arm: the LLM writes a self-contained **revm** `poc.rs` per finding (mirrors the Solana LLM-writes-`poc.rs` model), loading the target creation-bytecode from argv.
- **`compile_run` EVM branch** — writes the target → `contracts/Target.sol`, the LLM PoC → `src/bin/poc.rs`, runs `node compile.js` (host-side solc 0.8.26) → `cargo build --release --offline --bin poc` → `poc Target.bin Attacker.bin`. The unchanged two-sided gate (`CONTROL OK:` + `INVARIANT VIOLATED:` + `exit 101`) stays the source of truth.
- **`.sol` reconn bypass** (full Solidity ingest is M2).
- `run-audit.sh` gains `--evm-harness` + `.sol` targets; the submission package preserves the EVM PoC + attacker. `evm-harness/compile.js` generalized to compile every `contracts/*.sol`; `package.json` pins solc 0.8.26.

## Validation (end-to-end, live `agentis` runtime, claude backend)

| target | verdict | package |
|---|---|---|
| `ReentrancyVaultInsecure.sol` | **VERIFIED** (Reentrancy/High/`withdraw`) — genuine two-sided revm PoC | human-gated package staged ✓ |
| `ReentrancyVaultSecure.sol` | **SAFE** — guard fired no EVM rule | none (no false-VERIFY) ✓ |

QA: **✅ ship-it** (full report in a comment below) — independently re-ran the standalone calibration (insecure exit 101 / secure exit 0), read the generated `poc.rs` end-to-end (confirmed genuine two-sided, not a rubber-stamp), confirmed `assess()` stays the truth-gate (no false-VERIFY/SAFE path). `colony-lint`: **353 passed, 0 failed**.

## Scope + follow-ups (tracked in #858)

Reentrancy class only. **M2** = Solidity reconn ingest (`solc --ast` → DAG); **M3** = broader EVM class set (access-control, unchecked-call, oracle, overflow) + EVM anti-forgery; **M4** = EVM calibration corpus + scorecard. Deferred M1 polish: an EVM arm for the `--poc` forgery gate (currently **fail-safe** — rejects a supplied PoC → inconclusive, never false-VERIFIED) and an EVM-aware `report.md` Reproduce line.

Submission stays **human-gated** — the colony never posts to a platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
