### PR TITLE
dark-factory: M3 recall harness + fuzzy matching for real forks + knowledge-market sharing (#861)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,27 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- M3 held-out recall harness + knowledge-market sharing (#861). Measures whether the seeded DAG
+  catches a finding's FORK it did not see seeded, and shares the corpus across the federation:
+  - `recall.sh` + `auditor/agents/recall-match.ag` seed with the real `seed-patterns.ag` (zero
+    seed-side drift) and match each held-out target with a mirror of reconn's exact + structural
+    matchers, then tally exact-only vs structural recall per class + precision on negatives.
+  - `evm-harness/make-variants.js` generates realistic fork variants of a seeded function (rename /
+    reformat / re-literal = what a real N-day fork is) plus structural negatives (call-kind swap,
+    injected guard) that MUST NOT match. Reuses `struct-sig.js`'s exported KEEP set so a renamed
+    fork keeps the same signature; `struct-sig.js` now `module.exports` its token rules.
+  - `harvest-sherlock.js` handles BOTH Sherlock judging layouts — the old `NNN-H`/`NNN-M` folders
+    and the new flat `NNN.md` files (severity inside the file).
+  - **Measured result** on 41 real shape-based findings from 4 Sherlock contests (164 held-out
+    forks): exact-only recall **6%**, structural recall **94%** (per class: AccessControl /
+    UncheckedCall / IntegerOverflow 100%, Reentrancy 90%, Oracle 88%); structural false-match on
+    negatives 7% (gate-safe — a match only sets the candidate class, the two-sided gate verifies).
+  - `auditor/agents/share-patterns.ag` + `run-audit.sh --share-patterns` publish each seeded
+    `bugpat:exact:<hash>` / `bugpat:struct:<hash>` to the knowledge market (`knowledge_sell`, keyed
+    by content hash) so other federation members can `knowledge_buy` it — "share the DAG via the
+    knowledge market". The buy side is a real economic exchange (the buyer escrows the ask price
+    from its CB pool), so importing a shared pattern requires a funded consumer.
+
 - M1+ structural-variant bug-pattern matching (#861) — `evm-harness/struct-sig.js` + a new reconn
   fallback. Exact-hash seed matching (the prior M1) catches only a byte-identical N-day fork of a
   recorded finding; this also catches a RENAMED / REFORMATTED / RE-LITTERED fork. `struct-sig.js`

--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -27,10 +27,29 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
     fork keeps the same signature; `struct-sig.js` now `module.exports` its token rules.
   - `harvest-sherlock.js` handles BOTH Sherlock judging layouts — the old `NNN-H`/`NNN-M` folders
     and the new flat `NNN.md` files (severity inside the file).
-  - **Measured result** on 41 real shape-based findings from 4 Sherlock contests (164 held-out
-    forks): exact-only recall **6%**, structural recall **94%** (per class: AccessControl /
-    UncheckedCall / IntegerOverflow 100%, Reentrancy 90%, Oracle 88%); structural false-match on
-    negatives 7% (gate-safe — a match only sets the candidate class, the two-sided gate verifies).
+  - **Synthetic result** on 41 real shape-based findings from 4 Sherlock contests (164 held-out
+    forks): exact-only recall 6%, structural recall 94%. But these forks are GENERATED
+    (rename/reformat/re-literal) — exactly the transforms struct-sig was built to be invariant to —
+    so 94% is an **upper bound on near-verbatim forks**, not a real-world hit-rate.
+  - **Real fork-pair result** (`evm-harness/forkpair-recall.js`, the honest measurement): seed a
+    function from one protocol and match the SAME function as actually deployed in a protocol that
+    forked it — Compound `CToken.sol` vs its Venus `VToken.sol` fork, 48 shared functions. Exact
+    signature recall is **17%** (only the simple getters; the vuln-bearing functions like
+    `redeemFresh`/`accrueInterest` are ~2x rewritten in the fork and never hit). Two struct-sig
+    fixes surfaced by this (modifier-order canonicalization + `uint`/`uint256` aliasing) lifted it
+    from 0% to 17%.
+  - **Fuzzy matcher** (`evm-harness/fuzzy-match.js`) — the recall lift for REAL forks. Matches on
+    shingle-Jaccard SIMILARITY instead of signature equality, so a restructured fork still hits:
+    Compound->Venus fuzzy recall **69% @ 0.30 / 54% @ 0.35 / 46% @ 0.40** (incl. the vuln functions),
+    at ~52-67% precision (structurally-similar-but-different functions also match — gate-safe, a
+    false candidate costs one inconclusive synthesis, never a finding). Wired into reconn
+    (`match_seeded_fuzzy_evm`, the third fallback after exact + structural) and the recall harness.
+    Proven end-to-end through the colony: seed Compound `redeemFresh`, audit Venus's real forked
+    `redeemFresh` (Jaccard 0.41) -> `SEEDED FUZZY MATCH -> Reentrancy`, guard fired `[High]` where
+    exact + structural both missed.
+  - Known limitation: the in-`.ag` `strip_comments` accumulates an O(n^2) string heap and overflows
+    on a full ~1500-line real contract target (the exact/structural paths run it first). Real
+    full-contract auditing needs that rewritten; single-function and mid-size targets are unaffected.
   - `auditor/agents/share-patterns.ag` + `run-audit.sh --share-patterns` publish each seeded
     `bugpat:exact:<hash>` / `bugpat:struct:<hash>` to the knowledge market (`knowledge_sell`, keyed
     by content hash) so other federation members can `knowledge_buy` it — "share the DAG via the

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -346,8 +346,34 @@ fn match_seeded_struct_evm(target: string) -> string {
     }, "");
 }
 
+// #861 M3+: FUZZY structural match. Where match_seeded_struct_evm needs an EXACT normalized
+// signature, this catches a RESTRUCTURED fork — a real fork roughly doubles the vuln-bearing
+// functions (adds error codes / fees / params, reorders), which exact-signature equality never
+// hits (fork-pair validation: Compound CToken -> Venus VToken, exact-sig 17% vs fuzzy ~60% incl.
+// the vuln functions). fuzzy-match.js cuts each function's signature into k-token shingles and
+// matches on shingle-Jaccard similarity >= FUZZY_THRESHOLD against the seed corpus TSV
+// ($FUZZY_SEEDS, written by run-audit.sh from the seed manifest). Lower precision than exact
+// (~52-67%) — but every match still has to clear the two-sided synthesis gate, so a false
+// candidate only costs one inconclusive synthesis, never a false finding. Returns class or "".
+fn match_seeded_fuzzy_evm(target: string) -> string {
+    let ed = getenv("EVM_HARNESS_DIR");
+    let seeds = getenv("FUZZY_SEEDS");
+    if len(ed) == 0 { return ""; }
+    if len(seeds) == 0 { return ""; }
+    file_write("h_fuzzy.sol", target);
+    let th = getenv("FUZZY_THRESHOLD");
+    // colony-lint: safe-exec-concat
+    let out = exec sh "node ${ed}/fuzzy-match.js h_fuzzy.sol ${seeds} ${th} 2>/dev/null || true";
+    return reduce(regex_split("\n", out), |acc: string, line: string| -> string {
+        if is_vuln_class(acc) { return acc; }
+        if is_vuln_class(line) { return line; }
+        return acc;
+    }, "");
+}
+
 // #861: try the seeded known-bug DAG against the target — exact byte-identical fork first (cheaper,
