### PR TITLE
dev-apprenticeship: resolve GitLab issue endpoint by item type (#1111)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,20 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Changed
+
+- GitLab issue-tracking REST endpoint resolution (#1111): all `gitlab-api.sh`
+  helpers (triage, planning, implementation, code-review) now resolve the
+  issue collection segment through a single `gl_items_path()` helper +
+  `ITEMS` variable instead of hardcoding `/issues` at 23 call sites. Defaults
+  to GitLab's renamed `work_items` collection; pin the legacy path on
+  un-migrated instances with `GITLAB_ITEMS_ENDPOINT=issues` (one env var, no
+  code change). All issue-family work-item types (issue / incident / task / …)
+  map to the unified `work_items` collection. **Note:** the `work_items`
+  REST response shape may differ from legacy `issues` (widget-based); the
+  `project_json` views still read flat fields — verify field compatibility
+  against the live instance (or roll back via the env var) as part of #1111.
+
 ### Added
 
 - Cross-repo reference detection in PR review prompts (#317): the four

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -85,6 +85,26 @@ fi
 
 API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
+# #1111: GitLab folded the legacy `issues` REST collection into the unified
+# `work_items` collection. Resolve the segment through one helper so the
+# rename — and any future per-item-type split — lives in one place instead
+# of every call site below. All issue-family work item types (issue,
+# incident, task, …) share the single project-level `work_items` collection
+# and are distinguished by a type field in the body, not by path. Operators
+# on an instance that still serves the legacy path can pin it with
+# GITLAB_ITEMS_ENDPOINT=issues (one env var, no code change).
+gl_items_path() {
+    if [ -n "${GITLAB_ITEMS_ENDPOINT:-}" ]; then
+        printf '%s' "$GITLAB_ITEMS_ENDPOINT"
+        return 0
+    fi
+    case "${1:-issue}" in
+        issue|incident|task|test_case|ticket) printf 'work_items' ;;
+        *)                                     printf 'work_items' ;;
+    esac
+}
+ITEMS="$(gl_items_path issue)"
+
 # gl_call <method> <url> [curl-args...]
 #
 # Single wrapper used by every gl_get/gl_get_q/gl_post/gl_put below.
@@ -314,7 +334,7 @@ case "$CMD" in
         case "$IID" in
             ''|*[!0-9]*) emit_error "iid must be numeric: $IID"; exit 2 ;;
         esac
-        gl_get "$API/issues/$IID"
+        gl_get "$API/$ITEMS/$IID"
         ;;
 
     rate-limit-status)

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -105,6 +105,26 @@ fi
 
 API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
+# #1111: GitLab folded the legacy `issues` REST collection into the unified
+# `work_items` collection. Resolve the segment through one helper so the
+# rename — and any future per-item-type split — lives in one place instead
+# of every call site below. All issue-family work item types (issue,
+# incident, task, …) share the single project-level `work_items` collection
+# and are distinguished by a type field in the body, not by path. Operators
+# on an instance that still serves the legacy path can pin it with
+# GITLAB_ITEMS_ENDPOINT=issues (one env var, no code change).
+gl_items_path() {
+    if [ -n "${GITLAB_ITEMS_ENDPOINT:-}" ]; then
+        printf '%s' "$GITLAB_ITEMS_ENDPOINT"
+        return 0
+    fi
+    case "${1:-issue}" in
+        issue|incident|task|test_case|ticket) printf 'work_items' ;;
+        *)                                     printf 'work_items' ;;
+    esac
+}
+ITEMS="$(gl_items_path issue)"
+
 # gl_call <method> <url> [curl-args...]
 #
 # Single wrapper used by every gl_get/gl_get_q/gl_post/gl_put below.
@@ -292,7 +312,7 @@ case "$CMD" in
 
     issue)
         IID="${1:?Usage: gitlab-api.sh issue <iid>}"
