### PR TITLE
feat(trading-binance): carry-verify.sh — deterministic delta-neutral carry settlement (#1175 M1)

### DIFF
--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -14,6 +14,15 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ## [Unreleased]
 
+### Added
+
+- `tools/carry-verify.sh` (#1175 M1): deterministic settlement verifier for a
+  delta-neutral funding-CARRY basket -- the carry analogue of verify-trade.sh.
+  Net carry = weighted sum of forward funding (short-perp receives positive
+  funding) minus amortised round-trip turnover cost vs the previous basket.
+  `tools/test-carry-verify.sh` (14 cases: known funding->carry, weighting,
+  negative funding, turnover cost, cash/empty, missing data, window selection).
+
 ### Fixed
 
 - The 6 replay strategists (`tribe-{alpha,beta,gamma,delta,epsilon,zeta}/agents/strategist.ag`)

--- a/trading-binance/tools/carry-verify.sh
+++ b/trading-binance/tools/carry-verify.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# carry-verify.sh -- deterministic settlement verifier for a delta-neutral
+# funding-CARRY basket decision (#1175 M1). The carry analogue of
+# verify-trade.sh.
+#
+# A delta-neutral carry position (short perp + long spot) has ~zero directional
+# PnL -- the two legs cancel -- so the realised return over a forward window is
+# the funding collected: when funding > 0 the short-perp leg RECEIVES it. The
+# net return of a basket is the weighted sum of each symbol's forward funding,
+# minus the turnover cost of changing the basket vs the previous one.
+#
+# Inputs (env):
+#   DECISION_JSON        Basket: {"positions":[{"symbol":"LINKUSDT","weight":0.25},...]}.
+#                        Empty positions / weights summing to 0 = cash (FLAT).
+#                        Weights are fractions of capital; remainder = cash (0 carry).
+#   FUNDING_DIR          Dir of per-symbol funding CSVs <SYM>.csv
+#                        (header fundingTime,fundingRate; as written by
+#                        tools/funding-download.py).
+#   SETTLE_START         Forward window start, epoch ms (inclusive).
+#   SETTLE_END           Forward window end, epoch ms (exclusive).
+#   COST_BPS_ROUNDTRIP   (optional, default 20) round-trip cost in bps applied
+#                        to basket turnover (both legs).
+#   PREV_POSITIONS_JSON  (optional, default empty) previous basket positions,
+#                        same shape as DECISION_JSON.positions, for turnover.
+#
+# Settlement:
+#   fwd_funding_s   = sum of fundingRate for symbol s in [SETTLE_START, SETTLE_END)
+#   carry_bps       = sum_s weight_s * fwd_funding_s * 10000
+#   turnover        = sum_s |weight_new_s - weight_prev_s|         # one-way x2 over a full cycle
+#   turnover_cost_bps = COST_BPS_ROUNDTRIP * turnover / 2          # amortised round-trip
+#   net_bps         = carry_bps - turnover_cost_bps
+#
+# Output (stdout, single-line JSON):
+#   {"verified":true,"carry_bps":..,"turnover_cost_bps":..,"net_bps":..,
+#    "per_symbol":[{"symbol":..,"weight":..,"funding_bps":..}, ...]}
+#
+# Exit codes: 0 ok; 2 bad/missing args.
+set -euo pipefail
+
+DECISION_JSON="${DECISION_JSON:-}"
+FUNDING_DIR="${FUNDING_DIR:-}"
+SETTLE_START="${SETTLE_START:-}"
+SETTLE_END="${SETTLE_END:-}"
+COST_BPS_ROUNDTRIP="${COST_BPS_ROUNDTRIP:-20}"
+PREV_POSITIONS_JSON="${PREV_POSITIONS_JSON:-}"
+
+if [ -z "$DECISION_JSON" ]; then
+    echo "carry-verify: DECISION_JSON is required" >&2; exit 2
+fi
+if [ -z "$FUNDING_DIR" ] || [ ! -d "$FUNDING_DIR" ]; then
+    echo "carry-verify: FUNDING_DIR must be an existing directory (got: '$FUNDING_DIR')" >&2; exit 2
+fi
+case "$SETTLE_START" in ''|*[!0-9]*) echo "carry-verify: SETTLE_START must be epoch ms (got: '$SETTLE_START')" >&2; exit 2;; esac
+case "$SETTLE_END" in ''|*[!0-9]*) echo "carry-verify: SETTLE_END must be epoch ms (got: '$SETTLE_END')" >&2; exit 2;; esac
+
+python3 - "$DECISION_JSON" "$FUNDING_DIR" "$SETTLE_START" "$SETTLE_END" \
+         "$COST_BPS_ROUNDTRIP" "$PREV_POSITIONS_JSON" <<'PYCARRY'
+import sys, json, csv, os
+
+decision_raw, funding_dir, start_s, end_s, cost_rt_s, prev_raw = sys.argv[1:7]
+start = int(start_s); end = int(end_s)
+try:
+    cost_rt = float(cost_rt_s)
+except ValueError:
+    cost_rt = 20.0
+
+
+def parse_positions(raw):
+    if not raw or not raw.strip():
+        return {}
+    try:
+        obj = json.loads(raw)
+    except Exception:
+        return {}
+    if isinstance(obj, dict):
+        pos = obj.get("positions", [])
+    elif isinstance(obj, list):
+        pos = obj
+    else:
+        pos = []
+    out = {}
+    for p in pos:
+        try:
+            sym = str(p["symbol"]).upper()
+            w = float(p.get("weight", 0.0))
+        except Exception:
+            continue
+        if sym:
+            out[sym] = out.get(sym, 0.0) + w
+    return out
+
+
+def fwd_funding(sym):
+    path = os.path.join(funding_dir, sym + ".csv")
+    if not os.path.isfile(path):
+        return None
+    total = 0.0
+    with open(path, newline="") as fh:
+        for r in csv.DictReader(fh):
+            try:
+                t = int(r["fundingTime"]); fr = float(r["fundingRate"])
+            except Exception:
+                continue
+            if start <= t < end:
+                total += fr
+    return total
+
+
+cur = parse_positions(decision_raw)
+prev = parse_positions(prev_raw)
+
+carry_bps = 0.0
+per_symbol = []
+for sym in sorted(cur.keys()):
+    w = cur[sym]
+    f = fwd_funding(sym)
+    f_eff = f if f is not None else 0.0
+    contrib = w * f_eff * 10000.0
+    carry_bps += contrib
+    per_symbol.append({
+        "symbol": sym,
+        "weight": round(w, 6),
+        "funding_bps": round(f_eff * 10000.0, 4),
+        "missing_data": f is None,
+    })
+
+# turnover = sum over the union of symbols of |w_new - w_prev|
+syms = set(cur) | set(prev)
+turnover = sum(abs(cur.get(s, 0.0) - prev.get(s, 0.0)) for s in syms)
+turnover_cost_bps = cost_rt * turnover / 2.0
+net_bps = carry_bps - turnover_cost_bps
+
+verdict = {
+    "verified": True,
+    "carry_bps": round(carry_bps, 4),
+    "turnover_cost_bps": round(turnover_cost_bps, 4),
+    "net_bps": round(net_bps, 4),
+    "gross_weight": round(sum(cur.values()), 6),
+    "per_symbol": per_symbol,
+}
+sys.stdout.write(json.dumps(verdict, separators=(",", ":")))
+PYCARRY

