### PR TITLE
dark-factory: M1+ structural-variant bug-pattern matching (#861)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,24 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Added
+
+- M1+ structural-variant bug-pattern matching (#861) — `evm-harness/struct-sig.js` + a new reconn
+  fallback. Exact-hash seed matching (the prior M1) catches only a byte-identical N-day fork of a
+  recorded finding; this also catches a RENAMED / REFORMATTED / RE-LITTERED fork. `struct-sig.js`
+  normalizes each Solidity function to a parser-free structural signature (identifier names → `_`,
+  literals → `0`, keeping Solidity keywords / types / external-call kinds), so a variant collapses to
+  the same content hash as the seed — no solc, so it works on a bare harvested fragment too.
+  `seed-patterns.ag` now seeds `bugpat:struct:<hash> = class` alongside the exact one (guarded to sigs
+  that carry a call-kind or storage-write, so a trivial getter is never seeded), and reconn
+  (`match_seeded_any_evm`) tries the exact match first, then the structural fallback. Proven end-to-end
+  through the colony: a Reentrancy seed matched a renamed/reformatted variant (`SEEDED STRUCTURAL
+  MATCH -> Reentrancy`, guard fired `[High]`) where exact-match returned nothing, while a CEI-reordered
+  SAFE version correctly did NOT match. A structurally-edited variant (reordered statements / changed
+  expression shape) is out of scope for v1 — that needs an AST/semantic signal. An over-broad match can
+  never mint a false finding: it only sets the candidate class; the two-sided synthesis gate stays the
+  only source of truth.
+
 ### Fixed
 
 - Decomposed-synthesis EXPLOIT slot now uses `try_call`/`try_call_value` (revert-tolerant) for the

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -320,6 +320,48 @@ fn match_seeded_evm(code: string) -> string {
     }, "");
 }
 
