### PR TITLE
test(trading-binance): deterministic tribe-zeta fade backtest — honest negative on BTCUSDT (#1123)

### DIFF
--- a/trading-binance/.gitignore
+++ b/trading-binance/.gitignore
@@ -1,0 +1,5 @@
+# Downloaded Binance market-data shards are not committed: they are mounted
+# into the replay container at runtime and are re-downloadable via
+# tools/binance-feed-download.py. Keep the directory present via .gitkeep.
+/data/*
+!/data/.gitkeep

--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,23 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Deterministic reference backtest of the `tribe-zeta` volume-divergence
+  **fade** signal over a real 90-day BTCUSDT 1h window (2026-03-01 →
+  2026-05-31), recorded under `runs/20260618T-fade-determ/`
+  (`backtest-fade-signal.py`, `comparison.md`, `results.json`,
+  `run-meta.json`). Decisions are settled by the repo's own ground-truth
+  verifier (`tools/verify-trade.sh`). **Honest verdict: the mechanical fade
+  signal has no edge on this window** — it loses at every lookback tested
+  (20 / 50 / 100 bars: total −360 / −324 / −424 bps, win rate < 50 %,
+  negative per-trade Sharpe) and beats neither FLAT (0 bps) nor buy-and-hold
+  (+757 bps); the window trended up, so fading new highs is the wrong side of
+  a trend. The full 6-tribe LLM replay (tribe-zeta vs the other five) is
+  deferred — it needs `OPENROUTER_API_KEY` (the replay's `openai` backend
+  hard-fails without it; the `claude`/`cli` backend is not yet wired into the
+  replay container), so #1123 stays open for that step (#1123).
+- `.gitignore` for the federation: downloaded market-data shards under
+  `data/` are not committed (mounted at runtime / re-downloadable), keeping
+  `data/.gitkeep` present.
 - Sixth tribe colony `tribe-zeta/` shipping a `strategist.ag` agent that encodes Dr. David Paul's volume-divergence **fade** setup: SHORT an unconfirmed new local high (volume <= volumeMA(20)), LONG an unconfirmed new local low, FLAT when volume confirms the move. Mirrors the `tribe-alpha/` structure exactly (M98 v3 prompt evolution, M106 hash-pointer inheritance, M2-Malthusian replicate, tier-gated settlement via the shared verifier); `setup` is `"volume_divergence"`. Self-contained and inert — not yet wired into `tools/run-replay.sh` or `BUNDLE.manifest` (#1121, follow-ups #1122/#1123).
 - `tools/run-ab-experiment.sh` A/B emergence experiment harness:
   runs N paired replicates x 2 arms (control =

--- a/trading-binance/runs/20260618T-fade-determ/backtest-fade-signal.py
+++ b/trading-binance/runs/20260618T-fade-determ/backtest-fade-signal.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""backtest-fade-signal.py -- deterministic reference backtest of the
+tribe-zeta volume-divergence FADE signal (issue #1123).
+
+This is the honest "does the signal even work" gate. It is a DETERMINISTIC
+reference implementation of the fade thesis encoded in
+`tribe-zeta/agents/strategist.ag`'s seed prompt -- it is NOT the LLM
+strategist's realised behaviour, and it does not run the other five tribes.
+Decisions are settled by the repo's own ground-truth verifier
+(`tools/verify-trade.sh`), the exact settler the replay uses, so the PnL
+numbers match what a replay would record for the same decisions.
+
+Signal (per candle i, faithful to the seed prompt, raw OHLCV + volMA(20) only):
+  volMA = SMA(volume, VOL_MA) over the trailing VOL_MA candles ending at i.
+  new L-bar high  = high[i] > max(high[i-L .. i-1])
+  new L-bar low   = low[i]  < min(low[i-L .. i-1])
+    new high AND volume[i] <= volMA -> SHORT (fade the unconfirmed breakout)
+    new low  AND volume[i] <= volMA -> LONG  (fade the unconfirmed breakdown)
+    otherwise                        -> FLAT (incl. "volume confirms": at an
+                                              extreme but volume[i] > volMA)
+  size fixed at 1.0 (deterministic baseline; per-trade bps directly comparable).
+
+Settlement: each non-FLAT decision -> tools/verify-trade.sh with
+CONTEXT_TICK=i, HOLD_PERIOD, TIMEFRAME_MINUTES (60 for 1h), SLIPPAGE_BPS,
+FUNDING_RATE_BPS. FLAT = 0 bps by definition (not sent to the verifier).
+
+Baseline for the verdict = FLAT (always 0 bps, no trades, no costs).
+
+Standard library only.
+"""
+import argparse
+import csv
+import json
+import math
+import os
+import subprocess
+import sys
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(description="Deterministic fade-signal backtest (#1123).")
+    p.add_argument("--candles", required=True, help="Unified candle CSV (from load-candles.py).")
+    p.add_argument("--verifier", required=True, help="Path to tools/verify-trade.sh.")
+    p.add_argument("--hold-period", type=int, default=8)
+    p.add_argument("--vol-ma", type=int, default=20)
+    p.add_argument("--timeframe-minutes", type=int, default=60, help="1h = 60 (NOT the verifier's 30 default).")
+    p.add_argument("--slippage-bps", type=float, default=5.0)
+    p.add_argument("--funding-rate-bps", type=float, default=1.0)
+    p.add_argument("--lookbacks", default="20,50,100", help="Comma list of local-extreme lookback windows to sweep.")
+    p.add_argument("--size", type=float, default=1.0)
+    return p.parse_args(argv)
+
+
+def load_candles(path):
+    with open(path, "r", newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    out = []
+    for r in rows:
+        out.append({
+            "open": float(r["open"]),
+            "high": float(r["high"]),
+            "low": float(r["low"]),
+            "close": float(r["close"]),
+            "volume": float(r["volume"]),
+        })
+    return out
+
+
+def settle(verifier, action, size, tick, hold, candles_csv, slip, funding, tf_min):
+    """Call the repo verifier for one decision; return pnl_bps (float)."""
+    env = dict(os.environ)
+    env["DECISION_JSON"] = json.dumps({"action": action, "size": size, "setup": "volume_divergence", "rationale": "deterministic fade backtest"})
+    env["CONTEXT_TICK"] = str(tick)
+    env["HOLD_PERIOD"] = str(hold)
+    env["CANDLES_CSV"] = candles_csv
+    env["SLIPPAGE_BPS"] = str(slip)
+    env["FUNDING_RATE_BPS"] = str(funding)
+    env["TIMEFRAME_MINUTES"] = str(tf_min)
+    proc = subprocess.run(["bash", verifier], env=env, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError("verifier failed (rc=%d) tick=%d: %s" % (proc.returncode, tick, proc.stderr.strip()))
+    verdict = json.loads(proc.stdout.strip())
+    return float(verdict["pnl_bps"]), verdict["classification"]
+
+
+def signal_for(candles, i, lookback, vol_ma):
+    """Return 'LONG' | 'SHORT' | 'FLAT' for candle i under the fade rules."""
+    if i < lookback or i < vol_ma:
+        return "FLAT"
+    vol_window = [candles[j]["volume"] for j in range(i - vol_ma, i)]
+    vma = sum(vol_window) / float(vol_ma)
+    prior_highs = [candles[j]["high"] for j in range(i - lookback, i)]
+    prior_lows = [candles[j]["low"] for j in range(i - lookback, i)]
+    new_high = candles[i]["high"] > max(prior_highs)
+    new_low = candles[i]["low"] < min(prior_lows)
+    weak_volume = candles[i]["volume"] <= vma
+    # A bar that is simultaneously a new high and a new low (huge outside bar)
+    # is ambiguous -> FLAT.
+    if new_high and not new_low and weak_volume:
+        return "SHORT"
+    if new_low and not new_high and weak_volume:
+        return "LONG"
+    return "FLAT"
+
+
+def metrics_for_lookback(candles, candles_csv, lookback, args):
+    last_tradable = len(candles) - 1 - 1 - args.hold_period  # need entry i+1 and exit i+1+hold in range
+    pnls = []
+    wins = 0
+    longs = 0
+    shorts = 0
+    flats = 0
+    for i in range(len(candles)):
+        if i > last_tradable:
+            # decisions beyond here cannot be settled; count remaining as FLAT
+            flats += 1
+            continue
+        action = signal_for(candles, i, lookback, args.vol_ma)
+        if action == "FLAT":
+            flats += 1
+            continue
+        pnl, classification = settle(args.verifier, action, args.size, i, args.hold_period,
+                                     candles_csv, args.slippage_bps, args.funding_rate_bps,
+                                     args.timeframe_minutes)
+        pnls.append(pnl)
+        if classification == "WIN":
+            wins += 1
+        if action == "LONG":
+            longs += 1
+        else:
+            shorts += 1
+    n = len(pnls)
+    total = sum(pnls)
+    mean = total / n if n else 0.0
+    win_rate = (wins / n * 100.0) if n else 0.0
+    # per-trade Sharpe = mean / stddev (population) over realised trades
+    if n > 1:
+        var = sum((x - mean) ** 2 for x in pnls) / n
+        sd = math.sqrt(var)
+        sharpe = mean / sd if sd > 0 else 0.0
+    else:
+        sharpe = 0.0
+    # max drawdown (bps) on the cumulative PnL curve over the trade sequence
+    peak = 0.0
+    cum = 0.0
+    max_dd = 0.0
+    for x in pnls:
+        cum += x
+        peak = max(peak, cum)
+        max_dd = max(max_dd, peak - cum)
+    return {
+        "lookback": lookback,
+        "trades": n,
+        "longs": longs,
+        "shorts": shorts,
+        "flats": flats,
+        "win_rate_pct": round(win_rate, 1),
+        "total_pnl_bps": round(total, 2),
+        "mean_pnl_bps": round(mean, 3),
+        "max_drawdown_bps": round(max_dd, 2),
+        "per_trade_sharpe": round(sharpe, 4),
+    }
+
+
+def buy_and_hold_bps(candles, args):
+    """Reference: LONG the whole tradable window, size 1.0, net of one round-trip cost."""
+    first = candles[0]["open"]
+    last = candles[-1]["open"]
+    raw = (last - first) / first * 10000.0 * args.size
+    slippage = 2.0 * args.slippage_bps * args.size
+    # funding over the whole window
+    blocks = (len(candles) * args.timeframe_minutes) / 480.0
+    funding = args.funding_rate_bps * args.size * blocks
+    return round(raw - slippage - funding, 2), round(raw, 2)
+
+
+def main(argv):
+    args = parse_args(argv)
+    candles = load_candles(args.candles)
+    lookbacks = [int(x) for x in args.lookbacks.split(",") if x.strip()]
+    results = [metrics_for_lookback(candles, args.candles, L, args) for L in lookbacks]
+    bh_net, bh_raw = buy_and_hold_bps(candles, args)
+    out = {
+        "window_candles": len(candles),
+        "hold_period": args.hold_period,
+        "vol_ma": args.vol_ma,
+        "timeframe_minutes": args.timeframe_minutes,
+        "slippage_bps": args.slippage_bps,
+        "funding_rate_bps": args.funding_rate_bps,
+        "size": args.size,
+        "flat_baseline_total_pnl_bps": 0.0,
+        "buy_and_hold_net_bps": bh_net,
+        "buy_and_hold_raw_bps": bh_raw,
+        "results_by_lookback": results,
+    }
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/trading-binance/runs/20260618T-fade-determ/comparison.md
+++ b/trading-binance/runs/20260618T-fade-determ/comparison.md
@@ -1,0 +1,103 @@
+# tribe-zeta volume-divergence fade — backtest (#1123)
+
+**Run:** `20260618T-fade-determ` · **Symbol:** BTCUSDT · **Timeframe:** 1h ·
+**Window:** 2026-03-01 → 2026-05-31 (2208 candles, real Binance USDT-M klines)
+
+## What this is (and is not)
+
+This is the honest **"does the signal even work"** gate for Dr. David Paul's
+volume-divergence **fade** thesis (the `tribe-zeta` hypothesis from #1121).
+
+- It is a **deterministic reference implementation** of the fade signal —
+  the exact rules encoded in `tribe-zeta/agents/strategist.ag`'s seed prompt,
+  expressed as mechanical code. It is **not** the LLM strategist's realised
+  behaviour, and it does **not** run the other five tribes.
+- Decisions are settled by the repo's own ground-truth verifier
+  (`tools/verify-trade.sh`) — the exact settler the live replay uses — so the
+  PnL numbers are what a replay would record for these same decisions
+  (slippage 5 bps/side, funding 1 bps/8h, `HOLD_PERIOD=8`, `TIMEFRAME_MINUTES=60`).
+- The full **6-tribe LLM replay** (tribe-zeta vs alpha…epsilon, the literal
+  scope of #1123) is **deferred** — see "Deferred" below.
+
+## Signal (deterministic, faithful to the seed prompt)
+
+Per candle `i`, with `volMA = SMA(volume, 20)` and a local-extreme lookback `L`:
+
+| Condition | Action |
+|-----------|--------|
+| new `L`-bar high (`high[i] > max(high[i-L..i-1])`) **and** `volume[i] <= volMA` | **SHORT** (fade unconfirmed breakout) |
+| new `L`-bar low (`low[i] < min(low[i-L..i-1])`) **and** `volume[i] <= volMA` | **LONG** (fade unconfirmed breakdown) |
+| otherwise (incl. "volume confirms": at an extreme but `volume[i] > volMA`) | **FLAT** |
+
+Size fixed at `1.0`; no indicators beyond raw OHLCV + volMA(20).
+
+## Results (lookback sweep)
+
+Baseline for the verdict is **FLAT = 0 bps** (no trades, no costs).
+Buy-and-hold over the window (LONG, size 1.0, net of one round trip + funding):
+**+757.01 bps** (raw price move +1043 bps ≈ +10.4%). The window was a clear
+**uptrend**.
+
+| Lookback `L` | Trades | Long / Short | Win rate | Total PnL (bps) | Mean PnL/trade (bps) | Max drawdown (bps) | Per-trade Sharpe |
+|---|---|---|---|---|---|---|---|
+| 20  | 64 | 39 / 25 | 46.9 % | **−360.02** | −5.625  | 646.63 | −0.0763 |
+| 50  | 24 | 13 / 11 | 41.7 % | **−323.53** | −13.480 | 566.55 | −0.2028 |
+| 100 | 16 | 7 / 9   | 37.5 % | **−424.02** | −26.501 | 653.11 | −0.3544 |
+
+(Full machine-readable output: [`results.json`](./results.json).)
+
+## Verdict — honest, and negative
+
+**No. On this window the deterministic volume-divergence fade signal does not
+beat FLAT, and it does not beat buy-and-hold.** It loses money at every
+lookback tested: total PnL is negative (−324 to −424 bps), win rate is below
+50 % everywhere, and per-trade Sharpe is negative. The effect **worsens** as
+the lookback lengthens (more "decisive" extremes → larger average loss).
+
+The mechanism is intuitive: BTCUSDT trended **up** ~10 % over this window, so
+fading new highs with a SHORT is systematically the wrong side of a trend.
+A fade-the-extremes heuristic is structurally counter-trend, and this window
+was strongly trending — exactly the regime where a naive fade bleeds. This is
+a useful negative result: the fade thesis is a heuristic, not a law, and on a
+single trending window the mechanical version of it has **no edge**.
+
+## Validation caveats
+
+- **Single window, in-sample.** One 90-day window is not robust. No
+  walk-forward, no out-of-sample, no multiple regimes (the result might differ
+  in a ranging or mean-reverting regime, which is where fades are supposed to
+  work).
+- **Deterministic signal ≠ LLM strategist.** The live `tribe-zeta` strategist
+  is an LLM that can read context the mechanical rule cannot (regime, structure,
+  rationale) and whose prompt evolves (M98 v3). This backtest bounds the *raw
+  signal*, not the tribe's realised behaviour.
+- **No cross-tribe comparison yet.** "Beats the other five tribes?" is
+  unanswered here — that needs the LLM replay.
+- Fixed size 1.0 and the verifier's flat cost model (5 bps slippage, 1 bps/8h
+  funding) — not a live-fill model.
+
+## Deferred — the 6-tribe LLM replay
+
+The literal #1123 scope ("run `tools/run-replay.sh` with all six tribes,
+compare tribe-zeta vs the other five") requires an LLM backend.
+`tools/run-replay.sh` defaults to `llm.backend=openai` and **hard-fails
+without `OPENROUTER_API_KEY`**; the `claude`/`cli` backend is not yet wired
+into the replay container (`tools/Containerfile.replay`: "Future replay-side
+claude backend support …"). The 6-tribe replay is therefore deferred and is
+**operator-reproducible** with a key:
+
+```bash
+export OPENROUTER_API_KEY=...                      # cheap Qwen path
+python3 trading-binance/tools/binance-feed-download.py \
+  --symbol BTCUSDT --timeframe 1h --start 2026-03-01 --end 2026-05-31
+REPLAY_SYMBOL=BTCUSDT REPLAY_TIMEFRAME=1h bash trading-binance/tools/run-replay.sh
+# then read tribe-zeta's trade-ledger.jsonl + experience rows and compare to the other five.
+```
+
+#1123 remains **open** for that step.
+
+## Reproduce this deterministic backtest
+
+See [`run-meta.json`](./run-meta.json) for exact parameters and the
+download/regenerate command (raw market-data shards and the unified
+`candles.csv` are intentionally not committed).

--- a/trading-binance/runs/20260618T-fade-determ/results.json
+++ b/trading-binance/runs/20260618T-fade-determ/results.json
@@ -1,0 +1,50 @@
+{
+  "window_candles": 2208,
+  "hold_period": 8,
+  "vol_ma": 20,
+  "timeframe_minutes": 60,
+  "slippage_bps": 5.0,
+  "funding_rate_bps": 1.0,
+  "size": 1.0,
+  "flat_baseline_total_pnl_bps": 0.0,
+  "buy_and_hold_net_bps": 757.01,
+  "buy_and_hold_raw_bps": 1043.01,
+  "results_by_lookback": [
+    {
+      "lookback": 20,
+      "trades": 64,
+      "longs": 39,
+      "shorts": 25,
+      "flats": 2144,
+      "win_rate_pct": 46.9,
+      "total_pnl_bps": -360.02,
+      "mean_pnl_bps": -5.625,
+      "max_drawdown_bps": 646.63,
+      "per_trade_sharpe": -0.0763
+    },
+    {
+      "lookback": 50,
+      "trades": 24,
+      "longs": 13,
+      "shorts": 11,
+      "flats": 2184,
+      "win_rate_pct": 41.7,
+      "total_pnl_bps": -323.53,
+      "mean_pnl_bps": -13.48,
+      "max_drawdown_bps": 566.55,
+      "per_trade_sharpe": -0.2028
+    },
+    {
+      "lookback": 100,
+      "trades": 16,
+      "longs": 7,
+      "shorts": 9,
+      "flats": 2192,
+      "win_rate_pct": 37.5,
+      "total_pnl_bps": -424.02,
+      "mean_pnl_bps": -26.501,
+      "max_drawdown_bps": 653.11,
+      "per_trade_sharpe": -0.3544
+    }
+  ]
+}

--- a/trading-binance/runs/20260618T-fade-determ/run-meta.json
+++ b/trading-binance/runs/20260618T-fade-determ/run-meta.json
@@ -1,0 +1,21 @@
+{
+  "run_id": "20260618T-fade-determ",
+  "issue": 1123,
+  "kind": "deterministic-reference-backtest",
+  "note": "Deterministic reference implementation of the tribe-zeta volume-divergence FADE signal, settled by tools/verify-trade.sh. NOT the LLM strategist; the 6-tribe LLM replay is deferred (needs OPENROUTER_API_KEY).",
+  "symbol": "BTCUSDT",
+  "timeframe": "1h",
+  "window_start": "2026-03-01",
+  "window_end": "2026-05-31",
+  "window_candles": 2208,
+  "verifier": "tools/verify-trade.sh",
+  "hold_period": 8,
+  "vol_ma": 20,
+  "timeframe_minutes": 60,
+  "slippage_bps": 5,
+  "funding_rate_bps": 1,
+  "size": 1.0,
+  "lookbacks_swept": [20, 50, 100],
+  "base_commit": "ed7ca90401a1d42b2a6a7cb4377c302aee98875f",
+  "reproduce": "python3 tools/binance-feed-download.py --symbol BTCUSDT --timeframe 1h --start 2026-03-01 --end 2026-05-31 && python3 tools/load-candles.py --data-dir data --symbol BTCUSDT --timeframe 1h --start 2026-03-01 --end 2026-05-31 > candles.csv && python3 runs/20260618T-fade-determ/backtest-fade-signal.py --candles candles.csv --verifier tools/verify-trade.sh --hold-period 8 --vol-ma 20 --timeframe-minutes 60 --lookbacks 20,50,100"
+}


### PR DESCRIPTION
## Summary

The honest **"does the volume-divergence fade signal even work"** gate for `tribe-zeta` (#1123), over a **real 90-day BTCUSDT 1h window** (2026-03-01 → 2026-05-31, 2208 candles). Step 3/3 of the tribe-zeta increment — **partial**: this delivers the deterministic edge-existence result; the literal 6-tribe LLM replay is deferred (see below), so **this PR does NOT close #1123**.

## Approach

A **deterministic reference implementation** of the fade rules encoded in `tribe-zeta/agents/strategist.ag`'s seed prompt (`volMA(20)`, new `L`-bar high/low, fade only on weak volume) — decisions are settled by the repo's **own ground-truth verifier** `tools/verify-trade.sh` (the exact settler the live replay uses; slippage 5 bps/side, funding 1 bps/8h, `HOLD_PERIOD=8`, `TIMEFRAME_MINUTES=60`). This isolates "the raw signal" from "the PnL ground truth" and is fully reproducible (no LLM).

## Result — honest, and negative

Baseline = **FLAT (0 bps)**. Buy-and-hold over the window = **+757 bps** (market trended up ~10%).

| Lookback `L` | Trades | Win rate | Total PnL (bps) | Mean/trade (bps) | Max DD (bps) | Per-trade Sharpe |
|---|---|---|---|---|---|---|
| 20  | 64 | 46.9 % | **−360.02** | −5.625  | 646.63 | −0.0763 |
| 50  | 24 | 41.7 % | **−323.53** | −13.480 | 566.55 | −0.2028 |
| 100 | 16 | 37.5 % | **−424.02** | −26.501 | 653.11 | −0.3544 |

**Verdict: the mechanical fade signal has no edge on this window.** It loses at every lookback, win rate < 50 % everywhere, negative per-trade Sharpe; it beats neither FLAT nor buy-and-hold. Mechanism: BTC trended up, and fading new highs (SHORT) is structurally the wrong side of a trend. A negative result is valid and is recorded, not hidden (the issue explicitly asks for this).

Caveats (in `comparison.md`): single in-sample window, no walk-forward, deterministic-signal ≠ LLM strategist, no cross-tribe comparison yet.

## Deferred — the 6-tribe LLM replay

The literal scope ("run `tools/run-replay.sh` with all six tribes, compare tribe-zeta vs the other five") needs an LLM backend: `run-replay.sh` defaults to `llm.backend=openai` and **hard-fails without `OPENROUTER_API_KEY`** (the cheap Qwen path), and the `claude`/`cli` backend is **not yet wired** into the replay container (`tools/Containerfile.replay`: "Future replay-side claude backend support …"). `comparison.md` documents the operator-reproducible command. **#1123 stays open for that step.**

## Files

Under `trading-binance/runs/20260618T-fade-determ/`: `backtest-fade-signal.py`, `comparison.md`, `results.json`, `run-meta.json`. Plus a federation `.gitignore` so downloaded market-data shards under `data/` are never committed (raw shards + unified `candles.csv` intentionally not committed; re-downloadable).

## Verification

- `./tools/colony-lint.sh` → 416 passed, 0 failed, 5 skipped.
- `python3 -m py_compile backtest-fade-signal.py` → clean.
- Staging confirmed to exclude all `data/BTCUSDT/*` shards.

Addresses #1123 (partial — deterministic backtest done; 6-tribe LLM replay deferred pending `OPENROUTER_API_KEY`).