--- a/trading-binance/tools/test-carry-verify.sh
+++ b/trading-binance/tools/test-carry-verify.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# test-carry-verify.sh -- unit tests for carry-verify.sh (#1175 M1).
+# Builds a fixed funding-CSV fixture in a tempdir and exercises the
+# delta-neutral carry settlement: known funding -> known carry, weighting,
+# turnover cost, cash/empty, missing data.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VERIFIER="$SCRIPT_DIR/carry-verify.sh"
+
+if [ ! -x "$VERIFIER" ]; then
+    echo "FAIL: verifier not executable: $VERIFIER" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+
+# LINKUSDT: funding 0.0003 + 0.0004 + 0.0003 = 0.0010 over [1000,3500) -> 10 bps at weight 1.0
+printf 'fundingTime,fundingRate\n1000,0.0003\n2000,0.0004\n3000,0.0003\n4000,0.0009\n' > "$FIX/LINKUSDT.csv"
+# AAVEUSDT: 0.0002 + 0.0002 = 0.0004 over [1000,3500) -> 4 bps at weight 1.0
+# (the -0.0001 at 4000 is OUTSIDE the [1000,3500) test window)
+printf 'fundingTime,fundingRate\n1000,0.0002\n2000,0.0002\n4000,-0.0001\n' > "$FIX/AAVEUSDT.csv"
+# NEGUSDT: negative funding (short-perp PAYS): -0.0005 over [1000,3500)
+printf 'fundingTime,fundingRate\n1000,-0.0002\n2000,-0.0003\n' > "$FIX/NEGUSDT.csv"
+
+# field <json> <key> -> numeric value
+jget() { python3 -c 'import sys,json; v=json.loads(sys.argv[1]); print(v[sys.argv[2]])' "$1" "$2"; }
+
+assert_eq() {
+    # $1 label, $2 got, $3 want (numeric, tolerance 1e-6)
+    local label="$1" got="$2" want="$3"
+    if python3 -c 'import sys; g=float(sys.argv[1]); w=float(sys.argv[2]); sys.exit(0 if abs(g-w)<1e-6 else 1)' "$got" "$want"; then
+        echo "[PASS] $label (=$got)"; PASS=$((PASS+1))
+    else
+        echo "[FAIL] $label got=$got want=$want"; FAIL=$((FAIL+1))
+    fi
+}
+
+# 1. single symbol, full weight, positive funding -> 10 bps carry, no prev -> turnover full (cost = 20*1/2 = 10)
+V="$(DECISION_JSON='{"positions":[{"symbol":"LINKUSDT","weight":1.0}]}' FUNDING_DIR="$FIX" \
+     SETTLE_START=1000 SETTLE_END=3500 COST_BPS_ROUNDTRIP=20 "$VERIFIER")"
+assert_eq "1a. carry_bps single LINK weight1" "$(jget "$V" carry_bps)" "10.0"
+assert_eq "1b. turnover_cost from-cash (turnover=1, cost=20*1/2)" "$(jget "$V" turnover_cost_bps)" "10.0"
+assert_eq "1c. net_bps = carry - cost" "$(jget "$V" net_bps)" "0.0"
+
+# 2. positive funding => positive carry (delta-neutral short-perp receives)
+V="$(DECISION_JSON='{"positions":[{"symbol":"LINKUSDT","weight":0.5}]}' FUNDING_DIR="$FIX" \
+     SETTLE_START=1000 SETTLE_END=3500 PREV_POSITIONS_JSON='{"positions":[{"symbol":"LINKUSDT","weight":0.5}]}' "$VERIFIER")"
+assert_eq "2a. weight 0.5 -> 5 bps carry" "$(jget "$V" carry_bps)" "5.0"
+assert_eq "2b. unchanged basket -> 0 turnover cost" "$(jget "$V" turnover_cost_bps)" "0.0"
+
+# 3. negative funding -> negative carry (short-perp pays)
+V="$(DECISION_JSON='{"positions":[{"symbol":"NEGUSDT","weight":1.0}]}' FUNDING_DIR="$FIX" \
+     SETTLE_START=1000 SETTLE_END=3500 PREV_POSITIONS_JSON='{"positions":[{"symbol":"NEGUSDT","weight":1.0}]}' "$VERIFIER")"
+assert_eq "3. negative funding -> -5 bps carry" "$(jget "$V" carry_bps)" "-5.0"
+
+# 4. multi-symbol weighted basket: 0.5*LINK(10) + 0.5*AAVE(4) = 5 + 2 = 7 bps
+V="$(DECISION_JSON='{"positions":[{"symbol":"LINKUSDT","weight":0.5},{"symbol":"AAVEUSDT","weight":0.5}]}' FUNDING_DIR="$FIX" \
+     SETTLE_START=1000 SETTLE_END=3500 PREV_POSITIONS_JSON='{"positions":[{"symbol":"LINKUSDT","weight":0.5},{"symbol":"AAVEUSDT","weight":0.5}]}' "$VERIFIER")"
+assert_eq "4. weighted basket carry 0.5*10 + 0.5*4" "$(jget "$V" carry_bps)" "7.0"
+
+# 5. cash / empty positions -> 0 carry, 0 cost
+V="$(DECISION_JSON='{"positions":[]}' FUNDING_DIR="$FIX" SETTLE_START=1000 SETTLE_END=3500 "$VERIFIER")"
+assert_eq "5a. empty basket carry 0" "$(jget "$V" carry_bps)" "0.0"
+assert_eq "5b. empty basket cost 0" "$(jget "$V" turnover_cost_bps)" "0.0"
+
+# 6. turnover cost on rotation: prev=LINK(1.0), new=AAVE(1.0) -> turnover=2, cost=20*2/2=20
+V="$(DECISION_JSON='{"positions":[{"symbol":"AAVEUSDT","weight":1.0}]}' FUNDING_DIR="$FIX" \
+     SETTLE_START=1000 SETTLE_END=3500 COST_BPS_ROUNDTRIP=20 \
+     PREV_POSITIONS_JSON='{"positions":[{"symbol":"LINKUSDT","weight":1.0}]}' "$VERIFIER")"
+assert_eq "6a. full rotation turnover cost (turnover=2)" "$(jget "$V" turnover_cost_bps)" "20.0"
+assert_eq "6b. rotated carry = AAVE 4 bps" "$(jget "$V" carry_bps)" "4.0"
+
+# 7. missing symbol data -> funding 0 (graceful)
+V="$(DECISION_JSON='{"positions":[{"symbol":"NOSUCHUSDT","weight":1.0}]}' FUNDING_DIR="$FIX" \
+     SETTLE_START=1000 SETTLE_END=3500 PREV_POSITIONS_JSON='{"positions":[{"symbol":"NOSUCHUSDT","weight":1.0}]}' "$VERIFIER")"
+assert_eq "7. missing-data symbol -> 0 carry" "$(jget "$V" carry_bps)" "0.0"
+
+# 8. window selection: tighter window [1000,2500) picks only first two LINK events 0.0003+0.0004=0.0007 -> 7 bps
+V="$(DECISION_JSON='{"positions":[{"symbol":"LINKUSDT","weight":1.0}]}' FUNDING_DIR="$FIX" \
+     SETTLE_START=1000 SETTLE_END=2500 PREV_POSITIONS_JSON='{"positions":[{"symbol":"LINKUSDT","weight":1.0}]}' "$VERIFIER")"
+assert_eq "8. forward-window funding sum [1000,2500)" "$(jget "$V" carry_bps)" "7.0"
+
+# 9. bad args -> exit 2
+if DECISION_JSON='{"positions":[]}' FUNDING_DIR="$FIX" SETTLE_START=abc SETTLE_END=3500 "$VERIFIER" >/dev/null 2>&1; then
+    echo "[FAIL] 9. bad SETTLE_START should exit 2"; FAIL=$((FAIL+1))
+else
+    echo "[PASS] 9. bad SETTLE_START exits non-zero"; PASS=$((PASS+1))
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

