### PR TITLE
feat(trading-binance): R-multiple stop/target exit model in verify-trade.sh (#1148)

### DIFF
--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,22 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- `tools/verify-trade.sh` optional R-multiple stop-loss / take-profit
+  settlement via two new env knobs `STOP_BPS` / `TARGET_BPS` (both bps of
+  the entry price, default `0` = disabled). When either is `> 0`, the
+  verifier scans the forward candles intrabar (`low` / `high`) for the
+  first stop / target touch and exits there; a same-candle tie resolves
+  pessimistically to the stop; with no touch it falls back to the legacy
+  fixed-time open exit. On this path funding accrues over the ACTUAL hold
+  (exit candle − entry candle) and the verdict carries an additional
+  `exit_reason` field (`"stop"` | `"target"` | `"time"`). **Fully
+  backward-compatible**: with both knobs unset / `0` the behaviour AND
+  output JSON are byte-identical to the prior fixed-time path (no
+  `exit_reason` key) — `run-replay.sh` never sets these knobs, so the live
+  settlement is unaffected. `tools/test-verify-trade.sh` grows from 13 to
+  31 assertions covering stop-first, target-first, time-fallback,
+  same-candle tie, SHORT mirror, funding-over-actual-hold, and a
+  byte-identical disabled-path regression (#1148).
 - Deterministic reference backtest of the `tribe-zeta` volume-divergence
   **fade** signal over a real 90-day BTCUSDT 1h window (2026-03-01 →
   2026-05-31), recorded under `runs/20260618T-fade-determ/`

--- a/trading-binance/tools/test-verify-trade.sh
+++ b/trading-binance/tools/test-verify-trade.sh
@@ -4,6 +4,12 @@
 # Builds a fixed 20-candle CSV fixture in a tempdir, then exercises the
 # verifier across LONG/SHORT/FLAT, slippage/funding subtraction, size
 # scaling, and edge cases (overflow, missing file, malformed JSON).
+#
+# Also covers the optional R-multiple stop-loss / take-profit settlement
+# (#1148) via dedicated engineered intrabar fixtures: stop-first,
+# target-first, time-fallback, same-candle tie (pessimistic), SHORT mirror,
+# funding-over-actual-hold, and a byte-identical disabled-path regression
+# proving the verdict carries no `exit_reason` key when the knobs are unset.
 
 set -e
 
@@ -248,6 +254,201 @@ else
     echo "[FAIL] 13b: pnl_bps_x100 expected $expected got $field_x100"
 fi
 rm -f "$PRICES_CSV13"
+
+# === R-multiple stop-loss / take-profit settlement (#1148) ===
+#
+# The 20-candle fixture above has ±0.5 intrabar range on a ~100 price
+# (≈ ±50 bps), too tight to express controlled stop/target touches with
+# margin. Build a dedicated fixture with engineered intrabar high/low rows
+# so each scenario touches exactly one level deterministically.
+#
+# RFIX layout (entry candle is row[CONTEXT_TICK+1] = row[1]):
+#   row 0 : seed (decision tick, not entered)
+#   row 1 : entry, open=100.00, tight body (no touch)
+#   row 2 : DOWN spike  — low=98.50 (-150 bps), high=100.20  (stop for LONG)
+#   row 3 : UP   spike  — low=99.90, high=102.00 (+200 bps)  (target for LONG)
+#   row 4 : TIE  candle — low=98.00 (-200 bps), high=102.00 (+200 bps)
+#   rows 5..11 : flat body around 100 (no touch), open=100.00
+# This lets a LONG with STOP_BPS=100/TARGET_BPS=180 hit:
+#   - stop first  when the window includes row 2 before row 3,
+#   - target first when row 3 is reachable but row 2's stop is disabled,
+#   - tie (row 4) resolves pessimistically to stop.
+RFIX="$WORK_DIR/candles-rmultiple.csv"
+python3 - "$RFIX" <<'PYRFIX'
+import sys
+path = sys.argv[1]
+# (open, high, low, close)
+rows = [
+    (100.00, 100.20, 99.80, 100.00),  # 0 seed
+    (100.00, 100.20, 99.90, 100.00),  # 1 entry (no touch)
+    (100.00, 100.20, 98.50, 99.00),   # 2 down spike -> LONG stop @ -150 bps
+    (100.00, 102.00, 99.90, 101.50),  # 3 up spike   -> LONG target @ +200 bps
+    (100.00, 102.00, 98.00, 100.00),  # 4 tie: both stop & target touched
+    (100.00, 100.10, 99.90, 100.00),  # 5 flat
+    (100.00, 100.10, 99.90, 100.00),  # 6 flat
+    (100.00, 100.10, 99.90, 100.00),  # 7 flat
+    (100.00, 100.10, 99.90, 100.00),  # 8 flat
+    (100.00, 100.10, 99.90, 100.00),  # 9 flat
+    (100.00, 100.10, 99.90, 100.00),  # 10 flat
+    (100.00, 100.10, 99.90, 100.00),  # 11 flat
+]
+with open(path, "w") as out:
+    out.write("ts,open,high,low,close,volume\n")
+    for idx, (o, h, lo, c) in enumerate(rows):
+        out.write(f"{idx},{o:.2f},{h:.2f},{lo:.2f},{c:.2f},1000\n")
+PYRFIX
+
+# --- Test 14: stop-first (LONG) ---
+# Window entry_idx=1 .. last_idx=1+HOLD_PERIOD. With STOP_BPS=100 the down
+# spike at row 2 (low=98.50 <= stop_px=99.00) is the first touch; target is
+# disabled (TARGET_BPS=0) so exit_reason=stop, pnl negative-ish.
+verdict14="$(DECISION_JSON='{"action":"LONG","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$RFIX" STOP_BPS=100 TARGET_BPS=0 \
+    bash "$VERIFIER" 2>/dev/null)"
+assert_field "14a: stop-first exit_reason" "$verdict14" "exit_reason" "stop"
+assert_pnl_sign "14b: stop-first pnl negative" "$verdict14" "neg"
+
+# --- Test 15: target-first (LONG) ---
+# STOP_BPS=0 disables the down-spike stop; the up spike at row 3
+# (high=102.00 >= tgt_px=101.80 for TARGET_BPS=180) is the first touch.
+verdict15="$(DECISION_JSON='{"action":"LONG","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$RFIX" STOP_BPS=0 TARGET_BPS=180 \
+    bash "$VERIFIER" 2>/dev/null)"
+assert_field "15a: target-first exit_reason" "$verdict15" "exit_reason" "target"
+assert_pnl_sign "15b: target-first pnl positive" "$verdict15" "pos"
+
+# --- Test 16: time-fallback (neither touched) ---
+# Stop @ -300 bps (px 97.00) and target @ +300 bps (px 103.00) are never
+# touched by any candle in the window (max swing is row 4 at ±200 bps).
+# exit_reason=time, and pnl must equal the legacy fixed-time path for the
+# same DECISION_JSON + tick (R-multiple disabled).
+verdict16="$(DECISION_JSON='{"action":"LONG","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$RFIX" STOP_BPS=300 TARGET_BPS=300 \
+    bash "$VERIFIER" 2>/dev/null)"
+verdict16_legacy="$(DECISION_JSON='{"action":"LONG","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$RFIX" \
+    bash "$VERIFIER" 2>/dev/null)"
+assert_field "16a: time-fallback exit_reason" "$verdict16" "exit_reason" "time"
+pnl16="$(python3 -c 'import sys,json; print(json.loads(sys.argv[1])["pnl_bps"])' "$verdict16")"
+pnl16_legacy="$(python3 -c 'import sys,json; print(json.loads(sys.argv[1])["pnl_bps"])' "$verdict16_legacy")"
+assert_approx "16b: time-fallback pnl == legacy fixed-time pnl" "$pnl16" "$pnl16_legacy" "0.001"
+
+# --- Test 17: same-candle tie (pessimistic -> stop) ---
+# A dedicated tie fixture where the FIRST forward candle (row 2) touches
+# both levels intrabar: low=98.00 and high=102.00. With STOP_BPS=100
+# (stop_px=99.00) and TARGET_BPS=100 (tgt_px=101.00), row 2's low <= stop
+# AND high >= target -> a same-candle tie that must resolve pessimistically
+# to the stop.
+TIEFIX="$WORK_DIR/candles-tie.csv"
+python3 - "$TIEFIX" <<'PYTIE'
+import sys
+path = sys.argv[1]
+rows = [
+    (100.00, 100.20, 99.80, 100.00),  # 0 seed
+    (100.00, 100.10, 99.90, 100.00),  # 1 entry (no touch)
+    (100.00, 102.00, 98.00, 100.00),  # 2 TIE: low -200bps & high +200bps
+    (100.00, 100.10, 99.90, 100.00),  # 3 flat
+    (100.00, 100.10, 99.90, 100.00),  # 4 flat
+    (100.00, 100.10, 99.90, 100.00),  # 5 flat
+    (100.00, 100.10, 99.90, 100.00),  # 6 flat
+    (100.00, 100.10, 99.90, 100.00),  # 7 flat
+    (100.00, 100.10, 99.90, 100.00),  # 8 flat
+    (100.00, 100.10, 99.90, 100.00),  # 9 flat
+    (100.00, 100.10, 99.90, 100.00),  # 10 flat
+    (100.00, 100.10, 99.90, 100.00),  # 11 flat
+]
+with open(path, "w") as out:
+    out.write("ts,open,high,low,close,volume\n")
+    for idx, (o, h, lo, c) in enumerate(rows):
+        out.write(f"{idx},{o:.2f},{h:.2f},{lo:.2f},{c:.2f},1000\n")
+PYTIE
+# LONG, STOP_BPS=100 (stop_px=99.00, row2 low 98.00 <= 99.00 -> stop hit)
+# TARGET_BPS=100 (tgt_px=101.00, row2 high 102.00 >= 101.00 -> target hit)
+# both in the same candle -> pessimistic stop wins.
+verdict17="$(DECISION_JSON='{"action":"LONG","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$TIEFIX" STOP_BPS=100 TARGET_BPS=100 \
+    bash "$VERIFIER" 2>/dev/null)"
+assert_field "17a: same-candle tie -> stop (pessimistic)" "$verdict17" "exit_reason" "stop"
+assert_pnl_sign "17b: tie stop pnl negative" "$verdict17" "neg"
+
+# --- Test 18: SHORT mirror (stop on high, target on low) ---
+# SHORT direction: stop_px = entry*(1+STOP/10000) (above), tgt_px =
+# entry*(1-TARGET/10000) (below). On TIEFIX row 2 (high=102.00, low=98.00):
+#   STOP_BPS=100 -> stop_px=101.00, high 102.00 >= 101.00 -> stop hit (loss).
+#   TARGET_BPS=100 -> tgt_px=99.00, low 98.00 <= 99.00 -> target hit (win).
+# Same-candle tie -> stop wins -> SHORT stopped out -> pnl negative.
+verdict18="$(DECISION_JSON='{"action":"SHORT","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$TIEFIX" STOP_BPS=100 TARGET_BPS=100 \
+    bash "$VERIFIER" 2>/dev/null)"
+assert_field "18a: SHORT tie -> stop" "$verdict18" "exit_reason" "stop"
+assert_pnl_sign "18b: SHORT stop pnl negative" "$verdict18" "neg"
+# SHORT target-only (stop disabled): row 2 low 98.00 <= tgt_px 99.00 -> win.
+verdict18b="$(DECISION_JSON='{"action":"SHORT","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$TIEFIX" STOP_BPS=0 TARGET_BPS=100 \
+    bash "$VERIFIER" 2>/dev/null)"
+assert_field "18c: SHORT target-only exit_reason" "$verdict18b" "exit_reason" "target"
+assert_pnl_sign "18d: SHORT target pnl positive" "$verdict18b" "pos"
+
+# --- Test 19: funding over ACTUAL hold (< HOLD_PERIOD) ---
+# A target hit at row 2 (TIEFIX) means held = 1 candle, far short of
+# HOLD_PERIOD=8. Funding accrues over the actual hold, so the R-multiple
+# funding cost is strictly smaller than the legacy full-hold funding for the
+# same params. Compare R-multiple target-hit vs the same trade run with a
+# huge FUNDING_RATE_BPS to make the magnitude difference observable.
+# held=1 -> funding_blocks=(1*30)/480=0.0625; legacy held=8 -> 0.5.
+# Use FUNDING_RATE_BPS=100 size=1.0: R-multiple funding = 6.25 bps,
+# legacy full-hold funding = 50 bps. Toggle FUNDING_RATE_BPS=0 to isolate.
+v19_fund="$(DECISION_JSON='{"action":"SHORT","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$TIEFIX" STOP_BPS=0 TARGET_BPS=100 \
+    FUNDING_RATE_BPS=100 SLIPPAGE_BPS=0 \
+    bash "$VERIFIER" 2>/dev/null)"
+v19_nofund="$(DECISION_JSON='{"action":"SHORT","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$TIEFIX" STOP_BPS=0 TARGET_BPS=100 \
+    FUNDING_RATE_BPS=0 SLIPPAGE_BPS=0 \
+    bash "$VERIFIER" 2>/dev/null)"
+p19_fund="$(python3 -c 'import sys,json; print(json.loads(sys.argv[1])["pnl_bps"])' "$v19_fund")"
+p19_nofund="$(python3 -c 'import sys,json; print(json.loads(sys.argv[1])["pnl_bps"])' "$v19_nofund")"
+# Actual funding charged = nofund - fund. Held=1 candle -> 100 * 0.0625 = 6.25 bps.
+actual_fund="$(python3 -c 'import sys; print(float(sys.argv[1]) - float(sys.argv[2]))' "$p19_nofund" "$p19_fund")"
+assert_approx "19a: funding over actual hold (held=1 -> 6.25 bps)" "$actual_fund" "6.25" "0.01"
+# Legacy full-hold funding for the same FUNDING_RATE_BPS would be 50 bps;
+# assert the R-multiple charge is strictly smaller (6.25 << 50).
+fund_strictly_smaller="$(python3 -c 'import sys; print("yes" if float(sys.argv[1]) < 50.0 else "no")' "$actual_fund")"
+if [ "$fund_strictly_smaller" = "yes" ]; then
+    echo "[PASS] 19b: R-multiple funding (6.25 bps) < legacy full-hold funding (50 bps)"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] 19b: R-multiple funding not smaller than legacy full-hold"
+    FAIL=$((FAIL + 1))
+fi
+
+# --- Test 20: BYTE-IDENTICAL disabled-path regression ---
+# Same DECISION_JSON + tick with STOP_BPS / TARGET_BPS UNSET must produce a
+# verdict with NO exit_reason key, byte-identical to the legacy path.
+verdict20="$(DECISION_JSON='{"action":"LONG","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$CANDLES" \
+    bash "$VERIFIER" 2>/dev/null)"
+has_exit_reason="$(python3 -c 'import sys,json; print("yes" if "exit_reason" in json.loads(sys.argv[1]) else "no")' "$verdict20")"
+if [ "$has_exit_reason" = "no" ]; then
+    echo "[PASS] 20a: disabled path emits NO exit_reason key"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] 20a: disabled path leaked exit_reason key (verdict=$verdict20)"
+    FAIL=$((FAIL + 1))
+fi
+# Explicit STOP_BPS=0 TARGET_BPS=0 must be byte-identical to the unset case.
+verdict20_zero="$(DECISION_JSON='{"action":"LONG","size":1.0,"setup":"price_action","rationale":"x"}' \
+    CONTEXT_TICK=0 HOLD_PERIOD=8 CANDLES_CSV="$CANDLES" STOP_BPS=0 TARGET_BPS=0 \
+    bash "$VERIFIER" 2>/dev/null)"
+if [ "$verdict20" = "$verdict20_zero" ]; then
+    echo "[PASS] 20b: STOP_BPS=0 TARGET_BPS=0 byte-identical to unset path"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] 20b: zero knobs differ from unset (unset=$verdict20 zero=$verdict20_zero)"
+    FAIL=$((FAIL + 1))
+fi
+# pnl_bps for the disabled path matches test 1's winning LONG slice sign.
+assert_pnl_sign "20c: disabled-path pnl positive (legacy LONG win)" "$verdict20" "pos"
 
 # --- Summary ---
 echo ""

