### PR TITLE
fix(dev-apprenticeship): colony.example.toml [llm] backend back to "cli" (inherit, per CLAUDE.md)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,18 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Fixed
+
+- Reverted the `[llm] backend` in all 5 `*/config/colony.example.toml`
+  blocks from `"claude"` back to `"cli"` (a follow-up correction to #1131).
+  Per the CLAUDE.md "LLM backend" convention, `"cli"` means "use the
+  agentis daemon default" and **inherits** the federation-level backend
+  from `.agentis/config` (flat-cyborg); a specific backend must **not** be
+  hardcoded in the colony block (it would override the federation default
+  and break the host wrapper path). The block is inert per #351 either way,
+  so this is doc-consistency only — the real backend (`llm.backend = claude`
+  + the flat-cyborg wrapper) is written to `.agentis/config` by install.sh.
+
 ### Added
 
 - **flat-cyborg is now the default CLI LLM backend** (#1131). New shared

--- a/dev-apprenticeship/code-review/config/colony.example.toml
+++ b/dev-apprenticeship/code-review/config/colony.example.toml
@@ -56,8 +56,13 @@ me      = ""  # your GitLab username (optional, enables personal/team tagging)
 # install.sh §6). install.sh wires the default CLI = the flat-cyborg PTY
 # wrapper over Claude Code.
 [llm]
-backend = "claude"
-# command = "tools/flat-cyborg-claude.sh"   # default CLI over Claude Code (illustrative; install.sh writes the resolved path to .agentis/config — this [llm] block is inert per #351)
+# "cli" = inherit the agentis daemon default (the federation backend in
+# .agentis/config — flat-cyborg, set by install.sh). Do NOT hardcode a
+# specific backend here: this [llm] block is inert per #351 (the daemon
+# reads .agentis/config) so hardcoding would only mislead. See the
+# "LLM backend" section in CLAUDE.md.
+backend = "cli"
+# command = "claude"
 # model = "claude-sonnet-4"
 # api_key_env = "ANTHROPIC_API_KEY"
 

--- a/dev-apprenticeship/implementation/config/colony.example.toml
+++ b/dev-apprenticeship/implementation/config/colony.example.toml
@@ -72,8 +72,13 @@ require_assignee = false
 # install.sh §6). install.sh wires the default CLI = the flat-cyborg PTY
 # wrapper over Claude Code.
 [llm]
-backend = "claude"
-# command = "tools/flat-cyborg-claude.sh"   # default CLI over Claude Code (illustrative; install.sh writes the resolved path to .agentis/config — this [llm] block is inert per #351)
+# "cli" = inherit the agentis daemon default (the federation backend in
+# .agentis/config — flat-cyborg, set by install.sh). Do NOT hardcode a
+# specific backend here: this [llm] block is inert per #351 (the daemon
+# reads .agentis/config) so hardcoding would only mislead. See the
+# "LLM backend" section in CLAUDE.md.
+backend = "cli"
+# command = "claude"
 # model = "claude-sonnet-4"
 # api_key_env = "ANTHROPIC_API_KEY"
 

--- a/dev-apprenticeship/planning/config/colony.example.toml
+++ b/dev-apprenticeship/planning/config/colony.example.toml
@@ -75,8 +75,13 @@ me      = ""  # your GitLab username (optional, enables personal/team tagging)
 # install.sh §6). install.sh wires the default CLI = the flat-cyborg PTY
 # wrapper over Claude Code.
 [llm]
-backend = "claude"
-# command = "tools/flat-cyborg-claude.sh"   # default CLI over Claude Code (illustrative; install.sh writes the resolved path to .agentis/config — this [llm] block is inert per #351)
+# "cli" = inherit the agentis daemon default (the federation backend in
+# .agentis/config — flat-cyborg, set by install.sh). Do NOT hardcode a
+# specific backend here: this [llm] block is inert per #351 (the daemon
+# reads .agentis/config) so hardcoding would only mislead. See the
+# "LLM backend" section in CLAUDE.md.
+backend = "cli"
+# command = "claude"
 # model = "claude-sonnet-4"
 # api_key_env = "ANTHROPIC_API_KEY"
 

--- a/dev-apprenticeship/release/config/colony.example.toml
+++ b/dev-apprenticeship/release/config/colony.example.toml
@@ -58,8 +58,13 @@ default_branch = "main"  # primary branch (#224)
 # install.sh §6). install.sh wires the default CLI = the flat-cyborg PTY
 # wrapper over Claude Code.
 [llm]
-backend = "claude"
-# command = "tools/flat-cyborg-claude.sh"   # default CLI over Claude Code (illustrative; install.sh writes the resolved path to .agentis/config — this [llm] block is inert per #351)
+# "cli" = inherit the agentis daemon default (the federation backend in
+# .agentis/config — flat-cyborg, set by install.sh). Do NOT hardcode a
+# specific backend here: this [llm] block is inert per #351 (the daemon
+# reads .agentis/config) so hardcoding would only mislead. See the
+# "LLM backend" section in CLAUDE.md.
+backend = "cli"
+# command = "claude"
 # model = "claude-sonnet-4"
 # api_key_env = "ANTHROPIC_API_KEY"
 

--- a/dev-apprenticeship/triage/config/colony.example.toml
+++ b/dev-apprenticeship/triage/config/colony.example.toml
@@ -56,8 +56,13 @@ me      = ""  # your GitLab username (optional, enables personal/team tagging)
 # install.sh §6). install.sh wires the default CLI = the flat-cyborg PTY
 # wrapper over Claude Code.
 [llm]
-backend = "claude"
-# command = "tools/flat-cyborg-claude.sh"   # default CLI over Claude Code (illustrative; install.sh writes the resolved path to .agentis/config — this [llm] block is inert per #351)
+# "cli" = inherit the agentis daemon default (the federation backend in
+# .agentis/config — flat-cyborg, set by install.sh). Do NOT hardcode a
+# specific backend here: this [llm] block is inert per #351 (the daemon
+# reads .agentis/config) so hardcoding would only mislead. See the
+# "LLM backend" section in CLAUDE.md.
+backend = "cli"
+# command = "claude"
 # model = "claude-sonnet-4"
 # api_key_env = "ANTHROPIC_API_KEY"
 


### PR DESCRIPTION
Follow-up correction to #1131.

The CLAUDE.md **"LLM backend"** convention (added in #1132) is explicit: a colony's `[llm] backend` in `colony.example.toml` is `"cli"` — meaning *"use the agentis daemon default"*, which **inherits** the federation-level backend from `.agentis/config`; a specific backend must **not** be hardcoded there (it would override the federation default and break the host wrapper path).

#1131 flipped all 5 `colony.example.toml` blocks to `backend = "claude"` to silence a deprecation warning — but that warning comes from `.agentis/config` (where `install.sh` correctly writes `claude`), **not** from the colony block, which is **inert per #351** (the daemon reads `.agentis/config`). So the change was unnecessary and contradicted the documented convention.

## Change
- Revert `backend` → `"cli"` in all 5 `dev-apprenticeship/*/config/colony.example.toml`.
- Add a comment documenting the `cli` = inherit / don't-hardcode / inert-per-#351 semantics, pointing at the CLAUDE.md "LLM backend" section.
- Doc-consistency only — the real backend (`llm.backend = claude` + the flat-cyborg wrapper) is still written to `.agentis/config` by `install.sh`; runtime behaviour unchanged.

## Verification
- colony-lint: **417 passed, 0 failed, 5 skipped**
- All 5 `[llm]` blocks byte-identical; no `backend = "claude"` left in any colony.example.toml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)