### PR TITLE
test(trading-binance): momentum + R-multiple backtest — honest negative, lever validated (#1154)

### DIFF
--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,23 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Deterministic **momentum/breakout** backtest under the #1148 R-multiple
+  exits over the real 90-day BTCUSDT 1h window (2026-03-01 → 2026-05-31),
+  recorded under `runs/20260619T-momentum-rmultiple/`
+  (`backtest-momentum-rmultiple.py`, `comparison.md`, `results.json`,
+  `run-meta.json`). Tests whether asymmetric payoff (small stop, larger
+  target) produces a positive expectancy where the #1123 fade lost.
+  **Honest verdict: no — momentum + R-multiple loses worse than the fade**
+  and worse as the target widens (1R/2R/3R: total −5252/−6443/−7090 bps,
+  win rate < 44 %, profit factor < 1, expectancy negative); the wider target
+  almost never hits (119 → 41 → 17 targets of 341), because most 1h BTCUSDT
+  breakouts are false on this window. The R-multiple **lever is validated
+  mechanically** (exit_reason stop/target/time distributes as the geometry
+  predicts, funding over the actual hold) — but asymmetric payoff alone
+  doesn't create an edge: both deterministic signals (fade AND momentum) lose
+  on this window. Selection metric is expectancy + profit factor, not win
+  rate. Single in-sample window; deterministic signal ≠ LLM strategist;
+  no walk-forward (#1154).
 - `tools/verify-trade.sh` optional R-multiple stop-loss / take-profit
   settlement via two new env knobs `STOP_BPS` / `TARGET_BPS` (both bps of
   the entry price, default `0` = disabled). When either is `> 0`, the

--- a/trading-binance/runs/20260619T-momentum-rmultiple/backtest-momentum-rmultiple.py
+++ b/trading-binance/runs/20260619T-momentum-rmultiple/backtest-momentum-rmultiple.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""backtest-momentum-rmultiple.py -- deterministic momentum/breakout backtest
+under the R-multiple exit model (issue #1154, follow-up to #1148).
+
+The honest "does the lever move the goal" gate. Tests whether a positive-skew
+**momentum** signal settled by the **R-multiple** verifier (small stop, larger
+target) produces a positive EXPECTANCY on the same real BTCUSDT window where
+the #1123 deterministic FADE (negative skew, fixed-time exit) lost (-360 bps).
+
+It is a DETERMINISTIC reference signal, NOT the LLM strategist. Decisions are
+settled by the repo's own ground-truth verifier (tools/verify-trade.sh) with
+its #1148 R-multiple stop/target exits, so the PnL is what a replay would
+record for the same decisions.
+
+Signal (momentum / breakout -- the inverse of the fade; enter WITH confirmed moves):
+  volMA = SMA(volume, VOL_MA) over the trailing VOL_MA candles ending at i.
+  new L-bar high = high[i] > max(high[i-L .. i-1]); new L-bar low = low[i] < min(...).
+  confirmed = volume[i] >= volMA (genuine move, not a thin/manipulated one).
+    new high AND confirmed AND not new low -> LONG  (ride the breakout up)
+    new low  AND confirmed AND not new high -> SHORT (ride the breakdown)
+    otherwise                                -> FLAT
+  size fixed at 1.0.
+
+Exit: R-multiple via verify-trade.sh -- STOP_BPS / TARGET_BPS (swept), small
+stop + larger target = asymmetric payoff (low win rate, larger winners). FLAT
+= 0 bps, not sent to the verifier.
+
+Reports per R-multiple config: trades, win rate (expected LOW), total + mean
+PnL bps (= expectancy), PROFIT FACTOR (gross win / gross loss), max drawdown,
+and the exit_reason breakdown (stop / target / time). Baselines: FLAT (0),
+the #1123 fade (-360 bps), buy-and-hold.
+
+Standard library only.
+"""
+import argparse
+import csv
+import json
+import math
+import os
+import subprocess
+import sys
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(description="Momentum + R-multiple backtest (#1154).")
+    p.add_argument("--candles", required=True)
+    p.add_argument("--verifier", required=True)
+    p.add_argument("--hold-period", type=int, default=8)
+    p.add_argument("--vol-ma", type=int, default=20)
+    p.add_argument("--lookback", type=int, default=20)
+    p.add_argument("--timeframe-minutes", type=int, default=60)
+    p.add_argument("--slippage-bps", type=float, default=5.0)
+    p.add_argument("--funding-rate-bps", type=float, default=1.0)
+    p.add_argument("--size", type=float, default=1.0)
+    # R-multiple sweep: each entry is "stop_bps:target_bps".
+    p.add_argument("--r-configs", default="100:100,100:200,100:300")
+    return p.parse_args(argv)
+
+
+def load_candles(path):
+    with open(path, "r", newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    return [{
+        "open": float(r["open"]), "high": float(r["high"]),
+        "low": float(r["low"]), "close": float(r["close"]),
+        "volume": float(r["volume"]),
+    } for r in rows]
+
+
+def settle(verifier, action, size, tick, hold, candles_csv, slip, funding, tf_min, stop_bps, target_bps):
+    env = dict(os.environ)
+    env["DECISION_JSON"] = json.dumps({"action": action, "size": size, "setup": "momentum", "rationale": "deterministic momentum r-multiple backtest"})
+    env["CONTEXT_TICK"] = str(tick)
+    env["HOLD_PERIOD"] = str(hold)
+    env["CANDLES_CSV"] = candles_csv
+    env["SLIPPAGE_BPS"] = str(slip)
+    env["FUNDING_RATE_BPS"] = str(funding)
+    env["TIMEFRAME_MINUTES"] = str(tf_min)
+    env["STOP_BPS"] = str(stop_bps)
+    env["TARGET_BPS"] = str(target_bps)
+    proc = subprocess.run(["bash", verifier], env=env, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError("verifier rc=%d tick=%d: %s" % (proc.returncode, tick, proc.stderr.strip()))
+    v = json.loads(proc.stdout.strip())
+    return float(v["pnl_bps"]), v["classification"], v.get("exit_reason", "time")
+
+
+def signal_for(candles, i, lookback, vol_ma):
+    """Momentum/breakout: enter WITH a confirmed new extreme."""
+    if i < lookback or i < vol_ma:
+        return "FLAT"
+    vma = sum(candles[j]["volume"] for j in range(i - vol_ma, i)) / float(vol_ma)
+    prior_highs = [candles[j]["high"] for j in range(i - lookback, i)]
+    prior_lows = [candles[j]["low"] for j in range(i - lookback, i)]
+    new_high = candles[i]["high"] > max(prior_highs)
+    new_low = candles[i]["low"] < min(prior_lows)
+    confirmed = candles[i]["volume"] >= vma
+    if new_high and confirmed and not new_low:
+        return "LONG"
+    if new_low and confirmed and not new_high:
+        return "SHORT"
+    return "FLAT"
+
+
+def metrics(candles, candles_csv, args, stop_bps, target_bps):
+    last_tradable = len(candles) - 1 - 1 - args.hold_period
+    pnls, longs, shorts, wins = [], 0, 0, 0
+    flats = 0
+    reasons = {"stop": 0, "target": 0, "time": 0}
+    for i in range(len(candles)):
+        if i > last_tradable:
+            flats += 1
+            continue
+        action = signal_for(candles, i, args.lookback, args.vol_ma)
+        if action == "FLAT":
+            flats += 1
+            continue
+        pnl, cls, reason = settle(args.verifier, action, args.size, i, args.hold_period,
+                                  candles_csv, args.slippage_bps, args.funding_rate_bps,
+                                  args.timeframe_minutes, stop_bps, target_bps)
+        pnls.append(pnl)
+        reasons[reason] = reasons.get(reason, 0) + 1
+        if cls == "WIN":
+            wins += 1
+        if action == "LONG":
+            longs += 1
+        else:
+            shorts += 1
+    n = len(pnls)
+    total = sum(pnls)
+    mean = total / n if n else 0.0
+    win_rate = (wins / n * 100.0) if n else 0.0
+    gross_win = sum(x for x in pnls if x > 0)
+    gross_loss = -sum(x for x in pnls if x < 0)
+    profit_factor = (gross_win / gross_loss) if gross_loss > 0 else (float("inf") if gross_win > 0 else 0.0)
+    peak = cum = max_dd = 0.0
+    for x in pnls:
+        cum += x
+        peak = max(peak, cum)
+        max_dd = max(max_dd, peak - cum)
+    return {
+        "stop_bps": stop_bps, "target_bps": target_bps,
+        "r_multiple": round(target_bps / stop_bps, 2) if stop_bps else None,
+        "trades": n, "longs": longs, "shorts": shorts, "flats": flats,
+        "win_rate_pct": round(win_rate, 1),
+        "total_pnl_bps": round(total, 2),
+        "mean_pnl_bps_expectancy": round(mean, 3),
+        "profit_factor": (round(profit_factor, 3) if profit_factor != float("inf") else "inf"),
+        "max_drawdown_bps": round(max_dd, 2),
+        "exit_reasons": reasons,
+    }
+
+
+def buy_and_hold_bps(candles, args):
+    first, last = candles[0]["open"], candles[-1]["open"]
+    raw = (last - first) / first * 10000.0 * args.size
+    slippage = 2.0 * args.slippage_bps * args.size
+    blocks = (len(candles) * args.timeframe_minutes) / 480.0
+    funding = args.funding_rate_bps * args.size * blocks
+    return round(raw - slippage - funding, 2)
+
+
+def main(argv):
+    args = parse_args(argv)
+    candles = load_candles(args.candles)
+    configs = []
+    for spec in args.r_configs.split(","):
+        s, t = spec.split(":")
+        configs.append((float(s), float(t)))
+    results = [metrics(candles, args.candles, args, s, t) for s, t in configs]
+    out = {
+        "window_candles": len(candles),
+        "hold_period": args.hold_period, "vol_ma": args.vol_ma, "lookback": args.lookback,
+        "timeframe_minutes": args.timeframe_minutes,
+        "slippage_bps": args.slippage_bps, "funding_rate_bps": args.funding_rate_bps,
+        "size": args.size,
+        "flat_baseline_total_pnl_bps": 0.0,
+        "fade_1123_total_pnl_bps_L20": -360.02,
+        "buy_and_hold_net_bps": buy_and_hold_bps(candles, args),
+        "results_by_r_multiple": results,
+    }
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/trading-binance/runs/20260619T-momentum-rmultiple/comparison.md
+++ b/trading-binance/runs/20260619T-momentum-rmultiple/comparison.md
@@ -1,0 +1,85 @@
+# Momentum + R-multiple backtest (#1154)
+
+**Run:** `20260619T-momentum-rmultiple` · **Symbol:** BTCUSDT · **Timeframe:** 1h ·
+**Window:** 2026-03-01 → 2026-05-31 (2208 candles, real Binance USDT-M klines)
+
+## What this tests
+
+The honest **"does the lever move the goal"** gate. #1148 added an R-multiple
+(stop/target) exit model to `tools/verify-trade.sh` — the structural lever for
+**profitable trades with a low win rate but a higher net return** (asymmetric
+payoff: small stop, larger target). This run pairs that lever with a
+positive-skew **momentum / breakout** signal (the inverse of the #1123 fade)
+and asks: does asymmetric payoff produce a **positive expectancy** where the
+fade (negative skew, fixed-time exit) lost (−360 bps)?
+
+- **Deterministic** reference signal, **not** the LLM strategist; decisions
+  settled by the repo's own R-multiple verifier (`tools/verify-trade.sh`,
+  slippage 5 bps/side, funding 1 bps/8h over the *actual* hold, `HOLD_PERIOD=8`,
+  `TIMEFRAME_MINUTES=60`).
+- Signal: `volMA = SMA(volume, 20)`, lookback `L=20`. New `L`-bar high on
+  **confirming** volume (`volume ≥ volMA`) → **LONG**; new `L`-bar low on
+  confirming volume → **SHORT**; else **FLAT**. Enter *with* the move; ride to
+  the target or get cut at the stop.
+
+## Results (R-multiple sweep, 341 entries each)
+
+Selection metric is **expectancy** (mean PnL bps/trade) + **profit factor**
+(gross win / gross loss), not win rate. Baselines: FLAT **0 bps**; #1123 fade
+**−360 bps**; buy-and-hold **+757 bps**.
+
+| Config | Win rate | Total PnL (bps) | Expectancy (bps/trade) | Profit factor | Max DD (bps) | stop / target / time |
+|---|---|---|---|---|---|---|
+| 1R (stop 100 / target 100) | 43.1 % | **−5252** | −15.40 | 0.68 | 5450 | 132 / 119 / 90 |
+| 2R (stop 100 / target 200) | 36.1 % | **−6443** | −18.89 | 0.64 | 6780 | 143 / 41 / 157 |
+| 3R (stop 100 / target 300) | 34.9 % | **−7090** | −20.79 | 0.62 | 7722 | 146 / 17 / 178 |
+
+(Full machine-readable output: [`results.json`](./results.json).)
+
+## Verdict — honest, and negative (worse than the fade)
+
+**No.** On this window the momentum/breakout signal under R-multiple exits is
+**not profitable** — it loses at every R-multiple, **more** than the #1123 fade
+(−360 bps), and it gets **worse as the target widens** (1R −5252 → 3R −7090 bps).
+Profit factor is below 1.0 everywhere, expectancy is negative, and every config
+beats neither FLAT nor buy-and-hold.
+
+The mechanism is clear in the `exit_reason` breakdown: the wider the target, the
+**rarer** a target hit (119 → 41 → **17** of 341) while stops/time-exits pile up.
+On this 1h BTCUSDT window most breakouts are **false** — price prints a new
+extreme on volume, then reverts into the stop. A 3R target almost never reaches;
+the asymmetric payoff has nothing to pay out on.
+
+## What this means (the useful part)
+
+1. **The R-multiple lever works mechanically.** The exit fires correctly: a
+   tighter target hits more often, funding accrues over the *actual* hold, and
+   the stop/target/time mix shifts exactly as the geometry predicts. The #1148
+   change is validated on real data.
+2. **Asymmetric payoff alone does not create an edge.** Both deterministic
+   signals now lose on this window — the **fade** (negative skew, fixed-time)
+   AND the **momentum** (positive skew, R-multiple). The exit model is
+   **necessary but not sufficient**; it only amplifies whatever edge the signal
+   has, and a 1h breakout signal has **negative** edge here (the window is a
+   choppy +10 % grind that punishes both fading extremes and chasing them).
+3. For the goal (*low win rate, high return*), the next lever is the **signal**,
+   not the exit: a signal with genuine positive expectancy, found by searching
+   the strategy space (the substrate / evolution) and/or a regime filter that
+   only trades breakouts when follow-through is likely — validated walk-forward,
+   not on one window. The verifier did its job: it refused to let either
+   mechanical hypothesis look profitable when it isn't.
+
+## Validation caveats
+
+- **Single in-sample window**, no walk-forward / out-of-sample. One 90-day 1h
+  window is not robust; a trend-following signal can flip sign in a trending vs
+  ranging regime.
+- **Deterministic signal ≠ LLM strategist** — bounds the raw signal, not the
+  tribe's realised behaviour.
+- **Static R-multiple** (fixed stop/target in bps), not an ATR-scaled or
+  trailing stop; fixed size 1.0; the verifier's flat cost model.
+
+## Reproduce
+
+See [`run-meta.json`](./run-meta.json) for exact parameters and the
+download/regenerate command (raw shards + unified `candles.csv` not committed).

--- a/trading-binance/runs/20260619T-momentum-rmultiple/results.json
+++ b/trading-binance/runs/20260619T-momentum-rmultiple/results.json
@@ -1,0 +1,72 @@
+{
+  "window_candles": 2208,
+  "hold_period": 8,
+  "vol_ma": 20,
+  "lookback": 20,
+  "timeframe_minutes": 60,
+  "slippage_bps": 5.0,
+  "funding_rate_bps": 1.0,
+  "size": 1.0,
+  "flat_baseline_total_pnl_bps": 0.0,
+  "fade_1123_total_pnl_bps_L20": -360.02,
+  "buy_and_hold_net_bps": 757.01,
+  "results_by_r_multiple": [
+    {
+      "stop_bps": 100.0,
+      "target_bps": 100.0,
+      "r_multiple": 1.0,
+      "trades": 341,
+      "longs": 183,
+      "shorts": 158,
+      "flats": 1867,
+      "win_rate_pct": 43.1,
+      "total_pnl_bps": -5252.35,
+      "mean_pnl_bps_expectancy": -15.403,
+      "profit_factor": 0.681,
+      "max_drawdown_bps": 5449.98,
+      "exit_reasons": {
+        "stop": 132,
+        "target": 119,
+        "time": 90
+      }
+    },
+    {
+      "stop_bps": 100.0,
+      "target_bps": 200.0,
+      "r_multiple": 2.0,
+      "trades": 341,
+      "longs": 183,
+      "shorts": 158,
+      "flats": 1867,
+      "win_rate_pct": 36.1,
+      "total_pnl_bps": -6442.76,
+      "mean_pnl_bps_expectancy": -18.894,
+      "profit_factor": 0.644,
+      "max_drawdown_bps": 6780.21,
+      "exit_reasons": {
+        "stop": 143,
+        "target": 41,
+        "time": 157
+      }
+    },
+    {
+      "stop_bps": 100.0,
+      "target_bps": 300.0,
+      "r_multiple": 3.0,
+      "trades": 341,
+      "longs": 183,
+      "shorts": 158,
+      "flats": 1867,
+      "win_rate_pct": 34.9,
+      "total_pnl_bps": -7090.02,
+      "mean_pnl_bps_expectancy": -20.792,
+      "profit_factor": 0.616,
+      "max_drawdown_bps": 7721.68,
+      "exit_reasons": {
+        "stop": 146,
+        "target": 17,
+        "time": 178
+      }
+    }
+  ]
+}

--- a/trading-binance/runs/20260619T-momentum-rmultiple/run-meta.json
+++ b/trading-binance/runs/20260619T-momentum-rmultiple/run-meta.json
@@ -1,0 +1,14 @@
+{
+  "run_id": "20260619T-momentum-rmultiple",
+  "issue": 1154,
+  "kind": "deterministic-momentum-rmultiple-backtest",
+  "note": "Deterministic momentum/breakout signal settled by the #1148 R-multiple verifier. NOT the LLM strategist. Tests whether asymmetric payoff produces positive expectancy where the #1123 fade lost.",
+  "symbol": "BTCUSDT", "timeframe": "1h",
+  "window_start": "2026-03-01", "window_end": "2026-05-31", "window_candles": 2208,
+  "verifier": "tools/verify-trade.sh (R-multiple, #1148)",
+  "hold_period": 8, "vol_ma": 20, "lookback": 20, "timeframe_minutes": 60,
+  "slippage_bps": 5, "funding_rate_bps": 1, "size": 1.0,
+  "r_configs": ["100:100 (1R)", "100:200 (2R)", "100:300 (3R)"],
+  "base_commit": "1396d365305bcbf8b78fdf3aaa41ad28d8536616",
+  "reproduce": "python3 tools/binance-feed-download.py --symbol BTCUSDT --timeframe 1h --start 2026-03-01 --end 2026-05-31 && python3 tools/load-candles.py --data-dir data --symbol BTCUSDT --timeframe 1h --start 2026-03-01 --end 2026-05-31 > candles.csv && python3 runs/20260619T-momentum-rmultiple/backtest-momentum-rmultiple.py --candles candles.csv --verifier tools/verify-trade.sh --hold-period 8 --vol-ma 20 --lookback 20 --timeframe-minutes 60 --r-configs 100:100,100:200,100:300"
+}


### PR DESCRIPTION
## Summary

Follow-up to #1148: pair the **R-multiple exit lever** with a positive-skew **momentum/breakout** signal (the inverse of the #1123 fade) over the same real 90-day BTCUSDT 1h window, to test whether asymmetric payoff produces a **positive expectancy** where the fade lost (−360 bps). Deterministic, key-free, mirrors the #1123 harness; decisions settled by the repo's R-multiple `verify-trade.sh`.

## Result — honest, and negative (worse than the fade)

Baselines: FLAT **0**, #1123 fade **−360**, buy-and-hold **+757** bps.

| Config | Win rate | Total PnL (bps) | Expectancy | Profit factor | stop / target / time |
|---|---|---|---|---|---|
| 1R (100/100) | 43.1 % | **−5252** | −15.40 | 0.68 | 132 / 119 / 90 |
| 2R (100/200) | 36.1 % | **−6443** | −18.89 | 0.64 | 143 / 41 / 157 |
| 3R (100/300) | 34.9 % | **−7090** | −20.79 | 0.62 | 146 / 17 / 178 |

**Momentum + R-multiple is not profitable** on this window — it loses worse than the fade, and worse as the target widens. The `exit_reason` breakdown shows why: the wider the target, the rarer it hits (119 → 41 → **17** of 341) while stops/time-exits pile up — most 1h BTCUSDT breakouts are **false** on this choppy +10 % window.

## What this means

- **The R-multiple lever (#1148) is validated mechanically**: the stop/target/time mix shifts exactly as the geometry predicts and funding accrues over the *actual* hold.
- **Asymmetric payoff alone does not create an edge.** Both deterministic signals — the fade (negative skew) AND the momentum (positive skew) — lose on this window. The exit model is **necessary but not sufficient**; it amplifies a signal's edge, and a 1h breakout signal has **negative** edge here. The next lever is the **signal** (search + walk-forward), not the exit.
- The verifier did its job: it refused to let a bad signal look profitable.

## Caveats

Single in-sample window, no walk-forward; deterministic signal ≠ LLM strategist; static R-multiple (not ATR-scaled/trailing); 1h intraday is noisy.

## Files

Under `trading-binance/runs/20260619T-momentum-rmultiple/`: `backtest-momentum-rmultiple.py`, `comparison.md`, `results.json`, `run-meta.json`. Raw shards + unified `candles.csv` not committed (gitignored; reproducible via `run-meta.json`).

## Verification

- `./tools/colony-lint.sh` → 417 passed, 0 failed; `py_compile` clean.
- Staging confirmed to exclude all `data/BTCUSDT/*` shards.

Closes #1154.
