### PR TITLE
fix(dev-apprenticeship): resolve GitLab issue collection by item type (/issues → /work_items) (#1119)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -32,6 +32,22 @@ is asserted until multi-version CI is in place.
   closed-by-index}.{sh,py}`. Test: `tools/test-cross-repo-refs.sh` (7
   cases). Dashboard timeline overlay deferred to follow-up.
 
+### Fixed
+
+- GitLab issue-collection rename (#1119): GitLab migrated the
+  issue-tracking REST collection from `/issues` to the unified
+  `/work_items` collection, which broke every issue read/write on a
+  migrated instance. Each colony's `gitlab-api.sh` (triage / planning /
+  implementation / code-review) now resolves the collection segment in
+  one place via `ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"`
+  and routes all issue reads, writes, `/notes`, and
+  `/resource_label_events` sub-paths through it. Default is `work_items`;
+  set `GITLAB_ISSUE_COLLECTION=issues` to pin the legacy path on a
+  non-migrated instance (no code change). `release/gitlab-api.sh` defines
+  the same knob for cross-script consistency (it only talks to
+  `/merge_requests` today). Documented in the README troubleshooting
+  section.
+
 ## [2.0.0] — 2026-04-29
 
 **Requires:** agentis >= 1.4.7

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -417,6 +417,8 @@ agentis knowledge import /tmp/donor-knowledge.json --merge
 
 **"GitLab poll failed"**: Token lacks `api` scope, or the project path is wrong.
 
+**Issue reads/writes 404 on a self-hosted GitLab**: GitLab renamed the issue-tracking REST collection from `/issues` to the unified `/work_items` collection ([#1119](https://github.com/Replikanti/agentis-colonies/issues/1119)). The colony `gitlab-api.sh` helpers default to `work_items`. If your instance has **not** migrated yet, set `GITLAB_ISSUE_COLLECTION=issues` in the environment that launches the federation to pin the legacy path — no code change required. The default (`work_items`) is correct for migrated instances. This knob, like `GITLAB_CURL_MAX_TIME` / `GITLAB_CURL_RETRIES`, is read from the operator environment by each colony's `gitlab-api.sh` and is not seeded from `colony.toml`.
+
 **"Config not found"**: Run `./install.sh` or copy the template: `cp config/colony.example.toml config/colony.toml`
 
 **LLM errors**: Check your backend configuration in `.agentis/config`. For CLI backends, verify the command works in your terminal. For HTTP backends, verify the endpoint is reachable and the API key is set.

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -85,6 +85,13 @@ fi
 
 API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
+# GitLab renamed the issue-tracking REST collection from /issues to the unified
+# /work_items collection (#1119). Resolve the collection segment in one place so
+# every issue read/write routes through it. Default = work_items (migrated
+# instances). Set GITLAB_ISSUE_COLLECTION=issues to pin the legacy path on a
+# non-migrated instance — no code change required.
+ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"
+
 # gl_call <method> <url> [curl-args...]
 #
 # Single wrapper used by every gl_get/gl_get_q/gl_post/gl_put below.
@@ -314,7 +321,7 @@ case "$CMD" in
         case "$IID" in
             ''|*[!0-9]*) emit_error "iid must be numeric: $IID"; exit 2 ;;
         esac
-        gl_get "$API/issues/$IID"
+        gl_get "$API/$ISSUE_COLLECTION/$IID"
         ;;
 
     rate-limit-status)

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -105,6 +105,13 @@ fi
 
 API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
+# GitLab renamed the issue-tracking REST collection from /issues to the unified
+# /work_items collection (#1119). Resolve the collection segment in one place so
+# every issue read/write routes through it. Default = work_items (migrated
+# instances). Set GITLAB_ISSUE_COLLECTION=issues to pin the legacy path on a
+# non-migrated instance — no code change required.
+ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"
+
 # gl_call <method> <url> [curl-args...]
 #
 # Single wrapper used by every gl_get/gl_get_q/gl_post/gl_put below.
@@ -292,7 +299,7 @@ case "$CMD" in
 
     issue)
         IID="${1:?Usage: gitlab-api.sh issue <iid>}"
-        gl_get "$API/issues/$IID"
+        gl_get "$API/$ISSUE_COLLECTION/$IID"
         ;;
 
     assigned-issues)
@@ -326,10 +333,10 @@ case "$CMD" in
         if [ -n "$VIEW" ]; then
             # Two-step pipe so gl_call's non-zero exit survives projection (see
             # merge-requests branch above).
-            body="$(gl_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+            body="$(gl_get_q "$API/$ISSUE_COLLECTION" "${ARGS[@]}")" || exit $?
             printf '%s' "$body" | project_json "$VIEW"
         else
