### PR TITLE
fix(dark-factory): idempotent terminal policy attribution — count each action once (#1026)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -116,6 +116,24 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Fixed
 
+- **Coordinator orchestrate loop double-counted the final action's policy on a `stop`/dry-cap stop** (#1026).
+  In `ORCHESTRATE_ENABLED` mode `coordinator.ag` attributes each step's PREVIOUS action inside `step_fn`, and a
+  post-loop FINAL ATTRIBUTION block attributes the last action the loop did not get to. On a `stop`/dry-cap
+  termination the stop-deciding step's `decide_once` had ALREADY attributed that last executed action, so the
+  final block counted it a SECOND time — a run with 2 executed hunts ended `hunt=-0.4500` (3 × −0.15) instead
+  of the correct `hunt=-0.3000` (2 × −0.15). The carried state now tracks a `lastAttr` flag (state field
+  18); the FINAL ATTRIBUTION fires only for an action the in-loop pass did NOT already attribute — and drops
+  both the extra `learn()` AND the extra carried-int delta, so the in-loop policy still equals the
+  experience-store `read_policy()` sum. Attribution is now IDEMPOTENT: every EXECUTED action (hunt / refute /
+  poc-screen / invent-method) is counted EXACTLY once across both termination paths (budget-exhaustion and
+  the dry-cap `stop`); `stop` is a decision, never an executed action, so it is never attributed. The
+  per-step `decisions.tsv` trace rows are unchanged (the double-count was in the terminal policy only).
+  `demo-orchestrate.sh` gains a #1026 regression guard (proof (5): a dry-cap-terminated run attributes the
+  last action exactly once — N executed hunts → N × the delta, not N+1) and its comments note the in-substrate
+  policy is now the correct once-per-action attribution (no longer reproducing the M2 shell loop's stop-path
+  double-count — that was the bug). The single-decision path (`demo-coordinator.sh`, `ORCHESTRATE_ENABLED`
+  absent) is byte-identical, and the budget-exhaustion GOLDEN (`hunt=0.6000;refute=-0.6000`) is unchanged
+  (that path never double-counted).
 - **`run-coordinator.sh` dispatch dropped a hunt's class** (#1014 v1 follow-up). The coordinator's
   `ACTION|<type>|<args>|<rationale>` line was parsed with a flat `cut -f3`/`-f4-`, but a `hunt`'s
   `<args>` is two `|`-fields (`subsystem|class`) where every other action's is one. The class leaked

--- a/dark-factory/auditor/agents/coordinator.ag
+++ b/dark-factory/auditor/agents/coordinator.ag
@@ -496,14 +496,22 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
 //                 the store, sorted; the seen flags reproduce that (a key is omitted until first attributed)
 //   16 trace      the accumulating decisions.tsv body (rows joined by `\n`, each a real TSV row)
 //   17 budget0    the ORIGINAL budget (for the BUDGET fact each row reports as the shell's REMAINING)
+//   18 lastAttr   "1" once the carried prevAction has ALREADY been attributed in-loop (so the post-loop FINAL
+//                 ATTRIBUTION must NOT attribute it again), else "0". On a `stop`/dry-cap termination the stop
+//                 step's decide_once already attributed the last executed action (#1026), so this flag is "1"
+//                 and the final block skips it; on budget-exhaustion the last action is never attributed
+//                 in-loop (the next step's decide_once never runs), so it stays "0" and the final block
+//                 attributes it exactly once. Makes attribution IDEMPOTENT: every EXECUTED action counted once.
 //
 // POLICY THREADING. decide_once() is fed the formatted carried policy (fields 8-15 -> the `type=delta;...`
 // string read_policy would return), so the in-loop decision ranks options against the SAME evolving policy
 // the shell read between calls. The attribution for the PREVIOUS action is applied to the carried ints at
 // the START of each step (exactly when read_policy reflects it: the shell's read_policy at step N already
 // includes the call-(N-1) write, but NOT the call-N write of action N-1 — so the policy string a step uses
-// is the pre-attribution snapshot). After the loop, prevAction is attributed ONE more time, mirroring the
-// shell's final BUDGET=0 record call (which double-counts the last real action on a `stop` — reproduced).
+// is the pre-attribution snapshot). After the loop, prevAction is attributed ONE more time ONLY when the loop
+// did NOT already attribute it (field 18) — so every EXECUTED action is counted exactly once. `stop` is a
+// decision, never an executed action, so it is never attributed. (#1026 fixed the prior double-count where a
+// `stop`/dry-cap termination attributed the last executed action twice: the stop step AND the final block.)
 
 // Format a ten-thousandths int as a fixed `%.4f` decimal, byte-identical to Python "%.4f" (the shell's
 // read_policy formatting). pad4 zero-pads the fractional part to 4 digits.
