### PR TITLE
feat(dark-factory): add monitor colony — continuous invariant + oracle anomaly watching (#1085)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -114,6 +114,34 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   `tools/test-invariant-prover-repair-loop.sh`, pins the loop (grep over the `.ag`, no LLM/forge).
 
 ### Added
+- **`monitor` colony — continuous protocol monitoring with confidence-tiered alerting** (#1085). A new colony
+  alongside `auditor` that continuously WATCHES a target EVM protocol and emits reasoned, high-signal anomaly
+  alerts on the bus (`monitor:alert`). NON-custodial / read-only: every watcher only READS chain state via
+  `cast`/RPC over `exec sh` (each dynamic value `shell_escape()`d) — no agent signs a transaction or touches
+  funds. The hot-path verdicts are FACTS (an on-chain read + a deterministic comparison), never an LLM opinion.
+  This PR ships the lint-clean foundation: the colony scaffold (`monitor/{agents,config,scripts,README.md}`,
+  `[forge] type = "none"` per ADR-0003), two highest-value watchers, the fusion coordinator, and a webhook sink.
+  - `monitor/agents/invariant-watcher.ag` — evaluates a derived protocol invariant (e.g. `totalSupply() <=
+    totalAssets()`) against current on-chain state and flags a violation or a thin margin-to-violation. The
+    invariant sides, target address, relation, and margin band come from env/config (getenv).
+  - `monitor/agents/oracle-watcher.ag` — watches a price feed for deviation (vs a learned baseline) / staleness
+    (feed age) / out-of-bounds price, same on-chain read pattern.
+  - `monitor/agents/coordinator.ag` — fuses the two watcher signals off the shared `monitor:signal:*` blackboard
+    (single-assignment helpers, no loops), dedups a persistent condition against the last emitted signature,
+    decides fused severity, and emits one consolidated `monitor:alert`.
+  - **Confidence-tiered alerting (ADR-0001) as the false-positive control.** Every agent makes ONE `tier()` call
+    per tick and branches once; the tier gates EMISSION only (the verdict is identical at every tier): `shadow`/
+    `dormant` observe + learn a baseline (no emit), `propose` emits a DRAFT alert (low severity), `review-gated`/
+    `autonomous` emit a DIRECT page (high severity). `cb <N>;` matches `cb_budget`, and every tick ends with
+    `memo_write("<agent>:last_check", now)`.
+  - `monitor/scripts/start-colony.sh` — ADR-0003-conformant daemon launcher (symlink-safe `$0`, sources
+    `parse-toml.sh`, exports the `MONITOR_*` env contract, `--restart-agent`, allowlisted daemon flags).
+  - `monitor/scripts/notify.sh` — a thin POSIX-sh / dash-safe notifier that POSTs an alert payload to a
+    Discord/Slack webhook when `MONITOR_WEBHOOK_URL` is set (no secret committed; read-only); prints to stdout
+    as a no-op sink when unset.
+  - `monitor/README.md` — agent table + mermaid diagram + the env contract + the tier semantics.
+  Follow-ups (out of scope here): the liquidity / governance / flow watchers, the live-watch runtime (#1086),
+  and a dashboard view. The colony NEVER signs, NEVER touches funds, and NEVER posts without a configured sink.
 - **invariant-prover cross-contract multi-deploy harnesses (composable-fresh)** (#1075, epic #1041). The
   FRESH-DEPLOY real-target path deployed ONE target (single-contract) + mocked its externals, so the
   highest-value stablecoin bugs — which are CROSS-contract (oracle manipulation → manager mispricing; reward

--- a/dark-factory/monitor/README.md
+++ b/dark-factory/monitor/README.md
@@ -1,0 +1,115 @@
+# Monitor Colony
+
+> Part of the [Dark Factory](../) federation.
+
+A continuous **protocol monitor**. Three cooperating agents watch a target EVM
+protocol on-chain and emit reasoned, high-signal anomaly alerts on the colony bus
+(`monitor:alert`). The colony is **non-custodial / read-only**: every watcher only
+**reads** chain state via `cast`/RPC — it never signs a transaction and never
+touches funds.
+
+The hot-path verdicts are **facts** (an on-chain read + a deterministic
+comparison), never an LLM opinion. Emission is gated purely on each agent's
+[ADR-0001](../../doc/adr/ADR-0001-confidence-tiers.md) confidence tier as the
+false-positive control: a watcher learns the protocol's normal state in `shadow`
+before it is ever trusted to page.
+
+## Agents
+
+| Agent | Role | Output |
+|-------|------|--------|
+| `invariant-watcher` | Evaluates a derived protocol invariant (e.g. `totalSupply() <= totalAssets()`) against current on-chain state; flags a violation or a thin margin-to-violation | `monitor:signal:invariant`, `monitor:alert` (tier-gated) |
+| `oracle-watcher` | Watches a price feed for deviation / staleness / out-of-bounds price | `monitor:signal:oracle`, `monitor:alert` (tier-gated) |
+| `coordinator` | Fuses the watcher signals off the shared blackboard, dedups a persistent condition, decides fused severity, emits one consolidated alert | `monitor:alert` (tier-gated) |
+
+Each agent runs as its own `agentis daemon`. The watchers post their latest
+verdict to a durable blackboard memo (`monitor:signal:*`); the coordinator reads
+both each tick and fuses them.
+
+```mermaid
+flowchart LR
+    C[cast / RPC<br/>read-only] --> IW[invariant-watcher]
+    C --> OW[oracle-watcher]
+    IW -->|monitor:signal:invariant| CO[coordinator]
+    OW -->|monitor:signal:oracle| CO
+    IW -->|monitor:alert| BUS[(bus)]
+    OW -->|monitor:alert| BUS
+    CO -->|monitor:alert<br/>fused + deduped| BUS
+    BUS --> N[notify.sh<br/>Discord / Slack webhook]
+```
+
+## Confidence-tiered alerting (ADR-0001)
+
+Every agent makes ONE `tier()` call per tick and branches once. The tier gates
+**emission only** — the verdict is computed identically at every tier:
+
+- `shadow` / `dormant` — observe + `learn()` a baseline (record the normal
+  state); **no emit, no external write**.
+- `propose` — emit a **draft** `monitor:alert` (low severity) for review.
+- `review-gated` / `autonomous` — emit a **direct-page** `monitor:alert` (high
+  severity), once the detector has proven reliable.
+
+This is the false-positive control: a fresh watcher seeded at `shadow` learns the
+protocol's normal state before it can page, and auto-promotion lifts it as its
+alerts prove real over noise.
+
+## Setup
+
+1. Copy and edit the config:
+   ```bash
+   cp config/colony.example.toml config/colony.toml
+   ```
+
+2. Export the watch target's environment contract (see the table below), then
+   start the colony:
+   ```bash
+   ./scripts/start-colony.sh
+   ```
+
+3. (Optional) Wire an alert sink. With `MONITOR_WEBHOOK_URL` set, pipe an alert
+   to the notifier:
+   ```bash
+   echo '<alert payload>' | ./scripts/notify.sh
+   ```
+   Unset, `notify.sh` prints the alert to stdout (a no-op sink) — no secret is
+   ever committed; the webhook URL is read from the environment.
+
+dark-factory is a non-forge federation (`forge.type = "none"`); no forge
+credentials are required.
+
+## Environment contract
+
+Inputs are passed via the environment (all optional). Export them before
+launching, and add each to `exec.env_passthrough` in `.agentis/config` so the
+sandboxed `exec sh` can read them. With no `MONITOR_CAST` / `MONITOR_RPC_URL` a
+watcher reads nothing and only observes — it never raises a false alert.
+
+| Var | Meaning | Default |
+|-----|---------|---------|
+| `MONITOR_CAST` | Absolute path to the `cast` binary (foundry), the read tool. | unset (observe only) |
+| `MONITOR_RPC_URL` | Chain RPC endpoint `cast` reads from (read-only). | unset (observe only) |
+| `MONITOR_TARGET` | Target protocol contract address (`0x...`) for the invariant. | unset |
+| `MONITOR_INV_LHS_SIG` | `cast call` signature for the invariant's LHS quantity (e.g. `totalSupply()`). | unset |
+| `MONITOR_INV_RHS_SIG` | Signature for the RHS quantity (e.g. `totalAssets()`); `""` ⇒ use the literal const. | unset |
+| `MONITOR_INV_RHS_CONST` | Literal integer RHS bound (used when `RHS_SIG` is empty). | unset |
+| `MONITOR_INV_REL` | Required relation: `le` \| `ge` \| `eq`. | `le` |
+| `MONITOR_INV_MARGIN_BP` | Margin-to-violation band in basis points (0..10000). | `0` |
+| `MONITOR_INV_LABEL` | Human label for the invariant (alert body). | the LHS signature |
+| `MONITOR_ORACLE` | Price-feed contract address (`0x...`). | unset |
+| `MONITOR_ORACLE_PRICE_SIG` | Signature returning the price. | `latestAnswer()` |
+| `MONITOR_ORACLE_TS_SIG` | Signature returning the feed's last-update unix ts; `""` ⇒ skip staleness. | unset |
+| `MONITOR_ORACLE_MAX_AGE` | Max feed age in seconds before STALENESS flags. | `0` (skip) |
+| `MONITOR_ORACLE_DEV_BP` | Deviation band in basis points vs the last baseline. | `0` (skip) |
+| `MONITOR_ORACLE_MIN` / `MONITOR_ORACLE_MAX` | Lower / upper price sanity bounds. | unset (no bound) |
+| `MONITOR_ORACLE_LABEL` | Human label for the feed (alert body). | the oracle address |
+| `MONITOR_WEBHOOK_URL` | Discord/Slack incoming-webhook URL for `notify.sh`. **Never commit a real URL.** | unset (stdout sink) |
+
+## Status
+
+Experimental, lint-clean foundation. This PR ships the colony scaffold + the two
+highest-value watchers + the fusion coordinator + a webhook sink. Follow-ups
+(see [#1085](https://github.com/Replikanti/agentis-colonies/issues/1085) and the
+[live-watch runtime, #1086](https://github.com/Replikanti/agentis-colonies/issues/1086)):
+the liquidity / governance / flow watchers, a live-watch runtime, and a dashboard
+view. The colony is **read-only** and **never** posts an alert without a
+configured sink — and **never** signs or touches funds.

--- a/dark-factory/monitor/agents/coordinator.ag
+++ b/dark-factory/monitor/agents/coordinator.ag
@@ -198,12 +198,14 @@ fn tick(reason: string) -> void {
         };
     };
 
-    // Record the signature we just acted on so the next tick dedups against it
-    // (a memo write — allowed at every tier). Only advance it on an anomaly so a
-    // return to quiet re-arms the next genuine anomaly for emission.
-    if anomaly {
-        memo_write("coordinator:last_signature", sig);
-    };
+    // Record the signature we just fused so the next tick dedups against it (a
+    // memo write — allowed at every tier). Written EVERY tick, including quiet
+    // ones: a quiet tick stores the "quiet" signature, so a genuine anomaly that
+    // RECURS after a quiet gap is novel again and re-pages, while a persistent,
+    // unbroken condition keeps the same signature and pages exactly once. (Guarding
+    // this write on `anomaly` would pin last_signature to the first anomaly and
+    // silently suppress an identical recurrence after a quiet gap — QA #1087.)
+    memo_write("coordinator:last_signature", sig);
 
     memo_write("coordinator:last_check", to_string(now_ms()));
 }

--- a/dark-factory/monitor/agents/coordinator.ag
+++ b/dark-factory/monitor/agents/coordinator.ag
@@ -1,0 +1,209 @@
+// coordinator.ag — Monitor colony (Dark Factory federation).
+//
+// The fusion + dedup + severity-decision agent. The two watchers
+// (invariant-watcher, oracle-watcher) each post their latest verdict to a shared
+// blackboard memo (`monitor:signal:<watcher>`); each ALSO emits its own
+// per-watcher `monitor:alert`. This coordinator reads BOTH blackboard signals
+// every tick, FUSES them into one consolidated picture, DEDUPS against the last
+// consolidated signature it emitted (so a persistent condition pages once, not
+// every tick), DECIDES the fused severity, and emits ONE consolidated
+// `monitor:alert`. NON-custodial / read-only: it reads memos + emits on the bus
+// only — no signing, no fund access, no `exec sh`.
+//
+// Pattern (per dark-factory/auditor/agents/coordinator.ag): single-assignment
+// helpers (no `let` reassignment), reduce/recursion instead of loops. The fused
+// verdict is a deterministic function of the watchers' FACTS — never an LLM call.
+//
+// Emission is gated PURELY on the ADR-0001 tier of this agent:
+//   shadow / dormant -> observe + learn the fused picture, NO emit;
+//   propose          -> emit a DRAFT consolidated `monitor:alert` (low severity);
+//   review-gated /    -> emit a DIRECT-page consolidated `monitor:alert`.
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant.
+//
+// Reads (durable memos written by the watchers): monitor:signal:invariant,
+//   monitor:signal:oracle.
+// Emits: "monitor:alert" (the colony bus contract).
+
+cb 120000;
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("coordinator:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- read a watcher's blackboard signal + pull its verdict ---------------------
+// json_get on a miss returns Void -> to_string => "void"; collapse that to "".
+fn sanitize(s: string) -> string {
+    if s == "void" { return ""; }
+    return s;
+}
+
+// The verdict token a watcher last posted ("" when the watcher has not run yet).
+fn signal_verdict(sig: string) -> string {
+    if len(sig) == 0 { return ""; }
+    return sanitize(to_string(json_get(sig, "verdict")));
+}
+
+// Is a watcher verdict an ANOMALY worth fusing into an alert? "ok" / "no-read" /
+// "" (not run) are quiet. Everything else (violated / margin / bounds / stale /
+// deviation) is an anomalous signal.
+fn is_anomalous(verdict: string) -> bool {
+    if len(verdict) == 0 { return false; }
+    if verdict == "ok" { return false; }
+    if verdict == "no-read" { return false; }
+    return true;
+}
+
+// A signal's contribution to the fused SEVERITY SCORE. A hard violation/break
+// (invariant violated, oracle bounds/stale) is the highest-severity tell; a
+// margin / deviation is a softer warning. Scores accumulate across watchers so
+// two simultaneous anomalies fuse to a higher severity than either alone.
+fn severity_score(verdict: string) -> int {
+    if verdict == "violated" { return 3; }
+    if verdict == "bounds" { return 3; }
+    if verdict == "stale" { return 2; }
+    if verdict == "deviation" { return 1; }
+    if verdict == "margin" { return 1; }
+    return 0;
+}
+
+// Map a fused score to a severity token. 0 = no anomaly; 1-2 = warn; >=3 = page.
+fn severity_label(score: int) -> string {
+    if score >= 3 { return "high"; }
+    if score >= 1 { return "warn"; }
+    return "none";
+}
+
+// --- fused consolidated picture (single-assignment over the two signals) -------
+// The deterministic fused score = sum of the per-watcher severity contributions.
+fn fuse_score(invVerdict: string, oracleVerdict: string) -> int {
+    return severity_score(invVerdict) + severity_score(oracleVerdict);
+}
+
+// .ag has no short-circuit `&&` / `||` (single-assignment grammar), so the two
+// fused boolean predicates are expressed as explicit nested-if helpers.
+fn either_anomalous(invVerdict: string, oracleVerdict: string) -> bool {
+    if is_anomalous(invVerdict) { return true; }
+    if is_anomalous(oracleVerdict) { return true; }
+    return false;
+}
+
+fn anomaly_and_novel(anomaly: bool, novel: bool) -> bool {
+    if !anomaly { return false; }
+    return novel;
+}
+
+// A stable DEDUP SIGNATURE for the consolidated picture: the two watchers'
+// verdicts joined. The same pair of conditions yields the same signature, so a
+// persistent anomaly is emitted ONCE (until a verdict changes) rather than every
+// tick. Quiet ticks (no anomaly) produce the "quiet" signature.
+fn fused_signature(invVerdict: string, oracleVerdict: string, anomaly: bool) -> string {
+    if !anomaly { return "quiet"; }
+    let inv = if len(invVerdict) > 0 { invVerdict } else { "none" };
+    let orc = if len(oracleVerdict) > 0 { oracleVerdict } else { "none" };
+    return "inv=" + inv + ";oracle=" + orc;
+}
+
+// The consolidated alert payload (JSON). All fields are facts the coordinator
+// fused from the watchers; none is LLM text. `sev` is set per tier on emit.
+fn fused_payload(invVerdict: string, oracleVerdict: string, score: int, sig: string, sev: string) -> string {
+    let inv = if len(invVerdict) > 0 { invVerdict } else { "none" };
+    let orc = if len(oracleVerdict) > 0 { oracleVerdict } else { "none" };
+    return "{\"watcher\":\"coordinator\",\"kind\":\"fused\",\"invariant\":\"" + inv
+         + "\",\"oracle\":\"" + orc + "\",\"score\":" + to_string(score)
+         + ",\"signature\":\"" + sig + "\",\"severity\":\"" + sev + "\"}";
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. A high-severity
+// fused page is the anomaly the colony exists to surface (failure); a warn-level
+// fusion is partial; a quiet tick is a healthy observation (success).
+fn outcome_of(sevLabel: string) -> string {
+    if sevLabel == "high" { return "failure"; }
+    if sevLabel == "warn" { return "partial"; }
+    return "success";
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("coordinator:last_check", now);
+
+    // Read the two watchers' latest blackboard signals + pull their verdicts.
+    let invSig = recall_latest("monitor:signal:invariant");
+    let oracleSig = recall_latest("monitor:signal:oracle");
+    let invVerdict = signal_verdict(invSig);
+    let oracleVerdict = signal_verdict(oracleSig);
+
+    // FUSE: deterministic score + anomaly flag + severity label + dedup signature.
+    let anomaly = either_anomalous(invVerdict, oracleVerdict);
+    let score = fuse_score(invVerdict, oracleVerdict);
+    let sevLabel = severity_label(score);
+    let sig = fused_signature(invVerdict, oracleVerdict, anomaly);
+    let outcome = outcome_of(sevLabel);
+
+    // DEDUP: only a NEW signature (vs the last one we acted on) is novel; a
+    // persistent condition holds the same signature and is not re-paged.
+    let lastSig = recall_latest("coordinator:last_signature");
+    let novel = sig != lastSig;
+
+    print("coordinator: fuse inv=" + invVerdict + " oracle=" + oracleVerdict
+        + " -> score=" + to_string(score) + " sev=" + sevLabel + " novel=" + to_string(novel)
+        + " (conf=" + to_string(get_confidence()) + ")");
+
+    let key = "fused:" + sig;
+    let desc = "fused inv=" + invVerdict + " oracle=" + oracleVerdict + " score=" + to_string(score);
+    // Worth emitting only when there is an anomaly AND it is a NEW signature.
+    let emitWorthy = anomaly_and_novel(anomaly, novel);
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
+    // fused verdict above is unchanged by tier. shadow/dormant fall through.
+    // (.ag has no `else if`; the tiers nest as `else { if ... { } else { } }`.)
+    let my_tier = tier("coordinator");
+    if my_tier == "autonomous" {
+        // Proven reliable -> a DIRECT consolidated page on a new anomaly.
+        if emitWorthy {
+            emit("monitor:alert", fused_payload(invVerdict, oracleVerdict, score, sig, sevLabel));
+            learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "acted"]);
+        } else {
+            learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "observed"]);
+        };
+    } else {
+        if my_tier == "review-gated" {
+            // Trusted to page under a review gate -> a DIRECT consolidated page.
+            if emitWorthy {
+                emit("monitor:alert", fused_payload(invVerdict, oracleVerdict, score, sig, sevLabel));
+                learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "review-gated"]);
+            } else {
+                learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "observed"]);
+            };
+        } else {
+            if my_tier == "propose" {
+                // Enough signal to contribute -> a DRAFT consolidated alert (low).
+                if emitWorthy {
+                    emit("monitor:alert", fused_payload(invVerdict, oracleVerdict, score, sig, "low"));
+                    learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "emitted"]);
+                } else {
+                    learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "observed"]);
+                };
+            } else {
+                // shadow / dormant: learn the fused picture ONLY — no emit.
+                learn("monitor-fuse", key, desc + " (baseline)", outcome, [sevLabel, outcome, "observed"]);
+                print("coordinator: observing (tier: " + my_tier + ") — no emit");
+            };
+        };
+    };
+
+    // Record the signature we just acted on so the next tick dedups against it
+    // (a memo write — allowed at every tier). Only advance it on an anomaly so a
+    // return to quiet re-arms the next genuine anomaly for emission.
+    if anomaly {
+        memo_write("coordinator:last_signature", sig);
+    };
+
+    memo_write("coordinator:last_check", to_string(now_ms()));
+}

