### PR TITLE
dark-factory: run the EVM colony on real multi-file Foundry/Hardhat targets (#859 phases 1-4)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,17 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Real multi-file Foundry/Hardhat target support (#980). The EVM colony can now compile + run on
+  real multi-file projects (OpenZeppelin/lib imports, inheritance, a project-pinned solc), not just
+  self-contained single-file contracts. A project-aware compiler (`evm-harness/compile-project.js`
+  + shared `evm-harness/solc-resolve.js`) resolves a target contract's imports via the project's
+  remappings + layout (lib/ submodules, node_modules) and selects/loads the project's solc version
+  (offline from an on-disk soljson cache, host-side `--warm` pre-download); a dep-fetch helper
+  (`fetch-target.sh`) clones a target repo with its submodules/deps; `run-audit.sh` gains
+  `--repo` / `--in-scope` / `--contract`; and the `auditor.ag` `compile_run` + reconn (`ast.js`)
+  paths dispatch to the project compiler when a repo target is set. The colony detects + verifies
+  the single-contract bug classes on real code via the unchanged two-sided real-EVM gate; complex
+  multi-contract protocol-exploit verification remains the later frontier.
 - EVM/Solidity auditing — M4 (agentis-core#858). The EVM calibration corpus + harness, the peer of
   the Solana `calibrate-sealevel.sh` / `sealevel-scorecard.md`. A five-class vuln+safe corpus in
   `evm-harness/contracts/` (Reentrancy + AccessControl reused from M1–M3, plus new UncheckedCall,

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -577,6 +577,22 @@ fn compile_run(poc: string, target_src: string) -> string {
         // offline (cargo + revm only); solc/node runs host-side. revm is slow in debug, so build +
         // run --release (the warmed profile). An empty poc keeps the harness's committed poc.rs.
         file_write("h_target.sol", target_src);
+        // #859: a REAL multi-file repo target. The in-scope source (challenge-augmented) compiles
+        // WITH its deps via compile-project.js (remappings + lib/ + node_modules, project solc,
+        // offline from the host-warmed .solc-cache). compile.js still builds the committed generic
+        // Attacker (self-contained). No contracts/Target.sol is written — that would break compile.js's
+        // import-less batch (#820 regression) — Target.bin comes from the project compile, content-
+        // overridden by h_inscope.sol so the per-run challenge fn rides in the bytecode without
+        // mutating the operator's repo. $BOUNTY_* are shell-expanded from the passed-through env.
+        if len(getenv("BOUNTY_REPO")) > 0 {
+            if len(poc) > 0 {
+                file_write("h_poc.rs", poc);
+                // colony-lint: safe-exec-concat
+                return exec sh "set -e; cp h_poc.rs ${ed}/src/bin/poc.rs; cp h_target.sol ${ed}/h_inscope.sol; rm -f ${ed}/contracts/Target.sol ${ed}/contracts/bin/Target.bin; cd ${ed}; set +e; node compile.js > solc.out 2>&1; SRC=$?; if [ $SRC -ne 0 ]; then cat solc.out; echo __rc=$SRC; else node compile-project.js \"$BOUNTY_REPO\" \"$BOUNTY_IN_SCOPE\" contracts/bin/Target.bin \"$BOUNTY_CONTRACT\" h_inscope.sol > proj.out 2>&1; PRC=$?; if [ $PRC -ne 0 ]; then cat proj.out; echo __rc=$PRC; else export PATH=$HOME/.cargo/bin:$PATH; CARGO_NET_OFFLINE=1 cargo build --quiet --release --bin poc --offline > build.out 2>&1; BRC=$?; if [ $BRC -ne 0 ]; then cat build.out; echo __rc=$BRC; else RAYON_NUM_THREADS=4 ./target/release/poc contracts/bin/Target.bin contracts/bin/Attacker.bin 2>&1; echo __rc=$?; fi; fi; fi";
+            }
+            // colony-lint: safe-exec-concat
+            return exec sh "set -e; cp h_target.sol ${ed}/h_inscope.sol; rm -f ${ed}/contracts/Target.sol ${ed}/contracts/bin/Target.bin; cd ${ed}; set +e; node compile.js > solc.out 2>&1; SRC=$?; if [ $SRC -ne 0 ]; then cat solc.out; echo __rc=$SRC; else node compile-project.js \"$BOUNTY_REPO\" \"$BOUNTY_IN_SCOPE\" contracts/bin/Target.bin \"$BOUNTY_CONTRACT\" h_inscope.sol > proj.out 2>&1; PRC=$?; if [ $PRC -ne 0 ]; then cat proj.out; echo __rc=$PRC; else export PATH=$HOME/.cargo/bin:$PATH; CARGO_NET_OFFLINE=1 cargo build --quiet --release --bin poc --offline > build.out 2>&1; BRC=$?; if [ $BRC -ne 0 ]; then cat build.out; echo __rc=$BRC; else RAYON_NUM_THREADS=4 ./target/release/poc contracts/bin/Target.bin contracts/bin/Attacker.bin 2>&1; echo __rc=$?; fi; fi; fi";
+        }
         if len(poc) > 0 {
             file_write("h_poc.rs", poc);
             // colony-lint: safe-exec-concat
@@ -1208,6 +1224,14 @@ fn ingest_evm_nodes(target: string) -> string {
     let ed = getenv("EVM_HARNESS_DIR");
     if len(ed) == 0 {
         return "[]";
+    }
+    // #859: a repo target's in-scope file imports deps — point ast.js at the file IN the repo
+    // plus the repo ROOT so its imports resolve (remappings + lib/ + node_modules) and the node
+    // stream is non-empty instead of degrading to "[]" on the first unresolved import. BOUNTY_TARGET
+    // is the in-scope file's absolute path; ast.js keys it project-relative for correct import normalization.
+    if len(getenv("BOUNTY_REPO")) > 0 {
+        // colony-lint: safe-exec-concat
+        return exec sh "cd ${ed}; node ast.js \"$BOUNTY_TARGET\" \"$BOUNTY_REPO\" 2>/dev/null || echo '[]'";
     }
     file_write("h_ingest.sol", target);
     // colony-lint: safe-exec-concat

--- a/dark-factory/evm-harness/.gitignore
+++ b/dark-factory/evm-harness/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 # the committed contracts/bin/{ReentrancyVault*,Attacker}.bin are the calibration artifacts.
 build.out
 solc.out
+proj.out
+.solc-cache/
+h_inscope.sol
 contracts/Target.sol
 contracts/Ingest.sol
 contracts/bin/Target.bin

--- a/dark-factory/evm-harness/ast.js
+++ b/dark-factory/evm-harness/ast.js
@@ -4,7 +4,12 @@
 // (auditor.ag::node_extractor): it walks the parsed program and emits a single-line JSON
 // array of {"kind","name"} nodes, the EVM peer of the Rust fn/struct/impl node stream.
 //
-// Usage:   node ast.js <target.sol>
+// Usage:   node ast.js <target.sol> [project-root]
+//   With a [project-root] the target's imports are resolved (remappings + lib/ + node_modules,
+//   via the shared solc-resolve) and the project's solc version is selected — so a REAL
+//   multi-file repo target yields a non-empty node stream instead of degrading to "[]" on the
+//   first unresolved import (phases 1+3 of agentis-core#859). Without it, the legacy
+//   single-self-contained-file behaviour is unchanged.
 // Output:  one line, a JSON array on stdout, e.g.
 //   [{"kind":"function","name":"ReentrancyVaultInsecure.withdraw"},
 //    {"kind":"call","name":"ReentrancyVaultInsecure.withdraw.call"},
@@ -26,6 +31,7 @@
 
 const solc = require('solc');
 const fs = require('fs');
+const path = require('path');
 
 function emit(nodes) {
   process.stdout.write('[' + nodes.join(',') + ']\n');
@@ -97,8 +103,9 @@ function walkBody(n, scope, nodes) {
   }
 }
 
-function main() {
+async function main() {
   const file = process.argv[2];
+  const root = process.argv[3]; // optional project root -> resolve imports + pick the project solc
   if (!file) {
     emit([]);
     return;
@@ -111,15 +118,36 @@ function main() {
     return;
   }
 
+  // Repo target: key the source by its project-relative path (so relative imports normalize
+  // correctly), resolve imports via the shared callback, and use the project's solc version.
+  // Single-file (no root): the legacy `target.sol` / pinned-solc path.
+  let compiler = solc;
+  let srcKey = 'target.sol';
+  let importCb;
+  if (root) {
+    try {
+      const R = require('./solc-resolve');
+      const maps = R.readRemappings(root);
+      srcKey = path.relative(root, path.resolve(file)) || path.basename(file);
+      importCb = { import: R.makeResolver(root, maps) };
+      compiler = await R.getSolc(R.detectVersion(root, file)); // disk-cached / pinned; offline in-sandbox
+    } catch (e) {
+      // fall back to the pinned single-file path (still graceful -> may degrade to "[]")
+      srcKey = 'target.sol';
+      importCb = undefined;
+      compiler = solc;
+    }
+  }
+
   const input = {
     language: 'Solidity',
-    sources: { 'target.sol': { content: src } },
+    sources: { [srcKey]: { content: src } },
     settings: { outputSelection: { '*': { '': ['ast'] } } },
   };
 
   let out;
   try {
-    out = JSON.parse(solc.compile(JSON.stringify(input)));
+    out = JSON.parse(compiler.compile(JSON.stringify(input), importCb));
   } catch (e) {
     emit([]);
     return;
@@ -135,7 +163,7 @@ function main() {
     }
   }
 
-  const srcUnit = out.sources && out.sources['target.sol'] && out.sources['target.sol'].ast;
+  const srcUnit = out.sources && out.sources[srcKey] && out.sources[srcKey].ast;
   if (!srcUnit || !Array.isArray(srcUnit.nodes)) {
     emit([]);
     return;
@@ -158,4 +186,4 @@ function main() {
   emit(nodes);
 }
 
-main();
+main().catch(() => emit([]));

--- a/dark-factory/evm-harness/compile-project.js
+++ b/dark-factory/evm-harness/compile-project.js
@@ -53,7 +53,13 @@ async function main() {
     return;
   }
 
-  const content = overrideFile ? fs.readFileSync(overrideFile, 'utf8') : fs.readFileSync(srcAbs, 'utf8');
+  let content;
+  try {
+    content = overrideFile ? fs.readFileSync(overrideFile, 'utf8') : fs.readFileSync(srcAbs, 'utf8');
+  } catch (e) {
+    console.error('in-scope source not readable: ' + (overrideFile || srcAbs) + ' (' + (e.code || e.message) + ')');
+    process.exit(1);
+  }
   const input = {
     language: 'Solidity',
     sources: { [srcKey]: { content } },
@@ -67,14 +73,19 @@ async function main() {
     process.exit(1);
   }
   const file = out.contracts[srcKey];
-  const c = file && (file[contractName] || file[Object.keys(file).find((k) => file[k].evm && file[k].evm.bytecode.object)]);
+  // Use the requested contract when present, else the first deployable contract in the file
+  // (Foundry is one-contract-per-file). Track which key actually built so the log never claims
+  // success for a name that wasn't compiled (a typo'd --contract must be visible, not masked).
+  const builtKey = file && (file[contractName] ? contractName : Object.keys(file).find((k) => file[k].evm && file[k].evm.bytecode.object));
+  const c = builtKey && file[builtKey];
   if (!c || !c.evm.bytecode.object) {
     console.error('no deployable bytecode for ' + contractName + ' in ' + srcKey + ' (contracts: ' + Object.keys(file || {}).join(', ') + ')');
     process.exit(1);
   }
   fs.mkdirSync(path.dirname(outBin), { recursive: true });
   fs.writeFileSync(outBin, c.evm.bytecode.object);
-  console.log('OK: ' + contractName + ' -> ' + c.evm.bytecode.object.length / 2 + ' bytes (solc ' + (solc.version().split('+')[0]) + ', ' + maps.length + ' remappings) -> ' + outBin);
+  const label = builtKey === contractName ? contractName : builtKey + ' (requested ' + contractName + ' not found; used first deployable)';
+  console.log('OK: ' + label + ' -> ' + c.evm.bytecode.object.length / 2 + ' bytes (solc ' + (solc.version().split('+')[0]) + ', ' + maps.length + ' remappings) -> ' + outBin);
 }
 
 main().catch((e) => { console.error('compile-project failed: ' + e.stack); process.exit(1); });

--- a/dark-factory/evm-harness/compile-project.js
+++ b/dark-factory/evm-harness/compile-project.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Project-aware Solidity compiler for REAL multi-file targets (Foundry/Hardhat).
+// Unlike compile.js (single self-contained file), this resolves a target contract's
+// imports via the project's remappings + layout (lib/ submodules, node_modules), selects
+// the project's solc version (loading it from the on-disk cache), and emits the in-scope
+// contract's creation bytecode. The colony's compile_run uses this when auditing a real
+// repo target (phases 1+3 of agentis-core#859). The in-sandbox build stays offline: a
+// host-side `--warm` step (run-audit.sh) pre-downloads any non-pinned solc into .solc-cache,
+// so the sandboxed compile reads the compiler from disk (cargo + revm + solc, all offline).
+//
+// Usage: node compile-project.js <project-root> <in-scope-contract-path> [out.bin] [ContractName] [content-override.sol]
+//   <in-scope-contract-path> is relative to <project-root> (or absolute).
+//   ContractName defaults to the in-scope file's basename (Foundry one-contract-per-file).
+//   content-override.sol  compile THIS content as the in-scope source (keeping its project
+//                         path, so relative imports still resolve) — used to inject the colony's
+//                         per-run anti-forgery challenge fn without mutating the operator's repo.
+//   --warm                host-side: select + download the project's solc into .solc-cache, then
+//                         exit 0 WITHOUT compiling (pre-flight so the sandboxed build is offline).
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { readRemappings, makeResolver, detectVersion, getSolc } = require('./solc-resolve');
+
+async function main() {
+  const argv = process.argv.slice(2).filter((a) => a !== '--warm');
+  const warm = process.argv.includes('--warm');
+  const root = path.resolve(argv[0] || '.');
+  const inRel = argv[1];
+  if (!inRel) {
+    console.error('usage: compile-project.js <project-root> <in-scope-contract-path> [out.bin] [ContractName] [content-override.sol] [--warm]');
+    process.exit(2);
+  }
+  const srcAbs = path.isAbsolute(inRel) ? inRel : path.resolve(root, inRel);
+  const srcKey = path.relative(root, srcAbs); // keep the project-relative key so relative imports normalize right
+  const contractName = argv[3] || path.basename(inRel, '.sol');
+  const outBin = argv[2] || path.join(root, contractName + '.bin');
+  const overrideFile = argv[4]; // optional: compile this content as the in-scope source
+
+  const maps = readRemappings(root);
+  const version = detectVersion(root, srcAbs);
+  let solc;
+  try {
+    solc = await getSolc(version);
+  } catch (e) {
+    if (warm) { console.error('warm: solc ' + version + ' fetch failed (' + e.message + ')'); process.exit(1); }
+    console.error('solc ' + version + ' load failed (' + e.message + '); falling back to local');
+    solc = require('solc');
+  }
+
+  // --warm: the solc version is now on disk (or already pinned) — pre-flight done, don't compile.
+  if (warm) {
+    console.log('warmed: solc ' + solc.version().split('+')[0] + ' ready for ' + srcKey + ' (' + maps.length + ' remappings)');
+    return;
+  }
+
+  const content = overrideFile ? fs.readFileSync(overrideFile, 'utf8') : fs.readFileSync(srcAbs, 'utf8');
+  const input = {
+    language: 'Solidity',
+    sources: { [srcKey]: { content } },
+    settings: { optimizer: { enabled: true, runs: 200 }, outputSelection: { '*': { '*': ['evm.bytecode.object'] } } },
+  };
+  const out = JSON.parse(solc.compile(JSON.stringify(input), { import: makeResolver(root, maps) }));
+  const errs = (out.errors || []).filter((e) => e.severity === 'error');
+  if (errs.length) {
+    console.error('COMPILE ERRORS (' + errs.length + '):');
+    errs.slice(0, 8).forEach((e) => console.error('  ' + (e.formattedMessage || e.message).split('\n')[0]));
+    process.exit(1);
+  }
+  const file = out.contracts[srcKey];
+  const c = file && (file[contractName] || file[Object.keys(file).find((k) => file[k].evm && file[k].evm.bytecode.object)]);
+  if (!c || !c.evm.bytecode.object) {
+    console.error('no deployable bytecode for ' + contractName + ' in ' + srcKey + ' (contracts: ' + Object.keys(file || {}).join(', ') + ')');
+    process.exit(1);
+  }
+  fs.mkdirSync(path.dirname(outBin), { recursive: true });
+  fs.writeFileSync(outBin, c.evm.bytecode.object);
+  console.log('OK: ' + contractName + ' -> ' + c.evm.bytecode.object.length / 2 + ' bytes (solc ' + (solc.version().split('+')[0]) + ', ' + maps.length + ' remappings) -> ' + outBin);
+}
+
+main().catch((e) => { console.error('compile-project failed: ' + e.stack); process.exit(1); });

--- a/dark-factory/evm-harness/solc-resolve.js
+++ b/dark-factory/evm-harness/solc-resolve.js
@@ -1,0 +1,117 @@
+// Shared Solidity project-resolution helpers for the colony's real-target (multi-file
+// Foundry/Hardhat) support — phases 1+3 of agentis-core#859. Both compile-project.js
+// (creation bytecode) and ast.js (reconn node stream) require this so a repo target's
+// imports + solc version resolve identically in the compile path and the recon path.
+//
+//   readRemappings(root)        parse remappings.txt + foundry.toml `remappings = [...]`
+//   makeResolver(root, maps)    solc import callback (remap longest-prefix -> rel -> node_modules/lib)
+//   detectVersion(root, src)    project solc version (foundry.toml solc/solc_version, else exact pragma)
+//   getSolc(version, cacheDir)  the matching solcjs, loaded OFFLINE from an on-disk soljson cache
+//                               (a host-side --warm step downloads it once; the in-sandbox build reads disk)
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const solcMod = require('solc'); // the harness's pinned solcjs (resolved from ./node_modules)
+
+function readRemappings(root) {
+  const maps = [];
+  const add = (e) => {
+    const i = e.indexOf('=');
+    if (i > 0) maps.push([e.slice(0, i).trim(), e.slice(i + 1).trim()]);
+  };
+  const rf = path.join(root, 'remappings.txt');
+  if (fs.existsSync(rf)) {
+    for (const line of fs.readFileSync(rf, 'utf8').split('\n')) {
+      const t = line.trim();
+      if (t && !t.startsWith('#')) add(t);
+    }
+  }
+  const ft = path.join(root, 'foundry.toml');
+  if (fs.existsSync(ft)) {
+    const m = fs.readFileSync(ft, 'utf8').match(/remappings\s*=\s*\[([\s\S]*?)\]/);
+    if (m) for (const q of m[1].matchAll(/["']([^"']+=[^"']+)["']/g)) add(q[1]);
+  }
+  // longest prefix first so the most specific remapping wins
+  maps.sort((a, b) => b[0].length - a[0].length);
+  return maps;
+}
+
+function makeResolver(root, maps) {
+  return function (importPath) {
+    const tries = [];
+    for (const [pre, tgt] of maps) {
+      if (importPath.startsWith(pre)) {
+        tries.push(path.resolve(root, tgt, importPath.slice(pre.length)));
+      }
+    }
+    // common dependency roots + project-relative (solcjs normalizes relative imports
+    // against the importer, so by the time we get here the path is project-anchored)
+    tries.push(path.resolve(root, importPath));
+    tries.push(path.resolve(root, 'node_modules', importPath));
+    tries.push(path.resolve(root, 'lib', importPath));
+    for (const c of tries) {
+      try {
+        return { contents: fs.readFileSync(c, 'utf8') };
+      } catch (e) { /* try next */ }
+    }
+    return { error: 'import not found: ' + importPath + ' (tried ' + tries.length + ' paths)' };
+  };
+}
+
+function detectVersion(root, srcPath) {
+  const ft = path.join(root, 'foundry.toml');
+  if (fs.existsSync(ft)) {
+    const m = fs.readFileSync(ft, 'utf8').match(/solc(?:_version)?\s*=\s*["']([0-9]+\.[0-9]+\.[0-9]+)["']/);
+    if (m) return m[1];
+  }
+  // exact-pinned pragma (e.g. `pragma solidity 0.8.18;`) — a caret/range pragma returns null (use local)
+  const src = fs.readFileSync(srcPath, 'utf8');
+  const m = src.match(/pragma\s+solidity\s+(?:=\s*)?([0-9]+\.[0-9]+\.[0-9]+)\s*;/);
+  if (m) return m[1];
+  return null;
+}
+
+// GET that follows the soliditylang redirect (binaries.soliditylang.org -> github releases),
+// resolving to a Buffer of the body. Used host-side only (the --warm step); the in-sandbox
+// build never reaches here because the soljson is already on disk.
+function httpGet(url) {
+  return new Promise((res, rej) => {
+    https.get(url, (r) => {
+      if (r.statusCode >= 300 && r.statusCode < 400 && r.headers.location) {
+        r.resume();
+        return httpGet(r.headers.location).then(res, rej);
+      }
+      if (r.statusCode !== 200) { r.resume(); return rej(new Error('HTTP ' + r.statusCode + ' for ' + url)); }
+      const d = [];
+      r.on('data', (c) => d.push(c));
+      r.on('end', () => res(Buffer.concat(d)));
+    }).on('error', rej);
+  });
+}
+
+// Return the solcjs matching `version`. The pinned local build is used when it already
+// matches (no fetch). Otherwise the versioned soljson is loaded from the on-disk cache
+// (OFFLINE — the in-sandbox build path); only when it is absent do we fetch + persist it
+// (the host-side --warm step run-audit.sh performs before the sandboxed run, like
+// snapshot-rpc.sh). This keeps the in-sandbox build network-free even for a non-pinned solc.
+async function getSolc(version, cacheDir) {
+  const local = solcMod.version().split('+')[0];
+  if (!version || version === local) return solcMod;
+  cacheDir = cacheDir || path.join(__dirname, '.solc-cache');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  // already cached? load it offline via the wrapper (full versioned filename = soljson-v<ver>+commit.*.js)
+  let full = fs.readdirSync(cacheDir).find((f) => f.startsWith('soljson-v' + version + '+') && f.endsWith('.js'));
+  if (!full) {
+    // not cached — resolve the full name + download once (host-side, network)
+    const list = JSON.parse((await httpGet('https://binaries.soliditylang.org/bin/list.json')).toString());
+    full = list.releases && list.releases[version]; // e.g. "soljson-v0.8.18+commit.87f61d96.js"
+    if (!full) throw new Error('no solc release for ' + version);
+    const buf = await httpGet('https://binaries.soliditylang.org/bin/' + full);
+    fs.writeFileSync(path.join(cacheDir, full), buf);
+  }
+  // wrap the on-disk soljson (require() resolves solc/wrapper from this dir's node_modules)
+  return require('solc/wrapper')(require(path.join(cacheDir, full)));
+}
+
+module.exports = { readRemappings, makeResolver, detectVersion, getSolc, httpGet };

--- a/dark-factory/fetch-target.sh
+++ b/dark-factory/fetch-target.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fetch a real audit target repo WITH its dependencies, for a multi-file colony audit
+# (phase 2 of agentis-core#859). Foundry projects vendor deps as git submodules under lib/
+# (-> --recursive); Hardhat/npm projects need node_modules (-> npm ci). HOST-SIDE network —
+# the operator's one allowed fetch step, like snapshot-rpc.sh; the in-sandbox build stays offline.
+#
+# Usage: fetch-target.sh <git-url> <dest-dir> [git-ref]
+set -eu
+
+URL="${1:-}"; DEST="${2:-}"; REF="${3:-}"
+[ -n "$URL" ] && [ -n "$DEST" ] || { echo "usage: fetch-target.sh <git-url> <dest-dir> [git-ref]" >&2; exit 2; }
+[ -e "$DEST" ] && { echo "fetch-target: dest exists: $DEST (remove it first)" >&2; exit 2; }
+
+# --recursive pulls Foundry lib/ submodules (openzeppelin, forge-std, ...). --depth 1 keeps it light.
+if [ -n "$REF" ]; then
+  git clone --recursive --depth 1 --shallow-submodules --branch "$REF" "$URL" "$DEST"
+else
+  git clone --recursive --depth 1 --shallow-submodules "$URL" "$DEST"
+fi
+
+# Hardhat / npm projects: deps live in node_modules, not lib/.
+if [ -f "$DEST/package.json" ] && [ ! -d "$DEST/node_modules" ]; then
+  ( cd "$DEST" && { npm ci 2>/dev/null || npm install 2>/dev/null; } ) \
+    || echo "fetch-target: npm install skipped/failed (pure-Foundry project, or no registry access)" >&2
+fi
+
+echo "fetch-target: $URL -> $DEST"
+echo "  foundry.toml: $( [ -f "$DEST/foundry.toml" ] && echo yes || echo no )  remappings.txt: $( [ -f "$DEST/remappings.txt" ] && echo yes || echo no )  lib/: $( [ -d "$DEST/lib" ] && echo yes || echo no )  node_modules/: $( [ -d "$DEST/node_modules" ] && echo yes || echo no )"

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -9,11 +9,17 @@
 #
 # Usage:
 #   run-audit.sh --target <program.rs|target.sol> [options]
+#   run-audit.sh --repo <dir> --in-scope <path-within-repo> [options]   # real multi-file EVM target
 # Options:
-#   --target <file>          REQUIRED. The in-scope program source to audit (.rs or .sol).
+#   --target <file>          The in-scope program source to audit (.rs or .sol). REQUIRED unless --repo.
+#   --repo <dir>             A real multi-file Foundry/Hardhat repo (clone with fetch-target.sh).
+#                            The colony compiles the in-scope contract WITH its deps (#859 phases 1-4).
+#   --in-scope <path>        Required with --repo: the in-scope contract, relative to <repo>.
+#   --contract <Name>        With --repo: the contract name to extract (default: in-scope file basename).
 #   --harness <dir>          Native solana-program-test harness dir (SOLANA_HARNESS_DIR).
 #   --anchor-harness <dir>   Anchor harness dir (SOLANA_ANCHOR_HARNESS_DIR).
 #   --evm-harness <dir>      EVM revm harness dir (EVM_HARNESS_DIR) for a Solidity target.
+#                            With --repo this defaults to the bundled ./evm-harness when omitted.
 #   --snapshot <file>        Frozen on-chain account dump (BOUNTY_SNAPSHOT; see snapshot-rpc.sh).
 #   --poc <file>             Operator-supplied PoC candidate (BOUNTY_POC; still gated).
 #   --backend <mock|claude>  LLM backend (default: claude). mock = offline-deterministic.
@@ -25,12 +31,16 @@ set -eu
 HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 TARGET="" ; HARNESS="" ; ANCHOR_HARNESS="" ; EVM_HARNESS="" ; SNAPSHOT="" ; POC=""
+REPO="" ; IN_SCOPE="" ; CONTRACT=""
 BACKEND="claude" ; SANDBOX="hardened" ; OUT="$PWD/audit-out"
 
 need() { [ "$1" -ge 2 ] || { echo "run-audit.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
   case "$1" in
     --target) need "$#"; TARGET="$2"; shift 2 ;;
+    --repo) need "$#"; REPO="$2"; shift 2 ;;
+    --in-scope) need "$#"; IN_SCOPE="$2"; shift 2 ;;
+    --contract) need "$#"; CONTRACT="$2"; shift 2 ;;
     --harness) need "$#"; HARNESS="$2"; shift 2 ;;
     --anchor-harness) need "$#"; ANCHOR_HARNESS="$2"; shift 2 ;;
     --evm-harness) need "$#"; EVM_HARNESS="$2"; shift 2 ;;
@@ -45,7 +55,22 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-[ -n "$TARGET" ] || { echo "run-audit.sh: --target <program.rs|target.sol> is required (the operator picks the in-scope program; this tool never auto-picks a scope)" >&2; exit 2; }
+# --repo mode (#859 phases 1-4): a REAL multi-file Foundry/Hardhat target. The operator points
+# at the repo + the in-scope contract within it; the colony compiles that contract WITH its deps
+# (remappings + lib/ submodules + node_modules) at the project's solc version. The in-scope file
+# becomes the BOUNTY_TARGET (so ingest/reconn work unchanged); BOUNTY_REPO/BOUNTY_IN_SCOPE drive
+# compile_run's project-compile path. --repo is EVM-only and defaults --evm-harness to the bundle.
+if [ -n "$REPO" ]; then
+  [ -d "$REPO" ] || { echo "run-audit.sh: --repo dir not found: $REPO (clone it first with fetch-target.sh)" >&2; exit 2; }
+  REPO="$(cd "$REPO" && pwd)"
+  [ -n "$IN_SCOPE" ] || { echo "run-audit.sh: --repo requires --in-scope <path-within-repo> (the operator picks the in-scope contract; this tool never auto-picks a scope)" >&2; exit 2; }
+  [ -f "$REPO/$IN_SCOPE" ] || { echo "run-audit.sh: in-scope contract not found in repo: $REPO/$IN_SCOPE" >&2; exit 2; }
+  [ -n "$TARGET" ] && { echo "run-audit.sh: pass either --target OR --repo/--in-scope, not both" >&2; exit 2; }
+  TARGET="$REPO/$IN_SCOPE"            # the in-scope file IS the audit target (ingest/reconn read it)
+  [ -n "$EVM_HARNESS" ] || EVM_HARNESS="$HERE/evm-harness"   # --repo is EVM; default to the bundled harness
+fi
+
+[ -n "$TARGET" ] || { echo "run-audit.sh: --target <program.rs|target.sol> (or --repo + --in-scope) is required (the operator picks the in-scope program; this tool never auto-picks a scope)" >&2; exit 2; }
 [ -f "$TARGET" ] || { echo "run-audit.sh: target not found: $TARGET" >&2; exit 2; }
 command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-audit.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
 
@@ -58,6 +83,17 @@ if [ -n "$POC" ]; then [ -f "$POC" ] || { echo "run-audit.sh: poc not found: $PO
 if [ -n "$HARNESS" ]; then [ -d "$HARNESS" ] || { echo "run-audit.sh: harness dir not found: $HARNESS" >&2; exit 2; }; HARNESS="$(cd "$HARNESS" && pwd)"; fi
 if [ -n "$ANCHOR_HARNESS" ]; then [ -d "$ANCHOR_HARNESS" ] || { echo "run-audit.sh: anchor-harness dir not found: $ANCHOR_HARNESS" >&2; exit 2; }; ANCHOR_HARNESS="$(cd "$ANCHOR_HARNESS" && pwd)"; fi
 if [ -n "$EVM_HARNESS" ]; then [ -d "$EVM_HARNESS" ] || { echo "run-audit.sh: evm-harness dir not found: $EVM_HARNESS" >&2; exit 2; }; EVM_HARNESS="$(cd "$EVM_HARNESS" && pwd)"; fi
+
+# --repo: pre-compile the in-scope contract HOST-SIDE (this is the operator's one allowed network
+# step, like snapshot-rpc.sh). It (1) fails fast if the imports/remappings/solc version are wrong
+# — before the slow sandboxed run — and (2) warms .solc-cache with any non-pinned solc so the
+# in-sandbox per-run compile (which re-runs with the anti-forgery challenge injected) stays offline.
+if [ -n "$REPO" ]; then
+  command -v node >/dev/null 2>&1 || { echo "run-audit.sh: node is required for --repo (the EVM project compiler runs on it)" >&2; exit 3; }
+  echo "run-audit.sh: pre-compiling $IN_SCOPE against $REPO host-side (validates imports + warms solc)..." >&2
+  node "$EVM_HARNESS/compile-project.js" "$REPO" "$IN_SCOPE" "$EVM_HARNESS/contracts/bin/Target.bin" "$CONTRACT" >&2 \
+    || { echo "run-audit.sh: host-side compile of $IN_SCOPE failed — check --repo, --in-scope, remappings, and the solc version. Aborting before the sandboxed run." >&2; exit 4; }
+fi
 
 COLONY="$HERE/auditor/agents/auditor.ag"
 [ -f "$COLONY" ] || { echo "run-audit.sh: colony not found at $COLONY" >&2; exit 3; }
@@ -73,7 +109,7 @@ cp "$COLONY" "$RUN/auditor.ag"
   echo "llm.backend = $BACKEND"
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 180000"; }
   echo "trace.level = normal"
-  echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,EVM_HARNESS_DIR,BOUNTY_SNAPSHOT"
+  echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,EVM_HARNESS_DIR,BOUNTY_SNAPSHOT,BOUNTY_REPO,BOUNTY_IN_SCOPE,BOUNTY_CONTRACT"
   echo "exec.default_timeout_ms = 180000"
 } > "$RUN/.agentis/config"
 
@@ -84,6 +120,7 @@ ENV=(BOUNTY_TARGET="$TARGET")
 [ -n "$EVM_HARNESS" ]    && ENV+=(EVM_HARNESS_DIR="$EVM_HARNESS")
 [ -n "$SNAPSHOT" ]       && ENV+=(BOUNTY_SNAPSHOT="$SNAPSHOT")
 [ -n "$POC" ]            && ENV+=(BOUNTY_POC="$POC")
+[ -n "$REPO" ]           && ENV+=(BOUNTY_REPO="$REPO" BOUNTY_IN_SCOPE="$IN_SCOPE" BOUNTY_CONTRACT="$CONTRACT")
 
 GO=(go auditor.ag --enable-exec --enable-messaging)
 [ "$SANDBOX" = "hardened" ] && GO+=(--sandbox-profile hardened)


### PR DESCRIPTION
## What

The EVM colony (#858 M1–M4 + the storage-read fix) audits self-contained single-file Solidity. Real bounty targets (Immunefi Attackathons, c4-successor competitions) are **multi-file Foundry/Hardhat projects** — OZ/lib imports, inheritance, a project-pinned solc. This makes the colony **compile + run on them** so it detects + verifies the single-contract bug classes on real code. Complex multi-contract protocol-exploit verification stays the later frontier (phase 5, out of scope).

## Phases

| Phase | Deliverable | What it does |
|---|---|---|
| **P1** multi-file compile | `evm-harness/compile-project.js` | Parse remappings (`remappings.txt` + `foundry.toml`), resolve imports via a solcjs import callback (longest-prefix remap → project-relative → `node_modules` → `lib/`), extract the in-scope contract's creation bytecode. A content-override arg compiles the colony's per-run challenge-augmented source **without mutating the operator's repo**. No `forge` needed. |
| **P2** dep-fetch | `fetch-target.sh` | Clone a target repo WITH deps (`git --recursive` for Foundry submodules, `npm ci` for Hardhat). Host-side network — the operator's one allowed fetch step, like `snapshot-rpc.sh`. |
| **P3** solc selection | `evm-harness/solc-resolve.js` | Pick the project solc (`foundry.toml` `solc`/`solc_version`, else exact-pinned pragma) and load it from an on-disk soljson cache. A host-side `--warm` pre-download keeps the in-sandbox build **offline** even for a non-pinned solc. |
| **P4** repo dispatch | `run-audit.sh` + `auditor.ag` | `run-audit.sh` gains `--repo` / `--in-scope` / `--contract`; the in-scope file becomes `BOUNTY_TARGET` (ingest/reconn unchanged), `BOUNTY_REPO`/`BOUNTY_IN_SCOPE` drive `compile_run`'s project-compile path. reconn's `ast.js` resolves imports against the repo root so the node stream is non-empty. The two-sided real-EVM gate is unchanged. |

`ast.js` and `compile-project.js` share `solc-resolve.js` so the compile path and the recon path resolve a repo's imports + solc version identically.

## Validated end-to-end through the agentis colony

Against a Foundry project (`VulnToken`: `ERC20 + Ownable`, `mint()` missing `onlyOwner`):

```
pre-compile: VulnToken -> 2767 bytes (solc 0.8.26, 2 remappings)   # OZ imports resolved
reconn: EVM/Solidity ingest -> 2 node(s)                           # repo ast.js arm
guard: AccessControl fired [Critical] (EVM)
synthesis: prompt-generated PoC verified (two-sided)
synthesis: VERIFIED — real-EVM two-sided PoC (revm)
Verdict: VERIFIED
```

`compile_run`'s repo branch builds the committed generic Attacker via `compile.js` and the in-scope `Target.bin` via `compile-project.js` (challenge-augmented, OZ imports resolved); the two-sided gate (`CONTROL OK` + `INVARIANT VIOLATED` + `exit 101`) lands VERIFIED and a human-gated package is staged. **Submission stays a separate, explicit human action — the colony never posts to a platform.**

The offline solc disk-cache + `solc/wrapper` load was separately proven on a non-pinned version (0.8.18 → download once → compile offline). The anti-forgery `pocChallenge_<nonce>` rides into the `compile-project.js` bytecode (content-override) and the wrapped PoC resolves it.

## Notes

- Harness runs (EVM + Solana) operate under `--sandbox none` because the cargo-based harness must write into the harness dir; the hardened bwrap profile mounts the host FS read-only + a fresh `/tmp` tmpfs, so it suits only the embedded std-only target. Pre-existing; unchanged here.
- `.solc-cache/` (downloaded soljson) and the per-run harness scratch are gitignored.
- Does **not** address phase 5 (multi-contract protocol-exploit verification) — out of scope by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)