### PR TITLE
dark-factory: reject stub harness + fix flaky LLM delivery at the source (flat-cyborg v0.10.0)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -33,6 +33,14 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   `flat-cyborg` backend branch previously set only the timeout and left `llm.command`
   unset. `--backend claude` (metered `claude -p`) stays an explicit opt-in. Requires
   flat-cyborg >= v0.9.1 (`--extract` implies the screen grid).
+- `run-autoharness.sh`: **rejects a vacuous stub harness**. A generated file must carry a real fork
+  (`createSelectFork`), a `testFuzz_*(uint256 ...)` fuzz entrypoint, and a `require()` invariant, or it is
+  sent back to the compile-repair loop with the full structural requirement re-stated — a live sDAI run
+  exposed the LLM occasionally returning a degenerate `1+1==2` sanity test that compiled but hunted nothing.
+  The shell-side prompt-fold + empty-retry workaround is removed now that delivery is fixed at the source:
+  `flat-cyborg-claude.sh` passes `--wrap-input 72` (folds the long instruction block so it no longer
+  overflows claude's editor) and flat-cyborg >= v0.10.0 gates `--extract` on the reply sentinel (a slow
+  first reply is no longer captured as empty). Bumps the flat-cyborg floor to **v0.10.0**.
 
 
 ### Added

--- a/dark-factory/flat-cyborg-claude.sh
+++ b/dark-factory/flat-cyborg-claude.sh
@@ -12,7 +12,10 @@
 set -eu
 PROMPT="${1:-}"
 if [ -z "$PROMPT" ]; then PROMPT="$(cat)"; fi
-exec flat-cyborg --extract --no-jitter --auto-approve \
+# --wrap-input 72: fold the (often single-line, ~700-char) instruction block so it
+# does not overflow claude's editor input. flat-cyborg >=0.10.0 also gates --extract
+# on the reply sentinel, so a slow first reply is no longer captured as empty.
+exec flat-cyborg --extract --no-jitter --auto-approve --wrap-input 72 \
   --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" \
   --timeout-ms "${FLAT_CYBORG_TIMEOUT_MS:-180000}" \
   --cmd "$PROMPT" -- claude

--- a/dark-factory/run-autoharness.sh
+++ b/dark-factory/run-autoharness.sh
@@ -42,21 +42,43 @@ printf '[profile.default]\ntest = "test"\nsolc = "0.8.24"\nevm_version = "cancun
 PROMPT="$WORK/prompt.txt"
 { echo "You are an autonomous smart-contract bug-hunting harness generator. Output ONLY a single Solidity file (no markdown, no prose): a forge-std-FREE Foundry test, contract name AutoHarness, pragma ^0.8.24. Use the cheatcode interface at 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D (createSelectFork(string,uint256), envString, envUint, store, load). Fund the test contract by storage-slot scan + approve. Expose the protocol's primitive operations as fuzzable try/catch actions. Add a FUZZ test function testFuzz_hunt(uint256 seed) that derives a SEQUENCE of ops from the seed, executes them on the REAL forked protocol, then require()s the deep invariant. Fork via env ETH_RPC + the block below.";
   echo "=== TARGET RECON ==="; cat "$SPEC"; } > "$PROMPT"
+SOL="$WORK/test/AutoHarness.t.sol"
+# A REAL fork-fuzz harness — not a trivial compiling stub — must FORK the chain, expose a seed-derived FUZZ
+# function, and assert a deep invariant. A bare `test_sanity()` that asserts `1+1==2` compiles cleanly but
+# proves NOTHING, so the compile gate alone is not enough: a degenerate stub would otherwise yield a vacuous
+# "CLEAN" verdict. Require the three structural markers before accepting the harness; absent any, keep
+# repairing (and tell the LLM exactly what a real harness needs), then give up rather than hunt a stub.
+real_harness() {
+  grep -q 'createSelectFork' "$SOL" \
+    && grep -qE 'function +testFuzz[A-Za-z_]*\([^)]*uint256' "$SOL" \
+    && grep -q 'require(' "$SOL"
+}
 ATT=0
-"$WRAP" < "$PROMPT" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}' > "$WORK/test/AutoHarness.t.sol"
+"$WRAP" < "$PROMPT" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}' > "$SOL"
 while : ; do
   ERR="$( cd "$WORK" && forge build 2>&1 )"
