### PR TITLE
feat(dark-factory): multi-candidate carrying — each lead verifies on its own context (Int M2, #1037)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,41 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Multi-candidate carrying — each pending lead verifies its OWN target, not one shared operator env**
+  (Integration M2, #1037). M1's live route read the target from a SINGLE flat env (`INV_REPO`/`INV_TARGET`),
+  so every candidate the loop verified hit the same operator-supplied target. M2 makes each candidate carry
+  its **own** repo/target context via the durable memo channel, so the loop can verify several pending leads
+  and each `invariant-hunt`/`symbolic-prove` runs on the **right** lead — closing the loop from discovery
+  (many leads) to a sound verdict on each *specific* lead.
+  - `auditor/agents/coordinator.ag` — `run_invariant_live(candId)` and `run_symbolic_live(candId)` now take the
+    candidate id (the action `args`, threaded from the `action_outcome` live branches) and resolve repo/target/
+    match (and the symbolic `sym_repo`/`sym_spec`/`sym_function`) **per-candidate-first, env-fallback** via a
+    new `cand_fact(candId, field, envKey)` helper: read `candidate:<id>:<field>` (the `recall_latest`-durable
+    cross-process channel), use it when non-empty, else fall back to the flat M1 env. The live-route **GATE**
+    keys on the **resolved** repo+target (per-candidate OR env), so a candidate carrying only its own memo
+    (flat env empty) still routes live; with neither it falls through to the honest stub. Run-level forge
+    budgets (`INV_RUNS`/`INV_DEPTH`/`INV_SEED`) stay env-only. **Purely additive** — an empty per-candidate
+    memo ⇒ the M1 env path ⇒ **byte-identical M1 behaviour** (the `decide_once` scoring and state-field carry
+    are untouched; all M1 + sibling goldens stay green). Every resolved value is still `shell_escape()`d.
+  - `run-autonomous-hunt.sh` — a repeatable `--candidate '<id>|<repo>|<target>[|<match>]'` flag. Each candidate
+    is validated (a foundry dir + an existing target), `agentis memo set candidate:<id>:repo/target/match` into
+    the shared store (after `agentis init`, before `agentis go` — NOT in `exec.env_passthrough`, they cross via
+    the durable memo channel), and contributes one `<id>|…` cell to `PENDING`. The single `--repo/--target`
+    stays as the one-candidate `cand-0` shorthand (full M1 back-compat — `demo-autonomous-hunt.sh` passes
+    unchanged). With candidates supplied, `BUDGET`/`STEPS` auto-scale to `>= 2 × candidate-count` so every
+    candidate is both routed and attributed; `INV_POLICY_TT` seeding keeps `invariant-hunt` winning the VERIFY
+    tier for each.
+  - `demo-candidate-carry.sh` — the rigorous proof. Builds the vulnerable inflation vault (project A) + hardened
+    twin (project B) in two separate temp foundry projects, drives ONE `run-autonomous-hunt.sh` with TWO
+    `--candidate` args, and **leaves the flat `INV_REPO`/`INV_TARGET` env EMPTY** so the ONLY way each candidate
+    can resolve a target is via its carried `candidate:<id>:*` memo. Asserts BOTH the autonomous choice
+    (`ACTION|invariant-hunt|cand-{0,1}`) and the SPLIT verdict (`DISPATCH|invariant-hunt|cand-0|confirmed` on A,
+    `…|cand-1|refuted` on B) — a shared env could not produce two different verdicts, so the split PROVES
+    per-candidate carrying. `[SKIP]` + exit 0 when forge/agentis are absent (CI convention).
+  - `docs/autonomous-hunt.md` — a "Per-candidate context carrying (M2)" section documenting the
+    `candidate:<id>:{repo,target,match,sym_repo,sym_spec,sym_function}` memo convention, the
+    per-candidate-first/env-fallback rule, and that `run-discovery.sh`/`hunter.ag` can populate these memos as
+    the discovery producer. Wired into `README.md` (the Hunt-autonomously section + the Layout map).
 - **The self-orchestrating coordinator AUTONOMOUSLY chooses + LIVE-runs the stateful-invariant fuzzer — a new
   `invariant-hunt` action, end-to-end** (Integration M1, #1037). #1035 shipped the fuzzer as a *callable
   engine* (an operator runs `run-invariant-hunt.sh`); Int M1 wires it into the #1014 self-orchestrating

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -419,6 +419,23 @@ spend*, the fuzzer decides *whether the bug reproduces*, a human decides *whethe
 posts. See [`docs/autonomous-hunt.md`](./docs/autonomous-hunt.md) for the end-to-end flow, the verdict→outcome
 mapping, and the human-gated submit boundary.
 
+**Multi-candidate carrying (Int M2, #1037).** Each pending lead can carry its **own** repo/target via the
+durable `candidate:<id>:{repo,target,match}` memo, so when the loop verifies several leads each `invariant-hunt`
+runs on the **right** lead — not one shared operator env. The live route resolves each fact per-candidate-first,
+env-fallback (empty memo ⇒ the M1 env path ⇒ byte-identical M1). A repeatable `--candidate
+'<id>|<repo>|<target>[|<match>]'` seeds them (the single `--repo/--target` is the one-candidate `cand-0`
+shorthand). [`demo-candidate-carry.sh`](./demo-candidate-carry.sh) is the rigorous proof: two candidates, the
+flat `INV_REPO`/`INV_TARGET` env left EMPTY, yielding a SPLIT verdict (`cand-0|confirmed` on the vulnerable
+vault, `cand-1|refuted` on the hardened twin) that a shared env could not produce.
+
+```bash
+# multi-candidate, each lead carrying its OWN target via its candidate:<id>:* memo:
+dark-factory/run-autonomous-hunt.sh \
+  --candidate "cand-0|$PWD/A|test/Inv.t.sol" --candidate "cand-1|$PWD/B|test/Inv.t.sol" --seed 1
+# the split-verdict proof (flat env EMPTY; SKIPs without forge/agentis):
+dark-factory/demo-candidate-carry.sh
+```
+
 ## Exercise the evolve/fitness loop (`evolve-fitness.sh`)
 
 Every hunt the colony runs records a `learn("hunt", "<class>:<subsystem>", ..., outcome, [...])` row in
@@ -500,7 +517,7 @@ dark-factory/
   run-symbolic.sh               # operator entrypoint: GENERATE a Halmos spec per candidate + VERIFY it (#1015 M2)
   run-invariant-hunt.sh         # operator entrypoint: GENERATE a Foundry stateful-invariant test + VERIFY it with the fuzzer (#1035)
   run-coordinator.sh            # bootstrap for the self-orchestrating loop (ONE agentis go; the loop lives in-substrate; #1014 M3)
-  run-autonomous-hunt.sh        # integration: the coordinator CHOOSES + LIVE-runs the stateful fuzzer on a target (Int M1, #1037)
+  run-autonomous-hunt.sh        # integration: the coordinator CHOOSES + LIVE-runs the stateful fuzzer on a target; --candidate carries each lead's own context (Int M1+M2, #1037)
   demo-coordinator.sh           # offline, deterministic proof of the #1014 fact-driven + evolving-policy loop
   demo-dispatch.sh              # offline, deterministic proof of the #1014 M2 substrate DISPATCH (every action type)
   demo-orchestrate.sh           # offline, deterministic proof of the #1014 M3 in-substrate loop (byte-identical to the M2 shell loop)
@@ -514,6 +531,7 @@ dark-factory/
   demo-symbolic-orchestrate.sh  # offline, deterministic proof of the #1015 M3 coordinator routing a candidate to the sound symbolic engine
   demo-invariant-hunt.sh        # offline-deterministic proof of the #1035 stateful-fuzzing loop (vulnerable -> FINDING, hardened -> CLEAN; SKIPs without forge)
   demo-autonomous-hunt.sh       # offline-deterministic proof of the Int M1 autonomous hunt (coordinator CHOOSES + LIVE-runs the fuzzer; SKIPs without forge)
+  demo-candidate-carry.sh       # Int M2 proof: TWO candidates carry their OWN target via candidate:<id>:* memos, flat env EMPTY -> SPLIT verdict (cand-0|confirmed, cand-1|refuted; SKIPs without forge)
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)
@@ -548,7 +566,7 @@ dark-factory/
   docs/halmos.md                # the Halmos gate's verdict/exit contract, toolchain install, epic fit (#1015)
   docs/generate-verify.md       # the #1015 M2 generate-and-verify loop: LLM hypothesizes, Halmos proves; verdict-source contract
   docs/invariant-hunt.md        # the #1035 stateful-invariant-fuzzing loop: LLM writes deep invariants, the fuzzer finds the multi-step exploit; verdict-source contract
-  docs/autonomous-hunt.md       # the Int M1 (#1037) end-to-end: coordinator CHOOSES (policy) + LIVE-runs the fuzzer; verdict->outcome mapping; human-gated submit boundary
+  docs/autonomous-hunt.md       # the Int M1+M2 (#1037) end-to-end: coordinator CHOOSES (policy) + LIVE-runs the fuzzer; per-candidate context carrying (candidate:<id>:* memos); verdict->outcome mapping; human-gated submit boundary
   sealevel/                     # modernized coral-xyz/sealevel-attacks lessons (corpus) (V6)
   fixtures/                     # detection fixtures (vuln + safe + rigged-harness cases)
 ```

--- a/dark-factory/auditor/agents/coordinator.ag
+++ b/dark-factory/auditor/agents/coordinator.ag
@@ -361,11 +361,21 @@ fn sym_fn_prefix(raw: string) -> string {
     if len(raw) == 0 { return "check"; }
     return raw;
 }
-fn run_symbolic_live() -> string {
+// Int M2 (#1037): resolve a per-candidate context fact PER-CANDIDATE-FIRST, env-fallback. The candidate id
+// carries its own context in a `candidate:<id>:<field>` memo (the durable cross-process channel); when that
+// memo is empty (the M1 single-target case), fall back to the flat env fact. Empty per-candidate memo =>
+// the M1 env path => byte-identical M1 behaviour (purely additive). `repo`/`target`/`spec` are the run-level
+// knobs (INV_RUNS/_DEPTH/_SEED) stay env-only.
+fn cand_fact(candId: string, field: string, envKey: string) -> string {
+    let pc = recall_latest("candidate:" + candId + ":" + field);
+    if len(pc) > 0 { return pc; }
+    return getenv(envKey);
+}
+fn run_symbolic_live(candId: string) -> string {
     let gate = getenv("HALMOS_VERIFY");
-    let repo = getenv("SYM_REPO");
-    let spec = getenv("SYM_SPEC");
-    let fnPrefix = sym_fn_prefix(getenv("SYM_FUNCTION"));
+    let repo = cand_fact(candId, "sym_repo", "SYM_REPO");
+    let spec = cand_fact(candId, "sym_spec", "SYM_SPEC");
+    let fnPrefix = sym_fn_prefix(cand_fact(candId, "sym_function", "SYM_FUNCTION"));
     let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --repo " + shell_escape(repo)
                + " --target " + shell_escape(spec) + " --function " + shell_escape(fnPrefix)
                + " 2>&1; echo __rc=$?";
@@ -382,6 +392,8 @@ fn run_symbolic_live() -> string {
 // own default invariant prefix is `invariant`; default to it when INV_MATCH is unset (invariant-prover.ag's
 // match_prefix). INV_RUNS/INV_DEPTH/INV_SEED are OPTIONAL forge budgets, appended as --runs/--depth/--seed
 // only when non-empty (built exactly like invariant-prover.ag's `budget` concat), each value shell_escape()d.
+// Int M2 (#1037): repo/target/match resolve PER-CANDIDATE-FIRST via cand_fact(candId, ...) (the
+// `candidate:<id>:{repo,target,match}` memo) then env-fallback, so each pending lead verifies its OWN target.
 fn inv_match_prefix(raw: string) -> string {
     if len(raw) == 0 { return "invariant"; }
     return raw;
@@ -390,11 +402,11 @@ fn inv_opt_flag(flag: string, val: string) -> string {
     if len(val) == 0 { return ""; }
     return " " + flag + " " + shell_escape(val);
 }
-fn run_invariant_live() -> string {
+fn run_invariant_live(candId: string) -> string {
     let gate = getenv("FORGE_INVARIANT");
-    let repo = getenv("INV_REPO");
-    let target = getenv("INV_TARGET");
-    let match = inv_match_prefix(getenv("INV_MATCH"));
+    let repo = cand_fact(candId, "repo", "INV_REPO");
+    let target = cand_fact(candId, "target", "INV_TARGET");
+    let match = inv_match_prefix(cand_fact(candId, "match", "INV_MATCH"));
     let budget = inv_opt_flag("--runs", getenv("INV_RUNS")) + inv_opt_flag("--depth", getenv("INV_DEPTH"))
                + inv_opt_flag("--seed", getenv("INV_SEED"));
     // colony-lint: safe-exec-concat
@@ -432,38 +444,41 @@ fn action_outcome(atype: string, args: string) -> string {
             return "dry";
         }
     }
-    // LIVE symbolic-prove (#1032): an operator-supplied single-candidate context (SYM_REPO + SYM_SPEC + the
-    // HALMOS_VERIFY gate path) routes the chosen candidate through REAL Halmos end-to-end inside the loop.
-    // All three must be present; otherwise this falls through to the honest stub (additive — no live env =
-    // unchanged behaviour). The verdict is Halmos's exit code, mapped COUNTEREXAMPLE->confirmed / PROVED->
-    // refuted / INCONCLUSIVE|harness->dry — never an LLM judgement.
+    // LIVE symbolic-prove (#1032): a per-candidate-first context (the `candidate:<id>:sym_repo` / `:sym_spec`
+    // memo, else the flat SYM_REPO / SYM_SPEC env — Int M2 #1037) plus the HALMOS_VERIFY gate path routes the
+    // chosen candidate through REAL Halmos end-to-end inside the loop. The GATE keys on the RESOLVED repo+spec
+    // (per-candidate OR env): a candidate with only its carried memo still routes live; with neither it falls
+    // through to the honest stub (additive — no live context = byte-identical M1). The verdict is Halmos's
+    // exit code, mapped COUNTEREXAMPLE->confirmed / PROVED->refuted / INCONCLUSIVE|harness->dry — never an LLM.
     if atype == "symbolic-prove" {
         let gate = getenv("HALMOS_VERIFY");
-        let repo = getenv("SYM_REPO");
-        let spec = getenv("SYM_SPEC");
+        let repo = cand_fact(args, "sym_repo", "SYM_REPO");
+        let spec = cand_fact(args, "sym_spec", "SYM_SPEC");
         if len(gate) > 0 {
             if len(repo) > 0 {
                 if len(spec) > 0 {
                     print("coordinator: LIVE symbolic-prove of '" + args + "' -> running REAL Halmos via " + gate + " on " + spec + " (SOUND verdict; the LLM never judges).");
-                    return run_symbolic_live();
+                    return run_symbolic_live(args);
                 }
             }
         }
     }
-    // LIVE invariant-hunt (Int M1, #1037): an operator-supplied single-candidate context (INV_REPO foundry dir
-    // + INV_TARGET invariant `*.t.sol` + the FORGE_INVARIANT gate path) routes the chosen candidate through the
-    // REAL stateful fuzzer end-to-end inside the loop. All three must be present; otherwise this falls through
-    // to the honest stub (additive — no live env = unchanged behaviour). The verdict is forge's shrunk witness
-    // (its exit code), mapped FINDING->confirmed / CLEAN->refuted / HARNESS_ERROR->dry — never an LLM judgement.
+    // LIVE invariant-hunt (Int M1, #1037): a per-candidate-first context (the `candidate:<id>:repo` /
+    // `:target` memo, else the flat INV_REPO foundry dir / INV_TARGET invariant `*.t.sol` env — Int M2 #1037)
+    // plus the FORGE_INVARIANT gate path routes the chosen candidate through the REAL stateful fuzzer
+    // end-to-end inside the loop. The GATE keys on the RESOLVED repo+target (per-candidate OR env): a candidate
+    // carrying only its own memo still routes live; with neither it falls through to the honest stub (additive
+    // — no live context = byte-identical M1). The verdict is forge's shrunk witness (its exit code), mapped
+    // FINDING->confirmed / CLEAN->refuted / HARNESS_ERROR->dry — never an LLM judgement.
     if atype == "invariant-hunt" {
         let gate = getenv("FORGE_INVARIANT");
-        let repo = getenv("INV_REPO");
-        let target = getenv("INV_TARGET");
+        let repo = cand_fact(args, "repo", "INV_REPO");
+        let target = cand_fact(args, "target", "INV_TARGET");
         if len(gate) > 0 {
             if len(repo) > 0 {
                 if len(target) > 0 {
                     print("coordinator: LIVE invariant-hunt of '" + args + "' -> running the REAL stateful fuzzer via " + gate + " on " + target + " (verdict = forge's shrunk witness; the LLM never judges).");
-                    return run_invariant_live();
+                    return run_invariant_live(args);
                 }
             }
         }

--- a/dark-factory/demo-candidate-carry.sh
+++ b/dark-factory/demo-candidate-carry.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# demo-candidate-carry.sh — Integration M2 (#1037): each discovered lead carries its OWN target context, so the
+# coordinator's LIVE invariant-hunt verifies the RIGHT lead — not one shared operator env.
+#
+# demo-autonomous-hunt.sh (M1) proves ONE candidate routed through the coordinator's autonomous choice over a
+# SINGLE flat env (INV_REPO/INV_TARGET). THIS demo proves M2's per-candidate carrying: it seeds TWO candidates
+# in ONE run-autonomous-hunt.sh invocation, each with its OWN `candidate:<id>:{repo,target,match}` context, and
+# leaves the flat INV_REPO/INV_TARGET env EMPTY. The ONLY way a verdict can resolve for each candidate is via
+# its carried memo (the per-candidate-first, env-fallback resolution in run_invariant_live). It then asserts:
+#   (A) the coordinator AUTONOMOUSLY chose invariant-hunt for BOTH candidates (ACTION|invariant-hunt|cand-0 and
+#       |cand-1) — the COORDINATOR picked the engine, not the operator;
+#   (B) DISPATCH|invariant-hunt|cand-0|confirmed (it ran on the VULNERABLE vault A) AND
+#       DISPATCH|invariant-hunt|cand-1|refuted (it ran on the HARDENED twin B).
+# The SPLIT verdict is the proof: a single shared env could NOT produce two different verdicts. confirmed-on-A
+# + refuted-on-B with the flat env EMPTY means each candidate verified its OWN carried target.
+#
+# The two vaults are the SAME inflation-vault + hardened-twin demo-autonomous-hunt.sh builds (same contracts,
+# same fixture handler+invariant that already produce FINDING/CLEAN there). The verdict is the FUZZER's exit
+# code, never the LLM's opinion. A FINDING is a LEAD a human triages, never an auto-submission; this colony
+# never posts.
+#
+# CI has no forge (nor necessarily agentis), so if EITHER is missing this prints a single [SKIP] line and
+# exits 0 (mirroring demo-autonomous-hunt.sh / the colony-lint skip convention). Install the toolchain to run:
+#   curl -L https://foundry.paradigm.xyz | bash && foundryup    # forge (has built-in invariant fuzzing)
+#
+# Usage:  dark-factory/demo-candidate-carry.sh
+# Exit: 0 = both carried verdicts correct (cand-0->confirmed on A, cand-1->refuted on B, each the coordinator's
+#       autonomous choice, with the flat env EMPTY), or tools absent -> SKIP ; non-zero = an assertion failed.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUNNER="$HERE/run-autonomous-hunt.sh"
+
+FAILS=0
+note() { echo "demo-candidate-carry.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+skip() { echo "  [SKIP] $*"; }
+
+# Skip EARLY (before any work) when the toolchain is missing, so CI without forge reports a clean [SKIP] +
+# exit 0 rather than a harness error. agentis is required to drive the substrate coordinator loop.
+if ! command -v forge >/dev/null 2>&1; then
+  skip "forge not on PATH — install foundryup (https://getfoundry.sh) to run this demo"
+  exit 0
+fi
+if ! command -v agentis >/dev/null 2>&1; then
+  skip "agentis not on PATH — install the agentis runtime to drive the substrate coordinator loop"
+  exit 0
+fi
+
+[ -x "$RUNNER" ] || { note "runner not found / not executable: $RUNNER" >&2; exit 3; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/demo-candidate-carry.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# ----------------------------------------------------------------------------------------------------------
+# Build the two tiny foundry repos: VULNERABLE (no virtual offset, project A) and HARDENED (large virtual-share
+# offset, project B). Identical to demo-autonomous-hunt.sh's scaffolding so the SAME fixture handler+invariant
+# drives both — only the share-pricing math differs (the inflation attack is a MULTI-STEP bug the fuzzer must
+# find by sequence). Each lives in its OWN temp foundry project; each is carried by its OWN candidate.
+# ----------------------------------------------------------------------------------------------------------
+mk_repo() {  # $1 = repo dir, $2 = the `s = ...` deposit pricing line, $3 = the `assets = ...` withdraw line
+  _dir="$1"; _depositMath="$2"; _withdrawMath="$3"
+  mkdir -p "$_dir/src" "$_dir/test"
+  printf '[profile.default]\nsrc = "src"\nout = "out"\n\n[invariant]\nruns = 64\ndepth = 32\nfail_on_revert = false\n' > "$_dir/foundry.toml"
+  cat > "$_dir/src/Vault.sol" <<SOL
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+contract Token {
+  mapping(address=>uint) public balanceOf; uint public totalSupply;
+  function mint(address to,uint a) external { balanceOf[to]+=a; totalSupply+=a; }
+  function transfer(address to,uint a) external returns(bool){ balanceOf[msg.sender]-=a; balanceOf[to]+=a; return true; }
+  function transferFrom(address f,address t,uint a) external returns(bool){ balanceOf[f]-=a; balanceOf[t]+=a; return true; }
+}
+contract Vault {
+  Token public asset; uint public totalShares; mapping(address=>uint) public shares;
+  uint constant VS = 1000000000000000000000000000; uint constant VA = 1; // virtual offset (1e27); VS=1 in the vulnerable build below
+  constructor(Token a){ asset=a; }
+  function deposit(uint assets) external returns(uint s){
+    uint ta = asset.balanceOf(address(this));
+    ${_depositMath}
+    asset.transferFrom(msg.sender,address(this),assets);
+    shares[msg.sender]+=s; totalShares+=s;
+  }
+  function withdraw(uint s) external returns(uint assets){
+    uint ta = asset.balanceOf(address(this));
+    ${_withdrawMath}
+    shares[msg.sender]-=s; totalShares-=s;
+    asset.transfer(msg.sender,assets);
+  }
+}
+SOL
+}
+
+# VULNERABLE (project A): classic ERC4626 share price (no virtual offset) -> donation inflates ta, the next
+# deposit mints 0 shares -> the depositor's claim collapses far below their deposit (a MULTI-STEP attack).
+mk_repo "$WORK/A" \
+  's = totalShares==0 ? assets : assets*totalShares/ta;' \
+  'assets = s*ta/totalShares;'
+
+# HARDENED (project B): a large virtual-share/asset offset (the OpenZeppelin ERC4626 decimal-offset mitigation)
+# so the share price cannot be inflated enough to round a real depositor to zero shares -> the same attack fails.
+mk_repo "$WORK/B" \
+  's = assets * (totalShares + VS) / (ta + VA);' \
+  'assets = s * (ta + VA) / (totalShares + VS);'
+
+# ----------------------------------------------------------------------------------------------------------
+# The PROVEN fixture handler+invariant (from demo-autonomous-hunt.sh), written DIRECTLY into each repo's test/
+# dir so each candidate's carried --target points the coordinator's LIVE invariant route at it. A `Handler`
+# exposes the protocol's actions as bounded actor functions (attackerSeed / attackerDonate / victimDeposit)
+# and a DEEP invariant (`invariant_victim_not_robbed`). forge-std-free: targets via the `targetContracts()`
+# StdInvariant ABI forge auto-discovers, asserted with plain `require`.
+# ----------------------------------------------------------------------------------------------------------
+write_fixture() {  # $1 = repo dir
+  cat > "$1/test/Inv.t.sol" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import {Vault, Token} from "../src/Vault.sol";
+
+// The protocol's actions as a real attacker/user calls them, with fuzzed inputs bounded to realistic ranges.
+contract Handler {
+    Vault public v; Token public t;
+    uint public victimDeposited;   // total assets the honest victim has put in
+    uint public victimShares;      // shares the victim holds
+    constructor(Vault _v, Token _t){ v=_v; t=_t; }
+    // forge-std-free bound: keep a fuzzed uint inside [lo, hi] without the forge-std `bound` cheatcode.
+    function _bound(uint x, uint lo, uint hi) internal pure returns (uint) {
+        if (hi <= lo) return lo;
+        return lo + (x % (hi - lo + 1));
+    }
+    function attackerSeed() public { t.mint(address(this), 1); v.deposit(1); }              // seed 1 share
+    function attackerDonate(uint a) public { a = _bound(a, 1, 1e24); t.mint(address(v), a); } // direct transfer, no shares
+    function victimDeposit(uint a) public {
+        a = _bound(a, 1e6, 1e18);
+        t.mint(address(this), a);
+        uint s = v.deposit(a);
+        victimDeposited += a; victimShares += s;
+    }
+}
+
+// StdInvariant ABI forge auto-discovers: targetContracts() lists the addresses the fuzzer drives. No forge-std.
+abstract contract InvBase {
+    address[] private _targets;
+    function targetContracts() public view returns (address[] memory) { return _targets; }
+    function _target(address a) internal { _targets.push(a); }
+}
+
+contract VaultInvariantTest is InvBase {
+    Vault v; Token t; Handler h;
+    function setUp() public { t=new Token(); v=new Vault(t); h=new Handler(v,t); _target(address(h)); }
+    // DEEP invariant: the victim's CLAIM on the vault (shares * vaultBalance / totalShares) must always be
+    // worth >= what they deposited, minus dust. The inflation attack makes a victim deposit mint 0 shares,
+    // so their claim collapses far below their deposit -> a SEQUENCE the fuzzer must find.
+    function invariant_victim_not_robbed() public view {
+        uint vd = h.victimDeposited();
+        if (vd == 0) return;
+        uint ts = v.totalShares();
+        uint claim = ts == 0 ? 0 : h.victimShares() * t.balanceOf(address(v)) / ts;
+        require(claim + 1e6 >= vd, "victim robbed");   // claim within dust(1e6) of deposit
+    }
+}
+SOL
+}
+write_fixture "$WORK/A"
+write_fixture "$WORK/B"
+
+# ----------------------------------------------------------------------------------------------------------
+# ONE run-autonomous-hunt.sh invocation, TWO candidates, each carrying its OWN context. CRITICAL RIGOR: we do
+# NOT pass --repo/--target, AND we wipe the flat INV_REPO/INV_TARGET/INV_MATCH from the environment, so the
+# ONLY way each candidate can resolve a target is via its carried `candidate:<id>:*` memo. cand-0 -> A
+# (vulnerable), cand-1 -> B (hardened). A fixed --seed makes the search reproducible.
+# ----------------------------------------------------------------------------------------------------------
+OUT="$WORK/out"
+SEED=1
+note "driving ONE coordinator loop with TWO carried candidates (flat INV_REPO/INV_TARGET EMPTY) ..."
+env -u INV_REPO -u INV_TARGET -u INV_MATCH \
+  "$RUNNER" \
+    --candidate "cand-0|$WORK/A|$WORK/A/test/Inv.t.sol|invariant" \
+    --candidate "cand-1|$WORK/B|$WORK/B/test/Inv.t.sol|invariant" \
+    --backend mock --runs 256 --depth 64 --seed "$SEED" --out "$OUT" >"$OUT.log" 2>&1
+RC=$?
+
+LOG="$OUT/run/orchestrate.log"
+if [ "$RC" -ne 0 ] || [ ! -f "$LOG" ]; then
+  bad "run-autonomous-hunt.sh did not complete (exit $RC); runner log:"
+  sed 's/^/        | /' "$OUT.log" 2>/dev/null | tail -30
+  note "DEMO FAILED — the multi-candidate run did not produce an orchestrate log." >&2
+  exit 1
+fi
+
+# Proof that the flat env really WAS empty for this run (the runner forwards INV_REPO/INV_TARGET from its own
+# environment; env -u above wiped them, and no --repo/--target was passed). Surface it for the trail.
+note "flat env this run: INV_REPO=[${INV_REPO:-}] INV_TARGET=[${INV_TARGET:-}] (both EMPTY -> verdicts can ONLY come from carried memos)"
+note "autonomous decision trail:"
+grep -E '^(ACTION|DISPATCH)\|invariant-hunt\|' "$LOG" | sed 's/^/        | /'
+
+# (A) the coordinator AUTONOMOUSLY chose invariant-hunt for BOTH candidates (not the operator).
+for cid in cand-0 cand-1; do
+  if grep -qE "^ACTION\|invariant-hunt\|$cid\|" "$LOG"; then
+    ok "(A) coordinator AUTONOMOUSLY chose invariant-hunt for $cid (not the operator)"
+  else
+    bad "(A) no 'ACTION|invariant-hunt|$cid|' line — the coordinator did not choose the engine for $cid"
+    sed 's/^/        | /' "$LOG" 2>/dev/null | tail -30
+  fi
+done
+
+# (B) the SPLIT verdict — each candidate's carried target produced its OWN verdict. A shared env could not.
+assert_dispatch() {  # $1 = candidate id, $2 = expected verdict, $3 = which carried project
+  _cid="$1"; _want="$2"; _proj="$3"
+  _line="$(grep -E "^DISPATCH\|invariant-hunt\|$_cid\|" "$LOG" | head -1)"
+  case "$_line" in
+    DISPATCH\|invariant-hunt\|"$_cid"\|"$_want")
+      ok "(B) DISPATCH|invariant-hunt|$_cid|$_want — ran on its carried $_proj (the LIVE fuzzer's verdict)" ;;
+    *)
+      bad "(B) expected 'DISPATCH|invariant-hunt|$_cid|$_want', got '$_line'"
+      note "  the LIVE-route message + verdict the fuzzer produced for $_cid:"
+      grep -E "LIVE invariant-hunt of '$_cid'|FORGE-INVARIANT:" "$LOG" 2>/dev/null | sed 's/^/        | /' ;;
+  esac
+}
+assert_dispatch "cand-0" "confirmed" "VULNERABLE vault A"
+assert_dispatch "cand-1" "refuted"   "HARDENED twin B"
+
+echo
+echo "=================================================================================="
+if [ "$FAILS" -eq 0 ]; then
+  note "PROVEN. ONE coordinator loop, TWO pending leads, each carrying its OWN context via the durable"
+  note "candidate:<id>:{repo,target} memo — with the flat INV_REPO/INV_TARGET env EMPTY. The coordinator"
+  note "autonomously chose invariant-hunt for BOTH and the LIVE fuzzer returned a SPLIT verdict: cand-0 ->"
+  note "confirmed (it ran on the VULNERABLE vault A) and cand-1 -> refuted (it ran on the HARDENED twin B)."
+  note "A shared env could NOT produce two different verdicts — the split PROVES per-candidate carrying."
+  note "The verdict is the FUZZER's exit code, never the LLM's; submission stays human-gated; this colony"
+  note "never posts."
+  exit 0
+fi
+note "DEMO FAILED — $FAILS assertion(s) did not hold (see above)." >&2
+exit 1

--- a/dark-factory/docs/autonomous-hunt.md
+++ b/dark-factory/docs/autonomous-hunt.md
@@ -1,4 +1,4 @@
-# Autonomous stateful-invariant hunt — Integration M1 (#1037)
+# Autonomous stateful-invariant hunt — Integration M1 + M2 (#1037)
 
 Two pieces shipped separately: the **self-orchestrating coordinator** ([`docs/coordinator.md`](./coordinator.md),
 #1014) that DECIDES the next audit action from facts + an evolving policy, and the **stateful-invariant
@@ -89,10 +89,69 @@ dark-factory/demo-autonomous-hunt.sh
 bug), for the HARDENED twin `…|refuted` (no false positive). It asserts (A) the coordinator AUTONOMOUSLY chose
 the engine, (B) the LIVE fuzzer's verdict crossed back, and (C) the outcome evolved the policy.
 
+## Per-candidate context carrying (M2)
+
+M1's live route reads the target from a SINGLE flat env (`INV_REPO`/`INV_TARGET`/`INV_MATCH`), so every
+candidate the loop verifies hits the same operator-supplied target. **Integration M2** makes each pending lead
+carry its **own** repo/target context, so when the loop verifies several candidates each `invariant-hunt`
+(and `symbolic-prove`) runs on the **right** lead — closing the loop from discovery (many leads) to a sound
+verdict on each *specific* lead.
+
+### The `candidate:<id>:*` memo convention
+
+A candidate id `cand-N` carries its context in `recall_latest`-readable memos (the durable cross-process
+channel, dynamic-key) — NOT in env. The keys:
+
+| memo key | env fallback | role |
+|---|---|---|
+| `candidate:<id>:repo` | `INV_REPO` | foundry project root the fuzzer runs in |
+| `candidate:<id>:target` | `INV_TARGET` | the invariant `*.t.sol` the fuzzer scopes to |
+| `candidate:<id>:match` | `INV_MATCH` | invariant function-name prefix (default `invariant`) |
+| `candidate:<id>:sym_repo` | `SYM_REPO` | foundry project root Halmos runs in |
+| `candidate:<id>:sym_spec` | `SYM_SPEC` | the symbolic spec target Halmos scopes to |
+| `candidate:<id>:sym_function` | `SYM_FUNCTION` | symbolic check-function prefix (default `check`) |
+
+Run-level forge budgets (`INV_RUNS`/`INV_DEPTH`/`INV_SEED`) stay env-only — they are knobs of the *run*, not
+of a *candidate*.
+
+### Per-candidate-first, env-fallback
+
+`coordinator.ag`'s live routes (`run_invariant_live(candId)` / `run_symbolic_live(candId)`) resolve each fact
+**per-candidate-first**: read `candidate:<id>:<field>`; if that memo is non-empty use it, else fall back to the
+flat env. The live-route GATE keys on the **resolved** repo+target (per-candidate OR env), so a candidate
+carrying ONLY its own memo (flat env empty) still routes live; with **neither** it falls through to the honest
+stub. An empty per-candidate memo ⇒ the M1 env path ⇒ **byte-identical M1 behaviour** — M2 is purely additive.
+
+### Driving it — `--candidate`
+
+`run-autonomous-hunt.sh` takes a repeatable `--candidate '<id>|<repo>|<target>[|<match>]'`. For each candidate
+it `agentis memo set candidate:<id>:repo/target/match` into the shared store (after `agentis init`, before
+`agentis go`) and appends one `<id>|…` cell to `PENDING`. The single `--repo/--target` stays as the
+one-candidate `cand-0` shorthand (full M1 back-compat). With candidates supplied, `BUDGET`/`STEPS` auto-scale
+to `>= 2 × candidate-count` so every candidate is both routed (one step) and attributed (the next).
+
+```bash
+# multi-candidate: each lead carries its OWN target via its candidate:<id>:* memo
+dark-factory/run-autonomous-hunt.sh \
+  --candidate "cand-0|$PWD/A|test/Inv.t.sol" \
+  --candidate "cand-1|$PWD/B|test/Inv.t.sol" --seed 1
+
+# the rigorous proof: TWO candidates, flat INV_REPO/INV_TARGET EMPTY -> a SPLIT verdict
+# (cand-0|confirmed on the vulnerable vault, cand-1|refuted on the hardened twin) that a shared env
+# could not produce. SKIPs without forge/agentis.
+dark-factory/demo-candidate-carry.sh
+```
+
+### The discovery producer
+
+`run-discovery.sh` / `hunter.ag` (the discovery side) can populate these `candidate:<id>:*` memos as it
+emits leads, so a discovered lead carries its contract + invariant test straight through `PENDING` to the live
+verify — no operator re-typing the target per candidate. The memo convention is the contract between the
+producer (discovery) and the consumer (the coordinator's live verify routes).
+
 ## Honest scope
 
-This integration drives a SINGLE operator-supplied candidate through the live route — the minimum live slice,
-exactly the boundary `symbolic-prove`'s live route (#1032) set. Multi-candidate code-carrying (a discovered
-lead auto-carrying its contract + invariant test through `PENDING`), a long-lived daemon-tick reflex (the loop
-running continuously without a shell bootstrap), and the coordinator pruning a live cell manifest all remain
-follow-up on epics #1014 / #1035 / #1037.
+M2 carries each lead's repo/target context through the durable memo channel. A long-lived daemon-tick reflex
+(the loop running continuously without a shell bootstrap), auto-GENERATION of the per-candidate invariant test
+from a discovered lead (here the test is supplied alongside the contract), and the coordinator pruning a live
+cell manifest all remain follow-up on epics #1014 / #1035 / #1037.

--- a/dark-factory/run-autonomous-hunt.sh
+++ b/dark-factory/run-autonomous-hunt.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# run-autonomous-hunt.sh — Integration M1 (#1037): the self-orchestrating coordinator AUTONOMOUSLY chooses
-# and LIVE-runs the stateful-invariant fuzzer on a target, end-to-end.
+# run-autonomous-hunt.sh — Integration M1 + M2 (#1037): the self-orchestrating coordinator AUTONOMOUSLY
+# chooses and LIVE-runs the stateful-invariant fuzzer on one or more targets, end-to-end. M2 adds the
+# repeatable --candidate flag so each lead carries its OWN context and verifies on the RIGHT target.
 #
 # WHAT IT IS. This is the integration entrypoint that closes the loop between the #1014 self-orchestrating
 # coordinator and the #1035 stateful-invariant fuzzer (`evm-harness/forge-invariant.sh`). It drives ONE
@@ -115,6 +116,10 @@ for spec in "${CANDIDATES[@]}"; do
   c_target="${rest%%|*}"
   if [ "$rest" = "$c_target" ]; then c_match="$MATCH"; else c_match="${rest#*|}"; fi
   [ -n "$c_id" ]     || { echo "run-autonomous-hunt.sh: --candidate '$spec' has an empty id" >&2; exit 2; }
+  # The id becomes part of a `candidate:<id>:*` memo key (agentis memo keys reject whitespace and other
+  # special chars). Reject anything outside [A-Za-z0-9_:.-] up front so a malformed id is a clean error
+  # instead of a silenced `memo set` failure that would later degrade the candidate to the safe `dry` stub.
+  case "$c_id" in *[!A-Za-z0-9_:.-]*) echo "run-autonomous-hunt.sh: --candidate id '$c_id' must match [A-Za-z0-9_:.-] (no spaces/special chars — it is a memo key)" >&2; exit 2 ;; esac
   [ -n "$c_repo" ]   || { echo "run-autonomous-hunt.sh: --candidate '$c_id' has an empty repo" >&2; exit 2; }
   [ -n "$c_target" ] || { echo "run-autonomous-hunt.sh: --candidate '$c_id' has an empty target" >&2; exit 2; }
   [ -n "$c_match" ]  || c_match="$MATCH"

--- a/dark-factory/run-autonomous-hunt.sh
+++ b/dark-factory/run-autonomous-hunt.sh
@@ -15,14 +15,30 @@
 # coordinator CHOOSES the engine, the gate's exit code is the sound verdict, and the outcome evolves the
 # policy. Submission stays human-gated; this colony never posts to a bounty platform.
 #
+# Int M2 (#1037): MULTI-CANDIDATE. Each discovered lead carries its OWN target context so the coordinator's
+# live invariant-hunt verifies the RIGHT lead — not one shared operator env. A repeatable `--candidate` seeds
+# the per-candidate `candidate:<id>:{repo,target,match}` memos (the durable cross-process channel the
+# coordinator reads via recall_latest), and the coordinator resolves each fact PER-CANDIDATE-FIRST,
+# env-fallback. The single `--repo/--target` stays as the one-candidate `cand-0` shorthand (full M1
+# back-compat: with no --candidate the flat INV_REPO/INV_TARGET env path is byte-identical to M1).
+#
 # Usage:
 #   run-autonomous-hunt.sh --repo <foundry-root> --target <Invariant.t.sol>
 #                          [--match <prefix>] [--backend mock|flat-cyborg|claude]
 #                          [--runs N] [--depth D] [--seed S] [--steps N] [--out <dir>]
 #                          [--agentis <bin>]
+#   run-autonomous-hunt.sh --candidate '<id>|<repo>|<target>[|<match>]' [--candidate ...] [flags...]
 #
-#   --repo <dir>      Foundry project root (must hold foundry.toml) the fuzzer runs in. REQUIRED.
-#   --target <file>   The invariant `*.t.sol` the fuzzer scopes to (absolute or relative to --repo). REQUIRED.
+#   --repo <dir>      Foundry project root (must hold foundry.toml) the fuzzer runs in. REQUIRED unless one or
+#                     more --candidate are supplied.
+#   --target <file>   The invariant `*.t.sol` the fuzzer scopes to (absolute or relative to --repo). REQUIRED
+#                     unless one or more --candidate are supplied.
+#   --candidate '<id>|<repo>|<target>[|<match>]'
+#                     A pending lead carrying its OWN context (repeatable). <id> is the candidate id (e.g.
+#                     cand-0), <repo> a foundry root, <target> its invariant `*.t.sol`, optional <match> the
+#                     invariant prefix (default "invariant"). The flat INV_REPO/INV_TARGET env is NOT required
+#                     when candidates are supplied — each carries its target via its memo. BUDGET/STEPS auto-
+#                     scale to >= 2 x candidate-count so every candidate is both routed and attributed.
 #   --match <prefix>  Invariant function-name prefix forge runs (default "invariant").
 #   --backend <b>     LLM backend for the agentis store (default mock — the DECISION is offline-deterministic;
 #                     the verdict is the fuzzer's, so no LLM is needed for the integration loop).
@@ -49,29 +65,30 @@ RUNS=""
 DEPTH=""
 SEED=""
 STEPS_N=2
+STEPS_SET=0
 OUT="$PWD/autonomous-hunt-out"
+# Int M2 (#1037): accumulated --candidate specs, one per array slot (`<id>|<repo>|<target>[|<match>]`).
+CANDIDATES=()
 
 need() { [ "$1" -ge 2 ] || { echo "run-autonomous-hunt.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
   case "$1" in
-    --repo)    need "$#"; REPO="$2"; shift 2 ;;
-    --target)  need "$#"; TARGET="$2"; shift 2 ;;
-    --match)   need "$#"; MATCH="$2"; shift 2 ;;
-    --backend) need "$#"; BACKEND="$2"; shift 2 ;;
-    --runs)    need "$#"; RUNS="$2"; shift 2 ;;
-    --depth)   need "$#"; DEPTH="$2"; shift 2 ;;
-    --seed)    need "$#"; SEED="$2"; shift 2 ;;
-    --steps)   need "$#"; STEPS_N="$2"; shift 2 ;;
-    --out)     need "$#"; OUT="$2"; shift 2 ;;
-    --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
+    --repo)      need "$#"; REPO="$2"; shift 2 ;;
+    --target)    need "$#"; TARGET="$2"; shift 2 ;;
+    --candidate) need "$#"; CANDIDATES+=("$2"); shift 2 ;;
+    --match)     need "$#"; MATCH="$2"; shift 2 ;;
+    --backend)   need "$#"; BACKEND="$2"; shift 2 ;;
+    --runs)      need "$#"; RUNS="$2"; shift 2 ;;
+    --depth)     need "$#"; DEPTH="$2"; shift 2 ;;
+    --seed)      need "$#"; SEED="$2"; shift 2 ;;
+    --steps)     need "$#"; STEPS_N="$2"; STEPS_SET=1; shift 2 ;;
+    --out)       need "$#"; OUT="$2"; shift 2 ;;
+    --agentis)   need "$#"; AGENTIS="$2"; shift 2 ;;
     --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
     *) echo "run-autonomous-hunt.sh: unknown flag $1" >&2; exit 2 ;;
   esac
 done
 
-[ -n "$REPO" ] && [ -d "$REPO" ] || { echo "run-autonomous-hunt.sh: --repo <foundry project root> required" >&2; exit 2; }
-[ -f "$REPO/foundry.toml" ] || { echo "run-autonomous-hunt.sh: --repo is not a foundry project (no foundry.toml): $REPO" >&2; exit 2; }
-[ -n "$TARGET" ] || { echo "run-autonomous-hunt.sh: --target <Invariant.t.sol> required" >&2; exit 2; }
 [ -n "$MATCH" ] || { echo "run-autonomous-hunt.sh: --match prefix must be non-empty" >&2; exit 2; }
 case "$STEPS_N" in (*[!0-9]*|'') echo "run-autonomous-hunt.sh: --steps must be a non-negative integer" >&2; exit 2 ;; esac
 [ "$STEPS_N" -ge 1 ] || { echo "run-autonomous-hunt.sh: --steps must be >= 1 (one decision routes the candidate, the next attributes its outcome)" >&2; exit 2; }
@@ -79,16 +96,41 @@ for v in "$RUNS" "$DEPTH" "$SEED"; do
   case "$v" in '') ;; *[!0-9]*) echo "run-autonomous-hunt.sh: --runs/--depth/--seed must be whole numbers" >&2; exit 2 ;; esac
 done
 
-# Resolve the target to an ABSOLUTE path (the colony runs from the rundir, a different cwd; the exec sandbox
-# cannot read a relative/home-rooted path). Accept either an absolute/relative file OR a path under --repo.
-if [ -f "$TARGET" ]; then
-  TARGET="$(cd "$(dirname "$TARGET")" && pwd)/$(basename "$TARGET")"
-elif [ -f "$REPO/$TARGET" ]; then
-  TARGET="$(cd "$REPO" && pwd)/$TARGET"
-else
-  echo "run-autonomous-hunt.sh: --target test not found: $TARGET" >&2; exit 2
+# The single --repo/--target is the one-candidate `cand-0` shorthand (full M1 back-compat). It is folded into
+# the SAME candidate list the repeatable --candidate populates, so the seeding loop below treats both uniformly.
+if [ -n "$REPO" ] || [ -n "$TARGET" ]; then
+  [ -n "$REPO" ]   || { echo "run-autonomous-hunt.sh: --repo required alongside --target" >&2; exit 2; }
+  [ -n "$TARGET" ] || { echo "run-autonomous-hunt.sh: --target required alongside --repo" >&2; exit 2; }
+  CANDIDATES=("cand-0|$REPO|$TARGET|$MATCH" "${CANDIDATES[@]}")
 fi
-REPO="$(cd "$REPO" && pwd)"
+[ "${#CANDIDATES[@]}" -ge 1 ] || { echo "run-autonomous-hunt.sh: supply --repo/--target or at least one --candidate '<id>|<repo>|<target>[|<match>]'" >&2; exit 2; }
+
+# Validate + ABSOLUTE-resolve every candidate's repo/target (the colony runs from the rundir, a different cwd;
+# the exec sandbox cannot read a relative/home-rooted path). Each parsed candidate is stored back as
+# `<id>|<repoAbs>|<targetAbs>|<matchPrefix>` in C_RESOLVED for the memo-seeding + PENDING loops below.
+C_RESOLVED=()
+for spec in "${CANDIDATES[@]}"; do
+  c_id="${spec%%|*}"; rest="${spec#*|}"
+  c_repo="${rest%%|*}"; rest="${rest#*|}"
+  c_target="${rest%%|*}"
+  if [ "$rest" = "$c_target" ]; then c_match="$MATCH"; else c_match="${rest#*|}"; fi
+  [ -n "$c_id" ]     || { echo "run-autonomous-hunt.sh: --candidate '$spec' has an empty id" >&2; exit 2; }
+  [ -n "$c_repo" ]   || { echo "run-autonomous-hunt.sh: --candidate '$c_id' has an empty repo" >&2; exit 2; }
+  [ -n "$c_target" ] || { echo "run-autonomous-hunt.sh: --candidate '$c_id' has an empty target" >&2; exit 2; }
+  [ -n "$c_match" ]  || c_match="$MATCH"
+  [ -d "$c_repo" ]   || { echo "run-autonomous-hunt.sh: --candidate '$c_id' repo is not a directory: $c_repo" >&2; exit 2; }
+  [ -f "$c_repo/foundry.toml" ] || { echo "run-autonomous-hunt.sh: --candidate '$c_id' repo is not a foundry project (no foundry.toml): $c_repo" >&2; exit 2; }
+  if [ -f "$c_target" ]; then
+    c_target="$(cd "$(dirname "$c_target")" && pwd)/$(basename "$c_target")"
+  elif [ -f "$c_repo/$c_target" ]; then
+    c_target="$(cd "$c_repo" && pwd)/$c_target"
+  else
+    echo "run-autonomous-hunt.sh: --candidate '$c_id' target test not found: $c_target" >&2; exit 2
+  fi
+  c_repo="$(cd "$c_repo" && pwd)"
+  C_RESOLVED+=("$c_id|$c_repo|$c_target|$c_match")
+done
+N_CAND="${#C_RESOLVED[@]}"
 
 command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-autonomous-hunt.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
 
@@ -123,6 +165,19 @@ cp "$COORD_AG" "$RUN/coordinator.ag"
   echo "experience.enabled = true"
 } > "$RUN/.agentis/config"
 
+# Int M2 (#1037): seed each candidate's OWN context into the SHARED store the coordinator reads from via
+# recall_latest("candidate:<id>:..."). MUST run AFTER `agentis init` (the store exists) and BEFORE `agentis go`
+# (the loop reads them). These keys are NOT in exec.env_passthrough — they cross via the durable memo channel,
+# not env — so each pending lead verifies its OWN repo/target, env-fallback only when a memo is empty.
+for spec in "${C_RESOLVED[@]}"; do
+  c_id="${spec%%|*}"; rest="${spec#*|}"
+  c_repo="${rest%%|*}"; rest="${rest#*|}"
+  c_target="${rest%%|*}"; c_match="${rest#*|}"
+  ( cd "$RUN" && "$AGENTIS" memo set "candidate:$c_id:repo" "$c_repo" >/dev/null 2>&1 )
+  ( cd "$RUN" && "$AGENTIS" memo set "candidate:$c_id:target" "$c_target" >/dev/null 2>&1 )
+  ( cd "$RUN" && "$AGENTIS" memo set "candidate:$c_id:match" "$c_match" >/dev/null 2>&1 )
+done
+
 # SEED the in-substrate loop's INITIAL invariant-hunt policy weight high enough that score_invariant
 # (94 + 4x lead) beats score_refute (100): lead >= ~1.6 lifts invariant-hunt above refute. We use 2.0
 # (= INV_POLICY_TT 20000 ten-thousandths) so the coordinator AUTONOMOUSLY chooses invariant-hunt from step 0.
@@ -131,12 +186,30 @@ cp "$COORD_AG" "$RUN/coordinator.ag"
 # builtin, so the integer is supplied directly, exactly like run-coordinator.sh's SYM_POLICY_TT.)
 INV_POLICY_TT=20000
 
-# A single pending candidate represents the target — the same shape the orchestrate loop expects (seeded into
-# PENDING so a VERIFY action, here invariant-hunt, is the chosen action immediately). The SCOPE/CLASS_FITNESS
-# carry one cell so the post-verify fallback (after the candidate is consumed) has a lens to fall back to.
+# Int M2 (#1037): one PENDING cell PER candidate (`<id>|<subsystem>|<class>`) in submission order — the
+# orchestrate loop pops the first pending lead each VERIFY step, routes it through invariant-hunt, and the
+# per-candidate memo seeded above makes that lead verify its OWN target. The SCOPE/CLASS_FITNESS carry one
+# cell so the post-verify fallback (after the last candidate is consumed) has a lens to fall back to.
 SCOPE="vault accounting|C1"
 CLASS_FITNESS="C1=0.5500"
-PENDING="cand-0|vault accounting|C1"
+PENDING=""
+for spec in "${C_RESOLVED[@]}"; do
+  c_id="${spec%%|*}"
+  cell="$c_id|vault accounting|C1"
+  if [ -z "$PENDING" ]; then PENDING="$cell"; else PENDING="$PENDING
+$cell"; fi
+done
+
+# Int M2 (#1037): scale the loop budget to >= 2 x candidate-count so EVERY candidate is both routed (one step)
+# AND its outcome attributed to the policy (the next step), never starved by the bound. A larger explicit
+# --steps wins; otherwise STEPS_N climbs to 2*N. BUDGET tracks STEPS_N so the loop runs that many decisions.
+MIN_STEPS=$((2 * N_CAND))
+if [ "$STEPS_SET" -eq 0 ] && [ "$STEPS_N" -lt "$MIN_STEPS" ]; then
+  STEPS_N="$MIN_STEPS"
+elif [ "$STEPS_SET" -eq 1 ] && [ "$STEPS_N" -lt "$MIN_STEPS" ]; then
+  echo "run-autonomous-hunt.sh: --steps $STEPS_N < 2 x candidates ($MIN_STEPS); each candidate needs a route + an attribute step" >&2
+  exit 2
+fi
 
 # STEPS is a BOUND, not a sequence authority (agentis has no range(); a reduce over this list bounds the loop
 # at <steps> iterations). BUDGET matches so the loop runs exactly <steps> decisions worst-case.
@@ -147,8 +220,11 @@ fi
 
 RUN_LOG="$RUN/orchestrate.log"
 # ONE in-substrate run drives the autonomous hunt. ORCHESTRATE_ENABLED selects the loop; DISPATCH_ENABLED keeps
-# each action's dispatch in-substrate; DISPATCH_FIXTURE is EMPTY so invariant-hunt takes its LIVE route (the
-# REAL forge-invariant gate over INV_REPO/INV_TARGET). INV_POLICY_TT seeds the policy so the engine is chosen.
+# each action's dispatch in-substrate; DISPATCH_FIXTURE is EMPTY so invariant-hunt takes its LIVE route. Int M2
+# (#1037): the per-candidate `candidate:<id>:*` memos (seeded into the store above) carry each lead's repo/
+# target; the flat INV_REPO/INV_TARGET/INV_MATCH below are only the env-FALLBACK (set by the --repo/--target
+# shorthand, EMPTY in the multi-candidate path so each lead resolves purely from its carried memo). INV_POLICY_TT
+# seeds the policy so the engine is chosen.
 ( cd "$RUN" && env \
     SCOPE="$SCOPE" \
     CLASS_FITNESS="$CLASS_FITNESS" \


### PR DESCRIPTION
## What

Part of #1037 (**Int M2**). M1 wired the coordinator to live-run the fuzzer, but the live routes read the target from a **single flat env** (`INV_REPO`/`INV_TARGET`, `SYM_REPO`/`SYM_SPEC`) — so every candidate the coordinator verifies hit the same operator-supplied target. M2 makes each pending candidate carry its **own** context, so when the loop verifies several discovered leads, each `invariant-hunt`/`symbolic-prove` runs on the **right** lead. This closes the loop from discovery (many leads) → a sound/fuzzed verdict on each *specific* lead.

## How — per-candidate context via the durable memo channel

A candidate id `cand-N` carries its context in `recall_latest`-readable memos (dynamic-key, the cross-process durable channel): `candidate:<id>:{repo,target,match,sym_repo,sym_spec,sym_function}`.

- **`coordinator.ag`** — new `cand_fact(candId, field, envKey)` resolves **per-candidate first** (`recall_latest("candidate:<id>:<field>")`), **env second**. `run_invariant_live(candId)` / `run_symbolic_live(candId)` take the candidate id and resolve repo/target/match (and the symbolic trio) through it; the `action_outcome` live branches thread `args` and gate on the **resolved** repo+target, so a candidate with only per-candidate context (flat env empty) still routes live. **Purely additive** — no per-candidate memo ⇒ env path ⇒ byte-identical M1 behaviour. `decide_once` scoring + the state-field carry are untouched.
- **`run-autonomous-hunt.sh`** — repeatable `--candidate '<id>|<repo>|<target>[|<match>]'` (the single `--repo/--target` stays as the `cand-0` shorthand). Each seeds `candidate:<id>:*` into the shared store + a `PENDING` cell; `BUDGET`/`STEPS` auto-scale to `>= 2 × candidate-count`.
- **`demo-candidate-carry.sh`** — the rigorous proof + docs/README/CHANGELOG.

## Verification (LIVE — forge 1.7.1, halmos 0.3.3, agentis 1.19.0)

- **`demo-candidate-carry.sh` — GREEN**: two candidates (vulnerable A / hardened B), the **flat `INV_REPO`/`INV_TARGET` env WIPED** (`env -u`), so the only way a verdict can resolve is via each candidate's carried memo. The result is a **SPLIT verdict** — `DISPATCH|invariant-hunt|cand-0|confirmed` (ran on A) AND `DISPATCH|invariant-hunt|cand-1|refuted` (ran on B). A shared env **could not** produce two different verdicts, so this proves per-candidate carrying. Reproducible across runs.
- **No regression** — LIVE: `demo-autonomous-hunt.sh` (M1 back-compat, byte-identical), `demo-symbolic-orchestrate-live.sh`, `demo-orchestrate.sh`, `demo-symbolic-orchestrate.sh`, `demo-coordinator.sh`, `demo-symbolic.sh`, `demo-invariant-hunt.sh`, `demo-dispatch.sh` sync-guard — all green.
- **`colony-lint.sh` → 367 / 0 / 5**; `check-exec-sh` clean.

## Boundary

Verdict = the engine's exit code, never the LLM; the colony NEVER auto-submits. Method-invention + DAG pattern memory is #1037 M3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
