### PR TITLE
feat(dark-factory): Halmos symbolic-execution verification gate (#1015 M1)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,27 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Halmos symbolic-execution verification gate — a SOUND oracle that PROVES an invariant or returns a
+  concrete counterexample, exhaustive over all inputs** (#1015 M1). New `evm-harness/halmos-verify.sh` runs
+  [Halmos](https://github.com/a16z/halmos) (symbolic execution + the z3 SMT solver) over a `*.t.sol` spec
+  and parses its `Symbolic test result: N passed; M failed` summary into a structured verdict + exit code:
+  **PROVED** (exit 0 — holds for every input), **COUNTEREXAMPLE** (exit 1 — a concrete input violates the
+  property, a real bug), **INCONCLUSIVE** (exit 3 — solver `unknown` / timeout / unbounded loop / nothing
+  matched), and harness/usage error (exit 2 — bad args, `--repo` not a Foundry project, or `halmos`/`forge`
+  absent with an install hint). It is the SYMBOLIC sibling of `evm-harness/forge-verify.sh` (which witnesses
+  one concrete exploit path) and an **additional** sound oracle alongside it — `forge-verify.sh` is
+  unchanged. Tools are resolved via `PATH` (`command -v`), no install location is hardcoded; the banner
+  (`================ HALMOS-VERIFY: <VERDICT> ================`) mirrors `forge-verify.sh`. Ships two
+  self-contained example specs under `evm-harness/halmos-specs/` (a `Ledger` with an honest `transferSafe`
+  Halmos PROVES value-conserving, a buggy `transferBuggy` Halmos REFUTES with a concrete witness, and an
+  under-unrolled-loop spec the gate must report **INCONCLUSIVE** — a soundness guard so a not-fully-explored
+  loop is never over-claimed as PROVED) plus `demo-halmos.sh`, which asserts all three verdicts against the
+  real solver (deterministic, no mock) and prints a single `[SKIP]` + exit 0 when `halmos`/`forge` are not on
+  `PATH` (so CI passes without the toolchain). New
+  `docs/halmos.md` documents the verdict/exit contract, toolchain install, and how the gate fits the epic
+  (the LLM hypothesizes; Halmos is the sound verdict). Honest scope: M1 is the **callable gate only** —
+  auto-routing discovery candidates into it (generate-and-verify) is a later milestone. **Requires:** halmos
+  >= 0.3 + foundry (forge) for a real run; both are optional for the rest of the federation.
 - **The shell loop is DISSOLVED — the federation self-orchestrates the whole multi-step audit in the
   substrate** (#1014 M3). Through M2 the decision and each action's dispatch lived in the substrate, but a
   thin shell while-loop (`run-coordinator.sh`) still **drove** the loop (per step: one `agentis go`, read the

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -157,6 +157,22 @@ dark-factory/evm-harness/forge-verify.sh --repo "$PWD/target" --poc "$PWD/Exploi
 # exit 0 = VERIFIED (the exploit PoC passes); only a VERIFIED lead is worth a human-gated submission.
 ```
 
+For invariant-shaped leads there is a second, **sound** gate alongside the execution one:
+[`evm-harness/halmos-verify.sh`](./evm-harness/halmos-verify.sh) (#1015) runs
+[Halmos](https://github.com/a16z/halmos) (symbolic execution + z3) over a `*.t.sol` spec and either
+**PROVES** the invariant holds for every input or returns a **concrete counterexample**:
+
+```bash
+dark-factory/evm-harness/halmos-verify.sh --repo "$PWD/target" --target test/Spec.t.sol
+# exit 0 = PROVED (holds for ALL inputs) ; 1 = COUNTEREXAMPLE (a concrete input is a real bug) ;
+#   3 = INCONCLUSIVE (solver unknown / timeout) ; 2 = harness/usage (tools missing, bad args).
+# Offline demo + verdict contract: `dark-factory/demo-halmos.sh`, `docs/halmos.md`.
+```
+
+`forge-verify.sh` witnesses one concrete exploit path; `halmos-verify.sh` decides the property over all
+inputs. They are complementary — see [`docs/halmos.md`](./docs/halmos.md) for the verdict/exit contract,
+toolchain install, and how the gate fits the epic (the LLM hypothesizes; Halmos is the sound verdict).
+
 A clean sweep (no candidate survives) is a **rigorous negative** — a valid outcome on audited code;
 nothing is submitted. As with `run-audit.sh`, the colony never posts to a platform.
 
@@ -379,6 +395,7 @@ dark-factory/
   state-export.sh               # export/verify/import a trained federation's evolved state (checksum-verified)
   gen-agent.sh                  # materialise a colony-lint-valid .ag agent from an invented METHOD line (#1000)
   demo-blackboard.sh            # offline, deterministic demo of the #1001 blackboard coordination loop
+  demo-halmos.sh                # proof of the #1015 Halmos symbolic gate (PROVED + COUNTEREXAMPLE; SKIPs without the toolchain)
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)
@@ -405,6 +422,9 @@ dark-factory/
   solana-harness-anchor/        # offline anchor-lang 0.31 harness (real SVM, Anchor) (V6)
   evm-harness/                  # offline revm crate: two-sided EVM PoC (real EVM, Solidity)
     forge-verify.sh             # multi-contract custom-protocol PoC gate (real Foundry deploy+exploit)
+    halmos-verify.sh            # sound symbolic gate: PROVES an invariant or returns a counterexample (Halmos+z3; #1015)
+    halmos-specs/               # self-contained Foundry specs: one Halmos PROVES, one it REFUTES (demo fixtures)
+  docs/halmos.md                # the Halmos gate's verdict/exit contract, toolchain install, epic fit (#1015)
   sealevel/                     # modernized coral-xyz/sealevel-attacks lessons (corpus) (V6)
   fixtures/                     # detection fixtures (vuln + safe + rigged-harness cases)
 ```

--- a/dark-factory/demo-halmos.sh
+++ b/dark-factory/demo-halmos.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# demo-halmos.sh — reproducible proof that the #1015 Halmos symbolic-execution gate returns the right
+# SOUND verdict on a known-good and a known-bad spec.
+#
+# Halmos is a deterministic solver (symbolic execution + z3), so a real run IS the deterministic proof —
+# there is no mock and no sampling. The demo runs evm-harness/halmos-verify.sh against the two example
+# specs under evm-harness/halmos-specs/ and asserts the contract:
+#   - test/LedgerProved.t.sol         -> PROVED         (exit 0): the conservation invariant holds for ALL inputs
+#   - test/LedgerCounterexample.t.sol -> COUNTEREXAMPLE (exit 1): a concrete input mints value (a planted bug)
+#
+# CI has neither halmos nor forge, so if EITHER is missing this prints a single [SKIP] line and exits 0
+# (mirroring the colony-lint skip convention) instead of failing. Install the toolchain to run it for real:
+#   curl -L https://foundry.paradigm.xyz | bash && foundryup    # forge
+#   uv tool install halmos                                      # halmos (bundles z3)
+#
+# Usage:  dark-factory/demo-halmos.sh
+# Exit: 0 = both verdicts correct (or tools absent -> SKIP) ; non-zero = a verdict was wrong.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+GATE="$HERE/evm-harness/halmos-verify.sh"
+SPECS="$HERE/evm-harness/halmos-specs"
+
+FAILS=0
+note() { echo "demo-halmos.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+skip() { echo "  [SKIP] $*"; }
+
+# The gate itself exits 2 when the toolchain is missing, but we skip EARLY (before invoking it) so CI
+# without halmos/forge reports a clean [SKIP] + exit 0 rather than a harness error.
+if ! command -v forge >/dev/null 2>&1 || ! command -v halmos >/dev/null 2>&1; then
+  skip "forge and/or halmos not on PATH — install foundryup + 'uv tool install halmos' to run this demo"
+  exit 0
+fi
+
+[ -x "$GATE" ] || { note "gate not found / not executable: $GATE" >&2; exit 3; }
+[ -d "$SPECS" ] || { note "specs dir not found: $SPECS" >&2; exit 3; }
+
+# Run the gate and assert BOTH the verdict banner and the exit code. $1 = label, $2 = target spec,
+# $3 = expected verdict token (PROVED|COUNTEREXAMPLE), $4 = expected exit code.
+assert_verdict() {
+  _label="$1"; _target="$2"; _want_verdict="$3"; _want_exit="$4"
+  _out="$("$GATE" --repo "$SPECS" --target "$_target" 2>&1)"; _rc=$?
+  _banner="$(printf '%s\n' "$_out" | grep -E 'HALMOS-VERIFY:' | tail -1 || true)"
+  if [ "$_rc" -eq "$_want_exit" ] && printf '%s' "$_banner" | grep -q "HALMOS-VERIFY: ${_want_verdict}"; then
+    ok "$_label -> $_want_verdict (exit $_rc)"
+  else
+    bad "$_label expected $_want_verdict / exit $_want_exit, got exit $_rc"
+    printf '%s\n' "$_out" | sed 's/^/        | /'
+  fi
+}
+
+note "running halmos-verify.sh against the two example specs (real solver, deterministic) ..."
+assert_verdict "true invariant (transferSafe conserves value)" \
+  "test/LedgerProved.t.sol" "PROVED" 0
+assert_verdict "planted bug (transferBuggy mints value)" \
+  "test/LedgerCounterexample.t.sol" "COUNTEREXAMPLE" 1
+# Soundness guard: an under-unrolled loop must NOT pass as PROVED. Halmos reports `0 failed` but warns
+# the loop was not fully explored, so the gate must return INCONCLUSIVE (exit 3), never a false proof.
+assert_verdict "under-unrolled loop (true invariant, incomplete exploration)" \
+  "test/LedgerInconclusive.t.sol" "INCONCLUSIVE" 3
+
+echo
+if [ "$FAILS" -eq 0 ]; then
+  note "PASS: Halmos PROVED the honest spec, REFUTED the buggy one with a concrete counterexample, and the"
+  note "      gate refused to over-claim PROVED on an under-unrolled loop (returned INCONCLUSIVE) (#1015)"
+  exit 0
+fi
+note "DEMO FAILED — a verdict did not match the contract" >&2
+exit 1

--- a/dark-factory/docs/halmos.md
+++ b/dark-factory/docs/halmos.md
@@ -1,0 +1,105 @@
+# Halmos symbolic-execution verification gate (#1015 M1)
+
+`evm-harness/halmos-verify.sh` is the **sound, exhaustive** verification gate for the discovery track.
+Given a `*.t.sol` spec that asserts an invariant over symbolic inputs, [Halmos](https://github.com/a16z/halmos)
+(symbolic execution + the z3 SMT solver) either **PROVES the property holds for every input**, or returns a
+**concrete counterexample input that violates it**. There is no fuzzing, no sampling, and no flakiness: on a
+clean verdict the correctness is the solver's, not a heuristic's.
+
+This is the symbolic sibling of [`evm-harness/forge-verify.sh`](../evm-harness/forge-verify.sh). The two
+are complementary oracles:
+
+| Gate | Method | What a pass means |
+|---|---|---|
+| `forge-verify.sh` | EXECUTION — runs one concrete PoC tx | this *one* path breaks the invariant (a witnessed exploit) |
+| `halmos-verify.sh` | SYMBOLIC — runs z3 over ALL inputs | the property holds for *every* input, or here is a concrete counterexample |
+
+`halmos-verify.sh` does not replace `forge-verify.sh`; it is an **additional** sound oracle.
+
+## How it fits the epic
+
+The discovery colony's LLM **hypothesizes**: it reads a protocol and proposes an invariant and a sketch of
+how it might break. An LLM proposal is, on its own, unverified — it can hallucinate both the bug and the
+fix. Halmos is the **sound verdict**. When a candidate is routed to a Halmos-gated check, the system's
+correctness on that check is *Halmos's*, not the LLM's: a `PROVED` is a real proof over all inputs, and a
+`COUNTEREXAMPLE` is a concrete witness a human can replay. The LLM's job shrinks to *writing the spec*; the
+truth of the answer is the solver's.
+
+**Scope of M1 (be honest):** this milestone ships the **callable gate only** — the script, two example
+specs, and an offline demo. Auto-routing discovery candidates into it (generate-a-spec-and-verify, closing
+the loop from prose lead to symbolic proof) is a **later milestone**. Today a human or a higher-level script
+invokes the gate with a hand-written or generated `*.t.sol`.
+
+## Verdict / exit contract
+
+```
+halmos-verify.sh --repo <foundry-project-root> --target <Spec.t.sol>
+                 [--function <prefix>] [--timeout <seconds>]
+```
+
+- `--repo` — a Foundry project root (must contain `foundry.toml`).
+- `--target` — the `*.t.sol` spec, absolute or relative to `--repo`.
+- `--function` — the symbolic-test name prefix Halmos runs (default `check`). By convention `check_*`
+  functions assert the invariant directly over their symbolic arguments.
+- `--timeout` — per-assertion solver timeout in seconds (default `60`); passed to Halmos as
+  `--solver-timeout-assertion`.
+
+The gate parses Halmos's `Symbolic test result: N passed; M failed` summary (Halmos's own process exit code
+is not a reliable verdict signal) and prints a
+`================ HALMOS-VERIFY: <VERDICT> ================` banner to stderr:
+
+| Verdict | Exit | Meaning |
+|---|---|---|
+| **PROVED** | `0` | `M failed` == 0 and `N passed` >= 1: the property holds exhaustively over all inputs. |
+| **COUNTEREXAMPLE** | `1` | >= 1 `failed` / a `Counterexample:` block: a concrete input violates the property — a real bug. |
+| **INCONCLUSIVE** | `3` | solver `unknown` / a path timed out / an unbounded loop / no functions matched: no sound verdict. |
+| **harness/usage** | `2` | bad args, `--repo` is not a Foundry project, or `halmos`/`forge` is not installed. |
+
+`INCONCLUSIVE` is deliberately distinct from `PROVED`: a timeout or an `unknown` from the solver is *not* a
+proof. The gate only reports `PROVED` when the solver decided every path.
+
+## Install the toolchain
+
+The gate resolves `forge` and `halmos` via `PATH` (it hardcodes no install location). Both must be present:
+
+```bash
+# Foundry (provides forge, which Halmos drives for compilation)
+curl -L https://foundry.paradigm.xyz | bash && foundryup
+
+# Halmos (bundles z3)
+uv tool install halmos
+```
+
+Requires **halmos >= 0.3** and **foundry** (forge). CI runners have neither, so the demo SKIPs cleanly
+there (see below).
+
+## Example specs + offline demo
+
+`evm-harness/halmos-specs/` is a minimal, self-contained Foundry project (no external libs):
+
+- `src/Ledger.sol` — a two-account ledger with an honest `transferSafe` and a buggy `transferBuggy` that
+  forgets to debit the sender when the transferred amount equals the balance (it mints value).
+- `test/LedgerProved.t.sol` — asserts value conservation against `transferSafe`. Halmos **PROVES** it
+  (`Symbolic test result: 1 passed; 0 failed`) → `PROVED`, exit 0.
+- `test/LedgerCounterexample.t.sol` — the same invariant against `transferBuggy`. Halmos **REFUTES** it with
+  a concrete `(from, to, amount)` witness (e.g. `from = amount = 0x80, to = 0x00`) → `COUNTEREXAMPLE`,
+  exit 1.
+
+Balances are `uint8` so the symbolic search returns a sound verdict in a couple of seconds.
+
+`dark-factory/demo-halmos.sh` runs the gate against both specs and asserts the contract (PROVED/exit 0 on
+the first, COUNTEREXAMPLE/exit 1 on the second). Halmos is deterministic, so a real run *is* the
+deterministic proof — there is no mock. If `halmos` or `forge` is not on `PATH`, the demo prints a single
+`[SKIP]` line and exits 0 (mirroring the colony-lint skip convention) so CI passes without the tools.
+
+```bash
+# with the toolchain on PATH
+dark-factory/demo-halmos.sh
+#   [OK]   true invariant (transferSafe conserves value) -> PROVED (exit 0)
+#   [OK]   planted bug (transferBuggy mints value) -> COUNTEREXAMPLE (exit 1)
+
+# verify a single spec directly
+dark-factory/evm-harness/halmos-verify.sh \
+  --repo dark-factory/evm-harness/halmos-specs \
+  --target test/LedgerProved.t.sol
+```

--- a/dark-factory/evm-harness/halmos-specs/.gitignore
+++ b/dark-factory/evm-harness/halmos-specs/.gitignore
@@ -1,0 +1,3 @@
+out/
+cache/
+broadcast/

--- a/dark-factory/evm-harness/halmos-specs/foundry.toml
+++ b/dark-factory/evm-harness/halmos-specs/foundry.toml
@@ -1,0 +1,9 @@
+# Minimal Foundry project for the Halmos symbolic-execution gate's example specs.
+# Self-contained: no external libs (no forge-std), so `forge build` / `halmos`
+# resolve everything from `src` + `test` alone. The specs use small bit-widths
+# so Halmos returns a sound verdict in a couple of seconds.
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+test = "test"

--- a/dark-factory/evm-harness/halmos-specs/src/Ledger.sol
+++ b/dark-factory/evm-harness/halmos-specs/src/Ledger.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+// A two-account ledger used by the Halmos example specs. `transferSafe` is the
+// honest implementation; `transferBuggy` plants a real bug (it credits the
+// receiver but forgets to debit the sender on the equal-balance path), so the
+// conserved-total invariant no longer holds for some symbolic inputs.
+//
+// Balances are uint8 so the symbolic search space stays tiny and Halmos returns
+// a sound verdict in a couple of seconds. The "value conservation" invariant
+// (sender_after + receiver_after == sender_before + receiver_before) is the
+// property the specs assert over ALL symbolic inputs.
+contract Ledger {
+    // Honest transfer: debit sender, credit receiver. Reverts on insufficient
+    // funds or on credit overflow, so the post-state always conserves the total.
+    function transferSafe(uint8 from, uint8 to, uint8 amount)
+        external
+        pure
+        returns (uint8 fromOut, uint8 toOut)
+    {
+        require(from >= amount, "insufficient");
+        require(uint16(to) + uint16(amount) <= type(uint8).max, "overflow");
+        fromOut = from - amount;
+        toOut = to + amount;
+    }
+
+    // Planted bug: when the transferred amount exactly equals the sender's
+    // balance, the sender is NOT debited (the `from - amount` write is skipped),
+    // so the conserved-total invariant breaks and value is minted out of thin
+    // air. Halmos must surface a concrete (from, to, amount) counterexample.
+    function transferBuggy(uint8 from, uint8 to, uint8 amount)
+        external
+        pure
+        returns (uint8 fromOut, uint8 toOut)
+    {
+        require(from >= amount, "insufficient");
+        require(uint16(to) + uint16(amount) <= type(uint8).max, "overflow");
+        if (amount == from) {
+            fromOut = from; // BUG: should be `from - amount` (i.e. 0)
+        } else {
+            fromOut = from - amount;
+        }
+        toOut = to + amount;
+    }
+}

--- a/dark-factory/evm-harness/halmos-specs/test/LedgerCounterexample.t.sol
+++ b/dark-factory/evm-harness/halmos-specs/test/LedgerCounterexample.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+import {Ledger} from "../src/Ledger.sol";
+
+// COUNTEREXAMPLE spec: the same conservation invariant asserted against the
+// buggy `transferBuggy`. Halmos finds the concrete input that violates it (any
+// case where `amount == from` mints value, e.g. from = to = amount = some
+// non-zero value), prints a `Counterexample:` block + `[FAIL]`, and the summary
+// reports `1 failed`. The gate returns COUNTEREXAMPLE (exit 1): a real bug with
+// a concrete witness, not a maybe.
+contract LedgerCounterexampleTest {
+    Ledger internal ledger;
+
+    function setUp() public {
+        ledger = new Ledger();
+    }
+
+    // Same invariant as the PROVED spec, but the buggy implementation breaks it
+    // on the `amount == from` path, so Halmos refutes it with a witness.
+    function check_conservation(uint8 from, uint8 to, uint8 amount) public {
+        uint16 before = uint16(from) + uint16(to);
+        (uint8 fromOut, uint8 toOut) = ledger.transferBuggy(from, to, amount);
+        uint16 afterTotal = uint16(fromOut) + uint16(toOut);
+        assert(afterTotal == before);
+    }
+}

--- a/dark-factory/evm-harness/halmos-specs/test/LedgerInconclusive.t.sol
+++ b/dark-factory/evm-harness/halmos-specs/test/LedgerInconclusive.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+// INCONCLUSIVE spec: a loop bounded by a SYMBOLIC count exceeds Halmos's unroll
+// bound, so Halmos cannot fully explore every path. The asserted property is
+// actually TRUE, and Halmos reports `0 failed` — but it also warns that "paths
+// have not been fully explored due to the loop" (#loop-bound). A `0 failed`
+// under incomplete exploration is NOT a sound proof, so the gate MUST return
+// INCONCLUSIVE (exit 3), never PROVED. This spec is the soundness regression
+// guard for that: if the gate ever mis-reports an under-unrolled loop as PROVED,
+// the demo fails.
+contract LedgerInconclusiveTest {
+    // `s` counts up to `n`; the invariant s == n is true, but the loop runs a
+    // symbolic number of times, beyond Halmos's default unroll bound.
+    function check_loop_sum(uint256 n) public pure {
+        uint256 s = 0;
+        for (uint256 i = 0; i < n; i++) {
+            s += 1;
+        }
+        assert(s == n);
+    }
+}

--- a/dark-factory/evm-harness/halmos-specs/test/LedgerProved.t.sol
+++ b/dark-factory/evm-harness/halmos-specs/test/LedgerProved.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+import {Ledger} from "../src/Ledger.sol";
+
+// PROVED spec: Halmos exhaustively proves that the honest `transferSafe`
+// conserves total value over ALL symbolic (from, to, amount) inputs. There is
+// no input that breaks it, so the summary reports `0 failed` and the gate
+// returns PROVED (exit 0). This is a sound proof, not a sampled fuzz run.
+contract LedgerProvedTest {
+    Ledger internal ledger;
+
+    function setUp() public {
+        ledger = new Ledger();
+    }
+
+    // For every symbolic input, the sum of the two balances after the transfer
+    // equals the sum before it: value is neither created nor destroyed.
+    function check_conservation(uint8 from, uint8 to, uint8 amount) public {
+        uint16 before = uint16(from) + uint16(to);
+        (uint8 fromOut, uint8 toOut) = ledger.transferSafe(from, to, amount);
+        uint16 afterTotal = uint16(fromOut) + uint16(toOut);
+        assert(afterTotal == before);
+    }
+}

--- a/dark-factory/evm-harness/halmos-verify.sh
+++ b/dark-factory/evm-harness/halmos-verify.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# halmos-verify.sh — the SYMBOLIC / exhaustive verification gate for the discovery track.
+#
+# forge-verify.sh (its sibling) EXECUTES a single concrete PoC tx and reports VERIFIED iff that one
+# path breaks an invariant. halmos-verify.sh is the SOUND, exhaustive oracle: it runs Halmos
+# (symbolic execution + an SMT solver, z3) over a `*.t.sol` spec and either PROVES a property holds
+# for ALL inputs, or returns a CONCRETE counterexample input that violates it. There is no sampling
+# and no flakiness — on a clean PROVED/COUNTEREXAMPLE verdict the correctness is the solver's, not a
+# heuristic's. (See dark-factory/docs/halmos.md for how this fits the epic.)
+#
+# A spec function name starts with the `--function` prefix (default `check`); each such function
+# asserts an invariant over its symbolic arguments. By convention `check_*` asserts the property
+# directly; Halmos proves it or refutes it with a witness.
+#
+# Usage:
+#   halmos-verify.sh --repo <foundry-project-root> --target <Spec.t.sol>
+#                    [--function <prefix>] [--timeout <seconds>]
+#
+# Verdict / exit contract:
+#   PROVED         exit 0  — summary shows `M failed` == 0 with >=1 passed: holds for ALL inputs.
+#   COUNTEREXAMPLE exit 1  — >=1 `failed` / a `Counterexample:` block: a concrete input is a real bug.
+#   INCONCLUSIVE   exit 3  — timeout / `unknown` / unbounded loop / no functions matched: no verdict.
+#   harness/usage  exit 2  — bad args, repo is not a foundry project, or halmos/forge not installed.
+set -euo pipefail
+
+REPO=""
+TARGET=""
+FUNCTION="check"
+# Per-assertion solver timeout in seconds. Halmos accepts a unit suffix; we pass milliseconds so the
+# value reads naturally in seconds at the CLI. 0 would mean "no timeout" to halmos — we keep a finite
+# default so the gate cannot hang a pipeline.
+TIMEOUT="60"
+
+usage() { sed -n '2,33p' "$0"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)     REPO="${2:-}"; shift 2 ;;
+    --target)   TARGET="${2:-}"; shift 2 ;;
+    --function) FUNCTION="${2:-}"; shift 2 ;;
+    --timeout)  TIMEOUT="${2:-}"; shift 2 ;;
+    -h|--help)  usage; exit 0 ;;
+    *) echo "halmos-verify: unknown arg $1" >&2; exit 2 ;;
+  esac
+done
+
+# --- usage / harness validation -----------------------------------------------------------------
+[ -n "$REPO" ] && [ -d "$REPO" ] || { echo "halmos-verify: --repo <foundry project root> required" >&2; exit 2; }
+[ -f "$REPO/foundry.toml" ] || { echo "halmos-verify: $REPO is not a foundry project (no foundry.toml)" >&2; exit 2; }
+[ -n "$TARGET" ] || { echo "halmos-verify: --target <Spec.t.sol> required" >&2; exit 2; }
+# Resolve the target relative to the repo if it is not an absolute / cwd-relative path.
+if [ -f "$TARGET" ]; then
+  TARGET_PATH="$TARGET"
+elif [ -f "$REPO/$TARGET" ]; then
+  TARGET_PATH="$REPO/$TARGET"
+else
+  echo "halmos-verify: target spec not found: $TARGET" >&2; exit 2
+fi
+[ -n "$FUNCTION" ] || { echo "halmos-verify: --function prefix must be non-empty" >&2; exit 2; }
+case "$TIMEOUT" in
+  ''|*[!0-9]*) echo "halmos-verify: --timeout must be a whole number of seconds" >&2; exit 2 ;;
+esac
+
+# --- tool presence ------------------------------------------------------------------------------
+# halmos drives `forge build` for compilation, so both must be on PATH. We do NOT hardcode any
+# install location — the caller is responsible for exporting the toolchain onto PATH.
+command -v forge >/dev/null 2>&1 || {
+  echo "halmos-verify: forge not installed (run foundryup; https://getfoundry.sh)" >&2; exit 2; }
+command -v halmos >/dev/null 2>&1 || {
+  echo "halmos-verify: halmos not installed (run: uv tool install halmos)" >&2; exit 2; }
+
+# --- scope to the contracts declared in the target spec -----------------------------------------
+# halmos selects by contract name, not file path. Pull every `contract <Name>` out of the target
+# and build a `--match-contract '^(A|B|...)$'` regex so the run is scoped to exactly this spec file.
+CONTRACTS="$(
+  grep -E '^[[:space:]]*contract[[:space:]]+[A-Za-z_]' "$TARGET_PATH" 2>/dev/null \
+    | sed -E 's/^[[:space:]]*contract[[:space:]]+([A-Za-z0-9_]+).*/\1/' \
+    | paste -sd '|' - || true
+)"
+[ -n "$CONTRACTS" ] || { echo "halmos-verify: no contract declarations found in $TARGET_PATH" >&2; exit 2; }
+MATCH_CONTRACT="^(${CONTRACTS})\$"
+
+TIMEOUT_MS=$((TIMEOUT * 1000))
+echo "== halmos-verify: symbolic-checking $(basename "$TARGET_PATH") (functions ${FUNCTION}*, ${TIMEOUT}s/assertion) ==" >&2
+
+# Capture combined output; halmos's own exit status is unreliable for the verdict (it can exit 0 even
+# with a failing test), so we parse the structured summary it prints instead.
+OUT="$(
+  cd "$REPO" && halmos \
+    --function "$FUNCTION" \
+    --match-contract "$MATCH_CONTRACT" \
+    --solver-timeout-assertion "${TIMEOUT_MS}ms" \
+    2>&1
+)" || true
+echo "$OUT" >&2
+
+# --- parse the verdict --------------------------------------------------------------------------
+# Halmos prints one summary line per run: `Symbolic test result: N passed; M failed; ...`.
+# `|| true` keeps a no-match grep (an errored run with no summary) from tripping `set -e`.
+SUMMARY="$(printf '%s\n' "$OUT" | grep -E 'Symbolic test result:' | tail -1 || true)"
+
+banner() { echo "================ HALMOS-VERIFY: $1 ================" >&2; }
+
+if [ -z "$SUMMARY" ]; then
+  # No summary at all: halmos errored before producing a verdict (e.g. `No tests with --match-...`,
+  # a compile failure, or a crash). Not a proof and not a refutation -> inconclusive.
+  banner "INCONCLUSIVE (no symbolic test result; nothing matched / run did not complete)"
+  exit 3
+fi
+
+PASSED="$(printf '%s\n' "$SUMMARY" | sed -E 's/.*result:[[:space:]]*([0-9]+) passed.*/\1/')"
+FAILED="$(printf '%s\n' "$SUMMARY" | sed -E 's/.*passed;[[:space:]]*([0-9]+) failed.*/\1/')"
+case "$PASSED" in ''|*[!0-9]*) PASSED=0 ;; esac
+case "$FAILED" in ''|*[!0-9]*) FAILED=0 ;; esac
+
+# An `unknown`/timeout/unbounded-loop signal means a path could not be decided: even with 0 reported
+# failures the result is NOT a sound proof. Treat any such marker as INCONCLUSIVE. NB halmos phrases an
+# under-unrolled loop as `paths have not been fully explored due to the loop` + a `#loop-bound` wiki link
+# (NOT "loop limit"), so a loop-containing spec that exceeds the unroll bound must NOT pass as PROVED —
+# match halmos's ACTUAL wording, not a guess.
+if printf '%s\n' "$OUT" | grep -qiE 'timed out|timeout|\bunknown\b|loop[ -]?(limit|bound)|unbounded|incomplete|not( been)? fully explored'; then
+  banner "INCONCLUSIVE (solver returned unknown / a path timed out / a loop was not fully explored)"
+  exit 3
+fi
+
+if [ "$FAILED" -gt 0 ] || printf '%s\n' "$OUT" | grep -q 'Counterexample:'; then
+  banner "COUNTEREXAMPLE (a concrete input violates the property — real bug, ${FAILED} failing)"
+  exit 1
+fi
+
+if [ "$PASSED" -ge 1 ]; then
+  banner "PROVED (property holds for ALL inputs — ${PASSED} proven, 0 counterexamples)"
+  exit 0
+fi
+
+# 0 passed, 0 failed, summary present but no proof: nothing was actually checked.
+banner "INCONCLUSIVE (0 passed / 0 failed — no property was checked)"
+exit 3


