### PR TITLE
feat(dark-factory): inter-agent coordination via a shared blackboard (#1001)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,24 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Discovery: **inter-agent coordination via a shared blackboard** — a first coordination primitive so
+  hunter cells influence each other within a run, instead of the run being a flat sum of independent
+  one-shot audits (#1001). The discovery fan-out runs every (subsystem × class) cell against ONE shared
+  agentis memo store, so `hunter.ag` now READS a rolling `dark-factory:blackboard:leads` memo before it
+  prompts and WRITES every CANDIDATE back to it (+ emits `dark-factory:lead`). A later cell that finds a
+  sibling's lead on the board is STEERED — its prompt gains a FOCUS block telling it to corroborate a
+  hit in the same subsystem or pivot toward a related attack surface a sibling already flagged.
+  `run-discovery.sh` surfaces both halves of the loop (a `↳ COORDINATION:` log line when a cell is
+  steered, a "posted a lead" line when one contributes) and appends an **Inter-agent coordination**
+  table to the discovery report. The mechanism is inert on a clean sweep (no finding → no steer → the
+  prompt and the existing rigorous-negative contract are byte-identical), so it is additive and does not
+  change single-cell behavior. `demo-blackboard.sh` proves the loop end-to-end OFFLINE (deterministic
+  fake LLM, no network): an oracle cell posts a stale-price lead and a downstream liquidation cell reads
+  it — the demo asserts the liquidation cell's prompt actually carried the oracle lead, so the steer is
+  real, not cosmetic. Scoped as ONE coordination step; the broader emergent-behavior vision (a
+  coordinator that reprioritizes/prunes the cell manifest from the board) is deliberately left as
+  follow-up — no overclaim of emergence.
+
 - `evolve-fitness.sh` + `auditor/agents/fitness-driver.ag` — actually drive the discovery colony's
   evolve/fitness LOOP over several runs and DEMONSTRABLY move per-class/per-method fitness in the agentis
   experience store (#996). Until now `hunter.ag` recorded each hunt via `learn("hunt", "<class>:<subsystem>",
@@ -30,6 +48,7 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   pause) fall behind — the colony's evolved ranking of which lenses to lean on. Validated end-to-end:
   60 cells over 6 iterations moved fitness on 9/10 lenses (C1/C6 +0.600, C3 -0.600); re-runs are
   byte-identical. `--corpus` overrides the corpus, `--json` emits a machine-readable before/after table.
+
 - `gen-agent.sh <method-name>` — close the self-extension loop (#1000). The
   method-discovery meta-loop (`method-inventor.ag` + `run-method-discovery.sh`,
   #998) invents and adopts new audit *methods* — reusable hunting techniques

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -160,6 +160,26 @@ dark-factory/evm-harness/forge-verify.sh --repo "$PWD/target" --poc "$PWD/Exploi
 A clean sweep (no candidate survives) is a **rigorous negative** — a valid outcome on audited code;
 nothing is submitted. As with `run-audit.sh`, the colony never posts to a platform.
 
+### Inter-agent coordination (shared blackboard, #1001)
+
+The fan-out is no longer a flat sum of independent cells. Because every (subsystem × class) cell runs
+against one shared agentis memo store, `hunter.ag` reads a rolling **blackboard**
+(`dark-factory:blackboard:leads`) before it prompts and posts every `CANDIDATE` back to it (also
+emitting `dark-factory:lead`). A later cell that sees a sibling's lead on the board is **steered** — its
+prompt gains a FOCUS block to corroborate a hit in the same subsystem or pivot toward a related surface
+a sibling already flagged — so one cell's finding changes what a later cell does. `run-discovery.sh`
+logs a `↳ COORDINATION:` line when a cell is steered and appends an **Inter-agent coordination** table
+to the report. The mechanism is inert on a clean sweep (no finding → identical prompt → the
+rigorous-negative behavior above is unchanged). Reproduce it offline (no network, deterministic fake
+LLM):
+
+```bash
+dark-factory/demo-blackboard.sh   # oracle cell posts a lead; downstream liquidation cell reads + is steered
+```
+
+This is one coordination step, not emergent behavior; a coordinator that reprioritizes/prunes the cell
+manifest from the board is a follow-up.
+
 ## Exercise the evolve/fitness loop (`evolve-fitness.sh`)
 
 Every hunt the colony runs records a `learn("hunt", "<class>:<subsystem>", ..., outcome, [...])` row in
@@ -188,6 +208,7 @@ dark-factory/
   run-discovery.sh              # operator entrypoint: custom-code discovery (hunter fan-out) -> leads
   evolve-fitness.sh             # drive the evolve/fitness loop over N iterations; show per-lens fitness move
   gen-agent.sh                  # materialise a colony-lint-valid .ag agent from an invented METHOD line (#1000)
+  demo-blackboard.sh            # offline, deterministic demo of the #1001 blackboard coordination loop
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)

--- a/dark-factory/auditor/agents/hunter.ag
+++ b/dark-factory/auditor/agents/hunter.ag
@@ -55,6 +55,87 @@ fn outcome_of(verdict: string) -> string {
     return "failure";
 }
 
+// --- #1001 shared BLACKBOARD: a first inter-agent coordination primitive ---
+// The discovery fan-out runs every (subsystem x class) cell against ONE shared agentis store, so a
+// memo a cell writes is visible to every LATER cell via recall_latest. That makes a "blackboard"
+// (Hayes-Roth) the minimal-but-real way for findings to STEER siblings instead of each cell being an
+// island: a cell that surfaces a CANDIDATE posts a one-line lead, and every cell that runs after it
+// reads the board and FOCUSES — corroborate a sibling's hit in the same subsystem, or pivot toward a
+// related attack surface a sibling already flagged. This is one coordination step, NOT a claim of
+// emergent behavior; the broader vision (a coordinator that reprioritizes/prunes the manifest) is
+// follow-up. The board is rolling newline-joined `subsystem|class|severity|one-line lead` lines.
+
+// Single-assignment .ag bindings — accumulate via pure helpers, never reassign a `let`.
+fn append_line(prev: string, line: string) -> string {
+    if len(line) == 0 { return prev; }
+    if len(prev) == 0 { return line; }
+    return prev + "\n" + line;
+}
+
+// First non-empty line of `s` (the verdict's lead summary lives on the first CANDIDATE| line).
+fn first_line(s: string) -> string {
+    return reduce(regex_split("\n", s), |acc: string, l: string| -> string {
+        if len(acc) > 0 { return acc; }
+        if len(l) > 0 { return l; }
+        return acc;
+    }, "");
+}
+
+// The first `CANDIDATE|...` line of the verdict as a lead summary, with the literal `CANDIDATE|` token
+// STRIPPED. Stripping matters: the board (and the diagnostic lines that echo it) must NOT carry a bare
+// `CANDIDATE|`, or run-discovery.sh's `grep 'CANDIDATE|'` report-scraper would double-count the
+// blackboard echo as a finding. The remaining `file:fn:line|class|sev|exploit|poc` is the lead body.
+fn lead_summary(verdict: string) -> string {
+    let at = index_of(verdict, "CANDIDATE|");
+    if at < 0 { return ""; }
+    let line = first_line(substring(verdict, at, len(verdict)));
+    return substring(line, len("CANDIDATE|"), len(line));
+}
+
+// Leads on the board that belong to `subsystem` (want_same=true) or to OTHER subsystems (false), each
+// rendered as a "  - <lead>" bullet. A lead line starts `subsystem|...`, so a same-subsystem match is
+// an exact prefix match on `subsystem + "|"`.
+fn board_bullets(board: string, subsystem: string, want_same: bool) -> string {
+    return reduce(regex_split("\n", board), |acc: string, l: string| -> string {
+        if len(l) == 0 { return acc; }
+        let is_same = index_of(l, subsystem + "|") == 0;
+        if is_same == want_same { return append_line(acc, "  - " + l); }
+        return acc;
+    }, "");
+}
+
+// The "corroborate THIS subsystem" paragraph (empty when no same-subsystem lead exists).
+fn corroborate_para(same: string) -> string {
+    if len(same) == 0 { return ""; }
+    return "A sibling cell already surfaced a lead in THIS subsystem — CORROBORATE or refute it, and "
+         + "check for the same root-cause class on adjacent functions:\n" + same + "\n";
+}
+
+// The "pivot toward an OTHER-subsystem lead" paragraph (empty when no other-subsystem lead exists).
+fn pivot_para(other: string) -> string {
+    if len(other) == 0 { return ""; }
+    return "Sibling cells flagged leads in OTHER subsystems — if any shares a dependency, code path, "
+         + "or invariant with what you are reviewing, PRIORITIZE that overlap:\n" + other + "\n";
+}
+
+// Render the FOCUS block injected into a later cell's prompt: split the board into leads from THIS
+// subsystem (corroborate) vs OTHER subsystems (pivot toward a related surface). Returns "" when the
+// board holds no sibling lead this cell should act on — so a virgin first cell prompts unchanged and
+// the existing single-cell behavior is preserved exactly. No `let` reassignment (single-assignment).
+fn focus_block(board: string, subsystem: string) -> string {
+    if len(board) == 0 { return ""; }
+    let same = board_bullets(board, subsystem, true);
+    let other = board_bullets(board, subsystem, false);
+    // No `&&`/`||` in .ag — nest: only the empty-same AND empty-other case returns "".
+    if len(same) == 0 {
+        if len(other) == 0 { return ""; }
+    }
+    return "=== BLACKBOARD — leads sibling cells already posted in THIS run (let them FOCUS your hunt) ===\n"
+         + corroborate_para(same) + pivot_para(other)
+         + "Use these as PRIORS, not facts: still trace the code yourself, still report SAFE if this class "
+         + "is genuinely clean here.\n\n";
+}
+
 let dir = getenv("TARGET_DIR");
 let files = getenv("IN_SCOPE");
 let cls = getenv("HUNT_CLASS");
@@ -63,13 +144,27 @@ let brief = cat_file(getenv("SCOPE_BRIEF"));
 let code = scoped_code(dir, files);
 let classDoc = class_section(getenv("TAXONOMY"), cls);
 
+// #1001 READ side: pull the shared blackboard FIRST, so a lead an EARLIER cell posted this run can
+// steer this one. `focus` is "" when the board is empty (first cell) or holds nothing for this cell —
+// then the instruction below is byte-identical to the pre-#1001 prompt (no behavior change). A printed
+// BLACKBOARD-FOCUS| line makes the steering observable in the cell log even on the mock backend (where
+// prompt() never reasons), so run-discovery.sh and the operator can SEE one cell steer another.
+let board = recall_latest("dark-factory:blackboard:leads");
+let focus = focus_block(board, subsystem);
+if len(focus) > 0 {
+    print("BLACKBOARD-FOCUS|" + subsystem + "|" + cls + "|focusing on leads sibling cells posted: "
+        + first_line(board));
+}
+
 // The instruction carries the lens (taxonomy class), the brief (invariants + known-issues), and the
 // strict output contract; the code is the prompt payload (matches auditor.ag::classify_evm_llm shape).
+// The (possibly empty) blackboard FOCUS block sits up top so prior siblings' leads bias the hunt.
 let instruction =
     "You are an elite adversarial smart-contract auditor hunting a HIGH or MEDIUM severity bug an EXTERNAL "
   + "attacker (holding NO privileged role) can exploit. Audit this code FRESH: assume nothing is safe until "
   + "you have traced the actual control/data flow yourself. An obvious-looking bug IS a real bug unless a "
   + "guard in the code provably stops it — do NOT assume prior auditors already caught it.\n\n"
+  + focus
   + "=== HUNT THIS BUG CLASS (the lens) ===\n" + classDoc + "\n\n"
   + "=== PROTOCOL BRIEF — invariants whose violation is a valid finding, and KNOWN ISSUES you MUST NOT report ===\n"
   + brief + "\n\n"
@@ -93,4 +188,18 @@ print(verdict);
 let outcome = outcome_of(verdict);
 emit("dark-factory:hunt_result", "{\"class\":\"" + cls + "\",\"subsystem\":\"" + subsystem + "\",\"outcome\":\"" + outcome + "\"}");
 learn("hunt", cls + ":" + subsystem, "discovery hunt of " + cls + " on " + subsystem, outcome, [cls, subsystem, outcome]);
+
+// #1001 WRITE side: a CANDIDATE is a LEAD worth steering siblings toward. POST it to the shared
+// blackboard (rolling, read by every later cell above) as `subsystem|class|<lead summary>`, and emit
+// `dark-factory:lead` on the bus so an out-of-band coordinator/dashboard can react too. A reasoned
+// SAFE writes nothing — only positive findings steer, never a clean result. memo_write overwrites the
+// key, so we read-append-write to keep prior siblings' leads (single shared store = no lost update,
+// cells run sequentially).
+if outcome == "success" {
+    let lead = subsystem + "|" + cls + "|" + lead_summary(verdict);
+    memo_write("dark-factory:blackboard:leads", append_line(board, lead));
+    memo_write("dark-factory:blackboard:" + subsystem, lead);
+    emit("dark-factory:lead", "{\"subsystem\":\"" + subsystem + "\",\"class\":\"" + cls + "\"}");
+    print("BLACKBOARD-POST|" + lead);
+}
 memo_write("hunter:last_check", "done");

--- a/dark-factory/demo-blackboard.sh
+++ b/dark-factory/demo-blackboard.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# demo-blackboard.sh — reproducible, OFFLINE demo of the #1001 inter-agent coordination primitive.
+#
+# The discovery colony used to fan out independent one-shot audits: each (subsystem x class) cell was an
+# island, so the run was exactly the sum of its cells. #1001 adds a shared in-run BLACKBOARD over the
+# agentis memo store: a cell that surfaces a CANDIDATE posts a one-line lead (`memo_write` +
+# `emit dark-factory:lead`), and every LATER cell reads the board (`recall_latest`) and is STEERED to
+# corroborate a sibling's hit or pivot to a related surface. One cell's finding now changes what a
+# later cell does — the point of the issue.
+#
+# This demo proves that loop end-to-end with NO network and NO real LLM, by standing up a deterministic
+# fake `claude` on PATH. It runs the REAL `run-discovery.sh` against a 2-subsystem fixture:
+#   cell 1  oracle / C2       -> finds a stale-price CANDIDATE, posts it to the blackboard
+#   cell 2  liquidation / C2  -> reads the board; its prompt now carries the oracle lead, so it is steered
+# The fake LLM ASSERTS on cell 2 that the prompt it received contains the oracle lead (the steer is real,
+# not cosmetic), then returns a corroborating CANDIDATE. The demo asserts the coordination shows up in
+# the run log + the discovery report, and exits non-zero if the steer did not happen.
+#
+# Usage:  dark-factory/demo-blackboard.sh
+# Requires: the `agentis` binary on PATH. Exit 0 = the blackboard steered cell 2 from cell 1's finding.
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+command -v agentis >/dev/null 2>&1 || { echo "demo-blackboard.sh: agentis binary not on PATH" >&2; exit 3; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+REPO="$WORK/target"; BIN="$WORK/bin"; OUT="$WORK/discovery-out"
+mkdir -p "$REPO/contracts" "$BIN"
+
+# --- fixture: an oracle lib + a liquidation engine that PRICES collateral through that oracle ---------
+# (The shared dependency is the whole point: a lead in `oracle` is a prior for the `liquidation` cell.)
+cat > "$REPO/contracts/OracleLib.sol" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+interface IFeed { function latestRoundData() external view returns (uint80,int256,uint256,uint256,uint80); }
+library OracleLib {
+    // NOTE (planted lead): no staleness / updatedAt check — returns whatever the feed last reported.
+    function getPrice(IFeed feed) internal view returns (uint256) {
+        (, int256 answer,,,) = feed.latestRoundData();
+        return uint256(answer);
+    }
+}
+SOL
+cat > "$REPO/contracts/LiquidationEngine.sol" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import {OracleLib, IFeed} from "./OracleLib.sol";
+contract LiquidationEngine {
+    using OracleLib for IFeed;
+    IFeed public feed;
+    mapping(address => uint256) public debt;
+    mapping(address => uint256) public collateral;
+    // Prices collateral via OracleLib.getPrice — inherits any oracle weakness on the liquidation path.
+    function liquidate(address user) external {
+        uint256 px = feed.getPrice();
+        require(collateral[user] * px < debt[user] * 1e18, "healthy");
+        collateral[user] = 0;
+        debt[user] = 0;
+    }
+}
+SOL
+
+cat > "$WORK/brief.md" <<'MD'
+# Demo protocol brief
+Invariants: a position may be liquidated ONLY when genuinely under-collateralized at a FRESH price.
+Known issues (do not report): none.
+Trust model: the keeper role is trusted; all other callers are untrusted external attackers.
+MD
+
+# scope: oracle FIRST (it will post the lead), liquidation SECOND (it will read + be steered). Same class
+# C2 keeps the demo focused; the steer is cross-SUBSYSTEM (oracle -> liquidation), the interesting case.
+cat > "$WORK/scope.tsv" <<'TSV'
+oracle      | C2 | contracts/OracleLib.sol
+liquidation | C2 | contracts/LiquidationEngine.sol
+TSV
+
+# --- deterministic fake `claude`: the LLM the hunter shells out to (run-discovery sets llm.command=claude)
+# It reads instruction+payload on stdin. For the liquidation cell it ASSERTS the blackboard FOCUS block
+# (carrying the oracle lead) is present, writing a marker the demo checks — that assertion IS the proof
+# the earlier cell steered the later one. Each cell gets a CANDIDATE so both post/observe the board.
+cat > "$BIN/claude" <<EOF
+#!/usr/bin/env bash
+set -eu
+PROMPT="\$(cat)"
+if printf '%s' "\$PROMPT" | grep -q 'LiquidationEngine.sol'; then
+  # cell 2: it MUST have received the oracle lead via the blackboard FOCUS block injected by hunter.ag.
+  if printf '%s' "\$PROMPT" | grep -q 'BLACKBOARD'; then
+    if printf '%s' "\$PROMPT" | grep -q 'oracle|C2'; then
+      : > "$WORK/STEER_CONFIRMED"
+    fi
+  fi
+  echo "Traced liquidate(): it prices collateral via OracleLib.getPrice, so the oracle lead applies here."
+  echo "CANDIDATE|LiquidationEngine.sol:liquidate:11|C2|High|stale oracle price (sibling lead) lets a healthy position be liquidated|deploy a stale feed, call liquidate, assert seize succeeds"
+  exit 0
+fi
+# cell 1 (oracle): surface the stale-price lead. No blackboard yet — it is the FIRST cell.
+echo "Traced OracleLib.getPrice: no updatedAt/staleness guard, so a stale answer is accepted."
+echo "CANDIDATE|OracleLib.sol:getPrice:7|C2|High|missing staleness check accepts a stale price|deploy a feed, let updatedAt go stale, read getPrice, assert it returns the stale value"
+exit 0
+EOF
+chmod +x "$BIN/claude"
+
+echo "demo-blackboard.sh: running run-discovery.sh (offline, fake LLM) ..." >&2
+RUN_LOG="$WORK/run.log"
+set +e
+PATH="$BIN:$PATH" "$HERE/run-discovery.sh" \
+  --repo "$REPO" --scope "$WORK/scope.tsv" --brief "$WORK/brief.md" \
+  --backend claude --out "$OUT" >"$RUN_LOG" 2>&1
+RC=$?
+set -e
+
+REPORT="$OUT/discovery-report.md"
+echo
+echo "================= run-discovery.sh log (coordination lines) ================="
+grep -E 'hunting|COORDINATION|posted a lead|DISCOVERY:' "$RUN_LOG" || true
+echo
+echo "================= discovery-report.md ================="
+cat "$REPORT" 2>/dev/null || echo "(no report)"
+echo "======================================================="
+echo
+
+# --- assertions: the steer must be real (cell 2's prompt carried cell 1's lead) and visible ----------
+FAIL=0
+[ "$RC" -eq 0 ] || { echo "FAIL: run-discovery.sh exited $RC" >&2; FAIL=1; }
+[ -f "$WORK/STEER_CONFIRMED" ] || { echo "FAIL: cell 2's prompt did NOT contain cell 1's blackboard lead (no steer)" >&2; FAIL=1; }
+grep -q '^BLACKBOARD-POST|oracle|C2|' "$OUT"/run/hunt_oracle_C2.log 2>/dev/null \
+  || { echo "FAIL: oracle cell did not POST its lead to the blackboard" >&2; FAIL=1; }
+grep -q '^BLACKBOARD-FOCUS|liquidation|C2|' "$OUT"/run/hunt_liquidation_C2.log 2>/dev/null \
+  || { echo "FAIL: liquidation cell did not log being steered by the blackboard" >&2; FAIL=1; }
+grep -q 'Inter-agent coordination (blackboard' "$REPORT" 2>/dev/null \
+  || { echo "FAIL: report is missing the coordination section" >&2; FAIL=1; }
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "PASS: cell 1 (oracle/C2) posted a lead; cell 2 (liquidation/C2) READ it from the blackboard and"
+  echo "      was steered to corroborate it — one cell's finding changed what a later cell did. (#1001)"
+  exit 0
+fi
+echo "DEMO FAILED — see $RUN_LOG" >&2
+exit 1

--- a/dark-factory/run-discovery.sh
+++ b/dark-factory/run-discovery.sh
@@ -113,7 +113,10 @@ REPORT="$OUT/discovery-report.md"
   echo "|---|---|---|"
 } > "$REPORT"
 
-CELLS=0 ; CANDIDATES=0
+CELLS=0 ; CANDIDATES=0 ; STEERS=0
+# #1001: rows recording where one cell's lead STEERED a later cell (the blackboard coordination loop),
+# folded into the report at the end. Kept separate from $REPORT so it can be appended as its own table.
+COORD="$RUN/coordination.tsv"; : > "$COORD"
 # Manifest loop: one subsystem per line, `subsystem | classes | files`. Run the hunter once per
 # (subsystem x class) — that cell is the colony-native analogue of one focused audit agent.
 while IFS='|' read -r SUBSYS CLS_CSV FILES_CSV || [ -n "${SUBSYS:-}" ]; do
@@ -148,14 +151,29 @@ while IFS='|' read -r SUBSYS CLS_CSV FILES_CSV || [ -n "${SUBSYS:-}" ]; do
         SLICER="$RUN/slice-fns.sh" \
         "$AGENTIS" go hunter.ag --enable-exec --enable-messaging ) >"$CELL_LOG" 2>&1 || \
         echo "run-discovery.sh: hunter run failed for $CLS/'$SUBSYS' (see $CELL_LOG)" >&2
+    # #1001 coordination: the hunter reads a shared BLACKBOARD before it prompts and posts every
+    # CANDIDATE back to it, so a lead an EARLIER cell found steers later cells (corroborate / pivot).
+    # Surface both halves of that loop to the operator and the report: BLACKBOARD-FOCUS| = THIS cell was
+    # steered by a sibling's lead; BLACKBOARD-POST| = this cell posted a lead for later cells.
+    if grep -q '^BLACKBOARD-FOCUS|' "$CELL_LOG"; then
+      FOCUS_LINE="$(grep '^BLACKBOARD-FOCUS|' "$CELL_LOG" | head -1 | sed 's/^BLACKBOARD-FOCUS|//')"
+      echo "run-discovery.sh:   ↳ COORDINATION: $CLS/'$SUBSYS' steered by the blackboard ($FOCUS_LINE)" >&2
+      printf '| %s | %s | steered by blackboard — %s |\n' "$SUBSYS" "$CLS" "$FOCUS_LINE" >> "$COORD"
+      STEERS=$((STEERS + 1))
+    fi
     # The hunter's contract: a `CANDIDATE|file:fn:line|class|severity|exploit|poc` line, or `SAFE`.
-    if grep -q 'CANDIDATE|' "$CELL_LOG"; then
+    # Exclude the hunter's own `BLACKBOARD-*` diagnostic lines: they echo a lead summary (which no longer
+    # carries a bare `CANDIDATE|` token, but stay defensive) and must never be scraped as findings.
+    if grep -v '^BLACKBOARD-' "$CELL_LOG" | grep -q 'CANDIDATE|'; then
       while IFS= read -r LINE; do
         CAND="$(printf '%s' "$LINE" | sed 's/^.*\(CANDIDATE|\)/\1/')"
         BODY="$(printf '%s' "$CAND" | sed 's/^CANDIDATE|//; s/|/ \/ /g')"
         printf '| %s | %s | %s |\n' "$SUBSYS" "$CLS" "$BODY" >> "$REPORT"
         CANDIDATES=$((CANDIDATES + 1))
-      done < <(grep 'CANDIDATE|' "$CELL_LOG")
+      done < <(grep -v '^BLACKBOARD-' "$CELL_LOG" | grep 'CANDIDATE|')
+      if grep -q '^BLACKBOARD-POST|' "$CELL_LOG"; then
+        echo "run-discovery.sh:   ↳ posted a lead to the blackboard for later cells to focus on" >&2
+      fi
     fi
     IFS=','
   done
@@ -171,8 +189,26 @@ fi
   echo "Cells run: $CELLS    Candidates surfaced: $CANDIDATES (all UNVERIFIED — forge-verify each before it counts)."
 } >> "$REPORT"
 
+# #1001: append the coordination table — where a lead from one cell STEERED a later cell via the shared
+# blackboard. This is what makes the run more than a sum of independent audits: emit it whenever any
+# cell was steered, so the operator can see the inter-agent influence (and audit it).
+if [ "$STEERS" -gt 0 ]; then
+  {
+    echo
+    echo "## Inter-agent coordination (blackboard, #1001)"
+    echo
+    echo "A cell that surfaces a CANDIDATE posts it to a shared in-run blackboard; every later cell reads"
+    echo "the board and is steered to corroborate a sibling's hit or pivot to a related surface. Cells"
+    echo "steered this run:"
+    echo
+    echo "| Subsystem | Class | Steer |"
+    echo "|---|---|---|"
+    cat "$COORD"
+  } >> "$REPORT"
+fi
+
 echo >&2
-echo "================ DISCOVERY: $CELLS cells, $CANDIDATES candidate(s) ================" >&2
+echo "================ DISCOVERY: $CELLS cells, $CANDIDATES candidate(s), $STEERS blackboard-steered ================" >&2
 echo "run-discovery.sh: leads at $REPORT" >&2
 if [ "$CANDIDATES" -gt 0 ]; then
   echo "run-discovery.sh: NEXT = verify each lead with evm-harness/forge-verify.sh; only a PASSING PoC is a finding. Submission stays human-gated." >&2


### PR DESCRIPTION
Closes #1001

## What

The discovery colony's `run-discovery.sh` fans out one-shot `hunter.ag` audits over every
(subsystem × class) cell. Until now those cells were islands — they never saw each other's findings, so
a run was a flat sum of independent audits with no colony-level behavior.

This PR adds a **first, real inter-agent coordination primitive**: a shared in-run **blackboard** over
the agentis memo store, so one cell's finding steers later cells.

- **`hunter.ag` (write):** on a `CANDIDATE`, the cell appends a one-line lead
  (`subsystem|class|file:fn:line|sev|exploit|poc`) to a rolling `dark-factory:blackboard:leads` memo and
  emits `dark-factory:lead`. A reasoned `SAFE` writes nothing — only positive findings steer.
- **`hunter.ag` (read/steer):** before it prompts, the cell reads the board. If a sibling already posted
  a lead, a **FOCUS block** is injected into the prompt telling this cell to *corroborate* a hit in the
  same subsystem, or *pivot* toward a related attack surface a sibling flagged in another subsystem. A
  printed `BLACKBOARD-FOCUS|` line makes the steer observable in the cell log.
- **`run-discovery.sh`:** logs a `↳ COORDINATION:` line when a cell is steered and a "posted a lead"
  line when one contributes, and appends an **Inter-agent coordination** table to the report.
- **`demo-blackboard.sh`:** reproduces the loop end-to-end **offline** (deterministic fake LLM, no
  network, no key) — and asserts the steer is real, not cosmetic (below).

## Demo — one cell's finding changes what a later cell does

`dark-factory/demo-blackboard.sh` runs the **real** `run-discovery.sh` against a 2-subsystem fixture (an
oracle lib + a liquidation engine that prices collateral through it). Cell 1 (`oracle/C2`) finds a
stale-price lead and posts it; cell 2 (`liquidation/C2`) reads the board and is steered. The fake LLM
**asserts cell 2's prompt actually contained cell 1's lead** before it answers, so the steer is proven,
not just logged.

```
================= run-discovery.sh log (coordination lines) =================
run-discovery.sh: hunting C2 on 'oracle' ...
run-discovery.sh:   ↳ posted a lead to the blackboard for later cells to focus on
run-discovery.sh: hunting C2 on 'liquidation' ...
run-discovery.sh:   ↳ COORDINATION: C2/'liquidation' steered by the blackboard (liquidation|C2|focusing on leads sibling cells posted: oracle|C2|OracleLib.sol:getPrice:7|C2|High|missing staleness check accepts a stale price|...)
run-discovery.sh:   ↳ posted a lead to the blackboard for later cells to focus on
================ DISCOVERY: 2 cells, 2 candidate(s), 1 blackboard-steered ================

## Inter-agent coordination (blackboard, #1001)
| Subsystem | Class | Steer |
|---|---|---|
| liquidation | C2 | steered by blackboard — liquidation|C2|focusing on leads sibling cells posted: oracle|C2|OracleLib.sol:getPrice:7|C2|High|missing staleness check accepts a stale price|... |

PASS: cell 1 (oracle/C2) posted a lead; cell 2 (liquidation/C2) READ it from the blackboard and
      was steered to corroborate it — one cell's finding changed what a later cell did. (#1001)
```

## Safety / non-regression

- **Inert on a clean sweep:** no finding → no lead → the FOCUS block is `""` → the prompt is
  byte-identical to the pre-PR prompt. Verified: an all-`SAFE` run still produces 0 candidates, 0 steers,
  no coordination section, and the unchanged rigorous-negative line.
- The documented `--backend mock --only … --classes …` wiring smoke is unchanged.
- Lead summaries strip the `CANDIDATE|` token and `run-discovery.sh` excludes the hunter's
  `BLACKBOARD-*` diagnostic lines from the candidate scraper, so the board echo is never miscounted as a
  finding.
- `hunter.ag` parses clean (`agentis commit`); `run-discovery.sh` + `demo-blackboard.sh` are `bash -n`
  clean; **`./tools/colony-lint.sh` = 359 passed, 0 failed, 5 skipped**.

## Scope / follow-up (no overclaim of emergence)

This is **one** coordination step — a shared blackboard that biases later cells' prompts. The broader
emergent-behavior vision from the issue (a coordinator agent that *reprioritizes or prunes the cell
manifest* from the board — e.g. skip a class a sibling already cleared, front-load subsystems adjacent to
a hot lead) is deliberately left as follow-up. Nothing here claims emergence; it claims that findings now
propagate between agents within a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
