### PR TITLE
feat(dark-factory): monitor alert-delivery pipeline — bridge + heartbeat/dead-man + hardened notify (#1092, #1093, #1094)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -14,6 +14,32 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Added
+- **monitor: alert-delivery pipeline — the bus→webhook bridge, liveness, and a hardened sink** (#1092, #1093,
+  #1094). The monitor colony emitted `monitor:alert` on the bus but nothing forwarded it, so in a real
+  deployment no page was ever delivered. A new `notifier` agent (`dark-factory/monitor/agents/notifier.ag`,
+  `cb 90000`) closes that last-mile gap:
+  - **#1092 bus→webhook bridge** — the `notifier` `listen()`s for `monitor:alert` and forwards each alert to
+    `scripts/notify.sh` via `exec sh`. The alert JSON is passed through an exported env var
+    (`MONITOR_ALERT_BODY`), never interpolated into the shell text, and every other dynamic value is
+    `shell_escape()`d. Forwarding is gated purely on the agent's ADR-0001 tier (one `tier()` call/tick, branch
+    once); needs `--enable-messaging` + `--enable-exec` (wired into `start-colony.sh` + registered in
+    `config/colony.example.toml`).
+  - **#1093 heartbeat + dead-man's switch** — a periodic low-severity `heartbeat` is sent through `notify.sh`
+    at `MONITOR_HEARTBEAT_INTERVAL_S` cadence (default daily) so silence is meaningful; and a memo-freshness
+    dead-man's switch emits a `high`/`liveness` meta-alert when no watcher tick / fresh `*:last_check` memo is
+    observed within `MONITOR_DEADMAN_WINDOW_S` (the RPC-blind / colony-down case), deduped against the last
+    liveness signature so a persistent outage pages once.
+  - **#1094 hardened `notify.sh`** — bounded exponential retry/backoff on a transient webhook failure
+    (`5xx`/network; a `4xx` is not retried); sink-side dedup keyed on the alert signature with a cooldown
+    window (`MONITOR_NOTIFY_DEDUP_COOLDOWN_S`, persisted to a small state file); and severity routing so
+    `warn`/`high` land in different channels (`MONITOR_WEBHOOK_URL_WARN` / `MONITOR_WEBHOOK_URL_HIGH`, each
+    falling back to `MONITOR_WEBHOOK_URL`). Dash-safe (`set -eu`, shellcheck clean, no `\xHH` escapes). Unset
+    config preserves the original single-webhook stdout-fallback behaviour exactly.
+
+  Non-custodial / read-only throughout: the notifier only reads the bus and sends an outbound notification — it
+  never signs and never touches funds.
+
 ### Fixed
 - **monitor: JSON-escape free-text fields in alert/signal payloads** (#1089). `invariant-watcher` and
   `oracle-watcher` now route the operator-supplied `label`/`addr` through a `json_escape()` helper (escapes

--- a/dark-factory/monitor/README.md
+++ b/dark-factory/monitor/README.md
@@ -2,11 +2,13 @@
 
 > Part of the [Dark Factory](../) federation.
 
-A continuous **protocol monitor**. Three cooperating agents watch a target EVM
+A continuous **protocol monitor**. Four cooperating agents watch a target EVM
 protocol on-chain and emit reasoned, high-signal anomaly alerts on the colony bus
-(`monitor:alert`). The colony is **non-custodial / read-only**: every watcher only
-**reads** chain state via `cast`/RPC — it never signs a transaction and never
-touches funds.
+(`monitor:alert`); a fourth agent — the **notifier** — bridges the bus to the
+configured webhook so a page is actually **delivered**, not just emitted. The
+colony is **non-custodial / read-only**: every watcher only **reads** chain state
+via `cast`/RPC and the notifier only sends an **outbound** notification — no agent
+signs a transaction and none ever touches funds.
 
 The hot-path verdicts are **facts** (an on-chain read + a deterministic
 comparison), never an LLM opinion. Emission is gated purely on each agent's
@@ -21,10 +23,12 @@ before it is ever trusted to page.
 | `invariant-watcher` | Evaluates the target's protocol invariant(s) against current on-chain state; flags a violation or a thin margin-to-violation. Evaluates a single env-configured invariant, OR — when a derived watch-spec is supplied (`MONITOR_INV_SPEC`, #1086) — the WHOLE derived invariant SET | `monitor:signal:invariant` (fused), `monitor:signal:invariant:<label>` (per-invariant), `monitor:alert` (tier-gated) |
 | `oracle-watcher` | Watches a price feed for deviation / staleness / out-of-bounds price | `monitor:signal:oracle`, `monitor:alert` (tier-gated) |
 | `coordinator` | Fuses the watcher signals off the shared blackboard, dedups a persistent condition, decides fused severity, emits one consolidated alert | `monitor:alert` (tier-gated) |
+| `notifier` | The bus→webhook **bridge** (#1092): `listen()`s for `monitor:alert` and forwards each to `scripts/notify.sh` so a page is delivered. Owns the liveness **heartbeat** + **dead-man's switch** (#1093) | webhook page (via `notify.sh`), `monitor:alert` (the dead-man's-switch meta-alert, severity `high` / kind `liveness`) |
 
 Each agent runs as its own `agentis daemon`. The watchers post their latest
 verdict to a durable blackboard memo (`monitor:signal:*`); the coordinator reads
-both each tick and fuses them.
+both each tick and fuses them. The notifier consumes the consolidated
+`monitor:alert` off the bus and forwards it to the configured sink.
 
 ```mermaid
 flowchart LR
@@ -35,7 +39,10 @@ flowchart LR
     IW -->|monitor:alert| BUS[(bus)]
     OW -->|monitor:alert| BUS
     CO -->|monitor:alert<br/>fused + deduped| BUS
-    BUS --> N[notify.sh<br/>Discord / Slack webhook]
+    BUS -->|monitor:alert| NF[notifier<br/>bridge + heartbeat<br/>+ dead-man's switch]
+    NF -->|monitor:alert<br/>liveness meta-alert| BUS
+    NF --> N[notify.sh<br/>retry · dedup · severity routing]
+    N --> W[Discord / Slack / PagerDuty<br/>webhook sink]
 ```
 
 ## Confidence-tiered alerting (ADR-0001)
@@ -52,6 +59,42 @@ Every agent makes ONE `tier()` call per tick and branches once. The tier gates
 This is the false-positive control: a fresh watcher seeded at `shadow` learns the
 protocol's normal state before it can page, and auto-promotion lifts it as its
 alerts prove real over noise.
+
+## Alert delivery — the bus→webhook bridge (#1092 / #1093 / #1094)
+
+Emitting `monitor:alert` on the in-process bus is not the same as **delivering** a
+page. The `notifier` agent closes that last-mile gap and turns the colony into a
+real 24/7 pager.
+
+- **Bridge (#1092)** — the `notifier` `listen()`s for `monitor:alert` each tick
+  and forwards each alert to `scripts/notify.sh`. The alert JSON is passed to
+  `notify.sh` through an **exported env var** (`MONITOR_ALERT_BODY`), never
+  interpolated into the shell text, and every other dynamic value is
+  `shell_escape()`d. Forwarding is gated on the notifier's ADR-0001 tier (the same
+  shadow → propose → review-gated/autonomous gradient as the watchers): at
+  `shadow`/`dormant` it observes only; at `propose`+ the bridge is live.
+- **Heartbeat (#1093)** — when due (every `MONITOR_HEARTBEAT_INTERVAL_S`, default
+  daily), the notifier sends a low-severity `heartbeat` payload through
+  `notify.sh`. A missing heartbeat at the sink is itself a signal: **silence is
+  meaningful**.
+- **Dead-man's switch (#1093)** — if no watcher tick / no fresh `*:last_check`
+  memo is observed within `MONITOR_DEADMAN_WINDOW_S` (unset / `0` ⇒ disabled), the
+  notifier emits a meta-alert (`monitor:alert`, severity `high`, kind `liveness`)
+  — the RPC-blind / colony-down case. This check is a memo-freshness **fact** and
+  runs independent of tier (a down colony must page regardless of the bridge's
+  confidence); it dedups against the last liveness signature so a persistent
+  outage pages once, not every tick, and re-pages after a recovery.
+- **Hardened sink (#1094)** — `notify.sh` adds, all opt-in and dash-safe:
+  bounded **exponential retry/backoff** on a transient webhook failure
+  (`5xx`/network; a `4xx` is not retried); **sink-side dedup** keyed on the alert
+  signature with a cooldown window (`MONITOR_NOTIFY_DEDUP_COOLDOWN_S`, persisted to
+  a small state file); and **severity routing** so `warn` and `high` land in
+  different channels (`MONITOR_WEBHOOK_URL_WARN` / `MONITOR_WEBHOOK_URL_HIGH`, each
+  falling back to `MONITOR_WEBHOOK_URL`). Unset config preserves the original
+  single-webhook stdout-fallback behaviour exactly.
+
+Read-only / non-custodial throughout: the notifier only reads the bus and sends an
+outbound notification — it never signs and never touches funds.
 
 ## Derive → watch the whole invariant set (#1086)
 
@@ -120,13 +163,15 @@ facts to read + compare; it carries no keys and never describes a write.
    ./scripts/start-colony.sh
    ```
 
-3. (Optional) Wire an alert sink. With `MONITOR_WEBHOOK_URL` set, pipe an alert
-   to the notifier:
+3. (Optional) Wire an alert sink. Export `MONITOR_WEBHOOK_URL` (a Discord / Slack
+   / PagerDuty incoming-webhook URL) **before** starting the colony and the
+   `notifier` agent forwards every `monitor:alert` to it automatically — no manual
+   step (#1092). Unset, the colony still runs and `notify.sh` prints each alert to
+   stdout (a no-op sink). You can also drive `notify.sh` by hand for a smoke test:
    ```bash
    echo '<alert payload>' | ./scripts/notify.sh
    ```
-   Unset, `notify.sh` prints the alert to stdout (a no-op sink) — no secret is
-   ever committed; the webhook URL is read from the environment.
+   No secret is ever committed; the webhook URL is read from the environment.
 
 dark-factory is a non-forge federation (`forge.type = "none"`); no forge
 credentials are required.
@@ -157,7 +202,15 @@ watcher reads nothing and only observes — it never raises a false alert.
 | `MONITOR_ORACLE_DEV_BP` | Deviation band in basis points vs the last baseline. | `0` (skip) |
 | `MONITOR_ORACLE_MIN` / `MONITOR_ORACLE_MAX` | Lower / upper price sanity bounds. | unset (no bound) |
 | `MONITOR_ORACLE_LABEL` | Human label for the feed (alert body). | the oracle address |
-| `MONITOR_WEBHOOK_URL` | Discord/Slack incoming-webhook URL for `notify.sh`. **Never commit a real URL.** | unset (stdout sink) |
+| `MONITOR_WEBHOOK_URL` | Discord/Slack/PagerDuty incoming-webhook URL for `notify.sh`. **Never commit a real URL.** | unset (stdout sink) |
+| `MONITOR_WEBHOOK_URL_WARN` | Channel for `warn`-severity pages (#1094 routing). | falls back to `MONITOR_WEBHOOK_URL` |
+| `MONITOR_WEBHOOK_URL_HIGH` | Channel for `high`-severity pages (#1094 routing). | falls back to `MONITOR_WEBHOOK_URL` |
+| `MONITOR_HEARTBEAT_INTERVAL_S` | Notifier heartbeat cadence in seconds (#1093); `0` disables. | `86400` (daily) |
+| `MONITOR_DEADMAN_WINDOW_S` | Dead-man's-switch window in seconds (#1093); no fresh watcher tick within it raises a `high`/`liveness` meta-alert. | `0` (disabled) |
+| `MONITOR_NOTIFY_MAX_RETRIES` | Bounded retry count on a transient webhook failure (#1094). | `3` |
+| `MONITOR_NOTIFY_BACKOFF_S` | Initial retry backoff in seconds, doubled each retry (#1094). | `2` |
+| `MONITOR_NOTIFY_DEDUP_COOLDOWN_S` | Sink-side dedup cooldown in seconds (#1094); `0` disables. | `0` (disabled) |
+| `MONITOR_NOTIFY_STATE_DIR` | Where `notify.sh` persists last-sent signatures (#1094). | `${XDG_STATE_HOME:-$HOME/.local/state}/dark-factory-monitor` |
 
 ## Status
 
@@ -166,7 +219,14 @@ watchers + the fusion coordinator + a webhook sink shipped in
 [#1085](https://github.com/Replikanti/agentis-colonies/issues/1085); the
 **live-watch runtime** (`run-live-watch.sh` + the `invariant-watcher`'s
 `MONITOR_INV_SPEC` derived-set path) shipped in
-[#1086](https://github.com/Replikanti/agentis-colonies/issues/1086). Follow-ups:
-the liquidity / governance / flow watchers and a dashboard view. The colony is
+[#1086](https://github.com/Replikanti/agentis-colonies/issues/1086); the
+**alert-delivery pipeline** — the `notifier` bus→webhook bridge
+([#1092](https://github.com/Replikanti/agentis-colonies/issues/1092)), the
+liveness heartbeat + dead-man's switch
+([#1093](https://github.com/Replikanti/agentis-colonies/issues/1093)), and the
+hardened `notify.sh` (retry/backoff, sink-side dedup, severity routing,
+[#1094](https://github.com/Replikanti/agentis-colonies/issues/1094)) — turns an
+emitted alert into a delivered page. Follow-ups: the liquidity / governance / flow
+watchers, an external dead-man's-switch cron, and a dashboard view. The colony is
 **read-only** and **never** posts an alert without a configured sink — and
 **never** signs or touches funds.

--- a/dark-factory/monitor/agents/notifier.ag
+++ b/dark-factory/monitor/agents/notifier.ag
@@ -1,0 +1,256 @@
+// notifier.ag — Monitor colony (Dark Factory federation).
+//
+// The bus->webhook BRIDGE (#1092): the last-mile that turns an emitted
+// `monitor:alert` into a DELIVERED page. Each tick it `listen()`s for one
+// pending `monitor:alert` and FORWARDS it to scripts/notify.sh (the configured
+// Discord/Slack/PagerDuty sink) via `exec sh`. So a page is actually delivered,
+// not merely emitted on the in-process bus. NON-custodial / read-only: it only
+// reads the bus + sends an OUTBOUND notification — no signing, no fund access.
+//
+// Two further liveness guarantees of a paid 24/7 service (#1093) live here too:
+//   * HEARTBEAT — a periodic "still watching, all green" signal through the same
+//     sink at MONITOR_HEARTBEAT_INTERVAL_S cadence (default daily), so SILENCE is
+//     meaningful: a missing heartbeat means the pager itself is down.
+//   * DEAD-MAN'S SWITCH — if no watcher tick / no fresh `*:last_check` memo is
+//     observed within MONITOR_DEADMAN_WINDOW_S, emit a meta-alert
+//     (`monitor:alert` severity `high`, kind `liveness`) — the RPC-blind /
+//     colony-down case, the single most important guarantee of the service. The
+//     emitted meta-alert is itself forwarded by a later notifier tick.
+//
+// Injection-safe forwarding: the alert JSON (operator/coordinator/watcher facts)
+// is passed to notify.sh through an EXPORTED env var (MONITOR_ALERT_BODY),
+// never interpolated into the shell text; every other dynamic value is
+// shell_escape()d. `set +e` + `|| true` so a transient sink failure leaves the
+// tick intact (notify.sh owns its own bounded retry — #1094).
+//
+// Emission/forwarding is gated PURELY on the ADR-0001 tier of this agent:
+//   shadow / dormant -> observe + learn the alert, NO forward, NO heartbeat;
+//   propose          -> forward the page + heartbeat (the bridge is active);
+//   review-gated /    -> forward the page + heartbeat (proven-reliable bridge).
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant. The
+// dead-man's switch emit is a memo-freshness FACT independent of tier (a down
+// colony must page regardless of the bridge's confidence), so it runs before the
+// tier branch — exactly like the watchers' blackboard memo write.
+//
+// Env contract (read inside the sandboxed `exec sh`; exported by
+// scripts/start-colony.sh; add each to exec.env_passthrough in .agentis/config):
+//   COLONY_DIR                  the colony root (locates scripts/notify.sh).
+//   MONITOR_WEBHOOK_URL[/_WARN/_HIGH]  the sink(s); unset => notify.sh stdout sink.
+//   MONITOR_HEARTBEAT_INTERVAL_S  heartbeat cadence in seconds; "" => 86400 (1d);
+//                               0 => heartbeat disabled.
+//   MONITOR_DEADMAN_WINDOW_S    liveness window in seconds; "" => 0 (dead-man's
+//                               switch disabled); when >0, no fresh watcher
+//                               `*:last_check` within the window raises the meta.
+// Emits: "monitor:alert" (the dead-man's switch meta-alert only).
+
+cb 90000;
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("notifier:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// json_get on a miss returns Void -> to_string => "void"; collapse that to "".
+fn sanitize(s: string) -> string {
+    if s == "void" { return ""; }
+    return s;
+}
+
+// listen() returns Value::Void on an empty inbox; to_string renders that as
+// "void". Collapse to "" so a quiet tick is distinguishable from a real alert.
+fn alert_or_empty(raw: string) -> string {
+    return sanitize(raw);
+}
+
+// Optional integer env fact: "" / non-numeric -> -1 (the "unset" sentinel).
+fn opt_int(raw: string) -> int {
+    if len(raw) == 0 { return -1; }
+    if len(regex_find_all("[^0-9]", raw)) > 0 { return -1; }
+    return parse_int(raw);
+}
+
+// Heartbeat cadence in seconds. "" => the daily default; an explicit 0 disables.
+fn heartbeat_interval_s(raw: string) -> int {
+    if len(raw) == 0 { return 86400; }
+    let n = opt_int(raw);
+    if n < 0 { return 86400; }
+    return n;
+}
+
+// --- forward one payload to scripts/notify.sh ----------------------------------
+// The alert body is passed through the EXPORTED env var MONITOR_ALERT_BODY so the
+// untrusted JSON is NEVER interpolated into the shell text; COLONY_DIR is the
+// only path that flows into the command and it is operator-supplied (exported by
+// start-colony.sh). `set +e` + `|| true` keeps the tick alive on a sink error —
+// notify.sh owns the bounded retry/backoff (#1094). Returns notify.sh's output.
+fn forward(payload: string) -> string {
+    if len(payload) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; export MONITOR_ALERT_BODY=" + shell_escape(payload)
+            + "; sh \"$COLONY_DIR/scripts/notify.sh\" \"$MONITOR_ALERT_BODY\" 2>&1 || true";
+    return out;
+}
+
+// --- heartbeat payload (a low-severity "still watching" signal) ----------------
+fn heartbeat_payload(now: string) -> string {
+    return "{\"watcher\":\"notifier\",\"kind\":\"heartbeat\",\"severity\":\"low\",\"verdict\":\"ok\",\"ts\":\"" + now + "\"}";
+}
+
+// --- dead-man's switch meta-alert payload (the RPC-blind / colony-down case) ---
+fn deadman_payload(staleS: int) -> string {
+    return "{\"watcher\":\"notifier\",\"kind\":\"liveness\",\"severity\":\"high\",\"verdict\":\"blind\",\"stale_s\":" + to_string(staleS) + "}";
+}
+
+// --- liveness: freshness of the watchers' last_check heartbeat memos -----------
+// Each watcher (+ the coordinator) writes `<agent>:last_check` = now_ms() at the
+// top AND bottom of every tick. The freshest of those is the colony's liveness
+// proof. opt_int is total: a missing/non-numeric memo => -1.
+fn freshest_last_check() -> int {
+    let inv = opt_int(recall_latest("invariant-watcher:last_check"));
+    let orc = opt_int(recall_latest("oracle-watcher:last_check"));
+    let coo = opt_int(recall_latest("coordinator:last_check"));
+    let a = if inv > orc { inv } else { orc };
+    return if coo > a { coo } else { a };
+}
+
+// Seconds since the freshest watcher tick. -1 when no watcher has ticked yet
+// (no baseline -> the switch must NOT fire on a cold start; only a colony that
+// WAS alive and went silent is the RPC-blind case).
+fn staleness_s(freshMs: int, nowMs: int) -> int {
+    if freshMs < 0 { return -1; }
+    if freshMs > nowMs { return 0; }
+    return (nowMs - freshMs) / 1000;
+}
+
+// The dead-man's switch trips only when a window is configured (>0), a baseline
+// exists (the colony WAS alive), and the staleness exceeds the window.
+fn deadman_tripped(windowS: int, staleS: int) -> bool {
+    if windowS <= 0 { return false; }
+    if staleS < 0 { return false; }
+    return staleS > windowS;
+}
+
+// Has enough time elapsed since the last heartbeat to send the next one?
+// disabled (interval 0) -> never due; no prior heartbeat (-1 baseline) -> due now.
+fn heartbeat_due(intervalS: int, lastMs: int, nowMs: int) -> bool {
+    if intervalS <= 0 { return false; }
+    if lastMs < 0 { return true; }
+    if lastMs > nowMs { return false; }
+    return ((nowMs - lastMs) / 1000) >= intervalS;
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("notifier:last_check", now);
+
+    let nowMs = now_ms();
+
+    // --- DEAD-MAN'S SWITCH (#1093): a memo-freshness FACT, tier-independent. ----
+    // A down colony / RPC-blind monitor must page regardless of the bridge's
+    // confidence, so this runs BEFORE the tier branch (like the watchers' memo
+    // write). It emits a meta-alert ONCE per stale-onset: dedup against the last
+    // liveness signature so a persistent outage pages once, not every tick.
+    let windowS = opt_int(getenv("MONITOR_DEADMAN_WINDOW_S"));
+    let freshMs = freshest_last_check();
+    let staleS = staleness_s(freshMs, nowMs);
+    let tripped = deadman_tripped(windowS, staleS);
+    let lastLive = recall_latest("notifier:last_liveness");
+    let liveSig = if tripped { "blind" } else { "alive" };
+    let liveNovel = liveSig != lastLive;
+    if tripped {
+        if liveNovel {
+            emit("monitor:alert", deadman_payload(staleS));
+            learn("monitor-notify", "liveness", "dead-man's switch: no watcher tick for " + to_string(staleS) + "s", "failure", ["liveness", "failure", "acted"]);
+            print("notifier: DEAD-MAN'S SWITCH tripped — no watcher tick for " + to_string(staleS) + "s (window=" + to_string(windowS) + "s) — meta-alert emitted");
+        };
+    };
+    // Record the liveness signature so the next tick dedups against it: a recovered
+    // colony stores "alive", so a fresh outage after recovery is novel and re-pages.
+    memo_write("notifier:last_liveness", liveSig);
+
+    // --- the pending alert to forward (one per tick; the bridge's hot path) -----
+    let alert = alert_or_empty(to_string(listen("monitor:alert", 500)));
+    let hasAlert = len(alert) > 0;
+
+    // --- heartbeat bookkeeping (the "still watching, all green" signal) ---------
+    let intervalS = heartbeat_interval_s(getenv("MONITOR_HEARTBEAT_INTERVAL_S"));
+    let lastBeatMs = opt_int(recall_latest("notifier:last_heartbeat"));
+    let beatDue = heartbeat_due(intervalS, lastBeatMs, nowMs);
+
+    print("notifier: alert=" + to_string(hasAlert) + " heartbeat_due=" + to_string(beatDue)
+        + " stale_s=" + to_string(staleS) + " (conf=" + to_string(get_confidence()) + ")");
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates FORWARDING +
+    // HEARTBEAT only; the dead-man's switch above is unchanged by tier.
+    // (.ag has no `else if`; the tiers nest as `else { if ... { } else { } }`.)
+    let my_tier = tier("notifier");
+    if my_tier == "autonomous" {
+        // Proven-reliable bridge -> deliver pages + heartbeats directly.
+        if hasAlert {
+            forward(alert);
+            learn("monitor-notify", "alert", "forwarded alert to sink", "success", ["alert", "success", "acted"]);
+        };
+        if beatDue {
+            forward(heartbeat_payload(now));
+            memo_write("notifier:last_heartbeat", now);
+            learn("monitor-notify", "heartbeat", "sent liveness heartbeat to sink", "success", ["heartbeat", "success", "acted"]);
+        };
+        if !hasAlert {
+            if !beatDue {
+                learn("monitor-notify", "idle", "no pending alert, heartbeat not yet due", "success", ["idle", "success", "observed"]);
+            };
+        };
+    } else {
+        if my_tier == "review-gated" {
+            // Trusted under a review gate -> deliver pages + heartbeats directly.
+            if hasAlert {
+                forward(alert);
+                learn("monitor-notify", "alert", "forwarded alert to sink", "success", ["alert", "success", "review-gated"]);
+            };
+            if beatDue {
+                forward(heartbeat_payload(now));
+                memo_write("notifier:last_heartbeat", now);
+                learn("monitor-notify", "heartbeat", "sent liveness heartbeat to sink", "success", ["heartbeat", "success", "review-gated"]);
+            };
+            if !hasAlert {
+                if !beatDue {
+                    learn("monitor-notify", "idle", "no pending alert, heartbeat not yet due", "success", ["idle", "success", "observed"]);
+                };
+            };
+        } else {
+            if my_tier == "propose" {
+                // Bridge active -> forward pages + heartbeats (notify.sh routes severity).
+                if hasAlert {
+                    forward(alert);
+                    learn("monitor-notify", "alert", "forwarded alert to sink", "success", ["alert", "success", "emitted"]);
+                };
+                if beatDue {
+                    forward(heartbeat_payload(now));
+                    memo_write("notifier:last_heartbeat", now);
+                    learn("monitor-notify", "heartbeat", "sent liveness heartbeat to sink", "success", ["heartbeat", "success", "emitted"]);
+                };
+                if !hasAlert {
+                    if !beatDue {
+                        learn("monitor-notify", "idle", "no pending alert, heartbeat not yet due", "success", ["idle", "success", "observed"]);
+                    };
+                };
+            } else {
+                // shadow / dormant: observe the alert ONLY — no forward, no heartbeat.
+                if hasAlert {
+                    learn("monitor-notify", "alert", "observed alert (bridge inactive at tier)", "success", ["alert", "success", "observed"]);
+                } else {
+                    learn("monitor-notify", "idle", "observing (bridge inactive at tier)", "success", ["idle", "success", "observed"]);
+                };
+                print("notifier: observing (tier: " + my_tier + ") — no forward");
+            };
+        };
+    };
+
+    memo_write("notifier:last_check", to_string(now_ms()));
+}

--- a/dark-factory/monitor/config/colony.example.toml
+++ b/dark-factory/monitor/config/colony.example.toml
@@ -55,6 +55,17 @@ source = "agents/coordinator.ag"
 cb_budget = 120000
 tick_interval_ms = 60000
 
+# The bus->webhook BRIDGE (#1092): listens for monitor:alert and forwards each to
+# scripts/notify.sh (the configured sink) so a page is actually delivered, not
+# just emitted. Also owns the liveness HEARTBEAT and the dead-man's switch
+# (#1093). Read-only / non-custodial (outbound notification only). Needs
+# --enable-messaging (listen) + --enable-exec (notify.sh).
+[[agents]]
+name = "notifier"
+source = "agents/notifier.ag"
+cb_budget = 90000
+tick_interval_ms = 60000
+
 # Monitor environment contract (consumed by the agents via getenv; exported by
 # scripts/start-colony.sh). Operators export these before launching, and add
 # each to exec.env_passthrough in .agentis/config so the sandboxed `exec sh` can
@@ -99,10 +110,28 @@ tick_interval_ms = 60000
 #   MONITOR_ORACLE_MAX      upper sanity bound on the price; "" => no upper bound.
 #   MONITOR_ORACLE_LABEL    a human label for the feed (alert body).
 #
-# Alert sink (optional, scripts/notify.sh):
+# Alert delivery — the bus->webhook bridge (notifier; #1092/#1093/#1094):
 #   MONITOR_WEBHOOK_URL     a Discord/Slack incoming-webhook URL. When set,
 #                           notify.sh POSTs the alert payload to it. NEVER commit
 #                           a real URL — export it in the operator's environment.
+#   MONITOR_WEBHOOK_URL_WARN  channel for `warn`-severity pages; falls back to
+#                           MONITOR_WEBHOOK_URL when unset (#1094 severity routing).
+#   MONITOR_WEBHOOK_URL_HIGH  channel for `high`-severity pages; falls back to
+#                           MONITOR_WEBHOOK_URL when unset (#1094 severity routing).
+#   MONITOR_HEARTBEAT_INTERVAL_S  heartbeat cadence in seconds (#1093); "" => 86400
+#                           (daily); 0 => heartbeat disabled.
+#   MONITOR_DEADMAN_WINDOW_S  dead-man's switch window in seconds (#1093); "" => 0
+#                           (disabled); when >0, no fresh watcher tick within the
+#                           window emits a `high`/`liveness` meta-alert (RPC-blind).
+#   MONITOR_NOTIFY_MAX_RETRIES  bounded retry count on a transient webhook failure
+#                           (#1094); "" => 3.
+#   MONITOR_NOTIFY_BACKOFF_S  initial backoff seconds, doubled each retry (#1094);
+#                           "" => 2.
+#   MONITOR_NOTIFY_DEDUP_COOLDOWN_S  sink-side dedup cooldown in seconds (#1094);
+#                           "" / 0 => disabled (no defence-in-depth dedup).
+#   MONITOR_NOTIFY_STATE_DIR  where notify.sh persists last-sent signatures
+#                           (#1094); "" => ${XDG_STATE_HOME:-$HOME/.local/state}/
+#                           dark-factory-monitor.
 [monitor]
 cast = ""
 rpc_url = ""

--- a/dark-factory/monitor/scripts/notify.sh
+++ b/dark-factory/monitor/scripts/notify.sh
@@ -135,7 +135,10 @@ sys.stdout.write(hashlib.sha256(sig.encode("utf-8")).hexdigest()[:16])
     fi
 
     AGE_S=$((NOW_S - LAST_TS))
-    if [ "$LAST_TS" -gt 0 ] && [ "$AGE_S" -lt "$COOLDOWN_S" ]; then
+    # A negative age (clock rollback after a write, or a tampered state file) must
+    # NEVER suppress a genuine page — only a fresh, in-cooldown duplicate is dropped
+    # (QA #1103: defence on the page-delivery path).
+    if [ "$LAST_TS" -gt 0 ] && [ "$AGE_S" -ge 0 ] && [ "$AGE_S" -lt "$COOLDOWN_S" ]; then
         echo "notify.sh: suppressed duplicate alert (signature $SIGNATURE, ${AGE_S}s < ${COOLDOWN_S}s cooldown)"
         exit 0
     fi

--- a/dark-factory/monitor/scripts/notify.sh
+++ b/dark-factory/monitor/scripts/notify.sh
@@ -1,23 +1,44 @@
 #!/bin/sh
-# notify.sh — thin alert notifier for the Monitor colony (Dark Factory).
+# notify.sh — hardened alert notifier for the Monitor colony (Dark Factory).
 #
-# POSTs an alert payload to a Discord/Slack incoming webhook when
-# MONITOR_WEBHOOK_URL is set. Read-only / non-custodial: it only sends an
-# outbound notification — it never signs, never touches funds, and holds no
-# secret in the repo (the webhook URL is read from the environment).
+# POSTs an alert payload to a Discord/Slack incoming webhook. Read-only /
+# non-custodial: it only sends an outbound notification — it never signs, never
+# touches funds, and holds no secret in the repo (the webhook URL is read from
+# the environment).
 #
 # Usage:
 #   MONITOR_WEBHOOK_URL=https://... ./scripts/notify.sh '<alert text>'
 #   echo '<alert text>' | MONITOR_WEBHOOK_URL=https://... ./scripts/notify.sh
 #
-# With MONITOR_WEBHOOK_URL unset it prints the alert to stdout and exits 0 (a
-# no-op sink), so the colony works out of the box without a configured webhook.
+# With NO webhook configured it prints the alert to stdout and exits 0 (a no-op
+# sink), so the colony works out of the box without a configured webhook.
+#
+# Hardening (#1094), all optional — unset config preserves the single-webhook
+# behaviour exactly:
+#   * Retry/backoff — a transient webhook failure (5xx / curl network error) is
+#     retried with bounded exponential backoff so a single failure does not drop
+#     a page. Tunables: MONITOR_NOTIFY_MAX_RETRIES (default 3),
+#     MONITOR_NOTIFY_BACKOFF_S (initial backoff seconds, default 2, doubled each
+#     retry). A 4xx (a bad request / mis-configured webhook) is NOT retried.
+#   * Sink-side dedup — a page is keyed on its alert SIGNATURE (severity + kind +
+#     verdict, or the whole body when those are absent) and suppressed if an
+#     identical signature was sent within MONITOR_NOTIFY_DEDUP_COOLDOWN_S
+#     (default 0 = disabled). Defence-in-depth over the coordinator's bus-level
+#     dedup. Last-sent signatures persist to a small state file
+#     (MONITOR_NOTIFY_STATE_DIR, default ${XDG_STATE_HOME:-$HOME/.local/state}/
+#     dark-factory-monitor).
+#   * Severity routing — `warn` vs `high` route to different channels via
+#     MONITOR_WEBHOOK_URL_WARN / MONITOR_WEBHOOK_URL_HIGH, each falling back to
+#     MONITOR_WEBHOOK_URL when unset. Severity is read from the alert JSON's
+#     "severity" field (high|warn|low|info|none); a non-JSON body routes to the
+#     base URL.
 #
 # POSIX sh / dash-safe: no bashisms, no arrays, no `\xHH` printf escapes. CI runs
 # this under `sh` = dash.
 #
-# Exit codes: 0 ok (sent, or stdout fallback), 2 usage error, 3 curl missing
-# while a webhook IS configured.
+# Exit codes: 0 ok (sent, deduped, or stdout fallback), 2 usage error, 3 curl
+# missing while a webhook IS configured, 4 permanent delivery failure after
+# exhausting retries.
 
 set -eu
 
@@ -33,34 +54,162 @@ if [ -z "${MSG:-}" ]; then
     exit 2
 fi
 
-WEBHOOK="${MONITOR_WEBHOOK_URL:-}"
+# --- severity routing ----------------------------------------------------------
+# Read the "severity" field from the alert JSON; "" when the body is not JSON or
+# carries no severity. python3 is already a hard dependency of the federation.
+SEVERITY="$(NOTIFY_MSG="$MSG" python3 -c '
+import json, os, sys
+try:
+    obj = json.loads(os.environ["NOTIFY_MSG"])
+    sys.stdout.write(str(obj.get("severity", "")) if isinstance(obj, dict) else "")
+except Exception:
+    sys.stdout.write("")
+')"
 
-# No webhook configured -> print to stdout and succeed (the default no-op sink).
+BASE_URL="${MONITOR_WEBHOOK_URL:-}"
+case "$SEVERITY" in
+    high)
+        WEBHOOK="${MONITOR_WEBHOOK_URL_HIGH:-$BASE_URL}"
+        ;;
+    warn)
+        WEBHOOK="${MONITOR_WEBHOOK_URL_WARN:-$BASE_URL}"
+        ;;
+    *)
+        WEBHOOK="$BASE_URL"
+        ;;
+esac
+
+# No webhook configured for this severity -> print to stdout and succeed (the
+# default no-op sink, behaviour preserved when nothing is configured).
 if [ -z "$WEBHOOK" ]; then
     echo "[monitor:alert] $MSG"
     exit 0
 fi
 
 if ! command -v curl >/dev/null 2>&1; then
-    echo "notify.sh: curl not found but MONITOR_WEBHOOK_URL is set" >&2
+    echo "notify.sh: curl not found but a webhook is configured" >&2
     exit 3
 fi
 
-# JSON-escape the message body with python3 (a `{"content": "..."}` payload that
-# both Discord and a Slack incoming webhook accept). python3 is already a hard
-# dependency of the federation (parse-toml.sh / start-colony.sh use it), so this
-# adds no new requirement and is robust against quotes/newlines in the payload.
-# The message is passed via the environment (NOTIFY_MSG) so no untrusted text is
-# interpolated into the python source — dash-safe and injection-safe.
+# --- sink-side dedup -----------------------------------------------------------
+# A stable signature for this alert: severity + kind + verdict when the body is
+# JSON, else a hash of the whole body. The same condition yields the same
+# signature, so an identical page within the cooldown window is suppressed.
+COOLDOWN_S="${MONITOR_NOTIFY_DEDUP_COOLDOWN_S:-0}"
+case "$COOLDOWN_S" in
+    ''|*[!0-9]*) COOLDOWN_S=0 ;;
+esac
+
+if [ "$COOLDOWN_S" -gt 0 ]; then
+    SIGNATURE="$(NOTIFY_MSG="$MSG" python3 -c '
+import hashlib, json, os, sys
+body = os.environ["NOTIFY_MSG"]
+try:
+    obj = json.loads(body)
+    if isinstance(obj, dict):
+        sig = "|".join(str(obj.get(k, "")) for k in ("severity", "kind", "verdict"))
+    else:
+        sig = ""
+except Exception:
+    sig = ""
+if not sig.strip("|"):
+    sig = "raw:" + hashlib.sha256(body.encode("utf-8")).hexdigest()[:16]
+sys.stdout.write(hashlib.sha256(sig.encode("utf-8")).hexdigest()[:16])
+')"
+
+    STATE_DIR="${MONITOR_NOTIFY_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/dark-factory-monitor}"
+    STATE_FILE="$STATE_DIR/notify-dedup.state"
+    mkdir -p "$STATE_DIR"
+    NOW_S="$(date -u +%s)"
+
+    # Look up the last-sent timestamp for this signature (state lines: "<sig> <ts>").
+    LAST_TS=0
+    if [ -f "$STATE_FILE" ]; then
+        FOUND="$(grep -- "^$SIGNATURE " "$STATE_FILE" 2>/dev/null | tail -n 1 || true)"
+        if [ -n "$FOUND" ]; then
+            LAST_TS="${FOUND#* }"
+            case "$LAST_TS" in
+                ''|*[!0-9]*) LAST_TS=0 ;;
+            esac
+        fi
+    fi
+
+    AGE_S=$((NOW_S - LAST_TS))
+    if [ "$LAST_TS" -gt 0 ] && [ "$AGE_S" -lt "$COOLDOWN_S" ]; then
+        echo "notify.sh: suppressed duplicate alert (signature $SIGNATURE, ${AGE_S}s < ${COOLDOWN_S}s cooldown)"
+        exit 0
+    fi
+
+    # Record this send (drop the prior line for this signature, keep the rest,
+    # then append the fresh timestamp). Atomic via a temp file + mv.
+    TMP_STATE="$STATE_FILE.tmp.$$"
+    if [ -f "$STATE_FILE" ]; then
+        grep -v -- "^$SIGNATURE " "$STATE_FILE" 2>/dev/null > "$TMP_STATE" || true
+    else
+        : > "$TMP_STATE"
+    fi
+    echo "$SIGNATURE $NOW_S" >> "$TMP_STATE"
+    mv "$TMP_STATE" "$STATE_FILE"
+fi
+
+# --- payload -------------------------------------------------------------------
+# JSON-escape the message into a `{"content": "..."}` body that both Discord and
+# a Slack incoming webhook accept. The message is passed via the environment
+# (NOTIFY_MSG) so no untrusted text is interpolated into the python source —
+# dash-safe and injection-safe.
 PAYLOAD="$(NOTIFY_MSG="$MSG" python3 -c 'import json, os; print(json.dumps({"content": os.environ["NOTIFY_MSG"]}))')"
 
-# POST it. -s quiet, -S show errors, -f fail on HTTP error so the exit code
-# reflects delivery. The webhook URL is the only secret and comes from the env.
-curl -sS -f \
-    -H 'Content-Type: application/json' \
-    -X POST \
-    -d "$PAYLOAD" \
-    "$WEBHOOK" >/dev/null
+# --- retry/backoff -------------------------------------------------------------
+# Bounded exponential retry on a transient failure. curl exit codes: 22 = HTTP
+# >= 400 (with -f); we re-probe the actual status to distinguish a retryable 5xx
+# from a permanent 4xx. A curl transport error (non-22 non-zero) is retryable.
+MAX_RETRIES="${MONITOR_NOTIFY_MAX_RETRIES:-3}"
+case "$MAX_RETRIES" in
+    ''|*[!0-9]*) MAX_RETRIES=3 ;;
+esac
+BACKOFF_S="${MONITOR_NOTIFY_BACKOFF_S:-2}"
+case "$BACKOFF_S" in
+    ''|*[!0-9]*) BACKOFF_S=2 ;;
+esac
 
-echo "notify.sh: alert delivered to webhook"
-exit 0
+attempt=0
+delay="$BACKOFF_S"
+while : ; do
+    # Capture the HTTP status; -s quiet, -S show transport errors. Do NOT use -f
+    # here so a 4xx/5xx still yields a status code rather than just exit 22.
+    set +e
+    HTTP_CODE="$(curl -sS \
+        -o /dev/null \
+        -w '%{http_code}' \
+        -H 'Content-Type: application/json' \
+        -X POST \
+        -d "$PAYLOAD" \
+        "$WEBHOOK" 2>/dev/null)"
+    CURL_RC=$?
+    set -e
+
+    if [ "$CURL_RC" -eq 0 ]; then
+        case "$HTTP_CODE" in
+            2*)
+                echo "notify.sh: alert delivered to webhook (HTTP $HTTP_CODE)"
+                exit 0
+                ;;
+            4*)
+                echo "notify.sh: webhook rejected the alert (HTTP $HTTP_CODE) — not retrying" >&2
+                exit 4
+                ;;
+            *)
+                : # 5xx (or other) -> retryable, fall through
+                ;;
+        esac
+    fi
+
+    attempt=$((attempt + 1))
+    if [ "$attempt" -gt "$MAX_RETRIES" ]; then
+        echo "notify.sh: delivery failed after $MAX_RETRIES retries (curl_rc=$CURL_RC http=$HTTP_CODE)" >&2
+        exit 4
+    fi
+    echo "notify.sh: transient failure (curl_rc=$CURL_RC http=$HTTP_CODE) — retry $attempt/$MAX_RETRIES in ${delay}s" >&2
+    sleep "$delay"
+    delay=$((delay * 2))
+done

--- a/dark-factory/monitor/scripts/start-colony.sh
+++ b/dark-factory/monitor/scripts/start-colony.sh
@@ -5,10 +5,13 @@
 #   ./scripts/start-colony.sh [path/to/colony.toml]
 #   ./scripts/start-colony.sh --restart-agent <name> [path/to/colony.toml]
 #
-# The monitor colony runs three long-lived daemons (invariant-watcher,
-# oracle-watcher, coordinator) that continuously WATCH a target EVM protocol and
-# emit reasoned anomaly alerts on the bus (`monitor:alert`). NON-custodial /
-# read-only: the watchers only READ chain state via `cast`/RPC; no agent signs a
+# The monitor colony runs four long-lived daemons (invariant-watcher,
+# oracle-watcher, coordinator, notifier) that continuously WATCH a target EVM
+# protocol and emit reasoned anomaly alerts on the bus (`monitor:alert`); the
+# notifier (#1092) forwards each alert to scripts/notify.sh so a page is actually
+# DELIVERED, and owns the liveness heartbeat + dead-man's switch (#1093).
+# NON-custodial / read-only: the watchers only READ chain state via `cast`/RPC
+# and the notifier only sends an OUTBOUND notification; no agent signs a
 # transaction or touches funds.
 #
 # ADR-0003 conformance: --restart-agent (#257) respawns one agent with the full
@@ -25,7 +28,9 @@
 #   MONITOR_TARGET MONITOR_INV_LHS_SIG MONITOR_INV_RHS_SIG ...    (single invariant)
 #   MONITOR_INV_SPEC                                              (derived invariant set, #1086)
 #   MONITOR_ORACLE MONITOR_ORACLE_PRICE_SIG MONITOR_ORACLE_TS_SIG (oracle)
-#   MONITOR_WEBHOOK_URL                                           (notify.sh sink)
+#   MONITOR_WEBHOOK_URL[/_WARN/_HIGH]                             (notify.sh sink + routing)
+#   MONITOR_HEARTBEAT_INTERVAL_S MONITOR_DEADMAN_WINDOW_S         (notifier liveness)
+#   MONITOR_NOTIFY_MAX_RETRIES MONITOR_NOTIFY_BACKOFF_S ...       (notify.sh hardening)
 
 set -e
 
@@ -109,6 +114,16 @@ MONITOR_ORACLE_MIN="${MONITOR_ORACLE_MIN:-}"
 MONITOR_ORACLE_MAX="${MONITOR_ORACLE_MAX:-}"
 MONITOR_ORACLE_LABEL="${MONITOR_ORACLE_LABEL:-}"
 MONITOR_WEBHOOK_URL="${MONITOR_WEBHOOK_URL:-}"
+# Alert delivery (notifier #1092 / #1093 / notify.sh hardening #1094). All
+# optional; unset preserves the single-webhook stdout-fallback behaviour.
+MONITOR_WEBHOOK_URL_WARN="${MONITOR_WEBHOOK_URL_WARN:-}"
+MONITOR_WEBHOOK_URL_HIGH="${MONITOR_WEBHOOK_URL_HIGH:-}"
+MONITOR_HEARTBEAT_INTERVAL_S="${MONITOR_HEARTBEAT_INTERVAL_S:-}"
+MONITOR_DEADMAN_WINDOW_S="${MONITOR_DEADMAN_WINDOW_S:-}"
+MONITOR_NOTIFY_MAX_RETRIES="${MONITOR_NOTIFY_MAX_RETRIES:-}"
+MONITOR_NOTIFY_BACKOFF_S="${MONITOR_NOTIFY_BACKOFF_S:-}"
+MONITOR_NOTIFY_DEDUP_COOLDOWN_S="${MONITOR_NOTIFY_DEDUP_COOLDOWN_S:-}"
+MONITOR_NOTIFY_STATE_DIR="${MONITOR_NOTIFY_STATE_DIR:-}"
 
 export COLONY_DIR COLONY_NAME
 export MONITOR_CAST MONITOR_RPC_URL
@@ -116,12 +131,16 @@ export MONITOR_TARGET MONITOR_INV_LHS_SIG MONITOR_INV_RHS_SIG MONITOR_INV_RHS_CO
 export MONITOR_INV_REL MONITOR_INV_MARGIN_BP MONITOR_INV_LABEL MONITOR_INV_SPEC
 export MONITOR_ORACLE MONITOR_ORACLE_PRICE_SIG MONITOR_ORACLE_TS_SIG MONITOR_ORACLE_MAX_AGE
 export MONITOR_ORACLE_DEV_BP MONITOR_ORACLE_MIN MONITOR_ORACLE_MAX MONITOR_ORACLE_LABEL
-export MONITOR_WEBHOOK_URL
+export MONITOR_WEBHOOK_URL MONITOR_WEBHOOK_URL_WARN MONITOR_WEBHOOK_URL_HIGH
+export MONITOR_HEARTBEAT_INTERVAL_S MONITOR_DEADMAN_WINDOW_S
+export MONITOR_NOTIFY_MAX_RETRIES MONITOR_NOTIFY_BACKOFF_S
+export MONITOR_NOTIFY_DEDUP_COOLDOWN_S MONITOR_NOTIFY_STATE_DIR
 
 AGENTS=(
     invariant-watcher
     oracle-watcher
     coordinator
+    notifier
 )
 
 # Per-agent tick interval. The watchers + coordinator all run at 60000ms by
@@ -131,6 +150,7 @@ tick_interval_for() {
         invariant-watcher) echo "${MONITOR_TICK_MS:-60000}" ;;
         oracle-watcher) echo "${MONITOR_TICK_MS:-60000}" ;;
         coordinator) echo "${MONITOR_TICK_MS:-60000}" ;;
+        notifier) echo "${MONITOR_TICK_MS:-60000}" ;;
         *) echo 60000 ;;
     esac
 }


### PR DESCRIPTION
The last-mile of the monitor service — reliably deliver `monitor:alert` and make silence meaningful. Read-only on-chain; alert delivery is outbound webhook only (no signing/funds).

- **#1092 notifier.ag** — bus→webhook bridge: `listen()`s `monitor:alert` → `scripts/notify.sh` (alert JSON via exported `MONITOR_ALERT_BODY`, never interpolated → injection-safe). One `tier()` call/tick.
- **#1093 heartbeat + dead-man's switch** — periodic "still watching, all green" signal (configurable cadence) so silence is meaningful; a tier-independent meta-alert when no fresh watcher tick within `MONITOR_DEADMAN_WINDOW_S` (RPC-blind / colony-down) — the key 24/7 guarantee.
- **#1094 hardened notify.sh** — bounded exponential retry/backoff on 5xx/network (4xx not retried), sink-side dedup (signature + cooldown, persisted), severity routing (`warn`/`high` → distinct channels w/ base-URL fallback). Dash-safe, shellcheck clean, unset config preserves stdout fallback.

`start-colony.sh` registers notifier + exports new env + launches `--enable-messaging --enable-exec`; config + README + CHANGELOG updated.

## Validation
`./tools/colony-lint.sh` → **401 passed, 0 failed, 5 skipped**. `agentis commit` parses notifier.ag; `sh -n`/`bash -n`/shellcheck clean. Functionally smoke-tested (retry-on-503, exhaust→exit4, 4xx-no-retry, severity routing, dedup cooldown, stdout fallback).

## Deferred
External watchdog cron (kill-federation registry liveness); PagerDuty/Opsgenie Events-API + ack/escalation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)