### PR TITLE
feat(dark-factory): fork-state invariant hunting — fuzz against real deployed on-chain state (FM1, #1041)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,43 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Fork-state invariant hunting — the stateful hunter now fuzzes deep invariants against FORKED REAL
+  ON-CHAIN STATE (the actual deployed contract at a pinned block), not only a fresh deploy** (FM1, #1041).
+  Proven foundation: `forge` invariant-fuzzed 512 sequences against the REAL deployed WETH at mainnet block
+  25318855 via a public RPC and the solvency invariant (`totalSupply() <= address(WETH).balance`) held. FM1
+  productises that into the hunter. **Purely additive** — with no `--fork-url` the #1035/#1037 behaviour is
+  byte-identical.
+  - `evm-harness/forge-invariant.sh` — optional `--fork-url <http(s)-rpc> [--fork-block <n>]`. The RPC shape
+    (`http(s)://…`) and block (whole number) are validated; `--fork-block` requires `--fork-url`. When set,
+    the gate threads forge 1.7.1's own `--fork-url <rpc> [--fork-block-number <n>]` (each value an array
+    element, never a concatenated string) into the `forge test` invocation; when unset the forge command is
+    **byte-identical** to today. A fork RPC failure (unreachable / rate-limited / "could not instantiate
+    forked environment") leaves forge with no parseable result, so the existing no-result path returns
+    **HARNESS_ERROR (2)** — never a false CLEAN/FINDING (the FM1 safety contract).
+  - `run-invariant-hunt.sh` / `run-autonomous-hunt.sh` — `--fork-url`/`--fork-block` pass-through to the gate
+    (the autonomous driver forwards them via `INV_FORK_URL`/`INV_FORK_BLOCK` to the coordinator's chosen
+    `invariant-hunt`, and through the `--pattern-store` prover-gate wrapper to the prover). `run-invariant-hunt.sh`
+    also exports `FORK_TARGET=<deployed address>` (+ `FORK_URL`/`FORK_BLOCK`) to the prover so the generated
+    test can reference the real deployed contract by address. Absent the flags, behaviour is unchanged.
+  - `auditor/agents/invariant-prover.ag` — in fork mode (`FORK_TARGET`/`FORK_URL` non-empty) the generation
+    prompt is told the target is a **live deployed contract at `<address>`** and to generate a Handler that
+    drives its real functions with bounded inputs and funded actors (`vm.deal`), plus a deep invariant checked
+    against the forked state (solvency / no-free-value-extraction / share-price monotonicity). The
+    `HANDLER_FIXTURE` path stays authoritative; the `--fork-url`/`--fork-block` are forwarded to the gate,
+    each `shell_escape`d. **Purely additive** — no `FORK_*` ⇒ the generation prompt + gate command are
+    byte-identical. `auditor/agents/coordinator.ag`'s `run_invariant_live` forwards `INV_FORK_URL`/`INV_FORK_BLOCK`
+    to the gate the same way (each value `shell_escape`d via `inv_opt_flag`).
+  - **NEW `demo-fork-hunt.sh`** — the foundation proof. Probes a public RPC (`ethereum-rpc.publicnode.com`,
+    fall back to `eth.drpc.org`); when forge is absent OR no RPC is reachable it `[SKIP]`s and exits 0.
+    Otherwise it builds a tiny Foundry project with the proven WETH handler + solvency invariant, forks the
+    REAL deployed WETH at block 25318855, and asserts **CLEAN** (the funded handler drove the deployed
+    contract's real `deposit()`/`withdraw()` over fuzzed sequences and the invariant held — the machinery ran
+    against real forked state), plus a forced-bad `--fork-url http://127.0.0.1:1` → **HARNESS_ERROR (exit 2)**,
+    never a false verdict. The RPC is an argument (no key hard-coded); the block is pinned for reproducibility.
+    A FINDING here would be a CANDIDATE a human triages — this colony **never auto-submits**.
+  - `docs/invariant-hunt.md` — a fork-mode section (the `--fork-url`/`--fork-block`/`FORK_TARGET` contract, the
+    RPC-failure→HARNESS_ERROR safety, the human-gated boundary, reproducibility via the pinned block).
+
 - **Method-invention feeds the hunt + DAG pattern memory — the federation invents its own attack methods,
   stores winning ones in the pattern DAG, and self-drives** (Integration M3, #1037, the FINAL milestone). M1
   made the coordinator live-drive the fuzzer; M2 let each lead carry its own context. M3 closes the loop: a

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -382,7 +382,20 @@ prints one `INVARIANT|<target>|<verdict>` line plus, on a FINDING, the **shrunk 
 dark-factory/run-invariant-hunt.sh --repo "$PWD/target" --target Vault.sol:Vault --class C-erc4626
 # offline / cheap wiring smoke (no real LLM): supply --handler-fixture <ready .t.sol> + --backend mock
 # offline-deterministic end-to-end proof (real fuzzer, fixture handler):  dark-factory/demo-invariant-hunt.sh
+# FM1 (#1041) fork mode — fuzz against the REAL deployed contract at a pinned block (RPC is an arg; no key):
+#   --fork-url <http(s)-rpc> [--fork-block <n>] [--fork-target <deployed-addr>]   |   proof: dark-factory/demo-fork-hunt.sh
 ```
+
+**Fork mode (FM1, #1041).** `--fork-url <rpc> [--fork-block <n>]` runs the same handler + deep invariants
+against **forked REAL on-chain state** (the actual deployed contract at a pinned block) instead of a fresh
+deploy — threading forge's own `--fork-url`/`--fork-block-number` into the run. `--fork-target <addr>` tells the
+generated test to drive the **live deployed contract by address** with funded actors (`vm.deal`). **Purely
+additive**: with no `--fork-url` the forge command is byte-identical to today. An unreachable / un-instantiable
+fork RPC is a **`HARNESS_ERROR`, never a false verdict**; the RPC is always an argument (no key hard-coded) and
+the pinned block makes a verdict reproducible. [`demo-fork-hunt.sh`](./demo-fork-hunt.sh) is the foundation
+proof: it forks the REAL deployed WETH at mainnet block `25318855` via a public RPC and asserts the funded
+solvency invariant → `CLEAN` (the machinery ran against real forked state), plus a forced-bad RPC →
+`HARNESS_ERROR`. A `FINDING` against real forked state is a **LEAD a human triages** — this colony never posts.
 
 The verdict is the **fuzzer's exit code, never the LLM's opinion**: `FINDING` = an invariant broke under a
 concrete SHRUNK call-sequence (a CANDIDATE with a reproducible witness), `CLEAN` = every invariant held
@@ -551,6 +564,7 @@ dark-factory/
   demo-autonomous-hunt.sh       # offline-deterministic proof of the Int M1 autonomous hunt (coordinator CHOOSES + LIVE-runs the fuzzer; SKIPs without forge)
   demo-candidate-carry.sh       # Int M2 proof: TWO candidates carry their OWN target via candidate:<id>:* memos, flat env EMPTY -> SPLIT verdict (cand-0|confirmed, cand-1|refuted; SKIPs without forge)
   demo-pattern-memory.sh        # Int M3 proof: a FINDING persists invpat:latest:<class> to the DAG, a same-class target RECALLs + reuses it across runs, invent-method seeds a new class (SKIPs without forge)
+  demo-fork-hunt.sh             # FM1 (#1041) foundation proof: forks the REAL deployed WETH at a pinned mainnet block -> funded-handler solvency invariant CLEAN against real forked state; forced-bad RPC -> HARNESS_ERROR (SKIPs without forge or a reachable public RPC)
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)
@@ -584,7 +598,7 @@ dark-factory/
     halmos-specs/               # self-contained Foundry specs: one Halmos PROVES, one it REFUTES (demo fixtures)
   docs/halmos.md                # the Halmos gate's verdict/exit contract, toolchain install, epic fit (#1015)
   docs/generate-verify.md       # the #1015 M2 generate-and-verify loop: LLM hypothesizes, Halmos proves; verdict-source contract
-  docs/invariant-hunt.md        # the #1035 stateful-invariant-fuzzing loop: LLM writes deep invariants, the fuzzer finds the multi-step exploit; verdict-source contract
+  docs/invariant-hunt.md        # the #1035 stateful-invariant-fuzzing loop: LLM writes deep invariants, the fuzzer finds the multi-step exploit; verdict-source contract; FM1 (#1041) fork mode: fuzz against forked REAL on-chain state (--fork-url/--fork-block/FORK_TARGET, RPC-failure->HARNESS_ERROR safety, human-gated boundary)
   docs/autonomous-hunt.md       # the Int M1+M2 (#1037) end-to-end: coordinator CHOOSES (policy) + LIVE-runs the fuzzer; per-candidate context carrying (candidate:<id>:* memos); verdict->outcome mapping; human-gated submit boundary
   sealevel/                     # modernized coral-xyz/sealevel-attacks lessons (corpus) (V6)
   fixtures/                     # detection fixtures (vuln + safe + rigged-harness cases)

--- a/dark-factory/auditor/agents/coordinator.ag
+++ b/dark-factory/auditor/agents/coordinator.ag
@@ -409,9 +409,15 @@ fn run_invariant_live(candId: string) -> string {
     let match = inv_match_prefix(cand_fact(candId, "match", "INV_MATCH"));
     let budget = inv_opt_flag("--runs", getenv("INV_RUNS")) + inv_opt_flag("--depth", getenv("INV_DEPTH"))
                + inv_opt_flag("--seed", getenv("INV_SEED"));
+    // FM1 (#1041): in FORK MODE the chosen invariant-hunt runs against FORKED REAL ON-CHAIN STATE. Forward
+    // --fork-url [--fork-block] to the gate (each value shell_escape()d via inv_opt_flag, exactly like the
+    // budget flags). Empty INV_FORK_URL/INV_FORK_BLOCK => "" => the gate command is byte-identical to the
+    // no-fork build (purely additive). A fork RPC failure is the gate's HARNESS_ERROR (2) -> dry, never a
+    // false confirmed/refuted.
+    let fork = inv_opt_flag("--fork-url", getenv("INV_FORK_URL")) + inv_opt_flag("--fork-block", getenv("INV_FORK_BLOCK"));
     // colony-lint: safe-exec-concat
     let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --repo " + shell_escape(repo)
-               + " --target " + shell_escape(target) + " --match " + shell_escape(match) + budget
+               + " --target " + shell_escape(target) + " --match " + shell_escape(match) + budget + fork
                + " 2>&1; echo __rc=$?";
     let rc = sym_rc_of(runOut);
     return sym_outcome_of(rc);

--- a/dark-factory/auditor/agents/invariant-prover.ag
+++ b/dark-factory/auditor/agents/invariant-prover.ag
@@ -97,6 +97,21 @@ let invMatch = match_prefix(getenv("INV_MATCH"));
 let fixturePath = getenv("HANDLER_FIXTURE");
 let code = cat_file(getenv("CODE_PATH"));
 
+// FM1 (#1041) — FORK MODE. When FORK_TARGET (and/or FORK_URL) is non-empty, the target is a LIVE DEPLOYED
+// contract at FORK_TARGET on a forked chain (run-invariant-hunt.sh threads --fork-url/--fork-block-number into
+// the gate). These env facts are UNTRUSTED operator input: FORK_TARGET / FORK_URL / FORK_BLOCK flow ONLY into
+// the LLM generation prompt (a plain string, never `exec sh`) and into the gate invocation where each is
+// shell_escape()d at the call site below — so no shell_escape is needed on the bare reads here.
+let forkUrl = getenv("FORK_URL");
+let forkBlock = getenv("FORK_BLOCK");
+let forkTarget = getenv("FORK_TARGET");
+fn fork_active(url: string, target: string) -> bool {
+    if len(url) > 0 { return true; }
+    if len(target) > 0 { return true; }
+    return false;
+}
+let forkMode = fork_active(forkUrl, forkTarget);
+
 // --- RECALL a prior winning invariant pattern (Int M3, #1037) ------------------------------------
 // Before GENERATE, recall the latest invariant pattern that produced a FINDING on THIS bug class from the
 // DAG pattern memory (the `invpat:latest:<class>` memo, mirroring recall-match.ag's recall_latest over the
@@ -141,9 +156,28 @@ fn recall_seed(klass: string, prior: string) -> string {
     return "A prior FINDING on bug class " + klass + " used this invariant pattern: " + prior
          + ". Adapt that invariant/handler shape to the current target.\n";
 }
-fn generate_test(klass: string, src: string, matchPrefix: string, prior: string) -> string {
+// FM1 (#1041) — FORK-MODE generation seed. When the target is a LIVE DEPLOYED contract on a forked chain, the
+// generator must drive the REAL deployed contract by ADDRESS (not deploy a fresh copy): a Handler that calls
+// its real functions with bounded inputs and FUNDED actors (`vm.deal`), plus a DEEP invariant checked against
+// the FORKED state (solvency / no-free-value-extraction / share-price monotonicity). Empty fork facts => "" so
+// the generation prompt is byte-identical to the no-fork build (purely additive). The address/url/block are
+// untrusted operator input but flow only into this plain-string prompt — never a shell.
+fn fork_seed(active: bool, target: string, url: string, block: string) -> string {
+    if !active { return ""; }
+    return "FORK MODE: the target is a LIVE DEPLOYED contract at address " + target
+         + " on a forked chain"
+         + (if len(url) > 0 { " (rpc " + url + (if len(block) > 0 { " @ block " + block } else { "" }) + ")" } else { "" })
+         + ". Do NOT deploy a fresh copy — interact with the deployed contract AT THAT ADDRESS so the handler "
+         + "and invariants run against the REAL on-chain state. Generate a Handler that drives the deployed "
+         + "contract's real functions with bounded inputs and FUNDED actors (use the cheatcode "
+         + "`vm.deal(address, amount)` at Vm address 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D to fund the "
+         + "handler), plus a deep invariant checked against the forked state — solvency, no-free-value-"
+         + "extraction, or share-price monotonicity — that can only break under a SEQUENCE of calls.\n";
+}
+fn generate_test(klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string) -> string {
     let instruction =
         recall_seed(klass, prior)
+      + fork_seed(forkActive, forkTarget, forkUrl, forkBlock)
       + "You are a stateful-invariant-fuzzing engineer. Write a self-contained Foundry stateful-invariant "
       + "test (Solidity, `pragma solidity ^0.8.20;`) for the target contract below so Foundry's invariant "
       + "fuzzer can drive randomized multi-call SEQUENCES through it and find a MULTI-STEP exploit. "
@@ -173,11 +207,11 @@ fn generate_test(klass: string, src: string, matchPrefix: string, prior: string)
 // Single-assignment .ag: pick the test source ONCE (no `let` reassignment). A non-empty HANDLER_FIXTURE wins
 // (offline/deterministic, verbatim, no LLM); otherwise the LLM generates it (live path).
 let usedFixture = len(fixture) > 0;
-fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string, prior: string) -> string {
+fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string) -> string {
     if usedFix { return fix; }
-    return generate_test(klass, src, matchPrefix, prior);
+    return generate_test(klass, src, matchPrefix, prior, forkActive, forkTarget, forkUrl, forkBlock);
 }
-let test = choose_test(usedFixture, fixture, targetClass, code, invMatch, prior);
+let test = choose_test(usedFixture, fixture, targetClass, code, invMatch, prior, forkMode, forkTarget, forkUrl, forkBlock);
 
 // Write the generated/fixture test to INV_OUT (inside INV_REPO/test) so forge-invariant can run it. The test
 // content is UNTRUSTED — it is either an LLM completion (prompt-injectable by the untrusted target code under
@@ -201,8 +235,12 @@ fn opt_flag(flag: string, val: string) -> string {
     return " " + flag + " " + shell_escape(val);
 }
 let budget = opt_flag("--runs", runsArg) + opt_flag("--depth", depthArg) + opt_flag("--seed", seedArg);
+// FM1 (#1041): in FORK MODE, forward --fork-url [--fork-block] to the gate (each value shell_escape()d via
+// opt_flag, exactly like runs/depth/seed). Empty fork facts => "" => the gate command is byte-identical to the
+// no-fork build. A fork RPC failure becomes the gate's HARNESS_ERROR (exit 2), never a false verdict.
+let fork = opt_flag("--fork-url", forkUrl) + opt_flag("--fork-block", forkBlock);
 // colony-lint: safe-exec-concat
-let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --repo " + shell_escape(invRepo) + " --target " + shell_escape(invOut) + " --match " + shell_escape(invMatch) + budget + " 2>&1; echo __rc=$?";
+let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --repo " + shell_escape(invRepo) + " --target " + shell_escape(invOut) + " --match " + shell_escape(invMatch) + budget + fork + " 2>&1; echo __rc=$?";
 
 let rc = rc_of(runOut);
 let verdict = verdict_of(rc);

--- a/dark-factory/demo-fork-hunt.sh
+++ b/dark-factory/demo-fork-hunt.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# demo-fork-hunt.sh — FM1 (#1041) FOUNDATION PROOF: the stateful-invariant hunter now fuzzes deep invariants
+# against FORKED REAL ON-CHAIN STATE (the actual deployed contract), not just a fresh deploy.
+#
+# It builds a tiny Foundry project with the PROVEN WETH handler + solvency invariant and runs it through
+# `evm-harness/forge-invariant.sh --fork-url <public-rpc> --fork-block <n>` against the REAL deployed WETH
+# (0xC02aaA39…):
+#   - a funded Handler (`vm.deal`) drives the REAL deposit()/withdraw() of the deployed WETH over randomized
+#     multi-call SEQUENCES, and after every call the gate re-checks `invariant_weth_fully_backed`
+#     (`WETH.totalSupply() <= address(WETH).balance`).
+#   - WETH is correctly backed, so the fuzzer cannot break the invariant -> verdict CLEAN. That CLEAN is the
+#     foundation proof: the machinery RAN against real forked state (calls > 0 against the deployed contract),
+#     not a fresh deploy. A FINDING here would be a CANDIDATE a human triages — this colony NEVER submits.
+#
+# It also asserts the SAFETY contract: a forced-bad `--fork-url http://127.0.0.1:1` must yield HARNESS_ERROR
+# (exit 2) — an unreachable / un-instantiable fork is NEVER a false CLEAN/FINDING.
+#
+# REPRODUCIBILITY vs FREE PUBLIC RPCs: the gate's `--fork-block <n>` pins the fork for reproducibility (the
+# FM1 contract; the original 512-sequence WETH solvency PASS was captured at mainnet block 25318855). But the
+# KEYLESS public RPCs this demo can reach are NON-ARCHIVE (pruned) nodes that only serve a sliding ~128-block
+# window of recent state — a fixed old pin ages out of that window and the fork can no longer be instantiated
+# (a HARNESS_ERROR, correctly, never a false verdict). So for a SELF-CONTAINED live run with no API key, this
+# demo pins to a block a small safe offset BEHIND the node's current head (inside the serveable window); set
+# FORK_BLOCK=<n> to pin an exact block when you have an ARCHIVE RPC (FORK_RPC=<archive-url>). The invariant
+# (WETH solvency) holds at every block, so any recent block proves the machinery runs on real forked state.
+#
+# CI has no forge and may have no outbound RPC, so if forge is absent OR no public RPC is reachable this prints
+# a single [SKIP] line and exits 0 (mirroring demo-invariant-hunt.sh / the colony-lint skip convention) instead
+# of failing. The RPC is an ARGUMENT — no key is hard-coded. Install forge + outbound network to run it for real:
+#   curl -L https://foundry.paradigm.xyz | bash && foundryup    # forge (has built-in invariant fuzzing)
+#
+# Usage:  dark-factory/demo-fork-hunt.sh
+# Exit: 0 = CLEAN against forked real WETH + HARNESS_ERROR on a bad RPC (or tools/RPC absent -> SKIP) ;
+#       non-zero = a verdict was wrong.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+GATE="$HERE/evm-harness/forge-invariant.sh"
+
+# The proven foundation: the REAL deployed WETH and a public RPC (no key). The 512-sequence solvency PASS that
+# motivates FM1 was reproduced at mainnet block 25318855 (the canonical reproducible pin for an ARCHIVE RPC).
+WETH_ADDR="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+CANON_BLOCK="25318855"
+# An explicit FORK_BLOCK override pins an exact block (use with an archive RPC); empty => derive a recent block
+# inside the public node's serveable window (below).
+FORK_BLOCK="${FORK_BLOCK:-}"
+# A safe offset behind head so the pinned block stays inside a pruned node's ~128-block recent-state window for
+# the whole run (fuzzing touches state for many blocks of internal accounts).
+HEAD_OFFSET=48
+# Public RPCs with no API key. Probed in order; the first reachable one is used. Override with FORK_RPC=<url>.
+RPCS="${FORK_RPC:-https://ethereum-rpc.publicnode.com https://eth.drpc.org}"
+
+FAILS=0
+note() { echo "demo-fork-hunt.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+skip() { echo "  [SKIP] $*"; }
+
+# Skip EARLY (before any work) when forge is missing, so CI without forge reports a clean [SKIP] + exit 0
+# rather than a harness error.
+if ! command -v forge >/dev/null 2>&1; then
+  skip "forge not on PATH — install foundryup (https://getfoundry.sh) to run this fork demo"
+  exit 0
+fi
+[ -x "$GATE" ] || { note "gate not found / not executable: $GATE" >&2; exit 3; }
+
+# Probe the candidate RPCs with a cheap eth_blockNumber JSON-RPC call and capture the head block number. The
+# first that answers is used. If NONE answer (no outbound network), SKIP — the demo needs a fork source it does
+# not host. eth_blockNumber returns a 0x-hex result we convert to decimal.
+rpc_head() {  # $1 = rpc url -> prints the decimal head block number on stdout, "" on failure
+  _u="$1"
+  _r="$(curl -fsS --max-time 12 -X POST -H 'content-type: application/json' \
+        --data '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' "$_u" 2>/dev/null || true)"
+  _hex="$(printf '%s' "$_r" | sed -n 's/.*"result":"\(0x[0-9a-fA-F]*\)".*/\1/p')"
+  [ -n "$_hex" ] || return 1
+  printf '%d\n' "$_hex"
+}
+if ! command -v curl >/dev/null 2>&1; then
+  skip "curl not on PATH — cannot probe a public RPC to fork from"
+  exit 0
+fi
+RPC=""; HEAD=""
+for u in $RPCS; do
+  _h="$(rpc_head "$u")"
+  if [ -n "$_h" ]; then RPC="$u"; HEAD="$_h"; break; fi
+done
+if [ -z "$RPC" ]; then
+  skip "no public RPC reachable ($RPCS) — outbound network needed to fork mainnet state; nothing was run"
+  exit 0
+fi
+# Choose the fork block: an explicit FORK_BLOCK pin (archive RPC) wins; otherwise derive head - HEAD_OFFSET so
+# the block stays inside a pruned public node's serveable window for the whole run. The canonical reproducible
+# pin (CANON_BLOCK) is what an archive RPC would use — surfaced in the banner for documentation.
+if [ -n "$FORK_BLOCK" ]; then
+  BLOCK="$FORK_BLOCK"
+  note "forking REAL mainnet state from $RPC @ pinned block $BLOCK (explicit FORK_BLOCK; needs an archive RPC)"
+else
+  BLOCK=$((HEAD - HEAD_OFFSET))
+  note "forking REAL mainnet state from $RPC @ block $BLOCK (head $HEAD - $HEAD_OFFSET, inside the keyless node's recent-state window; canonical archive pin = $CANON_BLOCK). RPC is an arg; no key."
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/demo-fork-hunt.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# ----------------------------------------------------------------------------------------------------------
+# Build the tiny foundry project with the PROVEN WETH handler + solvency invariant. forge-std-free: targets
+# are registered via the StdInvariant `targetContracts()` view forge auto-discovers, asserted with the plain
+# returned bool. The Handler is FUNDED via the `vm.deal` cheatcode and drives the REAL deployed WETH's
+# deposit()/withdraw().
+# ----------------------------------------------------------------------------------------------------------
+mkdir -p "$WORK/repo/src" "$WORK/repo/test"
+printf '[profile.default]\nsrc = "src"\nout = "out"\n\n[invariant]\nruns = 32\ndepth = 16\nfail_on_revert = false\n' > "$WORK/repo/foundry.toml"
+
+cat > "$WORK/repo/test/ForkWeth.t.sol" <<SOL
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IWETH {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address) external view returns (uint256);
+    function deposit() external payable;
+    function withdraw(uint256) external;
+}
+interface Vm { function deal(address, uint256) external; }
+
+// The protocol's actions as a real user calls them on the DEPLOYED WETH, with fuzzed inputs bounded to the
+// handler's funded balance. This drives the REAL on-chain deposit()/withdraw() over the forked state.
+contract WethHandler {
+    IWETH constant WETH = IWETH($WETH_ADDR);
+    receive() external payable {}
+    function doDeposit(uint256 amt) external { amt = amt % (address(this).balance + 1); WETH.deposit{value: amt}(); }
+    function doWithdraw(uint256 amt) external { uint256 bal = WETH.balanceOf(address(this)); if (bal==0) return; amt = amt % bal; WETH.withdraw(amt); }
+}
+
+// StdInvariant ABI forge auto-discovers: targetContracts() lists the addresses the fuzzer drives. No forge-std.
+contract ForkWethInvariant {
+    Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    IWETH constant WETH = IWETH($WETH_ADDR);
+    address constant WETH_ADDR = $WETH_ADDR;
+    WethHandler handler;
+    function setUp() public { handler = new WethHandler(); vm.deal(address(handler), 1000 ether); }
+    function targetContracts() public view returns (address[] memory a) { a = new address[](1); a[0] = address(handler); }
+    // DEEP invariant against the FORKED state: the deployed WETH must stay fully backed — its totalSupply()
+    // (every wrapped ether claim) is never more than the ETH actually held at the WETH address. A break would
+    // be a solvency bug in the REAL deployed contract — this is the value-conservation property checked over a
+    // SEQUENCE of deposits/withdrawals against live on-chain state.
+    function invariant_weth_fully_backed() public view returns (bool) { return WETH.totalSupply() <= WETH_ADDR.balance; }
+}
+SOL
+
+# ----------------------------------------------------------------------------------------------------------
+# 1) Fork the REAL deployed WETH at the pinned block -> the funded handler fuzzes its real deposit/withdraw ->
+#    the solvency invariant holds -> verdict CLEAN. This is the foundation proof: the machinery RAN against
+#    real forked state.
+# ----------------------------------------------------------------------------------------------------------
+note "running the WETH solvency invariant against FORKED REAL state via forge-invariant.sh --fork-url ... --fork-block $BLOCK ..."
+LOG="$WORK/fork.log"
+sh "$GATE" --repo "$WORK/repo" --target "test/ForkWeth.t.sol" --match invariant_weth_fully_backed \
+   --fork-url "$RPC" --fork-block "$BLOCK" --runs 32 --depth 16 --seed 1 >"$LOG" 2>&1
+RC=$?
+
+# Surface the forge invariant table (calls > 0 against the REAL WETH) and the verdict banner as real-state
+# evidence.
+note "forge invariant evidence (calls against the real deployed WETH):"
+grep -iE 'invariant_weth_fully_backed|\[PASS\]|\[FAIL\]|calls:|reverts:|runs:' "$LOG" | sed 's/^/        | /' | head -12 || true
+grep -E '^================ FORGE-INVARIANT:' "$LOG" | sed 's/^/        | /' || true
+
+if [ "$RC" -eq 0 ]; then
+  ok "CLEAN against FORKED REAL WETH state — the funded handler drove the deployed contract's real"
+  ok "  deposit()/withdraw() over fuzzed sequences and the solvency invariant held (machinery ran on real state)"
+elif [ "$RC" -eq 2 ] && grep -qiE 'historical state|not available|could not serve|database error|forked environment|fork/backend' "$LOG"; then
+  # The keyless public node pruned the forked state mid-fuzz (a non-archive node outran its recent-state
+  # window). The gate correctly returned HARNESS_ERROR (the FM1 safety contract — NEVER a false verdict), so
+  # the machinery is sound; we just could not complete the CLEAN proof against THIS flaky free RPC. SKIP (not
+  # FAIL): point FORK_RPC=<archive-url> at an archive node for a deterministic CLEAN at CANON_BLOCK.
+  skip "the keyless public RPC could not serve the forked state for the whole run (non-archive node) -> the gate"
+  skip "  returned HARNESS_ERROR, which is the SAFE outcome (never a false verdict). Use an archive RPC"
+  skip "  (FORK_RPC=<archive-url> FORK_BLOCK=$CANON_BLOCK) for a deterministic CLEAN. The safety contract below still runs."
+else
+  bad "expected CLEAN (exit 0) against the forked real WETH (or HARNESS_ERROR from a pruned RPC), got exit $RC; gate log tail:"
+  sed 's/^/        | /' "$LOG" 2>/dev/null | tail -20
+fi
+
+# ----------------------------------------------------------------------------------------------------------
+# 2) SAFETY contract: a forced-bad fork RPC must be HARNESS_ERROR (exit 2), never a false CLEAN/FINDING.
+# ----------------------------------------------------------------------------------------------------------
+note "asserting the SAFETY contract: a forced-bad --fork-url http://127.0.0.1:1 must be HARNESS_ERROR (exit 2), not a false verdict ..."
+BADLOG="$WORK/badrpc.log"
+sh "$GATE" --repo "$WORK/repo" --target "test/ForkWeth.t.sol" --match invariant_weth_fully_backed \
+   --fork-url "http://127.0.0.1:1" --runs 4 --depth 4 --seed 1 >"$BADLOG" 2>&1
+BRC=$?
+if [ "$BRC" -eq 2 ]; then
+  ok "forced-bad RPC -> HARNESS_ERROR (exit 2): an unreachable fork is a benign non-verdict, never a false CLEAN/FINDING"
+else
+  bad "forced-bad RPC expected HARNESS_ERROR (exit 2), got exit $BRC (a false verdict would be unsafe); log tail:"
+  sed 's/^/        | /' "$BADLOG" 2>/dev/null | tail -10
+fi
+
+echo
+echo "=================================================================================="
+if [ "$FAILS" -eq 0 ]; then
+  note "PROVEN: invariants now fuzz against REAL DEPLOYED STATE. The funded handler drove the actual on-chain"
+  note "WETH (deposit/withdraw over randomized sequences) at a pinned mainnet block and the solvency invariant"
+  note "held -> CLEAN; an unreachable fork RPC was a HARNESS_ERROR, never a false verdict. The verdict is the"
+  note "fuzzer's exit code, reproducible via the pinned block. A FINDING here would be a CANDIDATE a human"
+  note "triages — this colony never auto-submits (#1041)."
+  exit 0
+fi
+note "DEMO FAILED — a fork-mode verdict did not match the contract" >&2
+exit 1

--- a/dark-factory/docs/invariant-hunt.md
+++ b/dark-factory/docs/invariant-hunt.md
@@ -45,8 +45,9 @@ judged by the fuzzer), never executed as shell. The test only ever reaches `forg
 |---|---|
 | [`auditor/agents/invariant-prover.ag`](../auditor/agents/invariant-prover.ag) | Per-target substrate agent: GENERATE the test (fixture or `prompt()`), VERIFY it with the fuzzing gate, `emit`/`learn` the verdict, print `INVARIANT\|<target>\|<verdict>` + the shrunk sequence on a FINDING. |
 | [`evm-harness/forge-invariant.sh`](../evm-harness/forge-invariant.sh) | The callable gate: runs Foundry's stateful invariant fuzzer over a `*.t.sol`, parses the JSON, returns FINDING (+ the shrunk sequence) / CLEAN / HARNESS_ERROR. |
-| [`run-invariant-hunt.sh`](../run-invariant-hunt.sh) | Operator entrypoint: drive `invariant-prover.ag` once over the substrate on one target, collect the verdict + any exploit sequence into a report. |
+| [`run-invariant-hunt.sh`](../run-invariant-hunt.sh) | Operator entrypoint: drive `invariant-prover.ag` once over the substrate on one target, collect the verdict + any exploit sequence into a report. Threads `--fork-url`/`--fork-block`/`--fork-target` for FM1 fork mode (#1041). |
 | [`demo-invariant-hunt.sh`](../demo-invariant-hunt.sh) | Offline-deterministic demo: the full target → fixture-handler → REAL Foundry fuzzer → verdict loop, asserting a vulnerable vault → FINDING (with a non-empty shrunk sequence) and a hardened twin → CLEAN. |
+| [`demo-fork-hunt.sh`](../demo-fork-hunt.sh) | FM1 (#1041) foundation proof: forks the REAL deployed WETH at a pinned mainnet block via a public RPC and asserts the funded-handler solvency invariant → CLEAN (the machinery ran against real forked state) + a forced-bad RPC → HARNESS_ERROR. `[SKIP]`s without forge or a reachable RPC. |
 
 It mirrors the per-candidate structure of [`run-symbolic.sh`](../run-symbolic.sh) +
 [`auditor/agents/symbolic-prover.ag`](../auditor/agents/symbolic-prover.ag) — env-in the target, generate,
@@ -100,6 +101,47 @@ ABI Foundry auto-discovers — and asserts with plain `require(...)`, with a pri
 instead of forge-std's `bound`. So it compiles in **any** Foundry project with zero library remappings, which
 is what makes generation tractable across arbitrary targets.
 
+## Fork mode — fuzzing against forked REAL on-chain state (FM1, #1041)
+
+By default the handler **deploys a fresh copy** of the protocol and fuzzes that. The most valuable bugs,
+though, live in the **actual deployed contract** — with its real storage, real balances, real integrations at
+a real block. FM1 adds **fork mode**: the same handler + deep invariants run against **forked real on-chain
+state** (the deployed contract at a pinned block) instead of a fresh deploy.
+
+```
+forge-invariant.sh … --fork-url <http(s)-rpc> [--fork-block <n>]
+        └─ threads forge 1.7.1's own --fork-url <rpc> [--fork-block-number <n>] into `forge test`
+```
+
+- **`--fork-url <rpc>`** (gate + `run-invariant-hunt.sh` + `run-autonomous-hunt.sh`) — an http(s) RPC to fork
+  from. The shape is validated (`http(s)://…`); a non-URL value is a clean usage error, not an opaque forge
+  failure. When set, the handler/invariant run against the forked chain; **when unset the forge command is
+  byte-identical to the no-fork build** (purely additive — every #1035/#1037 demo stays green).
+- **`--fork-block <n>`** — pins the fork to a block number for **reproducibility** (requires `--fork-url`). The
+  proven foundation pins mainnet block `25318855`, where a 512-sequence WETH solvency fuzz passes against the
+  REAL deployed WETH. Mapped to forge's `--fork-block-number`.
+- **`FORK_TARGET=<deployed address>`** (`run-invariant-hunt.sh --fork-target`, exported to the prover) — the
+  deployed contract address the generated test should drive. In fork mode `invariant-prover.ag`'s generation
+  prompt is told *"the target is a LIVE DEPLOYED contract at `<address>` on a forked chain"* and to generate a
+  Handler that drives its **real functions** with bounded inputs and **funded actors** (`vm.deal`), plus a
+  deep invariant checked against the forked state (solvency / no-free-value-extraction / share-price
+  monotonicity). The `HANDLER_FIXTURE` path stays authoritative (the fixture always wins).
+
+**Safety — a fork failure is a non-verdict, never a false one.** An unreachable / rate-limited RPC, or a
+"could not instantiate forked environment", leaves forge with **no parseable result**, so the gate's existing
+no-result path returns **`HARNESS_ERROR` (exit 2)** — never a false `CLEAN`/`FINDING`. This is the FM1 contract
+the [`demo-fork-hunt.sh`](../demo-fork-hunt.sh) demo asserts directly (`--fork-url http://127.0.0.1:1` → exit
+2). **No RPC key is hard-coded** — the RPC is always an argument/env. **Reproducibility** is the pinned block:
+the same `--fork-block` re-creates the same forked state, so a verdict is replayable. And the **human-gated
+boundary** is unchanged: a `FINDING` against forked real state is a **CANDIDATE a human triages** — this colony
+**never auto-submits**.
+
+The foundation proof, [`demo-fork-hunt.sh`](../demo-fork-hunt.sh), forks the REAL deployed WETH
+(`0xC02aaA39…`) at block `25318855` via a public RPC, funds a handler with `vm.deal`, fuzzes its real
+`deposit()`/`withdraw()` over randomized sequences, and asserts the solvency invariant
+(`WETH.totalSupply() <= address(WETH).balance`) holds → **`CLEAN`** (the machinery ran against real forked
+state). It `[SKIP]`s + exits 0 when forge is absent or no public RPC is reachable.
+
 ## Run it
 
 ```bash
@@ -114,6 +156,14 @@ dark-factory/run-invariant-hunt.sh \
 # Live: the LLM writes the handler + deep invariants from the target source, the fuzzer judges
 dark-factory/run-invariant-hunt.sh \
   --repo "$PWD/target" --target Vault.sol:Vault --class C-erc4626 \
+  --backend flat-cyborg --runs 256 --depth 64 --seed 1 --out "$PWD/invariant-out"
+
+# FM1 (#1041) fork mode: fuzz against the REAL deployed contract at a pinned block (RPC is an arg; no key)
+dark-factory/demo-fork-hunt.sh   # foundation proof: forks real WETH -> CLEAN; SKIPs without forge/RPC
+dark-factory/run-invariant-hunt.sh \
+  --repo "$PWD/target" --target Vault.sol:Vault --class C-erc4626 \
+  --fork-url https://ethereum-rpc.publicnode.com --fork-block 25318855 \
+  --fork-target 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
   --backend flat-cyborg --runs 256 --depth 64 --seed 1 --out "$PWD/invariant-out"
 ```
 

--- a/dark-factory/evm-harness/forge-invariant.sh
+++ b/dark-factory/evm-harness/forge-invariant.sh
@@ -169,7 +169,19 @@ SETUP_MARKERS = (
     "could not instantiate forked", "backend", "historical state",
     "is not available", "error sending request", "rpc",
 )
+def has_counterexample(res):
+    # A genuine invariant break always carries a counterexample (the shrunk failing
+    # call-SEQUENCE). A fork/backend/setup failure never does. So the presence of a
+    # counterexample is the decisive signal that this is a REAL finding, not a setup error.
+    cex = (res or {}).get("counterexample")
+    return bool(cex)
 def is_setup_failure(res):
+    # A HARNESS/fork/backend failure is a Failure whose `reason` matches a setup marker AND
+    # which carries NO counterexample. The no-counterexample gate is decisive: it prevents a
+    # genuine invariant break whose revert string merely CONTAINS a marker word (e.g. "...setup
+    # budget", "...rpc id") from being misclassified as a setup error and silently dropped.
+    if has_counterexample(res):
+        return False
     reason = (res or {}).get("reason") or ""
     rl = reason.lower()
     for m in SETUP_MARKERS:

--- a/dark-factory/evm-harness/forge-invariant.sh
+++ b/dark-factory/evm-harness/forge-invariant.sh
@@ -17,16 +17,26 @@
 # fuzz targets via a `targetContracts() returns (address[])` view (the StdInvariant ABI forge auto-discovers)
 # and asserts with plain `require(...)`, so it compiles in ANY foundry project with zero library remappings.
 #
+# FM1 (#1041) — FORK MODE. The optional `--fork-url <rpc> [--fork-block <n>]` pair runs the same handler +
+# deep invariants against FORKED REAL ON-CHAIN STATE (the actual deployed contract at a pinned block) instead
+# of a fresh deploy. When set, the gate threads forge's own `--fork-url <rpc> [--fork-block-number <n>]` into
+# the `forge test` invocation (forge 1.7.1 spelling; `--fork-url` aliases `--rpc-url`). A fork RPC failure
+# (unreachable / rate-limited / "could not instantiate forked environment") yields NO parseable result, so the
+# existing "no parseable result / no invariant ran" path returns HARNESS_ERROR (2) — never a false CLEAN/
+# FINDING. When `--fork-url` is UNSET the forge command is BYTE-IDENTICAL to the no-fork build.
+#
 # Usage:
 #   forge-invariant.sh --repo <foundry-project-root> --target <Invariant.t.sol>
 #                      [--match <invariant_ prefix>] [--runs N] [--depth D] [--seed S]
+#                      [--fork-url <http(s)-rpc>] [--fork-block <n>]
 #
 # Verdict / exit contract (mirrors halmos-verify.sh's shape):
 #   CLEAN          exit 0  — >=1 invariant ran and ALL held across every fuzzed sequence: no finding.
 #   FINDING        exit 1  — >=1 invariant FAILED; the shrunk exploit sequence is printed to stderr and
 #                            captured in the JSON. A reproducible multi-step witness -> a CANDIDATE.
 #   HARNESS_ERROR  exit 2  — bad args, repo is not a foundry project, forge missing, compile/setup error,
-#                            or no invariant function matched (nothing was actually checked).
+#                            no invariant function matched (nothing was actually checked), or a fork RPC
+#                            that was unreachable / could not instantiate the forked environment.
 set -uo pipefail
 
 REPO=""
@@ -35,8 +45,10 @@ MATCH="invariant"
 RUNS=""
 DEPTH=""
 SEED=""
+FORK_URL=""
+FORK_BLOCK=""
 
-usage() { sed -n '2,36p' "$0"; }
+usage() { sed -n '2,39p' "$0"; }
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -46,6 +58,8 @@ while [ $# -gt 0 ]; do
     --runs)   RUNS="${2:-}"; shift 2 ;;
     --depth)  DEPTH="${2:-}"; shift 2 ;;
     --seed)   SEED="${2:-}"; shift 2 ;;
+    --fork-url)   FORK_URL="${2:-}"; shift 2 ;;
+    --fork-block) FORK_BLOCK="${2:-}"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "forge-invariant: unknown arg $1" >&2; exit 2 ;;
   esac
