### PR TITLE
feat(dark-factory): coordinator live-drives the stateful-invariant fuzzer (Int M1, #1037)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -27,7 +27,7 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
     at **base 94** (below `refute`(100) / `poc-screen`(98) / `symbolic-prove`(96) — the stateful fuzzer is the
     most EXPENSIVE verify, a multi-call sequence search, so the cheaper verifies go first by default), with the
     **steep ×4 policy term** so the colony can **learn** to lift it above the others (`94 + 4 × policy` beats
-    `refute`(100) at policy ≥ 1.5); a pending candidate still outranks any fresh hunt. The 3-way VERIFY argmax
+    `refute`(100) at policy > 1.5); a pending candidate still outranks any fresh hunt. The 3-way VERIFY argmax
     is refactored to a single-assignment **4-way climbing argmax** that preserves the default ordering
     `refute > poc-screen > symbolic-prove > invariant-hunt` on ties. It operates on the first pending candidate
     (args = the candidate id) and consumes it from `PENDING`.

--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,59 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **The self-orchestrating coordinator AUTONOMOUSLY chooses + LIVE-runs the stateful-invariant fuzzer — a new
+  `invariant-hunt` action, end-to-end** (Integration M1, #1037). #1035 shipped the fuzzer as a *callable
+  engine* (an operator runs `run-invariant-hunt.sh`); Int M1 wires it into the #1014 self-orchestrating
+  coordinator so the **federation itself CHOOSES** to spend it and LIVE-runs it on a target — finding the
+  multi-step bug without an operator picking the engine. This mirrors EXACTLY how `symbolic-prove` was added
+  as a VERIFY-tier action (#1015 M3) and given a live route (#1032).
+  - `auditor/agents/coordinator.ag` — a new `invariant-hunt` action in the VERIFY tier (alongside
+    `refute`/`poc-screen`/`symbolic-prove`): `is_action` accepts it, a new `score_invariant(policy)` scores it
+    at **base 94** (below `refute`(100) / `poc-screen`(98) / `symbolic-prove`(96) — the stateful fuzzer is the
+    most EXPENSIVE verify, a multi-call sequence search, so the cheaper verifies go first by default), with the
+    **steep ×4 policy term** so the colony can **learn** to lift it above the others (`94 + 4 × policy` beats
+    `refute`(100) at policy ≥ 1.5); a pending candidate still outranks any fresh hunt. The 3-way VERIFY argmax
+    is refactored to a single-assignment **4-way climbing argmax** that preserves the default ordering
+    `refute > poc-screen > symbolic-prove > invariant-hunt` on ties. It operates on the first pending candidate
+    (args = the candidate id) and consumes it from `PENDING`.
+  - **The LIVE route:** a new branch in `action_outcome` — when `invariant-hunt` is chosen AND no
+    `DISPATCH_FIXTURE` matched AND a live invariant env is present (`FORGE_INVARIANT` gate + `INV_REPO` foundry
+    dir + `INV_TARGET` invariant test), `run_invariant_live()` `exec sh`-runs `forge-invariant.sh --repo …
+    --target … --match … [--runs/--depth/--seed]` (optional budgets appended only when non-empty, every value
+    `shell_escape()`d), captures the exit code via the `__rc=$?` marker, and maps it **1 → confirmed** (FINDING,
+    a real multi-step bug with a shrunk witness), **0 → refuted** (CLEAN, the lead is killed in this budget),
+    **2/other → dry** (HARNESS_ERROR). The mapping is IDENTICAL to the symbolic route, so it **reuses**
+    `sym_rc_of`/`sym_outcome_of`. The branch is **purely additive** — absent any of the three env facts it
+    falls through to the existing honest stub, so behaviour with no live env is **byte-identical**. The verdict
+    is forge's shrunk witness, **never the LLM** — the **CHOICE** of engine is the policy's, the **VERDICT** is
+    the fuzzer's.
+  - The in-substrate orchestrate loop carries a 6th policy int (field 21) + seen flag (field 22) for
+    `invariant-hunt`, appended **after** the symbolic-prove fields so positions 0–20 are unchanged; a new
+    `INV_POLICY_TT` env fact (ten-thousandths) seeds the loop's initial `invariant-hunt` policy so the
+    coordinator can choose it from step 0 (exactly as `SYM_POLICY_TT` seeds `symbolic-prove`). `policy_string`
+    sorts `invariant-hunt` between `hunt` and `invent-method` (`inva` < `inve`), so a run that never touches it
+    renders the same string as before. `auditor/agents/dispatcher.ag` carries the byte-identical `is_action`
+    update (the `demo-dispatch.sh` sync-guard asserts the two copies do not drift). **With `ORCHESTRATE_ENABLED`
+    absent the single-decision path is byte-identical to before** (the new action never wins any
+    `demo-coordinator.sh` fact-state without a seeded policy).
+  - `run-autonomous-hunt.sh` — operator entrypoint mirroring `demo-symbolic-orchestrate-live.sh`'s driver.
+    `--repo <foundry-root> --target <Invariant.t.sol> [--match <prefix>] [--backend <b>] [--runs N] [--depth D]
+    [--seed S] [--steps N] [--out <dir>]`. Resolves `evm-harness/forge-invariant.sh` relative to `$0` into
+    `FORGE_INVARIANT`, builds a fresh agentis store, seeds a pending candidate for the target + `INV_POLICY_TT`
+    (= +2.0, representing the policy a prior run would have evolved), exports the LIVE env, runs ONE
+    `agentis go coordinator.ag --enable-exec --enable-messaging` in ORCHESTRATE mode, prints the autonomous
+    decision trail (`ACTION|`/`DISPATCH|`) + the final `coordinator:last_outcome` verdict.
+  - `demo-autonomous-hunt.sh` — offline-deterministic proof. Reuses `demo-invariant-hunt.sh`'s inflation-vault
+    + hardened-twin scaffolding (same contracts/handler/invariant), drives **`run-autonomous-hunt.sh`** (not
+    the fuzzer directly) on each, and asserts: (A) the coordinator AUTONOMOUSLY emitted `ACTION|invariant-hunt|`
+    (the coordinator chose the engine, not the operator), (B) `DISPATCH|invariant-hunt|…|confirmed` for the
+    vulnerable vault + `…|refuted` for the hardened twin (the LIVE fuzzer's verdict), (C) a `learn` for
+    `invariant-hunt` referencing the verdict appears in the store on the step AFTER the verdict (outcome →
+    policy). `[SKIP]` + exit 0 when forge/agentis are absent (CI convention).
+  - `docs/autonomous-hunt.md` — the end-to-end flow (coordinator chooses → live forge-invariant → sound verdict
+    → policy evolves), the verdict→outcome mapping, and the human-gated submit boundary. Wired into `README.md`
+    (`## Hunt autonomously (run-autonomous-hunt.sh, Int M1)` + the Layout map). **Requires:** foundry (forge)
+    for a real run; optional for the rest of the federation.
 - **The stateful-invariant-fuzzing bounty hunter — finds the MULTI-STEP bugs single-function symbolic exec
   misses** (#1035). The symbolic gate (#1015) proves a property over all inputs of ONE function; the refuter
   (#999) is a hostile LLM read of ONE claim. Both miss the **multi-step, stateful** bug — the ERC4626

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -396,6 +396,29 @@ many targets are follow-up. See [`docs/invariant-hunt.md`](./docs/invariant-hunt
 verdict-source contract, the fixture-vs-LLM paths, the deep-invariant taxonomy, and how it relates to the
 symbolic gate (#1015) and the discovery method-gap (#1033).
 
+## Hunt autonomously (`run-autonomous-hunt.sh`, Int M1)
+
+The fuzzer above is an **engine** an operator calls directly. Integration M1 (#1037) wires it into the
+self-orchestrating coordinator so the **federation itself CHOOSES** to spend it: you hand the coordinator a
+target and it routes the candidate through a new `invariant-hunt` VERIFY action — by its evolving **policy** (a
+policy-weighted argmax, never a fixed sequence) — then LIVE-runs the REAL forge invariant fuzzer and maps its
+exit code to the SOUND outcome (`FINDING → confirmed`, `CLEAN → refuted`, `HARNESS_ERROR → dry`). The
+**CHOICE** of engine is the coordinator's policy; the **VERDICT** is the fuzzer's shrunk witness — never the
+LLM. This mirrors exactly how `symbolic-prove` was given a live coordinator route (#1032).
+
+```bash
+dark-factory/run-autonomous-hunt.sh --repo "$PWD/target" --target test/Invariant.t.sol --seed 1
+# offline-deterministic proof (real fuzzer, inflation-vault + hardened twin; SKIPs without forge/agentis):
+dark-factory/demo-autonomous-hunt.sh
+```
+
+`invariant-hunt` sits in the VERIFY tier below `refute`(100) / `poc-screen`(98) / `symbolic-prove`(96) at base
+**94** (the stateful fuzzer is the most expensive verify); its ×4 policy term lets the colony learn to lift it.
+A FINDING is a **LEAD a human triages**, never an auto-submission — the coordinator decides *which engine to
+spend*, the fuzzer decides *whether the bug reproduces*, a human decides *whether to submit*; this colony never
+posts. See [`docs/autonomous-hunt.md`](./docs/autonomous-hunt.md) for the end-to-end flow, the verdict→outcome
+mapping, and the human-gated submit boundary.
+
 ## Exercise the evolve/fitness loop (`evolve-fitness.sh`)
 
 Every hunt the colony runs records a `learn("hunt", "<class>:<subsystem>", ..., outcome, [...])` row in
@@ -477,6 +500,7 @@ dark-factory/
   run-symbolic.sh               # operator entrypoint: GENERATE a Halmos spec per candidate + VERIFY it (#1015 M2)
   run-invariant-hunt.sh         # operator entrypoint: GENERATE a Foundry stateful-invariant test + VERIFY it with the fuzzer (#1035)
   run-coordinator.sh            # bootstrap for the self-orchestrating loop (ONE agentis go; the loop lives in-substrate; #1014 M3)
+  run-autonomous-hunt.sh        # integration: the coordinator CHOOSES + LIVE-runs the stateful fuzzer on a target (Int M1, #1037)
   demo-coordinator.sh           # offline, deterministic proof of the #1014 fact-driven + evolving-policy loop
   demo-dispatch.sh              # offline, deterministic proof of the #1014 M2 substrate DISPATCH (every action type)
   demo-orchestrate.sh           # offline, deterministic proof of the #1014 M3 in-substrate loop (byte-identical to the M2 shell loop)
@@ -489,6 +513,7 @@ dark-factory/
   demo-symbolic.sh              # offline-deterministic proof of the #1015 M2 generate-and-verify loop (fixture spec + real Halmos; SKIPs without the toolchain)
   demo-symbolic-orchestrate.sh  # offline, deterministic proof of the #1015 M3 coordinator routing a candidate to the sound symbolic engine
   demo-invariant-hunt.sh        # offline-deterministic proof of the #1035 stateful-fuzzing loop (vulnerable -> FINDING, hardened -> CLEAN; SKIPs without forge)
+  demo-autonomous-hunt.sh       # offline-deterministic proof of the Int M1 autonomous hunt (coordinator CHOOSES + LIVE-runs the fuzzer; SKIPs without forge)
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)
@@ -523,6 +548,7 @@ dark-factory/
   docs/halmos.md                # the Halmos gate's verdict/exit contract, toolchain install, epic fit (#1015)
   docs/generate-verify.md       # the #1015 M2 generate-and-verify loop: LLM hypothesizes, Halmos proves; verdict-source contract
   docs/invariant-hunt.md        # the #1035 stateful-invariant-fuzzing loop: LLM writes deep invariants, the fuzzer finds the multi-step exploit; verdict-source contract
+  docs/autonomous-hunt.md       # the Int M1 (#1037) end-to-end: coordinator CHOOSES (policy) + LIVE-runs the fuzzer; verdict->outcome mapping; human-gated submit boundary
   sealevel/                     # modernized coral-xyz/sealevel-attacks lessons (corpus) (V6)
   fixtures/                     # detection fixtures (vuln + safe + rigged-harness cases)
 ```

--- a/dark-factory/auditor/agents/coordinator.ag
+++ b/dark-factory/auditor/agents/coordinator.ag
@@ -160,8 +160,9 @@ fn score_symbolic(policy: string) -> float {
 // EXPENSIVE verify of the four (a multi-call search, not a single-input proof), so by DEFAULT the cheaper
 // LLM-read refute, the cheap eval_ag poc-screen, and the single-function symbolic-prove are tried first. The
 // policy term (x4, the same steep multiplier the symbolic tier uses) lets the colony LEARN that the fuzzer's
-// witness pays off and lift invariant-hunt ABOVE symbolic-prove (at policy >= 0.5), poc-screen (at >= 1.0),
-// or refute (at >= 1.5) — `coordinator:policy:invariant-hunt` is the cumulative experience delta, exactly
+// witness pays off and lift invariant-hunt ABOVE symbolic-prove (at policy > 0.5), poc-screen (at > 1.0),
+// or refute (at > 1.5) — the argmax compares with strict `>`, so a score that exactly ties an opponent's
+// base resolves to that higher-base opponent. `coordinator:policy:invariant-hunt` is the cumulative experience delta, exactly
 // like the other action types, so the choice is policy-evolvable. Default ordering WITHIN the VERIFY tier:
 // refute(100) > poc-screen(98) > symbolic-prove(96) > invariant-hunt(94); the policy re-sorts within it as
 // the engine earns its keep.

--- a/dark-factory/auditor/agents/coordinator.ag
+++ b/dark-factory/auditor/agents/coordinator.ag
@@ -37,8 +37,9 @@ cb 2000000;
 //   LAST_OUTCOME  the gate verdict for the previous action: "confirmed" | "dry" | "refuted" | "" (none)
 // Stdout: exactly one line
 //   ACTION|<type>|<args>|<rationale citing the facts that drove it>
-//   where <type> in {hunt, refute, poc-screen, invent-method, stop}; <args> is `subsystem|class` for
-//   hunt, the candidate id for refute/poc-screen, "" for invent-method/stop.
+//   where <type> in {hunt, refute, poc-screen, symbolic-prove, invariant-hunt, invent-method, stop}; <args>
+//   is `subsystem|class` for hunt, the candidate id for refute/poc-screen/symbolic-prove/invariant-hunt, ""
+//   for invent-method/stop.
 
 // --- single-assignment helpers (no `let` reassignment; pure accumulators, per hunter.ag) ----------
 
@@ -148,6 +149,24 @@ fn score_poc(policy: string) -> float {
 // the policy re-sorts within it as the engine earns its keep.
 fn score_symbolic(policy: string) -> float {
     return 96.0 + (4.0 * fit_value(policy, "symbolic-prove"));
+}
+
+// Score an `invariant-hunt` of a pending candidate (Int M1, #1037). Same VERIFY tier as refute/poc-screen/
+// symbolic-prove (all "verify a pending lead" before more hunting), so a pending candidate present still
+// outranks any fresh hunt. Base 96 BELOW refute(100)/poc-screen(98)/symbolic-prove(96)... — BASE 94 keeps the
+// default tier ordering refute(100) > poc-screen(98) > symbolic-prove(96) > invariant-hunt(94): routing a
+// candidate through the STATEFUL invariant fuzzer GENERATES a Foundry handler + deep invariants and drives
+// Foundry's invariant fuzzer over randomized call-SEQUENCES (forge-invariant.sh / the #1035 gate), the most
+// EXPENSIVE verify of the four (a multi-call search, not a single-input proof), so by DEFAULT the cheaper
+// LLM-read refute, the cheap eval_ag poc-screen, and the single-function symbolic-prove are tried first. The
+// policy term (x4, the same steep multiplier the symbolic tier uses) lets the colony LEARN that the fuzzer's
+// witness pays off and lift invariant-hunt ABOVE symbolic-prove (at policy >= 0.5), poc-screen (at >= 1.0),
+// or refute (at >= 1.5) — `coordinator:policy:invariant-hunt` is the cumulative experience delta, exactly
+// like the other action types, so the choice is policy-evolvable. Default ordering WITHIN the VERIFY tier:
+// refute(100) > poc-screen(98) > symbolic-prove(96) > invariant-hunt(94); the policy re-sorts within it as
+// the engine earns its keep.
+fn score_invariant(policy: string) -> float {
+    return 94.0 + (4.0 * fit_value(policy, "invariant-hunt"));
 }
 
 // Score hunting a `subsystem|class` cell. Base 50; +20 if a sibling already posted a lead for this
@@ -295,13 +314,15 @@ fn is_verdict(v: string) -> bool {
 }
 
 // Is `t` a real (dispatchable) action type? `stop` is terminal and never dispatched. Leaf compares.
-// `symbolic-prove` (#1015 M3) routes a pending candidate through the SOUND symbolic engine; it is a real
-// verify action and so is dispatched like refute/poc-screen.
+// `symbolic-prove` (#1015 M3) routes a pending candidate through the SOUND symbolic engine; `invariant-hunt`
+// (Int M1, #1037) routes a pending candidate through the STATEFUL invariant fuzzer; both are real verify
+// actions and so are dispatched like refute/poc-screen.
 fn is_action(t: string) -> bool {
     if t == "hunt" { return true; }
     if t == "refute" { return true; }
     if t == "poc-screen" { return true; }
     if t == "symbolic-prove" { return true; }
+    if t == "invariant-hunt" { return true; }
     if t == "invent-method" { return true; }
     return false;
 }
@@ -351,14 +372,50 @@ fn run_symbolic_live() -> string {
     return sym_outcome_of(rc);
 }
 
+// === Int M1 (#1037): the LIVE invariant-hunt route — run the REAL stateful fuzzer and map its SOUND verdict.
+// Mirrors run_symbolic_live() but drives evm-harness/forge-invariant.sh (the #1035 gate) instead of Halmos:
+// forge fuzzes randomized call-SEQUENCES through a generated Handler and re-checks each deep invariant. The
+// gate's exit-code -> coordinator-outcome mapping is IDENTICAL to the symbolic one (1=FINDING -> confirmed,
+// 0=CLEAN -> refuted, 2/else=HARNESS_ERROR -> dry), so we REUSE sym_rc_of/sym_outcome_of. The verdict is the
+// fuzzer's shrunk witness (forge's exit code), NEVER the LLM — that soundness is the whole point. The gate's
+// own default invariant prefix is `invariant`; default to it when INV_MATCH is unset (invariant-prover.ag's
+// match_prefix). INV_RUNS/INV_DEPTH/INV_SEED are OPTIONAL forge budgets, appended as --runs/--depth/--seed
+// only when non-empty (built exactly like invariant-prover.ag's `budget` concat), each value shell_escape()d.
+fn inv_match_prefix(raw: string) -> string {
+    if len(raw) == 0 { return "invariant"; }
+    return raw;
+}
+fn inv_opt_flag(flag: string, val: string) -> string {
+    if len(val) == 0 { return ""; }
+    return " " + flag + " " + shell_escape(val);
+}
+fn run_invariant_live() -> string {
+    let gate = getenv("FORGE_INVARIANT");
+    let repo = getenv("INV_REPO");
+    let target = getenv("INV_TARGET");
+    let match = inv_match_prefix(getenv("INV_MATCH"));
+    let budget = inv_opt_flag("--runs", getenv("INV_RUNS")) + inv_opt_flag("--depth", getenv("INV_DEPTH"))
+               + inv_opt_flag("--seed", getenv("INV_SEED"));
+    // colony-lint: safe-exec-concat
+    let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --repo " + shell_escape(repo)
+               + " --target " + shell_escape(target) + " --match " + shell_escape(match) + budget
+               + " 2>&1; echo __rc=$?";
+    let rc = sym_rc_of(runOut);
+    return sym_outcome_of(rc);
+}
+
 // Derive the gate OUTCOME for an action of `<type>` with `<args>`. Offline (DISPATCH_FIXTURE set, or the
 // M1 HUNT_FIXTURE alias for a hunt) -> the fixture rule, NO prompt()/LLM. The LIVE symbolic-prove route
 // (#1032): when `symbolic-prove` is chosen AND no fixture matched AND a live symbolic env is present (a
 // SYM_REPO foundry dir + a SYM_SPEC target spec + the HALMOS_VERIFY gate path), run REAL Halmos and map its
 // SOUND exit code (1->confirmed, 0->refuted, 3/2/other->dry) — the verdict is the solver's, never the LLM's.
-// This branch is PURELY ADDITIVE: absent any of the three env facts it falls through to the existing honest
-// stub, so behaviour with no live env is byte-identical. Otherwise the LIVE path is an honest per-type stub
-// that says what real wiring it needs (mirrors run-coordinator.sh::real_outcome) and returns a benign `dry`.
+// The LIVE invariant-hunt route (Int M1, #1037): when `invariant-hunt` is chosen AND no fixture matched AND a
+// live invariant env is present (an INV_REPO foundry dir + an INV_TARGET invariant test + the FORGE_INVARIANT
+// gate path), run the REAL stateful fuzzer and map its exit code (1->confirmed, 0->refuted, 2/other->dry) —
+// the verdict is forge's shrunk witness, never the LLM's. Both LIVE branches are PURELY ADDITIVE: absent any
+// of their three env facts they fall through to the existing honest stub, so behaviour with no live env is
+// byte-identical. Otherwise the LIVE path is an honest per-type stub that says what real wiring it needs
+// (mirrors run-coordinator.sh::real_outcome) and returns a benign `dry`.
 fn action_outcome(atype: string, args: string) -> string {
     let fixture = getenv("DISPATCH_FIXTURE");
     if len(fixture) > 0 {
@@ -392,7 +449,25 @@ fn action_outcome(atype: string, args: string) -> string {
             }
         }
     }
-    print("coordinator: LIVE " + atype + " of '" + args + "' needs its real wiring (hunt: TARGET_DIR/IN_SCOPE/SCOPE_BRIEF/TAXONOMY/SLICER per run-discovery.sh/hunter.ag; refute->run-refute.sh; poc-screen->screen-leads.sh; symbolic-prove->run-symbolic.sh; invent-method->run-method-discovery.sh); set DISPATCH_FIXTURE for the offline-deterministic path. No real action attempted.");
+    // LIVE invariant-hunt (Int M1, #1037): an operator-supplied single-candidate context (INV_REPO foundry dir
+    // + INV_TARGET invariant `*.t.sol` + the FORGE_INVARIANT gate path) routes the chosen candidate through the
+    // REAL stateful fuzzer end-to-end inside the loop. All three must be present; otherwise this falls through
+    // to the honest stub (additive — no live env = unchanged behaviour). The verdict is forge's shrunk witness
+    // (its exit code), mapped FINDING->confirmed / CLEAN->refuted / HARNESS_ERROR->dry — never an LLM judgement.
+    if atype == "invariant-hunt" {
+        let gate = getenv("FORGE_INVARIANT");
+        let repo = getenv("INV_REPO");
+        let target = getenv("INV_TARGET");
+        if len(gate) > 0 {
+            if len(repo) > 0 {
+                if len(target) > 0 {
+                    print("coordinator: LIVE invariant-hunt of '" + args + "' -> running the REAL stateful fuzzer via " + gate + " on " + target + " (verdict = forge's shrunk witness; the LLM never judges).");
+                    return run_invariant_live();
+                }
+            }
+        }
+    }
+    print("coordinator: LIVE " + atype + " of '" + args + "' needs its real wiring (hunt: TARGET_DIR/IN_SCOPE/SCOPE_BRIEF/TAXONOMY/SLICER per run-discovery.sh/hunter.ag; refute->run-refute.sh; poc-screen->screen-leads.sh; symbolic-prove->run-symbolic.sh; invariant-hunt->run-invariant-hunt.sh; invent-method->run-method-discovery.sh); set DISPATCH_FIXTURE for the offline-deterministic path. No real action attempted.");
     return "dry";
 }
 
@@ -446,21 +521,24 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
 
     // --- DECIDE: build the option list, score each from FACTS+POLICY, rank, and let `decide` select the top.
     // `stop` short-circuits the ranking when budget is exhausted or K consecutive dry — a hard fact gate.
-    // The verify tier (pending candidate present): refute, poc-screen, and symbolic-prove (#1015 M3) of the
-    // first pending candidate — the colony picks the highest-scored of the three (default ordering
-    // refute > poc-screen > symbolic-prove; the evolving policy can re-sort within the tier).
+    // The verify tier (pending candidate present): refute, poc-screen, symbolic-prove (#1015 M3), and
+    // invariant-hunt (Int M1, #1037) of the first pending candidate — the colony picks the highest-scored of
+    // the four (default ordering refute > poc-screen > symbolic-prove > invariant-hunt; the evolving policy
+    // can re-sort within the tier).
     let pendId = if pendingCount > 0 { cell_subsystem(firstPending) } else { "" };
     let refuteScore = score_refute(policy);
     let pocScore = score_poc(policy);
     let symScore = score_symbolic(policy);
-    // The winning VERIFY type by argmax of the three (single-assignment; ties resolve to the higher-base
-    // action, so the default ordering refute > poc-screen > symbolic-prove holds with no policy weight). The
-    // matching score is re-derived per-type in `chosenScore` below from the same three scores.
-    let verifyType =
-        if pocScore > refuteScore {
-            if symScore > pocScore { "symbolic-prove" } else { "poc-screen" }
-        }
-        else { if symScore > refuteScore { "symbolic-prove" } else { "refute" } };
+    let invScore = score_invariant(policy);
+    // The winning VERIFY type by a single-assignment climbing argmax over the four scores (each step keeps the
+    // running best type+score, only switching on a STRICT >, so a tie resolves to the higher-base action and
+    // the default ordering refute > poc-screen > symbolic-prove > invariant-hunt holds with no policy weight).
+    // The matching score is re-derived per-type in `chosenScore` below from the same four scores.
+    let v_a = if pocScore > refuteScore { "poc-screen" } else { "refute" };
+    let s_a = if pocScore > refuteScore { pocScore } else { refuteScore };
+    let v_b = if symScore > s_a { "symbolic-prove" } else { v_a };
+    let s_b = if symScore > s_a { symScore } else { s_a };
+    let verifyType = if invScore > s_b { "invariant-hunt" } else { v_b };
 
     // The hunt tier: the single best huntable cell (highest fact+policy score).
     let bestCell = best_hunt(scope, classFit, policy, board);
@@ -487,15 +565,17 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
         else { if chosenType == "refute" { pendId }
         else { if chosenType == "poc-screen" { pendId }
         else { if chosenType == "symbolic-prove" { pendId }
-        else { "" } } } };
+        else { if chosenType == "invariant-hunt" { pendId }
+        else { "" } } } } };
 
     let chosenScore =
         if chosenType == "stop" { 0.0 }
         else { if chosenType == "refute" { refuteScore }
         else { if chosenType == "poc-screen" { pocScore }
         else { if chosenType == "symbolic-prove" { symScore }
+        else { if chosenType == "invariant-hunt" { invScore }
         else { if chosenType == "hunt" { huntScore }
-        else { inventScore } } } } };
+        else { inventScore } } } } } };
 
     // Substrate-native selection step: present the chosen action as the FIRST (top-ranked) entry of a
     // `decide` option list, with the runner-up next, and let the substrate `decide` builtin make the
@@ -535,6 +615,9 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
         else { if selType == "symbolic-prove" {
             "pending unverified candidate '" + selArgs + "' -> route through the SOUND symbolic engine (generate a "
           + "Halmos spec, z3 judges) (policy symbolic-prove=" + to_string(fit_value(policy, "symbolic-prove")) + "; " + factSummary + ")" }
+        else { if selType == "invariant-hunt" {
+            "pending unverified candidate '" + selArgs + "' -> route through the STATEFUL invariant fuzzer (generate a "
+          + "handler + deep invariants, forge fuzzes call-SEQUENCES) (policy invariant-hunt=" + to_string(fit_value(policy, "invariant-hunt")) + "; " + factSummary + ")" }
         else { if selType == "hunt" {
             let bb = if board_has_subsystem(board, cell_subsystem(huntCell)) { "blackboard lead in this subsystem; " } else { "" };
             "hunt highest-scored lens '" + selArgs + "' (" + bb + "lens_fitness="
@@ -543,7 +626,7 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
         else {
             if len(huntCell) == 0 { "no huntable cell remains in scope -> invent a new method to open a fresh lens (" + factSummary + ")" }
             else { "ordinary hunting is not paying off (invent_policy=" + to_string(fit_value(policy, "invent-method"))
-                 + " > best hunt score " + to_string(huntScore) + ") -> invent a new method to open a fresh lens (" + factSummary + ")" } } } } } };
+                 + " > best hunt score " + to_string(huntScore) + ") -> invent a new method to open a fresh lens (" + factSummary + ")" } } } } } } };
 
     // --- OUTPUT exactly one ACTION line; record the decision on the bus + memo for the dispatcher. -----
     let actionLine = "ACTION|" + selType + "|" + selArgs + "|" + rationale;
@@ -608,6 +691,9 @@ fn decide_once(scope: string, classFit: string, policy: string, pending: string,
 //                 attributes it exactly once. Makes attribution IDEMPOTENT: every EXECUTED action counted once.
 //   19 pq         symbolic-prove cumulative policy in TEN-THOUSANDTHS (int), the 5th action type (#1015 M3).
 //   20 sq         symbolic-prove "seen" flag ("1"/"0").
+//   21 pj         invariant-hunt cumulative policy in TEN-THOUSANDTHS (int), the 6th action type (Int M1,
+//                 #1037), appended AFTER the symbolic-prove fields so positions 0-20 are unchanged.
+//   22 sj         invariant-hunt "seen" flag ("1"/"0").
 //
 // POLICY THREADING. decide_once() is fed the formatted carried policy (fields 8-15 -> the `type=delta;...`
 // string read_policy would return), so the in-loop decision ranks options against the SAME evolving policy
@@ -671,17 +757,21 @@ fn state_int(s: string, n: int) -> int {
 }
 
 // Build the `type=delta;...` POLICY string from the carried ints + seen flags — byte-identical to the
-// shell's read_policy(): only SEEN keys, ALPHABETICALLY sorted (hunt < invent-method < poc-screen < refute
-// < symbolic-prove), each `key=%.4f`, `;`-joined; "" when nothing has been attributed yet. symbolic-prove
-// (#1015 M3) sorts LAST (`r` < `s`), so it appends at the end exactly as Python's `sorted()` orders it.
-fn policy_string(ph: int, pi: int, pp: int, pr: int, pq: int, sh: bool, si: bool, sp: bool, sr: bool, sq: bool) -> string {
+// shell's read_policy(): only SEEN keys, ALPHABETICALLY sorted (hunt < invariant-hunt < invent-method <
+// poc-screen < refute < symbolic-prove), each `key=%.4f`, `;`-joined; "" when nothing has been attributed
+// yet. symbolic-prove (#1015 M3) sorts LAST (`r` < `s`). invariant-hunt (Int M1, #1037) sorts BETWEEN hunt
+// and invent-method (`inva` < `inve`), exactly as Python's `sorted()` orders it — its slot keeps every other
+// key's position byte-identical, so a run that never touches invariant-hunt renders the same string as before.
+fn policy_string(ph: int, pj: int, pi: int, pp: int, pr: int, pq: int, sh: bool, sj: bool, si: bool, sp: bool, sr: bool, sq: bool) -> string {
     let a = if sh { "hunt=" + fmt4(ph) } else { "" };
+    let f = if sj { "invariant-hunt=" + fmt4(pj) } else { "" };
     let b = if si { "invent-method=" + fmt4(pi) } else { "" };
     let c = if sp { "poc-screen=" + fmt4(pp) } else { "" };
     let d = if sr { "refute=" + fmt4(pr) } else { "" };
     let e = if sq { "symbolic-prove=" + fmt4(pq) } else { "" };
     let s1 = a;
-    let s2 = if len(b) > 0 { if len(s1) > 0 { s1 + ";" + b } else { b } } else { s1 };
+    let s1b = if len(f) > 0 { if len(s1) > 0 { s1 + ";" + f } else { f } } else { s1 };
+    let s2 = if len(b) > 0 { if len(s1b) > 0 { s1b + ";" + b } else { b } } else { s1b };
     let s3 = if len(c) > 0 { if len(s2) > 0 { s2 + ";" + c } else { c } } else { s2 };
     let s4 = if len(d) > 0 { if len(s3) > 0 { s3 + ";" + d } else { d } } else { s3 };
     let s5 = if len(e) > 0 { if len(s4) > 0 { s4 + ";" + e } else { e } } else { s4 };
@@ -744,10 +834,12 @@ fn step_fn(state: string, stepLabel: string) -> string {
     let budget0 = state_int(state, 17);
     let pqIn = state_int(state, 19);
     let sqIn = state_int(state, 20) == 1;
+    let pjIn = state_int(state, 21);
+    let sjIn = state_int(state, 22) == 1;
 
     // POLICY snapshot used for THIS decision + the trace row (the pre-attribution sum, as the shell's env
     // POLICY is read before the call's learn() write).
-    let policyStr = policy_string(phIn, piIn, ppIn, prIn, pqIn, shIn, siIn, spIn, srIn, sqIn);
+    let policyStr = policy_string(phIn, pjIn, piIn, ppIn, prIn, pqIn, shIn, sjIn, siIn, spIn, srIn, sqIn);
 
     // Apply the PREVIOUS action's attribution to the carried ints (the shell's read_policy at the NEXT step
     // reflects it). decide_once() ALSO learn()s it for the durable record.
@@ -758,12 +850,14 @@ fn step_fn(state: string, stepLabel: string) -> string {
     let pp = if prevAction == "poc-screen" { ppIn + d } else { ppIn };
     let pr = if prevAction == "refute" { prIn + d } else { prIn };
     let pq = if prevAction == "symbolic-prove" { pqIn + d } else { pqIn };
+    let pj = if prevAction == "invariant-hunt" { pjIn + d } else { pjIn };
     let didAttr = if len(prevAction) > 0 { len(sig) > 0 } else { false };
     let sh = if didAttr { if prevAction == "hunt" { true } else { shIn } } else { shIn };
     let si = if didAttr { if prevAction == "invent-method" { true } else { siIn } } else { siIn };
     let sp = if didAttr { if prevAction == "poc-screen" { true } else { spIn } } else { spIn };
     let sr = if didAttr { if prevAction == "refute" { true } else { srIn } } else { srIn };
     let sq = if didAttr { if prevAction == "symbolic-prove" { true } else { sqIn } } else { sqIn };
+    let sj = if didAttr { if prevAction == "invariant-hunt" { true } else { sjIn } } else { sjIn };
 
     // ONE decision + in-substrate dispatch on the CARRIED facts (board re-read fresh, like the shell).
     let dryCap = if len(getenv("DRY_CAP")) == 0 { 3 } else { parse_int(getenv("DRY_CAP")) };
@@ -796,7 +890,8 @@ fn step_fn(state: string, stepLabel: string) -> string {
              + "@@F@@" + to_string(ph) + "@@F@@" + to_string(pi) + "@@F@@" + to_string(pp) + "@@F@@" + to_string(pr)
              + "@@F@@" + bool_flag(sh) + "@@F@@" + bool_flag(si) + "@@F@@" + bool_flag(sp) + "@@F@@" + bool_flag(sr)
              + "@@F@@" + trace2 + "@@F@@" + to_string(budget0) + "@@F@@" + bool_flag(didAttr)
-             + "@@F@@" + to_string(pq) + "@@F@@" + bool_flag(sq);
+             + "@@F@@" + to_string(pq) + "@@F@@" + bool_flag(sq)
+             + "@@F@@" + to_string(pj) + "@@F@@" + bool_flag(sj);
     }
 
     // Read the dispatch verdict back (decide_once already ran dispatch() in-process, writing the memo).
@@ -805,13 +900,15 @@ fn step_fn(state: string, stepLabel: string) -> string {
     let outcome = if is_verdict(rawVerdict) { rawVerdict } else { "dry" };
 
     // Update PENDING from the outcome (the shell's case): a confirmed hunt pushes a candidate; refute /
-    // poc-screen / symbolic-prove (#1015 M3) consume the first pending candidate (the one they verified).
+    // poc-screen / symbolic-prove (#1015 M3) / invariant-hunt (Int M1, #1037) consume the first pending
+    // candidate (the one they verified).
     let pending2 =
         if selType == "hunt" { if outcome == "confirmed" { pending_push(pending, "cand-" + to_string(step) + "|" + selArgs) } else { pending } }
         else { if selType == "refute" { pending_pop(pending) }
         else { if selType == "poc-screen" { pending_pop(pending) }
         else { if selType == "symbolic-prove" { pending_pop(pending) }
-        else { pending } } } };
+        else { if selType == "invariant-hunt" { pending_pop(pending) }
+        else { pending } } } } };
 
     let dryStreak2 = if outcome == "confirmed" { 0 } else { dryStreak + 1 };
     let budget2 = budget - 1;
@@ -829,7 +926,8 @@ fn step_fn(state: string, stepLabel: string) -> string {
          + "@@F@@" + to_string(ph) + "@@F@@" + to_string(pi) + "@@F@@" + to_string(pp) + "@@F@@" + to_string(pr)
          + "@@F@@" + bool_flag(sh) + "@@F@@" + bool_flag(si) + "@@F@@" + bool_flag(sp) + "@@F@@" + bool_flag(sr)
          + "@@F@@" + trace2 + "@@F@@" + to_string(budget0) + "@@F@@0"
-         + "@@F@@" + to_string(pq) + "@@F@@" + bool_flag(sq);
+         + "@@F@@" + to_string(pq) + "@@F@@" + bool_flag(sq)
+         + "@@F@@" + to_string(pj) + "@@F@@" + bool_flag(sj);
 }
 
 // === TOP LEVEL ===
@@ -851,12 +949,22 @@ if len(getenv("ORCHESTRATE_ENABLED")) > 0 {
     // non-zero seed also lights the "seen" flag (field 20) so the seeded weight renders in the policy string.
     let symSeed = if len(getenv("SYM_POLICY_TT")) == 0 { 0 } else { parse_int(getenv("SYM_POLICY_TT")) };
     let symSeen = if symSeed == 0 { "0" } else { "1" };
+    // SEED the loop's INITIAL invariant-hunt policy (field 21) from the integer env fact INV_POLICY_TT, in
+    // ten-thousandths (Int M1, #1037), exactly as SYM_POLICY_TT seeds symbolic-prove. This lets a bootstrap
+    // pre-tilt the policy toward the STATEFUL fuzzer BEFORE the loop has accumulated experience, so an
+    // operator (or the autonomous-hunt demo) can have the loop CHOOSE invariant-hunt from step 0. Only the
+    // invariant-hunt component is seeded; the other five policy ints stay 0 (the existing goldens rely on
+    // hunt/refute/symbolic-prove starting cold), so the demo-orchestrate / demo-symbolic goldens are
+    // unaffected. A non-zero seed also lights the "seen" flag (field 22) so the seeded weight renders.
+    let invSeed = if len(getenv("INV_POLICY_TT")) == 0 { 0 } else { parse_int(getenv("INV_POLICY_TT")) };
+    let invSeen = if invSeed == 0 { "0" } else { "1" };
     // initial accumulator: nothing attributed yet (all ints 0, all seen "0"), no prev, empty trace, field 18
     // lastAttr "0" (no prev action to have attributed), field 19 symbolic-prove policy int (the seed), field
-    // 20 seen ("1" iff the seed is non-zero).
+    // 20 seen ("1" iff the seed is non-zero), field 21 invariant-hunt policy int (the seed), field 22 seen.
     let init = "0@@F@@" + to_string(budget0) + "@@F@@0@@F@@0@@F@@@@F@@@@F@@@@F@@" + initPending
              + "@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@0@@F@@@@F@@" + to_string(budget0) + "@@F@@0"
-             + "@@F@@" + to_string(symSeed) + "@@F@@" + symSeen;
+             + "@@F@@" + to_string(symSeed) + "@@F@@" + symSeen
+             + "@@F@@" + to_string(invSeed) + "@@F@@" + invSeen;
     let finalState = reduce(regex_split("\n", getenv("STEPS")),
                             |acc: string, s: string| -> string { return step_fn(acc, s); }, init);
 
@@ -884,16 +992,18 @@ if len(getenv("ORCHESTRATE_ENABLED")) > 0 {
     let fpp = state_int(finalState, 10) + (if fPrevAction == "poc-screen" { fd } else { 0 });
     let fpr = state_int(finalState, 11) + (if fPrevAction == "refute" { fd } else { 0 });
     let fpq = state_int(finalState, 19) + (if fPrevAction == "symbolic-prove" { fd } else { 0 });
+    let fpj = state_int(finalState, 21) + (if fPrevAction == "invariant-hunt" { fd } else { 0 });
     let fsh = if state_int(finalState, 12) == 1 { true } else { if fAttribute { fPrevAction == "hunt" } else { false } };
     let fsi = if state_int(finalState, 13) == 1 { true } else { if fAttribute { fPrevAction == "invent-method" } else { false } };
     let fsp = if state_int(finalState, 14) == 1 { true } else { if fAttribute { fPrevAction == "poc-screen" } else { false } };
     let fsr = if state_int(finalState, 15) == 1 { true } else { if fAttribute { fPrevAction == "refute" } else { false } };
     let fsq = if state_int(finalState, 20) == 1 { true } else { if fAttribute { fPrevAction == "symbolic-prove" } else { false } };
+    let fsj = if state_int(finalState, 22) == 1 { true } else { if fAttribute { fPrevAction == "invariant-hunt" } else { false } };
 
     // Publish the trace + the evolved policy to durable memos the bootstrap reads back (the cross-process
     // channel). The trace is the full decisions.tsv body; policy-after is the read_policy()-shaped string.
     memo_write("coordinator:trace", state_field(finalState, 16));
-    memo_write("coordinator:policy_after", policy_string(fph, fpi, fpp, fpr, fpq, fsh, fsi, fsp, fsr, fsq));
+    memo_write("coordinator:policy_after", policy_string(fph, fpj, fpi, fpp, fpr, fpq, fsh, fsj, fsi, fsp, fsr, fsq));
     print("ORCHESTRATE|done|steps=" + to_string(state_int(finalState, 3)));
 } else {
     // SINGLE DECISION (v1, byte-identical): read facts from env, run ONE decide_once(). The board is read

--- a/dark-factory/auditor/agents/dispatcher.ag
+++ b/dark-factory/auditor/agents/dispatcher.ag
@@ -5,7 +5,8 @@ cb 300000;
 // stub_outcome()/real_outcome() derived the gate verdict, then fed it back. M1 moved the `hunt` branch
 // of that dispatch onto the substrate. M2 GENERALISES it: the coordinator (coordinator.ag) `emit`s the
 // chosen action over the IN-PROCESS bus (`dark-factory:dispatch`, payload `<type>|<args>`) for ANY real
-// action (hunt / refute / poc-screen / invent-method); THIS agent fn `listen`s it, parses the action
+// action (hunt / refute / poc-screen / symbolic-prove / invariant-hunt / invent-method); THIS agent fn
+// `listen`s it, parses the action
 // `<type>`, derives the gate OUTCOME, writes it back as a DURABLE fact (`coordinator:last_outcome` memo),
 // and prints an observable `DISPATCH|...` marker. The shell loop then READS the verdict from the memo
 // instead of computing it in a `case` — for EVERY non-`stop` action, not just hunt.
@@ -134,13 +135,15 @@ fn is_verdict(v: string) -> bool {
 }
 
 // Is `t` a real (dispatchable) action type? `stop` is terminal and never dispatched. Leaf compares.
-// `symbolic-prove` (#1015 M3) routes a pending candidate through the SOUND symbolic engine; it is a real
-// verify action and so is dispatched like refute/poc-screen.
+// `symbolic-prove` (#1015 M3) routes a pending candidate through the SOUND symbolic engine; `invariant-hunt`
+// (Int M1, #1037) routes a pending candidate through the STATEFUL invariant fuzzer; both are real verify
+// actions and so are dispatched like refute/poc-screen.
 fn is_action(t: string) -> bool {
     if t == "hunt" { return true; }
     if t == "refute" { return true; }
     if t == "poc-screen" { return true; }
     if t == "symbolic-prove" { return true; }
+    if t == "invariant-hunt" { return true; }
     if t == "invent-method" { return true; }
     return false;
 }

--- a/dark-factory/demo-autonomous-hunt.sh
+++ b/dark-factory/demo-autonomous-hunt.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# demo-autonomous-hunt.sh — Integration M1 (#1037): the self-orchestrating coordinator AUTONOMOUSLY chooses
+# and LIVE-runs the stateful-invariant fuzzer, end-to-end, finding the multi-step bug.
+#
+# demo-invariant-hunt.sh proves the FUZZER engine (an operator calls run-invariant-hunt.sh directly). THIS
+# demo proves the INTEGRATION: the operator does NOT call the fuzzer — they hand the coordinator a target and
+# the coordinator CHOOSES (by its evolving policy, a policy-weighted argmax — never a fixed sequence) to route
+# the candidate through the `invariant-hunt` action, which runs the REAL forge invariant fuzzer and maps its
+# exit code to the SOUND outcome (FINDING -> confirmed, CLEAN -> refuted, HARNESS_ERROR -> dry). For EACH of
+# two vaults it drives run-autonomous-hunt.sh and asserts:
+#   (A) the coordinator AUTONOMOUSLY emitted ACTION|invariant-hunt| for the pending candidate — proving the
+#       COORDINATOR chose the engine, not the operator;
+#   (B) DISPATCH|invariant-hunt|...|confirmed for the VULNERABLE vault and ...|refuted for the HARDENED twin —
+#       the LIVE fuzzer's verdict, never the LLM's;
+#   (C) a learn / policy_update for invariant-hunt referencing the verdict appears in the store on the step
+#       AFTER the verdict — proving outcome -> policy.
+#
+# The two vaults are the SAME inflation-vault + hardened-twin demo-invariant-hunt.sh uses (same contracts,
+# same fixture handler+invariant that already produce FINDING/CLEAN there). The verdict is the FUZZER's exit
+# code, never the LLM's opinion — that is the whole point. A FINDING is a LEAD a human triages, never an
+# auto-submission; this colony never posts.
+#
+# CI has no forge (nor necessarily agentis), so if EITHER is missing this prints a single [SKIP] line and
+# exits 0 (mirroring demo-invariant-hunt.sh / the colony-lint skip convention). Install the toolchain to run:
+#   curl -L https://foundry.paradigm.xyz | bash && foundryup    # forge (has built-in invariant fuzzing)
+#
+# Usage:  dark-factory/demo-autonomous-hunt.sh
+# Exit: 0 = both verdicts correct (FINDING->confirmed on vulnerable, CLEAN->refuted on hardened, each with the
+#       coordinator's autonomous choice + the outcome->policy attribution), or tools absent -> SKIP ; non-zero
+#       = an assertion failed.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUNNER="$HERE/run-autonomous-hunt.sh"
+
+FAILS=0
+note() { echo "demo-autonomous-hunt.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+skip() { echo "  [SKIP] $*"; }
+
+# Skip EARLY (before any work) when the toolchain is missing, so CI without forge reports a clean [SKIP] +
+# exit 0 rather than a harness error. agentis is required to drive the substrate coordinator loop.
+if ! command -v forge >/dev/null 2>&1; then
+  skip "forge not on PATH — install foundryup (https://getfoundry.sh) to run this demo"
+  exit 0
+fi
+if ! command -v agentis >/dev/null 2>&1; then
+  skip "agentis not on PATH — install the agentis runtime to drive the substrate coordinator loop"
+  exit 0
+fi
+
+[ -x "$RUNNER" ] || { note "runner not found / not executable: $RUNNER" >&2; exit 3; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/demo-autonomous-hunt.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# ----------------------------------------------------------------------------------------------------------
+# Build the two tiny foundry repos: VULNERABLE (no virtual offset) and HARDENED (large virtual-share offset).
+# Identical to demo-invariant-hunt.sh's scaffolding so the SAME fixture handler+invariant drives both — only
+# the share-pricing math differs (the inflation attack is a MULTI-STEP bug the fuzzer must find by sequence).
+# ----------------------------------------------------------------------------------------------------------
+mk_repo() {  # $1 = repo dir, $2 = the `s = ...` deposit pricing line, $3 = the `assets = ...` withdraw line
+  _dir="$1"; _depositMath="$2"; _withdrawMath="$3"
+  mkdir -p "$_dir/src" "$_dir/test"
+  printf '[profile.default]\nsrc = "src"\nout = "out"\n\n[invariant]\nruns = 64\ndepth = 32\nfail_on_revert = false\n' > "$_dir/foundry.toml"
+  cat > "$_dir/src/Vault.sol" <<SOL
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+contract Token {
+  mapping(address=>uint) public balanceOf; uint public totalSupply;
+  function mint(address to,uint a) external { balanceOf[to]+=a; totalSupply+=a; }
+  function transfer(address to,uint a) external returns(bool){ balanceOf[msg.sender]-=a; balanceOf[to]+=a; return true; }
+  function transferFrom(address f,address t,uint a) external returns(bool){ balanceOf[f]-=a; balanceOf[t]+=a; return true; }
+}
+contract Vault {
+  Token public asset; uint public totalShares; mapping(address=>uint) public shares;
+  uint constant VS = 1000000000000000000000000000; uint constant VA = 1; // virtual offset (1e27); VS=1 in the vulnerable build below
+  constructor(Token a){ asset=a; }
+  function deposit(uint assets) external returns(uint s){
+    uint ta = asset.balanceOf(address(this));
+    ${_depositMath}
+    asset.transferFrom(msg.sender,address(this),assets);
+    shares[msg.sender]+=s; totalShares+=s;
+  }
+  function withdraw(uint s) external returns(uint assets){
+    uint ta = asset.balanceOf(address(this));
+    ${_withdrawMath}
+    shares[msg.sender]-=s; totalShares-=s;
+    asset.transfer(msg.sender,assets);
+  }
+}
+SOL
+}
+
+# VULNERABLE: classic ERC4626 share price (no virtual offset) -> donation inflates ta, the next deposit mints
+# 0 shares -> the depositor's claim collapses far below their deposit (a MULTI-STEP donation/inflation attack).
+mk_repo "$WORK/vuln" \
+  's = totalShares==0 ? assets : assets*totalShares/ta;' \
+  'assets = s*ta/totalShares;'
+
+# HARDENED: a large virtual-share/asset offset (the OpenZeppelin ERC4626 decimal-offset mitigation) so the
+# share price cannot be inflated enough to round a real depositor to zero shares -> the same attack fails.
+mk_repo "$WORK/hard" \
+  's = assets * (totalShares + VS) / (ta + VA);' \
+  'assets = s * (ta + VA) / (totalShares + VS);'
+
+# ----------------------------------------------------------------------------------------------------------
+# The PROVEN fixture handler+invariant (from demo-invariant-hunt.sh), written DIRECTLY into each repo's test/
+# dir so run-autonomous-hunt.sh's --target points the coordinator's LIVE invariant route at it. A `Handler`
+# exposes the protocol's actions as bounded actor functions (attackerSeed / attackerDonate / victimDeposit)
+# and a DEEP invariant (`invariant_victim_not_robbed`). forge-std-free: targets via the `targetContracts()`
+# StdInvariant ABI forge auto-discovers, asserted with plain `require`.
+# ----------------------------------------------------------------------------------------------------------
+write_fixture() {  # $1 = repo dir
+  cat > "$1/test/Inv.t.sol" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import {Vault, Token} from "../src/Vault.sol";
+
+// The protocol's actions as a real attacker/user calls them, with fuzzed inputs bounded to realistic ranges.
+contract Handler {
+    Vault public v; Token public t;
+    uint public victimDeposited;   // total assets the honest victim has put in
+    uint public victimShares;      // shares the victim holds
+    constructor(Vault _v, Token _t){ v=_v; t=_t; }
+    // forge-std-free bound: keep a fuzzed uint inside [lo, hi] without the forge-std `bound` cheatcode.
+    function _bound(uint x, uint lo, uint hi) internal pure returns (uint) {
+        if (hi <= lo) return lo;
+        return lo + (x % (hi - lo + 1));
+    }
+    function attackerSeed() public { t.mint(address(this), 1); v.deposit(1); }              // seed 1 share
+    function attackerDonate(uint a) public { a = _bound(a, 1, 1e24); t.mint(address(v), a); } // direct transfer, no shares
+    function victimDeposit(uint a) public {
+        a = _bound(a, 1e6, 1e18);
+        t.mint(address(this), a);
+        uint s = v.deposit(a);
+        victimDeposited += a; victimShares += s;
+    }
+}
+
+// StdInvariant ABI forge auto-discovers: targetContracts() lists the addresses the fuzzer drives. No forge-std.
+abstract contract InvBase {
+    address[] private _targets;
+    function targetContracts() public view returns (address[] memory) { return _targets; }
+    function _target(address a) internal { _targets.push(a); }
+}
+
+contract VaultInvariantTest is InvBase {
+    Vault v; Token t; Handler h;
+    function setUp() public { t=new Token(); v=new Vault(t); h=new Handler(v,t); _target(address(h)); }
+    // DEEP invariant: the victim's CLAIM on the vault (shares * vaultBalance / totalShares) must always be
+    // worth >= what they deposited, minus dust. The inflation attack makes a victim deposit mint 0 shares,
+    // so their claim collapses far below their deposit -> a SEQUENCE the fuzzer must find.
+    function invariant_victim_not_robbed() public view {
+        uint vd = h.victimDeposited();
+        if (vd == 0) return;
+        uint ts = v.totalShares();
+        uint claim = ts == 0 ? 0 : h.victimShares() * t.balanceOf(address(v)) / ts;
+        require(claim + 1e6 >= vd, "victim robbed");   // claim within dust(1e6) of deposit
+    }
+}
+SOL
+}
+write_fixture "$WORK/vuln"
+write_fixture "$WORK/hard"
+
+# Drive one vault through the FULL coordinator loop (the operator hands the coordinator the target; the
+# coordinator CHOOSES invariant-hunt and the REAL fuzzer judges). A fixed --seed makes the search reproducible.
+# $1 = repo, $2 = output dir. Captures the runner's stderr (the decision trail) + the run log into $2.log.
+SEED=1
+run_one() {
+  "$RUNNER" --repo "$1" --target "$1/test/Inv.t.sol" --match invariant \
+            --backend mock --runs 256 --depth 64 --seed "$SEED" --steps 2 --out "$2" >"$2.log" 2>&1
+}
+
+# The full orchestrate run log (where the ACTION|/DISPATCH| trail + the LIVE-route message land).
+run_log() { printf '%s' "$1/run/orchestrate.log"; }
+# The experience store the loop's learn() rows land in (for the outcome->policy attribution check).
+exp_store() { printf '%s' "$1/run/.agentis/experience/main.jsonl"; }
+
+assert_vault() {  # $1 = repo, $2 = out dir, $3 = expected verdict (confirmed|refuted), $4 = label
+  _repo="$1"; _out="$2"; _want="$3"; _label="$4"
+  note "driving the $_label vault -> the coordinator CHOOSES invariant-hunt -> REAL forge fuzzer -> verdict ..."
+  run_one "$_repo" "$_out"; _rc=$?
+  _log="$(run_log "$_out")"
+  _exp="$(exp_store "$_out")"
+  if [ "$_rc" -ne 0 ] || [ ! -f "$_log" ]; then
+    bad "$_label: run-autonomous-hunt.sh did not complete (exit $_rc); log:"
+    sed 's/^/        | /' "$_out.log" 2>/dev/null | tail -25
+    return
+  fi
+  # (A) the coordinator AUTONOMOUSLY chose invariant-hunt for the pending candidate.
+  _action="$(grep -E '^ACTION\|invariant-hunt\|' "$_log" | head -1)"
+  if [ -n "$_action" ]; then ok "$_label (A): coordinator AUTONOMOUSLY chose invariant-hunt (not the operator)"
+  else bad "$_label (A): no 'ACTION|invariant-hunt|' line — the coordinator did not choose the engine"; sed 's/^/        | /' "$_log" 2>/dev/null | tail -25; fi
+  # (B) the LIVE fuzzer's verdict crossed back as the expected DISPATCH| outcome.
+  _dispatch="$(grep -E '^DISPATCH\|invariant-hunt\|' "$_log" | head -1)"
+  case "$_dispatch" in
+    DISPATCH\|invariant-hunt\|cand-0\|"$_want")
+      ok "$_label (B): DISPATCH|invariant-hunt|cand-0|$_want (the LIVE fuzzer's verdict, never the LLM's)" ;;
+    *)
+      bad "$_label (B): expected 'DISPATCH|invariant-hunt|cand-0|$_want', got '$_dispatch'"
+      note "  the LIVE-route message + verdict the fuzzer produced:"
+      grep -E 'LIVE invariant-hunt|FORGE-INVARIANT:' "$_log" 2>/dev/null | sed 's/^/        | /' ;;
+  esac
+  # (C) the outcome -> policy attribution: a learn row for invariant-hunt referencing the verdict appears in
+  # the store on the step AFTER the verdict (step 1 attributes step 0's invariant-hunt). The DISPATCH outcome
+  # (confirmed/refuted/dry) is what the attribution records.
+  if [ -f "$_exp" ] && grep -q '"in":"invariant-hunt"' "$_exp" && grep -qE "outcome of previous invariant-hunt .* was (confirmed|refuted|dry)" "$_exp"; then
+    ok "$_label (C): outcome -> policy: a learn() for invariant-hunt referencing the verdict is in the store"
+  else
+    bad "$_label (C): no invariant-hunt outcome->policy learn row in the experience store ($_exp)"
+    [ -f "$_exp" ] && grep '"action":"coordinator"' "$_exp" 2>/dev/null | sed 's/^/        | /' | tail -5
+  fi
+}
+
+echo "=================================================================================="
+echo " (1) VULNERABLE vault: coordinator CHOOSES invariant-hunt -> FINDING -> confirmed"
+echo "=================================================================================="
+assert_vault "$WORK/vuln" "$WORK/vuln-out" "confirmed" "VULNERABLE"
+
+echo
+echo "=================================================================================="
+echo " (2) HARDENED twin: same autonomous route, CLEAN -> refuted (no false positive on the fix)"
+echo "=================================================================================="
+assert_vault "$WORK/hard" "$WORK/hard-out" "refuted" "HARDENED"
+
+echo
+echo "=================================================================================="
+if [ "$FAILS" -eq 0 ]; then
+  note "PROVEN. The operator handed the coordinator a target and the COORDINATOR autonomously CHOSE the"
+  note "stateful-invariant fuzzer (ACTION|invariant-hunt, by its evolving policy — not a fixed sequence) and"
+  note "LIVE-ran it: the VULNERABLE vault's inflation attack -> FINDING -> confirmed (a real multi-step bug),"
+  note "the HARDENED twin -> CLEAN -> refuted (no false positive). The verdict is the FUZZER's exit code,"
+  note "never the LLM's opinion; the outcome evolves the coordinator's policy. Submission stays human-gated;"
+  note "this colony never posts."
+  exit 0
+fi
+note "DEMO FAILED — $FAILS assertion(s) did not hold (see above)." >&2
+exit 1

--- a/dark-factory/docs/autonomous-hunt.md
+++ b/dark-factory/docs/autonomous-hunt.md
@@ -1,0 +1,98 @@
+# Autonomous stateful-invariant hunt — Integration M1 (#1037)
+
+Two pieces shipped separately: the **self-orchestrating coordinator** ([`docs/coordinator.md`](./coordinator.md),
+#1014) that DECIDES the next audit action from facts + an evolving policy, and the **stateful-invariant
+fuzzer** ([`docs/invariant-hunt.md`](./invariant-hunt.md), #1035) that finds the multi-step bug. Until now an
+operator had to call the fuzzer directly (`run-invariant-hunt.sh`). Integration M1 wires them together: the
+operator hands the coordinator a target, and the **coordinator itself CHOOSES** to route it through the
+fuzzer and LIVE-runs it — finding the bug end-to-end.
+
+This mirrors EXACTLY how the symbolic engine got a live coordinator route: `symbolic-prove` was added as a
+VERIFY-tier action (#1015 M3) and given a live route (#1032, [`demo-symbolic-orchestrate-live.sh`](../demo-symbolic-orchestrate-live.sh)).
+`invariant-hunt` is its sibling — same tier, same live-route shape, same sound-verdict contract.
+
+## The two sources of truth (never confused)
+
+```
+target ──(coordinator's evolving POLICY)──► CHOOSE invariant-hunt ──(forge-invariant.sh)──► FINDING/CLEAN verdict
+            the CHOICE of engine                                          the VERDICT (forge's shrunk witness)
+```
+
+- **The CHOICE of engine is the coordinator's evolving policy** — a policy-weighted argmax over fact-criteria,
+  never a fixed sequence and never an LLM judgement of the verdict. `invariant-hunt` sits in the VERIFY tier
+  (a pending candidate is verified before more hunting). Its base score is **94**, below `refute`(100),
+  `poc-screen`(98), and `symbolic-prove`(96) — routing a candidate through the STATEFUL fuzzer is the most
+  expensive verify (a multi-call search, not a single-input proof), so by default the cheaper verifies go
+  first. Its policy term is the steep ×4 multiplier (the same the symbolic tier uses), so the colony can
+  **learn** to lift it above the others as the fuzzer's witnesses pay off:
+  `94 + 4 × policy` beats `refute`(100) at policy ≥ 1.5.
+- **The FINDING/CLEAN VERDICT is the fuzzer's**, the exit code of [`evm-harness/forge-invariant.sh`](../evm-harness/forge-invariant.sh),
+  NEVER the LLM. The gate's exit code maps to the coordinator's gate-outcome enum exactly as the symbolic
+  route does:
+
+  | gate exit | gate verdict | coordinator outcome | meaning |
+  |---|---|---|---|
+  | `1` | FINDING | **confirmed** | an invariant broke under a concrete shrunk call-SEQUENCE — a real multi-step bug with a reproducible witness |
+  | `0` | CLEAN | **refuted** | every invariant held across the fuzzed search — the lead is killed in this budget (not a proof of safety) |
+  | `2` / else | HARNESS_ERROR | **dry** | the test did not compile / no invariant matched / forge absent — no verdict (the safe failure mode) |
+
+  The mapping is IDENTICAL to the symbolic one (1→confirmed, 0→refuted, 2/else→dry), so `coordinator.ag`
+  reuses `sym_rc_of`/`sym_outcome_of` to read the `__rc=$?` marker and map it.
+
+## End-to-end flow
+
+`run-autonomous-hunt.sh` drives ONE `agentis go coordinator.ag` in ORCHESTRATE mode:
+
+1. **seed a candidate** — the target is seeded as a pending candidate (`cand-0`), the same shape the
+   orchestrate loop's VERIFY tier expects.
+2. **seed the policy** — `INV_POLICY_TT=20000` (= +2.0) seeds the loop's initial `invariant-hunt` policy so
+   the coordinator chooses it from step 0. This stands in for the policy a PRIOR run would have evolved (the
+   fuzzer's witnesses having paid off and the colony having learned to lean on the stateful engine), exactly
+   as `--sym-policy` / `SYM_POLICY_TT` seeds `symbolic-prove`. agentis offers no float→int builtin, so the
+   ten-thousandths integer is supplied directly.
+3. **the coordinator DECIDES** — by its policy-weighted argmax, it emits
+   `ACTION|invariant-hunt|cand-0|...` (the rationale cites the policy weight + the facts).
+4. **the LIVE route runs the REAL fuzzer** — with `DISPATCH_FIXTURE` empty and the live env present
+   (`FORGE_INVARIANT` gate + `INV_REPO` foundry dir + `INV_TARGET` invariant test), `coordinator.ag`'s
+   `action_outcome` runs `forge-invariant.sh --repo … --target … --match … [--runs/--depth/--seed]` and maps
+   its exit code (table above). It prints a `LIVE invariant-hunt … running the REAL stateful fuzzer …` line so
+   the live route is observable. This branch is **purely additive** — absent any of the three env facts it
+   falls through to the honest stub, so behaviour with no live env is byte-identical.
+5. **the verdict crosses back** — `dispatch()` writes `coordinator:last_outcome` and prints
+   `DISPATCH|invariant-hunt|cand-0|<verdict>`. The candidate is consumed from `PENDING`.
+6. **the outcome evolves the policy** — the NEXT step's `decide_once()` attributes the previous
+   `invariant-hunt`'s gate outcome with the same `learn()` mechanic the lens-fitness loop uses (confirmed →
+   success / refuted → failure), so `coordinator:policy:invariant-hunt` reweights. The evolved policy lands in
+   `coordinator:policy_after`.
+
+## The human-gated submit boundary
+
+A `FINDING` (→ confirmed) is a **CANDIDATE the fuzzer reproduced** — a LEAD a human triages, with the shrunk
+exploit call-sequence as a reproducible witness. It is **never** auto-submitted. As everywhere in this colony,
+submission to Immunefi / Code4rena / Sherlock is a separate, explicit human action; the coordinator decides
+*which engine to spend*, the fuzzer decides *whether the bug reproduces*, and a human decides *whether to
+submit*. This colony never posts to a bounty platform.
+
+## Run it
+
+```bash
+# the integration: hand the coordinator a target; it CHOOSES + LIVE-runs the fuzzer
+dark-factory/run-autonomous-hunt.sh --repo "$PWD/target" --target test/Invariant.t.sol --seed 1
+
+# offline-deterministic proof (real fuzzer, the inflation-vault + hardened twin; SKIPs without forge/agentis)
+dark-factory/demo-autonomous-hunt.sh
+```
+
+`demo-autonomous-hunt.sh` reuses the inflation-vault + hardened-twin scaffolding from
+[`demo-invariant-hunt.sh`](../demo-invariant-hunt.sh): for the VULNERABLE vault the coordinator's chosen
+`invariant-hunt` returns `DISPATCH|invariant-hunt|cand-0|confirmed` (the inflation attack — a real multi-step
+bug), for the HARDENED twin `…|refuted` (no false positive). It asserts (A) the coordinator AUTONOMOUSLY chose
+the engine, (B) the LIVE fuzzer's verdict crossed back, and (C) the outcome evolved the policy.
+
+## Honest scope
+
+This integration drives a SINGLE operator-supplied candidate through the live route — the minimum live slice,
+exactly the boundary `symbolic-prove`'s live route (#1032) set. Multi-candidate code-carrying (a discovered
+lead auto-carrying its contract + invariant test through `PENDING`), a long-lived daemon-tick reflex (the loop
+running continuously without a shell bootstrap), and the coordinator pruning a live cell manifest all remain
+follow-up on epics #1014 / #1035 / #1037.

--- a/dark-factory/docs/autonomous-hunt.md
+++ b/dark-factory/docs/autonomous-hunt.md
@@ -25,7 +25,7 @@ target ──(coordinator's evolving POLICY)──► CHOOSE invariant-hunt ─�
   expensive verify (a multi-call search, not a single-input proof), so by default the cheaper verifies go
   first. Its policy term is the steep ×4 multiplier (the same the symbolic tier uses), so the colony can
   **learn** to lift it above the others as the fuzzer's witnesses pay off:
-  `94 + 4 × policy` beats `refute`(100) at policy ≥ 1.5.
+  `94 + 4 × policy` beats `refute`(100) at policy > 1.5 (at exactly 1.5 the score ties 100 and the tie resolves to the higher-base `refute`).
 - **The FINDING/CLEAN VERDICT is the fuzzer's**, the exit code of [`evm-harness/forge-invariant.sh`](../evm-harness/forge-invariant.sh),
   NEVER the LLM. The gate's exit code maps to the coordinator's gate-outcome enum exactly as the symbolic
   route does:

--- a/dark-factory/run-autonomous-hunt.sh
+++ b/dark-factory/run-autonomous-hunt.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# run-autonomous-hunt.sh — Integration M1 (#1037): the self-orchestrating coordinator AUTONOMOUSLY chooses
+# and LIVE-runs the stateful-invariant fuzzer on a target, end-to-end.
+#
+# WHAT IT IS. This is the integration entrypoint that closes the loop between the #1014 self-orchestrating
+# coordinator and the #1035 stateful-invariant fuzzer (`evm-harness/forge-invariant.sh`). It drives ONE
+# `agentis go coordinator.ag` in ORCHESTRATE mode: the coordinator reads the FACTS (a pending candidate
+# representing the target, the evolving policy) and DECIDES — by a policy-weighted argmax, never a fixed
+# sequence — to route the candidate through the `invariant-hunt` VERIFY action. That action runs the REAL
+# forge invariant fuzzer over the target test via `forge-invariant.sh` and maps its exit code to the gate
+# outcome: 1=FINDING -> confirmed, 0=CLEAN -> refuted, 2/else=HARNESS_ERROR -> dry. The CHOICE of engine is
+# the coordinator's evolving policy; the FINDING/CLEAN VERDICT is the FUZZER's shrunk witness — NEVER the LLM.
+#
+# This mirrors how `symbolic-prove` was given a live route (#1032 / demo-symbolic-orchestrate-live.sh): the
+# coordinator CHOOSES the engine, the gate's exit code is the sound verdict, and the outcome evolves the
+# policy. Submission stays human-gated; this colony never posts to a bounty platform.
+#
+# Usage:
+#   run-autonomous-hunt.sh --repo <foundry-root> --target <Invariant.t.sol>
+#                          [--match <prefix>] [--backend mock|flat-cyborg|claude]
+#                          [--runs N] [--depth D] [--seed S] [--steps N] [--out <dir>]
+#                          [--agentis <bin>]
+#
+#   --repo <dir>      Foundry project root (must hold foundry.toml) the fuzzer runs in. REQUIRED.
+#   --target <file>   The invariant `*.t.sol` the fuzzer scopes to (absolute or relative to --repo). REQUIRED.
+#   --match <prefix>  Invariant function-name prefix forge runs (default "invariant").
+#   --backend <b>     LLM backend for the agentis store (default mock — the DECISION is offline-deterministic;
+#                     the verdict is the fuzzer's, so no LLM is needed for the integration loop).
+#   --runs N          Optional forge invariant runs budget (search width); forwarded to the gate.
+#   --depth D         Optional forge invariant depth budget (calls per sequence); forwarded to the gate.
+#   --seed S          Optional forge --fuzz-seed for a reproducible search; forwarded to the gate.
+#   --steps N         Loop step bound (default 2): one decision routes the candidate to invariant-hunt; the
+#                     next attributes its outcome to the policy (proving outcome -> policy evolution).
+#   --out <dir>       Output dir for the run (default: ./autonomous-hunt-out). A fresh agentis store is built
+#                     under <out>/run.
+#   --agentis <bin>   agentis binary (default: `agentis` on PATH).
+#
+# Exit: 0 on a clean run that reached ORCHESTRATE|done; 2 on usage error; 3 on a missing prerequisite; 1 on a
+# run failure.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+AGENTIS="agentis"
+REPO=""
+TARGET=""
+MATCH="invariant"
+BACKEND="mock"
+RUNS=""
+DEPTH=""
+SEED=""
+STEPS_N=2
+OUT="$PWD/autonomous-hunt-out"
+
+need() { [ "$1" -ge 2 ] || { echo "run-autonomous-hunt.sh: missing value for the preceding flag" >&2; exit 2; }; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)    need "$#"; REPO="$2"; shift 2 ;;
+    --target)  need "$#"; TARGET="$2"; shift 2 ;;
+    --match)   need "$#"; MATCH="$2"; shift 2 ;;
+    --backend) need "$#"; BACKEND="$2"; shift 2 ;;
+    --runs)    need "$#"; RUNS="$2"; shift 2 ;;
+    --depth)   need "$#"; DEPTH="$2"; shift 2 ;;
+    --seed)    need "$#"; SEED="$2"; shift 2 ;;
+    --steps)   need "$#"; STEPS_N="$2"; shift 2 ;;
+    --out)     need "$#"; OUT="$2"; shift 2 ;;
+    --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
+    --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
+    *) echo "run-autonomous-hunt.sh: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$REPO" ] && [ -d "$REPO" ] || { echo "run-autonomous-hunt.sh: --repo <foundry project root> required" >&2; exit 2; }
+[ -f "$REPO/foundry.toml" ] || { echo "run-autonomous-hunt.sh: --repo is not a foundry project (no foundry.toml): $REPO" >&2; exit 2; }
+[ -n "$TARGET" ] || { echo "run-autonomous-hunt.sh: --target <Invariant.t.sol> required" >&2; exit 2; }
+[ -n "$MATCH" ] || { echo "run-autonomous-hunt.sh: --match prefix must be non-empty" >&2; exit 2; }
+case "$STEPS_N" in (*[!0-9]*|'') echo "run-autonomous-hunt.sh: --steps must be a non-negative integer" >&2; exit 2 ;; esac
+[ "$STEPS_N" -ge 1 ] || { echo "run-autonomous-hunt.sh: --steps must be >= 1 (one decision routes the candidate, the next attributes its outcome)" >&2; exit 2; }
+for v in "$RUNS" "$DEPTH" "$SEED"; do
+  case "$v" in '') ;; *[!0-9]*) echo "run-autonomous-hunt.sh: --runs/--depth/--seed must be whole numbers" >&2; exit 2 ;; esac
+done
+
+# Resolve the target to an ABSOLUTE path (the colony runs from the rundir, a different cwd; the exec sandbox
+# cannot read a relative/home-rooted path). Accept either an absolute/relative file OR a path under --repo.
+if [ -f "$TARGET" ]; then
+  TARGET="$(cd "$(dirname "$TARGET")" && pwd)/$(basename "$TARGET")"
+elif [ -f "$REPO/$TARGET" ]; then
+  TARGET="$(cd "$REPO" && pwd)/$TARGET"
+else
+  echo "run-autonomous-hunt.sh: --target test not found: $TARGET" >&2; exit 2
+fi
+REPO="$(cd "$REPO" && pwd)"
+
+command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-autonomous-hunt.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
+
+COORD_AG="$HERE/auditor/agents/coordinator.ag"
+# Resolve the stateful-fuzzing gate to an ABSOLUTE path (relative to this script's own location) and pass it
+# as FORGE_INVARIANT — the same env path invariant-prover.ag / run-invariant-hunt.sh use. No install location
+# is hardcoded; forge is the caller's PATH responsibility, exactly as forge-invariant.sh requires.
+FORGE_INVARIANT="$HERE/evm-harness/forge-invariant.sh"
+[ -f "$COORD_AG" ]        || { echo "run-autonomous-hunt.sh: coordinator agent not found at $COORD_AG" >&2; exit 3; }
+[ -f "$FORGE_INVARIANT" ] || { echo "run-autonomous-hunt.sh: forge-invariant gate not found at $FORGE_INVARIANT" >&2; exit 3; }
+
+mkdir -p "$OUT" || { echo "run-autonomous-hunt.sh: cannot create --out dir: $OUT" >&2; exit 1; }
+OUT="$(cd "$OUT" && pwd)"
+RUN="$OUT/run"
+rm -rf "$RUN"; mkdir -p "$RUN" || { echo "run-autonomous-hunt.sh: cannot create run dir: $RUN" >&2; exit 1; }
+cp "$COORD_AG" "$RUN/coordinator.ag"
+
+# A single shared agentis store for the whole orchestrate run (the policy the coordinator writes one step
+# must be visible to the next). init FIRST (before any .agentis/ subdir), else HEAD is unset.
+( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
+{
+  echo "llm.backend = $BACKEND"
+  [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 600000"; }
+  [ "$BACKEND" = "flat-cyborg" ] && echo "llm.cli_timeout_ms = 600000"
+  echo "trace.level = normal"
+  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS,SYM_POLICY_TT,INV_POLICY_TT,SYM_REPO,SYM_SPEC,SYM_FUNCTION,HALMOS_VERIFY,FORGE_INVARIANT,INV_REPO,INV_TARGET,INV_MATCH,INV_RUNS,INV_DEPTH,INV_SEED"
+  # A forge invariant run (build + a few hundred fuzzed sequences) far exceeds the 10s/30s defaults — match
+  # run-invariant-hunt.sh's 600s budget so the live fuzzer has room to run inside the loop.
+  echo "exec.default_timeout_ms = 600000"
+  # The whole point: every decision is recorded as experience so coordinator:policy:<type> reweights.
+  echo "learning.enabled = true"
+  echo "experience.enabled = true"
+} > "$RUN/.agentis/config"
+
+# SEED the in-substrate loop's INITIAL invariant-hunt policy weight high enough that score_invariant
+# (94 + 4x lead) beats score_refute (100): lead >= ~1.6 lifts invariant-hunt above refute. We use 2.0
+# (= INV_POLICY_TT 20000 ten-thousandths) so the coordinator AUTONOMOUSLY chooses invariant-hunt from step 0.
+# This stands in for the policy a PRIOR run would have evolved — the fuzzer's witnesses paying off and the
+# colony having learned to lean on the stateful engine for this candidate. (agentis offers no float->int
+# builtin, so the integer is supplied directly, exactly like run-coordinator.sh's SYM_POLICY_TT.)
+INV_POLICY_TT=20000
+
+# A single pending candidate represents the target — the same shape the orchestrate loop expects (seeded into
+# PENDING so a VERIFY action, here invariant-hunt, is the chosen action immediately). The SCOPE/CLASS_FITNESS
+# carry one cell so the post-verify fallback (after the candidate is consumed) has a lens to fall back to.
+SCOPE="vault accounting|C1"
+CLASS_FITNESS="C1=0.5500"
+PENDING="cand-0|vault accounting|C1"
+
+# STEPS is a BOUND, not a sequence authority (agentis has no range(); a reduce over this list bounds the loop
+# at <steps> iterations). BUDGET matches so the loop runs exactly <steps> decisions worst-case.
+STEPS=""
+if [ "$STEPS_N" -gt 0 ]; then
+  STEPS="$(awk -v n="$STEPS_N" 'BEGIN{ for (i=0;i<n;i++){ printf "%s%d", (i?"\n":""), i } }')"
+fi
+
+RUN_LOG="$RUN/orchestrate.log"
+# ONE in-substrate run drives the autonomous hunt. ORCHESTRATE_ENABLED selects the loop; DISPATCH_ENABLED keeps
+# each action's dispatch in-substrate; DISPATCH_FIXTURE is EMPTY so invariant-hunt takes its LIVE route (the
+# REAL forge-invariant gate over INV_REPO/INV_TARGET). INV_POLICY_TT seeds the policy so the engine is chosen.
+( cd "$RUN" && env \
+    SCOPE="$SCOPE" \
+    CLASS_FITNESS="$CLASS_FITNESS" \
+    PENDING="$PENDING" \
+    BUDGET="$STEPS_N" \
+    DRY_CAP=3 \
+    STEPS="$STEPS" \
+    INV_POLICY_TT="$INV_POLICY_TT" \
+    ORCHESTRATE_ENABLED=1 \
+    DISPATCH_ENABLED=1 \
+    DISPATCH_FIXTURE="" \
+    FORGE_INVARIANT="$FORGE_INVARIANT" \
+    INV_REPO="$REPO" \
+    INV_TARGET="$TARGET" \
+    INV_MATCH="$MATCH" \
+    INV_RUNS="$RUNS" \
+    INV_DEPTH="$DEPTH" \
+    INV_SEED="$SEED" \
+    "$AGENTIS" go coordinator.ag --enable-exec --enable-messaging ) >"$RUN_LOG" 2>&1 \
+  || { echo "run-autonomous-hunt.sh: in-substrate autonomous hunt failed (see $RUN_LOG)" >&2; exit 1; }
+
+grep -E '^ORCHESTRATE\|' "$RUN_LOG" >/dev/null 2>&1 \
+  || { echo "run-autonomous-hunt.sh: orchestration did not complete (no ORCHESTRATE| marker; see $RUN_LOG)" >&2; exit 1; }
+
+# Surface the AUTONOMOUS DECISION TRAIL: the coordinator's ACTION| lines (what it chose + why) and the
+# DISPATCH| lines (the fuzzer's verdict for each). The full run log (incl. the LIVE-route message + any
+# shrunk witness) is at $RUN_LOG.
+echo "run-autonomous-hunt.sh: autonomous decision trail:" >&2
+grep -E '^(ACTION|DISPATCH)\|' "$RUN_LOG" | while IFS= read -r line; do
+  echo "run-autonomous-hunt.sh: $line" >&2
+done
+
+# The FINAL VERDICT for the routed candidate is the durable coordinator:last_outcome memo (the substrate-native
+# cross-process channel): `<type>|<args>|<verdict>`. The verdict is the fuzzer's shrunk witness, never the LLM.
+OUTCOME="$( ( cd "$RUN" && "$AGENTIS" memo get coordinator:last_outcome ) 2>/dev/null | tail -1 )"
+POLICY_AFTER="$( ( cd "$RUN" && "$AGENTIS" memo get coordinator:policy_after ) 2>/dev/null )"
+echo "run-autonomous-hunt.sh: final coordinator:last_outcome = [$OUTCOME]" >&2
+echo "run-autonomous-hunt.sh: policy AFTER the run        = [$POLICY_AFTER]" >&2
+echo "run-autonomous-hunt.sh: full run log -> $RUN_LOG" >&2
+exit 0


### PR DESCRIPTION
## What

Part of #1037 (**Int M1**). Connects the autonomy layer to the real hunt: the self-orchestrating coordinator (#1014) now **autonomously chooses** and **live-runs** the #1035 stateful-invariant fuzzer on a target — finding a real multi-step bug end-to-end. Until now the coordinator (decides the workflow) and the bug-FINDING engines (Halmos #1015, the #1035 fuzzer) were built separately; this wires the fuzzer in as an action the coordinator can pick and dispatch live.

## How

Mirrors **exactly** how `symbolic-prove` was added as a VERIFY-tier action (#1015 M3) and given a live route (#1032):

- **`coordinator.ag`** — `invariant-hunt` becomes a 4th VERIFY-tier action: `score_invariant` (base 94; ×4 policy term, so the evolving policy can lift it to the top of the tier); `is_action`; the LIVE route `run_invariant_live()` runs the **REAL `evm-harness/forge-invariant.sh`** and maps its exit code via the shared `sym_outcome_of` (**1 = FINDING → confirmed, 0 = CLEAN → refuted, 2/else → dry** — the verdict is the fuzzer's shrunk witness, never the LLM). The in-substrate orchestrate loop carries an `invariant-hunt` policy int + seen flag (state fields 21/22, seeded from `INV_POLICY_TT`) exactly as `symbolic-prove` carries `SYM_POLICY_TT`. **Purely additive** — with no live env, behaviour is byte-identical, so every existing golden is unchanged.
- **`dispatcher.ag`** — `is_action` parity (the `demo-dispatch.sh` sync-guard stays green).
- **`run-autonomous-hunt.sh`** — operator entry: hand it `--repo`/`--target`, it seeds the candidate + the live env + the policy lead, runs ONE orchestrate `agentis go`, and the coordinator autonomously picks + live-runs the fuzzer.
- **`demo-autonomous-hunt.sh`**, **`docs/autonomous-hunt.md`**, README, CHANGELOG.

## Verification (run LIVE against real forge 1.7.1 + agentis 1.19.0)

- **`demo-autonomous-hunt.sh` — PROVEN live**: the coordinator **autonomously chose** `invariant-hunt` (`ACTION|invariant-hunt`, by its evolving policy — not an operator-fixed sequence) and live-ran the REAL fuzzer → the inflation vault: `DISPATCH|invariant-hunt|cand-0|confirmed` (a real multi-step exploit); the hardened twin: `...|refuted` (no false positive). The outcome evolved the policy (`learn` for `invariant-hunt`). All 6 assertions (A autonomous-choice / B verdict / C outcome→policy, × both vaults) green.
- **No regression** — live: `demo-invariant-hunt.sh` (#1035) PASS, `demo-symbolic-orchestrate-live.sh` (#1032) PROVEN, `demo-dispatch.sh` sync-guard green, `demo-orchestrate.sh`/`demo-coordinator.sh`/`demo-symbolic-orchestrate.sh` goldens green.
- **`colony-lint.sh` → 367 / 0 / 5**; `check-exec-sh` clean (every dynamic `exec sh` value `shell_escape`d).

## Boundary

The colony NEVER auto-submits — a FINDING is a human-triaged candidate. The LLM only writes the handler + invariants; the coordinator only **chooses the engine**; the verdict is the fuzzer's exit code. Multi-candidate carrying of a *discovered* lead + method-invention/DAG hookup are #1037 M2/M3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
