### PR TITLE
feat(dev-apprenticeship): shared GitLab snapshot + payload compression (#1111, #1112)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,32 @@ is asserted until multi-version CI is in place.
 
 ### Added
 
+- Shared GitLab snapshot + payload compression for the Triage colony
+  (#1111 / #1112). The `issues` collection is now fetched **once per
+  colony per tick** and shared via a memo instead of each of the four
+  triage agents (labeler / router / prioritizer / issue_creator)
+  curling it independently (the former 3–4× duplicate fetch per tick).
+  `triage/scripts/start-colony.sh` publishes the snapshot to
+  `gitlab:snapshot:issues` (+ epoch freshness key
+  `gitlab:snapshot:issues:ts`) via the new `forge-api.sh snapshot issues`
+  verb on bootstrap, and standalone via `--snapshot-refresh`. The
+  snapshot is **compressed before it reaches `prompt()`**: the new
+  `triage/scripts/snapshot-compress.py` (normalized-subtree-hashing,
+  reusing the `dark-factory/evm-harness/struct-sig.js` concept)
+  normalizes each item to role-relevant fields, content-addresses each
+  item's structure, interns repeated structures once, and references
+  them by index — deterministic + byte-stable, ~11× smaller than raw
+  on a realistic 20-issue payload. Agents read the memo via a new
+  `snapshot_issues_cmd()` helper and render their role view with
+  `forge-api.sh issues --from-snapshot --view <role>` (zero HTTP).
+  Backward-safe: a missing / empty / stale (> 600 s) / malformed
+  snapshot transparently degrades to the legacy direct fetch, and the
+  shared snapshot is used only on the single-repo path (multi-repo
+  fan-out keeps its per-repo fetch). Both `gitlab-api.sh` and
+  `github-api.sh` gained the symmetric `snapshot` verb +
+  `--from-snapshot` flag. The `merge_requests` collection in the other
+  four colonies uses label-event-filtered reads and is deferred to the
+  live run (#1117).
 - Cross-repo reference detection in PR review prompts (#317): the four
   code-review agents (logic / style / security / test) scan PR body
   for `<owner>/<repo>#<N>` references and splice resolved issue context

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -42,7 +42,34 @@ is asserted until multi-version CI is in place.
   `github-api.sh` gained the symmetric `snapshot` verb +
   `--from-snapshot` flag. The `merge_requests` collection in the other
   four colonies uses label-event-filtered reads and is deferred to the
-  live run (#1117).
+  live run (#1117). Three follow-up fixes harden the snapshot path:
+  - **Snapshot-refresh sidecar (#1111).** `start-federation.sh` now
+    runs a background loop that re-publishes the shared snapshot every
+    300 s (override via `SNAPSHOT_REFRESH_INTERVAL_S`) — shorter than
+    the 600 s freshness window — so the snapshot never goes stale and
+    the agents never permanently fall back to per-agent direct fetches
+    (the exact I/O problem #1111 fixes). It mirrors the auto-promote /
+    cost-cap sidecars (self-terminates on zero running daemons,
+    EXIT/TERM/INT trap) and is backward-safe (refresh failures are
+    logged to `.agentis/logs/snapshot-refresh.log`, never fatal).
+  - **Full `description` for the issue_creator view (#1112).**
+    `snapshot-compress.py` previously kept only a 200-char `desc_head`,
+    but the `issue_creator` view consumes the full `description`, so its
+    rehydrated input was truncated vs. the legacy direct fetch. The
+    compact form now carries the untruncated `description` (only the
+    issue_creator view projects it; labeler/router/prioritizer drop it),
+    making the rehydrated issue_creator `description` byte-identical to
+    the direct-fetch value. `--self-test` gained a full-description
+    fidelity assertion.
+  - **Quiet-project prompt suppression on the snapshot path (#1111).**
+    The shared snapshot is the full collection (not a `--since` delta),
+    so `raw` is non-empty every tick even when nothing changed, causing
+    `prompt()` on every tick. labeler / router / prioritizer now
+    fingerprint (SHA-256) their projected view, memo it as
+    `<agent>:snapshot_hash`, and skip `prompt()` on a tick whose
+    fingerprint matches the last-processed one — an additional gate that
+    restores the legacy `--since`-empty early-exit (one `tier()` call
+    per tick and the existing prompt-gate are preserved).
 - Cross-repo reference detection in PR review prompts (#317): the four
   code-review agents (logic / style / security / test) scan PR body
   for `<owner>/<repo>#<N>` references and splice resolved issue context

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -354,6 +354,33 @@ Each needs its own matcher (did the MR get merged? was the plan followed? was th
 
 Cross-colony wiring: Triage routes issues to Implementation. Implementation signals Code Review and Release when an MR is ready. See individual colony READMEs for internal event wiring.
 
+## Shared GitLab snapshot (#1111 / #1112)
+
+Without sharing, every agent in a colony curls the same GitLab collection on every tick and passes the raw JSON straight into `prompt()`. In the Triage colony that meant the `/issues` (now `/work_items`) endpoint was fetched **three times per tick** — once each by the labeler, router, and prioritizer (four with the issue_creator) — and each copy was the full ~74 KB raw payload. The duplicate fetches throttle the API; the raw payloads waste a factor 5–10× of the model's input budget.
+
+Two mechanisms fix this:
+
+**One shared fetch per colony per tick (#1111).** The Triage `scripts/start-colony.sh` publishes a single snapshot of the `issues` collection:
+
+- It fetches the collection **once** via `scripts/forge-api.sh snapshot issues` (the single fetch implementation — `gitlab-api.sh` / `github-api.sh` stay the only code that touches the network) and writes the result to the shared memo `gitlab:snapshot:issues`, with an epoch-seconds freshness key at `gitlab:snapshot:issues:ts`.
+- The publish runs on full-colony bootstrap, and can be re-run any time via `scripts/start-colony.sh --snapshot-refresh` (a lightweight, daemon-free mode for a per-tick sidecar).
+- Each agent reads `recall_latest("gitlab:snapshot:issues")` instead of curling the endpoint. The agent renders its role view from the snapshot via `forge-api.sh issues --from-snapshot --view <role>`, which rehydrates + projects the memo with **zero HTTP calls**.
+
+**Compressed before it reaches `prompt()` (#1112).** The snapshot is not stored raw. `scripts/snapshot-compress.py` (reusing the normalized-subtree-hashing idea from `dark-factory/evm-harness/struct-sig.js`) transforms the raw GitLab JSON into a compact, deduplicated, structurally-chunked envelope before it lands in the memo:
+
+- Each item is normalized to the union of role-relevant fields (everything else — `web_url`, `time_stats`, `references`, `milestone`, … — is dropped).
+- Each item's normalized **structure** is content-addressed (SHA-256 of its canonical JSON); identical structures are interned once in a `chunks` table and referenced by index, so repeated structure (and unchanged structure across ticks) is stored once, not re-serialized.
+- The transform is deterministic and **byte-stable** for identical input (the key that makes cross-tick caching sound). On a realistic 20-issue payload this is ~11× smaller than the raw JSON.
+
+**Backward-safe degrade.** Every read path is total-on-failure: if the snapshot memo is missing, empty, malformed, or older than the freshness window (600 s), the agent silently falls back to its legacy direct `forge-api.sh issues` fetch. A broken or stale snapshot never hard-fails a tick. The per-colony snapshot is used only on the single-repo path; the multi-repo (`[[forge.github]]`) fan-out keeps its per-repo direct fetch.
+
+| Memo key | Writer | Readers |
+|----------|--------|---------|
+| `gitlab:snapshot:issues` | `triage/scripts/start-colony.sh` (snapshot step) | labeler, router, prioritizer, issue_creator |
+| `gitlab:snapshot:issues:ts` | `triage/scripts/start-colony.sh` (snapshot step) | the four agents' `snapshot_fresh()` gate |
+
+> The same mechanism extends to the `merge_requests` collection in the Planning / Implementation / Code Review / Release colonies; their reads are label-event-filtered rather than plain full-collection fetches, so that wiring is driven by the live run (#1117) and is not enabled yet.
+
 ## Knowledge portability
 
 Every `learn()` call in the federation's agents tags entries with one of `observed` (shadow tier: passive learning from GitLab activity), `emitted` (propose tier: suggestion logged with draft external write), `review-gated` (review-gated tier: direct non-terminal external write under the review gate), or `acted` (autonomous tier: terminal external write with no second gate) plus the colony name (`triage`, `code-review`, `planning`, `implementation`, `release`). See [`doc/auto-promote.md#classification`](../doc/auto-promote.md#classification) for how the auto-promote heuristic consumes these tags.

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -364,7 +364,9 @@ Two mechanisms fix this:
 
 - It fetches the collection **once** via `scripts/forge-api.sh snapshot issues` (the single fetch implementation — `gitlab-api.sh` / `github-api.sh` stay the only code that touches the network) and writes the result to the shared memo `gitlab:snapshot:issues`, with an epoch-seconds freshness key at `gitlab:snapshot:issues:ts`.
 - The publish runs on full-colony bootstrap, and can be re-run any time via `scripts/start-colony.sh --snapshot-refresh` (a lightweight, daemon-free mode for a per-tick sidecar).
+- **`start-federation.sh` runs a snapshot-refresh sidecar** that re-publishes the snapshot every 300 s (override via `SNAPSHOT_REFRESH_INTERVAL_S`) — deliberately **shorter than the 600 s freshness window** so a fresh snapshot is always within reach. Without it the snapshot would go stale after the first window and every agent would fall back to the per-agent direct fetch the snapshot exists to eliminate, evaporating the I/O win. The sidecar mirrors the auto-promote / cost-cap sidecars: it self-terminates once the federation has zero running daemons and is killed on `start-federation.sh` shutdown (EXIT/TERM/INT trap). It is backward-safe — a missing `triage/scripts/start-colony.sh` or a refresh failure is logged to `.agentis/logs/snapshot-refresh.log` and ignored (the snapshot step leaves the prior snapshot in place on error), so a sidecar hiccup never breaks the federation.
 - Each agent reads `recall_latest("gitlab:snapshot:issues")` instead of curling the endpoint. The agent renders its role view from the snapshot via `forge-api.sh issues --from-snapshot --view <role>`, which rehydrates + projects the memo with **zero HTTP calls**.
+- Because the shared snapshot is the **full** collection (not a `--since last_check` delta), `raw` is non-empty on every tick even when nothing changed. To keep the quiet-project cost down, the labeler / router / prioritizer fingerprint their projected view (SHA-256) and memo it as `<agent>:snapshot_hash`; on a tick whose fingerprint matches the last-processed one they refresh `last_check` and skip `prompt()` entirely — restoring the legacy `--since`-empty early-exit on the snapshot path.
 
 **Compressed before it reaches `prompt()` (#1112).** The snapshot is not stored raw. `scripts/snapshot-compress.py` (reusing the normalized-subtree-hashing idea from `dark-factory/evm-harness/struct-sig.js`) transforms the raw GitLab JSON into a compact, deduplicated, structurally-chunked envelope before it lands in the memo:
 
@@ -376,8 +378,9 @@ Two mechanisms fix this:
 
 | Memo key | Writer | Readers |
 |----------|--------|---------|
-| `gitlab:snapshot:issues` | `triage/scripts/start-colony.sh` (snapshot step) | labeler, router, prioritizer, issue_creator |
-| `gitlab:snapshot:issues:ts` | `triage/scripts/start-colony.sh` (snapshot step) | the four agents' `snapshot_fresh()` gate |
+| `gitlab:snapshot:issues` | `triage/scripts/start-colony.sh` (snapshot step; refreshed by the `start-federation.sh` sidecar) | labeler, router, prioritizer, issue_creator |
+| `gitlab:snapshot:issues:ts` | `triage/scripts/start-colony.sh` (snapshot step; refreshed by the `start-federation.sh` sidecar) | the four agents' `snapshot_fresh()` gate |
+| `<agent>:snapshot_hash` | labeler / router / prioritizer (end of tick) | the same agent's per-tick no-change gate (skip `prompt()` when the view fingerprint is unchanged) |
 
 > The same mechanism extends to the `merge_requests` collection in the Planning / Implementation / Code Review / Release colonies; their reads are label-event-filtered rather than plain full-collection fetches, so that wiring is driven by the live run (#1117) and is not enabled yet.
 

--- a/dev-apprenticeship/start-federation.sh
+++ b/dev-apprenticeship/start-federation.sh
@@ -170,7 +170,7 @@ if [ -f "$AUTO_PROMOTE_INSTALL_FILE" ]; then
                 ) &
                 AUTO_PROMOTE_PID=$!
                 # shellcheck disable=SC2064  # Expand PID at trap-install time, not at trigger time.
-                trap "[ -n \"$AUTO_PROMOTE_PID\" ] && kill \"$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"\${COST_CAP_PID:-}\" ] && kill \"\$COST_CAP_PID\" 2>/dev/null; exit" EXIT TERM INT
+                trap "[ -n \"$AUTO_PROMOTE_PID\" ] && kill \"$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"\${COST_CAP_PID:-}\" ] && kill \"\$COST_CAP_PID\" 2>/dev/null; [ -n \"\${SNAPSHOT_REFRESH_PID:-}\" ] && kill \"\$SNAPSHOT_REFRESH_PID\" 2>/dev/null; exit" EXIT TERM INT
                 echo "Auto-promote scheduler: PID $AUTO_PROMOTE_PID, every ${AP_INTERVAL}s (log: .agentis/logs/auto-promote.log)"
                 echo ""
             fi
@@ -233,12 +233,73 @@ if [ -f "$COST_CAP_INSTALL_FILE" ]; then
                 ) &
                 COST_CAP_PID=$!
                 # shellcheck disable=SC2064
-                trap "[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"$COST_CAP_PID\" ] && kill \"$COST_CAP_PID\" 2>/dev/null; exit" EXIT TERM INT
+                trap "[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"$COST_CAP_PID\" ] && kill \"$COST_CAP_PID\" 2>/dev/null; [ -n \"\${SNAPSHOT_REFRESH_PID:-}\" ] && kill \"\$SNAPSHOT_REFRESH_PID\" 2>/dev/null; exit" EXIT TERM INT
                 echo "Cost-cap sidecar: PID $COST_CAP_PID, every ${CC_INTERVAL}s (log: .agentis/logs/cost-cap.log)"
                 echo ""
             fi
         fi
     fi
+fi
+
+# --- Shared-snapshot refresh sidecar (#1111) ---
+#
+# The Triage colony publishes ONE shared GitLab issues snapshot per colony
+# per tick (#1111/#1112): triage/scripts/start-colony.sh writes the compact
+# envelope to the `gitlab:snapshot:issues` memo plus an epoch freshness key
+# at `gitlab:snapshot:issues:ts`. Every triage agent reads that memo instead
+# of each curling /issues, collapsing the former 3-4x duplicate fetch per
+# tick down to one. The snapshot is published on full-colony bootstrap, but
+# the agents' snapshot_fresh() gate treats anything older than 600s as stale
+# and degrades to a per-agent direct fetch — i.e. without periodic refresh
+# the I/O win evaporates after the freshness window and every agent
+# permanently falls back to the per-agent fetch #1111 set out to eliminate.
+#
+# This sidecar keeps the snapshot fresh by re-running the daemon-free
+# `--snapshot-refresh` mode on an interval SHORTER than the 600s window
+# (default 300s) so a fresh snapshot is always within reach. It mirrors the
+# auto-promote / cost-cap sidecar shape: self-terminate when the federation
+# has zero running daemons, EXIT/TERM/INT trap that kills it on shutdown.
+#
+# Backward-safe: a missing triage start-colony.sh, or a refresh failure, is
+# logged and ignored — the snapshot step itself is total-on-failure (it
+# leaves the prior snapshot in place on error), so a sidecar hiccup never
+# breaks the federation; agents simply degrade to direct fetch until the
+# next successful refresh.
+SNAPSHOT_REFRESH_INTERVAL="${SNAPSHOT_REFRESH_INTERVAL_S:-300}"
+case "$SNAPSHOT_REFRESH_INTERVAL" in
+    ''|*[!0-9]*) SNAPSHOT_REFRESH_INTERVAL=300 ;;
+    *) [ "$SNAPSHOT_REFRESH_INTERVAL" -gt 0 ] || SNAPSHOT_REFRESH_INTERVAL=300 ;;
+esac
+SNAPSHOT_REFRESH_PID=""
+SNAP_START_COLONY="$FED_DIR/triage/scripts/start-colony.sh"
+if [ ! -x "$SNAP_START_COLONY" ]; then
+    echo "[!!] Snapshot-refresh sidecar: triage/scripts/start-colony.sh not executable, skipping."
+else
+    SNAP_LOG_DIR="$FED_DIR/.agentis/logs"
+    SNAP_LOG="$SNAP_LOG_DIR/snapshot-refresh.log"
+    mkdir -p "$SNAP_LOG_DIR"
+    (
+        # First action is a tick (not a sleep) so the snapshot is refreshed
+        # immediately and the freshness clock restarts right after spawn.
+        while :; do
+            if ! agentis daemon list --json 2>/dev/null | grep -Fq '"state":"running"'; then
+                printf '=== %s: no running daemons; sidecar exiting ===\n' \
+                    "$(date -Iseconds)" >> "$SNAP_LOG"
+                exit 0
+            fi
+            {
+                printf '=== %s: snapshot-refresh tick ===\n' "$(date -Iseconds)"
+                "$SNAP_START_COLONY" --snapshot-refresh 2>&1 \
+                    || printf '[sidecar] start-colony.sh --snapshot-refresh exited %s\n' "$?"
+            } >> "$SNAP_LOG"
+            sleep "$SNAPSHOT_REFRESH_INTERVAL"
+        done
+    ) &
+    SNAPSHOT_REFRESH_PID=$!
+    # shellcheck disable=SC2064  # Expand PID at trap-install time, not at trigger time.
+    trap "[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"\${COST_CAP_PID:-}\" ] && kill \"\$COST_CAP_PID\" 2>/dev/null; [ -n \"$SNAPSHOT_REFRESH_PID\" ] && kill \"$SNAPSHOT_REFRESH_PID\" 2>/dev/null; exit" EXIT TERM INT
+    echo "Snapshot-refresh sidecar: PID $SNAPSHOT_REFRESH_PID, every ${SNAPSHOT_REFRESH_INTERVAL}s (log: .agentis/logs/snapshot-refresh.log)"
+    echo ""
 fi
 
 wait

--- a/dev-apprenticeship/triage/README.md
+++ b/dev-apprenticeship/triage/README.md
@@ -51,6 +51,19 @@ Reactive agents (`router`, `prioritizer`) follow a **delta-check + early-exit** 
 
 The last-check refresh inside the early-exit branch is load-bearing — otherwise the `--since` window never advances on quiet projects and each tick would keep re-querying the same gap. This is the conventional structure for all reactive agents in this federation; see `agents/router.ag` and `agents/prioritizer.ag` for the canonical shape.
 
+## Shared issues snapshot (#1111 / #1112)
+
+All four agents read the same `issues` collection, so without sharing the endpoint is fetched once per agent per tick (3–4× the same payload). Instead, `scripts/start-colony.sh` publishes **one** compressed snapshot per colony per tick:
+
+- **Fetch once + compress:** `scripts/forge-api.sh snapshot issues` fetches the collection a single time and pipes it through `scripts/snapshot-compress.py`, producing a compact, deduplicated, structurally-chunked envelope (#1112) — the bytes that reach `prompt()` are this compact form, not raw JSON.
+- **Publish to a shared memo:** the envelope is written to `gitlab:snapshot:issues` with an epoch-seconds freshness key at `gitlab:snapshot:issues:ts`. Re-run the publish standalone with `./scripts/start-colony.sh --snapshot-refresh`.
+- **Agents read the memo:** each agent's `issues_cmd()` first tries `snapshot_issues_cmd(<view>)`, which `recall_latest()`s the snapshot and (when fresh, ≤ 600 s) renders its role view via `forge-api.sh issues --from-snapshot --view <view>` — **zero HTTP**. A missing / empty / stale / malformed snapshot returns `""`, so the agent transparently falls back to its legacy direct `forge-api.sh issues` fetch (backward-safe). The shared snapshot is used only on the single-repo path; the multi-repo (`[[forge.github]]`) fan-out keeps its per-repo direct fetch.
+
+| Key | Written by | Read by |
+|-----|-----------|---------|
+| `gitlab:snapshot:issues` | `start-colony.sh` snapshot step | `labeler`, `router`, `prioritizer`, `issue_creator` |
+| `gitlab:snapshot:issues:ts` | `start-colony.sh` snapshot step | each agent's `snapshot_fresh()` gate |
+
 ## Setup
 
 1. Copy and edit the config:

--- a/dev-apprenticeship/triage/README.md
+++ b/dev-apprenticeship/triage/README.md
@@ -57,12 +57,15 @@ All four agents read the same `issues` collection, so without sharing the endpoi
 
 - **Fetch once + compress:** `scripts/forge-api.sh snapshot issues` fetches the collection a single time and pipes it through `scripts/snapshot-compress.py`, producing a compact, deduplicated, structurally-chunked envelope (#1112) — the bytes that reach `prompt()` are this compact form, not raw JSON.
 - **Publish to a shared memo:** the envelope is written to `gitlab:snapshot:issues` with an epoch-seconds freshness key at `gitlab:snapshot:issues:ts`. Re-run the publish standalone with `./scripts/start-colony.sh --snapshot-refresh`.
+- **Keep it fresh:** `start-federation.sh` runs a snapshot-refresh sidecar that re-runs `--snapshot-refresh` every 300 s (`SNAPSHOT_REFRESH_INTERVAL_S` override) — shorter than the 600 s freshness window, so the snapshot never goes stale and the agents never permanently fall back to per-agent fetches. The sidecar self-terminates when the federation stops and is backward-safe (refresh failures are logged, not fatal).
 - **Agents read the memo:** each agent's `issues_cmd()` first tries `snapshot_issues_cmd(<view>)`, which `recall_latest()`s the snapshot and (when fresh, ≤ 600 s) renders its role view via `forge-api.sh issues --from-snapshot --view <view>` — **zero HTTP**. A missing / empty / stale / malformed snapshot returns `""`, so the agent transparently falls back to its legacy direct `forge-api.sh issues` fetch (backward-safe). The shared snapshot is used only on the single-repo path; the multi-repo (`[[forge.github]]`) fan-out keeps its per-repo direct fetch.
+- **No-change gate:** because the snapshot is the full collection (not a `--since` delta), `raw` is non-empty every tick even when nothing changed. `labeler` / `router` / `prioritizer` fingerprint (SHA-256) their projected view, memo it as `<agent>:snapshot_hash`, and skip `prompt()` on a tick whose fingerprint matches the last-processed one — restoring the quiet-project early-exit on the snapshot path. `issue_creator`'s suggest prompt is already gated by `poll_inbox()`.
 
 | Key | Written by | Read by |
 |-----|-----------|---------|
-| `gitlab:snapshot:issues` | `start-colony.sh` snapshot step | `labeler`, `router`, `prioritizer`, `issue_creator` |
-| `gitlab:snapshot:issues:ts` | `start-colony.sh` snapshot step | each agent's `snapshot_fresh()` gate |
+| `gitlab:snapshot:issues` | `start-colony.sh` snapshot step (refreshed by the `start-federation.sh` sidecar) | `labeler`, `router`, `prioritizer`, `issue_creator` |
+| `gitlab:snapshot:issues:ts` | `start-colony.sh` snapshot step (refreshed by the `start-federation.sh` sidecar) | each agent's `snapshot_fresh()` gate |
+| `<agent>:snapshot_hash` | `labeler` / `router` / `prioritizer` (end of tick) | the same agent's per-tick no-change gate |
 
 ## Setup
 

--- a/dev-apprenticeship/triage/agents/issue_creator.ag
+++ b/dev-apprenticeship/triage/agents/issue_creator.ag
@@ -73,7 +73,46 @@ fn repo_field(line: string, idx: int) -> string {
     return out;
 }
 
+// #1111: is the shared per-colony issues snapshot fresh enough to read?
+// start-colony.sh's snapshot step writes `gitlab:snapshot:issues:ts` (epoch
+// seconds) alongside the snapshot blob. A snapshot older than the window
+// (or with no ts at all) is treated as stale -> caller falls back to a
+// direct fetch. Total-on-failure: a missing/garbled ts yields stale=false
+// via the parse_int->0 path, so a broken snapshot can never starve an agent.
+fn snapshot_fresh() -> bool {
+    let ts_raw = recall_latest("gitlab:snapshot:issues:ts");
+    if len(ts_raw) == 0 { return false; };
+    let ts = parse_int(ts_raw);
+    if ts == 0 { return false; };
+    let now_raw = try { exec sh "date +%s"; } catch e { "0"; };
+    let now = parse_int(now_raw);
+    if now == 0 { return false; };
+    return (now - ts) <= 600;
+}
+
+// #1111: build a forge-api.sh command that projects `view` out of the
+// shared snapshot memo (zero HTTP) when a fresh snapshot exists; "" means
+// "no usable snapshot — degrade to a direct fetch". Reads the compressed
+// (#1112) envelope from the memo and passes it to the --from-snapshot path
+// via the GITLAB_SNAPSHOT env var. Only used on the legacy single-repo path
+// (owner==""); the per-colony snapshot is not repo-scoped.
+fn snapshot_issues_cmd(view: string) -> string {
+    let blob = recall_latest("gitlab:snapshot:issues");
+    if len(blob) < 20 { return ""; };
+    if !snapshot_fresh() { return ""; };
+    // colony-lint: safe-exec-concat
+    return "GITLAB_SNAPSHOT=" + shell_escape(blob) + " $COLONY_DIR/scripts/forge-api.sh issues --from-snapshot --view " + view;
+}
+
 fn issues_cmd(owner: string, repo: string) -> string {
+    // #1111: prefer the shared snapshot on the single-repo path. When it is
+    // fresh, every triage agent reads the same memo instead of each curling
+    // /issues (the 3x duplicate fetch per tick). Empty return = no fresh
+    // snapshot -> fall through to the legacy direct fetch below.
+    if len(owner) == 0 {
+        let snap = snapshot_issues_cmd("issue_creator");
+        if len(snap) > 0 { return snap; };
+    };
     let ts = recall_latest(scoped_memo(owner, repo, "issue_creator:last_check"));
     // colony-lint: safe-exec-concat
     if len(ts) > 0 {

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -121,6 +121,20 @@ fn snapshot_issues_cmd(view: string) -> string {
     return "GITLAB_SNAPSHOT=" + shell_escape(blob) + " $COLONY_DIR/scripts/forge-api.sh issues --from-snapshot --view " + view;
 }
 
+// #1111 (Fix #9): content fingerprint of the view bytes that would feed
+// prompt(). On the legacy `--since last_check` path a quiet project returns
+// `[]` (handled by the len(raw) < 3 early-exit), but the shared snapshot is
+// the FULL collection, so `raw` is non-empty every tick even when nothing
+// changed. Hashing the projected view and comparing to a per-agent memo
+// restores the quiet-project early-exit: identical content => no prompt().
+// Total-on-failure: a hash failure yields "" so the gate never matches and
+// the agent falls through to its normal prompt() path (never starved).
+fn content_hash(raw: string) -> string {
+    let cmd = "RAW=" + shell_escape(raw) +
+        " python3 -c 'import os,hashlib; print(hashlib.sha256(os.environ[\"RAW\"].encode(\"utf-8\")).hexdigest())'";
+    return try { exec sh cmd; } catch e { ""; };
+}
+
 fn issues_cmd(owner: string, repo: string) -> string {
     // #1111: prefer the shared snapshot on the single-repo path. When it is
     // fresh, every triage agent reads the same memo instead of each curling
@@ -514,6 +528,28 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         return;
     };
 
+    // #1111 (Fix #9): snapshot-content-hash gate. The shared snapshot is the
+    // full issues collection, so `raw` is non-empty every tick even on a
+    // quiet project — without this gate the agent would call prompt() each
+    // tick for no change. Compare the fingerprint of the current view bytes
+    // against the last-processed hash; if unchanged, no-op (refresh
+    // last_check, keep the hash) exactly like the legacy `--since`-empty
+    // early-exit. ADDITIONAL to the prompt-gate, not a replacement: one
+    // tier() call/tick and the recall_latest()-based check-prompt-gate stay
+    // intact. The pending-verdict reality checks above still run every tick
+    // (they precede this gate). A "" hash never matches -> agent proceeds.
+    let cur_hash = content_hash(raw);
+    let prev_hash = recall_latest(scoped_memo(owner, repo, "labeler:snapshot_hash"));
+    if len(cur_hash) > 0 {
+        if cur_hash == prev_hash {
+            let now_h = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_h) > 0 {
+                memo_write(scoped_memo(owner, repo, "labeler:last_check"), now_h);
+            };
+            return;
+        };
+    };
+
     // Analyze: find labeled and unlabeled issues
     let analysis = prompt(
         "Analyze this GitLab issues JSON. Count issues with labels (labeled_count) and without (unlabeled_count). Summarize labeling patterns (patterns). For unlabeled issues list their IDs and titles (unlabeled_issues). Return JSON: labeled_count (int), unlabeled_count (int), patterns (string), unlabeled_issues (string).",
@@ -632,6 +668,12 @@ fn tick_for_repo(owner: string, repo: string) -> void {
     let new_issue = listen("triage:new_issue", 100);
     if len(to_string(new_issue)) > 5 {
         print("[labeler] Received new issue draft, will label on next tick");
+    };
+
+    // #1111 (Fix #9): stamp the just-processed view fingerprint so the next
+    // tick's hash gate above can detect "nothing changed" and skip prompt().
+    if len(cur_hash) > 0 {
+        memo_write(scoped_memo(owner, repo, "labeler:snapshot_hash"), cur_hash);
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -90,7 +90,46 @@ fn repo_field(line: string, idx: int) -> string {
     return out;
 }
 
+// #1111: is the shared per-colony issues snapshot fresh enough to read?
+// start-colony.sh's snapshot step writes `gitlab:snapshot:issues:ts` (epoch
+// seconds) alongside the snapshot blob. A snapshot older than the window
+// (or with no ts at all) is treated as stale -> caller falls back to a
+// direct fetch. Total-on-failure: a missing/garbled ts yields stale=false
+// via the parse_int->0 path, so a broken snapshot can never starve an agent.
+fn snapshot_fresh() -> bool {
+    let ts_raw = recall_latest("gitlab:snapshot:issues:ts");
+    if len(ts_raw) == 0 { return false; };
+    let ts = parse_int(ts_raw);
+    if ts == 0 { return false; };
+    let now_raw = try { exec sh "date +%s"; } catch e { "0"; };
+    let now = parse_int(now_raw);
+    if now == 0 { return false; };
+    return (now - ts) <= 600;
+}
+
+// #1111: build a forge-api.sh command that projects `view` out of the
+// shared snapshot memo (zero HTTP) when a fresh snapshot exists; "" means
+// "no usable snapshot — degrade to a direct fetch". Reads the compressed
+// (#1112) envelope from the memo and passes it to the --from-snapshot path
+// via the GITLAB_SNAPSHOT env var. Only used on the legacy single-repo path
+// (owner==""); the per-colony snapshot is not repo-scoped.
+fn snapshot_issues_cmd(view: string) -> string {
+    let blob = recall_latest("gitlab:snapshot:issues");
+    if len(blob) < 20 { return ""; };
+    if !snapshot_fresh() { return ""; };
+    // colony-lint: safe-exec-concat
+    return "GITLAB_SNAPSHOT=" + shell_escape(blob) + " $COLONY_DIR/scripts/forge-api.sh issues --from-snapshot --view " + view;
+}
+
 fn issues_cmd(owner: string, repo: string) -> string {
+    // #1111: prefer the shared snapshot on the single-repo path. When it is
+    // fresh, every triage agent reads the same memo instead of each curling
+    // /issues (the 3x duplicate fetch per tick). Empty return = no fresh
+    // snapshot -> fall through to the legacy direct fetch below.
+    if len(owner) == 0 {
+        let snap = snapshot_issues_cmd("labeler");
+        if len(snap) > 0 { return snap; };
+    };
     let ts = recall_latest(scoped_memo(owner, repo, "labeler:last_check"));
     // colony-lint: safe-exec-concat
     if len(ts) > 0 {

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -118,6 +118,20 @@ fn snapshot_issues_cmd(view: string) -> string {
     return "GITLAB_SNAPSHOT=" + shell_escape(blob) + " $COLONY_DIR/scripts/forge-api.sh issues --from-snapshot --view " + view;
 }
 
+// #1111 (Fix #9): content fingerprint of the view bytes that would feed
+// prompt(). On the legacy `--since last_check` path a quiet project returns
+// `[]` (handled by the len(raw) < 3 early-exit), but the shared snapshot is
+// the FULL collection, so `raw` is non-empty every tick even when nothing
+// changed. Hashing the projected view and comparing to a per-agent memo
+// restores the quiet-project early-exit: identical content => no prompt().
+// Total-on-failure: a hash failure yields "" so the gate never matches and
+// the agent falls through to its normal prompt() path (never starved).
+fn content_hash(raw: string) -> string {
+    let cmd = "RAW=" + shell_escape(raw) +
+        " python3 -c 'import os,hashlib; print(hashlib.sha256(os.environ[\"RAW\"].encode(\"utf-8\")).hexdigest())'";
+    return try { exec sh cmd; } catch e { ""; };
+}
+
 fn issues_cmd(owner: string, repo: string) -> string {
     // #1111: prefer the shared snapshot on the single-repo path. When it is
     // fresh, every triage agent reads the same memo instead of each curling
@@ -163,6 +177,27 @@ fn tick_for_repo(owner: string, repo: string) -> void {
             memo_write(scoped_memo(owner, repo, "prioritizer:last_check"), now_e);
         };
         return;
+    };
+
+    // #1111 (Fix #9): snapshot-content-hash gate. The shared snapshot is the
+    // full issues collection, so `raw` is non-empty every tick even on a
+    // quiet project — without this gate the agent would call prompt() each
+    // tick for no change. Compare the fingerprint of the current view bytes
+    // against the last-processed hash; if unchanged, no-op (refresh
+    // last_check, keep the hash) exactly like the legacy `--since`-empty
+    // early-exit. ADDITIONAL to the prompt-gate, not a replacement: one
+    // tier() call/tick and the recall_latest()-based check-prompt-gate stay
+    // intact. A "" hash (compute failure) never matches -> agent proceeds.
+    let cur_hash = content_hash(raw);
+    let prev_hash = recall_latest(scoped_memo(owner, repo, "prioritizer:snapshot_hash"));
+    if len(cur_hash) > 0 {
+        if cur_hash == prev_hash {
+            let now_h = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_h) > 0 {
+                memo_write(scoped_memo(owner, repo, "prioritizer:last_check"), now_h);
+            };
+            return;
+        };
     };
 
     // #226: operator-configurable priority label vocabulary. The agentis
@@ -278,6 +313,12 @@ fn tick_for_repo(owner: string, repo: string) -> void {
     let new_issue = listen("triage:new_issue", 100);
     if len(to_string(new_issue)) > 5 {
         print("[prioritizer] Received new issue draft, will prioritize on next tick");
+    };
+
+    // #1111 (Fix #9): stamp the just-processed view fingerprint so the next
+    // tick's hash gate above can detect "nothing changed" and skip prompt().
+    if len(cur_hash) > 0 {
+        memo_write(scoped_memo(owner, repo, "prioritizer:snapshot_hash"), cur_hash);
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };

--- a/dev-apprenticeship/triage/agents/prioritizer.ag
+++ b/dev-apprenticeship/triage/agents/prioritizer.ag
@@ -87,7 +87,46 @@ fn repo_field(line: string, idx: int) -> string {
     return out;
 }
 
+// #1111: is the shared per-colony issues snapshot fresh enough to read?
+// start-colony.sh's snapshot step writes `gitlab:snapshot:issues:ts` (epoch
+// seconds) alongside the snapshot blob. A snapshot older than the window
+// (or with no ts at all) is treated as stale -> caller falls back to a
+// direct fetch. Total-on-failure: a missing/garbled ts yields stale=false
+// via the parse_int->0 path, so a broken snapshot can never starve an agent.
+fn snapshot_fresh() -> bool {
+    let ts_raw = recall_latest("gitlab:snapshot:issues:ts");
+    if len(ts_raw) == 0 { return false; };
+    let ts = parse_int(ts_raw);
+    if ts == 0 { return false; };
+    let now_raw = try { exec sh "date +%s"; } catch e { "0"; };
+    let now = parse_int(now_raw);
+    if now == 0 { return false; };
+    return (now - ts) <= 600;
+}
+
+// #1111: build a forge-api.sh command that projects `view` out of the
+// shared snapshot memo (zero HTTP) when a fresh snapshot exists; "" means
+// "no usable snapshot — degrade to a direct fetch". Reads the compressed
+// (#1112) envelope from the memo and passes it to the --from-snapshot path
+// via the GITLAB_SNAPSHOT env var. Only used on the legacy single-repo path
+// (owner==""); the per-colony snapshot is not repo-scoped.
+fn snapshot_issues_cmd(view: string) -> string {
+    let blob = recall_latest("gitlab:snapshot:issues");
+    if len(blob) < 20 { return ""; };
+    if !snapshot_fresh() { return ""; };
+    // colony-lint: safe-exec-concat
+    return "GITLAB_SNAPSHOT=" + shell_escape(blob) + " $COLONY_DIR/scripts/forge-api.sh issues --from-snapshot --view " + view;
+}
+
 fn issues_cmd(owner: string, repo: string) -> string {
+    // #1111: prefer the shared snapshot on the single-repo path. When it is
+    // fresh, every triage agent reads the same memo instead of each curling
+    // /issues (the 3x duplicate fetch per tick). Empty return = no fresh
+    // snapshot -> fall through to the legacy direct fetch below.
+    if len(owner) == 0 {
+        let snap = snapshot_issues_cmd("prioritizer");
+        if len(snap) > 0 { return snap; };
+    };
     let ts = recall_latest(scoped_memo(owner, repo, "prioritizer:last_check"));
     // colony-lint: safe-exec-concat
     if len(ts) > 0 {

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -150,6 +150,20 @@ fn snapshot_issues_cmd(view: string) -> string {
     return "GITLAB_SNAPSHOT=" + shell_escape(blob) + " $COLONY_DIR/scripts/forge-api.sh issues --from-snapshot --view " + view;
 }
 
+// #1111 (Fix #9): content fingerprint of the view bytes that would feed
+// prompt(). On the legacy `--since last_check` path a quiet project returns
+// `[]` (handled by the len(raw) < 3 early-exit), but the shared snapshot is
+// the FULL collection, so `raw` is non-empty every tick even when nothing
+// changed. Hashing the projected view and comparing to a per-agent memo
+// restores the quiet-project early-exit: identical content => no prompt().
+// Total-on-failure: a hash failure yields "" so the gate never matches and
+// the agent falls through to its normal prompt() path (never starved).
+fn content_hash(raw: string) -> string {
+    let cmd = "RAW=" + shell_escape(raw) +
+        " python3 -c 'import os,hashlib; print(hashlib.sha256(os.environ[\"RAW\"].encode(\"utf-8\")).hexdigest())'";
+    return try { exec sh cmd; } catch e { ""; };
+}
+
 fn issues_cmd(owner: string, repo: string) -> string {
     // #1111: prefer the shared snapshot on the single-repo path. When it is
     // fresh, every triage agent reads the same memo instead of each curling
@@ -197,6 +211,27 @@ fn tick_for_repo(owner: string, repo: string) -> void {
             memo_write(scoped_memo(owner, repo, "router:last_check"), now_e);
         };
         return;
+    };
+
+    // #1111 (Fix #9): snapshot-content-hash gate. The shared snapshot is the
+    // full issues collection, so `raw` is non-empty every tick even on a
+    // quiet project — without this gate the agent would call prompt() each
+    // tick for no change. Compare the fingerprint of the current view bytes
+    // against the last-processed hash; if unchanged, no-op (refresh
+    // last_check, keep the hash) exactly like the legacy `--since`-empty
+    // early-exit. ADDITIONAL to the prompt-gate, not a replacement: one
+    // tier() call/tick and the recall_latest()-based check-prompt-gate stay
+    // intact. A "" hash (compute failure) never matches -> agent proceeds.
+    let cur_hash = content_hash(raw);
+    let prev_hash = recall_latest(scoped_memo(owner, repo, "router:snapshot_hash"));
+    if len(cur_hash) > 0 {
+        if cur_hash == prev_hash {
+            let now_h = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now_h) > 0 {
+                memo_write(scoped_memo(owner, repo, "router:last_check"), now_h);
+            };
+            return;
+        };
     };
 
     // Get team members
@@ -304,6 +339,12 @@ fn tick_for_repo(owner: string, repo: string) -> void {
     let new_issue = listen("triage:new_issue", 100);
     if len(to_string(new_issue)) > 5 {
         print("[router] Received new issue draft, will route on next tick");
+    };
+
+    // #1111 (Fix #9): stamp the just-processed view fingerprint so the next
+    // tick's hash gate above can detect "nothing changed" and skip prompt().
+    if len(cur_hash) > 0 {
+        memo_write(scoped_memo(owner, repo, "router:snapshot_hash"), cur_hash);
     };
 
     let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };

--- a/dev-apprenticeship/triage/agents/router.ag
+++ b/dev-apprenticeship/triage/agents/router.ag
@@ -119,7 +119,46 @@ fn closed_by_context(owner: string, repo: string, blob: string) -> string {
     return try { exec sh cmd; } catch e { ""; };
 }
 
+// #1111: is the shared per-colony issues snapshot fresh enough to read?
+// start-colony.sh's snapshot step writes `gitlab:snapshot:issues:ts` (epoch
+// seconds) alongside the snapshot blob. A snapshot older than the window
+// (or with no ts at all) is treated as stale -> caller falls back to a
+// direct fetch. Total-on-failure: a missing/garbled ts yields stale=false
+// via the parse_int->0 path, so a broken snapshot can never starve an agent.
+fn snapshot_fresh() -> bool {
+    let ts_raw = recall_latest("gitlab:snapshot:issues:ts");
+    if len(ts_raw) == 0 { return false; };
+    let ts = parse_int(ts_raw);
+    if ts == 0 { return false; };
+    let now_raw = try { exec sh "date +%s"; } catch e { "0"; };
+    let now = parse_int(now_raw);
+    if now == 0 { return false; };
+    return (now - ts) <= 600;
+}
+
+// #1111: build a forge-api.sh command that projects `view` out of the
+// shared snapshot memo (zero HTTP) when a fresh snapshot exists; "" means
+// "no usable snapshot — degrade to a direct fetch". Reads the compressed
+// (#1112) envelope from the memo and passes it to the --from-snapshot path
+// via the GITLAB_SNAPSHOT env var. Only used on the legacy single-repo path
+// (owner==""); the per-colony snapshot is not repo-scoped.
+fn snapshot_issues_cmd(view: string) -> string {
+    let blob = recall_latest("gitlab:snapshot:issues");
+    if len(blob) < 20 { return ""; };
+    if !snapshot_fresh() { return ""; };
+    // colony-lint: safe-exec-concat
+    return "GITLAB_SNAPSHOT=" + shell_escape(blob) + " $COLONY_DIR/scripts/forge-api.sh issues --from-snapshot --view " + view;
+}
+
 fn issues_cmd(owner: string, repo: string) -> string {
+    // #1111: prefer the shared snapshot on the single-repo path. When it is
+    // fresh, every triage agent reads the same memo instead of each curling
+    // /issues (the 3x duplicate fetch per tick). Empty return = no fresh
+    // snapshot -> fall through to the legacy direct fetch below.
+    if len(owner) == 0 {
+        let snap = snapshot_issues_cmd("router");
+        if len(snap) > 0 { return snap; };
+    };
     let ts = recall_latest(scoped_memo(owner, repo, "router:last_check"));
     // colony-lint: safe-exec-concat
     if len(ts) > 0 {

--- a/dev-apprenticeship/triage/scripts/github-api.sh
+++ b/dev-apprenticeship/triage/scripts/github-api.sh
@@ -30,6 +30,11 @@
 
 set -e
 
+# Resolve this script's own directory so the snapshot verb (#1111/#1112) can
+# locate the sibling snapshot-compress.py helper (shared with gitlab-api.sh)
+# regardless of the caller's CWD.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # emit_error <message>
 # Matches gitlab-api.sh emit_error contract: JSON error object to stderr.
 emit_error() {
@@ -370,6 +375,7 @@ case "$CMD" in
         SINCE=""
         STATE="open"
         VIEW=""
+        FROM_SNAPSHOT=0
         while [ $# -gt 0 ]; do
             case "$1" in
                 # GitLab uses "opened" in the state filter; GitHub uses "open".
@@ -386,9 +392,24 @@ case "$CMD" in
                     shift 2
                     ;;
                 --view) VIEW="$2"; shift 2 ;;
+                --from-snapshot) FROM_SNAPSHOT=1; shift ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
+        # #1111: shared-snapshot read path (symmetric with gitlab-api.sh). The
+        # snapshot is already GitLab-normalized (snapshot-compress.py stores
+        # the normalized shape), so we rehydrate + project WITHOUT normalize_issues
+        # and WITHOUT any HTTP call. Empty/malformed snapshot -> `[]` -> the
+        # agent's `len(raw) < 3` early-exit treats it as no work (degrade).
+        if [ "$FROM_SNAPSHOT" = "1" ]; then
+            rehydrated="$(printf '%s' "${GITLAB_SNAPSHOT:-}" | python3 "$SCRIPT_DIR/snapshot-compress.py" --rehydrate 2>/dev/null || printf '[]')"
+            if [ -n "$VIEW" ]; then
+                printf '%s' "$rehydrated" | project_json "$VIEW"
+            else
+                printf '%s' "$rehydrated"
+            fi
+            exit 0
+        fi
         ARGS=(
             --data-urlencode "state=$STATE"
             --data-urlencode "per_page=20"
@@ -407,6 +428,45 @@ case "$CMD" in
         else
             printf '%s' "$normalized"
         fi
+        ;;
+
+    snapshot)
+        # #1111/#1112: fetch the GitHub issues collection ONCE, normalize to
+        # GitLab shape, and emit the COMPRESSED envelope. Symmetric with
+        # gitlab-api.sh snapshot so start-colony.sh's snapshot step is
+        # backend-agnostic (it always calls `forge-api.sh snapshot issues`).
+        COLLECTION="${1:-issues}"
+        case "$COLLECTION" in
+            issues|work_items) shift || true ;;
+            *) emit_error "snapshot: unsupported collection: $COLLECTION (expected: issues)"; exit 2 ;;
+        esac
+        STATE="open"
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --state)
+                    case "$2" in
+                        opened|open) STATE="open" ;;
+                        closed)      STATE="closed" ;;
+                        all)         STATE="all" ;;
+                        *) emit_error "unknown state: $2 (expected open|closed|all)"; exit 2 ;;
+                    esac
+                    shift 2
+                    ;;
+                --since) shift 2 ;;  # accepted + ignored: snapshot is full-set
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        SNAP_ARGS=(
+            --data-urlencode "state=$STATE"
+            --data-urlencode "per_page=20"
+            --data-urlencode "sort=updated"
+            --data-urlencode "direction=desc"
+        )
+        # Single fetch -> normalize -> compress. On any gh_call failure emit a
+        # valid empty envelope so the memo write never stores a stderr blob.
+        snap_body="$(gh_get_q "$API/issues" "${SNAP_ARGS[@]}")" || snap_body="[]"
+        snap_norm="$(printf '%s' "$snap_body" | normalize_issues 2>/dev/null || printf '[]')"
+        printf '%s' "$snap_norm" | python3 "$SCRIPT_DIR/snapshot-compress.py" issues
         ;;
 
     create-issue)

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -9,6 +9,8 @@
 #
 # Usage:
 #   gitlab-api.sh issues [--since ISO8601] [--state opened|closed|all] [--view <name>]
+#   gitlab-api.sh issues --from-snapshot --view <name>   (#1111: read shared snapshot)
+#   gitlab-api.sh snapshot issues [--state ...]          (#1111/#1112: fetch once + compress)
 #   gitlab-api.sh create-issue --title <t> --description <d> [--labels l1,l2] [--priority p]
 #   gitlab-api.sh update-issue <id> [--add-labels l1,l2] [--remove-labels l1,l2] [--priority p] [--assignee username]
 #   gitlab-api.sh members [--view <name>]
@@ -28,6 +30,11 @@
 # Returns JSON to stdout. Exit code 0 on success, 1 on error, 2 on unknown flag/view.
 
 set -e
+
+# Resolve this script's own directory so the snapshot verb (#1111/#1112) can
+# locate the sibling snapshot-compress.py helper regardless of the caller's
+# CWD. forge-api.sh execs us with an absolute $0, so dirname is reliable.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # emit_error <message>
 # Print a JSON error object to stderr with <message> safely encoded via
@@ -298,14 +305,34 @@ case "$CMD" in
         SINCE=""
         STATE="opened"
         VIEW=""
+        FROM_SNAPSHOT=0
         while [ $# -gt 0 ]; do
             case "$1" in
                 --since) SINCE="$2"; shift 2 ;;
                 --state) STATE="$2"; shift 2 ;;
                 --view) VIEW="$2"; shift 2 ;;
+                --from-snapshot) FROM_SNAPSHOT=1; shift ;;
                 *) emit_error "unknown flag: $1"; exit 2 ;;
             esac
         done
+        # #1111: shared-snapshot read path. The agent passes the compact
+        # snapshot envelope (the value of the `gitlab:snapshot:issues` memo,
+        # written once per tick by start-colony.sh's snapshot step) via the
+        # GITLAB_SNAPSHOT env var and asks for --from-snapshot. We rehydrate
+        # the compact form back to the GitLab-native item shape and run the
+        # SAME project_json view — zero HTTP calls. An empty / malformed
+        # snapshot rehydrates to `[]`, which the agent's `len(raw) < 3`
+        # early-exit treats as "no work", so the agent then naturally
+        # degrades to a direct fetch on the next tick (backward-safe).
+        if [ "$FROM_SNAPSHOT" = "1" ]; then
+            rehydrated="$(printf '%s' "${GITLAB_SNAPSHOT:-}" | python3 "$SCRIPT_DIR/snapshot-compress.py" --rehydrate 2>/dev/null || printf '[]')"
+            if [ -n "$VIEW" ]; then
+                printf '%s' "$rehydrated" | project_json "$VIEW"
+            else
+                printf '%s' "$rehydrated"
+            fi
+            exit 0
+        fi
         ARGS=(
             --data-urlencode "state=$STATE"
             --data-urlencode "per_page=20"
@@ -325,6 +352,46 @@ case "$CMD" in
         else
             gl_get_q "$API/$ISSUE_COLLECTION" "${ARGS[@]}"
         fi
+        ;;
+
+    snapshot)
+        # #1111/#1112: fetch one GitLab collection ONCE and emit its
+        # COMPRESSED representation on stdout. start-colony.sh's per-tick
+        # snapshot step runs this exactly once per collection per colony per
+        # tick and publishes the result to the `gitlab:snapshot:<collection>`
+        # memo; every agent then reads that memo instead of curling the
+        # endpoint itself (killing the 3x/4x duplicate fetch per tick).
+        #
+        # The compression (snapshot-compress.py, #1112) normalizes each item
+        # to the union of role-relevant fields, content-addresses each item's
+        # structure, interns repeated structures once, and references them by
+        # index — so the bytes that reach prompt() are the compact form, not
+        # raw JSON. Deterministic + byte-stable for identical input.
+        COLLECTION="${1:-issues}"
+        case "$COLLECTION" in
+            issues|work_items) shift || true ;;
+            *) emit_error "snapshot: unsupported collection: $COLLECTION (expected: issues)"; exit 2 ;;
+        esac
+        STATE="opened"
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --state) STATE="$2"; shift 2 ;;
+                --since) shift 2 ;;  # accepted + ignored: snapshot is full-set
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        SNAP_ARGS=(
+            --data-urlencode "state=$STATE"
+            --data-urlencode "per_page=20"
+            --data-urlencode "order_by=updated_at"
+            --data-urlencode "sort=desc"
+        )
+        # Single fetch. On any gl_call failure (auth/429/5xx/transport) we
+        # still emit a valid empty envelope so the memo write does not store
+        # a stderr error blob — agents degrade to direct fetch when the
+        # snapshot is empty/stale.
+        snap_body="$(gl_get_q "$API/$ISSUE_COLLECTION" "${SNAP_ARGS[@]}")" || snap_body="[]"
+        printf '%s' "$snap_body" | python3 "$SCRIPT_DIR/snapshot-compress.py" issues
         ;;
 
     create-issue)

--- a/dev-apprenticeship/triage/scripts/snapshot-compress.py
+++ b/dev-apprenticeship/triage/scripts/snapshot-compress.py
@@ -85,11 +85,17 @@ def normalize_issue(item):
         "author": _username(item.get("author")),
         "assignees": [_username(a) for a in item.get("assignees", []) if isinstance(item.get("assignees"), list)],
     }
-    # description is large; keep only its presence + a short head so the
-    # compact form does not re-import the very bulk we are compressing.
+    # description is consumed in FULL by the issue_creator view (it reads
+    # `description`), so the compact form must carry the untruncated value or
+    # the rehydrated issue_creator projection would silently differ from the
+    # legacy direct-fetch one. We keep the full string here; the
+    # labeler/router/prioritizer views drop `description` in their
+    # project_json projections, so this field never reaches their prompts —
+    # only the issue_creator view pays for it. Structural interning still
+    # collapses two issues with identical full descriptions to one chunk.
     desc = _str(item.get("description"))
     if desc:
-        out["desc_head"] = desc[:200]
+        out["description"] = desc
     return out
 
 
@@ -219,13 +225,13 @@ def rehydrate(env):
         assignees = chunk.get("assignees")
         if isinstance(assignees, list) and assignees:
             row["assignees"] = [{"username": a} for a in assignees]
-        for opt in ("desc_head", "source_branch", "target_branch"):
+        for opt in ("description", "source_branch", "target_branch"):
             if opt in chunk:
-                # desc_head maps back to description for the issue_creator
-                # view (which reads `description`); branch fields pass
-                # straight through for the MR views.
-                key = "description" if opt == "desc_head" else opt
-                row[key] = chunk.get(opt, "")
+                # `description` is carried in full (see normalize_issue) so the
+                # issue_creator view's rehydrated `description` is byte-identical
+                # to the legacy direct-fetch value; branch fields pass straight
+                # through for the MR views.
+                row[opt] = chunk.get(opt, "")
         out.append(row)
     return out
 
@@ -274,10 +280,16 @@ if __name__ == "__main__":
     # Allow `--self-test` for a quick local determinism/round-trip check
     # without standing up a GitLab instance. Not used at runtime.
     if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
+        # A description long enough that the legacy 200-char `desc_head` would
+        # have truncated it — used below to prove the issue_creator view's
+        # rehydrated `description` is now byte-identical to the source value.
+        long_desc = "Steps to reproduce:\n" + ("x" * 500) + "\nExpected: no crash."
         sample = json.dumps([
             {"iid": 1, "title": "fix bug", "labels": ["bug"], "state": "opened",
+             "description": long_desc,
              "author": {"username": "alice"}, "assignees": [{"username": "bob"}]},
             {"iid": 2, "title": "fix bug", "labels": ["bug"], "state": "opened",
+             "description": long_desc,
              "author": {"username": "alice"}, "assignees": [{"username": "bob"}]},
             {"iid": 3, "title": "add docs", "labels": [], "state": "opened",
              "author": {"username": "carol"}, "assignees": []},
@@ -305,9 +317,16 @@ if __name__ == "__main__":
         assert rh[0]["assignees"] == [{"username": "bob"}], rh[0]
         assert rh[2]["author"] == {"username": "carol"}, rh[2]
         assert "assignees" not in rh[2], rh[2]  # carol has no assignees
+        # #2b: the issue_creator view reads `description` in full. The
+        # rehydrated value must be byte-identical to the source description
+        # (the legacy desc_head[:200] truncation is gone). carol's issue had
+        # no description -> the field is absent (not "" — matches a
+        # direct-fetch item that omits a null description from the view).
+        assert rh[0]["description"] == long_desc, "description truncated/altered"
+        assert "description" not in rh[2], rh[2]  # carol has no description
         # rehydrate of garbage -> [] (total-on-failure).
         assert rehydrate({}) == [] and rehydrate("nope") == [], "rehydrate degrade"
-        sys.stderr.write("self-test OK: byte-stable, dedup 3->2 chunks, rehydrate round-trip, total-on-failure\n")
+        sys.stderr.write("self-test OK: byte-stable, dedup 3->2 chunks, rehydrate round-trip, full-description fidelity, total-on-failure\n")
         sys.exit(0)
     if len(sys.argv) > 1 and sys.argv[1] == "--rehydrate":
         main_rehydrate()

--- a/dev-apprenticeship/triage/scripts/snapshot-compress.py
+++ b/dev-apprenticeship/triage/scripts/snapshot-compress.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# snapshot-compress.py: structural-chunk compression for a GitLab collection
+# snapshot (#1112).
+#
+# Reads a raw GitLab JSON array (e.g. /work_items or /merge_requests, the
+# full `gitlab-api.sh issues`/`merge-requests` body) on stdin, emits a
+# compact, deduplicated, structurally-chunked representation on stdout. The
+# shared per-colony snapshot memo (#1111) stores THIS form, not the raw
+# blob, so the bytes that ultimately reach an agent's prompt() are the
+# compact form (the #119 "factor 5-10x raw-JSON waste").
+#
+# The compression reuses the dark-factory normalized-subtree-hashing idea
+# (see dark-factory/evm-harness/struct-sig.js): normalize each item to the
+# role-relevant fields, hash the normalized STRUCTURE of each item to a
+# content address, intern repeated structures once in a `chunks` table, and
+# reference them by index from each item. Identical structure across items
+# (and across ticks) is stored once and referenced, never re-serialized.
+#
+# Output schema (deterministic, byte-stable for identical input):
+#   {
+#     "v": 1,                       # format version
+#     "collection": "<name>",       # e.g. "issues" | "merge_requests"
+#     "count": <int>,               # number of items
+#     "fields": [ ... ],            # union of normalized field names, sorted
+#     "chunks": [ <structural-chunk>, ... ],  # interned, content-addressed
+#     "items": [ {"k": <key>, "c": <chunk-index>}, ... ]  # key + chunk ref
+#   }
+#
+# Each <structural-chunk> is the normalized field map for an item with the
+# item key removed (so two items that differ only by iid still share a
+# chunk when their other fields match). The item layer carries the per-item
+# key (iid for issues, iid for MRs) plus the chunk index. A reader
+# rehydrates an item as { "iid": k, **chunks[c] }.
+#
+# Determinism: dict keys are emitted sorted, the chunk table is ordered by
+# first-appearance, and json.dumps uses sort_keys + compact separators. The
+# same raw input therefore hashes to the same output on every run (the
+# #1112 byte-stability DoD).
+#
+# Total-on-failure: any parse / shape error -> emit an empty-but-valid
+# envelope ({"v":1,...,"count":0,"chunks":[],"items":[]}) on stdout and
+# exit 0. The snapshot step and the agents both treat an empty envelope as
+# "no snapshot" and degrade to the legacy direct-fetch path, so a malformed
+# upstream payload never hard-fails a tick (#1111 backward-safe degrade).
+
+import hashlib
+import json
+import os
+import sys
+
+FORMAT_VERSION = 1
+
+# Union of every field any dev-apprenticeship role projects out of a GitLab
+# item (see each colony's gitlab-api.sh project_json views). Keeping this an
+# explicit allowlist is what makes the compact form small: anything not in
+# the list (web_url, time_stats, references, ...) is dropped before the blob
+# ever reaches a prompt(). New role fields are added here in one place.
+ISSUE_FIELDS = ("iid", "title", "labels", "state", "description")
+MR_FIELDS = ("iid", "title", "labels", "state", "source_branch", "target_branch")
+
+
+def _str(v):
+    return v if isinstance(v, str) else ("" if v is None else str(v))
+
+
+def _username(obj):
+    if isinstance(obj, dict):
+        return _str(obj.get("username"))
+    return ""
+
+
+def _labels(v):
+    if isinstance(v, list):
+        return [_str(x) for x in v]
+    return []
+
+
+def normalize_issue(item):
+    # iid is the item key, carried at the item layer (not in the chunk) so
+    # two issues that differ only by iid still intern to the same chunk.
+    out = {
+        "title": _str(item.get("title")),
+        "labels": _labels(item.get("labels")),
+        "state": _str(item.get("state")),
+        "author": _username(item.get("author")),
+        "assignees": [_username(a) for a in item.get("assignees", []) if isinstance(item.get("assignees"), list)],
+    }
+    # description is large; keep only its presence + a short head so the
+    # compact form does not re-import the very bulk we are compressing.
+    desc = _str(item.get("description"))
+    if desc:
+        out["desc_head"] = desc[:200]
+    return out
+
+
+def normalize_mr(item):
+    out = {
+        "title": _str(item.get("title")),
+        "labels": _labels(item.get("labels")),
+        "state": _str(item.get("state")),
+        "source_branch": _str(item.get("source_branch")),
+        "target_branch": _str(item.get("target_branch")),
+        "author": _username(item.get("author")),
+    }
+    return out
+
+
+def normalize(collection, item):
+    if not isinstance(item, dict):
+        return None
+    if collection == "merge_requests":
+        chunk = normalize_mr(item)
+    else:
+        chunk = normalize_issue(item)
+    key = item.get("iid")
+    if not isinstance(key, int):
+        try:
+            key = int(_str(key))
+        except (TypeError, ValueError):
+            key = 0
+    return key, chunk
+
+
+def chunk_hash(chunk):
+    # Content address of a normalized structural chunk. The canonical JSON
+    # (sorted keys, compact separators) is what guarantees a verbatim,
+    # renamed-field-order, or reformatted-but-structurally-identical item
+    # collapses to the SAME hash -> stored once -> referenced. Mirrors
+    # struct-sig.js's normalize()->content-hash collapse for Solidity
+    # functions, applied here to GitLab item structure.
+    canon = json.dumps(chunk, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()[:16]
+
+
+def empty_envelope(collection):
+    return {
+        "v": FORMAT_VERSION,
+        "collection": collection,
+        "count": 0,
+        "fields": [],
+        "chunks": [],
+        "items": [],
+    }
+
+
+def compress(collection, raw):
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return empty_envelope(collection)
+    if not isinstance(data, list):
+        return empty_envelope(collection)
+
+    chunks = []
+    chunk_index = {}  # hash -> position in chunks (first-appearance order)
+    items = []
+    field_set = set()
+
+    for item in data:
+        norm = normalize(collection, item)
+        if norm is None:
+            continue
+        key, chunk = norm
+        field_set.update(chunk.keys())
+        h = chunk_hash(chunk)
+        idx = chunk_index.get(h)
+        if idx is None:
+            idx = len(chunks)
+            chunk_index[h] = idx
+            chunks.append(chunk)
+        items.append({"k": key, "c": idx})
+
+    return {
+        "v": FORMAT_VERSION,
+        "collection": collection,
+        "count": len(items),
+        "fields": sorted(field_set),
+        "chunks": chunks,
+        "items": items,
+    }
+
+
+def rehydrate(env):
+    # Expand a compact envelope back into the per-item list of normalized
+    # field maps (item key folded back in as "iid"). Used by the read-side
+    # `--from-snapshot` projection so an agent's view downselect operates on
+    # the same field set it saw pre-#1111, just sourced from the shared
+    # memo instead of a per-agent HTTP fetch.
+    if not isinstance(env, dict):
+        return []
+    chunks = env.get("chunks")
+    items = env.get("items")
+    if not isinstance(chunks, list) or not isinstance(items, list):
+        return []
+    out = []
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        idx = it.get("c")
+        if not isinstance(idx, int) or idx < 0 or idx >= len(chunks):
+            continue
+        chunk = chunks[idx]
+        if not isinstance(chunk, dict):
+            continue
+        # Reconstruct the GitLab-native nested shape (author/assignees as
+        # username objects) so the EXISTING project_json views in
+        # gitlab-api.sh project the rehydrated item byte-for-byte the same
+        # as a freshly-fetched one — no view code changes needed for the
+        # snapshot read path.
+        row = {
+            "iid": it.get("k"),
+            "title": chunk.get("title", ""),
+            "labels": chunk.get("labels", []),
+            "state": chunk.get("state", ""),
+        }
+        author = chunk.get("author", "")
+        if author:
+            row["author"] = {"username": author}
+        assignees = chunk.get("assignees")
+        if isinstance(assignees, list) and assignees:
+            row["assignees"] = [{"username": a} for a in assignees]
+        for opt in ("desc_head", "source_branch", "target_branch"):
+            if opt in chunk:
+                # desc_head maps back to description for the issue_creator
+                # view (which reads `description`); branch fields pass
+                # straight through for the MR views.
+                key = "description" if opt == "desc_head" else opt
+                row[key] = chunk.get(opt, "")
+        out.append(row)
+    return out
+
+
+def normalize_collection(name):
+    # Map the legacy /issues spelling and the migrated /work_items spelling
+    # (#1119) to the same logical collection name so the memo key + the
+    # compact form's "collection" tag are stable across the rename. The MR
+    # verb's hyphen spelling collapses to the underscore form too.
+    if name in ("work_items", "work-items"):
+        return "issues"
+    if name == "merge-requests":
+        return "merge_requests"
+    return name
+
+
+def main():
+    collection = sys.argv[1] if len(sys.argv) > 1 else "issues"
+    collection = normalize_collection(collection)
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        raw = ""
+    env = compress(collection, raw)
+    # Compact, sorted, deterministic. byte-stable for identical input.
+    sys.stdout.write(json.dumps(env, sort_keys=True, separators=(",", ":")))
+
+
+def main_rehydrate():
+    # `--rehydrate`: read a compact envelope on stdin, emit the rehydrated
+    # per-item JSON array on stdout (the shape an agent's --view projection
+    # consumes). Total-on-failure -> emit `[]` and exit 0 so the agent's
+    # `len(raw) < 3` early-exit treats a bad/empty snapshot as "no work".
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        raw = ""
+    try:
+        env = json.loads(raw)
+    except (ValueError, TypeError):
+        env = {}
+    sys.stdout.write(json.dumps(rehydrate(env), separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    # Allow `--self-test` for a quick local determinism/round-trip check
+    # without standing up a GitLab instance. Not used at runtime.
+    if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
+        sample = json.dumps([
+            {"iid": 1, "title": "fix bug", "labels": ["bug"], "state": "opened",
+             "author": {"username": "alice"}, "assignees": [{"username": "bob"}]},
+            {"iid": 2, "title": "fix bug", "labels": ["bug"], "state": "opened",
+             "author": {"username": "alice"}, "assignees": [{"username": "bob"}]},
+            {"iid": 3, "title": "add docs", "labels": [], "state": "opened",
+             "author": {"username": "carol"}, "assignees": []},
+        ])
+        a = json.dumps(compress("issues", sample), sort_keys=True, separators=(",", ":"))
+        b = json.dumps(compress("issues", sample), sort_keys=True, separators=(",", ":"))
+        assert a == b, "not byte-stable"
+        env = json.loads(a)
+        assert env["count"] == 3, env["count"]
+        # items 1 and 2 are structurally identical -> share a chunk; item 3
+        # differs -> own chunk. So exactly 2 interned chunks for 3 items.
+        assert len(env["chunks"]) == 2, len(env["chunks"])
+        assert env["items"][0]["c"] == env["items"][1]["c"], "dedup failed"
+        assert env["items"][2]["c"] != env["items"][0]["c"], "over-merge"
+        # malformed input -> empty-but-valid envelope, never a crash.
+        bad = compress("issues", "{not json")
+        assert bad["count"] == 0 and bad["chunks"] == [], bad
+        # rehydrate round-trip: compact -> per-item list keeps iid + fields
+        # in the GitLab-native nested shape the project_json views consume.
+        rh = rehydrate(env)
+        assert len(rh) == 3, len(rh)
+        assert rh[0]["iid"] == 1 and rh[2]["iid"] == 3, rh
+        assert rh[0]["title"] == "fix bug" and rh[2]["title"] == "add docs", rh
+        assert rh[0]["author"] == {"username": "alice"}, rh[0]
+        assert rh[0]["assignees"] == [{"username": "bob"}], rh[0]
+        assert rh[2]["author"] == {"username": "carol"}, rh[2]
+        assert "assignees" not in rh[2], rh[2]  # carol has no assignees
+        # rehydrate of garbage -> [] (total-on-failure).
+        assert rehydrate({}) == [] and rehydrate("nope") == [], "rehydrate degrade"
+        sys.stderr.write("self-test OK: byte-stable, dedup 3->2 chunks, rehydrate round-trip, total-on-failure\n")
+        sys.exit(0)
+    if len(sys.argv) > 1 and sys.argv[1] == "--rehydrate":
+        main_rehydrate()
+        sys.exit(0)
+    main()

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -28,6 +28,7 @@ set -e
 # path, for backwards compatibility with pre-#257 callers.
 RESTART_AGENT=""
 RATE_LIMIT_STATUS=0
+SNAPSHOT_REFRESH=0
 POSITIONAL=()
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -41,6 +42,14 @@ while [ $# -gt 0 ]; do
             ;;
         --rate-limit-status)
             RATE_LIMIT_STATUS=1
+            shift
+            ;;
+        --snapshot-refresh)
+            # #1111: re-run the shared-snapshot publish step and exit. Lets a
+            # lightweight sidecar (or start-federation.sh) refresh the
+            # per-colony GitLab snapshot every tick without re-bootstrapping
+            # the colony. Reuses the full env-load path below.
+            SNAPSHOT_REFRESH=1
             shift
             ;;
         --)
@@ -211,6 +220,53 @@ AGENTS=(
     router
 )
 
+# #1111/#1112: publish ONE shared GitLab snapshot per colony per tick.
+#
+# Fetches the issues collection exactly once via forge-api.sh (the single
+# fetch implementation), compresses it (#1112, snapshot-compress.py inside
+# the backend wrapper), and writes the compact envelope to the shared
+# `gitlab:snapshot:issues` memo plus an epoch-seconds freshness key at
+# `gitlab:snapshot:issues:ts`. Every triage agent then reads that memo via
+# recall_latest() instead of each curling /issues — collapsing the former
+# 3x-per-tick duplicate fetch (labeler + router + prioritizer; +
+# issue_creator) down to one.
+#
+# Total-on-failure: a fetch/compress failure leaves the prior snapshot (and
+# its ts) in place; agents see a stale ts and degrade to a direct fetch.
+# We only publish a snapshot that parses to a non-empty envelope, so a
+# transient error never overwrites a good snapshot with `[]`.
+publish_snapshot() {
+    local fed_root="$1"
+    local snap
+    snap="$("$COLONY_DIR/scripts/forge-api.sh" snapshot issues 2>/dev/null)" || return 0
+    # Guard: only publish a structurally-valid, non-empty envelope. The
+    # compressed empty form is `{"chunks":[],...,"count":0,...}`; refuse to
+    # clobber a good snapshot with an empty one on a transient fetch error.
+    local ok
+    ok="$(SNAP="$snap" python3 -c 'import os,json,sys
+try:
+    e=json.loads(os.environ["SNAP"])
+    sys.stdout.write("1" if isinstance(e,dict) and e.get("count",0)>0 else "0")
+except Exception:
+    sys.stdout.write("0")' 2>/dev/null || printf '0')"
+    if [ "$ok" != "1" ]; then
+        return 0
+    fi
+    local now
+    now="$(date +%s)"
+    (cd "$fed_root" && agentis memo set gitlab:snapshot:issues "$snap" >/dev/null 2>&1) || true
+    (cd "$fed_root" && agentis memo set gitlab:snapshot:issues:ts "$now" >/dev/null 2>&1) || true
+}
+
+# #1111: --snapshot-refresh mode. Re-publish the shared snapshot and exit.
+# Same env-load path as --rate-limit-status; safe to invoke every tick from
+# a sidecar. No daemon launches, no memo seeding, no log truncation.
+if [ "$SNAPSHOT_REFRESH" = "1" ]; then
+    SNAP_FED_ROOT="$(cd "$REPO_ROOT/dev-apprenticeship" && pwd)"
+    publish_snapshot "$SNAP_FED_ROOT"
+    exit 0
+fi
+
 # #226: vocabulary memo seeding. Operator-tuned priority label vocabulary
 # overrides the hardcoded defaults baked into the prioritizer prompts.
 # Read from colony.toml on every restart so config edits take effect on
@@ -245,6 +301,13 @@ if [ -z "$RESTART_AGENT" ] && [ "$RATE_LIMIT_STATUS" = "0" ]; then
             i=$((i + 1))
         done
     fi
+
+    # #1111: seed the shared GitLab snapshot once on full-colony bootstrap so
+    # the first tick of every agent already reads the memo instead of
+    # cold-curling /issues. A sidecar (or the next bootstrap) keeps it fresh
+    # via `--snapshot-refresh`. Best-effort: a fetch failure here just means
+    # the first tick falls back to a direct fetch (backward-safe).
+    publish_snapshot "$FED_ROOT"
 fi
 
 # Opt-in log truncation. Off by default so operators who rely on log


### PR DESCRIPTION
21 agents each `curl`'d the full GitLab endpoint per tick + pushed raw JSON into `prompt()` (`/issues` fetched 3×/tick) → throttling death spiral. This builds the **shared-snapshot + compression mechanism** and applies it to the **triage/issues** path (the canonical 3×→1× duplicate-fetch case the issues call the prerequisite for everything else).

**#1111 shared snapshot:** `start-colony` `publish_snapshot()` fetches issues ONCE → memo `gitlab:snapshot:issues` (+`:ts`); the 4 triage agents read via `recall_latest()` + `forge-api.sh issues --from-snapshot` instead of each curl'ing. `gitlab/github-api.sh` gain `snapshot`/`--from-snapshot` verbs (backend-symmetric). `--snapshot-refresh` sidecar mode. **Backward-safe:** missing/empty/stale(>600s)/malformed snapshot → agents fall back to legacy direct fetch (no crash).

**#1112 compression:** `snapshot-compress.py` normalizes items to role-relevant fields, content-addresses + interns repeated structures (normalized-subtree hashing, reusing the dark-factory `struct-sig` concept), refs by index → **~11× smaller**, byte-stable, `--self-test` + `--rehydrate`, total-on-failure.

## Honest scope
Mechanism + triage/issues path done. The `merge_requests` collections (planning/impl/code-review/release — label-event-FILTERED reads, not full-collection) are deferred to the live-run-driven #1117; the mechanism is portable + documented. Measured I/O reduction is only provable on #1117 (not runnable here) — DoD here = mechanism-correct + lint-clean + backward-safe.

## Validation
`./tools/colony-lint.sh` (agentis on PATH) → **416 passed, 0 failed, 5 skipped**; `snapshot-compress.py --self-test` passes (byte-stable round-trip); check-prompt-gate/check-exec-sh/check-forge-dispatch clean.

Closes #1111. Closes #1112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)