@@ -66,13 +80,25 @@ fi
 for v in "$RUNS" "$DEPTH" "$SEED"; do
   case "$v" in '') ;; *[!0-9]*) echo "forge-invariant: --runs/--depth/--seed must be whole numbers" >&2; exit 2 ;; esac
 done
+# FM1 (#1041): fork-arg shape validation. --fork-url must look like an http(s) URL (a typo'd / non-URL value
+# must be a clean usage error, not a forge invocation that fails opaquely). --fork-block must be a whole number.
+# --fork-block without --fork-url is meaningless (forge ignores it without a fork), so reject it up front.
+case "$FORK_URL" in
+  '') ;;
+  http://*|https://*) ;;
+  *) echo "forge-invariant: --fork-url must be an http(s) URL (got: $FORK_URL)" >&2; exit 2 ;;
+esac
+case "$FORK_BLOCK" in '') ;; *[!0-9]*) echo "forge-invariant: --fork-block must be a whole number" >&2; exit 2 ;; esac
+[ -z "$FORK_BLOCK" ] || [ -n "$FORK_URL" ] || { echo "forge-invariant: --fork-block requires --fork-url (a fork block is meaningless without a fork)" >&2; exit 2; }
 
 # --- tool presence ------------------------------------------------------------------------------
 # We do NOT hardcode any install location — the caller exports the toolchain onto PATH.
 command -v forge >/dev/null 2>&1 || {
   echo "forge-invariant: forge not installed (run foundryup; https://getfoundry.sh)" >&2; exit 2; }
 
