### PR TITLE
feat(dark-factory): add custom-code discovery track (hunter + run-discovery)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,31 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Custom-code DISCOVERY track — the colony can now hunt bugs in bespoke, never-forked protocols, not
+  just match known-fork patterns (#863). The DAG matcher (`auditor.ag`) fires only where in-scope code
+  recurs a seeded pattern, so it returns nothing on custom contest code (a fresh stablecoin, a new
+  vault). The discovery track closes that gap, entirely on the agentis substrate:
+  - `auditor/agents/hunter.ag` — a substrate discovery agent. One invocation hunts ONE bug class over
+    ONE subsystem: it slurps the in-scope contracts, loads the taxonomy lens + protocol brief, runs a
+    deep adversarial `prompt()`, and records the attempt via `learn()` (+ `emit`) so per-class fitness
+    reweights over targets (the #861 evolve loop, now over discovery).
+  - `auditor/bug-taxonomy.md` — the discovery knowledge: 14 DeFi bug classes (share-price/ERC4626,
+    oracle, cross-chain/LZ, withdrawal-queue, access-control, accounting, sig-replay, reentrancy,
+    decimals, liquidation, first-depositor, slippage, compliance, fork-delta), each with a "hunt" lens
+    distilled from real audits.
+  - `run-discovery.sh` — operator entrypoint. Takes `--repo` + a `--scope` manifest
+    (`subsystem | classes | files`) + a `--brief` (invariants-to-break, known-issues-to-exclude, trust
+    model) and fans out one substrate hunter per (subsystem × class), collecting `CANDIDATE` leads into
+    a report. Never posts to a platform; surfacing harness-checkable leads is the whole job.
+  - `evm-harness/forge-verify.sh` — the multi-contract verification gate. A custom protocol needs a full
+    Foundry deployment + attacker tx + invariant assertion (not the single-function revm harness), so a
+    candidate is VERIFIED only when its `Exploit.t.sol` PoC PASSES against the in-scope repo. A lead that
+    does not reproduce is not a finding (no junk submitted).
+  - **Proven end-to-end on a live, 3×-audited custom yield-bearing-stablecoin Sherlock contest**: the
+    substrate hunter read the ERC4626 savings + rewards-distributor contracts under the C1 share-price
+    lens and returned a reasoned `SAFE` — a rigorous negative, the valid outcome on audited code. Wiring
+    is mock-smoke-tested; the real claude pass completes the full prompt→verdict→learn loop.
+
 - M4 evolution — the matcher granularity tunes itself by fitness (#861). The fuzzy matcher's
   granularity (shingle-Jaccard threshold × shingle width `k`) is the knob no human can hand-tune:
   too loose floods synthesis, too tight misses forks, and the sweet spot is unknown a priori — a

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -119,25 +119,68 @@ a manual human action. `run-audit.sh` requires `--target` and never auto-picks a
 `--backend mock` runs offline-deterministically (structural heuristic, no LLM). Produce a
 frozen snapshot with `snapshot-rpc.sh --rpc <url> --out snap.txt <pubkey>`.
 
+## Discover bugs in custom code (`run-discovery.sh`)
+
+`run-audit.sh` drives the DAG fork-**matcher** (`auditor.ag`): it fires only where in-scope code
+**recurs a known-bug pattern**, so on a bespoke, never-forked protocol it returns nothing. Custom
+contest code (a fresh stablecoin, a new vault) needs **discovery**, not matching. `run-discovery.sh`
+drives the colony's discovery agent — [`auditor/agents/hunter.ag`](./auditor/agents/hunter.ag) — a
+taxonomy-driven, adversarial, per-(subsystem × bug-class) audit that runs **entirely through the
+agentis substrate** (`prompt` / `emit` / `learn`), so every hunt is recorded as experience and the
+taxonomy's per-class fitness reweights over time. It is the colony-native form of a hand-run
+multi-agent audit pass.
+
+The operator supplies three inputs and the colony fans out one substrate agent per cell:
+
+- `--repo <dir>` — the cloned target (use `fetch-target.sh`).
+- `--scope <scope.tsv>` — `subsystem | classid,… | file,…` per line (files relative to the repo).
+- `--brief <brief.md>` — the protocol's invariants-to-break, **known issues to exclude**, and trust model.
+
+```bash
+dark-factory/run-discovery.sh \
+    --repo "$PWD/target" --scope "$PWD/scope.tsv" --brief "$PWD/brief.md" \
+    --backend claude --out "$PWD/discovery-out"
+# cheap wiring smoke (no real LLM):  add  --backend mock --only "<subsystem>" --classes C1
+```
+
+The bug classes live in [`auditor/bug-taxonomy.md`](./auditor/bug-taxonomy.md) (14 DeFi classes —
+share-price/ERC4626, oracle, cross-chain/LZ, withdrawal-queue, access-control, accounting,
+sig-replay, reentrancy, decimals, …), each with a deep "hunt" lens distilled from real audits.
+
+Every `CANDIDATE` in `discovery-out/discovery-report.md` is a **lead, not a finding** — unverified
+until it reproduces through the multi-contract Foundry gate:
+
+```bash
+dark-factory/evm-harness/forge-verify.sh --repo "$PWD/target" --poc "$PWD/Exploit.t.sol" --lz-symlink
+# exit 0 = VERIFIED (the exploit PoC passes); only a VERIFIED lead is worth a human-gated submission.
+```
+
+A clean sweep (no candidate survives) is a **rigorous negative** — a valid outcome on audited code;
+nothing is submitted. As with `run-audit.sh`, the colony never posts to a platform.
+
 ## Layout
 
 ```
 dark-factory/
   README.md                     # this file
   VERSION  CHANGELOG.md  BUNDLE.manifest  install.sh
-  run-audit.sh                  # operator entrypoint: run an audit -> human-gated package
+  run-audit.sh                  # operator entrypoint: DAG fork-matcher audit -> human-gated package
+  run-discovery.sh              # operator entrypoint: custom-code discovery (hunter fan-out) -> leads
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)
   sealevel-scorecard.md         # calibration results (3/3 true-positive, 0 false-VERIFIED)
   auditor/                      # the single colony
-    agents/auditor.ag           # the audit pipeline (reconn → guard → tracker → synthesis)
+    agents/auditor.ag           # the DAG-match pipeline (reconn → guard → tracker → synthesis)
+    agents/hunter.ag            # the custom-code discovery agent (taxonomy-driven adversarial hunt)
+    bug-taxonomy.md             # 14 DeFi bug classes + per-class hunt lens (the discovery knowledge)
     config/colony.example.toml  # forge.type = "none"; cb_budget
     scripts/start-colony.sh     # thin `agentis go` launcher
     README.md
   solana-harness/               # offline solana-program-test crate (real SVM, native)
   solana-harness-anchor/        # offline anchor-lang 0.31 harness (real SVM, Anchor) (V6)
   evm-harness/                  # offline revm crate: two-sided EVM PoC (real EVM, Solidity)
+    forge-verify.sh             # multi-contract custom-protocol PoC gate (real Foundry deploy+exploit)
   sealevel/                     # modernized coral-xyz/sealevel-attacks lessons (corpus) (V6)
   fixtures/                     # detection fixtures (vuln + safe + rigged-harness cases)
 ```

--- a/dark-factory/auditor/agents/hunter.ag
+++ b/dark-factory/auditor/agents/hunter.ag
@@ -1,0 +1,80 @@
+cb 300000;
+// #863 — custom-code DISCOVERY hunter. Deep, taxonomy-driven adversarial audit of CUSTOM
+// (non-fork) in-scope code. Complements the DAG matcher (seed-patterns/recall-match), which
+// fires only on known-code RECURRENCE and returns nothing on bespoke protocols (a fresh stablecoin, a new vault).
+//
+// One invocation hunts ONE bug class over ONE subsystem; run-audit.sh --mode discovery fans out
+// (subsystem x class) in parallel — the colony-native version of a hand-run multi-agent audit pass,
+// feeding every candidate into the forge-verify gate before it counts as a finding.
+//
+// Env:
+//   TARGET_DIR  repo root of the cloned target
+//   IN_SCOPE    newline-separated contract paths (relative to TARGET_DIR) for this subsystem
+//   SCOPE_BRIEF path to a file holding the invariants-to-break + known-issues-to-exclude + trust model
+//   TAXONOMY    path to bug-taxonomy.md
+//   HUNT_CLASS  one class id, e.g. "C1"
+//   SUBSYSTEM   human label for this slice
+// Stdout: exactly one `CANDIDATE|file:fn:line|class|severity|exploit|poc` line per finding, else `SAFE`.
+
+// --- file readers (dynamic paths -> safe-exec-concat per recall-match.ag precedent) ---
+fn cat_file(path: string) -> string {
+    // colony-lint: safe-exec-concat
+    return exec sh "sed -n '1,700p' ${path} 2>/dev/null || true";
+}
+
+// Concatenate every in-scope contract into one labelled blob.
+fn scoped_code(dir: string, files: string) -> string {
+    return reduce(regex_split("\n", files), |acc: string, rel: string| -> string {
+        if len(rel) == 0 { return acc; }
+        return acc + "\n\n// ========== " + rel + " ==========\n" + cat_file(dir + "/" + rel);
+    }, "");
+}
+
+// Extract the `## <cls> ...` section from the taxonomy (until the next `## `).
+fn class_section(taxo: string, cls: string) -> string {
+    // colony-lint: safe-exec-concat
+    return exec sh "awk -v c=\"${cls}\" 'index($0,\"## \"c\" \")==1{f=1} f&&index($0,\"## \")==1&&index($0,\"## \"c\" \")!=1{exit} f{print}' ${taxo} 2>/dev/null || true";
+}
+
+// learn() outcome must be one of the runtime enum {success,failure,partial,timeout,error}.
+// A surfaced candidate = success; a rigorous SAFE = failure (so taxonomy fitness rewards the
+// classes that actually produce leads across targets, per #861's evolve loop). No reassignment.
+fn outcome_of(verdict: string) -> string {
+    if index_of(verdict, "CANDIDATE|") == 0 { return "success"; }
+    return "failure";
+}
+
+let dir = getenv("TARGET_DIR");
+let files = getenv("IN_SCOPE");
+let cls = getenv("HUNT_CLASS");
+let subsystem = getenv("SUBSYSTEM");
+let brief = cat_file(getenv("SCOPE_BRIEF"));
+let code = scoped_code(dir, files);
+let classDoc = class_section(getenv("TAXONOMY"), cls);
+
+// The instruction carries the lens (taxonomy class), the brief (invariants + known-issues), and the
+// strict output contract; the code is the prompt payload (matches auditor.ag::classify_evm_llm shape).
+let instruction =
+    "You are an elite adversarial smart-contract auditor competing in a LIVE audit contest for real money. "
+  + "Find a HIGH or MEDIUM severity bug an EXTERNAL attacker (holding NO privileged role) can exploit. "
+  + "This code is likely already audited, so report ONLY a bug you are confident survives expert judging — "
+  + "no speculation, no informational notes.\n\n"
+  + "=== HUNT THIS BUG CLASS (the lens) ===\n" + classDoc + "\n\n"
+  + "=== PROTOCOL BRIEF — invariants whose violation is a valid finding, and KNOWN ISSUES you MUST NOT report ===\n"
+  + brief + "\n\n"
+  + "=== RULES ===\nOnly Medium/High count. A trusted role acting WITHIN its documented permissions is OUT OF SCOPE; "
+  + "a role EXCEEDING its permissions, or any unprivileged user, IS in scope. Never report a listed KNOWN ISSUE. "
+  + "Subsystem under review: " + subsystem + ".\n\n"
+  + "=== OUTPUT CONTRACT ===\nIf you find a qualifying bug, output EXACTLY one line:\n"
+  + "CANDIDATE|<file:function:line>|<class=" + cls + ">|<severity=Medium|High>|<one-sentence external exploit path>|<concrete foundry PoC sketch: what to deploy, call, and assert>\n"
+  + "If after rigorous analysis there is NO qualifying bug of this class in this subsystem, output exactly:\nSAFE\n"
+  + "Output nothing else — no preamble, no markdown.";
+
+let verdict = prompt(instruction, code) -> string;
+
+// Surface to the verifier (stdout) and record the attempt so taxonomy fitness reweights over time.
+print(verdict);
+let outcome = outcome_of(verdict);
+emit("dark-factory:hunt_result", "{\"class\":\"" + cls + "\",\"subsystem\":\"" + subsystem + "\",\"outcome\":\"" + outcome + "\"}");
+learn("hunt", cls + ":" + subsystem, "discovery hunt of " + cls + " on " + subsystem, outcome, [cls, subsystem, outcome]);
+memo_write("hunter:last_check", "done");

--- a/dark-factory/auditor/bug-taxonomy.md
+++ b/dark-factory/auditor/bug-taxonomy.md
@@ -1,0 +1,118 @@
+# EVM bug-class taxonomy — custom-code discovery knowledge
+
+The DAG matcher (`seed-patterns.ag` / `recall-match.ag`) finds **recurrences of known code** — it only fires on forks / N-day variants. It returns nothing on *custom* protocols (a fresh stablecoin, a bespoke perp DEX, …), because there is no seeded sub-graph to match.
+
+This taxonomy is the complementary knowledge for the **discovery** track (`hunter.ag`): on custom code you cannot match the *code*, but you can apply heuristics for *how DeFi protocols break*. Each class is a lens a hunter applies adversarially against the in-scope contracts and the protocol's stated invariants, scoped EXTERNAL-only (an attacker holding no privileged role; trusted-role/leaked-key impacts are out of scope unless a role exceeds its permissions).
+
+It is consumed two ways:
+1. `hunter.ag` loads the relevant classes for a subsystem and builds a deep adversarial `prompt()` per class (the discovery query).
+2. `learn()` records which classes actually produced a forge-verified finding on which protocol-type, so the taxonomy is reweighted by fitness over time (the knowledge_market analog of the DAG's pattern fitness).
+
+Format per class: **hits** (protocol shapes where it lives) · **hunt** (the adversarial questions) · **breaks** (the invariant the bug violates) · **sev** (typical Sherlock/Immunefi severity) · **seen** (where we hit/cleared it).
+
+---
+
+## C1 — ERC4626 share-price / vault accounting
+- **hits:** yield-bearing/savings tokens, staking vaults (sDAI/sUSDe-style), `convertToShares/Assets`.
+- **hunt:** Can the share price (`totalAssets/totalSupply`) ever DECREASE outside rounding dust? Trace every write to the assets numerator and every input to `totalAssets()`. Does a direct token donation inflate the price (raw `balanceOf` vs a `_virtualBalance`)? Can a depositor enter right before a reward/yield step and exit right after to capture yield they didn't earn (vesting sandwich)? Is reward vesting *smooth* (linear) or a discrete jump that can be sandwiched? Does `claim` advance state in lockstep with the value moved (no double-claim, no stranded dust)?
+- **breaks:** "share price monotonic non-decreasing"; "totalAssets == tracked deposits + vested rewards".
+- **sev:** Medium–High (value extraction / dilution).
+- **seen:** a custom ERC4626 savings vault (clean — virtual-balance + smooth linear vest); Impossible kLast (non-payable).
+
+## C2 — Oracle integrity
+- **hits:** anything pricing collateral/debt via Chainlink/Pyth/Orakl or a derived source.
+- **hunt:** Is the staleness + deviation + **sequencer-uptime/grace** check applied on EVERY price-read path (mint AND withdrawal AND liquidation), or does one path skip it? Is `startedAt==0` treated as healthy (it should revert — canonical L2 pattern)? Is the deviation threshold compared against the right reference and direction? Are `roundId`/`answeredInRound` checked? Is the 6↔18 (token↔feed↔stable) decimal conversion exact, or does a scaling error systematically over-mint / over-withdraw? **Is any price sourced from a manipulable on-protocol spot** (the protocol's own low-liquidity DEX, an AMM reserve, a staking exchange-rate) without a TWAP/bound?
+- **breaks:** "price used == fair price"; "no over-mint/over-withdraw via mispricing".
+- **sev:** High (drain) for manipulable source / missing check; Medium for decimal/bound gaps.
+- **seen:** a custom Chainlink+sequencer oracle (clean — checks on all paths); KiloLend KiloOracle (Pyth/Orakl/admin, NOT a DEX → no manip); Curve scrvUSD (smoothing-capped).
+
+## C3 — Cross-chain / LayerZero OFT + compose
+- **hits:** OFT/OFTAdapter tokens, ovault composers, hub-lockbox + spoke-mint share bridges.
+- **hunt:** Lockbox conservation — can shares be minted on a spoke WITHOUT a matching lock on the hub (or unlocked without burn)? Compose partial-failure — deposit ok / stake fails: are funds refunded AND not double-spent; can an attacker trigger a refund and keep the shares? Is the compose entrypoint endpoint-gated (`msg.sender == endpoint`, `_composeSender ∈ peers`)? Shared-decimals dust (de-dust on debit vs credit) symmetric? Compliance desync across chains beyond the documented quarantine — a path letting a frozen address actually transfer/redeem cross-chain? Replay of a compose message?
+- **breaks:** "Σ spoke supply == hub locked"; "value conserved across every compose terminal state".
+- **sev:** High (cross-chain inflation/double-spend) — sponsor's usual #1 focus.
+- **seen:** a custom OFT ovault (clean — conserved + endpoint-gated).
+
+## C4 — Withdrawal queue / NFT claim accounting
+- **hits:** request→fill withdrawal queues, ERC721 withdrawal positions, express/standard tiers.
+- **hunt:** Does every burned unit produce a claim with the EXACT owed amount (no forge, no inflate)? Double-claim (re-list / re-burn a tokenId)? Capacity invariant (`available <= maxLimit`) holdable under request/fill/payback? Is a tier's fee applied consistently with its slippage check (fee-before-vs-after the user's min)? Confusion between two NFT instances (standard vs express)? Who can mint/burn the position NFT — only the manager?
+- **breaks:** "burned == claimable owed"; "available capacity bounded".
+- **sev:** Medium–High.
+- **seen:** a custom withdrawal-NFT queue (clean — atomic burn↔mint, exact amount).
+
+## C5 — Access control / role model
+- **hits:** AccessControl/AccessManaged/Ownable, role-gated setters, upgrade authorization, timelocks.
+- **hunt:** Does any sensitive setter LOSE its guard or get the WRONG role (esp. after an access-control rewrite vs the upstream)? OZ AccessManaged: is any (target,selector) mapped to `PUBLIC_ROLE` on-chain (verify the deployed config, not just the modifier)? Any unprivileged path to obtain a role (mis-set role-admin, broken `grantRole`)? UUPS: is `_authorizeUpgrade` restricted, implementation `_disableInitializers`'d? Can a role exceed its permissions to reach another role's function (THIS is in-scope even when roles are "trusted")?
+- **breaks:** "only the intended role can call X".
+- **sev:** High (privileged drain) if a real escalation; else trusted-role → out of scope.
+- **seen:** Parallel (clean — verified all 36 sensitive selectors role-gated on-chain via getTargetFunctionRole).
+
+## C6 — Accounting / rounding direction
+- **hits:** mint/redeem, fee math, AMM invariants, any `a*b/c`.
+- **hunt:** Does a mint→redeem round-trip ever net the user MORE than deposited? Does every rounding step favor the protocol (truncate against the user)? Is a fee added to debt vs deducted from output consistently (no unbacked/phantom mint)? Does a custom invariant (constant-product/sum, K-check) conserve value across a swap round-trip even at asymmetric params?
+- **breaks:** "no value extraction via round-trip"; "supply fully backed".
+- **sev:** Medium–High.
+- **seen:** Impossible (xybk round-trips net 0); Variational manager (provider-custodial → no external surface).
+
+## C7 — Signature / replay
+- **hits:** EIP-712 mint/permit, custodian-signed fiat mints, meta-tx relayers.
+- **hunt:** Domain separator binds `address(this)` + live `block.chainid` (no cross-deployment / cross-chain replay)? Nonce incremented after verify? Is a user-protective field (slippage/min) part of the signed payload (a relayer can't weaken it)? Replay guard (used-ref mapping) total? Expiry + chainId enforced? Can one signature be routed to a different privileged action (purpose-binding)?
+- **breaks:** "each authorization usable once, for exactly its intent".
+- **sev:** Medium–High.
+- **seen:** a custodian-signed fiat-mint (clean — `address(this)` bound, ref-replay guarded).
+
+## C8 — Reentrancy
+- **hits:** native-token (ETH/cEther) markets, ERC777/callback tokens, external calls before state writes.
+- **hunt:** CEI order — is any value-bearing external call (`.call`, `safeTransfer` of a callback token, native send) made BEFORE the caller's balance/supply/borrow is updated? Cross-function and read-only reentrancy (a view used by another contract mid-call)? Is the `nonReentrant` guard on every entrypoint that needs it (including the native path)?
+- **breaks:** "no recursive drain".
+- **sev:** High.
+- **seen:** KiloLend Compound fork (clean — CEI preserved, `to.transfer` 2300 gas, guards present).
+
+## C9 — Decimals / scaling
+- **hits:** mixed-decimal stablecoins (6) ↔ protocol token (18) ↔ feed (8), `1e36/price` inversions.
+- **hunt:** Every conversion exact + favoring the protocol? Any path that truncates a small amount to zero (dust griefing) or, worse, mis-scales by `10^(±k)` (a Pyth-expo or feed-decimal bug)? Inversion (`1e36/price`) skipping a later decimal adjustment?
+- **breaks:** "price/amount dimensionally consistent across all consumers".
+- **sev:** High if systematic over-credit; Low for dust.
+- **seen:** a 6↔18-decimal stablecoin (clean); KiloOracle Pyth-expo (latent, admin-path → out of scope).
+
+## C10 — Liquidation / redemption (CDP & money-market forks)
+- **hits:** Liquity/Compound/Aave-shaped lenders, `seizeInternal`, redemption ordering, stability-pool offset.
+- **hunt:** Seize math + liquidation-incentive rounding (self-liquidation, seize-more-than-owed)? Redemption order/hints + base-rate math vs the upstream? Stability-pool P/S/G product offset faithful? First-depositor / empty-market exchange-rate inflation (donation to a freshly-listed, unseeded market)? New collateral-egress paths added vs the parent (e.g. a fee-router that can pull collateral)?
+- **breaks:** "collateral conserved"; "no unbacked debt / over-seize".
+- **sev:** High.
+- **seen:** Hedgehog (Liquity fork — FeesRouter egress bounded-to-fee, clean); KiloLend (Compound — donation window closed, paused).
+
+## C11 — First-depositor / inflation
+- **hits:** any share-minting vault/market without a dead-shares mitigation.
+- **hunt:** Can an attacker mint 1 wei into an empty market then donate underlying to inflate the exchange rate so later depositors' shares round to 0? Is there a `MINIMUM_LIQUIDITY` / dead-shares / virtual-offset guard? Are new markets seeded at listing?
+- **breaks:** "later depositors get fair shares".
+- **sev:** High when a fresh/empty market is reachable.
+- **seen:** a virtual-balance savings vault (mitigates); KiloLend (markets seeded).
+
+## C12 — Slippage / MEV / fee-vs-protection
+- **hits:** swaps, withdrawals with user `minOut`, anything with a fee deducted around a user check.
+- **hunt:** Is the user's `minOut`/`minUsdc` checked against the PRE-fee gross while they receive the POST-fee net (protection silently weakened by the fee)? Is the gap bounded + documented (then likely Low) or unbounded (Medium+)? Sandwich/front-run of a user op via a manipulable intermediate?
+- **breaks:** "user receives ≥ their stated minimum".
+- **sev:** Low if fee-bounded+documented; Medium if material/undisclosed.
+- **seen:** a custom express-withdrawal tier (pre-fee slippage — bounded 5% + documented → Low/invalid, not submitted).
+
+## C13 — Pause / freeze / compliance consistency
+- **hits:** sanctions/blocklist enforcement via `_update` overrides, pausable flows.
+- **hunt:** Is the freeze/sanction check enforced on EVERY value-moving path (mint/burn/transfer/stake/redeem/NFT-transfer/bridge) with no inconsistency between contracts? Any `_update` bypass that isn't the documented quarantine? Is the sanctions wrapper fail-CLOSED (reverts/blocks on a failed external call, not fail-open)? Does pause coverage have a gap (one path missing `whenNotPaused`)?
+- **breaks:** "frozen/sanctioned cannot move value, consistently".
+- **sev:** Medium (compliance bypass).
+- **seen:** a sanctions-wrapped stablecoin (clean — consistent address-validation, fail-closed wrapper).
+
+## C14 — Fork-delta (bridge to the DAG matcher)
+- **hits:** any contract that forks an audited parent (the parent is picked-clean; the DELTA is the surface).
+- **hunt:** Semantic-diff the fork vs the audited parent (ignore renames/formatting). Audit ONLY the changed/added code + the documented "changes since" — that delta is unaudited. New facets/modules absent from the parent get full scrutiny.
+- **breaks:** whatever invariant the delta touches (route to C1–C13).
+- **sev:** inherits the touched class.
+- **seen:** Parallel/Monet/Rocky (Cooper-Labs Transmuter fork — clean delta); the whole #861 premise.
+
+---
+
+### Hunter usage notes
+- Map each in-scope contract to its likely classes (a savings token → C1/C11; an oracle → C2/C9; an ovault → C3; a manager → C4/C6/C7/C12; a lender → C8/C10/C11). Run one deep adversarial `prompt()` per (subsystem × class).
+- Always load the scope brief first: the **invariants** the sponsor wants held (each is a finding if broken) and the **known-issues / acceptable-risks** (never report these).
+- A class only produces a *finding* after the forge-verify harness reproduces it (deploy → exploit → assert the broken invariant). Static suspicion → candidate; forge-passing → finding. `learn()` the (class, protocol-type, verified?) tuple either way.

--- a/dark-factory/docs/RUNBOOK.md
+++ b/dark-factory/docs/RUNBOOK.md
@@ -69,6 +69,42 @@ The colony **never** contacts a platform. A human reviews `audit-out/submission/
 confirms the finding, and submits it manually to Immunefi / Code4rena / Sherlock. This is
 deliberate: autonomous posting risks anti-bot bans and duplicate-submission penalties.
 
+## EVM custom-code discovery (`run-discovery.sh`)
+
+The flow above is the DAG fork-**matcher**: it only fires where in-scope code recurs a seeded pattern,
+so on a bespoke, never-forked protocol it finds nothing. For **custom** contest code (a fresh
+stablecoin, a new vault), use the discovery track — `run-discovery.sh` fans the substrate discovery
+agent (`auditor/agents/hunter.ag`) out over (subsystem × bug-class).
+
+1. **Clone the target** (`fetch-target.sh`, or any git clone). Note the repo root (the dir holding
+   `contracts/` or `src/`).
+2. **Write a scope manifest** — one subsystem per line, `subsystem | classid,… | file,…` (files
+   relative to the repo root); `#` comments allowed. Pick classes per subsystem from
+   `auditor/bug-taxonomy.md`. Example:
+   ```
+   rewards + savings  | C1,C6,C11 | contracts/SavingsVault.sol,contracts/RewardsDistributor.sol
+   oracle             | C2,C9,C10 | contracts/PriceOracle.sol,contracts/LendingAdapter.sol
+   ```
+3. **Write a brief** — the protocol's invariants whose violation is a valid finding, the **known
+   issues to exclude** (from prior audits — the hunter must not re-report them), and the trust model
+   (which roles are in/out of scope). This is what stops the hunt from surfacing already-audited noise.
+4. **Run** (each cell is a deep adversarial LLM read; a full sweep is `Ncells × ~3 min`, serial):
+   ```
+   ./run-discovery.sh --repo <repo> --scope scope.tsv --brief brief.md --backend claude --out discovery-out
+   # cheap wiring smoke first (no real LLM):  --backend mock --only "<subsystem>" --classes C1
+   ```
+5. **Read the leads** — `discovery-out/discovery-report.md`. Each `CANDIDATE` row is an **unverified
+   lead** (file:fn:line / severity / exploit / PoC sketch). No candidate = **rigorous negative**, the
+   valid outcome on audited code; nothing is submitted.
+6. **Verify each lead** through the multi-contract Foundry gate — write the `Exploit.t.sol` the PoC
+   sketch describes (deploy the protocol, run the attacker tx, assert the broken invariant), then:
+   ```
+   ./evm-harness/forge-verify.sh --repo <repo> --poc Exploit.t.sol --lz-symlink
+   # exit 0 = VERIFIED (the PoC passed = exploit reproduced). A lead that does not reproduce is NOT a finding.
+   ```
+7. **Submit (manual, human-gated)** — only a forge-VERIFIED lead is worth submitting, and only a human
+   submits it. As everywhere in this colony, nothing is auto-posted.
+
 ## Calibration
 
 `sealevel-scorecard.md` records the auditor against real `coral-xyz/sealevel-attacks`

--- a/dark-factory/evm-harness/forge-verify.sh
+++ b/dark-factory/evm-harness/forge-verify.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# forge-verify.sh — the custom-protocol verification gate for the discovery track.
+#
+# The DAG/synthesis path (run-audit.sh + the revm two-sided gate) verifies ISOLATED function-level
+# vulns. Custom multi-contract protocols (a stablecoin: manager + vault + oracle + ovault + ...) need a
+# full deployment + an attacker tx + an invariant assertion — i.e. a real Foundry PoC. This gate
+# runs a candidate's PoC test against the in-scope code and reports VERIFIED only if the exploit
+# test PASSES (the invariant is broken / funds move). A candidate that does not compile+pass is
+# NOT a finding (no junk submitted).
+#
+# Usage:
+#   forge-verify.sh --repo <foundry-project-root> --poc <path/to/Exploit.t.sol> [--match <testFn>]
+#                   [--lz-symlink] [--skip 'script/**']
+# Exit: 0 = VERIFIED (PoC passed = exploit reproduced) ; 1 = NOT VERIFIED ; 2 = harness/usage error.
+set -euo pipefail
+
+REPO=""; POC=""; MATCH=""; LZ_SYMLINK=0; SKIP="script/**"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)  REPO="$2"; shift 2 ;;
+    --poc)   POC="$2"; shift 2 ;;
+    --match) MATCH="$2"; shift 2 ;;
+    --lz-symlink) LZ_SYMLINK=1; shift ;;
+    --skip)  SKIP="$2"; shift 2 ;;
+    -h|--help) sed -n '2,16p' "$0"; exit 0 ;;
+    *) echo "forge-verify: unknown arg $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$REPO" ] && [ -d "$REPO" ] || { echo "forge-verify: --repo <foundry project root> required" >&2; exit 2; }
+[ -n "$POC" ]  && [ -f "$POC" ]  || { echo "forge-verify: --poc <Exploit.t.sol> required" >&2; exit 2; }
+
+export PATH="$HOME/.foundry/bin:$PATH"
+command -v forge >/dev/null 2>&1 || { echo "forge-verify: forge not installed (run foundryup)" >&2; exit 2; }
+
+# Populate submodules + the LayerZero-v2 monorepo casing symlink some OFT projects need.
+( cd "$REPO" && git submodule update --init --recursive --depth 1 >/dev/null 2>&1 || true )
+if [ "$LZ_SYMLINK" -eq 1 ] && [ -d "$REPO/lib/LayerZero-v2" ] && [ ! -e "$REPO/lib/layerzero-v2" ]; then
+  ln -sfn LayerZero-v2 "$REPO/lib/layerzero-v2" || true
+fi
+
+# Drop the candidate PoC into the project's test tree so its remappings resolve.
+POC_DST="$REPO/test/_dfverify_$(basename "$POC")"
+cp "$POC" "$POC_DST"
+trap 'rm -f "$POC_DST"' EXIT
+
+echo "== forge-verify: running PoC $(basename "$POC") against $REPO ==" >&2
+ARGS=(test --skip "$SKIP" --match-path "$(basename "$POC_DST")")
+[ -n "$MATCH" ] && ARGS+=(--match-test "$MATCH")
+
+# The PoC is written to PASS iff the exploit succeeds (assert the broken invariant). So forge test
+# exit 0 == exploit reproduced == VERIFIED. A failing/non-compiling PoC == NOT verified.
+if ( cd "$REPO" && forge "${ARGS[@]}" ) ; then
+  echo "================ FORGE-VERIFY: VERIFIED (exploit PoC passed) ================" >&2
+  exit 0
+else
+  echo "================ FORGE-VERIFY: NOT VERIFIED (PoC failed/did not compile) ================" >&2
+  exit 1
+fi

