### PR TITLE
feat(dark-factory): stateful-invariant-fuzzing bounty hunter (#1035)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,49 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **The stateful-invariant-fuzzing bounty hunter — finds the MULTI-STEP bugs single-function symbolic exec
+  misses** (#1035). The symbolic gate (#1015) proves a property over all inputs of ONE function; the refuter
+  (#999) is a hostile LLM read of ONE claim. Both miss the **multi-step, stateful** bug — the ERC4626
+  inflation attack, an accounting drift that compounds, a re-entrancy that only breaks on the third interleave
+  — exactly the class that survives a single-function audit. This MVP ships the engine for that class: the LLM
+  writes the deep invariants + the handler, Foundry's stateful fuzzer finds the exploit SEQUENCE, and **the
+  verdict is the fuzzer's concrete failing call-sequence, never the LLM's opinion**.
+  - `auditor/agents/invariant-prover.ag` — per-target substrate agent (the third GENERATE-AND-VERIFY sibling
+    after `refuter.ag` and `symbolic-prover.ag`). It env-ins the target (`TARGET_FN` + class) + the contract
+    source, GENERATES a Foundry stateful-invariant test — a `Handler` exposing the protocol's actions as
+    bounded actor functions + a set of DEEP `invariant_*` properties (value-conservation, no-depositor-loss,
+    solvency-under-any-sequence, no-free-value-extraction, share-price-monotonicity) — verbatim from a
+    `HANDLER_FIXTURE` on the offline path or via `prompt()` on the live path (prompt-gate-ok per convention).
+    It writes the UNTRUSTED test injection-safely (`printf '%s' <shell_escape(test)>`, NEVER a heredoc),
+    VERIFIES it through the fuzzing gate, maps the exit code **1 → FINDING** / **0 → CLEAN** / **else →
+    HARNESS_ERROR**, `emit`s `dark-factory:invariant_verdict`, `learn`s the attempt (FINDING=success,
+    CLEAN=failure, harness=error) so invariant-prover fitness reweights, and prints `INVARIANT|<target>|
+    <verdict>` plus, on a FINDING, the shrunk exploit call-sequence (one `STEP|...` line per call).
+  - `evm-harness/forge-invariant.sh` — the callable gate. Runs Foundry's built-in stateful invariant fuzzer
+    over a `*.t.sol` (`forge test --match-test invariant --json`), parses the JSON without `jq`, and returns
+    **FINDING** (exit 1, with the shrunk exploit sequence surfaced on stderr) / **CLEAN** (exit 0, every
+    invariant held across the fuzzed search) / **HARNESS_ERROR** (exit 2, compile/setup error / no invariant
+    matched / forge absent). forge-std-free by design: the test registers fuzz targets via the
+    `targetContracts()` StdInvariant ABI Foundry auto-discovers and asserts with plain `require(...)`, so it
+    compiles in ANY Foundry project with zero remappings. runs/depth tune the search via
+    `FOUNDRY_INVARIANT_RUNS`/`_DEPTH`; `--seed` pins forge's fuzz seed for reproducibility.
+  - `run-invariant-hunt.sh` — operator entrypoint mirroring `run-symbolic.sh`. `--repo <foundry project>
+    --target <Contract.sol[:Name]> [--handler-fixture <file>] [--backend mock|flat-cyborg|claude] [--runs N]
+    [--depth D] [--seed S] [--out <dir>]`. Stages a fresh copy of `--repo` into the rundir, drops pre-existing
+    `*.t.sol` so the gate scopes to exactly the generated test, drives `invariant-prover.ag` over the
+    substrate, and collects the verdict + any shrunk exploit sequence into `<out>/invariant-report.md`.
+    Default backend flat-cyborg.
+  - `demo-invariant-hunt.sh` — offline-deterministic proof. Builds two tiny Foundry repos — a VULNERABLE
+    ERC4626-style vault (no virtual offset) and a HARDENED twin (a large virtual-share/asset offset) — and
+    drives the harness with a fixture handler on each: asserts the vulnerable vault → **FINDING** with a
+    non-empty shrunk exploit sequence (the inflation attack: donate → seed → victimDeposit), the hardened
+    vault → **CLEAN** (no false positive on the fix). A fixed `--seed` makes the search reproducible.
+    `[SKIP]` + exit 0 when forge/agentis are absent (CI convention).
+  - `docs/invariant-hunt.md` — the thesis (audit-surviving bugs are multi-step/stateful; the LLM writes deep
+    invariants + handlers, the fuzzer finds the exploit sequence, the verdict is the fuzzer's), the
+    verdict-source contract + verdict→outcome mapping, the deep-invariant taxonomy, fixture-vs-LLM paths,
+    honest scope (the engine; coordinator-routing + fan-out are follow-up), and how it relates to #1015 / #1033.
+    Wired into `README.md` (`## Hunt multi-step bugs (run-invariant-hunt.sh)` + the Layout map).
 - **The LIVE coordinator → Halmos `symbolic-prove` route — REAL symbolic execution inside the autonomous
   loop** (#1032). #1015 M3 proved the *offline* orchestration (a `DISPATCH_FIXTURE` stood in for the sound
   verdict); #1032 closes the **live** slice for an operator-supplied single candidate: when the coordinator

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -362,6 +362,40 @@ above and `dark-factory/demo-symbolic-orchestrate.sh`). See
 [`docs/generate-verify.md`](./docs/generate-verify.md) for the verdict-source contract, the fixture-vs-LLM
 paths, how it composes with M1, and the verdict→outcome mapping the coordinator routes on.
 
+## Hunt multi-step bugs (`run-invariant-hunt.sh`)
+
+The symbolic gate above PROVES a property over all inputs of **one function**; this gate catches the bug
+class that survives a single-function audit — the **multi-step, stateful** one that only emerges from a
+SEQUENCE of calls (the ERC4626 inflation attack, an accounting drift that compounds, a re-entrancy that
+only breaks on the third interleave). The **LLM is the hypothesis generator** — it turns a target contract
+into a Foundry **stateful-invariant test**: a `Handler` exposing the protocol's actions as bounded actor
+functions + a set of DEEP `invariant_*` properties (value-conservation, no-depositor-loss,
+solvency-under-any-sequence, no-free-value-extraction, share-price-monotonicity). The **fuzzer is the
+judge** — Foundry drives randomized multi-call sequences through the Handler, re-checks every invariant
+after each call, and on a break **shrinks** the offending sequence to a minimal reproducer.
+[`auditor/agents/invariant-prover.ag`](./auditor/agents/invariant-prover.ag) runs the whole step on the
+substrate (writes the test injection-safely, runs [`evm-harness/forge-invariant.sh`](./evm-harness/forge-invariant.sh),
+`emit`s `dark-factory:invariant_verdict`, `learn`s the attempt so invariant-prover fitness reweights) and
+prints one `INVARIANT|<target>|<verdict>` line plus, on a FINDING, the **shrunk exploit call-sequence**.
+
+```bash
+dark-factory/run-invariant-hunt.sh --repo "$PWD/target" --target Vault.sol:Vault --class C-erc4626
+# offline / cheap wiring smoke (no real LLM): supply --handler-fixture <ready .t.sol> + --backend mock
+# offline-deterministic end-to-end proof (real fuzzer, fixture handler):  dark-factory/demo-invariant-hunt.sh
+```
+
+The verdict is the **fuzzer's exit code, never the LLM's opinion**: `FINDING` = an invariant broke under a
+concrete SHRUNK call-sequence (a CANDIDATE with a reproducible witness), `CLEAN` = every invariant held
+across the fuzzed search (no finding in this budget — **not** a proof of safety), `HARNESS_ERROR` = the
+test did not compile / no invariant matched / forge absent (not a verdict). A `--handler-fixture` takes the
+**offline/deterministic** path (used verbatim, no LLM) so the target → fuzzer → verdict loop is provable
+with zero LLM cost; `--seed` pins forge's fuzz seed for a reproducible search. A FINDING is still a **LEAD
+a human triages**, never an auto-submission — this colony never posts. Honest scope: this ships the
+**engine** (one target → handler+invariants → the fuzzer's verdict); coordinator-routing and fan-out over
+many targets are follow-up. See [`docs/invariant-hunt.md`](./docs/invariant-hunt.md) for the
+verdict-source contract, the fixture-vs-LLM paths, the deep-invariant taxonomy, and how it relates to the
+symbolic gate (#1015) and the discovery method-gap (#1033).
+
 ## Exercise the evolve/fitness loop (`evolve-fitness.sh`)
 
 Every hunt the colony runs records a `learn("hunt", "<class>:<subsystem>", ..., outcome, [...])` row in
@@ -441,6 +475,7 @@ dark-factory/
   run-summary.sh                # one-shot run -> monitor-/dashboard-consumable run-summary.json (#995)
   run-refute.sh                 # operator entrypoint: adversarial refutation (refuter fan-out) -> verdicts
   run-symbolic.sh               # operator entrypoint: GENERATE a Halmos spec per candidate + VERIFY it (#1015 M2)
+  run-invariant-hunt.sh         # operator entrypoint: GENERATE a Foundry stateful-invariant test + VERIFY it with the fuzzer (#1035)
   run-coordinator.sh            # bootstrap for the self-orchestrating loop (ONE agentis go; the loop lives in-substrate; #1014 M3)
   demo-coordinator.sh           # offline, deterministic proof of the #1014 fact-driven + evolving-policy loop
   demo-dispatch.sh              # offline, deterministic proof of the #1014 M2 substrate DISPATCH (every action type)
@@ -453,6 +488,7 @@ dark-factory/
   demo-halmos.sh                # proof of the #1015 Halmos symbolic gate (PROVED + COUNTEREXAMPLE; SKIPs without the toolchain)
   demo-symbolic.sh              # offline-deterministic proof of the #1015 M2 generate-and-verify loop (fixture spec + real Halmos; SKIPs without the toolchain)
   demo-symbolic-orchestrate.sh  # offline, deterministic proof of the #1015 M3 coordinator routing a candidate to the sound symbolic engine
+  demo-invariant-hunt.sh        # offline-deterministic proof of the #1035 stateful-fuzzing loop (vulnerable -> FINDING, hardened -> CLEAN; SKIPs without forge)
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)
@@ -463,6 +499,7 @@ dark-factory/
     agents/poc-screener.ag      # substrate-native lead pre-screen via eval_ag (sandboxed PoC harness)
     agents/refuter.ag           # the adversarial-refutation agent (independent skeptic; default REFUTED)
     agents/symbolic-prover.ag   # generate-and-verify: LLM writes a Halmos spec, Halmos returns the sound verdict (#1015 M2)
+    agents/invariant-prover.ag  # stateful-fuzzing generate-and-verify: LLM writes a handler+deep invariants, the fuzzer returns the verdict + shrunk exploit sequence (#1035)
     agents/fitness-driver.ag    # one fitness-loop cell: hunter.ag's exact learn() over a ground-truth verdict
     agents/method-inventor.ag   # the meta-loop inventor: proposes a new audit method for a known gap (#998)
     agents/coordinator.ag       # self-orchestrating decider: fact+policy-driven actions (#1014); gated in-substrate dispatch for every action type (M2); gated in-substrate MULTI-STEP loop (M3)
@@ -481,9 +518,11 @@ dark-factory/
   evm-harness/                  # offline revm crate: two-sided EVM PoC (real EVM, Solidity)
     forge-verify.sh             # multi-contract custom-protocol PoC gate (real Foundry deploy+exploit)
     halmos-verify.sh            # sound symbolic gate: PROVES an invariant or returns a counterexample (Halmos+z3; #1015)
+    forge-invariant.sh          # stateful-fuzzing gate: drives Foundry invariant fuzzing -> FINDING (+ shrunk sequence) / CLEAN / HARNESS_ERROR (#1035)
     halmos-specs/               # self-contained Foundry specs: one Halmos PROVES, one it REFUTES (demo fixtures)
   docs/halmos.md                # the Halmos gate's verdict/exit contract, toolchain install, epic fit (#1015)
   docs/generate-verify.md       # the #1015 M2 generate-and-verify loop: LLM hypothesizes, Halmos proves; verdict-source contract
+  docs/invariant-hunt.md        # the #1035 stateful-invariant-fuzzing loop: LLM writes deep invariants, the fuzzer finds the multi-step exploit; verdict-source contract
   sealevel/                     # modernized coral-xyz/sealevel-attacks lessons (corpus) (V6)
   fixtures/                     # detection fixtures (vuln + safe + rigged-harness cases)
 ```

--- a/dark-factory/auditor/agents/invariant-prover.ag
+++ b/dark-factory/auditor/agents/invariant-prover.ag
@@ -1,0 +1,196 @@
+cb 300000;
+// #1035 — substrate-native STATEFUL-INVARIANT-FUZZING bounty hunter. The LLM is the HYPOTHESIS GENERATOR
+// (it turns a target protocol into a Foundry stateful-invariant test: a `Handler` exposing the protocol's
+// actions as bounded actor functions + a set of DEEP `invariant_*` properties); the FUZZER is the JUDGE
+// (Foundry drives randomized multi-call sequences through the Handler and re-checks every invariant after
+// each call — if one breaks it SHRINKS the offending sequence to a minimal reproducer). The verdict NEVER
+// comes from the LLM's opinion — it is the exit code of evm-harness/forge-invariant.sh over the just-written
+// test: a FAILED invariant + a concrete shrunk call-sequence is a CANDIDATE finding (a reproducible exploit
+// WITNESS); all invariants holding is no finding. That is the whole point.
+//
+// This is the third sibling of the GENERATE-AND-VERIFY family, after refuter.ag (the verdict is the LLM's
+// hostile read) and symbolic-prover.ag (the verdict is Halmos's proof over ALL inputs of ONE function). The
+// gap those two leave is the MULTI-STEP, multi-caller bug — the ERC4626 inflation attack, an accounting
+// drift that compounds, a re-entrancy that only breaks on the third interleave — exactly the class that
+// survives a single-function audit. Stateful fuzzing is the tool built for that class: it searches over
+// SEQUENCES of calls, not single inputs, so the witness it returns is a concrete exploit transaction order.
+//
+// A FINDING here is a CANDIDATE the fuzzer reproduced — still a LEAD a human triages, never a finding and
+// NEVER auto-submitted. CLEAN means every deep invariant held across the whole fuzzed search (no finding in
+// this budget — not a proof of safety). HARNESS_ERROR (the generated/fixture test did not compile, no
+// invariant matched, or forge is absent) is NOT a verdict. Submission stays an explicit, human-gated action
+// and this agent never posts to a bounty platform.
+//
+// Env:
+//   TARGET_FN     the target location, "path/to/Contract.sol[:Name]" (free-form label; the lens).
+//   TARGET_CLASS  the bug class id the target is filed under, e.g. "C-erc4626" (optional; "" if unknown).
+//   INV_REPO      absolute path to the foundry project root (must hold foundry.toml) the test is built in.
+//                 The exec sandbox cannot read $HOME — pass a rundir / /tmp path (run-invariant-hunt.sh stages it).
+//   INV_OUT       absolute path the generated/fixture `*.t.sol` invariant test is written to (under INV_REPO/test/...).
+//   INV_MATCH     the invariant function-name prefix forge-invariant runs (default "invariant" when "").
+//   HANDLER_FIXTURE optional path to a ready-made invariant test. When set (offline / deterministic path) it
+//                 is used VERBATIM as the test and NO LLM is called; otherwise the LLM generates it (live).
+//   CODE_PATH     optional path to the target contract source the LLM reads to write the handler; "" to skip.
+//   INV_RUNS      optional forge invariant runs budget (passed to the gate); "" = the gate / project default.
+//   INV_DEPTH     optional forge invariant depth budget (passed to the gate); "" = the gate / project default.
+//   INV_SEED      optional forge --fuzz-seed for a reproducible search; "" = forge's default seed.
+//   FORGE_INVARIANT the absolute path to evm-harness/forge-invariant.sh (the verdict gate).
+// Stdout: exactly one verdict marker line —
+//   INVARIANT|<file:fn>|<FINDING|CLEAN|HARNESS_ERROR>
+// followed, on a FINDING, by the shrunk exploit call-sequence (one `STEP|...` line per call).
+
+// --- file reader (dynamic path -> safe-exec-concat, per symbolic-prover.ag / refuter.ag precedent) ---
+fn cat_file(path: string) -> string {
+    if len(path) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    return exec sh "sed -n '1,4000p' ${path} 2>/dev/null || true";
+}
+
+// Map the forge-invariant.sh exit code to the colony verdict token. This is the ONLY source of the verdict
+// — the LLM never decides it. The exit contract mirrors evm-harness/forge-invariant.sh exactly:
+//   1 -> FINDING        (>=1 invariant broken by a multi-step sequence -> a CANDIDATE with a shrunk witness)
+//   0 -> CLEAN          (every invariant held across the whole fuzzed search -> no finding in this budget)
+//   else (2, etc.) -> HARNESS_ERROR (compile/setup error / no invariant matched / repo not foundry / forge missing)
+fn verdict_of(rc: int) -> string {
+    if rc == 1 { return "FINDING"; }
+    if rc == 0 { return "CLEAN"; }
+    return "HARNESS_ERROR";
+}
+
+// learn() outcome must be one of the runtime enum {success,failure,partial,timeout,error}. A FINDING is the
+// highest-value outcome the loop can produce (a reproduced multi-step exploit witness) = success; a CLEAN
+// consumed the hypothesis without yielding a candidate = failure (like a rigorous SAFE in hunter.ag); a
+// harness error = error. No reassignment of a `let` (single-assignment .ag).
+fn outcome_of(verdict: string) -> string {
+    if verdict == "FINDING" { return "success"; }
+    if verdict == "CLEAN" { return "failure"; }
+    return "error";
+}
+
+// Parse the `__rc=<n>` marker forge-invariant is wrapped to print as its LAST line (the auditor.ag exec
+// convention). regex_capture(pattern, input, group) returns the captured digits; parse_int is total
+// (non-numeric -> 0). A missing marker would wrongly read as 0/CLEAN, so a "no marker" case is forced to a
+// harness error (2). (symbolic-prover.ag / pattern-evolver.ag use the same regex_capture(pattern, out, 1).)
+fn rc_of(out: string) -> int {
+    if index_of(out, "__rc=") < 0 { return 2; }
+    return parse_int(regex_capture("__rc=([0-9]+)", out, 1));
+}
+
+// The gate prints the shrunk exploit sequence on stderr as `  step <n>: <call>` lines on a FINDING. Pull
+// them out of the captured run output verbatim so the marker line(s) carry the concrete witness a human
+// triages. Total: no match -> "" (a FINDING with no parsed steps still surfaces the marker).
+fn steps_of(out: string) -> string {
+    // colony-lint: safe-exec-concat
+    return exec sh "printf '%s' " + shell_escape(out) + " | sed -n 's/^[[:space:]]*step [0-9]*: /STEP|/p' || true";
+}
+
+let targetFn = getenv("TARGET_FN");
+let targetClass = getenv("TARGET_CLASS");
+let invRepo = getenv("INV_REPO");
+let invOut = getenv("INV_OUT");
+// forge-invariant.sh's own default function prefix is `invariant`; default to it when INV_MATCH is unset.
+fn match_prefix(raw: string) -> string {
+    if len(raw) == 0 { return "invariant"; }
+    return raw;
+}
+let invMatch = match_prefix(getenv("INV_MATCH"));
+let fixturePath = getenv("HANDLER_FIXTURE");
+let code = cat_file(getenv("CODE_PATH"));
+
+// --- GENERATE the handler + invariants -----------------------------------------------------------
+// Offline / deterministic path: a HANDLER_FIXTURE is a ready-made invariant test used VERBATIM, no LLM.
+// This is the path demo-invariant-hunt.sh and a `--backend mock` wiring smoke take, so the
+// target->handler->fuzzer->verdict loop is provable with zero LLM cost and a real fuzzer. The fixture is
+// read through the sandboxed reader.
+let fixture = cat_file(fixturePath);
+
+// Live path: the LLM is the HYPOTHESIS GENERATOR. It reads the target contract source and writes a
+// self-contained Foundry stateful-invariant test — a `Handler` that exposes the protocol's actions as
+// BOUNDED actor functions + a set of DEEP `invariant_*` properties (value-conservation, no-depositor-loss,
+// solvency-under-any-sequence, no-free-value-extraction, share-price-monotonicity). The verdict is STILL the
+// FUZZER's (below); the LLM only writes the handler + the properties to check. Cold path, one target in / one
+// test out (no per-tick staleness to gate) -> the prompt carries an explicit prompt-gate-ok marker.
+fn generate_test(klass: string, src: string, matchPrefix: string) -> string {
+    let instruction =
+        "You are a stateful-invariant-fuzzing engineer. Write a self-contained Foundry stateful-invariant "
+      + "test (Solidity, `pragma solidity ^0.8.20;`) for the target contract below so Foundry's invariant "
+      + "fuzzer can drive randomized multi-call SEQUENCES through it and find a MULTI-STEP exploit. "
+      + "Requirements:\n"
+      + "  - Import the target from `../src/...` if the project ships it there; otherwise inline a minimal "
+      + "copy. Do NOT import forge-std — this test must compile with ZERO library remappings.\n"
+      + "  - A `Handler` contract whose PUBLIC functions are the protocol's actions as a real attacker/user "
+      + "would call them (deposit, withdraw, donate, borrow, ...), each taking fuzzed `uint` inputs you BOUND "
+      + "to realistic ranges with a private `_bound(x, lo, hi)` helper (NO forge-std `bound`). Track the "
+      + "honest victim's deposits/shares in Handler state so an invariant can compare claim-vs-deposit.\n"
+      + "  - An `abstract contract InvBase` that exposes `function targetContracts() public view returns "
+      + "(address[] memory)` returning the addresses to fuzz, with an internal `_target(address)` that pushes "
+      + "to that array (this is the StdInvariant ABI Foundry auto-discovers — no forge-std needed).\n"
+      + "  - A test contract `is InvBase` with a `setUp()` that deploys the protocol + the Handler and calls "
+      + "`_target(address(handler))`, plus a set of DEEP `" + matchPrefix + "_*` view functions asserting with "
+      + "plain `require(...)`: value-conservation, no-depositor-loss (a depositor's claim >= their deposit "
+      + "minus dust), solvency-under-any-sequence, no-free-value-extraction, share-price-monotonicity. Each "
+      + "must catch a bug that only a SEQUENCE of calls can produce, not a single call.\n\n"
+      + "=== BUG CLASS (lens) ===\n" + klass + "\n\n"
+      + "=== HOW TO ANSWER ===\n"
+      + "Output ONLY the Solidity source of the `*.t.sol` test — no markdown fences, no prose before or "
+      + "after. It must compile and define at least one `contract` and one `" + matchPrefix + "_*` function.";
+    // colony-lint: prompt-gate-ok
+    return prompt(instruction, src) -> string;
+}
+
+// Single-assignment .ag: pick the test source ONCE (no `let` reassignment). A non-empty HANDLER_FIXTURE wins
+// (offline/deterministic, verbatim, no LLM); otherwise the LLM generates it (live path).
+let usedFixture = len(fixture) > 0;
+fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string) -> string {
+    if usedFix { return fix; }
+    return generate_test(klass, src, matchPrefix);
+}
+let test = choose_test(usedFixture, fixture, targetClass, code, invMatch);
+
+// Write the generated/fixture test to INV_OUT (inside INV_REPO/test) so forge-invariant can run it. The test
+// content is UNTRUSTED — it is either an LLM completion (prompt-injectable by the untrusted target code under
+// audit) or an operator fixture — so it MUST go through shell_escape(), never a heredoc (a heredoc body is
+// not escaped: a test line equal to the sentinel would terminate it early and the rest would execute as
+// shell). printf '%s' on a shell_escape()d single-quoted literal cannot be escaped by any content (no shell
+// metachar survives single-quoting), so the test is written verbatim with zero injection.
+let wrote = exec sh "printf '%s' " + shell_escape(test) + " > " + shell_escape(invOut) + "; echo __wrote=$?";
+
+// --- VERIFY with the stateful-fuzzing gate ------------------------------------------------------
+// Run evm-harness/forge-invariant.sh against the just-written test and capture its exit code via the
+// `__rc=$?` marker convention (auditor.ag). `set +e` so the gate's non-zero verdict exit (1/2) does not
+// abort the shell before the marker is printed. The verdict is THIS exit code — nothing else. Optional
+// runs/depth/seed are forwarded only when set, each as a shell_escape()d value.
+let gate = getenv("FORGE_INVARIANT");
+let runsArg = getenv("INV_RUNS");
+let depthArg = getenv("INV_DEPTH");
+let seedArg = getenv("INV_SEED");
+fn opt_flag(flag: string, val: string) -> string {
+    if len(val) == 0 { return ""; }
+    return " " + flag + " " + shell_escape(val);
+}
+let budget = opt_flag("--runs", runsArg) + opt_flag("--depth", depthArg) + opt_flag("--seed", seedArg);
+// colony-lint: safe-exec-concat
+let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --repo " + shell_escape(invRepo) + " --target " + shell_escape(invOut) + " --match " + shell_escape(invMatch) + budget + " 2>&1; echo __rc=$?";
+
+let rc = rc_of(runOut);
+let verdict = verdict_of(rc);
+
+// --- EMIT the FUZZER's verdict -------------------------------------------------------------------
+// Surface the marker (stdout, parsed by run-invariant-hunt.sh), then on a FINDING the shrunk exploit
+// sequence (one STEP| line per call), record it on the bus, and learn() the attribution so invariant-prover
+// fitness reweights over targets (FINDING=success, CLEAN=failure, harness=error). memo_write the last_check
+// per the agent convention.
+print("INVARIANT|" + targetFn + "|" + verdict);
+let steps = steps_of(runOut);
+if verdict == "FINDING" {
+    if len(steps) > 0 { print(steps); }
+}
+let outcome = outcome_of(verdict);
+fn gen_mode(usedFix: bool) -> string {
+    if usedFix { return "fixture"; }
+    return "llm";
+}
+let genMode = gen_mode(usedFixture);
+emit("dark-factory:invariant_verdict", "{\"target\":\"" + targetFn + "\",\"class\":\"" + targetClass + "\",\"verdict\":\"" + verdict + "\",\"gen\":\"" + genMode + "\",\"outcome\":\"" + outcome + "\"}");
+learn("invariant-prove", targetClass + ":" + targetFn, "stateful-invariant-fuzz generate-and-verify of " + targetFn + " (" + targetClass + ") -> " + verdict, outcome, [targetClass, verdict, outcome]);
+memo_write("invariant-prover:last_check", "done");

--- a/dark-factory/demo-invariant-hunt.sh
+++ b/dark-factory/demo-invariant-hunt.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# demo-invariant-hunt.sh — reproducible proof of the #1035 STATEFUL-INVARIANT-FUZZING loop: a target is
+# turned into a Foundry stateful-invariant test and the FUZZER (not the LLM) returns the verdict over
+# randomized MULTI-CALL sequences.
+#
+# This drives the FULL target -> handler+invariants -> forge-invariant -> verdict loop through the substrate
+# via `run-invariant-hunt.sh` + `auditor/agents/invariant-prover.ag`, using a FIXTURE handler (the
+# offline/deterministic path — NO LLM, mock backend) and a REAL Foundry invariant run. Two vaults exercise
+# both verdicts and prove the engine catches a real multi-step bug AND does not false-positive on the fix:
+#   - a VULNERABLE ERC4626-style vault (no virtual shares/assets)  -> verdict FINDING (the inflation attack:
+#     a SHRUNK call-sequence donate->...->victimDeposit robs the depositor — a reproducible exploit witness)
+#   - a HARDENED twin (large virtual-share/asset offset)           -> verdict CLEAN  (the same fuzzed search
+#     cannot break the invariant — no false positive on the fix)
+# The verdict is the FUZZER's exit code, never the LLM's opinion — that is the whole point of #1035. The
+# inflation attack is a MULTI-STEP bug a single-function symbolic check misses: it only emerges from the
+# attacker's seed+donate priming the share price BEFORE the victim's deposit. A fixed --seed makes the search
+# reproducible; the FINDING run is also repeated and asserted to surface a non-empty shrunk sequence.
+#
+# CI has no forge, so if it is missing this prints a single [SKIP] line and exits 0 (mirroring
+# demo-symbolic.sh / the colony-lint skip convention) instead of failing. Install the toolchain to run it:
+#   curl -L https://foundry.paradigm.xyz | bash && foundryup    # forge (has built-in invariant fuzzing)
+#
+# Usage:  dark-factory/demo-invariant-hunt.sh
+# Exit: 0 = both verdicts correct (FINDING + a non-empty witness on vulnerable, CLEAN on hardened), or tools
+#       absent -> SKIP ; non-zero = a verdict was wrong.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUNNER="$HERE/run-invariant-hunt.sh"
+
+FAILS=0
+note() { echo "demo-invariant-hunt.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+skip() { echo "  [SKIP] $*"; }
+
+# Skip EARLY (before any work) when the toolchain is missing, so CI without forge reports a clean [SKIP] +
+# exit 0 rather than a harness error. agentis is required to drive the substrate loop.
+if ! command -v forge >/dev/null 2>&1; then
+  skip "forge not on PATH — install foundryup (https://getfoundry.sh) to run this demo"
+  exit 0
+fi
+if ! command -v agentis >/dev/null 2>&1; then
+  skip "agentis not on PATH — install the agentis runtime to drive the substrate invariant-hunt loop"
+  exit 0
+fi
+
+[ -x "$RUNNER" ] || { note "runner not found / not executable: $RUNNER" >&2; exit 3; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ----------------------------------------------------------------------------------------------------------
+# Build the two tiny foundry repos: VULNERABLE (no virtual offset) and HARDENED (large virtual-share offset
+# so the inflation attack cannot round the victim to zero shares). Both ship the SAME minimal ERC20 + the
+# SAME public ABI, so the SAME fixture handler drives both — only the share-pricing math differs.
+# ----------------------------------------------------------------------------------------------------------
+mk_repo() {  # $1 = repo dir, $2 = the `s = ...` deposit pricing line, $3 = the `assets = ...` withdraw line
+  _dir="$1"; _depositMath="$2"; _withdrawMath="$3"
+  mkdir -p "$_dir/src" "$_dir/test"
+  printf '[profile.default]\nsrc = "src"\nout = "out"\n\n[invariant]\nruns = 64\ndepth = 32\nfail_on_revert = false\n' > "$_dir/foundry.toml"
+  cat > "$_dir/src/Vault.sol" <<SOL
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+contract Token {
+  mapping(address=>uint) public balanceOf; uint public totalSupply;
+  function mint(address to,uint a) external { balanceOf[to]+=a; totalSupply+=a; }
+  function transfer(address to,uint a) external returns(bool){ balanceOf[msg.sender]-=a; balanceOf[to]+=a; return true; }
+  function transferFrom(address f,address t,uint a) external returns(bool){ balanceOf[f]-=a; balanceOf[t]+=a; return true; }
+}
+contract Vault {
+  Token public asset; uint public totalShares; mapping(address=>uint) public shares;
+  uint constant VS = 1000000000000000000000000000; uint constant VA = 1; // virtual offset (1e27); VS=1 in the vulnerable build below
+  constructor(Token a){ asset=a; }
+  function deposit(uint assets) external returns(uint s){
+    uint ta = asset.balanceOf(address(this));
+    ${_depositMath}
+    asset.transferFrom(msg.sender,address(this),assets);
+    shares[msg.sender]+=s; totalShares+=s;
+  }
+  function withdraw(uint s) external returns(uint assets){
+    uint ta = asset.balanceOf(address(this));
+    ${_withdrawMath}
+    shares[msg.sender]-=s; totalShares-=s;
+    asset.transfer(msg.sender,assets);
+  }
+}
+SOL
+}
+
+# VULNERABLE: classic ERC4626 share price (no virtual offset) -> donation inflates ta, the next deposit mints
+# 0 shares -> the depositor's claim collapses far below their deposit (a MULTI-STEP donation/inflation attack).
+mk_repo "$WORK/vuln" \
+  's = totalShares==0 ? assets : assets*totalShares/ta;' \
+  'assets = s*ta/totalShares;'
+
+# HARDENED: a large virtual-share/asset offset (the OpenZeppelin ERC4626 decimal-offset mitigation) so the
+# share price cannot be inflated enough to round a real depositor to zero shares -> the same attack fails.
+mk_repo "$WORK/hard" \
+  's = assets * (totalShares + VS) / (ta + VA);' \
+  'assets = s * (ta + VA) / (totalShares + VS);'
+
+# ----------------------------------------------------------------------------------------------------------
+# The PROVEN fixture handler+invariant (the validated template, parameterized to the vault under test). A
+# `Handler` exposes the protocol's actions as bounded actor functions (attackerSeed / attackerDonate /
+# victimDeposit) and a DEEP invariant (`invariant_victim_not_robbed`): a depositor's claim on the vault must
+# always be worth at least what they deposited, minus dust. forge-std-free: targets are registered via the
+# `targetContracts()` view (the StdInvariant ABI forge auto-discovers) and asserted with plain `require`.
+# ----------------------------------------------------------------------------------------------------------
+cat > "$WORK/fixture.t.sol" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import {Vault, Token} from "../src/Vault.sol";
+
+// The protocol's actions as a real attacker/user calls them, with fuzzed inputs bounded to realistic ranges.
+contract Handler {
+    Vault public v; Token public t;
+    uint public victimDeposited;   // total assets the honest victim has put in
+    uint public victimShares;      // shares the victim holds
+    constructor(Vault _v, Token _t){ v=_v; t=_t; }
+    // forge-std-free bound: keep a fuzzed uint inside [lo, hi] without the forge-std `bound` cheatcode.
+    function _bound(uint x, uint lo, uint hi) internal pure returns (uint) {
+        if (hi <= lo) return lo;
+        return lo + (x % (hi - lo + 1));
+    }
+    function attackerSeed() public { t.mint(address(this), 1); v.deposit(1); }              // seed 1 share
+    function attackerDonate(uint a) public { a = _bound(a, 1, 1e24); t.mint(address(v), a); } // direct transfer, no shares
+    function victimDeposit(uint a) public {
+        a = _bound(a, 1e6, 1e18);
+        t.mint(address(this), a);
+        uint s = v.deposit(a);
+        victimDeposited += a; victimShares += s;
+    }
+}
+
+// StdInvariant ABI forge auto-discovers: targetContracts() lists the addresses the fuzzer drives. No forge-std.
+abstract contract InvBase {
+    address[] private _targets;
+    function targetContracts() public view returns (address[] memory) { return _targets; }
+    function _target(address a) internal { _targets.push(a); }
+}
+
+contract VaultInvariantTest is InvBase {
+    Vault v; Token t; Handler h;
+    function setUp() public { t=new Token(); v=new Vault(t); h=new Handler(v,t); _target(address(h)); }
+    // DEEP invariant: the victim's CLAIM on the vault (shares * vaultBalance / totalShares) must always be
+    // worth >= what they deposited, minus dust. The inflation attack makes a victim deposit mint 0 shares,
+    // so their claim collapses far below their deposit -> a SEQUENCE the fuzzer must find.
+    function invariant_victim_not_robbed() public view {
+        uint vd = h.victimDeposited();
+        if (vd == 0) return;
+        uint ts = v.totalShares();
+        uint claim = ts == 0 ? 0 : h.victimShares() * t.balanceOf(address(v)) / ts;
+        require(claim + 1e6 >= vd, "victim robbed");   // claim within dust(1e6) of deposit
+    }
+}
+SOL
+
+# The hardened build declares VS=1e27 in source; the vulnerable build's pricing ignores VS entirely (the
+# classic formula), so a single shared fixture is correct for both. (Belt-and-suspenders: confirm the vuln
+# source really uses the no-offset formula and the hardened one the VS/VA formula.)
+grep -q 'assets\*totalShares/ta' "$WORK/vuln/src/Vault.sol" || { note "internal: vulnerable vault did not get the no-offset pricing" >&2; exit 3; }
+grep -q 'totalShares + VS' "$WORK/hard/src/Vault.sol" || { note "internal: hardened vault did not get the virtual-offset pricing" >&2; exit 3; }
+
+# Drive one target through the FULL substrate loop (mock backend = no LLM; the FIXTURE drives the test, the
+# REAL Foundry fuzzer judges). $1 = repo, $2 = output dir.
+SEED=1
+run_one() {
+  "$RUNNER" --repo "$1" --target "Vault.sol:Vault" --class "C-erc4626" \
+            --handler-fixture "$WORK/fixture.t.sol" --backend mock \
+            --runs 256 --depth 64 --seed "$SEED" --out "$2" >"$2.log" 2>&1
+}
+
+# Read the verdict cell out of a report's table row for Vault.sol:Vault.
+verdict_of() {
+  _row="$(grep -F '| Vault.sol:Vault ' "$1" 2>/dev/null | tail -1 || true)"
+  printf '%s' "$_row" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/,"",$5); print $5}'
+}
+
+# ----------------------------------------------------------------------------------------------------------
+# 1) VULNERABLE vault -> FINDING with a NON-EMPTY shrunk exploit sequence.
+# ----------------------------------------------------------------------------------------------------------
+note "driving the VULNERABLE vault -> fixture handler -> REAL Foundry stateful fuzzer -> verdict (mock backend) ..."
+run_one "$WORK/vuln" "$WORK/vuln-out"; RC=$?
+VREPORT="$WORK/vuln-out/invariant-report.md"
+if [ "$RC" -ne 0 ] || [ ! -f "$VREPORT" ]; then
+  bad "run-invariant-hunt.sh did not complete on the vulnerable vault (exit $RC); log:"
+  sed 's/^/        | /' "$WORK/vuln-out.log" 2>/dev/null
+else
+  VV="$(verdict_of "$VREPORT")"
+  if [ "$VV" = "FINDING" ]; then
+    ok "VULNERABLE vault -> FINDING (the fuzzer's verdict, not the LLM's)"
+    # The witness must be a non-empty shrunk call-sequence (the reproducible exploit).
+    if grep -q '## Shrunk exploit call-sequence' "$VREPORT" && grep -qE 'victimDeposit\(|attackerDonate\(' "$VREPORT"; then
+      ok "  witness present: a non-empty shrunk multi-step exploit sequence"
+      note "  the shrunk exploit sequence the fuzzer found:"
+      sed -n '/```/,/```/p' "$VREPORT" | sed '/```/d' | sed 's/^/        | /'
+    else
+      bad "  FINDING but no non-empty shrunk exploit sequence in the report"
+    fi
+  else
+    bad "VULNERABLE vault expected FINDING, got '${VV:-<no row>}'"
+    sed 's/^/        | /' "$WORK/vuln-out.log" 2>/dev/null | tail -20
+  fi
+fi
+
+# ----------------------------------------------------------------------------------------------------------
+# 2) HARDENED vault -> CLEAN (no false positive on the fix).
+# ----------------------------------------------------------------------------------------------------------
+note "driving the HARDENED vault (same handler, same search) -> verdict (mock backend) ..."
+run_one "$WORK/hard" "$WORK/hard-out"; RC=$?
+HREPORT="$WORK/hard-out/invariant-report.md"
+if [ "$RC" -ne 0 ] || [ ! -f "$HREPORT" ]; then
+  bad "run-invariant-hunt.sh did not complete on the hardened vault (exit $RC); log:"
+  sed 's/^/        | /' "$WORK/hard-out.log" 2>/dev/null
+else
+  HV="$(verdict_of "$HREPORT")"
+  if [ "$HV" = "CLEAN" ]; then
+    ok "HARDENED vault -> CLEAN (the same fuzzed search could not break the invariant — no false positive)"
+  else
+    bad "HARDENED vault expected CLEAN, got '${HV:-<no row>}'"
+    sed 's/^/        | /' "$WORK/hard-out.log" 2>/dev/null | tail -20
+  fi
+fi
+
+echo
+if [ "$FAILS" -eq 0 ]; then
+  note "PASS: the LLM-as-generator / FUZZER-as-judge loop caught the VULNERABLE vault's multi-step inflation"
+  note "      attack with a concrete shrunk exploit sequence (a CANDIDATE witness), and did NOT false-positive"
+  note "      on the HARDENED twin — verdict is the fuzzer's, reproducible under a fixed seed; generation used a"
+  note "      fixture so no LLM was involved (#1035). A FINDING is a LEAD a human triages; this colony never posts."
+  exit 0
+fi
+note "DEMO FAILED — a verdict did not match the contract" >&2
+exit 1

--- a/dark-factory/docs/invariant-hunt.md
+++ b/dark-factory/docs/invariant-hunt.md
@@ -1,0 +1,147 @@
+# Stateful-invariant-fuzzing bounty hunter (#1035)
+
+The symbolic gate ([`docs/generate-verify.md`](./generate-verify.md), #1015) PROVES a property over **all
+inputs of one function**. The adversarial refuter ([`run-refute.sh`](../run-refute.sh), #999) is a hostile
+LLM read of a single claim. Both leave the same gap: the **multi-step, stateful** bug — the one that only
+emerges from a SEQUENCE of calls, across callers, in a particular order. That is precisely the class an
+auditor reading one function at a time misses, and the class that survives into production: the ERC4626
+**inflation/donation attack**, an accounting drift that compounds over many deposits, a re-entrancy that
+only breaks on the third interleave, a fee that rounds in the protocol's favour until it doesn't.
+
+This engine targets that class. Foundry ships a **stateful invariant fuzzer** built for it: it searches over
+SEQUENCES of calls, not single inputs, and on a break it **shrinks** the offending sequence to a minimal
+reproducer — a concrete exploit transaction order.
+
+## The contract: the LLM writes the invariants, the fuzzer finds the exploit
+
+```
+target contract ──(LLM writes a Handler + deep invariants)──► *.t.sol ──(forge-invariant.sh)──► verdict + shrunk sequence
+   the HYPOTHESIS GENERATOR                                              the JUDGE (Foundry's stateful fuzzer)
+```
+
+- The **LLM is the hypothesis generator.** It turns a target contract into a self-contained Foundry
+  stateful-invariant test: a `Handler` that exposes the protocol's actions as **bounded actor functions** (an
+  attacker / a victim calling `deposit`, `withdraw`, `donate`, `borrow`, …), plus a set of **deep
+  `invariant_*` properties**. An LLM proposal is, on its own, unverified — it can hallucinate both the bug and
+  the property.
+- **The fuzzer is the judge.** Foundry drives randomized multi-call sequences through the `Handler`,
+  re-checks every invariant after each call, and on a break shrinks the sequence to a minimal reproducer.
+
+**The verdict is the fuzzer's exit code — never the LLM's opinion.** That is the whole point: the LLM's job
+shrinks to *writing the handler + the properties to check*; the truth of the answer is the fuzzer's concrete
+pass/fail plus the shrunk witness. A `FINDING` is a reproducible exploit transaction order a human can
+replay; a `CLEAN` is the fuzzer failing to break any invariant in the given search budget.
+
+**Safety — the test content is untrusted.** The generated test is an LLM completion (prompt-injectable by the
+untrusted target code under audit) or an operator fixture, so
+[`auditor/agents/invariant-prover.ag`](../auditor/agents/invariant-prover.ag) writes it with
+`printf '%s' <shell_escape(test)>`, never a heredoc — a single-quoted `shell_escape`d literal cannot be
+escaped by any test content, so a malicious test is written verbatim (and then merely fails to compile or is
+judged by the fuzzer), never executed as shell. The test only ever reaches `forge` inside the run sandbox.
+
+## Components
+
+| File | Role |
+|---|---|
+| [`auditor/agents/invariant-prover.ag`](../auditor/agents/invariant-prover.ag) | Per-target substrate agent: GENERATE the test (fixture or `prompt()`), VERIFY it with the fuzzing gate, `emit`/`learn` the verdict, print `INVARIANT\|<target>\|<verdict>` + the shrunk sequence on a FINDING. |
+| [`evm-harness/forge-invariant.sh`](../evm-harness/forge-invariant.sh) | The callable gate: runs Foundry's stateful invariant fuzzer over a `*.t.sol`, parses the JSON, returns FINDING (+ the shrunk sequence) / CLEAN / HARNESS_ERROR. |
+| [`run-invariant-hunt.sh`](../run-invariant-hunt.sh) | Operator entrypoint: drive `invariant-prover.ag` once over the substrate on one target, collect the verdict + any exploit sequence into a report. |
+| [`demo-invariant-hunt.sh`](../demo-invariant-hunt.sh) | Offline-deterministic demo: the full target → fixture-handler → REAL Foundry fuzzer → verdict loop, asserting a vulnerable vault → FINDING (with a non-empty shrunk sequence) and a hardened twin → CLEAN. |
+
+It mirrors the per-candidate structure of [`run-symbolic.sh`](../run-symbolic.sh) +
+[`auditor/agents/symbolic-prover.ag`](../auditor/agents/symbolic-prover.ag) — env-in the target, generate,
+`emit`/`learn` the verdict, `memo_write` the `last_check`, print one observable marker — but where the
+symbolic prover's verdict is Halmos's proof over one function, the invariant prover's verdict is **the
+fuzzer's concrete failing call-sequence** over the whole protocol.
+
+## Verdict mapping
+
+`invariant-prover.ag` maps the gate's exit code (the only source of the verdict) directly:
+
+| forge-invariant exit | Verdict | Meaning | `learn()` outcome |
+|---|---|---|---|
+| `1` | **FINDING** | ≥1 invariant broke under a concrete SHRUNK multi-call sequence → a CANDIDATE with a reproducible witness | `success` |
+| `0` | **CLEAN** | every invariant held across the whole fuzzed search → no finding **in this budget** (NOT a proof of safety) | `failure` |
+| else (`2`, …) | **HARNESS_ERROR** | the test did not compile / no `invariant_*` matched / repo not a Foundry project / `forge` missing | `error` |
+
+A FINDING is the highest-value outcome (a reproduced multi-step exploit witness), so it is recorded as
+`success` (invariant-prover fitness rewards targets the fuzzer breaks); a CLEAN consumes the hypothesis
+without a finding, so it is `failure` — the same polarity as a rigorous `SAFE` in `hunter.ag`. **CLEAN is not
+a proof**: the fuzzer searched `runs × depth` sequences and found nothing, which bounds confidence but does
+not establish safety the way the symbolic gate's PROVED does.
+
+## The deep-invariant taxonomy (what the LLM is asked to assert)
+
+A shallow invariant (one that holds trivially, or only checks a single call) finds nothing. The generator
+prompt asks specifically for invariants that can only be broken by a SEQUENCE:
+
+- **value-conservation** — total assets in == total claimable out (no value appears or vanishes over a run).
+- **no-depositor-loss** — an honest depositor's claim (`shares × vaultBalance / totalShares`) is always worth
+  at least what they deposited, minus dust. (The inflation attack breaks exactly this: a victim deposit mints
+  0 shares after the price is inflated, so their claim collapses.)
+- **solvency-under-any-sequence** — the protocol can always honour every outstanding claim.
+- **no-free-value-extraction** — no actor ends a sequence with more than they put in (minus legitimate yield).
+- **share-price-monotonicity** — the price per share never moves in a direction that a depositor can be
+  sandwiched by.
+
+## Generation: offline (fixture) vs live (LLM)
+
+`invariant-prover.ag` has two generation paths, gated on a `HANDLER_FIXTURE` env fact:
+
+- **Offline / deterministic** — when `HANDLER_FIXTURE` is set, that test is used **verbatim** and **no LLM is
+  called**. This is the path [`demo-invariant-hunt.sh`](../demo-invariant-hunt.sh) and a `--backend mock`
+  wiring smoke take, so the target → fuzzer → verdict loop is provable with zero LLM cost and a real fuzzer.
+- **Live** — otherwise the LLM `prompt()`s the handler + invariants from the target contract source. The
+  verdict is **still** the fuzzer's; the LLM only writes the handler and the properties to check.
+
+The harness is **forge-std-free by design** (like [`evm-harness/halmos-specs`](../evm-harness/halmos-specs)):
+the test registers its fuzz targets via a `targetContracts() returns (address[])` view — the `StdInvariant`
+ABI Foundry auto-discovers — and asserts with plain `require(...)`, with a private `_bound(x, lo, hi)` helper
+instead of forge-std's `bound`. So it compiles in **any** Foundry project with zero library remappings, which
+is what makes generation tractable across arbitrary targets.
+
+## Run it
+
+```bash
+# Offline-deterministic proof of the WHOLE loop (real fuzzer, no LLM): vulnerable -> FINDING, hardened -> CLEAN
+dark-factory/demo-invariant-hunt.sh
+
+# Cheap wiring smoke (no real LLM): supply a ready handler + the mock backend
+dark-factory/run-invariant-hunt.sh \
+  --repo "$PWD/target" --target Vault.sol:Vault --class C-erc4626 \
+  --handler-fixture "$PWD/handler.t.sol" --backend mock --seed 1
+
+# Live: the LLM writes the handler + deep invariants from the target source, the fuzzer judges
+dark-factory/run-invariant-hunt.sh \
+  --repo "$PWD/target" --target Vault.sol:Vault --class C-erc4626 \
+  --backend flat-cyborg --runs 256 --depth 64 --seed 1 --out "$PWD/invariant-out"
+```
+
+`run-invariant-hunt.sh` stages a fresh copy of `--repo` into its rundir (so the sandboxed `exec sh` can write
+the test into `test/` and run forge there), drops any pre-existing `*.t.sol` so the gate scopes to exactly the
+generated test, and routes the target through the substrate (`prompt`/`emit`/`learn`). The verdict + any
+shrunk exploit sequence land at `<out>/invariant-report.md`. `--seed` pins forge's fuzz seed so the search is
+reproducible.
+
+## Honest scope, and how it relates to the rest of the epic
+
+This ships the **engine**: one target → a handler + deep invariants → the fuzzer's verdict (FINDING with a
+shrunk witness, or CLEAN). What it does **not** yet do:
+
+- **Generating a compiling Foundry handler for an arbitrary protocol is the hard part.** The offline path is
+  deterministic and proven; the live path's quality is bounded by whether the LLM emits a handler that both
+  compiles AND exercises the protocol deeply enough to surface the bug. The fixture path exists precisely so
+  the loop's verdict mechanic is provable independent of live-generation quality.
+- **CLEAN is budget-bounded, not a proof.** For an over-all-inputs guarantee on a single function, the
+  symbolic gate (#1015) is the right tool; this gate is the right tool for the multi-step class symbolic
+  execution cannot reach at scale.
+- **Coordinator-routing + fan-out are follow-up.** This is the callable per-target step, in the shape the
+  coordinator's `symbolic-prove` / `refute` / `poc-screen` actions take — wiring an `invariant-hunt` action
+  into the self-orchestrating loop, and fanning it over many targets, is the next increment.
+
+It complements the discovery method-gap doc ([`auditor/methods/gap-stateful.md`](../auditor/methods/gap-stateful.md),
+the #998/#1033 "stateful" gap the taxonomy-class lens misses) by making that gap **runnable as a verifier**:
+where `auditor/agents/stateful-invariant-fuzz.ag` is an LLM *lens* that proposes a candidate, this engine
+*reproduces* a multi-step exploit with the fuzzer and returns the concrete witness. As everywhere in this
+colony, a FINDING is a **LEAD a human triages** — submission stays an explicit, human-gated action and this
+colony **never auto-submits**.

--- a/dark-factory/evm-harness/forge-invariant.sh
+++ b/dark-factory/evm-harness/forge-invariant.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# forge-invariant.sh — the STATEFUL-FUZZING verification gate for the discovery track (#1035).
+#
+# halmos-verify.sh (its symbolic sibling) PROVES a single-function property over all inputs; forge-verify.sh
+# EXECUTES one concrete PoC tx. Neither finds the bugs that only emerge from a MULTI-STEP, multi-caller
+# SEQUENCE of calls (the ERC4626 inflation attack, an accounting drift that compounds, a re-entrancy that
+# only breaks on the third interleave) — exactly the class that survives a single-function audit.
+#
+# This gate runs Foundry's built-in STATEFUL INVARIANT FUZZER over a `*.t.sol` test: a `Handler` exposes the
+# protocol's actions as bounded actor functions, the fuzzer drives randomized call sequences through it, and
+# after every call it re-checks each `invariant_*` function. If ANY invariant breaks, Foundry SHRINKS the
+# offending sequence to a minimal reproducer and reports it. The verdict is the FUZZER's: a failed invariant
+# + a concrete shrunk call-sequence is a CANDIDATE finding (a reproducible exploit witness); all invariants
+# holding is CLEAN. There is no LLM opinion in the verdict — only forge's pass/fail + the witness.
+#
+# The harness is forge-std-free by design (like evm-harness/halmos-specs): the invariant test registers its
+# fuzz targets via a `targetContracts() returns (address[])` view (the StdInvariant ABI forge auto-discovers)
+# and asserts with plain `require(...)`, so it compiles in ANY foundry project with zero library remappings.
+#
+# Usage:
+#   forge-invariant.sh --repo <foundry-project-root> --target <Invariant.t.sol>
+#                      [--match <invariant_ prefix>] [--runs N] [--depth D] [--seed S]
+#
+# Verdict / exit contract (mirrors halmos-verify.sh's shape):
+#   CLEAN          exit 0  — >=1 invariant ran and ALL held across every fuzzed sequence: no finding.
+#   FINDING        exit 1  — >=1 invariant FAILED; the shrunk exploit sequence is printed to stderr and
+#                            captured in the JSON. A reproducible multi-step witness -> a CANDIDATE.
+#   HARNESS_ERROR  exit 2  — bad args, repo is not a foundry project, forge missing, compile/setup error,
+#                            or no invariant function matched (nothing was actually checked).
+set -uo pipefail
+
+REPO=""
+TARGET=""
+MATCH="invariant"
+RUNS=""
+DEPTH=""
+SEED=""
+
+usage() { sed -n '2,36p' "$0"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)   REPO="${2:-}"; shift 2 ;;
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --match)  MATCH="${2:-}"; shift 2 ;;
+    --runs)   RUNS="${2:-}"; shift 2 ;;
+    --depth)  DEPTH="${2:-}"; shift 2 ;;
+    --seed)   SEED="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "forge-invariant: unknown arg $1" >&2; exit 2 ;;
+  esac
+done
+
+# --- usage / harness validation -----------------------------------------------------------------
+[ -n "$REPO" ] && [ -d "$REPO" ] || { echo "forge-invariant: --repo <foundry project root> required" >&2; exit 2; }
+[ -f "$REPO/foundry.toml" ] || { echo "forge-invariant: $REPO is not a foundry project (no foundry.toml)" >&2; exit 2; }
+[ -n "$TARGET" ] || { echo "forge-invariant: --target <Invariant.t.sol> required" >&2; exit 2; }
+if [ -f "$TARGET" ]; then
+  TARGET_PATH="$TARGET"
+elif [ -f "$REPO/$TARGET" ]; then
+  TARGET_PATH="$REPO/$TARGET"
+else
+  echo "forge-invariant: target test not found: $TARGET" >&2; exit 2
+fi
+[ -n "$MATCH" ] || { echo "forge-invariant: --match prefix must be non-empty" >&2; exit 2; }
+for v in "$RUNS" "$DEPTH" "$SEED"; do
+  case "$v" in '') ;; *[!0-9]*) echo "forge-invariant: --runs/--depth/--seed must be whole numbers" >&2; exit 2 ;; esac
+done
+
+# --- tool presence ------------------------------------------------------------------------------
+# We do NOT hardcode any install location — the caller exports the toolchain onto PATH.
+command -v forge >/dev/null 2>&1 || {
+  echo "forge-invariant: forge not installed (run foundryup; https://getfoundry.sh)" >&2; exit 2; }
+
+echo "== forge-invariant: stateful-fuzzing $(basename "$TARGET_PATH") (invariants ${MATCH}*) ==" >&2
+
+# Build forge's invariant args. --match-path scopes to exactly this test file; --match-test to the
+# invariant_* functions. A finite seed makes the run reproducible (the demo pins it). forge has no CLI flag
+# for invariant runs/depth — those are tuned via the FOUNDRY_INVARIANT_RUNS / FOUNDRY_INVARIANT_DEPTH env
+# vars (exported below), which override the project's [invariant] config; left to it when unset.
+ARGS=(test --match-path "$TARGET_PATH" --match-test "$MATCH" --json)
+[ -n "$SEED" ] && ARGS+=(--fuzz-seed "$SEED")
+[ -n "$RUNS" ]  && export FOUNDRY_INVARIANT_RUNS="$RUNS"
+[ -n "$DEPTH" ] && export FOUNDRY_INVARIANT_DEPTH="$DEPTH"
+
+# A scratch dir for this run's JSON + parser. Trapped so we never leak temp files.
+TMPD="$(mktemp -d "${TMPDIR:-/tmp}/forge-invariant.XXXXXX")" || { echo "forge-invariant: cannot create temp dir" >&2; exit 2; }
+trap 'rm -rf "$TMPD"' EXIT
+
+# Capture forge's JSON to a file (forge prints the suite object to stdout on --json; build/setup errors go
+# to stderr). forge's own exit status is 1 on a failing test, but we parse the structured output for the
+# verdict rather than trust the code (a compile error and a real finding both exit non-zero — only the
+# parse distinguishes them).
+( cd "$REPO" && forge "${ARGS[@]}" ) >"$TMPD/out.json" 2>"$TMPD/err.txt" || true
+# Re-run WITHOUT --json so the shrunk sequence + traces are visible in logs (stderr). Build the no-json arg
+# list by element so we never mangle a flag (a `${ARR[@]/--json/}` substring substitution leaves an empty
+# element behind). A fixed seed keeps the human run aligned with the json run.
+HUMAN_ARGS=()
+for a in "${ARGS[@]}"; do [ "$a" = "--json" ] || HUMAN_ARGS+=("$a"); done
+( cd "$REPO" && forge "${HUMAN_ARGS[@]}" --fuzz-seed "${SEED:-1}" 1>&2 2>&1 ) || true
+
+banner() { echo "================ FORGE-INVARIANT: $1 ================" >&2; }
+
+# --- parse the verdict from forge's --json ------------------------------------------------------
+# forge --json emits a per-suite object (sometimes several concatenated values): { "<path>:<Contract>": {
+# "test_results": { "<fn>()": { "status": "Success"|"Failure", "counterexample": { "Sequence": [...] } } } } }.
+# We do not depend on jq; a small python reads the structure with a raw_decode loop (robust to a single
+# object OR several concatenated ones), counts ran/failed invariants, and pulls the shrunk sequence text.
+# The JSON is passed as a FILE argument (never stdin) so the heredoc body cannot be confused for input.
+cat > "$TMPD/parse.py" <<'PY'
+import sys, json
+match = sys.argv[1]
+raw = open(sys.argv[2]).read().strip()
+dec = json.JSONDecoder()
+objs = []; idx = 0
+while idx < len(raw):
+    while idx < len(raw) and raw[idx] in ' \t\r\n':
+        idx += 1
+    if idx >= len(raw):
+        break
+    try:
+        obj, end = dec.raw_decode(raw, idx)
+    except Exception:
+        break
+    objs.append(obj); idx = end
+if not objs:
+    print("PARSE_ERROR"); sys.exit(0)
+ran = 0; failed = 0; seqs = []
+for obj in objs:
+    if not isinstance(obj, dict):
+        continue
+    for suite in obj.values():
+        if not isinstance(suite, dict):
+            continue
+        results = suite.get("test_results", {})
+        if not isinstance(results, dict):
+            continue
+        for fn, res in results.items():
+            if not fn.startswith(match):
+                continue
+            ran += 1
+            if (res or {}).get("status", "") == "Failure":
+                failed += 1
+                cex = (res or {}).get("counterexample") or {}
+                seq = cex.get("Sequence") if isinstance(cex, dict) else None
+                # forge nests the sequence as [<n>, [ {step}, ... ]] or just [ {step}, ... ].
+                calls = None
+                if isinstance(seq, list):
+                    for el in seq:
+                        if isinstance(el, list):
+                            calls = el
+                            break
+                    if calls is None and seq and isinstance(seq[0], dict):
+                        calls = seq
+                steps = []
+                for c in (calls or []):
+                    if not isinstance(c, dict):
+                        continue
+                    fn_name = c.get("func_name") or c.get("signature") or "?"
+                    steps.append("%s(%s)  [sender=%s]" % (fn_name, c.get("args", ""), c.get("sender", "")))
+                seqs.append((fn.rstrip("()"), steps))
+print("RAN=%d" % ran)
+print("FAILED=%d" % failed)
+for label, steps in seqs:
+    print("SEQBEGIN=%s" % label)
+    for i, s in enumerate(steps, 1):
+        print("  step %d: %s" % (i, s))
+    print("SEQEND")
+PY
+PARSE="$(python3 "$TMPD/parse.py" "$MATCH" "$TMPD/out.json" 2>/dev/null || true)"
+ERROUT="$(cat "$TMPD/err.txt" 2>/dev/null || true)"
+
+RAN="$(printf '%s\n' "$PARSE" | sed -n 's/^RAN=//p' | head -1)"
+FAILED="$(printf '%s\n' "$PARSE" | sed -n 's/^FAILED=//p' | head -1)"
+case "$RAN" in    ''|*[!0-9]*) RAN=0 ;; esac
+case "$FAILED" in ''|*[!0-9]*) FAILED=0 ;; esac
+
+# A PARSE_ERROR (forge produced no JSON object) or a compile/setup failure means nothing was checked.
+if printf '%s' "$PARSE" | grep -q 'PARSE_ERROR' || [ ! -s "$TMPD/out.json" ]; then
+  banner "HARNESS_ERROR (forge produced no parseable result — compile/setup error or no test ran)"
+  printf '%s\n' "$ERROUT" | grep -iE 'error|compil|panic' | head -5 >&2 || true
+  exit 2
+fi
+
+# No invariant matched the prefix -> nothing was actually fuzzed -> not a verdict.
+if [ "$RAN" -eq 0 ]; then
+  banner "HARNESS_ERROR (no invariant_* function matched '${MATCH}' — nothing was checked)"
+  exit 2
+fi
+
+if [ "$FAILED" -gt 0 ]; then
+  banner "FINDING (${FAILED} invariant(s) broken by a multi-step sequence — reproducible witness below)"
+  # Surface the shrunk exploit sequence(s) so the operator + the .ag can capture them.
+  printf '%s\n' "$PARSE" | awk '
+    /^SEQBEGIN=/ { sub(/^SEQBEGIN=/,""); print "-- broken invariant: " $0 " — shrunk exploit sequence:"; next }
+    /^SEQEND$/   { next }
+    /^RAN=|^FAILED=/ { next }
+    { print }
+  ' >&2
+  exit 1
+fi
+
+banner "CLEAN (${RAN} invariant(s) held across every fuzzed call-sequence — no finding)"
+exit 0

