### PR TITLE
feat(dark-factory): target-intake funnel — discover, score, freshness, dedup, ranked queue (#1054)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,25 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Added
+- `run-funnel.sh` — the **target-intake funnel**: turns target selection from a human pick into a ranked,
+  freshness-checked, self-deduped queue (#1054, part of epic #1053). Pipeline: **discover** (live RUNNING
+  Sherlock contests via its JSON API, reusing `contest-watch.sh`'s `items[]` pattern, plus a best-effort
+  Cantina/Code4rena probe) with a `--from <candidates.json>` offline override for deterministic/reproducible
+  runs; **freshness** (drop any candidate whose `status` is not RUNNING); **self-dedup** (drop keys
+  `platform:id` already in the read-only ledger `${DARK_FACTORY_DIR:-$HOME/.dark-factory}/funnel-ledger.txt`,
+  whose `key<TAB>verdict<TAB>ts` rows the #1055 batch runner appends); **score** (a deterministic weighted sum
+  documented in-script — recency of `launched_at` 0..40, log-scaled prize/TVL hint 0..25, platform weight
+  contest>permanent 0..20, smaller in-scope size 0..15, max 100, ties broken by key ascending); and **emit** a
+  ranked TSV `score<TAB>platform:id<TAB>url<TAB>title<TAB>scope_hint` to stdout AND
+  `${DARK_FACTORY_DIR}/targets.queue`. No network AND no `--from` → `[SKIP]` + exit 0 (CI-safe). It NEVER
+  contacts a platform to submit — a queued target is a LEAD a human (or the #1055 batch runner) triages.
+- `demo-funnel.sh` — offline, deterministic proof of the funnel (mirrors the other `demo-*.sh`): feeds a
+  fixture candidate list (varying `launched_at`/prize for a non-trivial rank, one non-RUNNING candidate, one
+  pre-seeded in a temp ledger) to `run-funnel.sh --from` with `DARK_FACTORY_DIR` pointed at a temp dir, and
+  asserts the queue is ranked by score descending, the non-RUNNING candidate is dropped (freshness), the
+  ledger-seen candidate is dropped (self-dedup), and the run exits 0. No network, no LLM.
+
 ### Documentation
 - `dispatcher.ag`: documented as the **standalone sync-guard** canonical copy of the dispatch fn (used by
   `demo-dispatch.sh` to diff against `coordinator.ag`'s inlined dispatch on the offline fixture path).

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -567,6 +567,7 @@ dark-factory/
   run-invariant-hunt.sh         # operator entrypoint: GENERATE a Foundry stateful-invariant test + VERIFY it with the fuzzer (#1035); --pattern-store persists/recalls winning invariant patterns across runs (Int M3, #1037)
   run-coordinator.sh            # bootstrap for the self-orchestrating loop (ONE agentis go; the loop lives in-substrate; #1014 M3)
   run-autonomous-hunt.sh        # integration: the coordinator CHOOSES + LIVE-runs the stateful fuzzer on a target; --candidate carries each lead's own context; --pattern-store persists/recalls winning patterns + --method-fixture feeds invent-method (Int M1+M2+M3, #1037)
+  run-funnel.sh                 # target-intake funnel: discover (live Sherlock + Cantina/C4 probe, or --from <json>) -> freshness (drop status!=RUNNING) -> self-dedup (funnel-ledger.txt) -> deterministic weighted score -> ranked targets.queue TSV (#1054, epic #1053); SKIPs without network or --from; never submits
   demo-coordinator.sh           # offline, deterministic proof of the #1014 fact-driven + evolving-policy loop
   demo-dispatch.sh              # offline, deterministic proof of the #1014 M2 substrate DISPATCH (every action type)
   demo-orchestrate.sh           # offline, deterministic proof of the #1014 M3 in-substrate loop (byte-identical to the M2 shell loop)
@@ -584,6 +585,7 @@ dark-factory/
   demo-pattern-memory.sh        # Int M3 proof: a FINDING persists invpat:latest:<class> to the DAG, a same-class target RECALLs + reuses it across runs, invent-method seeds a new class (SKIPs without forge)
   demo-fork-hunt.sh             # FM1 (#1041) foundation proof: forks the REAL deployed WETH at a pinned mainnet block -> funded-handler solvency invariant CLEAN against real forked state; forced-bad RPC -> HARNESS_ERROR (SKIPs without forge or a reachable public RPC)
   demo-composability.sh         # FM2 (#1041) proof: synthetic MiniAMM+LendingVault+FlashLender; composable handler (target+dex+flashloan) -> FINDING with a cross-contract witness, single-contract handler same budget/seed -> CLEAN (the split proves composability is the lift; SKIPs without forge/agentis)
+  demo-funnel.sh                # offline, deterministic proof of the #1054 funnel: a fixture candidate list via --from -> ranked by score desc, non-RUNNING dropped (freshness), ledger-seen dropped (self-dedup), exit 0
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)

--- a/dark-factory/demo-funnel.sh
+++ b/dark-factory/demo-funnel.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# demo-funnel.sh — OFFLINE, DETERMINISTIC proof of the #1054 target-intake funnel: a fixture candidate list is
+# fed to run-funnel.sh via --from (NO network) and the FRESHNESS -> SELF-DEDUP -> SCORE -> ranked-queue
+# transform is asserted end to end. Mirrors the other dark-factory demo-*.sh (assert-based, PASS/FAIL lines,
+# temp dirs trap-cleaned, exit non-zero on any failure).
+#
+# The fixture is built so the score ordering is NON-TRIVIAL (varying launched_at recency + prize so the rank
+# is not just input order), and it exercises every drop path:
+#   - one candidate whose status is NOT RUNNING (a closed window)            -> must be absent (freshness)
+#   - one candidate whose key platform:id is pre-seeded in a temp ledger     -> must be absent (self-dedup)
+#   - four RUNNING, un-seen candidates with deliberately different scores     -> ranked by score DESC
+#
+# Asserts: (a) the queue is ranked by score descending; (b) the non-RUNNING candidate is absent; (c) the
+# ledger-seen candidate is absent; (d) run-funnel.sh exits 0. DARK_FACTORY_DIR points at a temp dir so the
+# real ledger/queue are never touched. No network, no LLM — a pure transform over the fixture JSON.
+#
+# Usage:  dark-factory/demo-funnel.sh
+# Requires: python3 (same floor as run-funnel.sh). Exit: 0 = all assertions held; non-zero = a failure.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+FUNNEL="$HERE/run-funnel.sh"
+
+FAILS=0
+note() { echo "demo-funnel.sh: $*"; }
+ok()   { echo "  [PASS] $*"; }
+bad()  { echo "  [FAIL] $*"; FAILS=$((FAILS + 1)); }
+
+command -v python3 >/dev/null 2>&1 || { echo "[SKIP] python3 not installed" >&2; exit 0; }
+[ -x "$FUNNEL" ] || { note "run-funnel.sh not found / not executable: $FUNNEL" >&2; exit 3; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/demo-funnel.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+DFD="$WORK/dark-factory"   # the temp DARK_FACTORY_DIR (ledger + queue live here, never the real ~/.dark-factory)
+mkdir -p "$DFD"
+
+# Deterministic-but-relative launched_at hints so the recency lever produces a NON-TRIVIAL, stable ordering
+# regardless of the wall-clock day the demo runs. d0 = today (freshest), d18 = mid, d28 = nearly-closed window.
+iso_days_ago() { python3 -c 'import sys,datetime; print((datetime.datetime.now(datetime.timezone.utc)-datetime.timedelta(days=int(sys.argv[1]))).strftime("%Y-%m-%d"))' "$1"; }
+D0="$(iso_days_ago 0)"
+D18="$(iso_days_ago 18)"
+D28="$(iso_days_ago 28)"
+
+# The fixture candidate list. Designed scores (recency + prize + platform + scope, see run-funnel.sh SCORING):
+#   top      : today + $5M + contest + 1 contract  -> HIGHEST (recency 40, prize ~22, plat 20, scope ~14)
+#   mid      : today + $5M + permanent + 1 contract -> below top (permanent platform lever 8 vs 20)
+#   low      : d18  + $50k + contest + 4 contracts  -> low recency + small prize + larger scope
+#   floor    : d28  + $0   + contest + 8 contracts  -> LOWEST of the survivors (near-closed, no prize)
+#   closed   : today + $9M + contest, status FINISHED -> DROPPED by freshness (would top the queue if kept)
+#   seen     : today + $8M + contest, RUNNING, key pre-seeded in the ledger -> DROPPED by self-dedup
+# The two dropped candidates carry the BIGGEST prizes on purpose: if either leaked through it would sit at the
+# very top of the ranked queue, so its mere absence is a strong assertion that the filter fired.
+CANDS="$WORK/cands.json"
+cat > "$CANDS" <<JSON
+[
+  {"platform":"sherlock","id":"top","title":"Fresh fat contest","url":"https://audits.example/top","scope_hint":"Vault.sol","prize_hint":"\$5,000,000","launched_at":"$D0","status":"RUNNING","kind":"contest"},
+  {"platform":"immunefi","id":"mid","title":"Permanent bounty","url":"https://audits.example/mid","scope_hint":"Vault.sol","prize_hint":"\$5,000,000","launched_at":"$D0","status":"RUNNING","kind":"permanent"},
+  {"platform":"sherlock","id":"low","title":"Older small contest","url":"https://audits.example/low","scope_hint":"A.sol, B.sol, C.sol, D.sol","prize_hint":"\$50,000","launched_at":"$D18","status":"RUNNING","kind":"contest"},
+  {"platform":"sherlock","id":"floor","title":"Nearly-closed wide contest","url":"https://audits.example/floor","scope_hint":"A.sol, B.sol, C.sol, D.sol, E.sol, F.sol, G.sol, H.sol","prize_hint":"","launched_at":"$D28","status":"RUNNING","kind":"contest"},
+  {"platform":"sherlock","id":"closed","title":"Closed contest","url":"https://audits.example/closed","scope_hint":"Vault.sol","prize_hint":"\$9,000,000","launched_at":"$D0","status":"FINISHED","kind":"contest"},
+  {"platform":"sherlock","id":"seen","title":"Already-processed contest","url":"https://audits.example/seen","scope_hint":"Vault.sol","prize_hint":"\$8,000,000","launched_at":"$D0","status":"RUNNING","kind":"contest"}
+]
+JSON
+
+# Pre-seed the ledger with the "seen" candidate's key (the #1055 batch-runner row shape: key<TAB>verdict<TAB>ts).
+printf 'sherlock:seen\trefuted\t2026-06-01T00:00:00Z\n' > "$DFD/funnel-ledger.txt"
+
+note "running the funnel over the fixture (offline, DARK_FACTORY_DIR=$DFD) ..."
+QUEUE_OUT="$(DARK_FACTORY_DIR="$DFD" "$FUNNEL" --from "$CANDS" 2>/dev/null)"; RC=$?
+echo "----- ranked queue -----"
+printf '%s\n' "$QUEUE_OUT" | sed 's/^/    /'
+echo "------------------------"
+
+# (d) exit 0
+if [ "$RC" -eq 0 ]; then ok "run-funnel.sh exited 0 on the offline --from path"
+else bad "run-funnel.sh exited $RC (expected 0)"; fi
+
+# Column 2 of each TSV row is the platform:id key; column 1 is the score.
+KEYS="$(printf '%s\n' "$QUEUE_OUT" | awk -F'\t' 'NF>=2{print $2}')"
+SCORES="$(printf '%s\n' "$QUEUE_OUT" | awk -F'\t' 'NF>=1{print $1}')"
+
+has_key() { printf '%s\n' "$KEYS" | grep -qxF "$1"; }
+
+# (b) the non-RUNNING candidate (biggest prize) was dropped by the freshness filter.
+if has_key "sherlock:closed"; then bad "freshness FAILED: 'sherlock:closed' (status FINISHED) is in the queue"
+else ok "freshness: the non-RUNNING candidate 'sherlock:closed' is absent"; fi
+
+# (c) the ledger-seen candidate (also a big prize) was dropped by self-dedup.
+if has_key "sherlock:seen"; then bad "self-dedup FAILED: 'sherlock:seen' (in the ledger) is in the queue"
+else ok "self-dedup: the ledger-seen candidate 'sherlock:seen' is absent"; fi
+
+# The four survivors must all be present (sanity: the filters did not over-drop).
+ALL_SURVIVORS=1
+for k in sherlock:top immunefi:mid sherlock:low sherlock:floor; do
+  has_key "$k" || { bad "expected survivor '$k' missing from the queue"; ALL_SURVIVORS=0; }
+done
+[ "$ALL_SURVIVORS" -eq 1 ] && ok "all four RUNNING, un-seen survivors are present"
+
+# (a) ranked by score DESCENDING — the printed score column must be non-increasing top to bottom.
+if [ -n "$SCORES" ] && printf '%s\n' "$SCORES" | awk 'NR>1 && $1>prev{exit 1} {prev=$1}'; then
+  ok "queue is ranked by score descending: $(printf '%s' "$SCORES" | tr '\n' ' ')"
+else
+  bad "queue is NOT sorted by score descending: $(printf '%s' "$SCORES" | tr '\n' ' ')"
+fi
+
+# Stronger ordering check: the exact expected key order (top > mid > low > floor by the documented levers).
+EXPECTED=$'sherlock:top\nimmunefi:mid\nsherlock:low\nsherlock:floor'
+if [ "$KEYS" = "$EXPECTED" ]; then
+  ok "exact rank order matches the documented scoring (top > mid > low > floor)"
+else
+  bad "rank order mismatch — got:"; printf '%s\n' "$KEYS" | sed 's/^/        /'
+  note "expected:"; printf '%s\n' "$EXPECTED" | sed 's/^/        /'
+fi
+
+# The queue FILE must equal the stdout view (run-funnel.sh writes both).
+if [ "$(cat "$DFD/targets.queue" 2>/dev/null)" = "$QUEUE_OUT" ]; then
+  ok "the targets.queue file equals the stdout view"
+else
+  bad "the targets.queue file differs from stdout"
+fi
+
+echo
+if [ "$FAILS" -eq 0 ]; then
+  note "PASS: the funnel turned a fixture candidate list into a ranked, freshness-checked, self-deduped queue —"
+  note "      the non-RUNNING and the ledger-seen candidates (both high-prize) were dropped, the four survivors"
+  note "      ranked by the deterministic weighted score, and run-funnel.sh exited 0. Offline + deterministic;"
+  note "      a queued target is a LEAD a human / the #1055 batch runner triages — this tool never submits."
+  exit 0
+fi
+note "DEMO FAILED: $FAILS assertion(s) did not hold — see above." >&2
+exit 1

--- a/dark-factory/run-funnel.sh
+++ b/dark-factory/run-funnel.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# run-funnel.sh — the TARGET-INTAKE FUNNEL: turn "what should we look at" from a human pick into a ranked,
+# freshness-checked, self-deduped QUEUE (#1054, epic #1053). Volume=1 (a human hand-picks every target and
+# writes the recon by hand) makes expected yield ~0 against #1041's honest per-target odds; this funnel raises
+# volume by mechanising intake.
+#
+# Pipeline (a PURE transform over the candidate JSON, so it is offline-testable end to end):
+#   1. DISCOVER  -> a normalized candidate list. Live: RUNNING Sherlock contests (the cleanest JSON API, reused
+#                   from contest-watch.sh's items[] pattern) + a best-effort Cantina/Code4rena probe. `--from
+#                   <json>` reads the candidate list from a file INSTEAD of the network (deterministic tests +
+#                   reproducible runs). With NO network AND no --from -> `[SKIP]` + exit 0 (CI-safe).
+#   2. FRESHNESS -> drop any candidate whose `status` is not RUNNING (a closed window / rotated scope).
+#   3. SELF-DEDUP-> drop any candidate whose key `platform:id` already appears in the ledger
+#                   ${DARK_FACTORY_DIR:-$HOME/.dark-factory}/funnel-ledger.txt. The batch runner (#1055) APPENDS
+#                   `key<TAB>verdict<TAB>ts` rows there; the funnel only READS it.
+#   4. SCORE     -> a deterministic weighted sum from the available signals (see SCORING below). Pure fn of the
+#                   candidate fields -> the same input always yields the same ranking.
+#   5. EMIT      -> the ranked queue (highest score first), one TSV line per candidate:
+#                   `score<TAB>platform:id<TAB>url<TAB>title<TAB>scope_hint`. Written to stdout AND to
+#                   ${DARK_FACTORY_DIR}/targets.queue.
+#
+# SCORING (documented here so it is auditable; computed in the python block below, integers only -> stable
+# sort). The four levers correlate with a real shot per #1041's "less-saturated" thesis. score = sum of:
+#   recency  : newer launched_at = less audit-time elapsed = less saturated. 40 * max(0, 1 - age_days/30),
+#              i.e. 40 at launch, decaying linearly to 0 by 30 days old (a closed-ish window). [0..40]
+#   prize    : a larger prize/TVL signal = more eyes worth it. 25 * min(1, log10(1+prize_usd)/7) — log-scaled
+#              so $10M does not swamp every other lever; ~0 at $0, ~25 at >=$10M. [0..25]
+#   platform : a fresh permissionless CONTEST (bug density highest day-1) outranks a permanent bounty.
+#              contest -> 20, permanent -> 8, anything else -> 0. [0..20]
+#   scope    : a SMALLER in-scope surface = higher finding density per unit effort. 15 * max(0, 1 - n/20),
+#              where n = the scope_hint contract/file count (0 -> full 15, >=20 -> 0). [0..15]
+# Max 100. Ties break by platform:id ascending (deterministic). A missing/garbled field contributes 0 for
+# that lever (never crashes the rank). The score is advisory ranking only — it never gates a submission.
+#
+# This tool NEVER contacts a platform to SUBMIT. Discovery + ranking only; a queued target is a LEAD a human
+# (or the #1055 batch runner) triages. Offline / no-network behaviour matches the sibling scripts.
+#
+# Usage: run-funnel.sh [--from <candidates.json>] [--min-score N] [--limit N] [-h]
+#   --from      : read the candidate list from <file> (a JSON array of candidate objects) instead of the
+#                 network. The deterministic path used by demo-funnel.sh and for reproducible runs.
+#   --min-score : drop candidates scoring below N after ranking (default 0 = keep all).
+#   --limit     : keep at most N top-ranked candidates (default 0 = no cap).
+# Candidate object fields (all optional except a usable key): {platform,id,title,url,scope_hint,prize_hint,
+#   launched_at,status,scope_count}. `platform` in {sherlock,cantina,code4rena,immunefi,...}; `status` must be
+#   RUNNING to survive the freshness filter; `launched_at` an ISO-8601 / epoch hint; `prize_hint` a USD number
+#   (bare or "$1,000,000"); `scope_count` the in-scope contract/file count (else inferred from scope_hint).
+# Requires: python3. Outbound HTTPS only on the live (no --from) path. Exit 0 on success OR clean [SKIP];
+# exit 2 on bad args.
+set -u
+
+DIR="${DARK_FACTORY_DIR:-$HOME/.dark-factory}"
+LEDGER="$DIR/funnel-ledger.txt"
+QUEUE="$DIR/targets.queue"
+
+# nv: a value-taking flag must be followed by a value; under `set -u` a bare trailing flag would otherwise
+# crash on $2 (unbound) instead of the promised exit 2. $1 = remaining argc ($#), $2 = the flag name.
+nv() { [ "$1" -ge 2 ] || { echo "run-funnel.sh: $2 requires a value" >&2; exit 2; }; }
+FROM="" ; MIN_SCORE="0" ; LIMIT="0"
+while [ $# -gt 0 ]; do case "$1" in
+  --from) nv "$#" "$1"; FROM="$2"; shift 2;;
+  --min-score) nv "$#" "$1"; MIN_SCORE="$2"; shift 2;;
+  --limit) nv "$#" "$1"; LIMIT="$2"; shift 2;;
+  -h|--help) sed -n '2,48p' "$0"; exit 0;;
+  *) echo "run-funnel.sh: unknown arg $1" >&2; exit 2;;
+esac; done
+
+command -v python3 >/dev/null || { echo "[SKIP] python3 not installed" >&2; exit 0; }
+mkdir -p "$DIR"; touch "$LEDGER"
+
+# ----------------------------------------------------------------------------------------------------------
+# 1) DISCOVER -> a normalized candidate JSON array written to $RAW. --from reads it from a file; otherwise the
+#    live path queries Sherlock (+ a best-effort Cantina/C4 probe). No --from AND no reachable source -> SKIP.
+# ----------------------------------------------------------------------------------------------------------
+RAW="$(mktemp "${TMPDIR:-/tmp}/funnel-raw.XXXXXX")"
+trap 'rm -f "$RAW"' EXIT
+
+if [ -n "$FROM" ]; then
+  [ -r "$FROM" ] || { echo "run-funnel.sh: --from <file> not readable: $FROM" >&2; exit 2; }
+  cp "$FROM" "$RAW"
+else
+  # Live discovery. Sherlock first (cleanest JSON; the contest-watch.sh items[] pattern). A network failure
+  # leaves an empty array -> SKIP below rather than a false-empty queue.
+  SHERLOCK="$(mktemp "${TMPDIR:-/tmp}/funnel-sherlock.XXXXXX")"
+  CANTINA="$(mktemp "${TMPDIR:-/tmp}/funnel-cantina.XXXXXX")"
+  C4="$(mktemp "${TMPDIR:-/tmp}/funnel-c4.XXXXXX")"
+  trap 'rm -f "$RAW" "$SHERLOCK" "$CANTINA" "$C4"' EXIT
+  GOT_NET=0
+  if curl -sS --max-time 20 https://mainnet-contest.sherlock.xyz/contests -o "$SHERLOCK" 2>/dev/null \
+       && [ -s "$SHERLOCK" ]; then GOT_NET=1; else echo '[]' > "$SHERLOCK"; fi
+  # Best-effort permanent/permissionless probes (HTML SPAs — treat a keyword hit as "go look", low weight).
+  curl -sS --max-time 20 -A 'Mozilla/5.0' https://cantina.xyz/competitions -o "$CANTINA" 2>/dev/null \
+    && [ -s "$CANTINA" ] && GOT_NET=1 || : > "$CANTINA"
+  curl -sS --max-time 20 -A 'Mozilla/5.0' https://code4rena.com/audits -o "$C4" 2>/dev/null \
+    && [ -s "$C4" ] && GOT_NET=1 || : > "$C4"
+  [ "$GOT_NET" -eq 1 ] || { echo "[SKIP] no network and no --from <candidates.json> — nothing to discover" >&2; exit 0; }
+  # Normalize the live sources into the same candidate-array shape --from accepts.
+  SHERLOCK="$SHERLOCK" CANTINA="$CANTINA" C4="$C4" python3 - > "$RAW" <<'PY'
+import os, json
+out = []
+# --- Sherlock: a RUNNING contest per items[] entry (page 1 newest), normalized to the candidate schema. ---
+try:
+    d = json.load(open(os.environ["SHERLOCK"]))
+except Exception:
+    d = []
+items = d if isinstance(d, list) else (d.get("items") if isinstance(d, dict) else [])
+for c in (items or []):
+    if not isinstance(c, dict):
+        continue
+    cid = c.get("id")
+    out.append({
+        "platform": "sherlock",
+        "id": cid,
+        "title": str(c.get("title", "")),
+        "url": "https://audits.sherlock.xyz/contests/%s" % cid,
+        "scope_hint": str(c.get("repo", c.get("scope", "")) or ""),
+        "prize_hint": c.get("prize_pool", c.get("rewards", "")),
+        "launched_at": c.get("starts_at", c.get("start_date", "")),
+        "status": str(c.get("status", "")).upper(),
+        "kind": "contest",
+    })
+# --- Cantina / Code4rena: a crude keyword probe -> ONE "go look" lead keyed by platform+date if the page
+#     mentions an actively-open competition cluster. SPA/RSC pages give no clean JSON, so this is best-effort
+#     and intentionally low-signal (the score's platform lever keeps it below a real contest). ---
+import datetime
+today = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+KW = ("accepting submissions", "live competition", "submissions open", "active competition")
+for plat, envk, base in (("cantina", "CANTINA", "https://cantina.xyz/competitions"),
+                         ("code4rena", "C4", "https://code4rena.com/audits")):
+    try:
+        html = open(os.environ[envk], encoding="utf-8", errors="ignore").read()
+    except Exception:
+        html = ""
+    if html and any(k in html.lower() for k in KW):
+        out.append({
+            "platform": plat,
+            "id": "probe-%s" % today,
+            "title": "%s: possible open competition (verify manually)" % plat,
+            "url": base,
+            "scope_hint": "",
+            "prize_hint": "",
+            "launched_at": today,
+            "status": "RUNNING",
+            "kind": "contest",
+        })
+print(json.dumps(out))
+PY
+fi
+
+# ----------------------------------------------------------------------------------------------------------
+# 2-5) FRESHNESS -> SELF-DEDUP -> SCORE -> EMIT. A single pure transform: drop status!=RUNNING, drop ledger
+#      keys, score by the documented weighted sum, sort by score desc (then platform:id asc), emit the TSV.
+# ----------------------------------------------------------------------------------------------------------
+RAW="$RAW" LEDGER="$LEDGER" MIN_SCORE="$MIN_SCORE" LIMIT="$LIMIT" python3 - > "$QUEUE" <<'PY'
+import os, json, math, re, datetime
+
+raw_path = os.environ["RAW"]
+ledger_path = os.environ["LEDGER"]
+try:
+    min_score = int(os.environ.get("MIN_SCORE", "0"))
+except ValueError:
+    min_score = 0
+try:
+    limit = int(os.environ.get("LIMIT", "0"))
+except ValueError:
+    limit = 0
+
+NOW = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)  # naive UTC, for age arithmetic
+
+try:
+    cands = json.load(open(raw_path))
+except Exception:
+    cands = []
+if not isinstance(cands, list):
+    cands = []
+
+# The ledger keys already-processed targets (key<TAB>verdict<TAB>ts). Read-only here; #1055 appends to it.
+seen = set()
+try:
+    for line in open(ledger_path, encoding="utf-8", errors="ignore"):
+        k = line.split("\t", 1)[0].strip()
+        if k:
+            seen.add(k)
+except Exception:
+    pass
+
+
+def key_of(c):
+    return "%s:%s" % (str(c.get("platform", "")).strip(), str(c.get("id", "")).strip())
+
+
+def parse_launched(v):
+    """A launched_at hint -> age in whole days (UTC). Accepts epoch seconds or an ISO-8601 date/datetime.
+    Unparseable -> None (the recency lever then contributes 0, never a crash)."""
+    if v is None or v == "":
+        return None
+    s = str(v).strip()
+    # epoch seconds
+    if re.fullmatch(r"\d{9,12}", s):
+        try:
+            dt = datetime.datetime.utcfromtimestamp(int(s[:10]))
+        except Exception:
+            return None
+    else:
+        iso = s.replace("Z", "").replace("T", " ").strip()
+        dt = None
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d", "%Y/%m/%d"):
+            try:
+                dt = datetime.datetime.strptime(iso[:len(fmt) + 4], fmt)
+                break
+            except Exception:
+                dt = None
+        if dt is None:
+            try:
+                dt = datetime.datetime.strptime(iso[:10], "%Y-%m-%d")
+            except Exception:
+                return None
+    age = (NOW - dt).total_seconds() / 86400.0
+    return age
+
+
+def parse_prize(v):
+    """A prize/TVL hint -> a USD float. Accepts a number or strings like "$1,000,000" / "1.2M" / "500k"."""
+    if v is None or v == "":
+        return 0.0
+    if isinstance(v, (int, float)):
+        return float(v)
+    s = str(v).strip().lower().replace("$", "").replace(",", "").replace("usd", "").strip()
+    m = re.match(r"^([0-9]*\.?[0-9]+)\s*([kmb]?)", s)
+    if not m:
+        return 0.0
+    n = float(m.group(1))
+    return n * {"": 1, "k": 1e3, "m": 1e6, "b": 1e9}[m.group(2)]
+
+
+def scope_count(c):
+    """The in-scope contract/file count. Prefer an explicit scope_count; else count comma/newline-separated
+    entries (or .sol mentions) in scope_hint; 0 if nothing usable (full scope lever credit)."""
+    sc = c.get("scope_count")
+    if isinstance(sc, (int, float)):
+        return int(sc)
+    if isinstance(sc, str) and sc.strip().isdigit():
+        return int(sc.strip())
+    hint = str(c.get("scope_hint", "") or "").strip()
+    if not hint:
+        return 0
+    sols = len(re.findall(r"\.sol\b", hint))
+    if sols:
+        return sols
+    parts = [p for p in re.split(r"[,\n;]+", hint) if p.strip()]
+    return len(parts)
+
+
+def score_of(c):
+    # recency: 40 at launch, linear to 0 by 30 days old.
+    age = parse_launched(c.get("launched_at"))
+    recency = 0.0 if age is None else 40.0 * max(0.0, 1.0 - age / 30.0)
+    # prize: log10-scaled, ~25 by $10M.
+    prize = parse_prize(c.get("prize_hint"))
+    prize_term = 25.0 * min(1.0, math.log10(1.0 + prize) / 7.0) if prize > 0 else 0.0
+    # platform: a fresh contest outranks a permanent bounty.
+    kind = str(c.get("kind", "")).strip().lower()
+    plat = str(c.get("platform", "")).strip().lower()
+    if kind == "contest" or plat in ("sherlock", "cantina", "code4rena"):
+        plat_term = 20.0
+    elif kind == "permanent" or plat in ("immunefi", "hats"):
+        plat_term = 8.0
+    else:
+        plat_term = 0.0
+    # scope: smaller surface = higher density. 15 at 0 contracts, 0 at >=20.
+    n = scope_count(c)
+    scope_term = 15.0 * max(0.0, 1.0 - n / 20.0)
+    return int(round(recency + prize_term + plat_term + scope_term))
+
+
+ranked = []
+for c in cands:
+    if not isinstance(c, dict):
+        continue
+    if str(c.get("status", "")).strip().upper() != "RUNNING":   # 2) FRESHNESS
+        continue
+    k = key_of(c)
+    if k == ":" or k.endswith(":") or k.startswith(":"):
+        continue
+    if k in seen:                                               # 3) SELF-DEDUP
+        continue
+    s = score_of(c)                                            # 4) SCORE
+    if s < min_score:
+        continue
+    title = str(c.get("title", "") or "").replace("\t", " ").replace("\n", " ").strip()
+    url = str(c.get("url", "") or "").replace("\t", " ").strip()
+    scope_hint = str(c.get("scope_hint", "") or "").replace("\t", " ").replace("\n", " ").strip()
+    ranked.append((s, k, url, title, scope_hint))
+
+# 5) EMIT: score DESC, then key ASC (deterministic tie-break).
+ranked.sort(key=lambda r: (-r[0], r[1]))
+if limit > 0:
+    ranked = ranked[:limit]
+for s, k, url, title, scope_hint in ranked:
+    print("%d\t%s\t%s\t%s\t%s" % (s, k, url, title, scope_hint))
+PY
+
+# Mirror the queue to stdout (the file is the durable artifact; stdout is the live view).
+cat "$QUEUE"
+N="$(grep -c . "$QUEUE" 2>/dev/null || echo 0)"
+echo "run-funnel: ranked $N candidate(s) -> $QUEUE" >&2

