### PR TITLE
feat(dark-factory): cross-contract multi-deploy harnesses for the fresh-deploy path (FM2) (#1075)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -52,6 +52,32 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   `tools/test-invariant-prover-repair-loop.sh`, pins the loop (grep over the `.ag`, no LLM/forge).
 
 ### Added
+- **invariant-prover cross-contract multi-deploy harnesses (composable-fresh)** (#1075, epic #1041). The
+  FRESH-DEPLOY real-target path deployed ONE target (single-contract) + mocked its externals, so the
+  highest-value stablecoin bugs — which are CROSS-contract (oracle manipulation → manager mispricing; reward
+  accrual → vault share inflation) — were structurally out of a single-contract harness's reach.
+  `run-invariant-hunt.sh` gains a repeatable `--aux <Contract.sol[:Name]>` flag (relative to `--repo`, like
+  `--target`): each value is validated the way `--target` is (exists, is a `*.sol`), staged into the rundir, and
+  threaded to the prover as `INV_AUX` — a sentinel-joined list of `<abs_path>:<Name>` entries (sentinel `@@A@@`,
+  which can occur in neither a filesystem path nor a Solidity identifier), also added to
+  `exec.env_passthrough`. When `INV_AUX` is non-empty (composable-fresh mode)
+  `auditor/agents/invariant-prover.ag` EXTENDS the generation prompt: it injects every auxiliary's source
+  (clearly delimited `=== AUX CONTRACT (<name>) ===`), an import line per auxiliary (reusing the #1070-B1
+  `import_line`/`rel_import_path`/`cat_file` helpers — no duplicated import/deploy machinery), and a new
+  `compose_fresh_seed()` directive: deploy + WIRE the WHOLE system in `setUp()` (deploy the target AND each
+  auxiliary, reading their constructors/initializers from the sources — the ERC1967Proxy recipe for upgradeable
+  ones — then wire them via their setter/admin functions inferred from the sources), register the relevant
+  contracts via `targetContracts()`, write a Handler whose actions SPAN the system, and EXACTLY ONE deep
+  cross-contract invariant (NO free value extraction / system solvency holds across any sequence). The size
+  budget grows to `~180 lines` in composable-fresh mode (still bounded). The whole composable-fresh extension is
+  gated behind a non-empty `INV_AUX`, so with no `--aux` the rendered single-target prompt is **byte-identical**
+  to #1070-B1 (verified by md5 of the rendered prompt), and the #1067 bounding, the #1073 compile-repair loop
+  (a multi-deploy `setUp()` is MORE likely to need repair, and the new prompt flows through the same
+  generate→write→gate→repair path), the fork-based `fork_seed`/`compose_seed` (FM1/FM2-fork), the offline
+  `HANDLER_FIXTURE` path, and the verdict-from-gate-exit-code contract are all preserved unchanged. A new
+  deterministic guard, `tools/test-invariant-prover-multideploy.sh`, pins the `--aux`→`INV_AUX` threading + the
+  composable-fresh directive and asserts the no-`--aux` path is unchanged (grep over the `.ag` + the runner, no
+  LLM/forge).
 - `submit-triage.sh` — the **human-gated submission triage** layer (#1056, epic #1053). Scans a staging
   root for the verified-FINDING packages `run-audit.sh` / `run-batch.sh` drop under
   `<out>/submission[/<key>]/` and scores each candidate's readiness (**READY** = report.md + a PoC/witness +

--- a/dark-factory/auditor/agents/invariant-prover.ag
+++ b/dark-factory/auditor/agents/invariant-prover.ag
@@ -143,6 +143,53 @@ fn import_line(name: string, rel: string) -> string {
 }
 let importLine = import_line(targetName, relImport);
 
+// FM2 (#1075) — COMPOSABLE-FRESH MODE. INV_AUX is the FRESH-DEPLOY sibling of FORK_CONTEXT: a sentinel-joined
+// list of AUXILIARY in-scope contracts the prover should ALSO deploy + WIRE alongside the target so the
+// generated handler can compose calls ACROSS the system (oracle -> manager mispricing, reward accrual ->
+// vault share inflation — the cross-contract bug a single-contract harness is structurally blind to). Each
+// entry is `<abs_path>:<Name>` (the staged rundir source path + the optional contract Name), entries joined by
+// the 5-char sentinel `@@A@@` (run-invariant-hunt.sh stages each aux under an ASCII `aux-code-<n>.sol` name, so
+// the sentinel can occur in neither a path nor a Solidity identifier — entries and the path:Name split are
+// unambiguous). INV_AUX is UNTRUSTED operator input that flows ONLY into the plain-string generation prompt
+// below (the aux SOURCES, import paths, and names — exactly like the target source), never into a verdict and
+// never into a shell as an unescaped concat (the rel-import realpath is read back from a shell_escape()d exec,
+// as for the target). Empty INV_AUX => composable-fresh is OFF => the single-target prompt is byte-identical.
+let invAux = getenv("INV_AUX");
+fn composable_fresh(aux: string) -> bool {
+    return len(aux) > 0;
+}
+let composableFresh = composable_fresh(invAux);
+// Split one `<abs_path>:<Name>` entry on its FIRST `:` (the Name, a Solidity identifier, carries none; an abs
+// path may, so we split on the first colon only and keep the remainder as the Name). field 0 = path, 1 = name.
+fn aux_field(entry: string, n: int) -> string {
+    let c = index_of(entry, ":");
+    if c < 0 {
+        if n == 0 { return entry; }
+        return "";
+    }
+    if n == 0 { return substring(entry, 0, c); }
+    return substring(entry, c + 1, len(entry));
+}
+// The list of `<abs_path>:<Name>` entries. regex_split on the empty string would yield a spurious [""] entry,
+// so an empty INV_AUX returns the empty list -> the reduces below produce "" -> the prompt is byte-identical.
+fn aux_entries(aux: string) -> list<string> {
+    if len(aux) == 0 { return []; }
+    return regex_split("@@A@@", aux);
+}
+let auxEntries = aux_entries(invAux);
+// The concatenated import-line directives for EVERY auxiliary (reusing the SAME import_line + rel_import_path
+// helpers as the target). Each aux source is staged in the rundir, so rel_import_path() computes its path
+// relative to dirname(INV_OUT) exactly as for the target. Empty list => "".
+let auxImportLines = reduce(auxEntries, |acc: string, entry: string| -> string {
+    return acc + import_line(aux_field(entry, 1), rel_import_path(invOut, aux_field(entry, 0)));
+}, "");
+// The concatenated aux SOURCE block — one clearly delimited `=== AUX CONTRACT (<name>) ===` section per
+// auxiliary, carrying the full source (via the sandboxed cat_file reader) so the model can read each aux's
+// constructor/initializer + setter/admin functions to deploy + WIRE the system. Empty list => "".
+let auxBlock = reduce(auxEntries, |acc: string, entry: string| -> string {
+    return acc + "=== AUX CONTRACT (" + aux_field(entry, 1) + ") ===\n" + cat_file(aux_field(entry, 0)) + "\n\n";
+}, "");
+
 // FM1 (#1041) — FORK MODE. When FORK_TARGET (and/or FORK_URL) is non-empty, the target is a LIVE DEPLOYED
 // contract at FORK_TARGET on a forked chain (run-invariant-hunt.sh threads --fork-url/--fork-block-number into
 // the gate). These env facts are UNTRUSTED operator input: FORK_TARGET / FORK_URL / FORK_BLOCK flow ONLY into
@@ -267,11 +314,34 @@ fn compose_seed(active: bool, ctx: string) -> string {
          + "manipulate-price-on-dex -> extract-from-target -> restore -> repay SEQUENCE that single-contract "
          + "fuzzing cannot reach.\n";
 }
-fn generate_test(klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string, deployName: string, importLine: string) -> string {
+// FM2 (#1075) — COMPOSABLE-FRESH generation seed (the FRESH-DEPLOY sibling of compose_seed's fork path). When
+// INV_AUX carries auxiliary in-scope contracts, the prover must DEPLOY + WIRE the WHOLE system from SOURCE (not
+// reference live addresses) so the handler can compose calls across it — the cross-contract bug class a
+// single-contract harness is blind to (oracle manipulation -> manager mispricing; reward accrual -> vault share
+// inflation). The aux SOURCES are injected separately (auxBlock, below `=== BUG CLASS ===`) and the import line
+// for EACH aux is injected next to the target's (auxImportLines); this seed adds the deploy+wire DIRECTIVE +
+// the EXACTLY-ONE deep cross-contract invariant + the grown (still bounded) size budget. Empty INV_AUX => "" so
+// the prompt is byte-identical to the #1070-B1 single-target build. The directive is a plain string — no shell.
+fn compose_fresh_seed(active: bool) -> string {
+    if !active { return ""; }
+    return "COMPOSABLE-FRESH MODE: in addition to the target, AUXILIARY in-scope contracts are provided below "
+         + "(each delimited `=== AUX CONTRACT (<name>) ===`). Deploy + WIRE the WHOLE system in `setUp()`: "
+         + "deploy the target AND each auxiliary contract (read their constructors/initializers from the sources "
+         + "— use the ERC1967Proxy recipe for upgradeable ones), then WIRE them together via their setter/admin "
+         + "functions (e.g. `manager.setOracle(oracle)`, `vault.setRewardsDistributor(rewards)` — INFER the "
+         + "wiring from the sources). Register the relevant contracts via `targetContracts()`. Write a Handler "
+         + "whose actions SPAN the system (e.g. move the oracle price, then mint/redeem via the manager, then "
+         + "check the vault), and EXACTLY ONE deep CROSS-CONTRACT invariant: NO free value extraction / system "
+         + "solvency holds across any sequence — an actor who starts and ends with the SAME external position "
+         + "must not have drained the system. In this composable-fresh mode the size budget grows to ~180 lines "
+         + "(still bounded) to fit the multi-deploy + wiring `setUp()`.\n";
+}
+fn generate_test(klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string, deployName: string, importLine: string, composeFresh: bool, auxBlock: string, auxImportLines: string) -> string {
     let instruction =
         recall_seed(klass, prior)
       + fork_seed(forkActive, forkTarget, forkUrl, forkBlock)
       + compose_seed(composeActive, forkContext)
+      + compose_fresh_seed(composeFresh)
       + "You are a stateful-invariant-fuzzing engineer. Write a self-contained Foundry stateful-invariant "
       + "test (Solidity, `pragma solidity ^0.8.20;`) for the target contract below so Foundry's invariant "
       + "fuzzer can drive randomized multi-call SEQUENCES through it and find a MULTI-STEP exploit. "
@@ -282,6 +352,7 @@ fn generate_test(klass: string, src: string, matchPrefix: string, prior: string,
       + "verdict is about real code. Do NOT import forge-std — this test must compile with ZERO library "
       + "remappings.\n"
       + importLine
+      + auxImportLines
       + "  - In `setUp()` deploy the real target. For a normal `constructor(args)`: `new " + deployName + "(args)`. "
       + "For an OpenZeppelin **upgradeable** contract whose constructor calls `_disableInitializers()`: deploy "
       + "behind a proxy — add `import {ERC1967Proxy} from \"@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol\";` "
@@ -304,6 +375,7 @@ fn generate_test(klass: string, src: string, matchPrefix: string, prior: string,
       + "The invariant must catch a bug that only a SEQUENCE of calls can produce, not a single call. "
       + "Keep the entire test under ~120 lines; do not exceed it — the real-deploy `setUp()` counts toward "
       + "that budget, so keep the import/deploy minimal and stay bounded.\n\n"
+      + auxBlock
       + "=== BUG CLASS (lens) ===\n" + klass + "\n\n"
       + "=== HOW TO ANSWER ===\n"
       + "Output ONLY the Solidity source of the `*.t.sol` test — no markdown fences, no prose before or "
@@ -316,11 +388,11 @@ fn generate_test(klass: string, src: string, matchPrefix: string, prior: string,
 // wins (offline/deterministic, verbatim, no LLM); otherwise the LLM generates it (live path). On the live path
 // this is only the FIRST attempt — the bounded compile-repair loop below may regenerate it (#1073).
 let usedFixture = len(fixture) > 0;
-fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string, deployName: string, importLine: string) -> string {
+fn choose_test(usedFix: bool, fix: string, klass: string, src: string, matchPrefix: string, prior: string, forkActive: bool, forkTarget: string, forkUrl: string, forkBlock: string, composeActive: bool, forkContext: string, deployName: string, importLine: string, composeFresh: bool, auxBlock: string, auxImportLines: string) -> string {
     if usedFix { return fix; }
-    return generate_test(klass, src, matchPrefix, prior, forkActive, forkTarget, forkUrl, forkBlock, composeActive, forkContext, deployName, importLine);
+    return generate_test(klass, src, matchPrefix, prior, forkActive, forkTarget, forkUrl, forkBlock, composeActive, forkContext, deployName, importLine, composeFresh, auxBlock, auxImportLines);
 }
-let test = choose_test(usedFixture, fixture, targetClass, code, invMatch, prior, forkMode, forkTarget, forkUrl, forkBlock, composableMode, forkContext, deployName, importLine);
+let test = choose_test(usedFixture, fixture, targetClass, code, invMatch, prior, forkMode, forkTarget, forkUrl, forkBlock, composableMode, forkContext, deployName, importLine, composableFresh, auxBlock, auxImportLines);
 
 // --- VERIFY with the stateful-fuzzing gate ------------------------------------------------------
 // The gate is evm-harness/forge-invariant.sh. We write the test to INV_OUT (inside INV_REPO/test) then run

--- a/dark-factory/run-invariant-hunt.sh
+++ b/dark-factory/run-invariant-hunt.sh
@@ -30,6 +30,16 @@
 #                        NO LLM). When set the verdict is the fuzzer's over THIS test. Omit = live (LLM) path.
 #   --code <file>        Path to the target contract source the LLM reads to write the handler (live path).
 #                        Defaults to <repo>/src/<Contract.sol> when omitted and a fixture is NOT supplied.
+#   --aux <C.sol[:Name]> FM2 (#1075): an AUXILIARY in-scope contract (relative to --repo, like --target) the
+#                        prover should ALSO deploy + WIRE alongside the target so the generated handler can
+#                        compose calls ACROSS the system (the FRESH-DEPLOY composability path — oracle ->
+#                        manager mispricing, reward accrual -> vault share inflation, ...). REPEATABLE. Each
+#                        value is validated like --target (exists, is a *.sol) and exported to the prover as
+#                        one entry of INV_AUX (a sentinel-joined list of `<abs_path>:<Name>` entries, sentinel
+#                        `@@A@@` — it cannot occur in a filesystem path or a Solidity identifier). No --aux =>
+#                        INV_AUX empty => the single-target generation prompt is byte-identical to today. This
+#                        is the FRESH-DEPLOY sibling of the FORK-mode --fork-target composability set: --aux
+#                        deploys the auxiliaries from SOURCE, --fork-target references them by on-chain address.
 #   --match <prefix>     Invariant function-name prefix the fuzzer runs (default "invariant").
 #   --backend <mock|flat-cyborg|claude>  LLM backend for the live generation path (default: flat-cyborg =
 #                        flat-rate PTY wrapper; claude = metered -p API; mock = offline wiring smoke). On the
@@ -85,6 +95,9 @@ FORK_URL="" ; FORK_BLOCK="" ; FORK_TARGET=""
 # FM2 (#1041): the composability context set — one `--fork-target '<role>=<addr>'` per array slot. A bare
 # `--fork-target <addr>` (FM1 shorthand, no '=') is normalised to a `target=<addr>` slot below.
 FORK_TARGET_SPECS=()
+# FM2 (#1075): the FRESH-DEPLOY auxiliary set — one `--aux <Contract.sol[:Name]>` per array slot (relative to
+# --repo, like --target). Resolved + staged + encoded into INV_AUX below. Empty => single-target behaviour.
+AUX_SPECS=()
 
 need() { [ "$1" -ge 2 ] || { echo "run-invariant-hunt.sh: missing value for the preceding flag" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
@@ -94,6 +107,7 @@ while [ $# -gt 0 ]; do
     --class) need "$#"; CLASS="$2"; shift 2 ;;
     --handler-fixture) need "$#"; FIXTURE="$2"; shift 2 ;;
     --code) need "$#"; CODE="$2"; shift 2 ;;
+    --aux) need "$#"; AUX_SPECS+=("$2"); shift 2 ;;
     --match) need "$#"; MATCH="$2"; shift 2 ;;
     --backend) need "$#"; BACKEND="$2"; shift 2 ;;
     --model) need "$#"; MODEL="$2"; shift 2 ;;
@@ -181,6 +195,30 @@ if [ -n "$CODE" ]; then
   CODE="$(cd "$(dirname "$CODE")" && pwd)/$(basename "$CODE")"
 fi
 
+# FM2 (#1075): resolve + validate each --aux <Contract.sol[:Name]> the way --target/--code are validated —
+# the FILE part is relative to --repo (tried as `<repo>/<file>` then the `<repo>/src/<file>` convention the
+# target's default-code path uses), must exist, and must be a *.sol. The optional `:Name` (a Solidity
+# identifier) is preserved verbatim so the prover can name the import. Each resolved entry is held as
+# `<abs_file>:<Name>` in AUX_ABS_SPECS; staging into the rundir + the INV_AUX encoding happen below (once the
+# rundir exists). Empty AUX_SPECS leaves AUX_ABS_SPECS empty => INV_AUX empty => single-target behaviour.
+AUX_ABS_SPECS=()
+for aspec in ${AUX_SPECS+"${AUX_SPECS[@]}"}; do
+  case "$aspec" in
+    *:*) _afile="${aspec%%:*}"; _aname="${aspec#*:}" ;;
+    *)   _afile="$aspec"; _aname="" ;;
+  esac
+  [ -n "$_afile" ] || { echo "run-invariant-hunt.sh: --aux file part must be non-empty (got: $aspec)" >&2; exit 2; }
+  case "$_afile" in
+    *.sol) ;;
+    *) echo "run-invariant-hunt.sh: --aux must be a *.sol file (got: $_afile)" >&2; exit 2 ;;
+  esac
+  if [ -f "$REPO/$_afile" ]; then _aabs="$REPO/$_afile";
+  elif [ -f "$REPO/src/$_afile" ]; then _aabs="$REPO/src/$_afile";
+  else echo "run-invariant-hunt.sh: --aux not found under --repo: $_afile" >&2; exit 2; fi
+  _aabs="$(cd "$(dirname "$_aabs")" && pwd)/$(basename "$_aabs")"
+  AUX_ABS_SPECS+=("$_aabs:$_aname")
+done
+
 PROVER="$HERE/auditor/agents/invariant-prover.ag"
 GATE="$HERE/evm-harness/forge-invariant.sh"
 [ -f "$PROVER" ] || { echo "run-invariant-hunt.sh: invariant-prover agent not found at $PROVER" >&2; exit 3; }
