### PR TITLE
feat(dark-factory): generate-and-verify orchestration — coordinator routes to the sound engine (#1015 M3)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,40 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **The self-orchestrating coordinator ROUTES a candidate to the SOUND symbolic engine — a new
+  `symbolic-prove` action** (#1015 M3). M2 shipped the *callable* generate-and-verify step; M3 wires it into
+  the #1014 self-orchestrating coordinator so the federation can **DECIDE** to route a pending candidate
+  through the sound symbolic engine, with the verdict weighted into its evolving policy.
+  - `auditor/agents/coordinator.ag` — new `symbolic-prove` action in the VERIFY tier (alongside
+    `refute`/`poc-screen`): `is_action` accepts it, a new `score_symbolic(policy)` scores it at **base 96**
+    (below `refute`(100) and `poc-screen`(98) — routing through the symbolic engine is the most expensive
+    verify, so the cheaper verifies go first by default), with the **steepest policy term in the tier** (×4)
+    so the colony can **learn** to lift it above either; a pending candidate still outranks any fresh hunt.
+    It operates on the first pending candidate (args = the candidate id, like refute/poc-screen) and consumes
+    it from `PENDING`. The in-substrate orchestrate loop carries a 5th policy int (field 19) + seen flag
+    (field 20) for `symbolic-prove`, appended **after** the existing fields so positions 0–18 are unchanged.
+    A new `SYM_POLICY_TT` env fact (ten-thousandths) seeds the loop's initial `symbolic-prove` policy so the
+    coordinator can choose it from step 0. **With `ORCHESTRATE_ENABLED` absent the single-decision path is
+    BYTE-IDENTICAL to before** (verified against `origin/main` on the `demo-coordinator.sh` fact-states — the
+    new action never wins any of those states since `refute` outranks it without a seeded policy).
+  - **The verdict→outcome mapping (the epic's thesis):** the SOUND symbolic verdict maps to the coordinator's
+    gate-outcome enum **COUNTEREXAMPLE → confirmed** (a real bug with a concrete witness),
+    **PROVED → refuted** (the lead is killed *by a proof*, safe), **INCONCLUSIVE → dry**. So the
+    confirmed/refuted policy signal the coordinator evolves on now comes from a **sound engine, never an LLM
+    opinion**. `auditor/agents/dispatcher.ag` documents the mapping prominently and routes `symbolic-prove`
+    to `run-symbolic.sh` on the honest live stub; on the offline path the `DISPATCH_FIXTURE` carries the
+    already-mapped outcome (`symbolic-prove|cand*=confirmed` = a COUNTEREXAMPLE, `=refuted` = a PROVED).
+  - `run-coordinator.sh` — new `--sym-policy <float>` flag seeds the in-substrate loop's `symbolic-prove`
+    policy weight (converted to `SYM_POLICY_TT` ten-thousandths) so an operator can have the coordinator
+    choose the symbolic route; usage/header list the new action; the in-loop-vs-store policy cross-check is
+    skipped when a seed is supplied (the seed is an in-loop offset not written to the experience store).
+  - `demo-symbolic-orchestrate.sh` — offline, deterministic proof: a hunt confirms → pushes a candidate →
+    the coordinator **CHOOSES** `symbolic-prove` for it → the SOUND verdict (via fixture) flows back as the
+    outcome (a COUNTEREXAMPLE run and a PROVED run, asserting the policy moves in **opposite** directions) →
+    the candidate is **consumed** from `PENDING` → the policy **evolves**; deterministic re-run. No real
+    Halmos needed for the orchestration proof (the fixture maps the sound verdict, exactly like every other
+    action's offline path). `docs/generate-verify.md` / `docs/coordinator.md` / `docs/dispatch.md` / `README.md`
+    updated with the action, the score/ordering rationale, and the verdict→outcome mapping.
 - **Generate-and-verify — the LLM HYPOTHESIZES a property, Halmos delivers the SOUND verdict** (#1015 M2).
   M1 shipped the *callable* Halmos gate; M2 closes the loop from a *candidate* to a symbolic verdict by
   **generating the spec** the gate runs. New `auditor/agents/symbolic-prover.ag` is a per-candidate substrate

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -244,6 +244,29 @@ scope: the loop self-orchestrates per bootstrap invocation; a long-lived daemon-
 refinement. v1 boundary (the live-path executor wiring per action is follow-up; manifest reprioritisation is
 follow-up; submission stays human-gated): [`docs/coordinator.md`](./docs/coordinator.md).
 
+**#1015 M3 — the coordinator ROUTES a candidate to the SOUND symbolic engine.** A new `symbolic-prove`
+coordinator ACTION lets the self-orchestrating loop **DECIDE** to route a pending candidate through the
+generate-and-verify gate (`run-symbolic.sh` / Halmos + z3, #1015 M2): a hunt confirms → pushes a candidate →
+the coordinator may CHOOSE `symbolic-prove` for it → the engine's **SOUND** verdict flows back into the
+evolving policy, mapped **COUNTEREXAMPLE → confirmed**, **PROVED → refuted** (the lead is killed *by a
+proof*), **INCONCLUSIVE → dry**. So the confirmed/refuted signal the policy evolves on now comes from a
+sound engine, never an LLM opinion — the epic's thesis as a coordinator decision. `symbolic-prove` sits in
+the VERIFY tier (default `refute` > `poc-screen` > `symbolic-prove`, the symbolic route being the most
+expensive verify; its policy term is the steepest, so the colony can learn to lift it). The orchestration is
+proven offline + deterministically with a fixture standing in for the sound verdict (no live Halmos needed,
+exactly like every other action's offline path):
+
+```sh
+dark-factory/demo-symbolic-orchestrate.sh   # hunt -> push -> CHOOSE symbolic-prove -> sound verdict ->
+                                            #   consumed from PENDING -> policy evolves; deterministic re-run
+# or bootstrap it yourself (--sym-policy seeds the symbolic-prove weight so the coordinator chooses it):
+dark-factory/run-coordinator.sh --scope <scope.tsv> --executor stub --fixture <fixture.tsv> --sym-policy 1.5
+```
+
+See [`docs/generate-verify.md`](./docs/generate-verify.md) (the verdict→outcome mapping) and
+[`docs/coordinator.md`](./docs/coordinator.md) (the action). The **live** symbolic route end-to-end from the
+coordinator's dispatch path remains follow-up; submission stays human-gated.
+
 ### Pre-screen a lead before the Foundry gate (`screen-leads.sh`)
 
 `forge-verify.sh` is the heavyweight gate (a full Foundry deploy + attacker tx). Between a hunter's
@@ -332,9 +355,12 @@ dark-factory/run-symbolic.sh --candidates "$PWD/candidates.tsv" --repo "$PWD/tar
 A `spec-fixture` in the manifest takes the **offline/deterministic** path — that spec is used verbatim and
 **no LLM is called** — so the candidate → halmos → verdict loop is provable with zero LLM cost and a real
 solver. A **COUNTEREXAMPLE** is still a **lead** a human reviews, not an auto-submission; this colony never
-posts. See [`docs/generate-verify.md`](./docs/generate-verify.md) for the verdict-source contract, the
-fixture-vs-LLM paths, how it composes with M1, and the honest scope (a callable step today; coordinator
-auto-routing is a later milestone).
+posts. **#1015 M3** wires this step into the self-orchestrating coordinator as the `symbolic-prove` action
+(the coordinator DECIDES to route a candidate here; the SOUND verdict maps **COUNTEREXAMPLE → confirmed** /
+**PROVED → refuted** / **INCONCLUSIVE → dry** back into its evolving policy — see the coordinator section
+above and `dark-factory/demo-symbolic-orchestrate.sh`). See
+[`docs/generate-verify.md`](./docs/generate-verify.md) for the verdict-source contract, the fixture-vs-LLM
+paths, how it composes with M1, and the verdict→outcome mapping the coordinator routes on.
 
 ## Exercise the evolve/fitness loop (`evolve-fitness.sh`)
 
@@ -426,6 +452,7 @@ dark-factory/
   demo-blackboard.sh            # offline, deterministic demo of the #1001 blackboard coordination loop
   demo-halmos.sh                # proof of the #1015 Halmos symbolic gate (PROVED + COUNTEREXAMPLE; SKIPs without the toolchain)
   demo-symbolic.sh              # offline-deterministic proof of the #1015 M2 generate-and-verify loop (fixture spec + real Halmos; SKIPs without the toolchain)
+  demo-symbolic-orchestrate.sh  # offline, deterministic proof of the #1015 M3 coordinator routing a candidate to the sound symbolic engine
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)

--- a/dark-factory/auditor/agents/coordinator.ag
+++ b/dark-factory/auditor/agents/coordinator.ag
@@ -135,6 +135,21 @@ fn score_poc(policy: string) -> float {
     return 98.0 + (2.0 * fit_value(policy, "poc-screen"));
 }
 
+// Score a `symbolic-prove` of a pending candidate (#1015 M3). Same VERIFY tier as refute/poc-screen (all
+// three "verify a pending lead" before more hunting), so a pending candidate present still outranks any
+// fresh hunt (base 50-75 — base 96 keeps the hard fact-priority intact). Base 96 — BELOW refute(100) and
+// poc-screen(98): routing a candidate through the SOUND symbolic engine GENERATES a Halmos spec and runs a
+// real z3 solver (run-symbolic.sh / the M1 gate, #1015 M2), the most EXPENSIVE verify, so by DEFAULT the
+// cheaper LLM-read refute and the cheap eval_ag poc-screen are tried first. The policy term (x4, the
+// steepest multiplier in the tier) lets the colony LEARN that the sound verdict pays off and lift
+// symbolic-prove ABOVE poc-screen (at policy >= 0.5) or refute (at policy >= 1.0) — `coordinator:policy:
+// symbolic-prove` is the cumulative experience delta, exactly like the other action types, so the choice is
+// policy-evolvable. Default ordering WITHIN the VERIFY tier: refute(100) > poc-screen(98) > symbolic-prove(96);
+// the policy re-sorts within it as the engine earns its keep.
+fn score_symbolic(policy: string) -> float {
+    return 96.0 + (4.0 * fit_value(policy, "symbolic-prove"));
+}
+
 // Score hunting a `subsystem|class` cell. Base 50; +20 if a sibling already posted a lead for this
 // subsystem on the blackboard (corroborate a fresh lead), + the lens fitness (a higher-fitness class is
 // preferred) + the hunt policy weight. So a board-matched hunt always beats an unmatched one of equal
@@ -280,10 +295,13 @@ fn is_verdict(v: string) -> bool {
 }
 
 // Is `t` a real (dispatchable) action type? `stop` is terminal and never dispatched. Leaf compares.
+// `symbolic-prove` (#1015 M3) routes a pending candidate through the SOUND symbolic engine; it is a real
+// verify action and so is dispatched like refute/poc-screen.
 fn is_action(t: string) -> bool {
     if t == "hunt" { return true; }
     if t == "refute" { return true; }
     if t == "poc-screen" { return true; }
+    if t == "symbolic-prove" { return true; }
     if t == "invent-method" { return true; }
     return false;
 }
@@ -307,7 +325,7 @@ fn action_outcome(atype: string, args: string) -> string {
             return "dry";
         }
     }
-    print("coordinator: LIVE " + atype + " of '" + args + "' needs its real wiring (hunt: TARGET_DIR/IN_SCOPE/SCOPE_BRIEF/TAXONOMY/SLICER per run-discovery.sh/hunter.ag; refute->run-refute.sh; poc-screen->screen-leads.sh; invent-method->run-method-discovery.sh); set DISPATCH_FIXTURE for the offline-deterministic path. No real action attempted.");
+    print("coordinator: LIVE " + atype + " of '" + args + "' needs its real wiring (hunt: TARGET_DIR/IN_SCOPE/SCOPE_BRIEF/TAXONOMY/SLICER per run-discovery.sh/hunter.ag; refute->run-refute.sh; poc-screen->screen-leads.sh; symbolic-prove->run-symbolic.sh; invent-method->run-method-discovery.sh); set DISPATCH_FIXTURE for the offline-deterministic path. No real action attempted.");
     return "dry";
 }
 
@@ -361,10 +379,21 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
 
     // --- DECIDE: build the option list, score each from FACTS+POLICY, rank, and let `decide` select the top.
     // `stop` short-circuits the ranking when budget is exhausted or K consecutive dry — a hard fact gate.
-    // The verify tier (pending candidate present): refute and poc-screen of the first pending candidate.
+    // The verify tier (pending candidate present): refute, poc-screen, and symbolic-prove (#1015 M3) of the
+    // first pending candidate — the colony picks the highest-scored of the three (default ordering
+    // refute > poc-screen > symbolic-prove; the evolving policy can re-sort within the tier).
     let pendId = if pendingCount > 0 { cell_subsystem(firstPending) } else { "" };
     let refuteScore = score_refute(policy);
     let pocScore = score_poc(policy);
+    let symScore = score_symbolic(policy);
+    // The winning VERIFY type by argmax of the three (single-assignment; ties resolve to the higher-base
+    // action, so the default ordering refute > poc-screen > symbolic-prove holds with no policy weight). The
+    // matching score is re-derived per-type in `chosenScore` below from the same three scores.
+    let verifyType =
+        if pocScore > refuteScore {
+            if symScore > pocScore { "symbolic-prove" } else { "poc-screen" }
+        }
+        else { if symScore > refuteScore { "symbolic-prove" } else { "refute" } };
 
     // The hunt tier: the single best huntable cell (highest fact+policy score).
     let bestCell = best_hunt(scope, classFit, policy, board);
@@ -382,7 +411,7 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
 
     let chosenType =
         if stopForced { "stop" }
-        else { if pendingCount > 0 { if pocScore > refuteScore { "poc-screen" } else { "refute" } }
+        else { if pendingCount > 0 { verifyType }
         else { if len(huntCell) > 0 { if huntScore >= inventScore { "hunt" } else { "invent-method" } }
         else { "invent-method" } } };
 
@@ -390,14 +419,16 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
         if chosenType == "hunt" { huntCell }
         else { if chosenType == "refute" { pendId }
         else { if chosenType == "poc-screen" { pendId }
-        else { "" } } };
+        else { if chosenType == "symbolic-prove" { pendId }
+        else { "" } } } };
 
     let chosenScore =
         if chosenType == "stop" { 0.0 }
         else { if chosenType == "refute" { refuteScore }
         else { if chosenType == "poc-screen" { pocScore }
+        else { if chosenType == "symbolic-prove" { symScore }
         else { if chosenType == "hunt" { huntScore }
-        else { inventScore } } } };
+        else { inventScore } } } } };
 
     // Substrate-native selection step: present the chosen action as the FIRST (top-ranked) entry of a
     // `decide` option list, with the runner-up next, and let the substrate `decide` builtin make the
