### PR TITLE
feat(dark-factory): coordinator autonomously runs auto-harness (closes the autonomous loop)

### DIFF
--- a/dark-factory/auditor/agents/coordinator.ag
+++ b/dark-factory/auditor/agents/coordinator.ag
@@ -428,6 +428,39 @@ fn run_invariant_live(candId: string) -> string {
     return sym_outcome_of(rc);
 }
 
+// === AUTO-HARNESS realization of invariant-hunt — the harness is GENERATED from a bare on-chain ADDRESS.
+// Same SOUND-verdict contract as run_invariant_live, but instead of a PRE-WRITTEN invariant `*.t.sol` it
+// drives dark-factory/run-autoharness.sh, which: keyless-recons the target ABI from Sourcify (no API key),
+// has the $0 flat-cyborg LLM GENERATE a complete fork-fuzz harness, compile-repairs it, and fuzzes seed-
+// derived call SEQUENCES against the REAL forked protocol. This is what lets the autonomous loop hunt an
+// audited deployed target with NO human writing the harness — proven to rediscover the real Euler $197M
+// audit-survivor. run-autoharness's exit code is its OWN protocol (1=FINDING, 3=CLEAN, 2=harness/fork error,
+// 0=[SKIP] no forge/wrapper/Sourcify) — so it gets its OWN map (NOT sym_outcome_of, whose 0->refuted is
+// wrong here): a FUZZER can only CONFIRM (it has a counterexample) or come up dry; it can NEVER refute /
+// prove safety, and a SKIP is not a verdict. So 1->confirmed and EVERYTHING else (3/2/0)->dry. Reuses
+// sym_rc_of to parse the `__rc=` marker. INV_FORK_* are not used here (run-autoharness owns its fork flags).
+fn ah_outcome_of(rc: int) -> string {
+    if rc == 1 { return "confirmed"; }
+    return "dry";
+}
+fn ah_chain_or1(raw: string) -> string {
+    if len(raw) == 0 { return "1"; }
+    return raw;
+}
+fn run_autoharness_live(candId: string) -> string {
+    let gate = getenv("AUTOHARNESS");
+    let addr = cand_fact(candId, "ah_address", "AH_ADDRESS");
+    let chain = ah_chain_or1(cand_fact(candId, "ah_chain", "AH_CHAIN"));
+    let rpc = cand_fact(candId, "ah_rpc", "AH_RPC");
+    let blk = cand_fact(candId, "ah_block", "AH_BLOCK");
+    // colony-lint: safe-exec-concat
+    let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --address " + shell_escape(addr)
+               + " --chain " + shell_escape(chain) + " --rpc " + shell_escape(rpc)
+               + " --block " + shell_escape(blk) + " 2>&1; echo __rc=$?";
+    let rc = sym_rc_of(runOut);
+    return ah_outcome_of(rc);
+}
+
 // Derive the gate OUTCOME for an action of `<type>` with `<args>`. Offline (DISPATCH_FIXTURE set, or the
 // M1 HUNT_FIXTURE alias for a hunt) -> the fixture rule, NO prompt()/LLM. The LIVE symbolic-prove route
 // (#1032): when `symbolic-prove` is chosen AND no fixture matched AND a live symbolic env is present (a
@@ -493,8 +526,29 @@ fn action_outcome(atype: string, args: string) -> string {
                 }
             }
         }
+        // AUTO-HARNESS fallback (#1047): no PRE-WRITTEN invariant test for this candidate, but an on-chain
+        // ADDRESS + an archive RPC + a fork block ARE present (the AUTOHARNESS gate path + AH_ADDRESS/AH_RPC/
+        // AH_BLOCK, per-candidate-first via cand_fact then env). The loop then GENERATES the fork-fuzz harness
+        // from the address (keyless Sourcify recon + $0 flat-cyborg LLM) and hunts — no human writes it. The
+        // verdict is the fuzzer's (FINDING->confirmed, everything else->dry; a fuzzer never refutes). All four
+        // facts must be present; otherwise this falls through to the honest stub (purely additive — no AH_*
+        // env => byte-identical to the pre-#1047 invariant-hunt stub, so the offline demos are unaffected).
+        let ahGate = getenv("AUTOHARNESS");
+        let ahAddr = cand_fact(args, "ah_address", "AH_ADDRESS");
+        let ahRpc = cand_fact(args, "ah_rpc", "AH_RPC");
+        let ahBlk = cand_fact(args, "ah_block", "AH_BLOCK");
+        if len(ahGate) > 0 {
+            if len(ahAddr) > 0 {
+                if len(ahRpc) > 0 {
+                    if len(ahBlk) > 0 {
+                        print("coordinator: LIVE invariant-hunt of '" + args + "' via AUTO-HARNESS -> GENERATING a fork-fuzz harness from address " + ahAddr + " (keyless recon, $0 flat-cyborg LLM) and hunting; verdict = the fuzzer's, never the LLM.");
+                        return run_autoharness_live(args);
+                    }
+                }
+            }
+        }
     }