--- a/dark-factory/run-funnel.sh
+++ b/dark-factory/run-funnel.sh
@@ -253,7 +253,7 @@ def scope_count(c):
 def score_of(c):
     # recency: 40 at launch, linear to 0 by 30 days old.
     age = parse_launched(c.get("launched_at"))
-    recency = 0.0 if age is None else 40.0 * max(0.0, 1.0 - age / 30.0)
+    recency = 0.0 if age is None else min(40.0, 40.0 * max(0.0, 1.0 - age / 30.0))
     # prize: log10-scaled, ~25 by $10M.
     prize = parse_prize(c.get("prize_hint"))
     prize_term = 25.0 * min(1.0, math.log10(1.0 + prize) / 7.0) if prize > 0 else 0.0
@@ -268,7 +268,7 @@ def score_of(c):
         plat_term = 0.0
     # scope: smaller surface = higher density. 15 at 0 contracts, 0 at >=20.
     n = scope_count(c)
-    scope_term = 15.0 * max(0.0, 1.0 - n / 20.0)
+    scope_term = min(15.0, 15.0 * max(0.0, 1.0 - n / 20.0))
     return int(round(recency + prize_term + plat_term + scope_term))
 
 
@@ -301,5 +301,7 @@ PY
 
 # Mirror the queue to stdout (the file is the durable artifact; stdout is the live view).
 cat "$QUEUE"