--- a/trading-binance/tools/verify-trade.sh
+++ b/trading-binance/tools/verify-trade.sh
@@ -20,11 +20,19 @@
 #                       in bps.
 #   TIMEFRAME_MINUTES   (optional, default 30) Candle interval in minutes,
 #                       used to compute funding blocks.
+#   STOP_BPS            (optional, default 0 = disabled) Stop-loss distance
+#                       in bps of the entry price. When > 0 (or TARGET_BPS
+#                       > 0) the verifier settles on an R-multiple path:
+#                       the forward candles are scanned intrabar and the
+#                       trade exits at the first stop / target touch.
+#   TARGET_BPS          (optional, default 0 = disabled) Take-profit
+#                       distance in bps of the entry price. Same R-multiple
+#                       semantics as STOP_BPS.
 #
 # PnL formula:
 #   direction = {LONG: 1, SHORT: -1, FLAT: 0}[action]
 #   if FLAT: pnl_bps = 0, classification = "FLAT"
-#   else:
+#   else (fixed-time exit, STOP_BPS == 0 and TARGET_BPS == 0):
 #     entry = candles[CONTEXT_TICK + 1].open
 #     exit  = candles[CONTEXT_TICK + 1 + HOLD_PERIOD].open
 #     raw_bps        = direction * (exit - entry) / entry * 10000 * size
