### PR TITLE
feat(trading-binance): walk-forward harness — evolve→freeze→test out-of-sample (#1167)

### DIFF
--- a/tools/test-walk-forward.sh
+++ b/tools/test-walk-forward.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# tools/test-walk-forward.sh — unit tests for tools/walk-forward.sh (#1167).
+#
+# Container-free coverage of the walk-forward orchestrator:
+#
+#   1. Fold-spec parsing: WF_FOLDS -> the correct per-fold train/test
+#      windows surface in the --dry-run plan (train start..end, test
+#      end..testEnd) for >= 2 folds.
+#   2. tribe -> pid -> evolved-prompt extraction against a synthetic
+#      finished TRAIN run dir (strategist-alpha.log with
+#      'child started (pid=42)' + memo strategist:42:strategy_prompt.jsonl
+#      carrying a known .value) -> --extract-prompt writes that value into
+#      seed/tribe-alpha.txt and exits 0; a tribe with no pid exits 5 and
+#      writes nothing.
+#   3. --dry-run prints >= 2 folds AND the seed/freeze wiring: the
+#      --extract-prompt step per tribe, REPLAY_SEED_PROMPTS_DIR threaded
+#      into the TEST phase, and the frozen evolution threshold (999999).
+#   4. Exit codes: dry-run 0, unknown flag 2, bad fold spec 2.
+#
+# Standard library only — no pytest, no podman, no live LLM. Self-contained:
+# the synthetic run dir is generated inline. dash-safe (POSIX sh idioms,
+# printf for fixtures, no bashisms in the assertions).
+#
+# Auto-discovered + run by tools/colony-lint.sh's tools-test loop.
+#
+# Usage: bash tools/test-walk-forward.sh
+# Exit 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WF="$SCRIPT_DIR/walk-forward.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+assert_contains() {
+    label="$1"; haystack="$2"; needle="$3"
+    if printf '%s' "$haystack" | grep -Fq -- "$needle"; then
+        pass "$label"
+    else
+        fail "$label" "needle not found: $needle"
+    fi
+}
+
+if [ ! -x "$WF" ]; then
+    echo "[FAIL] walk-forward.sh not executable at $WF"
+    exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+TWO_FOLDS="2026-03-01:2026-03-08:2026-03-12,2026-03-01:2026-03-12:2026-03-16"
+
+# ---------------------------------------------------------------------------
+# 1. Fold-spec parsing — both folds' train/test windows appear in the plan.
+# ---------------------------------------------------------------------------
+DRY_RC=0
+PLAN="$(WF_FOLDS="$TWO_FOLDS" WF_RUN_DIR="$WORK_DIR/wf1" \
+        bash "$WF" --dry-run 2>&1)" || DRY_RC=$?
+assert_contains "1a. dry-run reports 2 folds" "$PLAN" "folds: 2"
+assert_contains "1b. fold 1 train/test windows parsed" "$PLAN" \
+    "fold 1/2 : train 2026-03-01..2026-03-08 -> test 2026-03-08..2026-03-12"
+assert_contains "1c. fold 2 train/test windows parsed" "$PLAN" \
+    "fold 2/2 : train 2026-03-01..2026-03-12 -> test 2026-03-12..2026-03-16"
+assert_contains "1d. TRAIN phase window 1 surfaced" "$PLAN" \
+    "train phase: window 2026-03-01..2026-03-08 (evolution_threshold=3)"
+assert_contains "1e. TEST phase window 1 surfaced" "$PLAN" \
+    "test phase: window 2026-03-08..2026-03-12"
+
+# ---------------------------------------------------------------------------
+# 2. tribe -> pid -> prompt extraction against a synthetic TRAIN run dir.
+# ---------------------------------------------------------------------------
+TRAINRUN="$WORK_DIR/trainrun"
+mkdir -p "$TRAINRUN/laptop-node/.agentis/logs" "$TRAINRUN/laptop-node/.agentis/memo"
+printf 'boot\nchild started (pid=42) colony=tribe-alpha tick=40000\nready\n' \
+    >"$TRAINRUN/laptop-node/.agentis/logs/strategist-alpha.log"
+# Two memo records; the last .value wins (latest evolved prompt body).
+printf '{"value":"EVOLVED ALPHA gen1","ts":1}\n{"value":"EVOLVED ALPHA gen3 frozen","ts":2}\n' \
+    >"$TRAINRUN/laptop-node/.agentis/memo/strategist:42:strategy_prompt.jsonl"
+# tribe-beta has a log but no pid line -> extraction must skip (exit 5).
+printf 'boot\nno child line here\n' \
+    >"$TRAINRUN/laptop-node/.agentis/logs/strategist-beta.log"
+
+SEED_DIR="$WORK_DIR/seed"
+EX_RC=0
+bash "$WF" --extract-prompt "$TRAINRUN" alpha "$SEED_DIR/tribe-alpha.txt" >/dev/null 2>&1 || EX_RC=$?
+if [ "$EX_RC" -eq 0 ]; then
+    pass "2a. extract-prompt exits 0 on a tribe with a pid + prompt"
+else
+    fail "2a. extract-prompt exits 0 on a tribe with a pid + prompt" "rc=$EX_RC"
+fi
+if [ -f "$SEED_DIR/tribe-alpha.txt" ]; then
+    EX_VAL="$(cat "$SEED_DIR/tribe-alpha.txt")"
+    assert_contains "2b. extracted prompt is the latest .value" "$EX_VAL" \
+        "EVOLVED ALPHA gen3 frozen"
+else
+    fail "2b. extracted prompt is the latest .value" "seed file not written"
+fi
+
+BETA_RC=0
+bash "$WF" --extract-prompt "$TRAINRUN" beta "$SEED_DIR/tribe-beta.txt" >/dev/null 2>&1 || BETA_RC=$?
+if [ "$BETA_RC" -eq 5 ]; then
+    pass "2c. extract-prompt exits 5 when no pid"
+else
+    fail "2c. extract-prompt exits 5 when no pid" "rc=$BETA_RC"
+fi
+if [ -f "$SEED_DIR/tribe-beta.txt" ]; then
+    fail "2d. extract-prompt writes nothing when no pid" "stray seed file written"
+else
+    pass "2d. extract-prompt writes nothing when no pid"
+fi
+
+# tribe-gamma: pid line present but the memo .value is empty -> exit 5.
+printf 'child started (pid=77) colony=tribe-gamma\n' \
+    >"$TRAINRUN/laptop-node/.agentis/logs/strategist-gamma.log"
+printf '{"value":"","ts":1}\n' \
+    >"$TRAINRUN/laptop-node/.agentis/memo/strategist:77:strategy_prompt.jsonl"
+GAMMA_RC=0
+bash "$WF" --extract-prompt "$TRAINRUN" gamma "$SEED_DIR/tribe-gamma.txt" >/dev/null 2>&1 || GAMMA_RC=$?
+if [ "$GAMMA_RC" -eq 5 ]; then
+    pass "2e. extract-prompt exits 5 on empty prompt value"
+else
+    fail "2e. extract-prompt exits 5 on empty prompt value" "rc=$GAMMA_RC"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. --dry-run prints the seed/freeze wiring: per-tribe extract step,
+#    REPLAY_SEED_PROMPTS_DIR threaded into TEST, frozen threshold 999999.
+# ---------------------------------------------------------------------------
+assert_contains "3a. dry-run shows per-tribe extract step" "$PLAN" \
+    "--extract-prompt <trainrun> alpha"
+assert_contains "3b. dry-run threads REPLAY_SEED_PROMPTS_DIR into TEST" "$PLAN" \
+    "REPLAY_SEED_PROMPTS_DIR="
+assert_contains "3c. dry-run TEST phase uses the frozen evolution threshold" "$PLAN" \
+    "REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999999"
+assert_contains "3d. dry-run TRAIN phase keeps evolution armed (threshold=3)" "$PLAN" \
+    "REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=3"
+assert_contains "3e. dry-run names the run-replay.sh orchestrator" "$PLAN" \
+    "trading-binance/tools/run-replay.sh"
+assert_contains "3f. dry-run reports no containers spawned" "$PLAN" \
+    "no containers spawned"
+
+# ---------------------------------------------------------------------------
+# 4. Exit codes.
+# ---------------------------------------------------------------------------
+if [ "$DRY_RC" -eq 0 ]; then
+    pass "4a. --dry-run exits 0"
+else
+    fail "4a. --dry-run exits 0" "rc=$DRY_RC"
+fi
+
+UNKNOWN_RC=0
+bash "$WF" --bogus-flag >/dev/null 2>&1 || UNKNOWN_RC=$?
+if [ "$UNKNOWN_RC" -eq 2 ]; then
+    pass "4b. unknown flag exits 2"
+else
+    fail "4b. unknown flag exits 2" "rc=$UNKNOWN_RC"
+fi
+
+BADFOLD_RC=0
+WF_FOLDS="2026-03-01:2026-03-08" bash "$WF" --dry-run >/dev/null 2>&1 || BADFOLD_RC=$?
+if [ "$BADFOLD_RC" -eq 2 ]; then
+    pass "4c. malformed fold spec exits 2"
+else
+    fail "4c. malformed fold spec exits 2" "rc=$BADFOLD_RC"
+fi
+
+BADDATE_RC=0
+WF_FOLDS="2026-3-1:2026-03-08:2026-03-12" bash "$WF" --dry-run >/dev/null 2>&1 || BADDATE_RC=$?
+if [ "$BADDATE_RC" -eq 2 ]; then
+    pass "4d. malformed date in fold spec exits 2"
+else
+    fail "4d. malformed date in fold spec exits 2" "rc=$BADDATE_RC"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/walk-forward.sh
+++ b/tools/walk-forward.sh
@@ -1,0 +1,680 @@
+#!/bin/bash
+# walk-forward.sh — out-of-sample (walk-forward) harness for the
+# trading-binance 6-tribe replay (#1167).
+#
+# Trades the in-sample overfit of the single-window replay for an honest
+# out-of-sample read: per fold it EVOLVES the strategists on a TRAIN window
+# (run-replay.sh, evolution ON), FREEZES each tribe's final evolved prompt,
+# then MEASURES that frozen strategy on a later UNSEEN TEST window
+# (run-replay.sh with REPLAY_SEED_PROMPTS_DIR + a very high evolution
+# threshold). Metrics are computed from the TEST run only, so a tribe's edge
+# is judged on data it never trained on. Rolling forward across folds and
+# aggregating the OOS expectancy is the gate before any edge claim, paper
+# trading, or live size.
+#
+# Pipeline per fold N (train = trainStart..trainEnd, test = trainEnd..testEnd):
+#   1. TRAIN  run-replay.sh on the train window, evolution ON. Capture run dir.
+#   2. EXTRACT for each tribe: map tribe -> daemon pid via
+#              <trainrun>/laptop-node/.agentis/logs/strategist-<t>.log
+#              ('child started (pid=N)'), read the evolved prompt from
+#              <trainrun>/laptop-node/.agentis/memo/strategist:<N>:strategy_prompt.jsonl
+#              (`.value`), write to <wf-run>/fold-N/seed/tribe-<t>.txt.
+#              Tribes with no pid / empty prompt are skipped (logged).
+#   3. TEST   run-replay.sh on the test window with
+#              REPLAY_SEED_PROMPTS_DIR=<fold-N/seed> and
+#              STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999999 (frozen).
+#              Capture run dir.
+#   4. SCORE  from the TEST run's trade-ledger.jsonl + settled-log lines:
+#              directional trades, WIN/LOSS, total pnl_bps, mean pnl_bps/trade
+#              (expectancy), profit factor — federation-wide and per-tribe.
+# Aggregate across folds -> <wf-run>/walk-forward-summary.md + results.json
+# under trading-binance/runs/, with an honest verdict (does OOS expectancy
+# stay > 0 across folds, or not?).
+#
+# Env vars (all optional; defaults shown):
+#   WF_SYMBOL            Binance futures symbol. Default: BTCUSDT
+#   WF_TIMEFRAME         Candle interval: 30m | 1h | 1d. Default: 1h
+#   WF_LOOKBACK          Past candles visible per tick. Default: 50
+#   WF_HOLD              Forward candles for PnL settlement. Default: 8
+#   WF_SPEED             Replay multiplier (forwarded to run-replay.sh).
+#                        Default: 90
+#   WF_DATA_DIR          PR-2 CSV root. Default: trading-binance/data
+#   WF_FOLDS             Comma-separated fold specs, each
+#                        `trainStart:trainEnd:testEnd` (UTC YYYY-MM-DD).
+#                        train = trainStart..trainEnd evolves; test =
+#                        trainEnd..testEnd is frozen. Default: two consecutive
+#                        BTCUSDT 1h folds in 2026-03.
+#   WF_RUN_DIR           Output dir override. Default: auto-timestamped under
+#                        trading-binance/runs/wf-<YYYYMMDDTHHMMSSZ>/
+#   WF_FREEZE_THRESHOLD  STRATEGIST_PROMPT_EVOLUTION_THRESHOLD for the TEST
+#                        phase (high = frozen). Default: 999999
+#   WF_REPLAY            Path to run-replay.sh. Default: resolved relative to
+#                        this script (../trading-binance/tools/run-replay.sh).
+#   WF_DRY_RUN           1 = print the fold plan + run-replay invocations,
+#                        launch no containers. Default: "" (real run)
+#
+# Flags:
+#   --dry-run            Same as WF_DRY_RUN=1.
+#   --extract-prompt <trainrun> <tribe> <outfile>
+#                        Internal mode: extract one tribe's evolved prompt
+#                        from a finished TRAIN run dir into <outfile>.
+#                        Exit 0 + writes file on success; exit 5 if no pid /
+#                        empty prompt (file not written). Used by step 2 and
+#                        by tools/test-walk-forward.sh.
+#   -h | --help          Print this header.
+#
+# Output layout (under trading-binance/runs/wf-<YYYYMMDDTHHMMSSZ>/):
+#   walk-forward.log          orchestrator's own log
+#   fold-1/ ... fold-N/
+#     seed/tribe-<t>.txt      frozen evolved prompts from the TRAIN run
+#     fold-meta.json          fold windows + train/test run dir pointers
+#   walk-forward-summary.md   per-fold + aggregate OOS metrics + verdict
+#   results.json              machine-readable aggregate
+#
+# Exit codes:
+#   0   walk-forward completed (or dry-run plan emitted)
+#   1   prerequisite missing (run-replay.sh, python3 outside dry-run)
+#   2   invalid args / fold spec
+#   5   --extract-prompt found no pid / empty prompt (internal mode)
+
+set -euo pipefail
+
+SCRIPT_PATH="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")"
+TOOLS_DIR="$(dirname "$SCRIPT_PATH")"
+REPO_ROOT="$(dirname "$TOOLS_DIR")"
+FED_DIR="$REPO_ROOT/trading-binance"
+REPLAY="${WF_REPLAY:-$FED_DIR/tools/run-replay.sh}"
+
+# --- Tribe roster (matches run-replay.sh) ---
+TRIBES="alpha beta gamma delta epsilon zeta"
+
+# ---------------------------------------------------------------------------
+# extract_prompt <trainrun> <tribe> <outfile>
+# Map a tribe to its daemon pid via the strategist log, read the evolved
+# prompt body from the per-pid memo jsonl, write it to <outfile>. Returns 5
+# (and writes nothing) when there is no pid or the prompt is empty.
+# ---------------------------------------------------------------------------
+extract_prompt() {
+    trainrun="$1"; tribe="$2"; outfile="$3"
+    python3 - "$trainrun" "$tribe" "$outfile" <<'PYEXTRACT'
+import json
+import os
+import re
+import sys
+
+trainrun, tribe, outfile = sys.argv[1], sys.argv[2], sys.argv[3]
+
+log_path = os.path.join(
+    trainrun, "laptop-node", ".agentis", "logs", "strategist-" + tribe + ".log"
+)
+pid = ""
+try:
+    with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+        text = f.read()
+    m = re.search(r"child started \(pid=(\d+)", text)
+    if m:
+        pid = m.group(1)
+except OSError:
+    pass
+
+if not pid:
+    sys.stderr.write("extract: no pid for tribe-" + tribe + "\n")
+    sys.exit(5)
+
+memo_path = os.path.join(
+    trainrun, "laptop-node", ".agentis", "memo",
+    "strategist:" + pid + ":strategy_prompt.jsonl",
+)
+value = ""
+try:
+    with open(memo_path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(rec, dict) and "value" in rec:
+                value = rec["value"]
+except OSError:
+    pass
+
+if not isinstance(value, str) or value == "":
+    sys.stderr.write("extract: empty prompt for tribe-" + tribe + " (pid=" + pid + ")\n")
+    sys.exit(5)
+
+os.makedirs(os.path.dirname(os.path.abspath(outfile)), exist_ok=True)
+with open(outfile, "w", encoding="utf-8") as out:
+    out.write(value)
+sys.stderr.write("extract: tribe-" + tribe + " pid=" + pid + " bytes=" + str(len(value)) + "\n")
+sys.exit(0)
+PYEXTRACT
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing — handle the internal --extract-prompt mode first so it
+# can run container-free in tests, then fall through to orchestration flags.
+# ---------------------------------------------------------------------------
+DRY_RUN="${WF_DRY_RUN:-0}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --extract-prompt)
+            if [ $# -lt 4 ]; then
+                echo "walk-forward: --extract-prompt needs <trainrun> <tribe> <outfile>" >&2
+                exit 2
+            fi
+            extract_prompt "$2" "$3" "$4"
+            exit $?
+            ;;
+        -h|--help)
+            awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "$SCRIPT_PATH"
+            exit 0
+            ;;
+        *)
+            echo "walk-forward: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# --- Env-var defaults ---
+SYMBOL="${WF_SYMBOL:-BTCUSDT}"
+TIMEFRAME="${WF_TIMEFRAME:-1h}"
+LOOKBACK="${WF_LOOKBACK:-50}"
+HOLD="${WF_HOLD:-8}"
+SPEED="${WF_SPEED:-90}"
+DATA_DIR="${WF_DATA_DIR:-$FED_DIR/data}"
+FOLDS="${WF_FOLDS:-2026-03-01:2026-03-08:2026-03-12,2026-03-01:2026-03-12:2026-03-16}"
+FREEZE_THRESHOLD="${WF_FREEZE_THRESHOLD:-999999}"
+
+# --- Validation ---
+case "$TIMEFRAME" in
+    30m|1h|1d) ;;
+    *)
+        echo "walk-forward: WF_TIMEFRAME must be one of 30m|1h|1d (got '$TIMEFRAME')" >&2
+        exit 2
+        ;;
+esac
+
+val=""
+for var_name in LOOKBACK HOLD SPEED FREEZE_THRESHOLD; do
+    eval "val=\${$var_name}"
+    case "$val" in
+        ''|*[!0-9]*)
+            echo "walk-forward: $var_name must be a positive integer (got: $val)" >&2
+            exit 2
+            ;;
+    esac
+done
+unset val
+
+# Parse + validate fold specs into newline-separated trainStart\ttrainEnd\ttestEnd.
+DATE_RE='^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$'
+FOLD_LINES=""
+FOLD_COUNT=0
+OLD_IFS="$IFS"
+IFS=','
+for spec in $FOLDS; do
+    [ -n "$spec" ] || continue
+    train_start="${spec%%:*}"
+    rest="${spec#*:}"
+    train_end="${rest%%:*}"
+    test_end="${rest##*:}"
+    if [ "$train_start" = "$spec" ] || [ "$train_end" = "$rest" ] || \
+       [ -z "$train_start" ] || [ -z "$train_end" ] || [ -z "$test_end" ]; then
+        IFS="$OLD_IFS"
+        echo "walk-forward: bad fold spec '$spec' (want trainStart:trainEnd:testEnd)" >&2
+        exit 2
+    fi
+    for d in "$train_start" "$train_end" "$test_end"; do
+        if ! printf '%s' "$d" | grep -Eq "$DATE_RE"; then
+            IFS="$OLD_IFS"
+            echo "walk-forward: bad date '$d' in fold '$spec' (want YYYY-MM-DD)" >&2
+            exit 2
+        fi
+    done
+    FOLD_LINES="${FOLD_LINES}${train_start}	${train_end}	${test_end}
+"
+    FOLD_COUNT=$((FOLD_COUNT + 1))
+done
+IFS="$OLD_IFS"
+
+if [ "$FOLD_COUNT" -lt 1 ]; then
+    echo "walk-forward: WF_FOLDS parsed to 0 folds" >&2
+    exit 2
+fi
+
+# --- Per-run hermetic dir ---
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+WF_RUN="${WF_RUN_DIR:-$FED_DIR/runs/wf-$TS}"
+WF_LOG="$WF_RUN/walk-forward.log"
+WF_SUMMARY="$WF_RUN/walk-forward-summary.md"
+WF_RESULTS="$WF_RUN/results.json"
+
+# --- Dry-run / real-run dispatch helpers (mirrors run-replay.sh idiom) ---
+emit_cmd() {
+    if [ "$DRY_RUN" = "1" ]; then
+        printf '+ %s\n' "$*"
+    else
+        printf '+ %s\n' "$*" >>"$WF_LOG"
+        # shellcheck disable=SC2294
+        eval "$@"
+    fi
+}
+
+emit_step() {
+    if [ "$DRY_RUN" = "1" ]; then
+        printf '# %s\n' "$*"
+    else
+        printf '# %s\n' "$*" >>"$WF_LOG"
+    fi
+}
+
+# --- Prerequisite checks (skipped in dry-run for portability) ---
+if [ "$DRY_RUN" = "0" ]; then
+    if [ ! -x "$REPLAY" ]; then
+        echo "walk-forward: run-replay.sh not executable at $REPLAY" >&2
+        exit 1
+    fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "walk-forward: python3 not found on PATH" >&2
+        exit 1
+    fi
+    mkdir -p "$WF_RUN"
+    : >"$WF_LOG"
+fi
+
+emit_step "walk-forward: starting (dry_run=$DRY_RUN)"
+emit_step "run dir: $WF_RUN"
+emit_step "symbol: $SYMBOL"
+emit_step "timeframe: $TIMEFRAME"
+emit_step "lookback: $LOOKBACK"
+emit_step "hold: $HOLD"
+emit_step "speed: $SPEED"
+emit_step "data dir: $DATA_DIR"
+emit_step "freeze threshold (TEST phase): $FREEZE_THRESHOLD"
+emit_step "folds: $FOLD_COUNT"
+
+# ---------------------------------------------------------------------------
+# run_replay_phase <phase> <run-dir-out> <start> <end> <evolution-threshold> [seed-dir]
+# Invoke run-replay.sh for one TRAIN or TEST phase. In dry-run, prints the
+# invocation. In real mode, runs it and tees the run dir from the trailing
+# "[run-replay] run dir: <path>" line into the named output file.
+# ---------------------------------------------------------------------------
+run_replay_phase() {
+    phase="$1"; run_dir_out="$2"; start="$3"; end="$4"; ev_threshold="$5"; phase_seed="${6:-}"
+    seed_env=""
+    if [ -n "$phase_seed" ]; then
+        seed_env="REPLAY_SEED_PROMPTS_DIR=$phase_seed "
+    fi
+    inv="${seed_env}REPLAY_SYMBOL=$SYMBOL REPLAY_TIMEFRAME=$TIMEFRAME REPLAY_LOOKBACK_WINDOW=$LOOKBACK REPLAY_HOLD_PERIOD=$HOLD REPLAY_SPEED=$SPEED REPLAY_DATA_DIR=$DATA_DIR REPLAY_START=$start REPLAY_END=$end REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=$ev_threshold bash $REPLAY"
+    emit_step "$phase phase: window $start..$end (evolution_threshold=$ev_threshold${phase_seed:+ seed=$phase_seed})"
+    if [ "$DRY_RUN" = "1" ]; then
+        emit_cmd "$inv"
+        return 0
+    fi
+    phase_out="$WF_RUN/.${phase}.out"
+    # shellcheck disable=SC2086
+    if ! env ${seed_env}REPLAY_SYMBOL="$SYMBOL" REPLAY_TIMEFRAME="$TIMEFRAME" \
+            REPLAY_LOOKBACK_WINDOW="$LOOKBACK" REPLAY_HOLD_PERIOD="$HOLD" \
+            REPLAY_SPEED="$SPEED" REPLAY_DATA_DIR="$DATA_DIR" \
+            REPLAY_START="$start" REPLAY_END="$end" \
+            REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD="$ev_threshold" \
+            bash "$REPLAY" >"$phase_out" 2>>"$WF_LOG"; then
+        echo "walk-forward: $phase run-replay.sh failed (see $WF_LOG)" >&2
+        exit 1
+    fi
+    cat "$phase_out" >>"$WF_LOG"
+    rr_dir="$(grep -E '^\[run-replay\] run dir:' "$phase_out" | tail -1 | sed -E 's/^\[run-replay\] run dir:[[:space:]]*//')"
+    printf '%s' "$rr_dir" >"$run_dir_out"
+}
+
+# ---------------------------------------------------------------------------
+# score_test_run <testrun> <fold-meta> <out-json>
+# Compute OOS metrics (directional trades, WIN/LOSS, total pnl_bps, mean
+# pnl_bps/trade, profit factor) federation-wide + per-tribe from the TEST
+# run's trade-ledger.jsonl + the per-tribe settled-log lines in
+# .agentis/logs/strategist-<t>.log.
+# ---------------------------------------------------------------------------
+score_test_run() {
+    testrun="$1"; out_json="$2"
+    python3 - "$testrun" "$out_json" "$TRIBES" <<'PYSCORE'
+import json
+import os
+import re
+import sys
+
+testrun, out_json, tribes_str = sys.argv[1], sys.argv[2], sys.argv[3]
+tribes = tribes_str.split()
+
+
+def blank():
+    return {"trades": 0, "wins": 0, "losses": 0, "total_pnl_bps": 0.0,
+            "gross_win_bps": 0.0, "gross_loss_bps": 0.0}
+
+
+def settle(acc, tribe, pnl):
+    a = acc.setdefault(tribe, blank())
+    a["trades"] += 1
+    a["total_pnl_bps"] += pnl
+    if pnl > 0:
+        a["wins"] += 1
+        a["gross_win_bps"] += pnl
+    elif pnl < 0:
+        a["losses"] += 1
+        a["gross_loss_bps"] += -pnl
+
+
+acc = {}
+fed = blank()
+
+# Primary source: trade-ledger.jsonl. Rows carry pnl_bps + (when present)
+# tribe; only directional (non-FLAT) settled trades count.
+ledger = os.path.join(testrun, "trade-ledger.jsonl")
+try:
+    with open(ledger, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(rec, dict):
+                continue
+            action = str(rec.get("action", rec.get("direction", ""))).upper()
+            if action == "FLAT":
+                continue
+            if "pnl_bps" not in rec:
+                continue
+            try:
+                pnl = float(rec["pnl_bps"])
+            except (TypeError, ValueError):
+                continue
+            tribe = str(rec.get("tribe", rec.get("tribe_name", ""))).replace("tribe-", "")
+            if tribe not in tribes:
+                tribe = "_unknown"
+            settle(acc, tribe, pnl)
+            # federation aggregate
+            fed["trades"] += 1
+            fed["total_pnl_bps"] += pnl
+            if pnl > 0:
+                fed["wins"] += 1
+                fed["gross_win_bps"] += pnl
+            elif pnl < 0:
+                fed["losses"] += 1
+                fed["gross_loss_bps"] += -pnl
+except OSError:
+    pass
+
+# Fallback / per-tribe enrichment: settled-log lines. The strategist logs a
+# settlement line carrying pnl_bps=<N>; parse them per tribe only when the
+# ledger yielded nothing for that tribe (so we never double-count).
+pnl_re = re.compile(r"pnl_bps=(-?\d+(?:\.\d+)?)")
+for tribe in tribes:
+    if acc.get(tribe, blank())["trades"] > 0:
+        continue
+    log_path = os.path.join(
+        testrun, "laptop-node", ".agentis", "logs", "strategist-" + tribe + ".log"
+    )
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if "settle" not in line:
+                    continue
+                m = pnl_re.search(line)
+                if not m:
+                    continue
+                try:
+                    pnl = float(m.group(1))
+                except ValueError:
+                    continue
+                settle(acc, tribe, pnl)
+                fed["trades"] += 1
+                fed["total_pnl_bps"] += pnl
+                if pnl > 0:
+                    fed["wins"] += 1
+                    fed["gross_win_bps"] += pnl
+                elif pnl < 0:
+                    fed["losses"] += 1
+                    fed["gross_loss_bps"] += -pnl
+    except OSError:
+        pass
+
+
+def finalize(a):
+    trades = a["trades"]
+    expectancy = (a["total_pnl_bps"] / trades) if trades else 0.0
+    gl = a["gross_loss_bps"]
+    if gl > 0:
+        profit_factor = a["gross_win_bps"] / gl
+    elif a["gross_win_bps"] > 0:
+        profit_factor = None  # inf — wins, no losses
+    else:
+        profit_factor = 0.0
+    return {
+        "trades": trades,
+        "wins": a["wins"],
+        "losses": a["losses"],
+        "total_pnl_bps": round(a["total_pnl_bps"], 4),
+        "expectancy_bps": round(expectancy, 4),
+        "profit_factor": (round(profit_factor, 4) if profit_factor is not None else None),
+    }
+
+
+out = {
+    "test_run": testrun,
+    "federation": finalize(fed),
+    "tribes": {t: finalize(acc.get(t, blank())) for t in tribes},
+}
+with open(out_json, "w", encoding="utf-8") as f:
+    json.dump(out, f, indent=2)
+print(json.dumps(out["federation"]))
+PYSCORE
+}
+
+# ---------------------------------------------------------------------------
+# Per-fold loop.
+# ---------------------------------------------------------------------------
+fold_idx=0
+FOLD_RESULT_JSONS=""
+while IFS='	' read -r train_start train_end test_end; do
+    [ -n "$train_start" ] || continue
+    fold_idx=$((fold_idx + 1))
+    fold_dir="$WF_RUN/fold-$fold_idx"
+    seed_dir="$fold_dir/seed"
+    fold_result="$fold_dir/test-metrics.json"
+    emit_step "=== fold $fold_idx/$FOLD_COUNT : train $train_start..$train_end -> test $train_end..$test_end ==="
+    if [ "$DRY_RUN" = "0" ]; then
+        mkdir -p "$seed_dir"
+    fi
+
+    # 1) TRAIN — evolution ON (run-replay default threshold).
+    train_run_ptr="$fold_dir/.trainrun"
+    if [ "$DRY_RUN" = "0" ]; then
+        mkdir -p "$fold_dir"
+    fi
+    run_replay_phase "train" "$train_run_ptr" "$train_start" "$train_end" "3" ""
+
+    # 2) EXTRACT — freeze each tribe's evolved prompt into the seed dir.
+    emit_step "extracting frozen prompts -> $seed_dir/tribe-<t>.txt"
+    if [ "$DRY_RUN" = "1" ]; then
+        for t in $TRIBES; do
+            emit_cmd "bash $SCRIPT_PATH --extract-prompt <trainrun> $t $seed_dir/tribe-$t.txt"
+        done
+    else
+        trainrun="$(cat "$train_run_ptr")"
+        for t in $TRIBES; do
+            if extract_prompt "$trainrun" "$t" "$seed_dir/tribe-$t.txt" 2>>"$WF_LOG"; then
+                emit_step "frozen: tribe-$t"
+            else
+                emit_step "skipped (no pid/empty prompt): tribe-$t"
+            fi
+        done
+    fi
+
+    # 3) TEST — frozen (seed dir + very high evolution threshold).
+    test_run_ptr="$fold_dir/.testrun"
+    run_replay_phase "test" "$test_run_ptr" "$train_end" "$test_end" "$FREEZE_THRESHOLD" "$seed_dir"
+
+    # 4) SCORE — OOS metrics from the TEST run only.
+    emit_step "scoring TEST run -> $fold_result"
+    if [ "$DRY_RUN" = "1" ]; then
+        emit_cmd "score-test-run <testrun> $fold_result"
+    else
+        testrun="$(cat "$test_run_ptr")"
+        score_test_run "$testrun" "$fold_result" >>"$WF_LOG" 2>&1 || true
+        # Stamp the fold index + windows into the metrics file so the
+        # aggregator can label folds without re-deriving from path shape.
+        python3 -c 'import json,sys
+p=sys.argv[1]
+try:
+    d=json.load(open(p))
+except OSError:
+    d={}
+d["fold"]=int(sys.argv[2]); d["train_start"]=sys.argv[3]; d["train_end"]=sys.argv[4]; d["test_end"]=sys.argv[5]
+json.dump(d, open(p,"w"), indent=2)' \
+            "$fold_result" "$fold_idx" "$train_start" "$train_end" "$test_end" || true
+        FOLD_RESULT_JSONS="$FOLD_RESULT_JSONS $fold_result"
+        # fold-meta.json: windows + run dir pointers.
+        python3 -c 'import json,sys; json.dump({"fold":int(sys.argv[1]),"train_start":sys.argv[2],"train_end":sys.argv[3],"test_end":sys.argv[4],"train_run":sys.argv[5],"test_run":sys.argv[6]}, open(sys.argv[7],"w"), indent=2)' \
+            "$fold_idx" "$train_start" "$train_end" "$test_end" \
+            "$(cat "$train_run_ptr")" "$(cat "$test_run_ptr")" \
+            "$fold_dir/fold-meta.json"
+    fi
+done <<EOF
+$FOLD_LINES
+EOF
+
+# ---------------------------------------------------------------------------
+# Aggregate across folds -> summary + results.json (real run only).
+# ---------------------------------------------------------------------------
+if [ "$DRY_RUN" = "1" ]; then
+    emit_step "dry-run complete; $FOLD_COUNT folds planned, no containers spawned"
+    exit 0
+fi
+
+emit_step "aggregating $FOLD_COUNT folds -> $WF_SUMMARY + $WF_RESULTS"
+# shellcheck disable=SC2086
+python3 - "$WF_RUN" "$WF_SUMMARY" "$WF_RESULTS" "$SYMBOL" "$TIMEFRAME" $FOLD_RESULT_JSONS <<'PYAGG'
+import json
+import sys
+
+wf_run, summary_path, results_path, symbol, timeframe = sys.argv[1:6]
+fold_jsons = sys.argv[6:]
+
+folds = []
+for fj in fold_jsons:
+    try:
+        with open(fj, "r", encoding="utf-8") as f:
+            folds.append(json.load(f))
+    except OSError:
+        continue
+
+agg = {"trades": 0, "wins": 0, "losses": 0, "total_pnl_bps": 0.0}
+for fd in folds:
+    fed = fd.get("federation", {})
+    agg["trades"] += fed.get("trades", 0)
+    agg["wins"] += fed.get("wins", 0)
+    agg["losses"] += fed.get("losses", 0)
+    agg["total_pnl_bps"] += fed.get("total_pnl_bps", 0.0)
+
+agg_trades = agg["trades"]
+agg_expectancy = (agg["total_pnl_bps"] / agg_trades) if agg_trades else 0.0
+
+# Verdict: OOS edge survives only if expectancy stays > 0 on EVERY fold AND
+# the aggregate expectancy is > 0.
+per_fold_exp = [fd.get("federation", {}).get("expectancy_bps", 0.0) for fd in folds]
+all_positive = bool(per_fold_exp) and all(e > 0 for e in per_fold_exp)
+if all_positive and agg_expectancy > 0:
+    verdict = ("EDGE SURVIVES OOS: federation expectancy is positive on every "
+               "fold and in aggregate (%.4f bps/trade). Gate to paper trading, "
+               "with the single-symbol / single-regime caveats below." % agg_expectancy)
+else:
+    verdict = ("NO OOS EDGE: federation expectancy is not positive across all "
+               "folds (aggregate %.4f bps/trade). The frozen evolved strategy "
+               "does not generalise to unseen windows — do not advance to paper "
+               "trading or live size on this evidence." % agg_expectancy)
+
+results = {
+    "symbol": symbol,
+    "timeframe": timeframe,
+    "fold_count": len(folds),
+    "aggregate": {
+        "trades": agg_trades,
+        "wins": agg["wins"],
+        "losses": agg["losses"],
+        "total_pnl_bps": round(agg["total_pnl_bps"], 4),
+        "expectancy_bps": round(agg_expectancy, 4),
+    },
+    "folds": folds,
+    "verdict": verdict,
+}
+with open(results_path, "w", encoding="utf-8") as f:
+    json.dump(results, f, indent=2)
+
+lines = []
+lines.append("# Walk-forward summary — " + symbol + " " + timeframe)
+lines.append("")
+lines.append("Out-of-sample (walk-forward) evaluation: each fold evolves the "
+             "strategists on a TRAIN window, freezes the evolved prompts, and "
+             "scores them on a later UNSEEN TEST window. Metrics below are from "
+             "the TEST runs only.")
+lines.append("")
+lines.append("## Aggregate (across " + str(len(folds)) + " folds)")
+lines.append("")
+lines.append("| Trades | Wins | Losses | Total PnL (bps) | Expectancy (bps/trade) |")
+lines.append("|---|---|---|---|---|")
+lines.append("| %d | %d | %d | %.4f | %.4f |" % (
+    agg_trades, agg["wins"], agg["losses"],
+    round(agg["total_pnl_bps"], 4), round(agg_expectancy, 4)))
+lines.append("")
+for fd in folds:
+    fed = fd.get("federation", {})
+    window = ""
+    if fd.get("train_end") and fd.get("test_end"):
+        window = " (TEST window %s..%s)" % (fd.get("train_end"), fd.get("test_end"))
+    lines.append("## Fold %s%s" % (str(fd.get("fold", "?")), window))
+    lines.append("")
+    lines.append("TEST run: " + str(fd.get("test_run", "?")))
+    lines.append("")
+    lines.append("| Scope | Trades | Wins | Losses | Total PnL (bps) | Expectancy (bps) | Profit factor |")
+    lines.append("|---|---|---|---|---|---|---|")
+    pf = fed.get("profit_factor")
+    pf_s = "inf" if pf is None else ("%.4f" % pf)
+    lines.append("| federation | %d | %d | %d | %.4f | %.4f | %s |" % (
+        fed.get("trades", 0), fed.get("wins", 0), fed.get("losses", 0),
+        fed.get("total_pnl_bps", 0.0), fed.get("expectancy_bps", 0.0), pf_s))
+    for t, tm in sorted(fd.get("tribes", {}).items()):
+        tpf = tm.get("profit_factor")
+        tpf_s = "inf" if tpf is None else ("%.4f" % tpf)
+        lines.append("| tribe-%s | %d | %d | %d | %.4f | %.4f | %s |" % (
+            t, tm.get("trades", 0), tm.get("wins", 0), tm.get("losses", 0),
+            tm.get("total_pnl_bps", 0.0), tm.get("expectancy_bps", 0.0), tpf_s))
+    lines.append("")
+lines.append("## Verdict")
+lines.append("")
+lines.append(verdict)
+lines.append("")
+lines.append("### Caveats")
+lines.append("")
+lines.append("- Single symbol (" + symbol + ") unless extended.")
+lines.append("- Each OOS window is still one market regime.")
+lines.append("- The frozen state is the evolved prompt text only (no other state).")
+lines.append("- Cost is ~N x the single-run replay cost (one TRAIN + one TEST per fold).")
+with open(summary_path, "w", encoding="utf-8") as f:
+    f.write("\n".join(lines) + "\n")
+
+print(verdict)
+PYAGG
+
+emit_step "walk-forward: done"
+echo "[walk-forward] run dir: $WF_RUN"
+echo "[walk-forward] summary: $WF_SUMMARY"

--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -53,6 +53,29 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Walk-forward harness for out-of-sample edge validation (#1167). Three
+  parts: (1) a per-tribe **frozen-prompt seed-override** hook in all six
+  `tribe-{alpha,beta,gamma,delta,epsilon,zeta}/agents/strategist.ag` — when a
+  fresh daemon's `strategist:<pid>:strategy_prompt` is empty, it now FIRST
+  checks `strategist:seed_prompt:<tribe>` and, if non-empty, adopts it as the
+  initial prompt (byte-clamped, generation 0, `learn(...,
+  ["prompt-inheritance","walk-forward-seed",...])`), taking precedence over
+  the existing `pp:`-inherit / hardcoded-seed fallback; (2) a
+  `REPLAY_SEED_PROMPTS_DIR` knob in `tools/run-replay.sh` that stages host
+  `tribe-<t>.txt` prompts into the run dir's `seed-prompts/`
+  (`/run-root/seed-prompts/`) and, before launching the daemons, seeds
+  `strategist:seed_prompt:tribe-<t>` from each present file — absent dir is a
+  no-op (behaviour byte-identical to a normal replay); (3) a new
+  `tools/walk-forward.sh` orchestrator that, per fold, EVOLVES on a TRAIN
+  window (evolution on), FREEZES each tribe's final evolved prompt, then
+  MEASURES it on an UNSEEN TEST window (`REPLAY_SEED_PROMPTS_DIR` +
+  `STRATEGIST_PROMPT_EVOLUTION_THRESHOLD=999999`), computing OOS expectancy
+  / WIN-LOSS / profit factor per tribe and federation-wide, aggregated across
+  folds into `walk-forward-summary.md` + `results.json` with an honest verdict
+  (does OOS expectancy stay positive across folds?). `tools/test-walk-forward.sh`
+  covers fold-spec parsing, the tribe->pid->prompt extraction, and the
+  `--dry-run` seed/freeze wiring without containers; `tools/test-run-replay.sh`
+  grows seed-injection assertions (#1167).
 - `tools/claude-p.sh` — a `claude-p` (Claude Code PRINT mode) LLM backend for
   the replay. `claude -p "<prompt>"` is non-interactive, so it returns clean
   single-shot stdout JSON (no TUI, no line-wrap) and bills against the SAME

--- a/trading-binance/tools/run-replay.sh
+++ b/trading-binance/tools/run-replay.sh
@@ -92,6 +92,21 @@
 #                                Default: 200
 #   REPLAY_HOLD_PERIOD           Forward candles for PnL settlement.
 #                                Default: 8
+#   REPLAY_SEED_PROMPTS_DIR      Host dir holding per-tribe frozen-prompt
+#                                seeds named `tribe-<t>.txt` (one per
+#                                tribe). When set on a real run, each file
+#                                is copied into the run dir's
+#                                `seed-prompts/` (mounted at
+#                                /run-root/seed-prompts/) and the bootstrap
+#                                seeds `strategist:seed_prompt:tribe-<t>`
+#                                from it BEFORE launching the daemons, so
+#                                that tribe adopts the frozen prompt as its
+#                                initial strategy (walk-forward TEST phase,
+#                                #1167). Pair with
+#                                REPLAY_STRATEGIST_PROMPT_EVOLUTION_THRESHOLD
+#                                set very high to keep the seed frozen.
+#                                Absent (default "") = no-op, behaviour
+#                                byte-identical to a normal replay.
 #   REPLAY_DRY_RUN               1 = emit_step the plan, skip podman.
 #                                Default: "" (real run)
 #   REPLAY_RUN_DIR               Output dir override. Default: auto-
@@ -200,6 +215,7 @@ DAEMON_CB_PER_TICK="${REPLAY_DAEMON_CB_PER_TICK:-2000}"
 DAEMON_HEARTBEAT_MS="${REPLAY_DAEMON_HEARTBEAT_MS:-1800000}"
 LOOKBACK_WINDOW="${REPLAY_LOOKBACK_WINDOW:-200}"
 HOLD_PERIOD="${REPLAY_HOLD_PERIOD:-8}"
+SEED_PROMPTS_DIR="${REPLAY_SEED_PROMPTS_DIR:-}"
 IMAGE_TAG="${REPLAY_IMAGE_TAG:-trading-binance-replay:latest}"
 
 # Strategist M98 v3 prompt-evolution + fitness knobs. The first one
@@ -352,6 +368,7 @@ emit_step "hold period: $HOLD_PERIOD"
 emit_step "llm backend: $LLM_BACKEND"
 emit_step "image tag: $IMAGE_TAG"
 emit_step "data dir: $DATA_DIR"
+emit_step "seed prompts dir: ${SEED_PROMPTS_DIR:-<none>}"
 
 # --- 1) Load candles via helper (single point of file-existence enforcement) ---
 # Candles land in two places:
@@ -387,6 +404,31 @@ load_candles() {
 build_image() {
     emit_step "checking for existing image $IMAGE_TAG (build if missing)"
     emit_cmd "podman image exists $IMAGE_TAG || podman build -t $IMAGE_TAG -f $TOOLS_DIR/Containerfile.replay $FED_DIR"
+}
+
+# --- 2b) Seed-prompt staging (#1167 walk-forward TEST phase) ---
+# When REPLAY_SEED_PROMPTS_DIR is set, copy its `tribe-<t>.txt` files into
+# the run dir's seed-prompts/ so they land at /run-root/seed-prompts/ via
+# the existing /run-root bind mount. The bootstrap then seeds
+# `strategist:seed_prompt:tribe-<t>` from each present file before the
+# daemons launch. Absent dir = no-op (behaviour byte-identical to a normal
+# replay).
+stage_seed_prompts() {
+    if [ -z "$SEED_PROMPTS_DIR" ]; then
+        return 0
+    fi
+    emit_step "staging seed prompts from $SEED_PROMPTS_DIR into $LAPTOP_DIR/seed-prompts/"
+    if [ "$DRY_RUN" = "1" ]; then
+        emit_cmd "mkdir -p $LAPTOP_DIR/seed-prompts && cp $SEED_PROMPTS_DIR/tribe-*.txt $LAPTOP_DIR/seed-prompts/ 2>/dev/null || true"
+        return 0
+    fi
+    mkdir -p "$LAPTOP_DIR/seed-prompts"
+    for t in alpha beta gamma delta epsilon zeta; do
+        if [ -f "$SEED_PROMPTS_DIR/tribe-$t.txt" ]; then
+            cp "$SEED_PROMPTS_DIR/tribe-$t.txt" "$LAPTOP_DIR/seed-prompts/tribe-$t.txt"
+            emit_step "seed prompt staged: tribe-$t"
+        fi
+    done
 }
 
 # --- 3) Per-node bootstrap script generator ---
@@ -497,6 +539,21 @@ write_bootstrap() {
         printf 'for t in alpha beta gamma delta epsilon zeta; do\n'
         printf '    (cd /run-root && agentis memo set strategist:confidence 0.7 >/dev/null 2>&1 || true)\n'
         printf 'done\n'
+        # Walk-forward TEST-phase seed (#1167): when REPLAY_SEED_PROMPTS_DIR
+        # staged per-tribe frozen prompts into /run-root/seed-prompts/, seed
+        # `strategist:seed_prompt:tribe-<t>` from each present file BEFORE the
+        # daemons launch so the .ag seed-override branch adopts the frozen
+        # prompt as that tribe's initial strategy. `"$(cat ...)"` preserves
+        # multi-line prompt bodies through the memo set. Emitted only when
+        # REPLAY_SEED_PROMPTS_DIR is set, so an unseeded replay is
+        # byte-identical to before.
+        if [ -n "$SEED_PROMPTS_DIR" ]; then
+            printf 'for t in alpha beta gamma delta epsilon zeta; do\n'
+            printf '    if [ -f /run-root/seed-prompts/tribe-$t.txt ]; then\n'
+            printf '        (cd /run-root && agentis memo set strategist:seed_prompt:tribe-$t "$(cat /run-root/seed-prompts/tribe-$t.txt)" >/dev/null 2>&1 || true)\n'
+            printf '    fi\n'
+            printf 'done\n'
+        fi
         # Spawn one source strategist daemon per tribe. Each tribe's
         # M2-Malthusian replicate path grows the population from there.
         printf 'for t in alpha beta gamma delta epsilon zeta; do\n'
@@ -633,6 +690,7 @@ analyse_placeholder() {
 install_cleanup_trap
 load_candles
 build_image
+stage_seed_prompts
 write_bootstrap
 write_run_meta
 spawn_container

--- a/trading-binance/tools/test-run-replay.sh
+++ b/trading-binance/tools/test-run-replay.sh
@@ -36,6 +36,12 @@
 #       omits the /root/.claude AND /root/.claude.json mounts, and the script
 #       source keeps the llm.openai.api_key_env injection + the openai key
 #       enforcement (#1133, #1161)
+#  T-seed. Walk-forward seed-prompt injection (#1167): with
+#       REPLAY_SEED_PROMPTS_DIR set, the dry-run emits the seed-prompt
+#       staging step + copies host tribe-<t>.txt into the run dir's
+#       seed-prompts/, and the script source wires the per-tribe
+#       `agentis memo set strategist:seed_prompt:tribe-<t>` step; without it,
+#       no staging step and behaviour is byte-identical (the <none> sentinel).
 #  Header-doc: REPLAY_LLM_BACKEND + REPLAY_HOST_CLAUDE_DIR documented (#1133)
 #
 # Standard library only — no pytest, no requests, no live LLM, no podman.
@@ -350,6 +356,48 @@ assert_contains "T-b3. script source injects llm.openai.api_key_env" "$SRC" \
     "llm.openai.api_key_env"
 assert_contains "T-b4. script source enforces the openai key" "$SRC" \
     "required for llm.backend=openai"
+
+# ---------------------------------------------------------------------------
+# T-seed. Walk-forward seed-prompt injection (#1167). With
+# REPLAY_SEED_PROMPTS_DIR set on a dry-run, the orchestrator surfaces the
+# seed-prompt staging step (copy host tribe-<t>.txt into the run dir's
+# seed-prompts/) and the script source wires the per-tribe
+# `agentis memo set strategist:seed_prompt:tribe-<t>` step before the daemon
+# launch. Without the dir set, the staging step is NOT emitted (behaviour
+# byte-identical to a normal replay). The memo-set printf line lives in the
+# real-run bootstrap generator, so it is asserted on the script SOURCE.
+# ---------------------------------------------------------------------------
+SEED_SRC_DIR="$WORK_DIR/seed-prompts"
+mkdir -p "$SEED_SRC_DIR"
+printf 'frozen alpha strategy\nline two\n' >"$SEED_SRC_DIR/tribe-alpha.txt"
+SEED_OUT="$(REPLAY_DRY_RUN=1 \
+            REPLAY_SEED_PROMPTS_DIR="$SEED_SRC_DIR" \
+            REPLAY_SYMBOL=BTCUSDT \
+            REPLAY_TIMEFRAME=30m \
+            REPLAY_RUN_DIR="$WORK_DIR/run-seed" \
+            bash "$ORCH" 2>&1)"
+assert_contains "T-seed1. seeded dry-run names the seed prompts dir" "$SEED_OUT" \
+    "seed prompts dir: $SEED_SRC_DIR"
+assert_contains "T-seed2. seeded dry-run emits the seed-prompt staging step" "$SEED_OUT" \
+    "staging seed prompts from $SEED_SRC_DIR"
+assert_contains "T-seed3. seeded dry-run copies into the run dir seed-prompts/" "$SEED_OUT" \
+    "$WORK_DIR/run-seed/laptop-node/seed-prompts/"
+assert_contains "T-seed4. script source wires the seed_prompt memo-set step" "$SRC" \
+    "agentis memo set strategist:seed_prompt:tribe-\$t"
+assert_contains "T-seed5. header documents REPLAY_SEED_PROMPTS_DIR" "$SRC" \
+    "REPLAY_SEED_PROMPTS_DIR"
+
+# T-seed6. Unset REPLAY_SEED_PROMPTS_DIR -> the staging step is absent, the
+# default capture's "<none>" sentinel is used, and behaviour is unchanged.
+if printf '%s' "$OUT" | grep -Fq -- "staging seed prompts from"; then
+    echo "[FAIL] T-seed6. unseeded dry-run does not emit a staging step"
+    FAIL=$((FAIL + 1))
+else
+    echo "[PASS] T-seed6. unseeded dry-run does not emit a staging step"
+    PASS=$((PASS + 1))
+fi
+assert_contains "T-seed7. unseeded dry-run shows the <none> seed sentinel" "$OUT" \
+    "seed prompts dir: <none>"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/trading-binance/tribe-alpha/agents/strategist.ag
+++ b/trading-binance/tribe-alpha/agents/strategist.ag
@@ -307,8 +307,15 @@ fn tick(reason: string) -> void {
         let max_bytes_env = try { exec sh "printenv STRATEGIST_PROMPT_MAX_BYTES"; } catch e { ""; };
         let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
         let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_override = recall_latest("strategist:seed_prompt:" + _tribe_name);
         let pp_hash = _extract_pp_hash(_variant);
-        if len(pp_hash) > 0 {
+        if len(seed_override) > 0 {
+            let seed_ov_clamped = if len(seed_override) > max_bytes_eff { substring(seed_override, 0, max_bytes_eff); } else { seed_override; };
+            memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_ov_clamped);
+            memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
+            learn("strategist_prompt_inherit", _tribe_name + "/" + _self_pid, "seed-override", "success", ["prompt-inheritance", "walk-forward-seed", "trading-binance"]);
+            seed_ov_clamped;
+        } else { if len(pp_hash) > 0 {
             let inherited = recall_latest("strategist:prompt_body:" + pp_hash);
             if len(inherited) > 0 {
                 let inh_clamped = if len(inherited) > max_bytes_eff { substring(inherited, 0, max_bytes_eff); } else { inherited; };
@@ -330,7 +337,7 @@ fn tick(reason: string) -> void {
             memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_clamped);
             memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
             seed_clamped;
-        };
+        }; };
     } else {
         prompt_text_raw;
     };

--- a/trading-binance/tribe-beta/agents/strategist.ag
+++ b/trading-binance/tribe-beta/agents/strategist.ag
@@ -307,8 +307,15 @@ fn tick(reason: string) -> void {
         let max_bytes_env = try { exec sh "printenv STRATEGIST_PROMPT_MAX_BYTES"; } catch e { ""; };
         let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
         let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_override = recall_latest("strategist:seed_prompt:" + _tribe_name);
         let pp_hash = _extract_pp_hash(_variant);
-        if len(pp_hash) > 0 {
+        if len(seed_override) > 0 {
+            let seed_ov_clamped = if len(seed_override) > max_bytes_eff { substring(seed_override, 0, max_bytes_eff); } else { seed_override; };
+            memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_ov_clamped);
+            memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
+            learn("strategist_prompt_inherit", _tribe_name + "/" + _self_pid, "seed-override", "success", ["prompt-inheritance", "walk-forward-seed", "trading-binance"]);
+            seed_ov_clamped;
+        } else { if len(pp_hash) > 0 {
             let inherited = recall_latest("strategist:prompt_body:" + pp_hash);
             if len(inherited) > 0 {
                 let inh_clamped = if len(inherited) > max_bytes_eff { substring(inherited, 0, max_bytes_eff); } else { inherited; };
@@ -330,7 +337,7 @@ fn tick(reason: string) -> void {
             memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_clamped);
             memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
             seed_clamped;
-        };
+        }; };
     } else {
         prompt_text_raw;
     };

--- a/trading-binance/tribe-delta/agents/strategist.ag
+++ b/trading-binance/tribe-delta/agents/strategist.ag
@@ -307,8 +307,15 @@ fn tick(reason: string) -> void {
         let max_bytes_env = try { exec sh "printenv STRATEGIST_PROMPT_MAX_BYTES"; } catch e { ""; };
         let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
         let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_override = recall_latest("strategist:seed_prompt:" + _tribe_name);
         let pp_hash = _extract_pp_hash(_variant);
-        if len(pp_hash) > 0 {
+        if len(seed_override) > 0 {
+            let seed_ov_clamped = if len(seed_override) > max_bytes_eff { substring(seed_override, 0, max_bytes_eff); } else { seed_override; };
+            memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_ov_clamped);
+            memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
+            learn("strategist_prompt_inherit", _tribe_name + "/" + _self_pid, "seed-override", "success", ["prompt-inheritance", "walk-forward-seed", "trading-binance"]);
+            seed_ov_clamped;
+        } else { if len(pp_hash) > 0 {
             let inherited = recall_latest("strategist:prompt_body:" + pp_hash);
             if len(inherited) > 0 {
                 let inh_clamped = if len(inherited) > max_bytes_eff { substring(inherited, 0, max_bytes_eff); } else { inherited; };
@@ -330,7 +337,7 @@ fn tick(reason: string) -> void {
             memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_clamped);
             memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
             seed_clamped;
-        };
+        }; };
     } else {
         prompt_text_raw;
     };

--- a/trading-binance/tribe-epsilon/agents/strategist.ag
+++ b/trading-binance/tribe-epsilon/agents/strategist.ag
@@ -307,8 +307,15 @@ fn tick(reason: string) -> void {
         let max_bytes_env = try { exec sh "printenv STRATEGIST_PROMPT_MAX_BYTES"; } catch e { ""; };
         let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
         let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_override = recall_latest("strategist:seed_prompt:" + _tribe_name);
         let pp_hash = _extract_pp_hash(_variant);
-        if len(pp_hash) > 0 {
+        if len(seed_override) > 0 {
+            let seed_ov_clamped = if len(seed_override) > max_bytes_eff { substring(seed_override, 0, max_bytes_eff); } else { seed_override; };
+            memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_ov_clamped);
+            memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
+            learn("strategist_prompt_inherit", _tribe_name + "/" + _self_pid, "seed-override", "success", ["prompt-inheritance", "walk-forward-seed", "trading-binance"]);
+            seed_ov_clamped;
+        } else { if len(pp_hash) > 0 {
             let inherited = recall_latest("strategist:prompt_body:" + pp_hash);
             if len(inherited) > 0 {
                 let inh_clamped = if len(inherited) > max_bytes_eff { substring(inherited, 0, max_bytes_eff); } else { inherited; };
@@ -330,7 +337,7 @@ fn tick(reason: string) -> void {
             memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_clamped);
             memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
             seed_clamped;
-        };
+        }; };
     } else {
         prompt_text_raw;
     };

--- a/trading-binance/tribe-gamma/agents/strategist.ag
+++ b/trading-binance/tribe-gamma/agents/strategist.ag
@@ -307,8 +307,15 @@ fn tick(reason: string) -> void {
         let max_bytes_env = try { exec sh "printenv STRATEGIST_PROMPT_MAX_BYTES"; } catch e { ""; };
         let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
         let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_override = recall_latest("strategist:seed_prompt:" + _tribe_name);
         let pp_hash = _extract_pp_hash(_variant);
-        if len(pp_hash) > 0 {
+        if len(seed_override) > 0 {
+            let seed_ov_clamped = if len(seed_override) > max_bytes_eff { substring(seed_override, 0, max_bytes_eff); } else { seed_override; };
+            memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_ov_clamped);
+            memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
+            learn("strategist_prompt_inherit", _tribe_name + "/" + _self_pid, "seed-override", "success", ["prompt-inheritance", "walk-forward-seed", "trading-binance"]);
+            seed_ov_clamped;
+        } else { if len(pp_hash) > 0 {
             let inherited = recall_latest("strategist:prompt_body:" + pp_hash);
             if len(inherited) > 0 {
                 let inh_clamped = if len(inherited) > max_bytes_eff { substring(inherited, 0, max_bytes_eff); } else { inherited; };
@@ -330,7 +337,7 @@ fn tick(reason: string) -> void {
             memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_clamped);
             memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
             seed_clamped;
-        };
+        }; };
     } else {
         prompt_text_raw;
     };

--- a/trading-binance/tribe-zeta/agents/strategist.ag
+++ b/trading-binance/tribe-zeta/agents/strategist.ag
@@ -307,8 +307,15 @@ fn tick(reason: string) -> void {
         let max_bytes_env = try { exec sh "printenv STRATEGIST_PROMPT_MAX_BYTES"; } catch e { ""; };
         let max_bytes = if len(max_bytes_env) > 0 { parse_int(max_bytes_env); } else { 4096; };
         let max_bytes_eff = if max_bytes <= 0 { 4096; } else { max_bytes; };
+        let seed_override = recall_latest("strategist:seed_prompt:" + _tribe_name);
         let pp_hash = _extract_pp_hash(_variant);
-        if len(pp_hash) > 0 {
+        if len(seed_override) > 0 {
+            let seed_ov_clamped = if len(seed_override) > max_bytes_eff { substring(seed_override, 0, max_bytes_eff); } else { seed_override; };
+            memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_ov_clamped);
+            memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
+            learn("strategist_prompt_inherit", _tribe_name + "/" + _self_pid, "seed-override", "success", ["prompt-inheritance", "walk-forward-seed", "trading-binance"]);
+            seed_ov_clamped;
+        } else { if len(pp_hash) > 0 {
             let inherited = recall_latest("strategist:prompt_body:" + pp_hash);
             if len(inherited) > 0 {
                 let inh_clamped = if len(inherited) > max_bytes_eff { substring(inherited, 0, max_bytes_eff); } else { inherited; };
@@ -330,7 +337,7 @@ fn tick(reason: string) -> void {
             memo_write("strategist:" + _self_pid + ":strategy_prompt", seed_clamped);
             memo_write("strategist:" + _self_pid + ":strategy_generation", "0");
             seed_clamped;
-        };
+        }; };
     } else {
         prompt_text_raw;
     };


### PR DESCRIPTION
## Summary

Add a **walk-forward** harness so trading edge is judged on **out-of-sample** data, not the window the tribes evolved on. Closes #1167. (Methodology gate established after the single-window run #1166 showed no edge — the only honest way to validate any future edge claim.)

The evolutionary search rewrites each tribe's prompt from its window's settled trades (M98), so in-sample results overfit by construction. Walk-forward: **evolve on a train window → freeze the evolved prompt → measure on a later unseen test window → roll forward → aggregate OOS expectancy.**

## Three pieces

1. **Per-tribe frozen-prompt carry-forward** (6 `strategist.ag`): when `strategist:<pid>:strategy_prompt` is empty, a new highest-precedence branch adopts `strategist:seed_prompt:<tribe>` if set (above pp:-inherit / hardcoded seed). Identical across all 6 tribes (grammar has no `else if` → nested `else { if }`).
2. **`run-replay.sh` `REPLAY_SEED_PROMPTS_DIR`**: stages `tribe-<t>.txt` → `/run-root/seed-prompts/`; the bootstrap `agentis memo set strategist:seed_prompt:tribe-<t>` before launching daemons (emitted **only when set** → unseeded runs byte-identical). Evolution frozen via the existing `STRATEGIST_PROMPT_EVOLUTION_THRESHOLD` (set high in the test phase).
3. **`tools/walk-forward.sh`**: per fold TRAIN (evolution on) → EXTRACT each tribe's evolved prompt (tribe→pid via `strategist-<t>.log` → memo) → TEST (seeded + frozen) → SCORE OOS expectancy / profit-factor / per-tribe → aggregate to `runs/<wf>/walk-forward-summary.md` + `results.json` with an honest verdict. `--dry-run` + internal `--extract-prompt`.

## Validated

- **Live in-container**: a seeded run had **all 6 tribes adopt THEIR OWN frozen prompt** (per-pid `strategy_prompt` = the per-tribe seed marker — 51→alpha, 52→delta, 53→beta, 54→gamma, 55→epsilon, 56→zeta), **0 parse errors**, evolution frozen (threshold 999999). The seed staging + bootstrap memo-set fired; unseeded path unchanged.
- `tools/test-walk-forward.sh` → **20/0** (fold-spec parsing + tribe→pid→prompt extraction fixture + `--dry-run` seed/freeze wiring). `tools/test-run-replay.sh` → **55/0** (+7 seed asserts). `./tools/colony-lint.sh` → **421/0**, 5 skipped. All 6 strategists parse via `agentis commit`.
- `--dry-run` prints 2 folds with correct train/test windows + the seed/freeze run-replay invocations.

Live multi-fold walk-forward run (the OOS trading result) will be run after merge.

Closes #1167.