-// most precise), then the structural-variant fallback. Returns the matched vuln class, or "".
+// most precise), then the structural-variant fallback, then the fuzzy-similarity fallback (the
+// recall lift for REAL restructured forks). Returns the matched vuln class, or "".
 fn match_seeded_any_evm(ecode: string, target: string) -> string {
     let ex = match_seeded_evm(ecode);
     if is_vuln_class(ex) {
@@ -358,6 +384,11 @@ fn match_seeded_any_evm(ecode: string, target: string) -> string {
     if is_vuln_class(st) {
         print("reconn: SEEDED STRUCTURAL MATCH ->", st, "(known-bug DAG; a variant of a recorded finding — names/literals differ, shape matches)");
         return st;
+    }
+    let fz = match_seeded_fuzzy_evm(target);
+    if is_vuln_class(fz) {
+        print("reconn: SEEDED FUZZY MATCH ->", fz, "(known-bug DAG; a RESTRUCTURED fork of a recorded finding — shingle-similarity >= threshold)");
+        return fz;
     }
     return "";
 }

--- a/dark-factory/auditor/agents/recall-match.ag
+++ b/dark-factory/auditor/agents/recall-match.ag
@@ -61,6 +61,24 @@ fn match_struct(path: string) -> string {
     }, "");
 }
 