@@ -33,10 +41,26 @@
 #     funding_cost   = FUNDING_RATE_BPS * size * funding_blocks
 #     pnl_bps        = raw_bps - slippage_cost - funding_cost
 #     classification = "WIN" if pnl_bps > 0 else "LOSS"
+#   else (R-multiple exit, STOP_BPS > 0 or TARGET_BPS > 0):
+#     entry = candles[CONTEXT_TICK + 1].open
+#     LONG : stop_px = entry * (1 - STOP_BPS/10000),
+#            tgt_px  = entry * (1 + TARGET_BPS/10000)
+#     SHORT: stop_px = entry * (1 + STOP_BPS/10000),
+#            tgt_px  = entry * (1 - TARGET_BPS/10000)
+#     Scan candles[entry_idx .. min(entry_idx+HOLD_PERIOD, len-1)] intrabar
+#     (low/high) for the first stop / target touch; on a same-candle tie the
+#     stop wins (pessimistic). With no touch the trade exits at the
+#     fixed-time open candles[CONTEXT_TICK + 1 + HOLD_PERIOD].open.
+#     funding accrues over the ACTUAL hold (exit candle - entry candle),
+#     not the full HOLD_PERIOD. raw_bps / slippage_cost / pnl_bps /
+#     classification are computed as in the fixed-time path. The verdict
+#     additionally carries an `exit_reason` field ("stop" | "target" |
+#     "time"). This field is emitted ONLY on the R-multiple path.
 #
 # Stdout (one line):
 #   {"verified": true, "pnl_bps": -12.34, "classification": "LOSS",
 #    "entry": 60123.45, "exit": 60042.10}
