### PR TITLE
feat(dark-factory): keyless auto-recon — address → harness → hunt (no API key)

### DIFF
--- a/dark-factory/recon-from-address.sh
+++ b/dark-factory/recon-from-address.sh
@@ -13,10 +13,13 @@
 #   --out       : write the spec here (default: stdout, so it can be piped straight into --spec /dev/stdin).
 # Requires: python3 + outbound HTTPS to sourcify.dev. Exit 0 on success OR clean [SKIP]; exit 2 on bad args.
 set -u
+# nv: a value-taking flag must be followed by a value; under `set -u` a bare trailing flag would otherwise
+# crash on $2 (unbound) instead of the promised exit 2. $1 = remaining argc ($#), $2 = the flag name.
+nv() { [ "$1" -ge 2 ] || { echo "recon-from-address.sh: $2 requires a value" >&2; exit 2; }; }
 ADDR="" ; CHAIN="1" ; INV="" ; OUT=""
 while [ $# -gt 0 ]; do case "$1" in
-  --address) ADDR="$2"; shift 2;; --chain) CHAIN="$2"; shift 2;;
-  --invariant) INV="$2"; shift 2;; --out) OUT="$2"; shift 2;;
+  --address) nv "$#" "$1"; ADDR="$2"; shift 2;; --chain) nv "$#" "$1"; CHAIN="$2"; shift 2;;
+  --invariant) nv "$#" "$1"; INV="$2"; shift 2;; --out) nv "$#" "$1"; OUT="$2"; shift 2;;
   -h|--help) sed -n '2,13p' "$0"; exit 0;; *) echo "recon-from-address.sh: unknown arg $1" >&2; exit 2;; esac; done
 case "$ADDR" in 0x*) :;; *) echo "recon-from-address.sh: --address <0x..> required" >&2; exit 2;; esac
 command -v python3 >/dev/null || { echo "[SKIP] python3 not installed" >&2; exit 0; }