+// #861 M1+: STRUCTURAL variant match. Where match_seeded_evm needs a byte-identical fork, this
+// catches a RENAMED / REFORMATTED / RE-LITTERED fork: struct-sig.js normalizes each target
+// function (identifier names -> `_`, literals -> `0`, keeping Solidity keywords/types/call-kinds)
+// and we look the content hash up in the seeded `bugpat:struct:<hash>` memo. struct-sig.js is pure
+// text (no solc, no node_modules) so it runs anywhere and degrades to no output (no match) on any
+// error — never breaking the audit. Returns the first matched class, or "". A structurally-edited
+// variant (reordered statements, changed expression shape) is NOT caught — by design (v1 shape match).
+fn match_seeded_struct_evm(target: string) -> string {
+    let ed = getenv("EVM_HARNESS_DIR");
+    if len(ed) == 0 { return ""; }
+    file_write("h_struct.sol", target);
+    // colony-lint: safe-exec-concat
+    let sigs = exec sh "node ${ed}/struct-sig.js h_struct.sol 2>/dev/null || true";
+    return reduce(regex_split("\n", sigs), |acc: string, line: string| -> string {
+        if len(acc) > 0 { return acc; }
+        let sep = index_of(line, ":::");
+        if sep > 0 {
+            let sig = substring(line, sep + 3, len(line));
+            let h = dag_put(sig);
+            let cls = recall_latest("bugpat:struct:" + h);
+            if is_vuln_class(cls) { return cls; }
+        }
+        return acc;
+    }, "");
+}
+
+// #861: try the seeded known-bug DAG against the target — exact byte-identical fork first (cheaper,
+// most precise), then the structural-variant fallback. Returns the matched vuln class, or "".
+fn match_seeded_any_evm(ecode: string, target: string) -> string {
+    let ex = match_seeded_evm(ecode);
+    if is_vuln_class(ex) {
+        print("reconn: SEEDED PATTERN MATCH ->", ex, "(known-bug DAG; exact byte-identical fork of a recorded finding)");
+        return ex;
+    }
+    let st = match_seeded_struct_evm(target);
+    if is_vuln_class(st) {
+        print("reconn: SEEDED STRUCTURAL MATCH ->", st, "(known-bug DAG; a variant of a recorded finding — names/literals differ, shape matches)");
+        return st;
+    }
+    return "";
+}
+
 // Pick the prior verdict for a sub-graph: federation blacklist wins, else own cache.
 fn pick_prior(cached: string, black: string) -> string {
     if len(black) > 0 {
@@ -1358,12 +1400,11 @@ agent reconn() -> void {
         print("reconn: distilled", en, "sub-graph(s); target hash", substring(eth, 0, 12));
         // audit-once: reuse a prior verdict / federation blacklist for this exact sub-graph.
         let eprior = pick_prior(recall_latest("bounty:verdict:" + eth), recall_latest("bounty:blacklist:" + eth));
-        // #861: match each sub-graph against the seeded known-bug DAG (N-day forks). A hit is a
-        // high-confidence class signal that beats the LLM classifier's conservative SAFE on real code.
-        let patcls = match_seeded_evm(ecode);
-        if is_vuln_class(patcls) {
-            print("reconn: SEEDED PATTERN MATCH ->", patcls, "(known-bug DAG; a target sub-graph forks a recorded finding)");
-        }
+        // #861: match the target against the seeded known-bug DAG — exact byte-identical fork
+        // (N-day) first, then a structural-variant fallback (renamed/reformatted/re-littered fork).
+        // A hit is a high-confidence class signal that beats the LLM classifier's conservative
+        // SAFE on real code; the two-sided synthesis gate still has to verify it before any finding.
+        let patcls = match_seeded_any_evm(ecode, target);
         emit("guard:target", target);
         emit("guard:th", eth);
         emit("guard:cached", eprior);

--- a/dark-factory/auditor/agents/seed-patterns.ag
+++ b/dark-factory/auditor/agents/seed-patterns.ag
@@ -9,6 +9,22 @@ cb 200000;
 // guard fires the class directly — beating the LLM classifier's conservative SAFE on real code.
 // run-audit.sh runs this (per manifest line) after `agentis init`, before the audit, in the same store.
 
+// #861 M1+: a normalized structural sig is worth seeding only if it carries a shape signal —
+// an external-call kind or a storage-index write. Without one it is a trivial getter/setter whose
+// sig would match half the codebase (gate-safe, but a waste of synthesis cycles). Tokens are
+// space-joined by struct-sig.js, so a `.call` member is the lone token ` call `, etc.
+fn struct_has_signal(sig: string) -> bool {
+    if index_of(sig, " call ") >= 0 { return true; }
+    if index_of(sig, " delegatecall ") >= 0 { return true; }
+    if index_of(sig, " staticcall ") >= 0 { return true; }
+    if index_of(sig, " transfer ") >= 0 { return true; }
+    if index_of(sig, " send ") >= 0 { return true; }
+    if index_of(sig, "] -= ") >= 0 { return true; }
+    if index_of(sig, "] += ") >= 0 { return true; }
+    if index_of(sig, "] = ") >= 0 { return true; }
+    return false;
+}
+
 // Mirror of auditor.ag::strip_comments — the seed must canonicalize IDENTICALLY to reconn or the
 // content hashes won't match.
 fn strip_comments(src: string) -> string {
@@ -43,4 +59,30 @@ if len(src) == 0 {
         return acc + 1;
     }, 0);
     print("seed-patterns: scanned", n, "sub-graph(s) in", path);
+
+    // #861 M1+: also seed the STRUCTURAL signature so a RENAMED / REFORMATTED / RE-LITTERED fork
+    // (not only a byte-identical one) matches. struct-sig.js emits `<fnName>:::<normalized-sig>`
+    // per function (identifier names -> `_`, literals -> `0`, keeping keywords/types/call-kinds);
+    // it is pure text (no solc) so it runs on a bare harvested fragment too. Seed the marker
+    // function's sig under bugpat:struct:<hash> = class, mirroring reconn's match_seeded_struct_evm.
+    let ed = getenv("EVM_HARNESS_DIR");
+    if len(ed) > 0 {
+        // colony-lint: safe-exec-concat
+        let sigs = exec sh "node ${ed}/struct-sig.js ${path} 2>/dev/null || true";
+        let sm = reduce(regex_split("\n", sigs), |acc: int, line: string| -> int {
+            let sep = index_of(line, ":::");
+            if sep > 0 {
+                let fname = substring(line, 0, sep);
+                let sig = substring(line, sep + 3, len(line));
+                if index_of(fname, marker) >= 0 {
+                    if struct_has_signal(sig) {
+                        let h2 = dag_put(sig);
+                        memo_write("bugpat:struct:" + h2, cls);
+                        print("seed-patterns: seeded bugpat:struct:", substring(h2, 0, 16), "=", cls, "(fn", fname, "— variant match)");
+                    }
+                }
+            }
+            return acc + 1;
+        }, 0);
+    }
 }

--- a/dark-factory/auditor/agents/seed-patterns.ag
+++ b/dark-factory/auditor/agents/seed-patterns.ag
@@ -11,17 +11,18 @@ cb 200000;
 
 // #861 M1+: a normalized structural sig is worth seeding only if it carries a shape signal —
 // an external-call kind or a storage-index write. Without one it is a trivial getter/setter whose
-// sig would match half the codebase (gate-safe, but a waste of synthesis cycles). Tokens are
-// space-joined by struct-sig.js, so a `.call` member is the lone token ` call `, etc.
+// sig would match half the codebase (gate-safe, but a waste of synthesis cycles). struct-sig.js
+// space-joins EVERY token, so `.call` is the lone token ` call ` and a compound assign `-=` is the
+// two tokens `- =` — the index-write needles must match the SPLIT form (`] - = `, not `] -= `).
 fn struct_has_signal(sig: string) -> bool {
     if index_of(sig, " call ") >= 0 { return true; }
     if index_of(sig, " delegatecall ") >= 0 { return true; }
     if index_of(sig, " staticcall ") >= 0 { return true; }
     if index_of(sig, " transfer ") >= 0 { return true; }
     if index_of(sig, " send ") >= 0 { return true; }
-    if index_of(sig, "] -= ") >= 0 { return true; }
-    if index_of(sig, "] += ") >= 0 { return true; }
-    if index_of(sig, "] = ") >= 0 { return true; }
+    if index_of(sig, "] - = ") >= 0 { return true; }   // x[i] -= y  (debit; tokenized as `] - = `)
+    if index_of(sig, "] + = ") >= 0 { return true; }   // x[i] += y  (credit)
+    if index_of(sig, "] = ") >= 0 { return true; }     // x[i]  = y  (store; also trips on `==`, gate-safe)
     return false;
 }
 

--- a/dark-factory/evm-harness/struct-sig.js
+++ b/dark-factory/evm-harness/struct-sig.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// #861 M1+: parser-free STRUCTURAL signature of each Solidity function, for variant (not just
+// byte-identical) bug-pattern matching. ast.js (solc) is the right abstraction level but it
+// SUPPRESSES the AST on the first "Undeclared identifier" — and the seed side is always a
+// harvested FRAGMENT (a function lifted out of its contract, full of undefined refs). So this
+// uses a token normalizer instead, which is symmetric across seed (fragment) and match (full
+// contract) and needs no compile:
+//
+//   - strip comments
+//   - extract each `function <name>(...) <mods> { <brace-matched body> }` precisely (so the
+//     signature is independent of the surrounding functions — a variant with different
+//     neighbours still matches)
+//   - tokenize and normalize: identifier names -> `_`, number/string literals -> `0`, but KEEP
+//     Solidity keywords, type names, and structural/global members (call/delegatecall/transfer/
+//     value/gas/msg/sender/balance/...). Punctuation kept verbatim.
+//
+// A verbatim fork, a renamed fork, a reformatted fork, and a re-littered fork (different
+// constants) all collapse to the SAME normalized signature; the colony dag_put()s it to a
+// content hash and looks it up in the seeded `bugpat:struct:<hash>` memo. A structurally-edited
+// variant (reordered statements, different expression shape) is NOT caught — that needs a real
+// AST / semantic signal and is out of scope for v1. An over-broad match can never mint a false
+// finding: it only sets the candidate class; the two-sided synthesis gate stays the only truth.
+//
+// Usage:   node struct-sig.js <file.sol>
+// Output:  one line per function on stdout: `<funcName>:::<normalized-signature>`
+//          (the raw funcName is for seed-side selection only; it is NOT part of the hashed sig;
+//          `:::` never occurs inside a normalized sig — `:` is always a space-padded lone token).
+//          On any read error -> no output, exit 0 (caller degrades gracefully, like ast.js).
+'use strict';
+const fs = require('fs');
+
+// Identifiers kept verbatim: Solidity keywords, value-type roots, and the structural/global
+// members whose identity is semantically load-bearing for a vuln shape (a `.call` is not a
+// `.transfer`; `msg.sender` is not an arbitrary local). Everything else is a name -> `_`.
+const KEEP = new Set([
+  // declarations / control flow
+  'function', 'returns', 'return', 'if', 'else', 'for', 'while', 'do', 'break', 'continue',
+  'require', 'assert', 'revert', 'emit', 'new', 'delete', 'try', 'catch', 'unchecked', 'assembly',
+  'modifier', 'constructor', 'receive', 'fallback', 'mapping', 'struct', 'enum', 'event', 'error',
+  'contract', 'library', 'interface', 'using', 'is', 'import', 'pragma', 'abstract', 'override',
+  'virtual', 'return',
+  // visibility / mutability / data location
+  'external', 'public', 'internal', 'private', 'view', 'pure', 'payable', 'nonpayable', 'constant',
+  'immutable', 'memory', 'storage', 'calldata', 'indexed', 'anonymous',
+  // value types (sized variants — uint256, bytes32 — handled by sizedType() below)
+  'address', 'bool', 'string', 'bytes', 'byte', 'int', 'uint', 'fixed', 'ufixed', 'true', 'false',
+  // units
+  'wei', 'gwei', 'ether', 'finney', 'szabo', 'seconds', 'minutes', 'hours', 'days', 'weeks', 'years',
+  // globals / structural members (the load-bearing ones for vuln shapes)
+  'msg', 'block', 'tx', 'abi', 'this', 'super', 'type', 'value', 'gas', 'sender', 'origin', 'data',
+  'sig', 'balance', 'timestamp', 'number', 'coinbase', 'gasprice', 'gaslimit', 'chainid', 'basefee',
+  'difficulty', 'blockhash', 'length', 'push', 'pop',
+  // external-call kinds (the heart of a reentrancy / unchecked-call shape)
+  'call', 'delegatecall', 'staticcall', 'callcode', 'transfer', 'send',
+  // builtins
+  'keccak256', 'sha256', 'ripemd160', 'ecrecover', 'addmod', 'mulmod', 'selfdestruct', 'suicide',
+  'gasleft', 'blobhash',
+]);
+
+// uint8..uint256 / int8..int256 / bytes1..bytes32 / fixedMxN — a sized value type, kept verbatim.
+function sizedType(id) {
+  return /^(u?int|bytes)\d+$/.test(id) || /^u?fixed\d+x\d+$/.test(id);
+}
+
+// Strip // line comments and /* */ block comments (string-literal-naive, but seed+match run the
+// SAME stripper so any edge case is symmetric and cannot desync a hash).
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+}
+
+const TOK = /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|0x[0-9a-fA-F]+|\d[\d_.eE]*|[A-Za-z_$][\w$]*|\S/g;
+
+function normalize(unit) {
+  const toks = unit.match(TOK) || [];
+  const out = [];
+  for (const t of toks) {
+    const c = t[0];
+    if (c === '"' || c === "'") { out.push('0'); continue; }      // string literal
+    if (c === '0' && (t[1] === 'x' || t[1] === 'X')) { out.push('0'); continue; } // hex number
+    if (c >= '0' && c <= '9') { out.push('0'); continue; }        // number literal
+    if (/[A-Za-z_$]/.test(c)) {                                    // identifier
+      out.push(KEEP.has(t) || sizedType(t) ? t : '_');
+      continue;
+    }
+    out.push(t);                                                  // punctuation / operator, verbatim
+  }
+  return out.join(' ');
+}
+
+// Extract each function as `function <name>(<params>) <mods> { <brace-matched body> }` (or the
+// `;`-terminated declaration for an interface/abstract function with no body). Returns
+// [{name, unit}] in source order.
+function extractFunctions(code) {
+  const out = [];
+  const head = /\bfunction\s+([A-Za-z_$][\w$]*)\s*\(/g;
+  let m;
+  while ((m = head.exec(code)) !== null) {
+    const name = m[1];
+    const start = m.index;
+    // find end of the parameter list (balanced parens from the '(' we just matched)
+    let i = head.lastIndex - 1; // at '('
+    let depth = 0, parenEnd = -1;
+    for (; i < code.length; i++) {
+      if (code[i] === '(') depth++;
+      else if (code[i] === ')') { depth--; if (depth === 0) { parenEnd = i; break; } }
+    }
+    if (parenEnd < 0) continue;
+    // scan past modifiers/returns to the body '{' or the declaration ';'
+    let j = parenEnd + 1;
+    while (j < code.length && code[j] !== '{' && code[j] !== ';') j++;
+    if (j >= code.length) break;
+    let end;
+    if (code[j] === ';') {
+      end = j + 1; // no-body declaration
+    } else {
+      // brace-match the body
+      let bd = 0;
+      let k = j;
+      for (; k < code.length; k++) {
+        if (code[k] === '{') bd++;
+        else if (code[k] === '}') { bd--; if (bd === 0) { k++; break; } }
+      }
+      end = k;
+    }
+    out.push({ name, unit: code.slice(start, end) });
+    head.lastIndex = end; // continue after this function (skip nested `function` in the body)
+  }
+  return out;
+}
+
+function main() {
+  const file = process.argv[2];
+  if (!file) return;
+  let src;
+  try { src = fs.readFileSync(file, 'utf8'); } catch (e) { return; }
+  const code = stripComments(src);
+  const fns = extractFunctions(code);
+  const lines = fns.map((f) => f.name + ':::' + normalize(f.unit));
+  if (lines.length) process.stdout.write(lines.join('\n') + '\n');
+}
+
+main();

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -123,7 +123,9 @@ if [ -n "$SEED_MANIFEST" ]; then
   echo "run-audit.sh: seeding known-bug patterns from $(basename "$SEED_MANIFEST")" >&2
   while IFS='|' read -r SCLASS SSRC SMARK || [ -n "$SCLASS" ]; do
     case "$SCLASS" in ''|\#*) continue ;; esac
-    ( cd "$RUN" && env SEED_CLASS="$SCLASS" SEED_SRC="$SSRC" SEED_FUNC="$SMARK" "$AGENTIS" go seed-patterns.ag --enable-exec ) 2>&1 | grep -i 'seed' >&2
+    # EVM_HARNESS_DIR lets seed-patterns.ag also seed the STRUCTURAL signature (variant match) via
+    # struct-sig.js; empty for non-EVM seeds, where the struct pass self-skips (len(ed)==0).
+    ( cd "$RUN" && env SEED_CLASS="$SCLASS" SEED_SRC="$SSRC" SEED_FUNC="$SMARK" EVM_HARNESS_DIR="$EVM_HARNESS" "$AGENTIS" go seed-patterns.ag --enable-exec ) 2>&1 | grep -i 'seed' >&2
   done < "$SEED_MANIFEST"
 fi
 


### PR DESCRIPTION
## M1+ — structural-variant bug-pattern matching (#861)

Builds on M1 (exact-hash seed matching, #984). M1 only fires on a **byte-identical** N-day fork of a recorded finding. M1+ adds a structural fallback that also catches a **renamed / reformatted / re-littered** fork — the common copy-paste-rename N-day variant.

### How

`evm-harness/struct-sig.js` computes a **parser-free structural signature** per Solidity function: identifier names → `_`, number/string literals → `0`, keeping Solidity keywords / types / external-call kinds (`.call` / `.delegatecall` / `.transfer` / …). Each function is extracted precisely (brace-matched), so the signature is independent of the surrounding functions. A variant collapses to the same content hash as the seed.

**Why no AST?** The seed side is always a harvested *fragment* (a function lifted out of its contract, full of undefined references), and solc suppresses the AST on the first `Undeclared identifier` — so an AST signature is unavailable on the seed side. A token normalizer is the only thing symmetric across a fragment (seed) and a full contract (target). Verified empirically before building.

- `seed-patterns.ag` seeds `bugpat:struct:<hash> = class` alongside `bugpat:exact:<hash>`, guarded by `struct_has_signal()` so a trivial getter/setter (no call-kind, no storage-write) is never seeded as a noisy pattern.
- `auditor.ag` — `match_seeded_struct_evm()` runs `struct-sig.js` on the target and looks each function's sig up in the seeded struct memo; `match_seeded_any_evm()` tries exact first (cheaper, most precise), then the structural fallback.
- `run-audit.sh` passes `EVM_HARNESS_DIR` into the seed loop so the seeder can compute struct sigs.

### Proof (end-to-end through the colony, mock backend)

A Reentrancy seed (a vulnerable `withdraw`) matched a **renamed + reformatted + re-littered** variant (`LiquidityPool.cashOut` with renamed vars, different whitespace, different strings):

```
seed-patterns: seeded bugpat:struct: 7e5e4346a88346f9 = Reentrancy (fn withdraw — variant match)
reconn: SEEDED STRUCTURAL MATCH -> Reentrancy (... names/literals differ, shape matches)
guard: Reentrancy fired [High] (seeded known-bug pattern match — DAG)
```

Exact-match returned nothing on this variant (not byte-identical) — only the structural path caught it. A **CEI-reordered SAFE** version (state updated before the external call) correctly did **NOT** match: its sig differs.

### Bounds (honest)

- **Catches:** rename / reformat / re-literal forks that preserve expression structure.
- **Does NOT catch (v1):** a structurally-edited variant — reordered statements, a different expression shape. That needs an AST / semantic signal (e.g. richer nodes for guard-presence, oracle-staleness) and is the next recall step. Shape-based classes (Reentrancy, UncheckedCall) benefit most; semantic classes (oracle staleness, missing-guard) are not a *shape* and are largely unaffected by structural matching.
- **Safety:** an over-broad match can never mint a false finding — it only sets the candidate class; the two-sided synthesis gate (`CONTROL OK:` AND `INVARIANT VIOLATED:` + exit 101) stays the only source of truth. A stale/wrong seed costs at most one inconclusive synthesis. Submission stays human-gated.

colony-lint: 354 passed, 0 failed, 5 skipped.