+// #861 M3+: FUZZY structural match — shingle-Jaccard similarity (fuzzy-match.js) against the seed
+// corpus TSV ($FUZZY_SEEDS, one `Class:::sig` per line). The recall lift for REAL forks, where the
+// vuln function is restructured beyond exact-signature equality. Returns the matched class or "".
+fn match_fuzzy(path: string) -> string {
+    let ed = getenv("EVM_HARNESS_DIR");
+    let seeds = getenv("FUZZY_SEEDS");
+    if len(ed) == 0 { return ""; }
+    if len(seeds) == 0 { return ""; }
+    let th = getenv("FUZZY_THRESHOLD");
+    // colony-lint: safe-exec-concat
+    let out = exec sh "node ${ed}/fuzzy-match.js ${path} ${seeds} ${th} 2>/dev/null || true";
+    return reduce(regex_split("\n", out), |acc: string, line: string| -> string {
+        if is_vuln_class(acc) { return acc; }
+        if is_vuln_class(line) { return line; }
+        return acc;
+    }, "");
+}
+
 // Render a match result as the class name, or "MISS" when nothing matched (no reassignment — .ag
 // `let` bindings are single-assignment).
 fn label(c: string) -> string {
@@ -77,4 +95,5 @@ let src = exec sh "cat ${path} 2>/dev/null || true";
 let code = strip_comments(src);
 let ex = match_exact(code);
 let st = match_struct(path);
-print("RECALL|" + cls + "|" + id + "|" + tr + "|exact=" + label(ex) + "|struct=" + label(st));
+let fz = match_fuzzy(path);
+print("RECALL|" + cls + "|" + id + "|" + tr + "|exact=" + label(ex) + "|struct=" + label(st) + "|fuzzy=" + label(fz));

--- a/dark-factory/auditor/agents/recall-match.ag
+++ b/dark-factory/auditor/agents/recall-match.ag
@@ -1,0 +1,80 @@
+cb 200000;
+// #861 M3: match ONE held-out target against the ALREADY-seeded bugpat DAG and print the verdict
+// (exact + structural), for the recall harness. The seed side reuses the real seed-patterns.ag (zero
+// drift); this match side mirrors auditor.ag::match_seeded_evm and match_seeded_struct_evm EXACTLY
+// (same hashing, same is_vuln_class gate) so the measured recall reflects what reconn would do in
+// production. Env: TEST_SRC (path to the held-out .sol), TEST_CLASS (its true class), TEST_ID,
+// TEST_TRANSFORM (label), EVM_HARNESS_DIR. Prints one line:
+//   RECALL|<trueclass>|<id>|<transform>|exact=<class|MISS>|struct=<class|MISS>
+
+// Mirror of auditor.ag::strip_comments — must canonicalize IDENTICALLY to the exact-match path.
+fn strip_comments(src: string) -> string {
+    let lines = regex_split("\n", src);
+    return reduce(lines, |acc: string, l: string| -> string {
+        let c = index_of(l, "//");
+        if c >= 0 {
+            acc + substring(l, 0, c) + "\n";
+        } else {
+            acc + l + "\n";
+        }
+    }, "");
+}
+
+// Mirror of auditor.ag::is_vuln_class — only a recognized class counts as a hit (rejects "" / "void").
+fn is_vuln_class(c: string) -> bool {
+    if c == "Reentrancy" { return true; }
+    if c == "AccessControl" { return true; }
+    if c == "UncheckedCall" { return true; }
+    if c == "OracleManipulation" { return true; }
+    if c == "IntegerOverflow" { return true; }
+    return false;
+}
+
+// Mirror of auditor.ag::match_seeded_evm — exact byte-identical sub-graph match.
+fn match_exact(code: string) -> string {
+    return reduce(regex_split("function ", code), |acc: string, c: string| -> string {
+        if len(acc) > 0 { return acc; }
+        if len(c) == 0 { return acc; }
+        let h = dag_put("function " + c);
+        let cls = recall_latest("bugpat:exact:" + h);
+        if is_vuln_class(cls) { return cls; }
+        return acc;
+    }, "");
+}
+
+// Mirror of auditor.ag::match_seeded_struct_evm — structural-variant match via struct-sig.js.
+fn match_struct(path: string) -> string {
+    let ed = getenv("EVM_HARNESS_DIR");
+    if len(ed) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let sigs = exec sh "node ${ed}/struct-sig.js ${path} 2>/dev/null || true";
+    return reduce(regex_split("\n", sigs), |acc: string, line: string| -> string {
+        if len(acc) > 0 { return acc; }
+        let sep = index_of(line, ":::");
+        if sep > 0 {
+            let sig = substring(line, sep + 3, len(line));
+            let h = dag_put(sig);
+            let cls = recall_latest("bugpat:struct:" + h);
+            if is_vuln_class(cls) { return cls; }
+        }
+        return acc;
+    }, "");
+}
+
+// Render a match result as the class name, or "MISS" when nothing matched (no reassignment — .ag
+// `let` bindings are single-assignment).
+fn label(c: string) -> string {
+    if is_vuln_class(c) { return c; }
+    return "MISS";
+}
+
+let path = getenv("TEST_SRC");
+let cls = getenv("TEST_CLASS");
+let id = getenv("TEST_ID");
+let tr = getenv("TEST_TRANSFORM");
+// colony-lint: safe-exec-concat
+let src = exec sh "cat ${path} 2>/dev/null || true";
+let code = strip_comments(src);
+let ex = match_exact(code);
+let st = match_struct(path);
+print("RECALL|" + cls + "|" + id + "|" + tr + "|exact=" + label(ex) + "|struct=" + label(st));

--- a/dark-factory/auditor/agents/share-patterns.ag
+++ b/dark-factory/auditor/agents/share-patterns.ag
@@ -1,0 +1,28 @@
+cb 200000;
+// #861: publish every locally-seeded bug-pattern to the knowledge market so OTHER federation
+// members can buy it — "DAG sdílej přes knowledge market". The harvest+seed pipeline records each
+// finished-contest finding as a `bugpat:exact:<hash>` / `bugpat:struct:<hash>` memo (class as the
+// value); this lists each on the market via knowledge_sell(topic, class, ask_price), keyed by the
+// content hash so a buyer that matches the SAME sub-graph/signature can look it up by that hash.
+//
+// The consume side is knowledge_buy("bugpat:<kind>:<hash>", max_cb): a real economic exchange —
+// the buyer escrows ask_price from its CB pool and pays the seller, so importing a shared pattern
+// requires a funded consumer (colony/daemon economy), which is why this agent only owns the SELL
+// half. Requires learning.enabled + knowledge.enabled in .agentis/config. ask_price is nominal (1).
+//
+// Run in the SAME store the seeder populated (after seed-patterns.ag), e.g. via
+// run-audit.sh --share-patterns or recall.sh --share.
+
+let keys = memo_list("bugpat:");
+let n = reduce(keys, |acc: int, k: string| -> int {
+    let cls = recall_latest(k);
+    if len(cls) > 0 {
+        let ok = knowledge_sell(k, cls, 1);
+        if ok {
+            print("share: published", k, "=", cls);
+            return acc + 1;
+        }
+    }
+    return acc;
+}, 0);
+print("share: published", n, "pattern(s) to the knowledge market");

--- a/dark-factory/evm-harness/forkpair-recall.js
+++ b/dark-factory/evm-harness/forkpair-recall.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// #861 M3: REAL fork-pair recall — the honest real-world measurement that the synthetic recall
+// harness (recall.sh) only proxies. Synthetic variants (rename/reformat/reliteral) are what
+// struct-sig was BUILT to be invariant to, so the 94% there partly measures self-invariance. This
+// instead takes two protocols that actually forked a common base — e.g. Compound's CToken.sol and
+// its Venus VToken.sol fork — and measures, per shared function, whether the matcher catches the
+// fork's ACTUALLY-DEPLOYED (restructured) version.
+//
+// Result on Compound CToken <-> Venus VToken (48 shared functions): exact-signature recall 17%
+// (only near-verbatim getters), fuzzy shingle-Jaccard recall ~60-69% incl. the vuln-bearing
+// functions (a real fork ~2x-rewrites redeemFresh/accrueInterest, which exact-equality can't
+// absorb but shingle overlap can). The cost is precision (~52-67%): structurally-similar-but-
+// different functions also match — but every candidate still has to clear the two-sided synthesis
+// gate, so a false match costs one inconclusive synthesis, never a false finding.
+//
+// Usage:   node forkpair-recall.js <base.sol> <fork.sol> [threshold=0.35]
+'use strict';
+const fs = require('fs');
+const { extractFunctions, normalize, stripComments } = require('./struct-sig.js');
+
+const K = 4;
+function shingles(sig) {
+  const t = sig.split(' ').filter(Boolean);
+  const s = new Set();
+  for (let i = 0; i + K <= t.length; i++) s.add(t.slice(i, i + K).join(' '));
+  return s;
+}
+function jaccard(a, b) {
+  let inter = 0;
+  for (const x of a) if (b.has(x)) inter++;
+  return inter / (a.size + b.size - inter || 1);
+}
+function sigMap(file) {
+  let src = '';
+  try { src = fs.readFileSync(file, 'utf8'); } catch (e) { return {}; }
+  const m = {};
+  for (const f of extractFunctions(stripComments(src))) if (!(f.name in m)) m[f.name] = normalize(f.unit);
+  return m;
+}
+
+function main() {
+  const base = process.argv[2];
+  const fork = process.argv[3];
+  const th = process.argv[4] ? parseFloat(process.argv[4]) : 0.35;
+  if (!base || !fork) { console.error('usage: forkpair-recall.js <base.sol> <fork.sol> [threshold]'); process.exit(2); }
+  const B = sigMap(base);
+  const F = sigMap(fork);
+  const SB = {}; for (const k of Object.keys(B)) SB[k] = shingles(B[k]);
+  const SF = {}; for (const k of Object.keys(F)) SF[k] = shingles(F[k]);
+  const shared = Object.keys(B).filter((k) => k in F);
+
+  let exact = 0, fuzzy = 0;
+  for (const k of shared) {
+    if (B[k] === F[k]) exact++;
+    if (jaccard(SB[k], SF[k]) >= th) fuzzy++;
+  }
+  // precision probe: different-name base x fork pairs that the fuzzy matcher wrongly fires on.
+  let fp = 0;
+  for (const a of Object.keys(B)) for (const b of Object.keys(F)) {
+    if (a === b || SB[a].size < 2 || SF[b].size < 2) continue;
+    if (jaccard(SB[a], SF[b]) >= th) fp++;
+  }
+  const prec = fuzzy + fp > 0 ? Math.round((100 * fuzzy) / (fuzzy + fp)) : 0;
+  const p = (n) => shared.length ? Math.round((100 * n) / shared.length) + '%' : 'n/a';
+  console.log('fork-pair recall  (threshold ' + th + ')');
+  console.log('  base: ' + base);
+  console.log('  fork: ' + fork);
+  console.log('  shared functions: ' + shared.length);
+  console.log('  exact-signature recall: ' + exact + '/' + shared.length + ' (' + p(exact) + ')');
+  console.log('  fuzzy (shingle-Jaccard) recall: ' + fuzzy + '/' + shared.length + ' (' + p(fuzzy) + ')');
+  console.log('  fuzzy precision (vs different-name pairs): ' + prec + '% (' + fp + ' false-matches)');
+}
+
+main();

--- a/dark-factory/evm-harness/fuzzy-match.js
+++ b/dark-factory/evm-harness/fuzzy-match.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// #861 M3+: FUZZY structural match — the recall lift for REAL forks. Exact-hash matching (M1) and
+// exact-signature matching (M1+) only fire when a fork's function is byte- or token-identical to a
+// seed. Fork-pair validation (Compound CToken -> its Venus VToken fork) showed that's ~0% on the
+// vuln-bearing functions: a real fork ROUGHLY DOUBLES redeemFresh / accrueInterest / mintFresh
+// (adds error codes, fees, params, reorders), so exact-signature equality never hits them.
+//
+// This matches on SIMILARITY instead of equality: each function's normalized structural signature
+// (struct-sig.js) is cut into k-token shingles, and two functions match when their shingle-set
+// Jaccard similarity clears a threshold. On the Compound<->Venus fork pair this lifts real-fork
+// recall from 17% (exact) to ~60-69% incl. the vuln functions (threshold 0.30-0.35). Precision is
+// ~52-67% — about half the candidate matches are structurally-similar-but-different functions — but
+// every match still has to clear the two-sided synthesis gate, so a false candidate only costs one
+// inconclusive synthesis, never a false finding.
+//
+// Usage:   node fuzzy-match.js <target.sol> <seeds-file> [threshold=0.35]
+//   <seeds-file> is one `Class:::<normalized-sig>` per line (written by seed-patterns.ag).
+// Output:  the matched Class of the FIRST target function that clears the threshold against any
+//          seed (mirrors reconn's first-hit short-circuit), or nothing. Exit 0 always (graceful).
+'use strict';
+const fs = require('fs');
+const { extractFunctions, normalize, stripComments } = require('./struct-sig.js');
+
+const K = 4; // shingle width (tokens). 4 balances structural specificity vs fork-drift tolerance.
+
+function shingles(sig) {
+  const t = sig.split(' ').filter(Boolean);
+  const s = new Set();
+  for (let i = 0; i + K <= t.length; i++) s.add(t.slice(i, i + K).join(' '));
+  return s;
+}
+
+function jaccard(a, b) {
+  let inter = 0;
+  for (const x of a) if (b.has(x)) inter++;
+  return inter / (a.size + b.size - inter || 1);
+}
+
+function targetSigs(file) {
+  let src = '';
+  try { src = fs.readFileSync(file, 'utf8'); } catch (e) { return []; }
+  return extractFunctions(stripComments(src)).map((f) => normalize(f.unit));
+}
+
+function main() {
+  const target = process.argv[2];
+  const seedsFile = process.argv[3];
+  const threshold = process.argv[4] ? parseFloat(process.argv[4]) : 0.35;
+  if (!target || !seedsFile) return;
+  let seedLines = [];
+  try { seedLines = fs.readFileSync(seedsFile, 'utf8').split('\n').filter(Boolean); } catch (e) { return; }
+  const seeds = seedLines
+    .map((l) => { const i = l.indexOf(':::'); return i < 0 ? null : { cls: l.slice(0, i), sh: shingles(l.slice(i + 3)) }; })
+    .filter((s) => s && s.sh.size >= 2);
+  if (!seeds.length) return;
+  for (const ts of targetSigs(target)) {
+    const tsh = shingles(ts);
+    if (tsh.size < 2) continue;
+    let best = 0, bestCls = '';
+    for (const s of seeds) {
+      const j = jaccard(tsh, s.sh);
+      if (j > best) { best = j; bestCls = s.cls; }
+    }
+    if (best >= threshold) { process.stdout.write(bestCls + '\n'); return; }
+  }
+}
+
+main();

--- a/dark-factory/evm-harness/make-variants.js
+++ b/dark-factory/evm-harness/make-variants.js
@@ -46,14 +46,17 @@ function negCallKind(src) {
   return /\.call\b/.test(src) ? src.replace(/\.call\b/g, '.delegatecall') : null;
 }
 
-// NEGATIVE: inject an access guard as the first body statement. A guarded function is a DIFFERENT
-// (safer) shape than the unguarded vulnerable seed — must NOT match.
+// NEGATIVE: inject an access guard as the first body statement of the FIRST FUNCTION. A guarded
+// function is a DIFFERENT (safer) shape than the unguarded vulnerable seed — must NOT match. Anchor
+// on the function header's body brace (`function ...) ... {`), NOT the first `{` in the file — for a
+// seed wrapped in `contract X { ... }` the first `{` is the contract brace, which would leave the
+// function body unchanged and produce a spurious self-match (QA #987 finding).
 function negGuard(src) {
   let injected = false;
-  const out = src.replace(/\{/, (m) => {
+  const out = src.replace(/\bfunction\b[^{};]*\)[^{;]*\{/, (m) => {
     if (injected) return m;
     injected = true;
-    return '{\n        require(msg.sender == _guardOwner, "auth");';
+    return m + '\n        require(msg.sender == _guardOwner, "auth");';
   });
   return injected ? out : null;
 }

--- a/dark-factory/evm-harness/make-variants.js
+++ b/dark-factory/evm-harness/make-variants.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// #861 M3: generate realistic FORK variants of a seeded vulnerable function, to measure the
+// matcher's recall on held-out forks (exact-only ~0 vs structural) and its precision (false match
+// on structurally-different negatives). A real N-day fork is overwhelmingly a rename + reformat +
+// re-literal of the original — never a byte-identical copy — so these transforms model the real
+// thing. The negative controls are genuine STRUCTURAL edits that SHOULD NOT match (a different call
+// kind, an added guard); a matcher that fires on them is over-broad.
+//
+// Reuses struct-sig.js's exported KEEP set so `rename` renames EXACTLY the identifiers the matcher
+// normalizes away — keeping a renamed fork's signature identical to its seed (and only its bytes
+// different, so exact-match misses while structural matches).
+//
+// Usage:   node make-variants.js <seed.sol> <out-dir> <Class> <id-prefix>
+// Output:  writes <out-dir>/<id-prefix>-<transform>.sol and prints manifest lines to stdout:
+//          `<Class>|<abs-path>|<id-prefix>-<transform>|<transform>|<expect match|miss>`
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { KEEP, sizedType } = require('./struct-sig');
+
+// Consistently rename every non-keyword/non-type identifier to a fresh name. Same shape, new bytes.
+function rename(src) {
+  const map = {};
+  let n = 0;
+  return src.replace(/[A-Za-z_$][\w$]*/g, (id) =>
+    (KEEP.has(id) || sizedType(id)) ? id : (map[id] || (map[id] = 'r' + (++n))));
+}
+
+// Change literal VALUES (numbers, hex, strings) — a fork tuning constants. Shape unchanged.
+function reliteral(src) {
+  return src
+    .replace(/\b0x[0-9a-fA-F]+\b/g, '0xC0FFEE')
+    .replace(/\b\d[\d_]*\b/g, (m) => String((parseInt(m.replace(/_/g, ''), 10) || 0) + 13))
+    .replace(/"(?:\\.|[^"\\])*"/g, '"_v"')
+    .replace(/'(?:\\.|[^'\\])*'/g, "'_v'");
+}
+
+// Reflow whitespace/indentation — a fork reformatted by a different team's linter. Shape unchanged.
+function reformat(src) {
+  return src.replace(/[ \t]+/g, ' ').replace(/\s*\n\s*/g, '\n        ').replace(/\{\s*/g, ' {\n        ');
+}
+
+// NEGATIVE: swap the external-call KIND (.call -> .delegatecall). A genuine structural difference —
+// must NOT match. Only meaningful when the seed actually makes a low-level .call.
+function negCallKind(src) {
+  return /\.call\b/.test(src) ? src.replace(/\.call\b/g, '.delegatecall') : null;
+}
+
+// NEGATIVE: inject an access guard as the first body statement. A guarded function is a DIFFERENT
+// (safer) shape than the unguarded vulnerable seed — must NOT match.
+function negGuard(src) {
+  let injected = false;
+  const out = src.replace(/\{/, (m) => {
+    if (injected) return m;
+    injected = true;
+    return '{\n        require(msg.sender == _guardOwner, "auth");';
+  });
+  return injected ? out : null;
+}
+
+function main() {
+  const [seed, outDir, cls, idPrefix] = process.argv.slice(2);
+  if (!seed || !outDir || !cls || !idPrefix) {
+    console.error('usage: make-variants.js <seed.sol> <out-dir> <Class> <id-prefix>');
+    process.exit(2);
+  }
+  let src;
+  try { src = fs.readFileSync(seed, 'utf8'); } catch (e) {
+    console.error('make-variants: cannot read seed ' + seed); process.exit(2);
+  }
+  fs.mkdirSync(outDir, { recursive: true });
+  const transforms = [
+    ['rename', rename(src), 'match'],
+    ['reformat', reformat(src), 'match'],
+    ['reliteral', reliteral(src), 'match'],
+    ['combo', reformat(reliteral(rename(src))), 'match'], // the realistic fork: all three
+    ['neg-callkind', negCallKind(src), 'miss'],
+    ['neg-guard', negGuard(src), 'miss'],
+  ];
+  for (const [name, body, expect] of transforms) {
+    if (body == null) continue; // transform not applicable to this seed
+    const p = path.resolve(outDir, idPrefix + '-' + name + '.sol');
+    fs.writeFileSync(p, body.replace(/\s+$/, '') + '\n');
+    process.stdout.write(cls + '|' + p + '|' + idPrefix + '-' + name + '|' + name + '|' + expect + '\n');
+  }
+}
+
+main();

--- a/dark-factory/evm-harness/struct-sig.js
+++ b/dark-factory/evm-harness/struct-sig.js
@@ -70,6 +70,25 @@ function stripComments(src) {
 
 const TOK = /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|0x[0-9a-fA-F]+|\d[\d_.eE]*|[A-Za-z_$][\w$]*|\S/g;
 
+// Visibility / mutability / inheritance keywords whose ORDER in a function header carries no
+// structural meaning — `override external view` and `external view override` are the same function.
+// Real forks and different solc versions reorder these freely (Compound `override external view`
+// vs its Venus fork `external view override`), so a maximal run of them is sorted to a canonical
+// order before hashing. Identifier NAMES (a named modifier like nonReentrant -> `_`) are NOT in
+// this set, so they break the run and their presence/position is preserved (a guard still matters).
+const MOD_ORDER = new Set([
+  'external', 'public', 'internal', 'private', 'view', 'pure', 'payable', 'nonpayable',
+  'override', 'virtual', 'constant', 'immutable',
+]);
+
+// `uint`/`int` are exact aliases of `uint256`/`int256`; canonicalize so a fork that spells one way
+// matches a base that spells the other (Compound `uint` vs Venus `uint256`).
+function canonType(t) {
+  if (t === 'uint') return 'uint256';
+  if (t === 'int') return 'int256';
+  return t;
+}
+
 function normalize(unit) {
   const toks = unit.match(TOK) || [];
   const out = [];
@@ -79,10 +98,20 @@ function normalize(unit) {
     if (c === '0' && (t[1] === 'x' || t[1] === 'X')) { out.push('0'); continue; } // hex number
     if (c >= '0' && c <= '9') { out.push('0'); continue; }        // number literal
     if (/[A-Za-z_$]/.test(c)) {                                    // identifier
-      out.push(KEEP.has(t) || sizedType(t) ? t : '_');
+      out.push(KEEP.has(t) || sizedType(t) ? canonType(t) : '_');
       continue;
     }
     out.push(t);                                                  // punctuation / operator, verbatim
+  }
+  // Canonicalize modifier-keyword order: sort each maximal run of MOD_ORDER tokens.
+  for (let i = 0; i < out.length; ) {
+    if (MOD_ORDER.has(out[i])) {
+      let j = i;
+      while (j < out.length && MOD_ORDER.has(out[j])) j++;
+      const run = out.slice(i, j).sort();
+      for (let k = i; k < j; k++) out[k] = run[k - i];
+      i = j;
+    } else { i++; }
   }
   return out.join(' ');
 }

--- a/dark-factory/evm-harness/struct-sig.js
+++ b/dark-factory/evm-harness/struct-sig.js
@@ -139,4 +139,9 @@ function main() {
   if (lines.length) process.stdout.write(lines.join('\n') + '\n');
 }
 
-main();
+// Exported so the M3 recall harness's variant generator (make-variants.js) renames EXACTLY the
+// identifiers this normalizer drops — keeping a generated fork's signature identical to its seed.
+// Only run as a script when invoked directly (so `require()` doesn't trigger main()).
+module.exports = { KEEP, sizedType, normalize, extractFunctions, stripComments, TOK };
+
+if (require.main === module) main();

--- a/dark-factory/harvest-sherlock.js
+++ b/dark-factory/harvest-sherlock.js
@@ -63,6 +63,24 @@ function canonicalFinding(dir) {
   return mds.find((f) => /best/i.test(f)) || mds[0];
 }
 
+// Sherlock has shipped two judging-repo layouts. Old (e.g. 2024-04): one `NNN-H` / `NNN-M` folder
+// per valid finding, severity in the folder name, the report markdown(s) inside. New (2025+): one
+// flat `NNN.md` per valid finding at the top level (severity on line ~3), invalid findings under
+// `invalid/`. Return a uniform list of {id, file} for whichever layout this repo uses.
+function findingDocs(repo, entries) {
+  const folders = entries.filter((d) => /^\d+-[HM]$/.test(d) && fs.statSync(path.join(repo, d)).isDirectory());
+  if (folders.length) {
+    return folders.sort().map((f) => {
+      const md = canonicalFinding(path.join(repo, f));
+      return md ? { id: f, file: path.join(repo, f, md) } : null;
+    }).filter(Boolean);
+  }
+  return entries
+    .filter((f) => /^\d+\.md$/.test(f) && fs.statSync(path.join(repo, f)).isFile())
+    .sort()
+    .map((f) => ({ id: f.replace(/\.md$/, ''), file: path.join(repo, f) }));
+}
+
 function main() {
   const repo = process.argv[2];
   const out = process.argv[3];
@@ -75,14 +93,11 @@ function main() {
     process.exit(2);
   }
   fs.mkdirSync(out, { recursive: true });
-  const folders = entries.filter((d) => /^\d+-[HM]$/.test(d) && fs.statSync(path.join(repo, d)).isDirectory());
+  const docs = findingDocs(repo, entries);
   const manifest = [];
   let seeded = 0, skipped = 0;
-  for (const folder of folders.sort()) {
-    const dir = path.join(repo, folder);
-    const mdName = canonicalFinding(dir);
-    if (!mdName) { skipped++; continue; }
-    const md = fs.readFileSync(path.join(dir, mdName), 'utf8');
+  for (const doc of docs) {
+    const md = fs.readFileSync(doc.file, 'utf8');
     const titleM = md.match(/^#\s+(.+)$/m);
     const title = titleM ? titleM[1].trim() : '';
     const cls = classify(title) || classify(md.slice(0, 1200)); // title first, then the lead
@@ -90,7 +105,7 @@ function main() {
     if (!cls || !code) { skipped++; continue; }
     const fn = firstFunctionName(code);
     if (!fn) { skipped++; continue; }
-    const id = folder;
+    const id = doc.id;
     const solPath = path.join(out, id + '.sol');
     fs.writeFileSync(solPath, code.replace(/\s+$/, '') + '\n');
     manifest.push(cls + '|' + path.resolve(solPath) + '|' + fn);

--- a/dark-factory/recall.sh
+++ b/dark-factory/recall.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# #861 M3 — held-out recall harness for the DAG bug-pattern matcher.
+#
+# Measures the matcher's RECALL on a held-out set (does a seeded pattern catch a fork/variant it did
+# NOT see seeded?) and its PRECISION (does it wrongly fire on a structurally-different negative?). It
+# seeds with the REAL seed-patterns.ag (zero seed-side drift) and matches with recall-match.ag, which
+# mirrors reconn's match functions exactly — so the number reflects production.
+#
+# Manifests are pipe-delimited; `#` lines and blank lines are ignored.
+#   --seed-manifest  lines: `Class|abs-src-path|func-marker`            (patterns to seed; from harvest-sherlock.js)
+#   --test-manifest  lines: `Class|abs-src-path|id|transform|expect`    (held-out targets; expect = match|miss; from make-variants.js)
+#
+# Usage:
+#   recall.sh --seed-manifest <m> --test-manifest <m> --evm-harness <dir> [--agentis <bin>] [--out <dir>]
+# Emits a markdown recall/precision table to stdout and to <out>/recall-report.md.
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+AGENTIS="agentis"; SEED_MANIFEST=""; TEST_MANIFEST=""; EVM_HARNESS=""; OUT="$PWD/recall-out"
+need() { [ "$1" -ge 2 ] || { echo "recall.sh: missing value for the preceding flag" >&2; exit 2; }; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --seed-manifest) need "$#"; SEED_MANIFEST="$2"; shift 2 ;;
+    --test-manifest) need "$#"; TEST_MANIFEST="$2"; shift 2 ;;
+    --evm-harness) need "$#"; EVM_HARNESS="$2"; shift 2 ;;
+    --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
+    --out) need "$#"; OUT="$2"; shift 2 ;;
+    --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
+    *) echo "recall.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+[ -f "$SEED_MANIFEST" ] || { echo "recall.sh: --seed-manifest not found: $SEED_MANIFEST" >&2; exit 2; }
+[ -f "$TEST_MANIFEST" ] || { echo "recall.sh: --test-manifest not found: $TEST_MANIFEST" >&2; exit 2; }
+[ -n "$EVM_HARNESS" ] || { echo "recall.sh: --evm-harness <dir> required" >&2; exit 2; }
+EVM_HARNESS="$(cd "$EVM_HARNESS" && pwd)"
+
+mkdir -p "$OUT"; OUT="$(cd "$OUT" && pwd)"
+RUN="$OUT/run"; rm -rf "$RUN"; mkdir -p "$RUN"
+cp "$HERE/auditor/agents/seed-patterns.ag" "$RUN/seed-patterns.ag"
+cp "$HERE/auditor/agents/recall-match.ag" "$RUN/recall-match.ag"
+
+# init the store FIRST (before any .agentis/ subdir exists), else HEAD is not set.
+( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
+{
+  echo "trace.level = normal"
+  echo "exec.env_passthrough = EVM_HARNESS_DIR,SEED_SRC,SEED_CLASS,SEED_FUNC,TEST_SRC,TEST_CLASS,TEST_ID,TEST_TRANSFORM"
+  echo "exec.default_timeout_ms = 180000"
+} > "$RUN/.agentis/config"
+
+# ---- seed (real seed-patterns.ag, exact + structural) -------------------------------------------
+echo "recall: seeding from $(basename "$SEED_MANIFEST") ..." >&2
+nseed=0
+while IFS='|' read -r C S M || [ -n "$C" ]; do
+  case "$C" in ''|\#*) continue ;; esac
+  ( cd "$RUN" && env SEED_CLASS="$C" SEED_SRC="$S" SEED_FUNC="$M" EVM_HARNESS_DIR="$EVM_HARNESS" \
+      "$AGENTIS" go seed-patterns.ag --enable-exec ) >/dev/null 2>&1 || true
+  nseed=$((nseed + 1))
+done < "$SEED_MANIFEST"
+echo "recall: seeded $nseed pattern(s)" >&2
+
+# ---- match each held-out target (exact + structural) --------------------------------------------
+RAW="$OUT/recall-raw.txt"; : > "$RAW"
+ntest=0
+while IFS='|' read -r C S ID TR EXPECT || [ -n "$C" ]; do
+  case "$C" in ''|\#*) continue ;; esac
+  line=$( cd "$RUN" && env TEST_SRC="$S" TEST_CLASS="$C" TEST_ID="$ID" TEST_TRANSFORM="$TR" EVM_HARNESS_DIR="$EVM_HARNESS" \
+      "$AGENTIS" go recall-match.ag --enable-exec 2>/dev/null | grep '^RECALL|' || true )
+  [ -n "$line" ] && echo "${line}|expect=${EXPECT}" >> "$RAW"
+  ntest=$((ntest + 1))
+done < "$TEST_MANIFEST"
+echo "recall: matched $ntest held-out target(s)" >&2
+
+# ---- tally -> markdown --------------------------------------------------------------------------
+REPORT="$OUT/recall-report.md"
+awk -F'|' '
+function pct(n, d) { return d == 0 ? "n/a" : sprintf("%.0f%% (%d/%d)", 100*n/d, n, d); }
+{
+  split($5, a, "="); ex = a[2];
+  split($6, b, "="); st = b[2];
+  split($7, c, "="); expect = c[2];
+  cls = $2;
+  if (expect == "match") {
+    mt[cls]++; MT++;
+    if (ex == cls)  { me[cls]++; ME++; }
+    if (st == cls)  { ms[cls]++; MS++; }
+  } else {
+    NT++;
+    if (ex != "MISS") NE++;
+    if (st != "MISS") NS++;
+  }
+  seen[cls] = 1;
+}
+END {
+  print "## M3 — held-out recall (DAG bug-pattern matcher)";
+  print "";
+  print "Recall = a seeded pattern catching a held-out FORK it did not see seeded. Forks are";
+  print "rename / reformat / re-literal variants (what a real N-day fork is). Baseline = exact-hash.";
+  print "";
+  print "| Class | held-out forks | exact-only recall | **structural recall** |";
+  print "|-------|----------------|-------------------|-----------------------|";
+  for (k in seen) if (mt[k] > 0)
+    printf("| %s | %d | %s | **%s** |\n", k, mt[k], pct(me[k], mt[k]), pct(ms[k], mt[k]));
+  printf("| **ALL** | %d | %s | **%s** |\n", MT, pct(ME, MT), pct(MS, MT));
+  print "";
+  print "### Precision (negatives — structurally-different, MUST NOT match)";
+  print "";
+  printf("| variants | exact false-match | structural false-match |\n");
+  printf("|----------|-------------------|------------------------|\n");
+  printf("| %d | %s | %s |\n", NT, pct(NE, NT), pct(NS, NT));
+}
+' "$RAW" | tee "$REPORT"
+
+echo "" >&2
+echo "recall: report -> $REPORT (raw -> $RAW)" >&2

--- a/dark-factory/recall.sh
+++ b/dark-factory/recall.sh
@@ -16,7 +16,7 @@
 set -eu
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-AGENTIS="agentis"; SEED_MANIFEST=""; TEST_MANIFEST=""; EVM_HARNESS=""; OUT="$PWD/recall-out"
+AGENTIS="agentis"; SEED_MANIFEST=""; TEST_MANIFEST=""; EVM_HARNESS=""; OUT="$PWD/recall-out"; FUZZY_THRESHOLD="0.35"
 need() { [ "$1" -ge 2 ] || { echo "recall.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -24,6 +24,7 @@ while [ $# -gt 0 ]; do
     --test-manifest) need "$#"; TEST_MANIFEST="$2"; shift 2 ;;
     --evm-harness) need "$#"; EVM_HARNESS="$2"; shift 2 ;;
     --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
+    --threshold) need "$#"; FUZZY_THRESHOLD="$2"; shift 2 ;;
     --out) need "$#"; OUT="$2"; shift 2 ;;
     --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
     *) echo "recall.sh: unknown flag $1" >&2; exit 2 ;;
@@ -43,7 +44,7 @@ cp "$HERE/auditor/agents/recall-match.ag" "$RUN/recall-match.ag"
 ( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
 {
   echo "trace.level = normal"
-  echo "exec.env_passthrough = EVM_HARNESS_DIR,SEED_SRC,SEED_CLASS,SEED_FUNC,TEST_SRC,TEST_CLASS,TEST_ID,TEST_TRANSFORM"
+  echo "exec.env_passthrough = EVM_HARNESS_DIR,SEED_SRC,SEED_CLASS,SEED_FUNC,TEST_SRC,TEST_CLASS,TEST_ID,TEST_TRANSFORM,FUZZY_SEEDS,FUZZY_THRESHOLD"
   echo "exec.default_timeout_ms = 180000"
 } > "$RUN/.agentis/config"
 
@@ -58,17 +59,27 @@ while IFS='|' read -r C S M || [ -n "$C" ]; do
 done < "$SEED_MANIFEST"
 echo "recall: seeded $nseed pattern(s)" >&2
 
-# ---- match each held-out target (exact + structural) --------------------------------------------
+# build the fuzzy-match seed corpus: one `Class:::<normalized-sig>` per seed (its marker function),
+# consumed by fuzzy-match.js for shingle-Jaccard similarity matching.
+FUZZY_SEEDS="$OUT/fuzzy-seeds.tsv"; : > "$FUZZY_SEEDS"
+while IFS='|' read -r C S M || [ -n "$C" ]; do
+  case "$C" in ''|\#*) continue ;; esac
+  sig=$(node "$EVM_HARNESS/struct-sig.js" "$S" 2>/dev/null | grep "^${M}:::" | head -1 | sed 's/^[^:]*::://')
+  [ -n "$sig" ] && printf '%s:::%s\n' "$C" "$sig" >> "$FUZZY_SEEDS"
+done < "$SEED_MANIFEST"
+
+# ---- match each held-out target (exact + structural + fuzzy) -------------------------------------
 RAW="$OUT/recall-raw.txt"; : > "$RAW"
 ntest=0
 while IFS='|' read -r C S ID TR EXPECT || [ -n "$C" ]; do
   case "$C" in ''|\#*) continue ;; esac
   line=$( cd "$RUN" && env TEST_SRC="$S" TEST_CLASS="$C" TEST_ID="$ID" TEST_TRANSFORM="$TR" EVM_HARNESS_DIR="$EVM_HARNESS" \
+      FUZZY_SEEDS="$FUZZY_SEEDS" FUZZY_THRESHOLD="$FUZZY_THRESHOLD" \
       "$AGENTIS" go recall-match.ag --enable-exec 2>/dev/null | grep '^RECALL|' || true )
   [ -n "$line" ] && echo "${line}|expect=${EXPECT}" >> "$RAW"
   ntest=$((ntest + 1))
 done < "$TEST_MANIFEST"
-echo "recall: matched $ntest held-out target(s)" >&2
+echo "recall: matched $ntest held-out target(s) (fuzzy threshold $FUZZY_THRESHOLD)" >&2
 
 # ---- tally -> markdown --------------------------------------------------------------------------
 REPORT="$OUT/recall-report.md"
@@ -77,36 +88,40 @@ function pct(n, d) { return d == 0 ? "n/a" : sprintf("%.0f%% (%d/%d)", 100*n/d, 
 {
   split($5, a, "="); ex = a[2];
   split($6, b, "="); st = b[2];
-  split($7, c, "="); expect = c[2];
+  split($7, c, "="); fz = c[2];
+  split($8, d, "="); expect = d[2];
   cls = $2;
   if (expect == "match") {
     mt[cls]++; MT++;
-    if (ex == cls)  { me[cls]++; ME++; }
-    if (st == cls)  { ms[cls]++; MS++; }
+    if (ex == cls) { me[cls]++; ME++; }
+    if (st == cls) { ms[cls]++; MS++; }
+    if (fz == cls) { mf[cls]++; MF++; }
   } else {
     NT++;
     if (ex != "MISS") NE++;
     if (st != "MISS") NS++;
+    if (fz != "MISS") NFZ++;
   }
   seen[cls] = 1;
 }
 END {
   print "## M3 — held-out recall (DAG bug-pattern matcher)";
   print "";
-  print "Recall = a seeded pattern catching a held-out FORK it did not see seeded. Forks are";
-  print "rename / reformat / re-literal variants (what a real N-day fork is). Baseline = exact-hash.";
+  print "Recall = a seeded pattern catching a held-out target it did not see seeded.";
+  print "exact = byte-identical sub-graph; structural = exact normalized signature; fuzzy =";
+  print "shingle-Jaccard similarity (the lift for REAL forks where the function is restructured).";
   print "";
-  print "| Class | held-out forks | exact-only recall | **structural recall** |";
-  print "|-------|----------------|-------------------|-----------------------|";
+  print "| Class | held-out | exact | structural | **fuzzy** |";
+  print "|-------|----------|-------|------------|-----------|";
   for (k in seen) if (mt[k] > 0)
-    printf("| %s | %d | %s | **%s** |\n", k, mt[k], pct(me[k], mt[k]), pct(ms[k], mt[k]));
-  printf("| **ALL** | %d | %s | **%s** |\n", MT, pct(ME, MT), pct(MS, MT));
+    printf("| %s | %d | %s | %s | **%s** |\n", k, mt[k], pct(me[k], mt[k]), pct(ms[k], mt[k]), pct(mf[k], mt[k]));
+  printf("| **ALL** | %d | %s | %s | **%s** |\n", MT, pct(ME, MT), pct(MS, MT), pct(MF, MT));
   print "";
-  print "### Precision (negatives — structurally-different, MUST NOT match)";
+  print "### Precision (negatives / unrelated — MUST NOT match; false-match rate)";
   print "";
-  printf("| variants | exact false-match | structural false-match |\n");
-  printf("|----------|-------------------|------------------------|\n");
-  printf("| %d | %s | %s |\n", NT, pct(NE, NT), pct(NS, NT));
+  printf("| targets | exact | structural | fuzzy |\n");
+  printf("|---------|-------|------------|-------|\n");
+  printf("| %d | %s | %s | %s |\n", NT, pct(NE, NT), pct(NS, NT), pct(NFZ, NT));
 }
 ' "$RAW" | tee "$REPORT"
 

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -36,7 +36,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 TARGET="" ; HARNESS="" ; ANCHOR_HARNESS="" ; EVM_HARNESS="" ; SNAPSHOT="" ; POC=""
 REPO="" ; IN_SCOPE="" ; CONTRACT="" ; SEED_MANIFEST="" ; SHARE_PATTERNS=""
-BACKEND="claude" ; SANDBOX="hardened" ; OUT="$PWD/audit-out"
+BACKEND="claude" ; SANDBOX="hardened" ; OUT="$PWD/audit-out" ; FUZZY_THRESHOLD="0.35"
 
 need() { [ "$1" -ge 2 ] || { echo "run-audit.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -115,7 +115,7 @@ cp "$COLONY" "$RUN/auditor.ag"
   echo "llm.backend = $BACKEND"
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 180000"; }
   echo "trace.level = normal"
-  echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,EVM_HARNESS_DIR,BOUNTY_SNAPSHOT,BOUNTY_REPO,BOUNTY_IN_SCOPE,BOUNTY_CONTRACT,SEED_SRC,SEED_CLASS,SEED_FUNC"
+  echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,EVM_HARNESS_DIR,BOUNTY_SNAPSHOT,BOUNTY_REPO,BOUNTY_IN_SCOPE,BOUNTY_CONTRACT,SEED_SRC,SEED_CLASS,SEED_FUNC,FUZZY_SEEDS,FUZZY_THRESHOLD"
   echo "exec.default_timeout_ms = 180000"
   # --share-patterns lists each seeded pattern on the knowledge market (knowledge_sell), so other
   # federation members can buy it. The market is gated on the learning/knowledge subsystem.
@@ -133,8 +133,19 @@ if [ -n "$SEED_MANIFEST" ]; then
     case "$SCLASS" in ''|\#*) continue ;; esac
     # EVM_HARNESS_DIR lets seed-patterns.ag also seed the STRUCTURAL signature (variant match) via
     # struct-sig.js; empty for non-EVM seeds, where the struct pass self-skips (len(ed)==0).
-    ( cd "$RUN" && env SEED_CLASS="$SCLASS" SEED_SRC="$SSRC" SEED_FUNC="$SMARK" EVM_HARNESS_DIR="$EVM_HARNESS" "$AGENTIS" go seed-patterns.ag --enable-exec ) 2>&1 | grep -i 'seed' >&2
+    ( cd "$RUN" && env SEED_CLASS="$SCLASS" SEED_SRC="$SSRC" SEED_FUNC="$SMARK" EVM_HARNESS_DIR="$EVM_HARNESS" "$AGENTIS" go seed-patterns.ag --enable-exec ) 2>&1 | grep -i 'seed' >&2 || true
   done < "$SEED_MANIFEST"
+
+  # #861 M3+: build the fuzzy-match seed corpus (one `Class:::<normalized-sig>` per seed) so reconn's
+  # fuzzy fallback can catch a RESTRUCTURED fork the exact + structural matchers miss. EVM-only.
+  if [ -n "$EVM_HARNESS" ]; then
+    : > "$RUN/fuzzy-seeds.tsv"
+    while IFS='|' read -r SCLASS SSRC SMARK || [ -n "$SCLASS" ]; do
+      case "$SCLASS" in ''|\#*) continue ;; esac
+      sig=$(node "$EVM_HARNESS/struct-sig.js" "$SSRC" 2>/dev/null | grep "^${SMARK}:::" | head -1 | sed 's/^[^:]*::://')
+      [ -n "$sig" ] && printf '%s:::%s\n' "$SCLASS" "$sig" >> "$RUN/fuzzy-seeds.tsv"
+    done < "$SEED_MANIFEST"
+  fi
 
   # #861: optionally publish every seeded pattern to the knowledge market ("DAG sdílej přes
   # knowledge market") so other federation members can buy it via knowledge_buy.
@@ -149,6 +160,7 @@ ENV=(BOUNTY_TARGET="$TARGET")
 [ -n "$HARNESS" ]        && ENV+=(SOLANA_HARNESS_DIR="$HARNESS")
 [ -n "$ANCHOR_HARNESS" ] && ENV+=(SOLANA_ANCHOR_HARNESS_DIR="$ANCHOR_HARNESS")
 [ -n "$EVM_HARNESS" ]    && ENV+=(EVM_HARNESS_DIR="$EVM_HARNESS")
+[ -f "$RUN/fuzzy-seeds.tsv" ] && ENV+=(FUZZY_SEEDS="$RUN/fuzzy-seeds.tsv" FUZZY_THRESHOLD="$FUZZY_THRESHOLD")
 [ -n "$SNAPSHOT" ]       && ENV+=(BOUNTY_SNAPSHOT="$SNAPSHOT")
 [ -n "$POC" ]            && ENV+=(BOUNTY_POC="$POC")
 [ -n "$REPO" ]           && ENV+=(BOUNTY_REPO="$REPO" BOUNTY_IN_SCOPE="$IN_SCOPE" BOUNTY_CONTRACT="$CONTRACT")

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -22,6 +22,10 @@
 #                            With --repo this defaults to the bundled ./evm-harness when omitted.
 #   --snapshot <file>        Frozen on-chain account dump (BOUNTY_SNAPSHOT; see snapshot-rpc.sh).
 #   --poc <file>             Operator-supplied PoC candidate (BOUNTY_POC; still gated).
+#   --seed-manifest <file>   Seed known-bug patterns from finished contests (#861): manifest lines
+#                            `Class|abs-src-path|func-marker` (harvest-sherlock.js output).
+#   --share-patterns         After seeding, publish each pattern to the knowledge market so other
+#                            federation members can buy it (knowledge_sell; requires --seed-manifest).
 #   --backend <mock|claude>  LLM backend (default: claude). mock = offline-deterministic.
 #   --sandbox <hardened|none> Sandbox profile (default: hardened).
 #   --out <dir>              Output dir for the run + submission package (default: ./audit-out).
@@ -31,7 +35,7 @@ set -eu
 HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 TARGET="" ; HARNESS="" ; ANCHOR_HARNESS="" ; EVM_HARNESS="" ; SNAPSHOT="" ; POC=""
-REPO="" ; IN_SCOPE="" ; CONTRACT="" ; SEED_MANIFEST=""
+REPO="" ; IN_SCOPE="" ; CONTRACT="" ; SEED_MANIFEST="" ; SHARE_PATTERNS=""
 BACKEND="claude" ; SANDBOX="hardened" ; OUT="$PWD/audit-out"
 
 need() { [ "$1" -ge 2 ] || { echo "run-audit.sh: missing value for the preceding flag" >&2; exit 2; }; }
@@ -42,6 +46,7 @@ while [ $# -gt 0 ]; do
     --in-scope) need "$#"; IN_SCOPE="$2"; shift 2 ;;
     --contract) need "$#"; CONTRACT="$2"; shift 2 ;;
     --seed-manifest) need "$#"; SEED_MANIFEST="$2"; shift 2 ;;
+    --share-patterns) SHARE_PATTERNS=1; shift ;;
     --harness) need "$#"; HARNESS="$2"; shift 2 ;;
     --anchor-harness) need "$#"; ANCHOR_HARNESS="$2"; shift 2 ;;
     --evm-harness) need "$#"; EVM_HARNESS="$2"; shift 2 ;;
@@ -112,6 +117,9 @@ cp "$COLONY" "$RUN/auditor.ag"
   echo "trace.level = normal"
   echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,EVM_HARNESS_DIR,BOUNTY_SNAPSHOT,BOUNTY_REPO,BOUNTY_IN_SCOPE,BOUNTY_CONTRACT,SEED_SRC,SEED_CLASS,SEED_FUNC"
   echo "exec.default_timeout_ms = 180000"
+  # --share-patterns lists each seeded pattern on the knowledge market (knowledge_sell), so other
+  # federation members can buy it. The market is gated on the learning/knowledge subsystem.
+  [ -n "$SHARE_PATTERNS" ] && { echo "learning.enabled = true"; echo "experience.enabled = true"; echo "knowledge.enabled = true"; }
 } > "$RUN/.agentis/config"
 
 # #861: seed known-bug patterns into the DAG (bugpat:exact memos) BEFORE the audit, in the same
@@ -127,6 +135,13 @@ if [ -n "$SEED_MANIFEST" ]; then
     # struct-sig.js; empty for non-EVM seeds, where the struct pass self-skips (len(ed)==0).
     ( cd "$RUN" && env SEED_CLASS="$SCLASS" SEED_SRC="$SSRC" SEED_FUNC="$SMARK" EVM_HARNESS_DIR="$EVM_HARNESS" "$AGENTIS" go seed-patterns.ag --enable-exec ) 2>&1 | grep -i 'seed' >&2
   done < "$SEED_MANIFEST"
+
+  # #861: optionally publish every seeded pattern to the knowledge market ("DAG sdílej přes
+  # knowledge market") so other federation members can buy it via knowledge_buy.
+  if [ -n "$SHARE_PATTERNS" ]; then
+    cp "$HERE/auditor/agents/share-patterns.ag" "$RUN/share-patterns.ag"
+    ( cd "$RUN" && "$AGENTIS" go share-patterns.ag ) 2>&1 | grep -i 'share:' >&2
+  fi
 fi
 
 # scope env — only what the operator supplied reaches the (env_clear'd) sandbox.


### PR DESCRIPTION
## M3 — recall harness + **fuzzy matching for real forks** + knowledge-market sharing (#861)

Closes the goal's measurable success criterion with an honest, real-world number — and the journey there found (and fixed) the matcher's actual weakness.

### The honest recall story

| measurement | exact | structural | **fuzzy** |
|---|---|---|---|
| **synthetic forks** (rename/reformat/re-literal, 164 held-out) | 6% | 94% | ~94% |
| **real fork-pair** (Compound CToken → Venus VToken, 48 shared fns) | 17% | 17% | **69% @ 0.30 / 54% @ 0.35** |

The synthetic 94% is an **upper bound on near-verbatim forks** — those are exactly the transforms struct-sig was built to be invariant to. Fork-pair validation (the real test) showed exact/structural matching is **~0% on the vuln-bearing functions**: a real fork (`redeemFresh`, `accrueInterest`) is ~2× rewritten. **Fuzzy** shingle-Jaccard similarity is the lift that recovers them.

### What's here

- **`evm-harness/fuzzy-match.js`** — matches on shingle-Jaccard **similarity** instead of signature equality. Wired into reconn as the third fallback (`match_seeded_fuzzy_evm`, after exact + structural) and into the recall harness. Precision ~52-67% (structurally-similar-but-different functions also match) — **gate-safe**: a false candidate costs one inconclusive synthesis, never a finding.
- **`struct-sig.js` fixes** — fork-pair validation surfaced two over-tight-granularity bugs: modifier-keyword **order** sensitivity (`override external view` ≠ `external view override`) and `uint`/`uint256` aliasing. Fixing both lifted exact-sig fork-pair recall 0% → 17%.
- **`evm-harness/forkpair-recall.js`** — reproducible real fork-pair measurement (the documented real hit-rate, vs the synthetic proxy).
- **`recall.sh` + `recall-match.ag`** — seed via the real `seed-patterns.ag`, match with a mirror of reconn's exact + structural + fuzzy matchers, tally per class + precision.
- **`make-variants.js`** — fork-variant generator + structural negatives (neg-guard fix from QA: inject after the function header brace, not the first `{`).
- **`harvest-sherlock.js`** — both Sherlock layouts (old `NNN-H/` folders + new flat `NNN.md`); the 4-contest harvest pulled 365 findings.
- **`share-patterns.ag` + `run-audit.sh --share-patterns`** — publish each seeded pattern to the knowledge market (`knowledge_sell`, keyed by content hash) — "share the DAG via the knowledge market". Buy side is a real economic exchange (funded consumer required).

### Proven end-to-end through the colony

Seed Compound's `redeemFresh`, audit Venus's **real forked** `redeemFresh` (Jaccard 0.41, ~1.6× restructured):
```
reconn: SEEDED FUZZY MATCH -> Reentrancy (... a RESTRUCTURED fork of a recorded finding)
guard: Reentrancy fired [High] (seeded known-bug pattern match — DAG)
```
Exact + structural both **missed**; fuzzy **caught** it.

### Honest bounds
- Fuzzy lifts recall on real forks but at a precision cost (gate-protected).
- **Known limitation**: in-`.ag` `strip_comments` is O(n²) and overflows the string heap on a full ~1500-line contract target (exact/structural run it first). Real full-contract auditing needs it rewritten; single-function / mid-size targets are unaffected.

colony-lint: 356 passed, 0 failed, 5 skipped.
