### PR TITLE
fix(dark-factory): hunter was blind — reason-first prompt (returned SAFE on textbook bugs)

### DIFF
--- a/dark-factory/auditor/agents/hunter.ag
+++ b/dark-factory/auditor/agents/hunter.ag
@@ -51,7 +51,7 @@ fn class_section(taxo: string, cls: string) -> string {
 // A surfaced candidate = success; a rigorous SAFE = failure (so taxonomy fitness rewards the
 // classes that actually produce leads across targets, per #861's evolve loop). No reassignment.
 fn outcome_of(verdict: string) -> string {
-    if index_of(verdict, "CANDIDATE|") == 0 { return "success"; }
+    if index_of(verdict, "CANDIDATE|") >= 0 { return "success"; }
     return "failure";
 }
 
@@ -66,20 +66,25 @@ let classDoc = class_section(getenv("TAXONOMY"), cls);
 // The instruction carries the lens (taxonomy class), the brief (invariants + known-issues), and the
 // strict output contract; the code is the prompt payload (matches auditor.ag::classify_evm_llm shape).
 let instruction =
-    "You are an elite adversarial smart-contract auditor competing in a LIVE audit contest for real money. "
-  + "Find a HIGH or MEDIUM severity bug an EXTERNAL attacker (holding NO privileged role) can exploit. "
-  + "This code is likely already audited, so report ONLY a bug you are confident survives expert judging — "
-  + "no speculation, no informational notes.\n\n"
+    "You are an elite adversarial smart-contract auditor hunting a HIGH or MEDIUM severity bug an EXTERNAL "
+  + "attacker (holding NO privileged role) can exploit. Audit this code FRESH: assume nothing is safe until "
+  + "you have traced the actual control/data flow yourself. An obvious-looking bug IS a real bug unless a "
+  + "guard in the code provably stops it — do NOT assume prior auditors already caught it.\n\n"
   + "=== HUNT THIS BUG CLASS (the lens) ===\n" + classDoc + "\n\n"
   + "=== PROTOCOL BRIEF — invariants whose violation is a valid finding, and KNOWN ISSUES you MUST NOT report ===\n"
   + brief + "\n\n"
   + "=== RULES ===\nOnly Medium/High count. A trusted role acting WITHIN its documented permissions is OUT OF SCOPE; "
   + "a role EXCEEDING its permissions, or any unprivileged user, IS in scope. Never report a listed KNOWN ISSUE. "
   + "Subsystem under review: " + subsystem + ".\n\n"
-  + "=== OUTPUT CONTRACT ===\nIf you find a qualifying bug, output EXACTLY one line:\n"
+  + "=== HOW TO ANSWER ===\n"
+  + "FIRST reason step by step: walk EACH in-scope function relevant to this bug class and trace whether an "
+  + "external attacker can break an invariant — verify guards/CEI-order/rounding/auth in the actual code, do "
+  + "not hand-wave. THEN, for EVERY qualifying Medium/High bug you found, write one line:\n"
   + "CANDIDATE|<file:function:line>|<class=" + cls + ">|<severity=Medium|High>|<one-sentence external exploit path>|<concrete foundry PoC sketch: what to deploy, call, and assert>\n"
-  + "If after rigorous analysis there is NO qualifying bug of this class in this subsystem, output exactly:\nSAFE\n"
-  + "Output nothing else — no preamble, no markdown.";
+  + "If — after actually tracing the relevant functions — there is genuinely no qualifying bug of this class, "
+  + "write the single token: SAFE\n"
+  + "Reason for as long as you need first; ONLY the CANDIDATE| line(s) or the final SAFE token are parsed, so "
+  + "your analysis text above them is free.";
 
 let verdict = prompt(instruction, code) -> string;
 

--- a/dark-factory/run-discovery.sh
+++ b/dark-factory/run-discovery.sh
@@ -40,7 +40,7 @@ set -eu
 HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 REPO="" ; SCOPE="" ; BRIEF="" ; TAXONOMY="" ; ONLY="" ; CLASSES_OVERRIDE=""
-BACKEND="claude" ; OUT="$PWD/discovery-out"
+BACKEND="claude" ; MODEL="" ; OUT="$PWD/discovery-out"
 
 need() { [ "$1" -ge 2 ] || { echo "run-discovery.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -52,6 +52,7 @@ while [ $# -gt 0 ]; do
     --only) need "$#"; ONLY="$2"; shift 2 ;;
     --classes) need "$#"; CLASSES_OVERRIDE="$2"; shift 2 ;;
     --backend) need "$#"; BACKEND="$2"; shift 2 ;;
