### PR TITLE
feat(dark-factory): LIVE coordinator->halmos symbolic-prove route (#1032)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,36 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **The LIVE coordinator → Halmos `symbolic-prove` route — REAL symbolic execution inside the autonomous
+  loop** (#1032). #1015 M3 proved the *offline* orchestration (a `DISPATCH_FIXTURE` stood in for the sound
+  verdict); #1032 closes the **live** slice for an operator-supplied single candidate: when the coordinator
+  CHOOSES `symbolic-prove` and a live symbolic context is present, it runs REAL Halmos end-to-end and maps the
+  solver's exit code to the gate outcome — never an LLM opinion.
+  - `auditor/agents/coordinator.ag` — a new LIVE branch in `action_outcome`: when `symbolic-prove` is chosen
+    AND no `DISPATCH_FIXTURE` matched AND a live symbolic env is present (`SYM_REPO` foundry dir + `SYM_SPEC`
+    target spec + the `HALMOS_VERIFY` gate path), it `exec sh`-runs `halmos-verify.sh --repo <SYM_REPO>
+    --target <SYM_SPEC> --function <prefix>`, captures the exit code via the `__rc=$?` marker, and maps it
+    **1 → confirmed** (COUNTEREXAMPLE, a real bug), **0 → refuted** (PROVED, safe), **3/2/other → dry**
+    (INCONCLUSIVE / harness). ALL dynamic values are `shell_escape()`d; the gate is resolved via the
+    `HALMOS_VERIFY` env path. The branch is **purely additive** — absent any of the three env facts it falls
+    through to the existing honest stub, so behaviour with no live env is **byte-identical** (verified:
+    `demo-coordinator.sh` is unchanged against `origin/main`). `auditor/agents/dispatcher.ag` carries the
+    byte-identical live branch (the `demo-dispatch.sh` sync-guard asserts the two copies do not drift).
+  - `run-coordinator.sh` — new `--sym-repo <dir>` + `--sym-spec <file>` flags supply the single-candidate live
+    symbolic context (plus `--sym-function <prefix>`, default `check`); they must be supplied together,
+    `--sym-repo` must be a Foundry project, `--sym-spec` a readable file. `halmos-verify.sh` is resolved to an
+    absolute path and passed as `HALMOS_VERIFY`; `SYM_REPO,SYM_SPEC,SYM_FUNCTION,HALMOS_VERIFY` are whitelisted
+    in `exec.env_passthrough`; the per-step `exec.default_timeout_ms` is raised to 180s when a live context is
+    supplied (Halmos runs forge build + z3 — tens of seconds). Header/usage document the flags + the
+    verdict→outcome mapping.
+  - `demo-symbolic-orchestrate-live.sh` — new LIVE demo: builds a tiny Foundry vault with a real
+    rounding-direction solvency bug (`convertToAssets` rounds UP, minting value) + its fix (rounds DOWN) and a
+    Halmos solvency spec, drives the coordinator with the live env so its chosen `symbolic-prove` runs REAL
+    Halmos → the buggy spec returns a COUNTEREXAMPLE → **confirmed**, the fixed spec PROVES the invariant →
+    **refuted**; asserts the outcomes flip purely from the solver's verdict. `[SKIP]` + exit 0 when
+    forge/halmos/agentis are absent (CI convention). `docs/generate-verify.md` updated: the live coordinator
+    route now runs Halmos end-to-end for a supplied candidate, the offline fixture path is the CI proof, and
+    multi-candidate code-carrying remains the follow-up.
 - **The self-orchestrating coordinator ROUTES a candidate to the SOUND symbolic engine — a new
   `symbolic-prove` action** (#1015 M3). M2 shipped the *callable* generate-and-verify step; M3 wires it into
   the #1014 self-orchestrating coordinator so the federation can **DECIDE** to route a pending candidate

--- a/dark-factory/auditor/agents/coordinator.ag
+++ b/dark-factory/auditor/agents/coordinator.ag
@@ -306,10 +306,59 @@ fn is_action(t: string) -> bool {
     return false;
 }
 
+// === #1032: the LIVE symbolic-prove route — run REAL Halmos and map its SOUND verdict. =================
+// Parse the `__rc=<n>` marker the halmos-verify run is wrapped to print as its LAST line (the auditor.ag /
+// symbolic-prover.ag exec convention). regex_capture returns the captured digits; parse_int is total
+// (non-numeric -> 0). A missing marker would wrongly read as 0/refuted, so a "no marker" case is forced to
+// 2 (a harness error -> dry below), exactly as symbolic-prover.ag::rc_of does.
+fn sym_rc_of(out: string) -> int {
+    if index_of(out, "__rc=") < 0 { return 2; }
+    return parse_int(regex_capture("__rc=([0-9]+)", out, 1));
+}
+
+// Map the SOUND halmos-verify.sh exit code DIRECTLY to the coordinator's three-value gate-outcome enum
+// (the epic's thesis: the confirmed/refuted signal comes from a sound oracle, never an LLM). This is the
+// SAME mapping the offline DISPATCH_FIXTURE encodes (`symbolic-prove|cand*=confirmed` = a COUNTEREXAMPLE):
+//   1 -> confirmed   COUNTEREXAMPLE: a concrete input violates the invariant -> a REAL bug, CONFIRMED.
+//   0 -> refuted     PROVED: the invariant holds for ALL inputs -> the lead is killed BY A PROOF (safe).
+//   3/2/else -> dry  INCONCLUSIVE (solver unknown / timeout / loop not fully explored / nothing matched) or
+//                    a harness error -> no verdict; a non-productive step (the SAFE failure mode).
+fn sym_outcome_of(rc: int) -> string {
+    if rc == 1 { return "confirmed"; }
+    if rc == 0 { return "refuted"; }
+    return "dry";
+}
+
+// Run the SOUND M1 gate (evm-harness/halmos-verify.sh) against the operator-supplied SYM_REPO + SYM_SPEC and
+// return the mapped coordinator outcome. The verdict is HALMOS's exit code — never an LLM opinion. `set +e`
+// so a non-zero verdict exit (1/3/2) does not abort the shell before the `__rc=$?` marker prints; the gate,
+// repo, spec and function prefix are resolved from env and ALL passed shell_escape()d. The function prefix
+// defaults to `check` (halmos-verify's own default) when SYM_FUNCTION is unset — the args (the candidate id)
+// are NOT a function name, so the prefix is its own env fact.
+fn sym_fn_prefix(raw: string) -> string {
+    if len(raw) == 0 { return "check"; }
+    return raw;
+}
+fn run_symbolic_live() -> string {
+    let gate = getenv("HALMOS_VERIFY");
+    let repo = getenv("SYM_REPO");
+    let spec = getenv("SYM_SPEC");
+    let fnPrefix = sym_fn_prefix(getenv("SYM_FUNCTION"));
+    let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --repo " + shell_escape(repo)
+               + " --target " + shell_escape(spec) + " --function " + shell_escape(fnPrefix)
+               + " 2>&1; echo __rc=$?";
+    let rc = sym_rc_of(runOut);
+    return sym_outcome_of(rc);
+}
+
 // Derive the gate OUTCOME for an action of `<type>` with `<args>`. Offline (DISPATCH_FIXTURE set, or the
-// M1 HUNT_FIXTURE alias for a hunt) -> the fixture rule, NO prompt()/LLM. Otherwise the LIVE path: an
-// honest per-type stub that says what real wiring it needs (mirrors run-coordinator.sh::real_outcome) and
-// returns a benign `dry` — it does NOT attempt a real action.
+// M1 HUNT_FIXTURE alias for a hunt) -> the fixture rule, NO prompt()/LLM. The LIVE symbolic-prove route
+// (#1032): when `symbolic-prove` is chosen AND no fixture matched AND a live symbolic env is present (a
+// SYM_REPO foundry dir + a SYM_SPEC target spec + the HALMOS_VERIFY gate path), run REAL Halmos and map its
+// SOUND exit code (1->confirmed, 0->refuted, 3/2/other->dry) — the verdict is the solver's, never the LLM's.
+// This branch is PURELY ADDITIVE: absent any of the three env facts it falls through to the existing honest
+// stub, so behaviour with no live env is byte-identical. Otherwise the LIVE path is an honest per-type stub
+// that says what real wiring it needs (mirrors run-coordinator.sh::real_outcome) and returns a benign `dry`.
 fn action_outcome(atype: string, args: string) -> string {
     let fixture = getenv("DISPATCH_FIXTURE");
     if len(fixture) > 0 {
@@ -323,6 +372,24 @@ fn action_outcome(atype: string, args: string) -> string {
             let hv = hunt_fixture_verdict(huntFx, args);
             if is_verdict(hv) { return hv; }
             return "dry";
+        }
+    }
+    // LIVE symbolic-prove (#1032): an operator-supplied single-candidate context (SYM_REPO + SYM_SPEC + the
+    // HALMOS_VERIFY gate path) routes the chosen candidate through REAL Halmos end-to-end inside the loop.
+    // All three must be present; otherwise this falls through to the honest stub (additive — no live env =
+    // unchanged behaviour). The verdict is Halmos's exit code, mapped COUNTEREXAMPLE->confirmed / PROVED->
+    // refuted / INCONCLUSIVE|harness->dry — never an LLM judgement.
+    if atype == "symbolic-prove" {
+        let gate = getenv("HALMOS_VERIFY");
+        let repo = getenv("SYM_REPO");
+        let spec = getenv("SYM_SPEC");
+        if len(gate) > 0 {
+            if len(repo) > 0 {
+                if len(spec) > 0 {
+                    print("coordinator: LIVE symbolic-prove of '" + args + "' -> running REAL Halmos via " + gate + " on " + spec + " (SOUND verdict; the LLM never judges).");
+                    return run_symbolic_live();
+                }
+            }
         }
     }
     print("coordinator: LIVE " + atype + " of '" + args + "' needs its real wiring (hunt: TARGET_DIR/IN_SCOPE/SCOPE_BRIEF/TAXONOMY/SLICER per run-discovery.sh/hunter.ag; refute->run-refute.sh; poc-screen->screen-leads.sh; symbolic-prove->run-symbolic.sh; invent-method->run-method-discovery.sh); set DISPATCH_FIXTURE for the offline-deterministic path. No real action attempted.");

--- a/dark-factory/auditor/agents/dispatcher.ag
+++ b/dark-factory/auditor/agents/dispatcher.ag
@@ -166,13 +166,45 @@ fn is_action(t: string) -> bool {
 // the deterministic demo needs no live solver. The live mapping is realized end-to-end in symbolic-prover.ag
 // (exit code -> verdict -> learn outcome) behind run-symbolic.sh; the honest live stub below points there.
 
+// === #1032: the LIVE symbolic-prove route — run REAL Halmos and map its SOUND verdict. =================
+// Kept BYTE-FOR-BYTE in sync with coordinator.ag's inlined copy (the demo-dispatch.sh sync-guard asserts the
+// two do not drift). Parse the `__rc=<n>` marker the halmos-verify run prints as its LAST line, map the
+// SOUND exit code DIRECTLY to the coordinator outcome enum (1->confirmed COUNTEREXAMPLE, 0->refuted PROVED,
+// 3/2/else->dry INCONCLUSIVE/harness), and run the gate with every value shell_escape()d. See the THESIS
+// block above for the full verdict->outcome contract.
+fn sym_rc_of(out: string) -> int {
+    if index_of(out, "__rc=") < 0 { return 2; }
+    return parse_int(regex_capture("__rc=([0-9]+)", out, 1));
+}
+fn sym_outcome_of(rc: int) -> string {
+    if rc == 1 { return "confirmed"; }
+    if rc == 0 { return "refuted"; }
+    return "dry";
+}
+fn sym_fn_prefix(raw: string) -> string {
+    if len(raw) == 0 { return "check"; }
+    return raw;
+}
+fn run_symbolic_live() -> string {
+    let gate = getenv("HALMOS_VERIFY");
+    let repo = getenv("SYM_REPO");
+    let spec = getenv("SYM_SPEC");
+    let fnPrefix = sym_fn_prefix(getenv("SYM_FUNCTION"));
+    let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --repo " + shell_escape(repo)
+               + " --target " + shell_escape(spec) + " --function " + shell_escape(fnPrefix)
+               + " 2>&1; echo __rc=$?";
+    let rc = sym_rc_of(runOut);
+    return sym_outcome_of(rc);
+}
+
 // Derive the gate OUTCOME for an action of `<type>` with `<args>`. Offline (DISPATCH_FIXTURE set, or the
-// M1 HUNT_FIXTURE alias for a hunt) -> the fixture rule, NO prompt()/LLM. Otherwise the LIVE path: an
-// honest per-type stub that says what real wiring it needs (mirrors run-coordinator.sh::real_outcome) and
-// returns a benign `dry` — it does NOT attempt a real action. For `symbolic-prove` the real wiring is
-// run-symbolic.sh -> symbolic-prover.ag -> halmos-verify.sh, whose SOUND verdict maps through the
-// COUNTEREXAMPLE->confirmed / PROVED->refuted / INCONCLUSIVE->dry contract documented above — the
-// cross-process bridge from the sound engine's verdict to the coordinator's policy signal.
+// M1 HUNT_FIXTURE alias for a hunt) -> the fixture rule, NO prompt()/LLM. The LIVE symbolic-prove route
+// (#1032): when `symbolic-prove` is chosen AND no fixture matched AND a live symbolic env is present (a
+// SYM_REPO foundry dir + a SYM_SPEC target spec + the HALMOS_VERIFY gate path), run REAL Halmos and map its
+// SOUND exit code (1->confirmed, 0->refuted, 3/2/other->dry) — the verdict is the solver's, never the LLM's.
+// PURELY ADDITIVE: absent any of the three env facts it falls through to the honest stub. For the other
+// action types the real wiring is named on the live stub (hunt->run-discovery.sh, refute->run-refute.sh,
+// poc-screen->screen-leads.sh, invent-method->run-method-discovery.sh) and the stub returns a benign `dry`.
 fn action_outcome(atype: string, args: string) -> string {
     let fixture = getenv("DISPATCH_FIXTURE");
     if len(fixture) > 0 {
@@ -186,6 +218,23 @@ fn action_outcome(atype: string, args: string) -> string {
             let hv = hunt_fixture_verdict(huntFx, args);
             if is_verdict(hv) { return hv; }
             return "dry";
+        }
+    }
+    // LIVE symbolic-prove (#1032): an operator-supplied single-candidate context (SYM_REPO + SYM_SPEC + the
+    // HALMOS_VERIFY gate path) routes the chosen candidate through REAL Halmos end-to-end. All three must be
+    // present; otherwise this falls through to the honest stub (additive). The verdict is Halmos's exit code,
+    // mapped COUNTEREXAMPLE->confirmed / PROVED->refuted / INCONCLUSIVE|harness->dry — never an LLM judgement.
+    if atype == "symbolic-prove" {
+        let gate = getenv("HALMOS_VERIFY");
+        let repo = getenv("SYM_REPO");
+        let spec = getenv("SYM_SPEC");
+        if len(gate) > 0 {
+            if len(repo) > 0 {
+                if len(spec) > 0 {
+                    print("dispatcher: LIVE symbolic-prove of '" + args + "' -> running REAL Halmos via " + gate + " on " + spec + " (SOUND verdict; the LLM never judges).");
+                    return run_symbolic_live();
+                }
+            }
         }
     }
     print("dispatcher: LIVE " + atype + " of '" + args + "' needs its real wiring (hunt: TARGET_DIR/IN_SCOPE/SCOPE_BRIEF/TAXONOMY/SLICER per run-discovery.sh/hunter.ag; refute->run-refute.sh; poc-screen->screen-leads.sh; symbolic-prove->run-symbolic.sh (SOUND verdict: COUNTEREXAMPLE->confirmed, PROVED->refuted, INCONCLUSIVE->dry); invent-method->run-method-discovery.sh); set DISPATCH_FIXTURE for the offline-deterministic path. No real action attempted.");

--- a/dark-factory/demo-symbolic-orchestrate-live.sh
+++ b/dark-factory/demo-symbolic-orchestrate-live.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# demo-symbolic-orchestrate-live.sh — #1032: the LIVE coordinator -> Halmos symbolic-prove route, end-to-end.
+#
+# demo-symbolic-orchestrate.sh proves the OFFLINE orchestration: the self-orchestrating coordinator CHOOSES
+# `symbolic-prove` for a pending candidate and a DISPATCH_FIXTURE stands in for the SOUND verdict. THIS demo
+# closes the LIVE slice: with an operator-supplied single-candidate symbolic context (SYM_REPO + SYM_SPEC +
+# the HALMOS_VERIFY gate path), the coordinator's chosen `symbolic-prove` action runs REAL Halmos
+# (symbolic execution + z3) END-TO-END inside the autonomous loop and maps its SOUND exit code to the gate
+# outcome — never an LLM opinion:
+#   exit 1 = COUNTEREXAMPLE -> confirmed   (a concrete input is a real bug, CONFIRMED with a witness)
+#   exit 0 = PROVED         -> refuted     (the invariant holds for ALL inputs — the lead is killed by a proof)
+#   exit 3/2/other = INCONCLUSIVE/harness -> dry
+#
+# The fixture for the live route is a tiny Foundry vault with a REAL rounding-direction solvency bug:
+# `convertToAssets` rounds UP (`(shares*totalAssets + totalShares - 1) / totalShares`), so it can pay out
+# MORE than the fair floor `shares*totalAssets/totalShares` — value is minted, the vault becomes insolvent.
+# The Halmos spec asserts the solvency invariant `paid <= shares*totalAssets/totalShares` over SYMBOLIC
+# inputs: against the buggy vault Halmos returns a concrete COUNTEREXAMPLE (-> confirmed); against the FIXED
+# vault (round DOWN — `shares*totalAssets/totalShares`) Halmos PROVES it for all inputs (-> refuted).
+#
+# The coordinator is driven with a PENDING candidate seeded directly (so `symbolic-prove` is the chosen
+# VERIFY action immediately, with --sym-policy-style SYM_POLICY_TT lifting it over refute/poc-screen) and the
+# live SYM env supplied — exactly the single-candidate context run-coordinator.sh's --sym-repo/--sym-spec
+# flags wire. The multi-candidate code-carrying path (a discovered lead auto-carrying its contract+invariant
+# through PENDING) stays a broader follow-up; this demo proves the symbolic slice runs Halmos for real.
+#
+# CI has neither halmos nor forge (nor necessarily agentis), so if ANY is missing this prints a single
+# [SKIP] line and exits 0 (mirroring demo-symbolic.sh / the colony-lint skip convention) instead of failing.
+# Install the toolchain to run it for real:
+#   curl -L https://foundry.paradigm.xyz | bash && foundryup    # forge
+#   uv tool install halmos                                      # halmos (bundles z3)
+#
+# Usage:  dark-factory/demo-symbolic-orchestrate-live.sh
+# Exit: 0 = both live verdicts correct (or tools absent -> SKIP) ; non-zero = a live verdict was wrong.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+COORD_AG="$HERE/auditor/agents/coordinator.ag"
+GATE="$HERE/evm-harness/halmos-verify.sh"
+RUNNER="$HERE/run-coordinator.sh"
+
+FAILS=0
+note() { echo "demo-symbolic-orchestrate-live.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+skip() { echo "  [SKIP] $*"; }
+
+# Skip EARLY (before any work) when the toolchain is missing, so CI without halmos/forge/agentis reports a
+# clean [SKIP] + exit 0 rather than a harness error.
+if ! command -v forge >/dev/null 2>&1 || ! command -v halmos >/dev/null 2>&1; then
+  skip "forge and/or halmos not on PATH — install foundryup + 'uv tool install halmos' to run this demo"
+  exit 0
+fi
+if ! command -v agentis >/dev/null 2>&1; then
+  skip "agentis not on PATH — install the agentis runtime to drive the substrate coordinator loop"
+  exit 0
+fi
+
+[ -f "$COORD_AG" ] || { note "coordinator agent not found at $COORD_AG" >&2; exit 3; }
+[ -f "$GATE" ]     || { note "halmos-verify gate not found at $GATE" >&2; exit 3; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- build the tiny Foundry vault repo: a real rounding-direction solvency bug + its fix ---------------
+# VaultBuggy.convertToAssets rounds UP (mints value -> insolvent); VaultFixed rounds DOWN (floor -> solvent).
+# uint16 widths keep the symbolic search tiny so z3 returns a sound verdict in seconds. Specs are written
+# with printf '%s' / heredocs of TRUSTED static content authored HERE (not an LLM completion / untrusted
+# candidate code), so no shell_escape gymnastics are needed; the substrate write path (symbolic-prover.ag)
+# is the one that escapes UNTRUSTED specs.
+REPO="$WORK/vault"
+mkdir -p "$REPO/src" "$REPO/test"
+cat > "$REPO/foundry.toml" <<'EOF'
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+test = "test"
+EOF
+cat > "$REPO/src/Vault.sol" <<'EOF'
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+// A share-accounting vault. convertToAssets(shares) converts a share balance to its
+// redeemable asset amount. The SOLVENCY invariant is that a redemption never pays out
+// MORE than the fair floor `shares * totalAssets / totalShares` — paying more mints value
+// and makes the vault insolvent. uint16 widths keep the symbolic search space tiny.
+contract VaultBuggy {
+    // BUG: rounds UP (`+ totalShares - 1`), so a redemption can pay out one wei more than
+    // the fair floor — value is minted, the vault becomes insolvent. Halmos finds a concrete
+    // (shares, totalAssets, totalShares) witness that breaks `paid <= floor`.
+    function convertToAssets(uint16 shares, uint16 totalAssets, uint16 totalShares)
+        external pure returns (uint16)
+    {
+        require(totalShares > 0, "no shares");
+        require(shares <= totalShares, "too many");
+        uint256 num = uint256(shares) * uint256(totalAssets) + uint256(totalShares) - 1;
+        return uint16(num / uint256(totalShares));
+    }
+}
+
+contract VaultFixed {
+    // FIX: rounds DOWN (floor division), so the payout never exceeds the fair floor —
+    // solvency holds for ALL inputs and Halmos PROVES it.
+    function convertToAssets(uint16 shares, uint16 totalAssets, uint16 totalShares)
+        external pure returns (uint16)
+    {
+        require(totalShares > 0, "no shares");
+        require(shares <= totalShares, "too many");
+        uint256 num = uint256(shares) * uint256(totalAssets);
+        return uint16(num / uint256(totalShares));
+    }
+}
+EOF
+cat > "$REPO/test/SolvencyBuggy.t.sol" <<'EOF'
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+import {VaultBuggy} from "../src/Vault.sol";
+
+// SOLVENCY spec against the BUGGY vault: assert the redemption never exceeds the fair floor.
+// The round-UP bug violates it -> Halmos returns a COUNTEREXAMPLE (exit 1) -> outcome `confirmed`.
+contract SolvencyBuggyTest {
+    VaultBuggy internal vault;
+    function setUp() public { vault = new VaultBuggy(); }
+
+    function check_solvency(uint16 shares, uint16 totalAssets, uint16 totalShares) public view {
+        if (totalShares == 0) return;
+        if (shares > totalShares) return;
+        uint16 paid = vault.convertToAssets(shares, totalAssets, totalShares);
+        uint256 fairFloor = (uint256(shares) * uint256(totalAssets)) / uint256(totalShares);
+        assert(uint256(paid) <= fairFloor);
+    }
+}
+EOF
+cat > "$REPO/test/SolvencyFixed.t.sol" <<'EOF'
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+import {VaultFixed} from "../src/Vault.sol";
+
+// SAME solvency spec against the FIXED vault: round-DOWN payout never exceeds the floor, so
+// Halmos PROVES it for ALL inputs (exit 0) -> outcome `refuted` (the lead is killed by a proof).
+contract SolvencyFixedTest {
+    VaultFixed internal vault;
+    function setUp() public { vault = new VaultFixed(); }
+
+    function check_solvency(uint16 shares, uint16 totalAssets, uint16 totalShares) public view {
+        if (totalShares == 0) return;
+        if (shares > totalShares) return;
+        uint16 paid = vault.convertToAssets(shares, totalAssets, totalShares);
+        uint256 fairFloor = (uint256(shares) * uint256(totalAssets)) / uint256(totalShares);
+        assert(uint256(paid) <= fairFloor);
+    }
+}
+EOF
+
+# --- the coordinator store, configured EXACTLY like run-coordinator.sh's orchestrate bootstrap with the
+# LIVE symbolic env whitelisted (SYM_REPO/SYM_SPEC/SYM_FUNCTION/HALMOS_VERIFY) + the 180s exec timeout the
+# live Halmos run needs. $1 = store dir. ---------------------------------------------------------------
+init_store() {
+  _d="$1"; mkdir -p "$_d"; cp "$COORD_AG" "$_d/coordinator.ag"
+  ( cd "$_d" && agentis init >/dev/null 2>&1 )
+  {
+    echo "llm.backend = mock"
+    echo "trace.level = normal"
+    echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS,SYM_POLICY_TT,SYM_REPO,SYM_SPEC,SYM_FUNCTION,HALMOS_VERIFY"
+    echo "exec.default_timeout_ms = 180000"
+    echo "learning.enabled = true"
+    echo "experience.enabled = true"
+  } > "$_d/.agentis/config"
+}
+
+# The FACTS: one huntable cell, a candidate seeded directly into PENDING (so symbolic-prove is the chosen
+# VERIFY action immediately), the symbolic-prove policy SEEDED (SYM_POLICY_TT=15000 = +1.5) so it outranks
+# refute/poc-screen, and the LIVE symbolic env supplied so the chosen action runs REAL Halmos. BUDGET=1: one
+# decision, one live symbolic verify. $1 = store, $2 = the SYM_SPEC the live route runs.
+SCOPE_FX=$'vault accounting|C1'
+FIT_FX="C1=0.5500"
+orchestrate_live() {
+  _store="$1"; _spec="$2"
+  ( cd "$_store" && env \
+      SCOPE="$SCOPE_FX" CLASS_FITNESS="$FIT_FX" PENDING="cand-0|vault accounting|C1" \
+      BUDGET=1 DRY_CAP=3 STEPS="0" SYM_POLICY_TT=15000 \
+      SYM_REPO="$REPO" SYM_SPEC="$_spec" SYM_FUNCTION="check" \
+      HALMOS_VERIFY="$GATE" \
+      ORCHESTRATE_ENABLED=1 DISPATCH_ENABLED=1 DISPATCH_FIXTURE="" \
+      agentis go coordinator.ag --enable-exec --enable-messaging 2>&1 )
+}
+read_outcome() { ( cd "$1" && agentis memo get coordinator:last_outcome ) 2>/dev/null | tail -1; }
+
+# The action TYPE of one decisions.tsv row (the `action=<type>` field).
+row_action() { printf '%s' "$1" | awk -F'\t' '{ for (i=1;i<=NF;i++) if ($i ~ /^action=/) { sub(/^action=/,"",$i); print $i } }'; }
+
+echo "=================================================================================="
+echo " (1) BUGGY vault: coordinator CHOOSES symbolic-prove -> REAL Halmos -> COUNTEREXAMPLE -> confirmed"
+echo "=================================================================================="
+init_store "$WORK/cex"
+note "driving the coordinator with the LIVE symbolic env (SYM_REPO + SolvencyBuggy.t.sol) — running REAL Halmos ..."
+OUT_CEX="$(orchestrate_live "$WORK/cex" "$REPO/test/SolvencyBuggy.t.sol")"
+MARK_CEX="$(printf '%s\n' "$OUT_CEX" | grep -E '^ORCHESTRATE\|' | head -1)"
+ACTION_CEX="$(printf '%s\n' "$OUT_CEX" | grep -E '^ACTION\|symbolic-prove\|' | head -1)"
+LIVE_CEX="$(printf '%s\n' "$OUT_CEX" | grep -E 'LIVE symbolic-prove .* running REAL Halmos' | head -1)"
+DISPATCH_CEX="$(printf '%s\n' "$OUT_CEX" | grep -E '^DISPATCH\|symbolic-prove\|' | head -1)"
+OUTCOME_CEX="$(read_outcome "$WORK/cex")"
+
+if [ -n "$MARK_CEX" ]; then ok "the single agentis go completed in-substrate ($MARK_CEX)"
+else bad "no ORCHESTRATE| completion marker — the in-substrate loop did not run"; printf '%s\n' "$OUT_CEX" | sed 's/^/        | /' | tail -20; fi
+if [ -n "$ACTION_CEX" ]; then ok "the coordinator CHOSE symbolic-prove for the pending candidate"
+else bad "the coordinator did not choose symbolic-prove (the seeded policy did not lift it / wrong scenario)"; fi
+if [ -n "$LIVE_CEX" ]; then ok "the LIVE route fired: it ran REAL Halmos (not the honest stub)"
+else bad "the live symbolic route did NOT fire — symbolic-prove fell through to the stub (env not passed?)"; fi
+case "$DISPATCH_CEX" in DISPATCH\|symbolic-prove\|cand-0\|confirmed) ok "DISPATCH| outcome = confirmed (Halmos COUNTEREXAMPLE -> confirmed, the SOUND verdict)";; *) bad "expected 'DISPATCH|symbolic-prove|cand-0|confirmed', got '$DISPATCH_CEX'";; esac
+case "$OUTCOME_CEX" in symbolic-prove\|cand-0\|confirmed) ok "durable coordinator:last_outcome memo = '$OUTCOME_CEX' (a real bug, CONFIRMED by a concrete witness)";; *) bad "expected 'symbolic-prove|cand-0|confirmed' in the memo, got '$OUTCOME_CEX'";; esac
+
+echo
+echo "=================================================================================="
+echo " (2) FIXED vault: same route, Halmos PROVES the invariant -> PROVED -> refuted"
+echo "=================================================================================="
+init_store "$WORK/proved"
+note "driving the coordinator with the LIVE symbolic env (SYM_REPO + SolvencyFixed.t.sol) — running REAL Halmos ..."
+OUT_PROVED="$(orchestrate_live "$WORK/proved" "$REPO/test/SolvencyFixed.t.sol")"
+MARK_PROVED="$(printf '%s\n' "$OUT_PROVED" | grep -E '^ORCHESTRATE\|' | head -1)"
+DISPATCH_PROVED="$(printf '%s\n' "$OUT_PROVED" | grep -E '^DISPATCH\|symbolic-prove\|' | head -1)"
+OUTCOME_PROVED="$(read_outcome "$WORK/proved")"
+
+if [ -n "$MARK_PROVED" ]; then ok "the single agentis go completed in-substrate ($MARK_PROVED)"
+else bad "no ORCHESTRATE| completion marker on the FIXED run"; printf '%s\n' "$OUT_PROVED" | sed 's/^/        | /' | tail -20; fi
+case "$DISPATCH_PROVED" in DISPATCH\|symbolic-prove\|cand-0\|refuted) ok "DISPATCH| outcome = refuted (Halmos PROVED -> refuted, the lead killed by a proof)";; *) bad "expected 'DISPATCH|symbolic-prove|cand-0|refuted', got '$DISPATCH_PROVED'";; esac
+case "$OUTCOME_PROVED" in symbolic-prove\|cand-0\|refuted) ok "durable coordinator:last_outcome memo = '$OUTCOME_PROVED' (safe: the invariant holds for ALL inputs)";; *) bad "expected 'symbolic-prove|cand-0|refuted' in the memo, got '$OUTCOME_PROVED'";; esac
+
+echo
+echo "=================================================================================="
+echo " (3) THE SOUND VERDICT drives the sign: the SAME route, opposite outcomes from the vault alone"
+echo "=================================================================================="
+# The ONLY thing that changed between (1) and (2) is the vault (buggy vs fixed) the spec runs against; the
+# coordinator decision, the action, the env wiring are identical. The OUTCOME flipped confirmed<->refuted
+# purely from Halmos's exit code — never an LLM opinion. That is the epic's thesis, now LIVE.
+if [ "$OUTCOME_CEX" = "symbolic-prove|cand-0|confirmed" ] && [ "$OUTCOME_PROVED" = "symbolic-prove|cand-0|refuted" ]; then
+  ok "same coordinator route, opposite SOUND outcomes (buggy -> confirmed / fixed -> refuted) — the verdict is Halmos's exit code"
+else
+  bad "the live verdicts did not flip with the vault: buggy='$OUTCOME_CEX' fixed='$OUTCOME_PROVED'"
+fi
+
+echo
+echo "=================================================================================="
+echo " (4) run-coordinator.sh --sym-repo/--sym-spec wiring — the operator flags validate the live context"
+echo "=================================================================================="
+# Smoke the operator-facing flags: the two must be supplied together, --sym-repo must be a foundry project,
+# --sym-spec must exist. (The full hunt->push->route loop via run-coordinator.sh needs a hunt-confirm to push
+# a candidate, which the offline orchestration proof covers; here we assert the LIVE-context flag plumbing.)
+if [ -x "$RUNNER" ]; then
+  _scope="$WORK/scope.tsv"; printf 'vault accounting | C1\n' > "$_scope"
+  # --sym-repo without --sym-spec must fail (exit 2): the live context is supplied together.
+  if "$RUNNER" --scope "$_scope" --sym-repo "$REPO" --budget 0 >/dev/null 2>&1; then
+    bad "run-coordinator.sh accepted --sym-repo without --sym-spec (should require both)"
+  else
+    ok "run-coordinator.sh requires --sym-repo and --sym-spec together (the live context)"
+  fi
+  # A non-foundry --sym-repo must fail (exit 2).
+  _bad="$WORK/notfoundry"; mkdir -p "$_bad"
+  if "$RUNNER" --scope "$_scope" --sym-repo "$_bad" --sym-spec "$REPO/test/SolvencyBuggy.t.sol" --budget 0 >/dev/null 2>&1; then
+    bad "run-coordinator.sh accepted a non-foundry --sym-repo (no foundry.toml)"
+  else
+    ok "run-coordinator.sh rejects a --sym-repo that is not a foundry project (no foundry.toml)"
+  fi
+else
+  skip "run-coordinator.sh not executable — skipping the operator-flag smoke"
+fi
+
+echo
+echo "=================================================================================="
+if [ "$FAILS" -eq 0 ]; then
+  note "PROVEN LIVE. The self-orchestrating coordinator's symbolic-prove action ran REAL Halmos end-to-end"
+  note "inside the autonomous loop for an operator-supplied candidate: the BUGGY vault's solvency spec"
+  note "returned a COUNTEREXAMPLE -> confirmed (a real bug with a concrete witness); the FIXED vault PROVED"
+  note "the invariant -> refuted (safe). The verdict is Halmos's exit code, never an LLM opinion. Submission"
+  note "stays human-gated; this colony never posts. Multi-candidate code-carrying remains a follow-up."
+  exit 0
+fi
+note "FAILED: $FAILS assertion(s) did not hold — see above."
+exit 1