+#   (R-multiple path adds: "exit_reason": "stop" | "target" | "time")
 #
 # Exit codes:
 #   0  success — verdict written to stdout
@@ -57,6 +81,8 @@ CANDLES_CSV="${CANDLES_CSV:-}"
 SLIPPAGE_BPS="${SLIPPAGE_BPS:-5}"
 FUNDING_RATE_BPS="${FUNDING_RATE_BPS:-1}"
 TIMEFRAME_MINUTES="${TIMEFRAME_MINUTES:-30}"
+STOP_BPS="${STOP_BPS:-0}"
+TARGET_BPS="${TARGET_BPS:-0}"
 
 if [ -z "$DECISION_JSON" ]; then
     echo "verify-trade: DECISION_JSON env required" >&2
@@ -83,7 +109,8 @@ if [ -z "$CANDLES_CSV" ] || [ ! -f "$CANDLES_CSV" ]; then
 fi
 
 python3 - "$DECISION_JSON" "$CONTEXT_TICK" "$HOLD_PERIOD" "$CANDLES_CSV" \
-        "$SLIPPAGE_BPS" "$FUNDING_RATE_BPS" "$TIMEFRAME_MINUTES" <<'PYVERIFY'
+        "$SLIPPAGE_BPS" "$FUNDING_RATE_BPS" "$TIMEFRAME_MINUTES" \
+        "$STOP_BPS" "$TARGET_BPS" <<'PYVERIFY'
 import csv
 import json
 import sys
