### PR TITLE
feat(dark-factory): function-level slicing + 600s budget for the discovery hunter

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,15 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Discovery: **function-level slicing** + a 600s deep-read budget (#863). A scope entry can now be
+  written `file@fn1+fn2` to feed the hunter ONLY those functions (plus the contract header) instead of
+  the whole file — `auditor/slice-fns.sh` (awk, brace-matched) extracts them, wired through
+  `hunter.ag`'s `cat_file` (via the `SLICER` env) and `run-discovery.sh`. This fixes the deep
+  liquidation/redemption cells timing out on big contracts, where a whole-file concat overflowed the
+  LLM per-call budget (e.g. a Compound-fork `CToken.sol` 1193→134 lines, a credit-vault
+  `CollateralVaultBase.sol` 611→152 lines). The discovery LLM timeout is also raised 300s→600s — the
+  reasoning, not the payload, is the real cost, and one 600s attempt beats three wasted 300s retries.
+
 - Custom-code DISCOVERY track — the colony can now hunt bugs in bespoke, never-forked protocols, not
   just match known-fork patterns (#863). The DAG matcher (`auditor.ag`) fires only where in-scope code
   recurs a seeded pattern, so it returns nothing on custom contest code (a fresh stablecoin, a new

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -133,7 +133,9 @@ multi-agent audit pass.
 The operator supplies three inputs and the colony fans out one substrate agent per cell:
 
 - `--repo <dir>` — the cloned target (use `fetch-target.sh`).
-- `--scope <scope.tsv>` — `subsystem | classid,… | file,…` per line (files relative to the repo).
+- `--scope <scope.tsv>` — `subsystem | classid,… | file,…` per line (files relative to the repo). A
+  file may be written `file@fn1+fn2` to feed the hunter **only those functions** (+ the contract header)
+  — slice big/complex contracts this way so a deep liquidation/redemption read fits the LLM budget.
 - `--brief <brief.md>` — the protocol's invariants-to-break, **known issues to exclude**, and trust model.
 
 ```bash
@@ -174,6 +176,7 @@ dark-factory/
     agents/auditor.ag           # the DAG-match pipeline (reconn → guard → tracker → synthesis)
     agents/hunter.ag            # the custom-code discovery agent (taxonomy-driven adversarial hunt)
     bug-taxonomy.md             # 14 DeFi bug classes + per-class hunt lens (the discovery knowledge)
+    slice-fns.sh                # Solidity function-slicer (scope `file@fn1+fn2` -> header + named fns)
     config/colony.example.toml  # forge.type = "none"; cb_budget
     scripts/start-colony.sh     # thin `agentis go` launcher
     README.md

--- a/dark-factory/auditor/agents/hunter.ag
+++ b/dark-factory/auditor/agents/hunter.ag
@@ -18,8 +18,19 @@ cb 300000;
 
 // --- file readers (dynamic paths -> safe-exec-concat per recall-match.ag precedent) ---
 fn cat_file(path: string) -> string {
+    let at = index_of(path, "@");
+    if at < 0 {
+        // colony-lint: safe-exec-concat
+        return exec sh "sed -n '1,2000p' ${path} 2>/dev/null || true";
+    }
+    // Function-level slice: a scope entry `path@fn1+fn2` feeds ONLY those functions (+ the contract
+    // header) so a deep adversarial read of a big/complex contract fits the LLM per-call budget —
+    // whole-file concats overflow it and the liquidation/seize cells time out (#863).
+    let file = substring(path, 0, at);
+    let funcs = substring(path, at + 1, len(path));
+    let slicer = getenv("SLICER");
     // colony-lint: safe-exec-concat
-    return exec sh "sed -n '1,700p' ${path} 2>/dev/null || true";
+    return exec sh "sh ${slicer} ${file} '${funcs}' 2>/dev/null || true";
 }
 
 // Concatenate every in-scope contract into one labelled blob.

--- a/dark-factory/auditor/slice-fns.sh
+++ b/dark-factory/auditor/slice-fns.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# slice-fns.sh — extract a Solidity contract's HEADER + named functions (brace-matched), so the
+# discovery hunter can feed FUNCTION-LEVEL slices of large/complex contracts instead of whole files.
+# A whole-file concat of a 1000-2000 line contract overflows the LLM per-call budget on a deep
+# adversarial read (the liquidation/seize cells time out); a header + the 2-3 relevant functions fits.
+#
+# Usage:  slice-fns.sh <file.sol> "<fn1,fn2,...>"
+# Prints: the file's leading context (pragma / imports / contract decl / state vars / structs / events /
+#         modifiers — everything before the first function) followed by each named function in full
+#         (from its `function <name>` line to the matching close brace). If none of the requested names
+#         match, falls back to the first 2000 lines (so a typo never yields an empty payload).
+# Brace counting is line-based and best-effort: braces inside strings/comments can miscount (acceptable
+# for a discovery prompt — the worst case is a slightly over/under-sized slice, never a wrong verdict).
+set -eu
+
+F="${1:?slice-fns.sh: <file.sol> required}"
+FNS="${2:-}"
+[ -f "$F" ] || exit 0
+[ -n "$FNS" ] || { sed -n '1,2000p' "$F"; exit 0; }
+
+OUT="$(awk -v fns="$FNS" '
+BEGIN {
+  n = split(fns, A, /[,+]/)
+  for (i = 1; i <= n; i++) { gsub(/^[ \t]+|[ \t]+$/, "", A[i]); if (A[i] != "") want[A[i]] = 1 }
+  header = 1; infn = 0; depth = 0; started = 0; matched = 0
+}
+# Header: print every line up to the FIRST function definition (pragma/imports/state/structs/modifiers).
+header && /(^|[^[:alnum:]_])function[ \t(]/ { header = 0 }
+header { print; next }
+# Function start: capture the name; if wanted, enter capture mode (fall through to the infn block so
+# this very line is printed + brace-counted).
+!infn && /(^|[^[:alnum:]_])function[ \t]+[A-Za-z0-9_]+/ {
+  s = $0; sub(/.*function[ \t]+/, "", s); sub(/[ \t(].*/, "", s)
+  if (s in want) { infn = 1; depth = 0; started = 0; matched = 1 }
+}
+infn {
+  print
+  t = $0; o = gsub(/{/, "x", t); u = $0; c = gsub(/}/, "x", u); depth += o - c
+  if (o > 0) started = 1
+  if (started && depth <= 0) { infn = 0; print "" }
+  next
+}
+END { if (!matched) exit 3 }
+' "$F")" && rc=0 || rc=$?
+
+if [ "${rc:-0}" -eq 3 ]; then
+  sed -n '1,2000p' "$F"      # no requested function matched → whole-file fallback
+else
+  printf '%s\n' "$OUT"
+fi

--- a/dark-factory/docs/RUNBOOK.md
+++ b/dark-factory/docs/RUNBOOK.md
@@ -80,15 +80,20 @@ agent (`auditor/agents/hunter.ag`) out over (subsystem × bug-class).
    `contracts/` or `src/`).
 2. **Write a scope manifest** — one subsystem per line, `subsystem | classid,… | file,…` (files
    relative to the repo root); `#` comments allowed. Pick classes per subsystem from
-   `auditor/bug-taxonomy.md`. Example:
+   `auditor/bug-taxonomy.md`. A file may be written `file@fn1+fn2` to feed **only those functions**
+   (plus the contract header) instead of the whole file — use it for big/complex contracts (a 1000+
+   line CDP, money-market, or credit vault) whose whole-file read would overflow the LLM budget and
+   time out on a deep liquidation/redemption cell. Example:
    ```
    rewards + savings  | C1,C6,C11 | contracts/SavingsVault.sol,contracts/RewardsDistributor.sol
    oracle             | C2,C9,C10 | contracts/PriceOracle.sol,contracts/LendingAdapter.sol
+   vault liquidation  | C10       | contracts/Vault.sol@liquidate+seize+_redeem
    ```
 3. **Write a brief** — the protocol's invariants whose violation is a valid finding, the **known
    issues to exclude** (from prior audits — the hunter must not re-report them), and the trust model
    (which roles are in/out of scope). This is what stops the hunt from surfacing already-audited noise.
-4. **Run** (each cell is a deep adversarial LLM read; a full sweep is `Ncells × ~3 min`, serial):
+4. **Run** (each cell is a deep adversarial LLM read — ~3 min typical, up to ~8 min for a deep
+   liquidation/redemption cell, within the 600s per-call budget; a full sweep is serial):
    ```
    ./run-discovery.sh --repo <repo> --scope scope.tsv --brief brief.md --backend claude --out discovery-out
    # cheap wiring smoke first (no real LLM):  --backend mock --only "<subsystem>" --classes C1

--- a/dark-factory/run-discovery.sh
+++ b/dark-factory/run-discovery.sh
@@ -17,9 +17,13 @@
 #   run-discovery.sh --repo <dir> --scope <scope.tsv> --brief <brief.md> [options]
 #
 # Scope manifest (one subsystem per line; `#` and blank lines ignored):
-#   <subsystem label> | <classid,classid,...> | <file,file,...>      (files relative to --repo)
+#   <subsystem label> | <classid,classid,...> | <file[,file...]>     (files relative to --repo)
+# A file may be FUNCTION-SLICED as `file@fn1+fn2+...` to feed ONLY those functions (+ the contract
+# header) instead of the whole file. Use it for big/complex contracts whose whole-file payload
+# overflows the LLM per-call budget — without it the deep liquidation/redeem cells time out.
 # e.g.
 #   savings + rewards | C1,C6,C11 | contracts/SavingsVault.sol,contracts/RewardsDistributor.sol
+#   vault liquidation | C10       | contracts/Vault.sol@liquidate+seize+_redeem
 #
 # Options:
 #   --repo <dir>        Cloned target repo root (clone with fetch-target.sh). REQUIRED.
@@ -75,17 +79,20 @@ mkdir -p "$OUT"; OUT="$(cd "$OUT" && pwd)"
 RUN="$OUT/run"
 rm -rf "$RUN"; mkdir -p "$RUN"
 cp "$HUNTER" "$RUN/hunter.ag"
+cp "$HERE/auditor/slice-fns.sh" "$RUN/slice-fns.sh"   # function-level slicer (scope `file@fn1+fn2`)
 
 # init the agentis store FIRST (before any .agentis/ subdir exists), else HEAD is not set.
 ( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
 {
   echo "llm.backend = $BACKEND"
-  # 300s, not the auditor's 180s: a deep per-(subsystem x class) adversarial read of several full
-  # contracts legitimately exceeds 3 min, and eating a retry on every cell is wasteful.
-  [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 300000"; }
+  # 600s: a deep adversarial read of complex liquidation/redemption logic legitimately runs 4-8 min
+  # even on a function-level slice (the reasoning, not the payload, is the cost). 300s made the hard
+  # cells time out 3x and return nothing; one 600s attempt beats three wasted 300s retries. Keep
+  # cells focused with `file@fn` slicing so the common case stays fast.
+  [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 600000"; }
   echo "trace.level = normal"
   # The hunter reads source + the brief/taxonomy through exec sh; pass through its whole env contract.
-  echo "exec.env_passthrough = TARGET_DIR,IN_SCOPE,SCOPE_BRIEF,TAXONOMY,HUNT_CLASS,SUBSYSTEM"
+  echo "exec.env_passthrough = TARGET_DIR,IN_SCOPE,SCOPE_BRIEF,TAXONOMY,HUNT_CLASS,SUBSYSTEM,SLICER"
   echo "exec.default_timeout_ms = 30000"
   # Discovery records every attempt as experience and reweights taxonomy fitness over time.
   echo "learning.enabled = true"
@@ -137,6 +144,7 @@ while IFS='|' read -r SUBSYS CLS_CSV FILES_CSV || [ -n "${SUBSYS:-}" ]; do
         TAXONOMY="$TAXONOMY" \
         HUNT_CLASS="$CLS" \
         SUBSYSTEM="$SUBSYS" \
+        SLICER="$RUN/slice-fns.sh" \
         "$AGENTIS" go hunter.ag --enable-exec --enable-messaging ) >"$CELL_LOG" 2>&1 || \
         echo "run-discovery.sh: hunter run failed for $CLS/'$SUBSYS' (see $CELL_LOG)" >&2
     # The hunter's contract: a `CANDIDATE|file:fn:line|class|severity|exploit|poc` line, or `SAFE`.


### PR DESCRIPTION
## What

The discovery hunter's deep cells (liquidation / redemption) timed out on big contracts: a whole-file concat of a 1000–2000 line CDP / money-market / credit-vault overflows the LLM per-call budget, so a liquidation cell hit the 300s timeout **3×** and returned no verdict — a real coverage gap on the highest-value surface of complex targets.

## How

- **`auditor/slice-fns.sh`** (new) — an awk Solidity slicer: emits the contract header (pragma / imports / contract decl / state vars / structs / modifiers) + each named function in full (brace-matched). Falls back to the whole file if no name matches.
- **`auditor/agents/hunter.ag`** — `cat_file` now parses a `path@fn1+fn2` form and calls the slicer (resolved via the `SLICER` env) when present, else reads the whole file. A scope entry can thus feed the hunter **only the relevant functions** of a huge contract.
- **`run-discovery.sh`** — stages `slice-fns.sh` into the run dir, exports `SLICER`, adds it to `exec.env_passthrough`, and raises the discovery LLM timeout **300s → 600s** (the reasoning, not the payload, is the real cost on a deep cell; one 600s attempt beats three wasted 300s retries). The scope-manifest format gains the `file@fn1+fn2` option.
- **README / RUNBOOK / CHANGELOG** document the syntax.

## Validation

- `slice-fns.sh` on real contracts: a Compound-fork `CToken.sol` 1193→134 lines, a credit-vault `CollateralVaultBase.sol` 611→152 lines — header + the named functions, brace-matched and balanced (only the contract-level `{` is left open, harmless for a read).
- End-to-end: a liquidation cell that **3× timed out at 300s** on the whole-file payload now runs to a clean verdict under the 600s budget with the functions sliced. No timeout.
- `colony-lint.sh`: **358 passed, 0 failed** (`hunter.ag` syntax, shellcheck, markdown links all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)