### PR TITLE
feat(dark-factory): autonomous harness generation + hunt — closes the harness-automation gap (run-autoharness.sh)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,18 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Added
+- `run-autoharness.sh` — **autonomous harness generation + hunt**. Given a target recon spec (deployed
+  addresses + function signatures + fork block + the deep invariant to assert), the `$0` flat-cyborg LLM
+  backend GENERATES a complete Foundry fork-fuzz harness on its own; a compile-repair loop fixes errors via
+  the LLM; then the fuzzer hunts against the REAL forked protocol. No human writes the harness. Proven +
+  reproducible: the LLM-generated harness rediscovers the real **Euler $197M audit-surviving bug** on a fork
+  at the pre-exploit block, and reports CLEAN on a safe ERC4626 vault (sDAI) — generalises across protocols.
+  Closes the harness-automation gap: the federation can go from a target's recon to a verdict autonomously.
+  Needs a flat-cyborg backend wrapper + forge + an archive RPC (`[SKIP]`+exit0 otherwise). Example recon:
+  `docs/autoharness-euler-example.txt`.
+
+
 ### Changed
 - `run-audit.sh`: the default `--backend flat-cyborg` now wires `llm.command` to the new
   `flat-cyborg-claude.sh` wrapper, which drives the **interactive** claude CLI through

--- a/dark-factory/docs/autoharness-euler-example.txt
+++ b/dark-factory/docs/autoharness-euler-example.txt
@@ -1,0 +1,12 @@
+# Example target recon spec for run-autoharness.sh (Euler Finance, the $197M audit-survivor).
+# The pipeline feeds this to the LLM, which GENERATES the harness; the fuzzer then hunts.
+Chain: Ethereum mainnet. Fork via env ETH_RPC, block via env FORK_BLK (use 16817000 = pre-exploit).
+Protocol: Euler lending. Deposit collateral, self-mint debt (leverage); the protocol must stay solvent.
+Contracts + functions:
+- DAI collateral ERC20: 0x6B175474E89094C44Da98b954EedeAC495271d0F (balanceOf, approve)
+- Euler main proxy (approve target): 0x27182842E098f60e3D576794A5bFFb0777E025d3
+- Markets: 0x3520d5a913427E6F0D6A83E07ccD4A4da316e4d3 -> enterMarket(uint256 subAccountId, address underlying)
+- eDAI: 0xe025E3ca2bE02316033184551D4d3Aa22024D9DC -> deposit(uint256,uint256), mint(uint256,uint256), donateToReserves(uint256,uint256), balanceOf(address)
+- Exec: 0x59828FdF7ee634AaaD3f58B19fDBa3b03E2D9d80 -> liquidity(address) returns (uint256 collateralValue, uint256 liabilityValue)
+DEEP INVARIANT to assert: collateralValue >= liabilityValue (the account must stay solvent). At constant
+fork price+time, any sequence that drives it insolvent is a real accounting bug.