-  # forge build trivially "succeeds" on an empty dir, so also require a real contract in the generated file
-  # (guards against a truncated/empty LLM response being mistaken for a clean compile).
-  if echo "$ERR" | grep -q 'Compiler run successful' && grep -q 'contract[[:space:]]\+AutoHarness' "$WORK/test/AutoHarness.t.sol"; then
-    echo "run-autoharness: harness COMPILES (attempt $ATT)"; break
+  # forge build trivially "succeeds" on an empty dir, so also require a real AutoHarness contract AND the
+  # fork-fuzz structure (real_harness) — a stub that compiles is rejected, not mistaken for a ready harness.
+  if echo "$ERR" | grep -q 'Compiler run successful' && grep -q 'contract[[:space:]]\+AutoHarness' "$SOL" && real_harness; then
+    echo "run-autoharness: real fork-fuzz harness COMPILES (attempt $ATT)"; break
   fi
-  ATT=$((ATT+1)); [ "$ATT" -gt "$REPAIRS" ] && { echo "run-autoharness: gave up after $REPAIRS repair attempts" >&2; exit 1; }
-  { echo "Fix the Solidity compile error(s). Output ONLY the corrected complete .sol (no markdown), contract AutoHarness, pragma ^0.8.24, forge-std-free.";
-    echo "--- ERRORS ---"; echo "$ERR" | grep -iE 'error|-->' | head -20; echo "--- FILE ---"; cat "$WORK/test/AutoHarness.t.sol"; } > "$WORK/repair.txt"
-  "$WRAP" < "$WORK/repair.txt" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}' > "$WORK/test/AutoHarness.t.sol"
+  ATT=$((ATT+1)); [ "$ATT" -gt "$REPAIRS" ] && { echo "run-autoharness: gave up after $REPAIRS attempts — no real fork-fuzz harness (only a stub / non-compiling output)" >&2; exit 1; }
+  # Re-state the FULL structural requirement (not just 'fix the compile error') + the recon spec, so the LLM
+  # repairs toward a real fork-fuzz harness instead of degenerating into a trivial constant-asserting stub.
+  { echo "Your previous Solidity output is REJECTED. Output ONLY one complete .sol file (no markdown, no prose): contract AutoHarness, pragma ^0.8.24, forge-std-FREE. It MUST be a REAL fork-fuzz harness, NOT a sanity test:";
+    echo "  1. createSelectFork(envString(\"ETH_RPC\"), <FORK_BLOCK>) — fork the REAL chain at the block.";
+    echo "  2. Expose each TARGET state-changing op below as a try/catch action against the real deployed address.";
+    echo "  3. function testFuzz_hunt(uint256 seed): derive a SEQUENCE of those ops from seed, run them on the fork, then require() the deep solvency / no-free-value invariant.";
+    echo "  A test that only asserts constants (e.g. 1+1==2) or omits the fork / the fuzz fn / the require() is WRONG and will be rejected again.";
+    echo "--- COMPILE ERRORS (if any) ---"; echo "$ERR" | grep -iE 'error|-->' | head -20;
+    echo "--- TARGET RECON ---"; cat "$SPEC";
+    echo "--- YOUR REJECTED FILE ---"; cat "$SOL"; } > "$WORK/repair.txt"
+  "$WRAP" < "$WORK/repair.txt" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}' > "$SOL"
 done
-FN="$(grep -oE 'function (testFuzz|test)[A-Za-z_]*' "$WORK/test/AutoHarness.t.sol" | head -1 | sed 's/function //')"
+# Prefer the seed-derived testFuzz_ function (the real hunt) over any plain test_ helper the harness may also
+# carry — real_harness() already guarantees a testFuzz fn exists, so this never falls back to a sanity test.
+FN="$(grep -oE 'function +testFuzz[A-Za-z_]*' "$SOL" | head -1 | sed 's/function *//')"
+[ -n "$FN" ] || FN="$(grep -oE 'function +test[A-Za-z_]*' "$SOL" | head -1 | sed 's/function *//')"
 [ -n "$FN" ] || { echo "run-autoharness: no test/testFuzz function in generated harness (empty/truncated LLM output?)" >&2; exit 1; }
 echo "run-autoharness: hunting via $FN (fork $RPC @ $BLK) ..."
 HUNT="$( cd "$WORK" && ETH_RPC="$RPC" FORK_BLK="$BLK" FOUNDRY_FUZZ_RUNS="$RUNS" forge test --mt "$FN" --fork-url "$RPC" --fork-block-number "$BLK" 2>&1 )"

