### PR TITLE
fix(implementation): commit-files control chars + create-branch idempotency (#1149, #1150)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,22 @@ is asserted until multi-version CI is in place.
 
 ### Fixed
 
+- **`implementation/scripts/github-api.sh` `commit-files` now tolerates raw
+  control characters in `--actions` file content** (#1149). Both
+  `json.loads(ACTIONS)` calls (the up-front validation parse and the tree-build
+  parse) now pass `strict=False`, which permits literal newlines/tabs inside
+  JSON strings. LLM-generated file `content` routinely carries raw control
+  chars; the previous strict parse rejected such payloads with `Invalid control
+  character`, dead-ending the code_writer. Found during the #1117 first live
+  federation run.
+- **`implementation/scripts/github-api.sh` `create-branch` is now idempotent**
+  (#1150). A retry after a prior failed commit finds the branch already present,
+  and GitHub answers the create `POST /git/refs` with HTTP 422 "Reference
+  already exists". The branch being present is the desired end state, so that
+  one case is now treated as success: the wrapper GETs the existing ref and
+  emits it as a create-shaped payload (exit 0). Any other failure still
+  propagates with its original exit code and error. Found during the #1117
+  first live federation run.
 - Reverted the `[llm] backend` in all 5 `*/config/colony.example.toml`
   blocks from `"claude"` back to `"cli"` (a follow-up correction to #1131).
   Per the CLAUDE.md "LLM backend" convention, `"cli"` means "use the

--- a/dev-apprenticeship/implementation/scripts/github-api.sh
+++ b/dev-apprenticeship/implementation/scripts/github-api.sh
@@ -729,7 +729,39 @@ import os, json
 print(json.dumps({"ref": "refs/heads/" + os.environ["NAME"], "sha": os.environ["SHA"]}))
 PY
 )
-        gh_post "$API/git/refs" "$JSON_BODY"
+        # Idempotency (#1150): a retry after a prior failed commit finds the
+        # branch already present, and GitHub answers the create POST with HTTP
+        # 422 "Reference already exists". The branch being present is the
+        # desired end state, so treat that one case as success: GET the existing
+        # ref and emit it so callers receive a create-shaped payload, exit 0.
+        # gh_post surfaces the 422 body snippet on stderr (gh_call's 4xx arm),
+        # so we capture stderr to a temp file and only swallow the "already
+        # exists" signature — any other failure re-surfaces its error and
+        # propagates the original gh_post exit code.
+        create_err_file="$(mktemp)"
+        create_out=""
+        create_rc=0
+        create_out="$(gh_post "$API/git/refs" "$JSON_BODY" 2>"$create_err_file")" || create_rc=$?
+        if [ "$create_rc" -eq 0 ]; then
+            rm -f "$create_err_file"
+            printf '%s' "$create_out"
+        else
+            create_err="$(cat "$create_err_file")"
+            rm -f "$create_err_file"
+            case "$create_err" in
+                *"Reference already exists"*|*"already exists"*)
+                    # Branch already present — desired end state reached.
+                    existing_ref="$(gh_get "$API/git/refs/heads/$NAME")" || exit $?
+                    printf '%s' "$existing_ref"
+                    ;;
+                *)
+                    # Real failure: re-surface the captured error and propagate
+                    # the original gh_post exit code.
+                    printf '%s\n' "$create_err" >&2
+                    exit "$create_rc"
+                    ;;
+            esac
+        fi
         ;;
 
     commit-files)
@@ -765,7 +797,9 @@ PY
         ACTIONS="$ACTIONS" python3 - <<'PY' >/dev/null
 import os, json, sys
 try:
-    a = json.loads(os.environ["ACTIONS"])
+    # strict=False permits literal control chars (raw newlines, tabs) inside
+    # JSON strings — LLM-generated file `content` routinely carries them (#1149).
+    a = json.loads(os.environ["ACTIONS"], strict=False)
 except Exception as e:
     print(json.dumps({"error": f"invalid --actions JSON: {e}"}), file=sys.stderr)
     sys.exit(1)
