### PR TITLE
dark-factory: M4 — evolve the matcher granularity by fitness (#861)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,22 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- M4 evolution — the matcher granularity tunes itself by fitness (#861). The fuzzy matcher's
+  granularity (shingle-Jaccard threshold × shingle width `k`) is the knob no human can hand-tune:
+  too loose floods synthesis, too tight misses forks, and the sweet spot is unknown a priori — a
+  search problem, and the fork-pair recall harness IS the fitness function. `auditor/agents/
+  pattern-evolver.ag` + `evolve-matcher.sh` search the genome against a held-out fork-pair oracle
+  (forkpair-recall.js), record EACH candidate as substrate experience via `learn()`, select the
+  F-beta-max config (beta>1 = recall-leaning, since the two-sided gate absorbs false matches), and
+  write `evolved:fuzzy_threshold` / `evolved:fuzzy_k`. `run-audit.sh --use-evolved <dir>` adopts that
+  config (also `--fuzzy-threshold` / `--fuzzy-k` to set them directly); `fuzzy-match.js` /
+  `forkpair-recall.js` gained a `k` arg, and reconn/recall-match pass `FUZZY_K`.
+  - **Proven end-to-end on Compound→Venus**: the hand-set default (th=0.35, k=4) scores F-beta 0.549
+    (recall 54%); the evolver searched 15 genome points and picked **th=0.25, k=4 → F-beta 0.674
+    (recall 85%)** — a config no human chose — then `run-audit --use-evolved` adopted it
+    (`adopted evolved matcher granularity threshold=0.25 k=4`) and fuzzy-matched a real fork. The
+    granularity is now fitness-driven, not hand-guessed; `--beta` tunes the recall/precision trade.
+
 - M3 held-out recall harness + knowledge-market sharing (#861). Measures whether the seeded DAG
   catches a finding's FORK it did not see seeded, and shares the corpus across the federation:
   - `recall.sh` + `auditor/agents/recall-match.ag` seed with the real `seed-patterns.ag` (zero

--- a/dark-factory/auditor/agents/auditor.ag
+++ b/dark-factory/auditor/agents/auditor.ag
@@ -372,8 +372,9 @@ fn match_seeded_fuzzy_evm(target: string) -> string {
     if len(seeds) == 0 { return ""; }
     file_write("h_fuzzy.sol", target);
     let th = getenv("FUZZY_THRESHOLD");
+    let k = getenv("FUZZY_K");
     // colony-lint: safe-exec-concat
-    let out = exec sh "node ${ed}/fuzzy-match.js h_fuzzy.sol ${seeds} ${th} 2>/dev/null || true";
+    let out = exec sh "node ${ed}/fuzzy-match.js h_fuzzy.sol ${seeds} ${th} ${k} 2>/dev/null || true";
     return reduce(regex_split("\n", out), |acc: string, line: string| -> string {
         if is_vuln_class(acc) { return acc; }
         if is_vuln_class(line) { return line; }

--- a/dark-factory/auditor/agents/pattern-evolver.ag
+++ b/dark-factory/auditor/agents/pattern-evolver.ag
@@ -1,0 +1,89 @@
+cb 2000000;
+// #861 M4: evolve the fuzzy matcher's GRANULARITY genome (shingle-Jaccard threshold × shingle
+// width k) against the fork-pair FITNESS ORACLE (forkpair-recall.js on a held-out real fork pair).
+// The granularity is the knob no human could hand-tune — too loose floods synthesis, too tight
+// misses forks, and the sweet spot is unknown a priori. That is a search problem, and the recall
+// harness IS the fitness function. This agent searches the genome, records each candidate as
+// substrate experience via learn() (so the exploration accrues fitness in the experience store),
+// selects the F-beta-max config, and writes evolved:fuzzy_threshold / evolved:fuzzy_k for reconn to
+// adopt. Fitness = F-beta with beta>1 (recall-leaning): the two-sided synthesis gate absorbs false
+// matches, so on a real fork recall is worth more than precision.
+//
+// Env: FORK_BASE + FORK_FORK (held-out fork-pair .sol), EVM_HARNESS_DIR, EVOLVE_BETA (default 2).
+
+fn fbeta(r: float, p: float, b2: float) -> float {
+    let denom = b2 * p + r;
+    if denom == 0.0 { return 0.0; }
+    return (1.0 + b2) * p * r / denom;
+}
+
+// beta^2 from the EVOLVE_BETA env (default beta=2 -> 4) — no `let` reassignment in .ag.
+fn beta_sq(b: float) -> float {
+    if b == 0.0 { return 4.0; }
+    return b * b;
+}
+
+// Candidate outcome for the experience store: beats the default baseline or not.
+fn outcome_of(fit: float, base: float) -> string {
+    if fit > base { return "success"; }
+    return "partial";
+}
+
+// Run the oracle for one genome point and return its EVAL line.
+fn run_eval(ed: string, base: string, fork: string, th: string, k: string) -> string {
+    // colony-lint: safe-exec-concat
+    return exec sh "node ${ed}/forkpair-recall.js ${base} ${fork} ${th} ${k} 2>/dev/null | grep '^EVAL|' || true";
+}
+
+// F-beta fitness of an EVAL line.
+fn eval_fbeta(out: string, b2: float) -> float {
+    let r = parse_float(regex_capture("recall=([0-9.]+)", out, 1));
+    let p = parse_float(regex_capture("precision=([0-9.]+)", out, 1));
+    return fbeta(r, p, b2);
+}
+
+let ed = getenv("EVM_HARNESS_DIR");
+let base = getenv("FORK_BASE");
+let fork = getenv("FORK_FORK");
+let b2 = beta_sq(parse_float(getenv("EVOLVE_BETA")));   // default beta = 2 -> b2 = 4
+
+if len(ed) == 0 { print("evolve: ERROR — EVM_HARNESS_DIR unset"); }
+if len(base) == 0 { print("evolve: ERROR — FORK_BASE unset"); }
+
+// Baseline: the hand-set default genome (threshold 0.35, k 4).
+let base_out = run_eval(ed, base, fork, "0.35", "4");
+let base_fit = eval_fbeta(base_out, b2);
+print("evolve: baseline default(th=0.35,k=4) F-beta =", to_string(base_fit));
+
+// Genome: flattened `threshold:k` candidates spanning the granularity space.
+let genome = ["0.20:3", "0.20:4", "0.25:3", "0.25:4", "0.25:5", "0.30:3", "0.30:4", "0.30:5", "0.35:3", "0.35:4", "0.35:5", "0.40:3", "0.40:4", "0.40:5", "0.45:4"];
+
+// Search: evaluate each candidate, learn() it (substrate experience), track the F-beta-max as
+// "th:k:fitness". Single-assignment acc threads the running best.
+let best = reduce(genome, |acc: string, g: string| -> string {
+    let sep = index_of(g, ":");
+    let th = substring(g, 0, sep);
+    let k = substring(g, sep + 1, len(g));
+    let out = run_eval(ed, base, fork, th, k);
+    let fit = eval_fbeta(out, b2);
+    let outcome = outcome_of(fit, base_fit);
+    learn("matcher-genome", "th=" + th + " k=" + k, "F-beta " + to_string(fit), outcome, ["evolve", th, k]);
+    print("evolve: th=" + th + " k=" + k + " F-beta=" + to_string(fit) + " (" + outcome + ")");
+    let arest = substring(acc, index_of(acc, ":") + 1, len(acc));
+    let afit = parse_float(substring(arest, index_of(arest, ":") + 1, len(arest)));
+    if fit > afit {
+        return th + ":" + k + ":" + to_string(fit);
+    }
+    return acc;
+}, "0.35:4:" + to_string(base_fit));
+
+// Parse the winning genome and persist it for reconn to adopt.
+let bth = substring(best, 0, index_of(best, ":"));
+let brest = substring(best, index_of(best, ":") + 1, len(best));
+let bk = substring(brest, 0, index_of(brest, ":"));
+let bfit = substring(brest, index_of(brest, ":") + 1, len(brest));
+
+memo_write("evolved:fuzzy_threshold", bth);
+memo_write("evolved:fuzzy_k", bk);
+print("evolve: BEST genome th=" + bth + " k=" + bk + " F-beta=" + bfit + " vs baseline " + to_string(base_fit));
+print("evolve: wrote evolved:fuzzy_threshold=" + bth + " evolved:fuzzy_k=" + bk);

--- a/dark-factory/auditor/agents/recall-match.ag
+++ b/dark-factory/auditor/agents/recall-match.ag
@@ -78,8 +78,9 @@ fn match_fuzzy(path: string) -> string {
     if len(ed) == 0 { return ""; }
     if len(seeds) == 0 { return ""; }
     let th = getenv("FUZZY_THRESHOLD");
+    let k = getenv("FUZZY_K");
     // colony-lint: safe-exec-concat
-    let out = exec sh "node ${ed}/fuzzy-match.js ${path} ${seeds} ${th} 2>/dev/null || true";
+    let out = exec sh "node ${ed}/fuzzy-match.js ${path} ${seeds} ${th} ${k} 2>/dev/null || true";
     return reduce(regex_split("\n", out), |acc: string, line: string| -> string {
         if is_vuln_class(acc) { return acc; }
         if is_vuln_class(line) { return line; }

--- a/dark-factory/evm-harness/forkpair-recall.js
+++ b/dark-factory/evm-harness/forkpair-recall.js
@@ -18,7 +18,7 @@
 const fs = require('fs');
 const { extractFunctions, normalize, stripComments } = require('./struct-sig.js');
 
-const K = 4;
+let K = 4;
 function shingles(sig) {
   const t = sig.split(' ').filter(Boolean);
   const s = new Set();
@@ -42,7 +42,8 @@ function main() {
   const base = process.argv[2];
   const fork = process.argv[3];
   const th = process.argv[4] ? parseFloat(process.argv[4]) : 0.35;
-  if (!base || !fork) { console.error('usage: forkpair-recall.js <base.sol> <fork.sol> [threshold]'); process.exit(2); }
+  if (process.argv[5]) { const kv = parseInt(process.argv[5], 10); if (kv >= 1) K = kv; }
+  if (!base || !fork) { console.error('usage: forkpair-recall.js <base.sol> <fork.sol> [threshold] [shingle-k]'); process.exit(2); }
   const B = sigMap(base);
   const F = sigMap(fork);
   const SB = {}; for (const k of Object.keys(B)) SB[k] = shingles(B[k]);
@@ -60,15 +61,20 @@ function main() {
     if (a === b || SB[a].size < 2 || SF[b].size < 2) continue;
     if (jaccard(SB[a], SF[b]) >= th) fp++;
   }
-  const prec = fuzzy + fp > 0 ? Math.round((100 * fuzzy) / (fuzzy + fp)) : 0;
+  const prec = fuzzy + fp > 0 ? fuzzy / (fuzzy + fp) : 0;
+  const recall = shared.length ? fuzzy / shared.length : 0;
+  const exrec = shared.length ? exact / shared.length : 0;
   const p = (n) => shared.length ? Math.round((100 * n) / shared.length) + '%' : 'n/a';
-  console.log('fork-pair recall  (threshold ' + th + ')');
+  console.log('fork-pair recall  (threshold ' + th + ', shingle-k ' + K + ')');
   console.log('  base: ' + base);
   console.log('  fork: ' + fork);
   console.log('  shared functions: ' + shared.length);
   console.log('  exact-signature recall: ' + exact + '/' + shared.length + ' (' + p(exact) + ')');
   console.log('  fuzzy (shingle-Jaccard) recall: ' + fuzzy + '/' + shared.length + ' (' + p(fuzzy) + ')');
-  console.log('  fuzzy precision (vs different-name pairs): ' + prec + '% (' + fp + ' false-matches)');
+  console.log('  fuzzy precision (vs different-name pairs): ' + Math.round(100 * prec) + '% (' + fp + ' false-matches)');
+  // machine-readable line for the pattern-evolver (M4 fitness oracle): all 0..1 decimals.
+  console.log('EVAL|threshold=' + th + '|k=' + K + '|recall=' + recall.toFixed(4) +
+    '|precision=' + prec.toFixed(4) + '|exact=' + exrec.toFixed(4) + '|shared=' + shared.length);
 }
 
 main();

--- a/dark-factory/evm-harness/fuzzy-match.js
+++ b/dark-factory/evm-harness/fuzzy-match.js
@@ -13,15 +13,17 @@
 // every match still has to clear the two-sided synthesis gate, so a false candidate only costs one
 // inconclusive synthesis, never a false finding.
 //
-// Usage:   node fuzzy-match.js <target.sol> <seeds-file> [threshold=0.35]
+// Usage:   node fuzzy-match.js <target.sol> <seeds-file> [threshold=0.35] [shingle-k=4]
 //   <seeds-file> is one `Class:::<normalized-sig>` per line (written by seed-patterns.ag).
+//   threshold + shingle-k are the matcher's evolvable granularity genome (tuned by pattern-evolver
+//   against the fork-pair fitness oracle in M4).
 // Output:  the matched Class of the FIRST target function that clears the threshold against any
 //          seed (mirrors reconn's first-hit short-circuit), or nothing. Exit 0 always (graceful).
 'use strict';
 const fs = require('fs');
 const { extractFunctions, normalize, stripComments } = require('./struct-sig.js');
 
-const K = 4; // shingle width (tokens). 4 balances structural specificity vs fork-drift tolerance.
+let K = 4; // shingle width (tokens). 4 balances structural specificity vs fork-drift tolerance.
 
 function shingles(sig) {
   const t = sig.split(' ').filter(Boolean);
@@ -46,6 +48,7 @@ function main() {
   const target = process.argv[2];
   const seedsFile = process.argv[3];
   const threshold = process.argv[4] ? parseFloat(process.argv[4]) : 0.35;
+  if (process.argv[5]) { const kv = parseInt(process.argv[5], 10); if (kv >= 1) K = kv; }
   if (!target || !seedsFile) return;
   let seedLines = [];
   try { seedLines = fs.readFileSync(seedsFile, 'utf8').split('\n').filter(Boolean); } catch (e) { return; }

--- a/dark-factory/evolve-matcher.sh
+++ b/dark-factory/evolve-matcher.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# #861 M4 — evolve the fuzzy matcher's granularity (shingle-Jaccard threshold × shingle width k)
+# against a held-out fork-pair FITNESS ORACLE. Runs pattern-evolver.ag, which searches the genome,
+# records each candidate as substrate experience via learn(), and writes the F-beta-max config to
+# evolved:fuzzy_threshold / evolved:fuzzy_k. reconn adopts that config on the next audit (run-audit.sh
+# --use-evolved). The recall harness IS the fitness function — the granularity tunes itself.
+#
+# Usage:
+#   evolve-matcher.sh --fork-base <base.sol> --fork-fork <fork.sol> --evm-harness <dir> \
+#     [--beta 2] [--agentis <bin>] [--out <dir>]
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+AGENTIS="agentis"; FORK_BASE=""; FORK_FORK=""; EVM_HARNESS=""; OUT="$PWD/evolve-out"; BETA="2"
+need() { [ "$1" -ge 2 ] || { echo "evolve-matcher.sh: missing value for the preceding flag" >&2; exit 2; }; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --fork-base) need "$#"; FORK_BASE="$2"; shift 2 ;;
+    --fork-fork) need "$#"; FORK_FORK="$2"; shift 2 ;;
+    --evm-harness) need "$#"; EVM_HARNESS="$2"; shift 2 ;;
+    --beta) need "$#"; BETA="$2"; shift 2 ;;
+    --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
+    --out) need "$#"; OUT="$2"; shift 2 ;;
+    --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
+    *) echo "evolve-matcher.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+[ -f "$FORK_BASE" ] || { echo "evolve-matcher.sh: --fork-base not found: $FORK_BASE" >&2; exit 2; }
+[ -f "$FORK_FORK" ] || { echo "evolve-matcher.sh: --fork-fork not found: $FORK_FORK" >&2; exit 2; }
+[ -n "$EVM_HARNESS" ] || { echo "evolve-matcher.sh: --evm-harness <dir> required" >&2; exit 2; }
+EVM_HARNESS="$(cd "$EVM_HARNESS" && pwd)"
+FORK_BASE="$(cd "$(dirname "$FORK_BASE")" && pwd)/$(basename "$FORK_BASE")"
+FORK_FORK="$(cd "$(dirname "$FORK_FORK")" && pwd)/$(basename "$FORK_FORK")"
+
+mkdir -p "$OUT"; OUT="$(cd "$OUT" && pwd)"; RUN="$OUT/run"; rm -rf "$RUN"; mkdir -p "$RUN"
+cp "$HERE/auditor/agents/pattern-evolver.ag" "$RUN/pattern-evolver.ag"
+( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
+{
+  echo "trace.level = normal"
+  echo "experience.enabled = true"
+  echo "learning.enabled = true"
+  echo "exec.env_passthrough = EVM_HARNESS_DIR,FORK_BASE,FORK_FORK,EVOLVE_BETA"
+  echo "exec.default_timeout_ms = 60000"
+} > "$RUN/.agentis/config"
+
+echo "evolve: searching genome against fork-pair oracle $(basename "$FORK_BASE") -> $(basename "$FORK_FORK") (beta=$BETA) ..." >&2
+( cd "$RUN" && env EVM_HARNESS_DIR="$EVM_HARNESS" FORK_BASE="$FORK_BASE" FORK_FORK="$FORK_FORK" EVOLVE_BETA="$BETA" \
+    "$AGENTIS" go pattern-evolver.ag --enable-exec ) 2>&1 | grep '^evolve:'
+
+# surface the evolved config from the memo store for the operator / run-audit --use-evolved.
+TH="$(cd "$RUN" && "$AGENTIS" memo get evolved:fuzzy_threshold 2>/dev/null || true)"
+K="$(cd "$RUN" && "$AGENTIS" memo get evolved:fuzzy_k 2>/dev/null || true)"
+echo "evolved-config-dir: $RUN" >&2
+[ -n "$TH" ] && echo "evolved: fuzzy_threshold=$TH fuzzy_k=$K" >&2

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -36,7 +36,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 TARGET="" ; HARNESS="" ; ANCHOR_HARNESS="" ; EVM_HARNESS="" ; SNAPSHOT="" ; POC=""
 REPO="" ; IN_SCOPE="" ; CONTRACT="" ; SEED_MANIFEST="" ; SHARE_PATTERNS=""
-BACKEND="claude" ; SANDBOX="hardened" ; OUT="$PWD/audit-out" ; FUZZY_THRESHOLD="0.35"
+BACKEND="claude" ; SANDBOX="hardened" ; OUT="$PWD/audit-out" ; FUZZY_THRESHOLD="0.35" ; FUZZY_K="4" ; USE_EVOLVED=""
 
 need() { [ "$1" -ge 2 ] || { echo "run-audit.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -47,6 +47,9 @@ while [ $# -gt 0 ]; do
     --contract) need "$#"; CONTRACT="$2"; shift 2 ;;
     --seed-manifest) need "$#"; SEED_MANIFEST="$2"; shift 2 ;;
     --share-patterns) SHARE_PATTERNS=1; shift ;;
+    --use-evolved) need "$#"; USE_EVOLVED="$2"; shift 2 ;;
+    --fuzzy-threshold) need "$#"; FUZZY_THRESHOLD="$2"; shift 2 ;;
+    --fuzzy-k) need "$#"; FUZZY_K="$2"; shift 2 ;;
     --harness) need "$#"; HARNESS="$2"; shift 2 ;;
     --anchor-harness) need "$#"; ANCHOR_HARNESS="$2"; shift 2 ;;
     --evm-harness) need "$#"; EVM_HARNESS="$2"; shift 2 ;;
@@ -60,6 +63,17 @@ while [ $# -gt 0 ]; do
     *) echo "run-audit.sh: unknown flag $1" >&2; exit 2 ;;
   esac
 done
+
+# #861 M4: --use-evolved <evolve-out-dir> adopts the matcher granularity the pattern-evolver tuned
+# against the fork-pair fitness oracle (evolved:fuzzy_threshold / evolved:fuzzy_k memos) instead of
+# the hand-set default — the federation's own evolution picks the threshold/k.
+if [ -n "$USE_EVOLVED" ]; then
+  ET="$( ( cd "$USE_EVOLVED/run" 2>/dev/null && "$AGENTIS" memo get evolved:fuzzy_threshold 2>/dev/null ) || true )"
+  EK="$( ( cd "$USE_EVOLVED/run" 2>/dev/null && "$AGENTIS" memo get evolved:fuzzy_k 2>/dev/null ) || true )"
+  [ -n "$ET" ] && FUZZY_THRESHOLD="$ET"
+  [ -n "$EK" ] && FUZZY_K="$EK"
+  echo "run-audit.sh: adopted evolved matcher granularity threshold=$FUZZY_THRESHOLD k=$FUZZY_K" >&2
+fi
 
 # --repo mode (#859 phases 1-4): a REAL multi-file Foundry/Hardhat target. The operator points
 # at the repo + the in-scope contract within it; the colony compiles that contract WITH its deps
@@ -115,7 +129,7 @@ cp "$COLONY" "$RUN/auditor.ag"
   echo "llm.backend = $BACKEND"
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 180000"; }
   echo "trace.level = normal"
-  echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,EVM_HARNESS_DIR,BOUNTY_SNAPSHOT,BOUNTY_REPO,BOUNTY_IN_SCOPE,BOUNTY_CONTRACT,SEED_SRC,SEED_CLASS,SEED_FUNC,FUZZY_SEEDS,FUZZY_THRESHOLD"
+  echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,EVM_HARNESS_DIR,BOUNTY_SNAPSHOT,BOUNTY_REPO,BOUNTY_IN_SCOPE,BOUNTY_CONTRACT,SEED_SRC,SEED_CLASS,SEED_FUNC,FUZZY_SEEDS,FUZZY_THRESHOLD,FUZZY_K"
   echo "exec.default_timeout_ms = 180000"
   # --share-patterns lists each seeded pattern on the knowledge market (knowledge_sell), so other
   # federation members can buy it. The market is gated on the learning/knowledge subsystem.
@@ -160,7 +174,7 @@ ENV=(BOUNTY_TARGET="$TARGET")
 [ -n "$HARNESS" ]        && ENV+=(SOLANA_HARNESS_DIR="$HARNESS")
 [ -n "$ANCHOR_HARNESS" ] && ENV+=(SOLANA_ANCHOR_HARNESS_DIR="$ANCHOR_HARNESS")
 [ -n "$EVM_HARNESS" ]    && ENV+=(EVM_HARNESS_DIR="$EVM_HARNESS")
-[ -f "$RUN/fuzzy-seeds.tsv" ] && ENV+=(FUZZY_SEEDS="$RUN/fuzzy-seeds.tsv" FUZZY_THRESHOLD="$FUZZY_THRESHOLD")
+[ -f "$RUN/fuzzy-seeds.tsv" ] && ENV+=(FUZZY_SEEDS="$RUN/fuzzy-seeds.tsv" FUZZY_THRESHOLD="$FUZZY_THRESHOLD" FUZZY_K="$FUZZY_K")
 [ -n "$SNAPSHOT" ]       && ENV+=(BOUNTY_SNAPSHOT="$SNAPSHOT")
 [ -n "$POC" ]            && ENV+=(BOUNTY_POC="$POC")
 [ -n "$REPO" ]           && ENV+=(BOUNTY_REPO="$REPO" BOUNTY_IN_SCOPE="$IN_SCOPE" BOUNTY_CONTRACT="$CONTRACT")


### PR DESCRIPTION
## M4 — evolve the matcher granularity by fitness against the fork-pair oracle (#861)

The fuzzy matcher's **granularity** (shingle-Jaccard threshold × shingle width `k`) is the knob no human can hand-tune — too loose floods synthesis, too tight misses forks, and the sweet spot is unknown a priori. That's a search problem, and the **fork-pair recall harness IS the fitness function**. M4 lets the granularity tune itself.

### The loop

1. **Evolve** — `auditor/agents/pattern-evolver.ag` + `evolve-matcher.sh` search the `{threshold × k}` genome against a held-out fork-pair oracle (`forkpair-recall.js`), record **each candidate as substrate experience via `learn()`**, select the **F-beta-max** config (β>1 = recall-leaning, since the two-sided gate absorbs false matches — on a real fork, recall is worth more than precision), and write `evolved:fuzzy_threshold` / `evolved:fuzzy_k`.
2. **Adopt** — `run-audit.sh --use-evolved <dir>` reads the evolved config and audits with it (also `--fuzzy-threshold` / `--fuzzy-k` to set directly). `fuzzy-match.js` + `forkpair-recall.js` gained a `k` arg; reconn (`match_seeded_fuzzy_evm`) + `recall-match.ag` pass `FUZZY_K`.

### Proven end-to-end (Compound→Venus)

```
evolve: baseline default(th=0.35,k=4) F-beta = 0.549      # recall 54%
evolve: ... searched 15 genome points ...
evolve: BEST genome th=0.25 k=4 F-beta=0.674 vs baseline 0.549   # recall 85%
evolve: wrote evolved:fuzzy_threshold=0.25 evolved:fuzzy_k=4

run-audit.sh: adopted evolved matcher granularity threshold=0.25 k=4
reconn: SEEDED FUZZY MATCH -> Reentrancy
```

The evolver picked **th=0.25, k=4** — a config **no human chose** — lifting recall on the real fork pair from **54% → 85%**, and the colony adopts it. The granularity is now **fitness-driven, not hand-guessed**.

### This is the substrate being used, not just the runtime

Each genome candidate is recorded via `learn()` (substrate experience/fitness), the selection is fitness-driven against the real oracle, and the evolved config flows through the memo store to reconn. `--beta` tunes the recall/precision trade (the operator's cost model): recall-leaning because the two-sided synthesis gate means a false match costs one inconclusive synthesis, never a finding.

colony-lint: 357 passed, 0 failed, 5 skipped.