@@ -211,6 +249,22 @@ if [ -n "$CODE" ]; then
   CODE_IN_RUN="$RUN/target-code.sol"
 fi
 
+# FM2 (#1075): stage each resolved --aux source into the rundir (so the sandboxed reader can reach it) and
+# build INV_AUX — a sentinel-joined list of `<abs_path_in_run>:<Name>` entries, sentinel `@@A@@`. The sentinel
+# cannot occur in a filesystem path (it stages each aux under a colony-controlled `aux-code-<n>.sol` name, all
+# ASCII alnum + `-`) nor in a Solidity identifier, so the prover can split the list and each entry on the FIRST
+# `:` unambiguously. No --aux => AUX_ABS_SPECS empty => INV_AUX stays "" => the prover's single-target prompt
+# is byte-identical. The aux SOURCES + names flow only into the prover's plain-string prompt (never a shell).
+INV_AUX=""
+_aux_idx=0
+for entry in ${AUX_ABS_SPECS+"${AUX_ABS_SPECS[@]}"}; do
+  _aabs="${entry%:*}"; _aname="${entry##*:}"
+  _aux_in_run="$RUN/aux-code-${_aux_idx}.sol"
+  cp "$_aabs" "$_aux_in_run"
+  if [ -z "$INV_AUX" ]; then INV_AUX="$_aux_in_run:$_aname"; else INV_AUX="$INV_AUX@@A@@$_aux_in_run:$_aname"; fi
+  _aux_idx=$((_aux_idx + 1))
+done
+
 # init the agentis store FIRST (before any .agentis/ subdir exists), else HEAD is not set.
 ( cd "$RUN" && "$AGENTIS" init >/dev/null 2>&1 )
 {
@@ -223,7 +277,9 @@ fi
   # FM1 (#1041): FORK_URL/FORK_BLOCK thread the fork into the gate; FORK_TARGET is the deployed address the
   # generated handler/invariant references against the forked state. FM2 (#1041): FORK_CONTEXT carries the
   # role->address context set so the generation prompt can compose calls across the deployed protocols.
-  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT,FORK_URL,FORK_BLOCK,FORK_TARGET,FORK_CONTEXT,INV_REPAIR_ROUNDS"
+  # FM2 (#1075): INV_AUX carries the sentinel-joined `<abs_path>:<Name>` auxiliary-contract list so the prover
+  # can deploy + WIRE the whole system (fresh-deploy composability).
+  echo "exec.env_passthrough = TARGET_FN,TARGET_CLASS,INV_REPO,INV_OUT,INV_MATCH,HANDLER_FIXTURE,CODE_PATH,INV_RUNS,INV_DEPTH,INV_SEED,FORGE_INVARIANT,FORK_URL,FORK_BLOCK,FORK_TARGET,FORK_CONTEXT,INV_REPAIR_ROUNDS,INV_AUX"
   # A forge invariant run (build + a few hundred fuzzed sequences) far exceeds the 10s default.
   echo "exec.default_timeout_ms = 600000"
   # Each verify is recorded as experience; invariant-prover fitness reweights over targets.
@@ -274,6 +330,7 @@ echo "run-invariant-hunt.sh: generating + stateful-fuzzing $TARGET ($CLASS) ..."
     INV_MATCH="$MATCH" \
     HANDLER_FIXTURE="$FIXTURE_IN_RUN" \
     CODE_PATH="$CODE_IN_RUN" \
+    INV_AUX="$INV_AUX" \
     INV_RUNS="$RUNS" \
     INV_DEPTH="$DEPTH" \
     INV_SEED="$SEED" \

--- a/tools/test-invariant-prover-multideploy.sh
+++ b/tools/test-invariant-prover-multideploy.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# tools/test-invariant-prover-multideploy.sh -- deterministic regression
+# guard for #1075 (dark-factory, FM2). The fresh-deploy invariant-prover used
+# to deploy ONE real target (single-contract) + mock its externals, so the
+# highest-value CROSS-contract stablecoin bugs (oracle manipulation -> manager
+# mispricing; reward accrual -> vault share inflation) were structurally out
+# of reach. #1075 lets the operator pass AUXILIARY in-scope contracts via a
+# repeatable `--aux <Contract.sol[:Name]>` flag; the runner stages each, names
+# it, and threads the set to the prover as INV_AUX (a sentinel-joined
+# `<abs_path>:<Name>` list, sentinel `@@A@@`, also in exec.env_passthrough).
+# When INV_AUX is non-empty (composable-fresh mode) the prover EXTENDS the
+# generation prompt: it injects every aux source (delimited
+# `=== AUX CONTRACT (<name>) ===`), an import line per aux, and a directive to
+# DEPLOY + WIRE the whole system in setUp() + write EXACTLY ONE deep
+# cross-contract invariant (NO free value extraction / system solvency). When
+# INV_AUX is EMPTY the single-target prompt is byte-identical to #1070-B1.
+#
+# This test pins the --aux threading + the composable-fresh directive so they
+# cannot silently regress, and asserts the no-aux prompt path is unchanged
+# (the composable extension is gated behind a `composableFresh`/INV_AUX flag,
+# never injected unconditionally). Pure grep/awk over the .ag source + the
+# runner -- no agentis runtime, no LLM, no forge required. Auto-discovered and
+# run by tools/colony-lint.sh's `tools/test-*.sh` loop.
+#
+# Assertions:
+#   (a) run-invariant-hunt.sh parses a repeatable `--aux` flag, validates each
+#       value like --target (exists / is a *.sol), and threads the set as
+#       INV_AUX with the `@@A@@` sentinel.
+#   (b) run-invariant-hunt.sh adds INV_AUX to exec.env_passthrough AND to the
+#       `env ... INV_AUX=...` go invocation.
+#   (c) The prover reads INV_AUX, gates composable-fresh on a non-empty value,
+#       and reuses the existing import_line / rel_import_path / cat_file
+#       helpers over the aux entries (no duplicated import/deploy machinery).
+#   (d) The composable-fresh directive is emitted when INV_AUX is set: the
+#       deploy + WIRE the WHOLE system framing, the EXACTLY ONE deep
+#       cross-contract invariant, the NO free value extraction property, the
+#       `=== AUX CONTRACT (` source delimiter, and the grown (still bounded)
+#       ~180-line budget all live in `compose_fresh_seed()`.
+#   (e) The no-aux prompt is unchanged: the compose_fresh_seed/auxBlock/
+#       auxImportLines are gated behind the composableFresh flag (so they are
+#       "" when INV_AUX is empty), and the #1067/#1070-B1 single-target
+#       anchors (the ~120-line budget, the REAL-target directive) survive.
+#
+# Usage: bash tools/test-invariant-prover-multideploy.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AG="$REPO_ROOT/dark-factory/auditor/agents/invariant-prover.ag"
+RUNNER="$REPO_ROOT/dark-factory/run-invariant-hunt.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+for f in "$AG" "$RUNNER"; do
+    if [ ! -f "$f" ]; then
+        fail "source exists" "$f not found"
+        echo ""
+        echo "Results: $PASS passed, $FAIL failed"
+        exit 1
+    fi
+done
+
+ag_src="$(cat "$AG")"
+run_src="$(cat "$RUNNER")"
+
+# (a) The runner parses a repeatable --aux, validates it like --target, and
+# encodes the set into INV_AUX with the @@A@@ sentinel.
+a_fail=""
+# shellcheck disable=SC2016  # matching the literal source line, $ must not expand
+printf '%s\n' "$run_src" | grep -Fq -- '--aux) need "$#"; AUX_SPECS+=("$2")' \
+    || a_fail="${a_fail} no-aux-flag"
+printf '%s\n' "$run_src" | grep -Fq -- '--aux must be a *.sol file' \
+    || a_fail="${a_fail} no-sol-validation"
+printf '%s\n' "$run_src" | grep -Fq -- '--aux not found under --repo' \
+    || a_fail="${a_fail} no-exists-validation"
+# shellcheck disable=SC2016  # matching the literal source line, $ must not expand
+printf '%s\n' "$run_src" | grep -Fq 'INV_AUX="$INV_AUX@@A@@' \
+    || a_fail="${a_fail} no-sentinel-join"
+
+if [ -z "$a_fail" ]; then
+    pass "(a) run-invariant-hunt.sh parses + validates a repeatable --aux and joins it into INV_AUX (@@A@@ sentinel)"
+else
+    fail "(a) run-invariant-hunt.sh parses + validates --aux into INV_AUX" \
+         "missing piece(s):$a_fail"
+fi
+
+# (b) The runner threads INV_AUX: both into exec.env_passthrough and the env
+# go-invocation.
+b_fail=""
+printf '%s\n' "$run_src" | grep -Eq 'env_passthrough = .*,INV_AUX' \
+    || b_fail="${b_fail} no-env-passthrough"
+# shellcheck disable=SC2016  # matching the literal env-invocation line, $ must not expand
+printf '%s\n' "$run_src" | grep -Fq 'INV_AUX="$INV_AUX"' \
+    || b_fail="${b_fail} no-go-invocation"
+
+if [ -z "$b_fail" ]; then
+    pass "(b) INV_AUX is added to exec.env_passthrough AND the env go-invocation"
+else
+    fail "(b) INV_AUX is threaded through env_passthrough + the go invocation" \
+         "missing piece(s):$b_fail"
+fi
+
+# (c) The prover reads INV_AUX, gates composable-fresh on a non-empty value,
+# and reuses the existing import/deploy helpers (no duplication).
+c_fail=""
+printf '%s\n' "$ag_src" | grep -Fq 'let invAux = getenv("INV_AUX");' \
+    || c_fail="${c_fail} no-env-read"
+printf '%s\n' "$ag_src" | grep -Eq 'fn[[:space:]]+composable_fresh\(' \
+    || c_fail="${c_fail} no-gate-fn"
+printf '%s\n' "$ag_src" | grep -Fq 'let composableFresh = composable_fresh(invAux);' \
+    || c_fail="${c_fail} no-gate-binding"
+# The aux import lines must reuse import_line + rel_import_path (the #1070-B1
+# helpers), not a fresh copy.
+printf '%s\n' "$ag_src" | grep -Fq 'import_line(aux_field(entry, 1), rel_import_path(invOut, aux_field(entry, 0)))' \
+    || c_fail="${c_fail} no-helper-reuse"
+# The aux sources must be read through the same sandboxed cat_file reader.
+printf '%s\n' "$ag_src" | grep -Fq 'cat_file(aux_field(entry, 0))' \
+    || c_fail="${c_fail} no-cat_file-reuse"
+
+if [ -z "$c_fail" ]; then
+    pass "(c) the prover reads INV_AUX, gates composable-fresh, and reuses the import_line/rel_import_path/cat_file helpers"
+else
+    fail "(c) the prover reads INV_AUX + reuses the existing import/deploy helpers" \
+         "missing piece(s):$c_fail"
+fi
+
+# (d) The composable-fresh directive (deploy + WIRE the system + the EXACTLY
+# ONE cross-contract invariant) lives in compose_fresh_seed().
+seed_body="$(awk '/^fn compose_fresh_seed\(/{f=1} f{print} f&&/^}/{exit}' "$AG")"
+d_fail=""
+[ -n "$seed_body" ] || d_fail="${d_fail} no-compose_fresh_seed"
+printf '%s\n' "$seed_body" | grep -Fq 'Deploy + WIRE the WHOLE system' \
+    || d_fail="${d_fail} no-deploy-wire"
+printf '%s\n' "$seed_body" | grep -Fq 'EXACTLY ONE deep CROSS-CONTRACT invariant' \
+    || d_fail="${d_fail} no-cross-contract-invariant"
+printf '%s\n' "$seed_body" | grep -Fq 'NO free value extraction' \
+    || d_fail="${d_fail} no-free-value-extraction"
+printf '%s\n' "$seed_body" | grep -Fq '=== AUX CONTRACT (' \
+    || d_fail="${d_fail} no-aux-delimiter"
+printf '%s\n' "$seed_body" | grep -Eq 'budget grows to ~?180 lines' \
+    || d_fail="${d_fail} no-grown-budget"
+
+if [ -z "$d_fail" ]; then
+    pass "(d) compose_fresh_seed() emits the deploy+wire directive + the cross-contract invariant + the ~180-line budget"
+else
+    fail "(d) compose_fresh_seed() emits the composable-fresh directive" \
+         "missing piece(s):$d_fail"
+fi
+
+# (e) The no-aux prompt is unchanged: the composable extension is gated behind
+# the composableFresh flag (so it is "" when INV_AUX is empty), and the
+# single-target anchors survive.
+e_fail=""
+# compose_fresh_seed returns "" when inactive (the additive-only contract).
+printf '%s\n' "$seed_body" | grep -Fq 'if !active { return ""; }' \
+    || e_fail="${e_fail} no-inactive-empty"
+# The seed/auxBlock/auxImportLines are threaded into generate_test (so the
+# extension is conditional, never inlined unconditionally).
+printf '%s\n' "$ag_src" | grep -Fq 'compose_fresh_seed(composeFresh)' \
+    || e_fail="${e_fail} no-conditional-seed"
+# The #1067 single-target budget anchor must survive on the base path.
+printf '%s\n' "$ag_src" | grep -Eq 'under ~?120 lines' \
+    || e_fail="${e_fail} no-120-budget"
+# The #1070-B1 REAL-target directive must survive on the base path.
+printf '%s\n' "$ag_src" | grep -Fq 'IMPORT and DEPLOY the REAL target' \
+    || e_fail="${e_fail} no-real-target"
+
+if [ -z "$e_fail" ]; then
+    pass "(e) the no-aux prompt is unchanged (composable-fresh is flag-gated; the #1067/#1070-B1 anchors survive)"
+else
+    fail "(e) the no-aux prompt is unchanged" \
+         "missing piece(s):$e_fail"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Closes #1075. The single-contract real-target harness (#1070-B1) structurally can't reach **cross-contract** stablecoin bugs (oracle manipulation → manager mispricing; reward accrual → vault share inflation). FM2 lets the operator pass auxiliary in-scope contracts; the prover deploys + **wires** the target together with them and composes calls across the system.

- `run-invariant-hunt.sh`: repeatable `--aux <Contract.sol[:Name]>` (validated like `--target`, staged into the rundir), encoded as `INV_AUX` (a `@@A@@`-joined `abs_path:Name` list) and threaded (+ `exec.env_passthrough`). **No `--aux` ⇒ single-target behavior byte-identical** (the rendered single-target prompt is md5-identical to pre-change).
- `invariant-prover.ag`: in composable-fresh mode the prompt gains each aux source, a per-aux import line (reusing #1070-B1 `rel_import_path`/`import_line`), and a `compose_fresh_seed()` directive — deploy + wire the whole system (ERC1967Proxy recipe for upgradeable; infer setter wiring from sources), register via `targetContracts()`, ONE deep cross-contract invariant (no-free-value-extraction / system solvency). Budget grows to ~180 lines, still bounded.

Reuses #1067 bounding, #1070-B1 import/deploy, #1073 compile-repair loop. The fork-based `compose_seed` (FM2-fork) and the offline `HANDLER_FIXTURE` path are preserved.

## Test plan
- New guard `tools/test-invariant-prover-multideploy.sh`: `--aux`→`INV_AUX` threading + env_passthrough, the compose-fresh directive when `INV_AUX` set, no-aux prompt unchanged. 5/5 post-change, 5/5 fail pre-change. shellcheck-clean.
- All existing guards still pass (bounded-gen 4/4, real-target 4/4, repair-loop 5/5).
- `./tools/colony-lint.sh` → `372 passed, 0 failed, 5 skipped`.
- Mock-backend probe: no-`--aux` single-target prompt md5-identical to pre-change; aux-mode prompt contains the directive + both aux source blocks + correct `../../aux-code-N.sol` import lines.

Related: epic #1041; builds on #1070-B1 + #1073.