--- a/dark-factory/recon-from-address.sh
+++ b/dark-factory/recon-from-address.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# recon-from-address.sh — KEYLESS auto-recon. Given a deployed contract address + chain id, fetches the
+# verified ABI from Sourcify (https://sourcify.dev — free, decentralized, NO API key) and emits a target
+# recon spec that run-autoharness.sh consumes via --spec. This closes the last human step before the
+# autonomous harness generator: address in -> recon spec out -> LLM-generated fork-fuzz harness -> hunt.
+#
+# No Etherscan key required (Sourcify is keyless). Contracts not verified on Sourcify cleanly [SKIP] with a
+# hint to supply a manual spec instead; coverage is partial but spans a large fraction of mainnet DeFi.
+#
+# Usage: recon-from-address.sh --address <0x..> [--chain <id>] [--invariant "<text>"] [--out <file>]
+#   --chain     : EVM chain id (default 1 = Ethereum mainnet).
+#   --invariant : the deep no-free-value / solvency property to assert (default: a solvency template).
+#   --out       : write the spec here (default: stdout, so it can be piped straight into --spec /dev/stdin).
+# Requires: python3 + outbound HTTPS to sourcify.dev. Exit 0 on success OR clean [SKIP]; exit 2 on bad args.
+set -u
+ADDR="" ; CHAIN="1" ; INV="" ; OUT=""
+while [ $# -gt 0 ]; do case "$1" in
+  --address) ADDR="$2"; shift 2;; --chain) CHAIN="$2"; shift 2;;
+  --invariant) INV="$2"; shift 2;; --out) OUT="$2"; shift 2;;
+  -h|--help) sed -n '2,13p' "$0"; exit 0;; *) echo "recon-from-address.sh: unknown arg $1" >&2; exit 2;; esac; done
+case "$ADDR" in 0x*) :;; *) echo "recon-from-address.sh: --address <0x..> required" >&2; exit 2;; esac
+command -v python3 >/dev/null || { echo "[SKIP] python3 not installed" >&2; exit 0; }
+
+DEFAULT_INV='Solvency / no-free-value: after any seed-derived SEQUENCE of the operations below, the target
+must remain solvent (total collateral value >= total liability value) and no caller may extract more value
+than they put in. require() that invariant; a counterexample is a finding.'
+[ -n "$INV" ] || INV="$DEFAULT_INV"
+
+SPEC="$( ADDR="$ADDR" CHAIN="$CHAIN" INV="$INV" python3 -c '
+import os, json, urllib.request
+addr, chain, inv = os.environ["ADDR"], os.environ["CHAIN"], os.environ["INV"]
+url = "https://sourcify.dev/server/v2/contract/%s/%s?fields=abi" % (chain, addr)
+try:
+    with urllib.request.urlopen(url, timeout=25) as r:
+        d = json.load(r)
+except Exception as e:
+    raise SystemExit("SKIP:%s" % e)
+abi = d.get("abi")
+if not abi:
+    raise SystemExit("SKIP:not verified on Sourcify")
+def sig(fn):
+    ins = ",".join(i.get("type","") for i in fn.get("inputs",[]))
+    sm  = fn.get("stateMutability","")
+    return "  %s(%s) [%s]" % (fn.get("name",""), ins, sm)
+fns = [f for f in abi if f.get("type")=="function"]
+muts = [sig(f) for f in fns if f.get("stateMutability") not in ("view","pure")]
+views= [sig(f) for f in fns if f.get("stateMutability") in ("view","pure")]
+print("TARGET %s (chain %s) — ABI auto-fetched keyless from Sourcify." % (addr, chain))
+print("")
+print("STATE-CHANGING operations (expose each as a fuzzable try/catch action):")
+print("\n".join(muts) if muts else "  (none)")
+print("")
+print("VIEW functions (use these to read on-chain state, discover related addresses, and check the invariant):")
+print("\n".join(views) if views else "  (none)")
+print("")
+print("DEEP INVARIANT TO ASSERT:")
+print(inv)
+' 2>&1 )"
+
+case "$SPEC" in
+  SKIP:*) echo "[SKIP] $ADDR not auto-reconnable: ${SPEC#SKIP:} — supply a manual --spec instead" >&2; exit 0;;
+esac
+
+if [ -n "$OUT" ]; then printf '%s\n' "$SPEC" > "$OUT"; echo "recon-from-address: wrote spec for $ADDR -> $OUT" >&2
+else printf '%s\n' "$SPEC"; fi

--- a/dark-factory/run-autoharness.sh
+++ b/dark-factory/run-autoharness.sh
@@ -6,23 +6,34 @@
 # protocol. No human writes the harness. Proven: the LLM-generated harness reproducibly rediscovers the
 # real Euler $197M audit-surviving bug on a fork at the pre-exploit block (and reports CLEAN on safe vaults).
 #
-# Usage: run-autoharness.sh --spec <recon.txt> --rpc <archive-rpc> --block <n> [--repairs N] [--runs N] [--out <dir>]
-#   --spec : a text file describing the target (addresses, function signatures, the deep invariant to assert).
+# Usage: run-autoharness.sh (--spec <recon.txt> | --address <0x..> [--chain <id>]) --rpc <archive-rpc> --block <n>
+#                           [--invariant "<text>"] [--repairs N] [--runs N] [--out <dir>]
+#   --spec    : a text file describing the target (addresses, function signatures, the deep invariant).
+#   --address : instead of a hand-written spec, auto-fetch the verified ABI keyless from Sourcify (no API key)
+#               and build the recon spec from it — full chain: address -> recon -> harness -> hunt, no human.
 # Requires: a flat-cyborg LLM backend wrapper on PATH (LLM_WRAP env or ./flat-cyborg-claude.sh), forge, an
 # ARCHIVE RPC (forge fork execution at a historical block needs a true archive node).
 set -u
 HERE="$(cd "$(dirname "$0")" && pwd)"
 WRAP="${LLM_WRAP:-$HERE/flat-cyborg-claude.sh}"
