### PR TITLE
feat(dark-factory): generate-and-verify — LLM hypothesizes, Halmos judges (#1015 M2)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,43 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Generate-and-verify — the LLM HYPOTHESIZES a property, Halmos delivers the SOUND verdict** (#1015 M2).
+  M1 shipped the *callable* Halmos gate; M2 closes the loop from a *candidate* to a symbolic verdict by
+  **generating the spec** the gate runs. New `auditor/agents/symbolic-prover.ag` is a per-candidate substrate
+  agent (modelled on `refuter.ag`: `cb 300000;`, one-shot, no `fn tick`; env reads via `getenv`; reads via
+  `exec sh` with `// colony-lint: safe-exec-concat`; `emit`/`learn`/`memo_write`): it **GENERATES** a Halmos
+  `*.t.sol` property spec for one candidate — verbatim from a `SPEC_FIXTURE` env fact on the offline /
+  deterministic path (no LLM), or via `prompt()` on the live path — then **VERIFIES** it by running the M1
+  `evm-harness/halmos-verify.sh` through `exec sh` and mapping its exit code to the verdict (`0`→**PROVED**
+  = invariant holds for ALL inputs → candidate safe / refuted by a proof; `1`→**COUNTEREXAMPLE** = a concrete
+  input is a real bug, CONFIRMED with a witness; `3`→**INCONCLUSIVE**; else→**HARNESS_ERROR**). It `emit`s
+  `dark-factory:symbolic_verdict`, `learn`s the attempt (COUNTEREXAMPLE=success / PROVED=failure /
+  INCONCLUSIVE=partial / error) so symbolic-prover fitness reweights, and `print`s one
+  `SYMBOLIC|<file:fn>|<verdict>` marker. **The verdict is Halmos's exit code, NEVER the LLM's opinion** —
+  that is the whole point of the milestone; the LLM's job shrinks to writing the property to check.
+  - `run-symbolic.sh` — operator entrypoint mirroring `run-refute.sh`: drives `symbolic-prover.ag` once per
+    candidate over the substrate from a `file:fn | class | invariant | code-file | spec-fixture` manifest,
+    staging a fresh copy of `--repo` into the rundir (so the sandboxed `exec sh` can write the spec into
+    `test/` and run Halmos there) and threading `SPEC_FIXTURE` when provided. Default backend `flat-cyborg`
+    (consistent with the other `run-*.sh`); `--backend mock` + a fixture is the offline wiring smoke.
+    Collects verdicts into `symbolic-report.md`. A COUNTEREXAMPLE is a CONFIRMED bug but still a **lead** a
+    human reviews; submission stays human-gated and this tool NEVER posts.
+  - `demo-symbolic.sh` — offline-deterministic proof of the FULL candidate → spec → Halmos → verdict loop
+    with a **fixture spec** (no LLM) + **real Halmos**, over two candidates: the honest `transferSafe`
+    invariant Halmos PROVES (→ PROVED / safe) and the same invariant against the buggy `transferBuggy` Halmos
+    REFUTES (→ COUNTEREXAMPLE / confirmed). Reuses the M1 `evm-harness/halmos-specs` contracts; asserts both
+    verdicts and that a re-run is byte-identical (deterministic). Prints `[SKIP]` + exit 0 when
+    `halmos`/`forge`/`agentis` are absent (CI convention, like `demo-halmos.sh`).
+  - New `docs/generate-verify.md` documents the LLM-hypothesizes / Halmos-proves loop, the verdict-source
+    contract (the verdict is the solver's exit code), the offline-fixture vs live-LLM paths, how it composes
+    with M1, and the honest scope: M2 is the **callable** generate-and-verify step; coordinator auto-routing
+    (deciding *when* to spend a symbolic verify and feeding the verdict into the evolving policy) is a later
+    milestone. On the live path, a generated spec that does not compile / imports a missing contract /
+    writes an unbounded loop returns **INCONCLUSIVE** (the safe failure mode, never a false PROVED), so
+    INCONCLUSIVE is the honest common case for an un-reviewed live spec; the fixture path reaches a sound
+    PROVED / COUNTEREXAMPLE today. `README.md` updated (run-symbolic.sh in the verification flow + layout).
+    **Requires:** halmos >= 0.3 + foundry (forge) for a real verify; both optional for the rest of the
+    federation.
 - **Halmos symbolic-execution verification gate — a SOUND oracle that PROVES an invariant or returns a
   concrete counterexample, exhaustive over all inputs** (#1015 M1). New `evm-harness/halmos-verify.sh` runs
   [Halmos](https://github.com/a16z/halmos) (symbolic execution + the z3 SMT solver) over a `*.t.sol` spec

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -172,6 +172,8 @@ dark-factory/evm-harness/halmos-verify.sh --repo "$PWD/target" --target test/Spe
 `forge-verify.sh` witnesses one concrete exploit path; `halmos-verify.sh` decides the property over all
 inputs. They are complementary — see [`docs/halmos.md`](./docs/halmos.md) for the verdict/exit contract,
 toolchain install, and how the gate fits the epic (the LLM hypothesizes; Halmos is the sound verdict).
+To **generate** the `*.t.sol` spec for a candidate and then verify it through that gate in one substrate
+step, see [`run-symbolic.sh`](#generate-and-verify-a-candidate-run-symbolicsh) below.
 
 A clean sweep (no candidate survives) is a **rigorous negative** — a valid outcome on audited code;
 nothing is submitted. As with `run-audit.sh`, the colony never posts to a platform.
@@ -308,6 +310,32 @@ A **REAL** verdict is a lead that survived a hostile read — **not a finding**.
 through `evm-harness/forge-verify.sh` before it counts, and submission stays a separate, explicit human
 action. A **REFUTED** verdict is killed here and never reaches the forge gate. The colony never posts.
 
+## Generate and verify a candidate (`run-symbolic.sh`)
+
+M1 shipped the **callable** Halmos gate (`evm-harness/halmos-verify.sh`); `run-symbolic.sh` (#1015 M2)
+closes the loop from a *candidate* to a SOUND symbolic verdict by **generating the spec** the gate runs.
+The **LLM is the hypothesis generator** — it turns a candidate (`file:fn` + the invariant to encode + the
+relevant code) into a Halmos `*.t.sol` property spec; **Halmos is the judge** — it PROVES the invariant
+holds for all inputs (the lead is refuted **by a proof**, safe) or returns a **concrete counterexample**
+(a real bug, **confirmed**). The verdict is Halmos's exit code, **never the LLM's opinion**.
+[`auditor/agents/symbolic-prover.ag`](./auditor/agents/symbolic-prover.ag) runs the whole step on the
+substrate (`emit`s `dark-factory:symbolic_verdict`, `learn`s the attempt so symbolic-prover fitness
+reweights) and prints one `SYMBOLIC|<file:fn>|<verdict>` line.
+
+```bash
+# candidates.tsv: `file:fn | class | invariant | code-file | spec-fixture`  (one per line)
+dark-factory/run-symbolic.sh --candidates "$PWD/candidates.tsv" --repo "$PWD/target" --out "$PWD/symbolic-out"
+# offline / cheap wiring smoke (no real LLM): supply a `spec-fixture` column + add  --backend mock
+# offline-deterministic end-to-end proof (real Halmos, fixture specs):  dark-factory/demo-symbolic.sh
+```
+
+A `spec-fixture` in the manifest takes the **offline/deterministic** path — that spec is used verbatim and
+**no LLM is called** — so the candidate → halmos → verdict loop is provable with zero LLM cost and a real
+solver. A **COUNTEREXAMPLE** is still a **lead** a human reviews, not an auto-submission; this colony never
+posts. See [`docs/generate-verify.md`](./docs/generate-verify.md) for the verdict-source contract, the
+fixture-vs-LLM paths, how it composes with M1, and the honest scope (a callable step today; coordinator
+auto-routing is a later milestone).
+
 ## Exercise the evolve/fitness loop (`evolve-fitness.sh`)
 
 Every hunt the colony runs records a `learn("hunt", "<class>:<subsystem>", ..., outcome, [...])` row in
@@ -386,6 +414,7 @@ dark-factory/
   screen-leads.sh               # cheap substrate-native lead pre-screen (eval_ag) before forge-verify
   run-summary.sh                # one-shot run -> monitor-/dashboard-consumable run-summary.json (#995)
   run-refute.sh                 # operator entrypoint: adversarial refutation (refuter fan-out) -> verdicts
+  run-symbolic.sh               # operator entrypoint: GENERATE a Halmos spec per candidate + VERIFY it (#1015 M2)
   run-coordinator.sh            # bootstrap for the self-orchestrating loop (ONE agentis go; the loop lives in-substrate; #1014 M3)
   demo-coordinator.sh           # offline, deterministic proof of the #1014 fact-driven + evolving-policy loop
   demo-dispatch.sh              # offline, deterministic proof of the #1014 M2 substrate DISPATCH (every action type)
@@ -396,6 +425,7 @@ dark-factory/
   gen-agent.sh                  # materialise a colony-lint-valid .ag agent from an invented METHOD line (#1000)
   demo-blackboard.sh            # offline, deterministic demo of the #1001 blackboard coordination loop
   demo-halmos.sh                # proof of the #1015 Halmos symbolic gate (PROVED + COUNTEREXAMPLE; SKIPs without the toolchain)
+  demo-symbolic.sh              # offline-deterministic proof of the #1015 M2 generate-and-verify loop (fixture spec + real Halmos; SKIPs without the toolchain)
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)
@@ -405,6 +435,7 @@ dark-factory/
     agents/hunter.ag            # the custom-code discovery agent (taxonomy-driven adversarial hunt)
     agents/poc-screener.ag      # substrate-native lead pre-screen via eval_ag (sandboxed PoC harness)
     agents/refuter.ag           # the adversarial-refutation agent (independent skeptic; default REFUTED)
+    agents/symbolic-prover.ag   # generate-and-verify: LLM writes a Halmos spec, Halmos returns the sound verdict (#1015 M2)
     agents/fitness-driver.ag    # one fitness-loop cell: hunter.ag's exact learn() over a ground-truth verdict
     agents/method-inventor.ag   # the meta-loop inventor: proposes a new audit method for a known gap (#998)
     agents/coordinator.ag       # self-orchestrating decider: fact+policy-driven actions (#1014); gated in-substrate dispatch for every action type (M2); gated in-substrate MULTI-STEP loop (M3)
@@ -425,6 +456,7 @@ dark-factory/
     halmos-verify.sh            # sound symbolic gate: PROVES an invariant or returns a counterexample (Halmos+z3; #1015)
     halmos-specs/               # self-contained Foundry specs: one Halmos PROVES, one it REFUTES (demo fixtures)
   docs/halmos.md                # the Halmos gate's verdict/exit contract, toolchain install, epic fit (#1015)
+  docs/generate-verify.md       # the #1015 M2 generate-and-verify loop: LLM hypothesizes, Halmos proves; verdict-source contract
   sealevel/                     # modernized coral-xyz/sealevel-attacks lessons (corpus) (V6)
   fixtures/                     # detection fixtures (vuln + safe + rigged-harness cases)
 ```

--- a/dark-factory/auditor/agents/symbolic-prover.ag
+++ b/dark-factory/auditor/agents/symbolic-prover.ag
@@ -1,0 +1,164 @@
+cb 300000;
+// #1015 M2 — substrate-native GENERATE-AND-VERIFY. The LLM is the HYPOTHESIS GENERATOR (it turns ONE
+// candidate finding into a Halmos `*.t.sol` property spec encoding the candidate's invariant against the
+// in-scope contract); HALMOS is the JUDGE (it PROVES the invariant holds for ALL inputs -> the candidate
+// is SAFE / refuted by a proof, or it returns a CONCRETE COUNTEREXAMPLE -> a real bug with a witness).
+// The verdict NEVER comes from the LLM's opinion — it is the exit code of evm-harness/halmos-verify.sh,
+// the SOUND symbolic gate shipped in M1 (a deterministic z3 solver, no sampling). That is the whole point.
+//
+// This composes with M1: M1 shipped the callable gate + example specs + demo-halmos.sh; M2 closes the
+// loop from a candidate to a symbolic verdict by GENERATING the spec the gate runs. It mirrors
+// refuter.ag's per-candidate structure (env-in the candidate, prompt OR fixture, emit/learn the verdict,
+// memo the last_check, print one observable marker) — but where the refuter's verdict is the LLM's
+// hostile read, the symbolic prover's verdict is Halmos's proof.
+//
+// A PROVED here means the candidate's invariant HOLDS exhaustively -> the lead is refuted BY A PROOF (safe).
+// A COUNTEREXAMPLE means Halmos found a concrete input that breaks the invariant -> the bug is CONFIRMED
+// with a replayable witness. INCONCLUSIVE (solver unknown / timeout / loop not fully explored / nothing
+// matched) and a harness error are NOT verdicts. As everywhere in this colony, a CONFIRMED bug is still a
+// LEAD a human reviews; submission stays an explicit, human-gated action and this agent never posts.
+//
+// Env:
+//   CAND_FILE_FN  the candidate location, "path/to/Contract.sol:functionName" (free-form label; the lens).
+//   CAND_CLASS    the bug class id the candidate was filed under, e.g. "C10" (optional; "" if unknown).
+//   CAND_INVARIANT the one-sentence invariant the spec must encode (the property to prove/refute).
+//   SPEC_REPO     absolute path to the foundry project root (must hold foundry.toml) the spec is built in.
+//                 The exec sandbox cannot read $HOME — pass a rundir / /tmp path (run-symbolic.sh stages it).
+//   SPEC_OUT      absolute path the generated `*.t.sol` spec is written to (under SPEC_REPO/test/...).
+//   SPEC_FUNCTION the symbolic-test name prefix halmos-verify runs (default "check" when "").
+//   SPEC_FIXTURE  optional path to a ready-made spec. When set (offline / deterministic path) it is used
+//                 VERBATIM as the spec and NO LLM is called; otherwise the LLM generates the spec (live).
+//   CODE_PATH     optional path to the relevant in-scope code the LLM reads to write the spec; "" to skip.
+// Stdout: exactly one verdict marker line —
+//   SYMBOLIC|<file:fn>|<PROVED|COUNTEREXAMPLE|INCONCLUSIVE|HARNESS_ERROR>
+
+// --- file reader (dynamic path -> safe-exec-concat, per refuter.ag / hunter.ag precedent) ---
+fn cat_file(path: string) -> string {
+    if len(path) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    return exec sh "sed -n '1,4000p' ${path} 2>/dev/null || true";
+}
+
+// Map the SOUND halmos-verify.sh exit code to the colony verdict token. This is the ONLY source of the
+// verdict — the LLM never decides it. The exit contract mirrors evm-harness/halmos-verify.sh exactly:
+//   0 -> PROVED         (invariant holds for ALL inputs -> candidate SAFE / refuted by a proof)
+//   1 -> COUNTEREXAMPLE (a concrete input violates the invariant -> a real bug, CONFIRMED with a witness)
+//   3 -> INCONCLUSIVE   (solver unknown / timeout / loop not fully explored / nothing matched -> no verdict)
+//   else (2, etc.) -> HARNESS_ERROR (bad args / repo not a foundry project / halmos|forge missing)
+fn verdict_of(rc: int) -> string {
+    if rc == 0 { return "PROVED"; }
+    if rc == 1 { return "COUNTEREXAMPLE"; }
+    if rc == 3 { return "INCONCLUSIVE"; }
+    return "HARNESS_ERROR";
+}
+
+// learn() outcome must be one of the runtime enum {success,failure,partial,timeout,error}. A
+// COUNTEREXAMPLE is a confirmed bug (the highest-value outcome the loop can produce) = success; a PROVED
+// safely refutes the lead = failure (it consumed the hypothesis without yielding a finding, like a
+// rigorous SAFE in hunter.ag); INCONCLUSIVE = partial (the solver could not decide); a harness error =
+// error. No reassignment of a `let` (single-assignment .ag).
+fn outcome_of(verdict: string) -> string {
+    if verdict == "COUNTEREXAMPLE" { return "success"; }
+    if verdict == "PROVED" { return "failure"; }
+    if verdict == "INCONCLUSIVE" { return "partial"; }
+    return "error";
+}
+
+// Parse the `__rc=<n>` marker halmos-verify is wrapped to print as its LAST line (the auditor.ag exec
+// convention). regex_capture(pattern, input, group) returns the captured digits; parse_int is total
+// (non-numeric -> 0). A missing marker would wrongly read as 0/PROVED, so a "no marker" case is forced to
+// a harness error (2). (pattern-evolver.ag uses the same regex_capture(pattern, out, 1) idiom.)
+fn rc_of(out: string) -> int {
+    if index_of(out, "__rc=") < 0 { return 2; }
+    return parse_int(regex_capture("__rc=([0-9]+)", out, 1));
+}
+
+let candFn = getenv("CAND_FILE_FN");
+let candClass = getenv("CAND_CLASS");
+let candInvariant = getenv("CAND_INVARIANT");
+let specRepo = getenv("SPEC_REPO");
+let specOut = getenv("SPEC_OUT");
+// halmos-verify.sh's own default function prefix is `check`; default to it when SPEC_FUNCTION is unset.
+fn fn_prefix(raw: string) -> string {
+    if len(raw) == 0 { return "check"; }
+    return raw;
+}
+let specFn = fn_prefix(getenv("SPEC_FUNCTION"));
+let fixturePath = getenv("SPEC_FIXTURE");
+let code = cat_file(getenv("CODE_PATH"));
+
+// --- GENERATE the spec ---------------------------------------------------------------------------
+// Offline / deterministic path: a SPEC_FIXTURE is a ready-made spec used VERBATIM, no LLM. This is the
+// path demo-symbolic.sh and a `--backend mock` wiring smoke take, so the candidate->halmos->verdict loop
+// is provable with zero LLM cost and a real solver. The fixture is read through the sandboxed reader.
+let fixture = cat_file(fixturePath);
+
+// Live path: the LLM is the HYPOTHESIS GENERATOR. It reads the in-scope code + the claimed invariant and
+// emits a self-contained Halmos `*.t.sol` spec whose `check_*` function asserts the invariant over
+// SYMBOLIC inputs. The verdict is STILL Halmos's (below) — the LLM only writes the property to check.
+// This is the live cold path (one candidate in, one spec out); there is no per-tick staleness to gate, so
+// it carries an explicit prompt-gate-ok marker (this agent is also outside the prompt-gate scan scope —
+// auditor/agents/, like refuter.ag — but the marker documents the intent).
+fn generate_spec(invariant: string, klass: string, src: string, fnPrefix: string) -> string {
+    let instruction =
+        "You are a formal-verification engineer. Write a self-contained Halmos `*.t.sol` property spec "
+      + "(Solidity, `pragma solidity >=0.8.0;`) that encodes the INVARIANT below against the in-scope "
+      + "contract and lets Halmos (symbolic execution + z3) PROVE it or REFUTE it with a concrete "
+      + "counterexample. Requirements:\n"
+      + "  - Declare exactly the in-scope contract(s) the spec needs (inline a minimal copy, OR import from "
+      + "`../src/...` if the project already ships it — prefer inlining so the spec is self-contained).\n"
+      + "  - Add a test contract with a `setUp()` and ONE symbolic-test function whose name starts with `"
+      + fnPrefix + "` and that takes the symbolic inputs as arguments and `assert`s the invariant directly.\n"
+      + "  - Use SMALL bit-widths (uint8/uint16) for symbolic inputs so the solver returns a sound verdict "
+      + "quickly. No external libs (no forge-std). No fuzz cheatcodes — pure symbolic asserts.\n\n"
+      + "=== BUG CLASS (lens) ===\n" + klass + "\n\n"
+      + "=== THE INVARIANT THE SPEC MUST ENCODE ===\n" + invariant + "\n\n"
+      + "=== HOW TO ANSWER ===\n"
+      + "Output ONLY the Solidity source of the `*.t.sol` spec — no markdown fences, no prose before or "
+      + "after. The spec must compile and define at least one `contract` and one `" + fnPrefix + "*` function.";
+    // colony-lint: prompt-gate-ok
+    return prompt(instruction, src) -> string;
+}
+
+// Single-assignment .ag: pick the spec source ONCE (no `let` reassignment). A non-empty SPEC_FIXTURE wins
+// (offline/deterministic, verbatim, no LLM); otherwise the LLM generates it (live cold path).
+let usedFixture = len(fixture) > 0;
+fn choose_spec(usedFix: bool, fix: string, inv: string, klass: string, src: string, fnPrefix: string) -> string {
+    if usedFix { return fix; }
+    return generate_spec(inv, klass, src, fnPrefix);
+}
+let spec = choose_spec(usedFixture, fixture, candInvariant, candClass, code, specFn);
+
+// Write the generated/fixture spec to SPEC_OUT (inside SPEC_REPO/test) so halmos-verify can run it. The
+// spec content is UNTRUSTED — it is either an LLM completion (prompt-injectable by the untrusted candidate
+// code being audited) or an operator fixture — so it MUST go through shell_escape(), never a heredoc (a
+// heredoc body is not escaped: a spec line equal to the sentinel would terminate it early and the rest
+// would execute as shell). printf '%s' on a shell_escape()d single-quoted literal cannot be escaped by any
+// content (no shell metachar survives single-quoting), so the spec is written verbatim with zero injection.
+let wrote = exec sh "printf '%s' " + shell_escape(spec) + " > " + shell_escape(specOut) + "; echo __wrote=$?";
+
+// --- VERIFY with the SOUND M1 gate --------------------------------------------------------------
+// Run evm-harness/halmos-verify.sh against the just-written spec and capture its exit code via the
+// `__rc=$?` marker convention (auditor.ag). `set +e` so halmos-verify's non-zero verdict exit (1/3/2)
+// does not abort the shell before the marker is printed. The verdict is THIS exit code — nothing else.
+let gate = getenv("HALMOS_VERIFY");
+// colony-lint: safe-exec-concat
+let runOut = exec sh "set +e; sh ${gate} --repo ${specRepo} --target ${specOut} --function ${specFn} 2>&1; echo __rc=$?";
+
+let rc = rc_of(runOut);
+let verdict = verdict_of(rc);
+
+// --- EMIT the SOUND verdict ----------------------------------------------------------------------
+// Surface the marker (stdout, parsed by run-symbolic.sh), record it on the bus, and learn() the
+// attribution so symbolic-prover fitness reweights over candidates (COUNTEREXAMPLE=success, PROVED=failure,
+// INCONCLUSIVE=partial, harness=error). memo_write the last_check per the agent convention.
+print("SYMBOLIC|" + candFn + "|" + verdict);
+let outcome = outcome_of(verdict);
+fn gen_mode(usedFix: bool) -> string {
+    if usedFix { return "fixture"; }
+    return "llm";
+}
+let genMode = gen_mode(usedFixture);
+emit("dark-factory:symbolic_verdict", "{\"candidate\":\"" + candFn + "\",\"class\":\"" + candClass + "\",\"verdict\":\"" + verdict + "\",\"gen\":\"" + genMode + "\",\"outcome\":\"" + outcome + "\"}");
+learn("symbolic-prove", candClass + ":" + candFn, "symbolic generate-and-verify of " + candFn + " (" + candClass + ") -> " + verdict, outcome, [candClass, verdict, outcome]);
+memo_write("symbolic-prover:last_check", "done");

--- a/dark-factory/demo-symbolic.sh
+++ b/dark-factory/demo-symbolic.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# demo-symbolic.sh — reproducible proof of the #1015 M2 GENERATE-AND-VERIFY loop: a candidate is turned
+# into a Halmos property spec and HALMOS (not the LLM) returns the SOUND verdict.
+#
+# This drives the FULL candidate -> spec -> halmos -> verdict loop through the substrate via
+# `run-symbolic.sh` + `auditor/agents/symbolic-prover.ag`, using a FIXTURE spec (the offline/deterministic
+# path — NO LLM, mock backend) and a REAL Halmos run. Two candidates exercise both sound verdicts:
+#   - a candidate whose invariant Halmos PROVES         -> verdict PROVED         (lead refuted by a proof / safe)
+#   - a candidate Halmos REFUTES with a counterexample  -> verdict COUNTEREXAMPLE (a real bug, CONFIRMED)
+# The verdict is HALMOS's exit code, never the LLM's opinion — that is the whole point of M2. The loop is
+# also run TWICE and the two reports diffed, so the offline path is deterministic.
+#
+# It reuses the M1 example contracts (`evm-harness/halmos-specs/`): the honest `transferSafe` invariant
+# (Halmos PROVES) and the same invariant against the buggy `transferBuggy` (Halmos REFUTES). The fixtures
+# ARE those M1 specs, fed to symbolic-prover.ag as SPEC_FIXTUREs so no LLM is needed for a sound, repeatable
+# proof of the loop.
+#
+# CI has neither halmos nor forge, so if EITHER is missing this prints a single [SKIP] line and exits 0
+# (mirroring demo-halmos.sh / the colony-lint skip convention) instead of failing. Install the toolchain to
+# run it for real:
+#   curl -L https://foundry.paradigm.xyz | bash && foundryup    # forge
+#   uv tool install halmos                                      # halmos (bundles z3)
+#
+# Usage:  dark-factory/demo-symbolic.sh
+# Exit: 0 = both verdicts correct + deterministic (or tools absent -> SKIP) ; non-zero = a verdict was wrong.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUNNER="$HERE/run-symbolic.sh"
+SPECS="$HERE/evm-harness/halmos-specs"
+
+FAILS=0
+note() { echo "demo-symbolic.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+skip() { echo "  [SKIP] $*"; }
+
+# Skip EARLY (before any work) when the toolchain is missing, so CI without halmos/forge reports a clean
+# [SKIP] + exit 0 rather than a harness error. agentis is required to drive the substrate loop.
+if ! command -v forge >/dev/null 2>&1 || ! command -v halmos >/dev/null 2>&1; then
+  skip "forge and/or halmos not on PATH — install foundryup + 'uv tool install halmos' to run this demo"
+  exit 0
+fi
+if ! command -v agentis >/dev/null 2>&1; then
+  skip "agentis not on PATH — install the agentis runtime to drive the substrate generate-and-verify loop"
+  exit 0
+fi
+
+[ -x "$RUNNER" ] || { note "runner not found / not executable: $RUNNER" >&2; exit 3; }
+[ -d "$SPECS" ] || { note "specs dir not found: $SPECS" >&2; exit 3; }
+[ -f "$SPECS/foundry.toml" ] || { note "specs dir is not a foundry project: $SPECS" >&2; exit 3; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Stage the two M1 example specs as FIXTURES (the offline path: symbolic-prover uses them verbatim, no LLM)
+# and build a candidate manifest: one PROVED candidate, one COUNTEREXAMPLE candidate.
+cp "$SPECS/test/LedgerProved.t.sol" "$WORK/proved.t.sol"
+cp "$SPECS/test/LedgerCounterexample.t.sol" "$WORK/counterexample.t.sol"
+cat > "$WORK/candidates.tsv" <<'EOF'
+# file:fn | class | invariant | code-file | spec-fixture
+Ledger.sol:transferSafe  | C-acct | total value is conserved across a transfer | | proved.t.sol
+Ledger.sol:transferBuggy | C-acct | total value is conserved across a transfer | | counterexample.t.sol
+EOF
+
+# Run the full substrate loop (mock backend = no LLM; the FIXTURE drives the spec, real Halmos judges).
+# $1 = output dir.
+run_loop() {
+  "$RUNNER" --candidates "$WORK/candidates.tsv" --repo "$SPECS" \
+            --code-dir "$WORK" --backend mock --out "$1" >"$1.log" 2>&1
+}
+
+note "driving candidate -> fixture-spec -> REAL Halmos -> verdict through the substrate (mock backend, no LLM) ..."
+run_loop "$WORK/out1"; RC1=$?
+REPORT1="$WORK/out1/symbolic-report.md"
+if [ "$RC1" -ne 0 ] || [ ! -f "$REPORT1" ]; then
+  bad "run-symbolic.sh did not complete (exit $RC1); log:"
+  sed 's/^/        | /' "$WORK/out1.log" 2>/dev/null
+  note "DEMO FAILED — the generate-and-verify loop did not run" >&2
+  exit 1
+fi
+
+# Assert the per-candidate verdict in the report table. $1 = candidate file:fn, $2 = expected verdict.
+assert_verdict() {
+  _cand="$1"; _want="$2"
+  _row="$(grep -F "| $_cand " "$REPORT1" | tail -1 || true)"
+  _got="$(printf '%s' "$_row" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/,"",$5); print $5}')"
+  if [ "$_got" = "$_want" ]; then
+    ok "$_cand -> $_want (Halmos's sound verdict, not the LLM's)"
+  else
+    bad "$_cand expected $_want, got '${_got:-<no row>}'"
+  fi
+}
+
+assert_verdict "Ledger.sol:transferSafe" "PROVED"
+assert_verdict "Ledger.sol:transferBuggy" "COUNTEREXAMPLE"
+
+# Determinism: a second run of the offline path must produce a byte-identical verdict table.
+run_loop "$WORK/out2" >/dev/null 2>&1
+REPORT2="$WORK/out2/symbolic-report.md"
+if [ -f "$REPORT2" ] && diff -q "$REPORT1" "$REPORT2" >/dev/null 2>&1; then
+  ok "re-run is byte-identical (the offline fixture path is deterministic)"
+else
+  bad "re-run differs — the offline path is not deterministic"
+  diff "$REPORT1" "$REPORT2" 2>/dev/null | sed 's/^/        | /'
+fi
+
+echo
+if [ "$FAILS" -eq 0 ]; then
+  note "PASS: the LLM-as-generator / Halmos-as-judge loop PROVED the honest candidate's invariant (safe) and"
+  note "      REFUTED the buggy one with a concrete counterexample (confirmed bug) — verdict is Halmos's, sound,"
+  note "      and deterministic; generation used a fixture spec so no LLM was involved (#1015 M2)"
+  exit 0
+fi
+note "DEMO FAILED — a verdict did not match the contract" >&2
+exit 1

--- a/dark-factory/docs/generate-verify.md
+++ b/dark-factory/docs/generate-verify.md
@@ -1,0 +1,111 @@
+# Symbolic generate-and-verify (#1015 M2)
+
+M1 shipped the **callable** Halmos gate ([`docs/halmos.md`](./halmos.md)): given a hand-written `*.t.sol`
+spec, [`evm-harness/halmos-verify.sh`](../evm-harness/halmos-verify.sh) returns a SOUND verdict (PROVED /
+COUNTEREXAMPLE / INCONCLUSIVE) over **all** inputs. M2 closes the loop from a *candidate* to that verdict:
+it **generates** the spec the gate runs.
+
+## The contract: the LLM hypothesizes, Halmos proves
+
+```
+candidate ──(LLM writes a property spec)──► *.t.sol ──(halmos-verify.sh)──► SOUND verdict
+   the HYPOTHESIS GENERATOR                              the JUDGE
+```
+
+- The **LLM is the hypothesis generator.** It turns one candidate (a `file:fn` lens + the invariant to
+  encode + the relevant in-scope code) into a Halmos `*.t.sol` property spec whose `check_*` function
+  asserts the invariant over **symbolic** inputs. An LLM proposal is, on its own, unverified — it can
+  hallucinate both the bug and the property.
+- **Halmos is the judge.** It runs symbolic execution + the z3 SMT solver over the generated spec and either
+  **PROVES** the invariant holds for every input or returns a **concrete counterexample** that breaks it.
+  There is no fuzzing, no sampling, and no flakiness.
+
+**The verdict is Halmos's exit code — never the LLM's opinion.** That is the whole point of M2: the LLM's
+job shrinks to *writing the property to check*; the truth of the answer is the solver's. A `PROVED` is a
+real proof over all inputs (the lead is refuted **by a proof**, i.e. safe); a `COUNTEREXAMPLE` is a
+concrete witness a human can replay (the bug is **confirmed**).
+
+**Safety — the spec content is untrusted.** The generated spec is an LLM completion (prompt-injectable by
+the untrusted candidate code under audit) or an operator fixture, so `symbolic-prover.ag` writes it with
+`printf '%s' <shell_escape(spec)>`, never a heredoc — a single-quoted `shell_escape`d literal cannot be
+escaped by any spec content, so a malicious spec is written verbatim (and then merely fails to compile or
+is judged by Halmos), never executed as shell. The spec only ever reaches `forge`/`halmos` inside the run
+sandbox.
+
+## Components
+
+| File | Role |
+|---|---|
+| [`auditor/agents/symbolic-prover.ag`](../auditor/agents/symbolic-prover.ag) | Per-candidate substrate agent: GENERATE the spec (fixture or `prompt()`), VERIFY it with the M1 gate, `emit`/`learn` the verdict, print `SYMBOLIC\|<file:fn>\|<verdict>`. |
+| [`run-symbolic.sh`](../run-symbolic.sh) | Operator entrypoint: drive `symbolic-prover.ag` once per candidate over the substrate from a manifest, collect the verdicts into a report. |
+| [`demo-symbolic.sh`](../demo-symbolic.sh) | Offline-deterministic demo: the full candidate → fixture-spec → REAL Halmos → verdict loop, asserting PROVED-safe + COUNTEREXAMPLE-confirmed. |
+
+It mirrors the per-candidate structure of [`run-refute.sh`](../run-refute.sh) +
+[`auditor/agents/refuter.ag`](../auditor/agents/refuter.ag) — env-in the candidate, generate, `emit`/`learn`
+the verdict, `memo_write` the `last_check`, print one observable marker — but where the refuter's verdict is
+the LLM's hostile read, the symbolic prover's verdict is **Halmos's proof**.
+
+## Verdict mapping
+
+`symbolic-prover.ag` maps the M1 gate's exit code (the only source of the verdict) directly:
+
+| Halmos exit | Verdict | Meaning | `learn()` outcome |
+|---|---|---|---|
+| `0` | **PROVED** | invariant holds for ALL inputs → candidate SAFE (refuted by a proof) | `failure` |
+| `1` | **COUNTEREXAMPLE** | a concrete input violates the invariant → a real bug, CONFIRMED with a witness | `success` |
+| `3` | **INCONCLUSIVE** | solver `unknown` / timeout / loop not fully explored / nothing matched → no verdict | `partial` |
+| else (`2`, …) | **HARNESS_ERROR** | bad args / repo not a Foundry project / `halmos`/`forge` missing | `error` |
+
+A COUNTEREXAMPLE is the highest-value outcome, so it is recorded as `success` (symbolic-prover fitness
+rewards candidates that the solver confirms); a PROVED safely consumes the hypothesis without a finding, so
+it is `failure` — the same polarity as a rigorous `SAFE` in `hunter.ag`.
+
+## Generation: offline (fixture) vs live (LLM)
+
+`symbolic-prover.ag` has two generation paths, gated on a `SPEC_FIXTURE` env fact:
+
+- **Offline / deterministic** — when `SPEC_FIXTURE` is set, that spec is used **verbatim** and **no LLM is
+  called**. This is the path [`demo-symbolic.sh`](../demo-symbolic.sh) and a `--backend mock` wiring smoke
+  take, so the candidate → halmos → verdict loop is provable with zero LLM cost and a real solver.
+- **Live** — otherwise the LLM `prompt()`s the spec from the candidate's invariant + the in-scope code. The
+  verdict is **still** Halmos's; the LLM only writes the property to check.
+
+## Compose with M1
+
+```bash
+# Offline-deterministic proof of the WHOLE loop (real Halmos, no LLM):
+dark-factory/demo-symbolic.sh
+
+# Drive a real candidate manifest (cheap wiring smoke: --backend mock + a spec-fixture column):
+#   candidates.tsv: `file:fn | class | invariant | code-file | spec-fixture`  (one per line)
+dark-factory/run-symbolic.sh \
+  --candidates "$PWD/candidates.tsv" \
+  --repo "$PWD/target" \
+  --backend flat-cyborg \
+  --out "$PWD/symbolic-out"
+```
+
+`run-symbolic.sh` stages a fresh copy of `--repo` into its rundir (so the sandboxed `exec sh` can write the
+spec into `test/` and run Halmos there), drops any pre-existing `*.t.sol` so the gate scopes to exactly the
+generated spec, and routes each candidate through the substrate (`prompt`/`emit`/`learn`). The verdict table
+lands at `<out>/symbolic-report.md`.
+
+## Honest scope
+
+M2 ships the **callable** generate-and-verify step: an operator (or a higher-level script) invokes
+`run-symbolic.sh` over a candidate manifest. **Auto-routing** discovery candidates from `run-discovery.sh`
+into the symbolic gate inside the self-orchestrating coordinator ([`docs/coordinator.md`](./coordinator.md))
+— so the coordinator decides *when* to spend a symbolic verify and feeds the verdict back into its evolving
+policy — is a **later milestone** on epic #1015.
+
+On the **live** (LLM-generated-spec) path, an honest expectation: a generated Halmos spec must both **compile**
+(`forge build` via Halmos) and stay **decidable** (small symbolic widths, bounded loops) for a clean
+PROVED / COUNTEREXAMPLE. When the LLM emits a spec that does not compile, imports a contract the project
+does not ship, or writes an unbounded loop, the gate returns **INCONCLUSIVE** (or a harness error) rather
+than a false verdict — which is the **safe** failure mode, never a false PROVED. So `INCONCLUSIVE` is the
+honest common case for an un-reviewed live spec; the fixture path (and an operator who iterates the spec) is
+how you reach a sound PROVED / COUNTEREXAMPLE today. The soundness guarantee is the same either way: the
+verdict is Halmos's, and the gate never over-claims PROVED.
+
+As everywhere in this colony, a CONFIRMED bug is still a **lead** a human reviews; submission stays an
+explicit, human-gated action and these tools NEVER post to a bounty platform.

--- a/dark-factory/run-symbolic.sh
+++ b/dark-factory/run-symbolic.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# run-symbolic.sh — GENERATE-AND-VERIFY entrypoint for the Dark Factory federation (#1015 M2).
+#
+# The LLM is the HYPOTHESIS GENERATOR; HALMOS is the JUDGE. For each candidate this script runs
+# `auditor/agents/symbolic-prover.ag` once on the agentis substrate: it env-ins the candidate (file:fn +
+# the invariant to encode + class) and the relevant code, GENERATES a Halmos `*.t.sol` property spec
+# (verbatim from a supplied SPEC_FIXTURE on the offline path, or via `prompt()` on the live path), VERIFIES
+# it with the SOUND M1 gate `evm-harness/halmos-verify.sh`, and `print`s a `SYMBOLIC|<file:fn>|<verdict>`
+# line whose verdict is HALMOS's exit code — never the LLM's opinion. Every run is recorded as experience
+# (`learn` + `emit dark-factory:symbolic_verdict`) so symbolic-prover fitness reweights over candidates.
+# It mirrors run-refute.sh's per-candidate substrate loop; the difference is the verdict's SOURCE.
+#
+# This composes with M1: M1 shipped the callable Halmos gate + example specs + demo-halmos.sh; M2 closes
+# the loop from a candidate to a symbolic verdict by GENERATING the spec the gate runs. A COUNTEREXAMPLE is
+# a CONFIRMED bug (a concrete witness a human can replay); a PROVED safely refutes the lead by a proof; an
+# INCONCLUSIVE / harness error is not a verdict. As everywhere in this colony, a confirmed bug is still a
+# LEAD a human reviews — submission stays an explicit, human-gated action and this tool NEVER posts to a
+# bounty platform.
+#
+# Usage:
+#   run-symbolic.sh --candidates <cands.tsv> --repo <foundry project> [options]
+#
+# Candidate manifest (one candidate per line; `#` and blank lines ignored). Columns are `|`-separated:
+#   <file:fn> | <classid> | <invariant sentence> | <code-file> | <spec-fixture>
+# where:
+#   <file:fn>          free-form candidate label (the lens), e.g. "Ledger.sol:transferSafe".
+#   <classid>          the bug class id, e.g. "C-acct" ("" if unknown).
+#   <invariant sentence> the property the generated spec must encode (used by the LLM on the live path).
+#   <code-file>        OPTIONAL path (absolute, or relative to --code-dir) to the relevant in-scope code
+#                      the LLM reads to write the spec. "" to skip (e.g. when a fixture is supplied).
+#   <spec-fixture>     OPTIONAL path to a ready-made `*.t.sol` spec used VERBATIM (the offline/deterministic
+#                      path — NO LLM). When set the verdict is Halmos's over THIS spec. "" = live (LLM) path.
+# e.g.
+#   Ledger.sol:transferSafe  | C-acct | total value is conserved across a transfer | code/ledger.sol | specs/proved.t.sol
+#   Vault.sol:withdraw       | C10    | sum of balances never exceeds totalSupply  | code/vault.sol  |
+#
+# Options:
+#   --candidates <file>  Candidate manifest (see above). REQUIRED.
+#   --repo <dir>         Foundry project root (must hold foundry.toml). REQUIRED — the spec is built here.
+#   --code-dir <dir>     Base dir for a candidate's relative <code-file>/<spec-fixture> (default: dir of
+#                        --candidates).
+#   --only <file:fn>     Verify only the candidate whose file:fn matches (re-run / smoke one).
+#   --backend <mock|flat-cyborg|claude>  LLM backend for the live spec-generation path (default:
+#                        flat-cyborg = flat-rate PTY wrapper; claude = metered -p API; mock = offline wiring
+#                        smoke). On the offline path (a SPEC_FIXTURE in the manifest) the LLM is NOT called.
+#   --model <id>         Optional model id (claude: passed to the CLI; flat-cyborg: set as llm.model).
+#   --out <dir>          Output dir for the run + verdicts (default: ./symbolic-out).
+#   --agentis <bin>      agentis binary (default: `agentis` on PATH).
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+AGENTIS="agentis"
+CANDS="" ; REPO="" ; CODE_DIR="" ; ONLY=""
+BACKEND="flat-cyborg" ; MODEL="" ; OUT="$PWD/symbolic-out"
+
+need() { [ "$1" -ge 2 ] || { echo "run-symbolic.sh: missing value for the preceding flag" >&2; exit 2; }; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --candidates) need "$#"; CANDS="$2"; shift 2 ;;
+    --repo) need "$#"; REPO="$2"; shift 2 ;;
+    --code-dir) need "$#"; CODE_DIR="$2"; shift 2 ;;
+    --only) need "$#"; ONLY="$2"; shift 2 ;;
+    --backend) need "$#"; BACKEND="$2"; shift 2 ;;
+    --model) need "$#"; MODEL="$2"; shift 2 ;;
+    --out) need "$#"; OUT="$2"; shift 2 ;;
+    --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
+    --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
+    *) echo "run-symbolic.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$CANDS" ] && [ -f "$CANDS" ] || { echo "run-symbolic.sh: --candidates <file:fn|class|invariant|code-file|spec-fixture manifest> required" >&2; exit 2; }
+[ -n "$REPO" ] && [ -d "$REPO" ] || { echo "run-symbolic.sh: --repo <foundry project root> required" >&2; exit 2; }
+[ -f "$REPO/foundry.toml" ] || { echo "run-symbolic.sh: --repo is not a foundry project (no foundry.toml): $REPO" >&2; exit 2; }
+[ -n "$CODE_DIR" ] || CODE_DIR="$(cd "$(dirname "$CANDS")" && pwd)"
+[ -d "$CODE_DIR" ] || { echo "run-symbolic.sh: --code-dir not a directory: $CODE_DIR" >&2; exit 2; }
+command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-symbolic.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
+
+# Resolve operator paths to ABSOLUTE — the colony runs from the rundir (a different cwd) and the exec
+# sandbox cannot read $HOME, so a relative or home-rooted path would silently read empty. We build the
+# spec inside the rundir's copy of --repo so the sandbox can always reach it.
+REPO="$(cd "$REPO" && pwd)"
+CODE_DIR="$(cd "$CODE_DIR" && pwd)"
+
+PROVER="$HERE/auditor/agents/symbolic-prover.ag"
+GATE="$HERE/evm-harness/halmos-verify.sh"
+[ -f "$PROVER" ] || { echo "run-symbolic.sh: symbolic-prover agent not found at $PROVER" >&2; exit 3; }
+[ -f "$GATE" ] || { echo "run-symbolic.sh: halmos-verify gate not found at $GATE" >&2; exit 3; }
+
+mkdir -p "$OUT"; OUT="$(cd "$OUT" && pwd)"
+RUN="$OUT/run"
+rm -rf "$RUN"; mkdir -p "$RUN"
+cp "$PROVER" "$RUN/symbolic-prover.ag"
+cp "$GATE" "$RUN/halmos-verify.sh"
+# Stage a fresh copy of the foundry project into the rundir so the sandboxed exec sh can write the spec
+# into its test/ dir and run halmos there (it cannot reach a $HOME-rooted --repo). Drop any pre-existing
+# *.t.sol so a candidate's generated spec is the ONLY one halmos scopes to.
+REPO_IN_RUN="$RUN/repo"
+cp -R "$REPO" "$REPO_IN_RUN"
+rm -f "$REPO_IN_RUN/test/"*.t.sol 2>/dev/null || true
+mkdir -p "$REPO_IN_RUN/test"
+
+# init the agentis store FIRST (before any .agentis/ subdir exists), else HEAD is not set.
+( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
+{
+  echo "llm.backend = $BACKEND"
+  # 600s: writing a symbolic spec is the same order of cost as a discovery read.
+  [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p${MODEL:+ --model $MODEL}"; echo "llm.cli_timeout_ms = 600000"; }
+  [ "$BACKEND" = "flat-cyborg" ] && { echo "llm.cli_timeout_ms = 600000"; [ -n "$MODEL" ] && echo "llm.model = $MODEL"; }
+  echo "trace.level = normal"
+  # The prover reads code + the fixture and writes/runs the spec through exec sh; pass its whole env contract.
+  echo "exec.env_passthrough = CAND_FILE_FN,CAND_CLASS,CAND_INVARIANT,SPEC_REPO,SPEC_OUT,SPEC_FUNCTION,SPEC_FIXTURE,CODE_PATH,HALMOS_VERIFY"
+  # A cargo-free halmos run is fast, but forge build + z3 over a spec exceeds the 10s default.
+  echo "exec.default_timeout_ms = 180000"
+  # Each verify is recorded as experience; symbolic-prover fitness reweights over candidates.
+  echo "learning.enabled = true"
+  echo "experience.enabled = true"
+} > "$RUN/.agentis/config"
+
+REPORT="$OUT/symbolic-report.md"
+{
+  echo "# Dark Factory — symbolic generate-and-verify verdicts"
+  echo
+  echo "- backend: $BACKEND"
+  echo "- The LLM HYPOTHESIZES (writes the property spec); HALMOS JUDGES (the verdict is its exit code,"
+  echo "  never the LLM's opinion). PROVED = invariant holds for ALL inputs (lead refuted by a proof);"
+  echo "  COUNTEREXAMPLE = a concrete input is a real bug (CONFIRMED with a witness); INCONCLUSIVE /"
+  echo "  HARNESS_ERROR are not verdicts. A confirmed bug is a LEAD a human reviews; this colony never posts."
+  echo
+  echo "| Candidate (file:fn) | Class | Spec | Verdict |"
+  echo "|---|---|---|---|"
+} > "$REPORT"
+
+CHECKED=0 ; PROVED=0 ; CEX=0 ; INCONC=0 ; ERR=0
+# Manifest loop: one candidate per line, `file:fn | class | invariant | code-file | spec-fixture`.
+while IFS='|' read -r CFN CLS INV CODEF FIXT || [ -n "${CFN:-}" ]; do
+  CFN="$(printf '%s' "$CFN" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  case "$CFN" in ''|\#*) continue ;; esac
+  CLS="$(printf '%s' "$CLS" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  INV="$(printf '%s' "$INV" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  CODEF="$(printf '%s' "$CODEF" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  FIXT="$(printf '%s' "$FIXT" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  [ -n "$ONLY" ] && [ "$CFN" != "$ONLY" ] && continue
+
+  SLUG="$(printf '%s' "$CFN" | tr -cs 'A-Za-z0-9' '_' | sed 's/_*$//')"
+
+  # Resolve + stage the (optional) code file into the rundir so the sandboxed exec sh can read it.
+  CODE_IN_RUN=""
+  if [ -n "$CODEF" ]; then
+    case "$CODEF" in /*) CSRC="$CODEF" ;; *) CSRC="$CODE_DIR/$CODEF" ;; esac
+    if [ -f "$CSRC" ]; then
+      CODE_IN_RUN="$RUN/code_${SLUG}.txt"
+      cp "$CSRC" "$CODE_IN_RUN"
+    else
+      echo "run-symbolic.sh: code file not found for '$CFN': $CSRC (continuing without code)" >&2
+    fi
+  fi
+
+  # Resolve + stage the (optional) spec fixture. A fixture takes the OFFLINE/deterministic path (no LLM).
+  FIXT_IN_RUN=""
+  if [ -n "$FIXT" ]; then
+    case "$FIXT" in /*) FSRC="$FIXT" ;; *) FSRC="$CODE_DIR/$FIXT" ;; esac
+    if [ -f "$FSRC" ]; then
+      FIXT_IN_RUN="$RUN/fixture_${SLUG}.t.sol"
+      cp "$FSRC" "$FIXT_IN_RUN"
+    else
+      echo "run-symbolic.sh: spec fixture not found for '$CFN': $FSRC; skipping" >&2
+      continue
+    fi
+  fi
+
+  CHECKED=$((CHECKED + 1))
+  SPEC_OUT="$REPO_IN_RUN/test/Spec_${SLUG}.t.sol"
+  CELL_LOG="$RUN/symbolic_${SLUG}.log"
+  echo "run-symbolic.sh: generating + verifying $CFN ($CLS) ..." >&2
+  ( cd "$RUN" && env \
+      CAND_FILE_FN="$CFN" \
+      CAND_CLASS="$CLS" \
+      CAND_INVARIANT="$INV" \
+      SPEC_REPO="$REPO_IN_RUN" \
+      SPEC_OUT="$SPEC_OUT" \
+      SPEC_FUNCTION="check" \
+      SPEC_FIXTURE="$FIXT_IN_RUN" \
+      CODE_PATH="$CODE_IN_RUN" \
+      HALMOS_VERIFY="$RUN/halmos-verify.sh" \
+      "$AGENTIS" go symbolic-prover.ag --enable-exec --enable-messaging ) >"$CELL_LOG" 2>&1 || \
+      echo "run-symbolic.sh: symbolic-prover run failed for '$CFN' (see $CELL_LOG)" >&2
+
+  # The prover's contract: exactly one `SYMBOLIC|<file:fn>|<verdict>` line. Take the LAST match. No line
+  # at all = treat as HARNESS_ERROR (the run did not even produce a verdict).
+  VLINE="$(grep 'SYMBOLIC|' "$CELL_LOG" | tail -1 || true)"
+  if [ -z "$VLINE" ]; then
+    VERD="HARNESS_ERROR"
+  else
+    VERD="$(printf '%s' "$VLINE" | sed 's/.*SYMBOLIC|//' | cut -d'|' -f2)"
+  fi
+  case "$VERD" in
+    PROVED)         PROVED=$((PROVED + 1)) ;;
+    COUNTEREXAMPLE) CEX=$((CEX + 1)) ;;
+    INCONCLUSIVE)   INCONC=$((INCONC + 1)) ;;
+    *)              VERD="HARNESS_ERROR"; ERR=$((ERR + 1)) ;;
+  esac
+  SPEC_KIND="generated(LLM)"; [ -n "$FIXT_IN_RUN" ] && SPEC_KIND="fixture"
+  printf '| %s | %s | %s | %s |\n' "$CFN" "$CLS" "$SPEC_KIND" "$VERD" >> "$REPORT"
+done < "$CANDS"
+
+{
+  echo
+  echo "---"
+  echo "Checked: $CHECKED    PROVED (safe): $PROVED    COUNTEREXAMPLE (confirmed bug): $CEX    INCONCLUSIVE: $INCONC    HARNESS_ERROR: $ERR"
+} >> "$REPORT"
+
+echo >&2
+echo "================ SYMBOLIC: $CHECKED checked, $PROVED proved, $CEX counterexample, $INCONC inconclusive, $ERR error ================" >&2
+echo "run-symbolic.sh: verdicts at $REPORT" >&2
+if [ "$CEX" -gt 0 ]; then
+  echo "run-symbolic.sh: $CEX candidate(s) CONFIRMED by a Halmos counterexample — a human reviews each before any submission. This colony never posts." >&2
+else
+  echo "run-symbolic.sh: no counterexample — nothing was confirmed as a bug by the solver. Nothing submitted." >&2
+fi


### PR DESCRIPTION
## What

Epic #1015 **milestone 2**: **generate-and-verify** — the epic's core thesis made callable. A candidate is routed through the M1 Halmos gate so its verdict comes from a **sound engine**, not the LLM. The LLM is the **hypothesis generator** (it turns a candidate into a Halmos property spec); Halmos is the **judge**.

## How

- `dark-factory/auditor/agents/symbolic-prover.ag` — per candidate: GENERATE a Halmos `*.t.sol` spec (verbatim from a `SPEC_FIXTURE` offline = no LLM, or via `prompt()` on the live path), VERIFY it with M1's `halmos-verify.sh`, and emit the verdict mapped from the gate's **exit code**: `0→PROVED` (invariant holds → lead refuted **by a proof**, safe), `1→COUNTEREXAMPLE` (bug **confirmed** with a concrete witness), `3→INCONCLUSIVE`, else→HARNESS_ERROR. **The verdict is always Halmos's exit code, never the LLM's opinion.**
- `dark-factory/run-symbolic.sh` — operator entry (mirrors `run-refute.sh`).
- `dark-factory/demo-symbolic.sh` — proves the full candidate→fixture-spec→**real Halmos**→verdict loop deterministically; `[SKIP]` + exit 0 without the toolchain (CI-safe).

## Security (untrusted spec content)

The generated spec is an LLM completion — **prompt-injectable by the candidate code under audit** — or an operator fixture. It is written with `printf '%s' <shell_escape(spec)>`, **never a heredoc**: a `shell_escape`d single-quoted literal cannot be escaped by any content, so a malicious spec is written verbatim and merely fails to compile / is judged by Halmos, never executed as shell. (A QA found an earlier heredoc write was RCE-able via a sentinel line; this PR's write closes it — verified: a `touch`-canary injection payload no longer fires.)

## Boundaries

M2 is the callable generate-and-verify step; auto-routing it from the self-orchestrating coordinator (#1014) is a later milestone. On the live path a vague invariant / large contract yields a non-compiling spec → **INCONCLUSIVE**, the **safe** failure mode (never a false PROVED). Human-gated submission + the existing forge-verify/refuter gates stay intact; Halmos is an additional sound oracle.

## Verification

- `demo-symbolic.sh` → PROVED (`transferSafe`) + COUNTEREXAMPLE (`transferBuggy`) via fixture-spec + **real Halmos**, deterministic re-run, `[SKIP]` without tools.
- The **live `claude`-backend path** generated compilable specs for both and reached the matching sound verdicts (the generate-and-verify loop works end-to-end with a real LLM + real solver).
- `run-symbolic.sh --backend mock` wiring smoke; **injection PoC blocked**; `bash -n` clean; **`colony-lint.sh` → 366 / 0 / 5**.

Part of #1015 — does **NOT** close the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