-        gl_get "$API/issues/$IID"
+        gl_get "$API/$ITEMS/$IID"
         ;;
 
     assigned-issues)
@@ -326,10 +346,10 @@ case "$CMD" in
         if [ -n "$VIEW" ]; then
             # Two-step pipe so gl_call's non-zero exit survives projection (see
             # merge-requests branch above).
-            body="$(gl_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+            body="$(gl_get_q "$API/$ITEMS" "${ARGS[@]}")" || exit $?
             printf '%s' "$body" | project_json "$VIEW"
         else
-            gl_get_q "$API/issues" "${ARGS[@]}"
+            gl_get_q "$API/$ITEMS" "${ARGS[@]}"
         fi
         ;;
 
@@ -350,7 +370,7 @@ case "$CMD" in
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
-        body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || exit $?
+        body="$(gl_get "$API/$ITEMS/$IID/resource_label_events?per_page=100")" || exit $?
         # Pass body via env (BODY=) rather than stdin because the heredoc
         # (<<'PY') would otherwise override the piped input — shellcheck
         # SC2259. Same idiom as the split / hit / matched / final blocks
@@ -419,7 +439,7 @@ PY
         if [ "$INCLUDE_UNASSIGNED" = "0" ]; then
             BASE_ARGS+=(--data-urlencode "assignee_id=Any")
         fi
-        recent="$(gl_get_q "$API/issues" "${BASE_ARGS[@]}")" || exit $?
+        recent="$(gl_get_q "$API/$ITEMS" "${BASE_ARGS[@]}")" || exit $?
         split="$(RECENT="$recent" LABEL="$LABEL" python3 <<'PY'
 import os, json
 items = json.loads(os.environ["RECENT"])
@@ -433,7 +453,7 @@ PY
         iids_to_check="$(printf '%s' "$split" | python3 -c 'import sys,json;print(" ".join(str(i) for i in json.load(sys.stdin)["to_check"]))')"
         matched="[]"
         for IID in $iids_to_check; do
-            ev_body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || continue
+            ev_body="$(gl_get "$API/$ITEMS/$IID/resource_label_events?per_page=100")" || continue
             hit="$(EVBODY="$ev_body" LABEL="$LABEL" EV_SINCE="$EV_SINCE" python3 <<'PY'
 import os, json
 events = json.loads(os.environ["EVBODY"])
@@ -449,7 +469,7 @@ else:
 PY
 )"
             if [ -n "$hit" ]; then
-                issue_body="$(gl_get "$API/issues/$IID")" || continue
+                issue_body="$(gl_get "$API/$ITEMS/$IID")" || continue
                 matched="$(MATCHED="$matched" ISSUE="$issue_body" python3 <<'PY'
 import os, json
 acc = json.loads(os.environ["MATCHED"])
@@ -597,7 +617,7 @@ PY
             ''|*[!0-9]*) emit_error "issue iid must be numeric: $ID"; exit 2 ;;
         esac
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
-        gl_post "$API/issues/$ID/notes" "$JSON_BODY"
+        gl_post "$API/$ITEMS/$ID/notes" "$JSON_BODY"
         ;;
 
     post-note)

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -106,6 +106,26 @@ fi
 
 API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
+# #1111: GitLab folded the legacy `issues` REST collection into the unified
+# `work_items` collection. Resolve the segment through one helper so the
+# rename — and any future per-item-type split — lives in one place instead
+# of every call site below. All issue-family work item types (issue,
+# incident, task, …) share the single project-level `work_items` collection
+# and are distinguished by a type field in the body, not by path. Operators
+# on an instance that still serves the legacy path can pin it with
+# GITLAB_ITEMS_ENDPOINT=issues (one env var, no code change).
+gl_items_path() {
+    if [ -n "${GITLAB_ITEMS_ENDPOINT:-}" ]; then
+        printf '%s' "$GITLAB_ITEMS_ENDPOINT"
+        return 0
+    fi
+    case "${1:-issue}" in
+        issue|incident|task|test_case|ticket) printf 'work_items' ;;
+        *)                                     printf 'work_items' ;;
+    esac
+}
+ITEMS="$(gl_items_path issue)"
+
 # gl_call <method> <url> [curl-args...]
 #
 # Single wrapper used by every gl_get/gl_get_q/gl_post/gl_put below.
