### PR TITLE
fix(dark-factory): invariant-prover drives the REAL target, not a mock (#1070-B1)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,24 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Fixed
+- **invariant-prover drives the REAL target, not a mock** (#1070-B1, epic #1041). The live-path generation
+  instruction in `auditor/agents/invariant-prover.ag` (`generate_test()`) used to tell the model: import the
+  target "if the project ships it there; otherwise inline a minimal copy." On a realistically-sized target the
+  model frequently inlined a MOCK of the unit under test and fuzzed the mock, so the FUZZER's verdict was about
+  fake code, not the real contract. The bullet is now a STRONG real-target directive — IMPORT and DEPLOY the
+  REAL contract under test; a minimal mock of an EXTERNAL dependency (an ERC20 asset, an oracle) is fine, but
+  the unit under test MUST be the real imported contract — plus `setUp()` deploy guidance for both a normal
+  `constructor(args)` and an OpenZeppelin **upgradeable** contract (an `ERC1967Proxy` +
+  `abi.encodeCall(<Target>.initialize, ...)` recipe for the `_disableInitializers()` case). The agent also
+  computes the exact relative import path (`CODE_PATH` relative to `dirname(INV_OUT)` via
+  `realpath --relative-to`) and injects it as an `import {<Name>} from "<RELPATH>";` line so the model wires
+  the import correctly; when no target source is supplied the import-path line is skipped (today's behaviour).
+  The #1067 bounding is preserved unchanged — EXACTLY ONE lens-driven invariant + a minimal handler under the
+  `~120-line` budget (the real-deploy `setUp()` now counts toward that budget). A new deterministic guard,
+  `tools/test-invariant-prover-real-target.sh`, pins the real-target directive + the proxy recipe + the
+  import-path injection (grep over the `.ag`, no LLM). The compile-repair loop is a separate follow-up.
+
 ### Added
 - `submit-triage.sh` — the **human-gated submission triage** layer (#1056, epic #1053). Scans a staging
   root for the verified-FINDING packages `run-audit.sh` / `run-batch.sh` drop under

--- a/dark-factory/auditor/agents/invariant-prover.ag
+++ b/dark-factory/auditor/agents/invariant-prover.ag
@@ -95,7 +95,53 @@ fn match_prefix(raw: string) -> string {
 }
 let invMatch = match_prefix(getenv("INV_MATCH"));
 let fixturePath = getenv("HANDLER_FIXTURE");
-let code = cat_file(getenv("CODE_PATH"));
+let codePath = getenv("CODE_PATH");
+let code = cat_file(codePath);
+
+// #1070-B1 — drive the REAL target. The generated test is written to INV_OUT (under <repo>/test/...) and the
+// target source is CODE_PATH; the model needs the CORRECT relative import path so it can `import` and DEPLOY
+// the real contract instead of inlining a meaningless MOCK of it. Two facts feed the import directive:
+//   targetName  — the contract NAME the caller filed the target under (the `*.sol:Name` label in TARGET_FN,
+//                 the part after the `:`). Empty when only the FILE is known (no `:Name`) — then the
+//                 instruction tells the model to import the contract it sees DECLARED in the source below.
+//   relImport   — CODE_PATH made relative to dirname(INV_OUT), computed in the sandbox with
+//                 `realpath --relative-to` (both are absolute paths the colony staged into the rundir). Empty
+//                 when CODE_PATH is empty (no target source) -> the import-path line is skipped (today's path).
+// Both values are UNTRUSTED operator input; they flow ONLY into the plain-string generation prompt below,
+// never into a verdict and (relImport apart, which is read back from a shell_escape()d exec) never into a
+// shell as an unescaped concat.
+fn target_name(label: string) -> string {
+    let c = index_of(label, ":");
+    if c < 0 { return ""; }
+    return substring(label, c + 1, len(label));
+}
+let targetName = target_name(targetFn);
+// The NAME used in the DEPLOY guidance template. When the caller's label carries no `:Name` we fall back to
+// the `<Target>` placeholder so the `new <Target>(args)` / proxy-deploy template stays readable (the model
+// substitutes the declared contract name it reads from the source below).
+fn deploy_name(name: string) -> string {
+    if len(name) == 0 { return "<Target>"; }
+    return name;
+}
+let deployName = deploy_name(targetName);
+fn rel_import_path(out: string, src: string) -> string {
+    if len(src) == 0 { return ""; }
+    if len(out) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    return exec sh "realpath --relative-to \"$(dirname " + shell_escape(out) + ")\" " + shell_escape(src) + " 2>/dev/null | tr -d '\\n' || true";
+}
+let relImport = rel_import_path(invOut, codePath);
+// The import-path injection line the model reads. When the NAME is known we name it explicitly; when only the
+// file is known we point the model at the contract it sees DECLARED in the source. Empty when there is no
+// target source to import (relImport == "") -> today's behaviour (no import-path line).
+fn import_line(name: string, rel: string) -> string {
+    if len(rel) == 0 { return ""; }
+    if len(name) > 0 {
+        return "  - Import the target with: import {" + name + "} from \"" + rel + "\";\n";
+    }
+    return "  - Import the target from \"" + rel + "\" — import the contract you see DECLARED in the source below.\n";
+}
+let importLine = import_line(targetName, relImport);
 
 // FM1 (#1041) — FORK MODE. When FORK_TARGET (and/or FORK_URL) is non-empty, the target is a LIVE DEPLOYED
 // contract at FORK_TARGET on a forked chain (run-invariant-hunt.sh threads --fork-url/--fork-block-number into
@@ -221,7 +267,7 @@ fn compose_seed(active: bool, ctx: string) -> string {
          + "manipulate-price-on-dex -> extract-from-target -> restore -> repay SEQUENCE that single-contract "
          + "fuzzing cannot reach.\n";
 }
-fn generate_test(klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string) -> string {
+fn generate_test(klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string, deployName: string, importLine: string) -> string {
     let instruction =
         recall_seed(klass, prior)
       + fork_seed(forkActive, forkTarget, forkUrl, forkBlock)
@@ -230,8 +276,18 @@ fn generate_test(klass: string, src: string, matchPrefix: string, prior: string,
       + "test (Solidity, `pragma solidity ^0.8.20;`) for the target contract below so Foundry's invariant "
       + "fuzzer can drive randomized multi-call SEQUENCES through it and find a MULTI-STEP exploit. "
       + "Requirements:\n"
-      + "  - Import the target from `../src/...` if the project ships it there; otherwise inline a minimal "
-      + "copy. Do NOT import forge-std — this test must compile with ZERO library remappings.\n"
+      + "  - IMPORT and DEPLOY the REAL target contract under test (the contract whose source is shown below) "
+      + "— do NOT inline a mock copy of it. A minimal mock of an EXTERNAL dependency it needs (e.g. an ERC20 "
+      + "asset/token, an oracle) is fine, but the unit under test MUST be the real imported contract, so the "
+      + "verdict is about real code. Do NOT import forge-std — this test must compile with ZERO library "
+      + "remappings.\n"
+      + importLine
+      + "  - In `setUp()` deploy the real target. For a normal `constructor(args)`: `new " + deployName + "(args)`. "
+      + "For an OpenZeppelin **upgradeable** contract whose constructor calls `_disableInitializers()`: deploy "
+      + "behind a proxy — add `import {ERC1967Proxy} from \"@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol\";` "
+      + "and `" + deployName + " t = " + deployName + "(address(new ERC1967Proxy(address(new " + deployName
+      + "()), abi.encodeCall(" + deployName + ".initialize, (<args>)))));`. Read the target's "
+      + "constructor/initializer signature from the source below to wire the arguments correctly.\n"
       + "  - A `Handler` contract whose PUBLIC functions are the protocol's actions as a real attacker/user "
       + "would call them (deposit, withdraw, donate, borrow, ...), each taking fuzzed `uint` inputs you BOUND "
       + "to realistic ranges with a private `_bound(x, lo, hi)` helper (NO forge-std `bound`). Track the "
@@ -246,7 +302,8 @@ fn generate_test(klass: string, src: string, matchPrefix: string, prior: string,
       + "share-price monotonicity for a vault lens), do NOT enumerate every property. Expose in the Handler "
       + "ONLY the core state-changing actions needed to exercise THAT one invariant — not every protocol action. "
       + "The invariant must catch a bug that only a SEQUENCE of calls can produce, not a single call. "
-      + "Keep the entire test under ~120 lines; do not exceed it.\n\n"
+      + "Keep the entire test under ~120 lines; do not exceed it — the real-deploy `setUp()` counts toward "
+      + "that budget, so keep the import/deploy minimal and stay bounded.\n\n"
       + "=== BUG CLASS (lens) ===\n" + klass + "\n\n"
       + "=== HOW TO ANSWER ===\n"
       + "Output ONLY the Solidity source of the `*.t.sol` test — no markdown fences, no prose before or "
@@ -258,11 +315,11 @@ fn generate_test(klass: string, src: string, matchPrefix: string, prior: string,
 // Single-assignment .ag: pick the test source ONCE (no `let` reassignment). A non-empty HANDLER_FIXTURE wins
 // (offline/deterministic, verbatim, no LLM); otherwise the LLM generates it (live path).
 let usedFixture = len(fixture) > 0;
-fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string) -> string {
+fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string, deployName: string, importLine: string) -> string {
     if usedFix { return fix; }
-    return generate_test(klass, src, matchPrefix, prior, forkActive, forkTarget, forkUrl, forkBlock, composeActive, forkContext);
+    return generate_test(klass, src, matchPrefix, prior, forkActive, forkTarget, forkUrl, forkBlock, composeActive, forkContext, deployName, importLine);
 }
-let test = choose_test(usedFixture, fixture, targetClass, code, invMatch, prior, forkMode, forkTarget, forkUrl, forkBlock, composableMode, forkContext);
+let test = choose_test(usedFixture, fixture, targetClass, code, invMatch, prior, forkMode, forkTarget, forkUrl, forkBlock, composableMode, forkContext, deployName, importLine);
 
 // Write the generated/fixture test to INV_OUT (inside INV_REPO/test) so forge-invariant can run it. The test
 // content is UNTRUSTED — it is either an LLM completion (prompt-injectable by the untrusted target code under

--- a/tools/test-invariant-prover-real-target.sh
+++ b/tools/test-invariant-prover-real-target.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# tools/test-invariant-prover-real-target.sh -- deterministic regression
+# guard for #1070-B1 (dark-factory). The dark-factory invariant-prover used
+# to tell the model: "Import the target from `../src/...` if the project
+# ships it there; otherwise inline a minimal copy." On a realistically-sized
+# target the model frequently inlined a MOCK of the unit under test and
+# fuzzed the mock, so the FUZZER's verdict was about fake code, not the real
+# contract. The fix turns that bullet into a STRONG real-target directive
+# (IMPORT and DEPLOY the REAL contract; a mock of an EXTERNAL dependency is
+# fine, the unit under test must be the real imported contract), adds an
+# ERC1967Proxy upgradeable-deploy recipe, and INJECTS the exact relative
+# import path (CODE_PATH relative to dirname(INV_OUT), via
+# `realpath --relative-to`) so the model can wire the import correctly.
+#
+# This test pins that real-target directive so it cannot silently regress to
+# the import-or-inline-a-mock phrasing. Pure grep/awk over the .ag source —
+# no agentis runtime, no LLM, no forge required. Auto-discovered and run by
+# tools/colony-lint.sh's `tools/test-*.sh` loop.
+#
+# Assertions:
+#   (a) The `generate_test()` instruction now DIRECTS importing + deploying
+#       the REAL target ("IMPORT and DEPLOY the REAL target" + "do NOT inline
+#       a mock copy of it").
+#   (b) The `generate_test()` instruction no longer tells the model to
+#       "inline a minimal copy" of the target (the old import-or-inline
+#       bullet is gone).
+#   (c) The ERC1967Proxy upgradeable-deploy guidance is present (the proxy
+#       import + `_disableInitializers` recipe).
+#   (d) The import-path injection is present: the `realpath --relative-to`
+#       computation in the agent AND the injected `import {<Name>} from
+#       "<RELPATH>"` instruction line.
+#
+# Usage: bash tools/test-invariant-prover-real-target.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AG="$REPO_ROOT/dark-factory/auditor/agents/invariant-prover.ag"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$AG" ]; then
+    fail "ag exists" "$AG not found"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Extract only the `generate_test(...)` function body so the import/deploy
+# directive assertions scope to the live-generation instruction and never to
+# the doc comments or other agents. awk: from the `fn generate_test` line
+# through the next `\n}` at column 0 (the function close brace).
+gen_body="$(awk '/^fn generate_test\(/{f=1} f{print} f&&/^}/{exit}' "$AG")"
+
+if [ -z "$gen_body" ]; then
+    fail "generate_test body found" "no 'fn generate_test(...)' block in $AG"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# (a) The instruction must DIRECT importing + deploying the REAL target.
+if printf '%s\n' "$gen_body" | grep -Fq 'IMPORT and DEPLOY the REAL target' \
+   && printf '%s\n' "$gen_body" | grep -Fq 'do NOT inline a mock copy of it'; then
+    pass "(a) generate_test directs importing + deploying the REAL target"
+else
+    fail "(a) generate_test directs importing + deploying the REAL target" \
+         "missing the 'IMPORT and DEPLOY the REAL target' + 'do NOT inline a mock copy of it' directive"
+fi
+
+# (b) The old import-or-inline-a-mock bullet must be GONE: the model must not
+# be told it may "inline a minimal copy" of the target.
+if printf '%s\n' "$gen_body" | grep -Fq 'otherwise inline a minimal'; then
+    fail "(b) generate_test no longer offers the inline-a-mock fallback" \
+         "found the old 'otherwise inline a minimal copy' directive in the instruction"
+else
+    pass "(b) generate_test no longer offers the inline-a-mock fallback"
+fi
+
+# (c) The ERC1967Proxy upgradeable-deploy guidance must be present.
+if printf '%s\n' "$gen_body" | grep -Fq 'ERC1967Proxy' \
+   && printf '%s\n' "$gen_body" | grep -Fq '_disableInitializers'; then
+    pass "(c) generate_test carries the ERC1967Proxy upgradeable-deploy guidance"
+else
+    fail "(c) generate_test carries the ERC1967Proxy upgradeable-deploy guidance" \
+         "missing the ERC1967Proxy proxy-deploy recipe for _disableInitializers upgradeable targets"
+fi
+
+# (d) The import-path injection must be present: both the `realpath
+# --relative-to` computation in the agent (CODE_PATH relative to
+# dirname(INV_OUT)) and the injected `import {<Name>} from "<RELPATH>"` line.
+ip_fail=""
+grep -Fq 'realpath --relative-to' "$AG" \
+    || ip_fail="${ip_fail} relpath-compute"
+grep -Fq 'Import the target with: import {' "$AG" \
+    || ip_fail="${ip_fail} import-path-line"
+
+if [ -z "$ip_fail" ]; then
+    pass "(d) generate_test injects the computed relative import path"
+else
+    fail "(d) generate_test injects the computed relative import path" \
+         "missing import-path piece(s):$ip_fail"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Closes #1070 (part B1 — the real-target capability; B2 compile-repair is tracked as a follow-up). `invariant-prover.ag` `generate_test()` told the model to import the target *"if the project ships it there; otherwise inline a minimal copy."* On real targets the model inlined a **mock** of the unit-under-test and fuzzed that, so a CLEAN/FINDING verdict meant nothing for the real code.

B1 makes the prover **import + deploy the REAL target**:
- Strong directive: do NOT inline a mock of the unit-under-test (a mock for an external dependency like an ERC20 asset is fine).
- Deploy guidance: plain `new T(args)`, and the OpenZeppelin upgradeable proxy recipe (`new ERC1967Proxy(address(new T()), abi.encodeCall(T.initialize, (...)))`) for contracts whose constructor calls `_disableInitializers()`.
- Computes + injects the exact relative import path (`realpath --relative-to` from the harness dir to `CODE_PATH`) and the target name (from the `*.sol:Name` label).

## Preserved
#1067 bounding (one lens-driven invariant + minimal handler + ~120-line budget), all hard constraints (no forge-std, `targetContracts()` ABI, plain `require`, `<matchPrefix>_*` naming, output-only), the FM1/FM2 `fork_seed`/`compose_seed` (byte-identical), and the offline `HANDLER_FIXTURE` path.

## Test plan
- New deterministic guard `tools/test-invariant-prover-real-target.sh` (grep, no LLM): real-target directive present, old "inline a minimal copy" gone, ERC1967Proxy recipe present, import-path injection present. Passes 4/4 post-change, fails 4/4 pre-change. shellcheck-clean. The #1067 guard still passes.
- `./tools/colony-lint.sh` → `370 passed, 0 failed, 5 skipped`.
- **Verified END-TO-END**: the factory (flat-cyborg flat-rate backend + #1069 harness isolation) generated a harness that **imports + deploys the real `dreUSDs` ERC4626 vault via `ERC1967Proxy`**, drives deposit/withdraw/redeem/donate sequences with a `no-depositor-loss` invariant, and the fuzzer returned a real **CLEAN** verdict over a 256×32 budget — no inlined mock, compiled on the first generation.

Related: epic #1041; built on #1069 (harness isolation).