--- a/dark-factory/docs/generate-verify.md
+++ b/dark-factory/docs/generate-verify.md
@@ -39,6 +39,7 @@ sandbox.
 | [`auditor/agents/symbolic-prover.ag`](../auditor/agents/symbolic-prover.ag) | Per-candidate substrate agent: GENERATE the spec (fixture or `prompt()`), VERIFY it with the M1 gate, `emit`/`learn` the verdict, print `SYMBOLIC\|<file:fn>\|<verdict>`. |
 | [`run-symbolic.sh`](../run-symbolic.sh) | Operator entrypoint: drive `symbolic-prover.ag` once per candidate over the substrate from a manifest, collect the verdicts into a report. |
 | [`demo-symbolic.sh`](../demo-symbolic.sh) | Offline-deterministic demo: the full candidate → fixture-spec → REAL Halmos → verdict loop, asserting PROVED-safe + COUNTEREXAMPLE-confirmed. |
+| [`demo-symbolic-orchestrate-live.sh`](../demo-symbolic-orchestrate-live.sh) | LIVE demo (#1032): the **coordinator's** chosen `symbolic-prove` action runs REAL Halmos end-to-end on an operator-supplied vault — buggy → COUNTEREXAMPLE → confirmed, fixed → PROVED → refuted. `[SKIP]` + exit 0 without forge/halmos/agentis. |
 
 It mirrors the per-candidate structure of [`run-refute.sh`](../run-refute.sh) +
 [`auditor/agents/refuter.ag`](../auditor/agents/refuter.ag) — env-in the candidate, generate, `emit`/`learn`
@@ -127,8 +128,14 @@ never an LLM opinion. The symbolic gate's verdict maps to the coordinator's thre
 On the **offline / deterministic** path the `DISPATCH_FIXTURE` carries the already-mapped outcome directly —
 a `symbolic-prove|cand*=confirmed` rule stands in for a COUNTEREXAMPLE, `=refuted` for a PROVED — so the
 orchestration is provable with **no live solver** (every action's offline path works this way). On the
-**live** path the mapping is realized end-to-end in `symbolic-prover.ag` (Halmos exit code → verdict →
-outcome) behind `run-symbolic.sh`; `dispatcher.ag` / `coordinator.ag` document the contract and route to it.
+**live** path (#1032) the mapping is realized end-to-end inside `coordinator.ag` itself: when the coordinator
+**chooses** `symbolic-prove` and an operator-supplied live symbolic context is present (`SYM_REPO` +
+`SYM_SPEC` + the `HALMOS_VERIFY` gate path), `coordinator.ag::action_outcome` runs **REAL Halmos**
+(`halmos-verify.sh --repo <SYM_REPO> --target <SYM_SPEC>`) through `exec sh`, captures its exit code via the
+`__rc=$?` marker, and maps it (1→confirmed, 0→refuted, 3/2/other→dry) — the verdict is the solver's, never an
+LLM judgement. The branch is **purely additive**: absent any of the three env facts it falls through to the
+honest stub, so the offline orchestration is unchanged. `dispatcher.ag` carries the byte-identical live branch
+(the `demo-dispatch.sh` sync-guard asserts the two copies do not drift).
 
 ### Reproduce
 
@@ -138,11 +145,22 @@ outcome) behind `run-symbolic.sh`; `dispatcher.ag` / `coordinator.ag` document t
 #   flows back (COUNTEREXAMPLE->confirmed / PROVED->refuted) -> the candidate is consumed -> the policy evolves.
 dark-factory/demo-symbolic-orchestrate.sh      # exit 0 = proven; non-zero = an assertion failed
 
+# LIVE proof (#1032): the coordinator's chosen symbolic-prove action runs REAL Halmos end-to-end inside the
+# loop for an operator-supplied single candidate — a buggy vault's solvency spec -> COUNTEREXAMPLE -> confirmed,
+# a fixed vault's -> PROVED -> refuted. [SKIP] + exit 0 when forge/halmos/agentis are absent (CI convention).
+dark-factory/demo-symbolic-orchestrate-live.sh # needs forge + halmos on PATH; else SKIP
+
 # Bootstrap the in-substrate loop with a symbolic-prove route yourself (stub executor = offline; --sym-policy
 # seeds the symbolic-prove policy so the coordinator chooses it from step 0):
 dark-factory/run-coordinator.sh --scope <scope.tsv> --executor stub --fixture <fixture.tsv> \
     --sym-policy 1.5 --budget 4
 #   fixture rule: `symbolic-prove | cand* | confirmed`  (= a Halmos COUNTEREXAMPLE; `refuted` = a PROVED)
+
+# LIVE single-candidate route: supply a Foundry repo + a ready Halmos spec so the chosen symbolic-prove action
+# runs REAL Halmos (forge + halmos must be on PATH). The verdict is Halmos's exit code, mapped
+# COUNTEREXAMPLE->confirmed / PROVED->refuted / INCONCLUSIVE->dry — never an LLM opinion.
+dark-factory/run-coordinator.sh --scope <scope.tsv> --sym-policy 1.5 --budget 4 \
+    --sym-repo <foundry-dir> --sym-spec <Spec.t.sol>
 ```
 
 ## Honest scope
@@ -151,9 +169,15 @@ M2 ships the **callable** generate-and-verify step: an operator (or a higher-lev
 `run-symbolic.sh` over a candidate manifest. **M3 wires it into the self-orchestrating coordinator** (above):
 the coordinator decides *when* to spend a symbolic verify and feeds the SOUND verdict back into its evolving
 policy. The deterministic orchestration proof uses a fixture that maps the sound verdict (no live Halmos
-needed for the routing proof — exactly like every other action's offline path); the **live** symbolic route
-(`run-symbolic.sh` driving real Halmos behind the chosen action) is the same wiring M2 ships, and remains a
-follow-up to thread end-to-end from the coordinator's live dispatch path (epic #1015 / #1014).
+needed for the routing proof — exactly like every other action's offline path). **#1032 closes the LIVE
+slice for an operator-supplied single candidate:** when the coordinator chooses `symbolic-prove` and a live
+symbolic context is present (`--sym-repo` + `--sym-spec`, threaded as `SYM_REPO` / `SYM_SPEC` / `HALMOS_VERIFY`),
+`coordinator.ag::action_outcome` runs **REAL Halmos end-to-end inside the loop** and maps its exit code to the
+gate outcome — `demo-symbolic-orchestrate-live.sh` proves it against a vault with a real rounding-direction
+solvency bug (COUNTEREXAMPLE → confirmed) and its fix (PROVED → refuted). The offline fixture path remains the
+**CI proof** (no toolchain on the runners). **Multi-candidate code-carrying** — a *discovered* lead
+auto-carrying its contract + invariant through `PENDING` so the loop spins up the live context itself — stays
+the remaining follow-up (epic #1015 / #1014); this slice wires the operator-supplied single candidate.
 
 On the **live** (LLM-generated-spec) path, an honest expectation: a generated Halmos spec must both **compile**
 (`forge build` via Halmos) and stay **decidable** (small symbolic widths, bounded loops) for a clean

--- a/dark-factory/run-coordinator.sh
+++ b/dark-factory/run-coordinator.sh
@@ -56,6 +56,7 @@
 # Usage:
 #   run-coordinator.sh --scope <file> [--class-fitness <file>] [--budget N] [--dry-cap K]
 #                      [--executor real|stub] [--fixture <f>] [--sym-policy <float>]
+#                      [--sym-repo <foundry-dir> --sym-spec <Spec.t.sol> [--sym-function <prefix>]]
 #                      [--backend mock|flat-cyborg|claude] [--out <dir>] [--agentis <bin>]
 #
 # Scope manifest (one huntable cell per line; `#` and blank lines ignored), pipe-delimited:
@@ -76,6 +77,23 @@
 #   default verify ordering is refute > poc-screen > symbolic-prove; a seed >= 1.0 lifts symbolic-prove above
 #   refute. The verdict then comes from the symbolic gate (run-symbolic.sh) — never an LLM opinion.
 #
+# --sym-repo <dir> --sym-spec <Spec.t.sol> (#1032) supply the LIVE single-candidate symbolic context: when
+#   the coordinator CHOOSES symbolic-prove (typically combined with --sym-policy to lift it from step 0), it
+#   runs REAL Halmos END-TO-END inside the loop — `halmos-verify.sh --repo <SYM_REPO> --target <SYM_SPEC>
+#   [--function <prefix>]` — and maps the gate's SOUND exit code to the coordinator outcome:
+#     exit 1 = COUNTEREXAMPLE -> confirmed   (a concrete input is a real bug, CONFIRMED with a witness)
+#     exit 0 = PROVED         -> refuted     (the invariant holds for ALL inputs — the lead is killed by a proof)
+#     exit 3/2/other = INCONCLUSIVE/harness -> dry  (no verdict; a non-productive step)
+#   The verdict is HALMOS's exit code, NEVER an LLM opinion. --sym-repo must be a foundry project (hold a
+#   foundry.toml); --sym-spec must be a readable `*.t.sol` whose `--function`-prefixed (default `check`)
+#   symbolic test asserts the invariant. Both must be supplied together. halmos-verify.sh is resolved to an
+#   absolute path and passed as HALMOS_VERIFY; forge + halmos must be on PATH (the gate does NOT hardcode any
+#   install location). The flags are PURELY ADDITIVE: without them symbolic-prove falls through to the honest
+#   stub (-> dry) and the offline/fixture orchestration is unchanged. The single-candidate context is the
+#   minimum live slice; multi-candidate code-carrying (a discovered lead auto-carrying its contract+invariant
+#   through PENDING) remains a broader follow-up (epic #1015 / #1014). --sym-function <prefix> overrides the
+#   spec's symbolic-test name prefix (default `check`).
+#
 # Exit: 0 on a clean run that reached `stop`/budget; 2 on usage error; 3 on missing prerequisite.
 set -uo pipefail
 
@@ -90,6 +108,9 @@ FIXTURE=""
 BACKEND="mock"
 OUT="$PWD/coordinator-out"
 SYM_POLICY=""
+SYM_REPO=""
+SYM_SPEC=""
+SYM_FUNCTION=""
 
 need() { [ "$1" -ge 2 ] || { echo "run-coordinator.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -102,6 +123,9 @@ while [ $# -gt 0 ]; do
     --fixture)       need "$#"; FIXTURE="$2"; shift 2 ;;
     --backend)       need "$#"; BACKEND="$2"; shift 2 ;;
     --sym-policy)    need "$#"; SYM_POLICY="$2"; shift 2 ;;
+    --sym-repo)      need "$#"; SYM_REPO="$2"; shift 2 ;;
+    --sym-spec)      need "$#"; SYM_SPEC="$2"; shift 2 ;;
+    --sym-function)  need "$#"; SYM_FUNCTION="$2"; shift 2 ;;
     --out)           need "$#"; OUT="$2"; shift 2 ;;
     --agentis)       need "$#"; AGENTIS="$2"; shift 2 ;;
     --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
