### PR TITLE
dark-factory: Solidity reconn ingest for EVM targets — M2 (#858)

### DIFF
--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -285,6 +285,18 @@ fn distill_subgraphs(code: string) -> int {
     }, 0);
 }
 
+// M2 (#858): EVM peer of distill_subgraphs — split a Solidity target on the `function `
+// handler boundary so the same handler sub-graph across .sol targets/repos gets the same
+// content hash (structural dedup). dag_put is a leaf builtin (kept shallow on the stack).
+fn distill_subgraphs_evm(code: string) -> int {
+    return reduce(regex_split("function ", code), |acc: int, c: string| -> int {
+        if len(c) > 0 {
+            dag_put("function " + c);
+        }
+        return acc + 1;
+    }, 0);
+}
+
 // Pick the prior verdict for a sub-graph: federation blacklist wins, else own cache.
 fn pick_prior(cached: string, black: string) -> string {
     if len(black) > 0 {
@@ -983,19 +995,46 @@ fn ingest_nodes(target: string) -> string {
     return exec sh "rm -f extract; rustc --edition 2021 extract_nodes.rs -o extract 2>/dev/null && ./extract 2>/dev/null || echo '[]'";
 }
 
+// M2 (#858): EVM/Solidity node-stream ingestion — the EVM peer of ingest_nodes(). Execs the
+// host-side `ast.js` (pinned solc 0.8.26) in the EVM harness dir, where ast.js + node_modules/solc
+// live, mirroring how compile_run runs `node compile.js` there. solc parses the target to its AST;
+// ast.js walks it and emits the SAME canonical {"kind","name"} node stream the Rust extractor
+// produces (function / external-call / storage-write-sink nodes). Host-side parse, exactly like the
+// Rust exec-driven parse. Graceful — a solc fatal / missing ast.js degrades to "[]" and never breaks
+// the audit (the in-.ag structural reentrancy view is unaffected). `target` is written into the
+// harness scratch (h_ingest.sol, gitignored) so the parse never touches the committed contracts.
+fn ingest_evm_nodes(target: string) -> string {
+    let ed = getenv("EVM_HARNESS_DIR");
+    if len(ed) == 0 {
+        return "[]";
+    }
+    file_write("h_ingest.sol", target);
+    // colony-lint: safe-exec-concat
+    return exec sh "cp h_ingest.sol ${ed}/contracts/Ingest.sol 2>/dev/null; cd ${ed}; node ast.js contracts/Ingest.sol 2>/dev/null || echo '[]'";
+}
+
 agent reconn() -> void {
     let target = listen("audit:target");
-    // M1 (#858): EVM/Solidity targets BYPASS the Rust-shaped ingest. `cargo tree` needs a
-    // Cargo crate and the reference node-extractor parses Rust `fn`/`struct`/`impl`, neither of
-    // which applies to a `.sol`. Skip both and emit a trivial DAG node so the pipeline still
-    // flows to guard/synthesis/verify; the content-addressed target hash (verdict cache + dedup)
-    // is taken over the source text, which is language-agnostic. Full Solidity ingest (solc AST
-    // -> function/call/sink node stream) is M2.
+    // M2 (#858): EVM/Solidity targets get the FULL reconn->guard->tracker DAG pipeline (the
+    // M1 trivial-node bypass is gone). The Rust path's `cargo tree` + Rust fn/struct/impl
+    // node-extractor do not apply to a `.sol`, so reconn runs the EVM peer: a host-side solc
+    // AST parse (ast.js, pinned solc 0.8.26) -> the SAME canonical {"kind","name"} node stream
+    // (function / external-call / storage-write-sink nodes), dag_put as a sub-graph exactly like
+    // the Rust node stream. The content-addressed target hash (verdict cache + federation
+    // blacklist + dedup) stays `dag_put(strip_comments(target))`, byte-identical to M1, so a
+    // cached EVM verdict from before M2 still hits. Downstream (guard fires Reentrancy, the
+    // two-sided real-EVM synthesis gate) is unchanged — M2 only changes how reconn builds the DAG.
     if is_evm_target(target) {
+        let enodes = ingest_evm_nodes(target);
+        let enh = dag_put(enodes);
+        let encount = len(regex_find_all("\"name\"", enodes));
+        print("reconn: EVM/Solidity ingest ->", encount, "node(s) -> dag", substring(enh, 0, 12));
+        // distill: store each Solidity handler sub-graph in the content-addressed DAG (dedup cache).
         let ecode = strip_comments(target);
+        let en = distill_subgraphs_evm(ecode);
         let eth = dag_put(ecode);
-        let enode = dag_put("{\"kind\":\"solidity-target\",\"lang\":\"evm\"}");
-        print("reconn: EVM/Solidity target — Rust ingest bypassed (M1); target hash", substring(eth, 0, 12), "node", substring(enode, 0, 12));
+        print("reconn: distilled", en, "sub-graph(s); target hash", substring(eth, 0, 12));
+        // audit-once: reuse a prior verdict / federation blacklist for this exact sub-graph.
         let eprior = pick_prior(recall_latest("bounty:verdict:" + eth), recall_latest("bounty:blacklist:" + eth));
         emit("guard:target", target);
         emit("guard:th", eth);

--- a/dark-factory/evm-harness/.gitignore
+++ b/dark-factory/evm-harness/.gitignore
@@ -6,5 +6,7 @@ node_modules/
 build.out
 solc.out
 contracts/Target.sol
+contracts/Ingest.sol
 contracts/bin/Target.bin
+contracts/bin/Ingest.bin
 contracts/bin/IVault.bin

--- a/dark-factory/evm-harness/ast.js
+++ b/dark-factory/evm-harness/ast.js
@@ -1,0 +1,161 @@
+// Host-side Solidity AST -> canonical node-stream extractor for the colony's EVM reconn
+// ingest (M2 of #858). Reuses the pinned solc 0.8.26 (see package.json) — the SAME compiler
+// compile.js uses for creation bytecode. Mirrors the Rust path's reference node-extractor
+// (auditor.ag::node_extractor): it walks the parsed program and emits a single-line JSON
+// array of {"kind","name"} nodes, the EVM peer of the Rust fn/struct/impl node stream.
+//
+// Usage:   node ast.js <target.sol>
+// Output:  one line, a JSON array on stdout, e.g.
+//   [{"kind":"function","name":"ReentrancyVaultInsecure.withdraw"},
+//    {"kind":"call","name":"ReentrancyVaultInsecure.withdraw.call"},
+//    {"kind":"sink","name":"ReentrancyVaultInsecure.withdraw:balanceOf"}]
+// On any error (missing arg, solc fatal, unreadable file) it prints "[]" and exits 0 so the
+// colony's reconn degrades gracefully exactly like the Rust ingest (rustc failure -> "[]").
+//
+// Node kinds (the EVM peer of the Rust fn/struct/impl stream):
+//   function — every FunctionDefinition (named fn, or the receive/fallback/constructor kind),
+//              scoped <contract>.<name> so the same handler across contracts/repos dedups.
+//   call     — every external/low-level value-or-control call sink: a `.call` / `.transfer`
+//              / `.send` / `.delegatecall` / `.callcode` member call, or any cross-contract
+//              FunctionCall through a MemberAccess (the EVM analog of a Solana CPI sink).
+//   sink     — every storage-write effect: an Assignment whose LHS is an IndexAccess or a
+//              MemberAccess (state mapping / struct-field mutation, e.g. `balanceOf[..] = 0`).
+// Deterministic: nodes are emitted in source/AST traversal order, no clocks, no randomness.
+
+'use strict';
+
+const solc = require('solc');
+const fs = require('fs');
+
+function emit(nodes) {
+  process.stdout.write('[' + nodes.join(',') + ']\n');
+}
+
+function node(kind, name) {
+  // Match the Rust extractor's exact field shape: {"kind":"..","name":".."}.
+  return '{"kind":"' + kind + '","name":"' + name + '"}';
+}
+
+// JSON-safe an identifier fragment for embedding inside the manual {"name":".."} string
+// above (the only chars Solidity identifiers + our separators can contain are already
+// JSON-safe, but a defensive escape keeps the one-line array valid no matter what).
+function safe(s) {
+  return String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+// The low-level / value-bearing call members that are external-call sinks.
+const CALL_MEMBERS = { call: 1, delegatecall: 1, callcode: 1, staticcall: 1, transfer: 1, send: 1 };
+
+// A human-readable label for a function definition node (named fn, else its kind).
+function fnLabel(fn) {
+  if (fn.name && fn.name.length > 0) return fn.name;
+  return fn.kind || 'function'; // receive / fallback / constructor have empty name
+}
+
+// Best-effort base name of an LHS expression for a storage-write sink label.
+function lhsName(lhs) {
+  if (!lhs) return 'state';
+  // balanceOf[msg.sender] -> IndexAccess over a base expression; walk to the base ident.
+  let cur = lhs;
+  while (cur && cur.nodeType === 'IndexAccess') cur = cur.baseExpression;
+  if (cur && cur.nodeType === 'MemberAccess') return cur.memberName || 'state';
+  if (cur && cur.nodeType === 'Identifier') return cur.name || 'state';
+  return 'state';
+}
+
+// Walk a function body, appending call / sink nodes scoped to `<contract>.<fn>`.
+function walkBody(n, scope, nodes) {
+  if (!n || typeof n !== 'object') return;
+  if (Array.isArray(n)) {
+    for (const x of n) walkBody(x, scope, nodes);
+    return;
+  }
+  if (n.nodeType === 'FunctionCall') {
+    // The callee is either a direct MemberAccess (a.call / a.transfer / lib.foo()) or a
+    // FunctionCallOptions wrapping one (`a.call{value: v}(..)`). Reach through both.
+    let callee = n.expression;
+    if (callee && callee.nodeType === 'FunctionCallOptions') callee = callee.expression;
+    if (callee && callee.nodeType === 'MemberAccess') {
+      const m = callee.memberName || '';
+      if (CALL_MEMBERS[m]) {
+        nodes.push(node('call', safe(scope + '.' + m)));
+      } else {
+        // A cross-contract / external method call (e.g. vault.withdraw()) — the EVM analog
+        // of a CPI sink. Record it so reconn sees the external-interaction surface.
+        nodes.push(node('call', safe(scope + '.' + m)));
+      }
+    }
+  } else if (n.nodeType === 'Assignment') {
+    const lhs = n.leftHandSide;
+    if (lhs && (lhs.nodeType === 'IndexAccess' || lhs.nodeType === 'MemberAccess')) {
+      nodes.push(node('sink', safe(scope + ':' + lhsName(lhs))));
+    }
+  }
+  for (const k of Object.keys(n)) {
+    if (k === 'nodeType') continue;
+    walkBody(n[k], scope, nodes);
+  }
+}
+
+function main() {
+  const file = process.argv[2];
+  if (!file) {
+    emit([]);
+    return;
+  }
+  let src;
+  try {
+    src = fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    emit([]);
+    return;
+  }
+
+  const input = {
+    language: 'Solidity',
+    sources: { 'target.sol': { content: src } },
+    settings: { outputSelection: { '*': { '': ['ast'] } } },
+  };
+
+  let out;
+  try {
+    out = JSON.parse(solc.compile(JSON.stringify(input)));
+  } catch (e) {
+    emit([]);
+    return;
+  }
+  if (out.errors) {
+    for (const e of out.errors) {
+      // AST extraction tolerates warnings; only a hard parse/type error aborts (-> "[]").
+      if (e.severity === 'error') {
+        process.stderr.write((e.formattedMessage || e.message || 'solc error') + '\n');
+        emit([]);
+        return;
+      }
+    }
+  }
+
+  const srcUnit = out.sources && out.sources['target.sol'] && out.sources['target.sol'].ast;
+  if (!srcUnit || !Array.isArray(srcUnit.nodes)) {
+    emit([]);
+    return;
+  }
+
+  const nodes = [];
+  for (const c of srcUnit.nodes) {
+    if (c.nodeType !== 'ContractDefinition' || !Array.isArray(c.nodes)) continue;
+    const contract = c.name || '(contract)';
+    for (const m of c.nodes) {
+      if (m.nodeType !== 'FunctionDefinition') continue;
+      const label = fnLabel(m);
+      const scope = contract + '.' + label;
+      nodes.push(node('function', safe(scope)));
+      // External-call + storage-write sinks live inside the function body.
+      if (m.body) walkBody(m.body, scope, nodes);
+    }
+  }
+
+  emit(nodes);
+}
+
+main();


### PR DESCRIPTION
## Why

M2 of agentis-core#858. M1 dispatched EVM targets but **bypassed** reconn for `.sol` (a trivial DAG node). M2 gives EVM targets the **full reconn→guard→tracker DAG pipeline** via a real Solidity ingest.

## What

- **`evm-harness/ast.js`** (new) — host-side Solidity AST → canonical node-stream extractor. Reuses the pinned solc 0.8.26 (`solc.compile` with `outputSelection` AST), walks the program, and emits the **exact same `{"kind","name"}` node stream the Rust reference extractor produces** (so the existing `dag_put` / sub-graph distillation is reused verbatim). Node kinds: `function` (every `FunctionDefinition`, scoped `<contract>.<fn>`), `call` (external/low-level sinks: `.call`/`.transfer`/`.send`/`.delegatecall`/`.staticcall` + cross-contract calls), `sink` (storage-write `Assignment`s). Deterministic; degrades to `[]` on bad input like the Rust ingest.
- **`auditor.ag`** — `reconn()`'s EVM path now execs `ast.js` host-side (in `EVM_HARNESS_DIR`, mirroring how `compile_run` execs `compile.js`), `dag_put`s the node stream, prints `reconn: EVM/Solidity ingest -> N node(s) -> dag <hash>`, and distills per-`function` sub-graphs. The **target hash stays byte-identical to M1** (`dag_put(strip_comments(target))`), so cached verdicts/blacklist keys hit and the M1 two-sided gate is untouched.
- `.gitignore` covers the new parse scratch (`contracts/Ingest.sol`, `contracts/bin/Ingest.bin`).

## Validation

Deterministic mock path (no LLM), confirming M2's change end-to-end through reconn+guard:

| target | reconn | guard | target hash (== M1) |
|---|---|---|---|
| `ReentrancyVaultInsecure.sol` | `EVM/Solidity ingest -> 6 node(s) -> dag` (real ingest, not bypass) | **Reentrancy fired [High]** | `b6572b3de217` ✓ |
| `ReentrancyVaultSecure.sol` | `EVM/Solidity ingest -> 6 node(s) -> dag` | **no rule fired — safe** | `2cf387dc60dd` ✓ |

The CEI signal is preserved as **node-stream order** (insecure `withdraw` emits `call` before `sink`; secure emits `sink` before `call`). `ast.js` is deterministic across runs. `colony-lint`: **353 passed, 0 failed**; `node --check` + `bash -n` clean.

The synthesis→VERIFIED step is **unchanged M1 code** (merged green in #975; an M1 claude run VERIFIED end-to-end). A full M2 claude VERIFY hit **transient claude-CLI 180s timeouts** on the synthesis PoC-gen call (infra, not M2 — the run reached synthesis with the real DAG + Reentrancy fired before timing out), so M2's change is validated via the deterministic mock path + M1's proven synthesis.

## Scope + follow-ups (#858)

M2 only. **M3** = EVM class set (access-control, unchecked-call, oracle, overflow) + EVM anti-forgery; **M4** = EVM calibration corpus + scorecard. Pre-existing follow-up: `dark-factory/BUNDLE.manifest` declares neither `evm-harness/` nor `solana-harness-anchor/` (research scaffold; manifest is for a hypothetical release tarball) — separate hygiene task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