-SPEC="" ; RPC="" ; BLK="" ; REPAIRS=6 ; RUNS=400 ; OUT=""
+SPEC="" ; ADDR="" ; CHAIN="1" ; INV="" ; RPC="" ; BLK="" ; REPAIRS=6 ; RUNS=400 ; OUT=""
 while [ $# -gt 0 ]; do case "$1" in
-  --spec) SPEC="$2"; shift 2;; --rpc) RPC="$2"; shift 2;; --block) BLK="$2"; shift 2;;
+  --spec) SPEC="$2"; shift 2;; --address) ADDR="$2"; shift 2;; --chain) CHAIN="$2"; shift 2;;
+  --invariant) INV="$2"; shift 2;; --rpc) RPC="$2"; shift 2;; --block) BLK="$2"; shift 2;;
   --repairs) REPAIRS="$2"; shift 2;; --runs) RUNS="$2"; shift 2;; --out) OUT="$2"; shift 2;;
-  -h|--help) sed -n '2,12p' "$0"; exit 0;; *) echo "run-autoharness.sh: unknown arg $1" >&2; exit 2;; esac; done
-[ -f "$SPEC" ] || { echo "run-autoharness.sh: --spec <file> required" >&2; exit 2; }
+  -h|--help) sed -n '2,14p' "$0"; exit 0;; *) echo "run-autoharness.sh: unknown arg $1" >&2; exit 2;; esac; done
 [ -n "$RPC" ] && [ -n "$BLK" ] || { echo "run-autoharness.sh: --rpc and --block required" >&2; exit 2; }
 command -v forge >/dev/null || { echo "[SKIP] forge not installed" >&2; exit 0; }
 [ -x "$WRAP" ] || { echo "[SKIP] LLM backend wrapper not found ($WRAP); set LLM_WRAP" >&2; exit 0; }
 WORK="${OUT:-$(mktemp -d "${TMPDIR:-/tmp}/autoharness.XXXXXX")}"; mkdir -p "$WORK/test"
+# Auto-recon: --address with no --spec -> fetch ABI keyless from Sourcify and synthesize the recon spec.
+if [ -z "$SPEC" ] && [ -n "$ADDR" ]; then
+  SPEC="$WORK/recon.txt"
+  "$HERE/recon-from-address.sh" --address "$ADDR" --chain "$CHAIN" ${INV:+--invariant "$INV"} --out "$SPEC" \
+    || { echo "run-autoharness.sh: auto-recon failed for $ADDR" >&2; exit 1; }
+  [ -s "$SPEC" ] || { echo "[SKIP] auto-recon produced no spec for $ADDR (not on Sourcify?); supply --spec" >&2; exit 0; }
+fi
+[ -f "$SPEC" ] || { echo "run-autoharness.sh: --spec <file> or --address <0x..> required" >&2; exit 2; }
 printf '[profile.default]\ntest = "test"\nsolc = "0.8.24"\nevm_version = "cancun"\n' > "$WORK/foundry.toml"
 PROMPT="$WORK/prompt.txt"
 { echo "You are an autonomous smart-contract bug-hunting harness generator. Output ONLY a single Solidity file (no markdown, no prose): a forge-std-FREE Foundry test, contract name AutoHarness, pragma ^0.8.24. Use the cheatcode interface at 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D (createSelectFork(string,uint256), envString, envUint, store, load). Fund the test contract by storage-slot scan + approve. Expose the protocol's primitive operations as fuzzable try/catch actions. Add a FUZZ test function testFuzz_hunt(uint256 seed) that derives a SEQUENCE of ops from the seed, executes them on the REAL forked protocol, then require()s the deep invariant. Fork via env ETH_RPC + the block below.";
@@ -31,12 +42,17 @@ ATT=0
 "$WRAP" < "$PROMPT" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}' > "$WORK/test/AutoHarness.t.sol"
 while : ; do
   ERR="$( cd "$WORK" && forge build 2>&1 )"