@@ -434,6 +465,9 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
         else { if selType == "poc-screen" {
             "pending unverified candidate '" + selArgs + "' -> cheap eval_ag pre-screen first (policy poc-screen="
           + to_string(fit_value(policy, "poc-screen")) + "; " + factSummary + ")" }
+        else { if selType == "symbolic-prove" {
+            "pending unverified candidate '" + selArgs + "' -> route through the SOUND symbolic engine (generate a "
+          + "Halmos spec, z3 judges) (policy symbolic-prove=" + to_string(fit_value(policy, "symbolic-prove")) + "; " + factSummary + ")" }
         else { if selType == "hunt" {
             let bb = if board_has_subsystem(board, cell_subsystem(huntCell)) { "blackboard lead in this subsystem; " } else { "" };
             "hunt highest-scored lens '" + selArgs + "' (" + bb + "lens_fitness="
@@ -442,7 +476,7 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
         else {
             if len(huntCell) == 0 { "no huntable cell remains in scope -> invent a new method to open a fresh lens (" + factSummary + ")" }
             else { "ordinary hunting is not paying off (invent_policy=" + to_string(fit_value(policy, "invent-method"))
-                 + " > best hunt score " + to_string(huntScore) + ") -> invent a new method to open a fresh lens (" + factSummary + ")" } } } } };
+                 + " > best hunt score " + to_string(huntScore) + ") -> invent a new method to open a fresh lens (" + factSummary + ")" } } } } } };
 
     // --- OUTPUT exactly one ACTION line; record the decision on the bus + memo for the dispatcher. -----
     let actionLine = "ACTION|" + selType + "|" + selArgs + "|" + rationale;
@@ -492,8 +526,11 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
 //                 read_policy() (sum of experience `delta`) byte-for-byte: each ±0.15 attribution is ±1500
 //                 ten-thousandths, and fmt4() renders the same `%.4f` Python `read_policy` emits. (We ALSO
 //                 learn() for the durable experience record — the carried ints are the in-loop mirror.)
+//                 The symbolic-prove policy int is field 19 (appended after the #1026 lastAttr field) so the
+//                 existing field positions 0-18 are unchanged.
 //   12 sh,13 si,14 sp,15 sr  per-type "seen" flags ("1"/"0") — read_policy emits only keys that appear in
-//                 the store, sorted; the seen flags reproduce that (a key is omitted until first attributed)
+//                 the store, sorted; the seen flags reproduce that (a key is omitted until first attributed).
+//                 The symbolic-prove "seen" flag is field 20.
 //   16 trace      the accumulating decisions.tsv body (rows joined by `\n`, each a real TSV row)
 //   17 budget0    the ORIGINAL budget (for the BUDGET fact each row reports as the shell's REMAINING)
 //   18 lastAttr   "1" once the carried prevAction has ALREADY been attributed in-loop (so the post-loop FINAL
@@ -502,6 +539,8 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
 //                 and the final block skips it; on budget-exhaustion the last action is never attributed
 //                 in-loop (the next step's decide_once never runs), so it stays "0" and the final block
 //                 attributes it exactly once. Makes attribution IDEMPOTENT: every EXECUTED action counted once.
+//   19 pq         symbolic-prove cumulative policy in TEN-THOUSANDTHS (int), the 5th action type (#1015 M3).
+//   20 sq         symbolic-prove "seen" flag ("1"/"0").
 //
 // POLICY THREADING. decide_once() is fed the formatted carried policy (fields 8-15 -> the `type=delta;...`
 // string read_policy would return), so the in-loop decision ranks options against the SAME evolving policy
@@ -565,18 +604,21 @@ fn state_int(s: string, n: int) -> int {
 }
 
 // Build the `type=delta;...` POLICY string from the carried ints + seen flags — byte-identical to the