@@ -665,12 +673,16 @@ fn step_fn(state: string, stepLabel: string) -> string {
     let trace2 = append_line(trace, row);
 
     if selType == "stop" {
-        // Terminal: record the row, freeze the loop (no action executed, no PENDING/streak change).
+        // Terminal: record the row, freeze the loop (no action executed, no PENDING/streak change). The
+        // PREVIOUS (last executed) action was ALREADY attributed by this step's decide_once + the carried-int
+        // delta above (when didAttr), so flag it attributed (field 18) — the post-loop FINAL ATTRIBUTION must
+        // NOT count it again (#1026). `stop` itself is a decision, never an executed action, so it is never
+        // attributed regardless.
         return "1@@F@@" + to_string(budget) + "@@F@@" + to_string(dryStreak) + "@@F@@" + to_string(step)
              + "@@F@@" + prevAction + "@@F@@" + prevKey + "@@F@@" + lastOutcome + "@@F@@" + pending
              + "@@F@@" + to_string(ph) + "@@F@@" + to_string(pi) + "@@F@@" + to_string(pp) + "@@F@@" + to_string(pr)
              + "@@F@@" + bool_flag(sh) + "@@F@@" + bool_flag(si) + "@@F@@" + bool_flag(sp) + "@@F@@" + bool_flag(sr)
-             + "@@F@@" + trace2 + "@@F@@" + to_string(budget0);
+             + "@@F@@" + trace2 + "@@F@@" + to_string(budget0) + "@@F@@" + bool_flag(didAttr);
     }
 
     // Read the dispatch verdict back (decide_once already ran dispatch() in-process, writing the memo).
@@ -694,11 +706,14 @@ fn step_fn(state: string, stepLabel: string) -> string {
     // BOUND, not the authority — we stop the moment carried budget hits 0 by flipping `stopped`.
     let stopped2 = if budget2 <= 0 { "1" } else { "0" };
 
+    // The action JUST executed (selType) is the NEW carried prevAction; it has NOT been attributed yet (its
+    // attribution happens at the NEXT step's decide_once, or — on budget-exhaustion, when no next step runs —
+    // at the post-loop FINAL ATTRIBUTION). Flag it un-attributed (field 18 = "0"). (#1026)
     return stopped2 + "@@F@@" + to_string(budget2) + "@@F@@" + to_string(dryStreak2) + "@@F@@" + to_string(step2)
          + "@@F@@" + selType + "@@F@@" + selArgs + "@@F@@" + outcome + "@@F@@" + pending2
          + "@@F@@" + to_string(ph) + "@@F@@" + to_string(pi) + "@@F@@" + to_string(pp) + "@@F@@" + to_string(pr)
          + "@@F@@" + bool_flag(sh) + "@@F@@" + bool_flag(si) + "@@F@@" + bool_flag(sp) + "@@F@@" + bool_flag(sr)
-         + "@@F@@" + trace2 + "@@F@@" + to_string(budget0);
+         + "@@F@@" + trace2 + "@@F@@" + to_string(budget0) + "@@F@@0";
 }
 
 // === TOP LEVEL ===
@@ -710,36 +725,40 @@ if len(getenv("ORCHESTRATE_ENABLED")) > 0 {
     // a non-default cap arrives via DRY_CAP. BUDGET is the loop bound.
     let budget0 = if len(getenv("BUDGET")) == 0 { 0 } else { parse_int(getenv("BUDGET")) };
     let initPending = getenv("PENDING");
-    // initial accumulator: nothing attributed yet (all ints 0, all seen "0"), no prev, empty trace.
+    // initial accumulator: nothing attributed yet (all ints 0, all seen "0"), no prev, empty trace, field 18
+    // lastAttr "0" (no prev action to have attributed).
     let init = "0@@F@@" + to_string(budget0) + "@@F@@0@@F@@0@@F@@@@F@@@@F@@@@F@@" + initPending
-             + "@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@@@F@@" + to_string(budget0);
+             + "@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@@@F@@" + to_string(budget0) + "@@F@@0";
     let finalState = reduce(regex_split("\n", getenv("STEPS")),
                             |acc: string, s: string| -> string { return step_fn(acc, s); }, init);
 
-    // FINAL ATTRIBUTION: record the last action's outcome once more — the shell's terminal BUDGET=0 call.
-    // (On a `stop` this double-counts the last real action exactly as the shell does; on budget-exhaustion
-    // it attributes the final action the loop didn't get to attribute. Both match run-coordinator.sh.)
+    // FINAL ATTRIBUTION (#1026): attribute the last EXECUTED action's outcome ONCE — but ONLY if the in-loop
+    // pass did NOT already attribute it (field 18 `lastAttr`). On budget-exhaustion the last action is never
+    // attributed in-loop (the next step's decide_once never runs), so lastAttr is "0" and we attribute it here
+    // exactly once. On a `stop`/dry-cap termination the stop step's decide_once ALREADY attributed it, so
+    // lastAttr is "1" and we skip — no double-count. The carried policy ints already hold every executed
+    // action's delta; this block only adds the one the loop deferred. Attribution is thus IDEMPOTENT: every
+    // executed action is counted exactly once across all termination paths.
+    let fLastAttr = state_int(finalState, 18) == 1;
     let fPrevAction = state_field(finalState, 4);
     let fPrevKey = state_field(finalState, 5);
     let fLastOutcome = state_field(finalState, 6);
     let fSig = outcome_signal(fLastOutcome);
-    if len(fPrevAction) > 0 {
-        if len(fSig) > 0 {
-            learn("coordinator", fPrevAction,
-                  "outcome of previous " + fPrevAction + " (" + fPrevKey + ") was " + fLastOutcome,
-                  fSig, [fPrevAction, fSig]);
-        }
+    let fAttribute = if fLastAttr { false } else { if len(fPrevAction) > 0 { len(fSig) > 0 } else { false } };
+    if fAttribute {
+        learn("coordinator", fPrevAction,
+              "outcome of previous " + fPrevAction + " (" + fPrevKey + ") was " + fLastOutcome,
+              fSig, [fPrevAction, fSig]);
     }
-    let fd = signal_delta(fSig);
+    let fd = if fAttribute { signal_delta(fSig) } else { 0 };
     let fph = state_int(finalState, 8) + (if fPrevAction == "hunt" { fd } else { 0 });
     let fpi = state_int(finalState, 9) + (if fPrevAction == "invent-method" { fd } else { 0 });
     let fpp = state_int(finalState, 10) + (if fPrevAction == "poc-screen" { fd } else { 0 });
     let fpr = state_int(finalState, 11) + (if fPrevAction == "refute" { fd } else { 0 });
-    let fDidAttr = if len(fPrevAction) > 0 { len(fSig) > 0 } else { false };
-    let fsh = if state_int(finalState, 12) == 1 { true } else { if fDidAttr { fPrevAction == "hunt" } else { false } };
-    let fsi = if state_int(finalState, 13) == 1 { true } else { if fDidAttr { fPrevAction == "invent-method" } else { false } };
-    let fsp = if state_int(finalState, 14) == 1 { true } else { if fDidAttr { fPrevAction == "poc-screen" } else { false } };
-    let fsr = if state_int(finalState, 15) == 1 { true } else { if fDidAttr { fPrevAction == "refute" } else { false } };
+    let fsh = if state_int(finalState, 12) == 1 { true } else { if fAttribute { fPrevAction == "hunt" } else { false } };
+    let fsi = if state_int(finalState, 13) == 1 { true } else { if fAttribute { fPrevAction == "invent-method" } else { false } };
+    let fsp = if state_int(finalState, 14) == 1 { true } else { if fAttribute { fPrevAction == "poc-screen" } else { false } };
+    let fsr = if state_int(finalState, 15) == 1 { true } else { if fAttribute { fPrevAction == "refute" } else { false } };
 
     // Publish the trace + the evolved policy to durable memos the bootstrap reads back (the cross-process
     // channel). The trace is the full decisions.tsv body; policy-after is the read_policy()-shaped string.

--- a/dark-factory/demo-orchestrate.sh
+++ b/dark-factory/demo-orchestrate.sh
@@ -18,10 +18,20 @@
 #       (origin/main's run-coordinator.sh) produced for the SAME facts + fixture — captured below as the
 #       GOLDEN reference. Same decisions, same policy deltas; only the DRIVER moved into the substrate.
 #   (3) A re-run into a fresh store is byte-identical (deterministic, no RNG).
+#   (5) #1026 REGRESSION GUARD: a `stop`/dry-cap-terminated run attributes the LAST executed action EXACTLY
+#       ONCE. N executed hunts (all dry) -> policy hunt = N x -0.15, NOT (N+1) x -0.15. The prior in-substrate
+#       loop double-counted the last action on a stop (the stop step's decide_once attributed it AND the
+#       post-loop final block attributed it again); the fix makes attribution idempotent across all
+#       termination paths. `stop` is a decision, never an executed action, so it is never attributed.
 #
 # The GOLDEN reference (decisions.tsv + policy-after) was captured from `origin/main`'s shell-loop
 # `run-coordinator.sh` with the scope/class-fitness/fixture facts mirrored below (budget 8, dry-cap 3,
-# stub executor). It is the literal M2 output the M3 in-substrate loop must reproduce.
+# stub executor). This GOLDEN scenario terminates on BUDGET-EXHAUSTION (8 actions, never a `stop`), where the
+# old shell loop's final attribution was already CORRECT — so the GOLDEN_POLICY below is the once-per-action
+# value and stays byte-identical to the M2 shell loop. The #1026 double-count was specific to the `stop`/dry-
+# cap path, which is exercised + asserted separately in proof (5). After #1026 the in-substrate policy is the
+# CORRECT once-per-action attribution on EVERY path (no longer reproducing the shell loop's stop-path
+# double-count — that was the bug).
 #
 # Everything is deterministic and offline: the coordinator's choice is a fact+policy argmax (no RNG), the
 # dispatch verdicts come from a fixture (no LLM, no prompt()), and the backend is `mock` (zero cost).
@@ -198,6 +208,88 @@ if [ "$GUARD_STEPN" -eq "$GUARD_BUDGET" ]; then
   ok "budget=$GUARD_BUDGET ran all $GUARD_STEPN steps in one process (cb header covers the loop — no CB cliff)"
 else
   bad "budget=$GUARD_BUDGET produced $GUARD_STEPN/$GUARD_BUDGET trace rows — coordinator.ag cb header too low for the loop (CB cliff)"
+fi
+
+echo
+echo "=================================================================================="
+echo " (5) #1026 ONCE-PER-ACTION — a stop/dry-cap-terminated run attributes the last action EXACTLY ONCE"
+echo "=================================================================================="
+# Regression guard for #1026: before the fix the in-substrate loop double-counted the last EXECUTED action on
+# a `stop`/dry-cap termination (the stop step's decide_once attributed it AND the post-loop final block
+# attributed it again). Scenario: a single hunt cell that always comes back `dry`, dry-cap K=2. The loop hunts
+# twice (both dry -> dry-streak hits 2), then the 3rd decision is `stop`. Two EXECUTED hunts, each a failure
+# (-0.15). CORRECT once-per-action policy: hunt = 2 x -0.15 = -0.3000. The pre-fix double-count was -0.4500
+# (3 x -0.15). We assert BOTH the in-loop policy memo AND the experience-store sum equal -0.3000, AND that the
+# store holds EXACTLY 2 hunt attribution rows (N, not N+1). `stop` is a decision, not an executed action, so it
+# is never attributed.
+STOP_SCOPE=$'vault accounting|C1'
+STOP_FIT="C1=0.5500"
+STOP_FIXTURE="hunt|vault*=dry;refute|cand-*=refuted;poc-screen|cand-*=dry;invent-method|*=dry"
+STOP_BUDGET=8
+STOP_DRY_CAP=2
+EXPECT_HUNTS=2
+EXPECT_POLICY="hunt=-0.3000"
+init_store "$WORK/stop"
+STOP_STEPS="$(awk -v n="$STOP_BUDGET" 'BEGIN{ for (i=0;i<n;i++){ printf "%s%d", (i?"\n":""), i } }')"
+( cd "$WORK/stop" && env \
+    SCOPE="$STOP_SCOPE" CLASS_FITNESS="$STOP_FIT" PENDING="" \
+    BUDGET="$STOP_BUDGET" DRY_CAP="$STOP_DRY_CAP" STEPS="$STOP_STEPS" \
+    ORCHESTRATE_ENABLED=1 DISPATCH_ENABLED=1 DISPATCH_FIXTURE="$STOP_FIXTURE" \
+    agentis go coordinator.ag --enable-exec --enable-messaging >/dev/null 2>&1 )
+STOP_TRACE="$(read_trace "$WORK/stop")"
+STOP_POLICY="$(read_policy "$WORK/stop")"
+# The number of hunt actions actually EXECUTED (non-stop hunt rows in the trace).
+STOP_HUNTS="$(printf '%s\n' "$STOP_TRACE" | grep '^step=' | while IFS= read -r r; do row_action "$r"; done | grep -c '^hunt$')"
+# The number of hunt ATTRIBUTION rows in the durable experience store (must equal the executed hunts, not +1).
+STOP_HUNT_ROWS="$(python3 - "$WORK/stop/.agentis/experience/main.jsonl" <<'PY'
+import json, os, sys
+path = sys.argv[1]; n = 0
+if os.path.exists(path):
+    for line in open(path):
+        line = line.strip()
+        if not line: continue
+        try: r = json.loads(line)
+        except Exception: continue
+        if r.get("action") == "coordinator" and r.get("in") == "hunt": n += 1
+print(n)
+PY
+)"
+# The experience-store policy sum (the same read_policy() mechanic the shell uses) for the cross-check.
+STOP_STORE_POLICY="$(python3 - "$WORK/stop/.agentis/experience/main.jsonl" <<'PY'
+import json, os, sys
+path = sys.argv[1]; agg = {}
+if os.path.exists(path):
+    for line in open(path):
+        line = line.strip()
+        if not line: continue
+        try: r = json.loads(line)
+        except Exception: continue
+        if r.get("action") != "coordinator": continue
+        k = r.get("in", "")
+        if not k: continue
+        agg[k] = agg.get(k, 0.0) + float(r.get("delta", 0.0))
+print(";".join("%s=%.4f" % (k, agg[k]) for k in sorted(agg)))
+PY
+)"
+if [ "$STOP_HUNTS" -eq "$EXPECT_HUNTS" ]; then
+  ok "the run executed $STOP_HUNTS hunts then stopped (dry-cap) — the stop-terminated scenario under test"
+else
+  bad "expected $EXPECT_HUNTS executed hunts before the stop, got $STOP_HUNTS — wrong scenario"
+fi
+if [ "$STOP_POLICY" = "$EXPECT_POLICY" ]; then
+  ok "in-loop policy is $STOP_POLICY ($STOP_HUNTS hunts x -0.15) — last action attributed EXACTLY ONCE (not $((EXPECT_HUNTS + 1))x; #1026 fixed)"
+else
+  bad "in-loop policy '$STOP_POLICY' != expected '$EXPECT_POLICY' — the last action is double-counted (#1026 regressed)"
+fi
+if [ "$STOP_HUNT_ROWS" -eq "$EXPECT_HUNTS" ]; then
+  ok "the experience store holds EXACTLY $STOP_HUNT_ROWS hunt attribution rows (== executed hunts, not +1)"
+else
+  bad "the experience store holds $STOP_HUNT_ROWS hunt attribution rows, expected $EXPECT_HUNTS (the last action is double-attributed)"
+fi
+if [ "$STOP_POLICY" = "$STOP_STORE_POLICY" ]; then
+  ok "in-loop policy == experience-store read_policy() sum ($STOP_STORE_POLICY) on the stop path — both drop the double-count"
+else
+  bad "in-loop policy '$STOP_POLICY' != experience-store sum '$STOP_STORE_POLICY' on the stop path — the two sides disagree"
 fi
 
 echo


### PR DESCRIPTION
## What

Fixes #1026 — the coordinator's in-substrate orchestrate loop (`ORCHESTRATE_ENABLED`) double-counted the **final** action's policy attribution on a dry-cap stop.

## Bug

The loop attributes each step's PREVIOUS action inside `step_fn`, and a post-loop FINAL ATTRIBUTION block attributes the last action the loop didn't get to. On a dry-cap stop the stop-deciding step's `decide_once` had **already** attributed that last executed action, so the final block counted it a **second** time: a run with 2 executed hunts ended `hunt=-0.4500` (3 × −0.15) instead of the correct `hunt=-0.3000` (2 ×).

## Fix

Carry a `lastAttr` flag (state field 18); the FINAL ATTRIBUTION fires only for an action the in-loop pass did **not** already attribute, dropping both the extra `learn()` and the extra carried-int. Attribution is now **idempotent** — every executed action (hunt/refute/poc-screen/invent-method) is counted **exactly once** across both termination paths (budget-exhaustion and the dry-cap stop). `stop` is a decision, never an executed action, so it is never attributed.

## Verification

- Per-path attribution counts (independently counted from the experience store): dry-cap stop → `hunt=-0.3000` (2 rows for 2 hunts); **budget-exhaustion still attributes the last action once** → `hunt=-0.6000` (4 rows for 4 hunts — the fix did not break the path that was already correct); correct signs; idempotent for all 4 action types; immediate stop → 0 rows.
- In-loop policy == experience-store `read_policy()` sum (no drift); `demo-coordinator.sh` **byte-identical** to main (fix gated behind `ORCHESTRATE_ENABLED`); per-step `decisions.tsv` trace unchanged.
- `demo-orchestrate.sh` gains a #1026 regression guard (N hunts → N attributions, not N+1); `colony-lint.sh` → **365 / 0 / 5**.

Closes #1026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
