### PR TITLE
fix(implementation): durable code_writer->commit_composer MR handoff (#1151)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,21 @@ is asserted until multi-version CI is in place.
 
 ### Fixed
 
+- **`implementation` code_writer -> commit_composer MR handoff is now durable**
+  (#1151). The handoff used to depend on commit_composer catching the transient
+  `implementation:code_draft` bus event inside a 100ms `listen()` window; when
+  the event was missed the federation committed correct code to the branch but
+  never opened the merge request. `code_writer` now also persists a durable
+  single-slot memo (`implementation:pending_mr`, tab-delimited issue_id /
+  branch_name / summary) right after a successful autonomous commit.
+  `commit_composer`'s no-event branch consults that memo and, at the autonomous
+  tier, opens the MR via the same `create-mr` path (deterministic title and
+  description, no new `prompt()`), emits `implementation:mr_ready`, records an
+  idempotency marker (`commit_composer:last_mr_issue`), and clears the pending
+  memo. The live `code_draft` event stays the fast path — and that fast path now
+  records the same marker + clears the same memo, so a successful event-driven
+  open is never re-opened as a duplicate by the next tick's fallback. Found
+  during the #1117 first live federation run.
 - **`implementation/scripts/github-api.sh` `commit-files` now tolerates raw
   control characters in `--actions` file content** (#1149). Both
   `json.loads(ACTIONS)` calls (the up-front validation parse and the tree-build

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -276,6 +276,15 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                     if len(commit_result) > 0 {
                         print("[code_writer] Committed code to", draft.branch_name);
                         emit("implementation:code_draft", draft);
+                        // #1151: durable single-slot handoff to commit_composer.
+                        // The live `code_draft` bus event above is the fast path,
+                        // but commit_composer only catches it inside a 100ms
+                        // listen() window; a missed event left the branch
+                        // committed with no MR ever opened. Persist a durable
+                        // tab-delimited (issue_id, branch_name, summary) signal
+                        // so commit_composer's no-event branch can recover it.
+                        memo_write(scoped_memo(owner, repo, "implementation:pending_mr"),
+                            to_string(draft.issue_id) + "\t" + draft.branch_name + "\t" + draft.summary);
                         if len(owner) > 0 {
                             learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation", repo_tag(owner, repo)]);
                         } else {

--- a/dev-apprenticeship/implementation/agents/commit_composer.ag
+++ b/dev-apprenticeship/implementation/agents/commit_composer.ag
@@ -164,7 +164,68 @@ fn tick_for_repo(owner: string, repo: string) -> void {
     let code_str = to_string(code_draft);
 
     if len(code_str) < 5 {
-        // No code draft ready yet, nothing to compose
+        // #1151: the live `implementation:code_draft` event was not caught in
+        // this tick's 100ms listen() window. Fall back to the durable
+        // single-slot memo code_writer persists right after a successful
+        // commit, so a missed event no longer strands a committed branch
+        // without an MR. The memo is tab-delimited (issue_id, branch_name,
+        // summary); see code_writer.ag.
+        let pending = recall_latest(scoped_memo(owner, repo, "implementation:pending_mr"));
+        if len(pending) < 3 {
+            // No durable handoff pending either — nothing to compose.
+            let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now) > 0 {
+                memo_write(scoped_memo(owner, repo, "commit_composer:last_check"), now);
+            };
+            return;
+        };
+
+        let pending_issue = repo_field(pending, 0);
+        let pending_branch = repo_field(pending, 1);
+        let pending_summary = repo_field(pending, 2);
+
+        // Idempotency: skip if we already opened the MR for this issue.
+        let last_mr = recall_latest(scoped_memo(owner, repo, "commit_composer:last_mr_issue"));
+        if last_mr == pending_issue {
+            let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+            if len(now) > 0 {
+                memo_write(scoped_memo(owner, repo, "commit_composer:last_check"), now);
+            };
+            return;
+        };
+
+        // One tier() call per tick: this fallback path returns before the
+        // live-event path below ever reaches its own repo_tier() call.
+        let fallback_tier = repo_tier("commit_composer", owner, repo);
+        if fallback_tier == "autonomous" {
+            // Derive MR fields deterministically (no prompt(): the
+            // check-prompt-gate lint forbids an ungated prompt here, and the
+            // durable fallback is specifically the autonomous terminal write).
+            let mr_title = "feat: resolve #" + pending_issue;
+            let mr_description = pending_summary;
+            // colony-lint: safe-exec-concat
+            let mr_cmd = "$COLONY_DIR/scripts/forge-api.sh create-mr --source " + shell_escape(pending_branch) + " --title " + shell_escape(mr_title) + " --description " + shell_escape(mr_description) + repo_arg(owner, repo);
+            let mr_result = try { exec sh mr_cmd; } catch e {
+                print("[commit_composer] MR creation failed (durable handoff):", e);
+                "";
+            };
+
+            if len(mr_result) > 0 {
+                print("[commit_composer] Opened MR via durable handoff for issue", pending_issue);
+                emit("implementation:mr_ready", pending);
+                if len(owner) > 0 {
+                    learn("commit_compose", "issue " + pending_issue, mr_title, "success", ["acted", "implementation", repo_tag(owner, repo)]);
+                } else {
+                    learn("commit_compose", "issue " + pending_issue, mr_title, "success", ["acted", "implementation"]);
+                };
+                memo_write(scoped_memo(owner, repo, "commit_composer:last_mr_issue"), pending_issue);
+                memo_write(scoped_memo(owner, repo, "implementation:pending_mr"), "");
+            };
+        };
+        // Below autonomous: leave the durable memo in place so a later tick at
+        // a higher tier can still open the MR. The terminal write is gated to
+        // the autonomous tier only.
+
         let now = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
         if len(now) > 0 {
             memo_write(scoped_memo(owner, repo, "commit_composer:last_check"), now);
@@ -208,6 +269,10 @@ fn tick_for_repo(owner: string, repo: string) -> void {
             } else {
                 learn("commit_compose", "issue " + to_string(plan.issue_id), plan.mr_title, "success", ["acted", "implementation"]);
             };
+            // #1151: record the idempotency marker + clear the durable handoff
+            // so the no-event fallback does not re-open this same MR next tick.
+            memo_write(scoped_memo(owner, repo, "commit_composer:last_mr_issue"), to_string(plan.issue_id));
+            memo_write(scoped_memo(owner, repo, "implementation:pending_mr"), "");
         };
     } else {
         if my_tier == "review-gated" {

--- a/tools/test-mr-handoff-durable.sh
+++ b/tools/test-mr-handoff-durable.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# test-mr-handoff-durable.sh: durable code_writer -> commit_composer MR handoff
+# (#1151). Found during the #1117 first live federation run: the handoff relied
+# on commit_composer catching a transient `implementation:code_draft` bus event
+# inside a 100ms listen() window. When the event was missed the federation
+# committed correct code to the branch but never opened the MR.
+#
+# The fix adds a durable single-slot memo handoff:
+#   - code_writer, right after a successful autonomous commit, persists a
+#     tab-delimited (issue_id, branch_name, summary) signal to the scoped memo
+#     `implementation:pending_mr`.
+#   - commit_composer's no-event branch (len(code_str) < 5) consults that memo,
+#     and at the autonomous tier opens the MR via the same `create-mr` exec
+#     path, emits `implementation:mr_ready`, records an idempotency marker
+#     (`commit_composer:last_mr_issue`), and clears the pending memo.
+#
+# This test asserts the wiring is present and well-formed (grep-level) on both
+# agents and that both `.ag` files parse. A full daemon-level integration run is
+# out of scope.
+#
+# Usage: ./tools/test-mr-handoff-durable.sh [REPO_ROOT]
+# Exit 0 all-pass, 1 any-fail.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+CODE_WRITER="$REPO_ROOT/dev-apprenticeship/implementation/agents/code_writer.ag"
+COMMIT_COMPOSER="$REPO_ROOT/dev-apprenticeship/implementation/agents/commit_composer.ag"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+# =============================================================================
+# code_writer: persists the durable pending_mr memo after a successful commit.
+# =============================================================================
+if [ -f "$CODE_WRITER" ]; then
+    if grep -q 'implementation:pending_mr' "$CODE_WRITER"; then
+        pass "#1151 code_writer: writes the durable implementation:pending_mr memo"
+    else
+        fail "#1151 code_writer: missing implementation:pending_mr memo write"
+    fi
+
+    # The durable write must live in the committed-code path: it sits between
+    # the `Committed code to` log line and the success learn() tags.
+    if awk '
+        /Committed code to/ { seen_commit = 1 }
+        seen_commit && /implementation:pending_mr/ { found = 1 }
+        END { exit(found ? 0 : 1) }
+    ' "$CODE_WRITER"; then
+        pass "#1151 code_writer: pending_mr memo written after the successful commit"
+    else
+        fail "#1151 code_writer: pending_mr memo not on the post-commit path"
+    fi
+
+    # Tab-delimited (issue_id, branch_name, summary) payload.
+    if grep -Eq 'to_string\(draft\.issue_id\)[[:space:]]*\+[[:space:]]*"\\t"[[:space:]]*\+[[:space:]]*draft\.branch_name[[:space:]]*\+[[:space:]]*"\\t"[[:space:]]*\+[[:space:]]*draft\.summary' "$CODE_WRITER"; then
+        pass "#1151 code_writer: pending_mr payload is tab-delimited issue/branch/summary"
+    else
+        fail "#1151 code_writer: pending_mr payload is not the tab-delimited issue/branch/summary triple"
+    fi
+else
+    fail "#1151 code_writer: agent file not found at $CODE_WRITER"
+fi
+
+# =============================================================================
+# commit_composer: durable fallback in the no-event branch.
+# =============================================================================
+if [ -f "$COMMIT_COMPOSER" ]; then
+    # Reads the durable memo.
+    if grep -q 'recall_latest(scoped_memo(owner, repo, "implementation:pending_mr"))' "$COMMIT_COMPOSER"; then
+        pass "#1151 commit_composer: reads the durable implementation:pending_mr memo"
+    else
+        fail "#1151 commit_composer: does not recall the implementation:pending_mr memo"
+    fi
+
+    # The recall happens inside the no-event branch (after len(code_str) < 5),
+    # before the live-event create-mr path.
+    if awk '
+        /len\(code_str\) < 5/ { in_noevent = 1 }
+        in_noevent && /recall_latest\(scoped_memo\(owner, repo, "implementation:pending_mr"\)\)/ { found = 1 }
+        END { exit(found ? 0 : 1) }
+    ' "$COMMIT_COMPOSER"; then
+        pass "#1151 commit_composer: durable recall sits inside the no-event branch"
+    else
+        fail "#1151 commit_composer: durable recall is not in the no-event branch"
+    fi
+
+    # Idempotency marker read + write.
+    if grep -q 'commit_composer:last_mr_issue' "$COMMIT_COMPOSER"; then
+        pass "#1151 commit_composer: tracks the last_mr_issue idempotency marker"
+    else
+        fail "#1151 commit_composer: missing the last_mr_issue idempotency marker"
+    fi
+
+    # Opens the MR via the same create-mr exec path.
+    if grep -q 'create-mr --source' "$COMMIT_COMPOSER"; then
+        pass "#1151 commit_composer: opens the MR via the create-mr exec path"
+    else
+        fail "#1151 commit_composer: missing the create-mr exec path"
+    fi
+
+    # The durable-handoff MR open carries its own log line.
+    if grep -q 'Opened MR via durable handoff' "$COMMIT_COMPOSER"; then
+        pass "#1151 commit_composer: logs the durable-handoff MR open"
+    else
+        fail "#1151 commit_composer: missing the durable-handoff MR open log line"
+    fi
+
+    # Emits implementation:mr_ready from the fallback path. The no-event branch
+    # spans from `len(code_str) < 5` to its terminal top-level `return;`; assert
+    # the emit appears inside that span.
+    if awk '
+        /len\(code_str\) < 5/ { in_noevent = 1 }
+        in_noevent && /emit\("implementation:mr_ready"/ { found = 1 }
+        in_noevent && /^        return;/ { in_noevent = 0 }
+        END { exit(found ? 0 : 1) }
+    ' "$COMMIT_COMPOSER"; then
+        pass "#1151 commit_composer: emits implementation:mr_ready in the fallback path"
+    else
+        fail "#1151 commit_composer: does not emit implementation:mr_ready in the fallback path"
+    fi
+
+    # Clears the pending memo after a successful durable open (single-slot reset).
+    if grep -q 'memo_write(scoped_memo(owner, repo, "implementation:pending_mr"), "")' "$COMMIT_COMPOSER"; then
+        pass "#1151 commit_composer: clears the pending_mr memo after a durable open"
+    else
+        fail "#1151 commit_composer: does not clear the pending_mr memo after a durable open"
+    fi
+
+    # No double-open: BOTH the live-event MR open AND the durable fallback must
+    # set last_mr_issue + clear pending_mr, else the fast path leaves pending_mr
+    # set and the next tick's fallback re-opens a duplicate MR (QA #1151).
+    mark_writes="$(grep -c 'memo_write(scoped_memo(owner, repo, "commit_composer:last_mr_issue"),' "$COMMIT_COMPOSER")"
+    clear_writes="$(grep -c 'memo_write(scoped_memo(owner, repo, "implementation:pending_mr"), "")' "$COMMIT_COMPOSER")"
+    if [ "$mark_writes" -ge 2 ] && [ "$clear_writes" -ge 2 ]; then
+        pass "#1151 commit_composer: both live-event and fallback paths set last_mr_issue + clear pending_mr (no double-open)"
+    else
+        fail "#1151 commit_composer: live-event path missing the idempotency write (marks=$mark_writes clears=$clear_writes, need >=2 each)"
+    fi
+
+    # One tier() per tick: the fallback uses repo_tier(), and the no-event
+    # branch returns before the live-event path's own repo_tier() can run.
+    fallback_tier_count=$(grep -c 'repo_tier("commit_composer", owner, repo)' "$COMMIT_COMPOSER")
+    if [ "$fallback_tier_count" = "2" ]; then
+        pass "#1151 commit_composer: two repo_tier() sites (fallback + live), mutually exclusive per tick"
+    else
+        fail "#1151 commit_composer: expected exactly 2 repo_tier() sites, found $fallback_tier_count"
+    fi
+
+    # No new prompt() introduced in the fallback path (check-prompt-gate stays
+    # clean): the no-event branch derives MR fields deterministically. Strip
+    # `//` line comments before matching so the explanatory comment that names
+    # prompt() is not mistaken for a call (mirrors check-prompt-gate.sh).
+    if awk '
+        { clean = $0; sub(/\/\/.*/, "", clean) }
+        clean ~ /len\(code_str\) < 5/ { in_noevent = 1 }
+        in_noevent && clean ~ /^        return;/ { in_noevent = 0 }
+        in_noevent && clean ~ /prompt\(/ { found = 1 }
+        END { exit(found ? 1 : 0) }
+    ' "$COMMIT_COMPOSER"; then
+        pass "#1151 commit_composer: fallback path adds no prompt() (deterministic MR fields)"
+    else
+        fail "#1151 commit_composer: fallback path introduced a prompt() (check-prompt-gate risk)"
+    fi
+else
+    fail "#1151 commit_composer: agent file not found at $COMMIT_COMPOSER"
+fi
+
+# =============================================================================
+# Both .ag files parse (agentis commit), when the runtime is installed.
+# =============================================================================
+if command -v agentis >/dev/null 2>&1; then
+    PARSE_TMP="$(mktemp -d)"
+    trap 'rm -rf "$PARSE_TMP"' EXIT
+    (cd "$PARSE_TMP" && agentis init >/dev/null 2>&1) || true
+    for ag in "$CODE_WRITER" "$COMMIT_COMPOSER"; do
+        name="$(basename "$ag")"
+        if (cd "$PARSE_TMP" && agentis commit "$ag") >/dev/null 2>&1; then
+            pass "#1151 $name: parses (agentis commit)"
+        else
+            fail "#1151 $name: parse error (agentis commit)"
+        fi
+    done
+else
+    echo "[SKIP] agentis binary not installed — .ag parse check skipped"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1151.

Makes the code_writer → commit_composer MR handoff **durable** — it used to depend on commit_composer catching the transient `implementation:code_draft` event in a 100ms `listen()` window, so the federation committed correct code but never opened the MR (the final blocker in the #1117 first live run).

- **code_writer** (autonomous): after the commit + `emit`, persists a durable single-slot memo `implementation:pending_mr` (tab-delimited issue_id/branch_name/summary).
- **commit_composer** no-event branch: reads it and, at autonomous tier, opens the MR via the same `create-mr` path with **deterministically derived** title/description (no new `prompt()`), emits `mr_ready`, records `commit_composer:last_mr_issue`, clears the pending memo. Live event stays the fast path.
- **No double-open:** BOTH the fast path and the fallback set `last_mr_issue` + clear `pending_mr`, so a successful event-driven open isn't re-opened by the next tick's fallback (QA-caught + fixed inline).
- One `tier()`/tick preserved (paths mutually exclusive).

## Verification
- colony-lint: **419 passed, 0 failed, 5 skipped**
- new `tools/test-mr-handoff-durable.sh` 15/0 (incl. the no-double-open assertion); both agents parse.
- QA: ⚠️→✅ (the double-open race QA found is fixed inline + covered by a new assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)