-            gl_get_q "$API/issues" "${ARGS[@]}"
+            gl_get_q "$API/$ISSUE_COLLECTION" "${ARGS[@]}"
         fi
         ;;
 
@@ -350,7 +357,7 @@ case "$CMD" in
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
-        body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || exit $?
+        body="$(gl_get "$API/$ISSUE_COLLECTION/$IID/resource_label_events?per_page=100")" || exit $?
         # Pass body via env (BODY=) rather than stdin because the heredoc
         # (<<'PY') would otherwise override the piped input — shellcheck
         # SC2259. Same idiom as the split / hit / matched / final blocks
@@ -419,7 +426,7 @@ PY
         if [ "$INCLUDE_UNASSIGNED" = "0" ]; then
             BASE_ARGS+=(--data-urlencode "assignee_id=Any")
         fi
-        recent="$(gl_get_q "$API/issues" "${BASE_ARGS[@]}")" || exit $?
+        recent="$(gl_get_q "$API/$ISSUE_COLLECTION" "${BASE_ARGS[@]}")" || exit $?
         split="$(RECENT="$recent" LABEL="$LABEL" python3 <<'PY'
 import os, json
 items = json.loads(os.environ["RECENT"])
@@ -433,7 +440,7 @@ PY
         iids_to_check="$(printf '%s' "$split" | python3 -c 'import sys,json;print(" ".join(str(i) for i in json.load(sys.stdin)["to_check"]))')"
         matched="[]"
         for IID in $iids_to_check; do
-            ev_body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || continue
+            ev_body="$(gl_get "$API/$ISSUE_COLLECTION/$IID/resource_label_events?per_page=100")" || continue
             hit="$(EVBODY="$ev_body" LABEL="$LABEL" EV_SINCE="$EV_SINCE" python3 <<'PY'
 import os, json
 events = json.loads(os.environ["EVBODY"])
@@ -449,7 +456,7 @@ else:
 PY
 )"
             if [ -n "$hit" ]; then
-                issue_body="$(gl_get "$API/issues/$IID")" || continue
+                issue_body="$(gl_get "$API/$ISSUE_COLLECTION/$IID")" || continue
                 matched="$(MATCHED="$matched" ISSUE="$issue_body" python3 <<'PY'
 import os, json
 acc = json.loads(os.environ["MATCHED"])
@@ -597,7 +604,7 @@ PY
             ''|*[!0-9]*) emit_error "issue iid must be numeric: $ID"; exit 2 ;;
         esac
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
-        gl_post "$API/issues/$ID/notes" "$JSON_BODY"
+        gl_post "$API/$ISSUE_COLLECTION/$ID/notes" "$JSON_BODY"
         ;;
 
     post-note)

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -106,6 +106,13 @@ fi
 
 API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
+# GitLab renamed the issue-tracking REST collection from /issues to the unified
+# /work_items collection (#1119). Resolve the collection segment in one place so
+# every issue read/write routes through it. Default = work_items (migrated
+# instances). Set GITLAB_ISSUE_COLLECTION=issues to pin the legacy path on a
+# non-migrated instance — no code change required.
+ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"
+
 # gl_call <method> <url> [curl-args...]
 #
 # Single wrapper used by every gl_get/gl_get_q/gl_post/gl_put below.
@@ -276,10 +283,10 @@ case "$CMD" in
             # survives the projection pipe. A bare `gl_get_q ... | project_json`
             # would let python3 (or `cat` when GITLAB_VIEW_MODE=raw) override
             # the meaningful exit code with 0 or 1, masking the real failure.
-            body="$(gl_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+            body="$(gl_get_q "$API/$ISSUE_COLLECTION" "${ARGS[@]}")" || exit $?
             printf '%s' "$body" | project_json "$VIEW"
         else
-            gl_get_q "$API/issues" "${ARGS[@]}"
+            gl_get_q "$API/$ISSUE_COLLECTION" "${ARGS[@]}"
         fi
         ;;
 
@@ -300,7 +307,7 @@ case "$CMD" in
         # Use python3 json.dumps so newlines, quotes, backslashes, and control
         # chars are all escaped correctly and markdown formatting is preserved.
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
-        gl_post "$API/issues/$ID/notes" "$JSON_BODY"
+        gl_post "$API/$ISSUE_COLLECTION/$ID/notes" "$JSON_BODY"
         ;;
 
     issue-label-events)
@@ -320,7 +327,7 @@ case "$CMD" in
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
-        body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || exit $?
+        body="$(gl_get "$API/$ISSUE_COLLECTION/$IID/resource_label_events?per_page=100")" || exit $?
         # Pass body via env (BODY=) rather than stdin because the heredoc
         # (<<'PY') would otherwise override the piped input — shellcheck
         # SC2259. Same idiom as the split / hit / matched / final blocks
