### PR TITLE
fix(dark-factory): route the default LLM backend through flat-cyborg, not metered claude -p

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,15 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Changed
+- `run-audit.sh`: the default `--backend flat-cyborg` now wires `llm.command` to the new
+  `flat-cyborg-claude.sh` wrapper, which drives the **interactive** claude CLI through
+  flat-cyborg's PTY ($0 subscription) instead of the metered `claude -p` API. The
+  `flat-cyborg` backend branch previously set only the timeout and left `llm.command`
+  unset. `--backend claude` (metered `claude -p`) stays an explicit opt-in. Requires
+  flat-cyborg >= v0.9.1 (`--extract` implies the screen grid).
+
+
 ### Added
 
 - **Cross-contract composability — the fuzzer now composes call-SEQUENCES across the target AND the protocols

--- a/dark-factory/flat-cyborg-claude.sh
+++ b/dark-factory/flat-cyborg-claude.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# flat-cyborg-claude.sh — $0 LLM backend for agentis prompt(): drives the
+# INTERACTIVE claude CLI through flat-cyborg's PTY wrapper (uses the Claude Code
+# subscription session, NOT the metered `claude -p` API path). agentis invokes
+# the configured llm.command with the prompt as a trailing positional arg; this
+# wrapper takes the prompt from "$1" (falling back to stdin) and returns only the
+# model's reply on stdout (flat-cyborg --extract).
+#
+# Config (run-audit.sh and siblings): set
+#   llm.command = <abs path to this script>
+#   llm.args    =                       (empty — the prompt is the sole arg)
+set -eu
+PROMPT="${1:-}"
+if [ -z "$PROMPT" ]; then PROMPT="$(cat)"; fi
+exec flat-cyborg --extract --no-jitter --auto-approve \
+  --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" \
+  --timeout-ms "${FLAT_CYBORG_TIMEOUT_MS:-180000}" \
+  --cmd "$PROMPT" -- claude

--- a/dark-factory/run-audit.sh
+++ b/dark-factory/run-audit.sh
@@ -26,7 +26,9 @@
 #                            `Class|abs-src-path|func-marker` (harvest-sherlock.js output).
 #   --share-patterns         After seeding, publish each pattern to the knowledge market so other
 #                            federation members can buy it (knowledge_sell; requires --seed-manifest).
-#   --backend <mock|claude>  LLM backend (default: claude). mock = offline-deterministic.
+#   --backend <flat-cyborg|claude|mock>  LLM backend (default: flat-cyborg). flat-cyborg = flat-rate
+#                            PTY wrapper driving the interactive claude CLI ($0 subscription, via
+#                            flat-cyborg-claude.sh); claude = metered `claude -p` API; mock = offline.
 #   --sandbox <hardened|none> Sandbox profile (default: hardened).
 #   --out <dir>              Output dir for the run + submission package (default: ./audit-out).
 #   --agentis <bin>          agentis binary (default: `agentis` on PATH).
@@ -127,9 +129,10 @@ cp "$COLONY" "$RUN/auditor.ag"
 ( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
 {
   echo "llm.backend = $BACKEND"
-  # claude = metered `-p` API path (opt-in via --backend claude); flat-cyborg = flat-rate PTY wrapper (default)
+  # flat-cyborg = flat-rate PTY wrapper driving the interactive claude CLI (default, $0 subscription via
+  # flat-cyborg-claude.sh); claude = metered `claude -p` API path (explicit opt-in only — do not default to it).
   [ "$BACKEND" = "claude" ] && { echo "llm.command = claude"; echo "llm.args = -p"; echo "llm.cli_timeout_ms = 180000"; }
-  [ "$BACKEND" = "flat-cyborg" ] && echo "llm.cli_timeout_ms = 180000"
+  [ "$BACKEND" = "flat-cyborg" ] && { echo "llm.command = $HERE/flat-cyborg-claude.sh"; echo "llm.cli_timeout_ms = 180000"; }
   echo "trace.level = normal"
   echo "exec.env_passthrough = BOUNTY_TARGET,BOUNTY_POC,SOLANA_HARNESS_DIR,SOLANA_ANCHOR_HARNESS_DIR,EVM_HARNESS_DIR,BOUNTY_SNAPSHOT,BOUNTY_REPO,BOUNTY_IN_SCOPE,BOUNTY_CONTRACT,SEED_SRC,SEED_CLASS,SEED_FUNC,FUZZY_SEEDS,FUZZY_THRESHOLD,FUZZY_K"
   echo "exec.default_timeout_ms = 180000"


### PR DESCRIPTION
## What

`run-audit.sh` already defaulted to `--backend flat-cyborg`, but the `flat-cyborg` config branch only set `llm.cli_timeout_ms` and left **`llm.command` unset** — so the default backend had no LLM command wired, and the only command path that set one was the **metered `claude -p`** API. This routes the default backend through flat-cyborg's flat-rate PTY ($0 subscription) instead.

## How

- New **`dark-factory/flat-cyborg-claude.sh`** wrapper: takes the prompt as `$1` (agentis appends it as the trailing positional arg, as it does for `claude -p`) and drives the **interactive** claude CLI through flat-cyborg, returning only the model's reply (`flat-cyborg --extract --no-jitter --auto-approve`).
- `run-audit.sh`: the `flat-cyborg` branch now wires `llm.command = $HERE/flat-cyborg-claude.sh`. `--backend claude` (metered `claude -p`) stays an explicit opt-in. Stale `--backend` help fixed (default is `flat-cyborg`, not `claude`).

Requires **flat-cyborg >= v0.9.1** (Replikanti/flat-cyborg#44 — `--extract` implies the screen grid, so it works for the alt-screen claude CLI without `--tui`).

## Verification

- Wrapper verified standalone: `flat-cyborg-claude.sh "Reply ... WRAPOK_77"` → `WRAPOK_77`.
- `colony-lint.sh` → **367 / 0 / 5**.

The end-to-end agentis→wrapper path (agentis passing the prompt as the trailing positional arg) mirrors the existing `claude -p` invocation contract; a live agentis prompt run is the remaining confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