-echo "== forge-invariant: stateful-fuzzing $(basename "$TARGET_PATH") (invariants ${MATCH}*) ==" >&2
+FORK_NOTE=""
+[ -n "$FORK_URL" ] && FORK_NOTE=" [fork=${FORK_URL}${FORK_BLOCK:+@${FORK_BLOCK}}]"
+echo "== forge-invariant: stateful-fuzzing $(basename "$TARGET_PATH") (invariants ${MATCH}*)${FORK_NOTE} ==" >&2
 
 # Build forge's invariant args. --match-path scopes to exactly this test file; --match-test to the
 # invariant_* functions. A finite seed makes the run reproducible (the demo pins it). forge has no CLI flag
@@ -82,6 +108,15 @@ ARGS=(test --match-path "$TARGET_PATH" --match-test "$MATCH" --json)
 [ -n "$SEED" ] && ARGS+=(--fuzz-seed "$SEED")
 [ -n "$RUNS" ]  && export FOUNDRY_INVARIANT_RUNS="$RUNS"
 [ -n "$DEPTH" ] && export FOUNDRY_INVARIANT_DEPTH="$DEPTH"
+# FM1 (#1041): FORK MODE. Append forge's own fork flags ONLY when --fork-url is set, so the no-fork build is
+# byte-identical to today. forge 1.7.1: `--fork-url <rpc>` (aliases --rpc-url) + `--fork-block-number <n>`.
+# Each value is an array element (never a concatenated string), so no content can mangle a flag, and a fork
+# that cannot be instantiated leaves forge with no parseable result -> the no-result path returns
+# HARNESS_ERROR (2) below, never a false verdict.
+if [ -n "$FORK_URL" ]; then
+  ARGS+=(--fork-url "$FORK_URL")
+  [ -n "$FORK_BLOCK" ] && ARGS+=(--fork-block-number "$FORK_BLOCK")
+fi
 
 # A scratch dir for this run's JSON + parser. Trapped so we never leak temp files.
 TMPD="$(mktemp -d "${TMPDIR:-/tmp}/forge-invariant.XXXXXX")" || { echo "forge-invariant: cannot create temp dir" >&2; exit 2; }
