### PR TITLE
feat(dark-factory): batch/continuous runner — consume the funnel queue, hunt, stage, record (#1055)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -15,6 +15,18 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 ## [Unreleased]
 
 ### Added
+- `run-batch.sh` — the **batch/continuous runner** that operationalizes the proven engines at volume by
+  consuming the #1054 funnel queue (epic #1053). Per `targets.queue` line (highest score first): skip keys
+  already in `funnel-ledger.txt` (resumable; reuses the funnel dedup contract); run a hunt under a
+  per-target timeout via a pluggable `--hunt-cmd` (the seam — it gets `BATCH_KEY/URL/SCOPE` in env and
+  prints a `VERDICT|<confirmed|dry|refuted>` line) or a best-effort default (a resolvable `0x` address ->
+  `run-autoharness.sh` given `ETH_RPC`+`FORK_BLOCK`, else `dry`+`needs recon`); the verdict is the engine's,
+  NEVER an LLM; on `confirmed`, stage the finding under `<out>/submission/<key>/` marked PENDING HUMAN
+  REVIEW — the colony has no platform-egress and **never auto-submits**; append `key<TAB>verdict<TAB>ts` to
+  `funnel-ledger.txt` (the funnel dedups it next run) and `policy-outcomes.log`. Bounded by `--max-targets`;
+  resumable via the ledger. `demo-batch.sh` proves the loop offline + deterministically (fixture queue +
+  stub hunt-cmd -> score order, ledger-skip, staged confirmed, resumable no-op re-run). SKIPs cleanly with
+  no queue.
 - `run-funnel.sh` — the **target-intake funnel**: turns target selection from a human pick into a ranked,
   freshness-checked, self-deduped queue (#1054, part of epic #1053). Pipeline: **discover** (live RUNNING
   Sherlock contests via its JSON API, reusing `contest-watch.sh`'s `items[]` pattern, plus a best-effort

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -568,6 +568,7 @@ dark-factory/
   run-coordinator.sh            # bootstrap for the self-orchestrating loop (ONE agentis go; the loop lives in-substrate; #1014 M3)
   run-autonomous-hunt.sh        # integration: the coordinator CHOOSES + LIVE-runs the stateful fuzzer on a target; --candidate carries each lead's own context; --pattern-store persists/recalls winning patterns + --method-fixture feeds invent-method (Int M1+M2+M3, #1037)
   run-funnel.sh                 # target-intake funnel: discover (live Sherlock + Cantina/C4 probe, or --from <json>) -> freshness (drop status!=RUNNING) -> self-dedup (funnel-ledger.txt) -> deterministic weighted score -> ranked targets.queue TSV (#1054, epic #1053); SKIPs without network or --from; never submits
+  run-batch.sh                  # batch/continuous runner: consume targets.queue (score desc) -> skip ledgered keys (resumable) -> hunt each via --hunt-cmd or best-effort autoharness -> stage confirmed findings (NOT submitted) -> append funnel-ledger.txt + policy-outcomes.log (#1055, epic #1053); SKIPs with no queue; never submits
   demo-coordinator.sh           # offline, deterministic proof of the #1014 fact-driven + evolving-policy loop
   demo-dispatch.sh              # offline, deterministic proof of the #1014 M2 substrate DISPATCH (every action type)
   demo-orchestrate.sh           # offline, deterministic proof of the #1014 M3 in-substrate loop (byte-identical to the M2 shell loop)
@@ -586,6 +587,7 @@ dark-factory/
   demo-fork-hunt.sh             # FM1 (#1041) foundation proof: forks the REAL deployed WETH at a pinned mainnet block -> funded-handler solvency invariant CLEAN against real forked state; forced-bad RPC -> HARNESS_ERROR (SKIPs without forge or a reachable public RPC)
   demo-composability.sh         # FM2 (#1041) proof: synthetic MiniAMM+LendingVault+FlashLender; composable handler (target+dex+flashloan) -> FINDING with a cross-contract witness, single-contract handler same budget/seed -> CLEAN (the split proves composability is the lift; SKIPs without forge/agentis)
   demo-funnel.sh                # offline, deterministic proof of the #1054 funnel: a fixture candidate list via --from -> ranked by score desc, non-RUNNING dropped (freshness), ledger-seen dropped (self-dedup), exit 0
+  demo-batch.sh                 # offline, deterministic proof of the #1055 batch runner: a fixture queue + stub --hunt-cmd -> score order, ledgered key skipped, confirmed finding staged (NOT submitted), resumable no-op re-run, exit 0
   setup-solana-toolchain.sh     # one-time offline toolchain build (network ON)
   snapshot-rpc.sh               # host RPC getAccountInfo -> frozen on-chain snapshot (V4)
   calibrate-sealevel.sh         # detection+validation scorecard over the sealevel corpus (V6)

--- a/dark-factory/demo-batch.sh
+++ b/dark-factory/demo-batch.sh
@@ -80,7 +80,7 @@ else
 fi
 
 # (f) never-submit: the runner has no platform-egress (no curl/POST in its source).
-if ! grep -nE 'curl|wget|-X[[:space:]]*POST|--data' "$RUN" >/dev/null 2>&1; then
+if ! grep -nE 'curl|wget|nc |netcat|/dev/tcp|-X[[:space:]]*(POST|PUT)|--data|--upload|gh (pr|issue|api)|http[s]?://[^ ]*(submit|api)' "$RUN" >/dev/null 2>&1; then
   pass "run-batch.sh has no network-egress (never submits)"
 else
   fail "run-batch.sh contains an egress call — must never submit"

--- a/dark-factory/demo-batch.sh
+++ b/dark-factory/demo-batch.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# demo-batch.sh — offline, deterministic proof that run-batch.sh consumes the funnel queue, hunts each
+# fresh target via a pluggable hunt-cmd, stages a confirmed finding (NEVER submitting), records every
+# outcome to the dedup ledger, and is resumable (a re-run skips everything already in the ledger).
+#
+# No network, no real hunt: the hunt is a stub --hunt-cmd that returns canned VERDICT lines, and
+# DARK_FACTORY_DIR is a throwaway temp dir. Exits non-zero on any failed assertion.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUN="$HERE/run-batch.sh"
+
+FAIL=0
+pass() { echo "demo-batch.sh: [PASS] $1"; }
+fail() { echo "demo-batch.sh: [FAIL] $1" >&2; FAIL=1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export DARK_FACTORY_DIR="$WORK/df"
+mkdir -p "$DARK_FACTORY_DIR"
+QUEUE="$DARK_FACTORY_DIR/targets.queue"
+LEDGER="$DARK_FACTORY_DIR/funnel-ledger.txt"
+OUT="$WORK/out"
+
+# Fixture queue (already score-desc, as the funnel emits): a confirmed lead on top, a dry one, and a
+# candidate whose key is pre-seeded in the ledger (must be skipped as already-processed).
+printf '%s\n' \
+  "97	sherlock:top	https://audits.sherlock.xyz/contests/top	Top contest	Vault.sol" \
+  "85	cantina:mid	https://cantina.xyz/competitions/mid	Mid contest	Pool.sol" \
+  "70	sherlock:seen	https://audits.sherlock.xyz/contests/seen	Seen contest	Old.sol" \
+  > "$QUEUE"
+printf 'sherlock:seen\tdry\t2026-06-15T00:00:00Z\n' > "$LEDGER"
+
+# Stub hunt: confirmed for the *top* key, dry for everything else. Reads BATCH_KEY from env.
+STUB='case "$BATCH_KEY" in *:top) echo "VERDICT|confirmed|stub finding" ;; *) echo "VERDICT|dry|stub clean" ;; esac'
+
+OUT1="$("$RUN" --queue "$QUEUE" --hunt-cmd "$STUB" --out "$OUT" --max-targets 10 2>/dev/null)"
+rc=$?
+[ "$rc" -eq 0 ] && pass "run 1 exit 0" || fail "run 1 exit $rc (expected 0)"
+
+# (a) processed highest-score-first: top before mid in the stdout report.
+top_ln="$(printf '%s\n' "$OUT1" | grep -n '^sherlock:top' | head -1 | cut -d: -f1)"
+mid_ln="$(printf '%s\n' "$OUT1" | grep -n '^cantina:mid' | head -1 | cut -d: -f1)"
+if [ -n "$top_ln" ] && [ -n "$mid_ln" ] && [ "$top_ln" -lt "$mid_ln" ]; then
+  pass "processed highest-score-first (sherlock:top before cantina:mid)"
+else
+  fail "score order wrong (top line=$top_ln mid line=$mid_ln)"
+fi
+
+# (b) the pre-ledgered key was skipped (never hunted / never re-recorded).
+if ! printf '%s\n' "$OUT1" | grep -q '^sherlock:seen'; then
+  pass "pre-ledgered sherlock:seen skipped (resumable dedup)"
+else
+  fail "sherlock:seen was processed despite being in the ledger"
+fi
+if [ "$(grep -c '^sherlock:seen	' "$LEDGER")" -eq 1 ]; then
+  pass "sherlock:seen not duplicated in the ledger"
+else
+  fail "sherlock:seen ledger rows != 1"
+fi
+
+# (c) ledger gained the right key->verdict rows.
+if grep -q '^sherlock:top	confirmed	' "$LEDGER"; then pass "ledger records sherlock:top -> confirmed"; else fail "missing sherlock:top confirmed row"; fi
+if grep -q '^cantina:mid	dry	' "$LEDGER"; then pass "ledger records cantina:mid -> dry"; else fail "missing cantina:mid dry row"; fi
+
+# (d) the confirmed finding was staged (and marked NOT submitted), the dry one was not.
+if [ -f "$OUT/submission/sherlock:top/report.md" ] && grep -q 'NOT SUBMITTED' "$OUT/submission/sherlock:top/report.md"; then
+  pass "confirmed finding staged under submission/ + marked NOT SUBMITTED"
+else
+  fail "confirmed finding not staged (or missing NOT-SUBMITTED marker)"
+fi
+if [ ! -d "$OUT/submission/cantina:mid" ]; then pass "dry target was not staged"; else fail "dry target wrongly staged"; fi
+
+# (e) resumable: a second run skips everything now in the ledger (processes 0).
+OUT2="$("$RUN" --queue "$QUEUE" --hunt-cmd "$STUB" --out "$OUT" --max-targets 10 2>/dev/null)"
+rc2=$?
+if [ "$rc2" -eq 0 ] && [ -z "$(printf '%s' "$OUT2" | tr -d '[:space:]')" ]; then
+  pass "re-run processes 0 targets (all now in the ledger) — resumable"
+else
+  fail "re-run was not a clean no-op (exit $rc2, out: $OUT2)"
+fi
+
+# (f) never-submit: the runner has no platform-egress (no curl/POST in its source).
+if ! grep -nE 'curl|wget|-X[[:space:]]*POST|--data' "$RUN" >/dev/null 2>&1; then
+  pass "run-batch.sh has no network-egress (never submits)"
+else
+  fail "run-batch.sh contains an egress call — must never submit"
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "demo-batch.sh: PASS: the batch runner consumed a ranked queue, hunted each fresh target via the"
+  echo "      pluggable hunt-cmd, staged the confirmed finding (NOT submitted), recorded every outcome to"
+  echo "      the dedup ledger, and a re-run was a clean resumable no-op. Offline + deterministic."
+  exit 0
+fi
+echo "demo-batch.sh: FAIL — see [FAIL] lines above" >&2
+exit 1

--- a/dark-factory/run-batch.sh
+++ b/dark-factory/run-batch.sh
@@ -57,9 +57,9 @@ mkdir -p "$DIR"
 ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 TIMEOUT_BIN="$(command -v timeout || true)"
 
-# Empty / missing queue -> nothing to do (CI-safe, mirrors the sibling [SKIP] convention).
+# Empty / missing queue -> nothing to do (CI-safe; [SKIP] to stderr, mirroring run-funnel.sh).
 if [ ! -s "$QUEUE" ]; then
-  echo "[SKIP] no queue at $QUEUE (run run-funnel.sh first) — nothing to process"
+  echo "[SKIP] no queue at $QUEUE (run run-funnel.sh first) — nothing to process" >&2
   exit 0
 fi
 

--- a/dark-factory/run-batch.sh
+++ b/dark-factory/run-batch.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# run-batch.sh — the BATCH/CONTINUOUS RUNNER that operationalizes the proven engines at volume by
+# consuming the #1054 funnel queue (epic #1053). The funnel raises target VOLUME from 1; this loop is
+# what actually feeds those targets through a hunt, stages findings, and records outcomes so the funnel
+# dedups next run and the coordinator policy can learn across targets.
+#
+# Loop (per ${DARK_FACTORY_DIR}/targets.queue line `score<TAB>key<TAB>url<TAB>title<TAB>scope_hint`,
+#       highest score first — the funnel already ranked it):
+#   1. SKIP if `key` is already in funnel-ledger.txt (resumable; reuses the funnel's dedup contract).
+#   2. HUNT the target under a per-target timeout:
+#        --hunt-cmd "<cmd>"  : the cmd is the seam. It receives BATCH_KEY / BATCH_URL / BATCH_SCOPE in
+#                              env and MUST print one `VERDICT|<confirmed|dry|refuted>[|detail]` line.
+#                              This is what the demo drives and what an operator wires to a real hunt.
+#        default (no cmd)    : best-effort — if the entry carries a resolvable 0x address, route to
+#                              run-autoharness.sh (needs ETH_RPC + FORK_BLOCK in env; absent -> `dry`
+#                              + a skip note). Otherwise `dry` + `needs recon`. Full contest-URL ->
+#                              foundry-repo -> invariant resolution is target-specific and out of scope.
+#   3. VERDICT is the HUNT's (its VERDICT line / exit code), NEVER an LLM. On `confirmed`, stage the
+#      finding under <out>/submission/<key>/ (a report stub marked PENDING HUMAN REVIEW). This colony
+#      NEVER auto-submits to any platform — a staged finding is a LEAD a human reviews + submits.
+#   4. APPEND `key<TAB>verdict<TAB>ts` to funnel-ledger.txt (the funnel dedups it next run) AND to
+#      policy-outcomes.log (the coordinator can fold outcomes into its action policy).
+#   Bounded by --max-targets; resumable after interruption (the ledger is the checkpoint).
+#
+# This tool NEVER contacts a platform to submit. Offline / no-queue behaviour matches the sibling scripts.
+#
+# Usage: run-batch.sh [--queue <file>] [--hunt-cmd "<cmd>"] [--max-targets N] [--out <dir>] [--timeout S] [-h]
+#   --queue        : the ranked queue to consume (default ${DARK_FACTORY_DIR:-$HOME/.dark-factory}/targets.queue).
+#   --hunt-cmd     : a command run per target (BATCH_KEY/BATCH_URL/BATCH_SCOPE in env) that prints a
+#                    `VERDICT|<confirmed|dry|refuted>[|detail]` line. Default = best-effort autoharness.
+#   --max-targets  : process at most N targets this run (default 5). Alias: --budget.
+#   --out          : staging root for confirmed findings (default $PWD/batch-out).
+#   --timeout      : per-target timeout in seconds when `timeout` is available (default 600).
+# Requires: bash. Exit 0 on success OR clean [SKIP]; exit 2 on bad args.
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DIR="${DARK_FACTORY_DIR:-$HOME/.dark-factory}"
+LEDGER="$DIR/funnel-ledger.txt"
+POLICY_LOG="$DIR/policy-outcomes.log"
+
+# nv: a value-taking flag must be followed by a value; under `set -u` a bare trailing flag would
+# otherwise crash on $2 (unbound) instead of the promised exit 2. $1 = remaining argc, $2 = flag name.
+nv() { [ "$1" -ge 2 ] || { echo "run-batch.sh: $2 requires a value" >&2; exit 2; }; }
+QUEUE="$DIR/targets.queue" ; HUNT_CMD="" ; MAX_TARGETS="5" ; OUT="$PWD/batch-out" ; PER_TIMEOUT="600"
+while [ $# -gt 0 ]; do case "$1" in
+  --queue)        nv "$#" "$1"; QUEUE="$2"; shift 2;;
+  --hunt-cmd)     nv "$#" "$1"; HUNT_CMD="$2"; shift 2;;
+  --max-targets|--budget) nv "$#" "$1"; MAX_TARGETS="$2"; shift 2;;
+  --out)          nv "$#" "$1"; OUT="$2"; shift 2;;
+  --timeout)      nv "$#" "$1"; PER_TIMEOUT="$2"; shift 2;;
+  -h|--help)      sed -n '2,33p' "$0"; exit 0;;
+  *) echo "run-batch.sh: unknown arg: $1" >&2; exit 2;;
+esac; done
+
+mkdir -p "$DIR"
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+TIMEOUT_BIN="$(command -v timeout || true)"
+
+# Empty / missing queue -> nothing to do (CI-safe, mirrors the sibling [SKIP] convention).
+if [ ! -s "$QUEUE" ]; then
+  echo "[SKIP] no queue at $QUEUE (run run-funnel.sh first) — nothing to process"
+  exit 0
+fi
+
+# Run a command under the per-target timeout when `timeout(1)` is available, else plain.
+with_timeout() {
+  if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" "$PER_TIMEOUT" "$@"; else "$@"; fi
+}
+
+# True if `key` (col 1) already has a ledger row -> already processed -> skip (resumable + dedup).
+ledger_has() { [ -f "$LEDGER" ] && cut -f1 "$LEDGER" 2>/dev/null | grep -qxF "$1"; }
+
+# Append the outcome to the dedup ledger (the funnel reads it) AND the policy-outcomes log.
+record() {  # $1 = key, $2 = verdict
+  local t; t="$(ts)"
+  printf '%s\t%s\t%s\n' "$1" "$2" "$t" >> "$LEDGER"
+  printf '%s\t%s\t%s\n' "$1" "$2" "$t" >> "$POLICY_LOG"
+}
+
+# First 0x+40hex address found in the entry's url/scope, if any.
+addr_of() { printf '%s' "$1" | grep -oiE '0x[0-9a-f]{40}' | head -1 || true; }
+
+# Run the hunt for one target -> echo a single `VERDICT|<word>[|detail]` line. Verdict is the engine's.
+run_hunt() {  # $1 = key, $2 = url, $3 = scope
+  local k="$1" u="$2" s="$3" a ec
+  if [ -n "$HUNT_CMD" ]; then
+    BATCH_KEY="$k" BATCH_URL="$u" BATCH_SCOPE="$s" with_timeout sh -c "$HUNT_CMD" 2>/dev/null \
+      | grep -m1 '^VERDICT|' || echo "VERDICT|dry|hunt-cmd produced no VERDICT line"
+    return 0
+  fi
+  a="$(addr_of "$u $s")"
+  if [ -z "$a" ]; then
+    echo "VERDICT|dry|skip: needs recon (no auto-resolvable address in url/scope)"; return 0
+  fi
+  if [ -z "${ETH_RPC:-}" ] || [ -z "${FORK_BLOCK:-}" ]; then
+    echo "VERDICT|dry|skip: address $a found but ETH_RPC + FORK_BLOCK unset (run-autoharness needs them)"; return 0
+  fi
+  # run-autoharness exit: 1 = FINDING (confirmed), anything else = dry (no finding / harness error).
+  ec=0
+  with_timeout "$HERE/run-autoharness.sh" --address "$a" --rpc "$ETH_RPC" --block "$FORK_BLOCK" \
+    --out "$OUT/work/$k" >/dev/null 2>&1 || ec=$?
+  if [ "$ec" -eq 1 ]; then echo "VERDICT|confirmed|autoharness FINDING on $a"
+  else echo "VERDICT|dry|autoharness: no finding / harness error on $a (exit $ec)"; fi
+}
+
+processed=0 ; staged=0 ; skipped=0
+# Read the queue into an array first so a hunt-cmd is free to consume stdin.
+mapfile -t LINES < "$QUEUE"
+for line in "${LINES[@]}"; do
+  [ -n "$line" ] || continue
+  IFS=$'\t' read -r _score key url title scope <<< "$line"
+  : "${title:=}"  # title is captured for completeness; unused beyond the record
+  [ -n "${key:-}" ] || continue
+  if ledger_has "$key"; then skipped=$((skipped+1)); echo "skip (already in ledger): $key" >&2; continue; fi
+  if [ "$processed" -ge "$MAX_TARGETS" ]; then
+    echo "run-batch: reached --max-targets $MAX_TARGETS; stopping (re-run to continue — resumable via the ledger)" >&2
+    break
+  fi
+  processed=$((processed+1))
+  echo "run-batch: hunting $key (${url:-no-url}) ..." >&2
+  v="$(run_hunt "$key" "${url:-}" "${scope:-}")"
+  verdict="$(printf '%s' "$v" | cut -d'|' -f2)"; [ -n "$verdict" ] || verdict="dry"
+  detail="$(printf '%s' "$v" | cut -d'|' -f3-)"
+  if [ "$verdict" = "confirmed" ]; then
+    sd="$OUT/submission/$key"; mkdir -p "$sd"
+    {
+      echo "# FINDING — PENDING HUMAN REVIEW — NOT SUBMITTED"
+      echo
+      echo "- Target: $key"
+      echo "- URL: ${url:-}"
+      echo "- Scope: ${scope:-}"
+      echo "- Detail: ${detail:-}"
+      echo
+      echo "Verdict came from the hunt engine (exit code / VERDICT line), never an LLM. A human reviews"
+      echo "this package and submits it manually; this colony has no platform-egress and never auto-posts."
+    } > "$sd/report.md"
+    staged=$((staged+1))
+    echo "run-batch: FINDING staged -> $sd/report.md (NOT submitted)" >&2
+  fi
+  record "$key" "$verdict"
+  printf '%s\t%s%s\n' "$key" "$verdict" "${detail:+	($detail)}"
+done
+
+echo "run-batch: processed $processed, staged $staged finding(s), skipped $skipped already-ledgered; outcomes -> $LEDGER" >&2


