### PR TITLE
dark-factory: fix O(n²) strip_comments — unblock full-contract auditing (#861)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -74,6 +74,16 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Fixed
 
+- Real FULL-contract auditing — `strip_comments` no longer overflows the string heap (#861). The
+  in-`.ag` `strip_comments` builds its result with `reduce(lines, |acc,l| acc + ...)`, which is
+  O(n²) string allocation and overflowed the 16 MiB per-tick string heap on a full ~1500-line real
+  contract — so reconn/guard died before ever matching, and the colony could only audit extracted
+  single functions. agentis has no `join`/`regex_replace` builtin for an in-`.ag` O(n) rewrite, so
+  the EVM path now offloads to `evm-harness/strip-comments.js` (O(n), reuses struct-sig.js's
+  stripComments); the Rust path keeps the in-`.ag` stripper. Seed + match both offload, so exact
+  hashes stay aligned. Proven: the full 84 KB Venus `VToken.sol` (65 functions) now audits
+  end-to-end — `distilled 65 sub-graph(s)` → `SEEDED FUZZY MATCH -> Reentrancy` → guard fired
+  `[High]`, where before it died in `strip_comments` with `string_heap limit exceeded`.
 - Decomposed-synthesis EXPLOIT slot now uses `try_call`/`try_call_value` (revert-tolerant) for the
   attack step instead of `call`/`call_value` (which `die` on a revert). On a secure target the attack
   reverts — which means the invariant HELD — but a plain `call` turned that into a false

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -63,6 +63,16 @@ fn ingest_target() -> string {
 
 // Strip `//` line comments so they can neither forge nor mask a guard.
 fn strip_comments(src: string) -> string {
+    // EVM path: offload to strip-comments.js (O(n)). The in-.ag reduce below is O(n^2) string
+    // accumulation that overflows the per-tick string heap on a full ~1500-line real contract
+    // (agentis has no join/regex_replace builtin for an in-.ag O(n) rewrite). The Rust path
+    // (no EVM_HARNESS_DIR) keeps the in-.ag stripper. Both seed + match offload, so hashes align.
+    let ed = getenv("EVM_HARNESS_DIR");
+    if len(ed) > 0 {
+        file_write("h_strip.sol", src);
+        // colony-lint: safe-exec-concat
+        return exec sh "node ${ed}/strip-comments.js h_strip.sol 2>/dev/null || true";
+    }
     let lines = regex_split("\n", src);
     return reduce(lines, |acc: string, l: string| -> string {
         let c = index_of(l, "//");

--- a/dark-factory/auditor/agents/recall-match.ag
+++ b/dark-factory/auditor/agents/recall-match.ag
@@ -9,6 +9,14 @@ cb 200000;
 
 // Mirror of auditor.ag::strip_comments — must canonicalize IDENTICALLY to the exact-match path.
 fn strip_comments(src: string) -> string {
+    // Offload to strip-comments.js (O(n)) — match the EVM exact-match strip in reconn + seed-patterns
+    // exactly. The in-.ag reduce (O(n^2)) is the no-harness fallback.
+    let ed = getenv("EVM_HARNESS_DIR");
+    if len(ed) > 0 {
+        file_write("h_strip.sol", src);
+        // colony-lint: safe-exec-concat
+        return exec sh "node ${ed}/strip-comments.js h_strip.sol 2>/dev/null || true";
+    }
     let lines = regex_split("\n", src);
     return reduce(lines, |acc: string, l: string| -> string {
         let c = index_of(l, "//");

--- a/dark-factory/auditor/agents/seed-patterns.ag
+++ b/dark-factory/auditor/agents/seed-patterns.ag
@@ -29,6 +29,15 @@ fn struct_has_signal(sig: string) -> bool {
 // Mirror of auditor.ag::strip_comments — the seed must canonicalize IDENTICALLY to reconn or the
 // content hashes won't match.
 fn strip_comments(src: string) -> string {
+    // Offload to strip-comments.js (O(n)) so the seed strips comments IDENTICALLY to reconn's EVM
+    // exact-match path (which also offloads) — the in-.ag reduce is O(n^2). Falls back to the in-.ag
+    // stripper if no EVM_HARNESS_DIR (seeds are small, so the fallback never overflows).
+    let ed = getenv("EVM_HARNESS_DIR");
+    if len(ed) > 0 {
+        file_write("h_strip.sol", src);
+        // colony-lint: safe-exec-concat
+        return exec sh "node ${ed}/strip-comments.js h_strip.sol 2>/dev/null || true";
+    }
     let lines = regex_split("\n", src);
     return reduce(lines, |acc: string, l: string| -> string {
         let c = index_of(l, "//");

--- a/dark-factory/evm-harness/strip-comments.js
+++ b/dark-factory/evm-harness/strip-comments.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// #861: O(n) comment stripper for the EVM exact-match path. The in-`.ag` strip_comments builds its
+// result with `reduce(lines, |acc, l| acc + ... )` — O(n^2) string allocation that overflows the
+// 16 MiB per-tick string heap on a full ~1500-line real contract (the error that blocked auditing
+// real targets). agentis has no `join` / `regex_replace` builtin, so an in-`.ag` O(n) rewrite is not
+// possible; the EVM reconn/guard/seed/recall paths offload to this instead (the Rust path keeps the
+// in-`.ag` stripper). Reuses struct-sig.js's stripComments so the exact-match path strips comments
+// IDENTICALLY to the structural/fuzzy paths — and seed + match both call this, so the content hashes
+// stay aligned within a run.
+//
+// Usage:   node strip-comments.js <file.sol>   -> stripped source on stdout (empty on any error).
+'use strict';
+const fs = require('fs');
+const { stripComments } = require('./struct-sig.js');
+
+function main() {
+  const f = process.argv[2];
+  if (!f) return;
+  let src;
+  try { src = fs.readFileSync(f, 'utf8'); } catch (e) { return; }
+  process.stdout.write(stripComments(src));
+}
+
+main();


### PR DESCRIPTION
## Fix O(n²) `strip_comments` — unblock full-contract auditing (#861)

The follow-up blocker from #987: the colony could only audit **extracted single functions**, not real full contracts.

### The bug

The in-`.ag` `strip_comments` builds its result with `reduce(lines, |acc,l| acc + substring(...) + "\n")` — **O(n²) string allocation**. On a full ~1500-line real contract it overflowed the 16 MiB per-tick string heap (`ResourceExhausted` in reconn/guard's `strip_comments`) **before any matching ran**. agentis has no `join` / `regex_replace` builtin, so an in-`.ag` O(n) rewrite is impossible.

### The fix

The EVM path offloads to **`evm-harness/strip-comments.js`** (O(n), reuses `struct-sig.js`'s `stripComments`); the Rust path keeps the in-`.ag` stripper. `seed-patterns.ag` + `recall-match.ag` offload identically, so the exact sub-graph hashes stay aligned between seed and match within a run.

### Proven

The full **84 KB Venus `VToken.sol` (65 functions)** — the exact target that previously died with `string_heap limit 268435456 exceeded` — now audits end-to-end:
```
reconn: distilled 65 sub-graph(s); target hash 6c819b5014af
reconn: SEEDED FUZZY MATCH -> Reentrancy (a RESTRUCTURED fork of a recorded finding)
guard: Reentrancy fired [High] (seeded known-bug pattern match — DAG)
```
And exact-match still fires on a byte-identical target (hash consistency preserved across the stripper change):
```
reconn: SEEDED PATTERN MATCH -> Reentrancy (exact byte-identical fork of a recorded finding)
```

The colony can now audit **real full contracts**, not just extracted functions — the realistic end-to-end audit path.

colony-lint: 356 passed, 0 failed, 5 skipped.
