### PR TITLE
fix(tools): pipe-regression shim reaps its own sleep child (#1022)

### DIFF
--- a/tools/test-start-colony-restart.sh
+++ b/tools/test-start-colony-restart.sh
@@ -189,7 +189,17 @@ if [ "${1:-}" = "daemon" ] && [ "${2:-}" = "list" ]; then
     printf '[]\n'
     exit 0
 fi
-sleep 30
+# Background the long sleep and reap it on signal. The cleanup `pkill -f
+# "$SHIM_PIPE_DIR/agentis"` (below) reaches THIS bash process (its cmdline
+# carries the full shim path), but a foreground `sleep 30` would be a separate
+# child (argv `sleep 30`, no shim path) that pkill can't match and that would
+# linger, orphaned to systemd, for its remaining seconds (#1022). The trap
+# propagates the kill to the child. We still `wait` the full duration, so a
+# genuinely pipe-inheriting daemon still trips the subprocess.run timeout.
+sleep 30 &
+_sleep_pid=$!
+trap 'kill "$_sleep_pid" 2>/dev/null' TERM INT
+wait "$_sleep_pid"
 exit 0
 SHIM
     chmod +x "$SHIM_PIPE_DIR/agentis"


### PR DESCRIPTION
## What

Fixes #1022 — the `pipe-regression` subcase of `tools/test-start-colony-restart.sh` leaked orphaned `sleep` children after each run. Test-fixture-only change.

## Root cause (corrected from a /proc probe)

The cleanup `pkill -f "$SHIM_PIPE_DIR/agentis"` **does** reach the shim: a `#!/bin/bash` shim's detached daemon has cmdline `/bin/bash <SHIM_PIPE_DIR>/agentis daemon …`, which carries the full path. But the long-lived process is the shim's **`sleep` child** (argv `sleep 30`, no shim path). Killing the bash parent left the `sleep` reparented to `systemd --user`, running out its remaining seconds — up to one orphan per colony per run. (Made more visible after #1021 widened the shim sleep 5→30.)

## Fix

Background the sleep and trap `TERM`/`INT` to kill it, so the existing cleanup reaps the whole process tree:

```bash
sleep 30 &
_sleep_pid=$!
trap 'kill "$_sleep_pid" 2>/dev/null' TERM INT
wait "$_sleep_pid"
exit 0
```

No change to the cleanup line — it already matches the bash shim; the trap propagates the kill to the child. The shim still `wait`s the full 30s, so the detached-vs-inherited detection (an inherited pipe blocks past the 15s `subprocess.run` timeout) is unchanged.

## Verification

- **/proc probe:** after the test's exact `pkill -f "$SHIM_PIPE_DIR/agentis"`, **neither** the bash shim nor its `sleep` child survives (`ps` → none). Without the trap the `sleep 30` lingers.
- `tools/test-start-colony-restart.sh` → **26 passed / 0 failed**; `pgrep -af 'sleep 30'` shows **no orphan** after the run completes.
- `bash -n` clean; `colony-lint.sh` → **364 / 0 / 5**.
- No CHANGELOG entry — contributor test tooling, not a versioned federation component.

Closes #1022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