@@ -127,6 +151,28 @@ if [ -n "$SYM_POLICY" ]; then
   # awk would silently coerce to 0) is rejected, not treated as a no-op seed.
   case "$SYM_POLICY" in (*[0-9]*) : ;; (*) echo "run-coordinator.sh: --sym-policy must be a decimal number (e.g. 1.5 or -0.15)" >&2; exit 2 ;; esac
   SYM_POLICY_TT="$(awk -v v="$SYM_POLICY" 'BEGIN{ printf "%d", (v>=0 ? v*10000+0.5 : v*10000-0.5) }')"
+fi
+# --sym-repo / --sym-spec: the LIVE single-candidate symbolic context (#1032). When BOTH are supplied the
+# coordinator's chosen symbolic-prove action runs REAL Halmos end-to-end (halmos-verify.sh --repo <SYM_REPO>
+# --target <SYM_SPEC>) inside the loop and maps its SOUND exit code to the gate outcome (1=COUNTEREXAMPLE ->
+# confirmed, 0=PROVED -> refuted, 3/2/other=INCONCLUSIVE/harness -> dry). The verdict is Halmos's, never an
+# LLM opinion. Without the live env the symbolic-prove action falls through to the honest stub (-> dry), so
+# the flags are PURELY ADDITIVE. They must be supplied together; SYM_REPO must be a foundry project (hold a
+# foundry.toml) and SYM_SPEC must be a readable file. Both are resolved to ABSOLUTE paths (the colony runs
+# from the rundir, a different cwd) and exported into the in-substrate run.
+HALMOS_VERIFY=""
+if [ -n "$SYM_REPO" ] || [ -n "$SYM_SPEC" ]; then
+  [ -n "$SYM_REPO" ] && [ -n "$SYM_SPEC" ] || { echo "run-coordinator.sh: --sym-repo and --sym-spec must be supplied together (the LIVE symbolic context)" >&2; exit 2; }
+  [ -d "$SYM_REPO" ] || { echo "run-coordinator.sh: --sym-repo is not a directory: $SYM_REPO" >&2; exit 2; }
+  [ -f "$SYM_REPO/foundry.toml" ] || { echo "run-coordinator.sh: --sym-repo is not a foundry project (no foundry.toml): $SYM_REPO" >&2; exit 2; }
+  [ -f "$SYM_SPEC" ] || { echo "run-coordinator.sh: --sym-spec not found: $SYM_SPEC" >&2; exit 2; }
+  SYM_REPO="$(cd "$SYM_REPO" && pwd)"
+  SYM_SPEC="$(cd "$(dirname "$SYM_SPEC")" && pwd)/$(basename "$SYM_SPEC")"
+  # Resolve halmos-verify.sh to an ABSOLUTE path and pass it as HALMOS_VERIFY (the same env path
+  # symbolic-prover.ag / run-symbolic.sh use). No hardcoded install location — the toolchain (forge/halmos)
+  # is the caller's PATH responsibility, exactly as halmos-verify.sh requires.
+  HALMOS_VERIFY="$HERE/evm-harness/halmos-verify.sh"
+  [ -f "$HALMOS_VERIFY" ] || { echo "run-coordinator.sh: halmos-verify gate not found at $HALMOS_VERIFY" >&2; exit 3; }
 fi
 # The in-substrate orchestrate loop (coordinator.ag) encodes its carried state as fields joined by the
 # `@@F@@` sentinel; an input cell that literally contains it would corrupt that encoding. Reject it loudly
