### PR TITLE
fix(tests): deterministic + concurrency-safe daemon-restart test tooling (#1008)

### DIFF
--- a/tools/test-llm-per-colony.sh
+++ b/tools/test-llm-per-colony.sh
@@ -50,10 +50,25 @@ FAIL=0
 pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
 fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
 
-FIXTURE_ROOT="/tmp/qa-319-pr1-fed"
-rm -rf "$FIXTURE_ROOT"
-mkdir -p "$FIXTURE_ROOT"
-trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+# Per-run unique fixture root (#1008). A fixed path like /tmp/qa-319-pr1-fed
+# collides when several copies of this test run concurrently (sibling
+# worktrees on one host under a shared colony-lint pipeline): one copy's
+# startup `rm -rf` or EXIT-trap cleanup wipes another copy's
+# start-colony.stdout mid-flight, so assert_restart_ok reads an empty file
+# and the t5 subcase fails with empty stdout AND stderr. mktemp -d gives
+# each run its own tree, so two concurrent runs never touch each other's
+# fixtures. TMPDIR is honoured when set.
+FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/qa-319-pr1-fed.XXXXXX")"
+# Cleanup reaps both the fixture tree AND any still-sleeping shim daemons
+# this run backgrounded. The shims' argv embeds the unique $FIXTURE_ROOT
+# path, so `pkill -f` matches ONLY this run's processes — a concurrent copy
+# (different mktemp dir) is never hit. This is the #1008 host-global-marker
+# rule applied here: scope every pgrep/pkill to a per-run unique token.
+cleanup() {
+    pkill -f "$FIXTURE_ROOT" 2>/dev/null || true
+    rm -rf "$FIXTURE_ROOT"
+}
+trap cleanup EXIT
 
 # The shim records every `agentis daemon ...` invocation's argv to
 # AGENTIS_RECORD_FILE so the test can grep it for --config-override pairs.
@@ -78,9 +93,19 @@ case "${1:-}" in
         if [ -n "${AGENTIS_RECORD_FILE:-}" ]; then
             printf '%s\n' "$*" >> "$AGENTIS_RECORD_FILE"
         fi
-        # Sleep just long enough for start-colony.sh's `sleep 0.5` +
-        # `kill -0` liveness probe to see us as alive.
-        sleep 1
+        # #1008: deterministic readiness, not a sleep-vs-sleep race. The
+        # OLD shim slept a fixed 1s "just long enough for start-colony.sh's
+        # `sleep 0.5`"; under host CPU contention either side's scheduling
+        # could slip and start-colony.sh's `kill -0` probe could miss us, so
+        # no `started` line was printed and the harness read empty stdout.
+        # Instead, drop a sentinel the instant we're up (so the harness can
+        # poll for genuine readiness) and then stay alive long enough for the
+        # liveness probe to observe us regardless of load. AGENTIS_READY_FILE
+        # is exported by run_for_fixture.
+        if [ -n "${AGENTIS_READY_FILE:-}" ]; then
+            : > "$AGENTIS_READY_FILE"
+        fi
+        sleep 5
         exit 0
         ;;
     memo)
