### PR TITLE
docs(implementation): code-generation fidelity — route code-gen via claude -p (#1152)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,22 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Changed
+
+- **Documented the code-generation fidelity constraint** (#1152). flat-cyborg's
+  `--extract` is a TUI screen-scrape: great for prose (the observe / suggest /
+  review workflow), but it corrupts the fidelity-critical structured JSON the
+  autonomous `code_writer` feeds to `commit-files`, so the branch commits but
+  the file-contents commit fails (`Expecting ',' delimiter` / control chars).
+  The README LLM-backend section now documents this and the fix: run
+  code-generation-capable autonomous runs on the metered `claude -p` backend
+  (`llm.command = claude` / `llm.args = -p` in `.agentis/config`) while keeping
+  flat-cyborg as the default for the prose-only workflow. `code_writer` now also
+  prints a fidelity-backend hint on a commit failure so the cause is legible.
+  A true per-agent backend (flat-cyborg for prose + `claude -p` for `code_writer`
+  in the same run) is an agentis-core upstream dependency. Found in the #1117
+  first live run.
+
 ### Fixed
 
 - **`implementation` code_writer -> commit_composer MR handoff is now durable**

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -302,6 +302,20 @@ Two env-var knobs tune the wrapper (defaults shown):
 - `FLAT_CYBORG_IDLE_MS` (`8000`) — settle window before flat-cyborg reads the screen.
 - `FLAT_CYBORG_TIMEOUT_MS` (`180000`) — hard cap on a single generation.
 
+### Code-generation fidelity ([#1152](https://github.com/Replikanti/agentis-colonies/issues/1152))
+
+flat-cyborg's `--extract` is a **TUI screen-scrape** — it reads the model's reply off the rendered terminal. That is perfect for **prose** (the observe / suggest / review-gated workflow: routing, priority, plans, review notes all come back clean), but it **corrupts fidelity-critical structured output**. The one path that needs exact structured output is the **autonomous code-writer's terminal write** — `code_writer` asks the model for the file contents as a JSON array and feeds them to `commit-files`. On flat-cyborg the terminal's line-wrapping mangles that JSON (`Expecting ',' delimiter` / `Invalid control character`), so the branch is created and committed-to but the commit fails. (Observed end-to-end in the [#1117](https://github.com/Replikanti/agentis-colonies/issues/1117) first live run; switching the backend to `claude -p` produced correct committed code immediately.)
+
+**So: run code-generation-capable autonomous runs on the fidelity backend.** Set in `<fed>/.agentis/config`:
+
+```
+llm.backend = claude
+llm.command = claude
+llm.args    = -p
+```
+
+`claude -p` is the metered (per-token) Claude CLI print mode — clean stdout, proper JSON escaping, no screen-scrape. Keep **flat-cyborg as the default** for the prose-only observe/suggest workflow (flat-rate subscription); switch to `claude -p` when you want the implementation colony to actually write code and open PRs. A true per-agent backend (flat-cyborg for prose agents + `claude -p` for `code_writer` in the *same* run) needs an agentis-core per-agent/per-prompt backend override and is tracked as an upstream dependency.
+
 ## LLM backend (per-colony override, [#319](https://github.com/Replikanti/agentis-colonies/issues/319))
 
 Every agent reads its LLM backend from `<fed>/.agentis/config` by default — that is the federation-wide pin written by `install.sh` step 4 (one of `cli` / `http` / `mock`). A colony can pin its own backend via an optional `[llm]` block in `<colony>/config/colony.toml`:

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -270,6 +270,12 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                     let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json) + repo_arg(owner, repo);
                     let commit_result = try { exec sh commit_cmd; } catch e {
                         print("[code_writer] Commit failed:", e);
+                        // #1152: a recurring cause is an unparseable --actions JSON.
+                        // Code generation is fidelity-critical: a TUI screen-scrape
+                        // backend (flat-cyborg) corrupts the structured JSON of file
+                        // contents. Run code-gen on the metered `claude -p` backend
+                        // (see README "Code-generation fidelity"), not flat-cyborg.
+                        print("[code_writer] hint: if this is an '--actions JSON' parse error, code-gen needs a fidelity backend (claude -p), not the flat-cyborg screen-scrape — see README");
                         "";
                     };
 


### PR DESCRIPTION
Closes #1152.

flat-cyborg's `--extract` is a TUI screen-scrape — clean for **prose** (observe/suggest/review), but it corrupts the **fidelity-critical structured JSON** the autonomous `code_writer` feeds to `commit-files`, so the branch commits but the file-contents commit fails (`Expecting ',' delimiter` / control chars). Observed end-to-end in the #1117 first live run; switching to `claude -p` produced correct committed code.

## Change (colony-implementable part)
- **README** LLM-backend section: new **"Code-generation fidelity"** subsection — documents the constraint and the fix: run code-generation-capable autonomous runs on the metered `claude -p` backend (`llm.command = claude` / `llm.args = -p`), keep flat-cyborg as the default for the prose-only workflow.
- **code_writer.ag**: prints a fidelity-backend hint on a commit failure so an `--actions JSON` parse error is legible.

## Upstream dependency (not colony-fixable)
A true **per-agent** backend (flat-cyborg for prose agents + `claude -p` for `code_writer` in the *same* run) needs an agentis-core per-agent/per-prompt backend override — there is no per-agent `llm.command` today (`.agentis/config` is federation-wide; the colony `[llm]` block is inert per #351, and an `exec sh claude -p` escape hatch is unreliable on the stripped `exec.env_passthrough` PATH). Documented as the upstream ask.

## Verification
- colony-lint: **419 passed, 0 failed, 5 skipped** (code_writer.ag parses; README markdown links resolve).
- No `prompt()` / tier / exec change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)