### PR TITLE
feat(dark-factory): bounded compile-repair loop for generated harnesses (#1073)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -31,6 +31,25 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   `~120-line` budget (the real-deploy `setUp()` now counts toward that budget). A new deterministic guard,
   `tools/test-invariant-prover-real-target.sh`, pins the real-target directive + the proxy recipe + the
   import-path injection (grep over the `.ag`, no LLM). The compile-repair loop is a separate follow-up.
+- **invariant-prover bounded compile-repair loop** (#1073, epic #1041). With #1069 harness-isolation, a
+  `HARNESS_ERROR` (forge exit code not in {0,1}) on the **LLM-generated** path means OUR generated handler
+  failed to compile / matched no `invariant_*` — a recoverable fault, not the target's other tests. The prover
+  used to do ONE shot (generate → write to `INV_OUT` → run `forge-invariant.sh` → map the exit code to a
+  verdict), so a single bad first generation wasted the whole run. `auditor/agents/invariant-prover.ag` now
+  runs a BOUNDED compile-repair loop: on a `HARNESS_ERROR` it extracts a capped compiler-error excerpt from
+  forge's output, feeds it back to the model with the prior test source (a `repair_instruction()` reasserting
+  the same hard constraints — `pragma ^0.8.20`, no forge-std, `targetContracts()`, plain `require()`,
+  `<matchPrefix>_*` naming, import+deploy the REAL target, output-only), writes the repaired source through the
+  SAME `shell_escape()`d `printf` mechanism (never a heredoc — the test is untrusted), and re-runs the gate.
+  The loop is a bounded recursion (single-assignment `.ag` has no `while`/`for`) carrying the
+  `(stopped, testSrc, runOut)` state, with the round count from `getenv("INV_REPAIR_ROUNDS")` (default **2** —
+  so ≤3 total attempts — on unset/empty/non-numeric; `0` disables repair = today's one-shot). It STOPS the
+  moment the gate returns a real verdict (`FINDING`/`CLEAN`), and the verbatim `HANDLER_FIXTURE` path is NEVER
+  LLM-repaired (the fold is seeded already-stopped when `usedFixture`). The FINAL emitted verdict, the
+  `learn()`/experience outcome, and the `INVARIANT|<file:fn>|<token>` line stay the gate's exit code on the
+  LAST attempt — never the LLM's opinion (unchanged contract). `run-invariant-hunt.sh` gains a
+  `--repair-rounds N` flag that threads `INV_REPAIR_ROUNDS` through. A new deterministic guard,
+  `tools/test-invariant-prover-repair-loop.sh`, pins the loop (grep over the `.ag`, no LLM/forge).
 
 ### Added
 - `submit-triage.sh` — the **human-gated submission triage** layer (#1056, epic #1053). Scans a staging

--- a/dark-factory/auditor/agents/invariant-prover.ag
+++ b/dark-factory/auditor/agents/invariant-prover.ag
@@ -312,8 +312,9 @@ fn generate_test(klass: string, src: string, matchPrefix: string, prior: string,
     return prompt(instruction, src) -> string;
 }
 
-// Single-assignment .ag: pick the test source ONCE (no `let` reassignment). A non-empty HANDLER_FIXTURE wins
-// (offline/deterministic, verbatim, no LLM); otherwise the LLM generates it (live path).
+// Single-assignment .ag: pick the FIRST test source ONCE (no `let` reassignment). A non-empty HANDLER_FIXTURE
+// wins (offline/deterministic, verbatim, no LLM); otherwise the LLM generates it (live path). On the live path
+// this is only the FIRST attempt — the bounded compile-repair loop below may regenerate it (#1073).
 let usedFixture = len(fixture) > 0;
 fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string, deployName: string, importLine: string) -> string {
     if usedFix { return fix; }
@@ -321,19 +322,11 @@ fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPref
 }
 let test = choose_test(usedFixture, fixture, targetClass, code, invMatch, prior, forkMode, forkTarget, forkUrl, forkBlock, composableMode, forkContext, deployName, importLine);
 
-// Write the generated/fixture test to INV_OUT (inside INV_REPO/test) so forge-invariant can run it. The test
-// content is UNTRUSTED — it is either an LLM completion (prompt-injectable by the untrusted target code under
-// audit) or an operator fixture — so it MUST go through shell_escape(), never a heredoc (a heredoc body is
-// not escaped: a test line equal to the sentinel would terminate it early and the rest would execute as
-// shell). printf '%s' on a shell_escape()d single-quoted literal cannot be escaped by any content (no shell
-// metachar survives single-quoting), so the test is written verbatim with zero injection.
-let wrote = exec sh "printf '%s' " + shell_escape(test) + " > " + shell_escape(invOut) + "; echo __wrote=$?";
-
 // --- VERIFY with the stateful-fuzzing gate ------------------------------------------------------
-// Run evm-harness/forge-invariant.sh against the just-written test and capture its exit code via the
-// `__rc=$?` marker convention (auditor.ag). `set +e` so the gate's non-zero verdict exit (1/2) does not
-// abort the shell before the marker is printed. The verdict is THIS exit code — nothing else. Optional
-// runs/depth/seed are forwarded only when set, each as a shell_escape()d value.
+// The gate is evm-harness/forge-invariant.sh. We write the test to INV_OUT (inside INV_REPO/test) then run
+// the gate against it and capture its exit code via the `__rc=$?` marker convention (auditor.ag). `set +e` so
+// the gate's non-zero verdict exit (1/2) does not abort the shell before the marker is printed. The verdict is
+// THIS exit code — nothing else. Optional runs/depth/seed are forwarded only when set, each shell_escape()d.
 let gate = getenv("FORGE_INVARIANT");
 let runsArg = getenv("INV_RUNS");
 let depthArg = getenv("INV_DEPTH");
@@ -347,9 +340,143 @@ let budget = opt_flag("--runs", runsArg) + opt_flag("--depth", depthArg) + opt_f
 // opt_flag, exactly like runs/depth/seed). Empty fork facts => "" => the gate command is byte-identical to the
 // no-fork build. A fork RPC failure becomes the gate's HARNESS_ERROR (exit 2), never a false verdict.
 let fork = opt_flag("--fork-url", forkUrl) + opt_flag("--fork-block", forkBlock);
-// colony-lint: safe-exec-concat
-let runOut = exec sh "set +e; sh " + shell_escape(gate) + " --repo " + shell_escape(invRepo) + " --target " + shell_escape(invOut) + " --match " + shell_escape(invMatch) + budget + fork + " 2>&1; echo __rc=$?";
 
+// Write the generated/fixture test to INV_OUT. The test content is UNTRUSTED — it is either an LLM completion
+// (prompt-injectable by the untrusted target code under audit) or an operator fixture — so it MUST go through
+// shell_escape(), never a heredoc (a heredoc body is not escaped: a test line equal to the sentinel would
+// terminate it early and the rest would execute as shell). printf '%s' on a shell_escape()d single-quoted
+// literal cannot be escaped by any content (no shell metachar survives single-quoting), so the test is written
+// verbatim with zero injection. Wrapped in a fn so the repair loop below reuses the SAME write mechanism.
+fn write_test(src: string, out: string) -> string {
+    // colony-lint: safe-exec-concat
+    return exec sh "printf '%s' " + shell_escape(src) + " > " + shell_escape(out) + "; echo __wrote=$?";
+}
+// Run the gate over the just-written INV_OUT and capture its `__rc=<n>` marker. Wrapped in a fn so the repair
+// loop reuses the EXACT gate invocation (same flags, same shell_escape()ing) every attempt.
+fn run_gate(gateSh: string, repo: string, out: string, matchPrefix: string, budgetArgs: string, forkArgs: string) -> string {
+    // colony-lint: safe-exec-concat
+    return exec sh "set +e; sh " + shell_escape(gateSh) + " --repo " + shell_escape(repo) + " --target " + shell_escape(out) + " --match " + shell_escape(matchPrefix) + budgetArgs + forkArgs + " 2>&1; echo __rc=$?";
+}
+
+// --- BOUNDED COMPILE-REPAIR LOOP (#1073) --------------------------------------------------------
+// A single bad FIRST generation used to waste the whole run: with #1069 harness-isolation, a HARNESS_ERROR
+// (rc not in {0,1}) on the LLM path means OUR harness failed to compile / matched no invariant — a recoverable
+// fault, not the target's other tests. So on a HARNESS_ERROR we feed forge's compiler error back to the model
+// and regenerate, up to N EXTRA rounds. The loop runs ONLY on the LLM-generated path; the verbatim
+// HANDLER_FIXTURE path is NEVER LLM-repaired (an operator fixture is authoritative). The FINAL verdict stays
+// the gate's exit code on the LAST attempt — the LLM never decides it (unchanged contract).
+//
+// BOUND. INV_REPAIR_ROUNDS = number of EXTRA repair rounds, default 2 (so <=3 total attempts). 0 disables
+// repair (one shot — today's behaviour). Non-numeric / unset / empty => the default.
+fn repair_rounds(raw: string) -> int {
+    if len(raw) == 0 { return 2; }
+    if len(regex_find_all("[^0-9]", raw)) > 0 { return 2; }
+    return parse_int(raw);
+}
+let repairRounds = repair_rounds(getenv("INV_REPAIR_ROUNDS"));
+
+// Extract a useful compiler-error excerpt from the gate's captured output (forge stderr). Keep only the lines
+// that carry diagnostic signal (Error / error[ / a `-->` source pointer / a Compiler banner) so the repair
+// prompt stays focused, then cap the whole excerpt to a few KB so it stays bounded (forge can emit very long
+// build logs). Untrusted: it flows ONLY into the plain-string repair prompt below, never into a shell.
+fn error_excerpt(out: string) -> string {
+    // colony-lint: safe-exec-concat
+    let filtered = exec sh "printf '%s' " + shell_escape(out) + " | grep -E 'Error|error\\[|[-][-]>|Compiler' | head -n 80 || true";
+    if len(filtered) > 4000 { return substring(filtered, 0, 4000); }
+    return filtered;
+}
+// The repair instruction: hand the model the compiler error + its PRIOR test source, with the SAME hard
+// constraints as the first generation (pragma ^0.8.20, no forge-std, targetContracts(), plain require(),
+// `<matchPrefix>_*` naming, import+deploy the REAL target, output-only). prevSrc/excerpt are derived from the
+// LLM completion + the untrusted target's forge output — they flow ONLY into this plain-string prompt, never
+// a shell.
+fn repair_instruction(excerpt: string, prevSrc: string, matchPrefix: string) -> string {
+    return "The Foundry invariant test you wrote did NOT compile (or matched no `invariant_*`). Compiler output:\n"
+         + excerpt
+         + "\nYour previous test was:\n"
+         + prevSrc
+         + "\nFix it and output ONLY the corrected Solidity — same constraints (pragma ^0.8.20, NO forge-std, "
+         + "targetContracts(), plain require(), `" + matchPrefix + "_*` naming, import+deploy the REAL target, "
+         + "output-only).";
+}
+fn repair_test(excerpt: string, prevSrc: string, matchPrefix: string) -> string {
+    // colony-lint: prompt-gate-ok
+    return prompt(repair_instruction(excerpt, prevSrc, matchPrefix), "") -> string;
+}
+
+// STATE ENCODING for the repair loop. One string of 3 NAMED fields joined by the 5-char sentinel `@@F@@` (it
+// cannot occur in Solidity source or forge output; the same convention coordinator.ag uses for its carried
+// reduce accumulator). Fields, in order:
+//   0 stopped  "1" once a FINDING/CLEAN verdict (rc in {0,1}) ended the loop — then a repair round is a no-op
+//              — else "0"
+//   1 testSrc  the CURRENT test source written to INV_OUT for the latest attempt
+//   2 runOut   the gate's captured output (`...__rc=<n>`) for the latest attempt
+fn rstate_field(s: string, n: int) -> string {
+    let segs = regex_split("@@F@@", s);
+    let acc = reduce(segs, |a: string, seg: string| -> string {
+        let bar = index_of(a, "\t");
+        let idx = parse_int(substring(a, 0, bar));
+        let cap = substring(a, bar + 1, len(a));
+        if idx == n { return to_string(idx + 1) + "\t" + seg; }
+        return to_string(idx + 1) + "\t" + cap;
+    }, "0\t");
+    return substring(acc, index_of(acc, "\t") + 1, len(acc));
+}
+fn rstate(stopped: string, testSrc: string, runOut: string) -> string {
+    return stopped + "@@F@@" + testSrc + "@@F@@" + runOut;
+}
+// Flip `stopped` to "1" iff the gate produced a TERMINAL verdict (rc 1 FINDING / rc 0 CLEAN); a HARNESS_ERROR
+// (any other rc) leaves it "0" so the loop keeps repairing.
+fn stop_flag(rc: int) -> string {
+    if rc == 1 { return "1"; }
+    if rc == 0 { return "1"; }
+    return "0";
+}
+// One repair round over the carried state. A no-op once stopped (a FINDING/CLEAN was already reached). Else the
+// PRIOR attempt was a HARNESS_ERROR: regenerate from its compiler-error excerpt + prior source, write the
+// repaired source through the SAME shell_escape()d printf mechanism, re-run the gate, and STOP if the new rc is
+// FINDING/CLEAN. matchPrefix + the gate-invocation pieces are carried in as params (the .ag pass-everything
+// convention) so the body needs no module globals.
+fn repair_step(acc: string, gateSh: string, repo: string, out: string, matchPrefix: string, budgetArgs: string, forkArgs: string) -> string {
+    if rstate_field(acc, 0) == "1" { return acc; }
+    let prevSrc = rstate_field(acc, 1);
+    let prevOut = rstate_field(acc, 2);
+    let excerpt = error_excerpt(prevOut);
+    let fixed = repair_test(excerpt, prevSrc, matchPrefix);
+    let _wr = write_test(fixed, out);
+    let newOut = run_gate(gateSh, repo, out, matchPrefix, budgetArgs, forkArgs);
+    return rstate(stop_flag(rc_of(newOut)), fixed, newOut);
+}
+// BOUNDED RECURSION (single-assignment .ag has no `while`/`for`): drive `repair_step` at most `remaining`
+// times, decrementing per round, threading the carried (stopped, testSrc, runOut) state through each call.
+// `remaining <= 0` is a true no-op (returns the state untouched), so INV_REPAIR_ROUNDS=0 — and the fixture
+// path, which seeds stopped="1" — make ZERO extra prompt()/gate calls. `repair_step` itself short-circuits
+// once stopped, so a FINDING/CLEAN ends the recursion early even with rounds left.
+fn repair_loop(acc: string, remaining: int, gateSh: string, repo: string, out: string, matchPrefix: string, budgetArgs: string, forkArgs: string) -> string {
+    if remaining <= 0 { return acc; }
+    if rstate_field(acc, 0) == "1" { return acc; }
+    let next = repair_step(acc, gateSh, repo, out, matchPrefix, budgetArgs, forkArgs);
+    return repair_loop(next, remaining - 1, gateSh, repo, out, matchPrefix, budgetArgs, forkArgs);
+}
+
+// FIRST attempt: write the chosen test + run the gate ONCE (today's one-shot — byte-identical for the fixture
+// path and for INV_REPAIR_ROUNDS=0). `firstStop` is "1" iff the first attempt already produced a verdict, so
+// the loop below makes zero extra prompt()/gate calls once a FINDING/CLEAN is in hand.
+let wrote = write_test(test, invOut);
+let firstOut = run_gate(gate, invRepo, invOut, invMatch, budget, fork);
+let firstStop = stop_flag(rc_of(firstOut));
+// Repair fires ONLY on the LLM path: the fixture path seeds the loop ALREADY-stopped (stopped="1") so it can
+// never be LLM-repaired, regardless of its rc. On the LLM path the initial stopped flag is firstStop, so a
+// FINDING/CLEAN first attempt short-circuits (no repair) and a HARNESS_ERROR first attempt enters repair.
+let initStopped = if usedFixture { "1" } else { firstStop };
+let initState = rstate(initStopped, test, firstOut);
+// Bounded compile-repair loop (#1073): at most `repairRounds` EXTRA rounds, each a no-op once stopped. The
+// carried per-attempt state is the (stopped, testSrc, runOut) triple. repairRounds==0 (the disable path) and
+// the fixture path both leave `finalState` == `initState` (today's one-shot behaviour).
+let finalState = repair_loop(initState, repairRounds, gate, invRepo, invOut, invMatch, budget, fork);
+
+// The verdict is the gate's exit code on the LAST attempt — NEVER the LLM's opinion (unchanged contract).
+let runOut = rstate_field(finalState, 2);
 let rc = rc_of(runOut);
 let verdict = verdict_of(rc);
 

--- a/dark-factory/run-invariant-hunt.sh
+++ b/dark-factory/run-invariant-hunt.sh
@@ -58,6 +58,13 @@
 #                        Absent any role beyond `target` => FM1 behaviour byte-identical. Optional; "" leaves it
 #                        to the test. A --fork-target does NOT require --fork-url (the context contracts may be
 #                        deployed locally by the test — composability is orthogonal to fork; the two COMPOSE).
+#   --repair-rounds N    #1073: number of EXTRA bounded compile-repair rounds the prover runs when its FIRST
+#                        LLM-generated test does NOT compile / matches no invariant (a HARNESS_ERROR on the LLM
+#                        path). On each round the prover feeds forge's compiler error back to the model and
+#                        regenerates, then re-runs the gate; it STOPS the moment the gate returns a verdict
+#                        (FINDING/CLEAN). Default 2 (so <=3 total attempts). 0 disables repair (one shot). The
+#                        verbatim HANDLER_FIXTURE path is NEVER repaired. Exported to the prover as
+#                        INV_REPAIR_ROUNDS; omitted => the prover's own default (2) applies.
 #   --out <dir>          Output dir for the run + report (default: ./invariant-out).
 #   --pattern-store <dir>  Int M3 (#1037): a PERSISTENT pattern-DAG store reused ACROSS runs. When set, the
 #                        winning-invariant patterns the prover PERSISTS on a FINDING (`invpat:*` memos) are
@@ -73,6 +80,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 AGENTIS="agentis"
 REPO="" ; TARGET="" ; CLASS="" ; FIXTURE="" ; CODE="" ; MATCH="invariant"
 BACKEND="flat-cyborg" ; MODEL="" ; RUNS="" ; DEPTH="" ; SEED="" ; OUT="$PWD/invariant-out" ; PATTERN_STORE=""
+REPAIR_ROUNDS=""  # #1073: extra compile-repair rounds; "" => the prover's own default (2)
 FORK_URL="" ; FORK_BLOCK="" ; FORK_TARGET=""
 # FM2 (#1041): the composability context set — one `--fork-target '<role>=<addr>'` per array slot. A bare
 # `--fork-target <addr>` (FM1 shorthand, no '=') is normalised to a `target=<addr>` slot below.
@@ -92,6 +100,7 @@ while [ $# -gt 0 ]; do
     --runs) need "$#"; RUNS="$2"; shift 2 ;;
     --depth) need "$#"; DEPTH="$2"; shift 2 ;;
     --seed) need "$#"; SEED="$2"; shift 2 ;;