@@ -380,7 +387,7 @@ PY
             --data-urlencode "sort=desc"
             --data-urlencode "updated_after=$EV_SINCE"
         )
-        recent="$(gl_get_q "$API/issues" "${BASE_ARGS[@]}")" || exit $?
+        recent="$(gl_get_q "$API/$ISSUE_COLLECTION" "${BASE_ARGS[@]}")" || exit $?
         # Split into currently-labeled (include directly) and need-events-check.
         split="$(RECENT="$recent" LABEL="$LABEL" python3 <<'PY'
 import os, json
@@ -395,7 +402,7 @@ PY
         iids_to_check="$(printf '%s' "$split" | python3 -c 'import sys,json;print(" ".join(str(i) for i in json.load(sys.stdin)["to_check"]))')"
         matched="[]"
         for IID in $iids_to_check; do
-            ev_body="$(gl_get "$API/issues/$IID/resource_label_events?per_page=100")" || continue
+            ev_body="$(gl_get "$API/$ISSUE_COLLECTION/$IID/resource_label_events?per_page=100")" || continue
             hit="$(EVBODY="$ev_body" LABEL="$LABEL" EV_SINCE="$EV_SINCE" python3 <<'PY'
 import os, json
 events = json.loads(os.environ["EVBODY"])
@@ -411,7 +418,7 @@ else:
 PY
 )"
             if [ -n "$hit" ]; then
-                issue_body="$(gl_get "$API/issues/$IID")" || continue
+                issue_body="$(gl_get "$API/$ISSUE_COLLECTION/$IID")" || continue
                 matched="$(MATCHED="$matched" ISSUE="$issue_body" python3 <<'PY'
 import os, json
 acc = json.loads(os.environ["MATCHED"])

--- a/dev-apprenticeship/release/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/release/scripts/gitlab-api.sh
@@ -121,6 +121,16 @@ fi
 
 API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
+# GitLab renamed the issue-tracking REST collection from /issues to the unified
+# /work_items collection (#1119). Resolve the collection segment in one place so
+# every issue read/write routes through it. Default = work_items (migrated
+# instances). Set GITLAB_ISSUE_COLLECTION=issues to pin the legacy path on a
+# non-migrated instance — no code change required. The release colony only talks
+# to /merge_requests today, so this is defined for cross-script consistency and
+# is intentionally unused here (SC2034) until a future issue call site lands.
+# shellcheck disable=SC2034
+ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"
+
 # gl_call <method> <url> [curl-args...]
 #
 # Single wrapper used by every gl_get/gl_get_q/gl_post/gl_put below.

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -146,6 +146,13 @@ fi
 
 API="$GITLAB_URL/api/v4/projects/$GITLAB_PROJECT"
 
+# GitLab renamed the issue-tracking REST collection from /issues to the unified
+# /work_items collection (#1119). Resolve the collection segment in one place so
+# every issue read/write routes through it. Default = work_items (migrated
+# instances). Set GITLAB_ISSUE_COLLECTION=issues to pin the legacy path on a
+# non-migrated instance — no code change required.
+ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"
+
 # gl_call <method> <url> [curl-args...]
 #
 # Single wrapper used by every gl_get/gl_get_q/gl_post/gl_put below.
@@ -313,10 +320,10 @@ case "$CMD" in
             # survives the projection pipe. A bare `gl_get_q ... | project_json`
             # would let python3 (or `cat` when GITLAB_VIEW_MODE=raw) override
             # the meaningful exit code with 0 or 1, masking the real failure.
-            body="$(gl_get_q "$API/issues" "${ARGS[@]}")" || exit $?
+            body="$(gl_get_q "$API/$ISSUE_COLLECTION" "${ARGS[@]}")" || exit $?
             printf '%s' "$body" | project_json "$VIEW"
         else
-            gl_get_q "$API/issues" "${ARGS[@]}"
+            gl_get_q "$API/$ISSUE_COLLECTION" "${ARGS[@]}"
         fi
         ;;
 
@@ -354,7 +361,7 @@ if os.environ.get("PRIORITY"):
 print(json.dumps(body))
 PY
 )
-        gl_post "$API/issues" "$JSON_BODY"
+        gl_post "$API/$ISSUE_COLLECTION" "$JSON_BODY"
         ;;
 
     update-issue)
@@ -419,7 +426,7 @@ if os.environ.get("ASSIGNEE_ID"):
 print(json.dumps(body))
 PY
 )
-        gl_put "$API/issues/$ID" "$JSON_BODY"
+        gl_put "$API/$ISSUE_COLLECTION/$ID" "$JSON_BODY"
         ;;
 
     members)
