### PR TITLE
feat(dark-factory): pattern-DAG memory + method-invention feed the hunt (Int M3, #1037)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,52 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Method-invention feeds the hunt + DAG pattern memory — the federation invents its own attack methods,
+  stores winning ones in the pattern DAG, and self-drives** (Integration M3, #1037, the FINAL milestone). M1
+  made the coordinator live-drive the fuzzer; M2 let each lead carry its own context. M3 closes the loop: a
+  winning invariant pattern (one that produced a FINDING) is **persisted to the pattern DAG** and **recalled
+  to seed future hunts**, and `invent-method` can propose a **new** invariant class the next hunt then uses.
+  It **reuses the existing `bugpat:*` DAG infrastructure** — the same `dag_put`/`recall_latest`/`memo_write`
+  primitives the fork-matcher seed/recall agents use, in a parallel `invpat:*` namespace — rather than building
+  a new store.
+  - `auditor/agents/invariant-prover.ag` — two additive hooks around its GENERATE-and-VERIFY step. **RECALL
+    before GENERATE:** reads `recall_latest("invpat:latest:<class>")` (falling back to `invpat:invented:<class>`
+    — the invent-method hint), prints `RECALL-INVPAT|<class>|<descriptor>` when non-empty, and folds the
+    descriptor into the LLM generation seed ("a prior FINDING on this class used this invariant pattern: …;
+    adapt it"); on the `HANDLER_FIXTURE` path the fixture stays authoritative but the `RECALL-INVPAT|` line is
+    still printed so the loop is observable. **PERSIST on FINDING:** *after* the verdict print (so a persist
+    failure can never alter the verdict), and only when `verdict == "FINDING"`, computes a deterministic
+    signature `<class>::<target>::<match-prefix>`, `dag_put`s it, writes `invpat:exact:<hash>` +
+    `invpat:latest:<class>`, emits `dark-factory:invariant_pattern_learned`, and prints
+    `INVPAT-LEARNED|<class>|<descriptor>`. Recall/persist steer GENERATION only — **the verdict stays the
+    fuzzer's exit code**; `prior`/the signature flow only into the prompt + the plain-stdout `RECALL-INVPAT|`
+    line, never into `exec sh`. **Purely additive** — with no recalled pattern the instruction is
+    byte-identical to M2.
+  - `run-invariant-hunt.sh` — a `--pattern-store <dir>` flag: a **persistent** agentis store reused across
+    runs where the `invpat:*` memos are kept. A bridge (via the `agentis memo` CLI) moves them **in** before
+    the prover run (so RECALL sees a prior run's confirmed shapes) and **out** after (so this run's FINDING is
+    kept for the next). Absent the flag the per-run store is ephemeral → no cross-run memory (byte-identical).
+  - `run-autonomous-hunt.sh` — `--pattern-store <dir>` routes the coordinator's chosen invariant-hunt through
+    `invariant-prover.ag` (so persist/recall happen) **without touching `coordinator.ag`**: it hands the
+    coordinator a thin prover-gate wrapper as `FORGE_INVARIANT` that speaks the gate's exact CLI + exit
+    contract (`1=FINDING/0=CLEAN/2=error`), so `run_invariant_live` + `sym_rc_of`/`sym_outcome_of` are
+    byte-identical, while internally routing through the prover in the persistent store (the prover's
+    `RECALL-INVPAT|`/`INVPAT-LEARNED|` lines are surfaced into the orchestrate log). A `--method-fixture <file>`
+    flag (Part B) consults a deterministic `METHOD|…` method-inventor proposal, parses the proposed bug class,
+    and seeds it as `invpat:invented:<class>` so the next hunt's generation consults it as a hint (the live
+    `method-inventor.ag` path stays prompt-driven; the fixture proves the wiring without an LLM). Absent
+    `--pattern-store` the coordinator calls the bare gate directly — M1/M2 byte-identical.
+  - `demo-pattern-memory.sh` — the end-to-end proof, all through `run-autonomous-hunt.sh --pattern-store`:
+    **Run 1** on the vulnerable vault A (class C1) → FINDING → the winning pattern is PERSISTED to the shared
+    store (`invpat:latest:C1` present + `INVPAT-LEARNED|C1|…`); **Run 2** on a structurally-different
+    vulnerable vault B of the SAME class → the prover RECALLs the stored pattern (`RECALL-INVPAT|C1|…`) and
+    B → FINDING (discovered → stored in the DAG → recalled → reused ACROSS targets); the **invent-method leg**
+    seeds a new invariant class (`invpat:invented:C1`) that the next hunt's generation consults. Honest
+    framing: the claim is the MEMORY LOOP works (persist/recall/reuse), not that recall is necessary for the
+    fuzzer to find B. `[SKIP]` + exit 0 when forge/agentis are absent (CI convention).
+  - `docs/autonomous-hunt.md` — a "Pattern memory (M3)" section documenting the `invpat:{exact,latest,invented}`
+    namespace, the persist-on-FINDING / recall-before-generate loop, `--pattern-store`, the prover-gate
+    wrapper, and the `invent-method` feed; notes it reuses the `bugpat:*` DAG infra. Wired into `README.md`.
 - **Multi-candidate carrying — each pending lead verifies its OWN target, not one shared operator env**
   (Integration M2, #1037). M1's live route read the target from a SINGLE flat env (`INV_REPO`/`INV_TARGET`),
   so every candidate the loop verified hit the same operator-supplied target. M2 makes each candidate carry

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -436,6 +436,24 @@ dark-factory/run-autonomous-hunt.sh \
 dark-factory/demo-candidate-carry.sh
 ```
 
+**Pattern memory + invent-method feed (Int M3, #1037).** A winning invariant pattern — one that produced a
+FINDING — is **persisted to the pattern DAG** (`invpat:latest:<class>`, reusing the same `dag_put`/
+`recall_latest` infra as the `bugpat:*` fork-matcher) and **recalled to seed a later hunt** on the same bug
+class (the prover prints `RECALL-INVPAT|<class>|…` / `INVPAT-LEARNED|<class>|…`), and `invent-method` can
+propose a **new** invariant class the next hunt then uses. `--pattern-store <dir>` is the persistent cross-run
+store; absent it, behaviour is byte-identical to M1/M2. `--method-fixture <file>` seeds an invented class
+(`invpat:invented:<class>`) deterministically. [`demo-pattern-memory.sh`](./demo-pattern-memory.sh) proves the
+loop: discovered → stored in the DAG → recalled → reused across a structurally-different same-class target,
+plus the invent-method leg.
+
+```bash
+# Run 1 persists a winning pattern; Run 2 on a same-class target recalls + reuses it (shared store S):
+dark-factory/run-autonomous-hunt.sh --repo "$PWD/A" --target test/Inv.t.sol --pattern-store "$PWD/S" --seed 1
+dark-factory/run-autonomous-hunt.sh --repo "$PWD/B" --target test/Inv.t.sol --pattern-store "$PWD/S" --seed 1
+# the persist -> recall -> reuse proof + the invent-method feed (SKIPs without forge/agentis):
+dark-factory/demo-pattern-memory.sh
+```
+
 ## Exercise the evolve/fitness loop (`evolve-fitness.sh`)
 
 Every hunt the colony runs records a `learn("hunt", "<class>:<subsystem>", ..., outcome, [...])` row in
@@ -515,9 +533,9 @@ dark-factory/
   run-summary.sh                # one-shot run -> monitor-/dashboard-consumable run-summary.json (#995)
   run-refute.sh                 # operator entrypoint: adversarial refutation (refuter fan-out) -> verdicts
   run-symbolic.sh               # operator entrypoint: GENERATE a Halmos spec per candidate + VERIFY it (#1015 M2)
-  run-invariant-hunt.sh         # operator entrypoint: GENERATE a Foundry stateful-invariant test + VERIFY it with the fuzzer (#1035)
+  run-invariant-hunt.sh         # operator entrypoint: GENERATE a Foundry stateful-invariant test + VERIFY it with the fuzzer (#1035); --pattern-store persists/recalls winning invariant patterns across runs (Int M3, #1037)
   run-coordinator.sh            # bootstrap for the self-orchestrating loop (ONE agentis go; the loop lives in-substrate; #1014 M3)
-  run-autonomous-hunt.sh        # integration: the coordinator CHOOSES + LIVE-runs the stateful fuzzer on a target; --candidate carries each lead's own context (Int M1+M2, #1037)
+  run-autonomous-hunt.sh        # integration: the coordinator CHOOSES + LIVE-runs the stateful fuzzer on a target; --candidate carries each lead's own context; --pattern-store persists/recalls winning patterns + --method-fixture feeds invent-method (Int M1+M2+M3, #1037)
   demo-coordinator.sh           # offline, deterministic proof of the #1014 fact-driven + evolving-policy loop
   demo-dispatch.sh              # offline, deterministic proof of the #1014 M2 substrate DISPATCH (every action type)
   demo-orchestrate.sh           # offline, deterministic proof of the #1014 M3 in-substrate loop (byte-identical to the M2 shell loop)
@@ -532,6 +550,7 @@ dark-factory/
   demo-invariant-hunt.sh        # offline-deterministic proof of the #1035 stateful-fuzzing loop (vulnerable -> FINDING, hardened -> CLEAN; SKIPs without forge)
   demo-autonomous-hunt.sh       # offline-deterministic proof of the Int M1 autonomous hunt (coordinator CHOOSES + LIVE-runs the fuzzer; SKIPs without forge)
   demo-candidate-carry.sh       # Int M2 proof: TWO candidates carry their OWN target via candidate:<id>:* memos, flat env EMPTY -> SPLIT verdict (cand-0|confirmed, cand-1|refuted; SKIPs without forge)
+  demo-pattern-memory.sh        # Int M3 proof: a FINDING persists invpat:latest:<class> to the DAG, a same-class target RECALLs + reuses it across runs, invent-method seeds a new class (SKIPs without forge)
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)
@@ -542,7 +561,7 @@ dark-factory/
     agents/poc-screener.ag      # substrate-native lead pre-screen via eval_ag (sandboxed PoC harness)
     agents/refuter.ag           # the adversarial-refutation agent (independent skeptic; default REFUTED)
     agents/symbolic-prover.ag   # generate-and-verify: LLM writes a Halmos spec, Halmos returns the sound verdict (#1015 M2)
-    agents/invariant-prover.ag  # stateful-fuzzing generate-and-verify: LLM writes a handler+deep invariants, the fuzzer returns the verdict + shrunk exploit sequence (#1035)
+    agents/invariant-prover.ag  # stateful-fuzzing generate-and-verify: LLM writes a handler+deep invariants, the fuzzer returns the verdict + shrunk exploit sequence (#1035); RECALLs a prior winning pattern before GENERATE + PERSISTs one on a FINDING to the invpat:* DAG memory (Int M3, #1037)
     agents/fitness-driver.ag    # one fitness-loop cell: hunter.ag's exact learn() over a ground-truth verdict
     agents/method-inventor.ag   # the meta-loop inventor: proposes a new audit method for a known gap (#998)
     agents/coordinator.ag       # self-orchestrating decider: fact+policy-driven actions (#1014); gated in-substrate dispatch for every action type (M2); gated in-substrate MULTI-STEP loop (M3)

--- a/dark-factory/auditor/agents/invariant-prover.ag
+++ b/dark-factory/auditor/agents/invariant-prover.ag
@@ -97,6 +97,29 @@ let invMatch = match_prefix(getenv("INV_MATCH"));
 let fixturePath = getenv("HANDLER_FIXTURE");
 let code = cat_file(getenv("CODE_PATH"));
 
+// --- RECALL a prior winning invariant pattern (Int M3, #1037) ------------------------------------
+// Before GENERATE, recall the latest invariant pattern that produced a FINDING on THIS bug class from the
+// DAG pattern memory (the `invpat:latest:<class>` memo, mirroring recall-match.ag's recall_latest over the
+// bugpat namespace). Recall steers GENERATION only — it can never change the verdict (which stays the
+// fuzzer's exit code). When non-empty we print a `RECALL-INVPAT|<class>|<descriptor>` line so the
+// discovered->stored->recalled->reused transfer is OBSERVABLE in the run log, and fold the descriptor into
+// the LLM generation seed (the HANDLER_FIXTURE path is authoritative — the fixture is unchanged — but the
+// RECALL line is STILL printed so the loop is observable). `prior` is derived from prior agent state, so it
+// is treated as UNTRUSTED: it flows ONLY into the prompt (a plain string) and the plain-stdout RECALL line,
+// never into `exec sh` — no shell_escape is needed because it never reaches a shell.
+// Int M3 (#1037) Part B: also consult `invpat:invented:<class>` — a NEW invariant class proposed by the
+// coordinator's invent-method action (method-inventor.ag, fixture path) — as an additional generation hint.
+// When the persisted-FINDING pattern is empty, the invented hint stands in as the recall descriptor.
+fn recall_pattern(klass: string) -> string {
+    let learned = recall_latest("invpat:latest:" + klass);
+    if len(learned) > 0 { return learned; }
+    return recall_latest("invpat:invented:" + klass);
+}
+let prior = recall_pattern(targetClass);
+if len(prior) > 0 {
+    print("RECALL-INVPAT|" + targetClass + "|" + prior);
+}
+
 // --- GENERATE the handler + invariants -----------------------------------------------------------
 // Offline / deterministic path: a HANDLER_FIXTURE is a ready-made invariant test used VERBATIM, no LLM.
 // This is the path demo-invariant-hunt.sh and a `--backend mock` wiring smoke take, so the
@@ -110,9 +133,18 @@ let fixture = cat_file(fixturePath);
 // solvency-under-any-sequence, no-free-value-extraction, share-price-monotonicity). The verdict is STILL the
 // FUZZER's (below); the LLM only writes the handler + the properties to check. Cold path, one target in / one
 // test out (no per-tick staleness to gate) -> the prompt carries an explicit prompt-gate-ok marker.
-fn generate_test(klass: string, src: string, matchPrefix: string) -> string {
+// Int M3 (#1037): fold a recalled prior pattern into the generation seed. When `prior` is non-empty (a prior
+// FINDING on this class, or an invented class hint), prepend a line steering the LLM to adapt that proven
+// invariant/handler shape to the current target. Empty `prior` => the instruction is byte-identical to M2.
+fn recall_seed(klass: string, prior: string) -> string {
+    if len(prior) == 0 { return ""; }
+    return "A prior FINDING on bug class " + klass + " used this invariant pattern: " + prior
+         + ". Adapt that invariant/handler shape to the current target.\n";
+}
+fn generate_test(klass: string, src: string, matchPrefix: string, prior: string) -> string {
     let instruction =
-        "You are a stateful-invariant-fuzzing engineer. Write a self-contained Foundry stateful-invariant "
+        recall_seed(klass, prior)
+      + "You are a stateful-invariant-fuzzing engineer. Write a self-contained Foundry stateful-invariant "
       + "test (Solidity, `pragma solidity ^0.8.20;`) for the target contract below so Foundry's invariant "
       + "fuzzer can drive randomized multi-call SEQUENCES through it and find a MULTI-STEP exploit. "
       + "Requirements:\n"
@@ -141,11 +173,11 @@ fn generate_test(klass: string, src: string, matchPrefix: string) -> string {
 // Single-assignment .ag: pick the test source ONCE (no `let` reassignment). A non-empty HANDLER_FIXTURE wins
 // (offline/deterministic, verbatim, no LLM); otherwise the LLM generates it (live path).
 let usedFixture = len(fixture) > 0;
-fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string) -> string {
+fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string, prior: string) -> string {
     if usedFix { return fix; }
-    return generate_test(klass, src, matchPrefix);
+    return generate_test(klass, src, matchPrefix, prior);
 }
-let test = choose_test(usedFixture, fixture, targetClass, code, invMatch);
+let test = choose_test(usedFixture, fixture, targetClass, code, invMatch, prior);
 
 // Write the generated/fixture test to INV_OUT (inside INV_REPO/test) so forge-invariant can run it. The test
 // content is UNTRUSTED — it is either an LLM completion (prompt-injectable by the untrusted target code under
@@ -193,4 +225,25 @@ fn gen_mode(usedFix: bool) -> string {
 let genMode = gen_mode(usedFixture);
 emit("dark-factory:invariant_verdict", "{\"target\":\"" + targetFn + "\",\"class\":\"" + targetClass + "\",\"verdict\":\"" + verdict + "\",\"gen\":\"" + genMode + "\",\"outcome\":\"" + outcome + "\"}");
 learn("invariant-prove", targetClass + ":" + targetFn, "stateful-invariant-fuzz generate-and-verify of " + targetFn + " (" + targetClass + ") -> " + verdict, outcome, [targetClass, verdict, outcome]);
+
+// --- PERSIST the winning invariant pattern to the DAG memory (Int M3, #1037) ---------------------
+// AFTER the verdict print (above), and ONLY on a FINDING, record the invariant pattern the fuzzer just
+// CONFIRMED into the same DAG pattern memory recall_pattern() reads from next time. This mirrors
+// seed-patterns.ag's `let h = dag_put(content); memo_write("bugpat:exact:" + h, class)` exactly, in the
+// parallel `invpat:*` namespace. The signature is a DETERMINISTIC, stable descriptor: the bug class + the
+// target label (the `INVARIANT|<target>` lens) + the invariant match-prefix — the same shape produces the
+// same `psig` across runs, so a later FINDING on the same class/shape recalls it. Placing PERSIST AFTER the
+// verdict print guarantees a persist failure can NEVER alter the verdict — persistence only RECORDS what the
+// fuzzer already confirmed; it does not change `verdict`, the printed marker, or the learn() outcome.
+fn persist_pattern(verd: string, klass: string, target: string, matchPrefix: string) -> void {
+    if verd == "FINDING" {
+        let psig = klass + "::" + target + "::" + matchPrefix;
+        let h = dag_put(psig);
+        memo_write("invpat:exact:" + h, klass);
+        memo_write("invpat:latest:" + klass, psig);
+        emit("dark-factory:invariant_pattern_learned", "{\"class\":\"" + klass + "\",\"sig\":\"" + psig + "\"}");
+        print("INVPAT-LEARNED|" + klass + "|" + psig);
+    }
+}
+persist_pattern(verdict, targetClass, targetFn, invMatch);
 memo_write("invariant-prover:last_check", "done");

--- a/dark-factory/demo-pattern-memory.sh
+++ b/dark-factory/demo-pattern-memory.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# demo-pattern-memory.sh — Integration M3 (#1037, FINAL milestone): the federation INVENTS its own attack
+# methods, STORES the winning ones in the pattern DAG, and RECALLS them to seed future hunts — the loop the
+# user described, closed end-to-end.
+#
+# M1 made the coordinator AUTONOMOUSLY choose + LIVE-run the stateful-invariant fuzzer; M2 let each lead carry
+# its OWN context. M3 adds the PATTERN MEMORY: a winning invariant pattern (one that produced a FINDING) is
+# PERSISTED to the DAG pattern memory (the `invpat:*` namespace, reusing the same `dag_put`/`recall_latest`/
+# `memo_write` primitives as the `bugpat:*` fork-matcher) and RECALLED to seed a LATER hunt on the same bug
+# class — and `invent-method` can propose a NEW invariant class the next hunt then uses.
+#
+# This demo proves the MEMORY LOOP across three legs, ALL through `run-autonomous-hunt.sh --pattern-store` (the
+# coordinator's autonomous choice + the prover's persist/recall), with a PERSISTENT store S shared across runs:
+#   (1) Run 1 on the VULNERABLE vault A (class C1) -> FINDING -> the winning pattern is PERSISTED to S
+#       (`invpat:latest:C1` present in S + an `INVPAT-LEARNED|C1|...` line in the run log).
+#   (2) Run 2 on a STRUCTURALLY-DIFFERENT vulnerable vault B of the SAME class C1 -> the prover RECALLS the
+#       stored pattern (`RECALL-INVPAT|C1|...` in the run log) and B -> FINDING. discovered -> stored in the
+#       DAG -> recalled -> reused ACROSS targets.
+#   (3) invent-method leg: a deterministic method-inventor proposal (a `METHOD|...` fixture) seeds a NEW
+#       invariant class as `invpat:invented:C1`; the next hunt's prover consults it as a generation hint
+#       (`RECALL-INVPAT|C1|METHOD|...`) and finds the bug -> FINDING. the self-invents feed.
+#
+# HONEST FRAMING. The claim is the MEMORY LOOP works (persist / recall / reuse), NOT that recall is strictly
+# necessary for the fuzzer to find B — both vaults are vulnerable, so each would FIND on its own. What the demo
+# proves is that the discovered pattern is STORED in the DAG and RECALLED to seed the later hunt, observably.
+# The verdict is the FUZZER's exit code, never the LLM's; a FINDING is a LEAD a human triages, never an
+# auto-submission; this colony never posts.
+#
+# CI has no forge (nor necessarily agentis), so if EITHER is missing this prints a single [SKIP] line and
+# exits 0 (mirroring demo-autonomous-hunt.sh / demo-candidate-carry.sh). Install the toolchain to run:
+#   curl -L https://foundry.paradigm.xyz | bash && foundryup    # forge (has built-in invariant fuzzing)
+#
+# Usage:  dark-factory/demo-pattern-memory.sh
+# Exit: 0 = the memory loop held (persist on A, recall+reuse on B, invent-method seeds + steers the next hunt),
+#       or tools absent -> SKIP ; non-zero = an assertion failed.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUNNER="$HERE/run-autonomous-hunt.sh"
+
+FAILS=0
+note() { echo "demo-pattern-memory.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+skip() { echo "  [SKIP] $*"; }
+
+# Skip EARLY (before any work) when the toolchain is missing, so CI without forge reports a clean [SKIP] +
+# exit 0 rather than a harness error. agentis is required to drive the substrate coordinator loop + the store.
+if ! command -v forge >/dev/null 2>&1; then
+  skip "forge not on PATH — install foundryup (https://getfoundry.sh) to run this demo"
+  exit 0
+fi
+if ! command -v agentis >/dev/null 2>&1; then
+  skip "agentis not on PATH — install the agentis runtime to drive the substrate coordinator loop"
+  exit 0
+fi
+
+[ -x "$RUNNER" ] || { note "runner not found / not executable: $RUNNER" >&2; exit 3; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/demo-pattern-memory.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# ----------------------------------------------------------------------------------------------------------
+# Build the foundry repos: TWO structurally-different VULNERABLE vaults of the SAME class C1 (the ERC4626
+# inflation attack). A and B differ in the share-pricing expression's STRUCTURE (spacing/parenthesization) but
+# are the same vulnerable class — so the SAME deep invariant catches both, and B's pattern is a genuine
+# transfer target for A's recalled pattern. Same scaffolding demo-autonomous-hunt.sh / demo-candidate-carry.sh
+# use, so the SAME fixture handler+invariant drives both. C is a third copy for the invent-method leg.
+# ----------------------------------------------------------------------------------------------------------
+mk_repo() {  # $1 = repo dir, $2 = the `s = ...` deposit pricing line, $3 = the `assets = ...` withdraw line
+  _dir="$1"; _depositMath="$2"; _withdrawMath="$3"
+  mkdir -p "$_dir/src" "$_dir/test"
+  printf '[profile.default]\nsrc = "src"\nout = "out"\n\n[invariant]\nruns = 64\ndepth = 32\nfail_on_revert = false\n' > "$_dir/foundry.toml"
+  cat > "$_dir/src/Vault.sol" <<SOL
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+contract Token {
+  mapping(address=>uint) public balanceOf; uint public totalSupply;
+  function mint(address to,uint a) external { balanceOf[to]+=a; totalSupply+=a; }
+  function transfer(address to,uint a) external returns(bool){ balanceOf[msg.sender]-=a; balanceOf[to]+=a; return true; }
+  function transferFrom(address f,address t,uint a) external returns(bool){ balanceOf[f]-=a; balanceOf[t]+=a; return true; }
+}
+contract Vault {
+  Token public asset; uint public totalShares; mapping(address=>uint) public shares;
+  uint constant VS = 1000000000000000000000000000; uint constant VA = 1; // virtual offset (unused in the vulnerable builds)
+  constructor(Token a){ asset=a; }
+  function deposit(uint assets) external returns(uint s){
+    uint ta = asset.balanceOf(address(this));
+    ${_depositMath}
+    asset.transferFrom(msg.sender,address(this),assets);
+    shares[msg.sender]+=s; totalShares+=s;
+  }
+  function withdraw(uint s) external returns(uint assets){
+    uint ta = asset.balanceOf(address(this));
+    ${_withdrawMath}
+    shares[msg.sender]-=s; totalShares-=s;
+    asset.transfer(msg.sender,assets);
+  }
+}
+SOL
+}
+
+# VULNERABLE vault A: classic ERC4626 share price (no virtual offset) -> donation inflates ta, the next
+# deposit mints 0 shares -> the depositor's claim collapses far below their deposit (a MULTI-STEP attack).
+mk_repo "$WORK/A" \
+  's = totalShares==0 ? assets : assets*totalShares/ta;' \
+  'assets = s*ta/totalShares;'
+
+# VULNERABLE vault B: SAME class C1 (no virtual offset, same inflation bug) but a structurally-different
+# pricing expression (fully parenthesized, spaced) — proving the recalled pattern transfers across a
+# differently-shaped target, not a byte-identical twin.
+mk_repo "$WORK/B" \
+  's = totalShares == 0 ? assets : (assets * totalShares) / ta;' \
+  'assets = (s * ta) / totalShares;'
+
+# VULNERABLE vault C: a third copy for the invent-method leg (a fresh store so the invented hint is the recall
+# descriptor, not a prior FINDING).
+mk_repo "$WORK/C" \
+  's = totalShares==0 ? assets : assets*totalShares/ta;' \
+  'assets = s*ta/totalShares;'
+
+# ----------------------------------------------------------------------------------------------------------
+# The PROVEN fixture handler+invariant (from demo-autonomous-hunt.sh / demo-candidate-carry.sh), written
+# DIRECTLY into each repo's test/ dir so each --target points the coordinator's LIVE invariant route at it.
+# ----------------------------------------------------------------------------------------------------------
+write_fixture() {  # $1 = repo dir
+  cat > "$1/test/Inv.t.sol" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import {Vault, Token} from "../src/Vault.sol";
+
+contract Handler {
+    Vault public v; Token public t;
+    uint public victimDeposited;
+    uint public victimShares;
+    constructor(Vault _v, Token _t){ v=_v; t=_t; }
+    function _bound(uint x, uint lo, uint hi) internal pure returns (uint) {
+        if (hi <= lo) return lo;
+        return lo + (x % (hi - lo + 1));
+    }
+    function attackerSeed() public { t.mint(address(this), 1); v.deposit(1); }
+    function attackerDonate(uint a) public { a = _bound(a, 1, 1e24); t.mint(address(v), a); }
+    function victimDeposit(uint a) public {
+        a = _bound(a, 1e6, 1e18);
+        t.mint(address(this), a);
+        uint s = v.deposit(a);
+        victimDeposited += a; victimShares += s;
+    }
+}
+
+abstract contract InvBase {
+    address[] private _targets;
+    function targetContracts() public view returns (address[] memory) { return _targets; }
+    function _target(address a) internal { _targets.push(a); }
+}
+
+contract VaultInvariantTest is InvBase {
+    Vault v; Token t; Handler h;
+    function setUp() public { t=new Token(); v=new Vault(t); h=new Handler(v,t); _target(address(h)); }
+    function invariant_victim_not_robbed() public view {
+        uint vd = h.victimDeposited();
+        if (vd == 0) return;
+        uint ts = v.totalShares();
+        uint claim = ts == 0 ? 0 : h.victimShares() * t.balanceOf(address(v)) / ts;
+        require(claim + 1e6 >= vd, "victim robbed");
+    }
+}
+SOL
+}
+write_fixture "$WORK/A"
+write_fixture "$WORK/B"
+write_fixture "$WORK/C"
+
+# The deterministic method-inventor proposal for the invent-method leg (the same `METHOD|...` shape
+# method-inventor.ag emits, used OFFLINE so the wiring is provable without an LLM).
+cat > "$WORK/method.txt" <<'METHOD'
+METHOD|seq-rounding-drift|C1|fuzz multi-call deposit/withdraw sequences asserting no-depositor-loss under any interleave|forge invariant over a Handler exposing the protocol actions as bounded actors|a control vault with a known share-rounding-drift bug must FAIL the invariant while the hardened twin holds
+METHOD
+
+SEED=1
+# Drive one target through the FULL coordinator loop with a PERSISTENT pattern store. $1=repo, $2=out dir,
+# $3=pattern store dir, $4 (optional) = a method-fixture for the invent-method leg.
+run_one() {
+  _repo="$1"; _out="$2"; _store="$3"; _method="${4:-}"
+  if [ -n "$_method" ]; then
+    "$RUNNER" --repo "$_repo" --target "$_repo/test/Inv.t.sol" --match invariant \
+              --backend mock --runs 256 --depth 64 --seed "$SEED" --steps 2 \
+              --pattern-store "$_store" --method-fixture "$_method" --out "$_out" >"$_out.log" 2>&1
+  else
+    "$RUNNER" --repo "$_repo" --target "$_repo/test/Inv.t.sol" --match invariant \
+              --backend mock --runs 256 --depth 64 --seed "$SEED" --steps 2 \
+              --pattern-store "$_store" --out "$_out" >"$_out.log" 2>&1
+  fi
+}
+run_log() { printf '%s' "$1/run/orchestrate.log"; }
+
+# ==========================================================================================================
+# (1) Run 1 — VULNERABLE vault A -> FINDING -> the winning pattern is PERSISTED to the shared store S.
+# ==========================================================================================================
+STORE="$WORK/pattern-store"
+echo "=================================================================================="
+echo " (1) RUN 1: vault A (class C1) -> coordinator CHOOSES invariant-hunt -> FINDING -> PERSIST to DAG"
+echo "=================================================================================="
+note "driving vault A through the coordinator loop with --pattern-store $STORE ..."
+run_one "$WORK/A" "$WORK/A-out" "$STORE"; RC1=$?
+LOG1="$(run_log "$WORK/A-out")"
+if [ "$RC1" -ne 0 ] || [ ! -f "$LOG1" ]; then
+  bad "Run 1 did not complete (exit $RC1); runner log:"
+  sed 's/^/        | /' "$WORK/A-out.log" 2>/dev/null | tail -25
+  note "DEMO FAILED — Run 1 produced no orchestrate log." >&2
+  exit 1
+fi
+# A: the coordinator autonomously chose invariant-hunt and the fuzzer confirmed (the bug reproduced).
+if grep -qE '^ACTION\|invariant-hunt\|cand-0\|' "$LOG1" && grep -qE '^DISPATCH\|invariant-hunt\|cand-0\|confirmed' "$LOG1"; then
+  ok "(1a) Run 1: coordinator AUTONOMOUSLY chose invariant-hunt on A and the LIVE fuzzer CONFIRMED (FINDING)"
+else
+  bad "(1a) Run 1: missing ACTION/DISPATCH confirmed for A"
+  grep -E '^(ACTION|DISPATCH)\|invariant-hunt\|' "$LOG1" | sed 's/^/        | /'
+fi
+# B: the winning pattern was PERSISTED to the DAG memory (the INVPAT-LEARNED line + the invpat:latest:C1 memo).
+if grep -qE '^INVPAT-LEARNED\|C1\|' "$LOG1"; then
+  ok "(1b) Run 1: the prover PERSISTED the winning invariant pattern (INVPAT-LEARNED|C1|... in the run log)"
+else
+  bad "(1b) Run 1: no INVPAT-LEARNED|C1| line — the winning pattern was not persisted"
+  grep -E 'INVPAT|RECALL' "$LOG1" | sed 's/^/        | /'
+fi
+LATEST="$( ( cd "$STORE" && agentis memo get invpat:latest:C1 ) 2>/dev/null )"
+if [ -n "$LATEST" ]; then
+  ok "(1c) Run 1: invpat:latest:C1 is present in the PERSISTENT store S  ->  [$LATEST]"
+else
+  bad "(1c) Run 1: invpat:latest:C1 is absent from the persistent store S ($STORE)"
+  ( cd "$STORE" && agentis memo list 2>/dev/null ) | grep -i invpat | sed 's/^/        | /'
+fi
+
+# ==========================================================================================================
+# (2) Run 2 — STRUCTURALLY-DIFFERENT vulnerable vault B of the SAME class C1, SAME store S -> the stored
+#     pattern is RECALLED to seed B's hunt, and B -> FINDING. discovered -> stored -> recalled -> reused.
+# ==========================================================================================================
+echo
+echo "=================================================================================="
+echo " (2) RUN 2: vault B (same class C1, different shape), same store S -> RECALL the stored pattern -> FINDING"
+echo "=================================================================================="
+note "driving vault B through the coordinator loop with the SAME --pattern-store $STORE ..."
+run_one "$WORK/B" "$WORK/B-out" "$STORE"; RC2=$?
+LOG2="$(run_log "$WORK/B-out")"
+if [ "$RC2" -ne 0 ] || [ ! -f "$LOG2" ]; then
+  bad "Run 2 did not complete (exit $RC2); runner log:"
+  sed 's/^/        | /' "$WORK/B-out.log" 2>/dev/null | tail -25
+  note "DEMO FAILED — Run 2 produced no orchestrate log." >&2
+  exit 1
+fi
+# The proof of the loop: the stored pattern from A was RECALLED to seed B's hunt (the prover's RECALL-INVPAT).
+if grep -qE '^RECALL-INVPAT\|C1\|' "$LOG2"; then
+  RECALLED="$(grep -E '^RECALL-INVPAT\|C1\|' "$LOG2" | head -1)"
+  ok "(2a) Run 2: the stored pattern was RECALLED to seed B's hunt  ->  $RECALLED"
+else
+  bad "(2a) Run 2: no RECALL-INVPAT|C1| line — the stored pattern was not recalled across runs"
+  grep -E 'INVPAT|RECALL' "$LOG2" | sed 's/^/        | /'
+fi
+# B reproduced (the recalled-pattern-seeded hunt still finds the bug on the differently-shaped target).
+if grep -qE '^DISPATCH\|invariant-hunt\|cand-0\|confirmed' "$LOG2"; then
+  ok "(2b) Run 2: vault B -> DISPATCH|invariant-hunt|cand-0|confirmed (FINDING on the recalled-pattern target)"
+else
+  bad "(2b) Run 2: vault B did not confirm"
+  grep -E '^DISPATCH\|invariant-hunt\|' "$LOG2" | sed 's/^/        | /'
+fi
+
+# ==========================================================================================================
+# (3) invent-method leg — a method-inventor proposal seeds a NEW invariant class (invpat:invented:C1) in a
+#     FRESH store; the next hunt's prover consults it as a generation hint and finds the bug.
+# ==========================================================================================================
+echo
+echo "=================================================================================="
+echo " (3) INVENT-METHOD: a proposed NEW invariant class (fixture) seeds the next hunt -> FINDING"
+echo "=================================================================================="
+INVENT_STORE="$WORK/invent-store"
+note "driving vault C with a method-inventor proposal (--method-fixture) into a fresh store ..."
+run_one "$WORK/C" "$WORK/C-out" "$INVENT_STORE" "$WORK/method.txt"; RC3=$?
+LOG3="$(run_log "$WORK/C-out")"
+if [ "$RC3" -ne 0 ] || [ ! -f "$LOG3" ]; then
+  bad "invent-method leg did not complete (exit $RC3); runner log:"
+  sed 's/^/        | /' "$WORK/C-out.log" 2>/dev/null | tail -25
+else
+  # The proposed class was seeded as invpat:invented:C1 in the store.
+  INVENTED="$( ( cd "$INVENT_STORE" && agentis memo get invpat:invented:C1 ) 2>/dev/null )"
+  if [ -n "$INVENTED" ]; then
+    ok "(3a) invent-method seeded a NEW invariant class as invpat:invented:C1 in the store"
+  else
+    bad "(3a) invent-method did not seed invpat:invented:C1"
+    ( cd "$INVENT_STORE" && agentis memo list 2>/dev/null ) | grep -i invent | sed 's/^/        | /'
+  fi
+  # The next hunt's prover consulted the invented class as a generation hint (the RECALL-INVPAT carries the METHOD line).
+  if grep -qE '^RECALL-INVPAT\|C1\|METHOD\|' "$LOG3"; then
+    ok "(3b) the next hunt's generation CONSULTED the invented class (RECALL-INVPAT|C1|METHOD|...)"
+  else
+    bad "(3b) the invented class was not consulted by the next hunt's generation"
+    grep -E 'INVPAT|RECALL' "$LOG3" | sed 's/^/        | /'
+  fi
+  # And the hunt still found the bug.
+  if grep -qE '^DISPATCH\|invariant-hunt\|cand-0\|confirmed' "$LOG3"; then
+    ok "(3c) the invent-method-seeded hunt found the bug -> DISPATCH|invariant-hunt|cand-0|confirmed"
+  else
+    bad "(3c) the invent-method-seeded hunt did not confirm"
+    grep -E '^DISPATCH\|invariant-hunt\|' "$LOG3" | sed 's/^/        | /'
+  fi
+fi
+
+echo
+echo "=================================================================================="
+if [ "$FAILS" -eq 0 ]; then
+  note "PROVEN. The MEMORY LOOP is closed end-to-end: Run 1 on vault A produced a FINDING and the winning"
+  note "invariant pattern was PERSISTED to the DAG pattern memory (invpat:latest:C1 in the shared store);"
+  note "Run 2 on a structurally-different vault B of the SAME class RECALLED that stored pattern to seed its"
+  note "hunt (RECALL-INVPAT|C1|...) and B -> FINDING — discovered -> stored in the DAG -> recalled -> reused"
+  note "ACROSS targets. The invent-method leg seeds a NEW proposed invariant class (invpat:invented:C1) that"
+  note "the next hunt's generation consults. HONEST scope: the claim is that the memory loop works (persist/"
+  note "recall/reuse), not that recall is necessary for the fuzzer to find B. The verdict is the FUZZER's"
+  note "exit code, never the LLM's; submission stays human-gated; this colony never posts."
+  exit 0
+fi
+note "DEMO FAILED — $FAILS assertion(s) did not hold (see above)." >&2
+exit 1

--- a/dark-factory/docs/autonomous-hunt.md
+++ b/dark-factory/docs/autonomous-hunt.md
@@ -1,4 +1,4 @@
-# Autonomous stateful-invariant hunt — Integration M1 + M2 (#1037)
+# Autonomous stateful-invariant hunt — Integration M1 + M2 + M3 (#1037)
 
 Two pieces shipped separately: the **self-orchestrating coordinator** ([`docs/coordinator.md`](./coordinator.md),
 #1014) that DECIDES the next audit action from facts + an evolving policy, and the **stateful-invariant
@@ -149,9 +149,99 @@ emits leads, so a discovered lead carries its contract + invariant test straight
 verify — no operator re-typing the target per candidate. The memo convention is the contract between the
 producer (discovery) and the consumer (the coordinator's live verify routes).
 
+## Pattern memory (M3)
+
+M1 made the coordinator live-drive the fuzzer; M2 let each lead carry its own context. **Integration M3**
+closes the loop the user described — *the federation invents its own attack methods, stores them in a DAG, and
+self-drives*: a winning invariant pattern (one that produced a FINDING) is **persisted to the pattern DAG** and
+**recalled to seed future hunts**, and `invent-method` can propose a new invariant class the next hunt then
+uses. It **reuses the existing `bugpat:*` DAG infrastructure** — the same `dag_put` / `recall_latest` /
+`memo_write` primitives the fork-matcher seed/recall agents use (`seed-patterns.ag` / `recall-match.ag`) and
+the same `knowledge_sell` cross-pollination channel (`share-patterns.ag`) — in a parallel `invpat:*` namespace.
+No new store is built.
+
+### The `invpat:*` namespace
+
+| memo key | written by | read by | role |
+|---|---|---|---|
+| `invpat:exact:<hash>` | `invariant-prover.ag` on a FINDING | (the DAG index, mirrors `bugpat:exact:<hash>`) | `dag_put(<signature>)` → the content-hash key class membership |
+| `invpat:latest:<class>` | `invariant-prover.ag` on a FINDING | `invariant-prover.ag` before GENERATE | the latest winning invariant pattern descriptor for a bug class |
+| `invpat:invented:<class>` | `run-autonomous-hunt.sh --method-fixture` | `invariant-prover.ag` before GENERATE | a NEW invariant class proposed by `invent-method` (a generation hint) |
+
+The signature persisted is a **deterministic, stable descriptor**: `<class>::<target-label>::<match-prefix>`
+— the same class/shape produces the same `invpat:exact:<hash>` across runs, so a later FINDING on the same
+class recalls it. `dag_put`'s content hash is the sha256 of the signature, so only the memo *values* travel
+between stores — re-`dag_put`ting the same signature reproduces the same key locally.
+
+### Persist-on-FINDING / recall-before-generate
+
+`invariant-prover.ag` (the GENERATE-and-VERIFY agent) gains two additive hooks:
+
+- **RECALL before GENERATE.** Before writing the test, it reads `recall_latest("invpat:latest:<class>")`
+  (falling back to `invpat:invented:<class>` — the invent-method hint — when no FINDING pattern exists yet).
+  When non-empty it prints `RECALL-INVPAT|<class>|<descriptor>` (so the transfer is observable) and folds the
+  descriptor into the LLM generation seed ("a prior FINDING on this class used this invariant pattern: …;
+  adapt it"). On the `HANDLER_FIXTURE` path the fixture is authoritative (recall does **not** change it) but
+  the `RECALL-INVPAT|` line is still printed so the loop is observable. **Recall steers GENERATION only — it
+  never changes the verdict** (which stays the fuzzer's exit code).
+- **PERSIST on FINDING.** *After* the verdict is printed (so a persist failure can never alter the verdict),
+  and only when `verdict == "FINDING"`, it computes the signature, `dag_put`s it, writes
+  `invpat:exact:<hash>` + `invpat:latest:<class>`, emits `dark-factory:invariant_pattern_learned`, and prints
+  `INVPAT-LEARNED|<class>|<descriptor>`. **Persistence only records what the fuzzer already confirmed.**
+
+`prior` / the signature are derived from prior agent state (treated as untrusted): they flow only into the
+prompt (a plain string) and the plain-stdout `RECALL-INVPAT|` line — never into `exec sh`.
+
+### Durable cross-run store — `--pattern-store`
+
+`run-invariant-hunt.sh` and `run-autonomous-hunt.sh` gain `--pattern-store <dir>`: a **persistent** agentis
+store reused across runs where the `invpat:*` memos are kept. The per-run store stays ephemeral; a small
+bridge (via the `agentis memo` CLI) moves `invpat:*` **in** before the run (so RECALL sees a prior run's
+confirmed shapes) and **out** after (so this run's FINDING is kept for the next).
+
+- `run-invariant-hunt.sh` bridges directly around its prover run.
+- `run-autonomous-hunt.sh` keeps the coordinator **byte-identical** by handing it a thin **prover-gate
+  wrapper** as `FORGE_INVARIANT`: the wrapper speaks the gate's exact CLI + exit contract
+  (`1=FINDING / 0=CLEAN / 2=error`), so the coordinator's `run_invariant_live` + `sym_rc_of` / `sym_outcome_of`
+  mapping is unchanged, but internally it routes through `invariant-prover.ag` in the persistent store (so
+  persist/recall happen and the prover's `RECALL-INVPAT|` / `INVPAT-LEARNED|` lines land in the run log).
+
+**Absent `--pattern-store` the behaviour is byte-identical to M1/M2** — the per-run store is ephemeral, no
+`invpat:*` is persisted, and the coordinator calls the bare gate directly (no wrapper).
+
+### The `invent-method` feed — `--method-fixture`
+
+`run-autonomous-hunt.sh --method-fixture <file>` consults a deterministic method-inventor proposal (a
+`METHOD|<name>|<bug-classes>|<technique>|<how-to-invoke>|<control-assert>` line — the same shape
+`method-inventor.ag` emits, used offline so the wiring is provable without an LLM). It parses the proposed bug
+class and seeds it as `invpat:invented:<class>` in the pattern store, so the next `invariant-hunt`
+generation's recall consults it as a hint. The live `method-inventor.ag` path stays prompt-driven; the
+fixture proves the wiring deterministically. Validation of an invented method stays the two-sided control
+gate `run-method-discovery.sh` already enforces.
+
+```bash
+# Run 1 persists a winning pattern; Run 2 on a same-class target recalls + reuses it (a shared store S):
+dark-factory/run-autonomous-hunt.sh --repo "$PWD/A" --target test/Inv.t.sol --pattern-store "$PWD/S" --seed 1
+dark-factory/run-autonomous-hunt.sh --repo "$PWD/B" --target test/Inv.t.sol --pattern-store "$PWD/S" --seed 1
+
+# the invent-method feed: a proposed NEW class steers the next hunt's generation
+dark-factory/run-autonomous-hunt.sh --repo "$PWD/C" --target test/Inv.t.sol \
+  --pattern-store "$PWD/S" --method-fixture method.txt --seed 1
+
+# the end-to-end proof (persist on A, recall+reuse on B, invent-method leg; SKIPs without forge/agentis):
+dark-factory/demo-pattern-memory.sh
+```
+
+`demo-pattern-memory.sh` proves the MEMORY LOOP works (persist → recall → reuse across a structurally-different
+same-class target, plus the invent-method feed). **Honest scope:** the claim is the memory loop works, **not**
+that recall is strictly necessary for the fuzzer to find B — both vaults are vulnerable, so each FINDs on its
+own; what the demo proves is that the discovered pattern is stored in the DAG and recalled to seed the later
+hunt, observably.
+
 ## Honest scope
 
-M2 carries each lead's repo/target context through the durable memo channel. A long-lived daemon-tick reflex
-(the loop running continuously without a shell bootstrap), auto-GENERATION of the per-candidate invariant test
-from a discovered lead (here the test is supplied alongside the contract), and the coordinator pruning a live
-cell manifest all remain follow-up on epics #1014 / #1035 / #1037.
+M2 carries each lead's repo/target context through the durable memo channel; M3 adds the cross-run pattern
+memory + the invent-method feed. A long-lived daemon-tick reflex (the loop running continuously without a
+shell bootstrap), auto-GENERATION of the per-candidate invariant test from a discovered lead (here the test is
+supplied alongside the contract), recall as a *requirement* (rather than a *seed*) for the fuzzer, and the
+coordinator pruning a live cell manifest all remain follow-up on epics #1014 / #1035 / #1037.

--- a/dark-factory/run-autonomous-hunt.sh
+++ b/dark-factory/run-autonomous-hunt.sh
@@ -50,6 +50,19 @@
 #                     next attributes its outcome to the policy (proving outcome -> policy evolution).
 #   --out <dir>       Output dir for the run (default: ./autonomous-hunt-out). A fresh agentis store is built
 #                     under <out>/run.
+#   --pattern-store <dir>  Int M3 (#1037): a PERSISTENT pattern-DAG store reused ACROSS runs. When set, the
+#                     coordinator's chosen invariant-hunt is routed through invariant-prover.ag (not the bare
+#                     gate) so a winning invariant pattern is PERSISTED on a FINDING (`invpat:*` memos in this
+#                     store) and RECALLED to seed a LATER run on the same bug class (the prover prints
+#                     `RECALL-INVPAT|<class>|<pattern>` + `INVPAT-LEARNED|<class>|<pattern>` into the run log).
+#                     The verdict stays the fuzzer's exit code; persist/recall steer GENERATION only. Absent
+#                     the flag the coordinator calls the gate directly -> no cross-run memory (M1/M2 byte-
+#                     identical).
+#   --method-fixture <file>  Int M3 (#1037) Part B: a deterministic method-inventor proposal (a `METHOD|...`
+#                     line) the coordinator's invent-method action consults OFFLINE (no LLM) to propose a NEW
+#                     invariant class. When set, its proposed class is seeded as `invpat:invented:<class>` in
+#                     the pattern store so the NEXT invariant-hunt generation reads it as a hint. Absent the
+#                     flag the invent-method stub behaviour is unchanged.
 #   --agentis <bin>   agentis binary (default: `agentis` on PATH).
 #
 # Exit: 0 on a clean run that reached ORCHESTRATE|done; 2 on usage error; 3 on a missing prerequisite; 1 on a
@@ -68,6 +81,12 @@ SEED=""
 STEPS_N=2
 STEPS_SET=0
 OUT="$PWD/autonomous-hunt-out"
+PATTERN_STORE=""
+METHOD_FIXTURE=""
+# Int M3 (#1037): the run-level bug class the prover keys its invpat:latest:<class> recall/persist on. This
+# driver scopes the loop to a single class (matches SCOPE/CLASS_FITNESS below); the pattern memory is keyed on
+# it so a later run on the SAME class recalls the earlier run's confirmed invariant shape.
+PATTERN_CLASS="C1"
 # Int M2 (#1037): accumulated --candidate specs, one per array slot (`<id>|<repo>|<target>[|<match>]`).
 CANDIDATES=()
 
@@ -84,6 +103,8 @@ while [ $# -gt 0 ]; do
     --seed)      need "$#"; SEED="$2"; shift 2 ;;
     --steps)     need "$#"; STEPS_N="$2"; STEPS_SET=1; shift 2 ;;
     --out)       need "$#"; OUT="$2"; shift 2 ;;
+    --pattern-store) need "$#"; PATTERN_STORE="$2"; shift 2 ;;
+    --method-fixture) need "$#"; METHOD_FIXTURE="$2"; shift 2 ;;
     --agentis)   need "$#"; AGENTIS="$2"; shift 2 ;;
     --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
     *) echo "run-autonomous-hunt.sh: unknown flag $1" >&2; exit 2 ;;
@@ -144,14 +165,126 @@ COORD_AG="$HERE/auditor/agents/coordinator.ag"
 # as FORGE_INVARIANT — the same env path invariant-prover.ag / run-invariant-hunt.sh use. No install location
 # is hardcoded; forge is the caller's PATH responsibility, exactly as forge-invariant.sh requires.
 FORGE_INVARIANT="$HERE/evm-harness/forge-invariant.sh"
+PROVER_AG="$HERE/auditor/agents/invariant-prover.ag"
 [ -f "$COORD_AG" ]        || { echo "run-autonomous-hunt.sh: coordinator agent not found at $COORD_AG" >&2; exit 3; }
 [ -f "$FORGE_INVARIANT" ] || { echo "run-autonomous-hunt.sh: forge-invariant gate not found at $FORGE_INVARIANT" >&2; exit 3; }
+
+# Int M3 (#1037): resolve the PERSISTENT pattern-DAG store and validate the optional method-fixture. Both are
+# only consulted on the --pattern-store path; absent --pattern-store the whole M3 layer is skipped and the
+# coordinator calls the bare gate (M1/M2 byte-identical).
+if [ -n "$PATTERN_STORE" ]; then
+  [ -f "$PROVER_AG" ] || { echo "run-autonomous-hunt.sh: invariant-prover agent not found at $PROVER_AG (needed for --pattern-store)" >&2; exit 3; }
+  mkdir -p "$PATTERN_STORE" || { echo "run-autonomous-hunt.sh: cannot create --pattern-store dir: $PATTERN_STORE" >&2; exit 1; }
+  PATTERN_STORE="$(cd "$PATTERN_STORE" && pwd)"
+  [ -d "$PATTERN_STORE/.agentis" ] || ( cd "$PATTERN_STORE" && "$AGENTIS" init >/dev/null 2>&1 )
+fi
+if [ -n "$METHOD_FIXTURE" ]; then
+  [ -f "$METHOD_FIXTURE" ] || { echo "run-autonomous-hunt.sh: --method-fixture not found: $METHOD_FIXTURE" >&2; exit 2; }
+  [ -n "$PATTERN_STORE" ] || { echo "run-autonomous-hunt.sh: --method-fixture requires --pattern-store (the invented class is seeded there)" >&2; exit 2; }
+  METHOD_FIXTURE="$(cd "$(dirname "$METHOD_FIXTURE")" && pwd)/$(basename "$METHOD_FIXTURE")"
+fi
 
 mkdir -p "$OUT" || { echo "run-autonomous-hunt.sh: cannot create --out dir: $OUT" >&2; exit 1; }
 OUT="$(cd "$OUT" && pwd)"
 RUN="$OUT/run"
 rm -rf "$RUN"; mkdir -p "$RUN" || { echo "run-autonomous-hunt.sh: cannot create run dir: $RUN" >&2; exit 1; }
 cp "$COORD_AG" "$RUN/coordinator.ag"
+
+# Int M3 (#1037): when --pattern-store is set, route the coordinator's chosen invariant-hunt through the
+# PROVER (which PERSISTS/RECALLS the winning invariant pattern) instead of the bare gate — WITHOUT touching
+# coordinator.ag. We do this by handing the coordinator a thin WRAPPER as FORGE_INVARIANT: it speaks the gate's
+# exact CLI (--repo/--target/--match[/--runs/--depth/--seed]) and exit contract (1=FINDING,0=CLEAN,2=error), so
+# the coordinator's run_invariant_live + sym_rc_of/sym_outcome_of mapping is byte-identical. Internally the
+# wrapper runs invariant-prover.ag in the PERSISTENT store with the candidate's class as TARGET_CLASS, so a
+# prior run's `invpat:latest:<class>` is RECALLED (the prover prints `RECALL-INVPAT|...`) before generation and
+# a FINDING is PERSISTED (`INVPAT-LEARNED|...`). The wrapper delegates the actual fuzzing to the real gate. The
+# prover's stdout (incl. RECALL-INVPAT/INVPAT-LEARNED) is teed to stderr so it lands in the orchestrate log.
+GATE_FOR_COORD="$FORGE_INVARIANT"
+if [ -n "$PATTERN_STORE" ]; then
+  cp "$PROVER_AG"       "$RUN/invariant-prover.ag"
+  cp "$FORGE_INVARIANT" "$RUN/forge-invariant.sh"
+  WRAP="$RUN/prover-gate.sh"
+  {
+    echo '#!/usr/bin/env bash'
+    echo '# Int M3 (#1037) prover-gate wrapper — auto-generated by run-autonomous-hunt.sh. Speaks the'
+    echo '# forge-invariant.sh CLI + exit contract but routes through invariant-prover.ag so the winning'
+    echo '# invariant pattern is persisted/recalled in the persistent pattern store. NOT for direct operator use.'
+    echo 'set -uo pipefail'
+    echo "RUNDIR=$(printf '%q' "$RUN")"
+    echo "AGENTIS=$(printf '%q' "$AGENTIS")"
+    echo "PATTERN_STORE=$(printf '%q' "$PATTERN_STORE")"
+    echo "REAL_GATE=$(printf '%q' "$RUN/forge-invariant.sh")"
+    # A stable trail file (the coordinator captures the wrapper's stdout/stderr into a string it discards, so
+    # the prover's RECALL-INVPAT/INVPAT-LEARNED lines are persisted here for the driver to surface afterwards).
+    echo "TRAIL=$(printf '%q' "$RUN/pattern-trail.log")"
+    echo 'REPO=""; TARGET=""; MATCH="invariant"; RUNS=""; DEPTH=""; SEED=""'
+    echo 'while [ $# -gt 0 ]; do case "$1" in'
+    echo '  --repo) REPO="${2:-}"; shift 2 ;; --target) TARGET="${2:-}"; shift 2 ;;'
+    echo '  --match) MATCH="${2:-}"; shift 2 ;; --runs) RUNS="${2:-}"; shift 2 ;;'
+    echo '  --depth) DEPTH="${2:-}"; shift 2 ;; --seed) SEED="${2:-}"; shift 2 ;;'
+    echo '  *) shift ;; esac; done'
+    # The candidate class the coordinator routes. The orchestrate loop's PENDING cells all carry the run-level
+    # class (the SCOPE class, C1), so the prover keys its invpat:latest:<class> recall/persist on it across runs.
+    # Baked as a literal here (the gate CLI has no class field) — set via --pattern-store's run class below.
+    echo "CLASS=$(printf '%q' "$PATTERN_CLASS")"
+    echo 'WORK="$(mktemp -d "${TMPDIR:-/tmp}/prover-gate.XXXXXX")"'
+    echo 'trap '"'"'rm -rf "$WORK"'"'"' EXIT'
+    echo 'cp "$RUNDIR/invariant-prover.ag" "$WORK/invariant-prover.ag"'
+    echo 'cp "$REAL_GATE" "$WORK/forge-invariant.sh"'
+    echo '( cd "$WORK" && "$AGENTIS" init >/dev/null 2>&1 )'
+    echo '{'
+    echo '  echo "llm.backend = mock"'
+    echo '  echo "trace.level = normal"'
+    echo '  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT"'
+    echo '  echo "exec.default_timeout_ms = 600000"'
+    echo '  echo "learning.enabled = true"'
+    echo '  echo "experience.enabled = true"'
+    echo '} > "$WORK/.agentis/config"'
+    # RECALL: bridge prior invpat:* from the persistent store into the prover work store so recall_pattern() sees them.
+    echo 'bridge() { _s="$1"; _d="$2"; ( cd "$_s" && "$AGENTIS" memo list 2>/dev/null ) | awk '"'"'{print $1}'"'"' | grep -E '"'"'^invpat:'"'"' | while IFS= read -r k; do v="$( ( cd "$_s" && "$AGENTIS" memo get "$k" ) 2>/dev/null )"; [ -n "$v" ] && ( cd "$_d" && "$AGENTIS" memo set "$k" "$v" >/dev/null 2>&1 ); done; }'
+    echo 'bridge "$PATTERN_STORE" "$WORK"'
+    # The prover writes the test into INV_REPO/test; stage a copy of the candidate repo so it can.
+    echo 'REPO_IN_WORK="$WORK/repo"; cp -R "$REPO" "$REPO_IN_WORK"; rm -f "$REPO_IN_WORK/test/"*.t.sol 2>/dev/null || true; mkdir -p "$REPO_IN_WORK/test"'
+    # Use the candidate's OWN target as the handler fixture (verbatim) so the verdict is the fuzzer's over the
+    # SAME test the live route would run — the prover's job here is the persist/recall, not regenerating the test.
+    echo 'cp "$TARGET" "$WORK/handler-fixture.t.sol"'
+    echo 'INV_OUT="$REPO_IN_WORK/test/Inv_gate.t.sol"'
+    echo 'OPT=""; [ -n "$RUNS" ] && OPT="$OPT --runs $RUNS"; [ -n "$DEPTH" ] && OPT="$OPT --depth $DEPTH"; [ -n "$SEED" ] && OPT="$OPT --seed $SEED"'
+    echo 'LOG="$WORK/prover.log"'
+    echo '( cd "$WORK" && env TARGET_FN="$TARGET" TARGET_CLASS="$CLASS" INV_REPO="$REPO_IN_WORK" INV_OUT="$INV_OUT" INV_MATCH="$MATCH" HANDLER_FIXTURE="$WORK/handler-fixture.t.sol" CODE_PATH="" INV_RUNS="$RUNS" INV_DEPTH="$DEPTH" INV_SEED="$SEED" FORGE_INVARIANT="$WORK/forge-invariant.sh" "$AGENTIS" go invariant-prover.ag --enable-exec --enable-messaging ) >"$LOG" 2>&1 || true'
+    # Surface the prover trail (incl. RECALL-INVPAT / INVPAT-LEARNED) to stderr AND append it to the stable
+    # trail file the driver reads back (the coordinator discards the captured exec output, so the trail file is
+    # the durable channel for the prover's recall/persist evidence).
+    echo 'grep -E "^(RECALL-INVPAT|INVPAT-LEARNED|INVARIANT)\|" "$LOG" | tee -a "$TRAIL" >&2 || true'
+    # PERSIST: bridge any invpat:* the prover wrote back OUT to the persistent store for the next run.
+    echo 'bridge "$WORK" "$PATTERN_STORE"'
+    # Map the prover verdict to the gate exit contract the coordinator expects (1=FINDING,0=CLEAN,2=error).
+    echo 'VL="$(grep "INVARIANT|" "$LOG" | tail -1 || true)"'
+    echo 'VERD="$(printf "%s" "$VL" | sed "s/.*INVARIANT|//" | cut -d"|" -f2)"'
+    echo 'case "$VERD" in FINDING) exit 1 ;; CLEAN) exit 0 ;; *) exit 2 ;; esac'
+  } > "$WRAP"
+  chmod +x "$WRAP"
+  GATE_FOR_COORD="$WRAP"
+fi
+
+# Int M3 (#1037) Part B: the invent-method feed. A --method-fixture is a deterministic method-inventor proposal
+# (a `METHOD|<name>|<bug-classes>|<technique>|<how-to-invoke>|<control-assert>` line — the same shape
+# method-inventor.ag emits, used OFFLINE so the wiring is provable without an LLM). We parse the proposed bug
+# class (field 3, the first comma-separated class) and seed it as `invpat:invented:<class>` in the PERSISTENT
+# pattern store, so the NEXT invariant-hunt generation's recall_pattern() reads it as a generation hint (the
+# prover checks `invpat:invented:<class>` when no persisted FINDING pattern exists yet). This is the
+# self-invents feed: a NEW invariant class the federation proposed steers a later hunt's GENERATE.
+if [ -n "$METHOD_FIXTURE" ]; then
+  M_LINE="$(grep -E '^METHOD\|' "$METHOD_FIXTURE" | head -1 || true)"
+  if [ -n "$M_LINE" ]; then
+    M_CLASSES="$(printf '%s' "$M_LINE" | cut -d'|' -f3)"
+    M_CLASS="$(printf '%s' "$M_CLASSES" | cut -d',' -f1 | tr -d '[:space:]')"
+    if [ -n "$M_CLASS" ]; then
+      ( cd "$PATTERN_STORE" && "$AGENTIS" memo set "invpat:invented:$M_CLASS" "$M_LINE" >/dev/null 2>&1 )
+      echo "run-autonomous-hunt.sh: invent-method seeded invpat:invented:$M_CLASS from $METHOD_FIXTURE" >&2
+    fi
+  fi
+fi
 
 # A single shared agentis store for the whole orchestrate run (the policy the coordinator writes one step
 # must be visible to the next). init FIRST (before any .agentis/ subdir), else HEAD is unset.
@@ -241,7 +374,7 @@ RUN_LOG="$RUN/orchestrate.log"
     ORCHESTRATE_ENABLED=1 \
     DISPATCH_ENABLED=1 \
     DISPATCH_FIXTURE="" \
-    FORGE_INVARIANT="$FORGE_INVARIANT" \
+    FORGE_INVARIANT="$GATE_FOR_COORD" \
     INV_REPO="$REPO" \
     INV_TARGET="$TARGET" \
     INV_MATCH="$MATCH" \
@@ -253,6 +386,19 @@ RUN_LOG="$RUN/orchestrate.log"
 
 grep -E '^ORCHESTRATE\|' "$RUN_LOG" >/dev/null 2>&1 \
   || { echo "run-autonomous-hunt.sh: orchestration did not complete (no ORCHESTRATE| marker; see $RUN_LOG)" >&2; exit 1; }
+
+# Int M3 (#1037): the prover-gate wrapper persists its RECALL-INVPAT / INVPAT-LEARNED evidence to the trail
+# file (the coordinator discards the captured exec output). Fold the trail INTO the orchestrate log so the
+# pattern-memory loop is observable in the run log the rest of the pipeline reads, and surface it on stderr.
+# Skipped (no-op) when --pattern-store was not supplied (the trail file does not exist).
+PATTERN_TRAIL="$RUN/pattern-trail.log"
+if [ -s "$PATTERN_TRAIL" ]; then
+  cat "$PATTERN_TRAIL" >> "$RUN_LOG"
+  echo "run-autonomous-hunt.sh: pattern-memory trail:" >&2
+  grep -E '^(RECALL-INVPAT|INVPAT-LEARNED)\|' "$PATTERN_TRAIL" | while IFS= read -r line; do
+    echo "run-autonomous-hunt.sh: $line" >&2
+  done
+fi
 
 # Surface the AUTONOMOUS DECISION TRAIL: the coordinator's ACTION| lines (what it chose + why) and the
 # DISPATCH| lines (the fuzzer's verdict for each). The full run log (incl. the LIVE-route message + any

--- a/dark-factory/run-invariant-hunt.sh
+++ b/dark-factory/run-invariant-hunt.sh
@@ -39,13 +39,20 @@
 #   --depth D            Forge invariant depth budget (calls per sequence). Default: the project's config.
 #   --seed S             Forge --fuzz-seed for a reproducible search. Default: forge's own seed.
 #   --out <dir>          Output dir for the run + report (default: ./invariant-out).
+#   --pattern-store <dir>  Int M3 (#1037): a PERSISTENT pattern-DAG store reused ACROSS runs. When set, the
+#                        winning-invariant patterns the prover PERSISTS on a FINDING (`invpat:*` memos) are
+#                        kept here, and any patterns a PRIOR run stored for the same bug class are RECALLED
+#                        into THIS run before GENERATE — so a later hunt on the same class is seeded by an
+#                        earlier hunt's confirmed invariant shape (discovered -> stored -> recalled -> reused).
+#                        Absent the flag the per-run store is ephemeral -> no cross-run pattern memory (the
+#                        M1/M2 behaviour is byte-identical).
 #   --agentis <bin>      agentis binary (default: `agentis` on PATH).
 set -eu
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 REPO="" ; TARGET="" ; CLASS="" ; FIXTURE="" ; CODE="" ; MATCH="invariant"
-BACKEND="flat-cyborg" ; MODEL="" ; RUNS="" ; DEPTH="" ; SEED="" ; OUT="$PWD/invariant-out"
+BACKEND="flat-cyborg" ; MODEL="" ; RUNS="" ; DEPTH="" ; SEED="" ; OUT="$PWD/invariant-out" ; PATTERN_STORE=""
 
 need() { [ "$1" -ge 2 ] || { echo "run-invariant-hunt.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -62,6 +69,7 @@ while [ $# -gt 0 ]; do
     --depth) need "$#"; DEPTH="$2"; shift 2 ;;
     --seed) need "$#"; SEED="$2"; shift 2 ;;
     --out) need "$#"; OUT="$2"; shift 2 ;;
+    --pattern-store) need "$#"; PATTERN_STORE="$2"; shift 2 ;;
     --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
     --help|-h) awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "$0"; exit 0 ;;
     *) echo "run-invariant-hunt.sh: unknown flag $1" >&2; exit 2 ;;
@@ -146,6 +154,36 @@ SLUG="$(printf '%s' "$TARGET" | tr -cs 'A-Za-z0-9' '_' | sed 's/_*$//')"
 INV_OUT="$REPO_IN_RUN/test/Inv_${SLUG}.t.sol"
 CELL_LOG="$RUN/invariant_${SLUG}.log"
 
+# Int M3 (#1037): the PERSISTENT pattern-DAG store. When --pattern-store is set we resolve it to an
+# absolute path and `agentis init` it once (idempotent — re-init of an existing store is a no-op for our
+# memos). It holds the `invpat:*` memos ACROSS runs. The per-run store above is still ephemeral (wiped each
+# run); the bridge below moves patterns IN before the run (so RECALL sees a prior run's confirmed shapes)
+# and OUT after (so this run's FINDING is kept for the next). Absent the flag, $PATTERN_STORE stays empty and
+# the whole bridge is skipped -> no cross-run memory (M1/M2 byte-identical).
+if [ -n "$PATTERN_STORE" ]; then
+  mkdir -p "$PATTERN_STORE"; PATTERN_STORE="$(cd "$PATTERN_STORE" && pwd)"
+  [ -d "$PATTERN_STORE/.agentis" ] || ( cd "$PATTERN_STORE" && "$AGENTIS" init >/dev/null 2>&1 )
+fi
+
+# Bridge every `invpat:*` memo from $1's store into $2's store via the agentis memo CLI. The DAG content
+# HASH is deterministic (sha256 of the signature), so only the memo VALUES need to travel between stores —
+# `recall_latest("invpat:latest:<class>")` is what the prover reads to seed GENERATE, and re-`dag_put`ting
+# the same signature reproduces the same `invpat:exact:<hash>` key locally. memo keys are restricted to a
+# safe charset upstream, so no key here can carry a shell metachar.
+bridge_invpat() {  # $1 = src store dir, $2 = dst store dir
+  _src="$1"; _dst="$2"
+  ( cd "$_src" && "$AGENTIS" memo list 2>/dev/null ) | awk '{print $1}' | grep -E '^invpat:' | while IFS= read -r k; do
+    _v="$( ( cd "$_src" && "$AGENTIS" memo get "$k" ) 2>/dev/null )"
+    [ -n "$_v" ] && ( cd "$_dst" && "$AGENTIS" memo set "$k" "$_v" >/dev/null 2>&1 )
+  done
+}
+
+# RECALL: seed the per-run store with any patterns a PRIOR run persisted, BEFORE `agentis go` (so the
+# prover's recall_pattern() sees them and folds them into GENERATE).
+if [ -n "$PATTERN_STORE" ]; then
+  bridge_invpat "$PATTERN_STORE" "$RUN"
+fi
+
 echo "run-invariant-hunt.sh: generating + stateful-fuzzing $TARGET ($CLASS) ..." >&2
 ( cd "$RUN" && env \
     TARGET_FN="$TARGET" \
@@ -161,6 +199,12 @@ echo "run-invariant-hunt.sh: generating + stateful-fuzzing $TARGET ($CLASS) ..."
     FORGE_INVARIANT="$RUN/forge-invariant.sh" \
     "$AGENTIS" go invariant-prover.ag --enable-exec --enable-messaging ) >"$CELL_LOG" 2>&1 || \
     echo "run-invariant-hunt.sh: invariant-prover run failed for '$TARGET' (see $CELL_LOG)" >&2
+
+# PERSIST: copy any `invpat:*` the prover wrote this run (on a FINDING) back OUT to the persistent store,
+# so the NEXT run on the same class recalls it. Skipped (no-op) when --pattern-store was not supplied.
+if [ -n "$PATTERN_STORE" ]; then
+  bridge_invpat "$RUN" "$PATTERN_STORE"
+fi
 
 # The prover's contract: exactly one `INVARIANT|<file:fn>|<verdict>` line, then (on a FINDING) `STEP|...`
 # lines. Take the LAST verdict match. No line at all = treat as HARNESS_ERROR (no verdict was produced).


### PR DESCRIPTION
## What

**Completes #1037** (Int M3, the final integration milestone). The federation now **stores the invariant patterns it discovers and recalls them to self-drive future hunts**, and `invent-method` can propose a new invariant class the hunter then uses — closing the loop the epic set out to build (the autonomy layer self-orchestrates, live-runs sound engines, carries per-candidate context, and **learns/reuses the patterns it finds**). It reuses the existing `bugpat:*` DAG primitives (`dag_put`/`recall_latest`/`memo_write`, the knowledge market) in a parallel `invpat:*` namespace — no new store built.

## How

- **`invariant-prover.ag`**
  - **PERSIST on FINDING** (placed *after* the verdict print, so it can never alter the verdict): `dag_put` the pattern signature `<class>::<target>::<match>`, write `invpat:exact:<hash>=class` + `invpat:latest:<class>=sig`, emit `dark-factory:invariant_pattern_learned`, print `INVPAT-LEARNED|<class>|…`.
  - **RECALL before GENERATE**: `recall_latest("invpat:latest:<class>")` (then the `invpat:invented:<class>` method-invention hint); when present, print `RECALL-INVPAT|<class>|<sig>` and fold the descriptor into the LLM generation seed. The `HANDLER_FIXTURE` stays authoritative; **recall steers GENERATION only, never the verdict**. Untrusted `prior` flows only into the prompt + plain stdout, never `exec sh`.
- **`run-invariant-hunt.sh` / `run-autonomous-hunt.sh`** — `--pattern-store <dir>`: a persistent store the `invpat:*` memos are bridged in/out of, so a later run sees an earlier run's patterns. `--method-fixture` seeds `invpat:invented:<class>` (the deterministic offline `invent-method` path). **Absent `--pattern-store`, behaviour is byte-identical to M1/M2** (the coordinator calls the bare gate; no wrapper/trail/invpat).
- **`demo-pattern-memory.sh`** + docs/README/CHANGELOG.

## Verification (LIVE — forge 1.7.1, halmos 0.3.3, agentis 1.19.0)

- **`demo-pattern-memory.sh` — 8/8 assertions green**: Run-1 persists `invpat:latest:C1` + `INVPAT-LEARNED|C1` on vault A; Run-2 prints `RECALL-INVPAT|C1|…` and reuses the pattern on a **structurally-different same-class** vault B → FINDING; the invent-method leg seeds `invpat:invented:C1` → next hunt uses it → FINDING. Honest framing: the claim is the **memory loop** works (persist → recall → reuse), not that recall is strictly necessary for the fuzzer to find B.
- **No regression** — LIVE: `demo-candidate-carry.sh` (M2), `demo-autonomous-hunt.sh` (M1), `demo-dispatch.sh` (sync-guard), `demo-symbolic-orchestrate-live.sh`, `demo-orchestrate.sh`, `demo-invariant-hunt.sh`, `demo-symbolic-orchestrate.sh`, `demo-coordinator.sh`, `demo-symbolic.sh` — all green. Byte-identity confirmed: without `--pattern-store`, no wrapper/trail/`invpat:*` and the coordinator's `ACTION|/DISPATCH|` trail is unchanged.
- **`colony-lint.sh` → 367 / 0 / 5**; `check-exec-sh` clean.

## Boundary

Verdict = the engine's exit code, never the LLM; the colony NEVER auto-submits. Persist/recall/invent steer GENERATION only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
