### PR TITLE
feat(dark-factory): FM4 audit-informed deep-invariant synthesis (#1058)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -15,6 +15,17 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 ## [Unreleased]
 
 ### Added
+- **FM4 — audit-informed deep-invariant synthesis** (#1058, epic #1041). Generic conservation /
+  single-function invariants are what auditors and formal tools check FIRST, so re-deriving them finds
+  nothing new. `run-autoharness.sh` gains `--audit-context <file>`: it folds the target's prior audit
+  findings + known-gap notes into the generation prompt and instructs the LLM to target what audits MISS
+  (cross-function emergent state, deep economic value-extraction, multi-step accounting drift) and to NOT
+  re-derive an already-disclosed finding (worthless on a first-reporter bounty). A new `--dry-prompt` mode
+  builds + prints the prompt without calling the LLM/forge, making the wiring offline-testable.
+  `demo-fm4-audit.sh` asserts (deterministically, no LLM): with `--audit-context` the prompt carries the
+  FM4 targeting block + the gap instruction + the do-not-re-report instruction + the disclosed findings
+  verbatim; without it the prompt is unchanged (additive); an unreadable context file errors loudly. The
+  invariant-quality uplift is the LLM's; this ships and proves the deterministic wiring.
 - **FM3 — oracle / price perturbation as a stateful fuzz dimension** (#1057, epic #1041). FM1 forks real
   state and FM2 composes protocols, but the price/oracle stayed STATIC, so the flashloan-funded
   price-manipulation drain (where bounty money concentrates) was unreachable. The harness-generation prompt

--- a/dark-factory/README.md
+++ b/dark-factory/README.md
@@ -388,6 +388,9 @@ dark-factory/run-invariant-hunt.sh --repo "$PWD/target" --target Vault.sol:Vault
 #   --fork-target target=<addr> --fork-target dex=<addr> --fork-target flashloan=<addr>   |   proof: dark-factory/demo-composability.sh
 # FM3 (#1041) oracle/price perturbation — the harness exposes a price-MOVEMENT action (swap/donation/feed write)
 #   so the fuzzer moves the price before the borrow/redeem; manipulate->act sequences reachable.   proof: dark-factory/demo-fm3-oracle.sh
+# FM4 (#1041) audit-informed synthesis — run-autoharness.sh --audit-context <file> folds prior audit findings
+#   + the gap lens into the gen prompt (target what audits miss; don't re-report disclosed); --dry-prompt
+#   dumps the prompt offline.   proof: dark-factory/demo-fm4-audit.sh
 ```
 
 **Fork mode (FM1, #1041).** `--fork-url <rpc> [--fork-block <n>]` runs the same handler + deep invariants

--- a/dark-factory/demo-fm4-audit.sh
+++ b/dark-factory/demo-fm4-audit.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# demo-fm4-audit.sh — FM4 (#1058, epic #1041): audit-informed deep-invariant synthesis.
+#
+# Generic conservation / single-function invariants are exactly what auditors and formal tools check FIRST,
+# so re-deriving them finds nothing new. FM4 folds the target's PRIOR AUDIT FINDINGS + the known-gap lens
+# into the harness-generation prompt, so the LLM aims at what audits MISS (cross-function emergent state,
+# deep economic value-extraction, multi-step accounting drift) and does NOT re-report an already-disclosed
+# bug (worthless on a first-reporter bounty).
+#
+# The LLM-quality uplift is the model's job and can't be asserted offline; this demo proves the WIRING is
+# correct and deterministic via run-autoharness.sh --dry-prompt (build + print the prompt, no LLM/forge):
+#   - WITH --audit-context: the assembled prompt carries the FM4 audit-targeting block + the gap instruction
+#     + the do-not-re-derive-disclosed instruction + the supplied audit findings verbatim;
+#   - WITHOUT it: the prompt is byte-free of the FM4 block (additive — non-audit runs are unchanged);
+#   - an unreadable --audit-context is a hard usage error (exit 2), never a silent skip.
+# Offline + deterministic; needs neither forge nor the LLM wrapper.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUN="$HERE/run-autoharness.sh"
+
+FAIL=0
+pass() { echo "demo-fm4-audit.sh: [PASS] $1"; }
+fail() { echo "demo-fm4-audit.sh: [FAIL] $1" >&2; FAIL=1; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# A minimal recon spec (run-autoharness just embeds it) and a prior-audit context with a unique marker
+# string + a clearly-disclosed finding so leakage/absence is unambiguous to assert.
+cat > "$WORK/recon.txt" <<'TXT'
+TARGET: 0x000000000000000000000000000000000000dEaD  (ExampleVault)
+FUNCTIONS: deposit(uint256), withdraw(uint256), borrow(uint256)
+FORK_BLOCK: 19000000
+INVARIANT: total user claims never exceed vault assets.
+TXT
+DISCLOSED_MARKER="FM4_DISCLOSED_donation_inflation_OZ_audit_2024"
+cat > "$WORK/audit.txt" <<TXT
+KNOWN-GAP CLASSES for this target (auditors covered conservation; these are the gaps):
+  - cross-function emergent state between borrow() and withdraw()
+  - rounding drift compounded across many deposit/withdraw cycles
+ALREADY-DISCLOSED (do not re-report):
+  - $DISCLOSED_MARKER : first-deposit share-inflation, fixed in v2 (OZ audit).
+TXT
+
+# 1. WITH --audit-context: the FM4 block + instructions + the disclosed marker must be in the prompt.
+P_WITH="$("$RUN" --spec "$WORK/recon.txt" --audit-context "$WORK/audit.txt" --dry-prompt 2>/dev/null)"
+rc=$?
+[ "$rc" -eq 0 ] && pass "--dry-prompt exits 0 with --audit-context" || fail "--dry-prompt + --audit-context exit $rc (expected 0)"
+printf '%s' "$P_WITH" | grep -q 'FM4: AUDIT-INFORMED INVARIANT TARGETING' && pass "prompt carries the FM4 audit-targeting header" || fail "FM4 header missing from prompt"
+printf '%s' "$P_WITH" | grep -qi 'GAP classes auditors' && pass "prompt instructs targeting the audit-GAP classes (not generic conservation)" || fail "gap-targeting instruction missing"
+printf '%s' "$P_WITH" | grep -qi 'do NOT re-derive any finding listed below as already DISCLOSED' && pass "prompt instructs NOT to re-derive disclosed findings" || fail "disclosed-avoidance instruction missing"
+printf '%s' "$P_WITH" | grep -qF "$DISCLOSED_MARKER" && pass "the supplied disclosed finding is folded into the prompt verbatim" || fail "audit-context contents not injected"
+printf '%s' "$P_WITH" | grep -q '=== TARGET RECON ===' && pass "the base recon prompt is still present (FM4 is additive)" || fail "base recon prompt lost"
+
+# 2. WITHOUT --audit-context: the FM4 block must be ABSENT (additive; non-audit runs unchanged).
+P_NONE="$("$RUN" --spec "$WORK/recon.txt" --dry-prompt 2>/dev/null)"
+if ! printf '%s' "$P_NONE" | grep -q 'FM4: AUDIT-INFORMED'; then
+  pass "no --audit-context -> prompt has NO FM4 block (additive, default unchanged)"
+else
+  fail "FM4 block leaked into the prompt without --audit-context"
+fi
+
+# 3. Unreadable --audit-context is a hard usage error (exit 2), not a silent skip.
+ec=0; "$RUN" --spec "$WORK/recon.txt" --audit-context "$WORK/does-not-exist.txt" --dry-prompt >/dev/null 2>&1 || ec=$?
+[ "$ec" -eq 2 ] && pass "unreadable --audit-context -> exit 2 (hard error, not silent)" || fail "unreadable --audit-context gave exit $ec (expected 2)"
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "demo-fm4-audit.sh: PASS: FM4 audit-informed targeting is wired correctly — prior-audit findings + the"
+  echo "      gap lens + the do-not-re-report-disclosed instruction reach the generation prompt under"
+  echo "      --audit-context, the prompt is unchanged without it, and a missing context file errors loudly."
+  echo "      (The invariant-quality uplift is the LLM's; this proves the deterministic wiring.)"
+  exit 0
+fi
+echo "demo-fm4-audit.sh: FAIL — see [FAIL] lines above" >&2
+exit 1

--- a/dark-factory/run-autoharness.sh
+++ b/dark-factory/run-autoharness.sh
@@ -8,15 +8,21 @@
 #
 # Usage: run-autoharness.sh (--spec <recon.txt> | --address <0x..> [--chain <id>]) --rpc <archive-rpc> --block <n>
 #                           [--invariant "<text>"] [--repairs N] [--runs N] [--out <dir>]
+#                           [--audit-context <file>] [--dry-prompt]
 #   --spec    : a text file describing the target (addresses, function signatures, the deep invariant).
 #   --address : instead of a hand-written spec, auto-fetch the verified ABI keyless from Sourcify (no API key)
 #               and build the recon spec from it — full chain: address -> recon -> harness -> hunt, no human.
+#   --audit-context <file> : FM4 (#1058) — fold the target's PRIOR AUDIT FINDINGS + known-gap notes into the
+#               generation prompt so the LLM targets what audits/formal tools MISS (cross-function emergent
+#               state, deep value-extraction) and does NOT re-derive an already-disclosed finding.
+#   --dry-prompt : build + print the generation prompt and exit (no LLM, no forge) — for inspecting/testing
+#               what the model is asked, incl. the --audit-context wiring. Offline.
 # Requires: a flat-cyborg LLM backend wrapper on PATH (LLM_WRAP env or ./flat-cyborg-claude.sh), forge, an
-# ARCHIVE RPC (forge fork execution at a historical block needs a true archive node).
+# ARCHIVE RPC (forge fork execution at a historical block needs a true archive node). (--dry-prompt needs none.)
 set -u
 HERE="$(cd "$(dirname "$0")" && pwd)"
 WRAP="${LLM_WRAP:-$HERE/flat-cyborg-claude.sh}"
-SPEC="" ; ADDR="" ; CHAIN="1" ; INV="" ; RPC="" ; BLK="" ; REPAIRS=6 ; RUNS=400 ; OUT=""
+SPEC="" ; ADDR="" ; CHAIN="1" ; INV="" ; RPC="" ; BLK="" ; REPAIRS=6 ; RUNS=400 ; OUT="" ; AUDITCTX="" ; DRYPROMPT=""
 # nv: a value-taking flag must be followed by a value; under `set -u` a bare trailing flag would otherwise
 # crash on $2 (unbound) instead of the promised exit 2. $1 = remaining argc ($#), $2 = the flag name.
 nv() { [ "$1" -ge 2 ] || { echo "run-autoharness.sh: $2 requires a value" >&2; exit 2; }; }
@@ -24,10 +30,15 @@ while [ $# -gt 0 ]; do case "$1" in
   --spec) nv "$#" "$1"; SPEC="$2"; shift 2;; --address) nv "$#" "$1"; ADDR="$2"; shift 2;; --chain) nv "$#" "$1"; CHAIN="$2"; shift 2;;
   --invariant) nv "$#" "$1"; INV="$2"; shift 2;; --rpc) nv "$#" "$1"; RPC="$2"; shift 2;; --block) nv "$#" "$1"; BLK="$2"; shift 2;;
   --repairs) nv "$#" "$1"; REPAIRS="$2"; shift 2;; --runs) nv "$#" "$1"; RUNS="$2"; shift 2;; --out) nv "$#" "$1"; OUT="$2"; shift 2;;
-  -h|--help) sed -n '2,14p' "$0"; exit 0;; *) echo "run-autoharness.sh: unknown arg $1" >&2; exit 2;; esac; done
-[ -n "$RPC" ] && [ -n "$BLK" ] || { echo "run-autoharness.sh: --rpc and --block required" >&2; exit 2; }
-command -v forge >/dev/null || { echo "[SKIP] forge not installed" >&2; exit 0; }
-[ -x "$WRAP" ] || { echo "[SKIP] LLM backend wrapper not found ($WRAP); set LLM_WRAP" >&2; exit 0; }
+  --audit-context) nv "$#" "$1"; AUDITCTX="$2"; shift 2;; --dry-prompt) DRYPROMPT=1; shift;;
+  -h|--help) sed -n '2,21p' "$0"; exit 0;; *) echo "run-autoharness.sh: unknown arg $1" >&2; exit 2;; esac; done
+# --dry-prompt builds + prints the generation prompt and exits WITHOUT calling the LLM or forge — so the
+# audit-context wiring is offline-testable. The real hunt needs --rpc/--block + forge + the LLM wrapper.
+if [ -z "$DRYPROMPT" ]; then
+  [ -n "$RPC" ] && [ -n "$BLK" ] || { echo "run-autoharness.sh: --rpc and --block required" >&2; exit 2; }
+  command -v forge >/dev/null || { echo "[SKIP] forge not installed" >&2; exit 0; }
+  [ -x "$WRAP" ] || { echo "[SKIP] LLM backend wrapper not found ($WRAP); set LLM_WRAP" >&2; exit 0; }
+fi
 WORK="${OUT:-$(mktemp -d "${TMPDIR:-/tmp}/autoharness.XXXXXX")}"; mkdir -p "$WORK/test"
 # Auto-recon: --address with no --spec -> fetch ABI keyless from Sourcify and synthesize the recon spec.
 if [ -z "$SPEC" ] && [ -n "$ADDR" ]; then
@@ -42,6 +53,24 @@ printf '[profile.default]\ntest = "test"\nsolc = "0.8.24"\nevm_version = "cancun
 PROMPT="$WORK/prompt.txt"
 { echo "You are an autonomous smart-contract bug-hunting harness generator. Output ONLY a single Solidity file (no markdown, no prose): a forge-std-FREE Foundry test, contract name AutoHarness, pragma ^0.8.24. Use the cheatcode interface at 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D (createSelectFork(string,uint256), envString, envUint, store, load). Fund the test contract by storage-slot scan + approve. Expose the protocol's primitive operations as fuzzable try/catch actions. Add a FUZZ test function testFuzz_hunt(uint256 seed) that derives a SEQUENCE of ops from the seed, executes them on the REAL forked protocol, then require()s the deep invariant. FM3 — if the target READS A PRICE/ORACLE (a spot reserve ratio, price()/getPrice()/latestAnswer(), a DEX quote), ALSO expose the price-MOVEMENT vector as a fuzzable action (a real swap on the forked pool, a large donation/transfer that skews reserves, or a manipulable-feed write) so the seed can move the price within attacker-reachable bounds BEFORE the borrow/redeem/liquidate — manipulate-then-act sequences are exactly where oracle bugs hide and a static price would miss them. Fork via env ETH_RPC + the block below.";
   echo "=== TARGET RECON ==="; cat "$SPEC"; } > "$PROMPT"
+# FM4 (#1058): fold in the target's prior audit findings + the known-gap lens so the LLM targets what
+# audits/Certora typically MISS (cross-function emergent state, deep economic value-extraction, multi-step
+# accounting drift) — NOT the generic single-function conservation an audit already checked — and does NOT
+# re-derive an already-disclosed finding (a re-find is worthless). Off unless --audit-context is supplied.
+if [ -n "$AUDITCTX" ]; then
+  [ -r "$AUDITCTX" ] || { echo "run-autoharness.sh: --audit-context file not readable: $AUDITCTX" >&2; exit 2; }
+  { echo "";
+    echo "=== FM4: AUDIT-INFORMED INVARIANT TARGETING ===";
+    echo "This target has PRIOR AUDITS. Generate invariants that target the GAP classes auditors / formal";
+    echo "tools typically miss — cross-function emergent state, deep economic value-extraction, multi-step";
+    echo "accounting drift — NOT the generic conservation / single-function properties an audit already";
+    echo "checks. Do NOT re-derive any finding listed below as already DISCLOSED; aim PAST them (a re-find";
+    echo "is worthless on a first-reporter bounty).";
+    echo "--- PRIOR AUDIT FINDINGS / KNOWN-GAP NOTES (already disclosed — do not re-report) ---";
+    cat "$AUDITCTX"; } >> "$PROMPT"
+fi
+# --dry-prompt: dump the assembled generation prompt and stop (offline; no LLM, no forge).
+if [ -n "$DRYPROMPT" ]; then cat "$PROMPT"; exit 0; fi
 SOL="$WORK/test/AutoHarness.t.sol"
 # A REAL fork-fuzz harness — not a trivial compiling stub — must FORK the chain, expose a seed-derived FUZZ
 # function, and assert a deep invariant. A bare `test_sanity()` that asserts `1+1==2` compiles cleanly but

--- a/dark-factory/run-autoharness.sh
+++ b/dark-factory/run-autoharness.sh
@@ -16,7 +16,8 @@
 #               generation prompt so the LLM targets what audits/formal tools MISS (cross-function emergent
 #               state, deep value-extraction) and does NOT re-derive an already-disclosed finding.
 #   --dry-prompt : build + print the generation prompt and exit (no LLM, no forge) — for inspecting/testing
-#               what the model is asked, incl. the --audit-context wiring. Offline.
+#               what the model is asked, incl. the --audit-context wiring. Offline WITH --spec; with
+#               --address it still fetches the recon from Sourcify (network) before printing.
 # Requires: a flat-cyborg LLM backend wrapper on PATH (LLM_WRAP env or ./flat-cyborg-claude.sh), forge, an
 # ARCHIVE RPC (forge fork execution at a historical block needs a true archive node). (--dry-prompt needs none.)
 set -u
@@ -31,7 +32,7 @@ while [ $# -gt 0 ]; do case "$1" in
   --invariant) nv "$#" "$1"; INV="$2"; shift 2;; --rpc) nv "$#" "$1"; RPC="$2"; shift 2;; --block) nv "$#" "$1"; BLK="$2"; shift 2;;
   --repairs) nv "$#" "$1"; REPAIRS="$2"; shift 2;; --runs) nv "$#" "$1"; RUNS="$2"; shift 2;; --out) nv "$#" "$1"; OUT="$2"; shift 2;;
   --audit-context) nv "$#" "$1"; AUDITCTX="$2"; shift 2;; --dry-prompt) DRYPROMPT=1; shift;;
-  -h|--help) sed -n '2,21p' "$0"; exit 0;; *) echo "run-autoharness.sh: unknown arg $1" >&2; exit 2;; esac; done
+  -h|--help) sed -n '2,22p' "$0"; exit 0;; *) echo "run-autoharness.sh: unknown arg $1" >&2; exit 2;; esac; done
 # --dry-prompt builds + prints the generation prompt and exits WITHOUT calling the LLM or forge — so the
 # audit-context wiring is offline-testable. The real hunt needs --rpc/--block + forge + the LLM wrapper.
 if [ -z "$DRYPROMPT" ]; then


### PR DESCRIPTION
Realizes the **FM4** box in epic #1041.

Generic conservation / single-function invariants are what auditors and formal tools check **first**, so re-deriving them finds nothing new. FM4 aims the generation at what audits *miss*.

## Changes
- **`run-autoharness.sh` `--audit-context <file>`**: folds the target's prior audit findings + known-gap notes into the generation prompt, instructing the LLM to target the gap classes auditors/formal tools miss (cross-function emergent state, deep economic value-extraction, multi-step accounting drift) — NOT the generic conservation an audit already checked — and to NOT re-derive an already-disclosed finding (worthless on a first-reporter bounty).
- **`--dry-prompt`**: builds + prints the assembled generation prompt and exits without calling the LLM or forge (and bypasses the rpc/block/forge/wrapper requirements), so the audit-context wiring is offline-testable.

## Tests
`demo-fm4-audit.sh` (deterministic, offline, no LLM): **8/8 PASS** — with `--audit-context` the prompt carries the FM4 targeting block + the gap instruction + the do-not-re-report instruction + the disclosed findings verbatim + the base recon (additive); without it the prompt has no FM4 block (default unchanged); an unreadable context file errors loudly (exit 2).
- `colony-lint.sh`: 367 passed, 0 failed, 5 skipped. `sh -n`/`bash -n` clean.
- CHANGELOG `[Unreleased]` + README updated.

## Honest scope
The invariant-**quality** uplift is the LLM's job and isn't offline-assertable; this PR ships + proves the deterministic **wiring** (audit context reaches the prompt; default behavior unchanged). Completes #1041's FM1–FM4 alongside FM3 (#1057).