### PR TITLE
dark-factory: handle caret/range pragmas + no-trailing-slash remappings (real-repo compile)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,17 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Real-repo compile robustness in `evm-harness/solc-resolve.js`: (1) handle caret/range pragmas
+  (`^0.7.6`, `~0.8.4`, `>=0.7.0 <0.8.0`) by selecting the floor solc version when its minor differs
+  from the local pinned build (real repos overwhelmingly use caret pragmas; an exact-pin-only match
+  fell through to the local solc and failed with "requires different compiler version"); (2) resolve
+  Foundry-default remappings written WITHOUT a trailing slash (`@openzeppelin/contracts=lib/…/contracts`)
+  via `path.join` instead of `path.resolve` (the no-trailing-slash remainder starts with `/`, which
+  `path.resolve` treated as absolute and discarded the project prefix → "import not found"). Surfaced
+  by running the colony on a real OpenZeppelin-based Foundry target (compiles 0.7.6 + resolves OZ imports).
+
 ### Added
 
 - Real multi-file Foundry/Hardhat target support (#980). The EVM colony can now compile + run on

--- a/dark-factory/evm-harness/solc-resolve.js
+++ b/dark-factory/evm-harness/solc-resolve.js
@@ -42,7 +42,11 @@ function makeResolver(root, maps) {
     const tries = [];
     for (const [pre, tgt] of maps) {
       if (importPath.startsWith(pre)) {
-        tries.push(path.resolve(root, tgt, importPath.slice(pre.length)));
+        // path.JOIN (not resolve): a remapping without a trailing slash (`@oz/contracts=lib/…/contracts`,
+        // the Foundry default) leaves the remainder starting with `/` (`/token/ERC20.sol`). path.resolve
+        // would treat that as ABSOLUTE and discard the root+tgt prefix; path.join folds the leading slash
+        // into a separator, so both `@oz/contracts/=…/contracts/` and `@oz/contracts=…/contracts` resolve.
+        tries.push(path.join(root, tgt, importPath.slice(pre.length)));
       }
     }
     // common dependency roots + project-relative (solcjs normalizes relative imports
@@ -65,10 +69,21 @@ function detectVersion(root, srcPath) {
     const m = fs.readFileSync(ft, 'utf8').match(/solc(?:_version)?\s*=\s*["']([0-9]+\.[0-9]+\.[0-9]+)["']/);
     if (m) return m[1];
   }
-  // exact-pinned pragma (e.g. `pragma solidity 0.8.18;`) — a caret/range pragma returns null (use local)
   const src = fs.readFileSync(srcPath, 'utf8');
-  const m = src.match(/pragma\s+solidity\s+(?:=\s*)?([0-9]+\.[0-9]+\.[0-9]+)\s*;/);
+  // exact-pinned pragma — `pragma solidity 0.8.18;` or `pragma solidity =0.8.18;`
+  let m = src.match(/pragma\s+solidity\s+=?\s*([0-9]+\.[0-9]+\.[0-9]+)\s*;/);
   if (m) return m[1];
+  // caret / range pragma — `^0.7.6`, `~0.8.4`, `>=0.7.0 <0.8.0`. Real repos overwhelmingly use these.
+  // Pick the FLOOR version (the release the code was written against) when its minor differs from the
+  // local pinned solc (e.g. a 0.7.x repo while local is 0.8.x — local can't compile it). When the minor
+  // MATCHES local, return null so the local pinned build (the latest in-range patch) compiles it — that
+  // avoids downgrading a `^0.8.x` repo to 0.8.0 and losing later-0.8 features the code may use.
+  m = src.match(/pragma\s+solidity\s+[~^>=<\s]*([0-9]+\.[0-9]+)\.([0-9]+)/);
+  if (m) {
+    const localMinor = solcMod.version().split('.').slice(0, 2).join('.'); // e.g. "0.8"
+    if (m[1] === localMinor) return null;
+    return m[1] + '.' + m[2];
+  }
   return null;
 }
 


### PR DESCRIPTION
## What

Two robustness fixes in `evm-harness/solc-resolve.js`, surfaced by running the EVM colony on a **real** Foundry target (Cyfrin Puppy Raffle — OpenZeppelin ERC721/Ownable/Address + a base64 lib, `pragma solidity ^0.7.6`, Foundry-default remapping). Both are gaps the clean synthetic fixture (exact-pin pragma + trailing-slash remapping) never hit.

| Fix | Before | After |
|---|---|---|
| **Caret/range pragma** | `detectVersion` only matched an EXACT-pinned pragma → `^0.7.6` fell through to the local pinned solc → `ParserError: requires different compiler version`. Real repos overwhelmingly use caret pragmas. | Pick the **floor** version (`^0.7.6` → `0.7.6`) when its minor differs from the local solc (a 0.7.x repo can't compile under local 0.8.x); when the minor **matches**, keep returning `null` so the local pinned build (latest in-range patch) compiles it — avoids downgrading a `^0.8.x` repo to 0.8.0 and losing later-0.8 features. |
| **No-trailing-slash remapping** | `makeResolver` used `path.resolve` for the remapped path; a remapping like `@openzeppelin/contracts=lib/…/contracts` (no trailing slash, the Foundry default) leaves the remainder starting with `/` → `path.resolve` treats it as **absolute** and discards the project prefix → `import not found`. | `path.join`, which folds the leading slash into a separator, so both `@oz/contracts/=…/contracts/` and `@oz/contracts=…/contracts` resolve. |

## Validation

- **Puppy Raffle now compiles**: `PuppyRaffle -> 14362 bytes (solc 0.7.6, 1 remappings)` — solc 0.7.6 fetched + cached, OZ ERC721/Ownable/Address + base64 imports resolved. Its reconn node stream is non-empty (29 nodes).
- **Regression clean**: the synthetic VulnToken fixture still compiles byte-identically (2767 bytes, solc 0.8.26 via the local-minor-match path); the `foundry.toml solc = "0.8.26"` path unchanged.

## Context

This came out of a real-target dry-run of the now-merged #980 (real multi-file target support). The **compile path (phases 1-4) handled the real OpenZeppelin-based 0.7.6 repo** once these two gaps were fixed — that was the primary thing the dry-run set out to validate. Separately, the colony's **synthesis** step did not produce a PoC for Puppy Raffle's complex *stateful* bugs within the LLM throughput envelope (the `claude -p` subprocess hit the 180s timeout × the retry budget on PoC generation) — that's a synthesis/harness-maturity axis, independent of these compile-layer fixes, and is the next thing to harden for end-to-end VERIFY on complex contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)