--- a/dark-factory/monitor/agents/invariant-watcher.ag
+++ b/dark-factory/monitor/agents/invariant-watcher.ag
@@ -1,0 +1,243 @@
+// invariant-watcher.ag — Monitor colony (Dark Factory federation).
+//
+// Continuously evaluates DERIVED protocol invariants against CURRENT on-chain
+// state and flags a violation (or a thin margin-to-violation) as a candidate
+// anomaly. NON-custodial / read-only: it only READS chain state via `cast`/RPC
+// over `exec sh` — it never signs a transaction and never touches funds.
+//
+// The signal is a FACT (an on-chain read + a deterministic comparison), never an
+// LLM opinion. Emission is gated PURELY on the ADR-0001 tier of this agent (the
+// false-positive control):
+//   shadow / dormant -> observe + learn a baseline, NO emit (learning the
+//                       protocol's normal state before it is trusted to page);
+//   propose          -> emit a DRAFT `monitor:alert` (low severity);
+//   review-gated /    -> emit a DIRECT-page `monitor:alert` (high severity).
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant.
+//
+// Env contract (all read via getenv; the coordinator + scripts/start-colony.sh
+// export them; add each to exec.env_passthrough in .agentis/config so the
+// sandboxed `exec sh` can read them):
+//   MONITOR_CAST        path to the `cast` binary (foundry) used for the read;
+//                       "" => the watcher has no reader and observes nothing.
+//   MONITOR_RPC_URL     the chain RPC endpoint `cast` reads from (read-only).
+//   MONITOR_TARGET      the target protocol contract address (0x...).
+//   MONITOR_INV_LHS_SIG the `cast call` function signature whose return is the
+//                       invariant's LEFT-hand quantity (e.g. "totalSupply()").
+//   MONITOR_INV_RHS_SIG the function signature for the RIGHT-hand quantity
+//                       (e.g. "totalAssets()"); "" => RHS is the literal bound
+//                       MONITOR_INV_RHS_CONST instead (a fixed reserve floor).
+//   MONITOR_INV_RHS_CONST a literal integer RHS bound used when RHS_SIG is "".
+//   MONITOR_INV_REL     the relation that MUST hold: "le" (lhs<=rhs, e.g.
+//                       solvency: supply<=assets), "ge" (lhs>=rhs), or "eq".
+//                       "" => default "le".
+//   MONITOR_INV_MARGIN_BP a margin-to-violation band in basis points (0..10000):
+//                       when the invariant HOLDS but the gap is within this band
+//                       of flipping, the watcher flags a margin warning. "" => 0
+//                       (only a hard violation flags).
+//   MONITOR_INV_LABEL   a human label for the invariant (for the alert body).
+// Emits: "monitor:alert" (the colony bus contract).
+
+cb 90000;
+
+// --- tier read (ADR-0001 / CLAUDE.md threshold table) --------------------------
+// Mirrors the runtime tier() builtin's table so a missing memo reads as dormant.
+// We STILL call tier("invariant-watcher") below (the lint requires the builtin
+// call); this helper is used only for the diagnostic get_confidence() log.
+fn get_confidence() -> float {
+    let raw = recall_latest("invariant-watcher:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- env facts -----------------------------------------------------------------
+fn rel_or_default(raw: string) -> string {
+    if len(raw) == 0 { return "le"; }
+    return raw;
+}
+
+fn label_or_sig(raw: string, lhs: string) -> string {
+    if len(raw) > 0 { return raw; }
+    return lhs;
+}
+
+// --- read a single uint return from an on-chain view via cast call -------------
+// `cast call --rpc-url <url> <addr> <sig>` prints one 0x-hex word; `cast --to-dec`
+// renders it as a decimal integer string. EVERY dynamic value (the cast path, the
+// rpc url, the address, the function signature) is shell_escape()d — they are all
+// operator/coordinator-supplied facts that flow into a shell, so none may be a
+// bare concat. `set +e` + `|| true` so a transient RPC failure returns "" (no
+// reading -> no false flag) instead of aborting the tick. Returns the decimal
+// string, or "" on any failure / empty reader.
+fn read_uint(castBin: string, rpc: string, addr: string, sig: string) -> string {
+    if len(castBin) == 0 { return ""; }
+    if len(rpc) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    if len(sig) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; " + shell_escape(castBin) + " call --rpc-url " + shell_escape(rpc)
+            + " " + shell_escape(addr) + " " + shell_escape(sig)
+            + " 2>/dev/null | " + shell_escape(castBin) + " --to-dec 2>/dev/null || true";
+    return out;
+}
+
+// Trim a trailing newline cast leaves on its decimal output, leaving only digits.
+fn first_token(s: string) -> string {
+    let nl = index_of(s, "\n");
+    if nl < 0 { return s; }
+    return substring(s, 0, nl);
+}
+
+// Parse a decimal reading to an int; an empty / non-numeric reading -> -1 (the
+// "no reading" sentinel, distinct from a legitimate 0). parse_int is total.
+fn reading_to_int(s: string) -> int {
+    let t = first_token(s);
+    if len(t) == 0 { return -1; }
+    if len(regex_find_all("[^0-9]", t)) > 0 { return -1; }
+    return parse_int(t);
+}
+
+// Resolve the RHS quantity: a live read of RHS_SIG when present, else the literal
+// MONITOR_INV_RHS_CONST. Returns -1 when neither yields a numeric value.
+fn resolve_rhs(castBin: string, rpc: string, addr: string, rhsSig: string, rhsConst: string) -> int {
+    if len(rhsSig) > 0 {
+        return reading_to_int(read_uint(castBin, rpc, addr, rhsSig));
+    }
+    if len(rhsConst) == 0 { return -1; }
+    if len(regex_find_all("[^0-9]", rhsConst)) > 0 { return -1; }
+    return parse_int(rhsConst);
+}
+
+// --- the deterministic invariant verdict (a FACT, never an LLM call) -----------
+// "violated" when the required relation does NOT hold; "margin" when it holds but
+// the gap is within MONITOR_INV_MARGIN_BP basis points of flipping; "ok" when it
+// holds comfortably; "no-read" when either side could not be read.
+fn within_margin(lhs: int, rhs: int, rel: string, marginBp: int) -> bool {
+    if marginBp <= 0 { return false; }
+    if rhs <= 0 { return false; }
+    // gap_bp = |lhs - rhs| * 10000 / rhs ; flag when the holding side is within
+    // marginBp of equality (the point the relation flips).
+    let diff = if lhs >= rhs { lhs - rhs } else { rhs - lhs };
+    let gapBp = (diff * 10000) / rhs;
+    return gapBp <= marginBp;
+}
+
+fn invariant_holds(lhs: int, rhs: int, rel: string) -> bool {
+    if rel == "le" { return lhs <= rhs; }
+    if rel == "ge" { return lhs >= rhs; }
+    if rel == "eq" { return lhs == rhs; }
+    return lhs <= rhs;
+}
+
+fn verdict_of(lhs: int, rhs: int, rel: string, marginBp: int) -> string {
+    if lhs < 0 { return "no-read"; }
+    if rhs < 0 { return "no-read"; }
+    if !invariant_holds(lhs, rhs, rel) { return "violated"; }
+    if within_margin(lhs, rhs, rel, marginBp) { return "margin"; }
+    return "ok";
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. A clean hold is a
+// confirmed-healthy observation (success); a violation is the anomaly the watcher
+// exists to catch (failure); a margin is a partial (holding but thin); a missing
+// read is an error (the reader could not produce a fact this tick).
+fn outcome_of(verdict: string) -> string {
+    if verdict == "ok" { return "success"; }
+    if verdict == "violated" { return "failure"; }
+    if verdict == "margin" { return "partial"; }
+    return "error";
+}
+
+// Is this verdict worth surfacing as an alert at all (vs a healthy/quiet tick)?
+fn is_anomaly(verdict: string) -> bool {
+    if verdict == "violated" { return true; }
+    if verdict == "margin" { return true; }
+    return false;
+}
+
+// A compact, deterministic alert payload (JSON). All fields are facts the watcher
+// computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
+fn alert_payload(label: string, verdict: string, lhs: int, rhs: int, rel: string, addr: string, sev: string) -> string {
+    return "{\"watcher\":\"invariant\",\"invariant\":\"" + label + "\",\"verdict\":\"" + verdict
+         + "\",\"lhs\":" + to_string(lhs) + ",\"rhs\":" + to_string(rhs) + ",\"rel\":\"" + rel
+         + "\",\"target\":\"" + addr + "\",\"severity\":\"" + sev + "\"}";
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first so the dashboard's memo-freshness probe sees the daemon
+    // alive even when the reader is unconfigured and the tick early-returns.
+    memo_write("invariant-watcher:last_check", now);
+
+    let castBin = getenv("MONITOR_CAST");
+    let rpc = getenv("MONITOR_RPC_URL");
+    let addr = getenv("MONITOR_TARGET");
+    let lhsSig = getenv("MONITOR_INV_LHS_SIG");
+    let rhsSig = getenv("MONITOR_INV_RHS_SIG");
+    let rhsConst = getenv("MONITOR_INV_RHS_CONST");
+    let rel = rel_or_default(getenv("MONITOR_INV_REL"));
+    let label = label_or_sig(getenv("MONITOR_INV_LABEL"), lhsSig);
+    let marginRaw = getenv("MONITOR_INV_MARGIN_BP");
+    let marginBp = if len(marginRaw) > 0 { reading_to_int(marginRaw) } else { 0 };
+
+    // Read BOTH sides of the invariant from current on-chain state (FACTS).
+    let lhs = reading_to_int(read_uint(castBin, rpc, addr, lhsSig));
+    let rhs = resolve_rhs(castBin, rpc, addr, rhsSig, rhsConst);
+    let verdict = verdict_of(lhs, rhs, rel, marginBp);
+    let outcome = outcome_of(verdict);
+
+    print("invariant-watcher: " + label + " " + rel + " -> " + verdict
+        + " (lhs=" + to_string(lhs) + " rhs=" + to_string(rhs) + ", conf=" + to_string(get_confidence()) + ")");
+
+    let key = label + ":" + addr;
+    let desc = "on-chain invariant " + label + " " + rel + " -> " + verdict;
+    let anomaly = is_anomaly(verdict);
+
+    // Post this watcher's latest verdict to the shared blackboard memo the
+    // coordinator reads each tick to fuse + dedup signals (a memo write — allowed
+    // at every tier, including shadow). The payload is the same fact JSON the
+    // emit carries, with a neutral severity the coordinator re-decides on fusion.
+    memo_write("monitor:signal:invariant", alert_payload(label, verdict, lhs, rhs, rel, addr, "info"));
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
+    // verdict above is unchanged by tier. shadow/dormant fall through to observe.
+    // (.ag has no `else if`; the tiers nest as `else { if ... { } else { } }`.)
+    let my_tier = tier("invariant-watcher");
+    if my_tier == "autonomous" {
+        // Proven reliable -> a DIRECT page on a real anomaly (high severity).
+        if anomaly {
+            emit("monitor:alert", alert_payload(label, verdict, lhs, rhs, rel, addr, "high"));
+            learn("invariant-watch", key, desc, outcome, [verdict, outcome, "acted"]);
+        } else {
+            learn("invariant-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+        };
+    } else {
+        if my_tier == "review-gated" {
+            // Trusted to page under a review gate -> a DIRECT page (high severity).
+            if anomaly {
+                emit("monitor:alert", alert_payload(label, verdict, lhs, rhs, rel, addr, "high"));
+                learn("invariant-watch", key, desc, outcome, [verdict, outcome, "review-gated"]);
+            } else {
+                learn("invariant-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+            };
+        } else {
+            if my_tier == "propose" {
+                // Enough signal to contribute -> a DRAFT alert (low severity).
+                if anomaly {
+                    emit("monitor:alert", alert_payload(label, verdict, lhs, rhs, rel, addr, "low"));
+                    learn("invariant-watch", key, desc, outcome, [verdict, outcome, "emitted"]);
+                } else {
+                    learn("invariant-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+                };
+            } else {
+                // shadow / dormant: learn the baseline ONLY — no emit, no write.
+                learn("invariant-watch", key, desc + " (baseline)", outcome, [verdict, outcome, "observed"]);
+                print("invariant-watcher: observing (tier: " + my_tier + ") — no emit");
+            };
+        };
+    };
+
+    memo_write("invariant-watcher:last_check", to_string(now_ms()));
+}

--- a/dark-factory/monitor/agents/oracle-watcher.ag
+++ b/dark-factory/monitor/agents/oracle-watcher.ag
@@ -25,6 +25,10 @@
 //   MONITOR_ORACLE        the price-feed contract address (0x...).
 //   MONITOR_ORACLE_PRICE_SIG the `cast call` signature returning the price
 //                         (e.g. "latestAnswer()"); default "latestAnswer()".
+//                         NOTE: the reader parses an UNSIGNED integer — a signed
+//                         feed (int256) returning a NEGATIVE value reads as
+//                         "no-read" (observed, never a false alert). Signed-feed
+//                         support is a follow-up (live-watch #1086).
 //   MONITOR_ORACLE_TS_SIG the signature returning the feed's last-update unix ts
 //                         (e.g. "latestTimestamp()"); "" => skip the staleness check.
 //   MONITOR_ORACLE_MAX_AGE max feed age in seconds before STALENESS flags; "" => 0

--- a/dark-factory/monitor/agents/oracle-watcher.ag
+++ b/dark-factory/monitor/agents/oracle-watcher.ag
@@ -1,0 +1,255 @@
+// oracle-watcher.ag — Monitor colony (Dark Factory federation).
+//
+// Watches a protocol's PRICE FEED for the three classic oracle-risk signals:
+//   * DEVIATION — the reported price has moved more than DEV_BP basis points
+//     from the last observed baseline (a flash move / manipulation tell);
+//   * STALENESS — the feed's updatedAt timestamp is older than MAX_AGE seconds
+//     (a frozen feed the protocol may still be trusting);
+//   * BOUNDS    — the price is outside an operator-set [MIN, MAX] sanity band.
+// NON-custodial / read-only: it only READS the feed via `cast`/RPC over
+// `exec sh`. It never signs a transaction and never touches funds.
+//
+// Same on-chain read pattern + tier-gated emission as invariant-watcher.ag. The
+// signal is a FACT (an on-chain read + a deterministic comparison), never an LLM
+// opinion. Emission is gated PURELY on the ADR-0001 tier of this agent:
+//   shadow / dormant -> observe + learn a baseline (record the price), NO emit;
+//   propose          -> emit a DRAFT `monitor:alert` (low severity);
+//   review-gated /    -> emit a DIRECT-page `monitor:alert` (high severity).
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant.
+//
+// Env contract (all read via getenv; exported by scripts/start-colony.sh; add
+// each to exec.env_passthrough in .agentis/config):
+//   MONITOR_CAST          path to the `cast` binary; "" => no reader, observe only.
+//   MONITOR_RPC_URL       the chain RPC endpoint (read-only).
+//   MONITOR_ORACLE        the price-feed contract address (0x...).
+//   MONITOR_ORACLE_PRICE_SIG the `cast call` signature returning the price
+//                         (e.g. "latestAnswer()"); default "latestAnswer()".
+//   MONITOR_ORACLE_TS_SIG the signature returning the feed's last-update unix ts
+//                         (e.g. "latestTimestamp()"); "" => skip the staleness check.
+//   MONITOR_ORACLE_MAX_AGE max feed age in seconds before STALENESS flags; "" => 0
+//                         (skip the staleness check).
+//   MONITOR_ORACLE_DEV_BP deviation band in basis points vs the last baseline;
+//                         "" => 0 (skip the deviation check).
+//   MONITOR_ORACLE_MIN    lower sanity bound on the price; "" => no lower bound.
+//   MONITOR_ORACLE_MAX    upper sanity bound on the price; "" => no upper bound.
+//   MONITOR_ORACLE_LABEL  a human label for the feed (for the alert body).
+// Emits: "monitor:alert" (the colony bus contract).
+
+cb 90000;
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("oracle-watcher:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- env defaults --------------------------------------------------------------
+fn price_sig_or_default(raw: string) -> string {
+    if len(raw) == 0 { return "latestAnswer()"; }
+    return raw;
+}
+
+fn label_or(raw: string, addr: string) -> string {
+    if len(raw) > 0 { return raw; }
+    return addr;
+}
+
+// --- read a single uint return from an on-chain view via cast call -------------
+// EVERY dynamic value (cast path, rpc url, feed address, function signature) is
+// shell_escape()d — all are operator/coordinator-supplied facts flowing into a
+// shell. `set +e` + `|| true` so a transient RPC failure returns "" (no reading
+// -> no false flag) instead of aborting the tick. Returns the decimal string,
+// or "" on any failure / empty reader.
+fn read_uint(castBin: string, rpc: string, addr: string, sig: string) -> string {
+    if len(castBin) == 0 { return ""; }
+    if len(rpc) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    if len(sig) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; " + shell_escape(castBin) + " call --rpc-url " + shell_escape(rpc)
+            + " " + shell_escape(addr) + " " + shell_escape(sig)
+            + " 2>/dev/null | " + shell_escape(castBin) + " --to-dec 2>/dev/null || true";
+    return out;
+}
+
+fn first_token(s: string) -> string {
+    let nl = index_of(s, "\n");
+    if nl < 0 { return s; }
+    return substring(s, 0, nl);
+}
+
+// Parse a decimal reading to an int; empty / non-numeric -> -1 (the "no reading"
+// sentinel, distinct from a legitimate 0). parse_int is total.
+fn reading_to_int(s: string) -> int {
+    let t = first_token(s);
+    if len(t) == 0 { return -1; }
+    if len(regex_find_all("[^0-9]", t)) > 0 { return -1; }
+    return parse_int(t);
+}
+
+// Optional integer env fact: "" / non-numeric -> -1 (the "unset" sentinel).
+fn opt_int(raw: string) -> int {
+    if len(raw) == 0 { return -1; }
+    if len(regex_find_all("[^0-9]", raw)) > 0 { return -1; }
+    return parse_int(raw);
+}
+
+// --- deterministic deviation / staleness / bounds verdicts (FACTS) -------------
+// Deviation in basis points of `price` vs `base`; -1 when no usable baseline.
+fn deviation_bp(price: int, base: int) -> int {
+    if base <= 0 { return -1; }
+    let diff = if price >= base { price - base } else { base - price };
+    return (diff * 10000) / base;
+}
+
+fn deviates(price: int, base: int, devBp: int) -> bool {
+    if devBp <= 0 { return false; }
+    let d = deviation_bp(price, base);
+    if d < 0 { return false; }
+    return d > devBp;
+}
+
+fn is_stale(updatedAt: int, nowSec: int, maxAge: int) -> bool {
+    if maxAge <= 0 { return false; }
+    if updatedAt < 0 { return false; }
+    if updatedAt > nowSec { return false; }
+    return (nowSec - updatedAt) > maxAge;
+}
+
+fn out_of_bounds(price: int, lo: int, hi: int) -> bool {
+    if lo >= 0 {
+        if price < lo { return true; }
+    }
+    if hi >= 0 {
+        if price > hi { return true; }
+    }
+    return false;
+}
+
+// Fuse the three checks into ONE verdict token. Precedence: a price that could
+// not be read is "no-read"; then bounds (hard sanity), staleness, deviation; a
+// clean read is "ok".
+fn verdict_of(price: int, base: int, devBp: int, updatedAt: int, nowSec: int, maxAge: int, lo: int, hi: int) -> string {
+    if price < 0 { return "no-read"; }
+    if out_of_bounds(price, lo, hi) { return "bounds"; }
+    if is_stale(updatedAt, nowSec, maxAge) { return "stale"; }
+    if deviates(price, base, devBp) { return "deviation"; }
+    return "ok";
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. A clean read is a
+// healthy observation (success); a bounds break or a stale feed is the anomaly
+// the watcher exists to catch (failure); a deviation is partial (moved, not yet
+// proven bad); a missing read is error.
+fn outcome_of(verdict: string) -> string {
+    if verdict == "ok" { return "success"; }
+    if verdict == "bounds" { return "failure"; }
+    if verdict == "stale" { return "failure"; }
+    if verdict == "deviation" { return "partial"; }
+    return "error";
+}
+
+fn is_anomaly(verdict: string) -> bool {
+    if verdict == "bounds" { return true; }
+    if verdict == "stale" { return true; }
+    if verdict == "deviation" { return true; }
+    return false;
+}
+
+// A compact, deterministic alert payload (JSON). All fields are facts the watcher
+// computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
+fn alert_payload(label: string, verdict: string, price: int, base: int, addr: string, sev: string) -> string {
+    return "{\"watcher\":\"oracle\",\"feed\":\"" + label + "\",\"verdict\":\"" + verdict
+         + "\",\"price\":" + to_string(price) + ",\"baseline\":" + to_string(base)
+         + ",\"oracle\":\"" + addr + "\",\"severity\":\"" + sev + "\"}";
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("oracle-watcher:last_check", now);
+
+    let castBin = getenv("MONITOR_CAST");
+    let rpc = getenv("MONITOR_RPC_URL");
+    let addr = getenv("MONITOR_ORACLE");
+    let priceSig = price_sig_or_default(getenv("MONITOR_ORACLE_PRICE_SIG"));
+    let tsSig = getenv("MONITOR_ORACLE_TS_SIG");
+    let maxAge = opt_int(getenv("MONITOR_ORACLE_MAX_AGE"));
+    let devBp = opt_int(getenv("MONITOR_ORACLE_DEV_BP"));
+    let lo = opt_int(getenv("MONITOR_ORACLE_MIN"));
+    let hi = opt_int(getenv("MONITOR_ORACLE_MAX"));
+    let label = label_or(getenv("MONITOR_ORACLE_LABEL"), addr);
+
+    // Read the current price + (optionally) the feed's last-update timestamp.
+    let price = reading_to_int(read_uint(castBin, rpc, addr, priceSig));
+    let updatedAt = if len(tsSig) > 0 { reading_to_int(read_uint(castBin, rpc, addr, tsSig)) } else { -1 };
+    // The DEVIATION baseline is the last price this watcher observed (durable
+    // memo). On the first read there is no baseline (-1) -> deviation is skipped
+    // this tick; the current price becomes the baseline for next time.
+    let base = opt_int(recall_latest("oracle-watcher:baseline:" + addr));
+    let nowSec = now_ms() / 1000;
+
+    let verdict = verdict_of(price, base, devBp, updatedAt, nowSec, maxAge, lo, hi);
+    let outcome = outcome_of(verdict);
+
+    print("oracle-watcher: " + label + " price=" + to_string(price) + " base=" + to_string(base)
+        + " -> " + verdict + " (conf=" + to_string(get_confidence()) + ")");
+
+    // Update the deviation baseline to the latest GOOD read so the next tick
+    // compares against a recent price (a no-read leaves the old baseline intact).
+    if price >= 0 {
+        memo_write("oracle-watcher:baseline:" + addr, to_string(price));
+    };
+
+    let key = label + ":" + addr;
+    let desc = "oracle feed " + label + " price=" + to_string(price) + " -> " + verdict;
+    let anomaly = is_anomaly(verdict);
+
+    // Post this watcher's latest verdict to the shared blackboard memo the
+    // coordinator reads each tick to fuse + dedup signals (a memo write — allowed
+    // at every tier, including shadow). Severity is re-decided by the coordinator.
+    memo_write("monitor:signal:oracle", alert_payload(label, verdict, price, base, addr, "info"));
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only.
+    // (.ag has no `else if`; the tiers nest as `else { if ... { } else { } }`.)
+    let my_tier = tier("oracle-watcher");
+    if my_tier == "autonomous" {
+        // Proven reliable -> a DIRECT page on a real anomaly (high severity).
+        if anomaly {
+            emit("monitor:alert", alert_payload(label, verdict, price, base, addr, "high"));
+            learn("oracle-watch", key, desc, outcome, [verdict, outcome, "acted"]);
+        } else {
+            learn("oracle-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+        };
+    } else {
+        if my_tier == "review-gated" {
+            // Trusted to page under a review gate -> a DIRECT page (high severity).
+            if anomaly {
+                emit("monitor:alert", alert_payload(label, verdict, price, base, addr, "high"));
+                learn("oracle-watch", key, desc, outcome, [verdict, outcome, "review-gated"]);
+            } else {
+                learn("oracle-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+            };
+        } else {
+            if my_tier == "propose" {
+                // Enough signal to contribute -> a DRAFT alert (low severity).
+                if anomaly {
+                    emit("monitor:alert", alert_payload(label, verdict, price, base, addr, "low"));
+                    learn("oracle-watch", key, desc, outcome, [verdict, outcome, "emitted"]);
+                } else {
+                    learn("oracle-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+                };
+            } else {
+                // shadow / dormant: learn the baseline ONLY — no emit, no write.
+                learn("oracle-watch", key, desc + " (baseline)", outcome, [verdict, outcome, "observed"]);
+                print("oracle-watcher: observing (tier: " + my_tier + ") — no emit");
+            };
+        };
+    };
+
+    memo_write("oracle-watcher:last_check", to_string(now_ms()));
+}

--- a/dark-factory/monitor/config/colony.example.toml
+++ b/dark-factory/monitor/config/colony.example.toml
@@ -1,0 +1,105 @@
+# Monitor Colony Configuration
+#
+# Part of the Dark Factory federation. The monitor colony continuously WATCHES a
+# target EVM protocol and emits reasoned, high-signal anomaly alerts on the
+# colony bus (`monitor:alert`). NON-custodial / read-only: every watcher only
+# READS chain state via `cast`/RPC; no agent signs a transaction or touches
+# funds. Copy to colony.toml and edit for your environment.
+
+[colony]
+name = "monitor"
+tick_interval_ms = 60000
+
+# dark-factory is a non-forge federation (ADR-0003). The monitor watchers read
+# on-chain state through `cast`/RPC inside the sandbox via `exec sh`; no agent
+# calls a GitLab/GitHub forge API. `forge.type = "none"` is the explicit
+# non-forge marker recognised by colony-lint — no [forge.gitlab] / [forge.github]
+# sub-block is required. See ADR-0003 for the portability contract and ADR-0002
+# for the forge-bound contract this opts out of.
+[forge]
+type = "none"
+
+[llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI
+# adapter. The watchers' verdicts are deterministic on-chain reads (no LLM call
+# on the hot path); the backend is declared for schema conformance + future
+# reasoning extensions.
+backend = "cli"
+
+# Agent definitions. Each agent runs as a separate `agentis daemon` process,
+# launched by scripts/start-colony.sh with a per-agent tick interval. They
+# coordinate via durable memos (the `monitor:signal:*` blackboard) and emit over
+# the bus. cb_budget MUST match the `cb <N>;` decl at the top of each .ag file.
+
+# Evaluates derived protocol invariants against current on-chain state and flags
+# a violation / margin-to-violation. Posts monitor:signal:invariant.
+[[agents]]
+name = "invariant-watcher"
+source = "agents/invariant-watcher.ag"
+cb_budget = 90000
+tick_interval_ms = 60000
+
+# Watches the price feed for deviation / staleness / out-of-bounds. Posts
+# monitor:signal:oracle.
+[[agents]]
+name = "oracle-watcher"
+source = "agents/oracle-watcher.ag"
+cb_budget = 90000
+tick_interval_ms = 60000
+
+# Fuses the watcher signals, dedups, decides severity, and emits one
+# consolidated monitor:alert. Reads the monitor:signal:* blackboard.
+[[agents]]
+name = "coordinator"
+source = "agents/coordinator.ag"
+cb_budget = 120000
+tick_interval_ms = 60000
+
+# Monitor environment contract (consumed by the agents via getenv; exported by
+# scripts/start-colony.sh). Operators export these before launching, and add
+# each to exec.env_passthrough in .agentis/config so the sandboxed `exec sh` can
+# read them. All watchers degrade safely when their reader is unconfigured: with
+# no MONITOR_CAST / MONITOR_RPC_URL they read nothing and only observe (no false
+# alert).
+#
+# Shared (both watchers):
+#   MONITOR_CAST            absolute path to the `cast` binary (foundry).
+#   MONITOR_RPC_URL         the chain RPC endpoint cast reads from (read-only).
+#
+# invariant-watcher:
+#   MONITOR_TARGET          the target protocol contract address (0x...).
+#   MONITOR_INV_LHS_SIG     cast-call signature for the invariant's LHS quantity
+#                           (e.g. "totalSupply()").
+#   MONITOR_INV_RHS_SIG     cast-call signature for the RHS quantity (e.g.
+#                           "totalAssets()"); "" => use MONITOR_INV_RHS_CONST.
+#   MONITOR_INV_RHS_CONST   a literal integer RHS bound (used when RHS_SIG is "").
+#   MONITOR_INV_REL         the relation that MUST hold: "le" | "ge" | "eq"
+#                           (default "le", e.g. solvency: supply <= assets).
+#   MONITOR_INV_MARGIN_BP   margin-to-violation band in basis points (0..10000);
+#                           "" => 0 (only a hard violation flags).
+#   MONITOR_INV_LABEL       a human label for the invariant (alert body).
+#
+# oracle-watcher:
+#   MONITOR_ORACLE          the price-feed contract address (0x...).
+#   MONITOR_ORACLE_PRICE_SIG cast-call signature returning the price
+#                           (default "latestAnswer()").
+#   MONITOR_ORACLE_TS_SIG   signature returning the feed's last-update unix ts
+#                           (e.g. "latestTimestamp()"); "" => skip staleness.
+#   MONITOR_ORACLE_MAX_AGE  max feed age in seconds before STALENESS flags;
+#                           "" => 0 (skip staleness).
+#   MONITOR_ORACLE_DEV_BP   deviation band in basis points vs the last baseline;
+#                           "" => 0 (skip deviation).
+#   MONITOR_ORACLE_MIN      lower sanity bound on the price; "" => no lower bound.
+#   MONITOR_ORACLE_MAX      upper sanity bound on the price; "" => no upper bound.
+#   MONITOR_ORACLE_LABEL    a human label for the feed (alert body).
+#
+# Alert sink (optional, scripts/notify.sh):
+#   MONITOR_WEBHOOK_URL     a Discord/Slack incoming-webhook URL. When set,
+#                           notify.sh POSTs the alert payload to it. NEVER commit
+#                           a real URL — export it in the operator's environment.
+[monitor]
+cast = ""
+rpc_url = ""
+target = ""
+oracle = ""
+webhook_url = ""

--- a/dark-factory/monitor/scripts/notify.sh
+++ b/dark-factory/monitor/scripts/notify.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# notify.sh — thin alert notifier for the Monitor colony (Dark Factory).
+#
+# POSTs an alert payload to a Discord/Slack incoming webhook when
+# MONITOR_WEBHOOK_URL is set. Read-only / non-custodial: it only sends an
+# outbound notification — it never signs, never touches funds, and holds no
+# secret in the repo (the webhook URL is read from the environment).
+#
+# Usage:
+#   MONITOR_WEBHOOK_URL=https://... ./scripts/notify.sh '<alert text>'
+#   echo '<alert text>' | MONITOR_WEBHOOK_URL=https://... ./scripts/notify.sh
+#
+# With MONITOR_WEBHOOK_URL unset it prints the alert to stdout and exits 0 (a
+# no-op sink), so the colony works out of the box without a configured webhook.
+#
+# POSIX sh / dash-safe: no bashisms, no arrays, no `\xHH` printf escapes. CI runs
+# this under `sh` = dash.
+#
+# Exit codes: 0 ok (sent, or stdout fallback), 2 usage error, 3 curl missing
+# while a webhook IS configured.
+
+set -eu
+
+# Read the alert message from $1 if given, else from stdin.
+if [ "$#" -ge 1 ]; then
+    MSG="$1"
+else
+    MSG="$(cat)"
+fi
+
+if [ -z "${MSG:-}" ]; then
+    echo "notify.sh: empty alert message" >&2
+    exit 2
+fi
+
+WEBHOOK="${MONITOR_WEBHOOK_URL:-}"
+
+# No webhook configured -> print to stdout and succeed (the default no-op sink).
+if [ -z "$WEBHOOK" ]; then
+    echo "[monitor:alert] $MSG"
+    exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "notify.sh: curl not found but MONITOR_WEBHOOK_URL is set" >&2
+    exit 3
+fi
+
+# JSON-escape the message body with python3 (a `{"content": "..."}` payload that
+# both Discord and a Slack incoming webhook accept). python3 is already a hard
+# dependency of the federation (parse-toml.sh / start-colony.sh use it), so this
+# adds no new requirement and is robust against quotes/newlines in the payload.
+# The message is passed via the environment (NOTIFY_MSG) so no untrusted text is
+# interpolated into the python source — dash-safe and injection-safe.
+PAYLOAD="$(NOTIFY_MSG="$MSG" python3 -c 'import json, os; print(json.dumps({"content": os.environ["NOTIFY_MSG"]}))')"
+
+# POST it. -s quiet, -S show errors, -f fail on HTTP error so the exit code
+# reflects delivery. The webhook URL is the only secret and comes from the env.
+curl -sS -f \
+    -H 'Content-Type: application/json' \
+    -X POST \
+    -d "$PAYLOAD" \
+    "$WEBHOOK" >/dev/null
+
+echo "notify.sh: alert delivered to webhook"
+exit 0

--- a/dark-factory/monitor/scripts/start-colony.sh
+++ b/dark-factory/monitor/scripts/start-colony.sh
@@ -12,10 +12,10 @@
 # transaction or touches funds.
 #
 # ADR-0003 conformance: --restart-agent (#257) respawns one agent with the full
-# colony env, skips memo seeding + log truncation. Exit codes: 0 ok, 2 unknown
-# flag / missing arg, 3 unknown agent, 4 daemon launch failure. On success of a
-# --restart-agent run, prints exactly one line `started <agent> pid=<n>
-# tick=<ms>` for the dashboard's /restart endpoint to parse.
+# colony env, skips memo seeding + log truncation. Exit codes: 0 ok, 1 agentis
+# not found, 2 unknown flag / missing arg, 3 unknown agent, 4 daemon launch
+# failure. On success of a --restart-agent run, prints exactly one line
+# `started <agent> pid=<n> tick=<ms>` for the dashboard's /restart endpoint to parse.
 #
 # Monitor inputs are passed via the environment (all optional; see
 # config/colony.example.toml [monitor] and the colony README). With no

--- a/dark-factory/monitor/scripts/start-colony.sh
+++ b/dark-factory/monitor/scripts/start-colony.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Start the Monitor colony (part of the Dark Factory federation).
+#
+# Usage:
+#   ./scripts/start-colony.sh [path/to/colony.toml]
+#   ./scripts/start-colony.sh --restart-agent <name> [path/to/colony.toml]
+#
+# The monitor colony runs three long-lived daemons (invariant-watcher,
+# oracle-watcher, coordinator) that continuously WATCH a target EVM protocol and
+# emit reasoned anomaly alerts on the bus (`monitor:alert`). NON-custodial /
+# read-only: the watchers only READ chain state via `cast`/RPC; no agent signs a
+# transaction or touches funds.
+#
+# ADR-0003 conformance: --restart-agent (#257) respawns one agent with the full
+# colony env, skips memo seeding + log truncation. Exit codes: 0 ok, 2 unknown
+# flag / missing arg, 3 unknown agent, 4 daemon launch failure. On success of a
+# --restart-agent run, prints exactly one line `started <agent> pid=<n>
+# tick=<ms>` for the dashboard's /restart endpoint to parse.
+#
+# Monitor inputs are passed via the environment (all optional; see
+# config/colony.example.toml [monitor] and the colony README). With no
+# MONITOR_CAST / MONITOR_RPC_URL a watcher reads nothing and only observes — it
+# never raises a false alert:
+#   MONITOR_CAST  MONITOR_RPC_URL                                 (shared reader)
+#   MONITOR_TARGET MONITOR_INV_LHS_SIG MONITOR_INV_RHS_SIG ...    (invariant)
+#   MONITOR_ORACLE MONITOR_ORACLE_PRICE_SIG MONITOR_ORACLE_TS_SIG (oracle)
+#   MONITOR_WEBHOOK_URL                                           (notify.sh sink)
+
+set -e
+
+RESTART_AGENT=""
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --restart-agent)
+            if [ -z "${2:-}" ]; then
+                echo "start-colony.sh: --restart-agent requires an agent name" >&2
+                exit 2
+            fi
+            RESTART_AGENT="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            POSITIONAL+=("$@")
+            break
+            ;;
+        -*)
+            echo "start-colony.sh: unknown flag: $1" >&2
+            exit 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- ${POSITIONAL[@]+"${POSITIONAL[@]}"}
+
+# Symlink-safe $0 resolution.
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+COLONY_DIR="$(dirname "$SCRIPT_DIR")"
+FED_DIR="$(dirname "$COLONY_DIR")"
+CONFIG="${1:-$COLONY_DIR/config/colony.toml}"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "Note: config not found ($CONFIG) — running with environment inputs only." >&2
+    echo "      Copy config/colony.example.toml to config/colony.toml to silence this." >&2
+fi
+
+# Source parse-toml.sh: try <fed>/tools first, then <fed>/../tools (the latter is
+# the in-repo layout; the former is for standalone tarball installs that ship
+# tools/ inside the federation directory).
+PARSE_TOML=""
+for cand in "$FED_DIR/tools/parse-toml.sh" "$FED_DIR/../tools/parse-toml.sh"; do
+    if [ -f "$cand" ]; then
+        PARSE_TOML="$cand"
+        break
+    fi
+done
+if [ -n "$PARSE_TOML" ]; then
+    # shellcheck source=/dev/null
+    . "$PARSE_TOML"
+fi
+
+COLONY_NAME="monitor"
+
+# Monitor environment contract (read by the .ag watchers via getenv inside the
+# sandboxed `exec sh`). Each falls back to its current value or empty; a watcher
+# with no reader configured simply observes and never raises a false alert.
+MONITOR_CAST="${MONITOR_CAST:-}"
+MONITOR_RPC_URL="${MONITOR_RPC_URL:-}"
+MONITOR_TARGET="${MONITOR_TARGET:-}"
+MONITOR_INV_LHS_SIG="${MONITOR_INV_LHS_SIG:-}"
+MONITOR_INV_RHS_SIG="${MONITOR_INV_RHS_SIG:-}"
+MONITOR_INV_RHS_CONST="${MONITOR_INV_RHS_CONST:-}"
+MONITOR_INV_REL="${MONITOR_INV_REL:-}"
+MONITOR_INV_MARGIN_BP="${MONITOR_INV_MARGIN_BP:-}"
+MONITOR_INV_LABEL="${MONITOR_INV_LABEL:-}"
+MONITOR_ORACLE="${MONITOR_ORACLE:-}"
+MONITOR_ORACLE_PRICE_SIG="${MONITOR_ORACLE_PRICE_SIG:-}"
+MONITOR_ORACLE_TS_SIG="${MONITOR_ORACLE_TS_SIG:-}"
+MONITOR_ORACLE_MAX_AGE="${MONITOR_ORACLE_MAX_AGE:-}"
+MONITOR_ORACLE_DEV_BP="${MONITOR_ORACLE_DEV_BP:-}"
+MONITOR_ORACLE_MIN="${MONITOR_ORACLE_MIN:-}"
+MONITOR_ORACLE_MAX="${MONITOR_ORACLE_MAX:-}"
+MONITOR_ORACLE_LABEL="${MONITOR_ORACLE_LABEL:-}"
+MONITOR_WEBHOOK_URL="${MONITOR_WEBHOOK_URL:-}"
+
+export COLONY_DIR COLONY_NAME
+export MONITOR_CAST MONITOR_RPC_URL
+export MONITOR_TARGET MONITOR_INV_LHS_SIG MONITOR_INV_RHS_SIG MONITOR_INV_RHS_CONST
+export MONITOR_INV_REL MONITOR_INV_MARGIN_BP MONITOR_INV_LABEL
+export MONITOR_ORACLE MONITOR_ORACLE_PRICE_SIG MONITOR_ORACLE_TS_SIG MONITOR_ORACLE_MAX_AGE
+export MONITOR_ORACLE_DEV_BP MONITOR_ORACLE_MIN MONITOR_ORACLE_MAX MONITOR_ORACLE_LABEL
+export MONITOR_WEBHOOK_URL
+
+AGENTS=(
+    invariant-watcher
+    oracle-watcher
+    coordinator
+)
+
+# Per-agent tick interval. The watchers + coordinator all run at 60000ms by
+# default; MONITOR_TICK_MS overrides all three for faster/slower polling.
+tick_interval_for() {
+    case "$1" in
+        invariant-watcher) echo "${MONITOR_TICK_MS:-60000}" ;;
+        oracle-watcher) echo "${MONITOR_TICK_MS:-60000}" ;;
+        coordinator) echo "${MONITOR_TICK_MS:-60000}" ;;
+        *) echo 60000 ;;
+    esac
+}
+
+if ! command -v agentis >/dev/null 2>&1; then
+    echo "start-colony.sh: agentis not found on PATH — install it before running the monitor." >&2
+    exit 1
+fi
+
+# --restart-agent mode (#257): respawn exactly one agent with the full colony
+# env; skip memo seeding + log truncation (full-colony bootstrap concerns).
+if [ -n "$RESTART_AGENT" ]; then
+    valid=0
+    for a in "${AGENTS[@]}"; do
+        [ "$a" = "$RESTART_AGENT" ] && valid=1
+    done
+    if [ "$valid" = "0" ]; then
+        echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
+        exit 3
+    fi
+    tick=$(tick_interval_for "$RESTART_AGENT")
+    agentis daemon "$COLONY_DIR/agents/${RESTART_AGENT}.ag" \
+        --colony monitor \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval "$tick" </dev/null >/dev/null 2>&1 &
+    agent_pid=$!
+    sleep 0.5
+    if ! kill -0 "$agent_pid" 2>/dev/null; then
+        echo "start-colony.sh: agentis daemon failed to launch $RESTART_AGENT" >&2
+        exit 4
+    fi
+    echo "started $RESTART_AGENT pid=$agent_pid tick=$tick"
+    exit 0
+fi
+
+# Seed propose-tier confidence so each daemon ticks past dormant on first launch.
+# (ADR-0001 seeds fresh agents at shadow/0.4; propose lets the watchers emit
+# draft alerts out of the box for a smoke run. Operators lower this to observe
+# baselines first.)
+for agent in "${AGENTS[@]}"; do
+    agentis memo set "${agent}:confidence" "0.7" >/dev/null 2>&1 || true
+done
+
+echo "Starting Monitor colony (${#AGENTS[@]} agents)..."
+
+for agent in "${AGENTS[@]}"; do
+    interval=$(tick_interval_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms)..."
+    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+        --colony monitor \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval "$interval" &
+    sleep 2
+done
+
+echo "Colony started. Use 'agentis daemon list' to monitor."
+echo "Stop with: agentis daemon stop --all"
+
+wait


### PR DESCRIPTION
Closes #1085 (first PR — lint-clean foundation; remaining watchers + live-watch runtime #1086 follow).

New `monitor` colony in the **dark-factory** federation: a **non-custodial, read-only** federation that continuously watches a target EVM protocol and emits reasoned, high-signal anomaly alerts on the colony bus (`monitor:alert`).

## What's in this PR
- **invariant-watcher.ag** — evaluates a derived protocol invariant against current on-chain state via `cast`/RPC (every dynamic `exec sh` value `shell_escape()`d); flags violation / margin-to-violation. Verdict is a deterministic FACT, no LLM on the hot path.
- **oracle-watcher.ag** — price-feed deviation (vs learned baseline) / staleness / out-of-bounds, same read pattern.
- **coordinator.ag** — fuses the two blackboard signals, dedups by signature (a persistent condition pages once, not every tick), decides fused severity, emits one consolidated alert. Memos + bus only; no `exec sh`, no signing.
- **Confidence-tiered alerting** (ADR-0001): shadow observes + learns a baseline (no emit); propose drafts; review-gated/autonomous direct-page. One `tier()` call per tick, branch once.
- `config/colony.example.toml` (`[forge] type="none"`, `cb_budget` == `cb` decls), `scripts/start-colony.sh` (ADR-0003), `scripts/notify.sh` (dash-safe webhook sink), `README.md`, dark-factory CHANGELOG entry.

## Safety
Non-custodial: read-only, never signs, never touches funds. No secrets committed (`MONITOR_WEBHOOK_URL` is operator-exported).

## Validation
`./tools/colony-lint.sh` → **386 passed, 0 failed, 5 skipped**. `bash -n`/`sh -n`/`shellcheck` clean on both scripts; all three `.ag` pass `agentis commit`.

## Deferred (follow-ups)
liquidity/governance/flow watchers; live-watch runtime (#1086); dashboard view; production webhook auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)