### PR TITLE
fix(dark-factory): big-number-safe invariant + oracle watchers (#1109)

### DIFF
--- a/dark-factory/CHANGELOG.md
+++ b/dark-factory/CHANGELOG.md
@@ -129,6 +129,33 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   never signs and never touches funds.
 
 ### Fixed
+- **monitor: big-number-safe wei handling in `invariant-watcher` / `oracle-watcher`** (#1109). The two CORE
+  watchers still read on-chain quantities through a bare `parse_int`, which SATURATES any value above i64 max
+  (9223372036854775807 ≈ 9.22 ETH at 18 dp) to `0`. `invariant-watcher` reads solvency-grade magnitudes like
+  `totalAssets()` / `totalSupply()` (a real $100M vault ≈ 1e26 wei), so BOTH sides read as `0`,
+  `verdict_of(0, 0, ge)` returned `ok`, and the watcher reported EVERY real protocol healthy regardless of true
+  state — solvency-blind on essentially every live target (confirmed: `parse_int("176142539498998091993593571")
+  = 0`). The margin band `(|lhs - rhs|) * 10000 / rhs` separately overflowed i64 for any in-range 18-digit side.
+  `oracle-watcher` shared the same `reading_to_int` + `(diff * 10000) / base` deviation pattern (mostly escaping
+  for 8-dp prices, but unsafe for large / high-decimal feeds). Both watchers now mirror the proven #1095 /
+  liquidity-watcher / value-scorer idiom: read each side as a validated DECIMAL STRING (`reading_to_dec` /
+  strip-leading-zeros / digits-only validate / `""` no-read sentinel); SCALE >18-digit values down by truncating
+  the same number of low-order digits from BOTH (the relation / ratio is preserved; the `""` sentinel survives
+  scaling, so cold-start and RPC-blind ticks never false-fire or divide by zero) BEFORE any `parse_int`; and
+  compute the basis-point margin / deviation DIVISION-FIRST (`unit = rhs / 10000`; `gap_bp = diff / unit`) so
+  there is no large multiply to overflow. `oracle-watcher`'s sanity BOUNDS now compare the un-scaled price
+  digit-string against MIN/MAX with the big-decimal comparator (exact for high-decimal feeds). The
+  single-invariant `tick()` path, the `MONITOR_INV_SPEC` multi-invariant SET path (`spec_verdict` / `fuse_set`),
+  and the alert/signal payloads (which now carry the full magnitudes as quoted JSON strings, like
+  liquidity-watcher's `value_for_json`) are all big-number-safe. Everything else is preserved: one `tier()` per
+  tick + branch once, `cb 90000`, `<agent>:last_check` at tick start + end, `shell_escape()` on every `exec sh`
+  value, the `cast-read.sh` / `MONITOR_CAST_READ` failover read path, the no-read (`""` / `-1`) and cold-start
+  sentinels → no false flag, non-custodial read-only. Verified via `agentis repl` with real 1e26 magnitudes: a
+  solvent vault (`totalAssets = 176142539498998091993593571` ≥ `totalSupply = 149658545051669083717603536`, rel
+  `ge`) now yields `ok` (was a false `0`-based `ok`), the same magnitude underwater (assets < shares) yields
+  `violated` (was a false `ok`), a thin-margin case yields `margin`, and cold-start (`-1`) / no-read (`""`) yield
+  no flag and no div-by-zero; `oracle-watcher` flags a 5% move on an 18-dp feed as `deviation` (`dev_bp = 500`,
+  was blind) and bounds-violations on high-decimal feeds as `bounds`.
 - **monitor: big-number-safe wei handling in `liquidity-watcher` / `flow-watcher`** (#1095, #1096). Both
   watchers read an on-chain reserve / level (a TVL proxy in wei) and fed it through a bare `parse_int`, which
   SATURATES any value above i64 max (9223372036854775807 ≈ 9.22 ETH at 18 dp) to `0` — so a 1000-ETH vault

--- a/dark-factory/monitor/agents/invariant-watcher.ag
+++ b/dark-factory/monitor/agents/invariant-watcher.ag
@@ -153,37 +153,113 @@ fn first_token(s: string) -> string {
     return substring(s, 0, nl);
 }
 
-// Parse a decimal reading to an int; an empty / non-numeric reading -> -1 (the
-// "no reading" sentinel, distinct from a legitimate 0). parse_int is total.
-fn reading_to_int(s: string) -> int {
-    let t = first_token(s);
-    if len(t) == 0 { return -1; }
-    if len(regex_find_all("[^0-9]", t)) > 0 { return -1; }
-    return parse_int(t);
+// --- big-number-safe wei handling (NO bare parse_int on the raw reading) -------
+// A realistic on-chain quantity is in wei: a $100M vault's totalAssets() ≈ 1e26,
+// far beyond the i64 range (~9.2e18, ≈ 9.22 ETH at 18 dp) parse_int can hold —
+// parse_int SATURATES such a value to 0, so totalAssets() and totalSupply() BOTH
+// read as 0, verdict_of(0,0,ge) returns "ok", and the watcher reported every real
+// protocol healthy regardless of true state (solvency-blind). The two invariant
+// sides are therefore kept as DECIMAL STRINGS and, when they exceed 18 digits,
+// SCALED DOWN by truncating the SAME number of low-order digits from BOTH (the
+// relation / ratio is preserved) BEFORE any parse_int — so every parse_int below
+// operates on a value guaranteed to fit i64. Mirrors the proven liquidity-watcher
+// / flow-watcher / prospector value-scorer idiom. (#1109.)
+
+// Strip leading zeros from a digit string, leaving at least one digit ("0").
+fn strip_leading_zeros(s: string) -> string {
+    let kept = reduce(regex_find_all("[0-9]", s), |acc: string, d: string| -> string {
+        if len(acc) > 0 { return acc + d; }
+        if d == "0" { return acc; }
+        return d;
+    }, "");
+    if len(kept) == 0 { return "0"; }
+    return kept;
 }
 
-// Resolve the RHS quantity: a live read of RHS_SIG when present, else the literal
-// MONITOR_INV_RHS_CONST. Returns -1 when neither yields a numeric value.
-fn resolve_rhs(castBin: string, rpc: string, addr: string, rhsSig: string, rhsConst: string) -> int {
+// Normalise a raw decimal reading to a clean digit string (leading zeros stripped).
+// "" / non-numeric -> "" (the "no reading" sentinel, distinct from a legitimate
+// "0"). Total. Mirrors prospector/value-scorer.ag's reading_to_dec.
+fn reading_to_dec(s: string) -> string {
+    let t = first_token(s);
+    if len(t) == 0 { return ""; }
+    if len(regex_find_all("[^0-9]", t)) > 0 { return ""; }
+    return strip_leading_zeros(t);
+}
+
+// The most significant digits a scaled value may keep so parse_int never wraps:
+// i64 max is 19 digits (9223372036854775807); 18 digits (<1e18) always fits.
+fn max_safe_digits() -> int {
+    return 18;
+}
+
+// How many low-order digits must be dropped so BOTH `a` and `b` fit i64: the
+// excess of the LONGER string over max_safe_digits(), clamped to >= 0. The SAME
+// drop is applied to both, so the relation / margin-bp ratio is preserved.
+fn excess_digits(a: string, b: string) -> int {
+    let longest = if len(a) > len(b) { len(a) } else { len(b) };
+    let excess = longest - max_safe_digits();
+    if excess < 0 { return 0; }
+    return excess;
+}
+
+// Truncate the `drop` low-order digits off a digit string (scale down by 10^drop).
+// The "" no-read sentinel is PRESERVED (a missing value must stay missing through
+// scaling — never become "0"). A real value whose every digit is dropped scales to
+// dust "0". Total.
+fn scale_dec(s: string, drop: int) -> string {
+    if len(s) == 0 { return ""; }
+    if drop <= 0 { return s; }
+    if drop >= len(s) { return "0"; }
+    return substring(s, 0, len(s) - drop);
+}
+
+// Parse a SCALED (<= 18-digit) digit string to int; "" -> -1 (the "no reading"
+// sentinel, distinct from a legitimate 0). parse_int is total and, post-scaling,
+// never overflows.
+fn scaled_to_int(s: string) -> int {
+    if len(s) == 0 { return -1; }
+    return parse_int(s);
+}
+
+// Resolve the RHS quantity as a big-number-safe DIGIT STRING: a live read of
+// RHS_SIG when present, else the literal MONITOR_INV_RHS_CONST. Returns "" (the
+// "no reading" sentinel) when neither yields a numeric value.
+fn resolve_rhs_dec(castBin: string, rpc: string, addr: string, rhsSig: string, rhsConst: string) -> string {
     if len(rhsSig) > 0 {
-        return reading_to_int(read_uint(castBin, rpc, addr, rhsSig));
+        return reading_to_dec(read_uint(castBin, rpc, addr, rhsSig));
     }
-    if len(rhsConst) == 0 { return -1; }
-    if len(regex_find_all("[^0-9]", rhsConst)) > 0 { return -1; }
-    return parse_int(rhsConst);
+    if len(rhsConst) == 0 { return ""; }
+    if len(regex_find_all("[^0-9]", rhsConst)) > 0 { return ""; }
+    return strip_leading_zeros(rhsConst);
+}
+
+// margin_bp may be absent / non-numeric (=> 0). A basis-point band (0..10000)
+// always fits i64, so a bare parse_int is safe here. "" / non-numeric -> 0.
+fn margin_int(raw: string) -> int {
+    if len(raw) == 0 { return 0; }
+    if len(regex_find_all("[^0-9]", raw)) > 0 { return 0; }
+    return parse_int(raw);
 }
 
 // --- the deterministic invariant verdict (a FACT, never an LLM call) -----------
 // "violated" when the required relation does NOT hold; "margin" when it holds but
 // the gap is within MONITOR_INV_MARGIN_BP basis points of flipping; "ok" when it
-// holds comfortably; "no-read" when either side could not be read.
+// holds comfortably; "no-read" when either side could not be read. lhs/rhs are
+// already SCALED to fit i64 (the same drop applied to both, so the relation +
+// margin ratio are preserved).
 fn within_margin(lhs: int, rhs: int, rel: string, marginBp: int) -> bool {
     if marginBp <= 0 { return false; }
     if rhs <= 0 { return false; }
-    // gap_bp = |lhs - rhs| * 10000 / rhs ; flag when the holding side is within
-    // marginBp of equality (the point the relation flips).
+    // gap_bp = |lhs - rhs| / (rhs / 10000) ; flag when the holding side is within
+    // marginBp of equality (the point the relation flips). DIVISION-FIRST: a
+    // `|lhs - rhs| * 10000 / rhs` ratio overflows i64 even for an in-range 18-digit
+    // rhs, so we compute `unit = rhs / 10000` (the per-bp magnitude) FIRST and then
+    // `diff / unit` — no large multiply, no overflow. An rhs below 10000 (after
+    // scaling) is dust: `unit < 1` -> treat as within margin (a tiny denominator).
     let diff = if lhs >= rhs { lhs - rhs } else { rhs - lhs };
-    let gapBp = (diff * 10000) / rhs;
+    let unit = rhs / 10000;
+    if unit < 1 { return true; }
+    let gapBp = diff / unit;
     return gapBp <= marginBp;
 }
 
@@ -220,11 +296,22 @@ fn is_anomaly(verdict: string) -> bool {
     return false;
 }
 
+// The lhs / rhs reported in the payload: the full (UN-scaled) digit string, or
+// "-1" for a no-read (the sentinel, mirroring the sibling watchers' convention).
+// Carried as a JSON STRING because a wei magnitude (>1e18) overflows the JSON
+// number parser downstream (the prospector value-scorer / liquidity-watcher
+// convention).
+fn value_for_json(s: string) -> string {
+    if len(s) == 0 { return "-1"; }
+    return s;
+}
+
 // A compact, deterministic alert payload (JSON). All fields are facts the watcher
 // computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
-fn alert_payload(label: string, verdict: string, lhs: int, rhs: int, rel: string, addr: string, sev: string) -> string {
+// lhs/rhs are the full (UN-scaled) wei digit strings, quoted (see value_for_json).
+fn alert_payload(label: string, verdict: string, lhs: string, rhs: string, rel: string, addr: string, sev: string) -> string {
     return "{\"watcher\":\"invariant\",\"invariant\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
-         + "\",\"lhs\":" + to_string(lhs) + ",\"rhs\":" + to_string(rhs) + ",\"rel\":\"" + rel
+         + "\",\"lhs\":\"" + value_for_json(lhs) + "\",\"rhs\":\"" + value_for_json(rhs) + "\",\"rel\":\"" + rel
          + "\",\"target\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
 }
 
@@ -271,25 +358,29 @@ fn spec_field(spec: string, i: int, field: string) -> string {
     return v;
 }
 
-// margin_bp may be absent (=> 0) or non-numeric (=> 0); reading_to_int is total.
+// margin_bp may be absent (=> 0) or non-numeric (=> 0); margin_int is total. A
+// basis-point band always fits i64, so no scaling is needed.
 fn spec_margin(spec: string, i: int) -> int {
-    let raw = spec_field(spec, i, "margin_bp");
-    if len(raw) == 0 { return 0; }
-    return reading_to_int(raw);
+    return margin_int(spec_field(spec, i, "margin_bp"));
 }
 
 // The per-invariant LIVE verdict for the i-th entry: read LHS (always a sig), read
-// RHS (a sig when rhs_sig is present, else the rhs_const literal), then the SAME
-// deterministic verdict_of() the single-invariant path uses. A FACT, never an LLM
-// call. rel "" defaults to "le" via rel_or_default, matching the env path.
+// RHS (a sig when rhs_sig is present, else the rhs_const literal) — BOTH as
+// big-number-safe DIGIT STRINGS — SCALE both down by the SAME drop so neither wraps
+// to 0, then the SAME deterministic verdict_of() the single-invariant path uses. A
+// FACT, never an LLM call. rel "" defaults to "le" via rel_or_default, matching the
+// env path.
 fn spec_verdict(castBin: string, rpc: string, addr: string, spec: string, i: int) -> string {
     let lhsSig = spec_field(spec, i, "lhs_sig");
     let rhsSig = spec_field(spec, i, "rhs_sig");
     let rhsConst = spec_field(spec, i, "rhs_const");
     let rel = rel_or_default(spec_field(spec, i, "rel"));
     let marginBp = spec_margin(spec, i);
-    let lhs = reading_to_int(read_uint(castBin, rpc, addr, lhsSig));
-    let rhs = resolve_rhs(castBin, rpc, addr, rhsSig, rhsConst);
+    let lhsDec = reading_to_dec(read_uint(castBin, rpc, addr, lhsSig));
+    let rhsDec = resolve_rhs_dec(castBin, rpc, addr, rhsSig, rhsConst);
+    let drop = excess_digits(lhsDec, rhsDec);
+    let lhs = scaled_to_int(scale_dec(lhsDec, drop));
+    let rhs = scaled_to_int(scale_dec(rhsDec, drop));
     return verdict_of(lhs, rhs, rel, marginBp);
 }
 
@@ -389,8 +480,7 @@ fn tick(reason: string) -> void {
     let lhsSig = getenv("MONITOR_INV_LHS_SIG");
     let rhsSig = getenv("MONITOR_INV_RHS_SIG");
     let rhsConst = getenv("MONITOR_INV_RHS_CONST");
-    let marginRaw = getenv("MONITOR_INV_MARGIN_BP");
-    let marginBp = if len(marginRaw) > 0 { reading_to_int(marginRaw) } else { 0 };
+    let marginBp = margin_int(getenv("MONITOR_INV_MARGIN_BP"));
 
     // The relation reported in the alert body. The SET fuses many relations, so the
     // fused body reports "set"; the env path reports its single configured relation.
@@ -405,13 +495,25 @@ fn tick(reason: string) -> void {
         label_or_sig(getenv("MONITOR_INV_LABEL"), lhsSig)
     };
 
+    // Read the two invariant sides as big-number-safe DIGIT STRINGS (env path only;
+    // on the SET path each member is read inside fuse_set()). A no-read yields the ""
+    // sentinel. lhs/rhs are only meaningful on the env path; on the SET path they are
+    // the "no single pair" sentinel "".
+    let lhsDec = if useSet { "" } else { reading_to_dec(read_uint(castBin, rpc, addr, lhsSig)) };
+    let rhsDec = if useSet { "" } else { resolve_rhs_dec(castBin, rpc, addr, rhsSig, rhsConst) };
+
+    // SCALE both to <= 18 digits by dropping the SAME number of low-order digits
+    // (the relation + margin ratio are preserved) BEFORE any parse_int, so a 1e26
+    // totalAssets()/totalSupply() never wraps to 0. A no-read ("") yields the -1
+    // sentinel and is never scaled.
+    let drop = excess_digits(lhsDec, rhsDec);
+    let lhs = scaled_to_int(scale_dec(lhsDec, drop));
+    let rhs = scaled_to_int(scale_dec(rhsDec, drop));
+
     // The VERDICT (a FACT, never an LLM call). SET path: the fused (worst) verdict
     // across every member, with each member ALSO posted to its own per-invariant
     // blackboard signal inside fuse_set(). Env path: the single deterministic
-    // verdict over the two configured sides. lhs/rhs are only meaningful on the env
-    // path; on the SET path they are the "no single pair" sentinel -1.
-    let lhs = if useSet { -1 } else { reading_to_int(read_uint(castBin, rpc, addr, lhsSig)) };
-    let rhs = if useSet { -1 } else { resolve_rhs(castBin, rpc, addr, rhsSig, rhsConst) };
+    // verdict over the two SCALED configured sides.
     let verdict = if useSet {
         fuse_set(castBin, rpc, addr, spec, 0, spec_max(), "no-read")
     } else {
@@ -420,7 +522,7 @@ fn tick(reason: string) -> void {
     let outcome = outcome_of(verdict);
 
     print("invariant-watcher: " + label + " " + rel + " -> " + verdict
-        + " (lhs=" + to_string(lhs) + " rhs=" + to_string(rhs) + ", conf=" + to_string(get_confidence()) + ")");
+        + " (lhs=" + value_for_json(lhsDec) + " rhs=" + value_for_json(rhsDec) + ", conf=" + to_string(get_confidence()) + ")");
 
     let key = label + ":" + addr;
     let desc = "on-chain invariant " + label + " " + rel + " -> " + verdict;
@@ -432,8 +534,9 @@ fn tick(reason: string) -> void {
     // fact JSON the emit carries, with a neutral severity the coordinator re-decides
     // on fusion. The per-invariant signals (monitor:signal:invariant:<label>) are
     // posted inside fuse_set(); this fused signal stays the single fact the existing
-    // coordinator already consumes (backward-compatible).
-    memo_write("monitor:signal:invariant", alert_payload(label, verdict, lhs, rhs, rel, addr, "info"));
+    // coordinator already consumes (backward-compatible). lhs/rhs carry the full
+    // (UN-scaled) wei magnitudes as quoted JSON strings.
+    memo_write("monitor:signal:invariant", alert_payload(label, verdict, lhsDec, rhsDec, rel, addr, "info"));
 
     // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only; the
     // verdict above is unchanged by tier. shadow/dormant fall through to observe.
@@ -442,7 +545,7 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         // Proven reliable -> a DIRECT page on a real anomaly (high severity).
         if anomaly {
-            emit("monitor:alert", alert_payload(label, verdict, lhs, rhs, rel, addr, "high"));
+            emit("monitor:alert", alert_payload(label, verdict, lhsDec, rhsDec, rel, addr, "high"));
             learn("invariant-watch", key, desc, outcome, [verdict, outcome, "acted"]);
         } else {
             learn("invariant-watch", key, desc, outcome, [verdict, outcome, "observed"]);
@@ -451,7 +554,7 @@ fn tick(reason: string) -> void {
         if my_tier == "review-gated" {
             // Trusted to page under a review gate -> a DIRECT page (high severity).
             if anomaly {
-                emit("monitor:alert", alert_payload(label, verdict, lhs, rhs, rel, addr, "high"));
+                emit("monitor:alert", alert_payload(label, verdict, lhsDec, rhsDec, rel, addr, "high"));
                 learn("invariant-watch", key, desc, outcome, [verdict, outcome, "review-gated"]);
             } else {
                 learn("invariant-watch", key, desc, outcome, [verdict, outcome, "observed"]);
@@ -460,7 +563,7 @@ fn tick(reason: string) -> void {
             if my_tier == "propose" {
                 // Enough signal to contribute -> a DRAFT alert (low severity).
                 if anomaly {
-                    emit("monitor:alert", alert_payload(label, verdict, lhs, rhs, rel, addr, "low"));
+                    emit("monitor:alert", alert_payload(label, verdict, lhsDec, rhsDec, rel, addr, "low"));
                     learn("invariant-watch", key, desc, outcome, [verdict, outcome, "emitted"]);
                 } else {
                     learn("invariant-watch", key, desc, outcome, [verdict, outcome, "observed"]);

--- a/dark-factory/monitor/agents/oracle-watcher.ag
+++ b/dark-factory/monitor/agents/oracle-watcher.ag
@@ -121,7 +121,9 @@ fn first_token(s: string) -> string {
 }
 
 // Parse a decimal reading to an int; empty / non-numeric -> -1 (the "no reading"
-// sentinel, distinct from a legitimate 0). parse_int is total.
+// sentinel, distinct from a legitimate 0). parse_int is total. Used for the feed's
+// last-update unix TIMESTAMP only (a unix ts ~1.7e9 always fits i64); the PRICE
+// goes through the big-number-safe digit-string path below.
 fn reading_to_int(s: string) -> int {
     let t = first_token(s);
     if len(t) == 0 { return -1; }
@@ -129,19 +131,125 @@ fn reading_to_int(s: string) -> int {
     return parse_int(t);
 }
 
-// Optional integer env fact: "" / non-numeric -> -1 (the "unset" sentinel).
+// Optional integer env fact: "" / non-numeric -> -1 (the "unset" sentinel). Bands
+// (basis points 0..10000) + max-age seconds always fit i64, so a bare parse_int is
+// safe here. The price BOUNDS (MIN/MAX) go through the digit-string path instead.
 fn opt_int(raw: string) -> int {
     if len(raw) == 0 { return -1; }
     if len(regex_find_all("[^0-9]", raw)) > 0 { return -1; }
     return parse_int(raw);
 }
 
+// --- big-number-safe wei handling (NO bare parse_int on the price reading) ------
+// A high-decimal feed can report a price beyond the i64 range (~9.2e18, ≈ 9.22 ETH
+// at 18 dp) — parse_int SATURATES such a value to 0, so two large prices both read
+// as 0 and a real deviation reads as `ok`, and the basis-point ratio
+// `(diff * 10000) / base` separately overflows i64 even for an in-range 18-digit
+// base. The price + deviation baseline + sanity bounds are therefore kept as
+// DECIMAL STRINGS and, for the deviation ratio, SCALED DOWN by truncating the same
+// number of low-order digits from BOTH (the ratio is preserved) BEFORE any
+// parse_int. Mirrors the proven liquidity-watcher / value-scorer idiom. (#1109.)
+
+// Strip leading zeros from a digit string, leaving at least one digit ("0").
+fn strip_leading_zeros(s: string) -> string {
+    let kept = reduce(regex_find_all("[0-9]", s), |acc: string, d: string| -> string {
+        if len(acc) > 0 { return acc + d; }
+        if d == "0" { return acc; }
+        return d;
+    }, "");
+    if len(kept) == 0 { return "0"; }
+    return kept;
+}
+
+// Normalise a raw decimal reading to a clean digit string (leading zeros stripped).
+// "" / non-numeric -> "" (the "no reading" sentinel, distinct from a legitimate
+// "0"). Total. Mirrors prospector/value-scorer.ag's reading_to_dec.
+fn reading_to_dec(s: string) -> string {
+    let t = first_token(s);
+    if len(t) == 0 { return ""; }
+    if len(regex_find_all("[^0-9]", t)) > 0 { return ""; }
+    return strip_leading_zeros(t);
+}
+
+// An optional digit-string env fact (a price bound): "" / non-numeric -> "" (the
+// "unset" / "no bound" sentinel). Total.
+fn opt_dec(raw: string) -> string {
+    if len(raw) == 0 { return ""; }
+    if len(regex_find_all("[^0-9]", raw)) > 0 { return ""; }
+    return strip_leading_zeros(raw);
+}
+
+// The most significant digits a scaled value may keep so parse_int never wraps:
+// i64 max is 19 digits (9223372036854775807); 18 digits (<1e18) always fits.
+fn max_safe_digits() -> int {
+    return 18;
+}
+
+// How many low-order digits must be dropped so BOTH `a` and `b` fit i64: the
+// excess of the LONGER string over max_safe_digits(), clamped to >= 0. The SAME
+// drop is applied to both, so the deviation-bp ratio is preserved.
+fn excess_digits(a: string, b: string) -> int {
+    let longest = if len(a) > len(b) { len(a) } else { len(b) };
+    let excess = longest - max_safe_digits();
+    if excess < 0 { return 0; }
+    return excess;
+}
+
+// Truncate the `drop` low-order digits off a digit string (scale down by 10^drop).
+// The "" no-read / no-baseline sentinel is PRESERVED (a missing value must stay
+// missing through scaling — never become "0"). Total.
+fn scale_dec(s: string, drop: int) -> string {
+    if len(s) == 0 { return ""; }
+    if drop <= 0 { return s; }
+    if drop >= len(s) { return "0"; }
+    return substring(s, 0, len(s) - drop);
+}
+
+// Parse a SCALED (<= 18-digit) digit string to int; "" -> -1 (the "no reading" /
+// "no baseline" sentinel, distinct from a legitimate 0). parse_int is total and,
+// post-scaling, never overflows.
+fn scaled_to_int(s: string) -> int {
+    if len(s) == 0 { return -1; }
+    return parse_int(s);
+}
+
+// --- big-decimal comparison (for the price-vs-bound sanity check) ---------------
+// The runtime's `>=` does not accept strings, so a big-decimal compare is open-coded
+// over single digits (the value-scorer idiom): a longer normalised string is the
+// larger number; equal length compares DIGIT-WISE from the most-significant end.
+fn digit_rank(c: string) -> int {
+    return index_of("0123456789", c);
+}
+
+fn same_len_ge(a: string, b: string, i: int) -> bool {
+    if i >= len(a) { return true; }
+    let da = digit_rank(substring(a, i, i + 1));
+    let db = digit_rank(substring(b, i, i + 1));
+    if da > db { return true; }
+    if da < db { return false; }
+    return same_len_ge(a, b, i + 1);
+}
+
+// Big-decimal `a >= b` over two normalised (no-leading-zero) digit strings. Total.
+fn dec_ge(a: string, b: string) -> bool {
+    if len(a) > len(b) { return true; }
+    if len(a) < len(b) { return false; }
+    return same_len_ge(a, b, 0);
+}
+
 // --- deterministic deviation / staleness / bounds verdicts (FACTS) -------------
-// Deviation in basis points of `price` vs `base`; -1 when no usable baseline.
+// Deviation in basis points of `price` vs `base`, both already SCALED to fit i64;
+// -1 when no usable baseline. DIVISION-FIRST: a `diff * 10000 / base` ratio
+// overflows i64 even for an in-range 18-digit base, so we compute `unit =
+// base / 10000` (the per-bp magnitude) FIRST and then `diff / unit` — no large
+// multiply, no overflow. A base below 10000 (after scaling) is dust: `unit < 1`
+// -> no deviation flag.
 fn deviation_bp(price: int, base: int) -> int {
     if base <= 0 { return -1; }
     let diff = if price >= base { price - base } else { base - price };
-    return (diff * 10000) / base;
+    let unit = base / 10000;
+    if unit < 1 { return 0; }
+    return diff / unit;
 }
 
 fn deviates(price: int, base: int, devBp: int) -> bool {
@@ -158,22 +266,28 @@ fn is_stale(updatedAt: int, nowSec: int, maxAge: int) -> bool {
     return (nowSec - updatedAt) > maxAge;
 }
 
-fn out_of_bounds(price: int, lo: int, hi: int) -> bool {
-    if lo >= 0 {
-        if price < lo { return true; }
+// Bounds check on the FULL (UN-scaled) price digit string vs the operator MIN/MAX
+// digit strings (big-decimal compare, never parse_int — a high-decimal price
+// overflows i64). "" lo/hi => that side is unbounded. price "" (no read) never
+// flags here (the no-read precedence handles it in verdict_of). price < lo is
+// `!dec_ge(price, lo)`; price > hi is `!dec_ge(hi, price)`.
+fn out_of_bounds(price: string, lo: string, hi: string) -> bool {
+    if len(price) == 0 { return false; }
+    if len(lo) > 0 {
+        if !dec_ge(price, lo) { return true; }
     }
-    if hi >= 0 {
-        if price > hi { return true; }
+    if len(hi) > 0 {
+        if !dec_ge(hi, price) { return true; }
     }
     return false;
 }
 
 // Fuse the three checks into ONE verdict token. Precedence: a price that could
-// not be read is "no-read"; then bounds (hard sanity), staleness, deviation; a
-// clean read is "ok".
-fn verdict_of(price: int, base: int, devBp: int, updatedAt: int, nowSec: int, maxAge: int, lo: int, hi: int) -> string {
+// not be read is "no-read"; then bounds (hard sanity, big-decimal on the UN-scaled
+// price), staleness, deviation (on the SCALED price/base). A clean read is "ok".
+fn verdict_of(price: int, base: int, devBp: int, updatedAt: int, nowSec: int, maxAge: int, priceDec: string, lo: string, hi: string) -> string {
     if price < 0 { return "no-read"; }
-    if out_of_bounds(price, lo, hi) { return "bounds"; }
+    if out_of_bounds(priceDec, lo, hi) { return "bounds"; }
     if is_stale(updatedAt, nowSec, maxAge) { return "stale"; }
     if deviates(price, base, devBp) { return "deviation"; }
     return "ok";
@@ -198,12 +312,23 @@ fn is_anomaly(verdict: string) -> bool {
     return false;
 }
 
+// The price / baseline reported in the payload: the full (UN-scaled) digit string,
+// or "-1" for a no-read / no-baseline (the sentinel, mirroring the sibling
+// watchers' convention). Carried as a JSON STRING because a high-decimal price
+// (>1e18) overflows the JSON number parser downstream (the prospector value-scorer
+// / liquidity-watcher convention).
+fn value_for_json(s: string) -> string {
+    if len(s) == 0 { return "-1"; }
+    return s;
+}
+
 // A compact, deterministic alert payload (JSON). All fields are facts the watcher
 // computed; none is LLM text. `sev` is set by the tier branch (draft vs page).
-fn alert_payload(label: string, verdict: string, price: int, base: int, addr: string, sev: string) -> string {
+// price/baseline are the full (UN-scaled) digit strings, quoted (see value_for_json).
+fn alert_payload(label: string, verdict: string, price: string, base: string, addr: string, sev: string) -> string {
     return "{\"watcher\":\"oracle\",\"feed\":\"" + json_escape(label) + "\",\"verdict\":\"" + verdict
-         + "\",\"price\":" + to_string(price) + ",\"baseline\":" + to_string(base)
-         + ",\"oracle\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
+         + "\",\"price\":\"" + value_for_json(price) + "\",\"baseline\":\"" + value_for_json(base)
+         + "\",\"oracle\":\"" + json_escape(addr) + "\",\"severity\":\"" + sev + "\"}";
 }
 
 fn tick(reason: string) -> void {
@@ -218,39 +343,52 @@ fn tick(reason: string) -> void {
     let tsSig = getenv("MONITOR_ORACLE_TS_SIG");
     let maxAge = opt_int(getenv("MONITOR_ORACLE_MAX_AGE"));
     let devBp = opt_int(getenv("MONITOR_ORACLE_DEV_BP"));
-    let lo = opt_int(getenv("MONITOR_ORACLE_MIN"));
-    let hi = opt_int(getenv("MONITOR_ORACLE_MAX"));
+    let lo = opt_dec(getenv("MONITOR_ORACLE_MIN"));
+    let hi = opt_dec(getenv("MONITOR_ORACLE_MAX"));
     let label = label_or(getenv("MONITOR_ORACLE_LABEL"), addr);
 
-    // Read the current price + (optionally) the feed's last-update timestamp.
-    let price = reading_to_int(read_uint(castBin, rpc, addr, priceSig));
+    // Read the current price as a big-number-safe DIGIT STRING + (optionally) the
+    // feed's last-update timestamp (a unix ts fits i64 -> reading_to_int).
+    let priceDec = reading_to_dec(read_uint(castBin, rpc, addr, priceSig));
     let updatedAt = if len(tsSig) > 0 { reading_to_int(read_uint(castBin, rpc, addr, tsSig)) } else { -1 };
-    // The DEVIATION baseline is the last price this watcher observed (durable
-    // memo). On the first read there is no baseline (-1) -> deviation is skipped
-    // this tick; the current price becomes the baseline for next time.
-    let base = opt_int(recall_latest("oracle-watcher:baseline:" + addr));
+    // The DEVIATION baseline is the last price this watcher observed (durable memo),
+    // persisted as the SAME digit string. On the first read there is no baseline
+    // ("") -> deviation is skipped this tick; the current price becomes the baseline
+    // for next time.
+    let baseDec = recall_latest("oracle-watcher:baseline:" + addr);
     let nowSec = now_ms() / 1000;
 
-    let verdict = verdict_of(price, base, devBp, updatedAt, nowSec, maxAge, lo, hi);
+    // SCALE price + baseline together to <= 18 digits (the SAME drop applied to
+    // both, so the deviation ratio is preserved) BEFORE any parse_int, so a
+    // high-decimal price never wraps to 0. A no-read / no-baseline ("") yields the
+    // -1 sentinel and is never scaled. The BOUNDS compare uses the UN-scaled
+    // priceDec (big-decimal), so a high-decimal MIN/MAX stays exact.
+    let drop = excess_digits(priceDec, baseDec);
+    let price = scaled_to_int(scale_dec(priceDec, drop));
+    let base = scaled_to_int(scale_dec(baseDec, drop));
+
+    let verdict = verdict_of(price, base, devBp, updatedAt, nowSec, maxAge, priceDec, lo, hi);
     let outcome = outcome_of(verdict);
 
-    print("oracle-watcher: " + label + " price=" + to_string(price) + " base=" + to_string(base)
+    print("oracle-watcher: " + label + " price=" + value_for_json(priceDec) + " base=" + value_for_json(baseDec)
         + " -> " + verdict + " (conf=" + to_string(get_confidence()) + ")");
 
-    // Update the deviation baseline to the latest GOOD read so the next tick
-    // compares against a recent price (a no-read leaves the old baseline intact).
-    if price >= 0 {
-        memo_write("oracle-watcher:baseline:" + addr, to_string(price));
+    // Update the deviation baseline to the latest GOOD read (the full digit string)
+    // so the next tick compares against a recent price (a no-read leaves the old
+    // baseline intact).
+    if len(priceDec) > 0 {
+        memo_write("oracle-watcher:baseline:" + addr, priceDec);
     };
 
     let key = label + ":" + addr;
-    let desc = "oracle feed " + label + " price=" + to_string(price) + " -> " + verdict;
+    let desc = "oracle feed " + label + " price=" + value_for_json(priceDec) + " -> " + verdict;
     let anomaly = is_anomaly(verdict);
 
     // Post this watcher's latest verdict to the shared blackboard memo the
     // coordinator reads each tick to fuse + dedup signals (a memo write — allowed
     // at every tier, including shadow). Severity is re-decided by the coordinator.
-    memo_write("monitor:signal:oracle", alert_payload(label, verdict, price, base, addr, "info"));
+    // price/baseline carry the full (UN-scaled) magnitudes as quoted JSON strings.
+    memo_write("monitor:signal:oracle", alert_payload(label, verdict, priceDec, baseDec, addr, "info"));
 
     // ONE tier() call, branch ONCE (ADR-0001). The tier gates EMISSION only.
     // (.ag has no `else if`; the tiers nest as `else { if ... { } else { } }`.)
@@ -258,7 +396,7 @@ fn tick(reason: string) -> void {
     if my_tier == "autonomous" {
         // Proven reliable -> a DIRECT page on a real anomaly (high severity).
         if anomaly {
-            emit("monitor:alert", alert_payload(label, verdict, price, base, addr, "high"));
+            emit("monitor:alert", alert_payload(label, verdict, priceDec, baseDec, addr, "high"));
             learn("oracle-watch", key, desc, outcome, [verdict, outcome, "acted"]);
         } else {
             learn("oracle-watch", key, desc, outcome, [verdict, outcome, "observed"]);
@@ -267,7 +405,7 @@ fn tick(reason: string) -> void {
         if my_tier == "review-gated" {
             // Trusted to page under a review gate -> a DIRECT page (high severity).
             if anomaly {
-                emit("monitor:alert", alert_payload(label, verdict, price, base, addr, "high"));
+                emit("monitor:alert", alert_payload(label, verdict, priceDec, baseDec, addr, "high"));
                 learn("oracle-watch", key, desc, outcome, [verdict, outcome, "review-gated"]);
             } else {
                 learn("oracle-watch", key, desc, outcome, [verdict, outcome, "observed"]);
@@ -276,7 +414,7 @@ fn tick(reason: string) -> void {
             if my_tier == "propose" {
                 // Enough signal to contribute -> a DRAFT alert (low severity).
                 if anomaly {
-                    emit("monitor:alert", alert_payload(label, verdict, price, base, addr, "low"));
+                    emit("monitor:alert", alert_payload(label, verdict, priceDec, baseDec, addr, "low"));
                     learn("oracle-watch", key, desc, outcome, [verdict, outcome, "emitted"]);
                 } else {
                     learn("oracle-watch", key, desc, outcome, [verdict, outcome, "observed"]);


### PR DESCRIPTION
**Found by a real-target onboarding** (live sDAI, Ethereum mainnet). The CORE watchers still overflowed i64: `parse_int` saturates to **0** for wei > i64 max (~9.22 ETH) — confirmed `parse_int("176142539498998091993593571")=0`. `invariant-watcher` read `totalAssets`/`totalSupply` (~1e26 wei on a real $100M vault) as 0 → `verdict_of(0,0,ge)=ok` → it reported **every real protocol "ok" regardless of true state** (solvency-blind). #1105 fixed liquidity/flow but not invariant/oracle.

Extends the proven #1105 big-decimal idiom to both core watchers: decimal-string reads + scale >18-digit values to fit i64 (both sides same drop) + division-first basis points (`diff/(base/10000)`, no `*10000`). Covers invariant's single + `MONITOR_INV_SPEC` set paths and oracle's deviation + bounds (`dec_ge` for high-decimal feeds; timestamp stays i64). Alert payloads carry full magnitudes as quoted JSON strings. Non-custodial / tier-gating / shell_escape / no-read sentinel all preserved.

## Validation (repl, real 1e26 magnitudes)
`SOLVENT→ok`, **`UNDERWATER→violated`** (false-ok gone), `THIN_MARGIN→margin`, cold-start/no-read → no false flag/no div-by-zero; oracle high-decimal deviation/bounds + 8dp regression intact. `./tools/colony-lint.sh` → **409 passed, 0 failed, 5 skipped**.

Closes #1109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)