### PR TITLE
feat(dark-factory): method-discovery meta-loop — federation invents+validates+adopts its own methods

### DIFF
--- a/dark-factory/auditor/agents/method-inventor.ag
+++ b/dark-factory/auditor/agents/method-inventor.ag
@@ -1,0 +1,39 @@
+cb 300000;
+// #863 — method-inventor. The federation's META layer: when the current audit method-set
+// plateaus (recent audits keep returning clean/refuted with the methods it already has),
+// propose ONE NEW method that catches a bug class the registry MISSES. The proposal is
+// validated downstream by run-method-discovery.sh against a known-bug control corpus
+// (fail-on-buggy + pass-on-clean = a two-sided gate) before it is adopted — so the
+// federation's method invention is EMPIRICAL, not speculation.
+//
+// Env:
+//   REGISTRY  path to the current method registry (methods the federation already has)
+//   GAP       path to a description of the bug class the current methods keep MISSING
+// Stdout: exactly one line
+//   METHOD|<name>|<bug-classes>|<one-sentence technique>|<how-to-invoke>|<what a known-bug control asserts>
+
+fn cat(path: string) -> string {
+    // colony-lint: safe-exec-concat
+    return exec sh "sed -n '1,400p' ${path} 2>/dev/null || true";
+}
+
+let registry = cat(getenv("REGISTRY"));
+let gap = cat(getenv("GAP"));
+
+let instruction = "You are the METHOD-INVENTOR for an autonomous smart-contract audit federation. "
+  + "The payload has the federation's CURRENT methods and a GAP (a class of bug those methods keep "
+  + "MISSING: recent audits came back clean with them, yet a known control holds a real bug they do not "
+  + "surface). Propose EXACTLY ONE NEW audit method that catches this class, DISTINCT from every method "
+  + "already listed, concretely runnable (a real technique/tool), and validatable against a known-bug "
+  + "control. Reason briefly, then output EXACTLY one final line, no markdown:\n"
+  + "METHOD|<short-name>|<target-bug-classes>|<one-sentence technique>|<how-to-invoke>|"
+  + "<what a known-bug control would assert>";
+
+let payload = "=== CURRENT METHODS ===\n" + registry + "\n\n=== GAP ===\n" + gap;
+
+let proposal = prompt(instruction, payload) -> string;
+
+// Surface to the orchestrator (stdout) + record the proposal on the bus.
+print(proposal);
+emit("dark-factory:method_proposed", proposal);
+memo_write("method-inventor:last_check", "done");

--- a/dark-factory/auditor/method-discovery/controls/.gitignore
+++ b/dark-factory/auditor/method-discovery/controls/.gitignore
@@ -1,0 +1,3 @@
+lib/
+out/
+cache/

--- a/dark-factory/auditor/method-discovery/controls/foundry.toml
+++ b/dark-factory/auditor/method-discovery/controls/foundry.toml
@@ -1,0 +1,10 @@
+[profile.default]
+src = "src"
+test = "test"
+libs = ["lib"]
+solc = "0.8.24"
+
+[invariant]
+runs = 256
+depth = 20
+fail_on_revert = false

--- a/dark-factory/auditor/method-discovery/controls/src/Controls.sol
+++ b/dark-factory/auditor/method-discovery/controls/src/Controls.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// ---------------------------------------------------------------------------
+// Method-discovery control corpus — bug class C6 (accounting / solvency drift).
+// A planted bug that is INVISIBLE to single-function review but caught by
+// stateful invariant fuzzing (a deposit -> transfer SEQUENCE breaks solvency).
+// Paired with a clean twin so a proposed method must DISCRIMINATE: fail on
+// Buggy, pass on Safe (the two-sided gate).
+// ---------------------------------------------------------------------------
+
+interface IERC20 {
+    function transfer(address, uint256) external returns (bool);
+    function transferFrom(address, address, uint256) external returns (bool);
+    function balanceOf(address) external view returns (uint256);
+}
+
+// Minimal ERC20 with no allowance check (keeps the fuzz harness approve-free).
+contract MockERC20 is IERC20 {
+    mapping(address => uint256) public balanceOf;
+    function mint(address to, uint256 a) external { balanceOf[to] += a; }
+    function transfer(address to, uint256 a) external returns (bool) {
+        balanceOf[msg.sender] -= a; balanceOf[to] += a; return true;
+    }
+    function transferFrom(address f, address t, uint256 a) external returns (bool) {
+        balanceOf[f] -= a; balanceOf[t] += a; return true;
+    }
+}
+
+// BUGGY: the internal `transfer()` double-counts `total` (stray `total += a`).
+// Read in isolation `transfer()` looks fine; only a deposit -> transfer SEQUENCE
+// makes `total` diverge from the real backing -> phantom funds -> insolvency.
+contract BuggyBank {
+    IERC20 public immutable token;
+    uint256 public total;
+    mapping(address => uint256) public balance;
+    constructor(IERC20 t) { token = t; }
+    function deposit(uint256 a) external {
+        token.transferFrom(msg.sender, address(this), a);
+        balance[msg.sender] += a; total += a;
+    }
+    function withdraw(uint256 a) external {
+        balance[msg.sender] -= a; total -= a;
+        token.transfer(msg.sender, a);
+    }
+    function transfer(address to, uint256 a) external {
+        balance[msg.sender] -= a; balance[to] += a;
+        total += a; // BUG: internal transfer must not change `total`
+    }
+}
+
+// SAFE: identical, but `transfer()` leaves `total` untouched.
+contract SafeBank {
+    IERC20 public immutable token;
+    uint256 public total;
+    mapping(address => uint256) public balance;
+    constructor(IERC20 t) { token = t; }
+    function deposit(uint256 a) external {
+        token.transferFrom(msg.sender, address(this), a);
+        balance[msg.sender] += a; total += a;
+    }
+    function withdraw(uint256 a) external {
+        balance[msg.sender] -= a; total -= a;
+        token.transfer(msg.sender, a);
+    }
+    function transfer(address to, uint256 a) external {
+        balance[msg.sender] -= a; balance[to] += a;
+    }
+}

