### PR TITLE
feat(dark-factory): dissolve the shell loop — federation self-orchestrates in the substrate (#1014 v2 M3)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,34 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **The shell loop is DISSOLVED — the federation self-orchestrates the whole multi-step audit in the
+  substrate** (#1014 M3). Through M2 the decision and each action's dispatch lived in the substrate, but a
+  thin shell while-loop (`run-coordinator.sh`) still **drove** the loop (per step: one `agentis go`, read the
+  verdict memo, push/pop `PENDING`, advance `DRY_STREAK`/`BUDGET`, re-read the policy, append a
+  `decisions.tsv` row). M3 moves that **entire loop** into `coordinator.ag`: gated on a new
+  `ORCHESTRATE_ENABLED` fact, the top level runs the audit as a `reduce` over a budget-bounded `STEPS` list —
+  deciding, dispatching in-substrate, reading the verdict, threading `PENDING` / `DRY_STREAK` / `BUDGET` and
+  the **evolving policy** entirely in-process, and accumulating the trace — then writes the final
+  `decisions.tsv` body + evolved policy to durable memos (`coordinator:trace`, `coordinator:policy_after`).
+  The single-decision top level is refactored into a `decide_once()` fn both paths call; with
+  `ORCHESTRATE_ENABLED` **absent** the top level does **exactly one** `decide_once()`, **byte-identical** to
+  before (the #1 regression guard — `demo-coordinator.sh` is unchanged). The in-process policy is carried in
+  the loop's state in ten-thousandths and rendered `%.4f`, so it stays **byte-identical** to the shell's
+  experience-store `read_policy()` sum step for step (the loop also `learn()`s for the durable record).
+  `run-coordinator.sh` becomes a **bootstrap**: it seeds the facts + a `STEPS` budget list, fires **one**
+  `agentis go coordinator.ag` with `ORCHESTRATE_ENABLED`, and reads the final trace + policy back from the
+  memos — the per-step shell loop and all shell-side `PENDING`/`DRY_STREAK`/`BUDGET` threading are removed;
+  `--executor stub` (offline) and the `--out` trace contract still work. New `demo-orchestrate.sh` proves
+  **one** `agentis go` runs a >=3-step audit with distinct chosen actions and that the resulting
+  `decisions.tsv` + evolved policy are **byte-identical** to the M2 shell-loop output for the same
+  facts/fixture (re-run byte-identical, mock backend, zero cost). `docs/coordinator.md`, `docs/dispatch.md`,
+  and `README.md` updated. Honest scope: the loop self-orchestrates per bootstrap invocation; a long-lived
+  daemon-tick reflex (the loop running continuously without a shell bootstrap) is a separate refinement still
+  on epic #1014. Because the whole loop now runs in **one** `agentis go`, `coordinator.ag`'s `cb` budget must
+  cover every step cumulatively (it was raised 300000 → 2000000 to match the colony `cb_budget` and clear the
+  default budget with headroom). `run-coordinator.sh` rejects a `--scope`/`--fixture` cell containing the
+  reserved `@@F@@` state-field sentinel. **Requires:** agentis >= 1.19.0.
+
 - **Every action's DISPATCH moved into the substrate** (#1014 M2). M1 moved the `hunt` slice; M2
   **generalises** the dispatch to *all* action types. `dispatcher.ag`'s `hunt_dispatch` becomes a `dispatch`
   agent fn that parses the action `<type>` from the bus payload (`<type>|<args>`) and handles `hunt`,

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -191,14 +191,13 @@ call) — and an evolving **policy**, then chooses **one** next action (`hunt` /
 more hunting; prefer a blackboard-flagged subsystem and a higher-fitness lens; stop on budget/dry). The
 decision policy **evolves**: each action's confirmed-finding → success / dry-or-refuted → failure is
 recorded with the same `learn()` mechanic the lens-fitness loop uses (#996), so
-`coordinator:policy:<action-type>` reweights which decisions it leans on. `run-coordinator.sh` is a thin
-**dispatcher** (not a decider): it loops {ask the coordinator → execute the chosen action → feed the
-outcome back} until `stop`/budget. Reproduce both halves offline (no network, deterministic, mock
-backend):
+`coordinator:policy:<action-type>` reweights which decisions it leans on. Reproduce both halves offline (no
+network, deterministic, mock backend):
 
 ```bash
 dark-factory/demo-coordinator.sh   # (a) distinct facts -> distinct actions; (b) the policy measurably evolves
 dark-factory/demo-dispatch.sh      # #1014 M2: every action's DISPATCH moved into the substrate (proof, offline)
+dark-factory/demo-orchestrate.sh   # #1014 M3: ONE agentis go self-orchestrates the whole multi-step audit (proof, offline)
 ```
 
 `decide(options, criteria)` **is** a real substrate builtin, but offline it resolves to the first option
@@ -210,11 +209,22 @@ in **one** `agentis go` it also *dispatches* any real action (hunt / refute / po
 it `emit`s `dark-factory:dispatch` (payload `<type>|<args>`) over the in-process bus and a sibling agent fn
 ([`auditor/agents/dispatcher.ag`](./auditor/agents/dispatcher.ag), inlined gated in `coordinator.ag`)
 derives the gate verdict from a `DISPATCH_FIXTURE` fact and writes it to the durable
-`coordinator:last_outcome` memo — which the shell loop **reads** instead of a shell `case`. The shell
-computes **no** action's outcome (the `stub_outcome()` / `real_outcome()` functions are gone); only `stop`
-is never dispatched. Full model in [`docs/dispatch.md`](./docs/dispatch.md). v1 boundary (the live-path
-executor wiring per action is follow-up; manifest reprioritisation is follow-up; submission stays
-human-gated): [`docs/coordinator.md`](./docs/coordinator.md).
+`coordinator:last_outcome` memo. Only `stop` is never dispatched. Full model in
+[`docs/dispatch.md`](./docs/dispatch.md).
+
+**#1014 M3 — the SHELL LOOP is DISSOLVED; the federation self-orchestrates the whole audit in the
+substrate.** Through M2 a thin shell while-loop still *drove* the loop (per step: one `agentis go`, read the
+verdict memo, push/pop `PENDING`, advance `DRY_STREAK`/`BUDGET`, re-read the policy, append a `decisions.tsv`
+row). M3 moves that **entire loop** into `coordinator.ag`: gated on `ORCHESTRATE_ENABLED`, the top level runs
+the audit as a `reduce` over a budget-bounded `STEPS` list — deciding, dispatching in-substrate, reading the
+verdict, threading `PENDING` / `DRY_STREAK` / `BUDGET` and the evolving policy **entirely in-process** — and
+writes the final `decisions.tsv` body + evolved policy to durable memos. `run-coordinator.sh` is now a thin
+**bootstrap** (not a loop driver): it seeds the facts + a `STEPS` budget list, fires **one** `agentis go`,
+and reads the final trace + policy back from the memos. With `ORCHESTRATE_ENABLED` **absent** the top level
+does **exactly one** decision, **byte-identical** to before (so `demo-coordinator.sh` is unchanged). Honest
+scope: the loop self-orchestrates per bootstrap invocation; a long-lived daemon-tick reflex is a separate
+refinement. v1 boundary (the live-path executor wiring per action is follow-up; manifest reprioritisation is
+follow-up; submission stays human-gated): [`docs/coordinator.md`](./docs/coordinator.md).
 
 ### Pre-screen a lead before the Foundry gate (`screen-leads.sh`)
 
@@ -360,9 +370,10 @@ dark-factory/
   screen-leads.sh               # cheap substrate-native lead pre-screen (eval_ag) before forge-verify
   run-summary.sh                # one-shot run -> monitor-/dashboard-consumable run-summary.json (#995)
   run-refute.sh                 # operator entrypoint: adversarial refutation (refuter fan-out) -> verdicts
-  run-coordinator.sh            # loop driver for the self-orchestrating loop (coordinator decides + dispatches in-substrate; #1014 M2)
+  run-coordinator.sh            # bootstrap for the self-orchestrating loop (ONE agentis go; the loop lives in-substrate; #1014 M3)
   demo-coordinator.sh           # offline, deterministic proof of the #1014 fact-driven + evolving-policy loop
   demo-dispatch.sh              # offline, deterministic proof of the #1014 M2 substrate DISPATCH (every action type)
+  demo-orchestrate.sh           # offline, deterministic proof of the #1014 M3 in-substrate loop (byte-identical to the M2 shell loop)
   evolve-fitness.sh             # drive the evolve/fitness loop over N iterations; show per-lens fitness move
   run-method-discovery.sh       # self-improvement: invent -> validate-on-control -> adopt a new method
   state-export.sh               # export/verify/import a trained federation's evolved state (checksum-verified)
@@ -379,7 +390,7 @@ dark-factory/
     agents/refuter.ag           # the adversarial-refutation agent (independent skeptic; default REFUTED)
     agents/fitness-driver.ag    # one fitness-loop cell: hunter.ag's exact learn() over a ground-truth verdict
     agents/method-inventor.ag   # the meta-loop inventor: proposes a new audit method for a known gap (#998)
-    agents/coordinator.ag       # self-orchestrating decider: one fact+policy-driven action per call (#1014); gated in-substrate dispatch for every action type (M2)
+    agents/coordinator.ag       # self-orchestrating decider: fact+policy-driven actions (#1014); gated in-substrate dispatch for every action type (M2); gated in-substrate MULTI-STEP loop (M3)
     agents/dispatcher.ag        # the substrate action-DISPATCH agent fn (emit/listen + durable verdict memo; #1014 M2)
     agents/stateful-invariant-fuzz.ag  # generated by gen-agent.sh from the like-named method (#1000)
     methods/registry.md         # the method registry gen-agent.sh reads (METHOD| lines; #998 loop, #1000 generator)

--- a/dark-factory/auditor/agents/coordinator.ag
+++ b/dark-factory/auditor/agents/coordinator.ag
@@ -1,4 +1,4 @@
-cb 300000;
+cb 2000000;
 // #1014 — self-orchestrating COORDINATOR. ONE decision per `agentis go` invocation: read the current
 // FACTS, enumerate the audit ACTION OPTIONS, and pick the next action by a fact-criteria + evolving
 // POLICY — NOT a hardcoded sequence. This replaces the DECISION-MAKING that run-discovery.sh / an
@@ -330,148 +330,430 @@ agent dispatch() -> void {
     memo_write("dispatcher:last_check", "done");
 }
 
-// --- read FACTS ------------------------------------------------------------------------------------
-let scope = getenv("SCOPE");
-let classFit = getenv("CLASS_FITNESS");
-let policy = getenv("POLICY");
-let pending = getenv("PENDING");
-let budgetStr = getenv("BUDGET");
-let dryStr = getenv("DRY_STREAK");
-let dryCapStr = getenv("DRY_CAP");
-let prevAction = getenv("PREV_ACTION");
-let prevKey = getenv("PREV_KEY");
-let lastOutcome = getenv("LAST_OUTCOME");
+// --- ONE DECISION (+ gated dispatch), as a pure-ish fn so BOTH the single-step top-level AND the #1014
+// M3 in-process loop run the SAME code. Takes every FACT as an explicit PARAMETER (no getenv inside) so a
+// loop iteration can feed CARRIED state instead of env; performs the identical side-effects in the
+// identical order the v1 top-level did — the prev-outcome attribution (learn + policy_update emit), the
+// `ACTION|` print, the `dark-factory:decision` emit, the `coordinator:last_decision` / `:last_check`
+// memo_writes, and the DISPATCH_ENABLED-gated emit+dispatch(). Returns the chosen action as
+// `<selType>@@F@@<selArgs>` so the loop can thread PENDING / DRY_STREAK / PREV_* without re-parsing the
+// `ACTION|` line. `dispatchEnabled`/`board` are passed so a loop carries them once, not per-iteration env.
+fn decide_once(scope: string, classFit: string, policy: string, pending: string, budget: int,
+               dryStreak: int, dryCap: int, prevAction: string, prevKey: string, lastOutcome: string,
+               board: string, dispatchEnabled: bool) -> string {
+    let pendingCount = count_lines(pending);
+    let firstPending = first_line(pending);
 
-// The shared blackboard is a FACT too (a fresh lead steers which subsystem to hunt) — read it directly
-// like hunter.ag does, so a lead posted earlier THIS run influences the decision.
-let board = recall_latest("dark-factory:blackboard:leads");
-
-let budget = if len(budgetStr) == 0 { 0 } else { parse_int(budgetStr) };
-let dryStreak = if len(dryStr) == 0 { 0 } else { parse_int(dryStr) };
-let dryCap = if len(dryCapStr) == 0 { 3 } else { parse_int(dryCapStr) };
-let pendingCount = count_lines(pending);
-let firstPending = first_line(pending);
-
-// --- EVOLVE FIRST: attribute the PREVIOUS action's gate OUTCOME to its action-type so the policy that
-// ranks THIS decision already reflects it. learn() is the same call fitness-driver.ag makes; the
-// cumulative delta per action-type key is the policy weight run-coordinator.sh reads back. No learn on
-// the first step (PREV_ACTION="") — there is nothing to attribute. ----------------------------------
-let signal = outcome_signal(lastOutcome);
-if len(prevAction) > 0 {
-    if len(signal) > 0 {
-        learn("coordinator", prevAction,
-              "outcome of previous " + prevAction + " (" + prevKey + ") was " + lastOutcome,
-              signal, [prevAction, signal]);
-        emit("dark-factory:policy_update",
-             "{\"action\":\"" + prevAction + "\",\"outcome\":\"" + lastOutcome + "\",\"signal\":\"" + signal + "\"}");
+    // --- EVOLVE FIRST: attribute the PREVIOUS action's gate OUTCOME to its action-type so the policy that
+    // ranks THIS decision already reflects it. learn() is the same call fitness-driver.ag makes; the
+    // cumulative delta per action-type key is the policy weight run-coordinator.sh reads back. No learn on
+    // the first step (PREV_ACTION="") — there is nothing to attribute. ------------------------------
+    let signal = outcome_signal(lastOutcome);
+    if len(prevAction) > 0 {
+        if len(signal) > 0 {
+            learn("coordinator", prevAction,
+                  "outcome of previous " + prevAction + " (" + prevKey + ") was " + lastOutcome,
+                  signal, [prevAction, signal]);
+            emit("dark-factory:policy_update",
+                 "{\"action\":\"" + prevAction + "\",\"outcome\":\"" + lastOutcome + "\",\"signal\":\"" + signal + "\"}");
+        }
     }
+
+    // --- DECIDE: build the option list, score each from FACTS+POLICY, rank, and let `decide` select the top.
+    // `stop` short-circuits the ranking when budget is exhausted or K consecutive dry — a hard fact gate.
+    // The verify tier (pending candidate present): refute and poc-screen of the first pending candidate.
+    let pendId = if pendingCount > 0 { cell_subsystem(firstPending) } else { "" };
+    let refuteScore = score_refute(policy);
+    let pocScore = score_poc(policy);
+
+    // The hunt tier: the single best huntable cell (highest fact+policy score).
+    let bestCell = best_hunt(scope, classFit, policy, board);
+    let huntCell = if len(bestCell) == 0 { "" } else { substring(bestCell, 0, index_of(bestCell, "\t")) };
+    let huntScore = if len(bestCell) == 0 { 0.0 } else { parse_float(substring(bestCell, index_of(bestCell, "\t") + 1, len(bestCell))) };
+    let inventScore = score_invent(policy);
+
+    // Decide the action TYPE by the fact gates + argmax of the scored options. Single-assignment: compute
+    // the chosen type, args, score, and rationale as one nested expression (no `let` reassignment).
+    // Priority of HARD fact gates (these are the colony's invariants, not policy): (1) stop on budget/dry,
+    // (2) verify a pending lead before more hunting, (3) hunt the best available lens, (4) invent a method
+    // when nothing is huntable. WITHIN the verify and hunt tiers the POLICY weight (and lens/board facts)
+    // set the order, so the policy genuinely steers the choice.
+    let stopForced = if budget <= 0 { true } else { dryStreak >= dryCap };
+
+    let chosenType =
+        if stopForced { "stop" }
+        else { if pendingCount > 0 { if pocScore > refuteScore { "poc-screen" } else { "refute" } }
+        else { if len(huntCell) > 0 { if huntScore >= inventScore { "hunt" } else { "invent-method" } }
+        else { "invent-method" } } };
+
+    let chosenArgs =
+        if chosenType == "hunt" { huntCell }
+        else { if chosenType == "refute" { pendId }
+        else { if chosenType == "poc-screen" { pendId }
+        else { "" } } };
+
+    let chosenScore =
+        if chosenType == "stop" { 0.0 }
+        else { if chosenType == "refute" { refuteScore }
+        else { if chosenType == "poc-screen" { pocScore }
+        else { if chosenType == "hunt" { huntScore }
+        else { inventScore } } } };
+
+    // Substrate-native selection step: present the chosen action as the FIRST (top-ranked) entry of a
+    // `decide` option list, with the runner-up next, and let the substrate `decide` builtin make the
+    // selection. Offline `decide` returns the top-ranked option (which IS our fact+policy argmax); a real
+    // backend may arbitrate a near-tie from the criteria. Either way the ORDERING is the coordinator's,
+    // derived from facts+policy. The selected token is `<type>|<args>` (re-split below).
+    let topOption = chosenType + "|" + chosenArgs;
+    let runnerUp =
+        if chosenType == "stop" { "stop|" }
+        else { if pendingCount > 0 { "hunt|" + huntCell }
+        else { if len(huntCell) > 0 { "invent-method|" }
+        else { "stop|" } } };
+    let criteria =
+        "Pick the next audit action. The list is pre-ranked by FACTS and the evolving policy: verify a "
+      + "pending candidate before more hunting; prefer a blackboard-flagged subsystem and a higher-fitness "
+      + "lens; stop when budget is exhausted or " + to_string(dryCap) + " consecutive dry. Choose the "
+      + "highest-priority (first) action.";
+    let selected = decide([topOption, runnerUp], criteria);
+    let selType = cell_subsystem(selected);
+    let selArgs = cell_class(selected);
+
+    // --- RATIONALE: cite the FACTS that drove the choice (not an opaque pick). ------------------------
+    let factSummary =
+        "budget=" + to_string(budget) + " dry=" + to_string(dryStreak) + "/" + to_string(dryCap)
+      + " pending=" + to_string(pendingCount) + " scope_cells=" + to_string(count_lines(scope));
+    let rationale =
+        if selType == "stop" {
+            if budget <= 0 { "budget exhausted (" + factSummary + ") -> halt" }
+            else { to_string(dryStreak) + " consecutive dry >= K=" + to_string(dryCap) + " (" + factSummary + ") -> halt" }
+        }
+        else { if selType == "refute" {
+            "pending unverified candidate '" + selArgs + "' -> verify via refute before more hunting (policy hunt="
+          + to_string(fit_value(policy, "hunt")) + ", refute=" + to_string(fit_value(policy, "refute")) + "; " + factSummary + ")" }
+        else { if selType == "poc-screen" {
+            "pending unverified candidate '" + selArgs + "' -> cheap eval_ag pre-screen first (policy poc-screen="
+          + to_string(fit_value(policy, "poc-screen")) + "; " + factSummary + ")" }
+        else { if selType == "hunt" {
+            let bb = if board_has_subsystem(board, cell_subsystem(huntCell)) { "blackboard lead in this subsystem; " } else { "" };
+            "hunt highest-scored lens '" + selArgs + "' (" + bb + "lens_fitness="
+          + to_string(fit_value(classFit, cell_class(huntCell))) + ", hunt_policy=" + to_string(fit_value(policy, "hunt"))
+          + ", score=" + to_string(chosenScore) + "; " + factSummary + ")" }
+        else {
+            if len(huntCell) == 0 { "no huntable cell remains in scope -> invent a new method to open a fresh lens (" + factSummary + ")" }
+            else { "ordinary hunting is not paying off (invent_policy=" + to_string(fit_value(policy, "invent-method"))
+                 + " > best hunt score " + to_string(huntScore) + ") -> invent a new method to open a fresh lens (" + factSummary + ")" } } } } };
+
+    // --- OUTPUT exactly one ACTION line; record the decision on the bus + memo for the dispatcher. -----
+    let actionLine = "ACTION|" + selType + "|" + selArgs + "|" + rationale;
+    print(actionLine);
+    emit("dark-factory:decision",
+         "{\"action\":\"" + selType + "\",\"args\":\"" + selArgs + "\",\"score\":\"" + to_string(chosenScore)
+       + "\",\"prev\":\"" + prevAction + "\",\"prev_outcome\":\"" + lastOutcome + "\"}");
+    memo_write("coordinator:last_decision", actionLine);
+    memo_write("coordinator:last_check", "done");
+
+    // --- DISPATCH (#1014 M2, GATED): when dispatch is enabled AND the chosen action is a real action (hunt /
+    // refute / poc-screen / invent-method), emit it over the in-process bus and run the dispatch chain in THIS
+    // same program — the verdict lands in the durable `coordinator:last_outcome` memo for the shell loop to
+    // read. DARK (no emit, no call, no extra output) unless DISPATCH_ENABLED is present, so a standalone
+    // coordinator run stays byte-identical. `stop` is terminal and never dispatched. The payload is
+    // `<type>|<args>` (the same shape dispatcher.ag's DISPATCH_ARGS takes). -----------------------------
+    if dispatchEnabled {
+        if is_action(selType) {
+            emit("dark-factory:dispatch", selType + "|" + selArgs);
+            dispatch();
+        }
+    }
+    return selType + "@@F@@" + selArgs;
 }
 
-// --- DECIDE: build the option list, score each from FACTS+POLICY, rank, and let `decide` select the top.
-// `stop` short-circuits the ranking when budget is exhausted or K consecutive dry — a hard fact gate.
-let scopeEmpty = count_lines(scope) == 0;
+// === #1014 M3: DISSOLVE THE SHELL LOOP — the federation self-orchestrates the whole multi-step audit in
+// ONE `agentis go`. The old run-coordinator.sh while-loop (per step: one `agentis go` decide+dispatch, read
+// the verdict memo, push/pop PENDING, advance DRY_STREAK/BUDGET, read_policy, append a decisions.tsv row)
+// now runs INSIDE the substrate as a `reduce` over a budget-bounded STEPS list. The shell is a BOOTSTRAP:
+// it seeds the facts + a STEPS list and reads the final trace/policy memo back. GATED on ORCHESTRATE_ENABLED
+// — absent, the top-level does EXACTLY ONE decide_once() with byte-identical output to v1 (the #1 guard).
+//
+// STATE ENCODING. The carried `reduce` accumulator is ONE string of NAMED fields joined by the 5-char
+// sentinel `@@F@@` (it cannot occur in any field — ids/rationales never contain it; regex-safe). Fields,
+// in order:
+//   0 stopped     "1" once a `stop`/budget/dry-cap terminated the loop (then step_fn is a no-op), else "0"
+//   1 budget      remaining step budget (int) — decremented per executed action
+//   2 dryStreak   consecutive non-productive steps (int)
+//   3 step        0-based step counter (for the cand-<step> id + the trace row)
+//   4 prevAction  previous action type ("" before step 0)
+//   5 prevKey     previous action args
+//   6 lastOutcome previous gate verdict ("confirmed"|"dry"|"refuted"|"")
+//   7 pending     the unverified-candidate list, newline-joined INTERNALLY (its own `\n` separator, which
+//                 `@@F@@` is chosen NOT to collide with) — push on hunt+confirmed, pop-first on refute/poc
+//   8 ph,9 pi,10 pp,11 pr   per-action-type cumulative policy in TEN-THOUSANDTHS (int): hunt /
+//                 invent-method / poc-screen / refute. Carrying the policy IN-PROCESS reproduces the shell's
+//                 read_policy() (sum of experience `delta`) byte-for-byte: each ±0.15 attribution is ±1500
+//                 ten-thousandths, and fmt4() renders the same `%.4f` Python `read_policy` emits. (We ALSO
+//                 learn() for the durable experience record — the carried ints are the in-loop mirror.)
+//   12 sh,13 si,14 sp,15 sr  per-type "seen" flags ("1"/"0") — read_policy emits only keys that appear in
+//                 the store, sorted; the seen flags reproduce that (a key is omitted until first attributed)
+//   16 trace      the accumulating decisions.tsv body (rows joined by `\n`, each a real TSV row)
+//   17 budget0    the ORIGINAL budget (for the BUDGET fact each row reports as the shell's REMAINING)
+//
+// POLICY THREADING. decide_once() is fed the formatted carried policy (fields 8-15 -> the `type=delta;...`
+// string read_policy would return), so the in-loop decision ranks options against the SAME evolving policy
+// the shell read between calls. The attribution for the PREVIOUS action is applied to the carried ints at
+// the START of each step (exactly when read_policy reflects it: the shell's read_policy at step N already
+// includes the call-(N-1) write, but NOT the call-N write of action N-1 — so the policy string a step uses
+// is the pre-attribution snapshot). After the loop, prevAction is attributed ONE more time, mirroring the
+// shell's final BUDGET=0 record call (which double-counts the last real action on a `stop` — reproduced).
 
-// The verify tier (pending candidate present): refute and poc-screen of the first pending candidate.
-let pendId = if pendingCount > 0 { cell_subsystem(firstPending) } else { "" };
-let refuteScore = score_refute(policy);
-let pocScore = score_poc(policy);
+// Format a ten-thousandths int as a fixed `%.4f` decimal, byte-identical to Python "%.4f" (the shell's
+// read_policy formatting). pad4 zero-pads the fractional part to 4 digits.
+fn pad4(n: int) -> string {
+    if n >= 1000 { return to_string(n); }
+    if n >= 100 { return "0" + to_string(n); }
+    if n >= 10 { return "00" + to_string(n); }
+    return "000" + to_string(n);
+}
+fn fmt4(t: int) -> string {
+    let neg = t < 0;
+    let a = if neg { 0 - t } else { t };
+    let whole = a / 10000;
+    let frac = a - (whole * 10000);
+    let body = to_string(whole) + "." + pad4(frac);
+    if neg { return "-" + body; }
+    return body;
+}
 
-// The hunt tier: the single best huntable cell (highest fact+policy score).
-let bestCell = best_hunt(scope, classFit, policy, board);
-let huntCell = if len(bestCell) == 0 { "" } else { substring(bestCell, 0, index_of(bestCell, "\t")) };
-let huntScore = if len(bestCell) == 0 { 0.0 } else { parse_float(substring(bestCell, index_of(bestCell, "\t") + 1, len(bestCell))) };
-let inventScore = score_invent(policy);
+// "1"/"0" string for a bool flag (no bool_flag builtin in v1.19.0).
+fn bool_flag(b: bool) -> string {
+    if b { return "1"; }
+    return "0";
+}
 
-// Decide the action TYPE by the fact gates + argmax of the scored options. Single-assignment: compute
-// the chosen type, args, score, and rationale as one nested expression (no `let` reassignment).
-// Priority of HARD fact gates (these are the colony's invariants, not policy): (1) stop on budget/dry,
-// (2) verify a pending lead before more hunting, (3) hunt the best available lens, (4) invent a method
-// when nothing is huntable. WITHIN the verify and hunt tiers the POLICY weight (and lens/board facts)
-// set the order, so the policy genuinely steers the choice.
-let stopForced = if budget <= 0 { true } else { dryStreak >= dryCap };
+// The TRAILING `|`-segment of `s` (the shell's `awk -F'|' '{print $NF}'`); "" when `s` is empty. The memo
+// verdict `<type>|<args>|<verdict>` carries the verdict last, and a hunt's args themselves contain a `|`,
+// so we cannot take field 2 — we walk to the last `|`.
+fn tail_field(s: string) -> string {
+    if len(s) == 0 { return ""; }
+    return reduce(regex_split("\\|", s), |acc: string, seg: string| -> string { return seg; }, "");
+}
 
-let chosenType =
-    if stopForced { "stop" }
-    else { if pendingCount > 0 { if pocScore > refuteScore { "poc-screen" } else { "refute" } }
-    else { if len(huntCell) > 0 { if huntScore >= inventScore { "hunt" } else { "invent-method" } }
-    else { "invent-method" } } };
+// The Nth `@@F@@` field of the state string. Same single-assignment reduce as payload_field, on the state
+// sentinel instead of `|` (the sentinel never collides with a field's `\n`/`\t`/`|`/spaces).
+fn state_field(s: string, n: int) -> string {
+    let segs = regex_split("@@F@@", s);
+    let acc = reduce(segs, |a: string, seg: string| -> string {
+        let bar = index_of(a, "\t");
+        let idx = parse_int(substring(a, 0, bar));
+        let cap = substring(a, bar + 1, len(a));
+        if idx == n { return to_string(idx + 1) + "\t" + seg; }
+        return to_string(idx + 1) + "\t" + cap;
+    }, "0\t");
+    return substring(acc, index_of(acc, "\t") + 1, len(acc));
+}
+fn state_int(s: string, n: int) -> int {
+    let v = state_field(s, n);
+    if len(v) == 0 { return 0; }
+    return parse_int(v);
+}
 
-let chosenArgs =
-    if chosenType == "hunt" { huntCell }
-    else { if chosenType == "refute" { pendId }
-    else { if chosenType == "poc-screen" { pendId }
-    else { "" } } };
+// Build the `type=delta;...` POLICY string from the carried ints + seen flags — byte-identical to the
+// shell's read_policy(): only SEEN keys, ALPHABETICALLY sorted (hunt < invent-method < poc-screen < refute),
+// each `key=%.4f`, `;`-joined; "" when nothing has been attributed yet.
+fn policy_string(ph: int, pi: int, pp: int, pr: int, sh: bool, si: bool, sp: bool, sr: bool) -> string {
+    let a = if sh { "hunt=" + fmt4(ph) } else { "" };
+    let b = if si { "invent-method=" + fmt4(pi) } else { "" };
+    let c = if sp { "poc-screen=" + fmt4(pp) } else { "" };
+    let d = if sr { "refute=" + fmt4(pr) } else { "" };
+    let s1 = a;
+    let s2 = if len(b) > 0 { if len(s1) > 0 { s1 + ";" + b } else { b } } else { s1 };
+    let s3 = if len(c) > 0 { if len(s2) > 0 { s2 + ";" + c } else { c } } else { s2 };
+    let s4 = if len(d) > 0 { if len(s3) > 0 { s3 + ";" + d } else { d } } else { s3 };
+    return s4;
+}
 
-let chosenScore =
-    if chosenType == "stop" { 0.0 }
-    else { if chosenType == "refute" { refuteScore }
-    else { if chosenType == "poc-screen" { pocScore }
-    else { if chosenType == "hunt" { huntScore }
-    else { inventScore } } } };
+// The ±1500 ten-thousandths delta a `learn()` signal applies (success +0.15, failure -0.15, else 0) — the
+// in-loop mirror of the experience `delta` read_policy sums.
+fn signal_delta(signal: string) -> int {
+    if signal == "success" { return 1500; }
+    if signal == "failure" { return 0 - 1500; }
+    return 0;
+}
 
-// Substrate-native selection step: present the chosen action as the FIRST (top-ranked) entry of a
-// `decide` option list, with the runner-up next, and let the substrate `decide` builtin make the
-// selection. Offline `decide` returns the top-ranked option (which IS our fact+policy argmax); a real
-// backend may arbitrate a near-tie from the criteria. Either way the ORDERING is the coordinator's,
-// derived from facts+policy. The selected token is `<type>|<args>` (re-split below).
-let topOption = chosenType + "|" + chosenArgs;
-let runnerUp =
-    if chosenType == "stop" { "stop|" }
-    else { if pendingCount > 0 { "hunt|" + huntCell }
-    else { if len(huntCell) > 0 { "invent-method|" }
-    else { "stop|" } } };
-let criteria =
-    "Pick the next audit action. The list is pre-ranked by FACTS and the evolving policy: verify a "
-  + "pending candidate before more hunting; prefer a blackboard-flagged subsystem and a higher-fitness "
-  + "lens; stop when budget is exhausted or " + to_string(dryCap) + " consecutive dry. Choose the "
-  + "highest-priority (first) action.";
-let selected = decide([topOption, runnerUp], criteria);
-let selType = cell_subsystem(selected);
-let selArgs = cell_class(selected);
+// --- PENDING list ops (mirror run-coordinator.sh's shell PENDING threading exactly) ----------------
+// Push a candidate onto the (newline-joined) pending list; drop empty lines first (the shell does
+// `grep -v '^$'`). A confirmed hunt at step S surfaces `cand-S|<args>`.
+fn pending_push(pending: string, cand: string) -> string {
+    let cleaned = reduce(regex_split("\n", pending), |acc: string, l: string| -> string {
+        if len(l) == 0 { return acc; }
+        return append_line(acc, l);
+    }, "");
+    return append_line(cleaned, cand);
+}
+// Pop the FIRST non-empty candidate (the one the coordinator pointed at) — the shell's `tail -n +2`.
+fn pending_pop(pending: string) -> string {
+    let cleaned = reduce(regex_split("\n", pending), |acc: string, l: string| -> string {
+        if len(l) == 0 { return acc; }
+        return append_line(acc, l);
+    }, "");
+    let drop = first_line(cleaned);
+    return reduce(regex_split("\n", cleaned), |acc: string, l: string| -> string {
+        if len(l) == 0 { return acc; }
+        if len(acc) == 0 { if l == drop { return acc; } }
+        return append_line(acc, l);
+    }, "");
+}
 
-// --- RATIONALE: cite the FACTS that drove the choice (not an opaque pick). ------------------------
-let factSummary =
-    "budget=" + to_string(budget) + " dry=" + to_string(dryStreak) + "/" + to_string(dryCap)
-  + " pending=" + to_string(pendingCount) + " scope_cells=" + to_string(count_lines(scope));
-let rationale =
+// --- one LOOP STEP: decode the carried state, run decide_once on it with the carried policy, dispatch +
+// read the verdict, update PENDING/DRY_STREAK/BUDGET/PREV_* + the policy ints, append the trace row, and
+// re-encode. A no-op once `stopped`. This IS the body of the old shell while-loop, now in-substrate. ----
+fn step_fn(state: string, stepLabel: string) -> string {
+    if state_int(state, 0) == 1 { return state; }
+    let budget = state_int(state, 1);
+    let dryStreak = state_int(state, 2);
+    let step = state_int(state, 3);
+    let prevAction = state_field(state, 4);
+    let prevKey = state_field(state, 5);
+    let lastOutcome = state_field(state, 6);
+    let pending = state_field(state, 7);
+    let phIn = state_int(state, 8);
+    let piIn = state_int(state, 9);
+    let ppIn = state_int(state, 10);
+    let prIn = state_int(state, 11);
+    let shIn = state_int(state, 12) == 1;
+    let siIn = state_int(state, 13) == 1;
+    let spIn = state_int(state, 14) == 1;
+    let srIn = state_int(state, 15) == 1;
+    let trace = state_field(state, 16);
+    let budget0 = state_int(state, 17);
+
+    // POLICY snapshot used for THIS decision + the trace row (the pre-attribution sum, as the shell's env
+    // POLICY is read before the call's learn() write).
+    let policyStr = policy_string(phIn, piIn, ppIn, prIn, shIn, siIn, spIn, srIn);
+
+    // Apply the PREVIOUS action's attribution to the carried ints (the shell's read_policy at the NEXT step
+    // reflects it). decide_once() ALSO learn()s it for the durable record.
+    let sig = outcome_signal(lastOutcome);
+    let d = signal_delta(sig);
+    let ph = if prevAction == "hunt" { phIn + d } else { phIn };
+    let pi = if prevAction == "invent-method" { piIn + d } else { piIn };
+    let pp = if prevAction == "poc-screen" { ppIn + d } else { ppIn };
+    let pr = if prevAction == "refute" { prIn + d } else { prIn };
+    let didAttr = if len(prevAction) > 0 { len(sig) > 0 } else { false };
+    let sh = if didAttr { if prevAction == "hunt" { true } else { shIn } } else { shIn };
+    let si = if didAttr { if prevAction == "invent-method" { true } else { siIn } } else { siIn };
+    let sp = if didAttr { if prevAction == "poc-screen" { true } else { spIn } } else { spIn };
+    let sr = if didAttr { if prevAction == "refute" { true } else { srIn } } else { srIn };
+
+    // ONE decision + in-substrate dispatch on the CARRIED facts (board re-read fresh, like the shell).
+    let dryCap = if len(getenv("DRY_CAP")) == 0 { 3 } else { parse_int(getenv("DRY_CAP")) };
+    let board = recall_latest("dark-factory:blackboard:leads");
+    let chosen = decide_once(getenv("SCOPE"), getenv("CLASS_FITNESS"), policyStr, pending, budget,
+                             dryStreak, dryCap, prevAction, prevKey, lastOutcome,
+                             board, true);
+    let selType = state_field(chosen, 0);
+    let selArgs = state_field(chosen, 1);
+
+    // Record the decisions.tsv row (byte-identical shape to run-coordinator.sh's printf). The rationale is
+    // the ACTION| line minus the fixed `ACTION|<selType>|<selArgs>|` prefix — robust even though a hunt's
+    // args (`subsystem|class`) and the rationale itself contain `|`, because we strip the EXACT prefix
+    // length rather than field-splitting.
+    let actionLine = recall_latest("coordinator:last_decision");
+    let prefix = "ACTION|" + selType + "|" + selArgs + "|";
+    let rationale = substring(actionLine, len(prefix), len(actionLine));
+    let row = "step=" + to_string(step) + "\taction=" + selType + "\targs=" + selArgs
+            + "\tpolicy=[" + policyStr + "]\trationale=" + rationale;
+    let trace2 = append_line(trace, row);
+
     if selType == "stop" {
-        if budget <= 0 { "budget exhausted (" + factSummary + ") -> halt" }
-        else { to_string(dryStreak) + " consecutive dry >= K=" + to_string(dryCap) + " (" + factSummary + ") -> halt" }
+        // Terminal: record the row, freeze the loop (no action executed, no PENDING/streak change).
+        return "1@@F@@" + to_string(budget) + "@@F@@" + to_string(dryStreak) + "@@F@@" + to_string(step)
+             + "@@F@@" + prevAction + "@@F@@" + prevKey + "@@F@@" + lastOutcome + "@@F@@" + pending
+             + "@@F@@" + to_string(ph) + "@@F@@" + to_string(pi) + "@@F@@" + to_string(pp) + "@@F@@" + to_string(pr)
+             + "@@F@@" + bool_flag(sh) + "@@F@@" + bool_flag(si) + "@@F@@" + bool_flag(sp) + "@@F@@" + bool_flag(sr)
+             + "@@F@@" + trace2 + "@@F@@" + to_string(budget0);
     }
-    else { if selType == "refute" {
-        "pending unverified candidate '" + selArgs + "' -> verify via refute before more hunting (policy hunt="
-      + to_string(fit_value(policy, "hunt")) + ", refute=" + to_string(fit_value(policy, "refute")) + "; " + factSummary + ")" }
-    else { if selType == "poc-screen" {
-        "pending unverified candidate '" + selArgs + "' -> cheap eval_ag pre-screen first (policy poc-screen="
-      + to_string(fit_value(policy, "poc-screen")) + "; " + factSummary + ")" }
-    else { if selType == "hunt" {
-        let bb = if board_has_subsystem(board, cell_subsystem(huntCell)) { "blackboard lead in this subsystem; " } else { "" };
-        "hunt highest-scored lens '" + selArgs + "' (" + bb + "lens_fitness="
-      + to_string(fit_value(classFit, cell_class(huntCell))) + ", hunt_policy=" + to_string(fit_value(policy, "hunt"))
-      + ", score=" + to_string(chosenScore) + "; " + factSummary + ")" }
-    else {
-        if len(huntCell) == 0 { "no huntable cell remains in scope -> invent a new method to open a fresh lens (" + factSummary + ")" }
-        else { "ordinary hunting is not paying off (invent_policy=" + to_string(fit_value(policy, "invent-method"))
-             + " > best hunt score " + to_string(huntScore) + ") -> invent a new method to open a fresh lens (" + factSummary + ")" } } } } };
 
-// --- OUTPUT exactly one ACTION line; record the decision on the bus + memo for the dispatcher. -----
-let actionLine = "ACTION|" + selType + "|" + selArgs + "|" + rationale;
-print(actionLine);
-emit("dark-factory:decision",
-     "{\"action\":\"" + selType + "\",\"args\":\"" + selArgs + "\",\"score\":\"" + to_string(chosenScore)
-   + "\",\"prev\":\"" + prevAction + "\",\"prev_outcome\":\"" + lastOutcome + "\"}");
-memo_write("coordinator:last_decision", actionLine);
-memo_write("coordinator:last_check", "done");
+    // Read the dispatch verdict back (decide_once already ran dispatch() in-process, writing the memo).
+    let memoOutcome = recall_latest("coordinator:last_outcome");
+    let rawVerdict = tail_field(memoOutcome);
+    let outcome = if is_verdict(rawVerdict) { rawVerdict } else { "dry" };
 
-// --- DISPATCH (#1014 M2, GATED): when dispatch is enabled AND the chosen action is a real action (hunt /
-// refute / poc-screen / invent-method), emit it over the in-process bus and run the dispatch chain in THIS
-// same program — the verdict lands in the durable `coordinator:last_outcome` memo for the shell loop to
-// read. DARK (no emit, no call, no extra output) unless DISPATCH_ENABLED is present, so a standalone
-// coordinator run stays byte-identical. `stop` is terminal and never dispatched. The payload is
-// `<type>|<args>` (the same shape dispatcher.ag's DISPATCH_ARGS takes). -----------------------------
-if len(getenv("DISPATCH_ENABLED")) > 0 {
-    if is_action(selType) {
-        emit("dark-factory:dispatch", selType + "|" + selArgs);
-        dispatch();
+    // Update PENDING from the outcome (the shell's case): a confirmed hunt pushes a candidate; refute/poc
+    // consume the first pending candidate.
+    let pending2 =
+        if selType == "hunt" { if outcome == "confirmed" { pending_push(pending, "cand-" + to_string(step) + "|" + selArgs) } else { pending } }
+        else { if selType == "refute" { pending_pop(pending) }
+        else { if selType == "poc-screen" { pending_pop(pending) }
+        else { pending } } };
+
+    let dryStreak2 = if outcome == "confirmed" { 0 } else { dryStreak + 1 };
+    let budget2 = budget - 1;
+    let step2 = step + 1;
+
+    // Terminate when the budget the loop carries is spent (the shell's `STEP < BUDGET`). The STEPS list is a
+    // BOUND, not the authority — we stop the moment carried budget hits 0 by flipping `stopped`.
+    let stopped2 = if budget2 <= 0 { "1" } else { "0" };
+
+    return stopped2 + "@@F@@" + to_string(budget2) + "@@F@@" + to_string(dryStreak2) + "@@F@@" + to_string(step2)
+         + "@@F@@" + selType + "@@F@@" + selArgs + "@@F@@" + outcome + "@@F@@" + pending2
+         + "@@F@@" + to_string(ph) + "@@F@@" + to_string(pi) + "@@F@@" + to_string(pp) + "@@F@@" + to_string(pr)
+         + "@@F@@" + bool_flag(sh) + "@@F@@" + bool_flag(si) + "@@F@@" + bool_flag(sp) + "@@F@@" + bool_flag(sr)
+         + "@@F@@" + trace2 + "@@F@@" + to_string(budget0);
+}
+
+// === TOP LEVEL ===
+// GATE: with ORCHESTRATE_ENABLED set, run the whole audit loop in-process; absent, do EXACTLY ONE
+// decide_once() with byte-identical output to v1 (demo-coordinator.sh's regression guard).
+if len(getenv("ORCHESTRATE_ENABLED")) > 0 {
+    // BOOTSTRAP FACTS (from the bootstrap shell): the same facts the v1 loop seeded, plus a STEPS budget
+    // list. The blackboard is re-read fresh inside each step. DRY_CAP defaults to 3 (the shell's default);
+    // a non-default cap arrives via DRY_CAP. BUDGET is the loop bound.
+    let budget0 = if len(getenv("BUDGET")) == 0 { 0 } else { parse_int(getenv("BUDGET")) };
+    let initPending = getenv("PENDING");
+    // initial accumulator: nothing attributed yet (all ints 0, all seen "0"), no prev, empty trace.
+    let init = "0@@F@@" + to_string(budget0) + "@@F@@0@@F@@0@@F@@@@F@@@@F@@@@F@@" + initPending
+             + "@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@@@F@@" + to_string(budget0);
+    let finalState = reduce(regex_split("\n", getenv("STEPS")),
+                            |acc: string, s: string| -> string { return step_fn(acc, s); }, init);
+
+    // FINAL ATTRIBUTION: record the last action's outcome once more — the shell's terminal BUDGET=0 call.
+    // (On a `stop` this double-counts the last real action exactly as the shell does; on budget-exhaustion
+    // it attributes the final action the loop didn't get to attribute. Both match run-coordinator.sh.)
+    let fPrevAction = state_field(finalState, 4);
+    let fPrevKey = state_field(finalState, 5);
+    let fLastOutcome = state_field(finalState, 6);
+    let fSig = outcome_signal(fLastOutcome);
+    if len(fPrevAction) > 0 {
+        if len(fSig) > 0 {
+            learn("coordinator", fPrevAction,
+                  "outcome of previous " + fPrevAction + " (" + fPrevKey + ") was " + fLastOutcome,
+                  fSig, [fPrevAction, fSig]);
+        }
     }
+    let fd = signal_delta(fSig);
+    let fph = state_int(finalState, 8) + (if fPrevAction == "hunt" { fd } else { 0 });
+    let fpi = state_int(finalState, 9) + (if fPrevAction == "invent-method" { fd } else { 0 });
+    let fpp = state_int(finalState, 10) + (if fPrevAction == "poc-screen" { fd } else { 0 });
+    let fpr = state_int(finalState, 11) + (if fPrevAction == "refute" { fd } else { 0 });
+    let fDidAttr = if len(fPrevAction) > 0 { len(fSig) > 0 } else { false };
+    let fsh = if state_int(finalState, 12) == 1 { true } else { if fDidAttr { fPrevAction == "hunt" } else { false } };
+    let fsi = if state_int(finalState, 13) == 1 { true } else { if fDidAttr { fPrevAction == "invent-method" } else { false } };
+    let fsp = if state_int(finalState, 14) == 1 { true } else { if fDidAttr { fPrevAction == "poc-screen" } else { false } };
+    let fsr = if state_int(finalState, 15) == 1 { true } else { if fDidAttr { fPrevAction == "refute" } else { false } };
+
+    // Publish the trace + the evolved policy to durable memos the bootstrap reads back (the cross-process
+    // channel). The trace is the full decisions.tsv body; policy-after is the read_policy()-shaped string.
+    memo_write("coordinator:trace", state_field(finalState, 16));
+    memo_write("coordinator:policy_after", policy_string(fph, fpi, fpp, fpr, fsh, fsi, fsp, fsr));
+    print("ORCHESTRATE|done|steps=" + to_string(state_int(finalState, 3)));
+} else {
+    // SINGLE DECISION (v1, byte-identical): read facts from env, run ONE decide_once(). The board is read
+    // here (as v1 did at top level). DISPATCH_ENABLED gates the in-substrate dispatch (as v1).
+    let board = recall_latest("dark-factory:blackboard:leads");
+    let budget = if len(getenv("BUDGET")) == 0 { 0 } else { parse_int(getenv("BUDGET")) };
+    let dryStreak = if len(getenv("DRY_STREAK")) == 0 { 0 } else { parse_int(getenv("DRY_STREAK")) };
+    let dryCap = if len(getenv("DRY_CAP")) == 0 { 3 } else { parse_int(getenv("DRY_CAP")) };
+    let _chosen = decide_once(getenv("SCOPE"), getenv("CLASS_FITNESS"), getenv("POLICY"), getenv("PENDING"),
+                              budget, dryStreak, dryCap, getenv("PREV_ACTION"), getenv("PREV_KEY"),
+                              getenv("LAST_OUTCOME"), board, len(getenv("DISPATCH_ENABLED")) > 0);
 }

--- a/dark-factory/demo-orchestrate.sh
+++ b/dark-factory/demo-orchestrate.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# demo-orchestrate.sh — #1014 M3: OFFLINE, DETERMINISTIC proof that the SHELL LOOP IS DISSOLVED — the whole
+# multi-step audit self-orchestrates INSIDE the substrate, in ONE `agentis go coordinator.ag`, with NO
+# network and NO real LLM.
+#
+# Through M2 the decision and each action's dispatch lived in the substrate, but a thin shell while-loop
+# (run-coordinator.sh) still DROVE the loop: per step it ran one `agentis go`, read the verdict memo, pushed
+# /popped PENDING, advanced DRY_STREAK / BUDGET, re-read the policy, and appended a decisions.tsv row. M3
+# moves that ENTIRE loop into the substrate: with ORCHESTRATE_ENABLED set, `coordinator.ag` runs the loop as
+# a `reduce` over a budget-bounded STEPS list — deciding, dispatching, reading the verdict, threading
+# PENDING / DRY_STREAK / BUDGET / the evolving policy, and accumulating the trace — and writes the final
+# decisions.tsv body + evolved policy to durable memos. The shell is now a BOOTSTRAP only.
+#
+# This demo proves:
+#   (1) ONE `agentis go` (ORCHESTRATE_ENABLED) runs a >=3-step audit and CHOOSES DIFFERENT ACTIONS across
+#       the steps (hunt then refute then hunt …) — a genuine multi-step self-orchestration, not one decision.
+#   (2) The resulting decisions.tsv + evolved policy are BYTE-IDENTICAL to what the M2 shell-loop
+#       (origin/main's run-coordinator.sh) produced for the SAME facts + fixture — captured below as the
+#       GOLDEN reference. Same decisions, same policy deltas; only the DRIVER moved into the substrate.
+#   (3) A re-run into a fresh store is byte-identical (deterministic, no RNG).
+#
+# The GOLDEN reference (decisions.tsv + policy-after) was captured from `origin/main`'s shell-loop
+# `run-coordinator.sh` with the scope/class-fitness/fixture facts mirrored below (budget 8, dry-cap 3,
+# stub executor). It is the literal M2 output the M3 in-substrate loop must reproduce.
+#
+# Everything is deterministic and offline: the coordinator's choice is a fact+policy argmax (no RNG), the
+# dispatch verdicts come from a fixture (no LLM, no prompt()), and the backend is `mock` (zero cost).
+#
+# Usage:  dark-factory/demo-orchestrate.sh
+# Requires: the `agentis` binary on PATH. Exit 0 = all proven; non-zero = an assertion failed.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+command -v agentis >/dev/null 2>&1 || { echo "demo-orchestrate.sh: agentis binary not on PATH" >&2; exit 3; }
+COORD_AG="$HERE/auditor/agents/coordinator.ag"
+[ -f "$COORD_AG" ] || { echo "demo-orchestrate.sh: coordinator agent not found at $COORD_AG" >&2; exit 3; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+FAILS=0
+note() { echo "demo-orchestrate.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+
+# The FACTS the audit runs under (the same scope/class-fitness/fixture the GOLDEN reference was captured
+# with). SCOPE = newline-joined `subsystem|class`; CLASS_FITNESS / DISPATCH_FIXTURE are the env-shaped facts
+# run-coordinator.sh builds from its --class-fitness / --fixture files.
+SCOPE_FX=$'vault accounting|C1\nreentrancy|C8\ncross-chain|C3'
+FIT_FX="C1=0.5500;C8=0.1000;C3=-0.2000"
+# Hunt of vault* confirms (-> pushes a candidate); refute of that candidate is refuted (-> pops it); so the
+# audit alternates hunt/refute as the policy evolves — a multi-step, fact-driven sequence.
+FIXTURE_FX="hunt|vault*=confirmed;refute|cand-*=refuted;poc-screen|cand-*=dry;hunt|reentr*=dry;invent-method|*=dry"
+BUDGET=8
+DRY_CAP=3
+
+# GOLDEN decisions.tsv — the M2 shell-loop (origin/main run-coordinator.sh) output for the facts above.
+read -r -d '' GOLDEN_TRACE <<'GOLDEN' || true
+step=0	action=hunt	args=vault accounting|C1	policy=[]	rationale=hunt highest-scored lens 'vault accounting|C1' (lens_fitness=0.55, hunt_policy=0, score=55.5; budget=8 dry=0/3 pending=0 scope_cells=3)
+step=1	action=refute	args=cand-0	policy=[]	rationale=pending unverified candidate 'cand-0' -> verify via refute before more hunting (policy hunt=0, refute=0; budget=7 dry=0/3 pending=1 scope_cells=3)
+step=2	action=hunt	args=vault accounting|C1	policy=[hunt=0.1500]	rationale=hunt highest-scored lens 'vault accounting|C1' (lens_fitness=0.55, hunt_policy=0.15, score=55.65; budget=6 dry=1/3 pending=0 scope_cells=3)
+step=3	action=refute	args=cand-2	policy=[hunt=0.1500;refute=-0.1500]	rationale=pending unverified candidate 'cand-2' -> verify via refute before more hunting (policy hunt=0.15, refute=-0.15; budget=5 dry=0/3 pending=1 scope_cells=3)
+step=4	action=hunt	args=vault accounting|C1	policy=[hunt=0.3000;refute=-0.1500]	rationale=hunt highest-scored lens 'vault accounting|C1' (lens_fitness=0.55, hunt_policy=0.3, score=55.8; budget=4 dry=1/3 pending=0 scope_cells=3)
+step=5	action=refute	args=cand-4	policy=[hunt=0.3000;refute=-0.3000]	rationale=pending unverified candidate 'cand-4' -> verify via refute before more hunting (policy hunt=0.3, refute=-0.3; budget=3 dry=0/3 pending=1 scope_cells=3)
+step=6	action=hunt	args=vault accounting|C1	policy=[hunt=0.4500;refute=-0.3000]	rationale=hunt highest-scored lens 'vault accounting|C1' (lens_fitness=0.55, hunt_policy=0.45, score=55.95; budget=2 dry=1/3 pending=0 scope_cells=3)
+step=7	action=refute	args=cand-6	policy=[hunt=0.4500;refute=-0.4500]	rationale=pending unverified candidate 'cand-6' -> verify via refute before more hunting (policy hunt=0.45, refute=-0.45; budget=1 dry=0/3 pending=1 scope_cells=3)
+GOLDEN
+GOLDEN_POLICY="hunt=0.6000;refute=-0.6000"
+
+# A fresh agentis store configured EXACTLY like run-coordinator.sh's bootstrap (experience enabled so the
+# loop can learn()/decide(); the loop + dispatch facts whitelisted). $1 = store dir.
+init_store() {
+  _d="$1"; mkdir -p "$_d"; cp "$COORD_AG" "$_d/coordinator.ag"
+  ( cd "$_d" && agentis init >/dev/null 2>&1 )
+  {
+    echo "llm.backend = mock"
+    echo "trace.level = normal"
+    echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS"
+    echo "exec.default_timeout_ms = 30000"
+    echo "learning.enabled = true"
+    echo "experience.enabled = true"
+  } > "$_d/.agentis/config"
+}
+
+# Run the WHOLE audit as ONE in-substrate `agentis go` (ORCHESTRATE_ENABLED) in store $1; echo the run's
+# stdout (we assert on the ORCHESTRATE| marker). STEPS is the budget-bounded `0..BUDGET-1` list.
+orchestrate() {
+  _store="$1"
+  _steps="$(awk -v n="$BUDGET" 'BEGIN{ for (i=0;i<n;i++){ printf "%s%d", (i?"\n":""), i } }')"
+  ( cd "$_store" && env \
+      SCOPE="$SCOPE_FX" CLASS_FITNESS="$FIT_FX" PENDING="" \
+      BUDGET="$BUDGET" DRY_CAP="$DRY_CAP" STEPS="$_steps" \
+      ORCHESTRATE_ENABLED=1 DISPATCH_ENABLED=1 DISPATCH_FIXTURE="$FIXTURE_FX" \
+      agentis go coordinator.ag --enable-exec --enable-messaging 2>/dev/null )
+}
+
+# Read the loop's durable trace / policy memos back (the cross-process channel the bootstrap reads).
+read_trace()  { ( cd "$1" && agentis memo get coordinator:trace ) 2>/dev/null; }
+read_policy() { ( cd "$1" && agentis memo get coordinator:policy_after ) 2>/dev/null; }
+
+# The action TYPE of one decisions.tsv row (the `action=<type>` field).
+row_action() { printf '%s' "$1" | awk -F'\t' '{ for (i=1;i<=NF;i++) if ($i ~ /^action=/) { sub(/^action=/,"",$i); print $i } }'; }
+
+echo "=================================================================================="
+echo " (1) ONE agentis go runs a >=3-step audit and CHOOSES DIFFERENT ACTIONS across steps"
+echo "=================================================================================="
+init_store "$WORK/run1"
+OUT1="$(orchestrate "$WORK/run1")"
+MARK="$(printf '%s\n' "$OUT1" | grep -E '^ORCHESTRATE\|' | head -1)"
+TRACE1="$(read_trace "$WORK/run1")"
+POLICY1="$(read_policy "$WORK/run1")"
+
+if [ -n "$MARK" ]; then ok "the single agentis go completed in-substrate ($MARK)"
+else bad "no ORCHESTRATE| completion marker — the in-substrate loop did not run"; fi
+
+NSTEPS="$(printf '%s\n' "$TRACE1" | grep -c '^step=')"
+if [ "$NSTEPS" -ge 3 ]; then ok "the audit ran $NSTEPS steps in ONE process (>= 3 — a real multi-step loop)"
+else bad "expected >= 3 steps from one agentis go, got $NSTEPS"; fi
+
+# Distinct action types across the steps (not one repeated decision).
+ACTIONS="$(printf '%s\n' "$TRACE1" | grep '^step=' | while IFS= read -r r; do row_action "$r"; done | sort -u)"
+NDISTINCT="$(printf '%s\n' "$ACTIONS" | grep -c .)"
+if [ "$NDISTINCT" -ge 2 ]; then ok "the loop chose $NDISTINCT DISTINCT action types ($(printf '%s' "$ACTIONS" | tr '\n' ' ')) — fact-driven, not a fixed single decision"
+else bad "expected >= 2 distinct action types across the steps, got $NDISTINCT ($ACTIONS)"; fi
+
+echo
+echo "=================================================================================="
+echo " (2) BYTE-IDENTICAL to the M2 shell-loop output (decisions.tsv + evolved policy)"
+echo "=================================================================================="
+if [ "$TRACE1" = "$GOLDEN_TRACE" ]; then
+  ok "decisions.tsv is BYTE-IDENTICAL to the M2 shell-loop golden (only the driver moved into the substrate)"
+else
+  bad "decisions.tsv DIFFERS from the M2 shell-loop golden:"
+  diff <(printf '%s\n' "$GOLDEN_TRACE") <(printf '%s\n' "$TRACE1") | sed 's/^/      /' >&2 || true
+fi
+if [ "$POLICY1" = "$GOLDEN_POLICY" ]; then
+  ok "evolved policy is BYTE-IDENTICAL to the M2 shell-loop golden ($POLICY1)"
+else
+  bad "evolved policy DIFFERS: golden '$GOLDEN_POLICY' vs in-substrate '$POLICY1'"
+fi
+
+# Cross-check: the in-loop policy must equal the experience-store read_policy() sum (the same mechanic the
+# shell read between calls) — proves the in-process policy threading mirrors the durable store byte-for-byte.
+STORE_POLICY="$(python3 - "$WORK/run1/.agentis/experience/main.jsonl" <<'PY'
+import json, os, sys
+path = sys.argv[1]; agg = {}
+if os.path.exists(path):
+    for line in open(path):
+        line = line.strip()
+        if not line: continue
+        try: r = json.loads(line)
+        except Exception: continue
+        if r.get("action") != "coordinator": continue
+        k = r.get("in", "")
+        if not k: continue
+        agg[k] = agg.get(k, 0.0) + float(r.get("delta", 0.0))
+print(";".join("%s=%.4f" % (k, agg[k]) for k in sorted(agg)))
+PY
+)"
+if [ "$POLICY1" = "$STORE_POLICY" ]; then
+  ok "in-loop policy == experience-store read_policy() sum ($STORE_POLICY) — the threading mirrors the store"
+else
+  bad "in-loop policy '$POLICY1' != experience-store sum '$STORE_POLICY' — the in-process threading drifted"
+fi
+
+echo
+echo "=================================================================================="
+echo " (3) DETERMINISM — a re-run into a fresh store is byte-identical"
+echo "=================================================================================="
+init_store "$WORK/run2"
+orchestrate "$WORK/run2" >/dev/null
+TRACE2="$(read_trace "$WORK/run2")"
+POLICY2="$(read_policy "$WORK/run2")"
+if [ "$TRACE1" = "$TRACE2" ] && [ "$POLICY1" = "$POLICY2" ]; then
+  ok "two independent in-substrate runs produced byte-identical decisions.tsv + policy (deterministic)"
+else
+  bad "the two runs DIFFERED:"
+  diff <(printf '%s\n' "$TRACE1") <(printf '%s\n' "$TRACE2") | sed 's/^/      /' >&2 || true
+fi
+
+echo
+echo "=================================================================================="
+echo " (4) CB-CLIFF GUARD — the whole loop runs in ONE agentis go, so the cb header must cover the budget"
+echo "=================================================================================="
+# The loop runs every step in ONE process, so coordinator.ag's `cb` budget must cover ALL steps (unlike the
+# old per-step agentis go). A budget that exceeds the cb cliff returns an empty trace. Run at the DEFAULT
+# budget (12 — above the old cb-300000 cliff at ~10) and assert a full, non-empty trace. Guards the cb header.
+GUARD_BUDGET=12
+init_store "$WORK/guard"
+GUARD_STEPS="$(awk -v n="$GUARD_BUDGET" 'BEGIN{ for (i=0;i<n;i++){ printf "%s%d", (i?"\n":""), i } }')"
+( cd "$WORK/guard" && env \
+    SCOPE="$SCOPE_FX" CLASS_FITNESS="$FIT_FX" PENDING="" \
+    BUDGET="$GUARD_BUDGET" DRY_CAP="$DRY_CAP" STEPS="$GUARD_STEPS" \
+    ORCHESTRATE_ENABLED=1 DISPATCH_ENABLED=1 DISPATCH_FIXTURE="$FIXTURE_FX" \
+    agentis go coordinator.ag --enable-exec --enable-messaging >/dev/null 2>&1 )
+GUARD_TRACE="$(read_trace "$WORK/guard")"
+GUARD_STEPN="$(printf '%s\n' "$GUARD_TRACE" | grep -c '^step=')"
+if [ "$GUARD_STEPN" -eq "$GUARD_BUDGET" ]; then
+  ok "budget=$GUARD_BUDGET ran all $GUARD_STEPN steps in one process (cb header covers the loop — no CB cliff)"
+else
+  bad "budget=$GUARD_BUDGET produced $GUARD_STEPN/$GUARD_BUDGET trace rows — coordinator.ag cb header too low for the loop (CB cliff)"
+fi
+
+echo
+echo "=================================================================================="
+if [ "$FAILS" -eq 0 ]; then
+  note "PROVEN offline + deterministically. The shell loop is DISSOLVED: ONE agentis go self-orchestrates"
+  note "the whole multi-step audit in the substrate (decide -> dispatch -> read verdict -> thread PENDING /"
+  note "DRY_STREAK / BUDGET / evolving policy -> accumulate the trace), and the resulting decisions.tsv +"
+  note "evolved policy are BYTE-IDENTICAL to the M2 shell-loop output — only the driver moved."
+  exit 0
+fi
+note "FAILED: $FAILS assertion(s) did not hold — see above."
+exit 1

--- a/dark-factory/docs/coordinator.md
+++ b/dark-factory/docs/coordinator.md
@@ -8,13 +8,19 @@ there is no fixed sequence, and the policy that ranks the options **improves by 
 
 This is v1 (MVP). It replaces the DECISIONS; **every action's DISPATCH also moved into the substrate in
 #1014 M2** (M1 did `hunt`; M2 generalised it to refute / poc-screen / invent-method too — see
-[`dispatch.md`](./dispatch.md) and [the v1 boundary](#the-v1-boundary) below). The shell loop still drives
-the loop and carries state between steps, but it computes **no** action's outcome.
+[`dispatch.md`](./dispatch.md) and [the v1 boundary](#the-v1-boundary) below). **In #1014 M3 the SHELL LOOP
+is DISSOLVED** — the whole multi-step audit self-orchestrates inside the substrate in **one** `agentis go`;
+the shell (`run-coordinator.sh`) is now a **bootstrap**, not a loop driver. See
+[the v1 boundary](#the-v1-boundary).
 
 ## The loop: fact → decide → record → evolve
 
+In #1014 M3 this whole loop runs INSIDE `coordinator.ag` (a `reduce` over a budget-bounded `STEPS` list); the
+box below is now ONE `agentis go`, with `run-coordinator.sh` only bootstrapping it and reading the final
+trace/policy memos back. The data flow is unchanged — only the driver moved into the substrate.
+
 ```
-                 ┌──────────────────── run-coordinator.sh (loop driver; reads the verdict memo) ─────────┐
+                 ┌──────────── coordinator.ag (#1014 M3: the loop runs IN-PROCESS; shell only bootstraps) ┐
                  │                                                                                       │
   FACTS  ───────▶│  coordinator.ag  ──▶  ACTION|<type>|<args>  ──▶  DISPATCH in-substrate  ──▶ OUTCOME (a gate verdict)
  (scope, per-    │   one decision +         (decide from facts +     emit → dispatch() →        confirmed / dry / refuted
@@ -90,26 +96,42 @@ What the **coordinator DECIDES** (in the substrate, from facts + an evolving pol
 - when to stop (budget exhausted or *K* consecutive dry);
 - how to reweight its own decision policy by outcome.
 
-What has **moved into the substrate since v1** (#1014 M1 → M2 — see [`dispatch.md`](./dispatch.md)):
+What has **moved into the substrate since v1** (#1014 M1 → M2 → M3 — see [`dispatch.md`](./dispatch.md)):
 
-- *dispatching EVERY action* (hunt / refute / poc-screen / invent-method). The decision **and** its
-  dispatch now happen in **one** `agentis go`: `coordinator.ag` decides the action, `emit`s it over the
+- *dispatching EVERY action* (hunt / refute / poc-screen / invent-method) — **M2**. The decision **and** its
+  dispatch happen in **one** `agentis go`: `coordinator.ag` decides the action, `emit`s it over the
   in-process bus (`dark-factory:dispatch`, payload `<type>|<args>`), and a sibling agent fn (`dispatch`,
   mirroring `auditor/agents/dispatcher.ag`) derives the gate verdict from the `DISPATCH_FIXTURE` fact and
-  writes it to the durable `coordinator:last_outcome` memo. The shell loop **reads the verdict from that
-  memo** for every non-`stop` action instead of a shell `case` — the `stub_outcome()` / `real_outcome()`
-  shell functions are gone.
+  writes it to the durable `coordinator:last_outcome` memo. The `stub_outcome()` / `real_outcome()` shell
+  functions are gone.
 
-What the **shell still does** (`run-coordinator.sh`):
+- *driving the WHOLE multi-step loop* — **M3**. Gated on `ORCHESTRATE_ENABLED`, `coordinator.ag`'s top level
+  runs the entire audit as a `reduce` over a budget-bounded `STEPS` list: per step it decides, dispatches
+  in-substrate, reads the verdict back (`recall_latest("coordinator:last_outcome")`), threads `PENDING`
+  (push on a confirmed hunt, pop-first on refute/poc-screen), `DRY_STREAK`, `BUDGET`, and the **evolving
+  policy** entirely in-process, and accumulates the `decisions.tsv` trace — then writes the final trace +
+  evolved policy to the `coordinator:trace` / `coordinator:policy_after` memos. The in-process policy is
+  carried in the loop state in ten-thousandths and rendered `%.4f`, so it is **byte-identical** to the
+  shell's old experience-store `read_policy()` sum step for step (the loop also `learn()`s for the durable
+  record). A `reduce` cannot `break`, so termination is modelled by a `stopped` flag that makes the step a
+  no-op once `stop` / budget / dry-cap fires. With `ORCHESTRATE_ENABLED` **absent**, the top level does
+  **exactly one** decision, **byte-identical** to before (the `demo-coordinator.sh` regression guard).
 
-- driving the loop and carrying state between steps (pending list, dry streak, budget) and feeding each
-  outcome back;
-- reading the cumulative policy from the experience store between calls.
+What the **shell still does** (`run-coordinator.sh`) — it is now a **bootstrap**, not a loop driver:
 
-  It no longer **computes** any action's outcome — that is the substrate dispatch's job; the shell reads one
-  `coordinator:last_outcome` memo per non-`stop` step.
+- builds the agentis store, seeds the FACTS + a `STEPS` budget list, and fires **one** `agentis go
+  coordinator.ag` with `ORCHESTRATE_ENABLED`;
+- reads the final `decisions.tsv` body + evolved policy back from the durable memos the in-substrate loop
+  wrote, and cross-checks the in-loop policy against the experience-store `read_policy()` sum.
+
+  It computes **no** action's outcome and carries **no** per-step loop state — both live in the substrate
+  now. (Honest scope: the loop self-orchestrates per bootstrap invocation; a long-lived daemon-tick reflex —
+  the loop running continuously without a shell bootstrap — is a separate refinement, below.)
 
 **Follow-up (kept on epic #1014):**
+
+- a long-lived **daemon-tick reflex** so the audit loop runs continuously in the substrate without a shell
+  bootstrap re-seeding it each run;
 
 - wire each action type to its real executor agent on the LIVE path (`refute`→`refuter.ag`,
   `poc-screen`→`poc-screener.ag`, `invent-method`→`method-inventor.ag`, hunt→`hunter.ag`), so the
@@ -140,7 +162,12 @@ dark-factory/demo-coordinator.sh        # exit 0 = both proven; non-zero = a cri
 # verdict via memo; per-type standalone-dispatcher sync-guard):
 dark-factory/demo-dispatch.sh           # exit 0 = all proven; non-zero = an assertion failed
 
-# Drive the loop yourself (stub executor = offline + deterministic; every action is dispatched in-substrate):
+# Proves the #1014 M3 in-substrate LOOP: ONE agentis go self-orchestrates a >=3-step audit, and the
+# resulting decisions.tsv + evolved policy are byte-identical to the M2 shell-loop output for the same facts:
+dark-factory/demo-orchestrate.sh        # exit 0 = proven; non-zero = an assertion failed
+
+# Bootstrap the in-substrate loop yourself (stub executor = offline + deterministic; ONE agentis go drives
+# the whole audit; the shell only seeds the facts + reads the trace/policy memos back):
 dark-factory/run-coordinator.sh --scope <scope.tsv> --class-fitness <fit.tsv> \
     --executor stub --fixture <fixture.tsv> --budget 8
 ```

--- a/dark-factory/docs/dispatch.md
+++ b/dark-factory/docs/dispatch.md
@@ -69,15 +69,18 @@ no emit, no call, no extra output — so the standalone decision path is **byte-
 
 ## What moved vs what is still shell
 
-| Concern | Before #1014 | After M2 |
-|---------|--------------|----------|
-| **decide** the next action | substrate (`coordinator.ag`) | substrate (unchanged) |
-| **dispatch** any action + derive its verdict | shell `case` (`stub_outcome` / `real_outcome`) | **substrate** (`coordinator.ag` emit → `dispatch` → memo) for **every** action type |
-| carry the verdict back to the loop | shell variable | **durable memo** read by the shell loop (every non-`stop` action) |
-| carry state between steps (PENDING / DRY_STREAK / BUDGET / policy read) | shell | shell (unchanged) |
+| Concern | Before #1014 | After M2 | After M3 |
+|---------|--------------|----------|---------|
+| **decide** the next action | substrate (`coordinator.ag`) | substrate (unchanged) | substrate (unchanged) |
+| **dispatch** any action + derive its verdict | shell `case` (`stub_outcome` / `real_outcome`) | **substrate** (`coordinator.ag` emit → `dispatch` → memo) for **every** action type | substrate (unchanged) |
+| carry the verdict back to the loop | shell variable | **durable memo** read by the shell loop (every non-`stop` action) | **in-process** `recall_latest` inside the loop |
+| carry state between steps (PENDING / DRY_STREAK / BUDGET / policy) | shell | shell | **substrate** — the loop threads it all in the carried `reduce` state (#1014 M3) |
+| **drive** the multi-step loop | shell while-loop | shell while-loop | **substrate** (`coordinator.ag` `reduce` over a budget-bounded `STEPS` list) |
 
-The `stub_outcome()` / `real_outcome()` shell functions and their `case` dispatch are **removed** —
-`run-coordinator.sh` no longer derives any outcome; it reads one memo per non-`stop` step.
+The `stub_outcome()` / `real_outcome()` shell functions and their `case` dispatch were **removed in M2** —
+the shell derives no outcome. **In M3 the shell while-loop itself is removed**: `run-coordinator.sh` is a
+**bootstrap** that fires **one** `agentis go` and reads the final `decisions.tsv` + evolved policy back from
+the `coordinator:trace` / `coordinator:policy_after` memos — see [`coordinator.md`](./coordinator.md).
 
 `auditor/agents/dispatcher.ag` is the standalone, separately-committable copy of the dispatch agent fn
 (`dispatch` + its helpers + a `DISPATCH_ARGS` top-level entry). Because agentis `go` has no file includes,

--- a/dark-factory/run-coordinator.sh
+++ b/dark-factory/run-coordinator.sh
@@ -102,6 +102,12 @@ case "$BUDGET"  in (*[!0-9]*|'') echo "run-coordinator.sh: --budget must be a no
 case "$DRY_CAP" in (*[!0-9]*|'') echo "run-coordinator.sh: --dry-cap must be a non-negative integer" >&2; exit 2 ;; esac
 case "$EXECUTOR" in real|stub) : ;; *) echo "run-coordinator.sh: --executor must be real|stub" >&2; exit 2 ;; esac
 [ "$EXECUTOR" = "stub" ] && { [ -n "$FIXTURE" ] || { echo "run-coordinator.sh: --executor stub needs --fixture <f>" >&2; exit 2; }; [ -f "$FIXTURE" ] || { echo "run-coordinator.sh: --fixture not found: $FIXTURE" >&2; exit 2; }; }
+# The in-substrate orchestrate loop (coordinator.ag) encodes its carried state as fields joined by the
+# `@@F@@` sentinel; an input cell that literally contains it would corrupt that encoding. Reject it loudly
+# (operator-controlled input; never legitimate in a subsystem label / class id / glob).
+if grep -qF '@@F@@' "$SCOPE_FILE" 2>/dev/null || { [ -n "$FIXTURE" ] && grep -qF '@@F@@' "$FIXTURE" 2>/dev/null; }; then
+  echo "run-coordinator.sh: --scope/--fixture must not contain the reserved '@@F@@' field sentinel" >&2; exit 2
+fi
 command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-coordinator.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
 
 COORD_AG="$HERE/auditor/agents/coordinator.ag"
@@ -122,7 +128,7 @@ cp "$COORD_AG" "$RUN/coordinator.ag"
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 600000"; }
   [ "$BACKEND" = "flat-cyborg" ] && echo "llm.cli_timeout_ms = 600000"
   echo "trace.level = normal"
-  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE"
+  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS"
   echo "exec.default_timeout_ms = 30000"
   # The whole point: every decision is recorded as experience so coordinator:policy:<type> reweights.
   echo "learning.enabled = true"
@@ -197,122 +203,66 @@ if [ "$EXECUTOR" = "stub" ] && [ -n "$FIXTURE" ]; then
   ' "$FIXTURE")"
 fi
 
-# --- the loop. State carried between steps: PENDING (unverified candidates), DRY_STREAK, BUDGET, and the
-# PREV action/outcome the coordinator attributes to its policy. The coordinator DECIDES; we DISPATCH. ---
-PENDING=""
-DRY_STREAK=0
-PREV_ACTION=""
-PREV_KEY=""
-LAST_OUTCOME=""
-STEP=0
+# --- #1014 M3: the shell LOOP is DISSOLVED. The whole multi-step audit now self-orchestrates INSIDE the
+# substrate: ONE `agentis go coordinator.ag` with ORCHESTRATE_ENABLED runs the entire decide -> dispatch ->
+# read-verdict -> update-PENDING/DRY_STREAK/BUDGET -> evolve-policy -> append-trace loop as a `reduce` over a
+# budget-bounded STEPS list. This script is now a BOOTSTRAP: it seeds the FACTS + a STEPS budget list, fires
+# the single in-substrate run, and reads the final `decisions.tsv` + evolved policy back from the durable
+# memos the loop writes (`coordinator:trace`, `coordinator:policy_after`). NO per-step shell loop, NO
+# shell-side PENDING/DRY_STREAK/BUDGET threading, NO shell-derived outcome — the federation drives the audit.
+# (Follow-up, still on epic #1014: a long-lived daemon-tick reflex so the loop runs continuously, not once
+# per bootstrap; the per-action LIVE executors.)
 TRACE="$OUT/decisions.tsv"
 : > "$TRACE"
 
-echo "run-coordinator.sh: policy BEFORE the run: [$(read_policy)]" >&2
-
-while [ "$STEP" -lt "$BUDGET" ]; do
-  REMAINING=$((BUDGET - STEP))
-  POLICY="$(read_policy)"
-
-  DEC_LOG="$RUN/decision_$STEP.log"
-  # ONE decision: hand the coordinator every FACT; it returns exactly one ACTION| line. DISPATCH_ENABLED
-  # makes coordinator.ag DISPATCH the chosen action itself (#1014 M2): for ANY real action it emits
-  # `dark-factory:dispatch` and runs dispatch() in THIS same `agentis go`, landing the gate verdict in the
-  # durable `coordinator:last_outcome` memo. We read that memo below for every non-`stop` action instead of
-  # a shell `case` — the shell no longer computes any outcome. DISPATCH_FIXTURE carries the offline verdict
-  # rules to the agent (all of --fixture, projected to `type|glob=verdict;...`).
-  ( cd "$RUN" && env \
-      SCOPE="$SCOPE" \
-      CLASS_FITNESS="$CLASS_FITNESS" \
-      POLICY="$POLICY" \
-      PENDING="$PENDING" \
-      BUDGET="$REMAINING" \
-      DRY_STREAK="$DRY_STREAK" \
-      DRY_CAP="$DRY_CAP" \
-      PREV_ACTION="$PREV_ACTION" \
-      PREV_KEY="$PREV_KEY" \
-      LAST_OUTCOME="$LAST_OUTCOME" \
-      DISPATCH_ENABLED=1 \
-      DISPATCH_FIXTURE="$DISPATCH_FIXTURE" \
-      "$AGENTIS" go coordinator.ag --enable-exec --enable-messaging ) >"$DEC_LOG" 2>&1 \
-    || { echo "run-coordinator.sh: coordinator call failed at step $STEP (see $DEC_LOG)" >&2; exit 1; }
-
-  ACTION_LINE="$(grep -E '^ACTION\|' "$DEC_LOG" | head -1)"
-  [ -n "$ACTION_LINE" ] || { echo "run-coordinator.sh: no ACTION line at step $STEP (see $DEC_LOG)" >&2; exit 1; }
-
-  # Parse `ACTION|<type>|<args>|<rationale>`. <args> is a SINGLE `|`-field for refute/poc-screen
-  # (a `cand-id`) and "" for invent-method/stop, but TWO fields for a hunt (`subsystem|class`). So the
-  # field where the rationale begins is type-dependent — a flat `cut -f3`/`-f4-` would otherwise drop a
-  # hunt's class into the rationale and build a malformed `cand-N|subsystem` PENDING id. Mirrors the
-  # field shape demo-coordinator.sh's `expect` helper documents.
-  ATYPE="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f2)"
-  if [ "$ATYPE" = "hunt" ]; then
-    AARGS="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f3-4)"
-    ARATIONALE="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f5-)"
-  else
-    AARGS="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f3)"
-    ARATIONALE="$(printf '%s' "$ACTION_LINE" | cut -d'|' -f4-)"
-  fi
-  printf 'step=%s\taction=%s\targs=%s\tpolicy=[%s]\trationale=%s\n' "$STEP" "$ATYPE" "$AARGS" "$POLICY" "$ARATIONALE" >> "$TRACE"
-  echo "run-coordinator.sh: step $STEP -> $ATYPE${AARGS:+ $AARGS}  ($ARATIONALE)" >&2
-
-  if [ "$ATYPE" = "stop" ]; then
-    echo "run-coordinator.sh: coordinator decided STOP at step $STEP" >&2
-    break
-  fi
-
-  # CAPTURE the chosen action's gate OUTCOME (a FACT, fed back next step). Since #1014 M2 the dispatch
-  # already happened IN the coordinator call above: for ANY real action it emitted `dark-factory:dispatch`
-  # and ran dispatch() in-process, recording the verdict in the durable `coordinator:last_outcome` memo. We
-  # READ it back here (a separate `agentis memo get`, the only substrate-native cross-process channel)
-  # instead of computing it in a shell `case` — the shell no longer derives any outcome. The memo value is
-  # `<type>|<args>|<verdict>`; we take the trailing verdict field (`dry` if malformed/missing).
-  MEMO_OUTCOME="$( ( cd "$RUN" && "$AGENTIS" memo get coordinator:last_outcome ) 2>/dev/null | tail -1 )"
-  OUTCOME="$(printf '%s' "$MEMO_OUTCOME" | awk -F'|' '{ print $NF }')"
-  case "$OUTCOME" in confirmed|dry|refuted) : ;; *) OUTCOME="dry" ;; esac
-  echo "run-coordinator.sh:   $ATYPE dispatched in-substrate; verdict from coordinator:last_outcome memo: $OUTCOME" >&2
-  echo "run-coordinator.sh:   dispatch outcome: $OUTCOME" >&2
-
-  # Update carried state from the outcome (these are FACTS, not decisions):
-  #  * a hunt that 'confirmed' surfaces a NEW candidate lead -> push it onto PENDING for verification.
-  #  * refute/poc-screen consume the first pending candidate (the one the coordinator pointed at),
-  #    regardless of confirmed/refuted — the gate has now spoken on it either way.
-  #  * dry/refuted advance the dry streak; a confirmed finding resets it.
-  case "$ATYPE" in
-    hunt)
-      if [ "$OUTCOME" = "confirmed" ]; then
-        CAND="cand-$STEP|$AARGS"
-        PENDING="$(printf '%s\n%s' "$PENDING" "$CAND" | grep -v '^$' || true)"
-      fi ;;
-    refute|poc-screen)
-      # consume the first pending candidate (the one the coordinator pointed at)
-      PENDING="$(printf '%s\n' "$PENDING" | grep -v '^$' | tail -n +2 || true)" ;;
-  esac
-
-  if [ "$OUTCOME" = "confirmed" ]; then
-    DRY_STREAK=0
-  else
-    DRY_STREAK=$((DRY_STREAK + 1))
-  fi
-
-  PREV_ACTION="$ATYPE"
-  PREV_KEY="$AARGS"
-  LAST_OUTCOME="$OUTCOME"
-  STEP=$((STEP + 1))
-done
-
-# Feed the FINAL action's outcome back so its policy delta is recorded too (the loop above attributes the
-# previous outcome on the NEXT call; a terminal `stop`/budget has no next call). One last coordinator
-# invocation with BUDGET=0 forces a stop AND records the last attribution, then exits.
-if [ -n "$PREV_ACTION" ]; then
-  ( cd "$RUN" && env \
-      SCOPE="$SCOPE" CLASS_FITNESS="$CLASS_FITNESS" POLICY="$(read_policy)" PENDING="$PENDING" \
-      BUDGET=0 DRY_STREAK="$DRY_STREAK" DRY_CAP="$DRY_CAP" \
-      PREV_ACTION="$PREV_ACTION" PREV_KEY="$PREV_KEY" LAST_OUTCOME="$LAST_OUTCOME" \
-      "$AGENTIS" go coordinator.ag --enable-exec --enable-messaging ) >"$RUN/decision_final.log" 2>&1 || true
+# STEPS is a BOUND, not a sequence authority: a `0\n1\n…\n<BUDGET-1>` list whose LENGTH caps the loop at
+# BUDGET iterations (agentis has no range(); a `reduce` over this string is the bounded-iteration idiom).
+# The coordinator stops the moment its carried budget/dry-cap fires — the list only bounds the worst case.
+STEPS=""
+if [ "$BUDGET" -gt 0 ]; then
+  STEPS="$(awk -v n="$BUDGET" 'BEGIN{ for (i=0;i<n;i++){ printf "%s%d", (i?"\n":""), i } }')"
 fi
 
-POLICY_AFTER="$(read_policy)"
+echo "run-coordinator.sh: policy BEFORE the run: [$(read_policy)]" >&2
+
+# ONE in-substrate run drives the ENTIRE audit. ORCHESTRATE_ENABLED selects the loop mode; DISPATCH_ENABLED
+# keeps every action's dispatch in-substrate (#1014 M2); DISPATCH_FIXTURE carries the offline verdict rules.
+RUN_LOG="$RUN/orchestrate.log"
+( cd "$RUN" && env \
+    SCOPE="$SCOPE" \
+    CLASS_FITNESS="$CLASS_FITNESS" \
+    PENDING="" \
+    BUDGET="$BUDGET" \
+    DRY_CAP="$DRY_CAP" \
+    STEPS="$STEPS" \
+    ORCHESTRATE_ENABLED=1 \
+    DISPATCH_ENABLED=1 \
+    DISPATCH_FIXTURE="$DISPATCH_FIXTURE" \
+    "$AGENTIS" go coordinator.ag --enable-exec --enable-messaging ) >"$RUN_LOG" 2>&1 \
+  || { echo "run-coordinator.sh: in-substrate orchestration failed (see $RUN_LOG)" >&2; exit 1; }
+
+grep -E '^ORCHESTRATE\|' "$RUN_LOG" >/dev/null 2>&1 \
+  || { echo "run-coordinator.sh: orchestration did not complete (no ORCHESTRATE| marker; see $RUN_LOG)" >&2; exit 1; }
+
+# Read the decisions.tsv body + the evolved policy back from the durable memos the loop wrote (the only
+# substrate-native cross-process channel). The trace memo is the full TSV body; policy_after is the
+# read_policy()-shaped `type=delta;…` string the in-loop policy threading produced.
+( cd "$RUN" && "$AGENTIS" memo get coordinator:trace ) 2>/dev/null > "$TRACE" || true
+
+# Echo each decision to stderr (the operator feed the per-step loop used to print live).
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  echo "run-coordinator.sh: $row" >&2
+done < "$TRACE"
+
+# The evolved policy: prefer the loop's in-process result (memo), cross-checked against the experience-store
+# read_policy() (they are byte-identical by construction — the in-loop threading mirrors the store sum).
+POLICY_LOOP="$( ( cd "$RUN" && "$AGENTIS" memo get coordinator:policy_after ) 2>/dev/null )"
+POLICY_STORE="$(read_policy)"
+if [ "$POLICY_LOOP" != "$POLICY_STORE" ]; then
+  echo "run-coordinator.sh: WARNING in-loop policy [$POLICY_LOOP] != experience-store policy [$POLICY_STORE]" >&2
+fi
+POLICY_AFTER="$POLICY_LOOP"
 echo "run-coordinator.sh: policy AFTER the run:  [$POLICY_AFTER]" >&2
 echo "run-coordinator.sh: decision trace -> $TRACE" >&2
 printf '%s' "$POLICY_AFTER" > "$OUT/policy-after.txt"


### PR DESCRIPTION
## What

Epic #1014 v2, **milestone 3** — the **shell loop is dissolved**. Through M2 the decision + every action's dispatch lived in the substrate, but `run-coordinator.sh` still drove the multi-step loop. M3 moves the **whole loop** into `coordinator.ag`: the federation self-orchestrates the entire multi-step audit in one `agentis go`.

## How

- Gated on a new `ORCHESTRATE_ENABLED` fact, `coordinator.ag`'s top level runs the audit as a `reduce` over a budget-bounded `STEPS` list. Each iteration: decide → dispatch (in-process emit+`dispatch()`) → read the verdict from the memo → thread carried state (PENDING push/pop, DRY_STREAK, BUDGET, PREV_*, an in-loop policy in ten-thousandths rendered `%.4f` to stay byte-identical to the shell's experience-store `read_policy()` sum) → `learn()` → accumulate the `decisions.tsv` row. Termination (stop/budget/dry-cap) uses a `stopped` flag (a `reduce` can't break) + one post-loop final attribution.
- **Without** `ORCHESTRATE_ENABLED`, the top level does exactly one decision, byte-identical to v1 — so `demo-coordinator.sh` is unchanged.
- `run-coordinator.sh` becomes a **bootstrap**: seed facts + a `STEPS` budget list, fire **one** `agentis go`, read the final trace + policy from the `coordinator:trace` / `coordinator:policy_after` memos. The per-step shell loop + all shell-side state threading are **removed**.

## Notes (from QA, fixed inline)

- The whole loop runs in one `agentis go`, so `coordinator.ag`'s `cb` budget must cover every step cumulatively — raised **300000 → 2000000** (matches the colony `cb_budget`; clears the default budget 12 with headroom). `demo-orchestrate.sh` gained a budget-12 cb-cliff guard.
- `run-coordinator.sh` rejects a `--scope`/`--fixture` cell containing the reserved `@@F@@` state-field sentinel (loud error, not silent corruption).
- A **pre-existing** terminal double-count of the final action's policy attribution is reproduced for parity and tracked separately as #1026.

## Boundaries

The loop self-orchestrates **per bootstrap invocation**; a long-lived daemon-tick reflex (the loop running continuously with no shell bootstrap) is a separate refinement still on #1014. Human-gated submission + forge-verify/refuter gates intact.

## Verification

- **`demo-coordinator.sh` byte-identical** to `origin/main` (loop mode dark without the flag).
- **`demo-orchestrate.sh`** — one `agentis go` runs a ≥3-step audit; `decisions.tsv` + evolved policy **byte-identical** to the M2 shell-loop golden; in-loop policy == experience-store `read_policy()` sum; deterministic re-run; **budget-12 cb-cliff guard** passes.
- **M2-parity** — branch in-substrate `decisions.tsv` byte-identical to main's M2 shell loop at the **default budget 12** and across stop / dry-cap / PENDING-round-trip / empty-scope scenarios. Only the driver moved into the substrate.
- `demo-dispatch.sh` unaffected; `bash -n` clean; **`colony-lint.sh` → 365 / 0 / 5**.

Part of #1014 — the run-*.sh fixed-sequence + loop authority is now fully removed (decide + dispatch + sequence all in the substrate). A daemon-tick reflex remains a future refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
