### PR TITLE
fix(trading-binance): add :z to run-replay /repo + /run-root mounts — SELinux boot fail (#1159)

### DIFF
--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -14,6 +14,17 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Fixed
+
+- `tools/run-replay.sh` now adds the `:z` SELinux relabel suffix to the
+  `/repo` and `/run-root` bind mounts (the `~/.claude` mount already had it).
+  Without it, on an SELinux-enforcing host (Fedora/RHEL) the `replay-laptop`
+  container cannot read the bind-mounted `bootstrap.sh` / `candles.csv` and
+  dies at boot with `Permission denied` (exit 126); the orchestrator then
+  loops `can only create exec sessions on running containers`. `:z` is a
+  no-op on SELinux-disabled hosts. `tools/test-run-replay.sh` asserts both
+  mounts carry `:z` (#1159).
+
 ### Added
 
 - Deterministic **momentum/breakout** backtest under the #1148 R-multiple

--- a/trading-binance/tools/run-replay.sh
+++ b/trading-binance/tools/run-replay.sh
@@ -444,13 +444,17 @@ spawn_container() {
     # trailing space inside CLAUDE_MOUNT_FLAG keeps the openai path
     # byte-identical (the flag collapses to empty). `:z` requests a shared
     # SELinux relabel — required on SELinux-enforcing hosts (Fedora/RHEL),
-    # a no-op on SELinux-disabled hosts (Ubuntu/Debian) (#540).
+    # a no-op on SELinux-disabled hosts (Ubuntu/Debian) (#540). All three
+    # bind mounts (/repo, /run-root, ~/.claude) carry `:z`: without it the
+    # container's SELinux context cannot read the bind-mounted bootstrap.sh /
+    # candles.csv and the container dies at boot with "Permission denied"
+    # (exit 126) on an enforcing host (#1159).
     CLAUDE_MOUNT_FLAG=""
     if [ "$LLM_BACKEND" = "flat-cyborg" ] || [ "$LLM_BACKEND" = "flat_cyborg" ]; then
         CLAUDE_MOUNT_FLAG="-v $HOST_CLAUDE_DIR:/root/.claude:rw,z "
     fi
     emit_step "spawning replay-laptop container (image=$IMAGE_TAG)"
-    emit_cmd "podman run -d --replace --name replay-laptop -e $OPENAI_KEY_ENV=\"\${$OPENAI_KEY_ENV:-}\" -v $REPO_ROOT:/repo:ro -v $LAPTOP_DIR:/run-root:rw ${CLAUDE_MOUNT_FLAG}$IMAGE_TAG /run-root/bootstrap.sh"
+    emit_cmd "podman run -d --replace --name replay-laptop -e $OPENAI_KEY_ENV=\"\${$OPENAI_KEY_ENV:-}\" -v $REPO_ROOT:/repo:ro,z -v $LAPTOP_DIR:/run-root:rw,z ${CLAUDE_MOUNT_FLAG}$IMAGE_TAG /run-root/bootstrap.sh"
 }
 
 # --- 5) Cleanup trap ---

--- a/trading-binance/tools/test-run-replay.sh
+++ b/trading-binance/tools/test-run-replay.sh
@@ -218,6 +218,14 @@ assert_contains "12. bootstrap-script generation step emitted" "$OUT" \
     "generating bootstrap script"
 assert_contains "13. container spawn command emitted via echo prefix" "$OUT" \
     "+ podman run -d --replace --name replay-laptop"
+# #1159: /repo and /run-root bind mounts carry the `:z` SELinux relabel suffix,
+# else the container cannot read bootstrap.sh/candles.csv on an enforcing host
+# and dies at boot with "Permission denied" (exit 126). Asserted on the default
+# (flat-cyborg) capture; the suffix is backend-independent.
+assert_contains "13a. /repo mount carries :z (SELinux relabel)" "$OUT" \
+    ":/repo:ro,z"
+assert_contains "13b. /run-root mount carries :z (SELinux relabel)" "$OUT" \
+    ":/run-root:rw,z"
 assert_contains "14. run-meta.json write step emitted" "$OUT" \
     "writing run-meta.json"
 assert_contains "15. cleanup trap installed" "$OUT" \


### PR DESCRIPTION
## Summary

On an **SELinux-enforcing** host (Fedora/RHEL) a real `bash tools/run-replay.sh` boots the `replay-laptop` container which immediately dies — blocking the 6-tribe LLM evolutionary search:

```
/bin/bash: /run-root/bootstrap.sh: Permission denied   (exit 126)
... can only create exec sessions on running containers: container state improper
```

`bootstrap.sh` is `0755` and readable on the host — the denial is **SELinux**. `spawn_container()` bind-mounted `-v $REPO_ROOT:/repo:ro` and `-v $LAPTOP_DIR:/run-root:rw` **without** a relabel suffix, so the container's SELinux context could not read them. The `~/.claude` flat-cyborg mount already carried `:z`; the pre-existing `/repo` + `/run-root` mounts did not.

## Fix

Add `:z` (shared relabel, matching the existing `~/.claude:rw,z`) to both mounts:
- `-v $REPO_ROOT:/repo:ro` → `-v $REPO_ROOT:/repo:ro,z`
- `-v $LAPTOP_DIR:/run-root:rw` → `-v $LAPTOP_DIR:/run-root:rw,z`

`:z` is a no-op on SELinux-disabled hosts (Ubuntu/Debian).

## Verification

- **Confirmed cause**: `getenforce` = Enforcing; a manual `podman run` with `:z` added to both mounts reads `bootstrap.sh` + `candles.csv` and runs `agentis v1.19.0` (without `:z` → the exact `Permission denied` boot death above).
- `bash tools/run-replay.sh --dry-run` now emits `:z` on all three mounts (`:/repo:ro,z`, `:/run-root:rw,z`, `:/root/.claude:rw,z`).
- `tools/test-run-replay.sh` → **41 passed, 0 failed** (added 13a/13b asserting both mounts carry `:z`).
- `./tools/colony-lint.sh` → **419 passed, 0 failed**, 5 skipped.

## Note

The sibling container orchestrators (`tribes-bench/tools/run-stage3-docker.sh`, `research-foundry/tools/run-research.sh`) likely have the same `:z` gap on their `/repo` + `/run-root` mounts — out of scope here; follow-up if they're run on SELinux.

Closes #1159.