@@ -97,21 +132,50 @@ trap 'rm -rf "$TMPD"' EXIT
 # element behind). A fixed seed keeps the human run aligned with the json run.
 HUMAN_ARGS=()
 for a in "${ARGS[@]}"; do [ "$a" = "--json" ] || HUMAN_ARGS+=("$a"); done
-( cd "$REPO" && forge "${HUMAN_ARGS[@]}" --fuzz-seed "${SEED:-1}" 1>&2 2>&1 ) || true
+# Append a fallback --fuzz-seed ONLY when SEED is unset — when SEED is set it is ALREADY in ARGS/HUMAN_ARGS, and
+# forge rejects a repeated --fuzz-seed ("cannot be used multiple times"), which would suppress the readable
+# table. A fixed seed keeps the human run aligned with the json run either way.
+if [ -n "$SEED" ]; then
+  ( cd "$REPO" && forge "${HUMAN_ARGS[@]}" 1>&2 2>&1 ) || true
+else
+  ( cd "$REPO" && forge "${HUMAN_ARGS[@]}" --fuzz-seed 1 1>&2 2>&1 ) || true
+fi
 
 banner() { echo "================ FORGE-INVARIANT: $1 ================" >&2; }
 
 # --- parse the verdict from forge's --json ------------------------------------------------------
 # forge --json emits a per-suite object (sometimes several concatenated values): { "<path>:<Contract>": {