--- a/dark-factory/run-invariant-hunt.sh
+++ b/dark-factory/run-invariant-hunt.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# run-invariant-hunt.sh — STATEFUL-INVARIANT-FUZZING entrypoint for the Dark Factory federation (#1035).
+#
+# The LLM is the HYPOTHESIS GENERATOR; the FUZZER is the JUDGE. For a target this script runs
+# `auditor/agents/invariant-prover.ag` once on the agentis substrate: it env-ins the target (file:fn + class)
+# and the contract source, GENERATES a Foundry stateful-invariant test (a `Handler` exposing the protocol's
+# actions as bounded actor functions + a set of DEEP `invariant_*` properties; verbatim from a supplied
+# HANDLER_FIXTURE on the offline path, or via `prompt()` on the live path), VERIFIES it by driving Foundry's
+# built-in stateful invariant fuzzer through `evm-harness/forge-invariant.sh`, and `print`s an
+# `INVARIANT|<target>|<verdict>` line whose verdict is the FUZZER's exit code — never the LLM's opinion. On a
+# FINDING it also prints the SHRUNK exploit call-sequence (the reproducible witness). Every run is recorded as
+# experience (`learn` + `emit dark-factory:invariant_verdict`) so invariant-prover fitness reweights over
+# targets. It mirrors run-symbolic.sh's per-target substrate loop; the difference is the verdict's SOURCE —
+# stateful fuzzing over call SEQUENCES, the tool built for the multi-step bug a single-function audit misses.
+#
+# A FINDING is a CANDIDATE the fuzzer reproduced — still a LEAD a human triages, NEVER auto-submitted. CLEAN
+# means every deep invariant held across the fuzzed search (no finding in this budget, not a proof). A
+# HARNESS_ERROR (the test did not compile, no invariant matched, or forge is absent) is not a verdict. As
+# everywhere in this colony, submission stays an explicit, human-gated action and this tool NEVER posts to a
+# bounty platform.
+#
+# Usage:
+#   run-invariant-hunt.sh --repo <foundry project> --target <Contract.sol[:Name]> [options]
+#
+# Options:
+#   --repo <dir>         Foundry project root (must hold foundry.toml). REQUIRED — the test is built here.
+#   --target <C.sol[:Name]>  Target contract label (the lens), e.g. "Vault.sol:Vault". REQUIRED.
+#   --class <id>         The bug class id the target is filed under, e.g. "C-erc4626" ("" if unknown).
+#   --handler-fixture <file>  Ready-made invariant `*.t.sol` used VERBATIM (the offline/deterministic path —
+#                        NO LLM). When set the verdict is the fuzzer's over THIS test. Omit = live (LLM) path.
+#   --code <file>        Path to the target contract source the LLM reads to write the handler (live path).
+#                        Defaults to <repo>/src/<Contract.sol> when omitted and a fixture is NOT supplied.
+#   --match <prefix>     Invariant function-name prefix the fuzzer runs (default "invariant").
+#   --backend <mock|flat-cyborg|claude>  LLM backend for the live generation path (default: flat-cyborg =
+#                        flat-rate PTY wrapper; claude = metered -p API; mock = offline wiring smoke). On the
+#                        offline path (a HANDLER_FIXTURE) the LLM is NOT called.
+#   --model <id>         Optional model id (claude: passed to the CLI; flat-cyborg: set as llm.model).
+#   --runs N             Forge invariant runs budget (search width). Default: the project's [invariant] config.
+#   --depth D            Forge invariant depth budget (calls per sequence). Default: the project's config.
+#   --seed S             Forge --fuzz-seed for a reproducible search. Default: forge's own seed.
+#   --out <dir>          Output dir for the run + report (default: ./invariant-out).
+#   --agentis <bin>      agentis binary (default: `agentis` on PATH).
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+AGENTIS="agentis"
+REPO="" ; TARGET="" ; CLASS="" ; FIXTURE="" ; CODE="" ; MATCH="invariant"
+BACKEND="flat-cyborg" ; MODEL="" ; RUNS="" ; DEPTH="" ; SEED="" ; OUT="$PWD/invariant-out"
+
+need() { [ "$1" -ge 2 ] || { echo "run-invariant-hunt.sh: missing value for the preceding flag" >&2; exit 2; }; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) need "$#"; REPO="$2"; shift 2 ;;
+    --target) need "$#"; TARGET="$2"; shift 2 ;;
+    --class) need "$#"; CLASS="$2"; shift 2 ;;
+    --handler-fixture) need "$#"; FIXTURE="$2"; shift 2 ;;
+    --code) need "$#"; CODE="$2"; shift 2 ;;
+    --match) need "$#"; MATCH="$2"; shift 2 ;;
+    --backend) need "$#"; BACKEND="$2"; shift 2 ;;
+    --model) need "$#"; MODEL="$2"; shift 2 ;;
+    --runs) need "$#"; RUNS="$2"; shift 2 ;;
+    --depth) need "$#"; DEPTH="$2"; shift 2 ;;
+    --seed) need "$#"; SEED="$2"; shift 2 ;;
+    --out) need "$#"; OUT="$2"; shift 2 ;;
+    --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
+    --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
+    *) echo "run-invariant-hunt.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$REPO" ] && [ -d "$REPO" ] || { echo "run-invariant-hunt.sh: --repo <foundry project root> required" >&2; exit 2; }
+[ -f "$REPO/foundry.toml" ] || { echo "run-invariant-hunt.sh: --repo is not a foundry project (no foundry.toml): $REPO" >&2; exit 2; }
+[ -n "$TARGET" ] || { echo "run-invariant-hunt.sh: --target <Contract.sol[:Name]> required" >&2; exit 2; }
+[ -n "$MATCH" ] || { echo "run-invariant-hunt.sh: --match prefix must be non-empty" >&2; exit 2; }
+for v in "$RUNS" "$DEPTH" "$SEED"; do
+  case "$v" in '') ;; *[!0-9]*) echo "run-invariant-hunt.sh: --runs/--depth/--seed must be whole numbers" >&2; exit 2 ;; esac
+done
+command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-invariant-hunt.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
+
+# Resolve operator paths to ABSOLUTE — the colony runs from the rundir (a different cwd) and the exec sandbox
+# cannot read $HOME, so a relative or home-rooted path would silently read empty. We build the test inside the
+# rundir's copy of --repo so the sandbox can always reach it.
+REPO="$(cd "$REPO" && pwd)"
+if [ -n "$FIXTURE" ]; then
+  [ -f "$FIXTURE" ] || { echo "run-invariant-hunt.sh: --handler-fixture not found: $FIXTURE" >&2; exit 2; }
+  FIXTURE="$(cd "$(dirname "$FIXTURE")" && pwd)/$(basename "$FIXTURE")"
+fi
+# Default the code path to <repo>/src/<Contract.sol> on the live path (the LLM reads it to write the handler).
+if [ -z "$FIXTURE" ] && [ -z "$CODE" ]; then
+  _c="${TARGET%%:*}"
+  [ -f "$REPO/src/$_c" ] && CODE="$REPO/src/$_c"
+fi
+if [ -n "$CODE" ]; then
+  [ -f "$CODE" ] || { echo "run-invariant-hunt.sh: --code not found: $CODE" >&2; exit 2; }
+  CODE="$(cd "$(dirname "$CODE")" && pwd)/$(basename "$CODE")"
+fi
+
+PROVER="$HERE/auditor/agents/invariant-prover.ag"
+GATE="$HERE/evm-harness/forge-invariant.sh"
+[ -f "$PROVER" ] || { echo "run-invariant-hunt.sh: invariant-prover agent not found at $PROVER" >&2; exit 3; }
+[ -f "$GATE" ] || { echo "run-invariant-hunt.sh: forge-invariant gate not found at $GATE" >&2; exit 3; }
+
+mkdir -p "$OUT"; OUT="$(cd "$OUT" && pwd)"
+RUN="$OUT/run"
+rm -rf "$RUN"; mkdir -p "$RUN"
+cp "$PROVER" "$RUN/invariant-prover.ag"
+cp "$GATE" "$RUN/forge-invariant.sh"
+# Stage a fresh copy of the foundry project into the rundir so the sandboxed exec sh can write the test into
+# its test/ dir and run forge there (it cannot reach a $HOME-rooted --repo). Drop any pre-existing *.t.sol so
+# the generated test is the ONLY one the fuzzer scopes to.
+REPO_IN_RUN="$RUN/repo"
+cp -R "$REPO" "$REPO_IN_RUN"
+rm -f "$REPO_IN_RUN/test/"*.t.sol 2>/dev/null || true
+mkdir -p "$REPO_IN_RUN/test"
+
+# Stage the (optional) fixture + code into the rundir so the sandboxed reader can reach them.
+FIXTURE_IN_RUN=""
+if [ -n "$FIXTURE" ]; then
+  cp "$FIXTURE" "$RUN/handler-fixture.t.sol"
+  FIXTURE_IN_RUN="$RUN/handler-fixture.t.sol"
+fi
+CODE_IN_RUN=""
+if [ -n "$CODE" ]; then
+  cp "$CODE" "$RUN/target-code.sol"
+  CODE_IN_RUN="$RUN/target-code.sol"
+fi
+
+# init the agentis store FIRST (before any .agentis/ subdir exists), else HEAD is not set.
+( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
+{
+  echo "llm.backend = $BACKEND"
+  # 600s: writing a stateful-invariant handler for a real protocol is the same order of cost as a discovery read.
+  [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p${MODEL:+ --model $MODEL}"; echo "llm.cli_timeout_ms = 600000"; }
+  [ "$BACKEND" = "flat-cyborg" ] && { echo "llm.cli_timeout_ms = 600000"; [ -n "$MODEL" ] && echo "llm.model = $MODEL"; }
+  echo "trace.level = normal"
+  # The prover reads code + the fixture and writes/runs the test through exec sh; pass its whole env contract.
+  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT"
+  # A forge invariant run (build + a few hundred fuzzed sequences) far exceeds the 10s default.
+  echo "exec.default_timeout_ms = 600000"
+  # Each verify is recorded as experience; invariant-prover fitness reweights over targets.
+  echo "learning.enabled = true"
+  echo "experience.enabled = true"
+} > "$RUN/.agentis/config"
+
+SLUG="$(printf '%s' "$TARGET" | tr -cs 'A-Za-z0-9' '_' | sed 's/_*$//')"
+INV_OUT="$REPO_IN_RUN/test/Inv_${SLUG}.t.sol"
+CELL_LOG="$RUN/invariant_${SLUG}.log"
+
+echo "run-invariant-hunt.sh: generating + stateful-fuzzing $TARGET ($CLASS) ..." >&2
+( cd "$RUN" && env \
+    TARGET_FN="$TARGET" \
+    TARGET_CLASS="$CLASS" \
+    INV_REPO="$REPO_IN_RUN" \
+    INV_OUT="$INV_OUT" \
+    INV_MATCH="$MATCH" \
+    HANDLER_FIXTURE="$FIXTURE_IN_RUN" \
+    CODE_PATH="$CODE_IN_RUN" \
+    INV_RUNS="$RUNS" \
+    INV_DEPTH="$DEPTH" \
+    INV_SEED="$SEED" \
+    FORGE_INVARIANT="$RUN/forge-invariant.sh" \
+    "$AGENTIS" go invariant-prover.ag --enable-exec --enable-messaging ) >"$CELL_LOG" 2>&1 || \
+    echo "run-invariant-hunt.sh: invariant-prover run failed for '$TARGET' (see $CELL_LOG)" >&2
+
+# The prover's contract: exactly one `INVARIANT|<file:fn>|<verdict>` line, then (on a FINDING) `STEP|...`
+# lines. Take the LAST verdict match. No line at all = treat as HARNESS_ERROR (no verdict was produced).
+VLINE="$(grep 'INVARIANT|' "$CELL_LOG" | tail -1 || true)"
+if [ -z "$VLINE" ]; then
+  VERD="HARNESS_ERROR"
+else
+  VERD="$(printf '%s' "$VLINE" | sed 's/.*INVARIANT|//' | cut -d'|' -f2)"
+fi
+case "$VERD" in
+  FINDING|CLEAN|HARNESS_ERROR) ;;
+  *) VERD="HARNESS_ERROR" ;;
+esac
+# Collect the shrunk exploit sequence (the STEP| lines) the prover printed on a FINDING.
+STEPS="$(grep '^STEP|' "$CELL_LOG" | sed 's/^STEP|//' || true)"
+
+GEN_KIND="generated(LLM)"; [ -n "$FIXTURE_IN_RUN" ] && GEN_KIND="fixture"
+
+REPORT="$OUT/invariant-report.md"
+{
+  echo "# Dark Factory — stateful-invariant-fuzzing verdicts"
+  echo
+  echo "- backend: $BACKEND"
+  echo "- The LLM HYPOTHESIZES (writes the handler + the deep invariants); the FUZZER JUDGES (the verdict is"
+  echo "  its exit code over randomized multi-call sequences, never the LLM's opinion). FINDING = an invariant"
+  echo "  broke under a concrete SHRUNK call-sequence (a CANDIDATE with a reproducible witness); CLEAN = every"
+  echo "  invariant held across the fuzzed search (no finding in this budget, NOT a proof); HARNESS_ERROR is"
+  echo "  not a verdict. A FINDING is a LEAD a human triages — this colony NEVER auto-submits."
+  echo
+  echo "| Target | Class | Handler | Verdict |"
+  echo "|---|---|---|---|"
+  printf '| %s | %s | %s | %s |\n' "$TARGET" "$CLASS" "$GEN_KIND" "$VERD"
+  echo
+  if [ "$VERD" = "FINDING" ] && [ -n "$STEPS" ]; then
+    echo "## Shrunk exploit call-sequence (the fuzzer's reproducible witness)"
+    echo
+    echo '```'
+    printf '%s\n' "$STEPS"
+    echo '```'
+    echo
+    echo "A human triages this candidate before any submission. This colony never posts."
+  fi
+} > "$REPORT"
+
+echo >&2
+echo "================ INVARIANT-HUNT: $TARGET -> $VERD ================" >&2
+echo "run-invariant-hunt.sh: verdict + any witness at $REPORT" >&2
+if [ "$VERD" = "FINDING" ]; then
+  echo "run-invariant-hunt.sh: a multi-step invariant was BROKEN — the shrunk exploit sequence is a reproducible witness a human triages. This colony never auto-submits." >&2
+elif [ "$VERD" = "CLEAN" ]; then
+  echo "run-invariant-hunt.sh: every deep invariant held across the fuzzed search — no finding in this budget (not a proof of safety). Nothing to triage." >&2
+else
+  echo "run-invariant-hunt.sh: HARNESS_ERROR — the test did not compile / no invariant matched / forge absent. No verdict was produced." >&2
+fi