@@ -154,8 +200,12 @@ cp "$COORD_AG" "$RUN/coordinator.ag"
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 600000"; }
   [ "$BACKEND" = "flat-cyborg" ] && echo "llm.cli_timeout_ms = 600000"
   echo "trace.level = normal"
-  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS,SYM_POLICY_TT"
-  echo "exec.default_timeout_ms = 30000"
+  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS,SYM_POLICY_TT,SYM_REPO,SYM_SPEC,SYM_FUNCTION,HALMOS_VERIFY"
+  # The LIVE symbolic-prove route (#1032) runs forge build + halmos + z3 over the supplied spec inside the
+  # loop — tens of seconds, well past the 10s/30s defaults — so the per-step exec timeout is raised to 180s
+  # when a live symbolic context is supplied (matches run-symbolic.sh's 180000ms). The offline/fixture path
+  # never runs the gate, so its timeout is unchanged at 30s.
+  if [ -n "$HALMOS_VERIFY" ]; then echo "exec.default_timeout_ms = 180000"; else echo "exec.default_timeout_ms = 30000"; fi
   # The whole point: every decision is recorded as experience so coordinator:policy:<type> reweights.
   echo "learning.enabled = true"
   echo "experience.enabled = true"
@@ -262,6 +312,10 @@ RUN_LOG="$RUN/orchestrate.log"
     DRY_CAP="$DRY_CAP" \
     STEPS="$STEPS" \
     SYM_POLICY_TT="$SYM_POLICY_TT" \