--- a/dark-factory/auditor/method-discovery/controls/test/SolvencyInvariant.t.sol
+++ b/dark-factory/auditor/method-discovery/controls/test/SolvencyInvariant.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/Controls.sol";
+
+// This test file IS the method "stateful invariant fuzzing" instantiated:
+// a handler drives random deposit/withdraw/transfer SEQUENCES by 2 actors, and
+// the invariant asserts solvency (accounted total == real token backing).
+// Run against BuggyBank -> FAIL (fuzzer finds the deposit->transfer counterexample);
+// against SafeBank -> PASS. That discrimination validates the method.
+
+interface IBank {
+    function deposit(uint256) external;
+    function withdraw(uint256) external;
+    function transfer(address, uint256) external;
+    function total() external view returns (uint256);
+    function balance(address) external view returns (uint256);
+}
+
+contract Handler is Test {
+    MockERC20 public token;
+    IBank public bank;
+    address[2] public actors = [address(0xA1), address(0xA2)];
+    constructor(MockERC20 t, address b) { token = t; bank = IBank(b); }
+
+    function deposit(uint256 i, uint256 a) public {
+        address u = actors[i % 2];
+        a = bound(a, 1, 1e24);
+        token.mint(u, a);
+        vm.prank(u);
+        bank.deposit(a);
+    }
+    function withdraw(uint256 i, uint256 a) public {
+        address u = actors[i % 2];
+        uint256 b = bank.balance(u);
+        if (b == 0) return;
+        a = bound(a, 1, b);
+        vm.prank(u);
+        bank.withdraw(a);
+    }
+    function transfer(uint256 i, uint256 a) public {
+        address u = actors[i % 2];
+        address to = actors[(i + 1) % 2];
+        uint256 b = bank.balance(u);
+        if (b == 0) return;
+        a = bound(a, 1, b);
+        vm.prank(u);
+        bank.transfer(to, a);
+    }
+}
+
+contract BuggyInvariantTest is Test {
+    Handler h; address bank; MockERC20 token;
+    function setUp() public {
+        token = new MockERC20();
+        bank = address(new BuggyBank(token));
+        h = new Handler(token, bank);
+        targetContract(address(h));
+    }
+    function invariant_solvent() public view {
+        assertEq(BuggyBank(bank).total(), token.balanceOf(bank), "phantom funds: accounted total != real backing");
+    }
+}
+
+contract SafeInvariantTest is Test {
+    Handler h; address bank; MockERC20 token;
+    function setUp() public {
+        token = new MockERC20();
+        bank = address(new SafeBank(token));
+        h = new Handler(token, bank);
+        targetContract(address(h));
+    }
+    function invariant_solvent() public view {
+        assertEq(SafeBank(bank).total(), token.balanceOf(bank), "phantom funds: accounted total != real backing");
+    }
+}

--- a/dark-factory/auditor/methods/gap-stateful.md
+++ b/dark-factory/auditor/methods/gap-stateful.md
@@ -1,0 +1,16 @@
+# GAP: multi-transaction invariant violations
+
+The methods in the registry are all either (a) STATIC reads of one function/contract, or
+(b) a single hand-written PoC of one hypothesis. None of them SYSTEMATICALLY searches the
+space of operation SEQUENCES. So a bug that holds for every single call but breaks under a
+specific interleaving of calls by multiple actors slips through.
+
+## Evidence — a known-bug control the current methods miss
+`method-discovery/controls` contains `BuggyBank`: its `transfer(to, amount)` accidentally
+does `total += amount` (double-counts the accounting total on an internal transfer). Read in
+isolation, `transfer()` looks fine; `deposit`, `withdraw`, `transfer` each look fine. The
+solvency invariant `total == token.balanceOf(bank)` only breaks after a deposit -> transfer
+SEQUENCE — exactly the kind of cross-call state corruption that a one-pass read or a single
+PoC does not reliably surface, but that a stateful search over random call sequences finds in
+milliseconds. A paired `SafeBank` twin (no double-count) must NOT trip the method (no false
+positive) — that two-sided discrimination is the adoption gate.