### PR DESCRIPTION
## What

Closes #1035 — a **stateful-invariant-fuzzing bounty hunter**. Bounty targets are audited+fixed+deployed code; the game is finding the bug the audits **missed**. Single-function symbolic-exec (the #1015 Halmos path) duplicates audits — it finds sound code or dust. Real audit-surviving bugs are **deep, multi-step, stateful**: emergent invariant violations across **sequences** of operations (e.g. the ERC4626 inflation attack). This adds the right engine.

## How (generate-and-verify, with the verifier = stateful fuzzing)

- `evm-harness/forge-invariant.sh` — the verdict gate: runs Foundry's stateful invariant fuzzer (`forge test --match-test invariant --json`, runs/depth via `FOUNDRY_INVARIANT_RUNS/_DEPTH`, `--seed` for reproducibility), parses without `jq`, returns **FINDING** (exit 1 + the shrunk exploit call-sequence) / **CLEAN** (exit 0) / **HARNESS_ERROR** (exit 2). Tests are forge-std-free so they compile in any project.
- `auditor/agents/invariant-prover.ag` — the third generate-and-verify sibling: **GENERATES** the handler + deep invariants (verbatim `HANDLER_FIXTURE` offline, or `prompt()` live), writes the untrusted test **injection-safely** (`printf '%s' <shell_escape>`, never a heredoc), runs the gate, maps its exit code to the verdict. **The verdict is the fuzzer's concrete failing sequence, never the LLM's opinion.** Never auto-submits — a human triages every candidate.
- `run-invariant-hunt.sh` — operator entry. `demo-invariant-hunt.sh` — offline proof.

## Verification

- **`demo-invariant-hunt.sh`** — the vulnerable inflation vault → **FINDING** with the textbook shrunk exploit (`attackerDonate(3e29) → attackerSeed() → victimDeposit(7e5)` mints 0 shares → victim robbed); the hardened twin (virtual shares) → **CLEAN** across **4 seeds** (not seed-luck — no false positive).
- Verdict provably from the fuzzer, not the LLM (QA traced the verdict-source isolation); a live `flat-cyborg` run had the LLM generate a compiling 294-line handler the fuzzer then broke.
- Injection-safe (a malicious fixture is written verbatim, not executed); `check-exec-sh` clean; **`colony-lint.sh` → 367 / 0 / 5**.

Part of #1035 — the engine; coordinator-routing + scaling across targets is the integration follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
