### PR TITLE
docs(trading-binance): first end-to-end 6-tribe evolutionary-search run record (claude-p)

### DIFF
--- a/trading-binance/runs/20260619T142507Z/results.json
+++ b/trading-binance/runs/20260619T142507Z/results.json
@@ -1,0 +1,16 @@
+{
+  "run_id": "20260619T142507Z",
+  "backend": "claude-p",
+  "symbol": "BTCUSDT", "timeframe": "1h",
+  "window": "2026-03-01..2026-03-05", "lookback": 50, "hold_period": 8, "speed": 90,
+  "decisions_total": 269, "parse_errors": 0,
+  "action_spread": {"FLAT": 216, "LONG": 42, "SHORT": 11},
+  "settled_total": 174, "settled_FLAT": 138, "settled_LOSS": 26, "settled_WIN": 10,
+  "directional_settled": 36, "wins": 10, "losses": 26,
+  "total_pnl_bps": -1130, "mean_pnl_bps_per_directional_trade": -31.4,
+  "m98_evolution_generations_per_tribe": [3, 3, 5, 3, 5, 4],
+  "m2_replicate_events": 0,
+  "per_tribe_fitness": [-362, 0, -97, 0, 40, -183],
+  "verdict": "substrate ran end-to-end (decisions->settle->fitness->M98 evolution); no trading edge (negative expectancy), consistent with deterministic-backtest prior",
+  "base_commit": "7482b0f54c939ef29b5ff391f46b69a09a3ce13a"
+}

--- a/trading-binance/runs/20260619T142507Z/summary.md
+++ b/trading-binance/runs/20260619T142507Z/summary.md
@@ -1,0 +1,44 @@
+# 6-tribe LLM evolutionary-search run
+
+**Run:** `20260619T142507Z` · **Symbol:** BTCUSDT 1h · **Window:** 2026-03-01 → 2026-03-05 (~70 tradable ticks, lookback 50, hold 8) · **Backend:** `claude-p` (Claude Code print mode, flat-rate subscription) · **Tribes:** 6 (alpha..zeta), each a distinct setup hypothesis.
+
+This is the first **end-to-end** run of the 6-tribe LLM evolutionary search on the flat-rate path — the goal being that the federation actually **uses the agentis substrate** (LLM strategists → deterministic settlement → fitness → M98 prompt evolution → M2 replicate), not just a demo.
+
+## The path to running it (4 merged infra fixes)
+
+The flat-rate replay was blocked by a stack of container/LLM-channel bugs, each fixed:
+
+| PR | Fix |
+|----|-----|
+| #1160 | SELinux `:z` on the `/repo` + `/run-root` bind mounts (container boot, exit 126) |
+| #1162 | mount `~/.claude.json` + route flat-cyborg via the `--extract-structural` wrapper (claude auth + reply) |
+| #1164 | strategist JSON-only directive + `flat-cyborg-unwrap.py` (kill prose, undo TUI line-wrap) |
+| #1165 | **`claude-p` backend** — the decisive fix |
+
+The flat-cyborg `--extract-structural` **TUI screen-scrape** gave **0% parse success** in the daemon replay (every tick `unexpected character 'N'` / line-wrapped JSON), even at single-tribe concurrency, despite single isolated calls working. `claude -p` (print mode) is non-interactive → clean single-shot stdout JSON, **same flat-rate subscription**, ~10× faster (~12s vs ~120s). Mirrors #1152's code-gen resolution.
+
+## Substrate ran end-to-end ✅
+
+| Metric | Value |
+|---|---|
+| Decisions (ledger rows) | **269** |
+| **Parse errors** | **0** (claude-p clean across all 269) |
+| Action spread | 216 FLAT / 42 LONG / 11 SHORT (53 directional, ~20%) |
+| Settled trades | 174 (138 FLAT / 26 LOSS / 10 WIN) |
+| **M98 prompt evolution** | **fired — 3–5 generations per tribe** (strategy prompts rewritten from settled-trade outcomes; the `settled_trades` buffer resets to `[]` after each evolution, confirming it) |
+| M2 replicate | did **not** fire — correct: no tribe cleared the replicate fitness threshold |
+
+Per-tribe final fitness (bps-derived): −362, 0, −97, 0, **+40**, −183. One tribe ended marginally positive; the rest flat/negative.
+
+## Honest trading outcome ❌ (no edge — as predicted)
+
+Across the 36 settled **directional** trades: **10 WIN / 26 LOSS**, total **−1130 bps**, mean **−31.4 bps/trade** — negative expectancy; every tribe net-negative or flat. This matches the deterministic-backtest prior (the fade and momentum reference signals both lost on this window). The LLM strategists, evolving over a single 5-day window, found **no durable edge**.
+
+## What this run demonstrates
+
+- **The substrate works**: LLM strategists decide → the deterministic verifier settles real PnL → fitness updates → M98 evolves the prompts → replicate is correctly gated on fitness. The flat-rate channel (claude-p) is reliable (0 parse errors over 269 decisions).
+- **The trading hypothesis does not** (yet): no positive expectancy on this window. The verifier again prevented self-deception — it reports the losses honestly.
+
+## Caveats
+
+Single in-sample 5-day window; no walk-forward / out-of-sample; 6 fixed setup hypotheses; evolution had only ~70 ticks to work with (3–5 generations is early). A real search needs many windows + out-of-sample validation before any edge claim. Raw `trade-ledger.jsonl` + logs are gitignored (reproducible via `run-replay.sh` with the documented params).


### PR DESCRIPTION
Run record for the first flat-rate 6-tribe LLM evolutionary search that ran end-to-end (claude-p backend #1165). Substrate ran: 269 decisions / 0 parse errors / 174 settled / M98 evolution 3-5 gens per tribe; M2 replicate correctly gated off (no tribe cleared fitness). Honest trading outcome: **negative** (36 directional, 10W/26L, **-1130 bps**, -31.4 bps/trade) — no edge on this single window, matching the deterministic-backtest prior. Docs-only artifact (summary.md + results.json); raw ledger/logs gitignored. Closes the evolutionary-search arc.