--- a/dark-factory/auditor/methods/registry.md
+++ b/dark-factory/auditor/methods/registry.md
@@ -1,0 +1,16 @@
+# Dark-factory audit method registry
+
+The methods the federation can apply. The method-discovery meta-loop
+(`run-method-discovery.sh`) appends `invented` methods here only after they pass the
+known-bug control gate. Machine-readable lines:
+
+`METHOD|<name>|<bug-classes>|<technique>|<how-to-invoke>|<status>|<fitness>`
+
+METHOD|breadth-screen|C1-C14|per (subsystem x bug-class) reason-first adversarial LLM pass over sliced in-scope contracts|run-discovery.sh|builtin|0.50
+METHOD|function-slicing|*|extract `file@fn` slices (contract header + named fns) so big contracts fit the LLM budget|slice-fns.sh|builtin|0.60
+METHOD|brief-ingestion|*|fold the target's own audit docs / known-issues into the hunt anchor to exclude documented findings|run-discovery.sh --brief|builtin|0.70
+METHOD|deep-cross-function-audit|C5-C12|whole-contract read, enumerate invariants, trace the call-graph, build sequenced multi-actor attack hypotheses|deep-audit subagent|builtin|0.55
+METHOD|poc-build-run|*|build a forge harness over mocks, write + run a test to reproduce/refute a hypothesis|forge-verify.sh|builtin|0.65
+METHOD|adversarial-refute|*|independently try to REFUTE each candidate vs real control-flow + economic-honesty (count all positions)|refute subagent|builtin|0.75
+METHOD|fork-differential|*|clone the upstream parent, diff, audit ONLY the delta (the lines the upstream auditors never saw)|fork-diff subagent|builtin|0.80
+METHOD|onchain-verify|C5,C14|Sourcify verified source + public-RPC eth_call + keccak selector/role checks on the live deployment|recall.sh / cast|builtin|0.50