@@ -276,10 +296,10 @@ case "$CMD" in
             # survives the projection pipe. A bare `gl_get_q ... | project_json`
             # would let python3 (or `cat` when GITLAB_VIEW_MODE=raw) override
             # the meaningful exit code with 0 or 1, masking the real failure.
-            body="$(gl_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+            body="$(gl_get_q "$API/$ITEMS" "${ARGS[@]}")" || exit $?
             printf '%s' "$body" | project_json "$VIEW"
         else
-            gl_get_q "$API/issues" "${ARGS[@]}"
+            gl_get_q "$API/$ITEMS" "${ARGS[@]}"
         fi
         ;;
 
@@ -300,7 +320,7 @@ case "$CMD" in
         # Use python3 json.dumps so newlines, quotes, backslashes, and control
         # chars are all escaped correctly and markdown formatting is preserved.
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
-        gl_post "$API/issues/$ID/notes" "$JSON_BODY"
+        gl_post "$API/$ITEMS/$ID/notes" "$JSON_BODY"
         ;;
 
     issue-label-events)
@@ -320,7 +340,7 @@ case "$CMD" in
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
-        body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || exit $?
+        body="$(gl_get "$API/$ITEMS/$IID/resource_label_events?per_page=100")" || exit $?
         # Pass body via env (BODY=) rather than stdin because the heredoc
         # (<<'PY') would otherwise override the piped input — shellcheck
         # SC2259. Same idiom as the split / hit / matched / final blocks
@@ -380,7 +400,7 @@ PY
             --data-urlencode "sort=desc"
             --data-urlencode "updated_after=$EV_SINCE"
         )
-        recent="$(gl_get_q "$API/issues" "${BASE_ARGS[@]}")" || exit $?
+        recent="$(gl_get_q "$API/$ITEMS" "${BASE_ARGS[@]}")" || exit $?
         # Split into currently-labeled (include directly) and need-events-check.
         split="$(RECENT="$recent" LABEL="$LABEL" python3 <<'PY'
 import os, json
@@ -395,7 +415,7 @@ PY
         iids_to_check="$(printf '%s' "$split" | python3 -c 'import sys,json;print(" ".join(str(i) for i in json.load(sys.stdin)["to_check"]))')"
         matched="[]"
         for IID in $iids_to_check; do
-            ev_body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || continue
+            ev_body="$(gl_get "$API/$ITEMS/$IID/resource_label_events?per_page=100")" || continue
             hit="$(EVBODY="$ev_body" LABEL="$LABEL" EV_SINCE="$EV_SINCE" python3 <<'PY'
 import os, json
 events = json.loads(os.environ["EVBODY"])
@@ -411,7 +431,7 @@ else:
 PY
 )"
             if [ -n "$hit" ]; then
-                issue_body="$(gl_get "$API/issues/$IID")" || continue
+                issue_body="$(gl_get "$API/$ITEMS/$IID")" || continue
                 matched="$(MATCHED="$matched" ISSUE="$issue_body" python3 <<'PY'
 import os, json
 acc = json.loads(os.environ["MATCHED"])

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -146,6 +146,26 @@ fi
 
 API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