+    --model) need "$#"; MODEL="$2"; shift 2 ;;
     --out) need "$#"; OUT="$2"; shift 2 ;;
     --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
     --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
@@ -89,7 +90,7 @@ cp "$HERE/auditor/slice-fns.sh" "$RUN/slice-fns.sh"   # function-level slicer (s
   # even on a function-level slice (the reasoning, not the payload, is the cost). 300s made the hard
   # cells time out 3x and return nothing; one 600s attempt beats three wasted 300s retries. Keep
   # cells focused with `file@fn` slicing so the common case stays fast.
-  [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 600000"; }
+  [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p${MODEL:+ --model $MODEL}"; echo "llm.cli_timeout_ms = 600000"; }
   echo "trace.level = normal"
   # The hunter reads source + the brief/taxonomy through exec sh; pass through its whole env contract.
   echo "exec.env_passthrough = TARGET_DIR,IN_SCOPE,SCOPE_BRIEF,TAXONOMY,HUNT_CLASS,SUBSYSTEM,SLICER"


### PR DESCRIPTION
## The bug (critical)

The discovery hunter's prompt **suppressed all findings**, returning `SAFE` even on blatant High-severity bugs:
1. It forced an immediate single-line verdict — *"output EXACTLY one line, nothing else — no preamble, no markdown"* — leaving the model no room to reason through a bug (LLMs need chain-of-thought to find vulns), so it defaulted to `SAFE`.
2. It primed dismissal — *"this code is likely already audited, report ONLY a bug you are confident survives expert judging"* — telling the model to assume bugs were already caught.

**Consequence:** every prior hunter `SAFE` is an **unvalidated false negative**, not a true negative. A bug-finding system that finds nothing is not "clean targets" — it may be a blind detector. It was.

## The fix

- Let the model **reason step-by-step first**, then emit `CANDIDATE|…` line(s) or a final `SAFE`. `run-discovery.sh` greps `CANDIDATE|` anywhere, so free-form analysis before the verdict is parsed correctly.
- Drop the "already-audited / dismiss" framing → *"an obvious-looking bug IS a real bug unless a guard provably stops it; do NOT assume prior auditors caught it."*
- `outcome_of` matches `CANDIDATE|` anywhere (`>= 0`), not only at offset 0, so `learn()` fitness is right with reasoning-first output.

## Validation (positive control)

A `VulnVault` with 3 known textbook High bugs (reentrancy, first-depositor inflation, missing access control):

| | reentrancy (C8) | first-depositor (C11/C6) | missing-auth (C5) |
|---|---|---|---|
| **before** (blind) | SAFE | SAFE | SAFE |
| **after** (fixed) | ✅ CANDIDATE | ✅ CANDIDATE | ✅ CANDIDATE |

After the fix: **4/4 cells CANDIDATE**, each with the correct exploit path + a concrete Foundry PoC sketch. A plain `claude -p` on the same source finds the same bugs — confirming the model was capable and the *prompt* was the blindfold.

> Follow-up: re-screening the previously-"SAFE" real targets (dreUSD, CapyFi, Alchemix, Twyne) with the fixed hunter, since those negatives were produced by the blind version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)