@@ -95,6 +122,14 @@ candles_csv = sys.argv[4]
 slippage_bps = float(sys.argv[5])
 funding_rate_bps = float(sys.argv[6])
 timeframe_minutes = float(sys.argv[7])
+try:
+    stop_bps = float(sys.argv[8])
+except (IndexError, TypeError, ValueError):
+    stop_bps = 0.0
+try:
+    target_bps = float(sys.argv[9])
+except (IndexError, TypeError, ValueError):
+    target_bps = 0.0
 
 try:
     decision = json.loads(decision_raw)
@@ -139,6 +174,110 @@ if direction == 0:
         "classification": "FLAT",
         "entry": None,
         "exit": None,
+    }
+    sys.stdout.write(json.dumps(verdict, separators=(",", ":")) + "\n")
+    sys.exit(0)
+
+if stop_bps > 0 or target_bps > 0:
+    # R-multiple path (#1148): scan forward candles intrabar for the first
+    # stop / target touch; on a same-candle tie the stop wins (pessimistic).
+    # With no touch, fall back to the fixed-time open exit. Funding accrues
+    # over the ACTUAL hold (exit candle - entry candle). Purely additive:
+    # disabled (both knobs 0) preserves the legacy `else` path byte-for-byte.
+    if entry_idx >= len(rows):
+        sys.stderr.write(
+            "verify-trade: context_tick + 1 + hold_period overflows candle stream "
+            "(entry_idx=" + str(entry_idx) + " exit_idx=" + str(exit_idx)
+            + " len=" + str(len(rows)) + ")\n"
+        )
+        sys.exit(2)
+
+    try:
+        entry_price = float(rows[entry_idx]["open"])
+    except (KeyError, TypeError, ValueError) as exc:
+        sys.stderr.write("verify-trade: failed to read open price (" + str(exc) + ")\n")
+        sys.exit(3)
+
+    if entry_price <= 0:
+        sys.stderr.write("verify-trade: non-positive entry price: " + str(entry_price) + "\n")
+        sys.exit(3)
+
+    last_idx = min(entry_idx + hold_period, len(rows) - 1)
+
+    if direction == 1:
+        stop_px = entry_price * (1 - stop_bps / 10000.0)
+        tgt_px = entry_price * (1 + target_bps / 10000.0)
+    else:
+        stop_px = entry_price * (1 + stop_bps / 10000.0)
+        tgt_px = entry_price * (1 - target_bps / 10000.0)
+
+    exit_px = None
+    exit_reason = None
+    exit_i = None
+    for i in range(entry_idx, last_idx + 1):
+        try:
+            lo = float(rows[i]["low"])
+            hi = float(rows[i]["high"])
+        except (KeyError, TypeError, ValueError) as exc:
+            sys.stderr.write("verify-trade: failed to read intrabar price (" + str(exc) + ")\n")
+            sys.exit(3)
+        if direction == 1:
+            stop_hit = stop_bps > 0 and lo <= stop_px
+            tgt_hit = target_bps > 0 and hi >= tgt_px
+        else:
+            stop_hit = stop_bps > 0 and hi >= stop_px
+            tgt_hit = target_bps > 0 and lo <= tgt_px
+        if stop_hit and tgt_hit:
+            exit_px = stop_px
+            exit_reason = "stop"
+            exit_i = i
+            break
+        elif stop_hit:
+            exit_px = stop_px
+            exit_reason = "stop"
+            exit_i = i
+            break
+        elif tgt_hit:
+            exit_px = tgt_px
+            exit_reason = "target"
+            exit_i = i
+            break
+
+    if exit_px is None:
+        # Time exit: neither stop nor target touched within the hold window.
+        exit_idx = context_tick + 1 + hold_period
+        if exit_idx >= len(rows):
+            sys.stderr.write(
+                "verify-trade: context_tick + 1 + hold_period overflows candle stream "
+                "(entry_idx=" + str(entry_idx) + " exit_idx=" + str(exit_idx)
+                + " len=" + str(len(rows)) + ")\n"
+            )
+            sys.exit(2)
+        try:
+            exit_px = float(rows[exit_idx]["open"])
+        except (KeyError, TypeError, ValueError) as exc:
+            sys.stderr.write("verify-trade: failed to read open price (" + str(exc) + ")\n")
+            sys.exit(3)
+        exit_reason = "time"
+        exit_i = exit_idx
+
+    held = exit_i - entry_idx
+    funding_blocks = (held * timeframe_minutes) / 480.0
+    funding_cost = funding_rate_bps * size * funding_blocks
+    raw_bps = direction * (exit_px - entry_price) / entry_price * 10000.0 * size
+    slippage_cost = 2.0 * slippage_bps * size
+    pnl_bps = raw_bps - slippage_cost - funding_cost
+
+    classification = "WIN" if pnl_bps > 0 else "LOSS"
+
+    verdict = {
+        "verified": True,
+        "pnl_bps": round(pnl_bps, 2),
+        "pnl_bps_x100": int(round(pnl_bps * 100)),
+        "classification": classification,
+        "entry": round(entry_price, 4),
+        "exit": round(exit_px, 4),
+        "exit_reason": exit_reason,
     }
     sys.stdout.write(json.dumps(verdict, separators=(",", ":")) + "\n")
     sys.exit(0)