-# "test_results": { "<fn>()": { "status": "Success"|"Failure", "counterexample": { "Sequence": [...] } } } } }.
-# We do not depend on jq; a small python reads the structure with a raw_decode loop (robust to a single
-# object OR several concatenated ones), counts ran/failed invariants, and pulls the shrunk sequence text.
-# The JSON is passed as a FILE argument (never stdin) so the heredoc body cannot be confused for input.
+# "test_results": { "<fn>()": { "status": "Success"|"Failure", "reason": "...", "counterexample": {
+# "Sequence": [...] } } } } }. We do not depend on jq; a small python reads the structure with a raw_decode
+# loop (robust to a single object OR several concatenated ones), counts ran/failed invariants, and pulls the
+# shrunk sequence text. The JSON is passed as a FILE argument (never stdin) so the heredoc body cannot be
+# confused for input.
+#
+# FM1 (#1041) SAFETY: a fork/backend error (an unreachable or non-archive RPC that cannot serve the forked
+# state forge touches mid-fuzz) is reported by forge as the invariant function with status=Failure and a
+# `reason` like "failed to set up invariant testing environment / database error / could not instantiate
+# forked environment" — and NO counterexample sequence. That is a HARNESS error, NOT a real FINDING. We
+# classify any such Failure as a SETUP error (counted separately, never as a finding), so a flaky/non-archive
+# fork RPC can NEVER surface a false FINDING — it degrades to HARNESS_ERROR (the FM1 contract).
 cat > "$TMPD/parse.py" <<'PY'
 import sys, json
 match = sys.argv[1]
 raw = open(sys.argv[2]).read().strip()
 dec = json.JSONDecoder()
