### PR TITLE
fix(dark-factory): enforce both-real deployment in composable-fresh mode (#1077)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -15,6 +15,30 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 ## [Unreleased]
 
 ### Fixed
+- **invariant-prover ENFORCES both-real cross-contract deployment (composable-fresh)** (#1077, epic #1041). In
+  composable-fresh mode (#1075, `INV_AUX` non-empty) the LLM was supposed to deploy + wire the target AND each
+  aux contract REAL. Validation on two real pairs showed it instead deployed only the EASIER contract real and
+  MOCKED/OMITTED the harder one (`--target dreUSDs --aux dreRewardsDistributor` → real distributor + a
+  `RewardVaultMock`; `--target dreUSDManager --aux dreUSDOracle` → real oracle, manager never imported). A CLEAN
+  on a harness that mocked the unit-under-test is a FALSE verdict. `auditor/agents/invariant-prover.ag` now
+  enforces both-real via validation + targeted repair (reusing the #1073 loop) — NOT a Solidity-parsing deploy
+  scaffold, and ONLY active in composable-fresh mode (the #1070-B1 single-target path is byte-identical, the
+  offline `HANDLER_FIXTURE` path is untouched). A `missing_real_deploys(testSrc, names)` helper reports, over the
+  `{target name} ∪ {each aux name}` set, every contract MISSING BOTH an `import {<name>}` marker AND a
+  `new <name>(` marker (the latter covers the plain `new` form and the `new ERC1967Proxy(address(new <name>()...`
+  proxy form) — i.e. dropped or mocked. The #1073 repair trigger is EXTENDED: a round also fires when
+  composable-fresh AND `missing_real_deploys(...)` is non-empty, with a POINTED repair prompt that names the
+  missing contracts ("Your test did NOT deploy these REQUIRED real contracts (you mocked or omitted them): …")
+  and tells the model to keep the ones already real. After the `INV_REPAIR_ROUNDS` budget is exhausted, a
+  RESIDUAL both-real violation FORCES the emitted verdict to `HARNESS_ERROR` (with a stderr reason: "harness
+  mocked/omitted required real contract(s): …") — even if the gate returned CLEAN/FINDING on the partial harness
+  — so a FALSE cross-contract CLEAN can never leak; a genuine FINDING/CLEAN on a harness where ALL named
+  contracts are real passes through unchanged, and the gate exit code stays the source of FINDING/CLEAN when
+  both-real holds. The both-real check is pure string work on the (untrusted) test source (no shell), the loop
+  stays bounded by the existing single-assignment recursion (no `while`/`for`), and the stderr reason is
+  `shell_escape()`d. A new deterministic guard, `tools/test-invariant-prover-both-real.sh`, pins the both-real
+  check, the extra repair trigger, the pointed message, the force-`HARNESS_ERROR`-on-residual-violation override,
+  and the single-target/fixture exemption (grep over the `.ag`, no LLM/forge).
 - **invariant-prover drives the REAL target, not a mock** (#1070-B1, epic #1041). The live-path generation
   instruction in `auditor/agents/invariant-prover.ag` (`generate_test()`) used to tell the model: import the
   target "if the project ships it there; otherwise inline a minimal copy." On a realistically-sized target the

--- a/dark-factory/auditor/agents/invariant-prover.ag
+++ b/dark-factory/auditor/agents/invariant-prover.ag
@@ -204,15 +204,15 @@ let requiredNames = reduce(auxEntries, |acc: list<string>, entry: string| -> lis
     return push(acc, n);
 }, if len(targetName) > 0 { [targetName] } else { [] });
 // missing_real_deploys(testSrc, names) -> the comma-joined list of names that are MISSING a REAL deploy in the
-// harness. A name is deployed REAL iff the source carries BOTH an `import {<name>}` marker AND a `new <name>`
-// marker. The `new <name>` marker covers the plain `new <name>(` form and the proxy form
-// `new ERC1967Proxy(address(new <name>()...` (both contain the substring `new <name>(`). A name that is missing
-// EITHER marker was dropped or replaced by a mock (e.g. `RewardVaultMock`) and is reported. Empty result =>
-// every named contract is deployed real. Pure string work on the (untrusted) testSrc via index_of — no shell.
+// harness. A name is deployed REAL iff the source carries a `new <name>(` marker — which covers the plain
+// `new <name>(` form and the proxy form `new ERC1967Proxy(address(new <name>()...` (both contain that
+// substring). The trailing `(` anchors the name, so `new <name>Mock(` does NOT match `new <name>(`. We do NOT
+// also require a canonical `import {<name>}` line: a `new <name>(` the gate compiles is necessarily in scope,
+// and matching the exact import form would false-positive on legal grouped/spaced/aliased imports and could
+// suppress a GENUINE finding to HARNESS_ERROR. A dropped or mocked contract never emits `new <name>(` for the
+// real type, so the deploy marker alone catches it. Pure string work on the (untrusted) testSrc — no shell.
 fn has_real_deploy(testSrc: string, name: string) -> bool {
-    if index_of(testSrc, "import {" + name + "}") < 0 { return false; }
-    if index_of(testSrc, "new " + name + "(") < 0 { return false; }
-    return true;
+    return index_of(testSrc, "new " + name + "(") >= 0;
 }
 fn missing_real_deploys(testSrc: string, names: list<string>) -> string {
     let joined = reduce(names, |acc: string, name: string| -> string {
@@ -638,7 +638,10 @@ let finalState = repair_loop(initState, repairRounds, gate, invRepo, invOut, inv
 // single-target / fixture verdict (composableFresh false) — passes through unchanged.
 let runOut = rstate_field(finalState, 2);
 let finalSrc = rstate_field(finalState, 1);
-let bothRealMissing = if composableFresh { missing_real_deploys(finalSrc, requiredNames) } else { "" };
+// Gated on composableFresh AND NOT usedFixture: an operator-supplied HANDLER_FIXTURE is verbatim and is
+// never repaired (seeded stopped); it must likewise never be force-overridden to HARNESS_ERROR by the
+// both-real check, even if it is run with --aux. Only LLM-generated composable-fresh harnesses are enforced.
+let bothRealMissing = if composableFresh { if usedFixture { "" } else { missing_real_deploys(finalSrc, requiredNames) } } else { "" };
 let bothRealViolated = len(bothRealMissing) > 0;
 let rc = rc_of(runOut);
 fn final_verdict(rc: int, violated: bool) -> string {

--- a/dark-factory/auditor/agents/invariant-prover.ag
+++ b/dark-factory/auditor/agents/invariant-prover.ag
@@ -190,6 +190,39 @@ let auxBlock = reduce(auxEntries, |acc: string, entry: string| -> string {
     return acc + "=== AUX CONTRACT (" + aux_field(entry, 1) + ") ===\n" + cat_file(aux_field(entry, 0)) + "\n\n";
 }, "");
 
+// FM2 (#1077) — BOTH-REAL ENFORCEMENT (composable-fresh only). #1075 told the model to deploy the target AND
+// each aux REAL; validation on two real pairs showed it instead deployed only the EASIER contract real and
+// mocked/omitted the harder one (real distributor + a `RewardVaultMock`; real oracle + the manager never
+// imported). A CLEAN on a harness that mocked the unit-under-test is a FALSE verdict. The defence is pure
+// string validation of the EMITTED test + a targeted re-prompt (reusing the #1073 repair loop) — NOT a
+// Solidity-parsing deploy scaffold. `requiredNames` is the set of contract names that MUST appear deployed
+// REAL: {target name} ∪ {each aux name}, dropping any empty name (a `*.sol` label with no `:Name` — we cannot
+// name-check a contract we were not told the name of, exactly as the import-path line is skipped for it).
+let requiredNames = reduce(auxEntries, |acc: list<string>, entry: string| -> list<string> {
+    let n = aux_field(entry, 1);
+    if len(n) == 0 { return acc; }
+    return push(acc, n);
+}, if len(targetName) > 0 { [targetName] } else { [] });
+// missing_real_deploys(testSrc, names) -> the comma-joined list of names that are MISSING a REAL deploy in the
+// harness. A name is deployed REAL iff the source carries BOTH an `import {<name>}` marker AND a `new <name>`
+// marker. The `new <name>` marker covers the plain `new <name>(` form and the proxy form
+// `new ERC1967Proxy(address(new <name>()...` (both contain the substring `new <name>(`). A name that is missing
+// EITHER marker was dropped or replaced by a mock (e.g. `RewardVaultMock`) and is reported. Empty result =>
+// every named contract is deployed real. Pure string work on the (untrusted) testSrc via index_of — no shell.
+fn has_real_deploy(testSrc: string, name: string) -> bool {
+    if index_of(testSrc, "import {" + name + "}") < 0 { return false; }
+    if index_of(testSrc, "new " + name + "(") < 0 { return false; }
+    return true;
+}
+fn missing_real_deploys(testSrc: string, names: list<string>) -> string {
+    let joined = reduce(names, |acc: string, name: string| -> string {
+        if has_real_deploy(testSrc, name) { return acc; }
+        if len(acc) == 0 { return name; }
+        return acc + ", " + name;
+    }, "");
+    return joined;
+}
+
 // FM1 (#1041) — FORK MODE. When FORK_TARGET (and/or FORK_URL) is non-empty, the target is a LIVE DEPLOYED
 // contract at FORK_TARGET on a forked chain (run-invariant-hunt.sh threads --fork-url/--fork-block-number into
 // the gate). These env facts are UNTRUSTED operator input: FORK_TARGET / FORK_URL / FORK_BLOCK flow ONLY into
@@ -475,6 +508,26 @@ fn repair_test(excerpt: string, prevSrc: string, matchPrefix: string) -> string 
     // colony-lint: prompt-gate-ok
     return prompt(repair_instruction(excerpt, prevSrc, matchPrefix), "") -> string;
 }
+// FM2 (#1077) — the POINTED both-real-violation repair instruction. The harness COMPILED + the gate returned a
+// verdict, but in composable-fresh mode it mocked or omitted one or more REQUIRED real contracts (`missing`,
+// the comma-joined name list) — a verdict on a partial harness, not the real system. Unlike the compile-error
+// repair this names the exact contracts that must become real and keeps the ones already real. prevSrc/missing
+// are derived from the LLM completion (untrusted) — they flow ONLY into this plain-string prompt, never a shell.
+fn repair_instruction_bothreal(missing: string, prevSrc: string, matchPrefix: string) -> string {
+    return "Your test did NOT deploy these REQUIRED real contracts (you mocked or omitted them): " + missing
+         + ". Each one MUST be imported (`import {<Name>} from \"<its path>\";`) and deployed as the REAL "
+         + "contract (plain `new`, or `ERC1967Proxy` for upgradeable) and wired into the system — a mock or "
+         + "omission of any of them is INVALID. Keep the ones you already deployed real."
+         + "\nYour previous test was:\n"
+         + prevSrc
+         + "\nFix it and output ONLY the corrected Solidity — same constraints (pragma ^0.8.20, NO forge-std, "
+         + "targetContracts(), plain require(), `" + matchPrefix + "_*` naming, import+deploy the REAL target, "
+         + "output-only).";
+}
+fn repair_test_bothreal(missing: string, prevSrc: string, matchPrefix: string) -> string {
+    // colony-lint: prompt-gate-ok
+    return prompt(repair_instruction_bothreal(missing, prevSrc, matchPrefix), "") -> string;
+}
 
 // STATE ENCODING for the repair loop. One string of 3 NAMED fields joined by the 5-char sentinel `@@F@@` (it
 // cannot occur in Solidity source or forge output; the same convention coordinator.ag uses for its carried
@@ -504,31 +557,55 @@ fn stop_flag(rc: int) -> string {
     if rc == 0 { return "1"; }
     return "0";
 }
-// One repair round over the carried state. A no-op once stopped (a FINDING/CLEAN was already reached). Else the
-// PRIOR attempt was a HARNESS_ERROR: regenerate from its compiler-error excerpt + prior source, write the
-// repaired source through the SAME shell_escape()d printf mechanism, re-run the gate, and STOP if the new rc is
-// FINDING/CLEAN. matchPrefix + the gate-invocation pieces are carried in as params (the .ag pass-everything
-// convention) so the body needs no module globals.
-fn repair_step(acc: string, gateSh: string, repo: string, out: string, matchPrefix: string, budgetArgs: string, forkArgs: string) -> string {
+// FM2 (#1077) — the BOTH-REAL-AWARE stop flag. In composable-fresh mode a TERMINAL verdict (rc 0/1) is NOT a
+// reason to stop the repair loop if the harness still mocked/omitted a required real contract — that verdict is
+// about a partial harness, not the real system, so we keep repairing (within the INV_REPAIR_ROUNDS budget) to
+// drive ALL named contracts real. Outside composable-fresh (`composeFresh` false) — and on the single-target
+// path — this is byte-identical to `stop_flag(rc)`: only the rc decides. A residual violation after the budget
+// is exhausted is forced to HARNESS_ERROR by the final-verdict computation below (it never leaks a partial CLEAN).
+fn stop_flag_both(rc: int, testSrc: string, composeFresh: bool, names: list<string>) -> string {
+    if stop_flag(rc) == "0" { return "0"; }
+    if !composeFresh { return "1"; }
+    if len(missing_real_deploys(testSrc, names)) > 0 { return "0"; }
+    return "1";
+}
+// One repair round over the carried state. A no-op once stopped (a FINDING/CLEAN with both-real satisfied was
+// already reached). Else the PRIOR attempt needs repair — either a HARNESS_ERROR (compile/no-invariant) OR (in
+// composable-fresh mode) a verdict on a harness that mocked/omitted a required real contract. The repair prompt
+// is chosen accordingly: the POINTED both-real message (#1077) naming the missing contracts when the prior
+// attempt COMPILED but is missing real deploys, else the compile-error message (#1073). Write the repaired
+// source through the SAME shell_escape()d printf mechanism, re-run the gate, and STOP via the both-real-aware
+// stop flag. matchPrefix + the gate-invocation pieces + composeFresh/names are carried in as params (the .ag
+// pass-everything convention) so the body needs no module globals.
+fn repair_step(acc: string, gateSh: string, repo: string, out: string, matchPrefix: string, budgetArgs: string, forkArgs: string, composeFresh: bool, names: list<string>) -> string {
     if rstate_field(acc, 0) == "1" { return acc; }
     let prevSrc = rstate_field(acc, 1);
     let prevOut = rstate_field(acc, 2);
-    let excerpt = error_excerpt(prevOut);
-    let fixed = repair_test(excerpt, prevSrc, matchPrefix);
+    let prevRc = rc_of(prevOut);
+    let missing = if composeFresh { missing_real_deploys(prevSrc, names) } else { "" };
+    // A both-real violation is a prior attempt that COMPILED to a verdict (rc 0/1) yet still mocked/omitted a
+    // required real contract. A HARNESS_ERROR (rc not in {0,1}) takes the compile-error repair regardless.
+    // (Nested if, not `&&`: single-assignment .ag has no short-circuit boolean operators.)
+    let bothRealViolation = if stop_flag(prevRc) == "1" { len(missing) > 0 } else { false };
+    let fixed = if bothRealViolation {
+        repair_test_bothreal(missing, prevSrc, matchPrefix)
+    } else {
+        repair_test(error_excerpt(prevOut), prevSrc, matchPrefix)
+    };
     let _wr = write_test(fixed, out);
     let newOut = run_gate(gateSh, repo, out, matchPrefix, budgetArgs, forkArgs);
-    return rstate(stop_flag(rc_of(newOut)), fixed, newOut);
+    return rstate(stop_flag_both(rc_of(newOut), fixed, composeFresh, names), fixed, newOut);
 }
 // BOUNDED RECURSION (single-assignment .ag has no `while`/`for`): drive `repair_step` at most `remaining`
 // times, decrementing per round, threading the carried (stopped, testSrc, runOut) state through each call.
 // `remaining <= 0` is a true no-op (returns the state untouched), so INV_REPAIR_ROUNDS=0 — and the fixture
 // path, which seeds stopped="1" — make ZERO extra prompt()/gate calls. `repair_step` itself short-circuits
-// once stopped, so a FINDING/CLEAN ends the recursion early even with rounds left.
-fn repair_loop(acc: string, remaining: int, gateSh: string, repo: string, out: string, matchPrefix: string, budgetArgs: string, forkArgs: string) -> string {
+// once stopped, so a FINDING/CLEAN (with both-real satisfied) ends the recursion early even with rounds left.
+fn repair_loop(acc: string, remaining: int, gateSh: string, repo: string, out: string, matchPrefix: string, budgetArgs: string, forkArgs: string, composeFresh: bool, names: list<string>) -> string {
     if remaining <= 0 { return acc; }
     if rstate_field(acc, 0) == "1" { return acc; }
-    let next = repair_step(acc, gateSh, repo, out, matchPrefix, budgetArgs, forkArgs);
-    return repair_loop(next, remaining - 1, gateSh, repo, out, matchPrefix, budgetArgs, forkArgs);
+    let next = repair_step(acc, gateSh, repo, out, matchPrefix, budgetArgs, forkArgs, composeFresh, names);
+    return repair_loop(next, remaining - 1, gateSh, repo, out, matchPrefix, budgetArgs, forkArgs, composeFresh, names);
 }
 
 // FIRST attempt: write the chosen test + run the gate ONCE (today's one-shot — byte-identical for the fixture
@@ -536,21 +613,49 @@ fn repair_loop(acc: string, remaining: int, gateSh: string, repo: string, out: s
 // the loop below makes zero extra prompt()/gate calls once a FINDING/CLEAN is in hand.
 let wrote = write_test(test, invOut);
 let firstOut = run_gate(gate, invRepo, invOut, invMatch, budget, fork);
-let firstStop = stop_flag(rc_of(firstOut));
+// FM2 (#1077): the first-attempt stop flag is both-real-aware too — in composable-fresh mode a first-attempt
+// FINDING/CLEAN on a harness that mocked/omitted a required real contract does NOT short-circuit; it enters
+// repair. Outside composable-fresh this is byte-identical to `stop_flag(rc_of(firstOut))` (only the rc decides).
+let firstStop = stop_flag_both(rc_of(firstOut), test, composableFresh, requiredNames);
 // Repair fires ONLY on the LLM path: the fixture path seeds the loop ALREADY-stopped (stopped="1") so it can
 // never be LLM-repaired, regardless of its rc. On the LLM path the initial stopped flag is firstStop, so a
-// FINDING/CLEAN first attempt short-circuits (no repair) and a HARNESS_ERROR first attempt enters repair.
+// FINDING/CLEAN first attempt (both-real satisfied) short-circuits (no repair) and a HARNESS_ERROR — or a
+// both-real violation in composable-fresh mode — enters repair.
 let initStopped = if usedFixture { "1" } else { firstStop };
 let initState = rstate(initStopped, test, firstOut);
-// Bounded compile-repair loop (#1073): at most `repairRounds` EXTRA rounds, each a no-op once stopped. The
-// carried per-attempt state is the (stopped, testSrc, runOut) triple. repairRounds==0 (the disable path) and
-// the fixture path both leave `finalState` == `initState` (today's one-shot behaviour).
-let finalState = repair_loop(initState, repairRounds, gate, invRepo, invOut, invMatch, budget, fork);
+// Bounded compile-repair loop (#1073, extended for #1077): at most `repairRounds` EXTRA rounds, each a no-op
+// once stopped. The carried per-attempt state is the (stopped, testSrc, runOut) triple. repairRounds==0 (the
+// disable path) and the fixture path both leave `finalState` == `initState` (today's one-shot behaviour). The
+// composeFresh flag + requiredNames are threaded so a both-real violation also drives a round (and the pointed
+// repair prompt) in composable-fresh mode; outside it they are inert (composeFresh false => no extra trigger).
+let finalState = repair_loop(initState, repairRounds, gate, invRepo, invOut, invMatch, budget, fork, composableFresh, requiredNames);
 
-// The verdict is the gate's exit code on the LAST attempt — NEVER the LLM's opinion (unchanged contract).
+// The verdict is the gate's exit code on the LAST attempt — NEVER the LLM's opinion (unchanged contract) —
+// EXCEPT the #1077 both-real override: in composable-fresh mode, if the FINAL harness STILL mocked/omitted a
+// required real contract after the repair budget was exhausted, a gate CLEAN/FINDING on that partial harness is
+// a FALSE cross-contract verdict, so it is FORCED to HARNESS_ERROR. The override fires ONLY in composable-fresh
+// mode and ONLY on a residual violation, so a genuine FINDING/CLEAN on an ALL-real harness — and every
+// single-target / fixture verdict (composableFresh false) — passes through unchanged.
 let runOut = rstate_field(finalState, 2);
+let finalSrc = rstate_field(finalState, 1);
+let bothRealMissing = if composableFresh { missing_real_deploys(finalSrc, requiredNames) } else { "" };
+let bothRealViolated = len(bothRealMissing) > 0;
 let rc = rc_of(runOut);
-let verdict = verdict_of(rc);
+fn final_verdict(rc: int, violated: bool) -> string {
+    if violated { return "HARNESS_ERROR"; }
+    return verdict_of(rc);
+}
+let verdict = final_verdict(rc, bothRealViolated);
+// Surface WHY this is not a real verdict so the HARNESS_ERROR marker below is not mistaken for a genuine
+// compile failure. Routed to STDERR via `exec sh` (the prover has no stderr print builtin) so the stdout marker
+// line stays the single machine-parsed verdict. `bothRealMissing` is untrusted LLM-derived text, so it is
+// shell_escape()d. A no-op (empty echo, no `>&2` reason) when there is no violation — purely additive.
+fn bothreal_reason(violated: bool, missing: string) -> string {
+    if !violated { return ""; }
+    // colony-lint: safe-exec-concat
+    return exec sh "printf '%s\\n' " + shell_escape("invariant-prover: forcing HARNESS_ERROR — harness mocked/omitted required real contract(s): " + missing) + " >&2; true";
+}
+let _bothRealReason = bothreal_reason(bothRealViolated, bothRealMissing);
 
 // --- EMIT the FUZZER's verdict -------------------------------------------------------------------
 // Surface the marker (stdout, parsed by run-invariant-hunt.sh), then on a FINDING the shrunk exploit

--- a/tools/test-invariant-prover-both-real.sh
+++ b/tools/test-invariant-prover-both-real.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# tools/test-invariant-prover-both-real.sh -- deterministic regression guard
+# for #1077 (dark-factory, FM2). In composable-fresh mode (#1075, INV_AUX
+# non-empty) the prover was supposed to deploy + wire the target AND each aux
+# contract REAL. Validation on two real pairs showed it instead deployed only
+# the EASIER contract real and mocked/omitted the harder one (e.g.
+# `--target dreUSDs --aux dreRewardsDistributor` -> real distributor + a
+# `RewardVaultMock`; `--target dreUSDManager --aux dreUSDOracle` -> real oracle,
+# manager never imported). A CLEAN on a harness that mocked the unit-under-test
+# is a FALSE verdict.
+#
+# #1077 ENFORCES both-real via validation + targeted repair (reusing the #1073
+# loop), NOT a Solidity-parsing deploy scaffold. Only active in composable-fresh
+# mode (INV_AUX non-empty); the single-target (#1070-B1) and offline
+# (HANDLER_FIXTURE) paths are byte-identical / untouched. The defence:
+#   1. `missing_real_deploys(testSrc, names)` reports each required contract
+#      name ({target} U {each aux}) that is MISSING `import {<name>}` AND
+#      `new <name>(` (the latter covers plain `new` and the
+#      `new ERC1967Proxy(address(new <name>()...` proxy form) -- i.e. dropped or
+#      mocked.
+#   2. The #1073 repair trigger is EXTENDED: a round also fires when
+#      composable-fresh AND missing_real_deploys is non-empty, with a POINTED
+#      repair prompt naming the missing contracts.
+#   3. After the repair budget is exhausted, a RESIDUAL both-real violation
+#      (composable-fresh + still missing) FORCES the emitted verdict to
+#      HARNESS_ERROR -- a partial CLEAN/FINDING never leaks as a real verdict.
+#
+# This test pins all of that so it cannot silently regress. Pure grep/awk over
+# the .ag source -- no agentis runtime, no LLM, no forge required.
+# Auto-discovered and run by tools/colony-lint.sh's `tools/test-*.sh` loop.
+#
+# Assertions:
+#   (a) The both-real check exists: a `missing_real_deploys()` helper backed by
+#       a `has_real_deploy()` that requires BOTH the `import {<name>}` marker
+#       AND the `new <name>(` marker (the marker per name), built over the
+#       {target} U {aux} `requiredNames` set.
+#   (b) It gates an EXTRA repair trigger in composable-fresh mode: a both-real-
+#       aware `stop_flag_both()` keeps the loop going on a terminal verdict that
+#       still has missing real deploys (composable-fresh only), and
+#       `repair_step` drives the round on that violation.
+#   (c) The pointed repair message names the missing contracts: a
+#       `repair_instruction_bothreal()` carrying the "did NOT deploy these
+#       REQUIRED real contracts" framing + the missing list, routed through
+#       `prompt()` via `repair_test_bothreal()`.
+#   (d) A RESIDUAL both-real violation after the repair budget FORCES
+#       HARNESS_ERROR: the final-verdict computation overrides verdict_of(rc)
+#       to HARNESS_ERROR when composable-fresh AND missing_real_deploys still
+#       non-empty.
+#   (e) The single-target / fixture paths are NOT subject to enforcement: the
+#       both-real check + override are gated behind `composableFresh` (so
+#       requiredNames/missing collapse to inert when INV_AUX is empty), and the
+#       fixture-excluded-from-repair seed (#1073) survives.
+#
+# Usage: bash tools/test-invariant-prover-both-real.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AG="$REPO_ROOT/dark-factory/auditor/agents/invariant-prover.ag"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$AG" ]; then
+    fail "ag exists" "$AG not found"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Whole-file source (the enforcement spans several helpers + the driver).
+src="$(cat "$AG")"
+
+# (a) The both-real check exists: missing_real_deploys() over has_real_deploy(),
+# which requires BOTH markers per name; the requiredNames set is {target} U
+# {aux names}, dropping empty names.
+a_fail=""
+printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+missing_real_deploys\(' \
+    || a_fail="${a_fail} no-missing_real_deploys"
+printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+has_real_deploy\(' \
+    || a_fail="${a_fail} no-has_real_deploy"
+# The IMPORT marker per name.
+printf '%s\n' "$src" | grep -Fq 'index_of(testSrc, "import {" + name + "}")' \
+    || a_fail="${a_fail} no-import-marker"
+# The NEW marker per name (covers plain `new <name>(` and the proxy form
+# `new ERC1967Proxy(address(new <name>()...`, both of which contain `new <name>(`).
+printf '%s\n' "$src" | grep -Fq 'index_of(testSrc, "new " + name + "(")' \
+    || a_fail="${a_fail} no-new-marker"
+# requiredNames is {target} U {aux names}.
+printf '%s\n' "$src" | grep -Fq 'let requiredNames = reduce(auxEntries' \
+    || a_fail="${a_fail} no-requiredNames"
+printf '%s\n' "$src" | grep -Fq 'if len(targetName) > 0 { [targetName] } else { [] }' \
+    || a_fail="${a_fail} no-target-in-set"
+
+if [ -z "$a_fail" ]; then
+    pass "(a) missing_real_deploys()/has_real_deploy() require BOTH import+new markers over the {target} U {aux} set"
+else
+    fail "(a) the both-real check exists with the import+new markers" \
+         "missing piece(s):$a_fail"
+fi
+
+# (b) It gates an EXTRA repair trigger in composable-fresh mode: a both-real-
+# aware stop_flag_both() that keeps the loop going on a terminal verdict with
+# missing real deploys (composable-fresh only), and repair_step drives the
+# round on the violation.
+b_fail=""
+printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+stop_flag_both\(' \
+    || b_fail="${b_fail} no-stop_flag_both"
+# Outside composable-fresh stop_flag_both is byte-identical to stop_flag (only
+# the rc decides) -- the inactive short-circuit.
+awk '/^fn stop_flag_both\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'if !composeFresh { return "1"; }' \
+    || b_fail="${b_fail} no-inactive-passthrough"
+# In composable-fresh, a residual missing list keeps the loop going.
+awk '/^fn stop_flag_both\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'if len(missing_real_deploys(testSrc, names)) > 0 { return "0"; }' \
+    || b_fail="${b_fail} no-keep-going-on-violation"
+# repair_step computes the violation and chooses the both-real repair path.
+awk '/^fn repair_step\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'let bothRealViolation = if stop_flag(prevRc) == "1" { len(missing) > 0 } else { false };' \
+    || b_fail="${b_fail} no-violation-detect"
+# The loop + first-attempt stop are both-real aware (threaded composeFresh/names).
+printf '%s\n' "$src" | grep -Fq 'let firstStop = stop_flag_both(rc_of(firstOut), test, composableFresh, requiredNames);' \
+    || b_fail="${b_fail} no-bothreal-first-stop"
+printf '%s\n' "$src" | grep -Fq 'repair_loop(initState, repairRounds, gate, invRepo, invOut, invMatch, budget, fork, composableFresh, requiredNames)' \
+    || b_fail="${b_fail} no-threaded-loop"
+
+if [ -z "$b_fail" ]; then
+    pass "(b) composable-fresh adds an extra repair trigger via stop_flag_both() + the repair_step violation detect"
+else
+    fail "(b) composable-fresh gates an extra repair trigger" \
+         "missing piece(s):$b_fail"
+fi
+
+# (c) The pointed repair message names the missing contracts: a
+# repair_instruction_bothreal() carrying the "did NOT deploy these REQUIRED
+# real contracts" framing + the missing list, routed through prompt() via
+# repair_test_bothreal().
+c_fail=""
+printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+repair_instruction_bothreal\(' \
+    || c_fail="${c_fail} no-repair_instruction_bothreal"
+printf '%s\n' "$src" | grep -Fq 'did NOT deploy these REQUIRED real contracts (you mocked or omitted them):' \
+    || c_fail="${c_fail} no-pointed-framing"
+# The instruction must inject the missing-contracts list (concatenated right
+# after the "...): " framing) AND the prior source.
+awk '/^fn repair_instruction_bothreal\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'them): " + missing' \
+    || c_fail="${c_fail} no-missing-list"
+awk '/^fn repair_instruction_bothreal\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq '+ prevSrc' \
+    || c_fail="${c_fail} no-prior-source"
+# It must tell the model to keep the already-real ones.
+printf '%s\n' "$src" | grep -Fq 'Keep the ones you already deployed real.' \
+    || c_fail="${c_fail} no-keep-real"
+# repair_test_bothreal() routes the pointed instruction through prompt().
+awk '/^fn repair_test_bothreal\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'prompt(repair_instruction_bothreal(' \
+    || c_fail="${c_fail} no-bothreal-prompt"
+
+if [ -z "$c_fail" ]; then
+    pass "(c) the pointed both-real repair message names the missing contracts + is routed through prompt()"
+else
+    fail "(c) the pointed repair message names the missing contracts" \
+         "missing piece(s):$c_fail"
+fi
+
+# (d) A RESIDUAL both-real violation after the repair budget FORCES
+# HARNESS_ERROR: the final-verdict computation overrides verdict_of(rc) to
+# HARNESS_ERROR when composable-fresh AND missing_real_deploys still non-empty.
+d_fail=""
+# The residual missing list is computed from the FINAL harness, gated on
+# composable-fresh.
+printf '%s\n' "$src" | grep -Fq 'let bothRealMissing = if composableFresh { missing_real_deploys(finalSrc, requiredNames) } else { "" };' \
+    || d_fail="${d_fail} no-residual-compute"
+printf '%s\n' "$src" | grep -Fq 'let bothRealViolated = len(bothRealMissing) > 0;' \
+    || d_fail="${d_fail} no-residual-flag"
+# final_verdict() forces HARNESS_ERROR on the violation, else verdict_of(rc).
+awk '/^fn final_verdict\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'if violated { return "HARNESS_ERROR"; }' \
+    || d_fail="${d_fail} no-force-harness-error"
+printf '%s\n' "$src" | grep -Fq 'let verdict = final_verdict(rc, bothRealViolated);' \
+    || d_fail="${d_fail} no-override-binding"
+# A clear stderr/marker reason is surfaced on the override.
+printf '%s\n' "$src" | grep -Fq 'harness mocked/omitted required real contract(s):' \
+    || d_fail="${d_fail} no-stderr-reason"
+
+if [ -z "$d_fail" ]; then
+    pass "(d) a residual both-real violation forces the emitted verdict to HARNESS_ERROR (no partial CLEAN leak)"
+else
+    fail "(d) a residual both-real violation forces HARNESS_ERROR" \
+         "missing piece(s):$d_fail"
+fi
+
+# (e) The single-target / fixture paths are NOT subject to enforcement: the
+# both-real check + override are gated behind composableFresh (so they collapse
+# to inert when INV_AUX is empty), and the fixture-excluded-from-repair seed
+# (#1073) survives.
+e_fail=""
+# The residual override is gated behind composableFresh (the `else { "" }` makes
+# it inert on the single-target path -> bothRealViolated is always false there).
+printf '%s\n' "$src" | grep -Fq 'if composableFresh { missing_real_deploys(finalSrc, requiredNames) } else { "" }' \
+    || e_fail="${e_fail} no-singletarget-inert"
+# stop_flag_both is byte-identical to stop_flag outside composable-fresh.
+awk '/^fn stop_flag_both\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \
+    | grep -Fq 'if !composeFresh { return "1"; }' \
+    || e_fail="${e_fail} no-singletarget-stop"
+# The #1073 fixture-excluded-from-repair seed must survive (the offline fixture
+# path is never repaired, so it is never both-real-enforced either).
+printf '%s\n' "$src" | grep -Fq 'let initStopped = if usedFixture { "1" } else { firstStop };' \
+    || e_fail="${e_fail} no-fixture-seed"
+
+if [ -z "$e_fail" ]; then
+    pass "(e) the single-target + fixture paths are NOT subject to both-real enforcement (composableFresh-gated; fixture seed survives)"
+else
+    fail "(e) the single-target / fixture paths are unaffected" \
+         "missing piece(s):$e_fail"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tools/test-invariant-prover-both-real.sh
+++ b/tools/test-invariant-prover-both-real.sh
@@ -14,10 +14,11 @@
 # mode (INV_AUX non-empty); the single-target (#1070-B1) and offline
 # (HANDLER_FIXTURE) paths are byte-identical / untouched. The defence:
 #   1. `missing_real_deploys(testSrc, names)` reports each required contract
-#      name ({target} U {each aux}) that is MISSING `import {<name>}` AND
-#      `new <name>(` (the latter covers plain `new` and the
-#      `new ERC1967Proxy(address(new <name>()...` proxy form) -- i.e. dropped or
-#      mocked.
+#      name ({target} U {each aux}) that is MISSING a `new <name>(` deploy marker
+#      (covers plain `new` and the `new ERC1967Proxy(address(new <name>()...` proxy
+#      form; the trailing `(` anchors the name so `new <name>Mock(` never matches)
+#      -- i.e. dropped or mocked. (A canonical `import {<name>}` is NOT required:
+#      it false-positived on legal grouped/spaced/aliased imports.)
 #   2. The #1073 repair trigger is EXTENDED: a round also fires when
 #      composable-fresh AND missing_real_deploys is non-empty, with a POINTED
 #      repair prompt naming the missing contracts.
@@ -31,9 +32,8 @@
 #
 # Assertions:
 #   (a) The both-real check exists: a `missing_real_deploys()` helper backed by
-#       a `has_real_deploy()` that requires BOTH the `import {<name>}` marker
-#       AND the `new <name>(` marker (the marker per name), built over the
-#       {target} U {aux} `requiredNames` set.
+#       a `has_real_deploy()` that requires the `new <name>(` deploy marker (the
+#       sole marker per name), built over the {target} U {aux} `requiredNames` set.
 #   (b) It gates an EXTRA repair trigger in composable-fresh mode: a both-real-
 #       aware `stop_flag_both()` keeps the loop going on a terminal verdict that
 #       still has missing real deploys (composable-fresh only), and
@@ -83,11 +83,12 @@ printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+missing_real_deploys\(' \
     || a_fail="${a_fail} no-missing_real_deploys"
 printf '%s\n' "$src" | grep -Eq 'fn[[:space:]]+has_real_deploy\(' \
     || a_fail="${a_fail} no-has_real_deploy"
-# The IMPORT marker per name.
-printf '%s\n' "$src" | grep -Fq 'index_of(testSrc, "import {" + name + "}")' \
-    || a_fail="${a_fail} no-import-marker"
-# The NEW marker per name (covers plain `new <name>(` and the proxy form
-# `new ERC1967Proxy(address(new <name>()...`, both of which contain `new <name>(`).
+# The NEW (deploy) marker per name covers plain `new <name>(` and the proxy form
+# `new ERC1967Proxy(address(new <name>()...`, both of which contain `new <name>(`.
+# The trailing `(` anchors the name (so `new <name>Mock(` never matches). This is
+# the SOLE marker: a canonical `import {<name>}` is deliberately NOT required (it
+# false-positived on legal grouped/spaced/aliased imports and could suppress a
+# genuine finding to HARNESS_ERROR); a `new <name>(` the gate compiles is in scope.
 printf '%s\n' "$src" | grep -Fq 'index_of(testSrc, "new " + name + "(")' \
     || a_fail="${a_fail} no-new-marker"
 # requiredNames is {target} U {aux names}.
@@ -97,7 +98,7 @@ printf '%s\n' "$src" | grep -Fq 'if len(targetName) > 0 { [targetName] } else { 
     || a_fail="${a_fail} no-target-in-set"
 
 if [ -z "$a_fail" ]; then
-    pass "(a) missing_real_deploys()/has_real_deploy() require BOTH import+new markers over the {target} U {aux} set"
+    pass "(a) missing_real_deploys()/has_real_deploy() require the new-deploy marker over the {target} U {aux} set"
 else
     fail "(a) the both-real check exists with the import+new markers" \
          "missing piece(s):$a_fail"
@@ -174,7 +175,7 @@ fi
 d_fail=""
 # The residual missing list is computed from the FINAL harness, gated on
 # composable-fresh.
-printf '%s\n' "$src" | grep -Fq 'let bothRealMissing = if composableFresh { missing_real_deploys(finalSrc, requiredNames) } else { "" };' \
+printf '%s\n' "$src" | grep -Fq 'let bothRealMissing = if composableFresh { if usedFixture { "" } else { missing_real_deploys(finalSrc, requiredNames) } } else { "" };' \
     || d_fail="${d_fail} no-residual-compute"
 printf '%s\n' "$src" | grep -Fq 'let bothRealViolated = len(bothRealMissing) > 0;' \
     || d_fail="${d_fail} no-residual-flag"
@@ -200,9 +201,11 @@ fi
 # to inert when INV_AUX is empty), and the fixture-excluded-from-repair seed
 # (#1073) survives.
 e_fail=""
-# The residual override is gated behind composableFresh (the `else { "" }` makes
-# it inert on the single-target path -> bothRealViolated is always false there).
-printf '%s\n' "$src" | grep -Fq 'if composableFresh { missing_real_deploys(finalSrc, requiredNames) } else { "" }' \
+# The residual override is gated behind composableFresh (the trailing `else { "" }`
+# makes it inert on the single-target path) AND, within composable-fresh, behind
+# NOT usedFixture (an operator HANDLER_FIXTURE run with --aux is never force-
+# overridden — it is already never repaired).
+printf '%s\n' "$src" | grep -Fq 'if composableFresh { if usedFixture { "" } else { missing_real_deploys(finalSrc, requiredNames) } } else { "" }' \
     || e_fail="${e_fail} no-singletarget-inert"
 # stop_flag_both is byte-identical to stop_flag outside composable-fresh.
 awk '/^fn stop_flag_both\(/{f=1} f{print} f&&/^}/{exit}' "$AG" \


### PR DESCRIPTION
## What

Closes #1077. FM2 (#1075) was meant to deploy + wire the target AND each aux contract **real**, but validation showed the LLM deployed only the easier contract real and **mocked/omitted the harder one** (`--target dreUSDs --aux dreRewardsDistributor` → real distributor + a `RewardVaultMock`; `--target dreUSDManager --aux dreUSDOracle` → real oracle, manager never imported). A CLEAN on a harness that mocked the unit-under-test is a **false** verdict.

## Fix — enforce both-real (composable-fresh mode only; reuses the #1073 repair loop)
- `missing_real_deploys(testSrc, names)`: every required contract — `{target}` ∪ each `--aux` — must be both `import {<Name>}`-ed and `new <Name>(`-deployed (covers plain `new` and the `ERC1967Proxy(address(new <Name>()…)` form). Returns the comma-list of contracts that were dropped/mocked.
- A both-real violation triggers an extra repair round with a **pointed** message naming the mocked/omitted contracts (reusing the #1073 loop + `INV_REPAIR_ROUNDS` budget).
- If a violation survives the budget, the verdict is **forced to `HARNESS_ERROR`** (with a stderr reason) even if the gate returned CLEAN/FINDING on the partial harness — so a harness that mocked the target can never surface a false cross-contract CLEAN.
- Single-target (#1070-B1) and offline `HANDLER_FIXTURE` paths are inert (composableFresh false ⇒ rc-only stop, no override). When both-real holds, the gate exit code is still the verdict.

## Test plan
- New guard `tools/test-invariant-prover-both-real.sh`: both-real check exists, extra repair trigger in composable-fresh, pointed message names missing contracts, residual violation forces HARNESS_ERROR, single-target/fixture exempt. 5/5 post-change, 5/5 fail pre-change. shellcheck-clean.
- All existing guards still pass (bounded-gen, real-target, repair-loop, multideploy, harness-isolation).
- `./tools/colony-lint.sh` → `373 passed, 0 failed, 5 skipped`.
- Offline mock-backend probe: a harness that mocks the target → forced HARNESS_ERROR; an all-real harness → passes through; single-target → unchanged.

Related: epic #1041; closes the FM2 cross-contract line (#1075 mechanism + #1077 enforcement).
