### PR TITLE
docs(flat-cyborg): document default LLM backend + correct scaffold comment (#1132)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,17 @@ bash -n scripts/gitlab-api.sh   # Bash syntax check on any script
 
 Colony lint must pass with 0 failures before merge. Current CI baseline: 42 passed, 0 failed, 1 skipped (agentis binary not installed on runners). Local runs add ~42 per-agent `.ag` syntax + tier-branch passes when `agentis` is installed, and 5 skips when `shellcheck` is not.
 
+## LLM backend
+
+Federations default to **flat-cyborg** ([`Replikanti/flat-cyborg`](https://github.com/Replikanti/flat-cyborg)) — a PTY wrapper that drives the interactive Claude Code session, so `prompt()` bills against a **flat-rate** Claude subscription instead of the metered `claude -p` API (`usage = None`). Two wiring styles, both flat-cyborg:
+
+- **Container federations** (`trading-binance`, `tribes-bench`, `research-foundry`) inject the **native** agentis-core backend `llm.backend = flat-cyborg` (requires agentis **>= v1.19.0** — pin `ARG AGENTIS_VERSION` accordingly in the federation's `Containerfile`) into the hermetic `.agentis/config` from their run/replay orchestrator, and bind-mount the host operator's `~/.claude` into the container at `/root/.claude:rw,z` (`:z` for SELinux/Fedora). Each orchestrator keeps a metered `claude` and/or `openai` path as an **opt-in fallback** via its `*_LLM_BACKEND` env knob (e.g. `REPLAY_LLM_BACKEND`, `STAGE3_LLM_BACKEND`, `RESEARCH_LLM_BACKEND`). `research-foundry` additionally routes per confidence tier via `llm.tier.<tier>.model` (haiku for dormant/shadow, sonnet for propose/review-gated/autonomous, opus for the terminal-writer agents).
+- **Host-run federations** (`dev-apprenticeship`, `dark-factory`) set `llm.backend = claude` + `llm.command = tools/flat-cyborg-claude.sh` (the wrapper script) in `.agentis/config` via `install.sh` / the run scripts, so the on-host `agentis daemon` shells out to flat-cyborg.
+
+A colony's `[llm] backend` in `colony.example.toml` is `"cli"` — meaning "use the agentis daemon default", which **inherits** the federation-level backend from `.agentis/config`. **Do not hardcode `"flat-cyborg"` there**: it would override the federation default and break the host wrapper path. The federation default (orchestrator hermetic config, or `install.sh`-written `.agentis/config`) is the single source of truth.
+
+Caveat: flat-cyborg's `--extract` is a TUI screen-scrape (output fidelity tracks the TUI layout). Keep the metered `claude` backend available for fidelity-critical paths. Deployment prereq: a `flat-cyborg` >= 0.9.0 binary with `--no-jitter` on PATH plus a logged-in `~/.claude`.
+
 ## Colony structure
 
 Every colony follows this layout:

--- a/tools/new-colony.sh
+++ b/tools/new-colony.sh
@@ -110,7 +110,12 @@ me = "your-username"
 # me    = "your-username"
 
 [llm]
-# Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
+# Only "backend" is read today. Keep "cli" — it means "use the agentis daemon
+# default CLI adapter", which INHERITS the federation backend from
+# .agentis/config (typically flat-cyborg, the flat-rate Claude PTY wrapper).
+# Do not hardcode "flat-cyborg" here: that would override the federation
+# default and break host-run federations that use the flat-cyborg-claude.sh
+# wrapper. See CLAUDE.md "LLM backend".
 backend = "cli"
 
 # Agent definitions

--- a/tools/new-federation.sh
+++ b/tools/new-federation.sh
@@ -312,7 +312,12 @@ tick_interval_ms = 60000
 $forge_block
 
 [llm]
-# Only "backend" is read today. "cli" uses the agentis daemon default CLI adapter.
+# Only "backend" is read today. Keep "cli" — it means "use the agentis daemon
+# default CLI adapter", which INHERITS the federation backend from
+# .agentis/config (typically flat-cyborg, the flat-rate Claude PTY wrapper).
+# Do not hardcode "flat-cyborg" here: that would override the federation
+# default and break host-run federations that use the flat-cyborg-claude.sh
+# wrapper. See CLAUDE.md "LLM backend".
 backend = "cli"
 
 # Agent definitions


### PR DESCRIPTION
## Summary

Final item of the flat-cyborg sweep (#1132): document flat-cyborg as the default LLM backend and correct the scaffold comment. Docs + scaffold-comment only — no functional code change.

## Context

All five federations now default to flat-cyborg (flat-rate Claude subscription via the PTY wrapper):
- **Container** (`trading-binance` #1133, `tribes-bench` #1136, `research-foundry` #1138) — native `llm.backend = flat-cyborg` (agentis >= v1.19.0, pinned via #1141 / #1138).
- **Host-run** (`dev-apprenticeship` #1131/#1135, `dark-factory`) — the `flat-cyborg-claude.sh` wrapper via `install.sh` / run scripts (these were already on flat-cyborg before this sweep).

## What changed

- **`CLAUDE.md`**: new **"LLM backend"** section — the two wiring styles (native vs wrapper), `research-foundry`'s per-tier `llm.tier.<tier>.model` routing, the opt-in metered `claude`/`openai` fallbacks, the v1.19.0 floor for the native backend + `~/.claude` mount, and the `--extract` TUI-scrape fidelity caveat.
- **`tools/new-colony.sh` + `tools/new-federation.sh`**: clarify the generated `[llm]` comment. The scaffold **keeps `backend = "cli"`** — which correctly *inherits* the federation default from `.agentis/config` — and now warns **not** to hardcode `"flat-cyborg"` there (it would override the federation default and break the host wrapper path). **No change to the generated value**; the federation default is the single source of truth.

## Why not flip the scaffold to `flat-cyborg`?

The original epic item said "scaffold default to flat-cyborg", but `backend = "cli"` is the *correct* portable scaffold: it means "use the agentis daemon default", which the federation sets (orchestrator hermetic config, or `install.sh`). Hardcoding `"flat-cyborg"` in a fresh colony would override that and break the two host-run federations that wire flat-cyborg via the `llm.command` wrapper (not the native backend). So this delivers the **documentation** intent without the incorrect functional change.

## Verification

- `./tools/colony-lint.sh` → 0 failed (no federation touched).
- `bash -n` clean on both scaffolds; `new-federation.sh` smoke-generates a valid `[llm]` block.

Part of #1132.
