### PR TITLE
feat(dev-apprenticeship): per-tick cost/rate instrumentation + CB cap & forge-429 backoff (#1114, #1115)

### DIFF
--- a/dev-apprenticeship/BUNDLE.manifest
+++ b/dev-apprenticeship/BUNDLE.manifest
@@ -42,6 +42,11 @@ tools/resolve-tick-interval.py
 tools/cost-cap.sh
 tools/cost-cap-sum.py
 tools/cost-cap-lock.py
+# Cost/rate instrumentation report (#1114) — driven by a start-federation.sh
+# sidecar that folds per-prompt spend rows + `agentis stats` into a
+# machine-readable per-agent / per-role cost+rate log.
+tools/cost-rate-report.sh
+tools/cost-rate-report.py
 tools/experience-transfer.sh
 tools/experience-transfer-pack.py
 # scaffold-agent.sh ships so installed federations can scaffold pre-built

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -85,6 +85,81 @@ is asserted until multi-version CI is in place.
   closed-by-index}.{sh,py}`. Test: `tools/test-cross-repo-refs.sh` (7
   cases). Dashboard timeline overlay deferred to follow-up.
 
+- **Cost / rate instrumentation report + sidecar (#1114).** New
+  `tools/cost-rate-report.sh <fed-dir> [--json] [--baseline] [--self-test]`
+  (all Python in `tools/cost-rate-report.py`, no heredocs) folds each
+  colony's per-prompt spend rows
+  (`<fed>/<colony>/.agentis/spend/<agent>.jsonl`, #311 — one row ≈ one
+  prompt) plus `agentis stats --json --per-identity` into a
+  machine-readable per-agent **and** per-role (per-colony) record:
+  `prompts`, `prompts_per_hour` (rolling over the trailing window from row
+  `ts`), `chars_in` (proxy: `avg_input_size` × prompts), `chars_out`
+  (proxy: Σ `output_tokens`), `cost_usd` (Σ `cost_usd`, null → 0), a
+  **throttle vs task-error split** (`throttle_events` = forge-429 /
+  `[llm.cancelled]` rows; `task_errors` = agent failure markers — kept as
+  separate fields end to end), and `retries` (0 with a documented note:
+  spend rows do not carry a colony-side retry count today, so the field is
+  wired but reads 0 until the runtime emits it). Default output is one
+  compact line per role (`role=… prompts=… pph=… cin=… cout=… cost=…
+  throttle=… retries=…`); `--json` emits the structured object;
+  `--baseline` stamps the pre-fix number (~74 KB/agent) to
+  `<fed>/.agentis/logs/cost-rate-baseline.json` so improvements are
+  provable. A **4th `start-federation.sh` sidecar** runs the report every
+  `COST_RATE_INTERVAL_S` (default 60 s) to `.agentis/logs/cost-rate.log`,
+  mirroring the snapshot-refresh / cost-cap / auto-promote sidecars
+  exactly (tick-first emit, `''|*[!0-9]*` / `-gt 0` interval validation,
+  self-terminate on zero running daemons, EXIT/TERM/INT trap that also
+  kills the new `COST_RATE_PID`, backward-safe skip-with-warning when the
+  report is not executable). `--self-test` seeds a synthetic spend.jsonl +
+  stats fixture in a temp dir and asserts every field including the
+  throttle-vs-error split and the baseline stamp. **Operator-run-gated /
+  upstream (NOT in this PR):** the real-backend baseline number, the
+  ≥ 90 % prompt-cache-hit DoD line, and the induced-rate-limit recovery
+  line all require a live LLM backend and are operator-run. The
+  LLM-backend HTTP-429 backoff / prompt cache that produces
+  `[llm.cancelled]` rows lives in the agentis runtime / LLM backend
+  (handled upstream); this report only observes the resulting rows. Tools
+  added to `BUNDLE.manifest`.
+
+- **Per-tick CB cap + forge rate-limit backoff (#1115).** Two colony-side
+  guardrails:
+  - **`--cb-per-tick` cap.** All five colonies' `start-colony.sh` now
+    splice `--cb-per-tick <n>` onto every `agentis daemon` launch (both the
+    normal launch and the `--restart-agent` respawn path), config-driven
+    via a new `cb_per_tick_for()` helper that mirrors the per-agent
+    `--tick-interval` pattern (#146): a per-agent `cb_per_tick` under the
+    matching `[[agents]]` entry wins, else the colony-wide
+    `[colony].cb_per_tick` default, else 2000 (matching
+    `daemon.cb_per_tick` in `<fed>/.agentis/config`). The example configs
+    document the key. Unlike `--config-override` (#351), `--cb-per-tick` is
+    a real `agentis daemon` flag, so this lands on the binary. A runaway
+    tick can no longer burn the whole budget in one pass.
+  - **Jittered forge-429 backoff + observable rate-limited state.** Every
+    colony's `gitlab-api.sh` retry loop now adds equal-jitter on top of its
+    existing exponential backoff (`_backoff_sleep`: slept value in
+    `[delay, delay + delay/2]`) so simultaneous retries from many agents do
+    not synchronise into a thundering herd. The agents that act on forge
+    writes (`approval_decider`, `risk_assessor`, `plan_reviewer`) detect a
+    rate-limited write (via the `rate-limit-status` contract), record a
+    growing jittered backoff window in a `<agent>:rate_limited_until` memo,
+    emit a `<colony>:rate-limited` event, and **defer** rather than mark the
+    task failed; a successful write clears the state. `--cb-per-tick` and
+    the LLM-backend HTTP-429 backoff are distinct layers: the latter lives
+    in the agentis runtime / LLM backend (handled upstream). Test:
+    `tools/test-rate-limit-backoff.sh` stubs a 429-on-every-attempt forge
+    call and asserts the backoff delays grow within their jitter bounds,
+    the call gives up after the retry budget (no retry storm), and the
+    rate-limited memo + emit + defer wiring is present. **Operator-run-gated
+    (NOT in this PR):** the live induced-rate-limit recovery DoD line
+    requires a real backend and is operator-run; this PR ships the
+    mechanism + synthetic proof. The `rl_is_limited` helper guards the
+    null/absent-`remaining` case (`to_string(json_get(...)) == "void"` →
+    not limited) so a genuine forge failure on an instance that emits no
+    `RateLimit-*` headers (null `remaining`, e.g. self-hosted GitLab with
+    rate limiting disabled) is no longer misclassified as a rate-limit and
+    swallowed into backoff — only a real numeric `remaining == 0` trips the
+    rate-limited path.
+
 ### Fixed
 
 - GitLab issue-collection rename (#1119): GitLab migrated the

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -49,6 +49,8 @@ graph LR
 - [What to expect](#what-to-expect)
 - [Auto-confidence from feedback](#auto-confidence-from-feedback-106)
 - [Colonies](#colonies)
+- [Cost / rate instrumentation](#cost--rate-instrumentation-1114)
+- [CB cap + forge rate-limit backoff](#cb-cap--forge-rate-limit-backoff-1115)
 - [Knowledge portability](#knowledge-portability)
 - [Troubleshooting](#troubleshooting)
 - [Extension points](#extension-points)
@@ -383,6 +385,27 @@ Two mechanisms fix this:
 | `<agent>:snapshot_hash` | labeler / router / prioritizer (end of tick) | the same agent's per-tick no-change gate (skip `prompt()` when the view fingerprint is unchanged) |
 
 > The same mechanism extends to the `merge_requests` collection in the Planning / Implementation / Code Review / Release colonies; their reads are label-event-filtered rather than plain full-collection fetches, so that wiring is driven by the live run (#1117) and is not enabled yet.
+
+## Cost / rate instrumentation (#1114)
+
+`tools/cost-rate-report.sh <fed-dir> [--json] [--baseline]` folds each colony's per-prompt spend rows (`<fed>/<colony>/.agentis/spend/<agent>.jsonl`, one row ≈ one prompt) plus `agentis stats --json --per-identity` into a machine-readable per-agent **and** per-role (per-colony) report:
+
+- `prompts` (spend-row count), `prompts_per_hour` (rolling over the trailing window from row `ts`), `chars_in` (proxy: `avg_input_size` × prompts), `chars_out` (proxy: Σ `output_tokens`), `cost_usd` (Σ `cost_usd`, null → 0).
+- A **throttle vs task-error split**: `throttle_events` counts forge-429 / `[llm.cancelled]` rows, `task_errors` counts agent failure markers — they are kept as separate fields.
+- `retries` (colony-side retry markers). Spend rows do not carry a retry count today, so this reads `0` until the runtime emits it; the field is wired end to end so it lights up the moment a row stamps `retries`.
+
+Default output is one compact line per role; `--json` emits the structured object; `--baseline` stamps the pre-fix number (~74 KB/agent) to `<fed>/.agentis/logs/cost-rate-baseline.json` so improvements are provable. `tools/cost-rate-report.sh --self-test` seeds a synthetic spend.jsonl + stats fixture and asserts every field (including the throttle-vs-error split and the baseline stamp).
+
+**`start-federation.sh` runs a cost-rate sidecar** that re-runs the report every `COST_RATE_INTERVAL_S` (default 60 s) to `.agentis/logs/cost-rate.log` — the recorded artifact that proves "a run produces a machine-readable log with all fields". It mirrors the snapshot-refresh / cost-cap / auto-promote sidecars exactly: tick-first emit, self-terminate on zero running daemons, killed on shutdown (EXIT/TERM/INT trap), and backward-safe (skipped with a warning if the report is not executable). The real-backend baseline number, the ≥ 90 % prompt-cache-hit line, and the induced-rate-limit recovery line require a live LLM backend and are operator-run.
+
+## CB cap + forge rate-limit backoff (#1115)
+
+Two colony-side guardrails bound per-tick spend and survive a rate-limited forge:
+
+- **Per-tick CB cap.** Every colony's `start-colony.sh` splices `--cb-per-tick <n>` onto each `agentis daemon` launch (normal launch **and** `--restart-agent` respawn). It is config-driven: a per-agent `cb_per_tick` under the matching `[[agents]]` entry wins, otherwise the colony-wide `[colony].cb_per_tick` (documented in `config/colony.example.toml`), otherwise `2000` (matching `daemon.cb_per_tick` in `<fed>/.agentis/config`). A single runaway tick can no longer burn the whole budget in one pass.
+- **Jittered forge-429 backoff + observable rate-limited state.** Each colony's `gitlab-api.sh` retry loop adds equal-jitter on top of its existing exponential backoff (slept value in `[delay, delay + delay/2]`) so simultaneous retries from many agents do not synchronise into a thundering herd. When a forge write hits the backend rate limit, the acting agents (`approval_decider`, `risk_assessor`, `plan_reviewer`) record a growing jittered backoff window in a `<agent>:rate_limited_until` memo, emit a `<colony>:rate-limited` event, and **defer** the write to a later tick rather than mark the task failed; a successful write clears the state. `tools/test-rate-limit-backoff.sh` stubs a 429-on-every-attempt forge call and asserts the delays grow within their jitter bounds, the call gives up after the retry budget (no retry storm), and the rate-limited memo + emit + defer wiring is present.
+
+> The LLM-backend HTTP-429 backoff and prompt cache are a separate layer that lives in the agentis runtime / LLM backend (handled upstream). The `--cb-per-tick` cap and the forge-429 backoff above are the colony-side mechanisms; the live induced-rate-limit recovery DoD line is operator-run.
 
 ## Knowledge portability
 

--- a/dev-apprenticeship/code-review/agents/approval_decider.ag
+++ b/dev-apprenticeship/code-review/agents/approval_decider.ag
@@ -70,6 +70,89 @@ fn repo_field(line: string, idx: int) -> string {
     return out;
 }
 
+// --- Forge rate-limit backoff observability (#1115) ---
+//
+// When a forge write fails because the backend is rate-limited (the
+// gitlab-api.sh / github-api.sh wrapper returns exit 3 after exhausting its
+// own jittered exponential retries), the agent must NOT mark the task failed.
+// Instead it records a backoff window in the `<agent>:rate_limited_until`
+// memo and emits a `code-review:rate-limited` event so the condition is
+// observable, then defers the write to a later tick. The window grows
+// exponentially across consecutive rate-limit hits (tracked in
+// `<agent>:rl_count`) with +/-25% jitter so many agents do not resynchronise
+// their retries into a thundering herd. The LLM-backend HTTP-429 backoff /
+// prompt cache lives in the agentis runtime / LLM backend (handled upstream);
+// this helper only governs the colony-side forge calls.
+
+fn rl_now_epoch() -> int {
+    let raw = try { exec sh "date -u +%s"; } catch e { ""; };
+    if len(raw) == 0 { return 0; };
+    return parse_int(raw);
+}
+
+// Active when `rate_limited_until` is set and still in the future.
+fn rl_active(agent_name: string, owner: string, repo: string) -> int {
+    let until_raw = recall_latest(scoped_memo(owner, repo, agent_name + ":rate_limited_until"));
+    if len(until_raw) == 0 { return 0; };
+    let until = parse_int(until_raw);
+    let now = rl_now_epoch();
+    if now == 0 { return 0; };
+    if until > now { return 1; };
+    return 0;
+}
+
+// Compute a jittered exponential backoff (seconds) for the given hit count.
+// base 5s, doubled per consecutive hit, capped at 300s, then +/-25% jitter
+// via the shell so the value is non-deterministic between agents.
+fn rl_backoff_secs(count: int) -> int {
+    let cmd = "C=" + shell_escape(to_string(count)) +
+        " python3 -c 'import os,random; c=int(os.environ[\"C\"]); base=min(300, 5*(2**max(0,c-1))); lo=int(base*0.75); hi=int(base*1.25); print(random.randint(lo, hi) if hi>lo else base)'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    if len(out) == 0 { return 5; };
+    let secs = parse_int(out);
+    if secs <= 0 { return 5; };
+    return secs;
+}
+
+// Record a rate-limit hit: grow the count, stamp the until-memo, emit the
+// observable event. Returns nothing; the caller defers its write.
+fn rl_mark(agent_name: string, owner: string, repo: string) -> void {
+    let count_raw = recall_latest(scoped_memo(owner, repo, agent_name + ":rl_count"));
+    let prev = if len(count_raw) > 0 { parse_int(count_raw); } else { 0; };
+    let count = prev + 1;
+    let now = rl_now_epoch();
+    let backoff = rl_backoff_secs(count);
+    let until = now + backoff;
+    memo_write(scoped_memo(owner, repo, agent_name + ":rl_count"), to_string(count));
+    memo_write(scoped_memo(owner, repo, agent_name + ":rate_limited_until"), to_string(until));
+    emit("code-review:rate-limited", agent_name + " backoff " + to_string(backoff) + "s until " + to_string(until));
+    print("[approval_decider] rate-limited; backing off", backoff, "s (hit", count, ")");
+}
+
+// Clear the backoff state after a successful forge write.
+fn rl_clear(agent_name: string, owner: string, repo: string) -> void {
+    memo_write(scoped_memo(owner, repo, agent_name + ":rl_count"), "0");
+    memo_write(scoped_memo(owner, repo, agent_name + ":rate_limited_until"), "0");
+}
+
+// Detect whether a just-failed forge call failed because the backend is
+// rate-limited (vs an auth / 4xx / transport error). Consults the
+// `forge-api.sh rate-limit-status` contract ({remaining, limit, reset_at}):
+// `remaining == 0` is the rate-limit signature. Total-on-failure: when the
+// status call itself errors or the instance reports null remaining, returns
+// 0 so a non-rate-limit failure is not misclassified as a backoff.
+fn rl_is_limited(owner: string, repo: string) -> int {
+    // colony-lint: safe-exec-concat
+    let cmd = "$COLONY_DIR/scripts/forge-api.sh rate-limit-status" + repo_arg(owner, repo);
+    let raw = try { exec sh cmd; } catch e { ""; };
+    if len(raw) < 3 { return 0; };
+    let val = to_string(json_get(raw, "remaining"));
+    if val == "void" { return 0; };
+    let remaining = parse_int(val);
+    if remaining == 0 { return 1; };
+    return 0;
+}
+
 fn tick_for_repo(owner: string, repo: string) -> void {
     // #147: cheap delta-check. approval_decider has no GitLab poll —
     // its input is the colony bus. If no reviewer emitted findings
@@ -94,6 +177,19 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         let now_e = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now_e) > 0 {
             memo_write(scoped_memo(owner, repo, "approval_decider:last_check"), now_e);
+        };
+        return;
+    };
+
+    // #1115: rate-limit backoff gate. If a prior forge write tripped the
+    // backend's rate limit, `rate_limited_until` holds an epoch in the
+    // future; defer this tick's prompt + write entirely (task is NOT failed,
+    // just postponed) until the jittered backoff window elapses.
+    if rl_active("approval_decider", owner, repo) == 1 {
+        print("[approval_decider] in rate-limit backoff; deferring this tick");
+        let now_g = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_g) > 0 {
+            memo_write(scoped_memo(owner, repo, "approval_decider:last_check"), now_g);
         };
         return;
     };
@@ -140,8 +236,19 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         if decision.action == "approve" {
             // colony-lint: safe-exec-concat
             let approve_cmd = "$COLONY_DIR/scripts/forge-api.sh approve " + to_string(decision.mr_iid) + repo_arg(owner, repo);
-            try { exec sh approve_cmd; } catch e {
+            let approve_result = try { exec sh approve_cmd; } catch e {
                 print("[approval_decider] Failed to approve:", e);
+                "";
+            };
+            // #1115: a rate-limited write defers (records backoff + emits the
+            // observable event) instead of marking the task failed.
+            if len(approve_result) == 0 {
+                if rl_is_limited(owner, repo) == 1 {
+                    rl_mark("approval_decider", owner, repo);
+                    return;
+                };
+            } else {
+                rl_clear("approval_decider", owner, repo);
             };
             print("[approval_decider] Approved MR", decision.mr_iid);
             if len(owner) > 0 {
@@ -154,8 +261,18 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 let comment = "**Review Summary** (automated)\n\n" + decision.reasoning + "\n\nFindings: " + to_string(decision.total_findings) + " total, " + to_string(decision.critical_count) + " critical";
                 // colony-lint: safe-exec-concat
                 let post_cmd = "$COLONY_DIR/scripts/forge-api.sh post-note " + to_string(decision.mr_iid) + " --body " + shell_escape(comment) + repo_arg(owner, repo);
-                try { exec sh post_cmd; } catch e {
+                let post_result = try { exec sh post_cmd; } catch e {
                     print("[approval_decider] Failed to post:", e);
+                    "";
+                };
+                // #1115: defer on rate-limit instead of failing.
+                if len(post_result) == 0 {
+                    if rl_is_limited(owner, repo) == 1 {
+                        rl_mark("approval_decider", owner, repo);
+                        return;
+                    };
+                } else {
+                    rl_clear("approval_decider", owner, repo);
                 };
                 if len(owner) > 0 {
                     learn("approval_decision", "MR " + to_string(decision.mr_iid), "request_changes: " + decision.reasoning, "success", ["acted", "code-review", repo_tag(owner, repo)]);

--- a/dev-apprenticeship/code-review/config/colony.example.toml
+++ b/dev-apprenticeship/code-review/config/colony.example.toml
@@ -6,6 +6,13 @@
 [colony]
 name = "code-review"
 tick_interval_ms = 60000
+# Per-tick cognitive-budget cap (#1115). Splices `--cb-per-tick <n>` onto every
+# `agentis daemon` launch so a single runaway tick cannot burn the whole budget
+# in one pass. This colony-wide value is the default for every agent; override
+# it per agent with a `cb_per_tick` key inside that agent's `[[agents]]` entry.
+# Left unset, start-colony.sh falls back to 2000 (matching `daemon.cb_per_tick`
+# in `<fed>/.agentis/config` written by install.sh).
+# cb_per_tick = 2000
 
 # Forge backend selection (ADR-0002, #256). `type` picks which of the
 # per-backend blocks below is active. Legal values: "gitlab", "github".

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -114,6 +114,38 @@ ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"
 #   GITLAB_CURL_RETRIES   retry budget for 5xx/timeouts/429 (default 3).
 #                         Budget is attempts-after-first, so 3 means
 #                         4 total attempts before giving up.
+# _backoff_sleep <delay> — sleep for <delay> seconds plus jitter (#1115).
+#
+# The retry loop already grows <delay> exponentially (delay=$((delay * 2))).
+# Adding jitter on top spreads simultaneous retries from many agents so a
+# shared 429 does not synchronise into a thundering-herd retry storm. Jitter
+# is equal-jitter: the slept value lands in [delay, delay + delay/2], i.e. up
+# to +50% of the base delay, so the lower bound preserves the exponential
+# floor while the upper bound stays predictable for tests.
+#
+# GITLAB_BACKOFF_DRYRUN=1 turns this into a no-sleep trace: the chosen value
+# is appended to $GITLAB_BACKOFF_TRACE (one integer per line) and no sleep
+# happens, so tools/test-rate-limit-backoff.sh can assert growth + jitter
+# bounds deterministically without waiting on real wall-clock seconds.
+_backoff_sleep() {
+    local base="$1"
+    local span jitter slept
+    span=$((base / 2))
+    if [ "$span" -lt 1 ]; then
+        span=1
+    fi
+    # RANDOM is bash-builtin (0..32767); modulo into [0, span].
+    jitter=$((RANDOM % (span + 1)))
+    slept=$((base + jitter))
+    if [ "${GITLAB_BACKOFF_DRYRUN:-0}" = "1" ]; then
+        if [ -n "${GITLAB_BACKOFF_TRACE:-}" ]; then
+            echo "$slept" >> "$GITLAB_BACKOFF_TRACE"
+        fi
+        return 0
+    fi
+    sleep "$slept"
+}
+
 gl_call() {
     local method="$1" url="$2"
     shift 2
@@ -149,7 +181,7 @@ gl_call() {
         # curl didn't get a status line back, so $code is empty.
         if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
             if [ "$attempt" -le "$max_retries" ]; then
-                sleep "$delay"
+                _backoff_sleep "$delay"
                 delay=$((delay * 2))
                 continue
             fi
@@ -177,7 +209,7 @@ gl_call() {
                 # exponential backoff matches what a Retry-After would
                 # typically request on a self-hosted instance.
                 if [ "$attempt" -le "$max_retries" ]; then
-                    sleep "$delay"
+                    _backoff_sleep "$delay"
                     delay=$((delay * 2))
                     continue
                 fi
@@ -186,7 +218,7 @@ gl_call() {
                 ;;
             5*)
                 if [ "$attempt" -le "$max_retries" ]; then
-                    sleep "$delay"
+                    _backoff_sleep "$delay"
                     delay=$((delay * 2))
                     continue
                 fi

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -254,6 +254,42 @@ tick_interval_for() {
     esac
 }
 
+# Per-tick cognitive-budget cap override (#1115). Config-driven, mirroring
+# the per-agent tick-interval pattern (#146): a per-agent `cb_per_tick` under
+# the matching `[[agents]]` entry wins; otherwise the colony-wide
+# `[colony].cb_per_tick` default applies; otherwise the federation-wide
+# fallback (2000, matching `daemon.cb_per_tick` in `<fed>/.agentis/config`
+# written by install.sh). Spliced onto every `agentis daemon` launch as
+# `--cb-per-tick <n>` so a runaway tick cannot burn the whole budget in one
+# pass. The flag is a real `agentis daemon` flag (unlike `--config-override`,
+# #351), so this lands on the binary.
+CB_PER_TICK_DEFAULT="$(parse_toml colony cb_per_tick)"
+case "$CB_PER_TICK_DEFAULT" in
+    ''|*[!0-9]*) CB_PER_TICK_DEFAULT=2000 ;;
+    *) [ "$CB_PER_TICK_DEFAULT" -gt 0 ] || CB_PER_TICK_DEFAULT=2000 ;;
+esac
+
+cb_per_tick_for() {
+    local want="$1"
+    local n i name val
+    n="$(parse_toml_array_count agents 2>/dev/null || echo 0)"
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    i=0
+    while [ "$i" -lt "$n" ]; do
+        name="$(parse_toml_array_get agents "$i" name 2>/dev/null || echo '')"
+        if [ "$name" = "$want" ]; then
+            val="$(parse_toml_array_get agents "$i" cb_per_tick 2>/dev/null || echo '')"
+            case "$val" in
+                ''|*[!0-9]*) : ;;
+                *) if [ "$val" -gt 0 ]; then echo "$val"; return 0; fi ;;
+            esac
+            break
+        fi
+        i=$((i + 1))
+    done
+    echo "$CB_PER_TICK_DEFAULT"
+}
+
 # #319 PR 1 + #318: combined LLM-config override emitter.
 #
 # Precedence (highest first):
@@ -368,6 +404,7 @@ for d in daemons:
         done
     fi
     tick=$(tick_interval_for "$RESTART_AGENT")
+    cb=$(cb_per_tick_for "$RESTART_AGENT")
     # Detach daemon stdio from any inherited pipes (e.g. the dashboard's
     # subprocess.run(capture_output=True) pipes). Without this, the daemon
     # keeps those fds open after start-colony.sh exits, and the Python
@@ -383,6 +420,7 @@ for d in daemons:
         --enable-exec \
         --enable-messaging \
         --tick-interval "$tick" \
+        --cb-per-tick "$cb" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} </dev/null >/dev/null 2>&1 &
     agent_pid=$!
     sleep 0.5
@@ -407,12 +445,14 @@ while IFS= read -r line; do
 done < <(llm_override_args)
 for agent in "${AGENTS[@]}"; do
     interval=$(tick_interval_for "$agent")
-    echo "  Starting $agent (tick=${interval}ms)..."
+    cb=$(cb_per_tick_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms, cb-per-tick=${cb})..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony code-review \
         --enable-exec \
         --enable-messaging \
         --tick-interval "$interval" \
+        --cb-per-tick "$cb" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/implementation/config/colony.example.toml
+++ b/dev-apprenticeship/implementation/config/colony.example.toml
@@ -6,6 +6,13 @@
 [colony]
 name = "implementation"
 tick_interval_ms = 60000
+# Per-tick cognitive-budget cap (#1115). Splices `--cb-per-tick <n>` onto every
+# `agentis daemon` launch so a single runaway tick cannot burn the whole budget
+# in one pass. This colony-wide value is the default for every agent; override
+# it per agent with a `cb_per_tick` key inside that agent's `[[agents]]` entry.
+# Left unset, start-colony.sh falls back to 2000 (matching `daemon.cb_per_tick`
+# in `<fed>/.agentis/config` written by install.sh).
+# cb_per_tick = 2000
 
 # Forge backend selection (ADR-0002, #256). `type` picks which of the
 # per-backend blocks below is active. Legal values: "gitlab", "github".

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -134,6 +134,38 @@ ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"
 #   GITLAB_CURL_RETRIES   retry budget for 5xx/timeouts/429 (default 3).
 #                         Budget is attempts-after-first, so 3 means
 #                         4 total attempts before giving up.
+# _backoff_sleep <delay> — sleep for <delay> seconds plus jitter (#1115).
+#
+# The retry loop already grows <delay> exponentially (delay=$((delay * 2))).
+# Adding jitter on top spreads simultaneous retries from many agents so a
+# shared 429 does not synchronise into a thundering-herd retry storm. Jitter
+# is equal-jitter: the slept value lands in [delay, delay + delay/2], i.e. up
+# to +50% of the base delay, so the lower bound preserves the exponential
+# floor while the upper bound stays predictable for tests.
+#
+# GITLAB_BACKOFF_DRYRUN=1 turns this into a no-sleep trace: the chosen value
+# is appended to $GITLAB_BACKOFF_TRACE (one integer per line) and no sleep
+# happens, so tools/test-rate-limit-backoff.sh can assert growth + jitter
+# bounds deterministically without waiting on real wall-clock seconds.
+_backoff_sleep() {
+    local base="$1"
+    local span jitter slept
+    span=$((base / 2))
+    if [ "$span" -lt 1 ]; then
+        span=1
+    fi
+    # RANDOM is bash-builtin (0..32767); modulo into [0, span].
+    jitter=$((RANDOM % (span + 1)))
+    slept=$((base + jitter))
+    if [ "${GITLAB_BACKOFF_DRYRUN:-0}" = "1" ]; then
+        if [ -n "${GITLAB_BACKOFF_TRACE:-}" ]; then
+            echo "$slept" >> "$GITLAB_BACKOFF_TRACE"
+        fi
+        return 0
+    fi
+    sleep "$slept"
+}
+
 gl_call() {
     local method="$1" url="$2"
     shift 2
@@ -169,7 +201,7 @@ gl_call() {
         # curl didn't get a status line back, so $code is empty.
         if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
             if [ "$attempt" -le "$max_retries" ]; then
-                sleep "$delay"
+                _backoff_sleep "$delay"
                 delay=$((delay * 2))
                 continue
             fi
@@ -197,7 +229,7 @@ gl_call() {
                 # exponential backoff matches what a Retry-After would
                 # typically request on a self-hosted instance.
                 if [ "$attempt" -le "$max_retries" ]; then
-                    sleep "$delay"
+                    _backoff_sleep "$delay"
                     delay=$((delay * 2))
                     continue
                 fi
@@ -206,7 +238,7 @@ gl_call() {
                 ;;
             5*)
                 if [ "$attempt" -le "$max_retries" ]; then
-                    sleep "$delay"
+                    _backoff_sleep "$delay"
                     delay=$((delay * 2))
                     continue
                 fi

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -316,6 +316,42 @@ tick_interval_for() {
     esac
 }
 
+# Per-tick cognitive-budget cap override (#1115). Config-driven, mirroring
+# the per-agent tick-interval pattern (#146): a per-agent `cb_per_tick` under
+# the matching `[[agents]]` entry wins; otherwise the colony-wide
+# `[colony].cb_per_tick` default applies; otherwise the federation-wide
+# fallback (2000, matching `daemon.cb_per_tick` in `<fed>/.agentis/config`
+# written by install.sh). Spliced onto every `agentis daemon` launch as
+# `--cb-per-tick <n>` so a runaway tick cannot burn the whole budget in one
+# pass. The flag is a real `agentis daemon` flag (unlike `--config-override`,
+# #351), so this lands on the binary.
+CB_PER_TICK_DEFAULT="$(parse_toml colony cb_per_tick)"
+case "$CB_PER_TICK_DEFAULT" in
+    ''|*[!0-9]*) CB_PER_TICK_DEFAULT=2000 ;;
+    *) [ "$CB_PER_TICK_DEFAULT" -gt 0 ] || CB_PER_TICK_DEFAULT=2000 ;;
+esac
+
+cb_per_tick_for() {
+    local want="$1"
+    local n i name val
+    n="$(parse_toml_array_count agents 2>/dev/null || echo 0)"
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    i=0
+    while [ "$i" -lt "$n" ]; do
+        name="$(parse_toml_array_get agents "$i" name 2>/dev/null || echo '')"
+        if [ "$name" = "$want" ]; then
+            val="$(parse_toml_array_get agents "$i" cb_per_tick 2>/dev/null || echo '')"
+            case "$val" in
+                ''|*[!0-9]*) : ;;
+                *) if [ "$val" -gt 0 ]; then echo "$val"; return 0; fi ;;
+            esac
+            break
+        fi
+        i=$((i + 1))
+    done
+    echo "$CB_PER_TICK_DEFAULT"
+}
+
 # #319 PR 1 + #318: combined LLM-config override emitter.
 #
 # Precedence (highest first):
@@ -429,6 +465,7 @@ for d in daemons:
         done
     fi
     tick=$(tick_interval_for "$RESTART_AGENT")
+    cb=$(cb_per_tick_for "$RESTART_AGENT")
     # Detach daemon stdio from any inherited pipes (e.g. the dashboard's
     # subprocess.run(capture_output=True) pipes). Without this, the daemon
     # keeps those fds open after start-colony.sh exits, and the Python
@@ -444,6 +481,7 @@ for d in daemons:
         --enable-exec \
         --enable-messaging \
         --tick-interval "$tick" \
+        --cb-per-tick "$cb" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} </dev/null >/dev/null 2>&1 &
     agent_pid=$!
     sleep 0.5
@@ -468,12 +506,14 @@ while IFS= read -r line; do
 done < <(llm_override_args)
 for agent in "${AGENTS[@]}"; do
     interval=$(tick_interval_for "$agent")
-    echo "  Starting $agent (tick=${interval}ms)..."
+    cb=$(cb_per_tick_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms, cb-per-tick=${cb})..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony implementation \
         --enable-exec \
         --enable-messaging \
         --tick-interval "$interval" \
+        --cb-per-tick "$cb" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -84,6 +84,75 @@ fn repo_field(line: string, idx: int) -> string {
     return out;
 }
 
+// --- Forge rate-limit backoff observability (#1115) ---
+//
+// When a forge write fails because the backend is rate-limited (the
+// gitlab-api.sh / github-api.sh wrapper returns exit 3 after exhausting its
+// own jittered exponential retries), the agent must NOT mark the task failed.
+// Instead it records a backoff window in `<agent>:rate_limited_until` and
+// emits `planning:rate-limited` so the condition is observable, then defers
+// the write to a later tick. The window grows exponentially across
+// consecutive hits (`<agent>:rl_count`) with +/-25% jitter so many agents do
+// not resynchronise their retries into a thundering herd. The LLM-backend
+// HTTP-429 backoff / prompt cache lives in the agentis runtime / LLM backend
+// (handled upstream); this helper only governs the colony-side forge calls.
+
+fn rl_now_epoch() -> int {
+    let raw = try { exec sh "date -u +%s"; } catch e { ""; };
+    if len(raw) == 0 { return 0; };
+    return parse_int(raw);
+}
+
+fn rl_active(agent_name: string, owner: string, repo: string) -> int {
+    let until_raw = recall_latest(scoped_memo(owner, repo, agent_name + ":rate_limited_until"));
+    if len(until_raw) == 0 { return 0; };
+    let until = parse_int(until_raw);
+    let now = rl_now_epoch();
+    if now == 0 { return 0; };
+    if until > now { return 1; };
+    return 0;
+}
+
+fn rl_backoff_secs(count: int) -> int {
+    let cmd = "C=" + shell_escape(to_string(count)) +
+        " python3 -c 'import os,random; c=int(os.environ[\"C\"]); base=min(300, 5*(2**max(0,c-1))); lo=int(base*0.75); hi=int(base*1.25); print(random.randint(lo, hi) if hi>lo else base)'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    if len(out) == 0 { return 5; };
+    let secs = parse_int(out);
+    if secs <= 0 { return 5; };
+    return secs;
+}
+
+fn rl_mark(agent_name: string, owner: string, repo: string) -> void {
+    let count_raw = recall_latest(scoped_memo(owner, repo, agent_name + ":rl_count"));
+    let prev = if len(count_raw) > 0 { parse_int(count_raw); } else { 0; };
+    let count = prev + 1;
+    let now = rl_now_epoch();
+    let backoff = rl_backoff_secs(count);
+    let until = now + backoff;
+    memo_write(scoped_memo(owner, repo, agent_name + ":rl_count"), to_string(count));
+    memo_write(scoped_memo(owner, repo, agent_name + ":rate_limited_until"), to_string(until));
+    emit("planning:rate-limited", agent_name + " backoff " + to_string(backoff) + "s until " + to_string(until));
+    print("[plan_reviewer] rate-limited; backing off", backoff, "s (hit", count, ")");
+}
+
+fn rl_clear(agent_name: string, owner: string, repo: string) -> void {
+    memo_write(scoped_memo(owner, repo, agent_name + ":rl_count"), "0");
+    memo_write(scoped_memo(owner, repo, agent_name + ":rate_limited_until"), "0");
+}
+
+fn rl_is_limited(owner: string, repo: string) -> int {
+    // colony-lint: safe-exec-concat
+    let cmd = "$COLONY_DIR/scripts/forge-api.sh rate-limit-status" + repo_arg(owner, repo);
+    let raw = try { exec sh cmd; } catch e { ""; };
+    if len(raw) < 3 { return 0; };
+    let val = to_string(json_get(raw, "remaining"));
+    if val == "void" { return 0; };
+    let remaining = parse_int(val);
+    if remaining == 0 { return 1; };
+    return 0;
+}
+
 fn stash(owner: string, repo: string, slot: string, issue_id: int, body: string) -> void {
     if len(body) > 2 {
         memo_write(scoped_memo(owner, repo, "plan_reviewer:" + to_string(issue_id) + ":" + slot), body);
@@ -176,6 +245,13 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         return;
     };
 
+    // #1115: rate-limit backoff gate. Defer the prompt + write (task is NOT
+    // failed) while the jittered backoff window from a prior 429 is open.
+    if rl_active("plan_reviewer", owner, repo) == 1 {
+        print("[plan_reviewer] in rate-limit backoff; deferring this tick");
+        return;
+    };
+
     let s = recall_latest(scoped_memo(owner, repo, "plan_reviewer:" + to_string(target_iid) + ":scope"));
     let r = recall_latest(scoped_memo(owner, repo, "plan_reviewer:" + to_string(target_iid) + ":risks"));
     let b = recall_latest(scoped_memo(owner, repo, "plan_reviewer:" + to_string(target_iid) + ":breakdown"));
@@ -224,6 +300,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         // (auth/429/5xx/transport) we leave the marker unset so the
         // next tick retries instead of silently consuming the issue.
         if len(post_result) > 0 {
+            rl_clear("plan_reviewer", owner, repo);
             memo_write(posted_key, "1");
             if len(owner) > 0 {
                 learn(
@@ -244,6 +321,13 @@ fn tick_for_repo(owner: string, repo: string) -> void {
             };
             print("[plan_reviewer] Posted plan to issue", draft.issue_id);
         } else {
+            // #1115: a rate-limited write defers (records backoff + emits the
+            // observable event) instead of marking the task failed; the
+            // posted marker stays unset so a later tick retries after backoff.
+            if rl_is_limited(owner, repo) == 1 {
+                rl_mark("plan_reviewer", owner, repo);
+                return;
+            };
             if len(owner) > 0 {
                 learn(
                     "review_plan",

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -67,6 +67,75 @@ fn repo_field(line: string, idx: int) -> string {
     return out;
 }
 
+// --- Forge rate-limit backoff observability (#1115) ---
+//
+// When a forge write fails because the backend is rate-limited (the
+// gitlab-api.sh / github-api.sh wrapper returns exit 3 after exhausting its
+// own jittered exponential retries), the agent must NOT mark the task failed.
+// Instead it records a backoff window in `<agent>:rate_limited_until` and
+// emits `planning:rate-limited` so the condition is observable, then defers
+// the write to a later tick. The window grows exponentially across
+// consecutive hits (`<agent>:rl_count`) with +/-25% jitter so many agents do
+// not resynchronise their retries into a thundering herd. The LLM-backend
+// HTTP-429 backoff / prompt cache lives in the agentis runtime / LLM backend
+// (handled upstream); this helper only governs the colony-side forge calls.
+
+fn rl_now_epoch() -> int {
+    let raw = try { exec sh "date -u +%s"; } catch e { ""; };
+    if len(raw) == 0 { return 0; };
+    return parse_int(raw);
+}
+
+fn rl_active(agent_name: string, owner: string, repo: string) -> int {
+    let until_raw = recall_latest(scoped_memo(owner, repo, agent_name + ":rate_limited_until"));
+    if len(until_raw) == 0 { return 0; };
+    let until = parse_int(until_raw);
+    let now = rl_now_epoch();
+    if now == 0 { return 0; };
+    if until > now { return 1; };
+    return 0;
+}
+
+fn rl_backoff_secs(count: int) -> int {
+    let cmd = "C=" + shell_escape(to_string(count)) +
+        " python3 -c 'import os,random; c=int(os.environ[\"C\"]); base=min(300, 5*(2**max(0,c-1))); lo=int(base*0.75); hi=int(base*1.25); print(random.randint(lo, hi) if hi>lo else base)'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    if len(out) == 0 { return 5; };
+    let secs = parse_int(out);
+    if secs <= 0 { return 5; };
+    return secs;
+}
+
+fn rl_mark(agent_name: string, owner: string, repo: string) -> void {
+    let count_raw = recall_latest(scoped_memo(owner, repo, agent_name + ":rl_count"));
+    let prev = if len(count_raw) > 0 { parse_int(count_raw); } else { 0; };
+    let count = prev + 1;
+    let now = rl_now_epoch();
+    let backoff = rl_backoff_secs(count);
+    let until = now + backoff;
+    memo_write(scoped_memo(owner, repo, agent_name + ":rl_count"), to_string(count));
+    memo_write(scoped_memo(owner, repo, agent_name + ":rate_limited_until"), to_string(until));
+    emit("planning:rate-limited", agent_name + " backoff " + to_string(backoff) + "s until " + to_string(until));
+    print("[risk_assessor] rate-limited; backing off", backoff, "s (hit", count, ")");
+}
+
+fn rl_clear(agent_name: string, owner: string, repo: string) -> void {
+    memo_write(scoped_memo(owner, repo, agent_name + ":rl_count"), "0");
+    memo_write(scoped_memo(owner, repo, agent_name + ":rate_limited_until"), "0");
+}
+
+fn rl_is_limited(owner: string, repo: string) -> int {
+    // colony-lint: safe-exec-concat
+    let cmd = "$COLONY_DIR/scripts/forge-api.sh rate-limit-status" + repo_arg(owner, repo);
+    let raw = try { exec sh cmd; } catch e { ""; };
+    if len(raw) < 3 { return 0; };
+    let val = to_string(json_get(raw, "remaining"));
+    if val == "void" { return 0; };
+    let remaining = parse_int(val);
+    if remaining == 0 { return 1; };
+    return 0;
+}
+
 fn unplanned_cmd(owner: string, repo: string) -> string {
     let ts = recall_latest(scoped_memo(owner, repo, "risk_assessor:last_check"));
     // colony-lint: safe-exec-concat
@@ -199,6 +268,13 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         return;
     };
 
+    // #1115: rate-limit backoff gate. Defer the prompt + write (task is NOT
+    // failed) while the jittered backoff window from a prior 429 is open.
+    if rl_active("risk_assessor", owner, repo) == 1 {
+        print("[risk_assessor] in rate-limit backoff; deferring this tick");
+        return;
+    };
+
     let rec = recommend("risk_assessment", ["accuracy", "safety"]);
     let context = "Unplanned issues (newest first): " + issues_raw + "\nPast incident patterns: " + to_string(rec);
 
@@ -226,6 +302,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         // transport) leave the marker unset so the next tick retries
         // instead of silently consuming the issue.
         if len(post_result) > 0 {
+            rl_clear("risk_assessor", owner, repo);
             memo_write(posted_key, "1");
             if len(owner) > 0 {
                 learn(
@@ -245,6 +322,13 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 );
             };
         } else {
+            // #1115: a rate-limited write defers (records backoff + emits the
+            // observable event) instead of marking the task failed; the
+            // posted marker stays unset so a later tick retries after backoff.
+            if rl_is_limited(owner, repo) == 1 {
+                rl_mark("risk_assessor", owner, repo);
+                return;
+            };
             if len(owner) > 0 {
                 learn(
                     "risk_assessment",

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -6,6 +6,13 @@
 [colony]
 name = "planning"
 tick_interval_ms = 60000
+# Per-tick cognitive-budget cap (#1115). Splices `--cb-per-tick <n>` onto every
+# `agentis daemon` launch so a single runaway tick cannot burn the whole budget
+# in one pass. This colony-wide value is the default for every agent; override
+# it per agent with a `cb_per_tick` key inside that agent's `[[agents]]` entry.
+# Left unset, start-colony.sh falls back to 2000 (matching `daemon.cb_per_tick`
+# in `<fed>/.agentis/config` written by install.sh).
+# cb_per_tick = 2000
 
 [planning]
 # GitLab label that marks an issue as ready for planning. The 4 planning

--- a/dev-apprenticeship/planning/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/planning/scripts/gitlab-api.sh
@@ -135,6 +135,38 @@ ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"
 #   GITLAB_CURL_RETRIES   retry budget for 5xx/timeouts/429 (default 3).
 #                         Budget is attempts-after-first, so 3 means
 #                         4 total attempts before giving up.
+# _backoff_sleep <delay> — sleep for <delay> seconds plus jitter (#1115).
+#
+# The retry loop already grows <delay> exponentially (delay=$((delay * 2))).
+# Adding jitter on top spreads simultaneous retries from many agents so a
+# shared 429 does not synchronise into a thundering-herd retry storm. Jitter
+# is equal-jitter: the slept value lands in [delay, delay + delay/2], i.e. up
+# to +50% of the base delay, so the lower bound preserves the exponential
+# floor while the upper bound stays predictable for tests.
+#
+# GITLAB_BACKOFF_DRYRUN=1 turns this into a no-sleep trace: the chosen value
+# is appended to $GITLAB_BACKOFF_TRACE (one integer per line) and no sleep
+# happens, so tools/test-rate-limit-backoff.sh can assert growth + jitter
+# bounds deterministically without waiting on real wall-clock seconds.
+_backoff_sleep() {
+    local base="$1"
+    local span jitter slept
+    span=$((base / 2))
+    if [ "$span" -lt 1 ]; then
+        span=1
+    fi
+    # RANDOM is bash-builtin (0..32767); modulo into [0, span].
+    jitter=$((RANDOM % (span + 1)))
+    slept=$((base + jitter))
+    if [ "${GITLAB_BACKOFF_DRYRUN:-0}" = "1" ]; then
+        if [ -n "${GITLAB_BACKOFF_TRACE:-}" ]; then
+            echo "$slept" >> "$GITLAB_BACKOFF_TRACE"
+        fi
+        return 0
+    fi
+    sleep "$slept"
+}
+
 gl_call() {
     local method="$1" url="$2"
     shift 2
@@ -170,7 +202,7 @@ gl_call() {
         # curl didn't get a status line back, so $code is empty.
         if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
             if [ "$attempt" -le "$max_retries" ]; then
-                sleep "$delay"
+                _backoff_sleep "$delay"
                 delay=$((delay * 2))
                 continue
             fi
@@ -198,7 +230,7 @@ gl_call() {
                 # exponential backoff matches what a Retry-After would
                 # typically request on a self-hosted instance.
                 if [ "$attempt" -le "$max_retries" ]; then
-                    sleep "$delay"
+                    _backoff_sleep "$delay"
                     delay=$((delay * 2))
                     continue
                 fi
@@ -207,7 +239,7 @@ gl_call() {
                 ;;
             5*)
                 if [ "$attempt" -le "$max_retries" ]; then
-                    sleep "$delay"
+                    _backoff_sleep "$delay"
                     delay=$((delay * 2))
                     continue
                 fi

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -298,6 +298,42 @@ tick_interval_for() {
     esac
 }
 
+# Per-tick cognitive-budget cap override (#1115). Config-driven, mirroring
+# the per-agent tick-interval pattern (#146): a per-agent `cb_per_tick` under
+# the matching `[[agents]]` entry wins; otherwise the colony-wide
+# `[colony].cb_per_tick` default applies; otherwise the federation-wide
+# fallback (2000, matching `daemon.cb_per_tick` in `<fed>/.agentis/config`
+# written by install.sh). Spliced onto every `agentis daemon` launch as
+# `--cb-per-tick <n>` so a runaway tick cannot burn the whole budget in one
+# pass. The flag is a real `agentis daemon` flag (unlike `--config-override`,
+# #351), so this lands on the binary.
+CB_PER_TICK_DEFAULT="$(parse_toml colony cb_per_tick)"
+case "$CB_PER_TICK_DEFAULT" in
+    ''|*[!0-9]*) CB_PER_TICK_DEFAULT=2000 ;;
+    *) [ "$CB_PER_TICK_DEFAULT" -gt 0 ] || CB_PER_TICK_DEFAULT=2000 ;;
+esac
+
+cb_per_tick_for() {
+    local want="$1"
+    local n i name val
+    n="$(parse_toml_array_count agents 2>/dev/null || echo 0)"
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    i=0
+    while [ "$i" -lt "$n" ]; do
+        name="$(parse_toml_array_get agents "$i" name 2>/dev/null || echo '')"
+        if [ "$name" = "$want" ]; then
+            val="$(parse_toml_array_get agents "$i" cb_per_tick 2>/dev/null || echo '')"
+            case "$val" in
+                ''|*[!0-9]*) : ;;
+                *) if [ "$val" -gt 0 ]; then echo "$val"; return 0; fi ;;
+            esac
+            break
+        fi
+        i=$((i + 1))
+    done
+    echo "$CB_PER_TICK_DEFAULT"
+}
+
 # #319 PR 1 + #318: combined LLM-config override emitter.
 #
 # Precedence (highest first):
@@ -411,6 +447,7 @@ for d in daemons:
         done
     fi
     tick=$(tick_interval_for "$RESTART_AGENT")
+    cb=$(cb_per_tick_for "$RESTART_AGENT")
     # Detach daemon stdio from any inherited pipes (e.g. the dashboard's
     # subprocess.run(capture_output=True) pipes). Without this, the daemon
     # keeps those fds open after start-colony.sh exits, and the Python
@@ -426,6 +463,7 @@ for d in daemons:
         --enable-exec \
         --enable-messaging \
         --tick-interval "$tick" \
+        --cb-per-tick "$cb" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} </dev/null >/dev/null 2>&1 &
     agent_pid=$!
     sleep 0.5
@@ -450,12 +488,14 @@ while IFS= read -r line; do
 done < <(llm_override_args)
 for agent in "${AGENTS[@]}"; do
     interval=$(tick_interval_for "$agent")
-    echo "  Starting $agent (tick=${interval}ms)..."
+    cb=$(cb_per_tick_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms, cb-per-tick=${cb})..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony planning \
         --enable-exec \
         --enable-messaging \
         --tick-interval "$interval" \
+        --cb-per-tick "$cb" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/release/config/colony.example.toml
+++ b/dev-apprenticeship/release/config/colony.example.toml
@@ -6,6 +6,13 @@
 [colony]
 name = "release"
 tick_interval_ms = 60000
+# Per-tick cognitive-budget cap (#1115). Splices `--cb-per-tick <n>` onto every
+# `agentis daemon` launch so a single runaway tick cannot burn the whole budget
+# in one pass. This colony-wide value is the default for every agent; override
+# it per agent with a `cb_per_tick` key inside that agent's `[[agents]]` entry.
+# Left unset, start-colony.sh falls back to 2000 (matching `daemon.cb_per_tick`
+# in `<fed>/.agentis/config` written by install.sh).
+# cb_per_tick = 2000
 
 # Forge backend selection (ADR-0002, #256). `type` picks which of the
 # per-backend blocks below is active. Legal values: "gitlab", "github".

--- a/dev-apprenticeship/release/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/release/scripts/gitlab-api.sh
@@ -153,6 +153,38 @@ ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"
 #   GITLAB_CURL_RETRIES   retry budget for 5xx/timeouts/429 (default 3).
 #                         Budget is attempts-after-first, so 3 means
 #                         4 total attempts before giving up.
+# _backoff_sleep <delay> — sleep for <delay> seconds plus jitter (#1115).
+#
+# The retry loop already grows <delay> exponentially (delay=$((delay * 2))).
+# Adding jitter on top spreads simultaneous retries from many agents so a
+# shared 429 does not synchronise into a thundering-herd retry storm. Jitter
+# is equal-jitter: the slept value lands in [delay, delay + delay/2], i.e. up
+# to +50% of the base delay, so the lower bound preserves the exponential
+# floor while the upper bound stays predictable for tests.
+#
+# GITLAB_BACKOFF_DRYRUN=1 turns this into a no-sleep trace: the chosen value
+# is appended to $GITLAB_BACKOFF_TRACE (one integer per line) and no sleep
+# happens, so tools/test-rate-limit-backoff.sh can assert growth + jitter
+# bounds deterministically without waiting on real wall-clock seconds.
+_backoff_sleep() {
+    local base="$1"
+    local span jitter slept
+    span=$((base / 2))
+    if [ "$span" -lt 1 ]; then
+        span=1
+    fi
+    # RANDOM is bash-builtin (0..32767); modulo into [0, span].
+    jitter=$((RANDOM % (span + 1)))
+    slept=$((base + jitter))
+    if [ "${GITLAB_BACKOFF_DRYRUN:-0}" = "1" ]; then
+        if [ -n "${GITLAB_BACKOFF_TRACE:-}" ]; then
+            echo "$slept" >> "$GITLAB_BACKOFF_TRACE"
+        fi
+        return 0
+    fi
+    sleep "$slept"
+}
+
 gl_call() {
     local method="$1" url="$2"
     shift 2
@@ -188,7 +220,7 @@ gl_call() {
         # curl didn't get a status line back, so $code is empty.
         if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
             if [ "$attempt" -le "$max_retries" ]; then
-                sleep "$delay"
+                _backoff_sleep "$delay"
                 delay=$((delay * 2))
                 continue
             fi
@@ -216,7 +248,7 @@ gl_call() {
                 # exponential backoff matches what a Retry-After would
                 # typically request on a self-hosted instance.
                 if [ "$attempt" -le "$max_retries" ]; then
-                    sleep "$delay"
+                    _backoff_sleep "$delay"
                     delay=$((delay * 2))
                     continue
                 fi
@@ -225,7 +257,7 @@ gl_call() {
                 ;;
             5*)
                 if [ "$attempt" -le "$max_retries" ]; then
-                    sleep "$delay"
+                    _backoff_sleep "$delay"
                     delay=$((delay * 2))
                     continue
                 fi

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -261,6 +261,42 @@ tick_interval_for() {
     esac
 }
 
+# Per-tick cognitive-budget cap override (#1115). Config-driven, mirroring
+# the per-agent tick-interval pattern (#146): a per-agent `cb_per_tick` under
+# the matching `[[agents]]` entry wins; otherwise the colony-wide
+# `[colony].cb_per_tick` default applies; otherwise the federation-wide
+# fallback (2000, matching `daemon.cb_per_tick` in `<fed>/.agentis/config`
+# written by install.sh). Spliced onto every `agentis daemon` launch as
+# `--cb-per-tick <n>` so a runaway tick cannot burn the whole budget in one
+# pass. The flag is a real `agentis daemon` flag (unlike `--config-override`,
+# #351), so this lands on the binary.
+CB_PER_TICK_DEFAULT="$(parse_toml colony cb_per_tick)"
+case "$CB_PER_TICK_DEFAULT" in
+    ''|*[!0-9]*) CB_PER_TICK_DEFAULT=2000 ;;
+    *) [ "$CB_PER_TICK_DEFAULT" -gt 0 ] || CB_PER_TICK_DEFAULT=2000 ;;
+esac
+
+cb_per_tick_for() {
+    local want="$1"
+    local n i name val
+    n="$(parse_toml_array_count agents 2>/dev/null || echo 0)"
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    i=0
+    while [ "$i" -lt "$n" ]; do
+        name="$(parse_toml_array_get agents "$i" name 2>/dev/null || echo '')"
+        if [ "$name" = "$want" ]; then
+            val="$(parse_toml_array_get agents "$i" cb_per_tick 2>/dev/null || echo '')"
+            case "$val" in
+                ''|*[!0-9]*) : ;;
+                *) if [ "$val" -gt 0 ]; then echo "$val"; return 0; fi ;;
+            esac
+            break
+        fi
+        i=$((i + 1))
+    done
+    echo "$CB_PER_TICK_DEFAULT"
+}
+
 # #319 PR 1 + #318: combined LLM-config override emitter.
 #
 # Precedence (highest first):
@@ -374,6 +410,7 @@ for d in daemons:
         done
     fi
     tick=$(tick_interval_for "$RESTART_AGENT")
+    cb=$(cb_per_tick_for "$RESTART_AGENT")
     # Detach daemon stdio from any inherited pipes (e.g. the dashboard's
     # subprocess.run(capture_output=True) pipes). Without this, the daemon
     # keeps those fds open after start-colony.sh exits, and the Python
@@ -389,6 +426,7 @@ for d in daemons:
         --enable-exec \
         --enable-messaging \
         --tick-interval "$tick" \
+        --cb-per-tick "$cb" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} </dev/null >/dev/null 2>&1 &
     agent_pid=$!
     sleep 0.5
@@ -413,12 +451,14 @@ while IFS= read -r line; do
 done < <(llm_override_args)
 for agent in "${AGENTS[@]}"; do
     interval=$(tick_interval_for "$agent")
-    echo "  Starting $agent (tick=${interval}ms)..."
+    cb=$(cb_per_tick_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms, cb-per-tick=${cb})..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony release \
         --enable-exec \
         --enable-messaging \
         --tick-interval "$interval" \
+        --cb-per-tick "$cb" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/start-federation.sh
+++ b/dev-apprenticeship/start-federation.sh
@@ -170,7 +170,7 @@ if [ -f "$AUTO_PROMOTE_INSTALL_FILE" ]; then
                 ) &
                 AUTO_PROMOTE_PID=$!
                 # shellcheck disable=SC2064  # Expand PID at trap-install time, not at trigger time.
-                trap "[ -n \"$AUTO_PROMOTE_PID\" ] && kill \"$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"\${COST_CAP_PID:-}\" ] && kill \"\$COST_CAP_PID\" 2>/dev/null; [ -n \"\${SNAPSHOT_REFRESH_PID:-}\" ] && kill \"\$SNAPSHOT_REFRESH_PID\" 2>/dev/null; exit" EXIT TERM INT
+                trap "[ -n \"$AUTO_PROMOTE_PID\" ] && kill \"$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"\${COST_CAP_PID:-}\" ] && kill \"\$COST_CAP_PID\" 2>/dev/null; [ -n \"\${SNAPSHOT_REFRESH_PID:-}\" ] && kill \"\$SNAPSHOT_REFRESH_PID\" 2>/dev/null; [ -n \"\${COST_RATE_PID:-}\" ] && kill \"\$COST_RATE_PID\" 2>/dev/null; exit" EXIT TERM INT
                 echo "Auto-promote scheduler: PID $AUTO_PROMOTE_PID, every ${AP_INTERVAL}s (log: .agentis/logs/auto-promote.log)"
                 echo ""
             fi
@@ -233,7 +233,7 @@ if [ -f "$COST_CAP_INSTALL_FILE" ]; then
                 ) &
                 COST_CAP_PID=$!
                 # shellcheck disable=SC2064
-                trap "[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"$COST_CAP_PID\" ] && kill \"$COST_CAP_PID\" 2>/dev/null; [ -n \"\${SNAPSHOT_REFRESH_PID:-}\" ] && kill \"\$SNAPSHOT_REFRESH_PID\" 2>/dev/null; exit" EXIT TERM INT
+                trap "[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"$COST_CAP_PID\" ] && kill \"$COST_CAP_PID\" 2>/dev/null; [ -n \"\${SNAPSHOT_REFRESH_PID:-}\" ] && kill \"\$SNAPSHOT_REFRESH_PID\" 2>/dev/null; [ -n \"\${COST_RATE_PID:-}\" ] && kill \"\$COST_RATE_PID\" 2>/dev/null; exit" EXIT TERM INT
                 echo "Cost-cap sidecar: PID $COST_CAP_PID, every ${CC_INTERVAL}s (log: .agentis/logs/cost-cap.log)"
                 echo ""
             fi
@@ -297,8 +297,66 @@ else
     ) &
     SNAPSHOT_REFRESH_PID=$!
     # shellcheck disable=SC2064  # Expand PID at trap-install time, not at trigger time.
-    trap "[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"\${COST_CAP_PID:-}\" ] && kill \"\$COST_CAP_PID\" 2>/dev/null; [ -n \"$SNAPSHOT_REFRESH_PID\" ] && kill \"$SNAPSHOT_REFRESH_PID\" 2>/dev/null; exit" EXIT TERM INT
+    trap "[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"\${COST_CAP_PID:-}\" ] && kill \"\$COST_CAP_PID\" 2>/dev/null; [ -n \"$SNAPSHOT_REFRESH_PID\" ] && kill \"$SNAPSHOT_REFRESH_PID\" 2>/dev/null; [ -n \"\${COST_RATE_PID:-}\" ] && kill \"\$COST_RATE_PID\" 2>/dev/null; exit" EXIT TERM INT
     echo "Snapshot-refresh sidecar: PID $SNAPSHOT_REFRESH_PID, every ${SNAPSHOT_REFRESH_INTERVAL}s (log: .agentis/logs/snapshot-refresh.log)"
+    echo ""
+fi
+
+# --- Cost-rate instrumentation sidecar (#1114) ---
+#
+# Periodically runs tools/cost-rate-report.sh, which folds each colony's
+# per-prompt spend rows (#311) plus `agentis stats --json --per-identity`
+# into a machine-readable per-agent / per-role cost+rate report (prompts,
+# prompts/hour, chars in/out proxies, cost_usd, the throttle-vs-task-error
+# split, and retries). The log is the recorded artifact that proves the
+# #1114 "a run produces a machine-readable log with all fields" DoD line on
+# a live federation.
+#
+# Mirrors the snapshot-refresh / auto-promote / cost-cap sidecar shape: a
+# tick-first background loop (emit immediately, not after a sleep), the same
+# ''|*[!0-9]* / -gt 0 interval validation, self-terminate when the
+# federation has zero running daemons, and an EXIT/TERM/INT trap that kills
+# it on shutdown.
+#
+# Backward-safe: if tools/cost-rate-report.sh is not executable (broken
+# checkout, chmod -x), the sidecar is skipped with a warning and the
+# federation runs without it — the report is observational only and never
+# gates the agents.
+COST_RATE_INTERVAL="${COST_RATE_INTERVAL_S:-60}"
+case "$COST_RATE_INTERVAL" in
+    ''|*[!0-9]*) COST_RATE_INTERVAL=60 ;;
+    *) [ "$COST_RATE_INTERVAL" -gt 0 ] || COST_RATE_INTERVAL=60 ;;
+esac
+COST_RATE_PID=""
+COST_RATE_SCRIPT="$SCRIPT_DIR/../tools/cost-rate-report.sh"
+COST_RATE_FED_NAME="$(basename "$FED_DIR")"
+if [ ! -x "$COST_RATE_SCRIPT" ]; then
+    echo "[!!] Cost-rate sidecar: tools/cost-rate-report.sh not executable, skipping."
+else
+    CR_LOG_DIR="$FED_DIR/.agentis/logs"
+    CR_LOG="$CR_LOG_DIR/cost-rate.log"
+    mkdir -p "$CR_LOG_DIR"
+    (
+        # First action is a tick (not a sleep) so a cost-rate report appears
+        # immediately after spawn instead of after a full interval.
+        while :; do
+            if ! agentis daemon list --json 2>/dev/null | grep -Fq '"state":"running"'; then
+                printf '=== %s: no running daemons; sidecar exiting ===\n' \
+                    "$(date -Iseconds)" >> "$CR_LOG"
+                exit 0
+            fi
+            {
+                printf '=== %s: cost-rate tick ===\n' "$(date -Iseconds)"
+                "$COST_RATE_SCRIPT" "$COST_RATE_FED_NAME" 2>&1 \
+                    || printf '[sidecar] cost-rate-report.sh exited %s\n' "$?"
+            } >> "$CR_LOG"
+            sleep "$COST_RATE_INTERVAL"
+        done
+    ) &
+    COST_RATE_PID=$!
+    # shellcheck disable=SC2064  # Expand PID at trap-install time, not at trigger time.
+    trap "[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"\${COST_CAP_PID:-}\" ] && kill \"\$COST_CAP_PID\" 2>/dev/null; [ -n \"\${SNAPSHOT_REFRESH_PID:-}\" ] && kill \"\$SNAPSHOT_REFRESH_PID\" 2>/dev/null; [ -n \"$COST_RATE_PID\" ] && kill \"$COST_RATE_PID\" 2>/dev/null; exit" EXIT TERM INT
+    echo "Cost-rate sidecar: PID $COST_RATE_PID, every ${COST_RATE_INTERVAL}s (log: .agentis/logs/cost-rate.log)"
     echo ""
 fi
 

--- a/dev-apprenticeship/triage/config/colony.example.toml
+++ b/dev-apprenticeship/triage/config/colony.example.toml
@@ -6,6 +6,13 @@
 [colony]
 name = "triage"
 tick_interval_ms = 60000
+# Per-tick cognitive-budget cap (#1115). Splices `--cb-per-tick <n>` onto every
+# `agentis daemon` launch so a single runaway tick cannot burn the whole budget
+# in one pass. This colony-wide value is the default for every agent; override
+# it per agent with a `cb_per_tick` key inside that agent's `[[agents]]` entry.
+# Left unset, start-colony.sh falls back to 2000 (matching `daemon.cb_per_tick`
+# in `<fed>/.agentis/config` written by install.sh).
+# cb_per_tick = 2000
 
 # Forge backend selection (ADR-0002, #256). `type` picks which of the
 # per-backend blocks below is active. Legal values: "gitlab", "github".

--- a/dev-apprenticeship/triage/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/triage/scripts/gitlab-api.sh
@@ -182,6 +182,38 @@ ISSUE_COLLECTION="${GITLAB_ISSUE_COLLECTION:-work_items}"
 #   GITLAB_CURL_RETRIES   retry budget for 5xx/timeouts/429 (default 3).
 #                         Budget is attempts-after-first, so 3 means
 #                         4 total attempts before giving up.
+# _backoff_sleep <delay> — sleep for <delay> seconds plus jitter (#1115).
+#
+# The retry loop already grows <delay> exponentially (delay=$((delay * 2))).
+# Adding jitter on top spreads simultaneous retries from many agents so a
+# shared 429 does not synchronise into a thundering-herd retry storm. Jitter
+# is equal-jitter: the slept value lands in [delay, delay + delay/2], i.e. up
+# to +50% of the base delay, so the lower bound preserves the exponential
+# floor while the upper bound stays predictable for tests.
+#
+# GITLAB_BACKOFF_DRYRUN=1 turns this into a no-sleep trace: the chosen value
+# is appended to $GITLAB_BACKOFF_TRACE (one integer per line) and no sleep
+# happens, so tools/test-rate-limit-backoff.sh can assert growth + jitter
+# bounds deterministically without waiting on real wall-clock seconds.
+_backoff_sleep() {
+    local base="$1"
+    local span jitter slept
+    span=$((base / 2))
+    if [ "$span" -lt 1 ]; then
+        span=1
+    fi
+    # RANDOM is bash-builtin (0..32767); modulo into [0, span].
+    jitter=$((RANDOM % (span + 1)))
+    slept=$((base + jitter))
+    if [ "${GITLAB_BACKOFF_DRYRUN:-0}" = "1" ]; then
+        if [ -n "${GITLAB_BACKOFF_TRACE:-}" ]; then
+            echo "$slept" >> "$GITLAB_BACKOFF_TRACE"
+        fi
+        return 0
+    fi
+    sleep "$slept"
+}
+
 gl_call() {
     local method="$1" url="$2"
     shift 2
@@ -217,7 +249,7 @@ gl_call() {
         # curl didn't get a status line back, so $code is empty.
         if [ "$rc" -ne 0 ] || [ -z "$code" ]; then
             if [ "$attempt" -le "$max_retries" ]; then
-                sleep "$delay"
+                _backoff_sleep "$delay"
                 delay=$((delay * 2))
                 continue
             fi
@@ -245,7 +277,7 @@ gl_call() {
                 # exponential backoff matches what a Retry-After would
                 # typically request on a self-hosted instance.
                 if [ "$attempt" -le "$max_retries" ]; then
-                    sleep "$delay"
+                    _backoff_sleep "$delay"
                     delay=$((delay * 2))
                     continue
                 fi
@@ -254,7 +286,7 @@ gl_call() {
                 ;;
             5*)
                 if [ "$attempt" -le "$max_retries" ]; then
-                    sleep "$delay"
+                    _backoff_sleep "$delay"
                     delay=$((delay * 2))
                     continue
                 fi

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -350,6 +350,42 @@ tick_interval_for() {
     esac
 }
 
+# Per-tick cognitive-budget cap override (#1115). Config-driven, mirroring
+# the per-agent tick-interval pattern (#146): a per-agent `cb_per_tick` under
+# the matching `[[agents]]` entry wins; otherwise the colony-wide
+# `[colony].cb_per_tick` default applies; otherwise the federation-wide
+# fallback (2000, matching `daemon.cb_per_tick` in `<fed>/.agentis/config`
+# written by install.sh). Spliced onto every `agentis daemon` launch as
+# `--cb-per-tick <n>` so a runaway tick cannot burn the whole budget in one
+# pass. The flag is a real `agentis daemon` flag (unlike `--config-override`,
+# #351), so this lands on the binary.
+CB_PER_TICK_DEFAULT="$(parse_toml colony cb_per_tick)"
+case "$CB_PER_TICK_DEFAULT" in
+    ''|*[!0-9]*) CB_PER_TICK_DEFAULT=2000 ;;
+    *) [ "$CB_PER_TICK_DEFAULT" -gt 0 ] || CB_PER_TICK_DEFAULT=2000 ;;
+esac
+
+cb_per_tick_for() {
+    local want="$1"
+    local n i name val
+    n="$(parse_toml_array_count agents 2>/dev/null || echo 0)"
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    i=0
+    while [ "$i" -lt "$n" ]; do
+        name="$(parse_toml_array_get agents "$i" name 2>/dev/null || echo '')"
+        if [ "$name" = "$want" ]; then
+            val="$(parse_toml_array_get agents "$i" cb_per_tick 2>/dev/null || echo '')"
+            case "$val" in
+                ''|*[!0-9]*) : ;;
+                *) if [ "$val" -gt 0 ]; then echo "$val"; return 0; fi ;;
+            esac
+            break
+        fi
+        i=$((i + 1))
+    done
+    echo "$CB_PER_TICK_DEFAULT"
+}
+
 # #319 PR 1 + #318: combined LLM-config override emitter.
 #
 # Precedence (highest first):
@@ -463,6 +499,7 @@ for d in daemons:
         done
     fi
     tick=$(tick_interval_for "$RESTART_AGENT")
+    cb=$(cb_per_tick_for "$RESTART_AGENT")
     # Detach daemon stdio from any inherited pipes (e.g. the dashboard's
     # subprocess.run(capture_output=True) pipes). Without this, the daemon
     # keeps those fds open after start-colony.sh exits, and the Python
@@ -478,6 +515,7 @@ for d in daemons:
         --enable-exec \
         --enable-messaging \
         --tick-interval "$tick" \
+        --cb-per-tick "$cb" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} </dev/null >/dev/null 2>&1 &
     agent_pid=$!
     sleep 0.5
@@ -502,12 +540,14 @@ while IFS= read -r line; do
 done < <(llm_override_args)
 for agent in "${AGENTS[@]}"; do
     interval=$(tick_interval_for "$agent")
-    echo "  Starting $agent (tick=${interval}ms)..."
+    cb=$(cb_per_tick_for "$agent")
+    echo "  Starting $agent (tick=${interval}ms, cb-per-tick=${cb})..."
     agentis daemon "$COLONY_DIR/agents/${agent}.ag" \
         --colony triage \
         --enable-exec \
         --enable-messaging \
         --tick-interval "$interval" \
+        --cb-per-tick "$cb" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/tools/cost-rate-report.py
+++ b/tools/cost-rate-report.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""cost-rate-report.py - Per-agent / per-role cost + rate instrumentation
+reducer for tools/cost-rate-report.sh (#1114).
+
+Reads the per-prompt spend rows the agentis daemon publishes (one row ~= one
+prompt) under <fed>/<colony>/.agentis/spend/<agent>.jsonl (#311) and folds
+them into per-agent and per-role (per-colony) instrumentation records.
+
+Reuses the spend-row reader / timestamp parser shape from
+tools/cost-cap-sum.py (_row_ts, _read_rows) so the two reducers agree on how
+a malformed row, a null cost_usd, or a missing timestamp is handled.
+
+Per agent (and aggregated per role/colony) it computes:
+  prompts          — spend row count
+  prompts_per_hour — rolling rate over the trailing window from row ts
+  chars_in         — proxy: avg_input_size (from `agentis stats`) x prompts
+  chars_out        — proxy: sum of output_tokens over the rows
+  cost_usd         — sum of cost_usd (null / missing -> 0, like cost-cap-sum)
+  throttle_events  — forge-429 / "[llm.cancelled]" rows (SEPARATE from errors)
+  task_errors      — agent failure markers (SEPARATE from throttle)
+  retries          — colony-side retry markers (0 with a documented note when
+                     not derivable from the spend rows)
+
+The throttle-vs-task-error split is a hard DoD line: throttle and task_errors
+are kept as distinct fields and never collapsed.
+
+Input contract (positional args):
+    1: spend_glob   — glob for spend files, e.g.
+                      "<fed>/*/.agentis/spend/*.jsonl"
+    2: window_min   — int, trailing window (minutes) for prompts_per_hour
+    3: stats_json   — JSON string from `agentis stats --json --per-identity`
+                      (or a per-colony map keyed by colony name); "{}" when
+                      unavailable. Used only for the avg_input_size proxy.
+
+Output: a single JSON object on stdout:
+  {
+    "window_min": <int>,
+    "now_iso": "...",
+    "agents": [ {<record>}, ... ],   # one per (colony, agent)
+    "roles":  [ {<record>}, ... ]    # one per colony (role)
+  }
+
+Each <record> carries:
+  colony, agent (omitted on role records), prompts, prompts_per_hour,
+  chars_in, chars_out, cost_usd, throttle_events, task_errors, retries.
+
+Exits non-zero only on bad CLI usage; emits an empty (zeroed) structure on
+no-data so the sidecar can distinguish "no rows" from "broken helper".
+"""
+import datetime
+import glob
+import json
+import os
+import sys
+
+
+# Markers a spend row may carry to indicate a throttle (rate-limit) event vs a
+# task-level error. The runtime publishes a `cost_source` of "cancelled" /
+# "llm.cancelled" when an LLM call is cancelled (e.g. the LLM backend HTTP-429
+# backoff handled upstream by the agentis runtime / LLM backend); forge-429s
+# surface via an explicit `throttle`/`http_status` field on a row. Task-level
+# failures surface via an `outcome`/`error` field. Detection is intentionally
+# tolerant — any of these fields may be absent on a normal success row.
+_THROTTLE_SOURCES = ('cancelled', 'llm.cancelled')
+_TASK_ERROR_OUTCOMES = ('fail', 'error', 'failed')
+
+
+def _utc_now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _row_ts(row):
+    """Parse a spend-row timestamp. Mirrors cost-cap-sum.py._row_ts so the two
+    reducers agree on malformed / missing timestamps."""
+    ts = row.get('ts')
+    if isinstance(ts, (int, float)) and ts > 0:
+        try:
+            return datetime.datetime.fromtimestamp(float(ts), tz=datetime.timezone.utc)
+        except (OSError, OverflowError, ValueError):
+            return None
+    iso = row.get('ts_iso') or row.get('iso_ts')
+    if isinstance(iso, str) and iso:
+        try:
+            s = iso.replace('Z', '+00:00')
+            dt = datetime.datetime.fromisoformat(s)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=datetime.timezone.utc)
+            return dt
+        except ValueError:
+            return None
+    return None
+
+
+def _read_rows(path):
+    """Read one spend file into a list of row dicts. Mirrors
+    cost-cap-sum.py._read_rows but per-file (we need per-agent grouping)."""
+    rows = []
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except (json.JSONDecodeError, ValueError):
+                    continue
+    except OSError:
+        return []
+    return rows
+
+
+def _to_float(v):
+    try:
+        return float(v) if v is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _to_int(v):
+    try:
+        return int(v) if v is not None else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+def _colony_agent_from_path(path):
+    """Resolve (colony, agent) from a spend file path of the shape
+    <fed>/<colony>/.agentis/spend/<agent>.jsonl.
+
+    The colony is the directory two levels above the `.agentis` symlink; the
+    agent is the file stem. Falls back to ('', stem) when the layout does not
+    match so an unusual path never crashes the reducer."""
+    agent = os.path.basename(path)
+    if agent.endswith('.jsonl'):
+        agent = agent[:-6]
+    colony = ''
+    norm = os.path.normpath(path)
+    parts = norm.split(os.sep)
+    try:
+        idx = len(parts) - 1 - parts[::-1].index('.agentis')
+        if idx >= 1:
+            colony = parts[idx - 1]
+    except ValueError:
+        colony = ''
+    return colony, agent
+
+
+def _row_is_throttle(row):
+    """A throttle event = forge-429 / [llm.cancelled]. Kept distinct from a
+    task-level error (see _row_is_task_error)."""
+    src = str(row.get('cost_source') or '').lower()
+    if src in _THROTTLE_SOURCES:
+        return True
+    if row.get('throttle') is True or row.get('rate_limited') is True:
+        return True
+    status = _to_int(row.get('http_status') or row.get('status_code'))
+    if status == 429:
+        return True
+    return False
+
+
+def _row_is_task_error(row):
+    """A task-level error = an agent failure marker. Kept distinct from a
+    throttle/rate-limit event."""
+    if _row_is_throttle(row):
+        return False
+    outcome = str(row.get('outcome') or '').lower()
+    if outcome in _TASK_ERROR_OUTCOMES:
+        return True
+    if row.get('error'):
+        return True
+    return False
+
+
+def _avg_input_size(stats_obj, colony, agent):
+    """Look up the avg_input_size proxy. Accepts either a flat
+    `agentis stats --json` object or a {colony: stats_obj} map; an inner
+    per-identity / per-agent map is consulted first when present."""
+    if not isinstance(stats_obj, dict):
+        return 0.0
+    scope = stats_obj
+    # Per-colony map shape: {"triage": {...}, "planning": {...}}.
+    if colony and colony in stats_obj and isinstance(stats_obj[colony], dict):
+        scope = stats_obj[colony]
+    # Optional per-identity / per-agent breakdown.
+    for key in ('identities', 'per_identity', 'by_identity', 'agents'):
+        inner = scope.get(key)
+        if isinstance(inner, dict) and agent in inner and isinstance(inner[agent], dict):
+            return _to_float(inner[agent].get('avg_input_size'))
+        if isinstance(inner, list):
+            for ent in inner:
+                if isinstance(ent, dict) and ent.get('agent_id') == agent:
+                    return _to_float(ent.get('avg_input_size'))
+    return _to_float(scope.get('avg_input_size'))
+
+
+def _fold(rows, now, window_min):
+    """Fold a list of rows into an aggregate record (no colony/agent keys)."""
+    window_min = max(1, int(window_min))
+    window_start = now - datetime.timedelta(minutes=window_min)
+    prompts = 0
+    in_window = 0
+    chars_out = 0
+    cost_usd = 0.0
+    throttle_events = 0
+    task_errors = 0
+    retries = 0
+    for r in rows:
+        prompts += 1
+        cost_usd += _to_float(r.get('cost_usd'))
+        chars_out += _to_int(r.get('output_tokens'))
+        if _row_is_throttle(r):
+            throttle_events += 1
+        elif _row_is_task_error(r):
+            task_errors += 1
+        # Colony-side retry markers. Spend rows do not carry a retry count
+        # today, so this stays 0 unless a row explicitly stamps `retries`
+        # (documented note in cost-rate-report.sh + README). Counted here so
+        # the field is wired end-to-end the moment the runtime emits it.
+        retries += _to_int(r.get('retries'))
+        dt = _row_ts(r)
+        if dt is not None and dt >= window_start:
+            in_window += 1
+    prompts_per_hour = (in_window / float(window_min)) * 60.0
+    return {
+        'prompts': prompts,
+        'prompts_per_hour': round(prompts_per_hour, 4),
+        'chars_out': chars_out,
+        'cost_usd': round(cost_usd, 6),
+        'throttle_events': throttle_events,
+        'task_errors': task_errors,
+        'retries': retries,
+    }
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.stderr.write('Usage: %s <spend_glob> <window_min> [stats_json]\n' % sys.argv[0])
+        return 2
+    spend_glob = sys.argv[1]
+    try:
+        window_min = int(sys.argv[2])
+    except ValueError:
+        window_min = 60
+    if window_min <= 0:
+        window_min = 60
+    stats_raw = sys.argv[3] if len(sys.argv) > 3 else '{}'
+    try:
+        stats_obj = json.loads(stats_raw or '{}')
+    except (json.JSONDecodeError, ValueError):
+        stats_obj = {}
+
+    now = _utc_now()
+
+    agent_records = []
+    role_rows = {}
+    for path in sorted(glob.glob(spend_glob)):
+        colony, agent = _colony_agent_from_path(path)
+        rows = _read_rows(path)
+        rec = _fold(rows, now, window_min)
+        avg_in = _avg_input_size(stats_obj, colony, agent)
+        rec['chars_in'] = int(round(avg_in * rec['prompts']))
+        rec['colony'] = colony
+        rec['agent'] = agent
+        agent_records.append(rec)
+        role_rows.setdefault(colony, []).extend(rows)
+
+    role_records = []
+    for colony in sorted(role_rows.keys()):
+        rows = role_rows[colony]
+        rec = _fold(rows, now, window_min)
+        avg_in = _avg_input_size(stats_obj, colony, '')
+        rec['chars_in'] = int(round(avg_in * rec['prompts']))
+        rec['colony'] = colony
+        role_records.append(rec)
+
+    out = {
+        'window_min': window_min,
+        'now_iso': now.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'agents': agent_records,
+        'roles': role_records,
+    }
+    print(json.dumps(out))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/cost-rate-report.sh
+++ b/tools/cost-rate-report.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# cost-rate-report.sh - Per-agent / per-role cost + rate instrumentation
+# report (#1114).
+#
+# Reads each colony's per-prompt spend rows
+# (<fed>/<colony>/.agentis/spend/<agent>.jsonl, #311 — one row ~= one prompt)
+# plus `agentis stats --json --per-identity`, folds them via the Python
+# reducer in tools/cost-rate-report.py, and emits a machine-readable
+# cost+rate report per agent and aggregated per role (colony).
+#
+# Mirrors tools/cost-cap.sh shape: <fed-dir> arg, repo-relative path
+# resolution, all Python logic in a separate helper. Per the CLAUDE.md
+# no-heredoc invariant, this script never uses heredocs; the reducer logic
+# lives in tools/cost-rate-report.py.
+#
+# Usage:
+#     ./tools/cost-rate-report.sh <federation-dir> [--json] [--baseline]
+#     ./tools/cost-rate-report.sh --self-test
+#
+# Modes:
+#     (default)    one compact line per role on stdout:
+#                  role=<r> prompts=<n> pph=<x> cin=<n> cout=<n> cost=<usd> \
+#                      throttle=<n> retries=<n>
+#     --json       emit the full structured object (agents + roles).
+#     --baseline   additionally stamp the current per-agent number as a
+#                  recorded artifact at
+#                  <fed>/.agentis/logs/cost-rate-baseline.json so later
+#                  improvements are provable against a recorded "before".
+#     --self-test  seed a synthetic spend.jsonl + stats fixture in a temp
+#                  dir, run the full pipeline, and ASSERT every field
+#                  (incl. the throttle-vs-task-error split + baseline stamp).
+#                  Exits non-zero on any mismatch.
+#
+# Throttle vs task-error split (hard DoD line): the throttle counter counts
+# forge-429 / [llm.cancelled] rows; the task-error counter counts agent
+# failure markers. They are SEPARATE fields end to end (see
+# cost-rate-report.py). The LLM-backend HTTP-429 backoff / prompt cache that
+# produces [llm.cancelled] rows lives in the agentis runtime / LLM backend
+# (handled upstream); this report only observes the resulting rows.
+
+set -eu
+
+# --- Path resolution ---
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+REDUCER="$SCRIPT_DIR/cost-rate-report.py"
+
+# Trailing window (minutes) for prompts_per_hour. Override via env.
+WINDOW_MIN="${COST_RATE_WINDOW_MIN:-60}"
+case "$WINDOW_MIN" in
+    ''|*[!0-9]*) WINDOW_MIN=60 ;;
+    *) [ "$WINDOW_MIN" -gt 0 ] || WINDOW_MIN=60 ;;
+esac
+
+# Pre-fix baseline (#1114): ~74 KB/agent of chars before the instrumentation
+# work began. Stamped into the baseline artifact so improvements are provable.
+BASELINE_KB_PER_AGENT="${COST_RATE_BASELINE_KB:-74}"
+
+emit_compact() {
+    # $1 = full reducer JSON. Prints one compact line per role.
+    python3 -c "
+import json, sys
+data = json.loads(sys.argv[1] or '{}')
+for r in data.get('roles', []):
+    print('role=%s prompts=%d pph=%s cin=%d cout=%d cost=%s throttle=%d retries=%d' % (
+        r.get('colony') or '-',
+        int(r.get('prompts') or 0),
+        ('%.4f' % float(r.get('prompts_per_hour') or 0)),
+        int(r.get('chars_in') or 0),
+        int(r.get('chars_out') or 0),
+        ('%.6f' % float(r.get('cost_usd') or 0)),
+        int(r.get('throttle_events') or 0),
+        int(r.get('retries') or 0),
+    ))
+" "$1"
+}
+
+# stamp_baseline <fed> <reducer_json>: write the recorded pre-fix artifact.
+stamp_baseline() {
+    local fed="$1" reduced="$2"
+    local log_dir="$fed/.agentis/logs"
+    mkdir -p "$log_dir" 2>/dev/null || true
+    local out="$log_dir/cost-rate-baseline.json"
+    python3 -c "
+import json, sys, time
+reduced = json.loads(sys.argv[1] or '{}')
+kb = float(sys.argv[2])
+agents = reduced.get('agents', [])
+baseline = {
+    'ts': int(time.time()),
+    'ts_iso': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+    'baseline_kb_per_agent': kb,
+    'window_min': reduced.get('window_min'),
+    'agent_count': len(agents),
+    'agents': [
+        {
+            'colony': a.get('colony'),
+            'agent': a.get('agent'),
+            'prompts': a.get('prompts'),
+            'chars_in': a.get('chars_in'),
+            'chars_out': a.get('chars_out'),
+            'cost_usd': a.get('cost_usd'),
+            'throttle_events': a.get('throttle_events'),
+            'task_errors': a.get('task_errors'),
+            'retries': a.get('retries'),
+        }
+        for a in agents
+    ],
+}
+with open(sys.argv[3], 'w') as f:
+    json.dump(baseline, f)
+print(sys.argv[3])
+" "$reduced" "$BASELINE_KB_PER_AGENT" "$out"
+}
+
+# collect_stats <fed>: emit a JSON map {colony: stats_obj} from
+# `agentis stats --json --per-identity` run per colony (cwd-scoped). Missing
+# stats / a missing agentis binary degrade to {} (NOT an error) so the report
+# still runs against the spend rows alone.
+collect_stats() {
+    local fed="$1"
+    local map="{}"
+    if ! command -v agentis >/dev/null 2>&1; then
+        echo "$map"
+        return 0
+    fi
+    local colony stats_json
+    for colony_dir in "$fed"/*/; do
+        [ -d "$colony_dir" ] || continue
+        colony="$(basename "$colony_dir")"
+        # Skip the federation's own .agentis bookkeeping dir.
+        [ "$colony" = ".agentis" ] && continue
+        stats_json="$(cd "$colony_dir" && agentis stats --json --per-identity 2>/dev/null || echo '{}')"
+        map="$(C="$colony" S="$stats_json" M="$map" python3 -c '
+import json, os
+try:
+    m = json.loads(os.environ.get("M") or "{}")
+except Exception:
+    m = {}
+try:
+    s = json.loads(os.environ.get("S") or "{}")
+except Exception:
+    s = {}
+m[os.environ["C"]] = s
+print(json.dumps(m))' 2>/dev/null || echo "$map")"
+    done
+    echo "$map"
+}
+
+# run_report <fed> <emit_json> <do_baseline>: shared report driver. Used by
+# both the live path and the self-test.
+run_report() {
+    local fed="$1" emit_json="$2" do_baseline="$3"
+    local spend_glob="$fed/*/.agentis/spend/*.jsonl"
+    local stats_map reduced
+    stats_map="$(collect_stats "$fed")"
+    reduced="$(python3 "$REDUCER" "$spend_glob" "$WINDOW_MIN" "$stats_map" 2>/dev/null || echo '{}')"
+    if [ "$do_baseline" = "1" ]; then
+        stamp_baseline "$fed" "$reduced" >/dev/null
+    fi
+    if [ "$emit_json" = "1" ]; then
+        printf '%s\n' "$reduced"
+    else
+        emit_compact "$reduced"
+    fi
+}
+
+# --- --self-test ---
+
+# Global so the EXIT trap can reference it without tripping `set -u` after the
+# self_test function frame is gone (the trap fires at script exit, by which
+# point a `local tmp` would be out of scope).
+SELF_TEST_TMP=""
+cleanup_self_test() {
+    [ -n "${SELF_TEST_TMP:-}" ] && rm -rf "$SELF_TEST_TMP"
+}
+
+self_test() {
+    SELF_TEST_TMP="$(mktemp -d)"
+    trap cleanup_self_test EXIT
+    local tmp="$SELF_TEST_TMP"
+    local fed="$tmp/dev-apprenticeship"
+    local spend="$fed/triage/.agentis/spend"
+    mkdir -p "$spend"
+
+    # Seed a synthetic spend.jsonl for one agent. now-anchored timestamps so
+    # the trailing-window rate is deterministic: 3 rows inside a 60-min
+    # window. Mix of cost / output_tokens / a throttle row ([llm.cancelled])
+    # and a task-error row (outcome=fail) to exercise the split.
+    NOW="$(date +%s)"
+    SPEND_FILE="$spend/router.jsonl" NOW="$NOW" python3 -c '
+import json, os
+now = int(os.environ["NOW"])
+rows = [
+    {"ts": now - 60,  "cost_usd": 0.01, "output_tokens": 100, "cost_source": "real"},
+    {"ts": now - 120, "cost_usd": 0.02, "output_tokens": 200, "cost_source": "real"},
+    {"ts": now - 180, "cost_usd": None, "output_tokens": 50,  "cost_source": "cancelled"},
+    {"ts": now - 240, "cost_usd": 0.03, "output_tokens": 70,  "cost_source": "real", "outcome": "fail"},
+]
+with open(os.environ["SPEND_FILE"], "w") as f:
+    for r in rows:
+        f.write(json.dumps(r) + "\n")
+'
+
+    # Stats fixture: avg_input_size = 500 chars/prompt for the triage colony.
+    STATS_MAP='{"triage":{"avg_input_size":500.0,"total_prompts":4,"total_cb":20,"avg_cb_per_prompt":5.0}}'
+
+    local reduced
+    reduced="$(python3 "$REDUCER" "$fed/*/.agentis/spend/*.jsonl" 60 "$STATS_MAP")"
+
+    local fails=0
+    assert_field() {
+        # $1 jq-ish python path expr, $2 expected, $3 label
+        local got
+        got="$(R="$reduced" python3 -c "
+import json, os
+d = json.loads(os.environ['R'])
+$1
+print(val)" 2>/dev/null || echo '__ERR__')"
+        if [ "$got" = "$2" ]; then
+            echo "[PASS] $3 ($got)"
+        else
+            echo "[FAIL] $3 (got '$got', want '$2')"
+            fails=$((fails + 1))
+        fi
+    }
+
+    # Agent-level assertions (the single router agent record).
+    assert_field "val = d['agents'][0]['colony']"           "triage"  "agent colony"
+    assert_field "val = d['agents'][0]['agent']"            "router"  "agent name"
+    assert_field "val = d['agents'][0]['prompts']"          "4"       "prompts = row count"
+    # 4 rows all within the 60-min window: (4/60)*60 = 4.0 prompts/hour.
+    assert_field "val = ('%.1f' % d['agents'][0]['prompts_per_hour'])" "4.0" "prompts_per_hour"
+    # chars_in proxy = avg_input_size(500) * prompts(4) = 2000.
+    assert_field "val = d['agents'][0]['chars_in']"         "2000"    "chars_in proxy"
+    # chars_out proxy = sum(output_tokens) = 100+200+50+70 = 420.
+    assert_field "val = d['agents'][0]['chars_out']"        "420"     "chars_out proxy"
+    # cost_usd = 0.01 + 0.02 + 0(null) + 0.03 = 0.06.
+    assert_field "val = ('%.2f' % d['agents'][0]['cost_usd'])" "0.06" "cost_usd (null -> 0)"
+    # Throttle-vs-task-error split: 1 throttle ([llm.cancelled]), 1 task error.
+    assert_field "val = d['agents'][0]['throttle_events']"  "1"       "throttle_events (split)"
+    assert_field "val = d['agents'][0]['task_errors']"      "1"       "task_errors (split)"
+    # retries not derivable from spend rows -> 0 (documented note).
+    assert_field "val = d['agents'][0]['retries']"          "0"       "retries (0, documented)"
+
+    # Role-level aggregate mirrors the single agent.
+    assert_field "val = d['roles'][0]['colony']"            "triage"  "role colony"
+    assert_field "val = d['roles'][0]['prompts']"           "4"       "role prompts"
+    assert_field "val = d['roles'][0]['throttle_events']"   "1"       "role throttle_events"
+    assert_field "val = d['roles'][0]['task_errors']"       "1"       "role task_errors"
+
+    # Compact line shape.
+    local compact
+    compact="$(emit_compact "$reduced")"
+    case "$compact" in
+        *"role=triage prompts=4 pph=4.0000 cin=2000 cout=420 cost=0.060000 throttle=1 retries=0"*)
+            echo "[PASS] compact line shape" ;;
+        *)
+            echo "[FAIL] compact line shape (got '$compact')"
+            fails=$((fails + 1)) ;;
+    esac
+
+    # Baseline stamp.
+    stamp_baseline "$fed" "$reduced" >/dev/null
+    local baseline_file="$fed/.agentis/logs/cost-rate-baseline.json"
+    if [ -f "$baseline_file" ]; then
+        local b_kb b_count
+        b_kb="$(B="$baseline_file" python3 -c "import json,os;print(json.load(open(os.environ['B']))['baseline_kb_per_agent'])" 2>/dev/null || echo '')"
+        b_count="$(B="$baseline_file" python3 -c "import json,os;print(json.load(open(os.environ['B']))['agent_count'])" 2>/dev/null || echo '')"
+        if [ "$b_kb" = "74.0" ] && [ "$b_count" = "1" ]; then
+            echo "[PASS] baseline stamp (kb=$b_kb agents=$b_count)"
+        else
+            echo "[FAIL] baseline stamp (kb='$b_kb' agents='$b_count')"
+            fails=$((fails + 1))
+        fi
+    else
+        echo "[FAIL] baseline file not written: $baseline_file"
+        fails=$((fails + 1))
+    fi
+
+    echo ""
+    echo "Results: self-test fails=$fails"
+    [ "$fails" -eq 0 ]
+}
+
+# --- Arg parsing ---
+
+EMIT_JSON=0
+DO_BASELINE=0
+SELF_TEST=0
+FED_ARG=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --json)      EMIT_JSON=1; shift ;;
+        --baseline)  DO_BASELINE=1; shift ;;
+        --self-test) SELF_TEST=1; shift ;;
+        -*)
+            echo "cost-rate-report.sh: unknown flag: $1" >&2
+            exit 2
+            ;;
+        *)
+            if [ -z "$FED_ARG" ]; then
+                FED_ARG="$1"
+            else
+                echo "cost-rate-report.sh: unexpected extra arg: $1" >&2
+                exit 2
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [ "$SELF_TEST" = "1" ]; then
+    self_test
+    exit $?
+fi
+
+if [ -z "$FED_ARG" ]; then
+    echo "Usage: $0 <federation-dir> [--json] [--baseline]" >&2
+    echo "       $0 --self-test" >&2
+    exit 1
+fi
+
+FED_DIR="$REPO_ROOT/$FED_ARG"
+if [ ! -d "$FED_DIR" ]; then
+    FED_DIR="$FED_ARG"
+fi
+if [ ! -d "$FED_DIR" ]; then
+    echo "Federation directory not found: $FED_ARG" >&2
+    exit 1
+fi
+
+run_report "$FED_DIR" "$EMIT_JSON" "$DO_BASELINE"

--- a/tools/test-rate-limit-backoff.sh
+++ b/tools/test-rate-limit-backoff.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# tools/test-rate-limit-backoff.sh: simulated-429 backoff tests (#1115).
+#
+# Validates the forge-wrapper jittered exponential backoff and the colony-side
+# rate-limited observability primitives.
+#
+#   Test 1: a forge call that hits 429 on every attempt retries exactly
+#           GITLAB_CURL_RETRIES times then gives up with exit 3 (rate
+#           limited) — i.e. it backs off and stops, NOT a retry storm.
+#   Test 2: the jittered backoff delays GROW across attempts (exponential
+#           floor preserved: each base delay doubles).
+#   Test 3: each backoff delay lies within its jitter bound
+#           [base, base + base/2] (equal-jitter, +50% upper bound).
+#   Test 4: the .ag agents surface a rate-limited memo state
+#           (`<agent>:rate_limited_until`) and emit a `<colony>:rate-limited`
+#           event so the condition is observable and the task is NOT failed
+#           during backoff.
+#   Test 5: the .ag agents defer (do not mark failed) while the backoff
+#           window is open — the rl_active() gate + rl_mark()/rl_clear()
+#           helpers are wired into every autonomous forge-write path.
+#
+# The forge wrapper is exercised against a STUBBED curl that returns 429 on
+# every attempt, with GITLAB_BACKOFF_DRYRUN=1 so the backoff sleeps are traced
+# (one integer per line to $GITLAB_BACKOFF_TRACE) instead of really sleeping —
+# the test runs in well under a second with no wall-clock waits.
+#
+# Usage: ./tools/test-rate-limit-backoff.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FAKE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FAKE_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+GITLAB_API="$REPO_ROOT/dev-apprenticeship/triage/scripts/gitlab-api.sh"
+
+# Stub curl: always report HTTP 429, write nothing to the -o body file. The
+# real gl_call writes the status code to stdout via -w and the body via -o, so
+# we mimic that: echo 429 on stdout, leave the body file empty.
+FAKE_BIN="$FAKE_ROOT/bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/curl" <<'EOF'
+#!/bin/bash
+# Find the -o <file> arg and truncate it to empty (no body), then print 429.
+out=""
+prev=""
+for a in "$@"; do
+    if [ "$prev" = "-o" ]; then
+        out="$a"
+    fi
+    prev="$a"
+done
+if [ -n "$out" ]; then
+    : > "$out"
+fi
+printf '429'
+exit 0
+EOF
+chmod +x "$FAKE_BIN/curl"
+
+TRACE="$FAKE_ROOT/backoff-trace"
+: > "$TRACE"
+
+# ----- Test 1: retries exactly N times then exits 3 (no storm) -----
+RC=0
+PATH="$FAKE_BIN:$PATH" \
+GITLAB_URL="https://gitlab.example.com" \
+GITLAB_TOKEN="stub" \
+GITLAB_PROJECT="org%2Fproj" \
+GITLAB_CURL_RETRIES=3 \
+GITLAB_BACKOFF_DRYRUN=1 \
+GITLAB_BACKOFF_TRACE="$TRACE" \
+    "$GITLAB_API" issues >/dev/null 2>&1 || RC=$?
+
+TRACE_COUNT=$(wc -l < "$TRACE" | tr -d ' ')
+# Budget is attempts-after-first: 3 retries => 3 backoff sleeps, then give up.
+if [ "$RC" = "3" ] && [ "$TRACE_COUNT" = "3" ]; then
+    pass "429-on-every-attempt: backs off 3 times then exits 3 (no retry storm)"
+else
+    fail "expected rc=3 + 3 backoff sleeps, got rc=$RC sleeps=$TRACE_COUNT"
+fi
+
+# ----- Test 2 + 3: delays grow + lie within jitter bounds -----
+# Base delays are 3, 6, 12 (delay starts at 3, doubled each retry). Jitter is
+# equal-jitter: slept in [base, base + base/2]. So bounds are:
+#   attempt 1: [3, 4]   (base 3, +50% floor'd => +1)
+#   attempt 2: [6, 9]   (base 6, +50% => +3)
+#   attempt 3: [12, 18] (base 12, +50% => +6)
+D1=$(sed -n '1p' "$TRACE")
+D2=$(sed -n '2p' "$TRACE")
+D3=$(sed -n '3p' "$TRACE")
+
+grow_ok=1
+case "$D1$D2$D3" in
+    ''|*[!0-9]*) grow_ok=0 ;;
+esac
+if [ "$grow_ok" = "1" ]; then
+    if [ "$D2" -gt "$D1" ] && [ "$D3" -gt "$D2" ]; then
+        pass "backoff delays grow across attempts ($D1 -> $D2 -> $D3)"
+    else
+        fail "backoff delays did not grow ($D1 -> $D2 -> $D3)"
+    fi
+else
+    fail "backoff trace not numeric ('$D1' '$D2' '$D3')"
+fi
+
+bounds_ok=1
+check_bound() {
+    # $1 value, $2 lo, $3 hi, $4 label
+    if [ "$1" -lt "$2" ] || [ "$1" -gt "$3" ]; then
+        echo "  out-of-bound: $4 = $1 not in [$2, $3]"
+        bounds_ok=0
+    fi
+}
+if [ "$grow_ok" = "1" ]; then
+    check_bound "$D1" 3 4 "attempt-1"
+    check_bound "$D2" 6 9 "attempt-2"
+    check_bound "$D3" 12 18 "attempt-3"
+    if [ "$bounds_ok" = "1" ]; then
+        pass "each backoff delay within jitter bound [base, base+base/2]"
+    else
+        fail "a backoff delay fell outside its jitter bound"
+    fi
+else
+    fail "skipping jitter-bound check (non-numeric trace)"
+fi
+
+# ----- Test 4: .ag agents surface rate-limited memo + emit -----
+RL_AGENTS=(
+    "dev-apprenticeship/code-review/agents/approval_decider.ag"
+    "dev-apprenticeship/planning/agents/risk_assessor.ag"
+    "dev-apprenticeship/planning/agents/plan_reviewer.ag"
+)
+memo_ok=1
+emit_ok=1
+for rel in "${RL_AGENTS[@]}"; do
+    f="$REPO_ROOT/$rel"
+    if ! grep -q ':rate_limited_until' "$f"; then
+        echo "  $rel missing :rate_limited_until memo"
+        memo_ok=0
+    fi
+    if ! grep -Eq 'emit\("(code-review|planning):rate-limited"' "$f"; then
+        echo "  $rel missing <colony>:rate-limited emit"
+        emit_ok=0
+    fi
+done
+if [ "$memo_ok" = "1" ]; then
+    pass "agents write a <agent>:rate_limited_until memo state"
+else
+    fail "an agent is missing the rate_limited_until memo"
+fi
+if [ "$emit_ok" = "1" ]; then
+    pass "agents emit a <colony>:rate-limited observable event"
+else
+    fail "an agent is missing the <colony>:rate-limited emit"
+fi
+
+# ----- Test 5: backoff gate wired (defer, not fail) -----
+gate_ok=1
+for rel in "${RL_AGENTS[@]}"; do
+    f="$REPO_ROOT/$rel"
+    if ! grep -q 'rl_active(' "$f"; then
+        echo "  $rel missing rl_active() backoff gate"
+        gate_ok=0
+    fi
+    if ! grep -q 'rl_mark(' "$f"; then
+        echo "  $rel missing rl_mark() on rate-limited write"
+        gate_ok=0
+    fi
+    if ! grep -q 'rl_clear(' "$f"; then
+        echo "  $rel missing rl_clear() on successful write"
+        gate_ok=0
+    fi
+done
+if [ "$gate_ok" = "1" ]; then
+    pass "rl_active gate + rl_mark/rl_clear wired into every agent (defer, not fail)"
+else
+    fail "an agent is missing the rate-limit gate/mark/clear wiring"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1114. Closes #1115.

Colony-side cost/rate instrumentation + CB cap & forge-429 backoff. Plan + colony/upstream/operator split: #1114 plan comment.

## #1114 — per-tick cost/rate instrumentation
- `tools/cost-rate-report.{sh,py}` — per-agent **and** per-role aggregation from the existing spend stream (`<colony>/.agentis/spend/<agent>.jsonl`, agentis-core #311) + `agentis stats --json --per-identity`: `prompts`, `prompts_per_hour` (rolling), `chars_in`/`chars_out` (labeled **proxies**: avg_input_size×prompts / Σoutput_tokens), `cost_usd`, `throttle_events`, `retries`. Compact one-line-per-role default + `--json`.
- **Throttle vs task-error** are separate counters from distinct sources (forge-429 / `[llm.cancelled]` vs agent failure markers).
- `--baseline` stamps the pre-fix ~74 KB/agent number so improvements are provable.
- 4th sidecar in `start-federation.sh` (mirrors snapshot-refresh; `COST_RATE_PID` in all EXIT/TERM/INT traps); logs to `.agentis/logs/cost-rate.log`.
- `--self-test` seeds synthetic spend + stats and asserts every field incl. the split + baseline.

## #1115 — CB cap + backoff
- `--cb-per-tick` wired into all five colonies' `start-colony.sh` (normal launch + `--restart-agent` path), config-driven via `[colony].cb_per_tick` (a real `agentis daemon` flag, unlike `--config-override` #351).
- Jittered exponential forge-429 backoff in every `gitlab-api.sh` `_backoff_sleep`; `approval_decider`/`risk_assessor`/`plan_reviewer` record `<agent>:rate_limited_until`, emit `<colony>:rate-limited`, and **defer** instead of failing the task. `rl_is_limited` guards null/absent `remaining` so genuine failures on no-`RateLimit-*`-header instances aren't misclassified.
- `tools/test-rate-limit-backoff.sh` simulated-429 test (delays grow within jitter bounds, no retry storm, observable state).

## Honest boundaries
- **Operator-run-gated** (not claimed here): real-backend baseline number, ≥90% prompt-cache-hit (#1113), induced-rate-limit live recovery — these need the user's live federation run (#1117).
- **Upstream** (agentis runtime / LLM backend): HTTP-429 backoff + prompt cache primitive. Documented in code/CHANGELOG; filed separately.

## Verification
- colony-lint (agentis on PATH): **417 passed, 0 failed, 5 skipped**
- `cost-rate-report.sh --self-test` green · `test-rate-limit-backoff.sh` 6/0 · `test-cost-cap-install.sh` 7/0 · `test-auto-promote-install.sh` 13/0
- QA: ⚠️→✅ (the one MEDIUM finding, `rl_is_limited` null-`remaining` misclassification, fixed inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)