-// shell's read_policy(): only SEEN keys, ALPHABETICALLY sorted (hunt < invent-method < poc-screen < refute),
-// each `key=%.4f`, `;`-joined; "" when nothing has been attributed yet.
-fn policy_string(ph: int, pi: int, pp: int, pr: int, sh: bool, si: bool, sp: bool, sr: bool) -> string {
+// shell's read_policy(): only SEEN keys, ALPHABETICALLY sorted (hunt < invent-method < poc-screen < refute
+// < symbolic-prove), each `key=%.4f`, `;`-joined; "" when nothing has been attributed yet. symbolic-prove
+// (#1015 M3) sorts LAST (`r` < `s`), so it appends at the end exactly as Python's `sorted()` orders it.
+fn policy_string(ph: int, pi: int, pp: int, pr: int, pq: int, sh: bool, si: bool, sp: bool, sr: bool, sq: bool) -> string {
     let a = if sh { "hunt=" + fmt4(ph) } else { "" };
     let b = if si { "invent-method=" + fmt4(pi) } else { "" };
     let c = if sp { "poc-screen=" + fmt4(pp) } else { "" };
     let d = if sr { "refute=" + fmt4(pr) } else { "" };
+    let e = if sq { "symbolic-prove=" + fmt4(pq) } else { "" };
     let s1 = a;
     let s2 = if len(b) > 0 { if len(s1) > 0 { s1 + ";" + b } else { b } } else { s1 };
     let s3 = if len(c) > 0 { if len(s2) > 0 { s2 + ";" + c } else { c } } else { s2 };
     let s4 = if len(d) > 0 { if len(s3) > 0 { s3 + ";" + d } else { d } } else { s3 };
-    return s4;
+    let s5 = if len(e) > 0 { if len(s4) > 0 { s4 + ";" + e } else { e } } else { s4 };
+    return s5;
 }
 
 // The ±1500 ten-thousandths delta a `learn()` signal applies (success +0.15, failure -0.15, else 0) — the
@@ -633,10 +675,12 @@ fn step_fn(state: string, stepLabel: string) -> string {
     let srIn = state_int(state, 15) == 1;
     let trace = state_field(state, 16);
     let budget0 = state_int(state, 17);
+    let pqIn = state_int(state, 19);
+    let sqIn = state_int(state, 20) == 1;
 
     // POLICY snapshot used for THIS decision + the trace row (the pre-attribution sum, as the shell's env
     // POLICY is read before the call's learn() write).
-    let policyStr = policy_string(phIn, piIn, ppIn, prIn, shIn, siIn, spIn, srIn);
+    let policyStr = policy_string(phIn, piIn, ppIn, prIn, pqIn, shIn, siIn, spIn, srIn, sqIn);
 
     // Apply the PREVIOUS action's attribution to the carried ints (the shell's read_policy at the NEXT step
     // reflects it). decide_once() ALSO learn()s it for the durable record.
@@ -646,11 +690,13 @@ fn step_fn(state: string, stepLabel: string) -> string {
     let pi = if prevAction == "invent-method" { piIn + d } else { piIn };
     let pp = if prevAction == "poc-screen" { ppIn + d } else { ppIn };
     let pr = if prevAction == "refute" { prIn + d } else { prIn };
+    let pq = if prevAction == "symbolic-prove" { pqIn + d } else { pqIn };
     let didAttr = if len(prevAction) > 0 { len(sig) > 0 } else { false };
     let sh = if didAttr { if prevAction == "hunt" { true } else { shIn } } else { shIn };
     let si = if didAttr { if prevAction == "invent-method" { true } else { siIn } } else { siIn };
     let sp = if didAttr { if prevAction == "poc-screen" { true } else { spIn } } else { spIn };
     let sr = if didAttr { if prevAction == "refute" { true } else { srIn } } else { srIn };
+    let sq = if didAttr { if prevAction == "symbolic-prove" { true } else { sqIn } } else { sqIn };
 
     // ONE decision + in-substrate dispatch on the CARRIED facts (board re-read fresh, like the shell).
     let dryCap = if len(getenv("DRY_CAP")) == 0 { 3 } else { parse_int(getenv("DRY_CAP")) };
@@ -682,7 +728,8 @@ fn step_fn(state: string, stepLabel: string) -> string {
              + "@@F@@" + prevAction + "@@F@@" + prevKey + "@@F@@" + lastOutcome + "@@F@@" + pending
              + "@@F@@" + to_string(ph) + "@@F@@" + to_string(pi) + "@@F@@" + to_string(pp) + "@@F@@" + to_string(pr)
              + "@@F@@" + bool_flag(sh) + "@@F@@" + bool_flag(si) + "@@F@@" + bool_flag(sp) + "@@F@@" + bool_flag(sr)
-             + "@@F@@" + trace2 + "@@F@@" + to_string(budget0) + "@@F@@" + bool_flag(didAttr);
+             + "@@F@@" + trace2 + "@@F@@" + to_string(budget0) + "@@F@@" + bool_flag(didAttr)
+             + "@@F@@" + to_string(pq) + "@@F@@" + bool_flag(sq);
     }
 
     // Read the dispatch verdict back (decide_once already ran dispatch() in-process, writing the memo).
@@ -690,13 +737,14 @@ fn step_fn(state: string, stepLabel: string) -> string {
     let rawVerdict = tail_field(memoOutcome);
     let outcome = if is_verdict(rawVerdict) { rawVerdict } else { "dry" };
 
-    // Update PENDING from the outcome (the shell's case): a confirmed hunt pushes a candidate; refute/poc
-    // consume the first pending candidate.
+    // Update PENDING from the outcome (the shell's case): a confirmed hunt pushes a candidate; refute /
+    // poc-screen / symbolic-prove (#1015 M3) consume the first pending candidate (the one they verified).
     let pending2 =
         if selType == "hunt" { if outcome == "confirmed" { pending_push(pending, "cand-" + to_string(step) + "|" + selArgs) } else { pending } }
         else { if selType == "refute" { pending_pop(pending) }
         else { if selType == "poc-screen" { pending_pop(pending) }
-        else { pending } } };
+        else { if selType == "symbolic-prove" { pending_pop(pending) }
+        else { pending } } } };
 
     let dryStreak2 = if outcome == "confirmed" { 0 } else { dryStreak + 1 };
     let budget2 = budget - 1;
@@ -713,7 +761,8 @@ fn step_fn(state: string, stepLabel: string) -> string {
          + "@@F@@" + selType + "@@F@@" + selArgs + "@@F@@" + outcome + "@@F@@" + pending2
          + "@@F@@" + to_string(ph) + "@@F@@" + to_string(pi) + "@@F@@" + to_string(pp) + "@@F@@" + to_string(pr)
          + "@@F@@" + bool_flag(sh) + "@@F@@" + bool_flag(si) + "@@F@@" + bool_flag(sp) + "@@F@@" + bool_flag(sr)
-         + "@@F@@" + trace2 + "@@F@@" + to_string(budget0) + "@@F@@0";
+         + "@@F@@" + trace2 + "@@F@@" + to_string(budget0) + "@@F@@0"
+         + "@@F@@" + to_string(pq) + "@@F@@" + bool_flag(sq);
 }
 
 // === TOP LEVEL ===
@@ -725,10 +774,22 @@ if len(getenv("ORCHESTRATE_ENABLED")) > 0 {
     // a non-default cap arrives via DRY_CAP. BUDGET is the loop bound.
     let budget0 = if len(getenv("BUDGET")) == 0 { 0 } else { parse_int(getenv("BUDGET")) };
     let initPending = getenv("PENDING");
+    // SEED the loop's INITIAL symbolic-prove policy (field 19) from the integer env fact SYM_POLICY_TT, in
+    // ten-thousandths (the loop's internal policy unit — e.g. 15000 = +1.5). This lets a bootstrap pre-tilt
+    // the policy toward the SOUND symbolic engine BEFORE the loop has accumulated experience, so an operator
+    // (or the orchestration demo) can have the loop CHOOSE symbolic-prove from step 0. A ten-thousandths INT
+    // is used (not the float POLICY fact) because agentis offers no float->int builtin (parse_int rejects a
+    // decimal). Only the symbolic-prove component is seeded; the other four policy ints stay 0 (the existing
+    // M3 golden relies on hunt/refute starting cold), so the demo-orchestrate golden trace is unaffected. A
+    // non-zero seed also lights the "seen" flag (field 20) so the seeded weight renders in the policy string.
+    let symSeed = if len(getenv("SYM_POLICY_TT")) == 0 { 0 } else { parse_int(getenv("SYM_POLICY_TT")) };
+    let symSeen = if symSeed == 0 { "0" } else { "1" };
     // initial accumulator: nothing attributed yet (all ints 0, all seen "0"), no prev, empty trace, field 18
-    // lastAttr "0" (no prev action to have attributed).
+    // lastAttr "0" (no prev action to have attributed), field 19 symbolic-prove policy int (the seed), field
+    // 20 seen ("1" iff the seed is non-zero).
     let init = "0@@F@@" + to_string(budget0) + "@@F@@0@@F@@0@@F@@@@F@@@@F@@@@F@@" + initPending
-             + "@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@@@F@@" + to_string(budget0) + "@@F@@0";
+             + "@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@@@F@@" + to_string(budget0) + "@@F@@0"
+             + "@@F@@" + to_string(symSeed) + "@@F@@" + symSeen;
     let finalState = reduce(regex_split("\n", getenv("STEPS")),
                             |acc: string, s: string| -> string { return step_fn(acc, s); }, init);
 
@@ -755,15 +816,17 @@ if len(getenv("ORCHESTRATE_ENABLED")) > 0 {
     let fpi = state_int(finalState, 9) + (if fPrevAction == "invent-method" { fd } else { 0 });
     let fpp = state_int(finalState, 10) + (if fPrevAction == "poc-screen" { fd } else { 0 });
     let fpr = state_int(finalState, 11) + (if fPrevAction == "refute" { fd } else { 0 });
+    let fpq = state_int(finalState, 19) + (if fPrevAction == "symbolic-prove" { fd } else { 0 });
     let fsh = if state_int(finalState, 12) == 1 { true } else { if fAttribute { fPrevAction == "hunt" } else { false } };
     let fsi = if state_int(finalState, 13) == 1 { true } else { if fAttribute { fPrevAction == "invent-method" } else { false } };
     let fsp = if state_int(finalState, 14) == 1 { true } else { if fAttribute { fPrevAction == "poc-screen" } else { false } };
     let fsr = if state_int(finalState, 15) == 1 { true } else { if fAttribute { fPrevAction == "refute" } else { false } };
+    let fsq = if state_int(finalState, 20) == 1 { true } else { if fAttribute { fPrevAction == "symbolic-prove" } else { false } };
 
     // Publish the trace + the evolved policy to durable memos the bootstrap reads back (the cross-process
     // channel). The trace is the full decisions.tsv body; policy-after is the read_policy()-shaped string.
     memo_write("coordinator:trace", state_field(finalState, 16));
-    memo_write("coordinator:policy_after", policy_string(fph, fpi, fpp, fpr, fsh, fsi, fsp, fsr));
+    memo_write("coordinator:policy_after", policy_string(fph, fpi, fpp, fpr, fpq, fsh, fsi, fsp, fsr, fsq));
     print("ORCHESTRATE|done|steps=" + to_string(state_int(finalState, 3)));
 } else {
     // SINGLE DECISION (v1, byte-identical): read facts from env, run ONE decide_once(). The board is read

--- a/dark-factory/auditor/agents/dispatcher.ag
+++ b/dark-factory/auditor/agents/dispatcher.ag
@@ -134,18 +134,45 @@ fn is_verdict(v: string) -> bool {
 }
 
 // Is `t` a real (dispatchable) action type? `stop` is terminal and never dispatched. Leaf compares.
+// `symbolic-prove` (#1015 M3) routes a pending candidate through the SOUND symbolic engine; it is a real
+// verify action and so is dispatched like refute/poc-screen.
 fn is_action(t: string) -> bool {
     if t == "hunt" { return true; }
     if t == "refute" { return true; }
     if t == "poc-screen" { return true; }
+    if t == "symbolic-prove" { return true; }
     if t == "invent-method" { return true; }
     return false;
 }
 
+// === THE EPIC'S THESIS (#1015 M3): the SOUND symbolic verdict -> the coordinator OUTCOME enum. ===========
+// `symbolic-prove` routes a pending candidate through the SOUND symbolic engine (symbolic-prover.ag /
+// run-symbolic.sh, #1015 M2): the LLM only WRITES the property spec, but the verdict is HALMOS's exit code
+// (z3, no sampling) — never an LLM opinion. The engine's verdict tokens map to the coordinator's three-value
+// gate-outcome enum (confirmed | refuted | dry) as follows — this mapping is the WHOLE point of the action:
+//
+//   COUNTEREXAMPLE -> confirmed   a concrete input violates the invariant -> a REAL bug, CONFIRMED with a
+//                                 replayable witness (the highest-value outcome the loop can produce).
+//   PROVED         -> refuted     the invariant holds for ALL inputs -> the lead is killed BY A PROOF (safe);
+//                                 it is REFUTED — the same polarity a refuter's hostile read produces, but
+//                                 here from a sound proof, not an opinion.
+//   INCONCLUSIVE   -> dry         solver unknown / timeout / loop not fully explored / nothing matched -> no
+//                                 verdict; a non-productive step (the SAFE failure mode, never a false claim).
+//   HARNESS_ERROR / anything else -> dry   the run did not produce a verdict; treated as non-productive.
+//
+// So the confirmed/refuted policy signal the coordinator evolves on now comes from a SOUND oracle, not the
+// LLM. On the OFFLINE path the DISPATCH_FIXTURE carries the ALREADY-MAPPED outcome directly (a
+// `symbolic-prove|cand*=confirmed` rule stands in for a COUNTEREXAMPLE verdict, `=refuted` for a PROVED), so
+// the deterministic demo needs no live solver. The live mapping is realized end-to-end in symbolic-prover.ag
+// (exit code -> verdict -> learn outcome) behind run-symbolic.sh; the honest live stub below points there.
+
 // Derive the gate OUTCOME for an action of `<type>` with `<args>`. Offline (DISPATCH_FIXTURE set, or the
 // M1 HUNT_FIXTURE alias for a hunt) -> the fixture rule, NO prompt()/LLM. Otherwise the LIVE path: an
 // honest per-type stub that says what real wiring it needs (mirrors run-coordinator.sh::real_outcome) and
-// returns a benign `dry` — it does NOT attempt a real action.
+// returns a benign `dry` — it does NOT attempt a real action. For `symbolic-prove` the real wiring is
+// run-symbolic.sh -> symbolic-prover.ag -> halmos-verify.sh, whose SOUND verdict maps through the
+// COUNTEREXAMPLE->confirmed / PROVED->refuted / INCONCLUSIVE->dry contract documented above — the
+// cross-process bridge from the sound engine's verdict to the coordinator's policy signal.
 fn action_outcome(atype: string, args: string) -> string {
     let fixture = getenv("DISPATCH_FIXTURE");
     if len(fixture) > 0 {
@@ -161,7 +188,7 @@ fn action_outcome(atype: string, args: string) -> string {
             return "dry";
         }
     }
-    print("dispatcher: LIVE " + atype + " of '" + args + "' needs its real wiring (hunt: TARGET_DIR/IN_SCOPE/SCOPE_BRIEF/TAXONOMY/SLICER per run-discovery.sh/hunter.ag; refute->run-refute.sh; poc-screen->screen-leads.sh; invent-method->run-method-discovery.sh); set DISPATCH_FIXTURE for the offline-deterministic path. No real action attempted.");
+    print("dispatcher: LIVE " + atype + " of '" + args + "' needs its real wiring (hunt: TARGET_DIR/IN_SCOPE/SCOPE_BRIEF/TAXONOMY/SLICER per run-discovery.sh/hunter.ag; refute->run-refute.sh; poc-screen->screen-leads.sh; symbolic-prove->run-symbolic.sh (SOUND verdict: COUNTEREXAMPLE->confirmed, PROVED->refuted, INCONCLUSIVE->dry); invent-method->run-method-discovery.sh); set DISPATCH_FIXTURE for the offline-deterministic path. No real action attempted.");
     return "dry";
 }
 

--- a/dark-factory/demo-symbolic-orchestrate.sh
+++ b/dark-factory/demo-symbolic-orchestrate.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# demo-symbolic-orchestrate.sh — #1015 M3: OFFLINE, DETERMINISTIC proof that the self-orchestrating
+# coordinator ROUTES a pending candidate through the SOUND symbolic engine. In ONE `agentis go
+# coordinator.ag` (ORCHESTRATE_ENABLED), the federation hunts a lead, surfaces a candidate, and then CHOOSES
+# the `symbolic-prove` action for it — the verdict that flows back into its evolving policy is the symbolic
+# gate's SOUND outcome (a fixture stands in for the real Halmos run here, exactly as every other action's
+# offline path does), mapped COUNTEREXAMPLE->confirmed / PROVED->refuted / INCONCLUSIVE->dry. No network, no
+# real LLM, no Halmos toolchain needed — the orchestration is proven against the fixture-mapped verdict.
+#
+# This is the #1015 epic's thesis made a COORDINATOR DECISION: the confirmed/refuted policy signal the
+# coordinator evolves on now comes from a SOUND engine, not an LLM opinion. M2 shipped the callable
+# generate-and-verify step (run-symbolic.sh); M3 lets the self-orchestrating coordinator (#1014) DECIDE when
+# to spend a symbolic verify and feed the verdict back.
+#
+# This demo proves:
+#   (1) The coordinator CHOOSES `symbolic-prove` for a pending candidate (the new VERIFY-tier action) — with
+#       a seeded symbolic-prove policy that lifts it above refute/poc-screen, a hunt confirms -> pushes a
+#       candidate -> the coordinator routes THAT candidate through the symbolic engine.
+#   (2) The SOUND verdict maps to the right outcome: a `symbolic-prove|cand*=confirmed` fixture (= a Halmos
+#       COUNTEREXAMPLE) flows back as a `confirmed` policy SUCCESS; a `=refuted` fixture (= a Halmos PROVED)
+#       flows back as a `refuted` policy FAILURE. We run BOTH and assert the policy moves in opposite
+#       directions, with the candidate CONSUMED from PENDING either way.
+#   (3) PENDING is threaded correctly: a confirmed hunt pushes `cand-<step>`; the symbolic-prove of it
+#       consumes the first pending candidate (the trace alternates hunt/symbolic-prove with pending 0/1).
+#   (4) The decision policy EVOLVES: symbolic-prove's weight rises on COUNTEREXAMPLE-confirmed runs and falls
+#       on PROVED-refuted runs, and the in-loop policy equals the seed + the per-outcome experience deltas.
+#   (5) DETERMINISM: a re-run into a fresh store is byte-identical (no RNG; the verdict is the fixture's).
+#
+# Usage:  dark-factory/demo-symbolic-orchestrate.sh
+# Requires: the `agentis` binary on PATH. Exit 0 = all proven; non-zero = an assertion failed.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+command -v agentis >/dev/null 2>&1 || { echo "demo-symbolic-orchestrate.sh: agentis binary not on PATH" >&2; exit 3; }
+COORD_AG="$HERE/auditor/agents/coordinator.ag"
+[ -f "$COORD_AG" ] || { echo "demo-symbolic-orchestrate.sh: coordinator agent not found at $COORD_AG" >&2; exit 3; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+FAILS=0
+note() { echo "demo-symbolic-orchestrate.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+
+# The FACTS the audit runs under: one huntable cell whose hunt confirms (-> pushes a candidate). The
+# symbolic-prove policy is SEEDED (--sym-policy 1.5 -> SYM_POLICY_TT=15000) so symbolic-prove (base 96)
+# outranks refute (base 100) and poc-screen (base 98) in the VERIFY tier and the coordinator CHOOSES it.
+SCOPE_FX=$'vault accounting|C1'
+FIT_FX="C1=0.5500"
+BUDGET=4
+DRY_CAP=3
+SYM_TT=15000   # +1.5 in ten-thousandths; > 1.0 lifts symbolic-prove above refute
+
+# A fresh agentis store configured EXACTLY like run-coordinator.sh's orchestrate bootstrap (experience
+# enabled; the loop + dispatch + the symbolic-prove seed facts whitelisted). $1 = store dir.
+init_store() {
+  _d="$1"; mkdir -p "$_d"; cp "$COORD_AG" "$_d/coordinator.ag"
+  ( cd "$_d" && agentis init >/dev/null 2>&1 )
+  {
+    echo "llm.backend = mock"
+    echo "trace.level = normal"
+    echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS,SYM_POLICY_TT"
+    echo "exec.default_timeout_ms = 30000"
+    echo "learning.enabled = true"
+    echo "experience.enabled = true"
+  } > "$_d/.agentis/config"
+}
+
+# Run the WHOLE audit as ONE in-substrate `agentis go` (ORCHESTRATE_ENABLED) in store $1 with the
+# DISPATCH_FIXTURE in $2. STEPS is the budget-bounded `0..BUDGET-1` list.
+orchestrate() {
+  _store="$1"; _fixture="$2"
+  _steps="$(awk -v n="$BUDGET" 'BEGIN{ for (i=0;i<n;i++){ printf "%s%d", (i?"\n":""), i } }')"
+  ( cd "$_store" && env \
+      SCOPE="$SCOPE_FX" CLASS_FITNESS="$FIT_FX" PENDING="" \
+      BUDGET="$BUDGET" DRY_CAP="$DRY_CAP" STEPS="$_steps" SYM_POLICY_TT="$SYM_TT" \
+      ORCHESTRATE_ENABLED=1 DISPATCH_ENABLED=1 DISPATCH_FIXTURE="$_fixture" \
+      agentis go coordinator.ag --enable-exec --enable-messaging 2>/dev/null )
+}
+
+# Read the loop's durable trace / policy memos back.
+read_trace()  { ( cd "$1" && agentis memo get coordinator:trace ) 2>/dev/null; }
+read_policy() { ( cd "$1" && agentis memo get coordinator:policy_after ) 2>/dev/null; }
+
+# The action TYPE of one decisions.tsv row (the `action=<type>` field).
+row_action() { printf '%s' "$1" | awk -F'\t' '{ for (i=1;i<=NF;i++) if ($i ~ /^action=/) { sub(/^action=/,"",$i); print $i } }'; }
+
+# The cumulative experience-store delta for symbolic-prove (the same read_policy mechanic run-coordinator
+# uses) — the per-outcome ±0.15 sum, WITHOUT the in-loop seed.
+store_sym_delta() {
+  python3 - "$1/.agentis/experience/main.jsonl" <<'PY'
+import json, os, sys
+path = sys.argv[1]; tot = 0.0
+if os.path.exists(path):
+    for line in open(path):
+        line = line.strip()
+        if not line: continue
+        try: r = json.loads(line)
+        except Exception: continue
+        if r.get("action") == "coordinator" and r.get("in") == "symbolic-prove":
+            tot += float(r.get("delta", 0.0))
+print("%.4f" % tot)
+PY
+}
+
+# float comparison helper: `cmp_gt A B` -> exit 0 iff A > B.
+cmp_gt() { awk -v a="$1" -v b="$2" 'BEGIN{ exit !(a > b) }'; }
+
+echo "=================================================================================="
+echo " (1+2 CEX) COUNTEREXAMPLE->confirmed: hunt -> push -> CHOOSE symbolic-prove -> confirmed"
+echo "=================================================================================="
+# hunt confirms (-> pushes cand); symbolic-prove of cand maps a Halmos COUNTEREXAMPLE -> confirmed (success).
+CEX_FIXTURE="hunt|vault*=confirmed;symbolic-prove|cand-*=confirmed;refute|cand-*=refuted;poc-screen|cand-*=dry"
+init_store "$WORK/cex"
+OUT_CEX="$(orchestrate "$WORK/cex" "$CEX_FIXTURE")"
+MARK_CEX="$(printf '%s\n' "$OUT_CEX" | grep -E '^ORCHESTRATE\|' | head -1)"
+TRACE_CEX="$(read_trace "$WORK/cex")"
+POLICY_CEX="$(read_policy "$WORK/cex")"
+
+if [ -n "$MARK_CEX" ]; then ok "the single agentis go completed in-substrate ($MARK_CEX)"
+else bad "no ORCHESTRATE| completion marker — the in-substrate loop did not run"; fi
+
+# (1) the coordinator CHOSE symbolic-prove for a pending candidate.
+SYM_ROWS="$(printf '%s\n' "$TRACE_CEX" | grep '^step=' | while IFS= read -r r; do row_action "$r"; done | grep -c '^symbolic-prove$')"
+if [ "$SYM_ROWS" -ge 1 ]; then ok "the coordinator CHOSE symbolic-prove $SYM_ROWS time(s) — the new VERIFY-tier action was selected"
+else bad "the coordinator never chose symbolic-prove (the seeded policy did not lift it / wrong scenario)"; fi
+
+# Assert the first symbolic-prove row points at the candidate the prior hunt pushed (cand-0), proving it
+# routed the PENDING candidate (not a fresh hunt).
+SYM_ARGS="$(printf '%s\n' "$TRACE_CEX" | grep '^step=' | grep 'action=symbolic-prove' | head -1 | awk -F'\t' '{ for (i=1;i<=NF;i++) if ($i ~ /^args=/) { sub(/^args=/,"",$i); print $i } }')"
+if [ "$SYM_ARGS" = "cand-0" ]; then ok "symbolic-prove routed the pushed candidate 'cand-0' (the pending lead, not a fresh hunt)"
+else bad "expected symbolic-prove of 'cand-0', got '$SYM_ARGS'"; fi
+
+# (3) PENDING threaded: the step AFTER a hunt-confirm shows pending=1; the symbolic-prove consumes it so a
+# following hunt sees pending=0 again. The trace alternates hunt(pending=0)/symbolic-prove(pending=1).
+ALT="$(printf '%s\n' "$TRACE_CEX" | grep '^step=' | while IFS= read -r r; do row_action "$r"; done | sort -u | tr '\n' ' ')"
+if printf '%s' "$ALT" | grep -q 'hunt' && printf '%s' "$ALT" | grep -q 'symbolic-prove'; then
+  ok "the loop alternated hunt + symbolic-prove ($ALT) — push then route then push (PENDING consumed each verify)"
+else bad "expected a hunt + symbolic-prove alternation, got '$ALT'"; fi
+
+# (2 CEX) the policy ROSE: a COUNTEREXAMPLE-confirmed is a success, so symbolic-prove's weight climbs above
+# its seed. The experience store holds ONLY the per-outcome deltas (positive here), not the seed.
+SYM_STORE_CEX="$(store_sym_delta "$WORK/cex")"
+note "COUNTEREXAMPLE run: policy-after [$POLICY_CEX]  store symbolic-prove delta=$SYM_STORE_CEX"
+if cmp_gt "$SYM_STORE_CEX" "0.0"; then ok "symbolic-prove experience delta is POSITIVE ($SYM_STORE_CEX) — COUNTEREXAMPLE mapped to a confirmed SUCCESS"
+else bad "expected a positive symbolic-prove delta on the COUNTEREXAMPLE run, got $SYM_STORE_CEX"; fi
+
+echo
+echo "=================================================================================="
+echo " (2 PROVED) PROVED->refuted: same route, a PROOF kills the lead -> policy FALLS"
+echo "=================================================================================="
+# Same scenario, but symbolic-prove maps a Halmos PROVED -> refuted (failure): the candidate is still
+# CONSUMED (the lead is killed by a proof), but the policy signal is negative.
+PROVED_FIXTURE="hunt|vault*=confirmed;symbolic-prove|cand-*=refuted;refute|cand-*=refuted;poc-screen|cand-*=dry"
+init_store "$WORK/proved"
+orchestrate "$WORK/proved" "$PROVED_FIXTURE" >/dev/null
+TRACE_PROVED="$(read_trace "$WORK/proved")"
+POLICY_PROVED="$(read_policy "$WORK/proved")"
+SYM_STORE_PROVED="$(store_sym_delta "$WORK/proved")"
+note "PROVED run: policy-after [$POLICY_PROVED]  store symbolic-prove delta=$SYM_STORE_PROVED"
+
+# The coordinator still chose symbolic-prove and still consumed the candidate (a refuted verify pops PENDING).
+PROVED_SYM_ROWS="$(printf '%s\n' "$TRACE_PROVED" | grep '^step=' | while IFS= read -r r; do row_action "$r"; done | grep -c '^symbolic-prove$')"
+if [ "$PROVED_SYM_ROWS" -ge 1 ]; then ok "the coordinator chose symbolic-prove $PROVED_SYM_ROWS time(s) on the PROVED run too"
+else bad "the coordinator did not choose symbolic-prove on the PROVED run"; fi
+# A refuted verify consumes the candidate, so a hunt re-confirms a fresh one next step (PENDING returns to 0):
+# the run alternates hunt/symbolic-prove just like the CEX run, proving the candidate was popped each time.
+PROVED_HUNTS="$(printf '%s\n' "$TRACE_PROVED" | grep '^step=' | while IFS= read -r r; do row_action "$r"; done | grep -c '^hunt$')"
+if [ "$PROVED_HUNTS" -ge 2 ]; then ok "the PROVED run re-hunted $PROVED_HUNTS times — each symbolic-prove CONSUMED its candidate (PENDING popped, a fresh hunt followed)"
+else bad "expected >= 2 hunts (each verify consumed PENDING), got $PROVED_HUNTS"; fi
+
+# (2) the policy FELL: a PROVED-refuted is a failure, so the symbolic-prove experience delta is NEGATIVE —
+# the OPPOSITE sign of the COUNTEREXAMPLE run. The SOUND verdict, not an LLM, drives the sign.
+if cmp_gt "0.0" "$SYM_STORE_PROVED"; then ok "symbolic-prove experience delta is NEGATIVE ($SYM_STORE_PROVED) — PROVED mapped to a refuted FAILURE (opposite of COUNTEREXAMPLE)"
+else bad "expected a negative symbolic-prove delta on the PROVED run, got $SYM_STORE_PROVED"; fi
+if cmp_gt "$SYM_STORE_CEX" "$SYM_STORE_PROVED"; then
+  ok "the SOUND verdict drives the policy SIGN: COUNTEREXAMPLE delta ($SYM_STORE_CEX) > PROVED delta ($SYM_STORE_PROVED)"
+else
+  bad "the verdict did not flip the policy sign: CEX=$SYM_STORE_CEX vs PROVED=$SYM_STORE_PROVED"
+fi
+
+echo
+echo "=================================================================================="
+echo " (4) IN-LOOP POLICY == seed + experience deltas (the threading mirrors the store + the seed)"
+echo "=================================================================================="
+# The in-loop policy_after carries the SEED (1.5) plus the per-outcome experience deltas. The store holds
+# only the deltas. So in-loop symbolic-prove == 1.5 + store-delta, byte-for-byte. Verify for the CEX run.
+SYM_LOOP_CEX="$(printf '%s' "$POLICY_CEX" | awk -F';' '{ for(i=1;i<=NF;i++) if ($i ~ /^symbolic-prove=/) { sub(/^symbolic-prove=/,"",$i); print $i } }')"
+SYM_EXPECT_CEX="$(awk -v s="$SYM_STORE_CEX" 'BEGIN{ printf "%.4f", 1.5 + s }')"
+if [ "$SYM_LOOP_CEX" = "$SYM_EXPECT_CEX" ]; then
+  ok "in-loop symbolic-prove policy ($SYM_LOOP_CEX) == seed 1.5000 + experience delta ($SYM_STORE_CEX) — the threading mirrors store + seed"
+else
+  bad "in-loop symbolic-prove policy '$SYM_LOOP_CEX' != seed+delta '$SYM_EXPECT_CEX'"
+fi
+
+echo
+echo "=================================================================================="
+echo " (5) DETERMINISM — a re-run into a fresh store is byte-identical"
+echo "=================================================================================="
+init_store "$WORK/cex2"
+orchestrate "$WORK/cex2" "$CEX_FIXTURE" >/dev/null
+TRACE_CEX2="$(read_trace "$WORK/cex2")"
+POLICY_CEX2="$(read_policy "$WORK/cex2")"
+if [ "$TRACE_CEX" = "$TRACE_CEX2" ] && [ "$POLICY_CEX" = "$POLICY_CEX2" ]; then
+  ok "two independent in-substrate runs produced byte-identical decisions.tsv + policy (deterministic)"
+else
+  bad "the two runs DIFFERED:"
+  diff <(printf '%s\n' "$TRACE_CEX") <(printf '%s\n' "$TRACE_CEX2") | sed 's/^/      /' >&2 || true
+fi
+
+echo
+echo "=================================================================================="
+if [ "$FAILS" -eq 0 ]; then
+  note "PROVEN offline + deterministically. The self-orchestrating coordinator ROUTES a pending candidate"
+  note "through the SOUND symbolic engine: it CHOOSES symbolic-prove, the verdict maps COUNTEREXAMPLE->confirmed"
+  note "/ PROVED->refuted (the sign comes from the sound gate, never an LLM), the candidate is CONSUMED from"
+  note "PENDING, and the decision policy EVOLVES by that sound outcome. Deterministic re-run."
+  exit 0
+fi
+note "FAILED: $FAILS assertion(s) did not hold — see above."
+exit 1

--- a/dark-factory/docs/coordinator.md
+++ b/dark-factory/docs/coordinator.md
@@ -46,12 +46,21 @@ trace/policy memos back. The data flow is unchanged — only the driver moved in
      forge-verify / the refuter / the screen, *not* an LLM call).
 
 2. **Decide.** It enumerates the ACTION OPTIONS — `hunt|<subsystem>|<class>`, `refute|<candidate>`,
-   `poc-screen|<candidate>`, `invent-method`, `stop` — **scores** each from the facts and the policy, and
-   picks the **argmax** (a policy-weighted ranking). The fact-criteria are explicit:
-   - a pending unverified candidate ⇒ **verify** it (refute / poc-screen) before more hunting;
+   `poc-screen|<candidate>`, `symbolic-prove|<candidate>`, `invent-method`, `stop` — **scores** each from the
+   facts and the policy, and picks the **argmax** (a policy-weighted ranking). The fact-criteria are explicit:
+   - a pending unverified candidate ⇒ **verify** it (refute / poc-screen / symbolic-prove) before more hunting;
    - a fresh blackboard lead in a subsystem ⇒ prefer **hunting that subsystem**;
    - a higher-fitness lens ⇒ prefer it;
    - budget exhausted **or** *K* consecutive dry ⇒ **stop** (a hard fact gate).
+
+   `symbolic-prove` (#1015 M3) routes the pending candidate through the **SOUND symbolic engine**
+   (`run-symbolic.sh` / Halmos + z3 — see [`docs/generate-verify.md`](./generate-verify.md)); its verdict
+   maps **COUNTEREXAMPLE → confirmed**, **PROVED → refuted**, **INCONCLUSIVE → dry**, so the confirmed/refuted
+   policy signal comes from a sound proof, never an LLM opinion. It sits in the **VERIFY tier** with `refute`
+   and `poc-screen`: default scores `refute`(100) > `poc-screen`(98) > `symbolic-prove`(96) — the symbolic
+   route is the most expensive verify (generate a spec + run z3), so the cheaper ones go first by default —
+   but its policy term (the steepest in the tier, ×4) lets the colony **learn** the sound verdict pays off and
+   lift it above either. All three keep a pending candidate ahead of any fresh hunt.
 
    It then calls the substrate **`decide(options, criteria)`** builtin on the already-fact-ranked list as
    the selection step. See [`decide` vs argmax](#decide-vs-policy-weighted-argmax).

--- a/dark-factory/docs/dispatch.md
+++ b/dark-factory/docs/dispatch.md
@@ -7,7 +7,7 @@ shell loop (`run-coordinator.sh`) still **dispatched** that action — it ran a 
 `hunt` slice onto the substrate.
 
 **M2 moves the dispatch onto the substrate for EVERY action type.** The decision *and* its dispatch now
-happen in **one** `agentis go` for any real action (`hunt` / `refute` / `poc-screen` / `invent-method`):
+happen in **one** `agentis go` for any real action (`hunt` / `refute` / `poc-screen` / `symbolic-prove` / `invent-method`):
 the coordinator decides the action, emits it over the in-process bus, a sibling agent fn derives the gate
 verdict and writes it to a durable memo, and the shell loop **reads the verdict from the memo** instead of
 computing it in a `case`. **The shell computes no action's outcome.** Only `stop` is never dispatched — it
@@ -38,14 +38,18 @@ that is the only substrate-native way to reach the next process.
 `DISPATCH_FIXTURE` is the **offline-determinism** fact: the dispatch fn derives an action's verdict from it
 with **no `prompt()` / LLM**. Each rule is `<type>|<glob>=<verdict>`; it applies when `<type>` equals the
 chosen action type **and** `<glob>` (a **prefix** glob, trailing `*` optional) matches the action **args**
-(for a hunt that is `subsystem|class`; for refute/poc-screen the candidate id; invent-method has empty
-args, matched by a bare `*` or empty glob). First match wins, default `dry` — the same semantics
+(for a hunt that is `subsystem|class`; for refute/poc-screen/symbolic-prove the candidate id; invent-method
+has empty args, matched by a bare `*` or empty glob). First match wins, default `dry` — the same semantics
 `run-coordinator.sh`'s old `stub_outcome()` used, projected to one env string. `run-coordinator.sh` builds
-it from **all** rows of `--fixture` in stub mode. With `DISPATCH_FIXTURE` empty (and no `HUNT_FIXTURE`
+it from **all** rows of `--fixture` in stub mode. For `symbolic-prove` (#1015 M3) the fixture verdict is the
+**already-mapped** outcome of the SOUND symbolic engine: `symbolic-prove|cand*=confirmed` = a Halmos
+COUNTEREXAMPLE, `=refuted` = a PROVED, `=dry` = INCONCLUSIVE (the verdict→outcome mapping lives in
+[`generate-verify.md`](./generate-verify.md)). With `DISPATCH_FIXTURE` empty (and no `HUNT_FIXTURE`
 alias for a hunt), the dispatch fn takes an **honest per-type live stub** that prints what real wiring each
 action still needs (`hunt`: `TARGET_DIR` / `IN_SCOPE` / …; `refute` → `run-refute.sh`; `poc-screen` →
-`screen-leads.sh`; `invent-method` → `run-method-discovery.sh`, mirroring the old `real_outcome()` honesty)
-and returns a benign `dry` — it does **not** attempt a real action.
+`screen-leads.sh`; `symbolic-prove` → `run-symbolic.sh` (SOUND verdict: COUNTEREXAMPLE→confirmed,
+PROVED→refuted, INCONCLUSIVE→dry); `invent-method` → `run-method-discovery.sh`, mirroring the old
+`real_outcome()` honesty) and returns a benign `dry` — it does **not** attempt a real action.
 
 ## The flow
 

--- a/dark-factory/docs/generate-verify.md
+++ b/dark-factory/docs/generate-verify.md
@@ -1,4 +1,4 @@
-# Symbolic generate-and-verify (#1015 M2)
+# Symbolic generate-and-verify (#1015 M2 / M3)
 
 M1 shipped the **callable** Halmos gate ([`docs/halmos.md`](./halmos.md)): given a hand-written `*.t.sol`
 spec, [`evm-harness/halmos-verify.sh`](../evm-harness/halmos-verify.sh) returns a SOUND verdict (PROVED /
@@ -90,13 +90,70 @@ spec into `test/` and run Halmos there), drops any pre-existing `*.t.sol` so the
 generated spec, and routes each candidate through the substrate (`prompt`/`emit`/`learn`). The verdict table
 lands at `<out>/symbolic-report.md`.
 
+## Orchestration: the coordinator routes a candidate to the sound engine (#1015 M3)
+
+M2 ships the **callable** step (`run-symbolic.sh` over a candidate manifest). **M3 wires it into the
+self-orchestrating coordinator** ([`docs/coordinator.md`](./coordinator.md)): a new `symbolic-prove`
+coordinator ACTION lets the federation **DECIDE** to route a pending candidate through the SOUND symbolic
+engine, and the engine's verdict feeds back into the coordinator's **evolving policy** — the same
+`learn()` mechanic every other action uses.
+
+```
+coordinator decides ──▶ ACTION|symbolic-prove|<cand> ──▶ run-symbolic.sh / symbolic-prover.ag
+                                                              GENERATE spec ──▶ halmos-verify.sh (z3)
+                                                              SOUND verdict
+   policy evolves  ◀──── outcome (confirmed / refuted / dry) ◀──── verdict→outcome mapping
+```
+
+`symbolic-prove` lives in the coordinator's **VERIFY tier** alongside `refute` and `poc-screen` (a pending
+candidate present ⇒ verify it before more hunting). Base score **96**, below `refute` (100) and `poc-screen`
+(98) — routing through the symbolic engine is the most expensive verify (generate a spec + run z3), so the
+cheaper verifies are tried first by default; the **policy weight** (the steepest in the tier, ×4) lets the
+colony **learn** the sound verdict pays off and lift `symbolic-prove` above either. The ordering is
+fact-and-policy-driven and **policy-evolvable**, exactly like the other action types.
+
+### The verdict→outcome mapping (the epic's thesis)
+
+The whole point: the confirmed/refuted signal the coordinator evolves on now comes from a **sound engine**,
+never an LLM opinion. The symbolic gate's verdict maps to the coordinator's three-value gate-outcome enum:
+
+| Symbolic verdict | Coordinator outcome | Meaning | policy signal |
+|---|---|---|---|
+| **COUNTEREXAMPLE** | `confirmed` | a concrete input is a real bug, CONFIRMED with a replayable witness | success (+0.15) |
+| **PROVED** | `refuted` | the invariant holds for ALL inputs — the lead is killed **by a proof** (safe) | failure (−0.15) |
+| **INCONCLUSIVE** | `dry` | solver unknown / timeout / not fully explored — no verdict, a non-productive step | failure (−0.15) |
+| HARNESS_ERROR / other | `dry` | the run produced no verdict | failure (−0.15) |
+
+On the **offline / deterministic** path the `DISPATCH_FIXTURE` carries the already-mapped outcome directly —
+a `symbolic-prove|cand*=confirmed` rule stands in for a COUNTEREXAMPLE, `=refuted` for a PROVED — so the
+orchestration is provable with **no live solver** (every action's offline path works this way). On the
+**live** path the mapping is realized end-to-end in `symbolic-prover.ag` (Halmos exit code → verdict →
+outcome) behind `run-symbolic.sh`; `dispatcher.ag` / `coordinator.ag` document the contract and route to it.
+
+### Reproduce
+
+```bash
+# Offline-deterministic proof of the ORCHESTRATION (no Halmos needed — the fixture maps the sound verdict):
+#   a hunt confirms -> pushes a candidate -> the coordinator CHOOSES symbolic-prove -> the SOUND verdict
+#   flows back (COUNTEREXAMPLE->confirmed / PROVED->refuted) -> the candidate is consumed -> the policy evolves.
+dark-factory/demo-symbolic-orchestrate.sh      # exit 0 = proven; non-zero = an assertion failed
+
+# Bootstrap the in-substrate loop with a symbolic-prove route yourself (stub executor = offline; --sym-policy
+# seeds the symbolic-prove policy so the coordinator chooses it from step 0):
+dark-factory/run-coordinator.sh --scope <scope.tsv> --executor stub --fixture <fixture.tsv> \
+    --sym-policy 1.5 --budget 4
+#   fixture rule: `symbolic-prove | cand* | confirmed`  (= a Halmos COUNTEREXAMPLE; `refuted` = a PROVED)
+```
+
 ## Honest scope
 
 M2 ships the **callable** generate-and-verify step: an operator (or a higher-level script) invokes
-`run-symbolic.sh` over a candidate manifest. **Auto-routing** discovery candidates from `run-discovery.sh`
-into the symbolic gate inside the self-orchestrating coordinator ([`docs/coordinator.md`](./coordinator.md))
-— so the coordinator decides *when* to spend a symbolic verify and feeds the verdict back into its evolving
-policy — is a **later milestone** on epic #1015.
+`run-symbolic.sh` over a candidate manifest. **M3 wires it into the self-orchestrating coordinator** (above):
+the coordinator decides *when* to spend a symbolic verify and feeds the SOUND verdict back into its evolving
+policy. The deterministic orchestration proof uses a fixture that maps the sound verdict (no live Halmos
+needed for the routing proof — exactly like every other action's offline path); the **live** symbolic route
+(`run-symbolic.sh` driving real Halmos behind the chosen action) is the same wiring M2 ships, and remains a
+follow-up to thread end-to-end from the coordinator's live dispatch path (epic #1015 / #1014).
 
 On the **live** (LLM-generated-spec) path, an honest expectation: a generated Halmos spec must both **compile**
 (`forge build` via Halmos) and stay **decidable** (small symbolic widths, bounded loops) for a clean

--- a/dark-factory/run-coordinator.sh
+++ b/dark-factory/run-coordinator.sh
@@ -6,7 +6,8 @@
 # per-class lens fitness, the shared blackboard, pending unverified candidates, remaining budget, the
 # previous action's gate OUTCOME) and the evolving POLICY, and emits exactly one
 #   ACTION|<type>|<args>|<rationale citing the facts>
-# line (type in {hunt, refute, poc-screen, invent-method, stop}). This loop then DISPATCHES that action,
+# line (type in {hunt, refute, poc-screen, symbolic-prove, invent-method, stop}). This loop then DISPATCHES
+# that action,
 # captures its OUTCOME (a FACT from a gate, never an LLM judgement), feeds the outcome back, and repeats
 # until the coordinator says `stop` or the step budget is spent. The DECISION + its evolution are the
 # coordinator's; the loop only executes the chosen action and carries state between steps.
@@ -18,7 +19,7 @@
 #
 # #1014 M2 — EVERY action's DISPATCH is now in the substrate. The coordinator no longer just DECIDES; when
 # DISPATCH_ENABLED is set it also DISPATCHES the chosen action: for ANY real action (hunt / refute /
-# poc-screen / invent-method) coordinator.ag emits `dark-factory:dispatch` and runs dispatch()
+# poc-screen / symbolic-prove / invent-method) coordinator.ag emits `dark-factory:dispatch` and runs dispatch()
 # (auditor/agents/dispatcher.ag's fn, inlined gated in coordinator.ag) in the SAME `agentis go`, deriving
 # the gate verdict from DISPATCH_FIXTURE and writing it to the durable `coordinator:last_outcome` memo.
 # This loop READS that memo for every non-`stop` action's outcome (the emit/listen bus is in-process only;
@@ -39,8 +40,10 @@
 #   --executor real   (default) EVERY action is dispatched IN the substrate (coordinator.ag's dispatch()).
 #                     With no DISPATCH_FIXTURE the agent takes its live honest per-type stub path, which
 #                     names the real wiring each action still needs (hunt: TARGET_DIR/IN_SCOPE/...;
-#                     refute->run-refute.sh; poc-screen->screen-leads.sh; invent-method->run-method-
-#                     discovery.sh) and returns a benign `dry` — it does NOT attempt a real action. This
+#                     refute->run-refute.sh; poc-screen->screen-leads.sh; symbolic-prove->run-symbolic.sh
+#                     (SOUND verdict: COUNTEREXAMPLE->confirmed, PROVED->refuted, INCONCLUSIVE->dry);
+#                     invent-method->run-method-discovery.sh) and returns a benign `dry` — it does NOT
+#                     attempt a real action. This
 #                     mode is the integration surface for a live audit and needs a reasoning backend
 #                     (--backend flat-cyborg, flat-rate default; or --backend claude, metered) for the
 #                     agents to actually reason. (The decision is still offline-deterministic.)
@@ -52,8 +55,8 @@
 #
 # Usage:
 #   run-coordinator.sh --scope <file> [--class-fitness <file>] [--budget N] [--dry-cap K]
-#                      [--executor real|stub] [--fixture <f>] [--backend mock|flat-cyborg|claude]
-#                      [--out <dir>] [--agentis <bin>]
+#                      [--executor real|stub] [--fixture <f>] [--sym-policy <float>]
+#                      [--backend mock|flat-cyborg|claude] [--out <dir>] [--agentis <bin>]
 #
 # Scope manifest (one huntable cell per line; `#` and blank lines ignored), pipe-delimited:
 #   <subsystem label> | <class id>          e.g.  vault accounting | C1
@@ -61,9 +64,17 @@
 #   <class id> | <fitness float>            e.g.  C1 | 0.45
 # Fixture (stub mode; one rule per line, first match wins; `*` glob on args):
 #   <action-type> | <args-glob> | <confirmed|dry|refuted>   e.g.  hunt | vault* | confirmed
+#   <action-type> is one of {hunt, refute, poc-screen, symbolic-prove, invent-method}. For symbolic-prove
+#   the fixture verdict stands in for the SOUND symbolic engine's mapped outcome (a `symbolic-prove | cand* |
+#   confirmed` rule = a Halmos COUNTEREXAMPLE; `... | refuted` = a PROVED; `... | dry` = INCONCLUSIVE).
 #   NB: the rule is split on `|`, so <args-glob> must NOT contain a literal `|`. A hunt's args are
 #   `subsystem|class`; match them with a subsystem-prefix glob (`vault*`) whose trailing `*` spans the
 #   `|class` suffix — `vault accounting|C1` would be mis-split (the class read as the outcome field).
+#
+# --sym-policy <float> seeds the in-substrate loop's INITIAL symbolic-prove policy weight (e.g. 1.5), so the
+#   coordinator can CHOOSE to route a pending candidate through the SOUND symbolic engine from step 0. The
+#   default verify ordering is refute > poc-screen > symbolic-prove; a seed >= 1.0 lifts symbolic-prove above
+#   refute. The verdict then comes from the symbolic gate (run-symbolic.sh) — never an LLM opinion.
 #
 # Exit: 0 on a clean run that reached `stop`/budget; 2 on usage error; 3 on missing prerequisite.
 set -uo pipefail
@@ -78,6 +89,7 @@ EXECUTOR="real"
 FIXTURE=""
 BACKEND="mock"
 OUT="$PWD/coordinator-out"
+SYM_POLICY=""
 
 need() { [ "$1" -ge 2 ] || { echo "run-coordinator.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -89,6 +101,7 @@ while [ $# -gt 0 ]; do
     --executor)      need "$#"; EXECUTOR="$2"; shift 2 ;;
     --fixture)       need "$#"; FIXTURE="$2"; shift 2 ;;
     --backend)       need "$#"; BACKEND="$2"; shift 2 ;;
+    --sym-policy)    need "$#"; SYM_POLICY="$2"; shift 2 ;;
     --out)           need "$#"; OUT="$2"; shift 2 ;;
     --agentis)       need "$#"; AGENTIS="$2"; shift 2 ;;
     --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
@@ -102,6 +115,19 @@ case "$BUDGET"  in (*[!0-9]*|'') echo "run-coordinator.sh: --budget must be a no
 case "$DRY_CAP" in (*[!0-9]*|'') echo "run-coordinator.sh: --dry-cap must be a non-negative integer" >&2; exit 2 ;; esac
 case "$EXECUTOR" in real|stub) : ;; *) echo "run-coordinator.sh: --executor must be real|stub" >&2; exit 2 ;; esac
 [ "$EXECUTOR" = "stub" ] && { [ -n "$FIXTURE" ] || { echo "run-coordinator.sh: --executor stub needs --fixture <f>" >&2; exit 2; }; [ -f "$FIXTURE" ] || { echo "run-coordinator.sh: --fixture not found: $FIXTURE" >&2; exit 2; }; }
+# --sym-policy <float>: SEED the in-substrate loop's initial symbolic-prove policy weight so the coordinator
+# can CHOOSE symbolic-prove from step 0 (default ordering refute > poc-screen > symbolic-prove; a weight
+# >= 1.0 lifts symbolic-prove above refute). Convert the float to the loop's ten-thousandths int SYM_POLICY_TT
+# (agentis has no float->int builtin, so the integer is computed here). "" = no seed (the engine has to earn
+# its weight by outcome).
+SYM_POLICY_TT=""
+if [ -n "$SYM_POLICY" ]; then
+  case "$SYM_POLICY" in (-*[!0-9.]*|*[!0-9.-]*|''|*.*.*) echo "run-coordinator.sh: --sym-policy must be a decimal number (e.g. 1.5 or -0.15)" >&2; exit 2 ;; esac
+  # Require at least one digit so a bare `-`, `.`, or `-.` (which the metachar globs above let through and
+  # awk would silently coerce to 0) is rejected, not treated as a no-op seed.
+  case "$SYM_POLICY" in (*[0-9]*) : ;; (*) echo "run-coordinator.sh: --sym-policy must be a decimal number (e.g. 1.5 or -0.15)" >&2; exit 2 ;; esac
+  SYM_POLICY_TT="$(awk -v v="$SYM_POLICY" 'BEGIN{ printf "%d", (v>=0 ? v*10000+0.5 : v*10000-0.5) }')"
+fi
 # The in-substrate orchestrate loop (coordinator.ag) encodes its carried state as fields joined by the
 # `@@F@@` sentinel; an input cell that literally contains it would corrupt that encoding. Reject it loudly
 # (operator-controlled input; never legitimate in a subsystem label / class id / glob).
@@ -128,7 +154,7 @@ cp "$COORD_AG" "$RUN/coordinator.ag"
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 600000"; }
   [ "$BACKEND" = "flat-cyborg" ] && echo "llm.cli_timeout_ms = 600000"
   echo "trace.level = normal"
-  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS"
+  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS,SYM_POLICY_TT"
   echo "exec.default_timeout_ms = 30000"
   # The whole point: every decision is recorded as experience so coordinator:policy:<type> reweights.
   echo "learning.enabled = true"
@@ -235,6 +261,7 @@ RUN_LOG="$RUN/orchestrate.log"
     BUDGET="$BUDGET" \
     DRY_CAP="$DRY_CAP" \
     STEPS="$STEPS" \
+    SYM_POLICY_TT="$SYM_POLICY_TT" \
     ORCHESTRATE_ENABLED=1 \
     DISPATCH_ENABLED=1 \
     DISPATCH_FIXTURE="$DISPATCH_FIXTURE" \
@@ -256,10 +283,14 @@ while IFS= read -r row; do
 done < "$TRACE"
 
 # The evolved policy: prefer the loop's in-process result (memo), cross-checked against the experience-store
-# read_policy() (they are byte-identical by construction — the in-loop threading mirrors the store sum).
+# read_policy() (they are byte-identical by construction — the in-loop threading mirrors the store sum). The
+# cross-check holds ONLY when the loop started cold: --sym-policy seeds the in-loop symbolic-prove weight with
+# an initial offset that is NOT written to the experience store (only the per-outcome ±0.15 learn() deltas
+# are), so a seeded run's in-loop policy intentionally exceeds the store sum by the seed. Skip the equality
+# cross-check when a seed was supplied.
 POLICY_LOOP="$( ( cd "$RUN" && "$AGENTIS" memo get coordinator:policy_after ) 2>/dev/null )"
 POLICY_STORE="$(read_policy)"
-if [ "$POLICY_LOOP" != "$POLICY_STORE" ]; then
+if [ -z "$SYM_POLICY_TT" ] && [ "$POLICY_LOOP" != "$POLICY_STORE" ]; then
   echo "run-coordinator.sh: WARNING in-loop policy [$POLICY_LOOP] != experience-store policy [$POLICY_STORE]" >&2
 fi
 POLICY_AFTER="$POLICY_LOOP"


### PR DESCRIPTION
## What

Epic #1015 **milestone 3**: generate-and-verify **orchestration** — the lever that pairs this epic with #1014. The self-orchestrating coordinator can now **CHOOSE to route a pending candidate through the SOUND symbolic engine**, with the verdict weighted into the federation's evolving decision policy. This ties **self-orchestration (#1014)** + **sound verification (#1015)** into one autonomous auditor.

## How

- `coordinator.ag` — new `symbolic-prove` action (`score_symbolic = 96 + 4·policy`, VERIFY tier; default order `refute(100) > poc-screen(98) > symbolic-prove(96)` — the sound route is the most expensive verify, so last by default but the steepest to evolve; policy-evolvable like every action). Verifies the first pending candidate. The orchestrate loop carries a 5th policy int; `SYM_POLICY_TT` seeds it. Base 96 < refute → it never wins on a demo-coordinator state, so the single-decision path stays **byte-identical** to v1.
- `dispatcher.ag` — handles `symbolic-prove`; offline derives the outcome from a `symbolic-prove|<glob>=<verdict>` `DISPATCH_FIXTURE` rule; live route is an honest stub pointing at `run-symbolic.sh`.
- **Verdict→outcome mapping (the epic's thesis):** `COUNTEREXAMPLE → confirmed` (real finding, concrete witness), `PROVED → refuted` (lead killed **by a proof**, safe), `INCONCLUSIVE/error → dry`. The confirmed/refuted signal now comes from a **sound engine, never an LLM opinion**.
- `run-coordinator.sh` — new `--sym-policy <float>` to seed the engine's initial weight (validated; rejects junk).
- `demo-symbolic-orchestrate.sh` — deterministic proof the coordinator **chooses** symbolic-prove, the COUNTEREXAMPLE→confirmed (+0.30) / PROVED→refuted (−0.30) mapping flows back, the candidate is consumed from PENDING, and the policy evolves.

## Boundaries

M3 wires the sound engine into the autonomous loop as a choosable, policy-weighted action (offline-deterministic proof + honest live stub). Per-class engine routing and the other engines (hevm / SMT-direct / Lean / stateful-fuzzing) are additional coverage. Human-gated submission + existing gates intact.

## Verification

- **`demo-coordinator.sh` byte-identical** to origin/main (the new action never wins a single-decision state).
- **`demo-symbolic-orchestrate.sh`** 11/11, deterministic — coordinator chooses symbolic-prove; mapping + PENDING-consume + policy-evolve correct.
- `demo-orchestrate.sh` / `demo-dispatch.sh` / `demo-symbolic.sh` still pass; `run-coordinator.sh --executor stub` reaches a symbolic-prove verdict; **`colony-lint.sh` → 366 / 0 / 5**.

Part of #1015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