### PR DESCRIPTION
Part of epic #1053; pairs with the #1054 funnel.

`run-batch.sh` operationalizes the proven engines at volume by consuming the funnel's `targets.queue` (highest score first):

- **resumable dedup**: skip keys already in `funnel-ledger.txt` (the funnel's contract).
- **pluggable hunt**: `--hunt-cmd "<cmd>"` (gets `BATCH_KEY/URL/SCOPE` in env, prints `VERDICT|<confirmed|dry|refuted>`) — the seam an operator wires to a real hunt; default = best-effort (resolvable `0x` address → `run-autoharness.sh` given `ETH_RPC`+`FORK_BLOCK`, else `dry`+`needs recon`). Per-target `timeout`.
- **verdict is the engine's, never an LLM**; on `confirmed`, stage under `<out>/submission/<key>/` marked **PENDING HUMAN REVIEW — NOT SUBMITTED**. No platform-egress; never auto-submits.
- **record**: append `key⇥verdict⇥ts` to `funnel-ledger.txt` (funnel dedups next run) + `policy-outcomes.log` (coordinator can fold into policy).
- Bounded by `--max-targets`; resumable via the ledger; `[SKIP]` + exit 0 with no queue.

## Tests
`demo-batch.sh` (mirrors `demo-funnel.sh`) proves the loop offline + deterministically with a fixture queue + stub `--hunt-cmd`: **10/10 assertions PASS** — score order, ledgered key skipped, ledger gains the right key→verdict rows, confirmed finding staged + marked NOT SUBMITTED, dry not staged, resumable no-op re-run, no egress in the source, exit 0.

- `sh -n` + `bash -n` clean; both scripts `chmod +x`.
- `colony-lint.sh`: 367 passed, 0 failed, 5 skipped.
- CHANGELOG `[Unreleased]` + README updated.

Out of scope: full contest-URL → foundry-repo → invariant resolution is target-specific (the default hunt is best-effort; the `--hunt-cmd` seam is where a real per-target hunt plugs in).