### PR TITLE
dark-factory: route method-discovery direct-LLM fallback through flat-cyborg

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -41,6 +41,11 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   `flat-cyborg-claude.sh` passes `--wrap-input 72` (folds the long instruction block so it no longer
   overflows claude's editor) and flat-cyborg >= v0.10.0 gates `--extract` on the reply sentinel (a slow
   first reply is no longer captured as empty). Bumps the flat-cyborg floor to **v0.10.0**.
+- `run-method-discovery.sh`: the INVENT direct-LLM **fallback** (taken when the substrate-native `agentis go`
+  path yields no `METHOD|` line) now routes through the `flat-cyborg-claude.sh` wrapper instead of calling
+  `claude -p` directly — so the entire dark-factory federation's live LLM generation is on the flat-rate
+  subscription session. `claude -p` remains only as the explicit, opt-in `--backend claude` escape hatch in
+  the sibling run scripts. `LLM_WRAP` overrides the wrapper path.
 
 
 ### Added

--- a/dark-factory/run-method-discovery.sh
+++ b/dark-factory/run-method-discovery.sh
@@ -38,10 +38,16 @@ if [ -z "${NO_AGENTIS:-}" ] && command -v agentis >/dev/null 2>&1; then
   if [ -n "$proposal" ]; then echo "[invent] via agentis go (substrate-native)"; else echo "[invent] agentis go produced no METHOD| line (see $rd/err); falling back" >&2; fi
 fi
 if [ -z "$proposal" ]; then
-  # direct-LLM fallback (same reasoning the .ag prompt() performs)
+  # direct-LLM fallback (same reasoning the .ag prompt() performs), routed through
+  # the flat-cyborg PTY wrapper so this stays on the flat-rate subscription session
+  # rather than the metered `claude -p` API — same backend the substrate path above
+  # uses. LLM_WRAP overrides the wrapper path. (No --model: the wrapper drives the
+  # interactive claude session, which has no per-call model arg; the substrate path
+  # keeps llm.model = $MODEL.)
+  WRAP="${LLM_WRAP:-$HERE/flat-cyborg-claude.sh}"
   pr="$(printf 'You are the METHOD-INVENTOR for an autonomous smart-contract audit federation.\n\nCurrent methods:\n%s\n\nGAP (a bug class the current methods keep MISSING):\n%s\n\nPropose EXACTLY ONE new, distinct, concretely-runnable audit method that catches this class. Reason briefly then output EXACTLY one final line:\nMETHOD|<name>|<bug-classes>|<one-sentence technique>|<how-to-invoke>|<what a known-bug control asserts>' "$(cat "$REGISTRY")" "$(cat "$GAP")")"
-  proposal="$(claude -p --model "$MODEL" "$pr" 2>/dev/null | grep -m1 '^METHOD|' || true)"
-  [ -n "$proposal" ] && echo "[invent] via direct LLM fallback"
+  proposal="$("$WRAP" "$pr" 2>/dev/null | grep -m1 '^METHOD|' || true)"
+  [ -n "$proposal" ] && echo "[invent] via direct LLM fallback (flat-cyborg)"
 fi
 [ -z "$proposal" ] && { echo "FAIL: inventor produced no METHOD| line"; exit 1; }
 name="$(printf '%s' "$proposal" | cut -d'|' -f2)"


### PR DESCRIPTION
Closes #1051.

`run-method-discovery.sh` (the federation's self-improvement meta-loop) runs its INVENT step substrate-native by default (`agentis go method-inventor.ag`, `llm.backend = flat-cyborg`). When that path produced no `METHOD|` line, it fell back to a **direct `claude -p --model …` call** — the one spot in dark-factory that hit the metered API instead of the flat-rate subscription session.

## Change
- The fallback now routes through `flat-cyborg-claude.sh` (the same wrapper the rest of dark-factory uses), resolved as `WRAP="${LLM_WRAP:-$HERE/flat-cyborg-claude.sh}"`.
- `--model` is dropped on the fallback: the wrapper drives the interactive claude session, which has no per-call model arg. The substrate-native path keeps `llm.model = $MODEL`.
- `grep -m1 '^METHOD|'` extraction unchanged.

Net: the entire dark-factory federation's live LLM generation is on flat-cyborg; `claude -p` remains only as the explicit, opt-in `--backend claude` escape hatch in the sibling run scripts.

## Validation
- `sh -n` + `bash -n` clean; no live `claude -p` left (only a comment referencing it).
- `tools/colony-lint.sh`: 367 passed, 0 failed, 5 skipped.
- CHANGELOG `### Changed` bullet added.