### PR TITLE
dark-factory: decomposed EXPLOIT slot uses try_call (revert = invariant held, not HARNESS ERROR)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,12 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Fixed
 
+- Decomposed-synthesis EXPLOIT slot now uses `try_call`/`try_call_value` (revert-tolerant) for the
+  attack step instead of `call`/`call_value` (which `die` on a revert). On a secure target the attack
+  reverts — which means the invariant HELD — but a plain `call` turned that into a false
+  `HARNESS ERROR` (exit 2) that masked the verdict and burned `retry(5)` rounds. Surfaced running the
+  colony on a real complex target (Cyfrin Puppy Raffle): the decomposed synthesis produced
+  sophisticated correct exploit code and CONTROL passed, but the exploit's `call` reverted → exit 2.
 - Real-repo compile robustness in `evm-harness/solc-resolve.js`: (1) handle caret/range pragmas
   (`^0.7.6`, `~0.8.4`, `>=0.7.0 <0.8.0`) by selecting the floor solc version when its minor differs
   from the local pinned build (real repos overwhelmingly use caret pragmas; an exact-pin-only match

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -603,8 +603,12 @@ fn exploit_instruction(cls: string) -> string {
         "/ die; evm, target_code, attacker_code, deployer/attacker/user: Address; U256/TxKind/Address " +
         "imported; exit() in scope). Do NOT redefine, import, or write any fn/use/main. The invariant " +
         "under test: " + einv + " Write ONLY the EXPLOIT block: deploy a FRESH target via deploy(...), " +
-        "perform the attack the invariant describes — a non-owner/attacker account sends the offending tx; " +
-        "for a reentrancy class deploy the attacker with `deploy(&mut evm, attacker, &attacker_code, " +
+        "perform the attack the invariant describes — a non-owner/attacker account sends the offending tx. " +
+        "CRITICAL: use try_call / try_call_value (NOT call / call_value) for the ATTACK call itself — on a " +
+        "secure target the attack reverts, which means the invariant HELD; a revert must NOT crash the PoC. " +
+        "Plain call/call_value DIE on a revert and report a FALSE `HARNESS ERROR` (exit 2). Use plain " +
+        "call/call_value only for setup steps you expect to succeed, and reads. " +
+        "For a reentrancy class deploy the attacker with `deploy(&mut evm, attacker, &attacker_code, " +
         "&abi_addr(t))` (target address as its constructor arg) and call its attack() with a stake via " +
         "call_value(&mut evm, attacker, atk, U256::from(1_000_000_000_000_000_000u128), selector(\"attack()\")) " +
         "— then read the relevant state (a public " +


### PR DESCRIPTION
## What

Evidence-directed prompt fix to the decomposed synthesis (#982), found by running the colony on a **real complex target** (Cyfrin Puppy Raffle, solc 0.7.6, OZ imports).

The decomposed synthesis worked well — it produced **sophisticated, mostly-correct** exploit code (correct constructor args, correct dynamic-array ABI for `enterRaffle(address[])`, a multi-step flow) and **CONTROL passed** (`user deposited … and refund restored both balances`). But the EXPLOIT step used `call` (which `die`s on revert) and reverted → false `HARNESS ERROR: call reverted` (exit 2) that masked the verdict and burned `retry(5)` rounds.

## Fix

The EXPLOIT slot prompt now mandates `try_call`/`try_call_value` for the **attack call itself** — on a secure target the attack reverts, which means the invariant HELD, so a revert must not crash the PoC. Plain `call`/`call_value` are for setup steps + reads only. Prompt-only change; the skeleton already exposes `try_call`/`try_call_value`.

## Validation

- auditor.ag parses (`agentis commit` rc 0); `check-exec-sh.sh` rc 0; colony-lint clean.
- No behavior change to the CONTROL slot, the assembler, the skeleton, or the Solana/std one-shot path — only the EXPLOIT slot prompt wording.

This makes a no-finding outcome report cleanly (invariant held / inconclusive) instead of a misleading HARNESS ERROR, and stops wasting retries. Tracked in the earning progress log (private agentis-core#860).

🤖 Generated with [Claude Code](https://claude.com/claude-code)