+    --repair-rounds) need "$#"; REPAIR_ROUNDS="$2"; shift 2 ;;
     --fork-url) need "$#"; FORK_URL="$2"; shift 2 ;;
     --fork-block) need "$#"; FORK_BLOCK="$2"; shift 2 ;;
     --fork-target) need "$#"; FORK_TARGET_SPECS+=("$2"); shift 2 ;;
@@ -110,6 +119,9 @@ done
 for v in "$RUNS" "$DEPTH" "$SEED"; do
   case "$v" in '') ;; *[!0-9]*) echo "run-invariant-hunt.sh: --runs/--depth/--seed must be whole numbers" >&2; exit 2 ;; esac
 done
+# #1073: --repair-rounds must be a whole number when set (a non-numeric value would silently fall back to the
+# prover's default; reject it here so an operator typo surfaces).
+case "$REPAIR_ROUNDS" in '') ;; *[!0-9]*) echo "run-invariant-hunt.sh: --repair-rounds must be a whole number" >&2; exit 2 ;; esac
 # FM1 (#1041): fork-arg shape validation (mirrors the gate's). --fork-url must look like an http(s) URL,
 # --fork-block a whole number requiring --fork-url.
 case "$FORK_URL" in
@@ -211,7 +223,7 @@ fi
   # FM1 (#1041): FORK_URL/FORK_BLOCK thread the fork into the gate; FORK_TARGET is the deployed address the
   # generated handler/invariant references against the forked state. FM2 (#1041): FORK_CONTEXT carries the
   # role->address context set so the generation prompt can compose calls across the deployed protocols.