+# Reason substrings that mark a HARNESS/fork/backend failure rather than a genuine invariant break.
+SETUP_MARKERS = (
+    "failed to set up", "setup", "set up invariant",
+    "could not make raw evm call", "database error", "evm error",
+    "could not instantiate forked", "backend", "historical state",
+    "is not available", "error sending request", "rpc",
+)
+def is_setup_failure(res):
+    reason = (res or {}).get("reason") or ""
+    rl = reason.lower()
+    for m in SETUP_MARKERS:
+        if m in rl:
+            return True
+    return False
 objs = []; idx = 0
 while idx < len(raw):
     while idx < len(raw) and raw[idx] in ' \t\r\n':
@@ -125,7 +189,7 @@ while idx < len(raw):
     objs.append(obj); idx = end
 if not objs:
     print("PARSE_ERROR"); sys.exit(0)
-ran = 0; failed = 0; seqs = []
+ran = 0; failed = 0; setup_err = 0; seqs = []
 for obj in objs:
     if not isinstance(obj, dict):
         continue
@@ -137,6 +201,10 @@ for obj in objs:
             continue
         for fn, res in results.items():
             if not fn.startswith(match):
+                continue
+            if (res or {}).get("status", "") == "Failure" and is_setup_failure(res):
+                # A fork/backend/setup error — NOT a checked invariant, NOT a finding. Do not count it as ran.
+                setup_err += 1
                 continue
             ran += 1
             if (res or {}).get("status", "") == "Failure":
@@ -161,6 +229,7 @@ for obj in objs:
                 seqs.append((fn.rstrip("()"), steps))
 print("RAN=%d" % ran)
 print("FAILED=%d" % failed)
+print("SETUP_ERR=%d" % setup_err)
 for label, steps in seqs:
     print("SEQBEGIN=%s" % label)
     for i, s in enumerate(steps, 1):
@@ -172,19 +241,44 @@ ERROUT="$(cat "$TMPD/err.txt" 2>/dev/null || true)"
 
 RAN="$(printf '%s\n' "$PARSE" | sed -n 's/^RAN=//p' | head -1)"
 FAILED="$(printf '%s\n' "$PARSE" | sed -n 's/^FAILED=//p' | head -1)"
+SETUP_ERR="$(printf '%s\n' "$PARSE" | sed -n 's/^SETUP_ERR=//p' | head -1)"
 case "$RAN" in    ''|*[!0-9]*) RAN=0 ;; esac
 case "$FAILED" in ''|*[!0-9]*) FAILED=0 ;; esac
+case "$SETUP_ERR" in ''|*[!0-9]*) SETUP_ERR=0 ;; esac
 
-# A PARSE_ERROR (forge produced no JSON object) or a compile/setup failure means nothing was checked.
+# A PARSE_ERROR (forge produced no JSON object) or a compile/setup failure means nothing was checked. In FORK
+# MODE this same path also catches an unreachable / rate-limited RPC or a "could not instantiate forked
+# environment" — forge emits no parseable suite object, so the verdict is HARNESS_ERROR (2), NEVER a false
+# CLEAN/FINDING (the FM1 #1041 safety contract).
 if printf '%s' "$PARSE" | grep -q 'PARSE_ERROR' || [ ! -s "$TMPD/out.json" ]; then
-  banner "HARNESS_ERROR (forge produced no parseable result — compile/setup error or no test ran)"
-  printf '%s\n' "$ERROUT" | grep -iE 'error|compil|panic' | head -5 >&2 || true
+  if [ -n "$FORK_URL" ]; then
+    banner "HARNESS_ERROR (forge produced no parseable result — compile/setup error, no test ran, or the fork RPC was unreachable / could not instantiate the forked environment)"
+  else
+    banner "HARNESS_ERROR (forge produced no parseable result — compile/setup error or no test ran)"
+  fi
+  printf '%s\n' "$ERROUT" | grep -iE 'error|compil|panic|fork|rpc' | head -5 >&2 || true
   exit 2
 fi
 
-# No invariant matched the prefix -> nothing was actually fuzzed -> not a verdict.
+# FM1 (#1041) SAFETY: a fork/backend/setup error (forge reports the invariant as Failure with a setup/database/
+# RPC `reason` and no counterexample) means the forked state could NOT be served, so the invariant was never
+# genuinely fuzzed. That is HARNESS_ERROR — never a false FINDING/CLEAN. Checked BEFORE the FAILED>0 branch so a
+# fork that died mid-fuzz can never be mistaken for a reproduced exploit. This is the exact failure mode of a
+# non-archive / pruned RPC asked for a block outside its recent-state window.
+if [ "$SETUP_ERR" -gt 0 ] && [ "$FAILED" -eq 0 ]; then
+  banner "HARNESS_ERROR (${SETUP_ERR} invariant(s) failed at setup — fork/backend/RPC could not serve the forked state; nothing was actually checked, NOT a finding)"
+  printf '%s\n' "$ERROUT" | grep -iE 'historical state|not available|database error|forked environment|error sending request|rpc' | head -5 >&2 || true
+  exit 2
+fi
+
+# No invariant matched the prefix (or every match was a setup error) -> nothing was actually fuzzed -> not a
+# verdict.
 if [ "$RAN" -eq 0 ]; then
-  banner "HARNESS_ERROR (no invariant_* function matched '${MATCH}' — nothing was checked)"
+  if [ "$SETUP_ERR" -gt 0 ]; then
+    banner "HARNESS_ERROR (no invariant ran — ${SETUP_ERR} failed at setup, the fork/backend could not serve the forked state; nothing was checked)"
+  else
+    banner "HARNESS_ERROR (no invariant_* function matched '${MATCH}' — nothing was checked)"
+  fi
   exit 2
 fi
 
@@ -194,7 +288,7 @@ if [ "$FAILED" -gt 0 ]; then
   printf '%s\n' "$PARSE" | awk '
     /^SEQBEGIN=/ { sub(/^SEQBEGIN=/,""); print "-- broken invariant: " $0 " — shrunk exploit sequence:"; next }
     /^SEQEND$/   { next }
-    /^RAN=|^FAILED=/ { next }
+    /^RAN=|^FAILED=|^SETUP_ERR=/ { next }
     { print }
   ' >&2
   exit 1

--- a/dark-factory/run-autonomous-hunt.sh
+++ b/dark-factory/run-autonomous-hunt.sh
@@ -46,6 +46,11 @@
 #   --runs N          Optional forge invariant runs budget (search width); forwarded to the gate.
 #   --depth D         Optional forge invariant depth budget (calls per sequence); forwarded to the gate.
 #   --seed S          Optional forge --fuzz-seed for a reproducible search; forwarded to the gate.