-  echo "$ERR" | grep -q 'Compiler run successful' && { echo "run-autoharness: harness COMPILES (attempt $ATT)"; break; }
+  # forge build trivially "succeeds" on an empty dir, so also require a real contract in the generated file
+  # (guards against a truncated/empty LLM response being mistaken for a clean compile).
+  if echo "$ERR" | grep -q 'Compiler run successful' && grep -q 'contract[[:space:]]\+AutoHarness' "$WORK/test/AutoHarness.t.sol"; then
+    echo "run-autoharness: harness COMPILES (attempt $ATT)"; break
+  fi
   ATT=$((ATT+1)); [ "$ATT" -gt "$REPAIRS" ] && { echo "run-autoharness: gave up after $REPAIRS repair attempts" >&2; exit 1; }
   { echo "Fix the Solidity compile error(s). Output ONLY the corrected complete .sol (no markdown), contract AutoHarness, pragma ^0.8.24, forge-std-free.";
     echo "--- ERRORS ---"; echo "$ERR" | grep -iE 'error|-->' | head -20; echo "--- FILE ---"; cat "$WORK/test/AutoHarness.t.sol"; } > "$WORK/repair.txt"
   "$WRAP" < "$WORK/repair.txt" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}' > "$WORK/test/AutoHarness.t.sol"
 done
 FN="$(grep -oE 'function (testFuzz|test)[A-Za-z_]*' "$WORK/test/AutoHarness.t.sol" | head -1 | sed 's/function //')"
+[ -n "$FN" ] || { echo "run-autoharness: no test/testFuzz function in generated harness (empty/truncated LLM output?)" >&2; exit 1; }
 echo "run-autoharness: hunting via $FN (fork $RPC @ $BLK) ..."
 ( cd "$WORK" && ETH_RPC="$RPC" FORK_BLK="$BLK" FOUNDRY_FUZZ_RUNS="$RUNS" forge test --mt "$FN" --fork-url "$RPC" --fork-block-number "$BLK" 2>&1 ) | grep -iE '\[PASS\]|\[FAIL\]|VIOLAT|counterexample|Suite result'

--- a/dark-factory/run-autoharness.sh
+++ b/dark-factory/run-autoharness.sh
@@ -17,10 +17,13 @@ set -u
 HERE="$(cd "$(dirname "$0")" && pwd)"
 WRAP="${LLM_WRAP:-$HERE/flat-cyborg-claude.sh}"
 SPEC="" ; ADDR="" ; CHAIN="1" ; INV="" ; RPC="" ; BLK="" ; REPAIRS=6 ; RUNS=400 ; OUT=""
+# nv: a value-taking flag must be followed by a value; under `set -u` a bare trailing flag would otherwise
+# crash on $2 (unbound) instead of the promised exit 2. $1 = remaining argc ($#), $2 = the flag name.
+nv() { [ "$1" -ge 2 ] || { echo "run-autoharness.sh: $2 requires a value" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do case "$1" in
-  --spec) SPEC="$2"; shift 2;; --address) ADDR="$2"; shift 2;; --chain) CHAIN="$2"; shift 2;;
-  --invariant) INV="$2"; shift 2;; --rpc) RPC="$2"; shift 2;; --block) BLK="$2"; shift 2;;
-  --repairs) REPAIRS="$2"; shift 2;; --runs) RUNS="$2"; shift 2;; --out) OUT="$2"; shift 2;;
+  --spec) nv "$#" "$1"; SPEC="$2"; shift 2;; --address) nv "$#" "$1"; ADDR="$2"; shift 2;; --chain) nv "$#" "$1"; CHAIN="$2"; shift 2;;
+  --invariant) nv "$#" "$1"; INV="$2"; shift 2;; --rpc) nv "$#" "$1"; RPC="$2"; shift 2;; --block) nv "$#" "$1"; BLK="$2"; shift 2;;
+  --repairs) nv "$#" "$1"; REPAIRS="$2"; shift 2;; --runs) nv "$#" "$1"; RUNS="$2"; shift 2;; --out) nv "$#" "$1"; OUT="$2"; shift 2;;
   -h|--help) sed -n '2,14p' "$0"; exit 0;; *) echo "run-autoharness.sh: unknown arg $1" >&2; exit 2;; esac; done
 [ -n "$RPC" ] && [ -n "$BLK" ] || { echo "run-autoharness.sh: --rpc and --block required" >&2; exit 2; }
 command -v forge >/dev/null || { echo "[SKIP] forge not installed" >&2; exit 0; }
