### PR TITLE
fix(dark-factory): JSON-escape free-text fields in monitor alert/signal payloads (#1089)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -15,6 +15,11 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 ## [Unreleased]
 
 ### Fixed
+- **monitor: JSON-escape free-text fields in alert/signal payloads** (#1089). `invariant-watcher` and
+  `oracle-watcher` now route the operator-supplied `label`/`addr` through a `json_escape()` helper (escapes
+  `\` and `"`) in every alert/signal payload builder, so a label containing a `"` can no longer corrupt the
+  emitted JSON. Per-char fold (`.ag` has no string-replace builtin). Verified via `agentis repl`:
+  `json_escape("a\"b\\c")` → `a\"b\\c`.
 - **`flat-cyborg-claude.sh` uses `--extract-structural`** (#1083, needs flat-cyborg ≥ 0.10.2). claude
   intermittently omits the reply sentinel; strict `--extract` then burned the full `--timeout-ms` and exited
   "no fenced reply", which the agentis caller retried — repeated ~700 s gen hangs ending in HARNESS_ERROR

--- a/dark-factory/monitor/agents/invariant-watcher.ag
+++ b/dark-factory/monitor/agents/invariant-watcher.ag
@@ -86,6 +86,18 @@ fn label_or_sig(raw: string, lhs: string) -> string {
     return lhs;
 }
 
+// JSON-string escape a free-text field (#1089): backslash -> \\ and double-quote
+// -> \" , so an operator-authored label/address containing a `"` cannot corrupt
+// the alert/signal JSON. Per-char fold (.ag has no string-replace builtin);
+// regex_find_all over [\s\S] yields every char incl. whitespace.
+fn json_escape(s: string) -> string {
+    return reduce(regex_find_all("[\\s\\S]", s), |acc: string, c: string| -> string {
+        if c == "\\" { return acc + "\\\\"; }
+        if c == "\"" { return acc + "\\\""; }
+        return acc + c;
+    }, "");
+}
+
 // --- read a single uint return from an on-chain view via cast call -------------
 // `cast call --rpc-url <url> <addr> <sig>` prints one 0x-hex word; `cast --to-dec`
 // renders it as a decimal integer string. EVERY dynamic value (the cast path, the
@@ -183,9 +195,9 @@ fn is_anomaly(verdict: string) -> bool {
 // A compact, deterministic alert payload (JSON). All fields are facts the watcher
 // computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
 fn alert_payload(label: string, verdict: string, lhs: int, rhs: int, rel: string, addr: string, sev: string) -> string {
-    return "{\"watcher\":\"invariant\",\"invariant\":\"" + label + "\",\"verdict\":\"" + verdict
+    return "{\"watcher\":\"invariant\",\"invariant\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
          + "\",\"lhs\":" + to_string(lhs) + ",\"rhs\":" + to_string(rhs) + ",\"rel\":\"" + rel
-         + "\",\"target\":\"" + addr + "\",\"severity\":\"" + sev + "\"}";
+         + "\",\"target\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
 }
 
 // === #1086 — DERIVED watch-spec (multi-invariant SET) path =====================
@@ -299,8 +311,8 @@ fn signal_key_label(label: string) -> string {
 // sanitized label; the payload carries the original label.
 fn post_signal(label: string, verdict: string, addr: string) -> void {
     memo_write("monitor:signal:invariant:" + signal_key_label(label),
-        "{\"watcher\":\"invariant\",\"invariant\":\"" + label + "\",\"verdict\":\"" + verdict
-        + "\",\"target\":\"" + addr + "\",\"severity\":\"info\"}");
+        "{\"watcher\":\"invariant\",\"invariant\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
+        + "\",\"target\":\"" + json_escape(addr) + "\",\"severity\":\"info\"}");
 }
 
 // BOUNDED RECURSION over the spec array (single-assignment .ag has no while/for):

--- a/dark-factory/monitor/agents/oracle-watcher.ag
+++ b/dark-factory/monitor/agents/oracle-watcher.ag
@@ -57,6 +57,18 @@ fn price_sig_or_default(raw: string) -> string {
     return raw;
 }
 
+// JSON-string escape a free-text field (#1089): backslash -> \\ and double-quote
+// -> \" , so an operator-authored feed label/address containing a `"` cannot
+// corrupt the alert/signal JSON. Per-char fold (.ag has no string-replace
+// builtin); regex_find_all over [\s\S] yields every char incl. whitespace.
+fn json_escape(s: string) -> string {
+    return reduce(regex_find_all("[\\s\\S]", s), |acc: string, c: string| -> string {
+        if c == "\\" { return acc + "\\\\"; }
+        if c == "\"" { return acc + "\\\""; }
+        return acc + c;
+    }, "");
+}
+
 fn label_or(raw: string, addr: string) -> string {
     if len(raw) > 0 { return raw; }
     return addr;
@@ -167,9 +179,9 @@ fn is_anomaly(verdict: string) -> bool {
 // A compact, deterministic alert payload (JSON). All fields are facts the watcher
 // computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
 fn alert_payload(label: string, verdict: string, price: int, base: int, addr: string, sev: string) -> string {
-    return "{\"watcher\":\"oracle\",\"feed\":\"" + label + "\",\"verdict\":\"" + verdict
+    return "{\"watcher\":\"oracle\",\"feed\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
          + "\",\"price\":" + to_string(price) + ",\"baseline\":" + to_string(base)
-         + ",\"oracle\":\"" + addr + "\",\"severity\":\"" + sev + "\"}";
+         + ",\"oracle\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
 }
 
 fn tick(reason: string) -> void {


### PR DESCRIPTION
Closes #1089 (QA follow-up from #1086).

`invariant-watcher` (`alert_payload`, `post_signal`) and `oracle-watcher` (`alert_payload`) built the alert/signal JSON by hand-rolled concat; an operator-authored `label`/`addr` containing a literal `"` corrupted the payload JSON. This adds a `json_escape()` helper (escapes `\` and `"`; per-char fold since `.ag` has no string-replace builtin) and routes every free-text field through it. `verdict`/`rel`/`sev` are fixed enums (no escaping needed); the coordinator's fused payload carries no free text.

## Verified
Via `agentis repl`: `regex_find_all("[\\s\\S]", "abc")` → 3 (per-char); `json_escape("a\"b\\c d")` → `a\"b\\c d`; `json_escape("plain")` → `plain`. colony-lint **386 passed, 0 failed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)