### PR TITLE
fix(dark-factory): bound invariant-prover generation to one lens-driven invariant (#1067)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -85,6 +85,22 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   invariant-hunt/auto-harness divergence flagged in #1049 is by design, not a bug. Resolves #1049
   (comment-only, no behavior change).
 
+### Fixed
+- **`invariant-prover.ag` `generate_test()` degraded to HARNESS_ERROR on realistically-sized targets**
+  (#1067). The live-generation ask asked the model, in ONE completion, for a full `Handler` + abstract
+  `InvBase` + a test contract asserting FIVE deep invariants (value-conservation, no-depositor-loss,
+  solvency-under-any-sequence, no-free-value-extraction, share-price-monotonicity). On a real contract that
+  single generation is too large to return within the LLM timeout, so the engine produced no verdict
+  (HARNESS_ERROR). The ask is now **bounded**: EXACTLY ONE deep invariant — the single highest-value property
+  for the current bug-class lens (e.g. solvency/collateralization for an accounting lens, share-price
+  monotonicity for a vault lens) — plus a MINIMAL handler exposing only the actions needed to exercise that
+  one invariant, under an explicit `~120-line` size budget, so the generation returns reliably and compiles.
+  Breadth now comes from running the prover across MULTIPLE lenses (one focused invariant per run), not one
+  mega-test. All hard constraints are unchanged (`pragma solidity ^0.8.20;`, no forge-std import, the
+  StdInvariant `targetContracts()` ABI, plain `require(...)`, the `<matchPrefix>_*` naming, output-only
+  Solidity), and the FM1/FM2 fork/compose seeds stay byte-identical when inactive.
+  `tools/test-invariant-prover-bounded-gen.sh` pins the bounded ask (no LLM; grep over the `.ag` source).
+
 ## [0.2.0] — 2026-06-15
 
 ### Added

--- a/dark-factory/auditor/agents/invariant-prover.ag
+++ b/dark-factory/auditor/agents/invariant-prover.ag
@@ -160,11 +160,16 @@ if len(prior) > 0 {
 let fixture = cat_file(fixturePath);
 
 // Live path: the LLM is the HYPOTHESIS GENERATOR. It reads the target contract source and writes a
-// self-contained Foundry stateful-invariant test — a `Handler` that exposes the protocol's actions as
-// BOUNDED actor functions + a set of DEEP `invariant_*` properties (value-conservation, no-depositor-loss,
-// solvency-under-any-sequence, no-free-value-extraction, share-price-monotonicity). The verdict is STILL the
-// FUZZER's (below); the LLM only writes the handler + the properties to check. Cold path, one target in / one
-// test out (no per-tick staleness to gate) -> the prompt carries an explicit prompt-gate-ok marker.
+// self-contained Foundry stateful-invariant test — a MINIMAL `Handler` that exposes only the core
+// state-changing actions as BOUNDED actor functions + EXACTLY ONE deep `invariant_*` property: the single
+// highest-value invariant for the current bug-class lens (e.g. solvency/collateralization for an accounting
+// lens, share-price monotonicity for a vault lens). The ask is bounded (one focused invariant, a minimal
+// handler, ~120 lines) so the generation returns reliably and compiles instead of degrading to a
+// HARNESS_ERROR on a too-large single completion (#1067). BREADTH comes from running the prover across
+// MULTIPLE lenses — one focused invariant per run — not from one mega-test enumerating every property. The
+// verdict is STILL the FUZZER's (below); the LLM only writes the handler + the one property to check. Cold
+// path, one target in / one test out (no per-tick staleness to gate) -> the prompt carries an explicit
+// prompt-gate-ok marker.
 // Int M3 (#1037): fold a recalled prior pattern into the generation seed. When `prior` is non-empty (a prior
 // FINDING on this class, or an invented class hint), prepend a line steering the LLM to adapt that proven
 // invariant/handler shape to the current target. Empty `prior` => the instruction is byte-identical to M2.
@@ -235,10 +240,13 @@ fn generate_test(klass: string, src: string, matchPrefix: string, prior: string,
       + "(address[] memory)` returning the addresses to fuzz, with an internal `_target(address)` that pushes "
       + "to that array (this is the StdInvariant ABI Foundry auto-discovers — no forge-std needed).\n"
       + "  - A test contract `is InvBase` with a `setUp()` that deploys the protocol + the Handler and calls "
-      + "`_target(address(handler))`, plus a set of DEEP `" + matchPrefix + "_*` view functions asserting with "
-      + "plain `require(...)`: value-conservation, no-depositor-loss (a depositor's claim >= their deposit "
-      + "minus dust), solvency-under-any-sequence, no-free-value-extraction, share-price-monotonicity. Each "
-      + "must catch a bug that only a SEQUENCE of calls can produce, not a single call.\n\n"
+      + "`_target(address(handler))`, plus EXACTLY ONE deep `" + matchPrefix + "_*` view function asserting with "
+      + "plain `require(...)` the SINGLE highest-value property for the bug-class lens below — pick the one "
+      + "invariant most relevant to that lens (e.g. solvency / collateralization for an accounting lens, "
+      + "share-price monotonicity for a vault lens), do NOT enumerate every property. Expose in the Handler "
+      + "ONLY the core state-changing actions needed to exercise THAT one invariant — not every protocol action. "
+      + "The invariant must catch a bug that only a SEQUENCE of calls can produce, not a single call. "
+      + "Keep the entire test under ~120 lines; do not exceed it.\n\n"
       + "=== BUG CLASS (lens) ===\n" + klass + "\n\n"
       + "=== HOW TO ANSWER ===\n"
       + "Output ONLY the Solidity source of the `*.t.sol` test — no markdown fences, no prose before or "

--- a/tools/test-invariant-prover-bounded-gen.sh
+++ b/tools/test-invariant-prover-bounded-gen.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# tools/test-invariant-prover-bounded-gen.sh -- deterministic regression
+# guard for #1067 (dark-factory). The dark-factory invariant-prover used to
+# ask the model, in ONE completion, for a full Handler + abstract InvBase +
+# a test contract asserting FIVE deep invariants (value-conservation,
+# no-depositor-loss, solvency-under-any-sequence, no-free-value-extraction,
+# share-price-monotonicity). On a realistically-sized contract that single
+# generation is too large to return within the LLM timeout, so the engine
+# degraded to HARNESS_ERROR (no verdict). The fix bounds the ask to ONE
+# lens-driven invariant + a MINIMAL handler under an explicit ~120-line
+# budget, which returns reliably and compiles.
+#
+# This test pins that bounded ask in `generate_test()` so it cannot silently
+# regress to the five-invariant enumeration. Pure grep/awk over the .ag
+# source — no agentis runtime, no LLM, no forge required. Auto-discovered
+# and run by tools/colony-lint.sh's `tools/test-*.sh` loop.
+#
+# Assertions over the `generate_test()` instruction text:
+#   (a) It does NOT enumerate the old five invariants (no
+#       "no-depositor-loss" / "solvency-under-any-sequence" /
+#       "share-price-monotonicity" enumeration in the instruction body).
+#   (b) It requests EXACTLY ONE deep invariant driven by the bug-class lens
+#       (an "EXACTLY ONE" + lens-driven phrasing).
+#   (c) It carries an explicit line budget ("under ~120 lines").
+#   (d) The hard constraints are still present: `pragma solidity ^0.8.20;`,
+#       no forge-std import, the StdInvariant `targetContracts()` ABI, and
+#       the "Output ONLY the Solidity source" / "no markdown fences"
+#       instruction.
+#
+# Usage: bash tools/test-invariant-prover-bounded-gen.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AG="$REPO_ROOT/dark-factory/auditor/agents/invariant-prover.ag"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$AG" ]; then
+    fail "ag exists" "$AG not found"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Extract only the `generate_test(...)` function body so the assertions
+# scope to the live-generation instruction and never to the doc comments,
+# the fork/compose seeds, or other agents. awk: from the `fn generate_test`
+# line through the next `\n}` at column 0 (the function close brace).
+gen_body="$(awk '/^fn generate_test\(/{f=1} f{print} f&&/^}/{exit}' "$AG")"
+
+if [ -z "$gen_body" ]; then
+    fail "generate_test body found" "no 'fn generate_test(...)' block in $AG"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# (a) The instruction must NOT enumerate the old five invariants. The
+# bounded ask names AT MOST one example per lens, never the full list.
+if printf '%s\n' "$gen_body" | grep -Eq 'no-depositor-loss|solvency-under-any-sequence'; then
+    fail "(a) no five-invariant enumeration in generate_test" \
+         "found the old enumeration (no-depositor-loss / solvency-under-any-sequence) in the instruction"
+else
+    pass "(a) generate_test no longer enumerates the old five invariants"
+fi
+
+# (b) It must request EXACTLY ONE deep invariant, driven by the bug-class
+# lens (the prompt already injects "=== BUG CLASS (lens) ===").
+if printf '%s\n' "$gen_body" | grep -Eq 'EXACTLY ONE' \
+   && printf '%s\n' "$gen_body" | grep -Eiq 'lens'; then
+    pass "(b) generate_test requests EXACTLY ONE lens-driven invariant"
+else
+    fail "(b) generate_test requests EXACTLY ONE lens-driven invariant" \
+         "missing an 'EXACTLY ONE' + lens-driven single-invariant ask"
+fi
+
+# (c) It must carry an explicit line budget.
+if printf '%s\n' "$gen_body" | grep -Eq 'under ~?120 lines'; then
+    pass "(c) generate_test carries an explicit ~120-line budget"
+else
+    fail "(c) generate_test carries an explicit ~120-line budget" \
+         "no 'under ~120 lines' size budget in the instruction"
+fi
+
+# (d) The hard constraints must survive the change.
+hd_fail=""
+printf '%s\n' "$gen_body" | grep -Fq 'pragma solidity ^0.8.20;' \
+    || hd_fail="${hd_fail} pragma-solidity"
+printf '%s\n' "$gen_body" | grep -Fq 'Do NOT import forge-std' \
+    || hd_fail="${hd_fail} no-forge-std"
+printf '%s\n' "$gen_body" | grep -Fq 'targetContracts()' \
+    || hd_fail="${hd_fail} targetContracts-ABI"
+printf '%s\n' "$gen_body" | grep -Fq 'Output ONLY the Solidity source' \
+    || hd_fail="${hd_fail} output-only-solidity"
+printf '%s\n' "$gen_body" | grep -Fq 'no markdown fences' \
+    || hd_fail="${hd_fail} no-markdown-fences"
+
+if [ -z "$hd_fail" ]; then
+    pass "(d) generate_test keeps all hard constraints (pragma, no forge-std, StdInvariant ABI, output-only)"
+else
+    fail "(d) generate_test keeps all hard constraints" \
+         "missing constraint(s):$hd_fail"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Fixes #1067. `dark-factory/auditor/agents/invariant-prover.ag` `generate_test()` asked the model, in ONE completion, for a `Handler` + abstract `InvBase` + a test with **five** deep invariants (value-conservation, no-depositor-loss, solvency, no-free-value-extraction, share-price-monotonicity). On a realistically-sized contract that single generation exceeds the LLM timeout, so the stateful-invariant engine degrades to `HARNESS_ERROR` (a non-verdict) instead of a sound `CLEAN`/`FINDING`.

This bounds the ask to:
- a **minimal Handler** (only the actions needed to exercise the invariant),
- **exactly one** deep invariant chosen by the bug-class lens (`klass`),
- an explicit **~120-line budget**.

Breadth comes from running the prover across multiple lenses (one focused invariant per run), not one mega-test.

## Unchanged (verified)

- Hard constraints: `pragma ^0.8.20`, no `forge-std`, `targetContracts()` StdInvariant ABI, plain `require(...)`, `<matchPrefix>_*` naming, output-only Solidity.
- FM1/FM2 `fork_seed` / `compose_seed` are **byte-identical** (empty-when-inactive prompt unchanged).

## Test plan

- New deterministic regression guard `tools/test-invariant-prover-bounded-gen.sh` (grep/awk over the `.ag`, no LLM): asserts a single lens-driven invariant + line budget + surviving hard constraints; passes post-fix (4/4), fails 3/4 on a pre-fix copy.
- `./tools/colony-lint.sh` → `368 passed, 0 failed, 5 skipped`.
- Independent QA: ✅ ship-it (instruction correctness, single lens invariant, no FM1/FM2 regression, guard quality, lint, CHANGELOG all clean).

Scope is part 1 of the issue only; the `claude -p` completion-flag idea is N/A (the backend is `flat-cyborg`, interactive claude).
