### PR TITLE
fix(dark-factory): coordinator v1 follow-ups — hunt-args parse, fixture glob doc, README spacing

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -28,6 +28,17 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   `--extract` is a TUI screen-scrape — for reads where a refusal/malformed reply must never be misread,
   prefer `--backend claude` (fidelity hardening tracked in `Replikanti/flat-cyborg#42`).
 
+### Fixed
+
+- **`run-coordinator.sh` dispatch dropped a hunt's class** (#1014 v1 follow-up). The coordinator's
+  `ACTION|<type>|<args>|<rationale>` line was parsed with a flat `cut -f3`/`-f4-`, but a `hunt`'s
+  `<args>` is two `|`-fields (`subsystem|class`) where every other action's is one. The class leaked
+  into the logged rationale and the queued PENDING candidate id was built malformed as
+  `cand-N|subsystem` instead of the documented `cand-N|subsystem|class`. The parse is now type-aware
+  (hunt → fields 3-4 for args, 5- for rationale), mirroring `demo-coordinator.sh`. Also documented the
+  stub fixture's subsystem-prefix-glob rule (an args-glob must not contain a literal `|`) and fixed
+  `README.md` heading blank-line spacing (MD022).
+
 ### Added
 
 - Discovery: **self-orchestrating coordinator — fact-based, evolving decision policy** (v1 of #1014). The

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -179,6 +179,7 @@ dark-factory/demo-blackboard.sh   # oracle cell posts a lead; downstream liquida
 
 This is one coordination step, not emergent behavior; a coordinator that reprioritizes/prunes the cell
 manifest from the board is a follow-up.
+
 ### Self-orchestrating coordinator (`run-coordinator.sh`, #1014)
 
 The fan-out above still runs in a **fixed order** chosen by a script + an operator. The coordinator moves
@@ -204,6 +205,7 @@ dark-factory/demo-coordinator.sh   # (a) distinct facts -> distinct actions; (b)
 `decide` as the selection step over its already-ranked list. v1 boundary (the shell still dispatches;
 event-driven dispatch + manifest reprioritisation are follow-up; submission stays human-gated):
 [`docs/coordinator.md`](./docs/coordinator.md).
+
 ### Pre-screen a lead before the Foundry gate (`screen-leads.sh`)
 
 `forge-verify.sh` is the heavyweight gate (a full Foundry deploy + attacker tx). Between a hunter's
@@ -226,6 +228,7 @@ A reproduced screen is still a **lead, not a finding** — verify it through `fo
 submission human-gated. Which substrate primitives the colony adopted (and why `replicate` / `delegate`
 / `decide` / Lean / confidence-tiers do **not** currently fit) is documented in
 [`docs/SUBSTRATE-PRIMITIVES.md`](./docs/SUBSTRATE-PRIMITIVES.md).
+
 ## Observe a run (`run-summary.sh`)
 
 dark-factory runs **one-shot** (`agentis go`): no daemons, no `*:confidence` memos — so the
@@ -245,6 +248,7 @@ dark-factory/run-summary.sh --out "$PWD/discovery-out" --emit-event           # 
 ```
 
 Schema + the monitor/dashboard consumer contract: [`docs/run-observability.md`](./docs/run-observability.md).
+
 ## Refute candidate leads (`run-refute.sh`)
 
 Between discovery and a (costly) Foundry PoC there is a cheaper gate: a **second, independent skeptic**

--- a/dark-factory/run-coordinator.sh
+++ b/dark-factory/run-coordinator.sh
@@ -47,6 +47,9 @@
 #   <class id> | <fitness float>            e.g.  C1 | 0.45
 # Fixture (stub mode; one rule per line, first match wins; `*` glob on args):
 #   <action-type> | <args-glob> | <confirmed|dry|refuted>   e.g.  hunt | vault* | confirmed
+#   NB: the rule is split on `|`, so <args-glob> must NOT contain a literal `|`. A hunt's args are
+#   `subsystem|class`; match them with a subsystem-prefix glob (`vault*`) whose trailing `*` spans the
+#   `|class` suffix — `vault accounting|C1` would be mis-split (the class read as the outcome field).
 #
 # Exit: 0 on a clean run that reached `stop`/budget; 2 on usage error; 3 on missing prerequisite.
 set -uo pipefail
@@ -165,6 +168,8 @@ SCOPE="$(awk -F'|' '
 
 # --- stub executor: scripted outcome for a chosen action from the fixture (first match wins; `*` glob on
 # the action ARGS). Returns confirmed|dry|refuted on stdout; `dry` if no rule matches (a benign default).
+# The fixture line is split on `|` into type|glob|outcome, so the glob must not contain a literal `|`
+# (see the Fixture note in the header): a subsystem-prefix glob matches a `subsystem|class` hunt arg.
 stub_outcome() {
   _atype="$1"; _aargs="$2"
   awk -F'|' -v at="$_atype" -v ar="$_aargs" '
@@ -237,9 +242,19 @@ while [ "$STEP" -lt "$BUDGET" ]; do
   ACTION_LINE="$(grep -E '^ACTION\|' "$DEC_LOG" | head -1)"
   [ -n "$ACTION_LINE" ] || { echo "run-coordinator.sh: no ACTION line at step $STEP (see $DEC_LOG)" >&2; exit 1; }
 
+  # Parse `ACTION|<type>|<args>|<rationale>`. <args> is a SINGLE `|`-field for refute/poc-screen
+  # (a `cand-id`) and "" for invent-method/stop, but TWO fields for a hunt (`subsystem|class`). So the
+  # field where the rationale begins is type-dependent — a flat `cut -f3`/`-f4-` would otherwise drop a
+  # hunt's class into the rationale and build a malformed `cand-N|subsystem` PENDING id. Mirrors the
+  # field shape demo-coordinator.sh's `expect` helper documents.
   ATYPE="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f2)"
-  AARGS="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f3)"
-  ARATIONALE="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f4-)"
+  if [ "$ATYPE" = "hunt" ]; then
+    AARGS="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f3-4)"
+    ARATIONALE="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f5-)"
+  else
+    AARGS="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f3)"
+    ARATIONALE="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f4-)"
+  fi
   printf 'step=%s\taction=%s\targs=%s\tpolicy=[%s]\trationale=%s\n' "$STEP" "$ATYPE" "$AARGS" "$POLICY" "$ARATIONALE" >> "$TRACE"
   echo "run-coordinator.sh: step $STEP -> $ATYPE${AARGS:+ $AARGS}  ($ARATIONALE)" >&2
 


### PR DESCRIPTION
## What

Three non-blocking v1 follow-ups flagged in the [#1016 QA note](https://github.com/Replikanti/agentis-colonies/pull/1016) (v1 of #1014). All in the dispatch shell + docs — **`coordinator.ag` (the decider) and the decision policy are unchanged**.

| # | Fix | Kind |
|---|-----|------|
| 1 | `run-coordinator.sh` dispatch dropped a hunt's class | **bug** |
| 2 | stub fixture's `\|`-split glob collides with a full-cell glob | doc |
| 3 | `README.md` `##/###` heading blank-line spacing (MD022) | doc |

### 1 — hunt args parse (the real bug)

The dispatch loop parsed the coordinator's `ACTION|<type>|<args>|<rationale>` line with a flat `cut -f3`/`-f4-`. A **hunt**'s `<args>` is two `|`-fields (`subsystem|class`) where every other action's is one (`cand-id`, or empty). So `cut -f3` kept only `subsystem`, the `class` leaked into the logged rationale, and the queued PENDING candidate id was built malformed as `cand-N|subsystem` instead of the documented `cand-N|subsystem|class`.

Fix: type-aware parse — for `hunt`, args = fields 3-4 and rationale = 5-; all other action types unchanged. Mirrors the field shape `demo-coordinator.sh`'s `expect` helper already documents.

### 2 — stub fixture glob

`stub_outcome()` splits each fixture rule on `|` into `type|glob|outcome`, so a glob containing a literal `|` (a full `subsystem|class` cell) is mis-split. Documented the rule in the `--fixture` header block + the `stub_outcome` comment: use a subsystem-prefix glob (`vault*`) whose trailing `*` spans the `|class` suffix.

### 3 — README spacing

Blank line inserted before four `##/###` headings.

## Verification

- **Isolated parse test** — a `hunt` line yields `args=[vault accounting|C1]` with a clean rationale and a well-formed `cand-1|vault accounting|C1` id; refute/stop unchanged.
- **End-to-end stub run** (`--executor stub --backend mock`) — decision trace shows `step=0 action=hunt args=reentrancy|C8` (full cell, no leaked class) and the next step refutes the resulting `cand-0`.
- `demo-coordinator.sh` (offline coordinator demo) still **PASSes** (it asserts the full `ACTION|hunt|vault accounting|C1|...` shape).
- `colony-lint.sh` → **364 passed / 0 failed / 5 skipped**.
- `dark-factory/CHANGELOG.md` `[Unreleased] → Fixed` entry added.

## Scope

Part of #1014; this does **NOT** close the epic — the v2 event-driven substrate dispatch remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