@@ -805,7 +839,9 @@ PY
         # GitHub removes the path. For create/update, carry content inline.
         TREE_BODY=$(ACTIONS="$ACTIONS" BASE_TREE="$BASE_TREE_SHA" python3 - <<'PY'
 import os, json
-actions = json.loads(os.environ["ACTIONS"])
+# strict=False mirrors the up-front validation parse (#1149): file content
+# may contain raw control chars that strict JSON would reject.
+actions = json.loads(os.environ["ACTIONS"], strict=False)
 tree = []
 for a in actions:
     path = a["file_path"]

--- a/tools/test-github-implementation-robustness.sh
+++ b/tools/test-github-implementation-robustness.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# test-github-implementation-robustness.sh: command-dispatcher robustness tests
+# for dev-apprenticeship/implementation/scripts/github-api.sh, covering two
+# live-run regressions found during the #1117 first federation run:
+#
+#   #1149  commit-files --actions must tolerate raw control characters inside
+#          file `content` (LLM output routinely carries literal newlines/tabs).
+#          Both json.loads(ACTIONS) calls now pass strict=False; a strict parse
+#          rejects such payloads with "Invalid control character".
+#
+#   #1150  create-branch must be idempotent: when the create POST answers HTTP
+#          422 "Reference already exists" (a retry after a prior failed commit),
+#          the branch being present is the desired end state, so the wrapper
+#          GETs the existing ref and emits it as success (exit 0). Any OTHER
+#          failure must still propagate.
+#
+# Unlike test-github-implementation-normalize.sh (which sources just the
+# function defs and exercises the normalizers), this test drives the full CMD
+# dispatcher against a STUBBED curl placed on PATH — the same stub-curl idiom
+# as test-rate-limit-backoff.sh. The stub dispatches on "<method> <url-path>"
+# read from a per-request script file, writes the body to the curl -o file, and
+# prints the HTTP status code on stdout (mirroring real gh_call -w/-o behaviour).
+#
+# Usage: ./tools/test-github-implementation-robustness.sh
+# Exit 0 all-pass, 1 any-fail.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT="$REPO_ROOT/dev-apprenticeship/implementation/scripts/github-api.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+FAKE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FAKE_ROOT"' EXIT
+
+# ---- Stub curl ---------------------------------------------------------------
+# The stub maps "<METHOD> <url-suffix>" to a status code + body file. The
+# routing table lives in $STUB_DIR/routes (one "METHOD<TAB>suffix<TAB>code<TAB>bodyfile"
+# per line); the stub matches by METHOD plus a URL suffix substring. The real
+# gh_call passes "-o <body>", "-X <method>", and the URL as the final argv.
+FAKE_BIN="$FAKE_ROOT/bin"
+STUB_DIR="$FAKE_ROOT/stub"
+mkdir -p "$FAKE_BIN" "$STUB_DIR"
+cat > "$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+out=""
+method="GET"
+url=""
+prev=""
+for a in "$@"; do
+    case "$prev" in
+        -o) out="$a" ;;
+        -X) method="$a" ;;
+    esac
+    case "$a" in
+        http://*|https://*) url="$a" ;;
+    esac
+    prev="$a"
+done
+routes="$STUB_DIR/routes"
+code="404"
+body=""
+if [ -f "$routes" ]; then
+    while IFS=$'\t' read -r r_method r_suffix r_code r_bodyfile; do
+        [ -z "$r_method" ] && continue
+        if [ "$r_method" = "$method" ]; then
+            case "$url" in
+                *"$r_suffix") code="$r_code"; body="$r_bodyfile" ;;
+                *"$r_suffix"*) code="$r_code"; body="$r_bodyfile" ;;
+            esac
+        fi
+    done < "$routes"
+fi
+if [ -n "$out" ]; then
+    if [ -n "$body" ] && [ -f "$body" ]; then
+        cat "$body" > "$out"
+    else
+        : > "$out"
+    fi
+fi
+printf '%s' "$code"
+exit 0
+EOF
+chmod +x "$FAKE_BIN/curl"
+
+# add_route <method> <url-suffix> <http-code> <body-string>
+ROUTE_SEQ=0
+add_route() {
+    local method="$1" suffix="$2" code="$3" body="$4"
+    ROUTE_SEQ=$((ROUTE_SEQ + 1))
+    local bf="$STUB_DIR/body-$ROUTE_SEQ.json"
+    printf '%s' "$body" > "$bf"
+    printf '%s\t%s\t%s\t%s\n' "$method" "$suffix" "$code" "$bf" >> "$STUB_DIR/routes"
+}
+
+reset_routes() {
+    : > "$STUB_DIR/routes"
+    ROUTE_SEQ=0
+}
+
+run_api() {
+    PATH="$FAKE_BIN:$PATH" \
+    STUB_DIR="$STUB_DIR" \
+    GITHUB_URL="https://api.github.com" \
+    GITHUB_TOKEN="stub" \
+    GITHUB_OWNER="o" \
+    GITHUB_REPO="r" \
+    GITHUB_CURL_RETRIES=0 \
+        bash "$SCRIPT" "$@"
+}
+
+# =============================================================================
+# #1149: commit-files tolerates raw control chars in --actions content.
+# =============================================================================
+reset_routes
+HEAD_SHA="1111111111111111111111111111111111111111"
+TREE_SHA="2222222222222222222222222222222222222222"
+NEW_TREE_SHA="3333333333333333333333333333333333333333"
+NEW_COMMIT_SHA="4444444444444444444444444444444444444444"
+add_route GET   "/git/refs/heads/feat-x"  200 "{\"object\":{\"sha\":\"$HEAD_SHA\"}}"
+add_route GET   "/git/commits/$HEAD_SHA"   200 "{\"tree\":{\"sha\":\"$TREE_SHA\"}}"
+add_route POST  "/git/trees"               201 "{\"sha\":\"$NEW_TREE_SHA\"}"
+add_route POST  "/git/commits"             201 "{\"sha\":\"$NEW_COMMIT_SHA\"}"
+add_route PATCH "/git/refs/heads/feat-x"   200 "{\"ref\":\"refs/heads/feat-x\",\"object\":{\"sha\":\"$NEW_COMMIT_SHA\"}}"
+
+# --actions whose `content` carries RAW newlines (literal control chars in the
+# JSON string). A strict json.loads would raise "Invalid control character".
+ACTIONS_RAW_NL=$(python3 - <<'PY'
+import json
+# Build the payload, then re-emit with the content's newlines left LITERAL
+# (not \n-escaped) so the bytes handed to the wrapper contain raw control chars.
+content = "line one\nline two\n\tindented\n"
+payload = '[{"action":"create","file_path":"src/foo.py","content":' + json.dumps(content) + '}]'
+# json.dumps escaped the newlines; undo that so they are literal control chars.
+payload = payload.replace('\\n', '\n').replace('\\t', '\t')
+print(payload, end="")
+PY
+)
+
+CF_ERR_FILE="$FAKE_ROOT/cf-err"
+CF_OUT="$(run_api commit-files --branch feat-x --message "msg" --actions "$ACTIONS_RAW_NL" 2>"$CF_ERR_FILE")"
+CF_RC=$?
+CF_ERR="$(cat "$CF_ERR_FILE")"
+
+case "$CF_ERR" in
+    *"Invalid control character"*)
+        fail "#1149 commit-files: raw control chars in content rejected ('Invalid control character')" ;;
+    *)
+        pass "#1149 commit-files: raw control chars in content accepted (no 'Invalid control character')" ;;
+esac
+
+if [ "$CF_RC" -eq 0 ]; then
+    pass "#1149 commit-files: full Git-DB chain exits 0 with control-char content"
+else
+    fail "#1149 commit-files: expected exit 0, got $CF_RC (stderr: $CF_ERR)"
+fi
+
+case "$CF_OUT" in
+    *"refs/heads/feat-x"*)
+        pass "#1149 commit-files: final ref-patch body echoed on success" ;;
+    *)
+        fail "#1149 commit-files: expected ref body on stdout, got '$CF_OUT'" ;;
+esac
+
+# Strict-parse control: prove the OLD (strict) behaviour WOULD have failed, so
+# the test is actually guarding the strict=False change and not a no-op.
+STRICT_RC=0
+ACTIONS="$ACTIONS_RAW_NL" python3 -c 'import os,json; json.loads(os.environ["ACTIONS"])' 2>/dev/null || STRICT_RC=$?
+if [ "$STRICT_RC" -ne 0 ]; then
+    pass "#1149 control: strict json.loads rejects this payload (strict=False is load-bearing)"
+else
+    fail "#1149 control: strict json.loads unexpectedly accepted raw control chars"
+fi
+
+# =============================================================================
+# #1150: create-branch is idempotent on HTTP 422 "Reference already exists".
+# =============================================================================
+reset_routes
+BASE_SHA="abcdef0000000000000000000000000000000000"
+EXISTING_REF_BODY="{\"ref\":\"refs/heads/feat-y\",\"object\":{\"sha\":\"$BASE_SHA\",\"type\":\"commit\"}}"
+# Step 1: resolve --ref main to its head SHA.
+add_route GET  "/git/refs/heads/main"   200 "{\"object\":{\"sha\":\"$BASE_SHA\"}}"
+# Step 2: create POST answers 422 (branch already present).
+add_route POST "/git/refs"              422 "{\"message\":\"Reference already exists\",\"documentation_url\":\"https://docs.github.com/\"}"
+# Idempotent fallback: GET the existing ref.
+add_route GET  "/git/refs/heads/feat-y" 200 "$EXISTING_REF_BODY"
+
+CB_ERR_FILE="$FAKE_ROOT/cb-err"
+CB_OUT="$(run_api create-branch --name feat-y --ref main 2>"$CB_ERR_FILE")"
+CB_RC=$?
+CB_ERR="$(cat "$CB_ERR_FILE")"
+
+if [ "$CB_RC" -eq 0 ]; then
+    pass "#1150 create-branch: 422 'Reference already exists' treated as success (exit 0)"
+else
+    fail "#1150 create-branch: expected exit 0 on already-existing ref, got $CB_RC (stderr: $CB_ERR)"
+fi
+
+case "$CB_OUT" in
+    *"refs/heads/feat-y"*)
+        pass "#1150 create-branch: emits the existing ref body (create-shaped payload)" ;;
+    *)
+        fail "#1150 create-branch: expected existing ref on stdout, got '$CB_OUT'" ;;
+esac
+
+# Negative path: a DIFFERENT 422 (not 'already exists') must still propagate as
+# a failure — the idempotency shim must not mask real errors.
+reset_routes
+add_route GET  "/git/refs/heads/main"   200 "{\"object\":{\"sha\":\"$BASE_SHA\"}}"
+add_route POST "/git/refs"              422 "{\"message\":\"Validation Failed: sha is not a valid commit\"}"
+
+CB2_ERR_FILE="$FAKE_ROOT/cb2-err"
+run_api create-branch --name feat-z --ref main >/dev/null 2>"$CB2_ERR_FILE"
+CB2_RC=$?
+CB2_ERR="$(cat "$CB2_ERR_FILE")"
+
+if [ "$CB2_RC" -ne 0 ]; then
+    pass "#1150 create-branch: non-'already exists' 422 still propagates as failure (rc=$CB2_RC)"
+else
+    fail "#1150 create-branch: unrelated 422 was masked as success (should propagate)"
+fi
+
+case "$CB2_ERR" in
+    *"Validation Failed"*|*"client error"*)
+        pass "#1150 create-branch: real-error stderr re-surfaced on the non-idempotent path" ;;
+    *)
+        fail "#1150 create-branch: expected the original error on stderr, got '$CB2_ERR'" ;;
+esac
+
+# Happy path: a clean create (201) is unaffected by the idempotency shim.
+reset_routes
+add_route GET  "/git/refs/heads/main"   200 "{\"object\":{\"sha\":\"$BASE_SHA\"}}"
+add_route POST "/git/refs"              201 "{\"ref\":\"refs/heads/feat-new\",\"object\":{\"sha\":\"$BASE_SHA\"}}"
+
+CB3_OUT="$(run_api create-branch --name feat-new --ref main 2>/dev/null)"
+CB3_RC=$?
+if [ "$CB3_RC" -eq 0 ]; then
+    case "$CB3_OUT" in
+        *"refs/heads/feat-new"*)
+            pass "#1150 create-branch: clean 201 create still emits the created ref (exit 0)" ;;
+        *)
+            fail "#1150 create-branch: clean create lost its body, got '$CB3_OUT'" ;;
+    esac
+else
+    fail "#1150 create-branch: clean 201 create regressed to exit $CB3_RC"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1149. Closes #1150.