--- a/dark-factory/run-discovery.sh
+++ b/dark-factory/run-discovery.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# run-discovery.sh — custom-code DISCOVERY entrypoint for the Dark Factory federation.
+#
+# run-audit.sh drives the DAG fork-MATCHER (auditor.ag): it fires only where in-scope code RECURS a
+# known-bug pattern, so it returns nothing on a bespoke protocol. run-discovery.sh drives the colony's
+# DISCOVERY agent (auditor/agents/hunter.ag): a taxonomy-driven, adversarial, per-(subsystem x bug-class)
+# audit of CUSTOM multi-contract code — the colony-native, substrate-driven version of a hand-run
+# multi-agent pass. The hunter runs ENTIRELY through the agentis substrate (prompt/emit/learn), so every
+# attempt is recorded as experience and the taxonomy's per-class fitness reweights over time.
+#
+# A surfaced CANDIDATE is a LEAD, not a finding. It is UNVERIFIED until the operator reproduces it through
+# evm-harness/forge-verify.sh (a real Foundry PoC that PASSES only if the exploit fires). Only a forge-
+# VERIFIED candidate is a finding worth a human-gated submission. This tool NEVER contacts a bounty
+# platform and NEVER auto-submits — surfacing harness-checkable leads is the whole job.
+#
+# Usage:
+#   run-discovery.sh --repo <dir> --scope <scope.tsv> --brief <brief.md> [options]
+#
+# Scope manifest (one subsystem per line; `#` and blank lines ignored):
+#   <subsystem label> | <classid,classid,...> | <file,file,...>      (files relative to --repo)
+# e.g.
+#   savings + rewards | C1,C6,C11 | contracts/SavingsVault.sol,contracts/RewardsDistributor.sol
+#
+# Options:
+#   --repo <dir>        Cloned target repo root (clone with fetch-target.sh). REQUIRED.
+#   --scope <file>      Subsystem x class x files manifest (see above). REQUIRED.
+#   --brief <file>      Protocol brief: invariants-to-break + known-issues-to-exclude + trust model. REQUIRED.
+#   --taxonomy <file>   bug-taxonomy.md (default: bundled ./auditor/bug-taxonomy.md).
+#   --only <subsystem>  Hunt only the line whose subsystem label matches (smoke test / re-run one slice).
+#   --classes <ids>     Override EVERY line's class list with this comma list (e.g. C1,C2 for a cheap probe).
+#   --backend <mock|claude>  LLM backend (default: claude). mock = offline-deterministic wiring smoke.
+#   --out <dir>         Output dir for the run + leads (default: ./discovery-out).
+#   --agentis <bin>     agentis binary (default: `agentis` on PATH).
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+AGENTIS="agentis"
+REPO="" ; SCOPE="" ; BRIEF="" ; TAXONOMY="" ; ONLY="" ; CLASSES_OVERRIDE=""
+BACKEND="claude" ; OUT="$PWD/discovery-out"
+
+need() { [ "$1" -ge 2 ] || { echo "run-discovery.sh: missing value for the preceding flag" >&2; exit 2; }; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) need "$#"; REPO="$2"; shift 2 ;;
+    --scope) need "$#"; SCOPE="$2"; shift 2 ;;
+    --brief) need "$#"; BRIEF="$2"; shift 2 ;;
+    --taxonomy) need "$#"; TAXONOMY="$2"; shift 2 ;;
+    --only) need "$#"; ONLY="$2"; shift 2 ;;
+    --classes) need "$#"; CLASSES_OVERRIDE="$2"; shift 2 ;;
+    --backend) need "$#"; BACKEND="$2"; shift 2 ;;
+    --out) need "$#"; OUT="$2"; shift 2 ;;
+    --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
+    --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
+    *) echo "run-discovery.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$REPO" ]  && [ -d "$REPO" ]  || { echo "run-discovery.sh: --repo <cloned repo dir> required (clone it with fetch-target.sh)" >&2; exit 2; }
+[ -n "$SCOPE" ] && [ -f "$SCOPE" ] || { echo "run-discovery.sh: --scope <subsystem|classes|files manifest> required" >&2; exit 2; }
+[ -n "$BRIEF" ] && [ -f "$BRIEF" ] || { echo "run-discovery.sh: --brief <invariants + known-issues + trust model> required (this anchors the hunt and excludes known issues)" >&2; exit 2; }
+[ -n "$TAXONOMY" ] || TAXONOMY="$HERE/auditor/bug-taxonomy.md"
+[ -f "$TAXONOMY" ] || { echo "run-discovery.sh: taxonomy not found: $TAXONOMY" >&2; exit 2; }
+command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-discovery.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
+
+# Resolve every operator path to ABSOLUTE — the colony runs from a different cwd, so a relative path
+# would silently miss (the hunter reads files via absolute TARGET_DIR/<rel>).
+REPO="$(cd "$REPO" && pwd)"
+BRIEF="$(cd "$(dirname "$BRIEF")" && pwd)/$(basename "$BRIEF")"
+TAXONOMY="$(cd "$(dirname "$TAXONOMY")" && pwd)/$(basename "$TAXONOMY")"
+
+HUNTER="$HERE/auditor/agents/hunter.ag"
+[ -f "$HUNTER" ] || { echo "run-discovery.sh: hunter agent not found at $HUNTER" >&2; exit 3; }
+
+mkdir -p "$OUT"; OUT="$(cd "$OUT" && pwd)"
+RUN="$OUT/run"
+rm -rf "$RUN"; mkdir -p "$RUN"
+cp "$HUNTER" "$RUN/hunter.ag"
+
+# init the agentis store FIRST (before any .agentis/ subdir exists), else HEAD is not set.
+( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
+{
+  echo "llm.backend = $BACKEND"
+  # 300s, not the auditor's 180s: a deep per-(subsystem x class) adversarial read of several full
+  # contracts legitimately exceeds 3 min, and eating a retry on every cell is wasteful.
+  [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 300000"; }
+  echo "trace.level = normal"
+  # The hunter reads source + the brief/taxonomy through exec sh; pass through its whole env contract.
+  echo "exec.env_passthrough = TARGET_DIR,IN_SCOPE,SCOPE_BRIEF,TAXONOMY,HUNT_CLASS,SUBSYSTEM"
+  echo "exec.default_timeout_ms = 30000"
+  # Discovery records every attempt as experience and reweights taxonomy fitness over time.
+  echo "learning.enabled = true"
+  echo "experience.enabled = true"
+} > "$RUN/.agentis/config"
+
+REPORT="$OUT/discovery-report.md"
+{
+  echo "# Dark Factory — custom-code discovery leads"
+  echo
+  echo "- repo: \`$(basename "$REPO")\`   backend: $BACKEND"
+  echo "- Each CANDIDATE below is an UNVERIFIED LEAD. It is a finding ONLY after it reproduces through"
+  echo "  \`evm-harness/forge-verify.sh --repo <repo> --poc <Exploit.t.sol>\` (PoC PASSES = exploit fires)."
+  echo "- Submission is a separate, explicit human action. This colony never posts to a platform."
+  echo
+  echo "| Subsystem | Class | Lead (file:fn:line / severity / exploit / PoC sketch) |"
+  echo "|---|---|---|"
+} > "$REPORT"
+
+CELLS=0 ; CANDIDATES=0
+# Manifest loop: one subsystem per line, `subsystem | classes | files`. Run the hunter once per
+# (subsystem x class) — that cell is the colony-native analogue of one focused audit agent.
+while IFS='|' read -r SUBSYS CLS_CSV FILES_CSV || [ -n "${SUBSYS:-}" ]; do
+  # trim + skip blanks/comments
+  SUBSYS="$(printf '%s' "$SUBSYS" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  case "$SUBSYS" in ''|\#*) continue ;; esac
+  CLS_CSV="$(printf '%s' "$CLS_CSV" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  FILES_CSV="$(printf '%s' "$FILES_CSV" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  [ -n "$ONLY" ] && [ "$SUBSYS" != "$ONLY" ] && continue
+  [ -n "$CLASSES_OVERRIDE" ] && CLS_CSV="$CLASSES_OVERRIDE"
+  [ -n "$FILES_CSV" ] || { echo "run-discovery.sh: subsystem '$SUBSYS' has no files; skipping" >&2; continue; }
+
+  # IN_SCOPE is newline-separated (hunter splits on \n); convert the manifest's comma list.
+  IN_SCOPE="$(printf '%s' "$FILES_CSV" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' || true)"
+  SLUG="$(printf '%s' "$SUBSYS" | tr -cs 'A-Za-z0-9' '_' | sed 's/_*$//')"
+
+  OLDIFS="$IFS"; IFS=','
+  for CLS in $CLS_CSV; do
+    IFS="$OLDIFS"
+    CLS="$(printf '%s' "$CLS" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ -n "$CLS" ] || { IFS=','; continue; }
+    CELLS=$((CELLS + 1))
+    CELL_LOG="$RUN/hunt_${SLUG}_${CLS}.log"
+    echo "run-discovery.sh: hunting $CLS on '$SUBSYS' ..." >&2
+    ( cd "$RUN" && env \
+        TARGET_DIR="$REPO" \
+        IN_SCOPE="$IN_SCOPE" \
+        SCOPE_BRIEF="$BRIEF" \
+        TAXONOMY="$TAXONOMY" \
+        HUNT_CLASS="$CLS" \
+        SUBSYSTEM="$SUBSYS" \
+        "$AGENTIS" go hunter.ag --enable-exec --enable-messaging ) >"$CELL_LOG" 2>&1 || \
+        echo "run-discovery.sh: hunter run failed for $CLS/'$SUBSYS' (see $CELL_LOG)" >&2
+    # The hunter's contract: a `CANDIDATE|file:fn:line|class|severity|exploit|poc` line, or `SAFE`.
+    if grep -q 'CANDIDATE|' "$CELL_LOG"; then
+      while IFS= read -r LINE; do
+        CAND="$(printf '%s' "$LINE" | sed 's/^.*\(CANDIDATE|\)/\1/')"
+        BODY="$(printf '%s' "$CAND" | sed 's/^CANDIDATE|//; s/|/ \/ /g')"
+        printf '| %s | %s | %s |\n' "$SUBSYS" "$CLS" "$BODY" >> "$REPORT"
+        CANDIDATES=$((CANDIDATES + 1))
+      done < <(grep 'CANDIDATE|' "$CELL_LOG")
+    fi
+    IFS=','
+  done
+  IFS="$OLDIFS"
+done < "$SCOPE"
+
+if [ "$CANDIDATES" -eq 0 ]; then
+  echo "| _(none)_ | — | rigorous NEGATIVE — no candidate of any hunted class survived. A clean result on audited code is a valid outcome; nothing is submitted. |" >> "$REPORT"
+fi
+{
+  echo
+  echo "---"
+  echo "Cells run: $CELLS    Candidates surfaced: $CANDIDATES (all UNVERIFIED — forge-verify each before it counts)."
+} >> "$REPORT"
+
+echo >&2
+echo "================ DISCOVERY: $CELLS cells, $CANDIDATES candidate(s) ================" >&2
+echo "run-discovery.sh: leads at $REPORT" >&2
+if [ "$CANDIDATES" -gt 0 ]; then
+  echo "run-discovery.sh: NEXT = verify each lead with evm-harness/forge-verify.sh; only a PASSING PoC is a finding. Submission stays human-gated." >&2
+else
+  echo "run-discovery.sh: no candidates — rigorous negative. Nothing to verify, nothing submitted." >&2
+fi


### PR DESCRIPTION
## What

The dark-factory `auditor` colony could only **match** known fork patterns (`auditor.ag` → DAG matcher): it fires where in-scope code recurs a seeded sub-graph, so on a bespoke, never-forked protocol it returns nothing. This PR adds a **discovery** track so the colony can hunt bugs in custom contest code, entirely on the agentis substrate.

## How

- **`auditor/agents/hunter.ag`** — a substrate discovery agent. One invocation hunts ONE bug class over ONE subsystem: it slurps the in-scope contracts, loads the taxonomy lens + protocol brief, runs a deep adversarial `prompt()`, and records the attempt via `learn()` + `emit()` so per-class taxonomy fitness reweights over targets (the evolve loop, now over discovery).
- **`auditor/bug-taxonomy.md`** — the discovery knowledge: 14 DeFi bug classes (share-price/ERC4626, oracle, cross-chain/LZ, withdrawal-queue, access-control, accounting, sig-replay, reentrancy, decimals, liquidation, first-depositor, slippage, compliance, fork-delta), each with a hunt lens distilled from real audits.
- **`run-discovery.sh`** — operator entrypoint. Takes `--repo` + a `--scope` manifest (`subsystem | classes | files`) + a `--brief` (invariants-to-break, known-issues-to-exclude, trust model) and fans out one substrate hunter per (subsystem × class), collecting `CANDIDATE` leads into a report.
- **`evm-harness/forge-verify.sh`** — the multi-contract verification gate. A custom protocol needs a full Foundry deploy + attacker tx + invariant assert (not the single-function revm harness), so a candidate is VERIFIED only when its `Exploit.t.sol` PoC passes against the in-scope repo.

A surfaced `CANDIDATE` is a **lead, not a finding** — unverified until it reproduces through `forge-verify.sh`. Submission stays human-gated; the colony never posts to a platform. A clean sweep is a valid **rigorous negative**.

## Validation

- `colony-lint.sh`: **358 passed, 0 failed**, 5 skipped (markdown links, `.ag` syntax, shellcheck all green).
- Wiring smoke-tested end-to-end with `--backend mock` (manifest parse → env contract → file/taxonomy read → prompt assembly → verdict parse → learn/emit).
- Real `--backend claude` pass proven end-to-end on a live 3×-audited custom-stablecoin Sherlock contest: the substrate hunter read the ERC4626 savings + rewards-distributor contracts under the share-price lens and returned a reasoned `SAFE` (the expected rigorous negative on audited code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)