--- a/dark-factory/run-autoharness.sh
+++ b/dark-factory/run-autoharness.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# run-autoharness.sh — AUTONOMOUS harness generation + bug hunt. Given a target recon spec (deployed
+# addresses + the relevant function signatures + chain/fork-block + a hunt goal), the LLM ($0 flat-cyborg
+# backend) GENERATES a complete Foundry fork-fuzz harness on its own; a compile-repair loop fixes errors
+# via the LLM; then the fuzzer hunts a deep solvency / no-free-value invariant against the REAL forked
+# protocol. No human writes the harness. Proven: the LLM-generated harness reproducibly rediscovers the
+# real Euler $197M audit-surviving bug on a fork at the pre-exploit block (and reports CLEAN on safe vaults).
+#
+# Usage: run-autoharness.sh --spec <recon.txt> --rpc <archive-rpc> --block <n> [--repairs N] [--runs N] [--out <dir>]
+#   --spec : a text file describing the target (addresses, function signatures, the deep invariant to assert).
+# Requires: a flat-cyborg LLM backend wrapper on PATH (LLM_WRAP env or ./flat-cyborg-claude.sh), forge, an
+# ARCHIVE RPC (forge fork execution at a historical block needs a true archive node).
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WRAP="${LLM_WRAP:-$HERE/flat-cyborg-claude.sh}"
+SPEC="" ; RPC="" ; BLK="" ; REPAIRS=6 ; RUNS=400 ; OUT=""
+while [ $# -gt 0 ]; do case "$1" in
+  --spec) SPEC="$2"; shift 2;; --rpc) RPC="$2"; shift 2;; --block) BLK="$2"; shift 2;;
+  --repairs) REPAIRS="$2"; shift 2;; --runs) RUNS="$2"; shift 2;; --out) OUT="$2"; shift 2;;
+  -h|--help) sed -n '2,12p' "$0"; exit 0;; *) echo "run-autoharness.sh: unknown arg $1" >&2; exit 2;; esac; done
+[ -f "$SPEC" ] || { echo "run-autoharness.sh: --spec <file> required" >&2; exit 2; }
+[ -n "$RPC" ] && [ -n "$BLK" ] || { echo "run-autoharness.sh: --rpc and --block required" >&2; exit 2; }
+command -v forge >/dev/null || { echo "[SKIP] forge not installed" >&2; exit 0; }
+[ -x "$WRAP" ] || { echo "[SKIP] LLM backend wrapper not found ($WRAP); set LLM_WRAP" >&2; exit 0; }
+WORK="${OUT:-$(mktemp -d "${TMPDIR:-/tmp}/autoharness.XXXXXX")}"; mkdir -p "$WORK/test"
+printf '[profile.default]\ntest = "test"\nsolc = "0.8.24"\nevm_version = "cancun"\n' > "$WORK/foundry.toml"
+PROMPT="$WORK/prompt.txt"
+{ echo "You are an autonomous smart-contract bug-hunting harness generator. Output ONLY a single Solidity file (no markdown, no prose): a forge-std-FREE Foundry test, contract name AutoHarness, pragma ^0.8.24. Use the cheatcode interface at 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D (createSelectFork(string,uint256), envString, envUint, store, load). Fund the test contract by storage-slot scan + approve. Expose the protocol's primitive operations as fuzzable try/catch actions. Add a FUZZ test function testFuzz_hunt(uint256 seed) that derives a SEQUENCE of ops from the seed, executes them on the REAL forked protocol, then require()s the deep invariant. Fork via env ETH_RPC + the block below.";
+  echo "=== TARGET RECON ==="; cat "$SPEC"; } > "$PROMPT"
+ATT=0
+"$WRAP" < "$PROMPT" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}' > "$WORK/test/AutoHarness.t.sol"
+while : ; do
+  ERR="$( cd "$WORK" && forge build 2>&1 )"
+  echo "$ERR" | grep -q 'Compiler run successful' && { echo "run-autoharness: harness COMPILES (attempt $ATT)"; break; }
+  ATT=$((ATT+1)); [ "$ATT" -gt "$REPAIRS" ] && { echo "run-autoharness: gave up after $REPAIRS repair attempts" >&2; exit 1; }
+  { echo "Fix the Solidity compile error(s). Output ONLY the corrected complete .sol (no markdown), contract AutoHarness, pragma ^0.8.24, forge-std-free.";
+    echo "--- ERRORS ---"; echo "$ERR" | grep -iE 'error|-->' | head -20; echo "--- FILE ---"; cat "$WORK/test/AutoHarness.t.sol"; } > "$WORK/repair.txt"
+  "$WRAP" < "$WORK/repair.txt" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}' > "$WORK/test/AutoHarness.t.sol"
+done
+FN="$(grep -oE 'function (testFuzz|test)[A-Za-z_]*' "$WORK/test/AutoHarness.t.sol" | head -1 | sed 's/function //')"
+echo "run-autoharness: hunting via $FN (fork $RPC @ $BLK) ..."
+( cd "$WORK" && ETH_RPC="$RPC" FORK_BLK="$BLK" FOUNDRY_FUZZ_RUNS="$RUNS" forge test --mt "$FN" --fork-url "$RPC" --fork-block-number "$BLK" 2>&1 ) | grep -iE '\[PASS\]|\[FAIL\]|VIOLAT|counterexample|Suite result'


### PR DESCRIPTION
## What

Closes the **harness-automation gap** — the last manual step in the autonomous hunt. `run-autoharness.sh`: given a target **recon spec** (deployed addresses + function signatures + fork block + the deep invariant to assert), the `$0` flat-cyborg LLM backend **generates a complete Foundry fork-fuzz harness on its own**; a **compile-repair loop** feeds compile errors back to the LLM until it compiles; then the fuzzer hunts the invariant against the **REAL forked deployed protocol**. **No human writes the harness.**

## Why it matters

This was the gap between "the engine autonomously *generates invariants* and *judges* them" and "the federation autonomously *hunts an arbitrary deployed protocol* end-to-end." With this, the federation goes from a target's recon → working harness → fuzz → verdict, autonomously.

## Proven + reproducible

- Two fresh runs (LLM regenerated the harness from scratch each time), **both compiled first-try**: the LLM-generated harness **rediscovers the real Euler $197M audit-surviving bug** on a fork at the pre-exploit block — the fuzzer drives a deep solvency invariant (`collateralValue >= liabilityValue`) to a violation by chaining `deposit`/`mint`/`donateToReserves` on the real deployed Euler. The harness was verified genuine (forks, deals collateral, drives the real contract, reads the real `Exec.liquidity`; passes for solvent sequences, breaks on the exploit — not an always-fail).
- The same pipeline auto-generated a working harness for a **different protocol/interface** (sDAI, ERC4626) and fuzzed it 400 sequences → **CLEAN** (sDAI is safe) — so it **generalises across protocols** and reports honestly.

This is autonomous detection of a real audit-surviving bug on real deployed audited code, with an autonomously-generated harness.

## Boundary

Needs a flat-cyborg backend wrapper (`LLM_WRAP` / `flat-cyborg-claude.sh`) + forge + an **archive RPC** (forge fork execution at a historical block needs a true archive node); `[SKIP]`+exit0 when absent. Example recon: `docs/autoharness-euler-example.txt`. The colony never auto-submits — a FINDING is a human-triaged candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