@@ -33,7 +36,8 @@ if [ -z "$SPEC" ] && [ -n "$ADDR" ]; then
     || { echo "run-autoharness.sh: auto-recon failed for $ADDR" >&2; exit 1; }
   [ -s "$SPEC" ] || { echo "[SKIP] auto-recon produced no spec for $ADDR (not on Sourcify?); supply --spec" >&2; exit 0; }
 fi
-[ -f "$SPEC" ] || { echo "run-autoharness.sh: --spec <file> or --address <0x..> required" >&2; exit 2; }
+# -r (readable), not -f, so a piped spec works too — e.g. `recon-from-address.sh ... | run-autoharness --spec /dev/stdin`.
+[ -r "$SPEC" ] || { echo "run-autoharness.sh: --spec <file> or --address <0x..> required" >&2; exit 2; }
 printf '[profile.default]\ntest = "test"\nsolc = "0.8.24"\nevm_version = "cancun"\n' > "$WORK/foundry.toml"
 PROMPT="$WORK/prompt.txt"
 { echo "You are an autonomous smart-contract bug-hunting harness generator. Output ONLY a single Solidity file (no markdown, no prose): a forge-std-FREE Foundry test, contract name AutoHarness, pragma ^0.8.24. Use the cheatcode interface at 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D (createSelectFork(string,uint256), envString, envUint, store, load). Fund the test contract by storage-slot scan + approve. Expose the protocol's primitive operations as fuzzable try/catch actions. Add a FUZZ test function testFuzz_hunt(uint256 seed) that derives a SEQUENCE of ops from the seed, executes them on the REAL forked protocol, then require()s the deep invariant. Fork via env ETH_RPC + the block below.";


### PR DESCRIPTION
## What

Closes the last human step before the autonomous harness generator. Previously `run-autoharness.sh` needed a hand-written recon spec. Now it can take just a deployed **`--address`** and do the rest itself.

**Full autonomous chain:** `address → Sourcify ABI (keyless) → recon spec → LLM harness (flat-cyborg \$0 backend) → compile-repair → fork-fuzz hunt` — no human writes the harness *or* the recon spec.

## Why keyless

Auto-recon needs the target ABI from a bare address. No Etherscan API key is available — so this uses **Sourcify** (free, decentralized, no key). Coverage is partial (a large fraction of mainnet DeFi is verified there; some protocols, e.g. Euler, are not) — those `[SKIP]` cleanly with a hint to supply a manual `--spec`.

## Changes

- **`recon-from-address.sh`** (new): keyless Sourcify v2 ABI fetch → recon spec (state-changing ops + view functions + a deep solvency/no-free-value invariant). `[SKIP]`+exit0 when not verified on Sourcify or `python3`/network absent. Live-verified on DAI.
- **`run-autoharness.sh`**: new `--address` / `--chain` / `--invariant`; `--address` with no `--spec` auto-invokes `recon-from-address.sh`. Hardened against truncated LLM output — require `contract AutoHarness` before declaring a clean compile (an empty dir trivially passes `forge build`), and require a test/`testFuzz` function before hunting.

## Verification

- `bash -n` on both scripts — OK.
- `colony-lint` — **367 passed, 0 failed, 5 skipped**.
- Live end-to-end (DAI): `--address` → `recon.txt` written from Sourcify → LLM-generated harness compiled first try via flat-cyborg → hunt invoked. No key, no human spec.
- No internal absolute paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)