### PR TITLE
fix(trading-binance): strategist JSON-only directive + flat-cyborg JSON unwrap (#1163)

### DIFF
--- a/dev-apprenticeship/BUNDLE.manifest
+++ b/dev-apprenticeship/BUNDLE.manifest
@@ -77,6 +77,9 @@ tools/completion-gate.sh
 # Default CLI LLM backend (#1131): flat-cyborg PTY wrapper over Claude Code.
 # install.sh §6 resolves and wires it as `llm.command` in <fed>/.agentis/config.
 tools/flat-cyborg-claude.sh
+# #1163: the wrapper invokes this at runtime to unwrap JSON-shaped replies that
+# --extract-structural's TUI screen-scrape line-wrapped (newline inside JSON).
+tools/flat-cyborg-unwrap.py
 
 # ----- Federation dashboard -----
 # Extracted to a separately-versioned standalone component in #252.

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -33,6 +33,14 @@ is asserted until multi-version CI is in place.
 
 ### Fixed
 
+- **Shared `tools/flat-cyborg-claude.sh` wrapper now unwraps JSON-shaped replies**
+  (#1163). `--extract-structural` is a TUI screen-scrape, so claude's TUI
+  line-wraps long output and injects newline+indent INSIDE a JSON string,
+  breaking any `prompt() -> <struct>` decode. The wrapper post-processes the
+  extracted reply through `tools/flat-cyborg-unwrap.py`: a reply that is a single
+  `{…}` object has its soft-wrap whitespace collapsed to one line; every other
+  reply (the prose the observe / suggest / review workflow relies on) passes
+  through byte-for-byte. flat-cyborg's exit status is still propagated unchanged.
 - **`implementation` code_writer -> commit_composer MR handoff is now durable**
   (#1151). The handoff used to depend on commit_composer catching the transient
   `implementation:code_draft` bus event inside a 100ms `listen()` window; when

--- a/tools/flat-cyborg-claude.sh
+++ b/tools/flat-cyborg-claude.sh
@@ -20,6 +20,7 @@
 #
 # Knobs (env vars): FLAT_CYBORG_IDLE_MS, FLAT_CYBORG_TIMEOUT_MS.
 set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROMPT="${1:-}"
 if [ -z "$PROMPT" ]; then PROMPT="$(cat)"; fi
 # --wrap-input 72: fold the (often single-line, ~700-char) instruction block so it
@@ -30,7 +31,29 @@ if [ -z "$PROMPT" ]; then PROMPT="$(cat)"; fi
 # in HARNESS_ERROR. Structural mode completes on a SETTLED screen and recovers the
 # reply marker-first -> structural-fallback (fast + marker-less-tolerant); a reply that
 # DOES carry the markers is extracted exactly as before.
-exec flat-cyborg --extract --extract-structural --no-jitter --auto-approve --wrap-input 72 \
+# JSON-shaped-reply unwrap (#1163): --extract-structural is a TUI screen-scrape,
+# so claude's TUI LINE-WRAPS long output, injecting newline+indent INSIDE a JSON
+# string and breaking the JSON the caller decodes. Post-process the extracted
+# reply through tools/flat-cyborg-unwrap.py: when the trimmed reply is a single
+# JSON object (`{…}`) it collapses soft-wrap whitespace to one line; any other
+# reply (prose/code/markdown from non-JSON consumers) passes through
+# byte-for-byte. The filter only ever fires on `{…}`-shaped replies, so prose
+# consumers are safe.
+#
+# We do NOT pipe directly (POSIX sh / dash has no `pipefail` and no PIPESTATUS):
+# capture flat-cyborg's stdout to a temp file AND its exit status first,
+# propagate that status unchanged (a flat-cyborg failure must still reach the
+# agentis caller as before), then feed the captured reply through the unwrap
+# filter. A temp file (not `$(...)`) preserves the reply's bytes exactly,
+# including any trailing newline, so prose consumers stay byte-identical.
+REPLY_FILE="$(mktemp)"
+trap 'rm -f "$REPLY_FILE"' EXIT
+set +e
+flat-cyborg --extract --extract-structural --no-jitter --auto-approve --wrap-input 72 \
   --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" \
   --timeout-ms "${FLAT_CYBORG_TIMEOUT_MS:-180000}" \
-  --cmd "$PROMPT" -- claude
+  --cmd "$PROMPT" -- claude > "$REPLY_FILE"
+FC_RC=$?
+set -e
+[ "$FC_RC" -eq 0 ] || exit "$FC_RC"
+python3 "$SCRIPT_DIR/flat-cyborg-unwrap.py" < "$REPLY_FILE"

--- a/tools/flat-cyborg-unwrap.py
+++ b/tools/flat-cyborg-unwrap.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# tools/flat-cyborg-unwrap.py (#1163): post-process a flat-cyborg --extract
+# reply so a JSON-shaped reply that flat-cyborg's --extract-structural
+# screen-scrape LINE-WRAPPED (the TUI folds long output, injecting
+# newline+indent INSIDE the JSON string) parses again.
+#
+# Heuristic (safe, narrow): only fires when the trimmed reply looks like a
+# single JSON object — it starts with `{` AND ends with `}`. In that case any
+# run of `\s*\n\s*` (a soft TUI line-wrap + indent) collapses to one space, so
+# the JSON lands on one line. Anything else (prose, code, markdown, multi-line
+# explanations from other federations) passes through BYTE-FOR-BYTE unchanged,
+# so prose consumers are untouched.
+#
+# Shared by tools/flat-cyborg-claude.sh (the live wrapper pipes stdout through
+# this) and tools/test-flat-cyborg-claude.sh (the unit test exercises this same
+# file), so the wrapper and test can never drift apart.
+import re
+import sys
+
+s = sys.stdin.read()
+t = s.strip()
+if t.startswith("{") and t.endswith("}"):
+    sys.stdout.write(re.sub(r"\s*\n\s*", " ", t))
+else:
+    sys.stdout.write(s)

--- a/tools/test-flat-cyborg-claude.sh
+++ b/tools/test-flat-cyborg-claude.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# tools/test-flat-cyborg-claude.sh (#1163): unit-test the JSON-shaped-reply
+# UNWRAP LOGIC only. We do NOT invoke flat-cyborg or claude (they need the
+# binary + a logged-in ~/.claude). Instead we exercise the SAME filter the live
+# wrapper pipes its reply through — tools/flat-cyborg-unwrap.py — so the wrapper
+# and this test can never drift apart.
+#
+# Background (#1163): on the flat-rate flat-cyborg path, claude's
+# --extract-structural screen-scrape LINE-WRAPS long TUI output, injecting
+# newline+indent INSIDE a JSON string, so the strategist's Decision JSON failed
+# to parse. The wrapper now collapses soft-wrap whitespace, but ONLY for replies
+# that look like a single JSON object — prose/code replies from other federations
+# must pass through byte-for-byte.
+#
+# Cases:
+#   1. A JSON object with an embedded `\n  ` soft-wrap collapses to one line and
+#      stays valid JSON (parseable, fields intact).
+#   2. A JSON object already on one line is returned unchanged-but-valid.
+#   3. A multi-line prose reply (not `{…}`-shaped) passes through byte-for-byte.
+#
+# Auto-discovered by tools/colony-lint.sh's tools-test loop. Exit 0 if all pass.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UNWRAP="$SCRIPT_DIR/flat-cyborg-unwrap.py"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[SKIP] test-flat-cyborg-claude.sh: python3 not on PATH"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (skipped)"
+    exit 0
+fi
+if [ ! -f "$UNWRAP" ]; then
+    fail "missing filter: $UNWRAP"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# Run the real unwrap filter on stdin given as $1. Output captured verbatim.
+unwrap() {
+    printf '%s' "$1" | python3 "$UNWRAP"
+}
+
+# --- Test 1: JSON object with embedded soft-wrap collapses to one valid line --
+# The TUI folded the `rationale` value across two screen rows, injecting a
+# newline + two-space indent inside the string. The filter must collapse it.
+WRAPPED_JSON='{"action":"LONG","size":0.5,"rationale":"price bounced from VAL with
+  rising volume on the retest","setup":"volume_profile"}'
+OUT1="$(unwrap "$WRAPPED_JSON")"
+# (a) result is a single line.
+LINES1="$(printf '%s' "$OUT1" | wc -l | tr -d ' ')"
+# (b) result parses as JSON and the fields survive intact.
+if [ "$LINES1" = "0" ] && printf '%s' "$OUT1" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+assert d["action"] == "LONG", d.get("action")
+assert d["size"] == 0.5, d.get("size")
+assert d["setup"] == "volume_profile", d.get("setup")
+# the soft-wrap newline+indent collapsed to a single space inside the string.
+assert d["rationale"] == "price bounced from VAL with rising volume on the retest", repr(d["rationale"])
+' >/dev/null 2>&1; then
+    pass "test 1: embedded soft-wrap JSON collapses to one valid line, fields intact"
+else
+    fail "test 1: embedded soft-wrap JSON collapses to one valid line, fields intact" \
+         "out=[$OUT1] lines=$LINES1"
+fi
+
+# --- Test 2: single-line JSON returned unchanged-but-valid -------------------
+ONELINE_JSON='{"action":"FLAT","size":0.0,"rationale":"mid range","setup":"volume_profile"}'
+OUT2="$(unwrap "$ONELINE_JSON")"
+if [ "$OUT2" = "$ONELINE_JSON" ] && printf '%s' "$OUT2" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+assert d["action"] == "FLAT", d.get("action")
+assert d["size"] == 0.0, d.get("size")
+' >/dev/null 2>&1; then
+    pass "test 2: already-one-line JSON returned unchanged and still valid"
+else
+    fail "test 2: already-one-line JSON returned unchanged and still valid" \
+         "out=[$OUT2]"
+fi
+
+# --- Test 3: multi-line prose passes through byte-for-byte -------------------
+# A reply that is not `{…}`-shaped (prose / markdown / explanation from another
+# federation) must be returned exactly as received — newlines preserved.
+PROSE="Here is my analysis:
+
+- The market is ranging.
+- I would wait for a breakout.
+
+No trade right now."
+OUT3="$(unwrap "$PROSE")"
+if [ "$OUT3" = "$PROSE" ]; then
+    pass "test 3: multi-line prose passes through byte-for-byte (no JSON unwrap)"
+else
+    fail "test 3: multi-line prose passes through byte-for-byte (no JSON unwrap)" \
+         "out=[$OUT3]"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,19 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Fixed
 
+- The 6 replay strategists (`tribe-{alpha,beta,gamma,delta,epsilon,zeta}/agents/strategist.ag`)
+  now append a strict JSON-only output directive (`_output_format_directive()`)
+  at the `prompt() -> Decision` call site, OUTSIDE the evolvable prompt body so
+  M98 prompt-evolution cannot drop it. On the flat-rate flat-cyborg path claude
+  was writing verbose analysis prose before any JSON, so the Decision reply
+  failed to parse with `unexpected character N`. The shared
+  `tools/flat-cyborg-claude.sh` wrapper additionally post-processes JSON-shaped
+  replies through `tools/flat-cyborg-unwrap.py`: when a reply is a single
+  `{…}` object it collapses the soft-wrap whitespace that
+  `--extract-structural`'s TUI screen-scrape injects INSIDE the JSON string
+  (newline+indent from line-wrapping), so the JSON parses again; prose/code
+  replies pass through byte-for-byte. `tools/test-flat-cyborg-claude.sh` covers
+  the unwrap logic (#1163).
 - `tools/run-replay.sh` container flat-cyborg path now bind-mounts the
   host-level `~/.claude.json` (onboarding/oauth state) into
   `/root/.claude.json` alongside the existing `~/.claude` dir, and routes

--- a/trading-binance/tribe-alpha/agents/strategist.ag
+++ b/trading-binance/tribe-alpha/agents/strategist.ag
@@ -74,6 +74,15 @@ fn _variant_overlay_suffix() -> string {
     return "";
 }
 
+// #1163: a strict JSON-only output directive appended at the prompt() call
+// site (OUTSIDE the evolvable prompt body so M98 prompt-evolution cannot drop
+// it). On the flat-rate flat-cyborg path claude writes verbose analysis prose
+// before any JSON -> 'unexpected character N' parse error; this forces a
+// single-line minified Decision object and nothing else.
+fn _output_format_directive() -> string {
+    return "\n\nOUTPUT FORMAT (critical): Reply with ONLY a single-line minified JSON object and nothing else — no analysis, no reasoning, no preamble, no markdown, no code fence. Your entire reply must be exactly one line of the form {\"action\":\"LONG|SHORT|FLAT\",\"size\":<float 0.0-1.0>,\"rationale\":\"<one short sentence>\",\"setup\":\"<the exact setup string from your instructions>\"}";
+}
+
 // #520 M98 v3 PR 3/3: hash-pointer extraction over the M106 wire.
 fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
@@ -345,7 +354,7 @@ fn tick(reason: string) -> void {
     };
 
     let decision = prompt(
-        prompt_text + _variant_overlay_suffix(),
+        prompt_text + _variant_overlay_suffix() + _output_format_directive(),
         candles_csv
     ) -> Decision;
 

--- a/trading-binance/tribe-beta/agents/strategist.ag
+++ b/trading-binance/tribe-beta/agents/strategist.ag
@@ -74,6 +74,15 @@ fn _variant_overlay_suffix() -> string {
     return "";
 }
 
+// #1163: a strict JSON-only output directive appended at the prompt() call
+// site (OUTSIDE the evolvable prompt body so M98 prompt-evolution cannot drop
+// it). On the flat-rate flat-cyborg path claude writes verbose analysis prose
+// before any JSON -> 'unexpected character N' parse error; this forces a
+// single-line minified Decision object and nothing else.
+fn _output_format_directive() -> string {
+    return "\n\nOUTPUT FORMAT (critical): Reply with ONLY a single-line minified JSON object and nothing else — no analysis, no reasoning, no preamble, no markdown, no code fence. Your entire reply must be exactly one line of the form {\"action\":\"LONG|SHORT|FLAT\",\"size\":<float 0.0-1.0>,\"rationale\":\"<one short sentence>\",\"setup\":\"<the exact setup string from your instructions>\"}";
+}
+
 // #520 M98 v3 PR 3/3: hash-pointer extraction over the M106 wire.
 fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
@@ -345,7 +354,7 @@ fn tick(reason: string) -> void {
     };
 
     let decision = prompt(
-        prompt_text + _variant_overlay_suffix(),
+        prompt_text + _variant_overlay_suffix() + _output_format_directive(),
         candles_csv
     ) -> Decision;
 

--- a/trading-binance/tribe-delta/agents/strategist.ag
+++ b/trading-binance/tribe-delta/agents/strategist.ag
@@ -74,6 +74,15 @@ fn _variant_overlay_suffix() -> string {
     return "";
 }
 
+// #1163: a strict JSON-only output directive appended at the prompt() call
+// site (OUTSIDE the evolvable prompt body so M98 prompt-evolution cannot drop
+// it). On the flat-rate flat-cyborg path claude writes verbose analysis prose
+// before any JSON -> 'unexpected character N' parse error; this forces a
+// single-line minified Decision object and nothing else.
+fn _output_format_directive() -> string {
+    return "\n\nOUTPUT FORMAT (critical): Reply with ONLY a single-line minified JSON object and nothing else — no analysis, no reasoning, no preamble, no markdown, no code fence. Your entire reply must be exactly one line of the form {\"action\":\"LONG|SHORT|FLAT\",\"size\":<float 0.0-1.0>,\"rationale\":\"<one short sentence>\",\"setup\":\"<the exact setup string from your instructions>\"}";
+}
+
 // #520 M98 v3 PR 3/3: hash-pointer extraction over the M106 wire.
 fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
@@ -345,7 +354,7 @@ fn tick(reason: string) -> void {
     };
 
     let decision = prompt(
-        prompt_text + _variant_overlay_suffix(),
+        prompt_text + _variant_overlay_suffix() + _output_format_directive(),
         candles_csv
     ) -> Decision;
 

--- a/trading-binance/tribe-epsilon/agents/strategist.ag
+++ b/trading-binance/tribe-epsilon/agents/strategist.ag
@@ -74,6 +74,15 @@ fn _variant_overlay_suffix() -> string {
     return "";
 }
 
+// #1163: a strict JSON-only output directive appended at the prompt() call
+// site (OUTSIDE the evolvable prompt body so M98 prompt-evolution cannot drop
+// it). On the flat-rate flat-cyborg path claude writes verbose analysis prose
+// before any JSON -> 'unexpected character N' parse error; this forces a
+// single-line minified Decision object and nothing else.
+fn _output_format_directive() -> string {
+    return "\n\nOUTPUT FORMAT (critical): Reply with ONLY a single-line minified JSON object and nothing else — no analysis, no reasoning, no preamble, no markdown, no code fence. Your entire reply must be exactly one line of the form {\"action\":\"LONG|SHORT|FLAT\",\"size\":<float 0.0-1.0>,\"rationale\":\"<one short sentence>\",\"setup\":\"<the exact setup string from your instructions>\"}";
+}
+
 // #520 M98 v3 PR 3/3: hash-pointer extraction over the M106 wire.
 fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
@@ -345,7 +354,7 @@ fn tick(reason: string) -> void {
     };
 
     let decision = prompt(
-        prompt_text + _variant_overlay_suffix(),
+        prompt_text + _variant_overlay_suffix() + _output_format_directive(),
         candles_csv
     ) -> Decision;
 

--- a/trading-binance/tribe-gamma/agents/strategist.ag
+++ b/trading-binance/tribe-gamma/agents/strategist.ag
@@ -74,6 +74,15 @@ fn _variant_overlay_suffix() -> string {
     return "";
 }
 
+// #1163: a strict JSON-only output directive appended at the prompt() call
+// site (OUTSIDE the evolvable prompt body so M98 prompt-evolution cannot drop
+// it). On the flat-rate flat-cyborg path claude writes verbose analysis prose
+// before any JSON -> 'unexpected character N' parse error; this forces a
+// single-line minified Decision object and nothing else.
+fn _output_format_directive() -> string {
+    return "\n\nOUTPUT FORMAT (critical): Reply with ONLY a single-line minified JSON object and nothing else — no analysis, no reasoning, no preamble, no markdown, no code fence. Your entire reply must be exactly one line of the form {\"action\":\"LONG|SHORT|FLAT\",\"size\":<float 0.0-1.0>,\"rationale\":\"<one short sentence>\",\"setup\":\"<the exact setup string from your instructions>\"}";
+}
+
 // #520 M98 v3 PR 3/3: hash-pointer extraction over the M106 wire.
 fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
@@ -345,7 +354,7 @@ fn tick(reason: string) -> void {
     };
 
     let decision = prompt(
-        prompt_text + _variant_overlay_suffix(),
+        prompt_text + _variant_overlay_suffix() + _output_format_directive(),
         candles_csv
     ) -> Decision;
 

--- a/trading-binance/tribe-zeta/agents/strategist.ag
+++ b/trading-binance/tribe-zeta/agents/strategist.ag
@@ -74,6 +74,15 @@ fn _variant_overlay_suffix() -> string {
     return "";
 }
 
+// #1163: a strict JSON-only output directive appended at the prompt() call
+// site (OUTSIDE the evolvable prompt body so M98 prompt-evolution cannot drop
+// it). On the flat-rate flat-cyborg path claude writes verbose analysis prose
+// before any JSON -> 'unexpected character N' parse error; this forces a
+// single-line minified Decision object and nothing else.
+fn _output_format_directive() -> string {
+    return "\n\nOUTPUT FORMAT (critical): Reply with ONLY a single-line minified JSON object and nothing else — no analysis, no reasoning, no preamble, no markdown, no code fence. Your entire reply must be exactly one line of the form {\"action\":\"LONG|SHORT|FLAT\",\"size\":<float 0.0-1.0>,\"rationale\":\"<one short sentence>\",\"setup\":\"<the exact setup string from your instructions>\"}";
+}
+
 // #520 M98 v3 PR 3/3: hash-pointer extraction over the M106 wire.
 fn _extract_pp_hash(variant_tag: string) -> string {
     if len(variant_tag) < 67 { return ""; };
@@ -345,7 +354,7 @@ fn tick(reason: string) -> void {
     };
 
     let decision = prompt(
-        prompt_text + _variant_overlay_suffix(),
+        prompt_text + _variant_overlay_suffix() + _output_format_directive(),
         candles_csv
     ) -> Decision;
 


### PR DESCRIPTION
## Summary

Make the flat-rate (flat-cyborg) replay strategists' `prompt() -> Decision` parse reliably by fixing two flat-cyborg **screen-scrape fidelity** problems. Closes the JSON-fidelity wall from #1163 (follow-up to #1161).

1. **Verbose prose.** The volume-profile prompt led `claude` to emit reasoning before the JSON → `unexpected character 'N'`. New `_output_format_directive()` helper appends a strict *"reply with ONLY a single-line minified JSON object, no analysis/preamble/markdown"* directive at the `prompt()` call site — **outside** the evolvable prompt body so M98 prompt-evolution can't drop it. Identical edit across all 6 tribes (alpha..zeta).
2. **TUI soft-wrap.** `flat-cyborg --extract-structural` scrapes `claude`'s TUI, which line-wraps long output, injecting `\n`+indent **inside** the JSON string → invalid JSON. New `tools/flat-cyborg-unwrap.py`: when the trimmed reply is a single `{…}` object, collapse soft-wrap whitespace to one line; otherwise pass through unchanged (prose consumers — dev-apprenticeship / dark-factory — untouched). `flat-cyborg-claude.sh` pipes the extracted reply through it, preserving flat-cyborg's exit status (POSIX/dash-safe temp-file + `$?` propagation; no `pipefail`/`PIPESTATUS`).

## Validated (in-container)

The full wrapper now returns **clean, valid Decision JSON** for the complete strategist prompt: a FLAT decision whose multi-clause rationale the raw scrape had wrapped across 3 lines parses correctly after unwrap (confirmed end-to-end via the wrapper, rc 0). `flat-cyborg-unwrap.py` also fixes a captured real raw reply → valid JSON.

- `tools/test-flat-cyborg-claude.sh` → **3/3** (embedded-soft-wrap JSON collapses to one valid line; one-line JSON unchanged; multi-line prose passes through byte-for-byte).
- `./tools/colony-lint.sh` → **420 passed, 0 failed**, 5 skipped. `test-run-replay.sh` 45/45. `test-make-federation-bundle.sh` 11/11. All 6 strategists parse via `agentis commit`.
- `flat-cyborg-unwrap.py` added to `dev-apprenticeship/BUNDLE.manifest` (the bundled wrapper now invokes it).

## ⚠️ Scope note

Proven for **single well-formed calls**. The full 6-tribe **concurrent** run (6 `claude` TUIs scraped at once) is being measured separately — flat-cyborg's screen-scrape is timing-sensitive under concurrency (`idle_ms`), the same #1152 fidelity limit. Tunable via `FLAT_CYBORG_IDLE_MS`, or fall back to metered `claude -p` for guaranteed structured-output reliability. This PR is the correct, tested prerequisite that makes the flat-rate path produce parseable decisions for well-formed prompts.

Part of #1163.