### PR DESCRIPTION
## What

Epic #1015 **milestone 1**: a **Halmos symbolic-execution verification gate** — the epic's first sound-truth lever. It shifts a finding's verdict from the LLM (fallible) to a **sound engine**: Halmos symbolically executes a property over ALL inputs and either **PROVES** it or returns a concrete **COUNTEREXAMPLE** (a real bug, not an LLM hypothesis).

## How

- `dark-factory/evm-harness/halmos-verify.sh` — `--repo <foundry project> --target <Spec.t.sol> [--function <prefix>]`. Runs Halmos, parses its `N passed; M failed` summary (not its unreliable exit code) into a verdict + exit:
  - **PROVED** (exit 0) — holds for every input.
  - **COUNTEREXAMPLE** (exit 1) — a concrete input violates it.
  - **INCONCLUSIVE** (exit 3) — solver `unknown` / timeout / **a loop not fully explored** / nothing matched.
  - harness/usage error (exit 2) — bad args, not a Foundry project, or `halmos`/`forge` absent (with an install hint).
  Mirrors the existing `forge-verify.sh` conventions (banner, tool-absence checks). Halmos is an **additional** sound oracle alongside the execution-based forge-verify, not a replacement.
- **Soundness:** the gate treats halmos's real under-unrolled-loop warning (`paths have not been fully explored … #loop-bound`) as INCONCLUSIVE, so a not-fully-explored loop is **never** over-claimed as PROVED.