+    SYM_REPO="$SYM_REPO" \
+    SYM_SPEC="$SYM_SPEC" \
+    SYM_FUNCTION="$SYM_FUNCTION" \
+    HALMOS_VERIFY="$HALMOS_VERIFY" \
     ORCHESTRATE_ENABLED=1 \
     DISPATCH_ENABLED=1 \
     DISPATCH_FIXTURE="$DISPATCH_FIXTURE" \


### PR DESCRIPTION
## What

Closes #1032 — the **LIVE** coordinator→halmos `symbolic-prove` route. #1015 M3 proved the *offline* orchestration (a `DISPATCH_FIXTURE` rule supplied the verdict); this makes the self-orchestrating coordinator actually **run Halmos end-to-end** when it chooses `symbolic-prove`.

## How

- `coordinator.ag::action_outcome` gained a **purely-additive** live branch: when `symbolic-prove` is chosen AND no fixture matched AND a live context is supplied (`SYM_REPO` foundry project + `SYM_SPEC` Halmos spec + `HALMOS_VERIFY`), it `exec sh`-runs `evm-harness/halmos-verify.sh` and maps its **exit code** to the outcome: `1→confirmed` (COUNTEREXAMPLE, real bug), `0→refuted` (PROVED, safe by a proof), `3/2/else→dry`. **The verdict is Halmos's exit code, never the LLM.** Without the live env it falls through to the existing honest stub — so every offline path is byte-unchanged. `dispatcher.ag` carries the byte-identical branch (the `demo-dispatch.sh` sync-guard enforces no drift). All dynamic values `shell_escape`d; no heredoc.
- `run-coordinator.sh` — new `--sym-repo` / `--sym-spec` / `--sym-function` flags (validated); whitelists the env; resolves `halmos-verify.sh` to an absolute `HALMOS_VERIFY`; raises the per-step exec timeout to 180s for a live run.
- `demo-symbolic-orchestrate-live.sh` — builds a vault with a real round-UP solvency bug + its round-DOWN fix + Halmos solvency specs, drives the coordinator with the live env so its chosen `symbolic-prove` runs **REAL Halmos** → buggy→**confirmed** (COUNTEREXAMPLE), fixed→**refuted** (PROVED); `[SKIP]` + exit 0 without the toolchain.

## Boundary

A single **operator-supplied** candidate context. Auto-carrying a *discovered* lead's contract + invariant through the PENDING loop (so a `hunt→push→symbolic-prove` chain runs live) is the remaining follow-up — the other live actions still stub the same per-candidate env.

## Verification

- The live demo runs **real Halmos** through the coordinator: `confirmed` on the buggy spec (a genuine 1-wei solvency-violation counterexample), `refuted` on the fixed spec (PROVED). Independently re-verified.
- **`demo-coordinator.sh` byte-identical** to origin/main (the branch is additive); all offline demos (symbolic-orchestrate / orchestrate / dispatch / symbolic) pass.
- Injection-safe (`check-exec-sh` clean); `bash -n` clean; **`colony-lint.sh` → 366 / 0 / 5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