@@ -475,10 +482,10 @@ PY
             ''|*[!0-9]*) emit_error "iid must be numeric: $IID"; exit 2 ;;
         esac
         if [ -n "$VIEW" ]; then
-            body="$(gl_get "$API/issues/$IID")" || exit $?
+            body="$(gl_get "$API/$ISSUE_COLLECTION/$IID")" || exit $?
             printf '%s' "$body" | project_json "$VIEW"
         else
-            gl_get "$API/issues/$IID"
+            gl_get "$API/$ISSUE_COLLECTION/$IID"
         fi
         ;;
 
@@ -532,7 +539,7 @@ PY
             ''|*[!0-9]*) emit_error "issue iid must be numeric: $ID"; exit 2 ;;
         esac
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
-        gl_post "$API/issues/$ID/notes" "$JSON_BODY"
+        gl_post "$API/$ISSUE_COLLECTION/$ID/notes" "$JSON_BODY"
         ;;
 
     rate-limit-status)

--- a/tools/test-gitlab-add-note.sh
+++ b/tools/test-gitlab-add-note.sh
@@ -109,7 +109,8 @@ if [ "$rc" -eq 0 ] && [ -s "$CURL_TRACE" ]; then
     trace="$(cat "$CURL_TRACE")"
     ok=1
     printf '%s' "$trace" | grep -q '^METHOD=POST$' || ok=0
-    printf '%s' "$trace" | grep -q '/projects/42/issues/7/notes' || ok=0
+    # #1119: default issue collection is the unified /work_items.
+    printf '%s' "$trace" | grep -q '/projects/42/work_items/7/notes' || ok=0
     # JSON body should have {"body": "hello world"}.
     if ! printf '%s' "$trace" | python3 -c '
 import sys, json, re
@@ -122,12 +123,32 @@ assert b == {"body": "hello world"}, f"unexpected body: {b}"
         ok=0
     fi
     if [ "$ok" -eq 1 ]; then
-        pass "happy path: POST /issues/7/notes with {body:'hello world'}"
+        pass "happy path: POST /work_items/7/notes with {body:'hello world'}"
     else
         fail "happy path" "trace=$trace out=$out"
     fi
 else
     fail "happy path" "rc=$rc out=$out trace_exists=$([ -s "$CURL_TRACE" ] && echo yes || echo no)"
+fi
+
+# --- Test 5: rollback toggle pins the legacy /issues collection (#1119) ---
+# GITLAB_ISSUE_COLLECTION=issues restores the pre-migration path for
+# instances that have not migrated to the unified /work_items collection.
+: > "$CURL_TRACE"
+set +e
+out=$(PATH="$TMPDIR_SHIM:$PATH" GITLAB_ISSUE_COLLECTION=issues GITLAB_URL=http://example.gitlab GITLAB_TOKEN=tok GITLAB_PROJECT=42 "$SCRIPT" add-note 7 --body 'hello world' 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ] && [ -s "$CURL_TRACE" ]; then
+    trace="$(cat "$CURL_TRACE")"
+    if printf '%s' "$trace" | grep -q '/projects/42/issues/7/notes'; then
+        pass "rollback toggle: GITLAB_ISSUE_COLLECTION=issues hits legacy /issues/7/notes"
+    else
+        fail "rollback toggle" "trace=$trace out=$out"
+    fi
+else
+    fail "rollback toggle" "rc=$rc out=$out trace_exists=$([ -s "$CURL_TRACE" ] && echo yes || echo no)"
 fi
 
 echo ""


### PR DESCRIPTION
GitLab migrated the issue REST collection `/issues` → `/work_items`; the five dev-apprenticeship `gitlab-api.sh` scripts hardcoded `/issues` (~30 sites) → dead path on a migrated instance.

- Each script resolves `ISSUE_COLLECTION=${GITLAB_ISSUE_COLLECTION:-work_items}` in **one place**; every issue-collection path routes through it. **Sub-paths preserved** (`/issues/<iid>/notes` → `/$ISSUE_COLLECTION/<iid>/notes`; label-events + single-item likewise). `/merge_requests` untouched.
- **Rollback:** `GITLAB_ISSUE_COLLECTION=issues` restores the legacy path (default `work_items`). Documented in README env contract.
- `test-gitlab-add-note.sh`: default (`/work_items/7/notes`) + rollback (`/issues/7/notes`) both covered.

## Validation
`./tools/colony-lint.sh` → **409 passed, 0 failed, 5 skipped**; `bash -n` + `shellcheck -x` clean on all 5; sub-path suffixes byte-identical old↔new (no corruption); QA agent ✅ ship-it (all 7 axes + rollback test).

Closes #1119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)