### PR TITLE
feat(trading-binance): claude-p replay backend — clean flat-rate structured output, fixes the 6-tribe run (#1163)

### DIFF
--- a/tools/claude-p.sh
+++ b/tools/claude-p.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+# claude-p.sh — agentis llm.command backend that drives Claude Code in
+# PRINT mode (`claude -p`). Non-interactive => clean single-shot stdout
+# (no TUI screen-scrape, no line-wrap), billed against the flat-rate Claude
+# subscription (same ~/.claude creds as interactive). Used by the
+# trading-binance replay because flat-cyborg's --extract-structural scrape
+# is unreliable for the strategist's structured JSON (#1163; cf #1152
+# which routed code-gen to claude -p for the same fidelity reason).
+# Prompt from "$1", falling back to stdin; reply on stdout.
+set -eu
+PROMPT="${1:-}"
+if [ -z "$PROMPT" ]; then PROMPT="$(cat)"; fi
+exec claude -p "$PROMPT"

--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -53,6 +53,27 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- `tools/claude-p.sh` — a `claude-p` (Claude Code PRINT mode) LLM backend for
+  the replay. `claude -p "<prompt>"` is non-interactive, so it returns clean
+  single-shot stdout JSON (no TUI, no line-wrap) and bills against the SAME
+  flat-rate Claude subscription as interactive (same `~/.claude` creds, NOT
+  the metered API). `tools/run-replay.sh` now defaults `REPLAY_LLM_BACKEND`
+  to `claude-p` (was `flat-cyborg`): flat-cyborg's `--extract-structural` TUI
+  screen-scrape is unreliable for the strategist's structured Decision JSON —
+  the 6-tribe daemon replay parsed 0% of replies — so screen-scrape is no
+  longer the default. `claude-p` and `flat-cyborg` are both subscription-claude
+  backends (`CONFIG_BACKEND=claude`): they share the `~/.claude` +
+  `~/.claude.json` bind-mounts and the host-credential pre-flight, differing
+  ONLY in which wrapper `llm.command` points at
+  (`/repo/tools/claude-p.sh` vs `/repo/tools/flat-cyborg-claude.sh`).
+  flat-cyborg (`REPLAY_LLM_BACKEND=flat-cyborg`) and openai
+  (`REPLAY_LLM_BACKEND=openai`) stay available as opt-in alternatives.
+  `tools/test-run-replay.sh` asserts the default capture names `claude-p`,
+  wires `llm.command = /repo/tools/claude-p.sh`, and mounts both
+  `~/.claude` + `~/.claude.json`, with a flat-cyborg-explicit regression
+  capture and the openai regression kept green (consistent with #1152, which
+  routed code-gen to `claude -p` for the same fidelity reason) (#1163).
+
 - Deterministic **momentum/breakout** backtest under the #1148 R-multiple
   exits over the real 90-day BTCUSDT 1h window (2026-03-01 → 2026-05-31),
   recorded under `runs/20260619T-momentum-rmultiple/`

--- a/trading-binance/tools/run-replay.sh
+++ b/trading-binance/tools/run-replay.sh
@@ -30,8 +30,24 @@
 #                                in 36s wall clock. Default: 100
 #   REPLAY_DAEMON_COUNT          Number of strategist daemons to spawn.
 #                                Default: 6
-#   REPLAY_LLM_BACKEND           llm.backend value injected into hermetic
-#                                config. Default: flat-cyborg
+#   REPLAY_LLM_BACKEND           Which LLM backend the hermetic config
+#                                drives. Default: claude-p — Claude Code in
+#                                PRINT mode (`claude -p` via
+#                                tools/claude-p.sh): non-interactive, clean
+#                                single-shot stdout JSON, billed against the
+#                                flat-rate Claude subscription. The default
+#                                changed from flat-cyborg because its
+#                                --extract-structural TUI screen-scrape is
+#                                unreliable for the strategist's structured
+#                                JSON (#1163). Alternatives (opt-in):
+#                                flat-cyborg (interactive Claude via the
+#                                flat-cyborg PTY wrapper) and openai (metered
+#                                OpenRouter/Chat-Completions). claude-p and
+#                                flat-cyborg are both subscription-claude
+#                                backends (CONFIG_BACKEND=claude); they share
+#                                the ~/.claude + ~/.claude.json mounts and
+#                                pre-flight checks, differing only in which
+#                                wrapper llm.command points at.
 #   REPLAY_OPENAI_ENDPOINT       Chat-completions URL.
 #                                Default: https://openrouter.ai/api/v1/chat/completions
 #   REPLAY_OPENAI_MODEL          Model id when backend=openai.
@@ -44,12 +60,14 @@
 #   REPLAY_FLAT_CYBORG_IDLE_MS   flat-cyborg llm.flat_cyborg.idle_ms when
 #                                backend=flat-cyborg. Default: 4000
 #   REPLAY_HOST_CLAUDE_DIR       Host ~/.claude dir bind-mounted to
-#                                /root/.claude when backend=flat-cyborg.
+#                                /root/.claude on any subscription-claude
+#                                backend (claude-p or flat-cyborg).
 #                                Default: $HOME/.claude; a real run
 #                                requires it to exist.
 #   REPLAY_HOST_CLAUDE_JSON      Host ~/.claude.json file bind-mounted to
-#                                /root/.claude.json when backend=flat-cyborg
-#                                (claude onboarding/auth state).
+#                                /root/.claude.json on any subscription-claude
+#                                backend (claude-p or flat-cyborg);
+#                                claude onboarding/auth state.
 #                                Default: $HOME/.claude.json.
 #   REPLAY_DAEMON_CB_PER_TICK    Per-tick CB replenishment written into
 #                                hermetic .agentis/config as
@@ -163,7 +181,13 @@ START="${REPLAY_START:-}"
 END="${REPLAY_END:-}"
 SPEED="${REPLAY_SPEED:-100}"
 DAEMON_COUNT="${REPLAY_DAEMON_COUNT:-6}"
-LLM_BACKEND="${REPLAY_LLM_BACKEND:-flat-cyborg}"
+# Default backend is claude-p (Claude Code PRINT mode via tools/claude-p.sh):
+# non-interactive, clean single-shot stdout JSON, flat-rate Claude
+# subscription. flat-cyborg's --extract-structural TUI screen-scrape is
+# unreliable for the strategist's structured JSON (the 6-tribe replay parsed
+# 0% of Decision replies — #1163), so it is no longer the default. flat-cyborg
+# and openai stay available as opt-in REPLAY_LLM_BACKEND values.
+LLM_BACKEND="${REPLAY_LLM_BACKEND:-claude-p}"
 OPENAI_ENDPOINT="${REPLAY_OPENAI_ENDPOINT:-https://openrouter.ai/api/v1/chat/completions}"
 OPENAI_MODEL="${REPLAY_OPENAI_MODEL:-qwen/qwen3-coder-30b-a3b-instruct}"
 OPENAI_KEY_ENV="${REPLAY_OPENAI_KEY_ENV:-OPENROUTER_API_KEY}"
@@ -227,6 +251,20 @@ if [ "$DAEMON_COUNT" -lt 1 ]; then
     exit 2
 fi
 
+# A "subscription-claude" backend drives the operator's flat-rate Claude
+# subscription (NOT the metered openai path), so it needs the same hermetic
+# wiring: CONFIG_BACKEND=claude, the ~/.claude + ~/.claude.json bind-mounts,
+# and the host-side credential pre-flight. claude-p (Claude Code PRINT mode)
+# and flat-cyborg (interactive Claude via the PTY wrapper) differ ONLY in
+# which wrapper llm.command points at. Underscore aliases are accepted so the
+# env knob tolerates either separator.
+is_subscription_claude_backend() {
+    case "$1" in
+        claude-p|claude_p|flat-cyborg|flat_cyborg) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # Resolve DATA_DIR to absolute path (so we can pass it into containers /
 # helpers safely regardless of where the orchestrator is launched from).
 if [ -d "$DATA_DIR_RAW" ]; then
@@ -284,7 +322,7 @@ if [ "$DRY_RUN" = "0" ]; then
         fi
         unset openai_key_value
     fi
-    if [ "$LLM_BACKEND" = "flat-cyborg" ] || [ "$LLM_BACKEND" = "flat_cyborg" ]; then
+    if is_subscription_claude_backend "$LLM_BACKEND"; then
         if [ ! -d "$HOST_CLAUDE_DIR" ]; then
             echo "run-replay: REPLAY_HOST_CLAUDE_DIR=$HOST_CLAUDE_DIR does not exist" >&2
             echo "            set REPLAY_HOST_CLAUDE_DIR or install + log in to Claude Code first" >&2
@@ -376,16 +414,26 @@ write_bootstrap() {
         return
     fi
 
-    # #1161: the container flat-cyborg path runs through the
-    # tools/flat-cyborg-claude.sh wrapper (flat-cyborg --extract
-    # --extract-structural -- claude) under agentis's `claude` backend,
-    # because the native flat-cyborg backend's bare --extract can't
-    # scrape claude's TUI (intermittent sentinel omission -> exit 124).
+    # Both subscription-claude backends inject CONFIG_BACKEND=claude + an
+    # llm.command wrapper into the hermetic config; they differ ONLY in which
+    # wrapper llm.command points at:
+    #   claude-p     -> /repo/tools/claude-p.sh — Claude Code PRINT mode
+    #                   (`claude -p`): non-interactive, clean single-shot
+    #                   stdout JSON. Default, because flat-cyborg's
+    #                   --extract-structural TUI screen-scrape is unreliable
+    #                   for the strategist's structured JSON (#1163).
+    #   flat-cyborg  -> /repo/tools/flat-cyborg-claude.sh
+    #                   (flat-cyborg --extract --extract-structural -- claude):
+    #                   interactive Claude via the PTY wrapper (#1161, opt-in).
+    # The openai path keeps CONFIG_BACKEND="openai" and emits no llm.command.
     CONFIG_BACKEND="$LLM_BACKEND"
     LLM_COMMAND=""
-    if [ "$LLM_BACKEND" = "flat-cyborg" ] || [ "$LLM_BACKEND" = "flat_cyborg" ]; then
+    if is_subscription_claude_backend "$LLM_BACKEND"; then
         CONFIG_BACKEND="claude"
-        LLM_COMMAND="/repo/tools/flat-cyborg-claude.sh"
+        case "$LLM_BACKEND" in
+            claude-p|claude_p) LLM_COMMAND="/repo/tools/claude-p.sh" ;;
+            *)                 LLM_COMMAND="/repo/tools/flat-cyborg-claude.sh" ;;
+        esac
     fi
 
     {
@@ -422,11 +470,22 @@ write_bootstrap() {
             printf '  printf "llm.openai.model = %s\\n"\n' "$OPENAI_MODEL"
             printf '  printf "llm.openai.api_key_env = %s\\n"\n' "$OPENAI_KEY_ENV"
             printf '  printf "llm.openai.timeout_ms = %s\\n"\n' "$OPENAI_TIMEOUT_MS"
-        elif [ "$LLM_BACKEND" = "flat-cyborg" ] || [ "$LLM_BACKEND" = "flat_cyborg" ]; then
+        elif is_subscription_claude_backend "$LLM_BACKEND"; then
+            # Both claude-p and flat-cyborg run under CONFIG_BACKEND=claude and
+            # point llm.command at their wrapper (LLM_COMMAND, derived above).
             printf '  printf "llm.command = %s\\n"\n' "$LLM_COMMAND"
-            if [ -n "$FLAT_CYBORG_MODEL" ]; then
-                printf '  printf "llm.model = %s\\n"\n' "$FLAT_CYBORG_MODEL"
-            fi
+            # llm.model (the flat-cyborg model knob) is flat-cyborg-only; it
+            # has no meaning on the claude-p print-mode path. The native
+            # llm.flat_cyborg.idle_ms line is likewise NOT emitted here — both
+            # subscription-claude paths drive claude through a wrapper, not the
+            # native flat-cyborg backend.
+            case "$LLM_BACKEND" in
+                flat-cyborg|flat_cyborg)
+                    if [ -n "$FLAT_CYBORG_MODEL" ]; then
+                        printf '  printf "llm.model = %s\\n"\n' "$FLAT_CYBORG_MODEL"
+                    fi
+                    ;;
+            esac
         fi
         printf '} >> .agentis/config\n'
         printf 'for t in alpha beta gamma delta epsilon zeta; do\n'
@@ -459,26 +518,25 @@ write_bootstrap() {
 
 # --- 4) Spawn the container ---
 spawn_container() {
-    # #1133: on the flat-cyborg backend bind-mount the host operator's
-    # ~/.claude into the container's /root/.claude so the flat-cyborg PTY
-    # wrapper can drive the `claude` CLI on the operator's flat-rate
-    # subscription (mirrors the tribes-bench #535/#537 precedent).
+    # #1133: on any subscription-claude backend bind-mount the host operator's
+    # ~/.claude into the container's /root/.claude so the in-container `claude`
+    # CLI runs on the operator's flat-rate subscription (mirrors the
+    # tribes-bench #535/#537 precedent). Applies to BOTH claude-p (Claude Code
+    # PRINT mode, the default — #1163) and flat-cyborg (interactive Claude via
+    # the PTY wrapper — #1161).
     # #1161: BOTH ~/.claude (dir, credentials) AND ~/.claude.json (home-level
     # file, onboarding/oauth state) are bind-mounted — without the .json file
     # `claude` sits on the login menu (hasCompletedOnboarding/oauthAccount live
-    # there) and never replies. On this path the container drives claude via
-    # the tools/flat-cyborg-claude.sh wrapper (flat-cyborg --extract
-    # --extract-structural -- claude) under agentis's `claude` backend. The
-    # trailing space inside CLAUDE_MOUNT_FLAG keeps the openai path
-    # byte-identical (the flag collapses to empty). `:z` requests a shared
-    # SELinux relabel — required on SELinux-enforcing hosts (Fedora/RHEL),
-    # a no-op on SELinux-disabled hosts (Ubuntu/Debian) (#540). All bind
-    # mounts (/repo, /run-root, ~/.claude, ~/.claude.json) carry `:z`: without
-    # it the container's SELinux context cannot read the bind-mounted
+    # there) and never replies. The trailing space inside CLAUDE_MOUNT_FLAG
+    # keeps the openai path byte-identical (the flag collapses to empty). `:z`
+    # requests a shared SELinux relabel — required on SELinux-enforcing hosts
+    # (Fedora/RHEL), a no-op on SELinux-disabled hosts (Ubuntu/Debian) (#540).
+    # All bind mounts (/repo, /run-root, ~/.claude, ~/.claude.json) carry `:z`:
+    # without it the container's SELinux context cannot read the bind-mounted
     # bootstrap.sh / candles.csv and the container dies at boot with
     # "Permission denied" (exit 126) on an enforcing host (#1159).
     CLAUDE_MOUNT_FLAG=""
-    if [ "$LLM_BACKEND" = "flat-cyborg" ] || [ "$LLM_BACKEND" = "flat_cyborg" ]; then
+    if is_subscription_claude_backend "$LLM_BACKEND"; then
         CLAUDE_MOUNT_FLAG="-v $HOST_CLAUDE_DIR:/root/.claude:rw,z -v $HOST_CLAUDE_JSON:/root/.claude.json:rw,z "
     fi
     emit_step "spawning replay-laptop container (image=$IMAGE_TAG)"

--- a/trading-binance/tools/test-run-replay.sh
+++ b/trading-binance/tools/test-run-replay.sh
@@ -20,13 +20,18 @@
 #  13. Container spawn command is emitted in dry-run output (echo-only)
 #  14. Run-meta.json write step is emitted in dry-run output
 #  15. Cleanup trap is installed in dry-run output
-#  T-a. Default dry-run uses the flat-cyborg backend, bind-mounts
-#       /root/.claude, emits no OPENROUTER_API_KEY error, and the script
-#       source injects llm.flat_cyborg.idle_ms (#1133). The flat-cyborg path
-#       additionally routes through the tools/flat-cyborg-claude.sh wrapper
+#  T-a. Default dry-run uses the claude-p backend (Claude Code PRINT mode):
+#       names it in the plan, routes through the tools/claude-p.sh wrapper
 #       under agentis's `claude` backend (CONFIG_BACKEND="claude" +
-#       llm.command), and the spawn command bind-mounts /root/.claude.json
-#       (onboarding/oauth state) (#1161)
+#       llm.command=/repo/tools/claude-p.sh), bind-mounts BOTH /root/.claude
+#       AND /root/.claude.json, and emits no OPENROUTER_API_KEY error. The
+#       default flipped from flat-cyborg because its --extract-structural TUI
+#       screen-scrape is unreliable for the strategist's structured JSON
+#       (#1163; cf #1152). claude-p is clean single-shot stdout + flat-rate.
+#  T-fc. REPLAY_LLM_BACKEND=flat-cyborg (opt-in) regression: still names the
+#       flat-cyborg backend and still wires
+#       llm.command=/repo/tools/flat-cyborg-claude.sh under CONFIG_BACKEND=
+#       claude, bind-mounting both ~/.claude mounts (#1161 parity).
 #  T-b. REPLAY_LLM_BACKEND=openai fallback still names the openai backend,
 #       omits the /root/.claude AND /root/.claude.json mounts, and the script
 #       source keeps the llm.openai.api_key_env injection + the openai key
@@ -251,34 +256,61 @@ assert_contains "header documents REPLAY_LLM_BACKEND" "$SRC" "REPLAY_LLM_BACKEND
 assert_contains "header documents REPLAY_HOST_CLAUDE_DIR" "$SRC" "REPLAY_HOST_CLAUDE_DIR"
 
 # ---------------------------------------------------------------------------
-# T-a. Default backend is flat-cyborg: the default $OUT capture (no
-# REPLAY_LLM_BACKEND set) selects flat-cyborg, names it in the plan, bind-
-# mounts /root/.claude, never trips the openai key-empty hard-fail, and the
-# script source injects the llm.flat_cyborg.idle_ms hermetic-config line.
+# T-a. Default backend is claude-p (Claude Code PRINT mode): the default $OUT
+# capture (no REPLAY_LLM_BACKEND set) selects claude-p, names it in the plan,
+# routes through tools/claude-p.sh under agentis's `claude` backend
+# (CONFIG_BACKEND="claude" + llm.command=/repo/tools/claude-p.sh), bind-mounts
+# BOTH /root/.claude AND /root/.claude.json, and never trips the openai
+# key-empty hard-fail. The default flipped from flat-cyborg because its
+# --extract-structural TUI screen-scrape is unreliable for the strategist's
+# structured JSON (#1163).
 # ---------------------------------------------------------------------------
-assert_contains "T-a1. default backend is flat-cyborg" "$OUT" "llm backend: flat-cyborg"
-assert_contains "T-a2. flat-cyborg dry-run bind-mounts /root/.claude" "$OUT" \
+assert_contains "T-a1. default backend is claude-p" "$OUT" "llm backend: claude-p"
+assert_contains "T-a2. claude-p dry-run bind-mounts /root/.claude" "$OUT" \
     ":/root/.claude:rw,z"
 if printf '%s' "$OUT" | grep -Fq -- "OPENROUTER_API_KEY is empty"; then
-    echo "[FAIL] T-a3. flat-cyborg dry-run does not trip the openai key-empty fail"
+    echo "[FAIL] T-a3. claude-p dry-run does not trip the openai key-empty fail"
     FAIL=$((FAIL + 1))
 else
-    echo "[PASS] T-a3. flat-cyborg dry-run does not trip the openai key-empty fail"
+    echo "[PASS] T-a3. claude-p dry-run does not trip the openai key-empty fail"
     PASS=$((PASS + 1))
 fi
-assert_contains "T-a4. script source injects llm.flat_cyborg.idle_ms" "$SRC" \
-    "llm.flat_cyborg.idle_ms"
-# #1161: the container flat-cyborg path now runs through the
-# tools/flat-cyborg-claude.sh wrapper under agentis's `claude` backend (bare
-# --extract can't scrape claude's TUI). The generated hermetic config feeds
-# CONFIG_BACKEND (= "claude" on the flat-cyborg path) into llm.backend and
-# injects llm.command pointing at the wrapper; the spawn command additionally
+# The default claude-p path runs claude in PRINT mode (`claude -p`) via the
+# tools/claude-p.sh wrapper under agentis's `claude` backend: the generated
+# hermetic config feeds CONFIG_BACKEND (= "claude") into llm.backend and
+# injects llm.command pointing at /repo/tools/claude-p.sh; the spawn command
 # bind-mounts ~/.claude.json (onboarding/oauth state) into /root/.claude.json.
-assert_contains "T-a5. script source injects the flat-cyborg-claude.sh wrapper command" "$SRC" \
-    "flat-cyborg-claude.sh"
-assert_contains "T-a6. flat-cyborg path config backend is claude" "$SRC" \
+assert_contains "T-a4. script source wires the claude-p.sh wrapper command" "$SRC" \
+    "/repo/tools/claude-p.sh"
+assert_contains "T-a5. subscription-claude path config backend is claude" "$SRC" \
     'CONFIG_BACKEND="claude"'
-assert_contains "T-a7. flat-cyborg dry-run bind-mounts /root/.claude.json" "$OUT" \
+assert_contains "T-a6. claude-p dry-run bind-mounts /root/.claude.json" "$OUT" \
+    ":/root/.claude.json:rw,z"
+
+# ---------------------------------------------------------------------------
+# T-fc. flat-cyborg opt-in regression: REPLAY_LLM_BACKEND=flat-cyborg still
+# names the flat-cyborg backend in the plan, still wires
+# llm.command=/repo/tools/flat-cyborg-claude.sh under CONFIG_BACKEND=claude,
+# and still bind-mounts BOTH ~/.claude mounts. Keeps the #1161 path working
+# now that claude-p is the default.
+# ---------------------------------------------------------------------------
+FC_OUT="$(REPLAY_DRY_RUN=1 \
+          REPLAY_LLM_BACKEND=flat-cyborg \
+          REPLAY_SYMBOL=BTCUSDT \
+          REPLAY_TIMEFRAME=30m \
+          REPLAY_DAEMON_COUNT=5 \
+          REPLAY_LOOKBACK_WINDOW=200 \
+          REPLAY_HOLD_PERIOD=8 \
+          REPLAY_SPEED=100 \
+          REPLAY_RUN_DIR="$WORK_DIR/run-flat-cyborg" \
+          bash "$ORCH" 2>&1)"
+assert_contains "T-fc1. flat-cyborg opt-in names the flat-cyborg backend" "$FC_OUT" \
+    "llm backend: flat-cyborg"
+assert_contains "T-fc2. script source wires the flat-cyborg-claude.sh wrapper command" "$SRC" \
+    "/repo/tools/flat-cyborg-claude.sh"
+assert_contains "T-fc3. flat-cyborg opt-in bind-mounts /root/.claude" "$FC_OUT" \
+    ":/root/.claude:rw,z"
+assert_contains "T-fc4. flat-cyborg opt-in bind-mounts /root/.claude.json" "$FC_OUT" \
     ":/root/.claude.json:rw,z"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a **`claude-p`** (Claude Code print-mode) LLM backend for the trading-binance replay and make it the **default** — this is what finally makes the flat-rate 6-tribe LLM evolutionary search run end-to-end. Resolves #1163.

## Why

The flat-cyborg `--extract-structural` **TUI screen-scrape** is unreliable for the strategist's structured-JSON `prompt() -> Decision`: the real 6-tribe daemon replay had **0% parse success** (every tick `unexpected character 'N'` or TUI-line-wrapped JSON), even at single-tribe concurrency — despite single isolated wrapper calls working. `claude -p` (PRINT mode) is **non-interactive → clean single-shot stdout JSON** (no TUI, no scrape, no wrap), bills against the **same flat-rate Claude subscription** (NOT metered — same `~/.claude` creds), and is **~10× faster** (~12s vs ~120s). Same resolution #1152 used for code-generation.

## Changes

- **`tools/claude-p.sh`** (new): prompt from `$1`/stdin → `claude -p "$PROMPT"` → stdout. POSIX/dash-safe. Used as agentis `llm.command` under `llm.backend = claude`.
- **`trading-binance/tools/run-replay.sh`**: `REPLAY_LLM_BACKEND` default `flat-cyborg → claude-p`. New `is_subscription_claude_backend()` predicate shares the `~/.claude` + `~/.claude.json` mounts, pre-flight checks, and `CONFIG_BACKEND=claude` wiring across **claude-p AND flat-cyborg**; `LLM_COMMAND` resolves to `claude-p.sh` vs `flat-cyborg-claude.sh`. `flat-cyborg` + `openai` remain opt-in. openai path unchanged.
- **`tools/test-run-replay.sh`**: default-backend assertions → claude-p; flat-cyborg regression capture (`T-fc`) kept; openai regression kept.

## Validated (end-to-end, in-container)

- **`claude -p` in the image** → clean valid single-line Decision JSON, rc 0, ~12s (e.g. `{"action":"SHORT","size":1.0,"rationale":"...","setup":"volume_profile"}`).
- **A real 6-tribe replay** → **6/6 clean parsed decisions on the first tick, ZERO parse errors** (5 FLAT + 1 LONG; each tribe its own setup — volume_profile / mean_reversion / volume_divergence / fibo / …), written to `trade-ledger.jsonl`. The 0% flat-cyborg wall → **100%** with claude-p.
- `tools/test-run-replay.sh` → **48/0**; `./tools/colony-lint.sh` → **420/0**, 5 skipped; `sh -n`/`bash -n` clean.
- Dry-run: default emits `llm backend: claude-p` + mounts both `~/.claude` and `~/.claude.json`; `REPLAY_LLM_BACKEND=flat-cyborg` still wires `flat-cyborg-claude.sh`; openai omits the claude mounts.

Closes #1163.