--- a/dark-factory/run-autoharness.sh
+++ b/dark-factory/run-autoharness.sh
@@ -53,8 +53,21 @@ real_harness() {
     && grep -qE 'function +testFuzz[A-Za-z_]*\([^)]*uint256' "$SOL" \
     && grep -q 'require(' "$SOL"
 }
+# Generate a harness with the flat-cyborg LLM backend ($WRAP), then strip any
+# markdown fences and keep from the first SPDX/pragma line onward.
+#
+# flat-cyborg >=0.10.0 (set up in flat-cyborg-claude.sh with --wrap-input) makes
+# delivery reliable at the source: it folds the long single-line instruction block
+# so it no longer overflows claude's editor, and gates --extract on the reply
+# sentinel so a slow first reply (the model emits chrome / thinks before answering)
+# is no longer captured as empty. So no shell-side fold or retry is needed here; a
+# rare empty extraction is already handled by the compile/real_harness repair loop
+# below, which re-generates against a sharper prompt.
+gen() {
+  "$WRAP" < "$1" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}'
+}
 ATT=0
-"$WRAP" < "$PROMPT" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}' > "$SOL"
+gen "$PROMPT" > "$SOL"
 while : ; do
   ERR="$( cd "$WORK" && forge build 2>&1 )"
   # forge build trivially "succeeds" on an empty dir, so also require a real AutoHarness contract AND the
@@ -73,7 +86,7 @@ while : ; do
     echo "--- COMPILE ERRORS (if any) ---"; echo "$ERR" | grep -iE 'error|-->' | head -20;
     echo "--- TARGET RECON ---"; cat "$SPEC";
     echo "--- YOUR REJECTED FILE ---"; cat "$SOL"; } > "$WORK/repair.txt"
-  "$WRAP" < "$WORK/repair.txt" 2>/dev/null | sed -e 's/```[a-zA-Z]*//g' | awk 'f||/\/\/ SPDX|pragma/{f=1; print}' > "$SOL"
+  gen "$WORK/repair.txt" > "$SOL"
 done
 # Prefer the seed-derived testFuzz_ function (the real hunt) over any plain test_ helper the harness may also
 # carry — real_harness() already guarantees a testFuzz fn exists, so this never falls back to a sanity test.


### PR DESCRIPTION
Hardens autonomous harness generation (`run-autoharness.sh`) after a live end-to-end run on a real ERC4626 vault (sDAI) exposed two gaps, and moves the delivery fix from a shell workaround into the flat-cyborg tool itself.

## Changes

### 1. Reject a vacuous stub harness (commit 1)
The flat-cyborg LLM backend occasionally returned a degenerate ~27-line stub (a `test_sanity()` asserting `1+1==2`, no fork, no fuzz, no invariant) that compiled and so was mistaken for a ready harness — hunting nothing. `real_harness()` now gates on three structural requirements: a real fork (`createSelectFork`), a `testFuzz_*(uint256 ...)` fuzz entrypoint, and a `require()` invariant. A file missing any of them is sent back to the compile-repair loop with the full structural requirement re-stated, so the LLM repairs toward a real fork-fuzz harness instead of degenerating into a constant-asserting stub.

### 2. Fix flaky delivery at the source, drop the shell workaround (commit 2)
Driving the interactive claude CLI over a PTY surfaced two delivery/timing failures that the script had been papering over with a fold-the-prompt + retry-on-empty workaround:
- an ultra-long single-line instruction block overflowed claude's editor input;
- a slow first reply (model emits startup chrome / thinks before answering) was captured as empty.

Both are now fixed in flat-cyborg v0.10.0 (`--wrap-input` folds long lines; `--extract` is gated on the reply sentinel). `flat-cyborg-claude.sh` passes `--wrap-input 72` and the floor is bumped to v0.10.0, so `gen()` collapses back to a single backend call. A rare empty extraction is still handled by the compile/`real_harness` repair loop.

## Validation
- `colony-lint.sh`: 367 passed, 0 failed, 5 skipped.
- Both scripts pass `sh -n` (POSIX/dash-safe).
- CHANGELOG updated (`### Changed`, flat-cyborg floor → v0.10.0).

Upstream tool fix: flat-cyborg #46 / #47, released as v0.10.0.