### PR DESCRIPTION
## Summary

Add an **optional R-multiple stop/target exit model** to `tools/verify-trade.sh` — the structural lever for **profitable trades with a low win rate but higher return** (asymmetric payoff: small defined stop, larger target). The #1123 fade backtest showed a fixed-time exit yields a ~symmetric payoff and no edge; R-multiples change the payoff math. PR1 of the profitability arc (the demonstration momentum backtest is the follow-up).

## What changed

- **`tools/verify-trade.sh`**: opt-in `STOP_BPS` / `TARGET_BPS` (bps of entry; default 0 = disabled). When set, the verifier scans `candles[entry_idx .. entry_idx+HOLD_PERIOD]` intra-bar high/low and settles at the **first** stop or target touch (pessimistic: **stop wins** a same-candle tie); if neither hits → **time-exit** at the existing `open` (today's behaviour). Funding accrues over the **actual** hold. The verdict gains `exit_reason` (`stop`|`target`|`time`) **only** on the R-multiple path. LONG/SHORT mirrored.
- **HARD INVARIANT**: with `STOP_BPS`/`TARGET_BPS` unset/0 the verdict is **byte-identical to main** (no `exit_reason` key). The R-multiple branch is an early-return inserted **before** the unchanged legacy settlement block, so the live `run-replay.sh` settlement (`VERIFIER_PATH`, shipped in `BUNDLE.manifest`) and the 13 pre-existing tests are unaffected. The only non-additive diff lines are the docblock formula comment + the argv line (now appends the two knobs) — the legacy PnL compute is untouched.
- **`tools/test-verify-trade.sh`**: +18 assertions (stop-first, target-first, time-fallback == legacy pnl, same-candle tie → stop, SHORT mirror, funding-over-actual-hold, **byte-identical disabled-path regression**) with two engineered intra-bar fixtures. 31/0.
- `trading-binance/CHANGELOG.md` `[Unreleased]` entry (no VERSION bump).

## Verification

- `bash tools/test-verify-trade.sh` → **31 passed, 0 failed** (13 existing + 18 new); `bash -n` clean.
- Disabled-path proof: `{"verified":true,...,"classification":"WIN","entry":100.0,"exit":108.0}` — **no `exit_reason`**; explicit `STOP_BPS=0 TARGET_BPS=0` is byte-identical to the unset case.
- R-multiple: target-hit → `…"exit":101.5,"exit_reason":"target"`; stop-hit → `…"exit":99.5,"exit_reason":"stop"`.
- `./tools/colony-lint.sh` → **417 passed, 0 failed**, 5 skipped.

## Selection framing

Report/select on **expectancy** (mean PnL bps/trade) + **profit factor** (gross win / gross loss), not win rate — documented for the follow-up momentum backtest and any fitness use.

Closes #1148. Follow-up: deterministic trend/breakout backtest under this verifier (e.g. stop 100 / target 300 bps = 3R) vs FLAT and vs the #1123 fade.
