### PR TITLE
fix(dark-factory): isolate generated-harness compile from the target's own tests (#1069)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -86,6 +86,13 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   (comment-only, no behavior change).
 
 ### Fixed
+- **`forge-invariant.sh` degraded a self-contained harness to HARNESS_ERROR when the TARGET project's own
+  tests don't compile** (#1069). `forge test` compiles the whole project, so a real-world target whose own
+  `*.t.sol` fail under our forge/solc (e.g. a `view` function the compiler now rejects as state-modifying —
+  solc drift) blocked even a fully self-contained generated harness, producing a non-verdict for a reason
+  unrelated to our harness or the target's source. The gate now `--skip`s every other `*.sol` under the
+  target's `test/` dir from compilation, keeping only the harness + `src`; targets whose tests compile
+  cleanly are unaffected. Regression guard: `tools/test-forge-invariant-harness-isolation.sh`.
 - **`invariant-prover.ag` `generate_test()` degraded to HARNESS_ERROR on realistically-sized targets**
   (#1067). The live-generation ask asked the model, in ONE completion, for a full `Handler` + abstract
   `InvBase` + a test contract asserting FIVE deep invariants (value-conservation, no-depositor-loss,

--- a/dark-factory/evm-harness/forge-invariant.sh
+++ b/dark-factory/evm-harness/forge-invariant.sh
@@ -109,7 +109,27 @@ echo "== forge-invariant: stateful-fuzzing $(basename "$TARGET_PATH") (invariant
 # invariant_* functions. A finite seed makes the run reproducible (the demo pins it). forge has no CLI flag
 # for invariant runs/depth — those are tuned via the FOUNDRY_INVARIANT_RUNS / FOUNDRY_INVARIANT_DEPTH env
 # vars (exported below), which override the project's [invariant] config; left to it when unset.
-ARGS=(test --match-path "$TARGET_PATH" --match-test "$MATCH" --json)
+# HARNESS ISOLATION (#1069): `forge test` compiles the WHOLE project, including the target's OWN
+# `*.t.sol` files. A real-world target whose own tests do not compile under our forge/solc (e.g. a
+# function declared `view` that the compiler now rejects as state-modifying — solc drift in the
+# target's tests) would block even a fully self-contained generated harness, degrading a real run to
+# HARNESS_ERROR for a reason unrelated to our harness or the target's source. So we --skip every OTHER
+# `*.sol` under the target's test dir from COMPILATION, keeping only this harness + `src`. The harness
+# is self-contained by construction, so this is sound. (forge --skip is Rust-regex with no lookahead,
+# hence enumerate-and-skip-each rather than one "all-but-harness" pattern; each path is its own array
+# element so no value can mangle a flag.) Targets whose tests compile cleanly are unaffected — skipping
+# files that would have compiled is a no-op for this single-harness run.
+SKIP_ARGS=()
+_harness_abs="$(cd "$(dirname "$TARGET_PATH")" 2>/dev/null && pwd)/$(basename "$TARGET_PATH")"
+if [ -d "$REPO/test" ]; then
+  while IFS= read -r _tf; do
+    [ -n "$_tf" ] || continue
+    [ "$(cd "$(dirname "$_tf")" && pwd)/$(basename "$_tf")" = "$_harness_abs" ] && continue
+    SKIP_ARGS+=(--skip "${_tf#"$REPO"/}")
+  done < <(find "$REPO/test" -type f -name '*.sol' 2>/dev/null)
+fi
+
+ARGS=(test --match-path "$TARGET_PATH" --match-test "$MATCH" --json "${SKIP_ARGS[@]}")
 [ -n "$SEED" ] && ARGS+=(--fuzz-seed "$SEED")
 [ -n "$RUNS" ]  && export FOUNDRY_INVARIANT_RUNS="$RUNS"
 [ -n "$DEPTH" ] && export FOUNDRY_INVARIANT_DEPTH="$DEPTH"

--- a/dark-factory/evm-harness/forge-invariant.sh
+++ b/dark-factory/evm-harness/forge-invariant.sh
@@ -129,7 +129,10 @@ if [ -d "$REPO/test" ]; then
   done < <(find "$REPO/test" -type f -name '*.sol' 2>/dev/null)
 fi
 
-ARGS=(test --match-path "$TARGET_PATH" --match-test "$MATCH" --json "${SKIP_ARGS[@]}")
+# `${SKIP_ARGS[@]+"..."}` (not a bare `"${SKIP_ARGS[@]}"`): under `set -u`, expanding an EMPTY array
+# the bare way is an unbound-variable error on bash < 4.4 (stock macOS bash 3.2) — a target with no
+# OTHER test files leaves SKIP_ARGS empty. The `+` alternate form expands to nothing when empty, safely.
+ARGS=(test --match-path "$TARGET_PATH" --match-test "$MATCH" --json ${SKIP_ARGS[@]+"${SKIP_ARGS[@]}"})
 [ -n "$SEED" ] && ARGS+=(--fuzz-seed "$SEED")
 [ -n "$RUNS" ]  && export FOUNDRY_INVARIANT_RUNS="$RUNS"
 [ -n "$DEPTH" ] && export FOUNDRY_INVARIANT_DEPTH="$DEPTH"

--- a/tools/test-forge-invariant-harness-isolation.sh
+++ b/tools/test-forge-invariant-harness-isolation.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Regression guard for #1069: forge-invariant.sh must compile the generated harness in ISOLATION from
+# the target project's OWN test files, so a target whose own *.t.sol do not compile (solc drift) cannot
+# degrade a self-contained harness to a false HARNESS_ERROR. Deterministic (grep over the script; no
+# forge, no LLM). Asserts the --skip-other-tests logic is present and wired into the forge args.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+FI="$HERE/../dark-factory/evm-harness/forge-invariant.sh"
+fail=0
+pass()  { printf '  ok   %s\n' "$1"; }
+bad()   { printf '  FAIL %s\n' "$1"; fail=1; }
+check() { if grep -qE "$1" "$FI"; then pass "$2"; else bad "$2"; fi; }
+
+[ -f "$FI" ] || { echo "forge-invariant.sh not found at $FI"; exit 1; }
+
+check 'SKIP_ARGS=\(\)'           "SKIP_ARGS array declared"
+check 'find .*REPO/test'         "enumerates the target test dir"
+check 'harness_abs'              "excludes the harness from the skip set"
+check 'SKIP_ARGS\+=\(--skip'     "appends --skip per other test file"
+check 'ARGS=\(test .*SKIP_ARGS'  "SKIP_ARGS wired into the forge ARGS"
+
+if [ "$fail" -eq 0 ]; then
+  echo "test-forge-invariant-harness-isolation: all assertions passed"; exit 0
+else
+  echo "test-forge-invariant-harness-isolation: FAILED"; exit 1
+fi


### PR DESCRIPTION
## What

Fixes #1069. `evm-harness/forge-invariant.sh` runs `forge test --match-path <harness>`, but `--match-path` only scopes which tests **run** — forge still **compiles the whole project, including the target's own `*.t.sol`**. A real-world target whose own tests don't compile under our forge/solc (e.g. a function declared `view` that the compiler now rejects as state-modifying — solc drift in the target's tests) blocked even a fully self-contained generated harness, degrading a real run to `HARNESS_ERROR` for a reason unrelated to our harness or the target's source.

## Fix

Before building the forge args, enumerate every other `*.sol` under the target's `test/` dir and `--skip` them from compilation — keeping only the generated harness + `src`. The harness is self-contained by construction, so this is sound. `forge --skip` is Rust-regex (no lookahead), so it enumerates-and-skips-each rather than one "all-but-harness" pattern; each path is its own array element so no value can mangle a flag. Targets whose tests compile cleanly are unaffected.

## Test plan

- New deterministic guard `tools/test-forge-invariant-harness-isolation.sh` (grep, no forge/LLM): asserts the skip-other-tests logic is present and wired into the forge ARGS. shellcheck-clean.
- `./tools/colony-lint.sh` — 0 failures.
- **Live-verified**: a self-contained harness that previously `HARNESS_ERROR`'d on a real ERC4626 vault target (whose own `*.t.sol` fail to compile) now compiles in isolation, fuzzes, and yields a real verdict (`FINDING` with a shrunk witness).

Related: epic #1041. Sibling of #1070 (prover drives the real target).
