### PR TITLE
feat(dark-factory): monitor governance + liquidity/flow/pause watchers (#1095, #1096)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -73,6 +73,21 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   never signs and never touches funds.
 
 ### Fixed
+- **monitor: big-number-safe wei handling in `liquidity-watcher` / `flow-watcher`** (#1095, #1096). Both
+  watchers read an on-chain reserve / level (a TVL proxy in wei) and fed it through a bare `parse_int`, which
+  SATURATES any value above i64 max (9223372036854775807 ≈ 9.22 ETH at 18 dp) to `0` — so a 1000-ETH vault
+  (1e21 wei) baselined at `0`, and a real drain to 1 ETH read as verdict `ok`: the drain was invisible on
+  essentially every real target. The basis-point ratio `(base - reserve) * 10000 / base` separately overflowed
+  i64 for any drop past ~0.001 ETH on an 18-dp token, computing `drop_bp = 0`. Both watchers now keep the
+  reading + baseline as DECIMAL STRINGS (reusing the prospector `value-scorer`'s big-decimal idiom), SCALE both
+  down to ≤18 digits by truncating the same number of low-order digits from BOTH before any `parse_int` (the
+  ratio is preserved; the "" no-read / no-baseline sentinel survives scaling, so cold-start and RPC-blind ticks
+  never false-fire or divide by zero), and compute the basis-point drop DIVISION-FIRST (`unit = base / 10000`;
+  `drop_bp = diff / unit`) so there is no large multiply to overflow. The baseline is persisted as the same
+  digit string it is compared in, and the alert/signal payloads carry the full wei magnitudes as JSON strings.
+  Verified via `agentis repl`: a 1000-ETH baseline drained to 1 ETH now yields `drained` with `drop_bp ≈ 9990`
+  (was `ok`/`drop_bp = 0`), an in-range 5-ETH→2.5-ETH drop yields `drop_bp = 5000`, and cold-start / no-read
+  yield no flag.
 - **monitor: JSON-escape free-text fields in alert/signal payloads** (#1089). `invariant-watcher` and
   `oracle-watcher` now route the operator-supplied `label`/`addr` through a `json_escape()` helper (escapes
   `\` and `"`) in every alert/signal payload builder, so a label containing a `"` can no longer corrupt the

--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -15,6 +15,38 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 ## [Unreleased]
 
 ### Added
+- **monitor: governance / upgrade + liquidity / flow / pause-state watchers** (#1095, #1096). Four more
+  read-only, tier-gated watcher agents feed the monitor coordinator's `monitor:signal:*` blackboard, each with
+  the same ADR-0001 emission pattern as `invariant-watcher` / `oracle-watcher` (one `tier()` call per tick,
+  branch once; `cb 90000` matches `cb_budget`; `<agent>:last_check` written at the start AND end of every tick;
+  a baseline learned via a durable memo; degrade-safe — no reader ⇒ `no-read` ⇒ no false flag; every `exec sh`
+  dynamic value `shell_escape()`d). NON-custodial / read-only throughout (`cast call` / `cast storage` /
+  `cast balance` only — never a signed transaction, never fund access).
+  - **#1095 `governance-watcher.ag`** — the highest-value PRE-exploit early-warning. Reads the two canonical
+    EIP-1967 storage slots (implementation `0x360894…d382bbc` + admin `0xb53127…5d6103`) via `cast storage`,
+    plus an optional `owner()`/`admin()` view, a role-grant indicator, and a timelock-queue indicator via
+    `cast call`, and flags a CHANGE vs the learned per-field baseline (an impl-slot flip / a new admin or owner /
+    a role grant or pending timelock op — the upgrade-attack tell). Verdict tokens `impl-changed` /
+    `admin-changed` / `owner-changed` / `gov-changed` / `ok` / `no-read`. Posts `monitor:signal:governance`.
+  - **#1096 `liquidity-watcher.ag`** — reads a pool / vault reserve or TVL proxy (`totalAssets()` or, with no
+    view configured, native `cast balance`) and flags a drop beyond a learned band (`MONITOR_LIQ_DROP_BP`) — a
+    sudden drain; a rise is never an anomaly. Verdict `drained` / `ok` / `no-read`. Posts
+    `monitor:signal:liquidity`.
+  - **#1096 `flow-watcher.ag`** — reads the same level proxy and flags an abnormal net outflow burst over a
+    window (a net fall since the previous reading exceeding `MONITOR_FLOW_OUT_BP` of the held reserve). Verdict
+    `outflow-burst` / `ok` / `no-read`. Posts `monitor:signal:flow`.
+  - **#1096 `pause-state-watcher.ag`** — reads the `paused()` / circuit-breaker boolean and flags a state
+    transition vs the learned baseline (a protocol pausing itself is signal; a recovery is surfaced too).
+    Verdict `paused` / `unpaused` / `ok` / `no-read`. Posts `monitor:signal:pause`.
+  - `coordinator.ag` now fuses the four new `monitor:signal:*` kinds into the consolidated severity score, the
+    dedup signature, AND a per-signal dossier (the emitted `monitor:alert` carries a `"signals"` map of every
+    watcher's verdict), alongside the existing `invariant` / `oracle` signals — keeping its single-`tier()`-per-
+    tick discipline; the fusion math is a watcher-agnostic `reduce` over the signal list.
+  - All four agents are registered in `monitor/config/colony.example.toml` (`[[agents]]`, `cb_budget` matching
+    `cb`) and `monitor/scripts/start-colony.sh` (`AGENTS`, `tick_interval_for`, and the `MONITOR_GOV_*` /
+    `MONITOR_LIQ_*` / `MONITOR_FLOW_*` / `MONITOR_PAUSE_*` env exports). The new env contract is documented in the
+    config, `monitor/README.md` (agent table + mermaid + env table + a per-watcher section), and the `[monitor]`
+    comment block. Operators add each new `MONITOR_*` var to `exec.env_passthrough` in `.agentis/config`.
 - **monitor: alert-delivery pipeline — the bus→webhook bridge, liveness, and a hardened sink** (#1092, #1093,
   #1094). The monitor colony emitted `monitor:alert` on the bus but nothing forwarded it, so in a real
   deployment no page was ever delivered. A new `notifier` agent (`dark-factory/monitor/agents/notifier.ag`,

--- a/dark-factory/monitor/README.md
+++ b/dark-factory/monitor/README.md
@@ -2,13 +2,13 @@
 
 > Part of the [Dark Factory](../) federation.
 
-A continuous **protocol monitor**. Four cooperating agents watch a target EVM
+A continuous **protocol monitor**. Cooperating agents watch a target EVM
 protocol on-chain and emit reasoned, high-signal anomaly alerts on the colony bus
-(`monitor:alert`); a fourth agent — the **notifier** — bridges the bus to the
-configured webhook so a page is actually **delivered**, not just emitted. The
-colony is **non-custodial / read-only**: every watcher only **reads** chain state
-via `cast`/RPC and the notifier only sends an **outbound** notification — no agent
-signs a transaction and none ever touches funds.
+(`monitor:alert`); the **notifier** bridges the bus to the configured webhook so a
+page is actually **delivered**, not just emitted. The colony is **non-custodial /
+read-only**: every watcher only **reads** chain state via `cast`/RPC and the
+notifier only sends an **outbound** notification — no agent signs a transaction
+and none ever touches funds.
 
 The hot-path verdicts are **facts** (an on-chain read + a deterministic
 comparison), never an LLM opinion. Emission is gated purely on each agent's
@@ -22,22 +22,38 @@ before it is ever trusted to page.
 |-------|------|--------|
 | `invariant-watcher` | Evaluates the target's protocol invariant(s) against current on-chain state; flags a violation or a thin margin-to-violation. Evaluates a single env-configured invariant, OR — when a derived watch-spec is supplied (`MONITOR_INV_SPEC`, #1086) — the WHOLE derived invariant SET | `monitor:signal:invariant` (fused), `monitor:signal:invariant:<label>` (per-invariant), `monitor:alert` (tier-gated) |
 | `oracle-watcher` | Watches a price feed for deviation / staleness / out-of-bounds price | `monitor:signal:oracle`, `monitor:alert` (tier-gated) |
-| `coordinator` | Fuses the watcher signals off the shared blackboard, dedups a persistent condition, decides fused severity, emits one consolidated alert | `monitor:alert` (tier-gated) |
+| `governance-watcher` | Watches the governance / upgrade surface (the two EIP-1967 proxy slots — implementation + admin — plus an optional `owner()`/`admin()` view, a role-grant indicator, and a timelock-queue indicator); flags a CHANGE vs the learned baseline — the highest-value pre-exploit early-warning (#1095) | `monitor:signal:governance`, `monitor:alert` (tier-gated) |
+| `liquidity-watcher` | Watches a pool / vault reserve or TVL proxy (`totalAssets()` / native balance); flags a drop beyond a learned band (sudden drain) (#1096) | `monitor:signal:liquidity`, `monitor:alert` (tier-gated) |
+| `flow-watcher` | Watches net flow over a window; flags an abnormal net outflow burst vs the previous window (large outflow) (#1096) | `monitor:signal:flow`, `monitor:alert` (tier-gated) |
+| `pause-state-watcher` | Watches the `paused()` / circuit-breaker boolean; flags a state transition (a protocol pausing itself is signal) (#1096) | `monitor:signal:pause`, `monitor:alert` (tier-gated) |
+| `coordinator` | Fuses ALL watcher signals off the shared blackboard, dedups a persistent condition, decides fused severity, emits one consolidated alert carrying the per-signal dossier | `monitor:alert` (tier-gated) |
 | `notifier` | The bus→webhook **bridge** (#1092): `listen()`s for `monitor:alert` and forwards each to `scripts/notify.sh` so a page is delivered. Owns the liveness **heartbeat** + **dead-man's switch** (#1093) | webhook page (via `notify.sh`), `monitor:alert` (the dead-man's-switch meta-alert, severity `high` / kind `liveness`) |
 
 Each agent runs as its own `agentis daemon`. The watchers post their latest
 verdict to a durable blackboard memo (`monitor:signal:*`); the coordinator reads
-both each tick and fuses them. The notifier consumes the consolidated
+every signal each tick and fuses them. The notifier consumes the consolidated
 `monitor:alert` off the bus and forwards it to the configured sink.
 
 ```mermaid
 flowchart LR
     C[cast / RPC<br/>read-only] --> IW[invariant-watcher]
     C --> OW[oracle-watcher]
+    C --> GW[governance-watcher]
+    C --> LW[liquidity-watcher]
+    C --> FW[flow-watcher]
+    C --> PW[pause-state-watcher]
     IW -->|monitor:signal:invariant| CO[coordinator]
     OW -->|monitor:signal:oracle| CO
+    GW -->|monitor:signal:governance| CO
+    LW -->|monitor:signal:liquidity| CO
+    FW -->|monitor:signal:flow| CO
+    PW -->|monitor:signal:pause| CO
     IW -->|monitor:alert| BUS[(bus)]
     OW -->|monitor:alert| BUS
+    GW -->|monitor:alert| BUS
+    LW -->|monitor:alert| BUS
+    FW -->|monitor:alert| BUS
+    PW -->|monitor:alert| BUS
     CO -->|monitor:alert<br/>fused + deduped| BUS
     BUS -->|monitor:alert| NF[notifier<br/>bridge + heartbeat<br/>+ dead-man's switch]
     NF -->|monitor:alert<br/>liveness meta-alert| BUS
@@ -59,6 +75,48 @@ Every agent makes ONE `tier()` call per tick and branches once. The tier gates
 This is the false-positive control: a fresh watcher seeded at `shadow` learns the
 protocol's normal state before it can page, and auto-promotion lifts it as its
 alerts prove real over noise.
+
+## Governance / upgrade + liquidity / flow / pause watchers (#1095 / #1096)
+
+Four more read-only watchers feed the coordinator's `monitor:signal:*`
+blackboard, each with the same ADR-0001 tier-gated emission as the
+`invariant`/`oracle` watchers (one `tier()` call per tick, branch once; a
+baseline learned via a durable memo; degrade-safe — no reader ⇒ no false flag;
+every `exec sh` dynamic value `shell_escape()`d):
+
+- **`governance-watcher` (#1095)** — the highest-value **pre-exploit
+  early-warning**. The classic upgrade-attack tell is a proxy's implementation
+  pointer flipping (or the admin / owner rotating) moments before a malicious
+  implementation drains the protocol. The watcher reads the two canonical
+  **EIP-1967** storage slots — implementation
+  (`0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`) and admin
+  (`0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103`) — via
+  `cast storage`, plus an optional `owner()`/`admin()` view, a role-grant
+  indicator, and a timelock-queue indicator via `cast call`, and flags a **CHANGE
+  vs the learned baseline**. Verdict tokens: `impl-changed` / `admin-changed` /
+  `owner-changed` (hard) / `gov-changed` (a role grant or pending timelock op,
+  warn) / `ok` / `no-read`. Posts `monitor:signal:governance`.
+- **`liquidity-watcher` (#1096)** — reads a pool / vault **reserve or TVL proxy**
+  (`totalAssets()` or, with no view configured, the contract's native
+  `cast balance`) and flags a **drop beyond a learned band** (`MONITOR_LIQ_DROP_BP`
+  basis points) — a sudden drain. A rise (a deposit) is never an anomaly. Verdict:
+  `drained` / `ok` / `no-read`. Posts `monitor:signal:liquidity`.
+- **`flow-watcher` (#1096)** — reads the same level proxy and flags an **abnormal
+  net outflow burst** over a window: a net fall since the previous reading
+  exceeding `MONITOR_FLOW_OUT_BP` basis points of the held reserve (the
+  flood-vs-drip distinction the absolute-level band does not make alone). Verdict:
+  `outflow-burst` / `ok` / `no-read`. Posts `monitor:signal:flow`.
+- **`pause-state-watcher` (#1096)** — reads the `paused()` / circuit-breaker
+  boolean and flags a **state transition** vs the learned baseline. A protocol
+  pausing itself usually means the team detected something wrong, often during an
+  incident; a recovery is surfaced too. Verdict: `paused` (hard) / `unpaused`
+  (warn) / `ok` / `no-read`. Posts `monitor:signal:pause`.
+
+The `coordinator` fuses these new `monitor:signal:*` kinds into the consolidated
+severity score, the dedup signature, **and the per-signal dossier** (the emitted
+`monitor:alert` carries a `"signals"` map of every watcher's verdict) — alongside
+the existing `invariant` / `oracle` signals, keeping its single-`tier()`-per-tick
+discipline.
 
 ## Alert delivery — the bus→webhook bridge (#1092 / #1093 / #1094)
 
@@ -202,6 +260,22 @@ watcher reads nothing and only observes — it never raises a false alert.
 | `MONITOR_ORACLE_DEV_BP` | Deviation band in basis points vs the last baseline. | `0` (skip) |
 | `MONITOR_ORACLE_MIN` / `MONITOR_ORACLE_MAX` | Lower / upper price sanity bounds. | unset (no bound) |
 | `MONITOR_ORACLE_LABEL` | Human label for the feed (alert body). | the oracle address |
+| `MONITOR_GOV_TARGET` | (#1095) Governed proxy address (`0x...`) for the governance watch. | falls back to `MONITOR_TARGET` |
+| `MONITOR_GOV_OWNER_SIG` | (#1095) `cast call` signature returning the owner/admin address (e.g. `owner()` / `admin()`); `""` ⇒ skip the owner check (the two EIP-1967 proxy slots are always watched). | unset (slots only) |
+| `MONITOR_GOV_ROLE_SIG` | (#1095) `cast call` signature returning a role-grant indicator (e.g. a member count for a fixed role); `""` ⇒ skip. | unset (skip) |
+| `MONITOR_GOV_TIMELOCK_SIG` | (#1095) `cast call` signature returning a timelock-queue indicator (queued-op count / pending-op id); `""` ⇒ skip. | unset (skip) |
+| `MONITOR_GOV_LABEL` | (#1095) Human label for the governed target (alert body). | the target address |
+| `MONITOR_LIQ_TARGET` | (#1096) Pool / vault address (`0x...`) for the liquidity watch. | falls back to `MONITOR_TARGET` |
+| `MONITOR_LIQ_SIG` | (#1096) `cast call` signature for the reserve / TVL proxy (e.g. `totalAssets()`); `""` ⇒ native `cast balance`. | unset (native balance) |
+| `MONITOR_LIQ_DROP_BP` | (#1096) Drop band in basis points (0..10000); a fall past it flags a drain. | `0` (any drop) |
+| `MONITOR_LIQ_LABEL` | (#1096) Human label for the pool / vault (alert body). | the target address |
+| `MONITOR_FLOW_TARGET` | (#1096) Watched address (`0x...`) for the flow watch. | falls back to `MONITOR_TARGET` |
+| `MONITOR_FLOW_SIG` | (#1096) `cast call` signature for the level proxy (e.g. `totalAssets()`); `""` ⇒ native `cast balance`. | unset (native balance) |
+| `MONITOR_FLOW_OUT_BP` | (#1096) Per-window outflow band in basis points (0..10000); a net fall past it flags a burst. | `0` (any net outflow) |
+| `MONITOR_FLOW_LABEL` | (#1096) Human label for the contract (alert body). | the target address |
+| `MONITOR_PAUSE_TARGET` | (#1096) Watched address (`0x...`) for the pause-state watch. | falls back to `MONITOR_TARGET` |
+| `MONITOR_PAUSE_SIG` | (#1096) `cast call` signature returning the pause / circuit-breaker boolean. | `paused()` |
+| `MONITOR_PAUSE_LABEL` | (#1096) Human label for the contract (alert body). | the target address |
 | `MONITOR_WEBHOOK_URL` | Discord/Slack/PagerDuty incoming-webhook URL for `notify.sh`. **Never commit a real URL.** | unset (stdout sink) |
 | `MONITOR_WEBHOOK_URL_WARN` | Channel for `warn`-severity pages (#1094 routing). | falls back to `MONITOR_WEBHOOK_URL` |
 | `MONITOR_WEBHOOK_URL_HIGH` | Channel for `high`-severity pages (#1094 routing). | falls back to `MONITOR_WEBHOOK_URL` |
@@ -226,7 +300,11 @@ liveness heartbeat + dead-man's switch
 ([#1093](https://github.com/Replikanti/agentis-colonies/issues/1093)), and the
 hardened `notify.sh` (retry/backoff, sink-side dedup, severity routing,
 [#1094](https://github.com/Replikanti/agentis-colonies/issues/1094)) — turns an
-emitted alert into a delivered page. Follow-ups: the liquidity / governance / flow
-watchers, an external dead-man's-switch cron, and a dashboard view. The colony is
-**read-only** and **never** posts an alert without a configured sink — and
-**never** signs or touches funds.
+emitted alert into a delivered page. The **governance / upgrade watcher**
+([#1095](https://github.com/Replikanti/agentis-colonies/issues/1095)) and the
+**liquidity / flow / pause-state watchers**
+([#1096](https://github.com/Replikanti/agentis-colonies/issues/1096)) extend the
+fused signal set with the highest-value pre-exploit early-warnings. Follow-ups: an
+external dead-man's-switch cron and a dashboard view. The colony is **read-only**
+and **never** posts an alert without a configured sink — and **never** signs or
+touches funds.

--- a/dark-factory/monitor/agents/coordinator.ag
+++ b/dark-factory/monitor/agents/coordinator.ag
@@ -1,14 +1,15 @@
 // coordinator.ag — Monitor colony (Dark Factory federation).
 //
-// The fusion + dedup + severity-decision agent. The two watchers
-// (invariant-watcher, oracle-watcher) each post their latest verdict to a shared
-// blackboard memo (`monitor:signal:<watcher>`); each ALSO emits its own
-// per-watcher `monitor:alert`. This coordinator reads BOTH blackboard signals
-// every tick, FUSES them into one consolidated picture, DEDUPS against the last
-// consolidated signature it emitted (so a persistent condition pages once, not
-// every tick), DECIDES the fused severity, and emits ONE consolidated
-// `monitor:alert`. NON-custodial / read-only: it reads memos + emits on the bus
-// only — no signing, no fund access, no `exec sh`.
+// The fusion + dedup + severity-decision agent. The watchers (invariant-watcher,
+// oracle-watcher, governance-watcher, liquidity-watcher, flow-watcher,
+// pause-state-watcher) each post their latest verdict to a shared blackboard
+// memo (`monitor:signal:<watcher>`); each ALSO emits its own per-watcher
+// `monitor:alert`. This coordinator reads ALL blackboard signals every tick,
+// FUSES them into one consolidated picture, DEDUPS against the last consolidated
+// signature it emitted (so a persistent condition pages once, not every tick),
+// DECIDES the fused severity, and emits ONE consolidated `monitor:alert`.
+// NON-custodial / read-only: it reads memos + emits on the bus only — no signing,
+// no fund access, no `exec sh`.
 //
 // Pattern (per dark-factory/auditor/agents/coordinator.ag): single-assignment
 // helpers (no `let` reassignment), reduce/recursion instead of loops. The fused
@@ -22,7 +23,8 @@
 // One tier() call per tick, branch once, fall through to shadow/dormant.
 //
 // Reads (durable memos written by the watchers): monitor:signal:invariant,
-//   monitor:signal:oracle.
+//   monitor:signal:oracle, monitor:signal:governance, monitor:signal:liquidity,
+//   monitor:signal:flow, monitor:signal:pause.
 // Emits: "monitor:alert" (the colony bus contract).
 
 cb 120000;
@@ -59,16 +61,32 @@ fn is_anomalous(verdict: string) -> bool {
     return true;
 }
 
-// A signal's contribution to the fused SEVERITY SCORE. A hard violation/break
-// (invariant violated, oracle bounds/stale) is the highest-severity tell; a
-// margin / deviation is a softer warning. Scores accumulate across watchers so
-// two simultaneous anomalies fuse to a higher severity than either alone.
+// A signal's contribution to the fused SEVERITY SCORE. A hard violation/break is
+// the highest-severity tell; a softer warning scores less. Scores accumulate
+// across watchers so simultaneous anomalies fuse to a higher severity than any
+// alone. The tokens span every watcher:
+//   invariant:  violated (hard) / margin (warn);
+//   oracle:     bounds (hard) / stale (warn) / deviation (warn);
+//   governance: impl-changed / admin-changed / owner-changed (hard upgrade
+//               tells) / gov-changed (warn: a role grant or pending timelock op);
+//   liquidity:  drained (hard: a reserve fell past its band);
+//   flow:       outflow-burst (hard: a large net outflow in one window);
+//   pause:      paused (hard: a fresh circuit-breaker trip) / unpaused (warn: a
+//               recovery worth surfacing).
 fn severity_score(verdict: string) -> int {
     if verdict == "violated" { return 3; }
     if verdict == "bounds" { return 3; }
+    if verdict == "impl-changed" { return 3; }
+    if verdict == "admin-changed" { return 3; }
+    if verdict == "owner-changed" { return 3; }
+    if verdict == "drained" { return 3; }
+    if verdict == "outflow-burst" { return 3; }
+    if verdict == "paused" { return 3; }
     if verdict == "stale" { return 2; }
     if verdict == "deviation" { return 1; }
     if verdict == "margin" { return 1; }
+    if verdict == "gov-changed" { return 1; }
+    if verdict == "unpaused" { return 1; }
     return 0;
 }
 
@@ -79,18 +97,32 @@ fn severity_label(score: int) -> string {
     return "none";
 }
 
-// --- fused consolidated picture (single-assignment over the two signals) -------
-// The deterministic fused score = sum of the per-watcher severity contributions.
-fn fuse_score(invVerdict: string, oracleVerdict: string) -> int {
-    return severity_score(invVerdict) + severity_score(oracleVerdict);
+// --- fused consolidated picture (single-assignment fold over all signals) ------
+// Each watcher contributes one (name, verdict) pair. The fold helpers below walk
+// the list with reduce (no loops, no `let` reassignment) so adding a watcher is a
+// one-line list extension in tick() — the fusion math is watcher-agnostic.
+
+// A verdict's display token in the dossier: the verdict itself, or "none" when
+// the watcher has not run yet ("" verdict).
+fn verdict_or_none(verdict: string) -> string {
+    if len(verdict) > 0 { return verdict; }
+    return "none";
 }
 
-// .ag has no short-circuit `&&` / `||` (single-assignment grammar), so the two
-// fused boolean predicates are expressed as explicit nested-if helpers.
-fn either_anomalous(invVerdict: string, oracleVerdict: string) -> bool {
-    if is_anomalous(invVerdict) { return true; }
-    if is_anomalous(oracleVerdict) { return true; }
-    return false;
+// The deterministic fused score = sum of the per-watcher severity contributions.
+fn fuse_score(verdicts: list<string>) -> int {
+    return reduce(verdicts, |acc: int, v: string| -> int {
+        return acc + severity_score(v);
+    }, 0);
+}
+
+// .ag has no short-circuit `&&` / `||` (single-assignment grammar); the fused
+// "any anomalous?" predicate is a reduce over the per-watcher anomaly flags.
+fn any_anomalous(verdicts: list<string>) -> bool {
+    return reduce(verdicts, |acc: bool, v: string| -> bool {
+        if acc { return true; }
+        return is_anomalous(v);
+    }, false);
 }
 
 fn anomaly_and_novel(anomaly: bool, novel: bool) -> bool {
@@ -98,24 +130,49 @@ fn anomaly_and_novel(anomaly: bool, novel: bool) -> bool {
     return novel;
 }
 
-// A stable DEDUP SIGNATURE for the consolidated picture: the two watchers'
-// verdicts joined. The same pair of conditions yields the same signature, so a
-// persistent anomaly is emitted ONCE (until a verdict changes) rather than every
-// tick. Quiet ticks (no anomaly) produce the "quiet" signature.
-fn fused_signature(invVerdict: string, oracleVerdict: string, anomaly: bool) -> string {
+// A stable DEDUP SIGNATURE for the consolidated picture: every watcher's verdict
+// joined as `<name>=<verdict>` in a FIXED order. The same set of conditions
+// yields the same signature, so a persistent anomaly is emitted ONCE (until a
+// verdict changes) rather than every tick. Quiet ticks (no anomaly) produce the
+// "quiet" signature. `names`/`verdicts` are positionally paired (built together
+// in tick()); the fold walks the index it carries.
+// Strip the fold's `<index>|` cursor prefix off the accumulator, leaving the
+// joined dossier/signature body the fold built.
+fn drop_cursor(acc: string) -> string {
+    return substring(acc, index_of(acc, "|") + 1, len(acc));
+}
+
+fn fused_signature(names: list<string>, verdicts: list<string>, anomaly: bool) -> string {
     if !anomaly { return "quiet"; }
-    let inv = if len(invVerdict) > 0 { invVerdict } else { "none" };
-    let orc = if len(oracleVerdict) > 0 { oracleVerdict } else { "none" };
-    return "inv=" + inv + ";oracle=" + orc;
+    return drop_cursor(reduce(verdicts, |acc: string, v: string| -> string {
+        let i = parse_int(substring(acc, 0, index_of(acc, "|")));
+        let so_far = drop_cursor(acc);
+        let sep = if i == 0 { "" } else { ";" };
+        let entry = to_string(get(names, i)) + "=" + verdict_or_none(v);
+        return to_string(i + 1) + "|" + so_far + sep + entry;
+    }, "0|"));
+}
+
+// The fused dossier body: every watcher's verdict as a JSON key/value, in the
+// same fixed order, so the consolidated alert carries the PER-SIGNAL breakdown a
+// reader needs (not just the score). Built by the same index-carrying fold.
+fn fused_dossier(names: list<string>, verdicts: list<string>) -> string {
+    return drop_cursor(reduce(verdicts, |acc: string, v: string| -> string {
+        let i = parse_int(substring(acc, 0, index_of(acc, "|")));
+        let so_far = drop_cursor(acc);
+        let sep = if i == 0 { "" } else { "," };
+        let entry = "\"" + to_string(get(names, i)) + "\":\"" + verdict_or_none(v) + "\"";
+        return to_string(i + 1) + "|" + so_far + sep + entry;
+    }, "0|"));
 }
 
 // The consolidated alert payload (JSON). All fields are facts the coordinator
-// fused from the watchers; none is LLM text. `sev` is set per tier on emit.
-fn fused_payload(invVerdict: string, oracleVerdict: string, score: int, sig: string, sev: string) -> string {
-    let inv = if len(invVerdict) > 0 { invVerdict } else { "none" };
-    let orc = if len(oracleVerdict) > 0 { oracleVerdict } else { "none" };
-    return "{\"watcher\":\"coordinator\",\"kind\":\"fused\",\"invariant\":\"" + inv
-         + "\",\"oracle\":\"" + orc + "\",\"score\":" + to_string(score)
+// fused from the watchers; none is LLM text. `sev` is set per tier on emit. The
+// per-signal dossier carries every watcher's verdict so a reader sees the
+// breakdown that produced the score + signature.
+fn fused_payload(names: list<string>, verdicts: list<string>, score: int, sig: string, sev: string) -> string {
+    return "{\"watcher\":\"coordinator\",\"kind\":\"fused\",\"signals\":{" + fused_dossier(names, verdicts)
+         + "},\"score\":" + to_string(score)
          + ",\"signature\":\"" + sig + "\",\"severity\":\"" + sev + "\"}";
 }
 
@@ -133,17 +190,25 @@ fn tick(reason: string) -> void {
     // Heartbeat first (dashboard memo-freshness probe) even on an early return.
     memo_write("coordinator:last_check", now);
 
-    // Read the two watchers' latest blackboard signals + pull their verdicts.
-    let invSig = recall_latest("monitor:signal:invariant");
-    let oracleSig = recall_latest("monitor:signal:oracle");
-    let invVerdict = signal_verdict(invSig);
-    let oracleVerdict = signal_verdict(oracleSig);
+    // Read every watcher's latest blackboard signal + pull its verdict. The
+    // `names`/`verdicts` lists are positionally paired and in a FIXED order so the
+    // fused signature/dossier are stable across ticks; adding a watcher is one
+    // entry in each list (the fusion math is watcher-agnostic).
+    let names = ["invariant", "oracle", "governance", "liquidity", "flow", "pause"];
+    let verdicts = [
+        signal_verdict(recall_latest("monitor:signal:invariant")),
+        signal_verdict(recall_latest("monitor:signal:oracle")),
+        signal_verdict(recall_latest("monitor:signal:governance")),
+        signal_verdict(recall_latest("monitor:signal:liquidity")),
+        signal_verdict(recall_latest("monitor:signal:flow")),
+        signal_verdict(recall_latest("monitor:signal:pause"))
+    ];
 
     // FUSE: deterministic score + anomaly flag + severity label + dedup signature.
-    let anomaly = either_anomalous(invVerdict, oracleVerdict);
-    let score = fuse_score(invVerdict, oracleVerdict);
+    let anomaly = any_anomalous(verdicts);
+    let score = fuse_score(verdicts);
     let sevLabel = severity_label(score);
-    let sig = fused_signature(invVerdict, oracleVerdict, anomaly);
+    let sig = fused_signature(names, verdicts, anomaly);
     let outcome = outcome_of(sevLabel);
 
     // DEDUP: only a NEW signature (vs the last one we acted on) is novel; a
@@ -151,12 +216,12 @@ fn tick(reason: string) -> void {
     let lastSig = recall_latest("coordinator:last_signature");
     let novel = sig != lastSig;
 
-    print("coordinator: fuse inv=" + invVerdict + " oracle=" + oracleVerdict
-        + " -> score=" + to_string(score) + " sev=" + sevLabel + " novel=" + to_string(novel)
+    print("coordinator: fuse " + sig + " -> score=" + to_string(score)
+        + " sev=" + sevLabel + " novel=" + to_string(novel)
         + " (conf=" + to_string(get_confidence()) + ")");
 
     let key = "fused:" + sig;
-    let desc = "fused inv=" + invVerdict + " oracle=" + oracleVerdict + " score=" + to_string(score);
+    let desc = "fused " + sig + " score=" + to_string(score);
     // Worth emitting only when there is an anomaly AND it is a NEW signature.
     let emitWorthy = anomaly_and_novel(anomaly, novel);
 
@@ -167,7 +232,7 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         // Proven reliable -> a DIRECT consolidated page on a new anomaly.
         if emitWorthy {
-            emit("monitor:alert", fused_payload(invVerdict, oracleVerdict, score, sig, sevLabel));
+            emit("monitor:alert", fused_payload(names, verdicts, score, sig, sevLabel));
             learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "acted"]);
         } else {
             learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "observed"]);
@@ -176,7 +241,7 @@ fn tick(reason: string) -> void {
         if my_tier == "review-gated" {
             // Trusted to page under a review gate -> a DIRECT consolidated page.
             if emitWorthy {
-                emit("monitor:alert", fused_payload(invVerdict, oracleVerdict, score, sig, sevLabel));
+                emit("monitor:alert", fused_payload(names, verdicts, score, sig, sevLabel));
                 learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "review-gated"]);
             } else {
                 learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "observed"]);
@@ -185,7 +250,7 @@ fn tick(reason: string) -> void {
             if my_tier == "propose" {
                 // Enough signal to contribute -> a DRAFT consolidated alert (low).
                 if emitWorthy {
-                    emit("monitor:alert", fused_payload(invVerdict, oracleVerdict, score, sig, "low"));
+                    emit("monitor:alert", fused_payload(names, verdicts, score, sig, "low"));
                     learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "emitted"]);
                 } else {
                     learn("monitor-fuse", key, desc, outcome, [sevLabel, outcome, "observed"]);

--- a/dark-factory/monitor/agents/flow-watcher.ag
+++ b/dark-factory/monitor/agents/flow-watcher.ag
@@ -1,0 +1,264 @@
+// flow-watcher.ag — Monitor colony (Dark Factory federation).
+//
+// Watches a protocol's NET FLOW over a window for an abnormal OUTFLOW BURST — a
+// large net withdrawal relative to the held reserve in a single observation
+// window (the drip-vs-flood distinction the liquidity-watcher's absolute-level
+// band does not make on its own). Each tick reads the same reserve / balance
+// proxy, computes the NET CHANGE since the LAST observed reading (the window
+// delta), and flags an OUTFLOW (a fall) whose magnitude exceeds
+// MONITOR_FLOW_OUT_BP basis points of the held reserve. An inflow (a rise) is
+// never an anomaly. NON-custodial / read-only: it only READS chain state via
+// `cast`/RPC over `exec sh` — it never signs a transaction and never touches
+// funds.
+//
+// Same on-chain read pattern + tier-gated emission as the sibling watchers. The
+// signal is a FACT (an on-chain read + a deterministic comparison vs the last
+// window), never an LLM opinion. Emission is gated PURELY on the ADR-0001 tier of
+// this agent (the false-positive control):
+//   shadow / dormant -> observe + learn a baseline (record the level), NO emit;
+//   propose          -> emit a DRAFT `monitor:alert` (low severity);
+//   review-gated /    -> emit a DIRECT-page `monitor:alert` (high severity).
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant.
+//
+// Env contract (all read via getenv; exported by scripts/start-colony.sh; add
+// each to exec.env_passthrough in .agentis/config so the sandboxed `exec sh`
+// can read them):
+//   MONITOR_CAST          path to the `cast` binary; "" => no reader, observe only.
+//   MONITOR_RPC_URL       the chain RPC endpoint (read-only).
+//   MONITOR_FLOW_TARGET   the watched contract address (0x...); "" => falls back
+//                         to MONITOR_TARGET (the invariant target).
+//   MONITOR_FLOW_SIG      the `cast call` signature returning the level proxy
+//                         (e.g. "totalAssets()"); "" => the watcher uses the
+//                         contract's native `cast balance` instead.
+//   MONITOR_FLOW_OUT_BP   the per-window outflow band in basis points (0..10000):
+//                         a net fall of more than this fraction of the reserve in
+//                         one window flags an outflow burst; "" => 0 (any net
+//                         outflow flags — the most sensitive setting).
+//   MONITOR_FLOW_LABEL    a human label for the contract (for the alert body).
+// Emits: "monitor:alert" (the colony bus contract).
+
+cb 90000;
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("flow-watcher:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- env defaults --------------------------------------------------------------
+fn target_or(raw: string, fallback: string) -> string {
+    if len(raw) > 0 { return raw; }
+    return fallback;
+}
+
+fn label_or(raw: string, addr: string) -> string {
+    if len(raw) > 0 { return raw; }
+    return addr;
+}
+
+// JSON-string escape a free-text field (#1089): backslash -> \\ and double-quote
+// -> \" , so an operator-authored label/address containing a `"` cannot corrupt
+// the alert/signal JSON. Per-char fold (.ag has no string-replace builtin).
+fn json_escape(s: string) -> string {
+    return reduce(regex_find_all("[\\s\\S]", s), |acc: string, c: string| -> string {
+        if c == "\\" { return acc + "\\\\"; }
+        if c == "\"" { return acc + "\\\""; }
+        return acc + c;
+    }, "");
+}
+
+// --- read the level proxy (a view, else the native balance) --------------------
+// EVERY dynamic value (the cast path, the rpc url, the address, the signature) is
+// shell_escape()d — they are operator/coordinator-supplied facts flowing into a
+// shell. `set +e` + `|| true` so a transient RPC failure returns "" (no reading
+// -> no false flag). Returns the decimal string, or "" on any failure / empty
+// reader.
+fn read_view(castBin: string, rpc: string, addr: string, sig: string) -> string {
+    if len(castBin) == 0 { return ""; }
+    if len(rpc) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    if len(sig) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; " + shell_escape(castBin) + " call --rpc-url " + shell_escape(rpc)
+            + " " + shell_escape(addr) + " " + shell_escape(sig)
+            + " 2>/dev/null | " + shell_escape(castBin) + " --to-dec 2>/dev/null || true";
+    return out;
+}
+
+fn read_balance(castBin: string, rpc: string, addr: string) -> string {
+    if len(castBin) == 0 { return ""; }
+    if len(rpc) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; " + shell_escape(castBin) + " balance --rpc-url " + shell_escape(rpc)
+            + " " + shell_escape(addr)
+            + " 2>/dev/null || true";
+    return out;
+}
+
+fn read_level(castBin: string, rpc: string, addr: string, sig: string) -> string {
+    if len(sig) > 0 {
+        return read_view(castBin, rpc, addr, sig);
+    }
+    return read_balance(castBin, rpc, addr);
+}
+
+// Trim a trailing newline cast leaves on its output, leaving only the first token.
+fn first_token(s: string) -> string {
+    let nl = index_of(s, "\n");
+    if nl < 0 { return s; }
+    return substring(s, 0, nl);
+}
+
+// Parse a decimal reading to an int; empty / non-numeric -> -1 (the "no reading"
+// sentinel, distinct from a legitimate 0). parse_int is total.
+fn reading_to_int(s: string) -> int {
+    let t = first_token(s);
+    if len(t) == 0 { return -1; }
+    if len(regex_find_all("[^0-9]", t)) > 0 { return -1; }
+    return parse_int(t);
+}
+
+// Optional integer env fact: "" / non-numeric -> -1 (the "unset" sentinel).
+fn opt_int(raw: string) -> int {
+    if len(raw) == 0 { return -1; }
+    if len(regex_find_all("[^0-9]", raw)) > 0 { return -1; }
+    return parse_int(raw);
+}
+
+// --- the deterministic OUTFLOW verdict (a FACT, never an LLM call) -------------
+// The net outflow in basis points of `last` over one window: positive when the
+// level FELL from the last reading, normalised by the last (held) reserve so a
+// drain reads as a fraction of what was held. -1 when there is no usable prior
+// reading. An inflow (a rise) yields 0 (a rise is never an outflow).
+fn outflow_bp(level: int, last: int) -> int {
+    if last <= 0 { return -1; }
+    if level >= last { return 0; }
+    return ((last - level) * 10000) / last;
+}
+
+fn burst(level: int, last: int, outBp: int) -> bool {
+    if level < 0 { return false; }
+    let o = outflow_bp(level, last);
+    if o < 0 { return false; }
+    return o > outBp;
+}
+
+// Fuse the level read + prior window into ONE verdict token. A level that could
+// not be read is "no-read"; a net outflow past the band in one window is
+// "outflow-burst"; anything else (an inflow, a hold, or a sub-band drip) is "ok".
+fn verdict_of(level: int, last: int, outBp: int) -> string {
+    if level < 0 { return "no-read"; }
+    if burst(level, last, outBp) { return "outflow-burst"; }
+    return "ok";
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. A clean level
+// read is a healthy observation (success); an outflow burst is the anomaly the
+// watcher exists to catch (failure); a missing read is error.
+fn outcome_of(verdict: string) -> string {
+    if verdict == "ok" { return "success"; }
+    if verdict == "outflow-burst" { return "failure"; }
+    return "error";
+}
+
+fn is_anomaly(verdict: string) -> bool {
+    if verdict == "outflow-burst" { return true; }
+    return false;
+}
+
+// A compact, deterministic alert payload (JSON). All fields are facts the watcher
+// computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
+fn alert_payload(label: string, verdict: string, level: int, last: int, addr: string, sev: string) -> string {
+    return "{\"watcher\":\"flow\",\"contract\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
+         + "\",\"level\":" + to_string(level) + ",\"prev\":" + to_string(last)
+         + ",\"address\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("flow-watcher:last_check", now);
+
+    let castBin = getenv("MONITOR_CAST");
+    let rpc = getenv("MONITOR_RPC_URL");
+    let addr = target_or(getenv("MONITOR_FLOW_TARGET"), getenv("MONITOR_TARGET"));
+    let sig = getenv("MONITOR_FLOW_SIG");
+    let outBp = if len(getenv("MONITOR_FLOW_OUT_BP")) > 0 { opt_int(getenv("MONITOR_FLOW_OUT_BP")) } else { 0 };
+    let outBand = if outBp < 0 { 0 } else { outBp };
+    let label = label_or(getenv("MONITOR_FLOW_LABEL"), addr);
+
+    // Read the current level. The window baseline is the level this watcher
+    // observed on the PREVIOUS tick (durable memo). On the first read there is no
+    // prior level (-1) -> the outflow check is skipped this tick; the current
+    // level becomes the prior for the next window.
+    let level = reading_to_int(read_level(castBin, rpc, addr, sig));
+    let last = opt_int(recall_latest("flow-watcher:last_level:" + addr));
+
+    let verdict = verdict_of(level, last, outBand);
+    let outcome = outcome_of(verdict);
+
+    print("flow-watcher: " + label + " level=" + to_string(level) + " prev=" + to_string(last)
+        + " -> " + verdict + " (conf=" + to_string(get_confidence()) + ")");
+
+    // Roll the window: store the latest GOOD level as the prior for next tick (a
+    // no-read leaves the old prior intact). A burst reading STILL rolls forward
+    // AFTER this tick's flag, so one burst pages once and the new level becomes
+    // the next window's baseline.
+    if level >= 0 {
+        memo_write("flow-watcher:last_level:" + addr, to_string(level));
+    };
+
+    let key = label + ":" + addr;
+    let desc = "net flow " + label + " level=" + to_string(level) + " -> " + verdict;
+    let anomaly = is_anomaly(verdict);
+
+    // Post this watcher's latest verdict to the shared blackboard memo the
+    // coordinator reads each tick to fuse + dedup signals (a memo write — allowed
+    // at every tier, including shadow). Severity is re-decided by the coordinator.
+    memo_write("monitor:signal:flow", alert_payload(label, verdict, level, last, addr, "info"));
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
+    // verdict above is unchanged by tier. shadow/dormant fall through to observe.
+    // (.ag has no `else if`; the tiers nest as `else { if ... { } else { } }`.)
+    let my_tier = tier("flow-watcher");
+    if my_tier == "autonomous" {
+        // Proven reliable -> a DIRECT page on a real anomaly (high severity).
+        if anomaly {
+            emit("monitor:alert", alert_payload(label, verdict, level, last, addr, "high"));
+            learn("flow-watch", key, desc, outcome, [verdict, outcome, "acted"]);
+        } else {
+            learn("flow-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+        };
+    } else {
+        if my_tier == "review-gated" {
+            // Trusted to page under a review gate -> a DIRECT page (high severity).
+            if anomaly {
+                emit("monitor:alert", alert_payload(label, verdict, level, last, addr, "high"));
+                learn("flow-watch", key, desc, outcome, [verdict, outcome, "review-gated"]);
+            } else {
+                learn("flow-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+            };
+        } else {
+            if my_tier == "propose" {
+                // Enough signal to contribute -> a DRAFT alert (low severity).
+                if anomaly {
+                    emit("monitor:alert", alert_payload(label, verdict, level, last, addr, "low"));
+                    learn("flow-watch", key, desc, outcome, [verdict, outcome, "emitted"]);
+                } else {
+                    learn("flow-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+                };
+            } else {
+                // shadow / dormant: learn the baseline ONLY — no emit, no write.
+                learn("flow-watch", key, desc + " (baseline)", outcome, [verdict, outcome, "observed"]);
+                print("flow-watcher: observing (tier: " + my_tier + ") — no emit");
+            };
+        };
+    };
+
+    memo_write("flow-watcher:last_check", to_string(now_ms()));
+}

--- a/dark-factory/monitor/agents/flow-watcher.ag
+++ b/dark-factory/monitor/agents/flow-watcher.ag
@@ -114,16 +114,73 @@ fn first_token(s: string) -> string {
     return substring(s, 0, nl);
 }
 
-// Parse a decimal reading to an int; empty / non-numeric -> -1 (the "no reading"
-// sentinel, distinct from a legitimate 0). parse_int is total.
-fn reading_to_int(s: string) -> int {
-    let t = first_token(s);
-    if len(t) == 0 { return -1; }
-    if len(regex_find_all("[^0-9]", t)) > 0 { return -1; }
-    return parse_int(t);
+// --- big-number-safe wei handling (NO bare parse_int on the raw reading) -------
+// A realistic level / TVL is in wei: 1000 ETH = 1e21, far beyond the i64 range
+// (~9.2e18, ≈ 9.22 ETH at 18 dp) parse_int can hold — parse_int SATURATES such a
+// value to 0, so a 1000-ETH contract used to baseline at 0 and a real outflow read
+// as "ok". The reading + prior window are therefore kept as DECIMAL STRINGS and,
+// when they exceed 18 digits, SCALED DOWN by truncating the same number of
+// low-order digits from BOTH (the ratio is preserved) BEFORE any parse_int — so
+// every parse_int below operates on a value guaranteed to fit i64. (#1095.)
+
+// Strip leading zeros from a digit string, leaving at least one digit ("0").
+fn strip_leading_zeros(s: string) -> string {
+    let kept = reduce(regex_find_all("[0-9]", s), |acc: string, d: string| -> string {
+        if len(acc) > 0 { return acc + d; }
+        if d == "0" { return acc; }
+        return d;
+    }, "");
+    if len(kept) == 0 { return "0"; }
+    return kept;
 }
 
-// Optional integer env fact: "" / non-numeric -> -1 (the "unset" sentinel).
+// Normalise a raw decimal reading to a clean digit string (leading zeros stripped).
+// "" / non-numeric -> "" (the "no reading" sentinel, distinct from a legitimate
+// "0"). Total. Mirrors prospector/value-scorer.ag's reading_to_dec.
+fn reading_to_dec(s: string) -> string {
+    let t = first_token(s);
+    if len(t) == 0 { return ""; }
+    if len(regex_find_all("[^0-9]", t)) > 0 { return ""; }
+    return strip_leading_zeros(t);
+}
+
+// The most significant digits a scaled value may keep so parse_int never wraps:
+// i64 max is 19 digits (9223372036854775807); 18 digits (<1e18) always fits.
+fn max_safe_digits() -> int {
+    return 18;
+}
+
+// How many low-order digits must be dropped so BOTH `a` and `b` fit i64: the
+// excess of the LONGER string over max_safe_digits(), clamped to >= 0. The SAME
+// drop is applied to both, so the outflow_bp ratio is preserved.
+fn excess_digits(a: string, b: string) -> int {
+    let longest = if len(a) > len(b) { len(a) } else { len(b) };
+    let excess = longest - max_safe_digits();
+    if excess < 0 { return 0; }
+    return excess;
+}
+
+// Truncate the `drop` low-order digits off a digit string (scale down by 10^drop).
+// The "" no-read / no-prior sentinel is PRESERVED (a missing value must stay
+// missing through scaling — never become "0"). A real value whose every digit is
+// dropped scales to dust "0". Total.
+fn scale_dec(s: string, drop: int) -> string {
+    if len(s) == 0 { return ""; }
+    if drop <= 0 { return s; }
+    if drop >= len(s) { return "0"; }
+    return substring(s, 0, len(s) - drop);
+}
+
+// Parse a SCALED (<= 18-digit) digit string to int; "" -> -1 (the "no reading" /
+// "no prior" sentinel, distinct from a legitimate 0). parse_int is total and,
+// post-scaling, never overflows.
+fn scaled_to_int(s: string) -> int {
+    if len(s) == 0 { return -1; }
+    return parse_int(s);
+}
+
+// Optional integer env fact: "" / non-numeric -> -1 (the "unset" sentinel). Bands
+// (basis points 0..10000) always fit i64, so a bare parse_int is safe here.
 fn opt_int(raw: string) -> int {
     if len(raw) == 0 { return -1; }
     if len(regex_find_all("[^0-9]", raw)) > 0 { return -1; }
@@ -135,10 +192,16 @@ fn opt_int(raw: string) -> int {
 // level FELL from the last reading, normalised by the last (held) reserve so a
 // drain reads as a fraction of what was held. -1 when there is no usable prior
 // reading. An inflow (a rise) yields 0 (a rise is never an outflow).
+// DIVISION-FIRST: a basis-point ratio `(last - level) * 10000 / last` overflows
+// i64 even for an in-range 18-digit `last`, so we compute `unit = last / 10000`
+// (the per-bp magnitude) FIRST and then `diff / unit` — no large multiply, no
+// overflow. A `last` below 10000 (after scaling) is dust: `unit < 1` -> no flag.
 fn outflow_bp(level: int, last: int) -> int {
     if last <= 0 { return -1; }
     if level >= last { return 0; }
-    return ((last - level) * 10000) / last;
+    let unit = last / 10000;
+    if unit < 1 { return 0; }
+    return (last - level) / unit;
 }
 
 fn burst(level: int, last: int, outBp: int) -> bool {
@@ -148,9 +211,10 @@ fn burst(level: int, last: int, outBp: int) -> bool {
     return o > outBp;
 }
 
-// Fuse the level read + prior window into ONE verdict token. A level that could
-// not be read is "no-read"; a net outflow past the band in one window is
-// "outflow-burst"; anything else (an inflow, a hold, or a sub-band drip) is "ok".
+// Fuse the level read + prior window into ONE verdict token, both already SCALED
+// to fit i64. A level that could not be read is "no-read"; a net outflow past the
+// band in one window is "outflow-burst"; anything else (an inflow, a hold, or a
+// sub-band drip) is "ok".
 fn verdict_of(level: int, last: int, outBp: int) -> string {
     if level < 0 { return "no-read"; }
     if burst(level, last, outBp) { return "outflow-burst"; }
@@ -171,12 +235,22 @@ fn is_anomaly(verdict: string) -> bool {
     return false;
 }
 
+// The level / prev reported in the payload: the full (UN-scaled) digit string, or
+// "-1" for a no-read / no-prior (the sentinel, mirroring the sibling watchers'
+// convention). Carried as a JSON STRING because a wei magnitude (>1e18) overflows
+// the JSON number parser downstream (the prospector value-scorer convention).
+fn value_for_json(s: string) -> string {
+    if len(s) == 0 { return "-1"; }
+    return s;
+}
+
 // A compact, deterministic alert payload (JSON). All fields are facts the watcher
 // computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
-fn alert_payload(label: string, verdict: string, level: int, last: int, addr: string, sev: string) -> string {
+// level/prev are the full wei digit strings, quoted (see value_for_json).
+fn alert_payload(label: string, verdict: string, level: string, last: string, addr: string, sev: string) -> string {
     return "{\"watcher\":\"flow\",\"contract\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
-         + "\",\"level\":" + to_string(level) + ",\"prev\":" + to_string(last)
-         + ",\"address\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
+         + "\",\"level\":\"" + value_for_json(level) + "\",\"prev\":\"" + value_for_json(last)
+         + "\",\"address\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
 }
 
 fn tick(reason: string) -> void {
@@ -192,35 +266,44 @@ fn tick(reason: string) -> void {
     let outBand = if outBp < 0 { 0 } else { outBp };
     let label = label_or(getenv("MONITOR_FLOW_LABEL"), addr);
 
-    // Read the current level. The window baseline is the level this watcher
-    // observed on the PREVIOUS tick (durable memo). On the first read there is no
-    // prior level (-1) -> the outflow check is skipped this tick; the current
-    // level becomes the prior for the next window.
-    let level = reading_to_int(read_level(castBin, rpc, addr, sig));
-    let last = opt_int(recall_latest("flow-watcher:last_level:" + addr));
+    // Read the current level as a big-number-safe DIGIT STRING. The window baseline
+    // is the level this watcher observed on the PREVIOUS tick, persisted as the SAME
+    // digit string (so read, prior, and comparison share one representation). On the
+    // first read there is no prior level ("") -> the outflow check is skipped this
+    // tick; the current level becomes the prior for the next window.
+    let levelDec = reading_to_dec(read_level(castBin, rpc, addr, sig));
+    let lastDec = recall_latest("flow-watcher:last_level:" + addr);
+
+    // SCALE both to <= 18 digits by dropping the SAME number of low-order digits
+    // (the ratio is preserved) BEFORE any parse_int, so neither wraps to 0. A
+    // no-read / no-prior ("") yields the -1 sentinel and is never scaled.
+    let drop = excess_digits(levelDec, lastDec);
+    let level = scaled_to_int(scale_dec(levelDec, drop));
+    let last = scaled_to_int(scale_dec(lastDec, drop));
 
     let verdict = verdict_of(level, last, outBand);
     let outcome = outcome_of(verdict);
 
-    print("flow-watcher: " + label + " level=" + to_string(level) + " prev=" + to_string(last)
+    print("flow-watcher: " + label + " level=" + value_for_json(levelDec)
+        + " prev=" + value_for_json(lastDec)
         + " -> " + verdict + " (conf=" + to_string(get_confidence()) + ")");
 
-    // Roll the window: store the latest GOOD level as the prior for next tick (a
-    // no-read leaves the old prior intact). A burst reading STILL rolls forward
-    // AFTER this tick's flag, so one burst pages once and the new level becomes
-    // the next window's baseline.
-    if level >= 0 {
-        memo_write("flow-watcher:last_level:" + addr, to_string(level));
+    // Roll the window: store the latest GOOD level (the full digit string) as the
+    // prior for next tick (a no-read leaves the old prior intact). A burst reading
+    // STILL rolls forward AFTER this tick's flag, so one burst pages once and the
+    // new level becomes the next window's baseline.
+    if len(levelDec) > 0 {
+        memo_write("flow-watcher:last_level:" + addr, levelDec);
     };
 
     let key = label + ":" + addr;
-    let desc = "net flow " + label + " level=" + to_string(level) + " -> " + verdict;
+    let desc = "net flow " + label + " level=" + value_for_json(levelDec) + " -> " + verdict;
     let anomaly = is_anomaly(verdict);
 
     // Post this watcher's latest verdict to the shared blackboard memo the
     // coordinator reads each tick to fuse + dedup signals (a memo write — allowed
     // at every tier, including shadow). Severity is re-decided by the coordinator.
-    memo_write("monitor:signal:flow", alert_payload(label, verdict, level, last, addr, "info"));
+    memo_write("monitor:signal:flow", alert_payload(label, verdict, levelDec, lastDec, addr, "info"));
 
     // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
     // verdict above is unchanged by tier. shadow/dormant fall through to observe.
@@ -229,7 +312,7 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         // Proven reliable -> a DIRECT page on a real anomaly (high severity).
         if anomaly {
-            emit("monitor:alert", alert_payload(label, verdict, level, last, addr, "high"));
+            emit("monitor:alert", alert_payload(label, verdict, levelDec, lastDec, addr, "high"));
             learn("flow-watch", key, desc, outcome, [verdict, outcome, "acted"]);
         } else {
             learn("flow-watch", key, desc, outcome, [verdict, outcome, "observed"]);
@@ -238,7 +321,7 @@ fn tick(reason: string) -> void {
         if my_tier == "review-gated" {
             // Trusted to page under a review gate -> a DIRECT page (high severity).
             if anomaly {
-                emit("monitor:alert", alert_payload(label, verdict, level, last, addr, "high"));
+                emit("monitor:alert", alert_payload(label, verdict, levelDec, lastDec, addr, "high"));
                 learn("flow-watch", key, desc, outcome, [verdict, outcome, "review-gated"]);
             } else {
                 learn("flow-watch", key, desc, outcome, [verdict, outcome, "observed"]);
@@ -247,7 +330,7 @@ fn tick(reason: string) -> void {
             if my_tier == "propose" {
                 // Enough signal to contribute -> a DRAFT alert (low severity).
                 if anomaly {
-                    emit("monitor:alert", alert_payload(label, verdict, level, last, addr, "low"));
+                    emit("monitor:alert", alert_payload(label, verdict, levelDec, lastDec, addr, "low"));
                     learn("flow-watch", key, desc, outcome, [verdict, outcome, "emitted"]);
                 } else {
                     learn("flow-watch", key, desc, outcome, [verdict, outcome, "observed"]);

--- a/dark-factory/monitor/agents/governance-watcher.ag
+++ b/dark-factory/monitor/agents/governance-watcher.ag
@@ -1,0 +1,327 @@
+// governance-watcher.ag — Monitor colony (Dark Factory federation).
+//
+// Watches a protocol's GOVERNANCE / UPGRADE surface for a CHANGE versus the last
+// observed baseline — the highest-value PRE-exploit early-warning a monitor can
+// raise. The classic upgrade-attack tell is the implementation pointer of an
+// EIP-1967 proxy flipping (or the proxy admin / owner rotating) moments before a
+// malicious implementation drains the protocol. This watcher reads:
+//   * the EIP-1967 IMPLEMENTATION slot
+//     (0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc);
+//   * the EIP-1967 ADMIN slot
+//     (0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103);
+//   * an owner()/admin() view when the contract exposes one;
+//   * a timelock-queue indicator + a role-grant indicator when configured.
+// It flags a CHANGE (impl-slot moved / admin moved / owner moved / a new role
+// grant / a pending timelock op) by comparing the current read to a durable
+// baseline memo it learned on a prior tick. NON-custodial / read-only: it only
+// READS chain state via `cast`/RPC over `exec sh` — it never signs a transaction
+// and never touches funds.
+//
+// Same on-chain read pattern + tier-gated emission as invariant-watcher.ag /
+// oracle-watcher.ag. The signal is a FACT (an on-chain read + a deterministic
+// comparison vs the learned baseline), never an LLM opinion. Emission is gated
+// PURELY on the ADR-0001 tier of this agent (the false-positive control):
+//   shadow / dormant -> observe + learn a baseline (record the governance
+//                       state), NO emit (learning the protocol's normal upgrade
+//                       surface before it is trusted to page);
+//   propose          -> emit a DRAFT `monitor:alert` (low severity);
+//   review-gated /    -> emit a DIRECT-page `monitor:alert` (high severity).
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant.
+//
+// Env contract (all read via getenv; exported by scripts/start-colony.sh; add
+// each to exec.env_passthrough in .agentis/config so the sandboxed `exec sh`
+// can read them):
+//   MONITOR_CAST          path to the `cast` binary; "" => no reader, observe only.
+//   MONITOR_RPC_URL       the chain RPC endpoint (read-only).
+//   MONITOR_GOV_TARGET    the governed proxy contract address (0x...); "" =>
+//                         falls back to MONITOR_TARGET (the invariant target).
+//   MONITOR_GOV_OWNER_SIG the `cast call` signature returning the owner/admin
+//                         address (e.g. "owner()" / "admin()"); "" => skip the
+//                         owner check (proxy-slot-only watch).
+//   MONITOR_GOV_ROLE_SIG  a `cast call` signature returning a role-grant
+//                         indicator (e.g. "getRoleMemberCount(bytes32)" wired by
+//                         the operator to a fixed role, or a count view); "" =>
+//                         skip the role-grant check.
+//   MONITOR_GOV_TIMELOCK_SIG a `cast call` signature returning a timelock-queue
+//                         indicator (e.g. a queued-op count / a pending-op id);
+//                         "" => skip the timelock check.
+//   MONITOR_GOV_LABEL     a human label for the target (for the alert body).
+// Emits: "monitor:alert" (the colony bus contract).
+
+cb 90000;
+
+// The two canonical EIP-1967 storage slots. Constants (not env) so the operator
+// cannot mis-wire the standard slots; a non-standard proxy is covered by the
+// owner()/admin() view path instead.
+fn impl_slot() -> string {
+    return "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+}
+
+fn admin_slot() -> string {
+    return "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103";
+}
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("governance-watcher:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- env defaults --------------------------------------------------------------
+fn target_or(raw: string, fallback: string) -> string {
+    if len(raw) > 0 { return raw; }
+    return fallback;
+}
+
+fn label_or(raw: string, addr: string) -> string {
+    if len(raw) > 0 { return raw; }
+    return addr;
+}
+
+// JSON-string escape a free-text field (#1089): backslash -> \\ and double-quote
+// -> \" , so an operator-authored label/address containing a `"` cannot corrupt
+// the alert/signal JSON. Per-char fold (.ag has no string-replace builtin);
+// regex_find_all over [\s\S] yields every char incl. whitespace.
+fn json_escape(s: string) -> string {
+    return reduce(regex_find_all("[\\s\\S]", s), |acc: string, c: string| -> string {
+        if c == "\\" { return acc + "\\\\"; }
+        if c == "\"" { return acc + "\\\""; }
+        return acc + c;
+    }, "");
+}
+
+// --- read a raw storage slot via cast storage ----------------------------------
+// `cast storage --rpc-url <url> <addr> <slot>` prints one 0x-hex word (the slot's
+// contents). EVERY dynamic value (the cast path, the rpc url, the address, the
+// slot) is shell_escape()d — they are all operator/coordinator-supplied facts
+// that flow into a shell, so none may be a bare concat. `set +e` + `|| true` so a
+// transient RPC failure returns "" (no reading -> no false flag) instead of
+// aborting the tick. Returns the 0x-hex word, or "" on any failure / empty reader.
+fn read_slot(castBin: string, rpc: string, addr: string, slot: string) -> string {
+    if len(castBin) == 0 { return ""; }
+    if len(rpc) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    if len(slot) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; " + shell_escape(castBin) + " storage --rpc-url " + shell_escape(rpc)
+            + " " + shell_escape(addr) + " " + shell_escape(slot)
+            + " 2>/dev/null || true";
+    return out;
+}
+
+// --- read a single view return via cast call (owner/role/timelock indicators) --
+// EVERY dynamic value is shell_escape()d. `set +e` + `|| true` so a transient RPC
+// failure (or a contract with no such view) returns "" (no reading -> no false
+// flag). Returns the 0x-hex word cast prints, or "" on any failure / empty reader.
+fn read_view(castBin: string, rpc: string, addr: string, sig: string) -> string {
+    if len(castBin) == 0 { return ""; }
+    if len(rpc) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    if len(sig) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; " + shell_escape(castBin) + " call --rpc-url " + shell_escape(rpc)
+            + " " + shell_escape(addr) + " " + shell_escape(sig)
+            + " 2>/dev/null || true";
+    return out;
+}
+
+// Trim a trailing newline cast leaves on its output, leaving only the first token.
+fn first_token(s: string) -> string {
+    let nl = index_of(s, "\n");
+    if nl < 0 { return s; }
+    return substring(s, 0, nl);
+}
+
+// Normalise a raw cast read to a comparable token: the first whitespace-free
+// token, lowercased so a 0x-hex word compares case-insensitively (cast may render
+// the same word in either case across versions). "" stays "" (the "no read"
+// sentinel). A read that is not a 0x-hex word (e.g. an error string that leaked
+// past `2>/dev/null`) is collapsed to "" so it can never masquerade as a change.
+fn normalize_read(raw: string) -> string {
+    let tok = first_token(raw);
+    if len(tok) == 0 { return ""; }
+    if index_of(tok, "0x") != 0 { return ""; }
+    return to_lower(tok);
+}
+
+// A baseline is "present" once a non-empty value has been recorded for a field.
+// An empty baseline means this field has never been read cleanly -> the FIRST
+// good read seeds it (no change flagged on the seeding tick).
+fn baseline_present(base: string) -> bool {
+    if len(base) == 0 { return false; }
+    return true;
+}
+
+// --- the deterministic CHANGE verdict (a FACT, never an LLM call) --------------
+// A single field "changed" when it has BOTH a present baseline AND a present
+// current read that DIFFERS from the baseline. A missing current read (RPC blind)
+// is NOT a change (no-read -> no false flag); a missing baseline is the seeding
+// case (record, don't flag).
+fn field_changed(base: string, cur: string) -> bool {
+    if !baseline_present(base) { return false; }
+    if len(cur) == 0 { return false; }
+    if cur == base { return false; }
+    return true;
+}
+
+// Could this field be read at all this tick? (Both the configured reader produced
+// a value.) Used to decide whether the WHOLE watch was RPC-blind.
+fn field_readable(cur: string) -> bool {
+    if len(cur) == 0 { return false; }
+    return true;
+}
+
+// Fuse the per-field change flags into ONE verdict token. Precedence: an
+// implementation-pointer flip is the single most dangerous tell (impl-changed);
+// then an admin rotation (admin-changed); then an owner rotation (owner-changed);
+// then a new role grant / a pending timelock op (gov-changed). When nothing
+// changed but at least one field was readable, "ok". When NOTHING was readable
+// this tick, "no-read" (RPC-blind -> the watcher raises no false alarm).
+fn verdict_of(implCh: bool, adminCh: bool, ownerCh: bool, roleCh: bool, tlCh: bool, anyRead: bool) -> string {
+    if implCh { return "impl-changed"; }
+    if adminCh { return "admin-changed"; }
+    if ownerCh { return "owner-changed"; }
+    if roleCh { return "gov-changed"; }
+    if tlCh { return "gov-changed"; }
+    if anyRead { return "ok"; }
+    return "no-read";
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. A clean,
+// unchanged governance surface is a confirmed-healthy observation (success); an
+// impl/admin/owner rotation is the anomaly the watcher exists to catch (failure);
+// a role grant / pending timelock op is a partial (a change worth surfacing, not
+// yet proven hostile); a fully RPC-blind tick is an error (no fact produced).
+fn outcome_of(verdict: string) -> string {
+    if verdict == "ok" { return "success"; }
+    if verdict == "impl-changed" { return "failure"; }
+    if verdict == "admin-changed" { return "failure"; }
+    if verdict == "owner-changed" { return "failure"; }
+    if verdict == "gov-changed" { return "partial"; }
+    return "error";
+}
+
+fn is_anomaly(verdict: string) -> bool {
+    if verdict == "impl-changed" { return true; }
+    if verdict == "admin-changed" { return true; }
+    if verdict == "owner-changed" { return true; }
+    if verdict == "gov-changed" { return true; }
+    return false;
+}
+
+// A compact, deterministic alert payload (JSON). All fields are facts the watcher
+// computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
+fn alert_payload(label: string, verdict: string, addr: string, sev: string) -> string {
+    return "{\"watcher\":\"governance\",\"target\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
+         + "\",\"address\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("governance-watcher:last_check", now);
+
+    let castBin = getenv("MONITOR_CAST");
+    let rpc = getenv("MONITOR_RPC_URL");
+    let addr = target_or(getenv("MONITOR_GOV_TARGET"), getenv("MONITOR_TARGET"));
+    let ownerSig = getenv("MONITOR_GOV_OWNER_SIG");
+    let roleSig = getenv("MONITOR_GOV_ROLE_SIG");
+    let tlSig = getenv("MONITOR_GOV_TIMELOCK_SIG");
+    let label = label_or(getenv("MONITOR_GOV_LABEL"), addr);
+
+    // Read the current governance surface. The two proxy slots are always read;
+    // owner/role/timelock are read only when a signature is configured ("" reader
+    // -> "" read -> that field is simply absent from the watch, never a change).
+    let curImpl = normalize_read(read_slot(castBin, rpc, addr, impl_slot()));
+    let curAdmin = normalize_read(read_slot(castBin, rpc, addr, admin_slot()));
+    let curOwner = if len(ownerSig) > 0 { normalize_read(read_view(castBin, rpc, addr, ownerSig)) } else { "" };
+    let curRole = if len(roleSig) > 0 { normalize_read(read_view(castBin, rpc, addr, roleSig)) } else { "" };
+    let curTl = if len(tlSig) > 0 { normalize_read(read_view(castBin, rpc, addr, tlSig)) } else { "" };
+
+    // The learned baselines (durable per-field memos keyed by address). On the
+    // first read each is "" -> the field is seeded this tick and NOT flagged; the
+    // next tick compares against it.
+    let baseImpl = recall_latest("governance-watcher:baseline:impl:" + addr);
+    let baseAdmin = recall_latest("governance-watcher:baseline:admin:" + addr);
+    let baseOwner = recall_latest("governance-watcher:baseline:owner:" + addr);
+    let baseRole = recall_latest("governance-watcher:baseline:role:" + addr);
+    let baseTl = recall_latest("governance-watcher:baseline:timelock:" + addr);
+
+    // The per-field CHANGE flags (FACTS, never an LLM call), then the fused
+    // verdict. anyRead is the RPC-blind guard: when NO field was readable this
+    // tick the verdict is "no-read" and the watcher stays quiet.
+    let implCh = field_changed(baseImpl, curImpl);
+    let adminCh = field_changed(baseAdmin, curAdmin);
+    let ownerCh = field_changed(baseOwner, curOwner);
+    let roleCh = field_changed(baseRole, curRole);
+    let tlCh = field_changed(baseTl, curTl);
+    let anyRead = if field_readable(curImpl) { true } else { if field_readable(curAdmin) { true } else { if field_readable(curOwner) { true } else { if field_readable(curRole) { true } else { field_readable(curTl) } } } };
+    let verdict = verdict_of(implCh, adminCh, ownerCh, roleCh, tlCh, anyRead);
+    let outcome = outcome_of(verdict);
+
+    print("governance-watcher: " + label + " impl=" + curImpl + " admin=" + curAdmin
+        + " -> " + verdict + " (conf=" + to_string(get_confidence()) + ")");
+
+    // Update each per-field baseline to the latest GOOD read so the next tick
+    // compares against the current surface (a no-read leaves the old baseline
+    // intact; a clean read of a NEW value re-baselines AFTER it has been flagged
+    // this tick, so a one-time rotation pages once and then becomes the new normal).
+    if field_readable(curImpl) { memo_write("governance-watcher:baseline:impl:" + addr, curImpl); };
+    if field_readable(curAdmin) { memo_write("governance-watcher:baseline:admin:" + addr, curAdmin); };
+    if field_readable(curOwner) { memo_write("governance-watcher:baseline:owner:" + addr, curOwner); };
+    if field_readable(curRole) { memo_write("governance-watcher:baseline:role:" + addr, curRole); };
+    if field_readable(curTl) { memo_write("governance-watcher:baseline:timelock:" + addr, curTl); };
+
+    let key = label + ":" + addr;
+    let desc = "governance surface " + label + " -> " + verdict;
+    let anomaly = is_anomaly(verdict);
+
+    // Post this watcher's latest verdict to the shared blackboard memo the
+    // coordinator reads each tick to fuse + dedup signals (a memo write — allowed
+    // at every tier, including shadow). Severity is re-decided by the coordinator.
+    memo_write("monitor:signal:governance", alert_payload(label, verdict, addr, "info"));
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
+    // verdict above is unchanged by tier. shadow/dormant fall through to observe.
+    // (.ag has no `else if`; the tiers nest as `else { if ... { } else { } }`.)
+    let my_tier = tier("governance-watcher");
+    if my_tier == "autonomous" {
+        // Proven reliable -> a DIRECT page on a real anomaly (high severity).
+        if anomaly {
+            emit("monitor:alert", alert_payload(label, verdict, addr, "high"));
+            learn("governance-watch", key, desc, outcome, [verdict, outcome, "acted"]);
+        } else {
+            learn("governance-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+        };
+    } else {
+        if my_tier == "review-gated" {
+            // Trusted to page under a review gate -> a DIRECT page (high severity).
+            if anomaly {
+                emit("monitor:alert", alert_payload(label, verdict, addr, "high"));
+                learn("governance-watch", key, desc, outcome, [verdict, outcome, "review-gated"]);
+            } else {
+                learn("governance-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+            };
+        } else {
+            if my_tier == "propose" {
+                // Enough signal to contribute -> a DRAFT alert (low severity).
+                if anomaly {
+                    emit("monitor:alert", alert_payload(label, verdict, addr, "low"));
+                    learn("governance-watch", key, desc, outcome, [verdict, outcome, "emitted"]);
+                } else {
+                    learn("governance-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+                };
+            } else {
+                // shadow / dormant: learn the baseline ONLY — no emit, no write.
+                learn("governance-watch", key, desc + " (baseline)", outcome, [verdict, outcome, "observed"]);
+                print("governance-watcher: observing (tier: " + my_tier + ") — no emit");
+            };
+        };
+    };
+
+    memo_write("governance-watcher:last_check", to_string(now_ms()));
+}

--- a/dark-factory/monitor/agents/liquidity-watcher.ag
+++ b/dark-factory/monitor/agents/liquidity-watcher.ag
@@ -1,0 +1,266 @@
+// liquidity-watcher.ag — Monitor colony (Dark Factory federation).
+//
+// Watches a pool / vault's RESERVE or TVL PROXY for a sudden DROP beyond a
+// learned band — the canonical drain tell. A liquidity read is a single view
+// call (a 4626 `totalAssets()`, an AMM reserve, or — when no view fits — the
+// contract's native balance via `cast balance`). The watcher compares the
+// current reading to the last good reading (a durable learned baseline) and
+// flags a DROP whose magnitude exceeds MONITOR_LIQ_DROP_BP basis points. A RISE
+// (a deposit) is never an anomaly; only a fall past the band is. NON-custodial /
+// read-only: it only READS chain state via `cast`/RPC over `exec sh` — it never
+// signs a transaction and never touches funds.
+//
+// Same on-chain read pattern + tier-gated emission as invariant-watcher.ag /
+// oracle-watcher.ag. The signal is a FACT (an on-chain read + a deterministic
+// comparison vs the learned baseline), never an LLM opinion. Emission is gated
+// PURELY on the ADR-0001 tier of this agent (the false-positive control):
+//   shadow / dormant -> observe + learn a baseline (record the reserve), NO emit;
+//   propose          -> emit a DRAFT `monitor:alert` (low severity);
+//   review-gated /    -> emit a DIRECT-page `monitor:alert` (high severity).
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant.
+//
+// Env contract (all read via getenv; exported by scripts/start-colony.sh; add
+// each to exec.env_passthrough in .agentis/config so the sandboxed `exec sh`
+// can read them):
+//   MONITOR_CAST          path to the `cast` binary; "" => no reader, observe only.
+//   MONITOR_RPC_URL       the chain RPC endpoint (read-only).
+//   MONITOR_LIQ_TARGET    the pool / vault contract address (0x...); "" => falls
+//                         back to MONITOR_TARGET (the invariant target).
+//   MONITOR_LIQ_SIG       the `cast call` signature returning the reserve / TVL
+//                         proxy (e.g. "totalAssets()" / "getReserves()"); "" =>
+//                         the watcher uses the contract's native `cast balance`
+//                         instead (the ETH-reserve proxy).
+//   MONITOR_LIQ_DROP_BP   the drop band in basis points (0..10000): a fall of
+//                         more than this fraction vs the baseline flags a drain;
+//                         "" => 0 (any drop flags — the most sensitive setting).
+//   MONITOR_LIQ_LABEL     a human label for the pool / vault (for the alert body).
+// Emits: "monitor:alert" (the colony bus contract).
+
+cb 90000;
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("liquidity-watcher:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- env defaults --------------------------------------------------------------
+fn target_or(raw: string, fallback: string) -> string {
+    if len(raw) > 0 { return raw; }
+    return fallback;
+}
+
+fn label_or(raw: string, addr: string) -> string {
+    if len(raw) > 0 { return raw; }
+    return addr;
+}
+
+// JSON-string escape a free-text field (#1089): backslash -> \\ and double-quote
+// -> \" , so an operator-authored label/address containing a `"` cannot corrupt
+// the alert/signal JSON. Per-char fold (.ag has no string-replace builtin).
+fn json_escape(s: string) -> string {
+    return reduce(regex_find_all("[\\s\\S]", s), |acc: string, c: string| -> string {
+        if c == "\\" { return acc + "\\\\"; }
+        if c == "\"" { return acc + "\\\""; }
+        return acc + c;
+    }, "");
+}
+
+// --- read the reserve / TVL proxy ----------------------------------------------
+// When MONITOR_LIQ_SIG is set we read a view via `cast call`; otherwise we read
+// the contract's native balance via `cast balance`. EVERY dynamic value (the cast
+// path, the rpc url, the address, the signature) is shell_escape()d — they are
+// operator/coordinator-supplied facts that flow into a shell, so none may be a
+// bare concat. `set +e` + `|| true` so a transient RPC failure returns "" (no
+// reading -> no false flag) instead of aborting the tick. Returns the decimal
+// string, or "" on any failure / empty reader.
+fn read_view(castBin: string, rpc: string, addr: string, sig: string) -> string {
+    if len(castBin) == 0 { return ""; }
+    if len(rpc) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    if len(sig) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; " + shell_escape(castBin) + " call --rpc-url " + shell_escape(rpc)
+            + " " + shell_escape(addr) + " " + shell_escape(sig)
+            + " 2>/dev/null | " + shell_escape(castBin) + " --to-dec 2>/dev/null || true";
+    return out;
+}
+
+fn read_balance(castBin: string, rpc: string, addr: string) -> string {
+    if len(castBin) == 0 { return ""; }
+    if len(rpc) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; " + shell_escape(castBin) + " balance --rpc-url " + shell_escape(rpc)
+            + " " + shell_escape(addr)
+            + " 2>/dev/null || true";
+    return out;
+}
+
+// Read the reserve: a view when a signature is configured, else the native
+// balance. The chosen source is reflected in the alert body's verdict facts.
+fn read_reserve(castBin: string, rpc: string, addr: string, sig: string) -> string {
+    if len(sig) > 0 {
+        return read_view(castBin, rpc, addr, sig);
+    }
+    return read_balance(castBin, rpc, addr);
+}
+
+// Trim a trailing newline cast leaves on its output, leaving only the first token.
+fn first_token(s: string) -> string {
+    let nl = index_of(s, "\n");
+    if nl < 0 { return s; }
+    return substring(s, 0, nl);
+}
+
+// Parse a decimal reading to an int; empty / non-numeric -> -1 (the "no reading"
+// sentinel, distinct from a legitimate 0). parse_int is total.
+fn reading_to_int(s: string) -> int {
+    let t = first_token(s);
+    if len(t) == 0 { return -1; }
+    if len(regex_find_all("[^0-9]", t)) > 0 { return -1; }
+    return parse_int(t);
+}
+
+// Optional integer env fact: "" / non-numeric -> -1 (the "unset" sentinel).
+fn opt_int(raw: string) -> int {
+    if len(raw) == 0 { return -1; }
+    if len(regex_find_all("[^0-9]", raw)) > 0 { return -1; }
+    return parse_int(raw);
+}
+
+// --- the deterministic DROP verdict (a FACT, never an LLM call) ----------------
+// The drop in basis points of `reserve` vs `base` (positive when reserve FELL).
+// -1 when there is no usable baseline. A rise yields a negative number, mapped to
+// 0 (a rise is never a drop).
+fn drop_bp(reserve: int, base: int) -> int {
+    if base <= 0 { return -1; }
+    if reserve >= base { return 0; }
+    return ((base - reserve) * 10000) / base;
+}
+
+fn drained(reserve: int, base: int, dropBp: int) -> bool {
+    if reserve < 0 { return false; }
+    let d = drop_bp(reserve, base);
+    if d < 0 { return false; }
+    return d > dropBp;
+}
+
+// Fuse the reserve read + baseline into ONE verdict token. A reserve that could
+// not be read is "no-read"; a fall past the band is "drained"; anything else
+// (a rise, a hold, or a sub-band dip) is "ok".
+fn verdict_of(reserve: int, base: int, dropBp: int) -> string {
+    if reserve < 0 { return "no-read"; }
+    if drained(reserve, base, dropBp) { return "drained"; }
+    return "ok";
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. A clean reserve
+// read is a healthy observation (success); a drain past the band is the anomaly
+// the watcher exists to catch (failure); a missing read is error.
+fn outcome_of(verdict: string) -> string {
+    if verdict == "ok" { return "success"; }
+    if verdict == "drained" { return "failure"; }
+    return "error";
+}
+
+fn is_anomaly(verdict: string) -> bool {
+    if verdict == "drained" { return true; }
+    return false;
+}
+
+// A compact, deterministic alert payload (JSON). All fields are facts the watcher
+// computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
+fn alert_payload(label: string, verdict: string, reserve: int, base: int, addr: string, sev: string) -> string {
+    return "{\"watcher\":\"liquidity\",\"pool\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
+         + "\",\"reserve\":" + to_string(reserve) + ",\"baseline\":" + to_string(base)
+         + ",\"address\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("liquidity-watcher:last_check", now);
+
+    let castBin = getenv("MONITOR_CAST");
+    let rpc = getenv("MONITOR_RPC_URL");
+    let addr = target_or(getenv("MONITOR_LIQ_TARGET"), getenv("MONITOR_TARGET"));
+    let sig = getenv("MONITOR_LIQ_SIG");
+    let dropBp = if len(getenv("MONITOR_LIQ_DROP_BP")) > 0 { opt_int(getenv("MONITOR_LIQ_DROP_BP")) } else { 0 };
+    let dropBand = if dropBp < 0 { 0 } else { dropBp };
+    let label = label_or(getenv("MONITOR_LIQ_LABEL"), addr);
+
+    // Read the current reserve / TVL proxy. The DROP baseline is the last reserve
+    // this watcher observed (durable memo). On the first read there is no baseline
+    // (-1) -> the drop check is skipped this tick; the current reserve becomes the
+    // baseline for next time.
+    let reserve = reading_to_int(read_reserve(castBin, rpc, addr, sig));
+    let base = opt_int(recall_latest("liquidity-watcher:baseline:" + addr));
+
+    let verdict = verdict_of(reserve, base, dropBand);
+    let outcome = outcome_of(verdict);
+
+    print("liquidity-watcher: " + label + " reserve=" + to_string(reserve) + " base=" + to_string(base)
+        + " -> " + verdict + " (conf=" + to_string(get_confidence()) + ")");
+
+    // Update the drop baseline to the latest GOOD read so the next tick compares
+    // against a recent reserve (a no-read leaves the old baseline intact). A
+    // drained reading STILL re-baselines AFTER this tick's flag, so a single drain
+    // pages once and the new (lower) reserve becomes the next normal.
+    if reserve >= 0 {
+        memo_write("liquidity-watcher:baseline:" + addr, to_string(reserve));
+    };
+
+    let key = label + ":" + addr;
+    let desc = "pool reserve " + label + " reserve=" + to_string(reserve) + " -> " + verdict;
+    let anomaly = is_anomaly(verdict);
+
+    // Post this watcher's latest verdict to the shared blackboard memo the
+    // coordinator reads each tick to fuse + dedup signals (a memo write — allowed
+    // at every tier, including shadow). Severity is re-decided by the coordinator.
+    memo_write("monitor:signal:liquidity", alert_payload(label, verdict, reserve, base, addr, "info"));
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
+    // verdict above is unchanged by tier. shadow/dormant fall through to observe.
+    // (.ag has no `else if`; the tiers nest as `else { if ... { } else { } }`.)
+    let my_tier = tier("liquidity-watcher");
+    if my_tier == "autonomous" {
+        // Proven reliable -> a DIRECT page on a real anomaly (high severity).
+        if anomaly {
+            emit("monitor:alert", alert_payload(label, verdict, reserve, base, addr, "high"));
+            learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "acted"]);
+        } else {
+            learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+        };
+    } else {
+        if my_tier == "review-gated" {
+            // Trusted to page under a review gate -> a DIRECT page (high severity).
+            if anomaly {
+                emit("monitor:alert", alert_payload(label, verdict, reserve, base, addr, "high"));
+                learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "review-gated"]);
+            } else {
+                learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+            };
+        } else {
+            if my_tier == "propose" {
+                // Enough signal to contribute -> a DRAFT alert (low severity).
+                if anomaly {
+                    emit("monitor:alert", alert_payload(label, verdict, reserve, base, addr, "low"));
+                    learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "emitted"]);
+                } else {
+                    learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+                };
+            } else {
+                // shadow / dormant: learn the baseline ONLY — no emit, no write.
+                learn("liquidity-watch", key, desc + " (baseline)", outcome, [verdict, outcome, "observed"]);
+                print("liquidity-watcher: observing (tier: " + my_tier + ") — no emit");
+            };
+        };
+    };
+
+    memo_write("liquidity-watcher:last_check", to_string(now_ms()));
+}

--- a/dark-factory/monitor/agents/liquidity-watcher.ag
+++ b/dark-factory/monitor/agents/liquidity-watcher.ag
@@ -117,16 +117,73 @@ fn first_token(s: string) -> string {
     return substring(s, 0, nl);
 }
 
-// Parse a decimal reading to an int; empty / non-numeric -> -1 (the "no reading"
-// sentinel, distinct from a legitimate 0). parse_int is total.
-fn reading_to_int(s: string) -> int {
-    let t = first_token(s);
-    if len(t) == 0 { return -1; }
-    if len(regex_find_all("[^0-9]", t)) > 0 { return -1; }
-    return parse_int(t);
+// --- big-number-safe wei handling (NO bare parse_int on the raw reading) -------
+// A realistic reserve / TVL is in wei: 1000 ETH = 1e21, far beyond the i64 range
+// (~9.2e18, ≈ 9.22 ETH at 18 dp) parse_int can hold — parse_int SATURATES such a
+// value to 0, so a 1000-ETH vault used to baseline at 0 and a real drain read as
+// "ok". The reading + baseline are therefore kept as DECIMAL STRINGS and, when
+// they exceed 18 digits, SCALED DOWN by truncating the same number of low-order
+// digits from BOTH (the ratio is preserved) BEFORE any parse_int — so every
+// parse_int below operates on a value guaranteed to fit i64. (#1095.)
+
+// Strip leading zeros from a digit string, leaving at least one digit ("0").
+fn strip_leading_zeros(s: string) -> string {
+    let kept = reduce(regex_find_all("[0-9]", s), |acc: string, d: string| -> string {
+        if len(acc) > 0 { return acc + d; }
+        if d == "0" { return acc; }
+        return d;
+    }, "");
+    if len(kept) == 0 { return "0"; }
+    return kept;
 }
 
-// Optional integer env fact: "" / non-numeric -> -1 (the "unset" sentinel).
+// Normalise a raw decimal reading to a clean digit string (leading zeros stripped).
+// "" / non-numeric -> "" (the "no reading" sentinel, distinct from a legitimate
+// "0"). Total. Mirrors prospector/value-scorer.ag's reading_to_dec.
+fn reading_to_dec(s: string) -> string {
+    let t = first_token(s);
+    if len(t) == 0 { return ""; }
+    if len(regex_find_all("[^0-9]", t)) > 0 { return ""; }
+    return strip_leading_zeros(t);
+}
+
+// The most significant digits a scaled value may keep so parse_int never wraps:
+// i64 max is 19 digits (9223372036854775807); 18 digits (<1e18) always fits.
+fn max_safe_digits() -> int {
+    return 18;
+}
+
+// How many low-order digits must be dropped so BOTH `a` and `b` fit i64: the
+// excess of the LONGER string over max_safe_digits(), clamped to >= 0. The SAME
+// drop is applied to both, so the drop_bp ratio is preserved.
+fn excess_digits(a: string, b: string) -> int {
+    let longest = if len(a) > len(b) { len(a) } else { len(b) };
+    let excess = longest - max_safe_digits();
+    if excess < 0 { return 0; }
+    return excess;
+}
+
+// Truncate the `drop` low-order digits off a digit string (scale down by 10^drop).
+// The "" no-read / no-baseline sentinel is PRESERVED (a missing value must stay
+// missing through scaling — never become "0"). A real value whose every digit is
+// dropped scales to dust "0". Total.
+fn scale_dec(s: string, drop: int) -> string {
+    if len(s) == 0 { return ""; }
+    if drop <= 0 { return s; }
+    if drop >= len(s) { return "0"; }
+    return substring(s, 0, len(s) - drop);
+}
+
+// Parse a SCALED (<= 18-digit) digit string to int; "" -> -1 (the "no reading" /
+// "no baseline" sentinel, distinct from a legitimate 0). parse_int is total and,
+// post-scaling, never overflows.
+fn scaled_to_int(s: string) -> int {
+    if len(s) == 0 { return -1; }
+    return parse_int(s);
+}
+
+// Optional integer env fact: "" / non-numeric -> -1 (the "unset" sentinel). Bands
+// (basis points 0..10000) always fit i64, so a bare parse_int is safe here.
 fn opt_int(raw: string) -> int {
     if len(raw) == 0 { return -1; }
     if len(regex_find_all("[^0-9]", raw)) > 0 { return -1; }
@@ -135,12 +192,17 @@ fn opt_int(raw: string) -> int {
 
 // --- the deterministic DROP verdict (a FACT, never an LLM call) ----------------
 // The drop in basis points of `reserve` vs `base` (positive when reserve FELL).
-// -1 when there is no usable baseline. A rise yields a negative number, mapped to
-// 0 (a rise is never a drop).
+// -1 when there is no usable baseline. A rise yields 0 (a rise is never a drop).
+// DIVISION-FIRST: a basis-point ratio `(base - reserve) * 10000 / base` overflows
+// i64 even for an in-range 18-digit base, so we compute `unit = base / 10000`
+// (the per-bp magnitude) FIRST and then `diff / unit` — no large multiply, no
+// overflow. A base below 10000 (after scaling) is dust: `unit < 1` -> no drop.
 fn drop_bp(reserve: int, base: int) -> int {
     if base <= 0 { return -1; }
     if reserve >= base { return 0; }
-    return ((base - reserve) * 10000) / base;
+    let unit = base / 10000;
+    if unit < 1 { return 0; }
+    return (base - reserve) / unit;
 }
 
 fn drained(reserve: int, base: int, dropBp: int) -> bool {
@@ -150,9 +212,9 @@ fn drained(reserve: int, base: int, dropBp: int) -> bool {
     return d > dropBp;
 }
 
-// Fuse the reserve read + baseline into ONE verdict token. A reserve that could
-// not be read is "no-read"; a fall past the band is "drained"; anything else
-// (a rise, a hold, or a sub-band dip) is "ok".
+// Fuse the reserve read + baseline into ONE verdict token, both already SCALED to
+// fit i64. A reserve that could not be read is "no-read"; a fall past the band is
+// "drained"; anything else (a rise, a hold, or a sub-band dip) is "ok".
 fn verdict_of(reserve: int, base: int, dropBp: int) -> string {
     if reserve < 0 { return "no-read"; }
     if drained(reserve, base, dropBp) { return "drained"; }
@@ -173,12 +235,23 @@ fn is_anomaly(verdict: string) -> bool {
     return false;
 }
 
+// The reserve / baseline reported in the payload: the full (UN-scaled) digit
+// string, or "-1" for a no-read / no-baseline (the sentinel, mirroring the sibling
+// watchers' convention). Carried as a JSON STRING because a wei magnitude (>1e18)
+// overflows the JSON number parser downstream (the prospector value-scorer
+// convention).
+fn value_for_json(s: string) -> string {
+    if len(s) == 0 { return "-1"; }
+    return s;
+}
+
 // A compact, deterministic alert payload (JSON). All fields are facts the watcher
 // computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
-fn alert_payload(label: string, verdict: string, reserve: int, base: int, addr: string, sev: string) -> string {
+// reserve/baseline are the full wei digit strings, quoted (see value_for_json).
+fn alert_payload(label: string, verdict: string, reserve: string, base: string, addr: string, sev: string) -> string {
     return "{\"watcher\":\"liquidity\",\"pool\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
-         + "\",\"reserve\":" + to_string(reserve) + ",\"baseline\":" + to_string(base)
-         + ",\"address\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
+         + "\",\"reserve\":\"" + value_for_json(reserve) + "\",\"baseline\":\"" + value_for_json(base)
+         + "\",\"address\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
 }
 
 fn tick(reason: string) -> void {
@@ -194,35 +267,45 @@ fn tick(reason: string) -> void {
     let dropBand = if dropBp < 0 { 0 } else { dropBp };
     let label = label_or(getenv("MONITOR_LIQ_LABEL"), addr);
 
-    // Read the current reserve / TVL proxy. The DROP baseline is the last reserve
-    // this watcher observed (durable memo). On the first read there is no baseline
-    // (-1) -> the drop check is skipped this tick; the current reserve becomes the
-    // baseline for next time.
-    let reserve = reading_to_int(read_reserve(castBin, rpc, addr, sig));
-    let base = opt_int(recall_latest("liquidity-watcher:baseline:" + addr));
+    // Read the current reserve / TVL proxy as a big-number-safe DIGIT STRING. The
+    // DROP baseline is the last reserve this watcher observed, persisted as the SAME
+    // digit string (so read, baseline, and comparison share one representation). On
+    // the first read there is no baseline ("") -> the drop check is skipped this
+    // tick; the current reserve becomes the baseline for next time.
+    let reserveDec = reading_to_dec(read_reserve(castBin, rpc, addr, sig));
+    let baseDec = recall_latest("liquidity-watcher:baseline:" + addr);
+
+    // SCALE both to <= 18 digits by dropping the SAME number of low-order digits
+    // (the ratio is preserved) BEFORE any parse_int, so neither wraps to 0. A
+    // no-read / no-baseline ("") yields the -1 sentinel and is never scaled.
+    let drop = excess_digits(reserveDec, baseDec);
+    let reserve = scaled_to_int(scale_dec(reserveDec, drop));
+    let base = scaled_to_int(scale_dec(baseDec, drop));
 
     let verdict = verdict_of(reserve, base, dropBand);
     let outcome = outcome_of(verdict);
 
-    print("liquidity-watcher: " + label + " reserve=" + to_string(reserve) + " base=" + to_string(base)
+    print("liquidity-watcher: " + label + " reserve=" + value_for_json(reserveDec)
+        + " base=" + value_for_json(baseDec)
         + " -> " + verdict + " (conf=" + to_string(get_confidence()) + ")");
 
-    // Update the drop baseline to the latest GOOD read so the next tick compares
-    // against a recent reserve (a no-read leaves the old baseline intact). A
-    // drained reading STILL re-baselines AFTER this tick's flag, so a single drain
-    // pages once and the new (lower) reserve becomes the next normal.
-    if reserve >= 0 {
-        memo_write("liquidity-watcher:baseline:" + addr, to_string(reserve));
+    // Update the drop baseline to the latest GOOD read (the full digit string) so
+    // the next tick compares against a recent reserve (a no-read leaves the old
+    // baseline intact). A drained reading STILL re-baselines AFTER this tick's flag,
+    // so a single drain pages once and the new (lower) reserve becomes the next
+    // normal.
+    if len(reserveDec) > 0 {
+        memo_write("liquidity-watcher:baseline:" + addr, reserveDec);
     };
 
     let key = label + ":" + addr;
-    let desc = "pool reserve " + label + " reserve=" + to_string(reserve) + " -> " + verdict;
+    let desc = "pool reserve " + label + " reserve=" + value_for_json(reserveDec) + " -> " + verdict;
     let anomaly = is_anomaly(verdict);
 
     // Post this watcher's latest verdict to the shared blackboard memo the
     // coordinator reads each tick to fuse + dedup signals (a memo write — allowed
     // at every tier, including shadow). Severity is re-decided by the coordinator.
-    memo_write("monitor:signal:liquidity", alert_payload(label, verdict, reserve, base, addr, "info"));
+    memo_write("monitor:signal:liquidity", alert_payload(label, verdict, reserveDec, baseDec, addr, "info"));
 
     // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
     // verdict above is unchanged by tier. shadow/dormant fall through to observe.
@@ -231,7 +314,7 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         // Proven reliable -> a DIRECT page on a real anomaly (high severity).
         if anomaly {
-            emit("monitor:alert", alert_payload(label, verdict, reserve, base, addr, "high"));
+            emit("monitor:alert", alert_payload(label, verdict, reserveDec, baseDec, addr, "high"));
             learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "acted"]);
         } else {
             learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "observed"]);
@@ -240,7 +323,7 @@ fn tick(reason: string) -> void {
         if my_tier == "review-gated" {
             // Trusted to page under a review gate -> a DIRECT page (high severity).
             if anomaly {
-                emit("monitor:alert", alert_payload(label, verdict, reserve, base, addr, "high"));
+                emit("monitor:alert", alert_payload(label, verdict, reserveDec, baseDec, addr, "high"));
                 learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "review-gated"]);
             } else {
                 learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "observed"]);
@@ -249,7 +332,7 @@ fn tick(reason: string) -> void {
             if my_tier == "propose" {
                 // Enough signal to contribute -> a DRAFT alert (low severity).
                 if anomaly {
-                    emit("monitor:alert", alert_payload(label, verdict, reserve, base, addr, "low"));
+                    emit("monitor:alert", alert_payload(label, verdict, reserveDec, baseDec, addr, "low"));
                     learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "emitted"]);
                 } else {
                     learn("liquidity-watch", key, desc, outcome, [verdict, outcome, "observed"]);

--- a/dark-factory/monitor/agents/pause-state-watcher.ag
+++ b/dark-factory/monitor/agents/pause-state-watcher.ag
@@ -1,0 +1,235 @@
+// pause-state-watcher.ag — Monitor colony (Dark Factory federation).
+//
+// Watches a protocol's CIRCUIT-BREAKER / PAUSE state for a TRANSITION. A
+// protocol pausing ITSELF (or a guardian pausing it) is signal: it usually means
+// the team detected something wrong, often moments before — or during — an
+// incident. The watcher reads a `paused()` (or equivalent circuit-breaker)
+// boolean each tick and flags a CHANGE versus the last observed state (a learned
+// baseline): an unpause→pause is the high-value tell (the protocol just tripped
+// its breaker), an pause→unpause is a recovery worth surfacing too. NON-custodial
+// / read-only: it only READS chain state via `cast`/RPC over `exec sh` — it never
+// signs a transaction and never touches funds.
+//
+// Same on-chain read pattern + tier-gated emission as the sibling watchers. The
+// signal is a FACT (an on-chain read + a deterministic comparison vs the learned
+// baseline), never an LLM opinion. Emission is gated PURELY on the ADR-0001 tier
+// of this agent (the false-positive control):
+//   shadow / dormant -> observe + learn a baseline (record the state), NO emit;
+//   propose          -> emit a DRAFT `monitor:alert` (low severity);
+//   review-gated /    -> emit a DIRECT-page `monitor:alert` (high severity).
+//   autonomous
+// One tier() call per tick, branch once, fall through to shadow/dormant.
+//
+// Env contract (all read via getenv; exported by scripts/start-colony.sh; add
+// each to exec.env_passthrough in .agentis/config so the sandboxed `exec sh`
+// can read them):
+//   MONITOR_CAST          path to the `cast` binary; "" => no reader, observe only.
+//   MONITOR_RPC_URL       the chain RPC endpoint (read-only).
+//   MONITOR_PAUSE_TARGET  the watched contract address (0x...); "" => falls back
+//                         to MONITOR_TARGET (the invariant target).
+//   MONITOR_PAUSE_SIG     the `cast call` signature returning the pause /
+//                         circuit-breaker boolean (e.g. "paused()"); "" =>
+//                         default "paused()".
+//   MONITOR_PAUSE_LABEL   a human label for the contract (for the alert body).
+// Emits: "monitor:alert" (the colony bus contract).
+
+cb 90000;
+
+// --- diagnostic confidence read (logging only; tier() gates behaviour) ---------
+fn get_confidence() -> float {
+    let raw = recall_latest("pause-state-watcher:confidence");
+    if len(raw) > 0 {
+        return parse_float(raw);
+    }
+    return 0.0;
+}
+
+// --- env defaults --------------------------------------------------------------
+fn target_or(raw: string, fallback: string) -> string {
+    if len(raw) > 0 { return raw; }
+    return fallback;
+}
+
+fn pause_sig_or_default(raw: string) -> string {
+    if len(raw) == 0 { return "paused()"; }
+    return raw;
+}
+
+fn label_or(raw: string, addr: string) -> string {
+    if len(raw) > 0 { return raw; }
+    return addr;
+}
+
+// JSON-string escape a free-text field (#1089): backslash -> \\ and double-quote
+// -> \" , so an operator-authored label/address containing a `"` cannot corrupt
+// the alert/signal JSON. Per-char fold (.ag has no string-replace builtin).
+fn json_escape(s: string) -> string {
+    return reduce(regex_find_all("[\\s\\S]", s), |acc: string, c: string| -> string {
+        if c == "\\" { return acc + "\\\\"; }
+        if c == "\"" { return acc + "\\\""; }
+        return acc + c;
+    }, "");
+}
+
+// --- read the pause boolean via cast call --------------------------------------
+// `cast call <addr> paused()` prints one 0x-hex word (32-byte ABI bool). EVERY
+// dynamic value (the cast path, the rpc url, the address, the signature) is
+// shell_escape()d — they are operator/coordinator-supplied facts flowing into a
+// shell, so none may be a bare concat. `set +e` + `|| true` so a transient RPC
+// failure returns "" (no reading -> no false flag). Returns the 0x-hex word, or
+// "" on any failure / empty reader.
+fn read_view(castBin: string, rpc: string, addr: string, sig: string) -> string {
+    if len(castBin) == 0 { return ""; }
+    if len(rpc) == 0 { return ""; }
+    if len(addr) == 0 { return ""; }
+    if len(sig) == 0 { return ""; }
+    // colony-lint: safe-exec-concat
+    let out = exec sh "set +e; " + shell_escape(castBin) + " call --rpc-url " + shell_escape(rpc)
+            + " " + shell_escape(addr) + " " + shell_escape(sig)
+            + " 2>/dev/null || true";
+    return out;
+}
+
+// Trim a trailing newline cast leaves on its output, leaving only the first token.
+fn first_token(s: string) -> string {
+    let nl = index_of(s, "\n");
+    if nl < 0 { return s; }
+    return substring(s, 0, nl);
+}
+
+// Decode the raw ABI bool word to a state token: any 0x word whose last digit is
+// non-zero is "paused"; an all-zero word is "active"; an empty / non-hex read is
+// "" (the "no read" sentinel). Comparing the FULL word would be brittle across
+// cast's zero-padding widths, so the verdict keys on the canonical token.
+fn decode_bool(raw: string) -> string {
+    let tok = first_token(raw);
+    if len(tok) == 0 { return ""; }
+    if index_of(tok, "0x") != 0 { return ""; }
+    if len(regex_find_all("[1-9a-fA-F]", tok)) > 0 { return "paused"; }
+    return "active";
+}
+
+// A baseline is "present" once a non-empty state has been recorded.
+fn baseline_present(base: string) -> bool {
+    if len(base) == 0 { return false; }
+    return true;
+}
+
+// --- the deterministic TRANSITION verdict (a FACT, never an LLM call) ----------
+// "no-read" when the state could not be read (RPC-blind -> no false flag). When
+// there is no baseline yet, the FIRST good read seeds it -> "ok" (no transition
+// flagged on the seeding tick). An unpause->pause is "paused" (the high-value
+// tell); a pause->unpause is "unpaused" (a recovery, also surfaced); an unchanged
+// state is "ok".
+fn verdict_of(cur: string, base: string) -> string {
+    if len(cur) == 0 { return "no-read"; }
+    if !baseline_present(base) { return "ok"; }
+    if cur == base { return "ok"; }
+    if cur == "paused" { return "paused"; }
+    return "unpaused";
+}
+
+// learn() outcome enum {success,failure,partial,timeout,error}. An unchanged
+// state is a healthy observation (success); a fresh pause is the anomaly the
+// watcher exists to catch (failure); an unpause is a partial (a recovery worth
+// surfacing, not itself an incident); a missing read is error.
+fn outcome_of(verdict: string) -> string {
+    if verdict == "ok" { return "success"; }
+    if verdict == "paused" { return "failure"; }
+    if verdict == "unpaused" { return "partial"; }
+    return "error";
+}
+
+fn is_anomaly(verdict: string) -> bool {
+    if verdict == "paused" { return true; }
+    if verdict == "unpaused" { return true; }
+    return false;
+}
+
+// A compact, deterministic alert payload (JSON). All fields are facts the watcher
+// computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
+fn alert_payload(label: string, verdict: string, state: string, addr: string, sev: string) -> string {
+    return "{\"watcher\":\"pause\",\"contract\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
+         + "\",\"state\":\"" + state + "\",\"address\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
+}
+
+fn tick(reason: string) -> void {
+    let now = to_string(now_ms());
+    // Heartbeat first (dashboard memo-freshness probe) even on an early return.
+    memo_write("pause-state-watcher:last_check", now);
+
+    let castBin = getenv("MONITOR_CAST");
+    let rpc = getenv("MONITOR_RPC_URL");
+    let addr = target_or(getenv("MONITOR_PAUSE_TARGET"), getenv("MONITOR_TARGET"));
+    let sig = pause_sig_or_default(getenv("MONITOR_PAUSE_SIG"));
+    let label = label_or(getenv("MONITOR_PAUSE_LABEL"), addr);
+
+    // Read the current pause state. The baseline is the last state this watcher
+    // observed (durable memo). On the first read there is no baseline ("") -> the
+    // state is seeded this tick and NOT flagged; the next tick compares against it.
+    let cur = decode_bool(read_view(castBin, rpc, addr, sig));
+    let base = recall_latest("pause-state-watcher:baseline:" + addr);
+
+    let verdict = verdict_of(cur, base);
+    let outcome = outcome_of(verdict);
+
+    print("pause-state-watcher: " + label + " state=" + cur + " base=" + base
+        + " -> " + verdict + " (conf=" + to_string(get_confidence()) + ")");
+
+    // Update the baseline to the latest GOOD read so the next tick compares
+    // against the current state (a no-read leaves the old baseline intact). A
+    // transition STILL re-baselines AFTER this tick's flag, so one transition
+    // pages once and the new state becomes the next normal.
+    if len(cur) > 0 {
+        memo_write("pause-state-watcher:baseline:" + addr, cur);
+    };
+
+    let key = label + ":" + addr;
+    let desc = "pause state " + label + " state=" + cur + " -> " + verdict;
+    let anomaly = is_anomaly(verdict);
+
+    // Post this watcher's latest verdict to the shared blackboard memo the
+    // coordinator reads each tick to fuse + dedup signals (a memo write — allowed
+    // at every tier, including shadow). Severity is re-decided by the coordinator.
+    memo_write("monitor:signal:pause", alert_payload(label, verdict, cur, addr, "info"));
+
+    // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
+    // verdict above is unchanged by tier. shadow/dormant fall through to observe.
+    // (.ag has no `else if`; the tiers nest as `else { if ... { } else { } }`.)
+    let my_tier = tier("pause-state-watcher");
+    if my_tier == "autonomous" {
+        // Proven reliable -> a DIRECT page on a real anomaly (high severity).
+        if anomaly {
+            emit("monitor:alert", alert_payload(label, verdict, cur, addr, "high"));
+            learn("pause-state-watch", key, desc, outcome, [verdict, outcome, "acted"]);
+        } else {
+            learn("pause-state-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+        };
+    } else {
+        if my_tier == "review-gated" {
+            // Trusted to page under a review gate -> a DIRECT page (high severity).
+            if anomaly {
+                emit("monitor:alert", alert_payload(label, verdict, cur, addr, "high"));
+                learn("pause-state-watch", key, desc, outcome, [verdict, outcome, "review-gated"]);
+            } else {
+                learn("pause-state-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+            };
+        } else {
+            if my_tier == "propose" {
+                // Enough signal to contribute -> a DRAFT alert (low severity).
+                if anomaly {
+                    emit("monitor:alert", alert_payload(label, verdict, cur, addr, "low"));
+                    learn("pause-state-watch", key, desc, outcome, [verdict, outcome, "emitted"]);
+                } else {
+                    learn("pause-state-watch", key, desc, outcome, [verdict, outcome, "observed"]);
+                };
+            } else {
+                // shadow / dormant: learn the baseline ONLY — no emit, no write.
+                learn("pause-state-watch", key, desc + " (baseline)", outcome, [verdict, outcome, "observed"]);
+                print("pause-state-watcher: observing (tier: " + my_tier + ") — no emit");
+            };
+        };
+    };
+
+    memo_write("pause-state-watcher:last_check", to_string(now_ms()));
+}

--- a/dark-factory/monitor/config/colony.example.toml
+++ b/dark-factory/monitor/config/colony.example.toml
@@ -47,6 +47,40 @@ source = "agents/oracle-watcher.ag"
 cb_budget = 90000
 tick_interval_ms = 60000
 
+# Watches the governance / upgrade surface (EIP-1967 impl + admin slots,
+# owner/admin view, role grants, timelock queue) and flags a CHANGE vs the
+# learned baseline — the highest-value pre-exploit early-warning. Posts
+# monitor:signal:governance.
+[[agents]]
+name = "governance-watcher"
+source = "agents/governance-watcher.ag"
+cb_budget = 90000
+tick_interval_ms = 60000
+
+# Watches a pool / vault reserve or TVL proxy and flags a drop beyond a learned
+# band (sudden drain). Posts monitor:signal:liquidity.
+[[agents]]
+name = "liquidity-watcher"
+source = "agents/liquidity-watcher.ag"
+cb_budget = 90000
+tick_interval_ms = 60000
+
+# Watches net flow over a window and flags an abnormal outflow burst vs the
+# previous window. Posts monitor:signal:flow.
+[[agents]]
+name = "flow-watcher"
+source = "agents/flow-watcher.ag"
+cb_budget = 90000
+tick_interval_ms = 60000
+
+# Watches the paused() / circuit-breaker boolean and flags a state transition
+# (a protocol pausing itself is signal). Posts monitor:signal:pause.
+[[agents]]
+name = "pause-state-watcher"
+source = "agents/pause-state-watcher.ag"
+cb_budget = 90000
+tick_interval_ms = 60000
+
 # Fuses the watcher signals, dedups, decides severity, and emits one
 # consolidated monitor:alert. Reads the monitor:signal:* blackboard.
 [[agents]]
@@ -109,6 +143,38 @@ tick_interval_ms = 60000
 #   MONITOR_ORACLE_MIN      lower sanity bound on the price; "" => no lower bound.
 #   MONITOR_ORACLE_MAX      upper sanity bound on the price; "" => no upper bound.
 #   MONITOR_ORACLE_LABEL    a human label for the feed (alert body).
+#
+# governance-watcher (#1095) — flags a CHANGE vs the learned baseline:
+#   MONITOR_GOV_TARGET      the governed proxy address (0x...); "" => MONITOR_TARGET.
+#   MONITOR_GOV_OWNER_SIG   cast-call signature returning the owner/admin address
+#                           (e.g. "owner()" / "admin()"); "" => skip the owner check
+#                           (the two EIP-1967 proxy slots are always watched).
+#   MONITOR_GOV_ROLE_SIG    cast-call signature returning a role-grant indicator
+#                           (e.g. a member count for a fixed role); "" => skip.
+#   MONITOR_GOV_TIMELOCK_SIG cast-call signature returning a timelock-queue
+#                           indicator (queued-op count / pending-op id); "" => skip.
+#   MONITOR_GOV_LABEL       a human label for the target (alert body).
+#
+# liquidity-watcher (#1096) — flags a reserve / TVL drop past a learned band:
+#   MONITOR_LIQ_TARGET      the pool / vault address (0x...); "" => MONITOR_TARGET.
+#   MONITOR_LIQ_SIG         cast-call signature for the reserve / TVL proxy
+#                           (e.g. "totalAssets()"); "" => native `cast balance`.
+#   MONITOR_LIQ_DROP_BP     drop band in basis points (0..10000); "" => 0 (any drop).
+#   MONITOR_LIQ_LABEL       a human label for the pool / vault (alert body).
+#
+# flow-watcher (#1096) — flags an abnormal net outflow burst over a window:
+#   MONITOR_FLOW_TARGET     the watched address (0x...); "" => MONITOR_TARGET.
+#   MONITOR_FLOW_SIG        cast-call signature for the level proxy (e.g.
+#                           "totalAssets()"); "" => native `cast balance`.
+#   MONITOR_FLOW_OUT_BP     per-window outflow band in basis points (0..10000);
+#                           "" => 0 (any net outflow).
+#   MONITOR_FLOW_LABEL      a human label for the contract (alert body).
+#
+# pause-state-watcher (#1096) — flags a paused() / circuit-breaker transition:
+#   MONITOR_PAUSE_TARGET    the watched address (0x...); "" => MONITOR_TARGET.
+#   MONITOR_PAUSE_SIG       cast-call signature returning the pause boolean;
+#                           "" => default "paused()".
+#   MONITOR_PAUSE_LABEL     a human label for the contract (alert body).
 #
 # Alert delivery — the bus->webhook bridge (notifier; #1092/#1093/#1094):
 #   MONITOR_WEBHOOK_URL     a Discord/Slack incoming-webhook URL. When set,

--- a/dark-factory/monitor/scripts/start-colony.sh
+++ b/dark-factory/monitor/scripts/start-colony.sh
@@ -5,9 +5,10 @@
 #   ./scripts/start-colony.sh [path/to/colony.toml]
 #   ./scripts/start-colony.sh --restart-agent <name> [path/to/colony.toml]
 #
-# The monitor colony runs four long-lived daemons (invariant-watcher,
-# oracle-watcher, coordinator, notifier) that continuously WATCH a target EVM
-# protocol and emit reasoned anomaly alerts on the bus (`monitor:alert`); the
+# The monitor colony runs eight long-lived daemons (invariant-watcher,
+# oracle-watcher, governance-watcher, liquidity-watcher, flow-watcher,
+# pause-state-watcher, coordinator, notifier) that continuously WATCH a target
+# EVM protocol and emit reasoned anomaly alerts on the bus (`monitor:alert`); the
 # notifier (#1092) forwards each alert to scripts/notify.sh so a page is actually
 # DELIVERED, and owns the liveness heartbeat + dead-man's switch (#1093).
 # NON-custodial / read-only: the watchers only READ chain state via `cast`/RPC
@@ -28,6 +29,11 @@
 #   MONITOR_TARGET MONITOR_INV_LHS_SIG MONITOR_INV_RHS_SIG ...    (single invariant)
 #   MONITOR_INV_SPEC                                              (derived invariant set, #1086)
 #   MONITOR_ORACLE MONITOR_ORACLE_PRICE_SIG MONITOR_ORACLE_TS_SIG (oracle)
+#   MONITOR_GOV_TARGET MONITOR_GOV_OWNER_SIG MONITOR_GOV_ROLE_SIG (governance, #1095)
+#   MONITOR_GOV_TIMELOCK_SIG MONITOR_GOV_LABEL                    (governance, #1095)
+#   MONITOR_LIQ_TARGET MONITOR_LIQ_SIG MONITOR_LIQ_DROP_BP ...    (liquidity, #1096)
+#   MONITOR_FLOW_TARGET MONITOR_FLOW_SIG MONITOR_FLOW_OUT_BP ...  (flow, #1096)
+#   MONITOR_PAUSE_TARGET MONITOR_PAUSE_SIG MONITOR_PAUSE_LABEL    (pause-state, #1096)
 #   MONITOR_WEBHOOK_URL[/_WARN/_HIGH]                             (notify.sh sink + routing)
 #   MONITOR_HEARTBEAT_INTERVAL_S MONITOR_DEADMAN_WINDOW_S         (notifier liveness)
 #   MONITOR_NOTIFY_MAX_RETRIES MONITOR_NOTIFY_BACKOFF_S ...       (notify.sh hardening)
@@ -113,6 +119,26 @@ MONITOR_ORACLE_DEV_BP="${MONITOR_ORACLE_DEV_BP:-}"
 MONITOR_ORACLE_MIN="${MONITOR_ORACLE_MIN:-}"
 MONITOR_ORACLE_MAX="${MONITOR_ORACLE_MAX:-}"
 MONITOR_ORACLE_LABEL="${MONITOR_ORACLE_LABEL:-}"
+# governance-watcher (#1095) — flags a CHANGE vs the learned baseline.
+MONITOR_GOV_TARGET="${MONITOR_GOV_TARGET:-}"
+MONITOR_GOV_OWNER_SIG="${MONITOR_GOV_OWNER_SIG:-}"
+MONITOR_GOV_ROLE_SIG="${MONITOR_GOV_ROLE_SIG:-}"
+MONITOR_GOV_TIMELOCK_SIG="${MONITOR_GOV_TIMELOCK_SIG:-}"
+MONITOR_GOV_LABEL="${MONITOR_GOV_LABEL:-}"
+# liquidity-watcher (#1096) — flags a reserve / TVL drop past a learned band.
+MONITOR_LIQ_TARGET="${MONITOR_LIQ_TARGET:-}"
+MONITOR_LIQ_SIG="${MONITOR_LIQ_SIG:-}"
+MONITOR_LIQ_DROP_BP="${MONITOR_LIQ_DROP_BP:-}"
+MONITOR_LIQ_LABEL="${MONITOR_LIQ_LABEL:-}"
+# flow-watcher (#1096) — flags an abnormal net outflow burst over a window.
+MONITOR_FLOW_TARGET="${MONITOR_FLOW_TARGET:-}"
+MONITOR_FLOW_SIG="${MONITOR_FLOW_SIG:-}"
+MONITOR_FLOW_OUT_BP="${MONITOR_FLOW_OUT_BP:-}"
+MONITOR_FLOW_LABEL="${MONITOR_FLOW_LABEL:-}"
+# pause-state-watcher (#1096) — flags a paused() / circuit-breaker transition.
+MONITOR_PAUSE_TARGET="${MONITOR_PAUSE_TARGET:-}"
+MONITOR_PAUSE_SIG="${MONITOR_PAUSE_SIG:-}"
+MONITOR_PAUSE_LABEL="${MONITOR_PAUSE_LABEL:-}"
 MONITOR_WEBHOOK_URL="${MONITOR_WEBHOOK_URL:-}"
 # Alert delivery (notifier #1092 / #1093 / notify.sh hardening #1094). All
 # optional; unset preserves the single-webhook stdout-fallback behaviour.
@@ -131,6 +157,11 @@ export MONITOR_TARGET MONITOR_INV_LHS_SIG MONITOR_INV_RHS_SIG MONITOR_INV_RHS_CO
 export MONITOR_INV_REL MONITOR_INV_MARGIN_BP MONITOR_INV_LABEL MONITOR_INV_SPEC
 export MONITOR_ORACLE MONITOR_ORACLE_PRICE_SIG MONITOR_ORACLE_TS_SIG MONITOR_ORACLE_MAX_AGE
 export MONITOR_ORACLE_DEV_BP MONITOR_ORACLE_MIN MONITOR_ORACLE_MAX MONITOR_ORACLE_LABEL
+export MONITOR_GOV_TARGET MONITOR_GOV_OWNER_SIG MONITOR_GOV_ROLE_SIG
+export MONITOR_GOV_TIMELOCK_SIG MONITOR_GOV_LABEL
+export MONITOR_LIQ_TARGET MONITOR_LIQ_SIG MONITOR_LIQ_DROP_BP MONITOR_LIQ_LABEL
+export MONITOR_FLOW_TARGET MONITOR_FLOW_SIG MONITOR_FLOW_OUT_BP MONITOR_FLOW_LABEL
+export MONITOR_PAUSE_TARGET MONITOR_PAUSE_SIG MONITOR_PAUSE_LABEL
 export MONITOR_WEBHOOK_URL MONITOR_WEBHOOK_URL_WARN MONITOR_WEBHOOK_URL_HIGH
 export MONITOR_HEARTBEAT_INTERVAL_S MONITOR_DEADMAN_WINDOW_S
 export MONITOR_NOTIFY_MAX_RETRIES MONITOR_NOTIFY_BACKOFF_S
@@ -139,16 +170,24 @@ export MONITOR_NOTIFY_DEDUP_COOLDOWN_S MONITOR_NOTIFY_STATE_DIR
 AGENTS=(
     invariant-watcher
     oracle-watcher
+    governance-watcher
+    liquidity-watcher
+    flow-watcher
+    pause-state-watcher
     coordinator
     notifier
 )
 
 # Per-agent tick interval. The watchers + coordinator all run at 60000ms by
-# default; MONITOR_TICK_MS overrides all three for faster/slower polling.
+# default; MONITOR_TICK_MS overrides them all for faster/slower polling.
 tick_interval_for() {
     case "$1" in
         invariant-watcher) echo "${MONITOR_TICK_MS:-60000}" ;;
         oracle-watcher) echo "${MONITOR_TICK_MS:-60000}" ;;
+        governance-watcher) echo "${MONITOR_TICK_MS:-60000}" ;;
+        liquidity-watcher) echo "${MONITOR_TICK_MS:-60000}" ;;
+        flow-watcher) echo "${MONITOR_TICK_MS:-60000}" ;;
+        pause-state-watcher) echo "${MONITOR_TICK_MS:-60000}" ;;
         coordinator) echo "${MONITOR_TICK_MS:-60000}" ;;
         notifier) echo "${MONITOR_TICK_MS:-60000}" ;;
         *) echo 60000 ;;


### PR DESCRIPTION
Four new read-only, **non-custodial** tier-gated watchers feeding the monitor coordinator blackboard (same pattern as invariant/oracle watchers; `cast call` only):

- **governance-watcher.ag** (#1095) — EIP-1967 implementation slot / admin / owner / role-grant change vs baseline (the highest-value pre-exploit early warning) → `monitor:signal:governance`.
- **liquidity-watcher.ag** (#1096) — reserve/TVL drop beyond a learned band → `monitor:signal:liquidity`.
- **flow-watcher.ag** (#1096) — abnormal net out/in over a window vs baseline → `monitor:signal:flow`.
- **pause-state-watcher.ag** (#1096) — `paused()` / circuit-breaker state transition → `monitor:signal:pause`.

Coordinator fuses the new signal kinds into severity + dossier; `config/colony.example.toml` + `start-colony.sh` register all four + their `MONITOR_*` env; README + CHANGELOG updated. Each: one `tier()`/tick, `cb`==budget, `last_check` start+end, baseline via durable memo, degrade-safe, all `exec sh` dynamics `shell_escape()`d.

## Validation
`./tools/colony-lint.sh` → **409 passed, 0 failed, 5 skipped**.

Closes #1095. Closes #1096.

🤖 Generated with [Claude Code](https://claude.com/claude-code)