### PR TITLE
fix(tools): de-flake pipe-regression subcase under extreme host load (#1018)

### DIFF
--- a/tools/test-start-colony-restart.sh
+++ b/tools/test-start-colony-restart.sh
@@ -171,6 +171,11 @@ test_one_colony() {
     # every /restart. This test uses a shim that lives LONGER than the
     # subprocess.run timeout; if stdio is detached from the inherited
     # pipes the script returns in ~0.6s, otherwise Python hits TimeoutExpired.
+    # The shim sleep (30s) and the timeout (15s) are deliberately far apart:
+    # the detached path returns in ~0.6s, so 15s leaves ~14s of headroom for
+    # scheduling jitter under extreme host load (#1018 saw a 0.6s op pushed past
+    # 3s at load avg ~32), while an inherited pipe still blocks the full 30s and
+    # trips the 15s timeout. Do NOT tighten these toward each other.
     out="$TMPDIR_TEST/$colony.pipe.log"
     SHIM_PIPE_DIR="$TMPDIR_TEST/shim_pipe_$colony"
     mkdir -p "$SHIM_PIPE_DIR"
@@ -184,7 +189,7 @@ if [ "${1:-}" = "daemon" ] && [ "${2:-}" = "list" ]; then
     printf '[]\n'
     exit 0
 fi
-sleep 5
+sleep 30
 exit 0
 SHIM
     chmod +x "$SHIM_PIPE_DIR/agentis"
@@ -194,7 +199,7 @@ start = time.time()
 try:
     r = subprocess.run(
         ['bash', sys.argv[1], '--restart-agent', sys.argv[2], sys.argv[3]],
-        capture_output=True, text=True, timeout=3,
+        capture_output=True, text=True, timeout=15,
     )
     elapsed = time.time() - start
     print(f'OK rc={r.returncode} elapsed={elapsed:.2f} stdout={r.stdout.strip()!r}')


### PR DESCRIPTION
## What

Fixes the `pipe-regression` flake in `tools/test-start-colony-restart.sh` (#1018). Test-fixture-only change — no product code, no other subcase touched.

## Root cause

The `pipe-regression` subcase stands up a shim `agentis` whose daemon arm `sleep`s, then calls `start-colony.sh --restart-agent` through `subprocess.run(capture_output=True, timeout=N)`. A correctly-**detached** daemon returns in ~0.6s; a pipe-**inheriting** one blocks Python on the captured pipes until the shim exits, so the timeout fires first → `TimeoutExpired`. With `sleep 5` / `timeout=3` the detached-vs-inherited gap was only ~2.4s, so under extreme host load (~32 on a 12-core box, per the issue) scheduling jitter pushed the *detached* path's fork/exec/print past 3s too → spurious `TIMEOUT elapsed=3.01`.

## Fix

Widen the gap so jitter can't cross it:

| Knob | Before | After |
|------|--------|-------|
| pipe-regression shim `sleep` | `5` | `30` |
| Python `subprocess.run(timeout=)` | `3` | `15` |

`timeout (15) < shim_sleep (30)` is preserved, so a genuinely pipe-inheriting daemon still blocks the full 30s and trips the 15s timeout — assertion semantics (`OK rc=0` + `started …` → pass; `TimeoutExpired` → fail) unchanged. The detached path now has ~14s of jitter headroom (≈6× the observed ~3s jitter). No happy-path slowdown: the call returns as soon as `start-colony.sh` does; `timeout` is only the ceiling. A comment documents the margin so it isn't tightened back.

## Verification

- `tools/test-start-colony-restart.sh` → **26 passed / 0 failed** at normal load (all 5 pipe-regression subcases green).
- **Under-load smoke:** 24 CPU burners on a 12-core box (load avg ~6.8, ~25 runnable) → still **26/0**, every pipe-regression subcase PASS, **no `TIMEOUT`** (all detached returns well under 15s).
- `bash -n` clean; `colony-lint.sh` → 0 failures.
- No CHANGELOG entry — `tools/test-*.sh` is contributor tooling, not a versioned federation component.

Closes #1018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