**Phase 2 M1** of the funding-carry strategy (#1175): `tools/carry-verify.sh`, the deterministic settlement primitive — the carry analogue of `verify-trade.sh`. Everything in M2/M3 (carry-strategist, walk-forward carry run) settles through this.

A delta-neutral carry basket (short perp + long spot) has ~zero directional PnL, so its realised forward return is the funding collected:

```
carry_bps = Σ_s  weight_s · forward_funding_s · 1e4          (short-perp receives positive funding)
turnover_cost_bps = COST_BPS_ROUNDTRIP · Σ_s |w_new_s − w_prev_s| / 2   (amortised round-trip)
net_bps = carry_bps − turnover_cost_bps
```

Inputs via env (`DECISION_JSON` positions, `FUNDING_DIR`, `SETTLE_START`/`SETTLE_END` epoch-ms forward window, `COST_BPS_ROUNDTRIP`, `PREV_POSITIONS_JSON`); single-line JSON verdict (`carry_bps`, `turnover_cost_bps`, `net_bps`, `per_symbol`). Matches the Phase-1 backtest carry math (#1174).

## Verification

- `tools/test-carry-verify.sh` → **14/0**: known funding→carry, weighting, negative funding (short pays), turnover cost on rotation, cash/empty = 0, missing-data graceful, forward-window selection, bad-args → exit 2. `bash -n` clean.

Closes #1175 M1 (M2 carry-strategist + M3 walk-forward carry run are the follow-ups).