Two robustness fixes in `dev-apprenticeship/implementation/scripts/github-api.sh`, both surfaced by the #1117 first live federation run.

## #1149 — `commit-files` tolerates control chars
Both `json.loads(os.environ["ACTIONS"])` sites (validation + tree-build) now use `strict=False`, so LLM-generated file `content` with raw newlines parses (was failing `Invalid control character`). Structural malformation (missing commas, etc.) is still rejected — the flat-cyborg structural-corruption issue stays out of scope (that's #1152).

## #1150 — `create-branch` is idempotent
The final `POST /git/refs` dead-ended on HTTP 422 "Reference already exists" (a retry after a failed commit). It now re-fetches + emits the existing ref on that specific 422 (exit 0); **every other failure propagates with its original exit code**, the post-422 GET failure can't fake success, and the stderr temp file is always cleaned up.

## Tests
New `tools/test-github-implementation-robustness.sh` (9 assertions, stubs `curl`): control-char acceptance end-to-end, the 422-idempotency path, and the **propagate-real-errors** negative path; plus a strict-parse control proving `strict=False` is load-bearing.

## Verification
- colony-lint: **418 passed, 0 failed, 5 skipped**
- new test 9/0; `test-github-implementation-normalize.sh` 52/0; code-review/planning/release/triage normalize suites green; `bash -n` + `shellcheck` clean.
- QA: ✅ ship-it (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)