### PR TITLE
fix(dark-factory): flat-cyborg-claude.sh uses --extract-structural (needs flat-cyborg >=0.10.2) (#1083)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -15,6 +15,12 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 ## [Unreleased]
 
 ### Fixed
+- **`flat-cyborg-claude.sh` uses `--extract-structural`** (#1083, needs flat-cyborg ≥ 0.10.2). claude
+  intermittently omits the reply sentinel; strict `--extract` then burned the full `--timeout-ms` and exited
+  "no fenced reply", which the agentis caller retried — repeated ~700 s gen hangs ending in HARNESS_ERROR
+  (several sweep TIMEOUTs traced to exactly this). With flat-cyborg #55 (v0.10.2), `--extract-structural`
+  completes on a SETTLED screen and recovers the reply marker-first → structural-fallback (fast +
+  marker-less-tolerant); a marker-ful reply is extracted exactly as before.
 - **invariant-prover cuts false-positive findings — realistic input bounds + mocked-dep decimal/type fidelity**
   (#1080, epic #1041). A real autonomous sweep produced two FINDINGs that triaged to harness artifacts, not
   bugs: an oracle target's unbounded price-setter let the fuzzer drive the price to absurd magnitudes

--- a/dark-factory/flat-cyborg-claude.sh
+++ b/dark-factory/flat-cyborg-claude.sh
@@ -13,9 +13,14 @@ set -eu
 PROMPT="${1:-}"
 if [ -z "$PROMPT" ]; then PROMPT="$(cat)"; fi
 # --wrap-input 72: fold the (often single-line, ~700-char) instruction block so it
-# does not overflow claude's editor input. flat-cyborg >=0.10.0 also gates --extract
-# on the reply sentinel, so a slow first reply is no longer captured as empty.
-exec flat-cyborg --extract --no-jitter --auto-approve --wrap-input 72 \
+# does not overflow claude's editor input.
+# --extract-structural (needs flat-cyborg >=0.10.2): claude INTERMITTENTLY omits the
+# reply sentinel; strict --extract then burns the full --timeout-ms and exits "no
+# fenced reply", which the agentis caller retries -> repeated ~700s gen hangs that end
+# in HARNESS_ERROR. Structural mode completes on a SETTLED screen and recovers the
+# reply marker-first -> structural-fallback (fast + marker-less-tolerant); a reply that
+# DOES carry the markers is extracted exactly as before.
+exec flat-cyborg --extract --extract-structural --no-jitter --auto-approve --wrap-input 72 \
   --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" \
   --timeout-ms "${FLAT_CYBORG_TIMEOUT_MS:-180000}" \
   --cmd "$PROMPT" -- claude


### PR DESCRIPTION
Closes #1083. claude intermittently omits the reply sentinel; strict `--extract` then burned the full `--timeout-ms` and exited "no fenced reply", which the agentis caller retried — repeated ~700s gen hangs ending in HARNESS_ERROR (several real-sweep TIMEOUTs traced to this). With flat-cyborg #55 (v0.10.2), `--extract-structural` completes on a SETTLED screen and recovers the reply marker-first → structural-fallback (fast + marker-less-tolerant); a marker-ful reply is unchanged. sh -n + shellcheck clean; colony-lint clean; CHANGELOG updated.