### PR TITLE
feat(dark-factory): default LLM backend to flat-rate flat-cyborg

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,20 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Changed
+
+- **Default LLM backend across the live-reasoning orchestrators switched from the metered `claude -p`
+  path to the flat-rate `flat-cyborg` PTY-wrapper backend** (`llm.backend = flat-cyborg`). `run-audit.sh`,
+  `run-discovery.sh`, `run-refute.sh`, and `calibrate-evm.sh` now default `BACKEND=flat-cyborg`;
+  `run-method-discovery.sh` and `calibrate-sealevel.sh` (previously hardcoded `claude`) emit a
+  `flat-cyborg` config; `run-coordinator.sh` gains a `--backend flat-cyborg` branch (its default stays
+  `mock`). `--backend claude` remains the explicit metered `-p` opt-in for fidelity-critical work, and
+  `--backend mock` (offline-deterministic) is unchanged. Docs/examples (README, RUNBOOK,
+  run-observability) updated to show the flat-rate default. **Requires:** agentis >= 1.19.0 (the
+  `flat-cyborg` LLM backend) and a `flat-cyborg` binary with `--no-jitter` (>= v0.9.0) on PATH. Note:
+  `--extract` is a TUI screen-scrape — for reads where a refusal/malformed reply must never be misread,
+  prefer `--backend claude` (fidelity hardening tracked in `Replikanti/flat-cyborg#42`).
+
 ### Added
 
 - Discovery: **self-orchestrating coordinator — fact-based, evolving decision policy** (v1 of #1014). The

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -99,17 +99,17 @@ choose** and, on a VERIFIED finding, stages a **human-gated** submission package
 ```bash
 # native solana-program target
 dark-factory/run-audit.sh --target "$PWD/path/to/program.rs" \
-    --harness "$PWD/dark-factory/solana-harness" --backend claude
+    --harness "$PWD/dark-factory/solana-harness"   # default backend = flat-cyborg (flat-rate); add --backend claude for the metered -p path
 
 # Anchor target (+ optional frozen on-chain snapshot for state replay)
 dark-factory/run-audit.sh --target "$PWD/path/to/lib.rs" \
     --anchor-harness "$PWD/dark-factory/solana-harness-anchor" \
-    --snapshot "$PWD/snap.txt" --backend claude --out "$PWD/audit-out"
+    --snapshot "$PWD/snap.txt" --out "$PWD/audit-out"
 
 # EVM/Solidity target (M1: Reentrancy) — verified through the real EVM (revm).
 # One-time host-side: (cd dark-factory/evm-harness && npm i solc)   # pins solc 0.8.26 for compile.js
 dark-factory/run-audit.sh --target "$PWD/path/to/Contract.sol" \
-    --evm-harness "$PWD/dark-factory/evm-harness" --backend claude --out "$PWD/audit-out"
+    --evm-harness "$PWD/dark-factory/evm-harness" --out "$PWD/audit-out"
 ```
 
 On `Verdict: VERIFIED` the package lands at `<out>/submission/`: `report.md` (Immunefi-format,
@@ -141,7 +141,7 @@ The operator supplies three inputs and the colony fans out one substrate agent p
 ```bash
 dark-factory/run-discovery.sh \
     --repo "$PWD/target" --scope "$PWD/scope.tsv" --brief "$PWD/brief.md" \
-    --backend claude --out "$PWD/discovery-out"
+    --out "$PWD/discovery-out"
 # cheap wiring smoke (no real LLM):  add  --backend mock --only "<subsystem>" --classes C1
 ```
 
@@ -238,7 +238,7 @@ and verdict — that a monitor or dashboard can poll. It only reads what the run
 
 ```bash
 dark-factory/run-discovery.sh --repo "$PWD/target" --scope scope.tsv --brief brief.md \
-    --backend claude --out "$PWD/discovery-out"
+    --out "$PWD/discovery-out"
 dark-factory/run-summary.sh --out "$PWD/discovery-out"          # -> discovery-out/run-summary.json
 dark-factory/run-summary.sh --out "$PWD/discovery-out" --json | jq .verdict   # stdout is pure JSON
 dark-factory/run-summary.sh --out "$PWD/discovery-out" --emit-event           # + one NDJSON event line
@@ -260,7 +260,7 @@ cross-function audit, build-and-run PoC, fork-differential) onto the substrate.
 
 ```bash
 # candidates.tsv: `file:fn | classid | severity | claimed exploit | code-file`  (one per line)
-dark-factory/run-refute.sh --candidates "$PWD/candidates.tsv" --backend claude --out "$PWD/refute-out"
+dark-factory/run-refute.sh --candidates "$PWD/candidates.tsv" --out "$PWD/refute-out"
 # cheap wiring smoke (no real LLM):  add  --backend mock
 ```
 

--- a/dark-factory/calibrate-evm.sh
+++ b/dark-factory/calibrate-evm.sh
@@ -10,19 +10,20 @@
 #     hard blocker: a false-VERIFIED on a safe target is a ban-list risk on a live platform).
 #
 # Detection uses the configured LLM backend (the real classify_evm_llm). With the default
-# claude backend each class routes to its specific invariant; the mock backend has no class
-# router (it falls back to the structural reentrancy heuristic), so the per-class true-positive
-# tally is only meaningful under claude — run with the default BACKEND to populate the scorecard.
+# under a reasoning backend (the default flat-cyborg, or claude) each class routes to its specific
+# invariant; the mock backend has no class router (it falls back to the structural reentrancy
+# heuristic), so the per-class true-positive tally is only meaningful under a reasoning backend —
+# run with the default BACKEND to populate the scorecard.
 # The two-sided gate (CONTROL OK: + INVARIANT VIOLATED: + exit 101) is what makes a safe variant
 # resolve to a non-VERIFIED verdict even if detection over-flags it.
 #
-# Usage: AGENTIS=/path/to/agentis [BACKEND=claude] [EVM_HARNESS_DIR=/path/to/warm/harness] \
+# Usage: AGENTIS=/path/to/agentis [BACKEND=flat-cyborg] [EVM_HARNESS_DIR=/path/to/warm/harness] \
 #        ./calibrate-evm.sh [out.md]
 set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="${AGENTIS:-agentis}"
-BACKEND="${BACKEND:-claude}"
+BACKEND="${BACKEND:-flat-cyborg}"
 HARNESS="${EVM_HARNESS_DIR:-$HERE/evm-harness}"
 CORPUS="$HERE/evm-harness/contracts"
 OUT="${1:-$HERE/evm-scorecard.md}"

--- a/dark-factory/calibrate-sealevel.sh
+++ b/dark-factory/calibrate-sealevel.sh
@@ -44,7 +44,7 @@ run_one() {
     cd "$d" || exit 1
     "$AGENTIS" init >/dev/null 2>&1
     printf '%s\n' \
-      'llm.backend = claude' 'llm.command = claude' 'llm.args = -p' \
+      'llm.backend = flat-cyborg' \
       'llm.cli_timeout_ms = 180000' 'trace.level = quiet' \
       'exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_ANCHOR_HARNESS_DIR' \
       'exec.default_timeout_ms = 180000' > .agentis/config

--- a/dark-factory/demo-blackboard.sh
+++ b/dark-factory/demo-blackboard.sh
@@ -104,9 +104,12 @@ chmod +x "$BIN/claude"
 echo "demo-blackboard.sh: running run-discovery.sh (offline, fake LLM) ..." >&2
 RUN_LOG="$WORK/run.log"
 set +e
+# --backend claude is REQUIRED here: the fake LLM stood up on PATH above is a fake `claude`,
+# so the run must pin the claude backend (which honors llm.command). The default flat-cyborg
+# backend ignores llm.command and would drive the real claude TUI — defeating the offline demo.
 PATH="$BIN:$PATH" "$HERE/run-discovery.sh" \
   --repo "$REPO" --scope "$WORK/scope.tsv" --brief "$WORK/brief.md" \
-  --out "$OUT" >"$RUN_LOG" 2>&1
+  --backend claude --out "$OUT" >"$RUN_LOG" 2>&1
 RC=$?
 set -e
 

--- a/dark-factory/demo-blackboard.sh
+++ b/dark-factory/demo-blackboard.sh
@@ -106,7 +106,7 @@ RUN_LOG="$WORK/run.log"
 set +e
 PATH="$BIN:$PATH" "$HERE/run-discovery.sh" \
   --repo "$REPO" --scope "$WORK/scope.tsv" --brief "$WORK/brief.md" \
-  --backend claude --out "$OUT" >"$RUN_LOG" 2>&1
+  --out "$OUT" >"$RUN_LOG" 2>&1
 RC=$?
 set -e
 

--- a/dark-factory/docs/RUNBOOK.md
+++ b/dark-factory/docs/RUNBOOK.md
@@ -27,13 +27,13 @@ The **operator** chooses the in-scope program (this tool never auto-picks a scop
 - `--snapshot <file>` — optional frozen on-chain state to replay against. Produce one with:
   `./snapshot-rpc.sh --rpc <RPC_URL> --out snap.txt <ACCOUNT_PUBKEY> [...]`
   (host-side; for a live target the operator dumps that program's own accounts).
-- `--backend claude|mock` — real LLM (default) or offline-deterministic.
+- `--backend flat-cyborg|claude|mock` — flat-rate PTY wrapper driving claude (default), metered claude `-p` API, or offline-deterministic mock.
 
 ## 3. Run
 
 ```
 ./run-audit.sh --target <program.rs> --anchor-harness ./solana-harness-anchor \
-               --backend claude --out audit-out
+               --out audit-out
 ```
 
 The run is sandboxed with the hardened profile by default (`--unshare-all`, network closed;
@@ -95,7 +95,7 @@ agent (`auditor/agents/hunter.ag`) out over (subsystem × bug-class).
 4. **Run** (each cell is a deep adversarial LLM read — ~3 min typical, up to ~8 min for a deep
    liquidation/redemption cell, within the 600s per-call budget; a full sweep is serial):
    ```
-   ./run-discovery.sh --repo <repo> --scope scope.tsv --brief brief.md --backend claude --out discovery-out
+   ./run-discovery.sh --repo <repo> --scope scope.tsv --brief brief.md --out discovery-out
    # cheap wiring smoke first (no real LLM):  --backend mock --only "<subsystem>" --classes C1
    ```
 5. **Read the leads** — `discovery-out/discovery-report.md`. Each `CANDIDATE` row is an **unverified

--- a/dark-factory/docs/run-observability.md
+++ b/dark-factory/docs/run-observability.md
@@ -19,7 +19,7 @@ Run it after a discovery / audit run, pointed at the **same `--out` dir**:
 ```bash
 # 1. a one-shot discovery run
 dark-factory/run-discovery.sh --repo "$PWD/target" --scope scope.tsv --brief brief.md \
-    --backend claude --out "$PWD/discovery-out"
+    --out "$PWD/discovery-out"   # default backend = flat-cyborg (flat-rate); add --backend claude for metered -p
 
 # 2. distill it into a monitor-consumable summary
 dark-factory/run-summary.sh --out "$PWD/discovery-out"

--- a/dark-factory/evm-scorecard.md
+++ b/dark-factory/evm-scorecard.md
@@ -29,9 +29,9 @@ Each pair lives alongside the M1–M3 Reentrancy + AccessControl pairs in
 ## Methodology
 
 ```bash
-# AGENTIS = a built agentis binary; BACKEND defaults to claude (the only backend with a
-# per-class router — mock falls back to the structural reentrancy heuristic and cannot
-# confirm class routing). EVM_HARNESS_DIR defaults to ./evm-harness.
+# AGENTIS = a built agentis binary; BACKEND defaults to flat-cyborg (a reasoning backend routes
+# each class to its per-class invariant — mock has no class router and falls back to the structural
+# reentrancy heuristic, so it cannot confirm class routing). EVM_HARNESS_DIR defaults to ./evm-harness.
 AGENTIS=/path/to/agentis ./calibrate-evm.sh            # writes ./evm-scorecard.md
 AGENTIS=/path/to/agentis ./calibrate-evm.sh out.md     # or a chosen output path
 ```

--- a/dark-factory/evm-scorecard.md
+++ b/dark-factory/evm-scorecard.md
@@ -46,7 +46,7 @@ a false-VERIFIED.
 
 <!-- PARTIAL — Reentrancy + AccessControl recorded from operator-confirmed M1–M3 end-to-end runs
      (real verdicts, not the script). The three new classes await a full `calibrate-evm.sh`
-     (backend=claude) pass; that run is currently THROUGHPUT-GATED, not code-gated — a single
+     (reasoning backend) pass; that run is currently THROUGHPUT-GATED, not code-gated — a single
      colony run logs ~190 `[llm] still waiting` ticks + 180s `cli_timeout` retries, so a clean
      10-run sweep is an operator action for when the claude CLI is responsive. Re-run the script
      to overwrite this section with the full machine-scored table. -->

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -36,7 +36,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 TARGET="" ; HARNESS="" ; ANCHOR_HARNESS="" ; EVM_HARNESS="" ; SNAPSHOT="" ; POC=""
 REPO="" ; IN_SCOPE="" ; CONTRACT="" ; SEED_MANIFEST="" ; SHARE_PATTERNS=""
-BACKEND="claude" ; SANDBOX="hardened" ; OUT="$PWD/audit-out" ; FUZZY_THRESHOLD="0.35" ; FUZZY_K="4" ; USE_EVOLVED=""
+BACKEND="flat-cyborg" ; SANDBOX="hardened" ; OUT="$PWD/audit-out" ; FUZZY_THRESHOLD="0.35" ; FUZZY_K="4" ; USE_EVOLVED=""
 
 need() { [ "$1" -ge 2 ] || { echo "run-audit.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -127,7 +127,9 @@ cp "$COLONY" "$RUN/auditor.ag"
 ( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
 {
   echo "llm.backend = $BACKEND"
+  # claude = metered `-p` API path (opt-in via --backend claude); flat-cyborg = flat-rate PTY wrapper (default)
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 180000"; }
+  [ "$BACKEND" = "flat-cyborg" ] && echo "llm.cli_timeout_ms = 180000"
   echo "trace.level = normal"
   echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,EVM_HARNESS_DIR,BOUNTY_SNAPSHOT,BOUNTY_REPO,BOUNTY_IN_SCOPE,BOUNTY_CONTRACT,SEED_SRC,SEED_CLASS,SEED_FUNC,FUZZY_SEEDS,FUZZY_THRESHOLD,FUZZY_K"
   echo "exec.default_timeout_ms = 180000"

--- a/dark-factory/run-coordinator.sh
+++ b/dark-factory/run-coordinator.sh
@@ -29,7 +29,8 @@
 #   --executor real   (default) route hunt->hunter.ag, refute->refuter.ag, poc-screen->poc-screener.ag,
 #                     invent-method->method-inventor.ag, deriving the OUTCOME from the agent's verdict
 #                     line. Requires the per-action env a real run would set (TARGET_DIR/IN_SCOPE/...);
-#                     this mode is the integration surface for a live audit and needs --backend claude
+#                     this mode is the integration surface for a live audit and needs a reasoning
+#                     backend (--backend flat-cyborg, flat-rate default; or --backend claude, metered)
 #                     for the agents to actually reason. (The decision is still offline-deterministic.)
 #   --executor stub --fixture <f>   OFFLINE + DETERMINISTIC: dispatch each chosen action to a scripted
 #                     outcome read from a fixture (`<action-type> <args-glob> -> confirmed|dry|refuted`).
@@ -37,7 +38,7 @@
 #
 # Usage:
 #   run-coordinator.sh --scope <file> [--class-fitness <file>] [--budget N] [--dry-cap K]
-#                      [--executor real|stub] [--fixture <f>] [--backend mock|claude]
+#                      [--executor real|stub] [--fixture <f>] [--backend mock|flat-cyborg|claude]
 #                      [--out <dir>] [--agentis <bin>]
 #
 # Scope manifest (one huntable cell per line; `#` and blank lines ignored), pipe-delimited:
@@ -102,6 +103,7 @@ cp "$COORD_AG" "$RUN/coordinator.ag"
 {
   echo "llm.backend = $BACKEND"
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 600000"; }
+  [ "$BACKEND" = "flat-cyborg" ] && echo "llm.cli_timeout_ms = 600000"
   echo "trace.level = normal"
   echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME"
   echo "exec.default_timeout_ms = 30000"
@@ -180,7 +182,8 @@ stub_outcome() {
 
 # --- real executor: dispatch to the matching agent and DERIVE the outcome from its verdict line. This is
 # the v1 integration surface; it needs the per-action env a live audit would set (TARGET_DIR/IN_SCOPE/
-# CODE_PATH/...). With --backend mock the agents do not reason, so this path is for --backend claude wiring;
+# CODE_PATH/...). With --backend mock the agents do not reason, so this path needs a reasoning backend
+# (--backend flat-cyborg, flat-rate default; or --backend claude, metered) for wiring;
 # the offline+deterministic proof uses --executor stub. We keep the routing explicit and honest.
 real_outcome() {
   _atype="$1"; _aargs="$2"

--- a/dark-factory/run-discovery.sh
+++ b/dark-factory/run-discovery.sh
@@ -32,7 +32,8 @@
 #   --taxonomy <file>   bug-taxonomy.md (default: bundled ./auditor/bug-taxonomy.md).
 #   --only <subsystem>  Hunt only the line whose subsystem label matches (smoke test / re-run one slice).
 #   --classes <ids>     Override EVERY line's class list with this comma list (e.g. C1,C2 for a cheap probe).
-#   --backend <mock|claude>  LLM backend (default: claude). mock = offline-deterministic wiring smoke.
+#   --backend <mock|flat-cyborg|claude>  LLM backend (default: flat-cyborg = flat-rate PTY wrapper;
+#                       claude = metered -p API; mock = offline-deterministic wiring smoke).
 #   --out <dir>         Output dir for the run + leads (default: ./discovery-out).
 #   --agentis <bin>     agentis binary (default: `agentis` on PATH).
 set -eu
@@ -40,7 +41,7 @@ set -eu
 HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 REPO="" ; SCOPE="" ; BRIEF="" ; TAXONOMY="" ; ONLY="" ; CLASSES_OVERRIDE=""
-BACKEND="claude" ; MODEL="" ; OUT="$PWD/discovery-out"
+BACKEND="flat-cyborg" ; MODEL="" ; OUT="$PWD/discovery-out"
 
 need() { [ "$1" -ge 2 ] || { echo "run-discovery.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -91,6 +92,7 @@ cp "$HERE/auditor/slice-fns.sh" "$RUN/slice-fns.sh"   # function-level slicer (s
   # cells time out 3x and return nothing; one 600s attempt beats three wasted 300s retries. Keep
   # cells focused with `file@fn` slicing so the common case stays fast.
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p${MODEL:+ --model $MODEL}"; echo "llm.cli_timeout_ms = 600000"; }
+  [ "$BACKEND" = "flat-cyborg" ] && { echo "llm.cli_timeout_ms = 600000"; [ -n "$MODEL" ] && echo "llm.model = $MODEL"; }
   echo "trace.level = normal"
   # The hunter reads source + the brief/taxonomy through exec sh; pass through its whole env contract.
   echo "exec.env_passthrough = TARGET_DIR,IN_SCOPE,SCOPE_BRIEF,TAXONOMY,HUNT_CLASS,SUBSYSTEM,SLICER"

--- a/dark-factory/run-method-discovery.sh
+++ b/dark-factory/run-method-discovery.sh
@@ -31,7 +31,7 @@ if [ -z "${NO_AGENTIS:-}" ] && command -v agentis >/dev/null 2>&1; then
   rd="$(mktemp -d)"; cp "$INVENTOR" "$rd/method-inventor.ag"
   cp "$REGISTRY" "$rd/registry.md"; cp "$GAP" "$rd/gap.md"
   ( cd "$rd" && agentis init >/dev/null 2>&1
-    { echo "llm.backend = claude"; echo "llm.command = claude"; echo "llm.args = -p --model $MODEL"
+    { echo "llm.backend = flat-cyborg"; [ -n "$MODEL" ] && echo "llm.model = $MODEL"
       echo "exec.env_passthrough = REGISTRY,GAP"; echo "llm.cli_timeout_ms = 300000"; echo "exec.default_timeout_ms = 30000"; } >> .agentis/config
     REGISTRY="$rd/registry.md" GAP="$rd/gap.md" agentis go method-inventor.ag --enable-exec --enable-messaging ) > "$rd/out" 2>"$rd/err"
   proposal="$(grep -m1 '^METHOD|' "$rd/out" 2>/dev/null || true)"

--- a/dark-factory/run-refute.sh
+++ b/dark-factory/run-refute.sh
@@ -33,7 +33,7 @@
 #   --only <file:fn>     Refute only the candidate whose file:fn matches (re-run / smoke one).
 #   --backend <mock|flat-cyborg|claude>  LLM backend (default: flat-cyborg = flat-rate PTY wrapper;
 #                       claude = metered -p API; mock = offline-deterministic wiring smoke).
-#   --model <id>         Optional model id passed to the claude CLI.
+#   --model <id>         Optional model id (claude: passed to the CLI; flat-cyborg: set as llm.model).
 #   --out <dir>          Output dir for the run + verdicts (default: ./refute-out).
 #   --agentis <bin>      agentis binary (default: `agentis` on PATH).
 set -eu

--- a/dark-factory/run-refute.sh
+++ b/dark-factory/run-refute.sh
@@ -31,7 +31,8 @@
 #   --code-dir <dir>     Base dir for a candidate's relative <code-file> (default: dir of --candidates).
 #   --brief <file>       Optional protocol brief (invariants + known issues to exclude). Default: none.
 #   --only <file:fn>     Refute only the candidate whose file:fn matches (re-run / smoke one).
-#   --backend <mock|claude>  LLM backend (default: claude). mock = offline-deterministic wiring smoke.
+#   --backend <mock|flat-cyborg|claude>  LLM backend (default: flat-cyborg = flat-rate PTY wrapper;
+#                       claude = metered -p API; mock = offline-deterministic wiring smoke).
 #   --model <id>         Optional model id passed to the claude CLI.
 #   --out <dir>          Output dir for the run + verdicts (default: ./refute-out).
 #   --agentis <bin>      agentis binary (default: `agentis` on PATH).
@@ -40,7 +41,7 @@ set -eu
 HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 CANDS="" ; CODE_DIR="" ; BRIEF="" ; ONLY=""
-BACKEND="claude" ; MODEL="" ; OUT="$PWD/refute-out"
+BACKEND="flat-cyborg" ; MODEL="" ; OUT="$PWD/refute-out"
 
 need() { [ "$1" -ge 2 ] || { echo "run-refute.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -92,6 +93,7 @@ fi
   echo "llm.backend = $BACKEND"
   # 600s: a hostile cross-function trace of a candidate is the same order of cost as a discovery read.
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p${MODEL:+ --model $MODEL}"; echo "llm.cli_timeout_ms = 600000"; }
+  [ "$BACKEND" = "flat-cyborg" ] && { echo "llm.cli_timeout_ms = 600000"; [ -n "$MODEL" ] && echo "llm.model = $MODEL"; }
   echo "trace.level = normal"
   # The refuter reads the candidate code + brief through exec sh; pass through its whole env contract.
   echo "exec.env_passthrough = CAND_FILE_FN,CAND_CLASS,CAND_SEVERITY,CAND_EXPLOIT,CODE_PATH,BRIEF_PATH"


### PR DESCRIPTION
## What

Switch the dark-factory **live-reasoning orchestrators** from the metered `claude -p` path to the flat-rate **flat-cyborg** PTY-wrapper backend (`llm.backend = flat-cyborg`), so audit / discovery / refute / method-discovery runs no longer bill per token.

| Script | Before | After |
|--------|--------|-------|
| `run-audit.sh`, `run-discovery.sh`, `run-refute.sh`, `calibrate-evm.sh` | default `BACKEND=claude` | default `BACKEND=flat-cyborg` |
| `run-method-discovery.sh`, `calibrate-sealevel.sh` | hardcoded `claude` config | `flat-cyborg` config (model via `llm.model`) |
| `run-coordinator.sh` | `--backend mock\|claude` | adds `--backend flat-cyborg` branch; **default stays `mock`** |

## Unchanged

- `--backend claude` remains the explicit **metered `-p` opt-in** for fidelity-critical work.
- `--backend mock` (offline-deterministic wiring smoke) is untouched.
- mock-only scripts (`demo-coordinator.sh`, `evolve-fitness.sh`) and non-LLM scripts (`recall.sh`, `evolve-matcher.sh`) are untouched.

## Why flat-cyborg

`flat-cyborg` drives the interactive `claude` TUI through a PTY wrapper on the flat-rate subscription plan, so `prompt()` returns `usage = None` (zero per-token cost) instead of billing the per-token API. Verified end-to-end: a real `prompt()` through `flat-cyborg → claude` returns the correct reply with a spend-log row carrying `cost_usd: null`.

## Requires

- **agentis >= 1.19.0** (the `flat-cyborg` LLM backend).
- a **flat-cyborg** binary with `--no-jitter` on PATH (**>= v0.9.0**).

## Fidelity note

`--extract` is a TUI screen-scrape, not a structured envelope — on a refusal/malformed reply its structural fallback can return a non-empty chrome fragment. The happy path (well-framed `prompt()`) is reliable; for reads where a malformed reply must never be misread, use `--backend claude`. Hardening is tracked in `Replikanti/flat-cyborg#42`.

Docs/examples (README, RUNBOOK, run-observability, evm-scorecard) updated to show the flat-rate default. `bash -n` + colony-lint **364/0/5** clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)