-    print("coordinator: LIVE " + atype + " of '" + args + "' needs its real wiring (hunt: TARGET_DIR/IN_SCOPE/SCOPE_BRIEF/TAXONOMY/SLICER per run-discovery.sh/hunter.ag; refute->run-refute.sh; poc-screen->screen-leads.sh; symbolic-prove->run-symbolic.sh; invariant-hunt->run-invariant-hunt.sh; invent-method->run-method-discovery.sh); set DISPATCH_FIXTURE for the offline-deterministic path. No real action attempted.");
+    print("coordinator: LIVE " + atype + " of '" + args + "' needs its real wiring (hunt: TARGET_DIR/IN_SCOPE/SCOPE_BRIEF/TAXONOMY/SLICER per run-discovery.sh/hunter.ag; refute->run-refute.sh; poc-screen->screen-leads.sh; symbolic-prove->run-symbolic.sh; invariant-hunt->run-invariant-hunt.sh OR auto-harness via run-autoharness.sh when AH_ADDRESS/AH_RPC/AH_BLOCK+AUTOHARNESS are set; invent-method->run-method-discovery.sh); set DISPATCH_FIXTURE for the offline-deterministic path. No real action attempted.");
     return "dry";
 }
 

--- a/dark-factory/run-autoharness.sh
+++ b/dark-factory/run-autoharness.sh
@@ -59,4 +59,15 @@ done
 FN="$(grep -oE 'function (testFuzz|test)[A-Za-z_]*' "$WORK/test/AutoHarness.t.sol" | head -1 | sed 's/function //')"
 [ -n "$FN" ] || { echo "run-autoharness: no test/testFuzz function in generated harness (empty/truncated LLM output?)" >&2; exit 1; }
 echo "run-autoharness: hunting via $FN (fork $RPC @ $BLK) ..."
-( cd "$WORK" && ETH_RPC="$RPC" FORK_BLK="$BLK" FOUNDRY_FUZZ_RUNS="$RUNS" forge test --mt "$FN" --fork-url "$RPC" --fork-block-number "$BLK" 2>&1 ) | grep -iE '\[PASS\]|\[FAIL\]|VIOLAT|counterexample|Suite result'
+HUNT="$( cd "$WORK" && ETH_RPC="$RPC" FORK_BLK="$BLK" FOUNDRY_FUZZ_RUNS="$RUNS" forge test --mt "$FN" --fork-url "$RPC" --fork-block-number "$BLK" 2>&1 )"
+echo "$HUNT" | grep -iE '\[PASS\]|\[FAIL\]|VIOLAT|counterexample|Suite result'
+# Structured verdict so this doubles as a SOUND coordinator gate (the verdict is the FUZZER's, never an LLM).
+# A fuzzer can only CONFIRM a bug (it has a counterexample) or come up dry — it can NEVER prove safety, so a
+# clean run is `dry` (exit 3), NOT a refutation. exit 1 = FINDING (counterexample), 3 = clean (no witness), 2 = no verdict.
+if echo "$HUNT" | grep -qiE '\[FAIL\]|VIOLAT|counterexample'; then
+  echo "run-autoharness: FINDING — invariant violated, the autonomous harness has a counterexample"; exit 1
+elif echo "$HUNT" | grep -qi '\[PASS\]'; then
+  echo "run-autoharness: CLEAN — no counterexample (fuzzing is unsound; this is NOT a proof of safety)"; exit 3
+else
+  echo "run-autoharness: NO VERDICT — harness/fork error, treated as non-productive"; exit 2
+fi


### PR DESCRIPTION
## What

The federation's self-orchestrating coordinator loop can now invoke the **full `address → recon → harness → hunt` pipeline itself** — closing the last gap to a fully-autonomous hunter of audited, deployed targets. Builds on #1046 (auto-harness pipeline) + #1047 (keyless auto-recon).

## How — a realization of `invariant-hunt`, not a new action

Modeled as an alternative **realization of the existing `invariant-hunt` action** (deliberately *not* a new action type, so option scoring and the offline demos are untouched). When the coordinator picks `invariant-hunt` for a candidate that has **no pre-written invariant `*.t.sol`** but **does** carry an on-chain address + archive RPC + fork block (the `AUTOHARNESS` gate path + `AH_ADDRESS`/`AH_RPC`/`AH_BLOCK`, resolved per-candidate-first via `cand_fact` then env), the live route **generates** the fork-fuzz harness from the address (keyless Sourcify recon + the $0 flat-cyborg LLM backend) and hunts. Purely additive: absent `AH_*` env it is byte-identical to the prior `invariant-hunt` stub.

## Sound verdict, honest fuzzer semantics

- `run-autoharness.sh` gains structured verdict exit codes (`1`=FINDING, `3`=CLEAN, `2`=no-verdict) so it doubles as a **sound** coordinator gate — the verdict is the fuzzer's shrunk witness, never an LLM opinion.
- `ah_outcome_of` is its **own** map (not `sym_outcome_of`, whose `0→refuted` would be wrong here): a fuzzer can only **confirm** a bug (it has a counterexample) or come up **dry** — it can *never* refute / prove safety, and `run-autoharness` exit `0` is a `[SKIP]`, not a proof. So `1→confirmed`, everything else (`3` clean / `2` error / `0` skip) `→ dry`.

## Verification

- Drove the **real** coordinator (`agentis go coordinator.ag`, mock backend) with a policy-lifted `invariant-hunt` + a fake gate: it **chose `invariant-hunt` itself**, the auto-harness live route fired, and the verdict mapped `FINDING→confirmed`, `SKIP→dry`, `CLEAN→dry`, `ERROR→dry`.
- Both offline demos green post-rebase: `demo-coordinator.sh` (fact-driven decisions + policy evolution) and `demo-dispatch.sh` (the coordinator/dispatcher sync-guard).
- `bash -n` OK; `colony-lint`: **367 passed, 0 failed, 5 skipped**. No internal abs paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)