## Proof (deterministic — Halmos is a solver, no mock)

`dark-factory/evm-harness/halmos-specs/` ships three self-contained specs and `demo-halmos.sh` asserts all three against the real solver:
- honest `transferSafe` → **PROVED** (value conservation over all symbolic inputs; 7 explored paths).
- buggy `transferBuggy` (mints value when `amount == from`) → **COUNTEREXAMPLE** with a concrete witness.
- an under-unrolled loop (true invariant, incomplete exploration) → **INCONCLUSIVE** (the soundness regression guard).

`demo-halmos.sh` prints a single `[SKIP]` + exit 0 when `halmos`/`forge` are not on PATH, so **CI passes without the toolchain**.

## Boundaries

M1 is the **callable gate only**. Auto-routing discovery candidates into it (generate-and-verify orchestration), and the hevm / SMT-direct / Lean / stateful-fuzzing levers, are later milestones. Human-gated submission + the existing gates stay intact.

## Verification

PROVED / COUNTEREXAMPLE / INCONCLUSIVE verdicts + exit codes confirmed on real **Halmos 0.3.3 / forge 1.7.1 / z3 4.16.0**; tool-absent → exit 2; demo SKIPs cleanly without the tools; `bash -n` clean; **`colony-lint.sh` → 365 / 0 / 5**.

Part of #1015 — does **NOT** close the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
