### PR TITLE
fix(dark-factory): slim the embedded contract source in the gen prompt (#1079)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -15,6 +15,28 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 ## [Unreleased]
 
 ### Fixed
+- **invariant-hunt SLIMS the embedded contract source(s) in the generation prompt** (#1079, epic #1041). On a
+  real autonomous sweep every cross-contract PAIR (two full contract sources in ONE gen prompt) and one complex
+  single-contract target hit the per-run timeout: the flat-cyborg→claude generation hung on a SINGLE gen call
+  for ~712 s because the prompt embeds the FULL source of each contract (a pair ≈ 90 KB of Solidity), so all
+  cross-contract coverage was lost. The OUTPUT ask was already bounded (#1067); this slims the INPUT.
+  `run-invariant-hunt.sh` now stages the target source (`CODE_PATH`) and each `--aux` source (#1075) through a
+  portable awk Solidity-source SLIMMER (`slim_sol_source`) instead of a flat `cp`: it drops `//`/`///` line
+  comments (full-line + safe trailing), `/* ... */` block comments INCLUDING multi-line NatSpec `/** ... */`
+  (a single-pass block-comment state machine — a naive sed cannot span lines robustly), `import ...;` and
+  `pragma ...;` statement lines, and squeezes runs of blank lines to one — while KEEPING every line of real
+  callable surface + logic: the `contract <Name> is ...` declaration, state variables, every function signature
+  AND body, and structs/enums/events/errors. The prover's contract is unchanged — it still `cat_file`s the same
+  staged `CODE_PATH`/aux paths and the generation prompt's STRUCTURE is identical; only the embedded source
+  content is smaller (roughly halved on heavily-NatSpec'd sources). Trailing-comment stripping is CONSERVATIVE:
+  a `//` is stripped from a code line only when no quote (`"`/`'`) precedes it on that line, so a `//` inside a
+  string literal is NEVER corrupted (correctness of the staged Solidity over maximal slimming). An empty-output
+  guard never ships an empty / truncated `CODE_PATH`: a pathological all-comments/all-import source that slims to
+  only blank lines falls back to the ORIGINAL verbatim. A new deterministic guard,
+  `tools/test-invariant-hunt-slim-source.sh`, feeds a fixture `.sol` (every comment/import/pragma/blank-run noise
+  class + real `contract`/state/function/struct/event/error code) through the live slimmer and asserts the noise
+  is removed, the real code survives intact, a string-literal `//` is preserved, and the empty-output fallback
+  fires — plus that the runner wires the slimmer into BOTH stagings (grep/awk over the runner, no LLM/forge).
 - **invariant-prover ENFORCES both-real cross-contract deployment (composable-fresh)** (#1077, epic #1041). In
   composable-fresh mode (#1075, `INV_AUX` non-empty) the LLM was supposed to deploy + wire the target AND each
   aux contract REAL. Validation on two real pairs showed it instead deployed only the EASIER contract real and

--- a/dark-factory/run-invariant-hunt.sh
+++ b/dark-factory/run-invariant-hunt.sh
@@ -229,6 +229,82 @@ RUN="$OUT/run"
 rm -rf "$RUN"; mkdir -p "$RUN"
 cp "$PROVER" "$RUN/invariant-prover.ag"
 cp "$GATE" "$RUN/forge-invariant.sh"
+
+# #1079: SLIM a Solidity source before it is staged into the rundir as the prover's CODE_PATH / aux source.
+# The generation prompt embeds the FULL source of the target (and, in composable-fresh mode, of every aux),
+# so a cross-contract pair was ~90 KB of Solidity per gen call and hung flat-cyborg->claude on a SINGLE call
+# past the per-run timeout (all cross-contract coverage lost). The OUTPUT ask is already bounded (#1067); this
+# slims the INPUT. We drop only NOISE the model does not need — comments, imports, pragmas, blank-line runs —
+# and KEEP every line of real callable surface + logic (the `contract` decl, state vars, function signatures
+# AND bodies, structs/enums/events/errors). A reasonable target is roughly halving heavily-NatSpec'd sources.
+#
+# Portable awk (no GNU-only features) implementing, in ONE pass with a block-comment state machine:
+#   * `/* ... */` block comments INCLUDING multi-line NatSpec `/** ... */` (the state machine spans lines; a
+#     naive sed cannot do this robustly). A block opened and closed on one line is removed too.
+#   * full-line `//` / `///` line comments (after leading whitespace) -> the whole line is dropped.
+#   * trailing `// ...` on a code line -> stripped ONLY when the line carries no quote (`"` or `'`) before it,
+#     so a `//` inside a string literal is NEVER corrupted (conservative; correctness over maximal slimming).
+#   * `import ...;` and `pragma ...;` statement lines (after leading whitespace) -> dropped.
+#   * runs of blank lines squeezed to a single blank line.
+# Real code lines are emitted verbatim. The whole transform writes to a temp file; if it somehow EMPTIES the
+# source (pathological input), we fall back to a flat copy of the original so CODE_PATH is never empty/truncated.
+slim_sol_source() {  # $1 = src .sol path, $2 = dest staged path
+  _slim_src="$1"; _slim_dst="$2"
+  awk '
+    BEGIN { inblock = 0; blank = 0 }
+    {
+      line = $0
+      out = ""
+      i = 1
+      n = length(line)
+      # --- block-comment state machine (handles /* */, /** */, multi-line) ---
+      while (i <= n) {
+        if (inblock) {
+          # inside a block comment: look for the closing */
+          p = index(substr(line, i), "*/")
+          if (p == 0) { i = n + 1 }          # no close on this line -> consume the rest
+          else { i = i + p + 1; inblock = 0 } # skip past the */ and resume scanning
+          continue
+        }
+        c = substr(line, i, 1)
+        # opening of a // line comment: only honour it if no quote precedes it on the kept part so far
+        # (conservative: a // inside a string literal is left alone -> the whole line is kept verbatim).
+        if (c == "/" && substr(line, i + 1, 1) == "/") {
+          if (index(out, "\"") == 0 && index(out, "\x27") == 0) { i = n + 1; continue }
+          else { out = out substr(line, i); i = n + 1; continue }
+        }
+        # opening of a /* block comment (covers /** NatSpec)
+        if (c == "/" && substr(line, i + 1, 1) == "*") {
+          inblock = 1; i = i + 2; continue
+        }
+        out = out c
+        i = i + 1
+      }
+      # strip trailing whitespace left by a removed trailing comment
+      sub(/[ \t]+$/, "", out)
+      # drop import/pragma statement lines (after any leading whitespace)
+      tmp = out
+      sub(/^[ \t]+/, "", tmp)
+      if (tmp ~ /^import[ \t(]/ || tmp ~ /^pragma[ \t]/) { next }
+      # squeeze runs of blank lines to one
+      if (out ~ /^[ \t]*$/) {
+        if (blank) { next }
+        blank = 1
+        print ""
+        next
+      }
+      blank = 0
+      print out
+    }
+  ' "$_slim_src" > "$_slim_dst" 2>/dev/null || true
+  # Empty-output guard: never ship an empty CODE_PATH. A truly empty file, OR one with no non-whitespace
+  # content (e.g. a pathological all-comments/all-import source that slimmed down to only blank lines), falls
+  # back to the original verbatim so the prover always reads a real, complete source.
+  if [ ! -s "$_slim_dst" ] || ! grep -q '[^[:space:]]' "$_slim_dst" 2>/dev/null; then
+    cp "$_slim_src" "$_slim_dst"
+  fi
+}
+
 # Stage a fresh copy of the foundry project into the rundir so the sandboxed exec sh can write the test into
 # its test/ dir and run forge there (it cannot reach a $HOME-rooted --repo). Drop any pre-existing *.t.sol so
 # the generated test is the ONLY one the fuzzer scopes to.
@@ -245,7 +321,9 @@ if [ -n "$FIXTURE" ]; then
 fi
 CODE_IN_RUN=""
 if [ -n "$CODE" ]; then
-  cp "$CODE" "$RUN/target-code.sol"
+  # #1079: SLIM the target source on its way into the rundir (instead of a flat copy) so the generation prompt
+  # embeds a smaller, comment/import-free source — the gen call no longer hangs on a ~90 KB single completion.
+  slim_sol_source "$CODE" "$RUN/target-code.sol"
   CODE_IN_RUN="$RUN/target-code.sol"
 fi
 
@@ -260,7 +338,9 @@ _aux_idx=0
 for entry in ${AUX_ABS_SPECS+"${AUX_ABS_SPECS[@]}"}; do
   _aabs="${entry%:*}"; _aname="${entry##*:}"
   _aux_in_run="$RUN/aux-code-${_aux_idx}.sol"
-  cp "$_aabs" "$_aux_in_run"
+  # #1079: SLIM each aux source too — a cross-contract PAIR (two full sources in one prompt) was the worst
+  # offender for the gen-call timeout, so the aux staging goes through the same slimmer as the target.
+  slim_sol_source "$_aabs" "$_aux_in_run"
   if [ -z "$INV_AUX" ]; then INV_AUX="$_aux_in_run:$_aname"; else INV_AUX="$INV_AUX@@A@@$_aux_in_run:$_aname"; fi
   _aux_idx=$((_aux_idx + 1))
 done

--- a/tools/test-invariant-hunt-slim-source.sh
+++ b/tools/test-invariant-hunt-slim-source.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# tools/test-invariant-hunt-slim-source.sh -- deterministic regression guard
+# for #1079 (dark-factory). On a real autonomous sweep every cross-contract
+# pair (two full contract sources in ONE generation prompt) and one complex
+# single-contract target hit the per-run timeout: flat-cyborg->claude hung on a
+# SINGLE gen call for ~712 s because the prompt embedded the FULL source of each
+# contract (a pair was ~90 KB of Solidity). The OUTPUT ask is already bounded
+# (#1067); the fix slims the INPUT. run-invariant-hunt.sh now stages the target
+# source (CODE_PATH) and each --aux source through a Solidity-source SLIMMER
+# (`slim_sol_source`) instead of a flat copy: it drops `//`/`///` line comments
+# (full-line + safe trailing), `/* ... */` block comments INCLUDING multi-line
+# NatSpec `/** ... */`, `import ...;` and `pragma ...;` lines, and squeezes
+# runs of blank lines to one -- while KEEPING the `contract` decl, state vars,
+# every function signature AND body, and structs/enums/events/errors.
+#
+# This test FEEDS a fixture .sol through the live `slim_sol_source` function
+# (extracted verbatim from the runner) and asserts the slim contract, plus
+# pins that the runner WIRES the slimmer into both the target and the --aux
+# staging (so a pre-change flat `cp` staging fails). Pure bash/awk/grep over
+# the runner -- no agentis runtime, no LLM, no forge required. Auto-discovered
+# and run by tools/colony-lint.sh's `tools/test-*.sh` loop.
+#
+# Assertions:
+#   (a) The runner defines a `slim_sol_source()` function AND wires it into the
+#       target (CODE_PATH) staging and the --aux staging (not a flat `cp`).
+#   (b) Run over a fixture, the slimmer REMOVES: full-line `//`/`///` comments,
+#       multi-line `/** ... */` NatSpec blocks, inline `/* ... */` blocks,
+#       `import ...;` lines, `pragma ...;` lines, and squeezes blank-line runs.
+#   (c) The slimmer KEEPS the real code intact: the `contract <Name> is ...`
+#       declaration, a state-variable line, every function signature, and a
+#       struct/event/error line all survive.
+#   (d) Conservative trailing-comment handling: a `//` INSIDE a string literal
+#       is NEVER stripped (the code line carrying it survives verbatim), so the
+#       staged Solidity is never corrupted.
+#   (e) Empty-output fallback: a pathological all-comments/all-import source
+#       (which slims to only blank lines) falls back to the ORIGINAL verbatim,
+#       so CODE_PATH is never empty / truncated.
+#
+# Usage: bash tools/test-invariant-hunt-slim-source.sh
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNNER="$REPO_ROOT/dark-factory/run-invariant-hunt.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+summary_exit() {
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    if [ "$FAIL" -gt 0 ]; then
+        exit 1
+    fi
+    exit 0
+}
+
+if [ ! -f "$RUNNER" ]; then
+    fail "runner exists" "$RUNNER not found"
+    summary_exit
+fi
+
+run_src="$(cat "$RUNNER")"
+
+# (a) The runner defines slim_sol_source AND wires it into both stagings (a
+# pre-change flat `cp "$CODE" .../target-code.sol` / `cp "$_aabs" .../aux-code`
+# staging fails here).
+a_fail=""
+printf '%s\n' "$run_src" | grep -Eq '^slim_sol_source\(\) \{' \
+    || a_fail="${a_fail} no-slim-fn"
+# shellcheck disable=SC2016  # matching the literal staging line, $ must not expand
+printf '%s\n' "$run_src" | grep -Fq 'slim_sol_source "$CODE" "$RUN/target-code.sol"' \
+    || a_fail="${a_fail} target-not-slimmed"
+# shellcheck disable=SC2016  # matching the literal staging line, $ must not expand
+printf '%s\n' "$run_src" | grep -Fq 'slim_sol_source "$_aabs" "$_aux_in_run"' \
+    || a_fail="${a_fail} aux-not-slimmed"
+
+if [ -z "$a_fail" ]; then
+    pass "(a) runner defines slim_sol_source and wires it into the target + --aux staging"
+else
+    fail "(a) runner slims both stagings via slim_sol_source" \
+         "missing piece(s):$a_fail"
+fi
+
+# Extract the live slim_sol_source function verbatim so the behavioural
+# assertions exercise the SAME code the runner ships (not a re-implementation).
+SLIM_FN="$(awk '/^slim_sol_source\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$RUNNER")"
+
+if [ -z "$SLIM_FN" ]; then
+    fail "slim_sol_source extracted" "no 'slim_sol_source() { ... }' block in the runner"
+    summary_exit
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Run the extracted slimmer in a child shell over a given src -> dst.
+slim() {  # $1 = src, $2 = dst
+    { printf '%s\n' "$SLIM_FN"; printf 'slim_sol_source %s %s\n' "$1" "$2"; } | bash
+}
+
+# --- Fixture with EVERY noise class + real code to keep ---
+FIX="$WORK/Vault.sol"
+cat > "$FIX" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title A vault
+/// @notice keeps funds
+/**
+ * @dev multi-line NatSpec
+ *      block comment
+ */
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./Other.sol";
+
+contract Vault is IERC20 {
+    uint256 public totalAssets; // trailing comment on code
+
+
+    mapping(address => uint256) public shares;
+    struct Position { uint256 amount; uint256 since; }
+    event Deposit(address indexed who, uint256 amt);
+    error NotEnough();
+
+    // a full-line comment between functions
+    function deposit(uint256 amt) external {
+        string memory note = "use // not a comment"; // real trailing
+        totalAssets += amt; /* inline block */ shares[msg.sender] += amt;
+    }
+
+    function withdraw(uint256 amt) external {
+        require(shares[msg.sender] >= amt, "x");
+        totalAssets -= amt;
+    }
+}
+SOL
+
+OUT="$WORK/Vault.slim.sol"
+slim "$FIX" "$OUT"
+
+if [ ! -s "$OUT" ]; then
+    fail "slimmer produced output" "slim_sol_source wrote an empty file"
+    summary_exit
+fi
+
+# (b) Noise removed.
+b_fail=""
+grep -Fq 'SPDX-License-Identifier' "$OUT" \
+    && b_fail="${b_fail} spdx-line-comment-kept"
+grep -Fq '@title A vault' "$OUT" \
+    && b_fail="${b_fail} triple-slash-comment-kept"
+grep -Fq 'multi-line NatSpec' "$OUT" \
+    && b_fail="${b_fail} multiline-natspec-kept"
+grep -Fq 'block comment' "$OUT" \
+    && b_fail="${b_fail} natspec-body-kept"
+grep -Fq 'inline block' "$OUT" \
+    && b_fail="${b_fail} inline-block-kept"
+grep -Fq 'trailing comment on code' "$OUT" \
+    && b_fail="${b_fail} trailing-comment-kept"
+grep -Fq 'a full-line comment between functions' "$OUT" \
+    && b_fail="${b_fail} fullline-between-fns-kept"
+grep -Eq '^[[:space:]]*import[[:space:](]' "$OUT" \
+    && b_fail="${b_fail} import-kept"
+grep -Eq '^[[:space:]]*pragma[[:space:]]' "$OUT" \
+    && b_fail="${b_fail} pragma-kept"
+# No run of two consecutive blank lines survives (blank-squeeze). NR>1 guards
+# against the uninitialized `prev` matching a leading blank line on the 1st row.
+if awk 'NR>1 && prev=="" && $0=="" {bad=1} {prev=$0} END{exit bad?0:1}' "$OUT"; then
+    b_fail="${b_fail} blank-run-kept"
+fi
+
+if [ -z "$b_fail" ]; then
+    pass "(b) slimmer removes //, ///, /** */ NatSpec, inline /* */, import, pragma, and blank-line runs"
+else
+    fail "(b) slimmer removes comment/import/pragma/blank noise" \
+         "still present:$b_fail"
+fi
+
+# (c) Real code kept intact.
+c_fail=""
+grep -Fq 'contract Vault is IERC20 {' "$OUT" \
+    || c_fail="${c_fail} contract-decl-lost"
+grep -Fq 'uint256 public totalAssets;' "$OUT" \
+    || c_fail="${c_fail} state-var-lost"
+grep -Fq 'mapping(address => uint256) public shares;' "$OUT" \
+    || c_fail="${c_fail} mapping-state-var-lost"
+grep -Fq 'function deposit(uint256 amt) external {' "$OUT" \
+    || c_fail="${c_fail} deposit-sig-lost"
+grep -Fq 'function withdraw(uint256 amt) external {' "$OUT" \
+    || c_fail="${c_fail} withdraw-sig-lost"
+grep -Fq 'struct Position { uint256 amount; uint256 since; }' "$OUT" \
+    || c_fail="${c_fail} struct-lost"
+grep -Fq 'event Deposit(address indexed who, uint256 amt);' "$OUT" \
+    || c_fail="${c_fail} event-lost"
+grep -Fq 'error NotEnough();' "$OUT" \
+    || c_fail="${c_fail} error-lost"
+# A body statement survives (function bodies are kept, not just signatures).
+grep -Fq 'require(shares[msg.sender] >= amt, "x");' "$OUT" \
+    || c_fail="${c_fail} body-stmt-lost"
+
+if [ -z "$c_fail" ]; then
+    pass "(c) slimmer keeps the contract decl, state vars, function signatures + bodies, struct/event/error"
+else
+    fail "(c) slimmer keeps the real callable surface + logic" \
+         "lost:$c_fail"
+fi
+
+# (d) Conservative: a // inside a string literal is never stripped -> the line
+# carrying it survives VERBATIM (the string content is intact and uncorrupted).
+if grep -Fq 'string memory note = "use // not a comment";' "$OUT"; then
+    pass "(d) a // inside a string literal is preserved (string-literal line not corrupted)"
+else
+    fail "(d) string-literal // preserved" \
+         "the 'use // not a comment' string literal was corrupted or dropped"
+fi
+
+# (e) Empty-output fallback: an all-comments / all-import source slims to only
+# blank lines, so the slimmer falls back to the ORIGINAL verbatim.
+PATHO="$WORK/AllComments.sol"
+cat > "$PATHO" <<'SOL'
+// only comments
+/// more
+/** block
+    spanning lines */
+import "x";
+pragma solidity ^0.8.0;
+SOL
+PATHO_OUT="$WORK/AllComments.slim.sol"
+slim "$PATHO" "$PATHO_OUT"
+
+if [ -s "$PATHO_OUT" ] && cmp -s "$PATHO" "$PATHO_OUT"; then
+    pass "(e) a pathological all-comments source falls back to the original verbatim (never empty CODE_PATH)"
+else
+    fail "(e) empty-output fallback to the original" \
+         "all-comments source did not fall back to the original (would ship an empty/blank CODE_PATH)"
+fi
+
+summary_exit


### PR DESCRIPTION
## What
Closes #1079. On a real autonomous full-scope sweep, all 3 cross-contract pairs + 1 complex single target hit the per-run timeout — flat-cyborg/claude hung on a single ~712s gen call because the prompt embeds the FULL source of each contract (a pair ≈ 90KB). The output ask is already bounded (#1067); this slims the INPUT.

`run-invariant-hunt.sh` stages each embedded source (target `CODE_PATH` + each `--aux`, #1075) through a new `slim_sol_source()` (portable awk state machine) instead of a flat `cp`: strips `/* */` incl. multi-line NatSpec, full-line `//`/`///`, trailing `//` on quote-free lines (string-literal `//` preserved), `import`/`pragma`, squeezes blank runs — keeps all real code. Empty result falls back to the original. The prover is unchanged; only the staged content is smaller (~halves these NatSpec-heavy sources).

## Test plan
- New guard `tools/test-invariant-hunt-slim-source.sh`: 5/5 post-change, fails pre-change; shellcheck-clean.
- `bash -n run-invariant-hunt.sh` OK; `./tools/colony-lint.sh` → `374 passed, 0 failed, 5 skipped`.
- Operator end-to-end: a cross-contract pair (which previously TIMED OUT) is re-run with the slimmed source to confirm it now completes a gen+verdict in budget.

Related: epic #1041.