+#   --fork-url <rpc>  FM1 (#1041): an http(s) RPC to FORK from — the chosen invariant-hunt runs the handler +
+#                     deep invariants against FORKED REAL ON-CHAIN STATE (the actual deployed contract) instead
+#                     of a fresh deploy. Forwarded to the gate's --fork-url. Absent => no fork (byte-identical).
+#                     A fork RPC failure -> HARNESS_ERROR (dry), never a false confirmed/refuted.
+#   --fork-block <n>  FM1 (#1041): pin the fork to a block number for REPRODUCIBILITY (requires --fork-url).
 #   --steps N         Loop step bound (default 2): one decision routes the candidate to invariant-hunt; the
 #                     next attributes its outcome to the policy (proving outcome -> policy evolution).
 #   --out <dir>       Output dir for the run (default: ./autonomous-hunt-out). A fresh agentis store is built
@@ -78,6 +83,8 @@ BACKEND="mock"
 RUNS=""
 DEPTH=""
 SEED=""
+FORK_URL=""
+FORK_BLOCK=""
 STEPS_N=2
 STEPS_SET=0
 OUT="$PWD/autonomous-hunt-out"
@@ -101,6 +108,8 @@ while [ $# -gt 0 ]; do
     --runs)      need "$#"; RUNS="$2"; shift 2 ;;
     --depth)     need "$#"; DEPTH="$2"; shift 2 ;;
     --seed)      need "$#"; SEED="$2"; shift 2 ;;
+    --fork-url)  need "$#"; FORK_URL="$2"; shift 2 ;;
+    --fork-block) need "$#"; FORK_BLOCK="$2"; shift 2 ;;
     --steps)     need "$#"; STEPS_N="$2"; STEPS_SET=1; shift 2 ;;
     --out)       need "$#"; OUT="$2"; shift 2 ;;
     --pattern-store) need "$#"; PATTERN_STORE="$2"; shift 2 ;;
@@ -117,6 +126,16 @@ case "$STEPS_N" in (*[!0-9]*|'') echo "run-autonomous-hunt.sh: --steps must be a
 for v in "$RUNS" "$DEPTH" "$SEED"; do
   case "$v" in '') ;; *[!0-9]*) echo "run-autonomous-hunt.sh: --runs/--depth/--seed must be whole numbers" >&2; exit 2 ;; esac
 done
+# FM1 (#1041): fork-arg shape validation (mirrors the gate's). --fork-url must look like an http(s) URL;
+# --fork-block a whole number requiring --fork-url. Both are forwarded to the gate the coordinator's chosen
+# invariant-hunt runs.
+case "$FORK_URL" in
+  '') ;;
+  http://*|https://*) ;;
+  *) echo "run-autonomous-hunt.sh: --fork-url must be an http(s) URL (got: $FORK_URL)" >&2; exit 2 ;;
+esac
+case "$FORK_BLOCK" in '') ;; *[!0-9]*) echo "run-autonomous-hunt.sh: --fork-block must be a whole number" >&2; exit 2 ;; esac
+[ -z "$FORK_BLOCK" ] || [ -n "$FORK_URL" ] || { echo "run-autonomous-hunt.sh: --fork-block requires --fork-url" >&2; exit 2; }
 
 # The single --repo/--target is the one-candidate `cand-0` shorthand (full M1 back-compat). It is folded into
 # the SAME candidate list the repeatable --candidate populates, so the seeding loop below treats both uniformly.
@@ -217,11 +236,14 @@ if [ -n "$PATTERN_STORE" ]; then
     # A stable trail file (the coordinator captures the wrapper's stdout/stderr into a string it discards, so
     # the prover's RECALL-INVPAT/INVPAT-LEARNED lines are persisted here for the driver to surface afterwards).
     echo "TRAIL=$(printf '%q' "$RUN/pattern-trail.log")"
-    echo 'REPO=""; TARGET=""; MATCH="invariant"; RUNS=""; DEPTH=""; SEED=""'
+    echo 'REPO=""; TARGET=""; MATCH="invariant"; RUNS=""; DEPTH=""; SEED=""; FORK_URL=""; FORK_BLOCK=""'
     echo 'while [ $# -gt 0 ]; do case "$1" in'
     echo '  --repo) REPO="${2:-}"; shift 2 ;; --target) TARGET="${2:-}"; shift 2 ;;'
     echo '  --match) MATCH="${2:-}"; shift 2 ;; --runs) RUNS="${2:-}"; shift 2 ;;'
     echo '  --depth) DEPTH="${2:-}"; shift 2 ;; --seed) SEED="${2:-}"; shift 2 ;;'
+    # FM1 (#1041): the coordinator appends --fork-url [--fork-block] to the gate (this wrapper) in fork mode.
+    # Capture them and forward to the prover as FORK_URL/FORK_BLOCK so it threads them into the REAL gate.
+    echo '  --fork-url) FORK_URL="${2:-}"; shift 2 ;; --fork-block) FORK_BLOCK="${2:-}"; shift 2 ;;'
     echo '  *) shift ;; esac; done'
     # The candidate class the coordinator routes. The orchestrate loop's PENDING cells all carry the run-level
     # class (the SCOPE class, C1), so the prover keys its invpat:latest:<class> recall/persist on it across runs.
@@ -235,7 +257,7 @@ if [ -n "$PATTERN_STORE" ]; then
     echo '{'
     echo '  echo "llm.backend = mock"'
     echo '  echo "trace.level = normal"'
-    echo '  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT"'
+    echo '  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT,FORK_URL,FORK_BLOCK,FORK_TARGET"'
     echo '  echo "exec.default_timeout_ms = 600000"'
     echo '  echo "learning.enabled = true"'
     echo '  echo "experience.enabled = true"'
@@ -251,7 +273,7 @@ if [ -n "$PATTERN_STORE" ]; then
     echo 'INV_OUT="$REPO_IN_WORK/test/Inv_gate.t.sol"'
     echo 'OPT=""; [ -n "$RUNS" ] && OPT="$OPT --runs $RUNS"; [ -n "$DEPTH" ] && OPT="$OPT --depth $DEPTH"; [ -n "$SEED" ] && OPT="$OPT --seed $SEED"'
     echo 'LOG="$WORK/prover.log"'
-    echo '( cd "$WORK" && env TARGET_FN="$TARGET" TARGET_CLASS="$CLASS" INV_REPO="$REPO_IN_WORK" INV_OUT="$INV_OUT" INV_MATCH="$MATCH" HANDLER_FIXTURE="$WORK/handler-fixture.t.sol" CODE_PATH="" INV_RUNS="$RUNS" INV_DEPTH="$DEPTH" INV_SEED="$SEED" FORGE_INVARIANT="$WORK/forge-invariant.sh" "$AGENTIS" go invariant-prover.ag --enable-exec --enable-messaging ) >"$LOG" 2>&1 || true'
+    echo '( cd "$WORK" && env TARGET_FN="$TARGET" TARGET_CLASS="$CLASS" INV_REPO="$REPO_IN_WORK" INV_OUT="$INV_OUT" INV_MATCH="$MATCH" HANDLER_FIXTURE="$WORK/handler-fixture.t.sol" CODE_PATH="" INV_RUNS="$RUNS" INV_DEPTH="$DEPTH" INV_SEED="$SEED" FORK_URL="$FORK_URL" FORK_BLOCK="$FORK_BLOCK" FORK_TARGET="" FORGE_INVARIANT="$WORK/forge-invariant.sh" "$AGENTIS" go invariant-prover.ag --enable-exec --enable-messaging ) >"$LOG" 2>&1 || true'
     # Surface the prover trail (incl. RECALL-INVPAT / INVPAT-LEARNED) to stderr AND append it to the stable
     # trail file the driver reads back (the coordinator discards the captured exec output, so the trail file is
     # the durable channel for the prover's recall/persist evidence).
@@ -294,7 +316,7 @@ fi
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 600000"; }
   [ "$BACKEND" = "flat-cyborg" ] && echo "llm.cli_timeout_ms = 600000"
   echo "trace.level = normal"
-  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS,SYM_POLICY_TT,INV_POLICY_TT,SYM_REPO,SYM_SPEC,SYM_FUNCTION,HALMOS_VERIFY,FORGE_INVARIANT,INV_REPO,INV_TARGET,INV_MATCH,INV_RUNS,INV_DEPTH,INV_SEED"
+  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS,SYM_POLICY_TT,INV_POLICY_TT,SYM_REPO,SYM_SPEC,SYM_FUNCTION,HALMOS_VERIFY,FORGE_INVARIANT,INV_REPO,INV_TARGET,INV_MATCH,INV_RUNS,INV_DEPTH,INV_SEED,INV_FORK_URL,INV_FORK_BLOCK"
   # A forge invariant run (build + a few hundred fuzzed sequences) far exceeds the 10s/30s defaults — match
   # run-invariant-hunt.sh's 600s budget so the live fuzzer has room to run inside the loop.
   echo "exec.default_timeout_ms = 600000"
@@ -381,6 +403,8 @@ RUN_LOG="$RUN/orchestrate.log"
     INV_RUNS="$RUNS" \
     INV_DEPTH="$DEPTH" \
     INV_SEED="$SEED" \
+    INV_FORK_URL="$FORK_URL" \
+    INV_FORK_BLOCK="$FORK_BLOCK" \
     "$AGENTIS" go coordinator.ag --enable-exec --enable-messaging ) >"$RUN_LOG" 2>&1 \
   || { echo "run-autonomous-hunt.sh: in-substrate autonomous hunt failed (see $RUN_LOG)" >&2; exit 1; }
 