@@ -149,12 +174,17 @@ run_for_fixture() {
     local tag="$1"
     local shim_dir="$FIXTURE_ROOT/$tag/shim"
     local record_file="$FIXTURE_ROOT/$tag/agentis-argv.log"
+    local ready_file="$FIXTURE_ROOT/$tag/daemon-ready"
     local fed="$FIXTURE_ROOT/$tag/dev-apprenticeship"
     build_shim "$shim_dir" "$record_file"
     : > "$record_file"
+    rm -f "$ready_file"
     # Restrict PATH to shim + minimum so the real agentis cannot leak in.
+    # AGENTIS_READY_FILE (#1008) is the deterministic readiness sentinel the
+    # shim touches the instant the simulated daemon is up.
     PATH="$shim_dir:/usr/bin:/bin" \
         AGENTIS_RECORD_FILE="$record_file" \
+        AGENTIS_READY_FILE="$ready_file" \
         bash "$fed/triage/scripts/start-colony.sh" \
             --restart-agent labeler \
             "$fed/triage/config/colony.toml" \
@@ -203,22 +233,27 @@ assert_no_config_override_token() {
 assert_restart_ok() {
     local name="$1" tag="$2"
     # start-colony.sh exits 0 on success and prints `started <agent> pid=<n> tick=<ms>`.
-    # The shim's `sleep 1` keeps the simulated agentis-daemon alive long enough
-    # for the start-colony.sh `kill -0` liveness probe.
     #
-    # Retry-with-backoff: same flush race as `read_recorded_argv` — the
-    # start-colony.sh stdout redirect can lag the immediate grep on busy
-    # hosts. Up to 10 attempts x 150ms backoff (~1.5s ceiling). See #509.
+    # #1008: deterministic readiness. The shim touches AGENTIS_READY_FILE the
+    # instant the simulated daemon is up (not a fixed sleep), so the daemon's
+    # liveness is load-independent. We poll for BOTH signals with a bounded
+    # `until`-style loop + timeout ceiling: the readiness sentinel (proves the
+    # daemon came up) and the `started` stdout line (proves start-colony.sh
+    # parsed + printed its contract). Polling, not sleeping, removes the
+    # sleep-vs-sleep race regardless of host CPU contention. The fixture dir is
+    # per-run unique (mktemp) so a concurrent copy can no longer delete this
+    # run's stdout mid-flight, which was the empty-stdout/empty-stderr failure.
     local stdout_file="$FIXTURE_ROOT/$tag/start-colony.stdout"
+    local ready_file="$FIXTURE_ROOT/$tag/daemon-ready"
     local _i
-    for _i in 1 2 3 4 5 6 7 8 9 10; do
-        if grep -qE '^started ' "$stdout_file" 2>/dev/null; then
+    for _i in $(seq 1 200); do  # 200 x 50ms = 10s ceiling, ample under load
+        if [ -f "$ready_file" ] && grep -qE '^started ' "$stdout_file" 2>/dev/null; then
             pass "$name"
             return 0
         fi
-        sleep 0.15
+        sleep 0.05
     done
-    fail "$name" "expected 'started <agent>' line in stdout: $(cat "$stdout_file" 2>/dev/null) / stderr: $(cat "$FIXTURE_ROOT/$tag/start-colony.stderr" 2>/dev/null)"
+    fail "$name" "expected 'started <agent>' line in stdout: $(cat "$stdout_file" 2>/dev/null) / stderr: $(cat "$FIXTURE_ROOT/$tag/start-colony.stderr" 2>/dev/null) / ready=$([ -f "$ready_file" ] && echo yes || echo no)"
 }
 
 # ----- t1: no [llm] block at all -----

--- a/tools/test-start-colony-multi-repo.sh
+++ b/tools/test-start-colony-multi-repo.sh
@@ -25,8 +25,12 @@ INSTALL_SH="$REPO_ROOT/dev-apprenticeship/install.sh"
 PASS=0
 FAIL=0
 TMPDIR_TEST="$(mktemp -d)"
+# #1008: per-run-unique fake-daemon marker. A fixed `pkill -f` marker reaps a
+# concurrent run's fakes (sibling worktrees on one host); appending the PID +
+# the unique mktemp basename scopes every pkill to THIS run's processes.
+RUN_MARKER="fake-daemon-for-test-316m2-$$-$(basename "$TMPDIR_TEST")"
 cleanup() {
-    pkill -f 'fake-daemon-for-test-316m2' 2>/dev/null || true
+    pkill -f "$RUN_MARKER" 2>/dev/null || true
     rm -rf "$TMPDIR_TEST"
 }
 trap cleanup EXIT
@@ -36,8 +40,9 @@ fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
 skip() { echo "[SKIP] $1${2:+: $2}"; }
 
 # Shim: stub `agentis` so daemon launch dumps env then sleeps. The
-# `exec -a fake-daemon-for-test-316m2 sleep 5` form rewrites argv[0]
-# so the EXIT-trap pkill -f marker can find and reap the stray sleeps.
+# `exec -a "$T316M2_MARKER" sleep 5` form rewrites argv[0] to the per-run
+# unique marker (#1008) so the EXIT-trap pkill -f can reap THIS run's stray
+# sleeps without hitting a concurrent run's. The marker arrives via env.
 SHIM_DIR="$TMPDIR_TEST/shim"
 mkdir -p "$SHIM_DIR"
 cat > "$SHIM_DIR/agentis" <<'SHIM'
@@ -46,7 +51,7 @@ cat > "$SHIM_DIR/agentis" <<'SHIM'
 [ "${1:-}" = "memo" ] && exit 0
 if [ "${1:-}" = "daemon" ]; then
     [ -n "${T316M2_ENV_DUMP:-}" ] && env > "$T316M2_ENV_DUMP"
-    exec -a fake-daemon-for-test-316m2 sleep 5
+    exec -a "${T316M2_MARKER:-fake-daemon-for-test-316m2}" sleep 5
 fi
 exit 0
 SHIM
@@ -57,10 +62,10 @@ chmod +x "$SHIM_DIR/agentis"
 # daemon` invocation to $2. timeout 4s caps the test budget per call.
 run_start() {
     local config="$1" envdump="$2" rc=0
-    T316M2_ENV_DUMP="$envdump" PATH="$SHIM_DIR:$PATH" \
+    T316M2_ENV_DUMP="$envdump" T316M2_MARKER="$RUN_MARKER" PATH="$SHIM_DIR:$PATH" \
         timeout 4 bash "$START" --restart-agent issue_creator "$config" \
             >"$TMPDIR_TEST/stdout" 2>"$TMPDIR_TEST/stderr" || rc=$?
-    pkill -f 'fake-daemon-for-test-316m2' 2>/dev/null || true
+    pkill -f "$RUN_MARKER" 2>/dev/null || true
     return $rc
 }
 

--- a/tools/test-start-colony-per-repo-labels.sh
+++ b/tools/test-start-colony-per-repo-labels.sh
@@ -33,8 +33,12 @@ START_TRIAGE="$REPO_ROOT/dev-apprenticeship/triage/scripts/start-colony.sh"
 PASS=0
 FAIL=0
 TMPDIR_TEST="$(mktemp -d)"
+# #1008: per-run-unique fake-daemon marker. A fixed `pkill -f` marker reaps a
+# concurrent run's fakes (sibling worktrees on one host); appending the PID +
+# the unique mktemp basename scopes every pkill to THIS run's processes.
+RUN_MARKER="fake-daemon-for-test-316m5a-$$-$(basename "$TMPDIR_TEST")"
 cleanup() {
-    pkill -f 'fake-daemon-for-test-316m5a' 2>/dev/null || true
+    pkill -f "$RUN_MARKER" 2>/dev/null || true
     rm -rf "$TMPDIR_TEST"
 }
 trap cleanup EXIT
@@ -44,9 +48,9 @@ fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
 
 # Shim `agentis` so all `agentis memo set ...` calls land in a log file.
 # Each invocation appends one line: `memo set <key> <value>`. Daemon
-# launches still execute (rewritten to `sleep`) so the script reaches
-# the post-memo-seeding `agentis daemon` arm; the EXIT-trap pkill -f
-# marker reaps the strays.
+# launches still execute (rewritten to `sleep` with the per-run-unique
+# $RUN_MARKER as argv[0], #1008) so the script reaches the post-memo-seeding
+# `agentis daemon` arm; the EXIT-trap pkill -f marker reaps THIS run's strays.
 SHIM_DIR="$TMPDIR_TEST/shim"
 mkdir -p "$SHIM_DIR"
 MEMO_LOG="$TMPDIR_TEST/memo-calls.log"
@@ -62,7 +66,7 @@ if [ "\${1:-}" = "daemon" ] && [ "\${2:-}" = "list" ]; then
     exit 0
 fi
 if [ "\${1:-}" = "daemon" ]; then
-    exec -a fake-daemon-for-test-316m5a sleep 2
+    exec -a "$RUN_MARKER" sleep 2
 fi
 exit 0
 SHIM
@@ -77,7 +81,7 @@ run_start() {
     : > "$MEMO_LOG"
     PATH="$SHIM_DIR:$PATH" timeout 4 bash "$START_TRIAGE" "$config" \
         >"$TMPDIR_TEST/stdout" 2>"$TMPDIR_TEST/stderr" || rc=$?
-    pkill -f 'fake-daemon-for-test-316m5a' 2>/dev/null || true
+    pkill -f "$RUN_MARKER" 2>/dev/null || true
     return $rc
 }
 

--- a/tools/test-start-colony-restart.sh
+++ b/tools/test-start-colony-restart.sh
@@ -25,12 +25,21 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PASS=0
 FAIL=0
 TMPDIR_TEST="$(mktemp -d)"
+# #1008: per-run-unique fake-daemon marker. The marker was a fixed string
+# (`fake-daemon-inner-for-test-285`); under concurrent runs (sibling
+# worktrees on one host, shared colony-lint pipeline) the `pgrep -cf` count
+# in test_no_duplicate_on_restart matched ANOTHER run's fakes too, so the
+# "exactly 1 live daemon" assertion saw 2+ and flaked, and the cleanup
+# `pkill -f` reaped the other run's fakes mid-flight. Appending the PID +
+# the unique mktemp basename makes the marker collision-proof, so every
+# pgrep/pkill below matches ONLY this run's processes. The `-for-test-285`
+# stem is retained so the string still cannot collide with a real
+# `agentis daemon-inner` on the contributor's machine.
+RUN_MARKER="fake-daemon-inner-for-test-285-$$-$(basename "$TMPDIR_TEST")"
 # Kill any surviving fake daemons spawned by test_no_duplicate_on_restart
-# before the tmpdir is removed. The marker is deliberately unique (suffix
-# -for-test-285) so pkill cannot hit a real agentis process on the
-# contributor's machine.
+# before the tmpdir is removed. Scoped to this run's unique marker.
 cleanup() {
-    pkill -f 'fake-daemon-inner-for-test-285' 2>/dev/null || true
+    pkill -f "$RUN_MARKER" 2>/dev/null || true
     rm -rf "$TMPDIR_TEST"
 }
 trap cleanup EXIT
@@ -224,8 +233,8 @@ test_no_duplicate_on_restart() {
 
     # Dedicated shim dir. `agentis` impersonation:
     #   - `agentis daemon list --json` → JSON array of currently-alive
-    #     fake-daemon-inner-for-test-285 processes (colony, source, pid,
-    #     agent_id), constructed by pgrep-ing the marker.
+    #     $RUN_MARKER processes (colony, source, pid, agent_id),
+    #     constructed by pgrep-ing the per-run-unique marker.
     #   - `agentis daemon <path> --colony X ...` → exec into the long-sleep
     #     fake whose argv contains the marker and the agent source path
     #     (matchable by pgrep -f).
@@ -233,7 +242,10 @@ test_no_duplicate_on_restart() {
     local SHIM_BG_DIR="$TMPDIR_TEST/shim_bg_$colony"
     mkdir -p "$SHIM_BG_DIR"
 
-    cat > "$SHIM_BG_DIR/fake-daemon-inner-for-test-285" <<'FAKE'
+    # #1008: the fake-daemon binary is named with the per-run-unique
+    # $RUN_MARKER so its argv (and the pgrep that counts it) cannot collide
+    # with a concurrent run's fakes.
+    cat > "$SHIM_BG_DIR/$RUN_MARKER" <<'FAKE'
 #!/bin/bash
 # Long-lived stand-in for a real `agentis daemon-inner` child. Exits on
 # SIGTERM so the kill-before-spawn block exercises the TERM + 5s poll path
@@ -241,15 +253,18 @@ test_no_duplicate_on_restart() {
 trap 'exit 0' TERM
 while :; do sleep 60 & wait $!; done
 FAKE
-    chmod +x "$SHIM_BG_DIR/fake-daemon-inner-for-test-285"
+    chmod +x "$SHIM_BG_DIR/$RUN_MARKER"
 
     cat > "$SHIM_BG_DIR/agentis" <<SHIM
 #!/bin/bash
 SHIM_BG_DIR="$SHIM_BG_DIR"
+RUN_MARKER="$RUN_MARKER"
 if [ "\${1:-}" = "daemon" ] && [ "\${2:-}" = "list" ]; then
-    python3 - "\$SHIM_BG_DIR" <<'PY'
+    python3 - "\$RUN_MARKER" <<'PY'
 import json, os, re, subprocess, sys
-marker = os.path.basename(sys.argv[1] + '/fake-daemon-inner-for-test-285')
+# #1008: pgrep the per-run-unique marker (passed as argv[1]) so the
+# registry only ever reflects THIS run's fakes, never a sibling run's.
+marker = sys.argv[1]
 try:
     out = subprocess.check_output(
         ['pgrep', '-af', marker], stderr=subprocess.DEVNULL, text=True
@@ -263,7 +278,7 @@ for line in out.splitlines():
         continue
     pid = int(m.group(1))
     argv = m.group(2)
-    # Fake argv: "<shim>/fake-daemon-inner-for-test-285 <source.ag> <colony>".
+    # Fake argv: "<shim>/<marker> <source.ag> <colony>".
     m2 = re.search(r'(\S+\.ag)\s+(\S+)$', argv)
     if not m2:
         continue
@@ -289,7 +304,7 @@ if [ "\${1:-}" = "daemon" ]; then
             *) shift ;;
         esac
     done
-    exec "\$SHIM_BG_DIR/fake-daemon-inner-for-test-285" "\$script_path" "\$colony"
+    exec "\$SHIM_BG_DIR/\$RUN_MARKER" "\$script_path" "\$colony"
 fi
 exit 0
 SHIM
@@ -327,7 +342,7 @@ SHIM
         return
     fi
 
-    local pgrep_pat="fake-daemon-inner-for-test-285.*agents/${agent}\\.ag"
+    local pgrep_pat="$RUN_MARKER.*agents/${agent}\\.ag"
     local restart_ok=1
     for iter in 1 2 3; do
         out="$TMPDIR_TEST/$colony.dup_iter$iter.log"


### PR DESCRIPTION
Closes #1008

## Root cause

Both the `t5: --restart-agent` subcase of `tools/test-llm-per-colony.sh` and the `#285` count-invariant subcase of `tools/test-start-colony-restart.sh` flaked under host CPU contention (several `colony-lint.sh` runs executing concurrently across worktrees on one machine). The cause is **host-global shared state in the test fixtures**, not product code.

**`tools/test-llm-per-colony.sh` (the t5 flake in the issue):** the test used a fixed fixture root `/tmp/qa-319-pr1-fed` with a startup `rm -rf` + an EXIT-trap `rm -rf`. When several copies run concurrently, one copy's cleanup wipes another copy's `start-colony.stdout` mid-flight, so `assert_restart_ok` reads an empty file and fails with **empty stdout AND empty stderr** — the exact symptom reported.

I instrumented this to separate the two suspected causes:

| condition | t5 result |
|---|---|
| single isolated run, host load avg 26+ | passes (the `sleep 0.5` + `kill -0 $!` is robust: `$!` is the shim's PID, alive for its whole sleep) |
| 8 runs **sequential** under load | **0/8 fail** |
| 24 runs **concurrent** under load | **16/24 fail** |

So the shared-fixture collision is the dominant cause, not the sleep itself. The issue also asks for a deterministic readiness handshake to remove any residual sleep-vs-sleep race, which is done below.

**`tools/test-start-colony-restart.sh` (the QA-confirmed sibling flake):** the fake-daemon marker was a fixed string (`fake-daemon-inner-for-test-285`). Under concurrency, `pgrep -cf` counted **another** run's fakes (assertion saw `2`) and the cleanup `pkill -f` reaped another run's fakes (`0`). Demonstrated against the pristine `main` version run as 3 concurrent copies under load: the `pgrep` output literally showed a copy in fixture `tmp.ccmldn02R6` counting a fake from a different mktemp dir because the marker string was identical.

## Fix (test-only, no product change)

1. **Readiness race (`tools/test-llm-per-colony.sh` t5):** replaced the fixed `sleep`-based handshake with a deterministic one. The shim touches an `AGENTIS_READY_FILE` sentinel the instant the simulated daemon is up, and `assert_restart_ok` polls that sentinel (plus the `started` line) with a bounded loop and a timeout ceiling instead of relying on a fixed sleep. Removes the race regardless of host load. The printed contract `started <agent> pid=<n> tick=<ms>` is unchanged.

2. **Per-run-unique fixture root (`tools/test-llm-per-colony.sh`):** `FIXTURE_ROOT` is now `mktemp -d` instead of `/tmp/qa-319-pr1-fed`, so two concurrent runs never touch each other's fixtures. EXIT cleanup also `pkill`s this run's shim daemons, scoped to the unique fixture-root token.

3. **Per-run-unique fake-daemon marker (`tools/test-start-colony-restart.sh`):** the marker is now `<stem>-$$-<mktemp-basename>` and threaded through the fake binary name, the `daemon list` `pgrep`, the `exec`, and the count `pgrep`. Two concurrent runs can no longer see each other's fakes.

4. **Same marker-collision fix applied to the two siblings using the identical pattern:** `tools/test-start-colony-multi-repo.sh` (`316m2`) and `tools/test-start-colony-per-repo-labels.sh` (`316m5a`) both used a fixed `pkill -f` marker that reaps a concurrent run's fakes; both now use a per-run-unique marker.

**Product `dev-apprenticeship/triage/scripts/start-colony.sh` is NOT touched.** The instrumentation above proved the `sleep 0.5` pre-flight is not the racing element (an isolated run never failed even under heavy load), so the fix stays entirely in the test tooling — the preferred outcome.

## Under-load before/after proof

Method: 3 concurrent copies per test, 6-8 iterations, with a CPU-burn background load saturating all cores (the issue's "several concurrent colony-lint runs" scenario).

| subcase | before (pristine `main`) | after |
|---|---|---|
| `test-llm-per-colony.sh` t5 (24 concurrent runs) | **16/24 FAIL** (empty stdout AND stderr) | **0/24 FAIL** |
| `test-start-colony-restart.sh` #285 count invariant (18 concurrent runs) | **13/18 FAIL** (`got 2` / `got 0` cross-run contamination) | **0/18 FAIL** |
| combined (24 concurrent copies each, moderate load) | — | t5 0, #285-count 0 |

Sample pre-fix failure showing the cross-run contamination (pristine `main`):
```
[FAIL] triage: iter2 expected exactly 1 live fake, got 2: pgrep=2550199 .../tmp.ccmldn02R6/shim_bg_triage/fake-daemon-i...
[FAIL] triage: iter1 expected exactly 1 live fake, got 0
```

Validation:
- `./tools/colony-lint.sh` from repo root: **363 passed, 0 failed, 5 skipped**.
- `bash -n` clean on all four edited scripts.
- `shellcheck` clean on all four edited scripts.

## Note on a separate, out-of-scope flake

At an artificially extreme load (avg ~32, well beyond the "several concurrent lint runs" scenario), a different subcase of `test-start-colony-restart.sh` — the `pipe-regression` check that runs `python subprocess.run(..., timeout=3)` against a `sleep 5` shim — can hit its hardcoded 3s wall-clock purely from scheduler starvation (`elapsed=3.01`). This subcase is not part of #1008, is unmodified here, and is clean at realistic concurrency (0 failures in the combined run above). Filed #1018 to harden that hardcoded timeout separately rather than expand this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