+# #1111: GitLab folded the legacy `issues` REST collection into the unified
+# `work_items` collection. Resolve the segment through one helper so the
+# rename — and any future per-item-type split — lives in one place instead
+# of every call site below. All issue-family work item types (issue,
+# incident, task, …) share the single project-level `work_items` collection
+# and are distinguished by a type field in the body, not by path. Operators
+# on an instance that still serves the legacy path can pin it with
+# GITLAB_ITEMS_ENDPOINT=issues (one env var, no code change).
+gl_items_path() {
+    if [ -n "${GITLAB_ITEMS_ENDPOINT:-}" ]; then
+        printf '%s' "$GITLAB_ITEMS_ENDPOINT"
+        return 0
+    fi
+    case "${1:-issue}" in
+        issue|incident|task|test_case|ticket) printf 'work_items' ;;
+        *)                                     printf 'work_items' ;;
+    esac
+}
+ITEMS="$(gl_items_path issue)"
+
 # gl_call <method> <url> [curl-args...]
 #
 # Single wrapper used by every gl_get/gl_get_q/gl_post/gl_put below.
@@ -313,10 +333,10 @@ case "$CMD" in
             # survives the projection pipe. A bare `gl_get_q ... | project_json`
             # would let python3 (or `cat` when GITLAB_VIEW_MODE=raw) override
             # the meaningful exit code with 0 or 1, masking the real failure.
-            body="$(gl_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+            body="$(gl_get_q "$API/$ITEMS" "${ARGS[@]}")" || exit $?
             printf '%s' "$body" | project_json "$VIEW"
         else
-            gl_get_q "$API/issues" "${ARGS[@]}"
+            gl_get_q "$API/$ITEMS" "${ARGS[@]}"
         fi
         ;;
 
@@ -354,7 +374,7 @@ if os.environ.get("PRIORITY"):
 print(json.dumps(body))
 PY
 )
-        gl_post "$API/issues" "$JSON_BODY"
+        gl_post "$API/$ITEMS" "$JSON_BODY"
         ;;
 
     update-issue)
@@ -419,7 +439,7 @@ if os.environ.get("ASSIGNEE_ID"):
 print(json.dumps(body))
 PY
 )
-        gl_put "$API/issues/$ID" "$JSON_BODY"
+        gl_put "$API/$ITEMS/$ID" "$JSON_BODY"
         ;;
 
     members)
@@ -475,10 +495,10 @@ PY
             ''|*[!0-9]*) emit_error "iid must be numeric: $IID"; exit 2 ;;
         esac
         if [ -n "$VIEW" ]; then
-            body="$(gl_get "$API/issues/$IID")" || exit $?
+            body="$(gl_get "$API/$ITEMS/$IID")" || exit $?
             printf '%s' "$body" | project_json "$VIEW"
         else
-            gl_get "$API/issues/$IID"
+            gl_get "$API/$ITEMS/$IID"
         fi
         ;;
 
@@ -532,7 +552,7 @@ PY
             ''|*[!0-9]*) emit_error "issue iid must be numeric: $ID"; exit 2 ;;
         esac
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
-        gl_post "$API/issues/$ID/notes" "$JSON_BODY"
+        gl_post "$API/$ITEMS/$ID/notes" "$JSON_BODY"
         ;;
 
     rate-limit-status)


### PR DESCRIPTION
GitLab renamed the issue-tracking REST collection from `issues` to the
unified `work_items` collection. Replace the 23 hardcoded `$API/issues`
call sites across the triage/planning/implementation/code-review
gitlab-api.sh helpers with a single per-script gl_items_path() resolver +
$ITEMS variable.

- gl_items_path() maps any issue-family work-item type (issue, incident,
  task, …) to the unified `work_items` collection; default is work_items.
- GITLAB_ITEMS_ENDPOINT=issues pins the legacy path on un-migrated
  instances (one env var, no code change) — a clean rollback.
- Sub-resources (/notes, /resource_label_events) ride the resolved
  collection.

All 5 scripts pass `bash -n`. release/gitlab-api.sh is unchanged (no
issue call sites; merge_requests only).

Known follow-up: the work_items REST response shape may differ from
legacy issues (widget-based vs flat fields). The project_json views still
read flat iid/title/labels/assignees/author — verify against the live
instance as part of #1111, or roll back via the env var.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0181baHCPnPvzrm7QN1ndp4c