--- a/dark-factory/run-method-discovery.sh
+++ b/dark-factory/run-method-discovery.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Method-discovery meta-loop: INVENT -> VALIDATE-on-known-bug-control -> ADOPT.
+#
+# The federation's self-improvement layer. When the current method-set plateaus, the
+# method-inventor proposes a NEW method; it is adopted into the registry ONLY if it
+# DISCRIMINATES on a known-bug control corpus: it must catch the planted bug (Buggy suite
+# FAILS) AND stay clean on the paired safe twin (Safe suite PASSES). That two-sided gate
+# is what makes method invention empirical rather than speculation.
+#
+# Usage: ./run-method-discovery.sh [control-corpus-dir]
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REGISTRY="${REGISTRY:-$HERE/auditor/methods/registry.md}"
+GAP="${GAP:-$HERE/auditor/methods/gap-stateful.md}"
+CORPUS="${1:-${CORPUS:-/tmp/mdctl}}"
+MODEL="${MODEL:-claude-opus-4-8}"
+INVENTOR="$HERE/auditor/agents/method-inventor.ag"
+FORGE="${FORGE:-$HOME/.foundry/bin/forge}"
+
+echo "== method-discovery: INVENT -> VALIDATE -> ADOPT =="
+echo "registry=$REGISTRY  gap=$GAP  corpus=$CORPUS"
+
+# --- 1. INVENT (substrate-native by default; direct-LLM only as a fallback) --
+proposal=""
+if [ -z "${NO_AGENTIS:-}" ] && command -v agentis >/dev/null 2>&1; then
+  # Substrate-native path: mirror run-discovery.sh's hunter invocation
+  # (`agentis go ... --enable-exec --enable-messaging`). The sandboxed `exec sh`
+  # CANNOT read files under $HOME, so the registry/gap are copied into the /tmp
+  # rundir (sandbox-readable) and the agent reads those local copies — same
+  # reason run-discovery copies slice-fns.sh into $RUN and clones the target to /tmp.
+  rd="$(mktemp -d)"; cp "$INVENTOR" "$rd/method-inventor.ag"
+  cp "$REGISTRY" "$rd/registry.md"; cp "$GAP" "$rd/gap.md"
+  ( cd "$rd" && agentis init >/dev/null 2>&1
+    { echo "llm.backend = claude"; echo "llm.command = claude"; echo "llm.args = -p --model $MODEL"
+      echo "exec.env_passthrough = REGISTRY,GAP"; echo "llm.cli_timeout_ms = 300000"; echo "exec.default_timeout_ms = 30000"; } >> .agentis/config
+    REGISTRY="$rd/registry.md" GAP="$rd/gap.md" agentis go method-inventor.ag --enable-exec --enable-messaging ) > "$rd/out" 2>"$rd/err"
+  proposal="$(grep -m1 '^METHOD|' "$rd/out" 2>/dev/null || true)"
+  if [ -n "$proposal" ]; then echo "[invent] via agentis go (substrate-native)"; else echo "[invent] agentis go produced no METHOD| line (see $rd/err); falling back" >&2; fi
+fi
+if [ -z "$proposal" ]; then
+  # direct-LLM fallback (same reasoning the .ag prompt() performs)
+  pr="$(printf 'You are the METHOD-INVENTOR for an autonomous smart-contract audit federation.\n\nCurrent methods:\n%s\n\nGAP (a bug class the current methods keep MISSING):\n%s\n\nPropose EXACTLY ONE new, distinct, concretely-runnable audit method that catches this class. Reason briefly then output EXACTLY one final line:\nMETHOD|<name>|<bug-classes>|<one-sentence technique>|<how-to-invoke>|<what a known-bug control asserts>' "$(cat "$REGISTRY")" "$(cat "$GAP")")"
+  proposal="$(claude -p --model "$MODEL" "$pr" 2>/dev/null | grep -m1 '^METHOD|' || true)"
+  [ -n "$proposal" ] && echo "[invent] via direct LLM fallback"
+fi
+[ -z "$proposal" ] && { echo "FAIL: inventor produced no METHOD| line"; exit 1; }
+name="$(printf '%s' "$proposal" | cut -d'|' -f2)"
+echo "INVENTED: $proposal"
+
+# --- 2. VALIDATE on the known-bug control corpus (two-sided gate) -----------
+echo "== validate '$name' on control corpus =="
+buggy="$(cd "$CORPUS" && "$FORGE" test --match-contract BuggyInvariantTest 2>&1)"
+safe="$(cd "$CORPUS"  && "$FORGE" test --match-contract SafeInvariantTest  2>&1)"
+caught=0; clean=0
+printf '%s' "$buggy" | grep -q 'Suite result: FAILED' && caught=1
+printf '%s' "$safe"  | grep -q 'Suite result: ok'     && clean=1
+echo "   buggy-control caught (suite FAILED): $caught   safe-twin clean (suite ok): $clean"
+
+# --- 3. ADOPT (only on two-sided discrimination) ----------------------------
+if [ "$caught" = 1 ] && [ "$clean" = 1 ]; then
+  if ! grep -q "^METHOD|$name|" "$REGISTRY"; then
+    printf 'METHOD|%s|invented|0.50\n' "$(printf '%s' "$proposal" | sed 's/^METHOD|//')" >> "$REGISTRY"
+    echo "ADOPTED: '$name' appended to registry (status=invented, fitness=0.50)"
+  else
+    echo "ADOPTED: '$name' already present in registry"
+  fi
+  echo "== method-discovery OK: invented + validated + adopted '$name' =="
+  exit 0
+else
+  echo "REJECTED: '$name' did not discriminate on the control corpus (no adoption)"
+  exit 2
+fi


### PR DESCRIPTION
Closes #998 (and lands the method-discovery meta-loop).

The federation`s META layer: when the current method-set plateaus, the inventor proposes a NEW audit method for a bug class the registry misses; it is adopted ONLY if it DISCRIMINATES on a known-bug control corpus (fail-on-buggy + pass-on-clean) — empirical invention, not speculation.

- `auditor/agents/method-inventor.ag` — substrate-native inventor (`agentis go --enable-exec --enable-messaging`; reads registry+gap via sandboxed exec from rundir-local copies, since the sandbox cannot read `$HOME`).
- `auditor/methods/{registry.md,gap-stateful.md}` — the method registry (8 builtins) + the gap the inventor reasons over.
- `run-method-discovery.sh` — invent -> validate-on-corpus -> adopt orchestration.
- `auditor/method-discovery/controls/` — two-sided control corpus (BuggyBank double-counts `total` on internal transfer; SafeBank twin) proving forge invariant fuzzing discriminates.

**Verified end-to-end substrate-native:** inventor proposed `stateful-invariant-fuzz`, the corpus caught the planted bug (BuggyInvariantTest FAILED) and passed the SafeBank twin, method adopted (registry 8->9). Resolves #998`s ask (`exec_foreign` via `--enable-exec` + sandbox-readable rundir copies; substrate path is now default, direct-LLM only a fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)