-N="$(grep -c . "$QUEUE" 2>/dev/null || echo 0)"
-echo "run-funnel: ranked $N candidate(s) -> $QUEUE" >&2
+# grep -c prints the count (0 on no match) but exits 1 when empty; `|| true` keeps
+# the single printed number instead of appending a second 0.
+N="$(grep -c . "$QUEUE" 2>/dev/null || true)"
+echo "run-funnel: ranked ${N:-0} candidate(s) -> $QUEUE" >&2


### PR DESCRIPTION
Part of epic #1053.

`run-funnel.sh` turns target selection from a human decision into a ranked, freshness-checked, self-deduped queue — the `× many targets` half of the earning thesis.

## Pipeline
- **discover**: RUNNING Sherlock contests (live API, reusing `contest-watch.sh`'s `items[]` pattern) + best-effort Cantina/C4 probe. `--from <json>` offline override; no network and no `--from` → `[SKIP]` + exit 0 (CI-safe).
- **freshness**: drop `status != RUNNING`.
- **self-dedup**: skip keys in `${DARK_FACTORY_DIR}/funnel-ledger.txt` (the #1055 batch runner appends processed keys; the funnel only reads it).
- **score**: deterministic weighted sum — `recency (40) + log-scaled prize (25) + platform weight contest>permanent (20) + smaller-scope density (15)`, documented in-script. Advisory ranking only; never gates a submission.
- **emit**: ranked `targets.queue` (TSV `score⇥platform:id⇥url⇥title⇥scope_hint`) to stdout + `${DARK_FACTORY_DIR}`.

Never contacts a platform to submit — discovery + ranking only.

## Tests
`demo-funnel.sh` (mirrors the other `demo-*.sh`) feeds a 6-candidate fixture via `--from` and asserts offline + deterministically: ranked by score desc, the non-RUNNING candidate dropped, the ledger-seen candidate dropped (both high-prize, so leakage would top the queue), queue-file == stdout, exit 0.

- `sh -n` + `bash -n` clean; both scripts `chmod +x`.
- `colony-lint.sh`: 367 passed, 0 failed, 5 skipped.
- CHANGELOG `[Unreleased]` + README updated.

Out of scope: consuming the queue (batch runner #1055).