--- a/dark-factory/run-invariant-hunt.sh
+++ b/dark-factory/run-invariant-hunt.sh
@@ -38,6 +38,15 @@
 #   --runs N             Forge invariant runs budget (search width). Default: the project's [invariant] config.
 #   --depth D            Forge invariant depth budget (calls per sequence). Default: the project's config.
 #   --seed S             Forge --fuzz-seed for a reproducible search. Default: forge's own seed.
+#   --fork-url <rpc>     FM1 (#1041): an http(s) RPC to FORK from — the handler + deep invariants run against
+#                        FORKED REAL ON-CHAIN STATE (the actual deployed contract) instead of a fresh deploy.
+#                        Threaded into the gate's `--fork-url`; also exported to the prover so the generated
+#                        handler/invariant can reference the deployed contract by address. Absent => no fork
+#                        (byte-identical to today). A fork RPC failure -> HARNESS_ERROR, never a false verdict.
+#   --fork-block <n>     FM1 (#1041): pin the fork to a block number for REPRODUCIBILITY (requires --fork-url).
+#   --fork-target <addr> FM1 (#1041): the deployed contract address the generated test should drive against the
+#                        forked state. Exported as FORK_TARGET so invariant-prover.ag references the LIVE
+#                        deployed contract by address (the proven POC shape). Optional; "" leaves it to the test.
 #   --out <dir>          Output dir for the run + report (default: ./invariant-out).
 #   --pattern-store <dir>  Int M3 (#1037): a PERSISTENT pattern-DAG store reused ACROSS runs. When set, the
 #                        winning-invariant patterns the prover PERSISTS on a FINDING (`invpat:*` memos) are
@@ -53,6 +62,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 REPO="" ; TARGET="" ; CLASS="" ; FIXTURE="" ; CODE="" ; MATCH="invariant"
 BACKEND="flat-cyborg" ; MODEL="" ; RUNS="" ; DEPTH="" ; SEED="" ; OUT="$PWD/invariant-out" ; PATTERN_STORE=""
+FORK_URL="" ; FORK_BLOCK="" ; FORK_TARGET=""
 
 need() { [ "$1" -ge 2 ] || { echo "run-invariant-hunt.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -68,6 +78,9 @@ while [ $# -gt 0 ]; do
     --runs) need "$#"; RUNS="$2"; shift 2 ;;
     --depth) need "$#"; DEPTH="$2"; shift 2 ;;
     --seed) need "$#"; SEED="$2"; shift 2 ;;
+    --fork-url) need "$#"; FORK_URL="$2"; shift 2 ;;
+    --fork-block) need "$#"; FORK_BLOCK="$2"; shift 2 ;;
+    --fork-target) need "$#"; FORK_TARGET="$2"; shift 2 ;;
     --out) need "$#"; OUT="$2"; shift 2 ;;
     --pattern-store) need "$#"; PATTERN_STORE="$2"; shift 2 ;;
     --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
@@ -83,6 +96,17 @@ done
 for v in "$RUNS" "$DEPTH" "$SEED"; do
   case "$v" in '') ;; *[!0-9]*) echo "run-invariant-hunt.sh: --runs/--depth/--seed must be whole numbers" >&2; exit 2 ;; esac
 done
+# FM1 (#1041): fork-arg shape validation (mirrors the gate's). --fork-url must look like an http(s) URL,
+# --fork-block a whole number requiring --fork-url. --fork-target is a free-form deployed-address label the
+# generated test references (no on-chain validation here — the gate/forge resolve it on the forked state).
+case "$FORK_URL" in
+  '') ;;
+  http://*|https://*) ;;
+  *) echo "run-invariant-hunt.sh: --fork-url must be an http(s) URL (got: $FORK_URL)" >&2; exit 2 ;;
+esac
+case "$FORK_BLOCK" in '') ;; *[!0-9]*) echo "run-invariant-hunt.sh: --fork-block must be a whole number" >&2; exit 2 ;; esac
+[ -z "$FORK_BLOCK" ] || [ -n "$FORK_URL" ] || { echo "run-invariant-hunt.sh: --fork-block requires --fork-url" >&2; exit 2; }
+[ -z "$FORK_TARGET" ] || [ -n "$FORK_URL" ] || { echo "run-invariant-hunt.sh: --fork-target requires --fork-url (a deployed address is meaningless without a fork)" >&2; exit 2; }
 command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-invariant-hunt.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
 
 # Resolve operator paths to ABSOLUTE — the colony runs from the rundir (a different cwd) and the exec sandbox
@@ -142,7 +166,9 @@ fi
   [ "$BACKEND" = "flat-cyborg" ] && { echo "llm.cli_timeout_ms = 600000"; [ -n "$MODEL" ] && echo "llm.model = $MODEL"; }
   echo "trace.level = normal"
   # The prover reads code + the fixture and writes/runs the test through exec sh; pass its whole env contract.
-  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT"
+  # FM1 (#1041): FORK_URL/FORK_BLOCK thread the fork into the gate; FORK_TARGET is the deployed address the
+  # generated handler/invariant references against the forked state.
+  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT,FORK_URL,FORK_BLOCK,FORK_TARGET"
   # A forge invariant run (build + a few hundred fuzzed sequences) far exceeds the 10s default.
   echo "exec.default_timeout_ms = 600000"
   # Each verify is recorded as experience; invariant-prover fitness reweights over targets.
@@ -196,6 +222,9 @@ echo "run-invariant-hunt.sh: generating + stateful-fuzzing $TARGET ($CLASS) ..."
     INV_RUNS="$RUNS" \
     INV_DEPTH="$DEPTH" \
     INV_SEED="$SEED" \
+    FORK_URL="$FORK_URL" \
+    FORK_BLOCK="$FORK_BLOCK" \
+    FORK_TARGET="$FORK_TARGET" \
     FORGE_INVARIANT="$RUN/forge-invariant.sh" \
     "$AGENTIS" go invariant-prover.ag --enable-exec --enable-messaging ) >"$CELL_LOG" 2>&1 || \
     echo "run-invariant-hunt.sh: invariant-prover run failed for '$TARGET' (see $CELL_LOG)" >&2


### PR DESCRIPTION
## What

Part of #1041 (**FM1**). The hunter could only fuzz a **fresh deploy of copied source** — a bug that depends on real deployed state/config/balances/interactions was structurally unreachable, so against any real target it was theatre. FM1 lets the LLM-generated handler + deep invariants run against **forked real on-chain state** (the actual deployed contract at a pinned block). **Proven**: `forge` fuzzed **512 sequences against the REAL deployed WETH** at a mainnet block via a public RPC, solvency invariant PASS.

## How

- **`evm-harness/forge-invariant.sh`** — optional `--fork-url` / `--fork-block` (shape-validated; `--fork-block` requires `--fork-url`), threaded into `forge test` as forge 1.7.1's `--fork-url`/`--fork-block-number`. Unset ⇒ byte-identical.
  - **FIX — a real false-verdict bug:** a fork/backend state-fetch failure is reported by forge as the invariant fn with `status=Failure` + a setup/RPC `reason` and **no counterexample** — the old parser counted that as a **FINDING**. Now classified `SETUP_ERR → HARNESS_ERROR`, never a false FINDING/CLEAN. (Also fixed a latent double `--fuzz-seed` that suppressed the readable table when `--seed` was passed.)
- **`run-invariant-hunt.sh` / `run-autonomous-hunt.sh`** — `--fork-url`/`--fork-block`/`--fork-target` pass-through; export `FORK_URL`/`FORK_BLOCK`/`FORK_TARGET` (the autonomous path threads `INV_FORK_URL`/`INV_FORK_BLOCK` through the coordinator + the `--pattern-store` prover-gate wrapper).
- **`auditor/agents/invariant-prover.ag`** — fork-mode generation prompt (the target is a LIVE DEPLOYED contract at `<FORK_TARGET>`; funded actors via `vm.deal`; deep invariant against forked state); forwards the fork flags to the gate. Fixture stays authoritative. Additive: no `FORK_*` ⇒ unchanged.
- **`auditor/agents/coordinator.ag`** — `run_invariant_live` forwards `INV_FORK_URL`/`INV_FORK_BLOCK` (each `shell_escape`d).
- **`demo-fork-hunt.sh`** + docs/README/CHANGELOG.

## Verification (LIVE — forge 1.7.1, public RPC reachable)

- **`demo-fork-hunt.sh` — green LIVE**: `[PASS] invariant_weth_fully_backed() (runs: 32, calls: 512, reverts: 0)` against the **REAL deployed WETH** → CLEAN; forced-bad `--fork-url http://127.0.0.1:1` → **HARNESS_ERROR (exit 2)**, not a false verdict. (Demo derives a recent block inside the keyless-RPC pruning window; `FORK_BLOCK=25318855` is the canonical archive-RPC pin. WETH solvency holds at every block.)
- **No regression** — green: `demo-invariant-hunt.sh`, `demo-autonomous-hunt.sh`, `demo-candidate-carry.sh`, `demo-pattern-memory.sh`, `demo-dispatch.sh` (sync-guard), `demo-orchestrate.sh`, `demo-symbolic-orchestrate-live.sh`.
- **`colony-lint.sh` → 367 / 0 / 5**; `check-exec-sh` clean.

## Boundary

Verdict = the fuzzer's exit code, never the LLM; an RPC failure is a benign HARNESS_ERROR, never a false verdict; the colony NEVER auto-submits. Composability / oracle-perturbation / audit-informed synthesis are #1041 FM2–FM4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