-  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT,FORK_URL,FORK_BLOCK,FORK_TARGET,FORK_CONTEXT"
+  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT,FORK_URL,FORK_BLOCK,FORK_TARGET,FORK_CONTEXT,INV_REPAIR_ROUNDS"
   # A forge invariant run (build + a few hundred fuzzed sequences) far exceeds the 10s default.
   echo "exec.default_timeout_ms = 600000"
   # Each verify is recorded as experience; invariant-prover fitness reweights over targets.
@@ -265,6 +277,7 @@ echo "run-invariant-hunt.sh: generating + stateful-fuzzing $TARGET ($CLASS) ..."
     INV_RUNS="$RUNS" \
     INV_DEPTH="$DEPTH" \
     INV_SEED="$SEED" \
+    INV_REPAIR_ROUNDS="$REPAIR_ROUNDS" \
     FORK_URL="$FORK_URL" \
     FORK_BLOCK="$FORK_BLOCK" \
     FORK_TARGET="$FORK_TARGET" \

--- a/tools/test-invariant-prover-repair-loop.sh
+++ b/tools/test-invariant-prover-repair-loop.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# tools/test-invariant-prover-repair-loop.sh -- deterministic regression
+# guard for #1073 (dark-factory). With #1069 harness-isolation, a
+# HARNESS_ERROR (forge exit code not in {0,1}) on the LLM-generated path means
+# OUR generated handler did NOT compile / matched no `invariant_*` -- a
+# recoverable fault, not the target's other tests. The prover used to do ONE
+# shot: generate -> write -> run the gate -> map the exit code to a verdict; a
+# single bad first generation wasted the whole run. #1073 adds a BOUNDED
+# compile-repair loop: on a HARNESS_ERROR the prover feeds forge's compiler
+# error back to the model and regenerates, up to N EXTRA rounds, stopping the
+# moment the gate returns a real verdict (FINDING/CLEAN). The verbatim
+# HANDLER_FIXTURE path is NEVER LLM-repaired, and the FINAL verdict stays the
+# gate's exit code on the LAST attempt -- never the LLM's opinion.
+#
+# This test pins that loop so it cannot silently regress to the one-shot
+# behaviour. Pure grep/awk over the .ag source -- no agentis runtime, no LLM,
+# no forge required. Auto-discovered and run by tools/colony-lint.sh's
+# `tools/test-*.sh` loop.
+#
+# Assertions:
+#   (a) A bounded repair loop exists, keyed on HARNESS_ERROR: there is a
+#       `repair_loop()` bounded by a decrementing `remaining` counter (no
+#       `while`/`for` in single-assignment .ag) whose round body
+#       (`repair_step()`) only fires while the carried `stopped` flag is "0"
+#       (i.e. the prior attempt was a HARNESS_ERROR, not a verdict).
+#   (b) The bound comes from INV_REPAIR_ROUNDS with a default: a
+#       `repair_rounds()` helper reads `getenv("INV_REPAIR_ROUNDS")` and
+#       returns the default 2 on empty/non-numeric input.
+#   (c) The repair re-`prompt()`s with the compiler error + the prior source:
+#       a `repair_instruction()` carries the "did NOT compile" framing, an
+#       `error_excerpt` of forge's output, and the prior test source, and
+#       `repair_test()` feeds it to `prompt()`.
+#   (d) FINDING/CLEAN short-circuit (no repair): `stop_flag()` flips the
+#       carried `stopped` to "1" on rc 1 (FINDING) or rc 0 (CLEAN), and both
+#       `repair_loop()` and `repair_step()` are no-ops once stopped.
+#   (e) The fixture path is excluded from repair: the loop seeds `stopped`
+#       to "1" when `usedFixture` (the operator fixture is authoritative and
+#       must never be LLM-repaired).
+#
+# Usage: bash tools/test-invariant-prover-repair-loop.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AG="$REPO_ROOT/dark-factory/auditor/agents/invariant-prover.ag"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$AG" ]; then
+    fail "ag exists" "$AG not found"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Whole-file source (the loop spans several top-level helpers + the driver).
+src="$(cat "$AG")"
+
+# (a) A bounded repair loop keyed on HARNESS_ERROR. The loop is a recursive
+# `repair_loop(...)` bounded by a decrementing `remaining` counter, and its
+# per-round body `repair_step(...)` only acts while the carried `stopped`
+# field is "0" (a prior HARNESS_ERROR). Assert the recursion, the
+# `remaining - 1` decrement, the `remaining <= 0` floor, and the
+# `rstate_field(acc, 0) == "1"` stop guard.
+a_fail=""
+printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+repair_loop\(' \
+    || a_fail="${a_fail} no-repair_loop"
+printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+repair_step\(' \
+    || a_fail="${a_fail} no-repair_step"
+printf '%s\n' "$src" | grep -Fq 'repair_loop(next, remaining - 1' \
+    || a_fail="${a_fail} no-bounded-recursion"
+printf '%s\n' "$src" | grep -Fq 'if remaining <= 0' \
+    || a_fail="${a_fail} no-remaining-floor"
+printf '%s\n' "$src" | grep -Fq 'rstate_field(acc, 0) == "1"' \
+    || a_fail="${a_fail} no-stop-guard"
+
+if [ -z "$a_fail" ]; then
+    pass "(a) a bounded repair loop exists, keyed on the HARNESS_ERROR (stopped=0) state"
+else
+    fail "(a) a bounded repair loop exists" \
+         "missing piece(s):$a_fail"
+fi
+
+# (b) The bound comes from INV_REPAIR_ROUNDS with a default. A
+# `repair_rounds()` helper reads getenv("INV_REPAIR_ROUNDS") and returns the
+# default 2 on empty/non-numeric input.
+b_fail=""
+printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+repair_rounds\(' \
+    || b_fail="${b_fail} no-repair_rounds"
+printf '%s\n' "$src" | grep -Fq 'getenv("INV_REPAIR_ROUNDS")' \
+    || b_fail="${b_fail} no-env-read"
+# The default must be 2 for BOTH the empty case and the non-numeric case.
+printf '%s\n' "$src" | grep -Fq 'if len(raw) == 0 { return 2; }' \
+    || b_fail="${b_fail} no-empty-default"
+printf '%s\n' "$src" | grep -Fq 'regex_find_all("[^0-9]", raw)' \
+    || b_fail="${b_fail} no-numeric-guard"
+
+if [ -z "$b_fail" ]; then
+    pass "(b) the repair bound comes from INV_REPAIR_ROUNDS with a default of 2"
+else
+    fail "(b) the repair bound comes from INV_REPAIR_ROUNDS with a default" \
+         "missing piece(s):$b_fail"
+fi
+
+# (c) The repair re-prompt()s with the compiler error + prior source. A
+# `repair_instruction()` carries the "did NOT compile" framing, an
+# `error_excerpt` of forge's output, and the prior source; `repair_test()`
+# feeds it to prompt().
+c_fail=""
+printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+repair_instruction\(' \
+    || c_fail="${c_fail} no-repair_instruction"
+printf '%s\n' "$src" | grep -Fq 'did NOT compile' \
+    || c_fail="${c_fail} no-compile-framing"
+printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+error_excerpt\(' \
+    || c_fail="${c_fail} no-error_excerpt"
+printf '%s\n' "$src" | grep -Fq 'Your previous test was:' \
+    || c_fail="${c_fail} no-prior-source"
+# repair_test() must route the repair instruction through prompt().
+awk '/^fn repair_test\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'prompt(repair_instruction(' \
+    || c_fail="${c_fail} no-repair-prompt"
+
+if [ -z "$c_fail" ]; then
+    pass "(c) the repair re-prompt()s with the compiler-error excerpt + the prior test source"
+else
+    fail "(c) the repair re-prompt()s with the compiler error + prior source" \
+         "missing piece(s):$c_fail"
+fi
+
+# (d) FINDING/CLEAN short-circuit (no repair). `stop_flag()` flips stopped to
+# "1" on rc 1 (FINDING) and rc 0 (CLEAN); both the loop and the step are
+# no-ops once stopped.
+d_fail=""
+printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+stop_flag\(' \
+    || d_fail="${d_fail} no-stop_flag"
+# stop_flag must map BOTH terminal exit codes to the stop state.
+awk '/^fn stop_flag\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'if rc == 1 { return "1"; }' \
+    || d_fail="${d_fail} no-finding-stop"
+awk '/^fn stop_flag\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'if rc == 0 { return "1"; }' \
+    || d_fail="${d_fail} no-clean-stop"
+# repair_step must short-circuit once stopped.
+awk '/^fn repair_step\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'if rstate_field(acc, 0) == "1" { return acc; }' \
+    || d_fail="${d_fail} no-step-shortcircuit"
+
+if [ -z "$d_fail" ]; then
+    pass "(d) a FINDING/CLEAN verdict short-circuits the loop (no repair after a real verdict)"
+else
+    fail "(d) a FINDING/CLEAN verdict short-circuits the loop" \
+         "missing piece(s):$d_fail"
+fi
+
+# (e) The fixture path is excluded from repair. The loop seeds the carried
+# `stopped` flag to "1" when `usedFixture`, so the operator fixture is never
+# LLM-repaired regardless of its exit code.
+if printf '%s\n' "$src" | grep -Fq 'let initStopped = if usedFixture { "1" } else { firstStop };'; then
+    pass "(e) the verbatim HANDLER_FIXTURE path is excluded from LLM repair (seeded stopped=1)"
+else
+    fail "(e) the verbatim HANDLER_FIXTURE path is excluded from repair" \
+         "no 'usedFixture -> stopped=1' seed found; an operator fixture could be LLM-repaired"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Closes #1073. Adds a **bounded compile-repair loop** to `invariant-prover.ag`. With #1069 harness-isolation merged, a `HARNESS_ERROR` on the LLM-generated path means OUR harness failed to compile / matched no `invariant_*` (the target's own tests are `--skip`ped). Previously one bad first generation wasted the whole run; now the prover feeds the compiler error back and regenerates.

## Behavior
- On `HARNESS_ERROR`: extract a forge compiler-error excerpt from the gate output, `prompt()` a repair (error + previous test source), rewrite `INV_OUT`, re-run the gate.
- Bound: `INV_REPAIR_ROUNDS` extra rounds, **default 2** (≤3 total). `INV_REPAIR_ROUNDS=0` disables (one shot). `run-invariant-hunt.sh` gains `--repair-rounds N`.
- `FINDING`/`CLEAN` short-circuit (no repair). The offline `HANDLER_FIXTURE` path is seeded already-stopped — an operator fixture is **never** LLM-repaired.
- The final verdict is still the gate's **exit code** on the last attempt — never the LLM's opinion.

## Implementation
Bounded **recursion** (`.ag` is single-assignment; `range()`/`repeat_str` are absent and a `reduce` over a built list runs a stray iteration at rounds=0, breaking the disable path). Per-attempt state (stopped flag, current test source, last gate output) is carried through the recursion via a sentinel-joined string.

## Test plan
- New deterministic guard `tools/test-invariant-prover-repair-loop.sh`: bounded loop keyed on `HARNESS_ERROR`, `INV_REPAIR_ROUNDS` default, repair re-prompts with error + prior source, FINDING/CLEAN short-circuit, fixture path excluded. Passes 5/5 post-change, fails 5/5 pre-change. shellcheck-clean.
- Existing `tools/test-invariant-prover-bounded-gen.sh` (#1067) + `tools/test-invariant-prover-real-target.sh` (#1070-B1) still pass.
- `./tools/colony-lint.sh` → `371 passed, 0 failed, 5 skipped`.
- Loop mechanism verified with a mock LLM backend: prompt-call counts match the bound (unset→3, =2→3, =5→6, =0→1), the fixture path makes 0 prompts, FINDING short-circuits.

Preserves #1067 bounding, #1070-B1 real-target import/deploy, hard constraints, FM1/FM2 seeds (byte-identical). Related: epic #1041.
