### PR TITLE
feat(dark-factory): add prospector colony — qualify EVM protocols as monitoring targets (#871)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -119,6 +119,45 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   `tools/test-invariant-prover-repair-loop.sh`, pins the loop (grep over the `.ag`, no LLM/forge).
 
 ### Added
+- **`prospector` colony — qualify EVM protocols as monitoring targets by public on-chain/source signals**
+  (#871). A new colony alongside `monitor` + `auditor` that takes a list of candidate EVM protocols and decides
+  which ones are worth standing up the `monitor` colony on, and why. NON-custodial / read-only: every agent only
+  READS public source/ABI + on-chain state via `cast`/explorer over `exec sh` (each dynamic value
+  `shell_escape()`d) — no agent signs a transaction or touches funds, and the value-scorer uses ONLY `cast call`
+  / `cast balance` (never `cast send` / a key / a write-RPC). The qualification verdict is a FACT (a source/ABI
+  read + a read-only on-chain value read + a deterministic comparison), never an LLM opinion. This PR ships the
+  lint-clean foundation: the colony scaffold (`prospector/{agents,config,scripts,README.md}`, `[forge] type =
+  "none"` per ADR-0003), the four agents, and the confidence-tiered qualification pipeline.
+  - `prospector/agents/intake.ag` — ingests the candidate protocol list from `PROSPECTOR_CANDIDATES` (newline
+    `<address>|<chain>[|<metadata>]` cells), validates (`0x` + 40 hex address, integer chain id) + dedups each
+    candidate, and writes the normalised `prospector:candidates` blackboard memo.
+  - `prospector/agents/source-classifier.ag` — for each candidate reads its verified function-signature surface
+    via a configured reader command (`PROSPECTOR_ABI_CMD`, e.g. `cast interface` or a keyless Sourcify ABI fetch;
+    the address/chain reach the reader as exported env vars, never interpolated) and classifies whether it
+    exposes a DeFi value-invariant family (lending / vault-4626 / AMM / stablecoin / perps / staking / bridge) —
+    the monitorability gate. Posts `prospector:classified:<addr>`.
+  - `prospector/agents/value-scorer.ag` — for each candidate reads a read-only on-chain value proxy (a `cast
+    call` view such as `totalAssets()`, or the contract's native `cast balance`) and decides whether it clears a
+    configured value floor — the value-floor gate. The value + floor are compared as BIG-DECIMAL strings (a TVL
+    in wei exceeds i64, which `parse_int` cannot hold and which corrupts JSON number parsing downstream), so the
+    digit strings are compared digit-wise and carried as JSON strings. Posts `prospector:value:<addr>`.
+  - `prospector/agents/coordinator.ag` — fuses the three HARD GATES (verified-source + DeFi-value-invariants +
+    value-floor) into a per-target qualification verdict and writes the `prospector:qualified` dossier (per-target:
+    qualifies yes/no, the matched family, the failed gate when any, and the suggested invariant to watch — the
+    handoff to the `monitor` colony, phrased in the monitor's `MONITOR_INV_*` terms) plus a ranked
+    qualifying-target index. Single-assignment helpers, reduce/bounded-recursion (no loops), per the
+    `auditor`/`monitor` coordinator pattern.
+  - **Confidence-tiered qualification (ADR-0001) as the false-positive control.** Every agent makes ONE `tier()`
+    call per tick and branches once; the tier gates PUBLICATION only (the verdict is identical at every tier):
+    `shadow`/`dormant` score + write the dossier (no publish), `propose` emits a draft shortlist, `review-gated`/
+    `autonomous` publish the ranked dossier index. `cb <N>;` matches `cb_budget`, and every tick begins + ends
+    with `memo_write("<agent>:last_check", now)`.
+  - `prospector/scripts/start-colony.sh` — ADR-0003-conformant daemon launcher (symlink-safe `$0`, sources
+    `parse-toml.sh`, exports the `PROSPECTOR_*` env contract, `--restart-agent`, allowlisted daemon flags).
+  - `prospector/README.md` — agent table + mermaid diagram + the env contract + the tier semantics + the
+    `monitor`-colony handoff recipe.
+  Follow-ups (out of scope here): off-chain qualification signals (web-research scoring) and freshness via
+  deploy-time indexing. The colony NEVER signs and NEVER touches funds.
 - **`monitor` live-watch runtime — derive a target's invariant SET once, watch the whole set continuously**
   (#1086, builds on the `monitor` colony #1085). The `monitor` colony's `invariant-watcher` evaluated ONE
   env-configured invariant against live on-chain state; dark-factory separately DERIVES a target's deep

--- a/dark-factory/prospector/README.md
+++ b/dark-factory/prospector/README.md
@@ -1,0 +1,142 @@
+# Prospector Colony
+
+> Part of the [Dark Factory](../) federation.
+
+A **monitoring-target qualifier**. Four cooperating agents take a list of
+candidate EVM protocols and decide which ones are worth standing up the
+[`monitor`](../monitor/) colony on — and why. The colony is **non-custodial /
+read-only**: every agent only **reads** public source / ABI and on-chain state
+via `cast` / a verified-source explorer — it never signs a transaction and never
+touches funds.
+
+The qualification verdict is a **fact** (a source/ABI read + a read-only
+on-chain value read + a deterministic comparison), never an LLM opinion. A
+candidate **qualifies** as a monitoring target only when all three hard gates
+hold:
+
+1. **verified-source** — the contract exposes a real, readable source / ABI
+   surface;
+2. **DeFi value-invariants** — that surface matches a known value-invariant
+   family (lending / vault-4626 / AMM / stablecoin / perps / staking / bridge);
+3. **value-floor** — its read-only on-chain value clears a configured floor.
+
+The handoff to the `monitor` colony is the per-target **dossier**: for a
+qualifying target it names the value-invariant family and the **suggested
+invariant to watch** (phrased in the `monitor`'s `MONITOR_INV_*` terms), so an
+operator can stand up the monitor on exactly the right property.
+
+## Agents
+
+| Agent | Role | Output |
+|-------|------|--------|
+| `intake` | Ingests the candidate protocol list (`PROSPECTOR_CANDIDATES`, `<address>\|<chain>[\|<metadata>]` per line) onto the blackboard; validates + dedups each candidate | `prospector:candidates`, `prospector:intake` (tier-gated) |
+| `source-classifier` | Reads each candidate's verified source / ABI surface and classifies whether it exposes a DeFi value-invariant family (the monitorability gate) | `prospector:classified:<addr>`, `prospector:classified` (tier-gated) |
+| `value-scorer` | Reads a read-only on-chain value proxy (balance / TVL via `cast call`) for each candidate and decides whether it clears the value floor | `prospector:value:<addr>`, `prospector:value` (tier-gated) |
+| `coordinator` | Fuses the three hard gates into a ranked qualification verdict and writes the per-target dossier + ranked index (the monitor handoff) | `prospector:qualified:<addr>`, `prospector:qualified` (tier-gated) |
+
+Each agent runs as its own `agentis daemon`. The agents coordinate via durable
+blackboard memos (the `prospector:*` namespace); the coordinator reads the
+per-candidate verdicts the classifier and value-scorer posted and fuses them.
+
+```mermaid
+flowchart LR
+    ENV[PROSPECTOR_CANDIDATES<br/>address + chain + metadata] --> IN[intake]
+    IN -->|prospector:candidates| SC[source-classifier]
+    IN -->|prospector:candidates| VS[value-scorer]
+    SRC[cast interface / explorer<br/>read-only] --> SC
+    CHAIN[cast call / balance<br/>read-only] --> VS
+    SC -->|prospector:classified:addr| CO[coordinator]
+    VS -->|prospector:value:addr| CO
+    CO -->|prospector:qualified<br/>ranked dossier| MON[monitor colony<br/>handoff]
+```
+
+## Confidence-tiered qualification (ADR-0001)
+
+Every agent makes ONE `tier()` call per tick and branches once. The tier gates
+**publication only** — the verdict is computed identically at every tier:
+
+- `shadow` / `dormant` — score only: classify / score + `learn()` a baseline and
+  write the per-target dossier; **no publish on the bus**.
+- `propose` — emit a **draft** shortlist on the bus for review.
+- `review-gated` / `autonomous` — publish the **ranked dossier** index directly,
+  once the qualifier has proven reliable.
+
+This is the false-positive control: a fresh agent seeded at `shadow` learns the
+candidate set's normal shape before its shortlist is ever published, and
+auto-promotion lifts it as its verdicts prove out.
+
+## Hand off to the `monitor` colony
+
+A qualifying target's dossier (`prospector:qualified:<addr>`) carries the matched
+value-invariant family and a **suggested invariant to watch**, mapped to the
+`monitor` colony's invariant contract. For example, a `vault-4626` target's
+dossier suggests `totalAssets() ge totalSupply() (share solvency)` — which an
+operator wires into the monitor as:
+
+```bash
+# from the prospector dossier for a qualifying vault-4626 target:
+export MONITOR_TARGET=0xVAULT
+export MONITOR_INV_LHS_SIG="totalAssets()"
+export MONITOR_INV_RHS_SIG="totalSupply()"
+export MONITOR_INV_REL="ge"
+export MONITOR_CAST="$(command -v cast)" MONITOR_RPC_URL=https://rpc.example/x
+../monitor/scripts/start-colony.sh
+```
+
+The prospector decides **which** targets and **which** property; the
+[`monitor`](../monitor/README.md) colony does the continuous watching, and the
+[`monitor` live-watch runtime](../monitor/README.md) can derive the full
+invariant set for the chosen target.
+
+## Setup
+
+1. Copy and edit the config:
+   ```bash
+   cp config/colony.example.toml config/colony.toml
+   ```
+
+2. Export the candidate list + the read tools (see the env contract below), then
+   start the colony:
+   ```bash
+   export PROSPECTOR_CANDIDATES="0xVAULT|1|some vault
+   0xPOOL|1|some pool"
+   export PROSPECTOR_CAST="$(command -v cast)" PROSPECTOR_RPC_URL=https://rpc.example/x
+   export PROSPECTOR_VALUE_SIG="totalAssets()" PROSPECTOR_VALUE_FLOOR=1000000000000000000000
+   export PROSPECTOR_ABI_CMD='cast interface --rpc-url "$PROSPECTOR_RPC_URL" "$PROSPECTOR_ADDR" 2>/dev/null'
+   ./scripts/start-colony.sh
+   ```
+
+3. Add each `PROSPECTOR_*` var (plus `PROSPECTOR_ADDR` / `PROSPECTOR_CHAIN`, which
+   `source-classifier` exports into its reader) to `exec.env_passthrough` in
+   `.agentis/config` so the sandboxed `exec sh` readers can see them. With no
+   reader configured, a candidate classifies `no-read` and is never qualified.
+
+dark-factory is a non-forge federation (`forge.type = "none"`); no forge
+credentials are required.
+
+## Environment contract
+
+Inputs are passed via the environment (all optional). Export them before
+launching, and add each to `exec.env_passthrough` in `.agentis/config` so the
+sandboxed `exec sh` readers can read them. With no reader configured a candidate
+classifies `no-read` and is never falsely qualified.
+
+| Var | Meaning | Default |
+|-----|---------|---------|
+| `PROSPECTOR_CANDIDATES` | Newline-joined `<address>\|<chain>[\|<metadata>]` list of candidate protocols. address = `0x` + 40 hex; chain = EVM chain id; metadata optional. | unset (no candidates) |
+| `PROSPECTOR_ABI_CMD` | Reader command template that, given a candidate's address + chain (exported as `PROSPECTOR_ADDR` / `PROSPECTOR_CHAIN`, never interpolated), prints the verified function-signature surface, one signature per line (e.g. `cast interface`, or a keyless Sourcify ABI fetch). | unset (observe only) |
+| `PROSPECTOR_CAST` | Absolute path to the `cast` binary (foundry), the value-read tool. | unset (observe only) |
+| `PROSPECTOR_RPC_URL` | Chain RPC endpoint `cast` reads from (read-only). | unset (observe only) |
+| `PROSPECTOR_VALUE_SIG` | `cast call` signature returning the value proxy (e.g. `totalAssets()`); `""` ⇒ use the contract's native balance (`cast balance`). | unset (native balance) |
+| `PROSPECTOR_VALUE_FLOOR` | Minimum value (decimal integer, in the read's own units) a candidate must hold to clear the floor. | `0` (any non-zero read clears) |
+
+## Status
+
+Experimental, lint-clean foundation. This colony ships the scaffold
+(`prospector/{agents,config,scripts,README.md}`, `[forge] type = "none"` per
+ADR-0003), the four agents, and the confidence-tiered qualification pipeline in
+[#871](https://github.com/Replikanti/agentis-colonies/issues/871). Follow-ups
+(out of scope here): off-chain qualification signals (web-research scoring), and
+freshness via deploy-time indexing. The colony is **read-only**, **never** signs
+or touches funds, and uses **only** `cast call` / `cast balance` (never
+`cast send` / a key / a write-RPC).

--- a/dark-factory/prospector/agents/coordinator.ag
+++ b/dark-factory/prospector/agents/coordinator.ag
@@ -1,0 +1,328 @@
+// coordinator.ag — Prospector colony (Dark Factory federation).
+//
+// The fusion + ranking agent. For every candidate on the `prospector:candidates`
+// blackboard it reads the two upstream per-candidate verdicts the classifier and
+// the value-scorer posted (`prospector:classified:<addr>`,
+// `prospector:value:<addr>`), FUSES the HARD GATES into one QUALIFICATION
+// verdict, and writes a per-target DOSSIER to `prospector:qualified:<addr>` plus a
+// rolled-up `prospector:qualified` index. The dossier is the HANDOFF to the
+// `monitor` colony: for a qualifying target it names the value-invariant family
+// and the SUGGESTED INVARIANTS to watch (mapped to the monitor's MONITOR_INV_*
+// contract), so an operator can stand up the monitor on exactly the right
+// property.
+//
+// The HARD GATES (all must hold for a target to QUALIFY):
+//   1. verified-source       the classifier read a real source/ABI surface
+//                            (verdict != "no-read");
+//   2. DeFi value-invariants the surface matched a known value-invariant family
+//                            (lending / vault-4626 / AMM / stablecoin / perps /
+//                            staking / bridge);
+//   3. value-floor           the value-scorer's on-chain value cleared the floor
+//                            (verdict == "above").
+// A target failing ANY gate does NOT qualify (the dossier records which gate it
+// failed). The fused verdict is a deterministic function of the upstream FACTS —
+// never an LLM call.
+//
+// NON-custodial / read-only: it reads blackboard memos + writes blackboard memos
+// + emits on the bus only — no signing, no fund access, no `exec sh`.
+//
+// Pattern (per dark-factory/{auditor,monitor}/agents/coordinator.ag): single-
+// assignment helpers (no `let` reassignment), reduce/recursion instead of loops.
+//
+// Emission is gated PURELY on the ADR-0001 tier of this agent:
+//   shadow / dormant -> fuse + write the dossier, NO emit (score only, no publish);
+//   propose          -> + emit a DRAFT `prospector:qualified` shortlist (the
+//                        ranked qualifying-target index);
+//   review-gated /    -> + emit the DIRECT ranked dossier index.
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant. The
+// per-target dossiers are written at EVERY tier (a memo write) so the score is
+// always available; only the bus PUBLISH of the ranked index is tier-gated.
+//
+// Reads (blackboard): prospector:candidates, prospector:classified:<addr>,
+//   prospector:value:<addr>.
+// Writes (blackboard): prospector:qualified:<addr> (per-target dossier),
+//   prospector:qualified (the ranked qualifying-target index).
+// Emits: "prospector:qualified" (the colony bus contract).
+
+cb 150000;
+
+// Upper bound on how many candidates the coordinator fuses in one tick (the
+// bounded recursion's depth cap; .ag has no loops). Matches the upstream agents.
+fn board_max() -> int {
+    return 64;
+}
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("coordinator:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- candidate-cell field extraction (`<address>|<chain>|<metadata>`) -----------
+fn cell_address(cell: string) -> string {
+    let bar = index_of(cell, "|");
+    if bar < 0 { return cell; }
+    return substring(cell, 0, bar);
+}
+
+fn cell_chain(cell: string) -> string {
+    let bar = index_of(cell, "|");
+    if bar < 0 { return ""; }
+    let rest = substring(cell, bar + 1, len(cell));
+    let bar2 = index_of(rest, "|");
+    if bar2 < 0 { return rest; }
+    return substring(rest, 0, bar2);
+}
+
+fn cell_metadata(cell: string) -> string {
+    let bar = index_of(cell, "|");
+    if bar < 0 { return ""; }
+    let rest = substring(cell, bar + 1, len(cell));
+    let bar2 = index_of(rest, "|");
+    if bar2 < 0 { return ""; }
+    return substring(rest, bar2 + 1, len(rest));
+}
+
+// JSON-string escape a free-text field (mirrors the upstream agents' json_escape):
+// backslash -> \\ and double-quote -> \" so an operator-supplied metadata label
+// containing a `"` cannot corrupt the dossier JSON.
+fn json_escape(s: string) -> string {
+    return reduce(regex_find_all("[\\s\\S]", s), |acc: string, c: string| -> string {
+        if c == "\\" { return acc + "\\\\"; }
+        if c == "\"" { return acc + "\\\""; }
+        return acc + c;
+    }, "");
+}
+
+// json_get on a miss returns Void -> to_string => "void"; collapse to "".
+fn sanitize(s: string) -> string {
+    if s == "void" { return ""; }
+    return s;
+}
+
+// Pull a field from a stored signal JSON; "" on a miss / unread signal.
+fn signal_field(sig: string, field: string) -> string {
+    if len(sig) == 0 { return ""; }
+    return sanitize(to_string(json_get(sig, field)));
+}
+
+// --- the three HARD GATES, read off the upstream per-candidate signals ----------
+// Gate 1 + 2 (verified-source + value-invariant family): the classifier's
+// `family` field is "no-read" (gate 1 fails), "no-invariant" (gate 1 holds, gate
+// 2 fails), or a value-invariant family token (both hold).
+fn class_family(addr: string) -> string {
+    return signal_field(recall_latest("prospector:classified:" + addr), "family");
+}
+
+// Gate 3 (value-floor): the value-scorer's `verdict` is "no-read" / "below" /
+// "above". Only "above" clears.
+fn value_verdict(addr: string) -> string {
+    return signal_field(recall_latest("prospector:value:" + addr), "verdict");
+}
+
+fn gate_verified_source(family: string) -> bool {
+    if len(family) == 0 { return false; }
+    if family == "no-read" { return false; }
+    return true;
+}
+
+fn gate_value_invariant(family: string) -> bool {
+    if !gate_verified_source(family) { return false; }
+    if family == "no-invariant" { return false; }
+    return true;
+}
+
+fn gate_value_floor(verdict: string) -> bool {
+    return verdict == "above";
+}
+
+// A target QUALIFIES iff all three gates hold (nested ifs — .ag has no `&&`).
+fn qualifies(family: string, valVerdict: string) -> bool {
+    if !gate_verified_source(family) { return false; }
+    if !gate_value_invariant(family) { return false; }
+    return gate_value_floor(valVerdict);
+}
+
+// The first gate that FAILED (for the dossier's "why"); "" when all hold.
+fn failed_gate(family: string, valVerdict: string) -> string {
+    if !gate_verified_source(family) { return "verified-source"; }
+    if !gate_value_invariant(family) { return "value-invariant"; }
+    if !gate_value_floor(valVerdict) { return "value-floor"; }
+    return "";
+}
+
+// --- SUGGESTED INVARIANTS per value-invariant family (the monitor handoff) ------
+// Each family maps to the deep value-invariant the `monitor` colony's
+// invariant-watcher should watch, phrased in the monitor's MONITOR_INV_* terms (a
+// two-sided view comparison with a required relation). This is the qualification
+// pipeline's OUTPUT: not just "monitor this", but "watch THIS property".
+fn suggested_invariant(family: string) -> string {
+    if family == "vault-4626" { return "totalAssets() ge totalSupply() (share solvency)"; }
+    if family == "lending" { return "total collateral value ge total borrowed value (collateralisation)"; }
+    if family == "amm" { return "reserve product non-decreasing across swaps (k-invariant)"; }
+    if family == "stablecoin" { return "backing ge totalSupply() (peg backing)"; }
+    if family == "perps" { return "margin + collateral ge open-position notional (position solvency)"; }
+    if family == "staking" { return "staked balance ge accounted stake (reward accounting)"; }
+    if family == "bridge" { return "locked ge minted (cross-chain conservation)"; }
+    return "";
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. A qualifying
+// target is the productive signal (success); a fully-evaluated but non-qualifying
+// candidate is partial; no candidates / no upstream verdicts is partial too.
+fn outcome_of(qualified: int) -> string {
+    if qualified > 0 { return "success"; }
+    return "partial";
+}
+
+// The per-target dossier (JSON). Carries qualifies yes/no, the matched family,
+// the failed gate (when any), the suggested invariant (the monitor handoff), and
+// the value verdict. All fields are upstream FACTS; none is LLM text.
+fn dossier_payload(addr: string, chain: string, meta: string, family: string, valVerdict: string, qualified: bool, why: string, invariant: string) -> string {
+    return "{\"agent\":\"coordinator\",\"target\":\"" + json_escape(addr)
+         + "\",\"chain\":\"" + json_escape(chain) + "\",\"label\":\"" + json_escape(meta)
+         + "\",\"qualifies\":" + to_string(qualified) + ",\"family\":\"" + family
+         + "\",\"value\":\"" + valVerdict + "\",\"why\":\"" + why
+         + "\",\"watch\":\"" + json_escape(invariant) + "\"}";
+}
+
+// Write one candidate's dossier to its per-target blackboard memo (a memo write —
+// allowed at every tier). The address is the validated `0x` + 40-hex key.
+// Returns 1 when the target qualifies, else 0 (for the running count).
+fn fuse_cell(cell: string) -> int {
+    let addr = cell_address(cell);
+    let chain = cell_chain(cell);
+    let meta = cell_metadata(cell);
+    let family = class_family(addr);
+    let valVerdict = value_verdict(addr);
+    let qualified = qualifies(family, valVerdict);
+    let gate = failed_gate(family, valVerdict);
+    let why = if qualified { "all gates pass" } else { "failed gate: " + gate };
+    let invariant = if qualified { suggested_invariant(family) } else { "" };
+    memo_write("prospector:qualified:" + addr,
+        dossier_payload(addr, chain, meta, family, valVerdict, qualified, why, invariant));
+    print("coordinator: " + addr + " family=" + family + " value=" + valVerdict
+        + " -> qualifies=" + to_string(qualified));
+    if qualified { return 1; }
+    return 0;
+}
+
+// The i-th non-empty line of a newline-joined board; "" when out of range. The
+// board is split + folded (.ag has no list indexing), picking the line whose
+// non-empty position equals `i`. Total on every failure mode.
+fn nth_cell(lines: list<string>, i: int) -> string {
+    let acc = reduce(lines, |st: string, cell: string| -> string {
+        let pos = pick_pos(st);
+        let found = pick_found(st);
+        if len(found) > 0 { return st; }
+        if len(cell) == 0 { return st; }
+        if pos == i { return to_string(pos + 1) + "|" + cell; }
+        return to_string(pos + 1) + "|";
+    }, "0|");
+    return pick_found(acc);
+}
+
+fn pick_pos(st: string) -> int {
+    let bar = index_of(st, "|");
+    if bar < 0 { return 0; }
+    return parse_int(substring(st, 0, bar));
+}
+
+fn pick_found(st: string) -> string {
+    let bar = index_of(st, "|");
+    if bar < 0 { return ""; }
+    return substring(st, bar + 1, len(st));
+}
+
+fn count_cells(lines: list<string>) -> int {
+    return reduce(lines, |acc: int, cell: string| -> int {
+        if len(cell) == 0 { return acc; }
+        return acc + 1;
+    }, 0);
+}
+
+// BOUNDED RECURSION over the candidate board (single-assignment .ag has no
+// while/for): at each non-empty cell up to the board_max() cap, fuse the gates,
+// write the per-target dossier, and ACCUMULATE the ranked index of QUALIFYING
+// targets (one `<addr>|<family>` cell per qualifier). Stops at the cap or end of
+// board. Returns the ranked index (newline-joined; "" when none qualify).
+fn fuse_board(lines: list<string>, i: int, total: int, remaining: int, idx: string) -> string {
+    if remaining <= 0 { return idx; }
+    if i >= total { return idx; }
+    let cell = nth_cell(lines, i);
+    if len(cell) == 0 { return idx; }
+    let q = fuse_cell(cell);
+    if q > 0 {
+        let entry = cell_address(cell) + "|" + class_family(cell_address(cell));
+        let nextIdx = if len(idx) == 0 { entry } else { idx + "\n" + entry };
+        return fuse_board(lines, i + 1, total, remaining - 1, nextIdx);
+    }
+    return fuse_board(lines, i + 1, total, remaining - 1, idx);
+}
+
+fn count_index(idx: string) -> int {
+    if len(idx) == 0 { return 0; }
+    return reduce(regex_split("\n", idx), |acc: int, l: string| -> int {
+        if len(l) == 0 { return acc; }
+        return acc + 1;
+    }, 0);
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("coordinator:last_check", now);
+
+    let board = recall_latest("prospector:candidates");
+    let lines = regex_split("\n", board);
+    let total = count_cells(lines);
+    // FUSE: write every per-target dossier + accumulate the ranked qualifying index.
+    let idx = fuse_board(lines, 0, total, board_max(), "");
+    let qualified = count_index(idx);
+
+    print("coordinator: fused board -> " + to_string(qualified)
+        + " qualified of " + to_string(total) + " (conf=" + to_string(get_confidence()) + ")");
+
+    let outcome = outcome_of(qualified);
+    let key = "qualified:" + to_string(qualified);
+    let desc = "fused board -> " + to_string(qualified) + " qualified monitoring target(s)";
+
+    // Write the ranked qualifying-target INDEX to the rolled-up blackboard memo
+    // (a memo write — allowed at every tier). The per-target dossiers carry the
+    // detail; this index is the shortlist the monitor handoff consumes.
+    memo_write("prospector:qualified", idx);
+
+    // A compact summary payload for the bus (count only — no untrusted free text).
+    let summary = "{\"agent\":\"coordinator\",\"kind\":\"shortlist\",\"qualified\":"
+        + to_string(qualified) + ",\"evaluated\":" + to_string(total) + "}";
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates the bus PUBLISH of
+    // the ranked index only; the dossiers + index memo above are written at every
+    // tier. shadow/dormant fall through (score only, no publish).
+    // (.ag has no `else if`; the tiers nest as `else { if ... } else { }`.)
+    let my_tier = tier("coordinator");
+    if my_tier == "autonomous" {
+        emit("prospector:qualified", summary);
+        learn("prospector-qualify", key, desc, outcome, [outcome, "acted"]);
+    } else {
+        if my_tier == "review-gated" {
+            emit("prospector:qualified", summary);
+            learn("prospector-qualify", key, desc, outcome, [outcome, "review-gated"]);
+        } else {
+            if my_tier == "propose" {
+                emit("prospector:qualified", summary);
+                learn("prospector-qualify", key, desc, outcome, [outcome, "emitted"]);
+            } else {
+                // shadow / dormant: fuse + write the dossier ONLY — no publish.
+                learn("prospector-qualify", key, desc + " (baseline)", outcome, [outcome, "observed"]);
+                print("coordinator: observing (tier: " + my_tier + ") — no publish");
+            };
+        };
+    };
+
+    memo_write("coordinator:last_check", to_string(now_ms()));
+}

--- a/dark-factory/prospector/agents/intake.ag
+++ b/dark-factory/prospector/agents/intake.ag
@@ -1,0 +1,255 @@
+// intake.ag — Prospector colony (Dark Factory federation).
+//
+// The candidate-ingest agent. It reads a newline-list of candidate EVM
+// protocols from the environment (PROSPECTOR_CANDIDATES) and NORMALISES them
+// onto a shared blackboard memo (`prospector:candidates`) that the classifier,
+// the value-scorer, and the coordinator all read. The colony's job is to QUALIFY
+// EVM protocols as MONITORING TARGETS by public on-chain/source signals — i.e.
+// decide which candidates are worth standing up the `monitor` colony on. This
+// agent is the front of that pipeline: it turns an operator-supplied candidate
+// list into a clean, deduped fact the downstream agents key on.
+//
+// NON-custodial / read-only: it reads an env var + writes a blackboard memo
+// only. No on-chain read, no signing, no `exec sh`, no fund access.
+//
+// Each candidate line is `<address>|<chain>[|<metadata>]`:
+//   address   the deployed contract address (0x + 40 hex);
+//   chain     the EVM chain id (integer, e.g. 1 = Ethereum mainnet);
+//   metadata  OPTIONAL free-text label (a protocol name / note). Ignored for
+//             keying; carried verbatim into the normalised board for context.
+// A malformed line (no address, bad chain) is dropped — intake never emits a
+// candidate the downstream readers cannot key on.
+//
+// Emission is gated PURELY on the ADR-0001 tier of this agent:
+//   shadow / dormant -> normalise + learn the candidate set, NO emit;
+//   propose          -> + emit a DRAFT `prospector:intake` summary on the bus;
+//   review-gated /    -> + emit a DIRECT `prospector:intake` summary.
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant. The
+// normalised board is written at EVERY tier (a memo write — the downstream
+// agents read it regardless of intake's own tier).
+//
+// Env contract (read via getenv; exported by scripts/start-colony.sh):
+//   PROSPECTOR_CANDIDATES  newline-joined `<address>|<chain>[|<metadata>]` list.
+//                          "" => no candidates this tick (the board is cleared).
+// Writes (durable blackboard memo): prospector:candidates  (normalised,
+//   newline-joined `<address>|<chain>|<metadata>` cells the downstream agents read).
+// Emits: "prospector:intake" (a count summary; the colony bus contract).
+
+cb 60000;
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("intake:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- candidate-line field extraction (`<address>|<chain>|<metadata>`) -----------
+// The address is the segment before the first `|`.
+fn line_address(line: string) -> string {
+    let bar = index_of(line, "|");
+    if bar < 0 { return line; }
+    return substring(line, 0, bar);
+}
+
+// The chain id is the segment between the first and second `|` (or after the
+// first `|` to end-of-line when there is no metadata).
+fn line_chain(line: string) -> string {
+    let bar = index_of(line, "|");
+    if bar < 0 { return ""; }
+    let rest = substring(line, bar + 1, len(line));
+    let bar2 = index_of(rest, "|");
+    if bar2 < 0 { return rest; }
+    return substring(rest, 0, bar2);
+}
+
+// The OPTIONAL metadata is everything after the second `|`; "" when absent.
+fn line_metadata(line: string) -> string {
+    let bar = index_of(line, "|");
+    if bar < 0 { return ""; }
+    let rest = substring(line, bar + 1, len(line));
+    let bar2 = index_of(rest, "|");
+    if bar2 < 0 { return ""; }
+    return substring(rest, bar2 + 1, len(rest));
+}
+
+// Strip surrounding whitespace from a field (the operator's list may be
+// loosely formatted). .ag has no trim builtin, so leading/trailing ASCII
+// whitespace is removed by scanning in from both ends; interior spaces are
+// PRESERVED (a metadata label may contain spaces) by keeping everything from
+// the first to the last non-space character.
+fn trim(s: string) -> string {
+    let n = len(s);
+    if n == 0 { return ""; }
+    let startIdx = first_nonws(s, 0, n);
+    if startIdx >= n { return ""; }
+    let endIdx = last_nonws(s, n - 1);
+    if endIdx < startIdx { return ""; }
+    return substring(s, startIdx, endIdx + 1);
+}
+
+// Index of the first non-whitespace char from `i` (bounded recursion; .ag has
+// no while/for). Returns n when the whole string is whitespace.
+fn first_nonws(s: string, i: int, n: int) -> int {
+    if i >= n { return n; }
+    let c = substring(s, i, i + 1);
+    if is_ws(c) { return first_nonws(s, i + 1, n); }
+    return i;
+}
+
+// Index of the last non-whitespace char scanning down from `i`; -1 when none.
+fn last_nonws(s: string, i: int) -> int {
+    if i < 0 { return -1; }
+    let c = substring(s, i, i + 1);
+    if is_ws(c) { return last_nonws(s, i - 1); }
+    return i;
+}
+
+fn is_ws(c: string) -> bool {
+    if c == " " { return true; }
+    if c == "\t" { return true; }
+    if c == "\r" { return true; }
+    if c == "\n" { return true; }
+    return false;
+}
+
+// --- candidate validation (a candidate must be keyable by the downstream agents)-
+// A valid address is `0x` + exactly 40 hex digits. The classifier + value-scorer
+// pass it to `cast` as an on-chain key, so a malformed address is dropped here.
+fn is_hex40(addr: string) -> bool {
+    if len(addr) != 42 { return false; }
+    if substring(addr, 0, 2) != "0x" { return false; }
+    let body = substring(addr, 2, 42);
+    return len(regex_find_all("[^0-9a-fA-F]", body)) == 0;
+}
+
+// A valid chain id is a non-empty run of digits (an EVM chain id).
+fn is_chain_id(chain: string) -> bool {
+    if len(chain) == 0 { return false; }
+    return len(regex_find_all("[^0-9]", chain)) == 0;
+}
+
+// Is the candidate well-formed enough for the downstream agents to key on?
+fn valid_candidate(addr: string, chain: string) -> bool {
+    if !is_hex40(addr) { return false; }
+    return is_chain_id(chain);
+}
+
+// --- normalise one raw line into a clean `<address>|<chain>|<metadata>` cell ----
+// Returns "" for a malformed line (dropped). The metadata is carried verbatim
+// (trimmed); the address + chain are validated.
+fn normalise_line(line: string) -> string {
+    let addr = trim(line_address(line));
+    let chain = trim(line_chain(line));
+    let meta = trim(line_metadata(line));
+    if !valid_candidate(addr, chain) { return ""; }
+    return addr + "|" + chain + "|" + meta;
+}
+
+// --- accumulate the normalised board over the raw candidate list ----------------
+// Append `cell` to the running board, deduped on the `<address>|<chain>` key (a
+// candidate listed twice is ingested once). Single-assignment accumulator.
+fn cell_key(cell: string) -> string {
+    let bar = index_of(cell, "|");
+    if bar < 0 { return cell; }
+    let rest = substring(cell, bar + 1, len(cell));
+    let bar2 = index_of(rest, "|");
+    if bar2 < 0 { return cell; }
+    return substring(cell, 0, bar + 1 + bar2);
+}
+
+fn board_has_key(board: string, key: string) -> bool {
+    if len(board) == 0 { return false; }
+    return reduce(regex_split("\n", board), |acc: bool, l: string| -> bool {
+        if acc { return acc; }
+        if len(l) == 0 { return acc; }
+        return cell_key(l) == key;
+    }, false);
+}
+
+fn append_cell(board: string, cell: string) -> string {
+    if len(cell) == 0 { return board; }
+    if board_has_key(board, cell_key(cell)) { return board; }
+    if len(board) == 0 { return cell; }
+    return board + "\n" + cell;
+}
+
+// Fold the raw newline list into the normalised, deduped board.
+fn build_board(raw: string) -> string {
+    return reduce(regex_split("\n", raw), |acc: string, line: string| -> string {
+        if len(line) == 0 { return acc; }
+        return append_cell(acc, normalise_line(line));
+    }, "");
+}
+
+fn count_cells(board: string) -> int {
+    if len(board) == 0 { return 0; }
+    return reduce(regex_split("\n", board), |acc: int, l: string| -> int {
+        if len(l) == 0 { return acc; }
+        return acc + 1;
+    }, 0);
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. Ingesting at
+// least one valid candidate is a productive tick (success); an empty / all-
+// malformed list is a no-op (partial — nothing for the pipeline to qualify).
+fn outcome_of(n: int) -> string {
+    if n > 0 { return "success"; }
+    return "partial";
+}
+
+// A compact intake summary payload (JSON). Count only — no untrusted free text
+// reaches the bus, so no JSON escaping is needed.
+fn intake_payload(n: int) -> string {
+    return "{\"agent\":\"intake\",\"kind\":\"candidates\",\"count\":" + to_string(n) + "}";
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("intake:last_check", now);
+
+    let raw = getenv("PROSPECTOR_CANDIDATES");
+    let board = build_board(raw);
+    let n = count_cells(board);
+    let outcome = outcome_of(n);
+
+    print("intake: ingested " + to_string(n) + " candidate(s)"
+        + " (conf=" + to_string(get_confidence()) + ")");
+
+    // Publish the normalised board to the shared blackboard memo the downstream
+    // agents read each tick (a memo write — allowed at every tier, including
+    // shadow). Written EVERY tick so the board tracks the current candidate list.
+    memo_write("prospector:candidates", board);
+
+    let key = "intake:" + to_string(n);
+    let desc = "ingested " + to_string(n) + " candidate(s) from PROSPECTOR_CANDIDATES";
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates the BUS SUMMARY
+    // only; the board above is written at every tier. shadow/dormant fall through.
+    // (.ag has no `else if`; the tiers nest as `else { if ... { } else { } }`.)
+    let my_tier = tier("intake");
+    if my_tier == "autonomous" {
+        emit("prospector:intake", intake_payload(n));
+        learn("prospector-intake", key, desc, outcome, [outcome, "acted"]);
+    } else {
+        if my_tier == "review-gated" {
+            emit("prospector:intake", intake_payload(n));
+            learn("prospector-intake", key, desc, outcome, [outcome, "review-gated"]);
+        } else {
+            if my_tier == "propose" {
+                emit("prospector:intake", intake_payload(n));
+                learn("prospector-intake", key, desc, outcome, [outcome, "emitted"]);
+            } else {
+                // shadow / dormant: normalise + learn the candidate set, NO emit.
+                learn("prospector-intake", key, desc + " (baseline)", outcome, [outcome, "observed"]);
+                print("intake: observing (tier: " + my_tier + ") — no emit");
+            };
+        };
+    };
+
+    memo_write("intake:last_check", to_string(now_ms()));
+}

--- a/dark-factory/prospector/agents/source-classifier.ag
+++ b/dark-factory/prospector/agents/source-classifier.ag
@@ -1,0 +1,414 @@
+// source-classifier.ag — Prospector colony (Dark Factory federation).
+//
+// For each candidate on the `prospector:candidates` blackboard, READS the
+// candidate's verified source / ABI (the contract's function-signature surface)
+// and CLASSIFIES whether it exposes a DeFi VALUE-INVARIANT family worth
+// monitoring — lending / vault-4626 / AMM / stablecoin / perps / staking /
+// bridge. The verdict is a MONITORABILITY signal: a verified-source contract
+// whose surface matches a known value-invariant family is a candidate the
+// `monitor` colony can stand up derived invariants on; an unverified or
+// invariant-less contract is not.
+//
+// NON-custodial / read-only: it only READS the verified-source surface via a
+// reader command over `exec sh` (a keyless explorer/Sourcify ABI fetch, or
+// `cast interface`). EVERY dynamic value is shell_escape()d. It never signs a
+// transaction and never touches funds. The classification is a deterministic
+// match over the read signature surface — never an LLM opinion.
+//
+// Mirrors the monitor watchers' read pattern (`read_uint` over `exec sh`,
+// degrade-safe when the reader is unconfigured) and dark-factory's
+// source-classification heuristics (recon-from-address.sh fetches the verified
+// ABI keyless from Sourcify; the bug-taxonomy's DeFi value families).
+//
+// Emission is gated PURELY on the ADR-0001 tier of this agent:
+//   shadow / dormant -> classify + learn the verdict, NO emit;
+//   propose          -> + emit a DRAFT `prospector:classified` signal (low);
+//   review-gated /    -> + emit a DIRECT `prospector:classified` signal.
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant. The
+// per-candidate verdict is posted to a blackboard memo
+// (`prospector:classified:<addr>`) at EVERY tier so the coordinator can fuse it.
+//
+// Env contract (read via getenv; exported by scripts/start-colony.sh; add each
+// to exec.env_passthrough in .agentis/config so the sandboxed `exec sh` reads it):
+//   PROSPECTOR_ABI_CMD  the reader command template that, given a candidate's
+//                       address + chain id, prints the contract's verified
+//                       function-signature surface (one signature per line, e.g.
+//                       `cast interface` output or a Sourcify ABI fetch). It is
+//                       run as `sh -c "<cmd>"` with PROSPECTOR_ADDR / PROSPECTOR_CHAIN
+//                       exported into its environment (NOT concatenated — the
+//                       address/chain reach the reader as env vars, never as
+//                       shell-interpolated text). "" => no reader; every
+//                       candidate classifies "no-read" (observed, never a false
+//                       verdict).
+// Reads (blackboard): prospector:candidates (the normalised candidate board).
+// Writes (blackboard): prospector:classified:<addr> (per-candidate verdict JSON).
+// Emits: "prospector:classified" (the colony bus contract).
+
+cb 120000;
+
+// Upper bound on how many candidates the classifier walks in one tick (the
+// bounded recursion's depth cap, since .ag has no loops). A curated candidate
+// list is small; 64 keeps the per-tick on-chain read cost bounded.
+fn board_max() -> int {
+    return 64;
+}
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("source-classifier:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- candidate-cell field extraction (`<address>|<chain>|<metadata>`) -----------
+fn cell_address(cell: string) -> string {
+    let bar = index_of(cell, "|");
+    if bar < 0 { return cell; }
+    return substring(cell, 0, bar);
+}
+
+fn cell_chain(cell: string) -> string {
+    let bar = index_of(cell, "|");
+    if bar < 0 { return ""; }
+    let rest = substring(cell, bar + 1, len(cell));
+    let bar2 = index_of(rest, "|");
+    if bar2 < 0 { return rest; }
+    return substring(rest, 0, bar2);
+}
+
+// JSON-string escape a free-text field (mirrors the monitor watchers' #1089
+// json_escape): backslash -> \\ and double-quote -> \" so an address (validated
+// upstream, but defensive here) cannot corrupt the verdict JSON.
+fn json_escape(s: string) -> string {
+    return reduce(regex_find_all("[\\s\\S]", s), |acc: string, c: string| -> string {
+        if c == "\\" { return acc + "\\\\"; }
+        if c == "\"" { return acc + "\\\""; }
+        return acc + c;
+    }, "");
+}
+
+// --- read the verified function-signature surface for one candidate -------------
+// The reader command (PROSPECTOR_ABI_CMD) is run as `sh -c "<cmd>"`; the
+// candidate's address + chain are passed via the ENVIRONMENT (PROSPECTOR_ADDR /
+// PROSPECTOR_CHAIN), exported INSIDE the sandbox by an `export` prefix — so the
+// untrusted-from-the-board address/chain are NEVER interpolated into the shell
+// text. The reader command template itself is operator-supplied (config), so it
+// is the only thing that flows into the shell, and it is shell_escape()d as the
+// argument to `sh -c`. `set +e` + `|| true` so a transient explorer failure
+// returns "" (no read -> no false verdict) instead of aborting the tick.
+fn read_surface(abiCmd: string, addr: string, chain: string) -> string {
+    if len(abiCmd) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; export PROSPECTOR_ADDR=" + shell_escape(addr)
+            + "; export PROSPECTOR_CHAIN=" + shell_escape(chain)
+            + "; sh -c " + shell_escape(abiCmd) + " 2>/dev/null || true";
+    return out;
+}
+
+// Lowercase a string for a case-insensitive family match (the read surface uses
+// mixed-case ABI names like `totalAssets`). Per-char fold; .ag has no lower
+// builtin. Only ASCII letters are folded.
+fn to_lower(s: string) -> string {
+    return reduce(regex_find_all("[\\s\\S]", s), |acc: string, c: string| -> string {
+        return acc + lower_char(c);
+    }, "");
+}
+
+fn lower_char(c: string) -> string {
+    if c == "A" { return "a"; }
+    if c == "B" { return "b"; }
+    if c == "C" { return "c"; }
+    if c == "D" { return "d"; }
+    if c == "E" { return "e"; }
+    if c == "F" { return "f"; }
+    if c == "G" { return "g"; }
+    if c == "H" { return "h"; }
+    if c == "I" { return "i"; }
+    if c == "J" { return "j"; }
+    if c == "K" { return "k"; }
+    if c == "L" { return "l"; }
+    if c == "M" { return "m"; }
+    if c == "N" { return "n"; }
+    if c == "O" { return "o"; }
+    if c == "P" { return "p"; }
+    if c == "Q" { return "q"; }
+    if c == "R" { return "r"; }
+    if c == "S" { return "s"; }
+    if c == "T" { return "t"; }
+    if c == "U" { return "u"; }
+    if c == "V" { return "v"; }
+    if c == "W" { return "w"; }
+    if c == "X" { return "x"; }
+    if c == "Y" { return "y"; }
+    if c == "Z" { return "z"; }
+    return c;
+}
+
+// Does the (lowercased) surface contain `needle`? index_of is total.
+fn surface_has(surface: string, needle: string) -> bool {
+    return index_of(surface, needle) >= 0;
+}
+
+// --- DeFi value-invariant family classification (a FACT over the surface) -------
+// Each family is recognised by a small set of canonical view/action names that
+// imply a monitorable value-invariant. The match is deterministic over the read
+// signature surface — never an LLM call. The families track the DeFi value
+// classes dark-factory already reasons about (vault / lending / AMM / stablecoin
+// / perps / staking / bridge).
+//
+// vault-4626: an ERC-4626 tokenised vault exposes a solvency invariant
+// (totalAssets backing totalSupply / convertToAssets monotonicity).
+fn is_vault(surface: string) -> bool {
+    if surface_has(surface, "totalassets") { return true; }
+    if surface_has(surface, "converttoassets") { return true; }
+    if surface_has(surface, "converttoshares") { return true; }
+    return false;
+}
+
+// lending: a money-market exposes a collateralisation / solvency invariant.
+fn is_lending(surface: string) -> bool {
+    if surface_has(surface, "borrow") {
+        if surface_has(surface, "repay") { return true; }
+        if surface_has(surface, "liquidate") { return true; }
+    }
+    if surface_has(surface, "collateralfactor") { return true; }
+    if surface_has(surface, "borrowbalance") { return true; }
+    return false;
+}
+
+// amm: a constant-product / pool DEX exposes a reserve / k-invariant.
+fn is_amm(surface: string) -> bool {
+    if surface_has(surface, "getreserves") { return true; }
+    if surface_has(surface, "swap") {
+        if surface_has(surface, "addliquidity") { return true; }
+        if surface_has(surface, "mint") { return true; }
+    }
+    return false;
+}
+
+// stablecoin: a peg-bearing token exposes a backing / supply invariant.
+fn is_stablecoin(surface: string) -> bool {
+    if surface_has(surface, "totalsupply") {
+        if surface_has(surface, "mint") {
+            if surface_has(surface, "burn") { return true; }
+        }
+    }
+    return false;
+}
+
+// perps: a perpetuals / margin venue exposes a position-solvency invariant.
+fn is_perps(surface: string) -> bool {
+    if surface_has(surface, "openposition") { return true; }
+    if surface_has(surface, "fundingrate") { return true; }
+    if surface_has(surface, "liquidateposition") { return true; }
+    return false;
+}
+
+// staking: a staking pool exposes a staked-balance / reward-accounting invariant.
+fn is_staking(surface: string) -> bool {
+    if surface_has(surface, "stake") {
+        if surface_has(surface, "unstake") { return true; }
+        if surface_has(surface, "withdraw") { return true; }
+    }
+    if surface_has(surface, "rewardpertoken") { return true; }
+    return false;
+}
+
+// bridge: a cross-chain bridge exposes a locked-vs-minted conservation invariant.
+fn is_bridge(surface: string) -> bool {
+    if surface_has(surface, "deposit") {
+        if surface_has(surface, "relaytokens") { return true; }
+        if surface_has(surface, "claimwithdrawal") { return true; }
+    }
+    if surface_has(surface, "bridgetoken") { return true; }
+    return false;
+}
+
+// The FAMILY token a surface matches; "" when it matches no known family. First
+// match wins by a fixed family precedence (the families are largely disjoint by
+// signature; ties resolve deterministically).
+fn family_of(surface: string) -> string {
+    if is_vault(surface) { return "vault-4626"; }
+    if is_lending(surface) { return "lending"; }
+    if is_perps(surface) { return "perps"; }
+    if is_amm(surface) { return "amm"; }
+    if is_stablecoin(surface) { return "stablecoin"; }
+    if is_staking(surface) { return "staking"; }
+    if is_bridge(surface) { return "bridge"; }
+    return "";
+}
+
+// The MONITORABILITY verdict for a candidate:
+//   "no-read"    the reader produced no surface (unverified / unconfigured) —
+//                we cannot classify, so it is NOT a false verdict (observed);
+//   "no-invariant" the surface read but matched no value-invariant family —
+//                  not a monitoring target by this signal;
+//   "<family>"   the matched DeFi value-invariant family (monitorable).
+fn verdict_of(surface: string, family: string) -> string {
+    if len(surface) == 0 { return "no-read"; }
+    if len(family) == 0 { return "no-invariant"; }
+    return family;
+}
+
+// Does the verdict mark a monitorable target (a matched value-invariant family)?
+fn is_monitorable(verdict: string) -> bool {
+    if verdict == "no-read" { return false; }
+    if verdict == "no-invariant" { return false; }
+    return true;
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. A matched family
+// is the signal the classifier exists to surface (success); a read-but-no-family
+// is a confirmed non-target (partial); a missing read is error.
+fn outcome_of(verdict: string) -> string {
+    if verdict == "no-read" { return "error"; }
+    if verdict == "no-invariant" { return "partial"; }
+    return "success";
+}
+
+// A compact, deterministic per-candidate verdict payload (JSON). All fields are
+// facts; none is LLM text. `sev` is set by the tier branch.
+fn verdict_payload(addr: string, chain: string, verdict: string, monitorable: bool, sev: string) -> string {
+    return "{\"agent\":\"source-classifier\",\"target\":\"" + json_escape(addr)
+         + "\",\"chain\":\"" + json_escape(chain) + "\",\"family\":\"" + verdict
+         + "\",\"monitorable\":" + to_string(monitorable) + ",\"severity\":\"" + sev + "\"}";
+}
+
+// Post one candidate's verdict to its per-candidate blackboard memo so the
+// coordinator can fuse it (a memo write — allowed at every tier). The address is
+// the validated `0x` + 40-hex key, a safe memo-key charset, so it needs no extra
+// sanitisation.
+fn post_verdict(addr: string, chain: string, verdict: string, monitorable: bool) -> void {
+    memo_write("prospector:classified:" + addr,
+        verdict_payload(addr, chain, verdict, monitorable, "info"));
+}
+
+// Classify one candidate cell LIVE: read its surface, lowercase it, match a
+// family, decide the verdict, and post the per-candidate signal. Returns 1 when
+// the candidate is monitorable, 0 otherwise (for the running count).
+fn classify_cell(abiCmd: string, cell: string) -> int {
+    let addr = cell_address(cell);
+    let chain = cell_chain(cell);
+    let surface = to_lower(read_surface(abiCmd, addr, chain));
+    let family = family_of(surface);
+    let verdict = verdict_of(surface, family);
+    let monitorable = is_monitorable(verdict);
+    let _sig = post_verdict(addr, chain, verdict, monitorable);
+    print("source-classifier: " + addr + " (chain " + chain + ") -> " + verdict);
+    if monitorable { return 1; }
+    return 0;
+}
+
+// The i-th non-empty line of a newline-joined board; "" when out of range. The
+// board is split + folded (.ag has no list indexing), picking the line whose
+// position equals `i`. Total on every failure mode.
+fn nth_cell(lines: list<string>, i: int) -> string {
+    return reduce_indexed_pick(lines, i);
+}
+
+// Fold the split lines, tracking the running NON-EMPTY position; return the
+// cell at non-empty position `target` (skipping blank segments regex_split may
+// leave). Packs (pos, found) into a "pos|found" string accumulator so the
+// single-assignment fold carries both without a struct (unsupported in .ag).
+fn reduce_indexed_pick(lines: list<string>, target: int) -> string {
+    let acc = reduce(lines, |st: string, cell: string| -> string {
+        let pos = pick_pos(st);
+        let found = pick_found(st);
+        if len(found) > 0 { return st; }
+        if len(cell) == 0 { return st; }
+        if pos == target { return to_string(pos + 1) + "|" + cell; }
+        return to_string(pos + 1) + "|";
+    }, "0|");
+    return pick_found(acc);
+}
+
+// The position field (before the first `|`) of the pick accumulator.
+fn pick_pos(st: string) -> int {
+    let bar = index_of(st, "|");
+    if bar < 0 { return 0; }
+    return parse_int(substring(st, 0, bar));
+}
+
+// The found-cell field (after the first `|`) of the pick accumulator; "" until
+// the target position is reached.
+fn pick_found(st: string) -> string {
+    let bar = index_of(st, "|");
+    if bar < 0 { return ""; }
+    return substring(st, bar + 1, len(st));
+}
+
+// Count the non-empty cells on the board (for the bounded-recursion length).
+fn count_cells(lines: list<string>) -> int {
+    return reduce(lines, |acc: int, cell: string| -> int {
+        if len(cell) == 0 { return acc; }
+        return acc + 1;
+    }, 0);
+}
+
+// BOUNDED RECURSION over the candidate board (single-assignment .ag has no
+// while/for): at each non-empty cell up to the board_max() cap, classify the
+// candidate LIVE, post its per-candidate signal, and count the monitorable
+// matches. Stops at the cap or when the board is exhausted.
+fn classify_board(abiCmd: string, lines: list<string>, i: int, total: int, remaining: int, acc: int) -> int {
+    if remaining <= 0 { return acc; }
+    if i >= total { return acc; }
+    let cell = nth_cell(lines, i);
+    if len(cell) == 0 { return acc; }
+    let hit = classify_cell(abiCmd, cell);
+    return classify_board(abiCmd, lines, i + 1, total, remaining - 1, acc + hit);
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("source-classifier:last_check", now);
+
+    let abiCmd = getenv("PROSPECTOR_ABI_CMD");
+    let board = recall_latest("prospector:candidates");
+    let lines = regex_split("\n", board);
+    let total = count_cells(lines);
+    let monitorable = classify_board(abiCmd, lines, 0, total, board_max(), 0);
+
+    print("source-classifier: classified board -> " + to_string(monitorable)
+        + " monitorable (conf=" + to_string(get_confidence()) + ")");
+
+    // The tick-level verdict for the LEARN/EMIT layer: at least one monitorable
+    // candidate is the signal worth surfacing; none read / matched is quiet.
+    let verdict = if monitorable > 0 { "monitorable" } else { "none" };
+    let outcome = if monitorable > 0 { "success" } else { "partial" };
+    let key = "classified:" + to_string(monitorable);
+    let desc = "classified board -> " + to_string(monitorable) + " monitorable candidate(s)";
+
+    // A tick-level summary payload (count only — no untrusted free text).
+    let summary = "{\"agent\":\"source-classifier\",\"kind\":\"summary\",\"monitorable\":"
+        + to_string(monitorable) + ",\"verdict\":\"" + verdict + "\"}";
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
+    // per-candidate verdicts above are posted at every tier. shadow/dormant fall
+    // through. (.ag has no `else if`; the tiers nest as `else { if ... } else {}`.)
+    let my_tier = tier("source-classifier");
+    if my_tier == "autonomous" {
+        emit("prospector:classified", summary);
+        learn("prospector-classify", key, desc, outcome, [verdict, outcome, "acted"]);
+    } else {
+        if my_tier == "review-gated" {
+            emit("prospector:classified", summary);
+            learn("prospector-classify", key, desc, outcome, [verdict, outcome, "review-gated"]);
+        } else {
+            if my_tier == "propose" {
+                emit("prospector:classified", summary);
+                learn("prospector-classify", key, desc, outcome, [verdict, outcome, "emitted"]);
+            } else {
+                // shadow / dormant: classify + learn ONLY — no emit.
+                learn("prospector-classify", key, desc + " (baseline)", outcome, [verdict, outcome, "observed"]);
+                print("source-classifier: observing (tier: " + my_tier + ") — no emit");
+            };
+        };
+    };
+
+    memo_write("source-classifier:last_check", to_string(now_ms()));
+}

--- a/dark-factory/prospector/agents/value-scorer.ag
+++ b/dark-factory/prospector/agents/value-scorer.ag
@@ -1,0 +1,352 @@
+// value-scorer.ag — Prospector colony (Dark Factory federation).
+//
+// For each candidate on the `prospector:candidates` blackboard, computes a
+// read-only ON-CHAIN VALUE SCORE (a balance / TVL proxy) and decides whether the
+// candidate clears a VALUE FLOOR. Standing up a continuous monitor is only worth
+// it for a target holding non-trivial value — this agent supplies that gate: a
+// value-floor verdict the coordinator fuses with the source-classifier's
+// monitorability verdict.
+//
+// The value proxy is a single read-only `cast call` to a configured value view
+// (e.g. `totalAssets()` for a vault, `totalSupply()` for a token), OR — when no
+// value signature is configured — the contract's native balance via `cast
+// balance`. NON-custodial / read-only: only `cast call` / `cast balance`, never
+// `cast send`, never a key, never a write-RPC. EVERY dynamic value is
+// shell_escape()d. The score is a FACT (an on-chain read + a deterministic
+// comparison), never an LLM opinion.
+//
+// Mirrors the monitor watchers' read pattern (`read_uint` over `exec sh`,
+// degrade-safe when the reader is unconfigured: no reader => "no-read", observed,
+// never a false verdict).
+//
+// Emission is gated PURELY on the ADR-0001 tier of this agent:
+//   shadow / dormant -> score + learn the verdict, NO emit;
+//   propose          -> + emit a DRAFT `prospector:value` signal (low);
+//   review-gated /    -> + emit a DIRECT `prospector:value` signal.
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant. The
+// per-candidate verdict is posted to a blackboard memo (`prospector:value:<addr>`)
+// at EVERY tier so the coordinator can fuse it.
+//
+// Env contract (read via getenv; exported by scripts/start-colony.sh; add each
+// to exec.env_passthrough in .agentis/config so the sandboxed `exec sh` reads it):
+//   PROSPECTOR_CAST        absolute path to the `cast` binary (foundry); the read
+//                          tool. "" => no reader; every candidate "no-read".
+//   PROSPECTOR_RPC_URL     the chain RPC endpoint cast reads from (read-only).
+//   PROSPECTOR_VALUE_SIG   the `cast call` signature returning the value proxy
+//                          (e.g. "totalAssets()" / "totalSupply()"). "" => use
+//                          the contract's native balance (`cast balance`) instead.
+//   PROSPECTOR_VALUE_FLOOR the minimum value (decimal integer, in the read's own
+//                          units — wei for native balance, raw token units for a
+//                          view) a candidate must hold to clear the floor. "" => 0
+//                          (any successful read clears; the floor is effectively
+//                          "reads non-zero value").
+// Reads (blackboard): prospector:candidates (the normalised candidate board).
+// Writes (blackboard): prospector:value:<addr> (per-candidate verdict JSON).
+// Emits: "prospector:value" (the colony bus contract).
+
+cb 120000;
+
+// Upper bound on how many candidates the scorer walks in one tick (the bounded
+// recursion's depth cap; .ag has no loops). Matches the classifier's cap.
+fn board_max() -> int {
+    return 64;
+}
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("value-scorer:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- candidate-cell field extraction (`<address>|<chain>|<metadata>`) -----------
+fn cell_address(cell: string) -> string {
+    let bar = index_of(cell, "|");
+    if bar < 0 { return cell; }
+    return substring(cell, 0, bar);
+}
+
+fn cell_chain(cell: string) -> string {
+    let bar = index_of(cell, "|");
+    if bar < 0 { return ""; }
+    let rest = substring(cell, bar + 1, len(cell));
+    let bar2 = index_of(rest, "|");
+    if bar2 < 0 { return rest; }
+    return substring(rest, 0, bar2);
+}
+
+// JSON-string escape a free-text field (mirrors the monitor watchers' json_escape).
+fn json_escape(s: string) -> string {
+    return reduce(regex_find_all("[\\s\\S]", s), |acc: string, c: string| -> string {
+        if c == "\\" { return acc + "\\\\"; }
+        if c == "\"" { return acc + "\\\""; }
+        return acc + c;
+    }, "");
+}
+
+// --- read a single uint value proxy for one candidate via cast (read-only) ------
+// When a value signature is configured: `cast call <addr> <sig>` -> a 0x-hex word
+// -> `cast --to-dec` -> a decimal string. When not: `cast balance <addr>` -> the
+// native balance in wei (already decimal). EVERY dynamic value (cast path, rpc
+// url, address, signature) is shell_escape()d. `set +e` + `|| true` so a transient
+// RPC failure returns "" (no read -> no false verdict) instead of aborting.
+// READ-ONLY: `cast call` / `cast balance` only — never `cast send`, never a key.
+fn read_value(castBin: string, rpc: string, addr: string, sig: string) -> string {
+    if len(castBin) == 0 { return ""; }
+    if len(rpc) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    if len(sig) > 0 {
+        // colony-lint: safe-exec-concat
+        let out = exec sh "set +e; " + shell_escape(castBin) + " call --rpc-url " + shell_escape(rpc)
+                + " " + shell_escape(addr) + " " + shell_escape(sig)
+                + " 2>/dev/null | " + shell_escape(castBin) + " --to-dec 2>/dev/null || true";
+        return out;
+    }
+    // colony-lint: safe-exec-concat
+    let bal = exec sh "set +e; " + shell_escape(castBin) + " balance --rpc-url " + shell_escape(rpc)
+            + " " + shell_escape(addr) + " 2>/dev/null || true";
+    return bal;
+}
+
+// Trim a trailing newline cast leaves on its decimal output.
+fn first_token(s: string) -> string {
+    let nl = index_of(s, "\n");
+    if nl < 0 { return s; }
+    return substring(s, 0, nl);
+}
+
+// --- big-decimal value handling (NO parse_int — a TVL in wei OVERFLOWS i64) -----
+// A realistic value floor is in wei: 1000 ETH = 1e21, far beyond the i64 range
+// (~9.2e18) parse_int can hold, so the value + floor are kept as DECIMAL STRINGS
+// and compared with a length-then-lexicographic big-decimal comparator. This is
+// exact for arbitrarily large non-negative integers and never overflows.
+//
+// Normalise a raw decimal reading to a clean digit string: the first token, with
+// any leading zeros stripped (so "007" -> "7", "0" -> "0"). "" / non-numeric ->
+// "" (the "no reading" sentinel, distinct from a legitimate "0"). Total.
+fn reading_to_dec(s: string) -> string {
+    let t = first_token(s);
+    if len(t) == 0 { return ""; }
+    if len(regex_find_all("[^0-9]", t)) > 0 { return ""; }
+    return strip_leading_zeros(t);
+}
+
+// Strip leading zeros from a digit string, leaving at least one digit ("0").
+fn strip_leading_zeros(s: string) -> string {
+    let kept = reduce(regex_find_all("[0-9]", s), |acc: string, d: string| -> string {
+        if len(acc) > 0 { return acc + d; }
+        if d == "0" { return acc; }
+        return d;
+    }, "");
+    if len(kept) == 0 { return "0"; }
+    return kept;
+}
+
+// The configured value floor as a normalised digit string; "" / non-numeric -> "0"
+// (any successful read >= 0 clears a zero floor — i.e. "reads a value at all").
+fn floor_dec(raw: string) -> string {
+    if len(raw) == 0 { return "0"; }
+    if len(regex_find_all("[^0-9]", raw)) > 0 { return "0"; }
+    return strip_leading_zeros(raw);
+}
+
+// Big-decimal `a >= b` over two normalised (no-leading-zero) digit strings:
+// longer string is the larger number; equal length compares DIGIT-WISE from the
+// most-significant end (the runtime's `>=` does not accept strings, so the
+// lexicographic compare is open-coded over single digits). Total.
+fn dec_ge(a: string, b: string) -> bool {
+    if len(a) > len(b) { return true; }
+    if len(a) < len(b) { return false; }
+    return same_len_ge(a, b, 0);
+}
+
+// The rank (0..9) of a single decimal digit; -1 for a non-digit (defensive). The
+// inputs are validated digit strings, so the -1 path is unreachable in practice.
+fn digit_rank(c: string) -> int {
+    return index_of("0123456789", c);
+}
+
+// Digit-wise `a >= b` for two EQUAL-LENGTH digit strings, scanning from the most
+// significant digit. The first differing position decides; all-equal -> true (>=).
+fn same_len_ge(a: string, b: string, i: int) -> bool {
+    if i >= len(a) { return true; }
+    let da = digit_rank(substring(a, i, i + 1));
+    let db = digit_rank(substring(b, i, i + 1));
+    if da > db { return true; }
+    if da < db { return false; }
+    return same_len_ge(a, b, i + 1);
+}
+
+// --- the deterministic value-floor verdict (a FACT, never an LLM call) ----------
+// "no-read"  the value could not be read (unverified / unconfigured / RPC down);
+// "below"    the value read but is below the floor (not worth monitoring by value);
+// "above"    the value clears the floor (a value-qualified monitoring target).
+// A zero floor still requires a NON-ZERO read to clear (a contract holding 0 value
+// is not a monitoring target), so "0" >= "0" does not auto-qualify.
+fn verdict_of(value: string, floor: string) -> string {
+    if len(value) == 0 { return "no-read"; }
+    if value == "0" { return "below"; }
+    if !dec_ge(value, floor) { return "below"; }
+    return "above";
+}
+
+// Does the verdict clear the value floor (a value-qualified target)?
+fn clears_floor(verdict: string) -> bool {
+    return verdict == "above";
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. Clearing the
+// floor is the signal worth surfacing (success); a below-floor read is a
+// confirmed non-target (partial); a missing read is error.
+fn outcome_of(verdict: string) -> string {
+    if verdict == "no-read" { return "error"; }
+    if verdict == "below" { return "partial"; }
+    return "success";
+}
+
+// The value reported in the payload: the digit string, or "-1" for a no-read
+// (the no-read sentinel, mirroring the monitor watchers' convention).
+fn value_for_json(value: string) -> string {
+    if len(value) == 0 { return "-1"; }
+    return value;
+}
+
+// A compact, deterministic per-candidate verdict payload (JSON). All fields are
+// facts; none is LLM text. value/floor are emitted as JSON STRINGS (quoted): a
+// realistic value/floor is in wei (>1e21), which OVERFLOWS the JSON number
+// parser and would corrupt json_get on sibling fields downstream, so the
+// big-decimal digit strings are carried as strings (the coordinator keys on the
+// `verdict` field, not on re-parsing the magnitude). Both are validated digit
+// strings, so no JSON escaping is needed.
+fn verdict_payload(addr: string, chain: string, value: string, floor: string, verdict: string, sev: string) -> string {
+    return "{\"agent\":\"value-scorer\",\"target\":\"" + json_escape(addr)
+         + "\",\"chain\":\"" + json_escape(chain) + "\",\"value\":\"" + value_for_json(value)
+         + "\",\"floor\":\"" + floor + "\",\"verdict\":\"" + verdict
+         + "\",\"severity\":\"" + sev + "\"}";
+}
+
+// Post one candidate's verdict to its per-candidate blackboard memo so the
+// coordinator can fuse it. The address is the validated `0x` + 40-hex key.
+fn post_verdict(addr: string, chain: string, value: string, floor: string, verdict: string) -> void {
+    memo_write("prospector:value:" + addr,
+        verdict_payload(addr, chain, value, floor, verdict, "info"));
+}
+
+// Score one candidate cell LIVE: read its value proxy, compare to the floor, post
+// the per-candidate signal. Returns 1 when the candidate clears the floor, else 0.
+fn score_cell(castBin: string, rpc: string, sig: string, floor: string, cell: string) -> int {
+    let addr = cell_address(cell);
+    let chain = cell_chain(cell);
+    let value = reading_to_dec(read_value(castBin, rpc, addr, sig));
+    let verdict = verdict_of(value, floor);
+    let _sig = post_verdict(addr, chain, value, floor, verdict);
+    print("value-scorer: " + addr + " value=" + value_for_json(value) + " floor=" + floor
+        + " -> " + verdict);
+    if clears_floor(verdict) { return 1; }
+    return 0;
+}
+
+// The i-th non-empty line of a newline-joined board; "" when out of range. The
+// board is split + folded (.ag has no list indexing), picking the line whose
+// non-empty position equals `i`. Total on every failure mode.
+fn nth_cell(lines: list<string>, i: int) -> string {
+    let acc = reduce(lines, |st: string, cell: string| -> string {
+        let pos = pick_pos(st);
+        let found = pick_found(st);
+        if len(found) > 0 { return st; }
+        if len(cell) == 0 { return st; }
+        if pos == i { return to_string(pos + 1) + "|" + cell; }
+        return to_string(pos + 1) + "|";
+    }, "0|");
+    return pick_found(acc);
+}
+
+// The position field (before the first `|`) of the pick accumulator.
+fn pick_pos(st: string) -> int {
+    let bar = index_of(st, "|");
+    if bar < 0 { return 0; }
+    return parse_int(substring(st, 0, bar));
+}
+
+// The found-cell field (after the first `|`) of the pick accumulator; "" until
+// the target position is reached.
+fn pick_found(st: string) -> string {
+    let bar = index_of(st, "|");
+    if bar < 0 { return ""; }
+    return substring(st, bar + 1, len(st));
+}
+
+// Count the non-empty cells on the board (for the bounded-recursion length).
+fn count_cells(lines: list<string>) -> int {
+    return reduce(lines, |acc: int, cell: string| -> int {
+        if len(cell) == 0 { return acc; }
+        return acc + 1;
+    }, 0);
+}
+
+// BOUNDED RECURSION over the candidate board (single-assignment .ag has no
+// while/for): at each non-empty cell up to the board_max() cap, score the
+// candidate LIVE, post its per-candidate signal, and count the floor-clearing
+// matches. Stops at the cap or when the board is exhausted.
+fn score_board(castBin: string, rpc: string, sig: string, floor: string, lines: list<string>, i: int, total: int, remaining: int, acc: int) -> int {
+    if remaining <= 0 { return acc; }
+    if i >= total { return acc; }
+    let cell = nth_cell(lines, i);
+    if len(cell) == 0 { return acc; }
+    let hit = score_cell(castBin, rpc, sig, floor, cell);
+    return score_board(castBin, rpc, sig, floor, lines, i + 1, total, remaining - 1, acc + hit);
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("value-scorer:last_check", now);
+
+    let castBin = getenv("PROSPECTOR_CAST");
+    let rpc = getenv("PROSPECTOR_RPC_URL");
+    let sig = getenv("PROSPECTOR_VALUE_SIG");
+    let floor = floor_dec(getenv("PROSPECTOR_VALUE_FLOOR"));
+    let board = recall_latest("prospector:candidates");
+    let lines = regex_split("\n", board);
+    let total = count_cells(lines);
+    let cleared = score_board(castBin, rpc, sig, floor, lines, 0, total, board_max(), 0);
+
+    print("value-scorer: scored board -> " + to_string(cleared)
+        + " above floor (conf=" + to_string(get_confidence()) + ")");
+
+    let verdict = if cleared > 0 { "qualified" } else { "none" };
+    let outcome = if cleared > 0 { "success" } else { "partial" };
+    let key = "value:" + to_string(cleared);
+    let desc = "scored board -> " + to_string(cleared) + " candidate(s) above floor";
+
+    let summary = "{\"agent\":\"value-scorer\",\"kind\":\"summary\",\"above_floor\":"
+        + to_string(cleared) + ",\"verdict\":\"" + verdict + "\"}";
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
+    // per-candidate verdicts above are posted at every tier. shadow/dormant fall
+    // through. (.ag has no `else if`; the tiers nest as `else { if ... } else {}`.)
+    let my_tier = tier("value-scorer");
+    if my_tier == "autonomous" {
+        emit("prospector:value", summary);
+        learn("prospector-value", key, desc, outcome, [verdict, outcome, "acted"]);
+    } else {
+        if my_tier == "review-gated" {
+            emit("prospector:value", summary);
+            learn("prospector-value", key, desc, outcome, [verdict, outcome, "review-gated"]);
+        } else {
+            if my_tier == "propose" {
+                emit("prospector:value", summary);
+                learn("prospector-value", key, desc, outcome, [verdict, outcome, "emitted"]);
+            } else {
+                // shadow / dormant: score + learn ONLY — no emit.
+                learn("prospector-value", key, desc + " (baseline)", outcome, [verdict, outcome, "observed"]);
+                print("value-scorer: observing (tier: " + my_tier + ") — no emit");
+            };
+        };
+    };
+
+    memo_write("value-scorer:last_check", to_string(now_ms()));
+}

--- a/dark-factory/prospector/config/colony.example.toml
+++ b/dark-factory/prospector/config/colony.example.toml
@@ -1,0 +1,115 @@
+# Prospector Colony Configuration
+#
+# Part of the Dark Factory federation. The prospector colony QUALIFIES candidate
+# EVM protocols as MONITORING TARGETS by public on-chain/source signals: given a
+# list of candidate protocols, it decides which ones are worth standing up the
+# `monitor` colony on, and why. NON-custodial / read-only: every agent only READS
+# public source/ABI + on-chain state via `cast`/explorer over `exec sh`; no agent
+# signs a transaction or touches funds. Copy to colony.toml and edit for your
+# environment.
+
+[colony]
+name = "prospector"
+tick_interval_ms = 60000
+
+# dark-factory is a non-forge federation (ADR-0003). The prospector agents read
+# verified source/ABI + on-chain state through `cast`/explorer inside the sandbox
+# via `exec sh`; no agent calls a GitLab/GitHub forge API. `forge.type = "none"`
+# is the explicit non-forge marker recognised by colony-lint — no [forge.gitlab] /
+# [forge.github] sub-block is required. See ADR-0003 for the portability contract
+# and ADR-0002 for the forge-bound contract this opts out of.
+[forge]
+type = "none"
+
+[llm]
+# Only "backend" is read today. "cli" uses the agentis daemon default CLI
+# adapter. The agents' verdicts are deterministic source/on-chain reads (no LLM
+# call on the hot path); the backend is declared for schema conformance + future
+# reasoning extensions.
+backend = "cli"
+
+# Agent definitions. Each agent runs as a separate `agentis daemon` process,
+# launched by scripts/start-colony.sh with a per-agent tick interval. They
+# coordinate via durable memos (the `prospector:*` blackboard). cb_budget MUST
+# match the `cb <N>;` decl at the top of each .ag file.
+
+# Ingests the candidate protocol list from PROSPECTOR_CANDIDATES onto the
+# blackboard (prospector:candidates).
+[[agents]]
+name = "intake"
+source = "agents/intake.ag"
+cb_budget = 60000
+tick_interval_ms = 60000
+
+# Reads each candidate's verified source/ABI surface and classifies whether it
+# exposes a DeFi value-invariant family (the monitorability gate). Posts
+# prospector:classified:<addr>.
+[[agents]]
+name = "source-classifier"
+source = "agents/source-classifier.ag"
+cb_budget = 120000
+tick_interval_ms = 60000
+
+# Reads a read-only on-chain value proxy (balance / TVL) for each candidate and
+# decides whether it clears the value floor (the value-floor gate). Posts
+# prospector:value:<addr>.
+[[agents]]
+name = "value-scorer"
+source = "agents/value-scorer.ag"
+cb_budget = 120000
+tick_interval_ms = 60000
+
+# Fuses the hard gates (verified-source + DeFi-value-invariants + value-floor)
+# into a ranked qualification verdict and writes the prospector:qualified dossier
+# (per-target: qualifies yes/no, why, and the suggested invariant to watch — the
+# handoff to the monitor colony).
+[[agents]]
+name = "coordinator"
+source = "agents/coordinator.ag"
+cb_budget = 150000
+tick_interval_ms = 60000
+
+# Prospector environment contract (consumed by the agents via getenv; exported by
+# scripts/start-colony.sh). Operators export these before launching. The agents'
+# `exec sh` readers ALSO need each PROSPECTOR_* var (and the per-candidate
+# PROSPECTOR_ADDR / PROSPECTOR_CHAIN the classifier exports into its reader) added
+# to exec.env_passthrough in .agentis/config so the sandboxed shell can read them.
+# All agents degrade safely when their reader is unconfigured: with no
+# PROSPECTOR_ABI_CMD / PROSPECTOR_CAST a candidate classifies "no-read" and is not
+# qualified (never a false verdict).
+#
+# intake:
+#   PROSPECTOR_CANDIDATES   newline-joined `<address>|<chain>[|<metadata>]` list of
+#                           candidate protocols. address = 0x + 40 hex; chain = EVM
+#                           chain id (integer); metadata = OPTIONAL free-text label.
+#                           A malformed line is dropped. "" => no candidates.
+#
+# source-classifier:
+#   PROSPECTOR_ABI_CMD      a reader command template that, given a candidate's
+#                           address + chain (exported into its environment as
+#                           PROSPECTOR_ADDR / PROSPECTOR_CHAIN, NOT interpolated),
+#                           prints the contract's verified function-signature
+#                           surface (one signature per line — e.g. `cast interface`
+#                           output, or a keyless Sourcify ABI fetch like
+#                           recon-from-address.sh). "" => no reader (observe only).
+#
+# value-scorer:
+#   PROSPECTOR_CAST         absolute path to the `cast` binary (foundry); the read
+#                           tool. "" => no reader (observe only).
+#   PROSPECTOR_RPC_URL      the chain RPC endpoint cast reads from (read-only).
+#   PROSPECTOR_VALUE_SIG    the `cast call` signature returning the value proxy
+#                           (e.g. "totalAssets()" / "totalSupply()"). "" => use the
+#                           contract's native balance (`cast balance`) instead.
+#   PROSPECTOR_VALUE_FLOOR  the minimum value (decimal integer, in the read's own
+#                           units — wei for native balance, raw token units for a
+#                           view) a candidate must hold to clear the value floor.
+#                           "" => 0 (any non-zero read clears).
+#
+# READ-ONLY contract: the value-scorer uses ONLY `cast call` / `cast balance` —
+# never `cast send`, never a key, never a write-RPC.
+[prospector]
+abi_cmd = ""
+cast = ""
+rpc_url = ""
+value_sig = ""
+value_floor = ""

--- a/dark-factory/prospector/scripts/start-colony.sh
+++ b/dark-factory/prospector/scripts/start-colony.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# Start the Prospector colony (part of the Dark Factory federation).
+#
+# Usage:
+#   ./scripts/start-colony.sh [path/to/colony.toml]
+#   ./scripts/start-colony.sh --restart-agent <name> [path/to/colony.toml]
+#
+# The prospector colony runs four long-lived daemons (intake, source-classifier,
+# value-scorer, coordinator) that QUALIFY candidate EVM protocols as MONITORING
+# TARGETS by public on-chain/source signals — i.e. decide which candidates are
+# worth standing up the `monitor` colony on, and why. NON-custodial / read-only:
+# the agents only READ public source/ABI + on-chain state via `cast`/explorer; no
+# agent signs a transaction or touches funds.
+#
+# ADR-0003 conformance: --restart-agent (#257) respawns one agent with the full
+# colony env, skips memo seeding + log truncation. Exit codes: 0 ok, 1 agentis
+# not found, 2 unknown flag / missing arg, 3 unknown agent, 4 daemon launch
+# failure. On success of a --restart-agent run, prints exactly one line
+# `started <agent> pid=<n> tick=<ms>` for the dashboard's /restart endpoint to parse.
+#
+# Prospector inputs are passed via the environment (all optional; see
+# config/colony.example.toml [prospector] and the colony README). With no
+# PROSPECTOR_ABI_CMD / PROSPECTOR_CAST an agent reads nothing and only observes —
+# a candidate then classifies "no-read" and is never falsely qualified:
+#   PROSPECTOR_CANDIDATES                                       (intake list)
+#   PROSPECTOR_ABI_CMD                                          (source-classifier reader)
+#   PROSPECTOR_CAST PROSPECTOR_RPC_URL PROSPECTOR_VALUE_SIG ... (value-scorer reader)
+
+set -e
+
+RESTART_AGENT=""
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --restart-agent)
+            if [ -z "${2:-}" ]; then
+                echo "start-colony.sh: --restart-agent requires an agent name" >&2
+                exit 2
+            fi
+            RESTART_AGENT="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            POSITIONAL+=("$@")
+            break
+            ;;
+        -*)
+            echo "start-colony.sh: unknown flag: $1" >&2
+            exit 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- ${POSITIONAL[@]+"${POSITIONAL[@]}"}
+
+# Symlink-safe $0 resolution.
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+COLONY_DIR="$(dirname "$SCRIPT_DIR")"
+FED_DIR="$(dirname "$COLONY_DIR")"
+CONFIG="${1:-$COLONY_DIR/config/colony.toml}"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "Note: config not found ($CONFIG) — running with environment inputs only." >&2
+    echo "      Copy config/colony.example.toml to config/colony.toml to silence this." >&2
+fi
+
+# Source parse-toml.sh: try <fed>/tools first, then <fed>/../tools (the latter is
+# the in-repo layout; the former is for standalone tarball installs that ship
+# tools/ inside the federation directory).
+PARSE_TOML=""
+for cand in "$FED_DIR/tools/parse-toml.sh" "$FED_DIR/../tools/parse-toml.sh"; do
+    if [ -f "$cand" ]; then
+        PARSE_TOML="$cand"
+        break
+    fi
+done
+if [ -n "$PARSE_TOML" ]; then
+    # shellcheck source=/dev/null
+    . "$PARSE_TOML"
+fi
+
+COLONY_NAME="prospector"
+
+# Prospector environment contract (read by the .ag agents via getenv, and inside
+# the sandboxed `exec sh` readers). Each falls back to its current value or empty;
+# an agent with no reader configured simply observes and never falsely qualifies
+# a candidate.
+PROSPECTOR_CANDIDATES="${PROSPECTOR_CANDIDATES:-}"
+PROSPECTOR_ABI_CMD="${PROSPECTOR_ABI_CMD:-}"
+PROSPECTOR_CAST="${PROSPECTOR_CAST:-}"
+PROSPECTOR_RPC_URL="${PROSPECTOR_RPC_URL:-}"
+PROSPECTOR_VALUE_SIG="${PROSPECTOR_VALUE_SIG:-}"
+PROSPECTOR_VALUE_FLOOR="${PROSPECTOR_VALUE_FLOOR:-}"
+
+export COLONY_DIR COLONY_NAME
+export PROSPECTOR_CANDIDATES PROSPECTOR_ABI_CMD
+export PROSPECTOR_CAST PROSPECTOR_RPC_URL PROSPECTOR_VALUE_SIG PROSPECTOR_VALUE_FLOOR
+
+AGENTS=(
+    intake
+    source-classifier
+    value-scorer
+    coordinator
+)
+
+# Per-agent tick interval. All four run at 60000ms by default;
+# PROSPECTOR_TICK_MS overrides all of them for faster/slower polling.
+tick_interval_for() {
+    case "$1" in
+        intake) echo "${PROSPECTOR_TICK_MS:-60000}" ;;
+        source-classifier) echo "${PROSPECTOR_TICK_MS:-60000}" ;;
+        value-scorer) echo "${PROSPECTOR_TICK_MS:-60000}" ;;
+        coordinator) echo "${PROSPECTOR_TICK_MS:-60000}" ;;
+        *) echo 60000 ;;
+    esac
+}
+
+if ! command -v agentis >/dev/null 2>&1; then
+    echo "start-colony.sh: agentis not found on PATH — install it before running the prospector." >&2
+    exit 1
+fi
+
+# --restart-agent mode (#257): respawn exactly one agent with the full colony
+# env; skip memo seeding + log truncation (full-colony bootstrap concerns).
+if [ -n "$RESTART_AGENT" ]; then
+    valid=0
+    for a in "${AGENTS[@]}"; do
+        [ "$a" = "$RESTART_AGENT" ] && valid=1
+    done
+    if [ "$valid" = "0" ]; then
+        echo "start-colony.sh: unknown agent '$RESTART_AGENT' for this colony" >&2
+        exit 3
+    fi
+    tick=$(tick_interval_for "$RESTART_AGENT")
+    agentis daemon "$COLONY_DIR/agents/${RESTART_AGENT}.ag" \
+        --colony prospector \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval "$tick" </dev/null >/dev/null 2>&1 &
+    agent_pid=$!
+    sleep 0.5
+    if ! kill -0 "$agent_pid" 2>/dev/null; then
+        echo "start-colony.sh: agentis daemon failed to launch $RESTART_AGENT" >&2
+        exit 4
+    fi
+    echo "started $RESTART_AGENT pid=$agent_pid tick=$tick"
+    exit 0
+fi
+
+# Seed propose-tier confidence so each daemon ticks past dormant on first launch.
+# (ADR-0001 seeds fresh agents at shadow/0.4; propose lets the agents emit draft
+# signals out of the box for a smoke run. Operators lower this to observe / score
+# baselines first.)
+for agent in "${AGENTS[@]}"; do
+    agentis memo set "${agent}:confidence" "0.7" >/dev/null 2>&1 || true
+done
+
+echo "Starting Prospector colony (${#AGENTS[@]} agents)..."
+
+for agent in "${AGENTS[@]}"; do
+    interval=$(tick_interval_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms)..."
+    agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
+        --colony prospector \
+        --enable-exec \
+        --enable-messaging \
+        --tick-interval "$interval" &
+    sleep 2
+done
+
+echo "Colony started. Use 'agentis daemon list' to monitor."
+echo "Stop with: agentis daemon stop --all"
+
+wait


### PR DESCRIPTION
New read-only, **non-custodial** `prospector` colony in the dark-factory federation: ingests candidate EVM protocols and ranks which **qualify as monitoring targets** (for the `monitor` colony), by public on-chain/source signals.

## Agents
- **intake.ag** — ingest candidates (`address|chain|metadata` from `PROSPECTOR_CANDIDATES`), validate + dedup → `prospector:candidates` blackboard.
- **source-classifier.ag** — read verified ABI/source, classify the DeFi value-invariant family (vault-4626 / lending / amm / stablecoin / perps / staking / bridge) → monitorability gate.
- **value-scorer.ag** — read-only on-chain value proxy (`cast call`/`cast balance`) + value floor (big-decimal **string** compare to avoid JSON/i64 overflow).
- **coordinator.ag** — fuse hard gates (verified-source + DeFi-value-invariants + value-floor) → per-target dossier (`prospector:qualified:<addr>`: qualifies, family, failed gate, suggested invariant to watch) + a ranked `prospector:qualified` index = the **monitor-colony handoff**.

## Safety / conventions
Non-custodial read-only (`cast call` only; no send/keys/write-RPC). Confidence-tiered (one `tier()`/tick). `[forge] type="none"` (ADR-0003). All `exec sh` dynamic values `shell_escape()`d.

## Validation
`./tools/colony-lint.sh` → **399 passed, 0 failed, 5 skipped**. Runtime-verified end-to-end against offline `cast`/ABI stubs (intake → classify → score → dossier); two runtime-only bugs found + fixed (string `GtEq` rejection; big-number JSON/i64 overflow → big-decimal string compare).

## Deferred (follow-ups)
Off-chain qualification signals (web-research scoring); freshness via deploy-time indexing.

Tracked privately (commercial context lives in agentis-core); this PR ships the public capability colony only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
