### PR TITLE
dark-factory: decomposed EVM PoC synthesis — skeleton + two small slot-fills (#982)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -27,6 +27,16 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Decomposed EVM PoC synthesis (#982). The synthesis agent no longer asks the LLM for the WHOLE
+  `poc.rs` in one prompt — a large OUTPUT that stalls `claude -p` on a non-trivial contract (a real
+  target's one-shot never returned at a 600s timeout; a small-output fragment prompt returns in
+  ~40s). Instead a fixed skeleton (`evm-harness/poc-skeleton.rs`) carries all the revm-14 boilerplate
+  + helpers, and the LLM fills only two small slots — the CONTROL block and the EXPLOIT block (~15
+  lines each) — which `evm-harness/assemble-poc.js` splices in. Each generation is small + fast and
+  the LLM writes far less error-prone code (the helpers handle the fiddly revm API). The two-sided
+  gate (`CONTROL OK:` + `INVARIANT VIOLATED:` + exit 101) is unchanged. Validated end-to-end through
+  the live colony: a real OpenZeppelin Foundry target reaches VERIFIED in ~48s on the first attempt.
+  Solana / std-only targets keep the single one-shot prompt (their PoCs are smaller).
 - Real multi-file Foundry/Hardhat target support (#980). The EVM colony can now compile + run on
   real multi-file projects (OpenZeppelin/lib imports, inheritance, a project-pinned solc), not just
   self-contained single-file contracts. A project-aware compiler (`evm-harness/compile-project.js`

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -562,6 +562,82 @@ fn poc_instruction(cls: string) -> string {
         "`INVARIANT VIOLATED:` markers are REQUIRED. Output only the Rust source.";
 }
 
+// #982: DECOMPOSED EVM synthesis. The one-shot poc_instruction asks for the WHOLE poc.rs
+// (~200 lines) in a single prompt — a big OUTPUT that stalls `claude -p` on a non-trivial
+// contract (proven: a complex target's one-shot never returned at 600s, while a small-output
+// fragment prompt returns in ~40s). So for EVM we keep all the revm boilerplate in a FIXED
+// skeleton (evm-harness/poc-skeleton.rs) and ask the LLM only for two SMALL slots — the CONTROL
+// block and the EXPLOIT block (~12-18 lines each) — then splice them in (assemble-poc.js). Each
+// generation is small + fast; the two-sided gate (CONTROL OK: + INVARIANT VIOLATED: + exit 101)
+// is unchanged. The slot prompts describe the skeleton's helpers/vars so the fills compile against it.
+fn control_instruction(cls: string) -> string {
+    let einv = evm_invariant_for(cls);
+    return "You are filling ONLY the CONTROL block of a revm-14 Rust PoC against the Solidity contract " +
+        "given as input. A fixed skeleton already provides these helpers + vars — USE them, do NOT " +
+        "redefine, import, or write any `fn`/`use`/`main`: deploy(&mut evm, deployer, &target_code, " +
+        "&ctor_args) -> Address (deploys a FRESH target; append abi-encoded constructor args or pass " +
+        "&[]); call(&mut evm, from, to, data) -> Vec<u8> (NON-payable, 4 args, DIES on revert); " +
+        "call_value(&mut evm, from, to, value, data) -> Vec<u8> (payable, sends ETH); try_call(&mut evm, " +
+        "from, to, data) -> Option<Vec<u8>> (non-payable, None on revert); try_call_value(&mut evm, from, " +
+        "to, value, data) -> Option<Vec<u8>> (payable); selector(\"f(uint256)\") -> Vec<u8>; " +
+        "abi_addr(addr) -> Vec<u8>; abi_u256(amount) -> Vec<u8> (accepts a U256 or a u128/u64 integer); " +
+        "eth_balance(&mut evm, addr) -> U256; " +
+        "storage(&mut evm, addr, slot_u64) -> U256; u256(&bytes) -> U256; die(msg: String) -> !. Vars in " +
+        "scope: evm, target_code: Vec<u8>, attacker_code: Vec<u8> (argv[2], may be empty), " +
+        "deployer/attacker/user: Address (each funded 100 ETH). U256, TxKind, Address are imported. " +
+        "EXAMPLE of a read: `let mut d = selector(\"balanceOf(address)\"); d.extend(abi_addr(user)); " +
+        "let bal = u256(&call(&mut evm, user, t, d));`. The invariant under test: " + einv +
+        " Write ONLY the CONTROL block: deploy a fresh target and " +
+        "exercise the LEGITIMATE flow the invariant assumes; if it holds print exactly " +
+        "`CONTROL OK: <short detail>`. If the legitimate flow itself fails, call die(\"...\".into()) (a " +
+        "setup failure, NOT a verdict). Output ONLY Rust statements (~12 lines) — no code fences, no " +
+        "prose, no fn/use/main.";
+}
+
+fn exploit_instruction(cls: string) -> string {
+    let einv = evm_invariant_for(cls);
+    return "You are filling ONLY the EXPLOIT block of a revm-14 Rust PoC against the Solidity contract " +
+        "given as input. The SAME fixed skeleton/helpers/vars as the CONTROL block are available " +
+        "(deploy; call(&mut evm,from,to,data) NON-payable 4 args; call_value(&mut evm,from,to,value,data) " +
+        "payable; try_call / try_call_value; selector / abi_addr / abi_u256 / eth_balance / storage / u256 " +
+        "/ die; evm, target_code, attacker_code, deployer/attacker/user: Address; U256/TxKind/Address " +
+        "imported; exit() in scope). Do NOT redefine, import, or write any fn/use/main. The invariant " +
+        "under test: " + einv + " Write ONLY the EXPLOIT block: deploy a FRESH target via deploy(...), " +
+        "perform the attack the invariant describes — a non-owner/attacker account sends the offending tx; " +
+        "for a reentrancy class deploy the attacker with `deploy(&mut evm, attacker, &attacker_code, " +
+        "&abi_addr(t))` (target address as its constructor arg) and call its attack() with a stake via " +
+        "call_value(&mut evm, attacker, atk, U256::from(1_000_000_000_000_000_000u128), selector(\"attack()\")) " +
+        "— then read the relevant state (a public " +
+        "getter via call(), or storage(&mut evm, t, slot) for a private variable; slots are in declaration " +
+        "order from 0) and check the invariant. If it is VIOLATED, print exactly " +
+        "`INVARIANT VIOLATED: <short detail>` to stderr with eprintln! and call exit(101). Otherwise do " +
+        "nothing (the skeleton reports invariant-held). Output ONLY Rust statements (~18 lines) — no code " +
+        "fences, no prose, no fn/use/main.";
+}
+
+// Generate the EVM poc.rs by filling the skeleton's two slots from two small prompts, then splicing
+// via assemble-poc.js (runs from the colony cwd where the fills are written; reads the skeleton +
+// assembler by absolute path in the harness dir). Returns the assembled poc.rs on stdout.
+fn synth_evm_poc_decomposed(cls: string, target: string) -> string {
+    let ed = getenv("EVM_HARNESS_DIR");
+    let control = prompt(control_instruction(cls), target) -> string;
+    let exploit = prompt(exploit_instruction(cls), target) -> string;
+    file_write("h_control.rs", control);
+    file_write("h_exploit.rs", exploit);
+    // colony-lint: safe-exec-concat
+    return exec sh "node ${ed}/assemble-poc.js ${ed}/poc-skeleton.rs h_control.rs h_exploit.rs 2>/dev/null";
+}
+
+// Build a PoC candidate: decomposed skeleton-fill for EVM (#982), the single one-shot prompt for
+// Solana / std targets (their PoCs are smaller + the harness mechanics differ).
+fn gen_poc(cls: string, target: string) -> string {
+    if is_evm_target(target) {
+        return synth_evm_poc_decomposed(cls, target);
+    }
+    let p = prompt(poc_instruction(cls), target) -> string;
+    return p;
+}
+
 // Compile + run a PoC candidate, routing to the real Solana toolchain when
 // SOLANA_HARNESS_DIR is set (solana-program-test + BanksClient through the real SVM,
 // fully offline), else the std-only `rustc` path (offline-deterministic, V1 behaviour).
@@ -849,7 +925,7 @@ fn synth_via_prompt(cls: string, target: string) -> string {
     }
     let llm_out = try {
         retry(5, || -> string {
-            let poc = prompt(poc_instruction(cls), target) -> string;
+            let poc = gen_poc(cls, target);
             if index_of(poc, "fn main") < 0 {
                 print("synthesis: prompt candidate rejected — no usable Rust (no fn main)");
                 throw("prompt produced no usable Rust");

--- a/dark-factory/evm-harness/assemble-poc.js
+++ b/dark-factory/evm-harness/assemble-poc.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Assemble a decomposed EVM PoC: splice the LLM's two small slot-fills (CONTROL, EXPLOIT) into
+// the fixed poc-skeleton.rs at its `// <<CONTROL>>` / `// <<EXPLOIT>>` markers (#982). Each fill
+// is a small Rust fragment; the LLM tends to wrap it in a ```rust fence + prose, so we extract the
+// fenced code (or strip stray fences) before splicing. Prints the assembled poc.rs to stdout.
+//
+// Usage: node assemble-poc.js <skeleton.rs> <control-fill> <exploit-fill>
+'use strict';
+const fs = require('fs');
+
+// Pull the Rust out of an LLM fill: prefer the first ```...``` block (dropping an optional
+// `rust`/`rs` language tag), else drop any stray ``` lines and surrounding prose. Total on any shape.
+function extractCode(raw) {
+  const fence = raw.match(/```(?:rust|rs)?\s*\n([\s\S]*?)```/);
+  if (fence) return fence[1].replace(/\s+$/, '');
+  // no fenced block — drop bare ``` lines and trim
+  return raw.split('\n').filter((l) => l.trim() !== '```' && !/^```/.test(l.trim())).join('\n').replace(/\s+$/, '');
+}
+
+function main() {
+  const [skelPath, ctrlPath, explPath] = process.argv.slice(2);
+  if (!skelPath || !ctrlPath || !explPath) {
+    console.error('usage: assemble-poc.js <skeleton.rs> <control-fill> <exploit-fill>');
+    process.exit(2);
+  }
+  let skel = fs.readFileSync(skelPath, 'utf8');
+  const control = extractCode(fs.readFileSync(ctrlPath, 'utf8'));
+  const exploit = extractCode(fs.readFileSync(explPath, 'utf8'));
+  if (skel.indexOf('// <<CONTROL>>') < 0 || skel.indexOf('// <<EXPLOIT>>') < 0) {
+    console.error('skeleton missing // <<CONTROL>> or // <<EXPLOIT>> marker');
+    process.exit(1);
+  }
+  // indent the fills to match the marker (4 spaces inside main) for readable output; not required to compile
+  const indent = (code) => code.split('\n').map((l) => (l.length ? '    ' + l : l)).join('\n');
+  // Replace the marker as a STANDALONE line (anchored, `m` flag) so a prose mention of the marker
+  // elsewhere (e.g. a doc comment) is never hit; a FUNCTION replacement keeps `$` in the fill literal.
+  const splice = (s, name, label, fill) =>
+    s.replace(new RegExp('^[ \\t]*// <<' + name + '>>[ \\t]*$', 'm'), () => '    // ---- ' + label + ' (generated) ----\n' + indent(fill));
+  skel = splice(skel, 'CONTROL', 'CONTROL', control);
+  skel = splice(skel, 'EXPLOIT', 'EXPLOIT', exploit);
+  process.stdout.write(skel);
+}
+
+main();

--- a/dark-factory/evm-harness/poc-skeleton.rs
+++ b/dark-factory/evm-harness/poc-skeleton.rs
@@ -1,0 +1,148 @@
+//! Fixed two-sided revm PoC skeleton for the dark-factory EVM colony's DECOMPOSED synthesis
+//! (#982). All the revm-14 boilerplate + helpers live here so the LLM never regenerates them;
+//! synthesis fills only two small slots (the CONTROL and EXPLOIT blocks) — each ~15 lines,
+//! which keeps each generation small + fast (a whole-PoC one-shot stalls on a big contract). The
+//! two-sided gate is unchanged: a vulnerable target prints `CONTROL OK:` AND `INVARIANT VIOLATED:`
+//! and exits 101; exit 101 is reserved EXCLUSIVELY for a genuine violation (setup failures -> exit 2).
+//!
+//! argv[1] = target creation-bytecode (.bin hex). argv[2] = optional attacker .bin (reentrancy).
+//!
+//! Helpers the slots may call (do NOT redefine them):
+//!   deploy(&mut evm, deployer, &target_code, &ctor_args) -> Address   // fresh target; append abi args
+//!   call(&mut evm, from, to, data) -> Vec<u8>                         // non-payable call; DIES on revert
+//!   call_value(&mut evm, from, to, value, data) -> Vec<u8>            // payable call (sends ETH)
+//!   try_call(&mut evm, from, to, data) -> Option<Vec<u8>>             // non-payable; None on revert
+//!   try_call_value(&mut evm, from, to, value, data) -> Option<Vec<u8>> // payable; None on revert
+//!   selector("f(uint256)") -> Vec<u8>   abi_addr(a) -> Vec<u8>   abi_u256(n: u128) -> Vec<u8>
+//!   eth_balance(&mut evm, a) -> U256     storage(&mut evm, a, slot_u64) -> U256     u256(&bytes) -> U256
+//!   die(msg) -> !   (HARNESS ERROR + exit 2)
+//! Vars in scope: evm, target_code: Vec<u8>, attacker_code: Vec<u8> (argv[2], may be empty),
+//!   deployer/attacker/user: Address (each funded 100 ETH). U256/TxKind/Address are imported.
+use revm::db::{CacheDB, EmptyDB};
+use revm::primitives::{keccak256, AccountInfo, Address, Bytes, ExecutionResult, Output, TxKind, U256};
+use revm::{Database, Evm};
+use std::process::exit;
+
+type Db = CacheDB<EmptyDB>;
+
+fn die(msg: String) -> ! {
+    eprintln!("HARNESS ERROR: {msg}");
+    exit(2);
+}
+fn selector(sig: &str) -> Vec<u8> {
+    keccak256(sig.as_bytes())[..4].to_vec()
+}
+fn abi_addr(a: Address) -> Vec<u8> {
+    let mut v = vec![0u8; 12];
+    v.extend_from_slice(a.as_slice());
+    v
+}
+// The LLM passes amounts as either a U256 or a plain integer (u128/u64); ruint's `U256::from`
+// is an inherent method, NOT std `From`, so a `T: Into<U256>` bound would reject the integers.
+// A local trait impl'd for exactly those types accepts whatever the fill writes.
+trait Word {
+    fn word(self) -> [u8; 32];
+}
+impl Word for U256 {
+    fn word(self) -> [u8; 32] { self.to_be_bytes::<32>() }
+}
+impl Word for u128 {
+    fn word(self) -> [u8; 32] { U256::from(self).to_be_bytes::<32>() }
+}
+impl Word for u64 {
+    fn word(self) -> [u8; 32] { U256::from(self).to_be_bytes::<32>() }
+}
+fn abi_u256<T: Word>(n: T) -> Vec<u8> {
+    n.word().to_vec()
+}
+fn load_bin(path: &str) -> Vec<u8> {
+    let s = std::fs::read_to_string(path).unwrap_or_else(|e| die(format!("read {path}: {e}")));
+    hex::decode(s.trim()).unwrap_or_else(|e| die(format!("bad hex {path}: {e}")))
+}
+fn fund(evm: &mut Evm<'_, (), Db>, a: Address, wei: U256) {
+    evm.db_mut().insert_account_info(a, AccountInfo { balance: wei, ..Default::default() });
+}
+fn run(evm: &mut Evm<'_, (), Db>, from: Address, to: TxKind, value: U256, data: Vec<u8>) -> ExecutionResult {
+    {
+        let tx = evm.tx_mut();
+        tx.caller = from;
+        tx.transact_to = to;
+        tx.value = value;
+        tx.data = Bytes::from(data);
+        tx.gas_limit = 30_000_000;
+        tx.gas_price = U256::ZERO;
+        tx.nonce = None;
+    }
+    evm.transact_commit().unwrap_or_else(|e| die(format!("EVM transact failed: {e:?}")))
+}
+fn deploy(evm: &mut Evm<'_, (), Db>, from: Address, code: &[u8], ctor_args: &[u8]) -> Address {
+    let mut c = code.to_vec();
+    c.extend_from_slice(ctor_args);
+    match run(evm, from, TxKind::Create, U256::ZERO, c) {
+        ExecutionResult::Success { output: Output::Create(_, Some(a)), .. } => a,
+        o => die(format!("deploy failed: {o:?}")),
+    }
+}
+#[allow(dead_code)]
+fn call(evm: &mut Evm<'_, (), Db>, from: Address, to: Address, data: Vec<u8>) -> Vec<u8> {
+    call_value(evm, from, to, U256::ZERO, data) // non-payable (value 0) — the common case
+}
+#[allow(dead_code)]
+fn call_value(evm: &mut Evm<'_, (), Db>, from: Address, to: Address, value: U256, data: Vec<u8>) -> Vec<u8> {
+    match run(evm, from, TxKind::Call(to), value, data) {
+        ExecutionResult::Success { output: Output::Call(b), .. } => b.to_vec(),
+        o => die(format!("call reverted: {o:?}")),
+    }
+}
+#[allow(dead_code)]
+fn try_call(evm: &mut Evm<'_, (), Db>, from: Address, to: Address, data: Vec<u8>) -> Option<Vec<u8>> {
+    try_call_value(evm, from, to, U256::ZERO, data) // non-payable
+}
+#[allow(dead_code)]
+fn try_call_value(evm: &mut Evm<'_, (), Db>, from: Address, to: Address, value: U256, data: Vec<u8>) -> Option<Vec<u8>> {
+    match run(evm, from, TxKind::Call(to), value, data) {
+        ExecutionResult::Success { output: Output::Call(b), .. } => Some(b.to_vec()),
+        _ => None,
+    }
+}
+#[allow(dead_code)]
+fn eth_balance(evm: &mut Evm<'_, (), Db>, a: Address) -> U256 {
+    evm.db_mut().accounts.get(&a).map(|x| x.info.balance).unwrap_or(U256::ZERO)
+}
+#[allow(dead_code)]
+fn storage(evm: &mut Evm<'_, (), Db>, a: Address, slot: u64) -> U256 {
+    evm.db_mut().storage(a, U256::from(slot)).unwrap_or(U256::ZERO)
+}
+#[allow(dead_code)]
+fn u256(v: &[u8]) -> U256 {
+    U256::from_be_slice(v)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        die("usage: poc <target.bin> [attacker.bin]".into());
+    }
+    let target_code = load_bin(&args[1]);
+    let attacker_code: Vec<u8> = if args.len() > 2 {
+        std::fs::read_to_string(&args[2]).ok().and_then(|s| hex::decode(s.trim()).ok()).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let deployer = Address::from([0x11u8; 20]);
+    let attacker = Address::from([0x44u8; 20]);
+    let user = Address::from([0x22u8; 20]);
+    let mut evm = Evm::builder().with_db(CacheDB::new(EmptyDB::default())).build();
+    for a in [deployer, attacker, user] {
+        fund(&mut evm, a, U256::from(100_000_000_000_000_000_000u128)); // 100 ETH
+    }
+    // keep the skeleton compiling before the slots are filled
+    let _ = (&target_code, &attacker_code, deployer, attacker, user);
+
+    // <<CONTROL>>
+
+    // <<EXPLOIT>>
+
+    println!("invariant held: exploit did not violate the invariant on this target");
+    exit(0);
+}


### PR DESCRIPTION
## Problem

The synthesis agent asked the LLM for the WHOLE `poc.rs` (~200 lines) in **one** prompt — a large OUTPUT that stalls `claude -p` on a non-trivial contract. Measured: a real target's one-shot synthesis **never returned at a 600s timeout**, while a small-output fragment prompt returns in **~40s**. This blocked end-to-end VERIFY on anything beyond a trivial contract — the real wall for verifying the bugs that pay.

## Fix — decompose the generation

Keep all the revm-14 boilerplate + helpers in a **fixed skeleton** (`evm-harness/poc-skeleton.rs`) and ask the LLM only for **two small slots** — the CONTROL block and the EXPLOIT block (~15 lines each) — then splice them in (`evm-harness/assemble-poc.js`). Each generation is small + fast, and the LLM writes far less error-prone code because the skeleton's helpers handle the fiddly revm API:

`deploy / call / call_value / try_call / try_call_value / selector / abi_addr / abi_u256 / eth_balance / storage / u256 / die`, with `evm`, `target_code`, `attacker_code`, `deployer/attacker/user` in scope.

`auditor.ag`: new `control_instruction` / `exploit_instruction` (small slot prompts describing the helpers + an example), `synth_evm_poc_decomposed` (two prompts → `assemble-poc.js`), `gen_poc` (decomposed for EVM, the one-shot prompt for Solana/std — their PoCs are smaller). The `retry(5)` loop + two-sided `assess()` + the anti-forgery challenge are unchanged. The two-sided gate (`CONTROL OK:` + `INVARIANT VIOLATED:` + exit 101) is unchanged.

`abi_u256` accepts a `U256` OR a `u128`/`u64` integer via a local `Word` trait — ruint's `U256::from` is an inherent method (not std `From`), so a `T: Into<U256>` bound would reject integer args; the LLM mixes both forms, and now both compile.

## Validation

End-to-end through the **live colony** on a real OpenZeppelin Foundry target (`VulnToken`, `mint()` missing `onlyOwner`):

```
synthesis: generating AccessControl PoC (prompt 5-retry + class-specific invariant)
synthesis: prompt-generated PoC verified (two-sided)
synthesis: VERIFIED — real-EVM two-sided PoC (revm)
Verdict: VERIFIED          # ~48s, first attempt (vs the one-shot stall)
```

The LLM's **real** mixed-type fills (CONTROL passes `u128`, EXPLOIT passes `U256`) compile (0 errors) and fire the two-sided gate; human-gated package staged (the colony never auto-posts). `poc-skeleton.rs` also compiles standalone (markers are comments). colony-lint 353/0/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)