### PR TITLE
fix(federation): large-prompt (--cmd-file) + code_writer edits existing files (#1171, #1172)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -33,6 +33,33 @@ is asserted until multi-version CI is in place.
 
 ### Fixed
 
+- **flat-cyborg wrapper no longer overflows ARG_MAX on large prompts** (#1171).
+  `tools/flat-cyborg-claude.sh` passed the prompt to flat-cyborg as `--cmd
+  "$PROMPT"` (an argv value); a multi-MB prompt — which agents build on a real
+  repo from MR diffs + history — overflows `ARG_MAX`, so `exec flat-cyborg`
+  fails E2BIG (`Argument list too long`) and the agent's `prompt()` errors. The
+  wrapper now writes the prompt to a temp file and passes `--cmd-file
+  "$PROMPT_FILE"` (cleaned up by the existing `trap`). **Requires flat-cyborg
+  >= 0.11.0** (the `--cmd-file` flag); on an older flat-cyborg this fails with
+  `unknown flag: --cmd-file` — run `flat-cyborg update`. Found dogfooding the
+  federation on this repo (the release/planning agents hit it within seconds).
+- **`implementation` code_writer now EDITs existing files instead of clobbering them**
+  (#1172). The autonomous code-gen path built its prompt context from the issue,
+  the plan, and learned patterns but never fetched the *current* content of the
+  files it was about to write, so a task that modifies an existing file produced
+  a from-scratch rewrite that dropped everything the model did not reconstruct.
+  Both forge adapters gain a `get-file --path <path> [--ref <branch>]` verb
+  (`github-api.sh`, `gitlab-api.sh`) that base64-decodes the file's content to
+  stdout, returning empty + exit 0 on a 404 so the caller treats "no existing
+  content" as "new file"; any other HTTP error still propagates. code_writer
+  extracts the plan's primary file path from `draft.files` and folds the fetched
+  content into the code-gen context with an explicit "EDIT this — return the
+  full updated file, preserve everything you are not changing" instruction (or
+  "(file does not exist yet — create it)" when get-file is empty). The JSON-array
+  `{action, file_path, content}` output contract is unchanged. Single-file fetch
+  only — multi-file path extraction in `.ag` is impractical, so the rest of the
+  plan keeps the from-scratch fallback. Found dogfooding the federation on this
+  repo.
 - **Shared `tools/flat-cyborg-claude.sh` wrapper now unwraps JSON-shaped replies**
   (#1163). `--extract-structural` is a TUI screen-scrape, so claude's TUI
   line-wraps long output and injects newline+indent INSIDE a JSON string,

--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -295,7 +295,7 @@ The default CLI backend for this federation is **flat-cyborg**, a PTY wrapper th
 
 `install.sh` §6 wires it for you: when `flat-cyborg` is on your `PATH`, it offers (default Yes) to write `llm.backend = claude` and `llm.command = <fed>/tools/flat-cyborg-claude.sh` (with an empty `llm.args` — the prompt is the sole positional arg) into `<fed>/.agentis/config`. The wrapper path resolves from the federation root, so it works both in a source checkout and in the release bundle.
 
-**flat-cyborg must be installed** — get it from [Replikanti/flat-cyborg](https://github.com/Replikanti/flat-cyborg) (an installed copy self-updates with `flat-cyborg update`). If it is absent at install time, `install.sh` warns and falls back to printing the manual backend examples.
+**flat-cyborg must be installed, >= 0.11.0** — get it from [Replikanti/flat-cyborg](https://github.com/Replikanti/flat-cyborg) (an installed copy self-updates with `flat-cyborg update`). If it is absent at install time, `install.sh` warns and falls back to printing the manual backend examples. The wrapper passes the prompt via `--cmd-file` (flat-cyborg >= 0.11.0) so a multi-MB context does not overflow `ARG_MAX` (#1171); an older binary fails with `unknown flag: --cmd-file`.
 
 Two env-var knobs tune the wrapper (defaults shown):
 

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -69,6 +69,31 @@ fn repo_field(line: string, idx: int) -> string {
     return out;
 }
 
+// #1172: pull the primary file path out of `draft.files` (a markdown list of
+// "file path + what each does" lines). We fetch the existing content of that
+// one file so the code-gen prompt can EDIT it rather than clobber it. Multi-
+// file extraction in `.ag` is impractical, so we deliberately fetch only the
+// first/primary path; a from-scratch fallback still applies to the rest. The
+// helper scans for the first backtick-quoted token (the draft prompt tends to
+// wrap paths in backticks); failing that, the first slash-or-dot-bearing token
+// on the first list line. Returns "" when nothing path-shaped is found.
+fn primary_file_path(files: string) -> string {
+    let cmd = "F=" + shell_escape(files) +
+        " python3 -c 'import os,re,sys" +
+        "\nt=os.environ[\"F\"]" +
+        "\nm=re.search(r\"`([^`]+)`\", t)" +
+        "\nif m:" +
+        "\n    print(m.group(1).strip()); sys.exit(0)" +
+        "\nfor ln in t.splitlines():" +
+        "\n    s=ln.lstrip(\"-*0123456789. \\t\")" +
+        "\n    for tok in re.split(r\"[\\s:,]+\", s):" +
+        "\n        if (\"/\" in tok or \".\" in tok) and len(tok)>2:" +
+        "\n            print(tok.strip()); sys.exit(0)" +
+        "\nprint(\"\")'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
 fn merged_mr_cmd(owner: string, repo: string) -> string {
     let ts = recall_latest(scoped_memo(owner, repo, "code_writer:last_check"));
     // colony-lint: safe-exec-concat
@@ -259,10 +284,31 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                     // colony-lint: safe-exec-concat
                     let issue_cmd = "$COLONY_DIR/scripts/forge-api.sh issue " + to_string(draft.issue_id) + repo_arg(owner, repo);
                     let issue_detail = try { exec sh issue_cmd; } catch e { ""; };
-                    let code_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec);
+
+                    // #1172: before generating file contents from scratch, fetch
+                    // the existing content of the plan's primary file so an EDIT
+                    // task preserves everything it is not changing instead of
+                    // clobbering the file. get-file returns empty (exit 0) when
+                    // the file is new. Single-file fetch only — see
+                    // primary_file_path() for why multi-file is out of scope.
+                    let primary_path = primary_file_path(draft.files);
+                    let existing_block = if len(primary_path) > 0 {
+                        // colony-lint: safe-exec-concat
+                        let getfile_cmd = "$COLONY_DIR/scripts/forge-api.sh get-file --path " + shell_escape(primary_path) + " --ref main" + repo_arg(owner, repo);
+                        let existing_content = try { exec sh getfile_cmd; } catch e { ""; };
+                        if len(existing_content) > 0 {
+                            "\nExisting file " + primary_path + " (EDIT this — return the full updated file, preserve everything you are not changing):\n" + existing_content;
+                        } else {
+                            "\nExisting file " + primary_path + ": (file does not exist yet — create it)";
+                        };
+                    } else {
+                        "";
+                    };
+
+                    let code_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec) + existing_block;
 
                     let actions_json = prompt(
-                        "You are a code writer. Generate the actual file contents for this implementation plan. Return a JSON array of objects, each with: action (string, 'create' or 'update'), file_path (string), content (string, the full file content). Follow the learned naming and structure patterns. Only return the JSON array, nothing else.",
+                        "You are a code writer. Generate the actual file contents for this implementation plan. If an existing file is shown, EDIT it — return the FULL updated file content with only the necessary changes, preserving everything else. Only create from scratch when no existing content is shown. Return a JSON array of objects, each with: action (string, 'create' or 'update'), file_path (string), content (string, the full file content). Follow the learned naming and structure patterns. Only return the JSON array, nothing else.",
                         code_context
                     ) -> string;
 

--- a/dev-apprenticeship/implementation/scripts/github-api.sh
+++ b/dev-apprenticeship/implementation/scripts/github-api.sh
@@ -36,6 +36,7 @@
 #   github-api.sh commit-files --branch <b> --message <m> --actions <json>
 #   github-api.sh create-mr --source <branch> --title <title> [--description <d>]
 #   github-api.sh add-note <number> --body <text>
+#   github-api.sh get-file --path <path> [--ref <branch>]
 #
 # Views (opt-in projection; byte-identical to gitlab-api.sh):
 #   merge-requests  --view impl       [{iid, title, merged_at, target_branch}]
@@ -935,6 +936,53 @@ PY
         esac
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
         gh_post "$API/issues/$IID/comments" "$JSON_BODY"
+        ;;
+
+    get-file)
+        # #1172: fetch the raw decoded content of a single file at --ref so
+        # code_writer can EDIT an existing file instead of clobbering it with
+        # a from-scratch rewrite. GET /repos/{o}/{r}/contents/{path}?ref={ref}
+        # returns a JSON object with base64-encoded `.content`; we decode it to
+        # stdout. A 404 (file does not exist on that ref) is NOT an error here:
+        # the caller treats empty output as "new file", so we swallow the 404
+        # and exit 0. Any other HTTP error propagates (gh_get's emit_error +
+        # non-zero return).
+        FILE_PATH=""
+        FILE_REF="${GITLAB_DEFAULT_BRANCH:-main}"
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --path) FILE_PATH="$2"; shift 2 ;;
+                --ref) FILE_REF="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$FILE_PATH" ]; then
+            emit_error "--path is required"
+            exit 1
+        fi
+        # gh_get emits a 404 client error on stderr and returns 4. Capture both
+        # so we can distinguish the benign "file absent" 404 from a real error.
+        gf_err_file="$(mktemp)"
+        gf_out=""
+        gf_rc=0
+        gf_out="$(gh_get_q "$API/contents/$FILE_PATH" --data-urlencode "ref=$FILE_REF" 2>"$gf_err_file")" || gf_rc=$?
+        if [ "$gf_rc" -eq 0 ]; then
+            rm -f "$gf_err_file"
+            printf '%s' "$gf_out" | python3 -c 'import sys,json,base64; d=json.loads(sys.stdin.read()); sys.stdout.buffer.write(base64.b64decode((d.get("content") or "")))'
+        else
+            gf_err="$(cat "$gf_err_file")"
+            rm -f "$gf_err_file"
+            case "$gf_err" in
+                *"HTTP 404"*)
+                    # File does not exist on this ref — emit nothing, exit 0.
+                    :
+                    ;;
+                *)
+                    printf '%s\n' "$gf_err" >&2
+                    exit "$gf_rc"
+                    ;;
+            esac
+        fi
         ;;
 
     rate-limit-status)

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -27,6 +27,7 @@
 #   gitlab-api.sh create-mr --source <branch> --title <title> [--description <d>]
 #   gitlab-api.sh add-note <iid> --body <text>
 #   gitlab-api.sh post-note <iid> --body <text>
+#   gitlab-api.sh get-file --path <path> [--ref <branch>]
 #
 # Views (opt-in projection; default is full JSON):
 #   merge-requests  --view impl       [{iid, title, merged_at, target_branch}]
@@ -655,6 +656,56 @@ PY
         fi
         JSON_BODY=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.dumps({"body": sys.stdin.read()}))')
         gl_post "$API/merge_requests/$IID/notes" "$JSON_BODY"
+        ;;
+
+    get-file)
+        # #1172: fetch the raw decoded content of a single file at --ref so
+        # code_writer can EDIT an existing file instead of clobbering it with
+        # a from-scratch rewrite. GET /projects/{id}/repository/files/{path}?ref={ref}
+        # returns a JSON object with base64-encoded `.content`; we decode it to
+        # stdout. The file path must be URL-encoded into the path segment (GitLab
+        # requires the whole path percent-encoded, including slashes). A 404
+        # (file does not exist on that ref) is NOT an error here: the caller
+        # treats empty output as "new file", so we swallow the 404 and exit 0.
+        # Any other HTTP error propagates (gl_get's emit_error + non-zero return).
+        FILE_PATH=""
+        FILE_REF="${GITLAB_DEFAULT_BRANCH:-main}"
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --path) FILE_PATH="$2"; shift 2 ;;
+                --ref) FILE_REF="$2"; shift 2 ;;
+                *) emit_error "unknown flag: $1"; exit 2 ;;
+            esac
+        done
+        if [ -z "$FILE_PATH" ]; then
+            emit_error "--path is required"
+            exit 1
+        fi
+        # GitLab needs the file path percent-encoded into the URL path segment
+        # (slashes become %2F). python3 urllib.parse.quote with safe="" encodes
+        # every reserved char. The ref travels as a -G query param via gl_get_q.
+        ENC_PATH="$(FILE_PATH="$FILE_PATH" python3 -c 'import os,urllib.parse;print(urllib.parse.quote(os.environ["FILE_PATH"], safe=""))')"
+        gf_err_file="$(mktemp)"
+        gf_out=""
+        gf_rc=0
+        gf_out="$(gl_get_q "$API/repository/files/$ENC_PATH" --data-urlencode "ref=$FILE_REF" 2>"$gf_err_file")" || gf_rc=$?
+        if [ "$gf_rc" -eq 0 ]; then
+            rm -f "$gf_err_file"
+            printf '%s' "$gf_out" | python3 -c 'import sys,json,base64; d=json.loads(sys.stdin.read()); sys.stdout.buffer.write(base64.b64decode((d.get("content") or "")))'
+        else
+            gf_err="$(cat "$gf_err_file")"
+            rm -f "$gf_err_file"
+            case "$gf_err" in
+                *"HTTP 404"*)
+                    # File does not exist on this ref — emit nothing, exit 0.
+                    :
+                    ;;
+                *)
+                    printf '%s\n' "$gf_err" >&2
+                    exit "$gf_rc"
+                    ;;
+            esac
+        fi
         ;;
 
     rate-limit-status)

--- a/tools/flat-cyborg-claude.sh
+++ b/tools/flat-cyborg-claude.sh
@@ -47,12 +47,19 @@ if [ -z "$PROMPT" ]; then PROMPT="$(cat)"; fi
 # filter. A temp file (not `$(...)`) preserves the reply's bytes exactly,
 # including any trailing newline, so prose consumers stay byte-identical.
 REPLY_FILE="$(mktemp)"
-trap 'rm -f "$REPLY_FILE"' EXIT
+# #1171: pass the prompt via --cmd-file (a file), NOT --cmd (an argv value). A
+# multi-MB prompt as a command-line argument overflows ARG_MAX (exec fails
+# E2BIG / "Argument list too long") — agents on a real repo build multi-MB
+# contexts (MR diffs + history) and hit exactly this. Requires flat-cyborg
+# >= 0.11.0 (the --cmd-file flag).
+PROMPT_FILE="$(mktemp)"
+printf '%s' "$PROMPT" > "$PROMPT_FILE"
+trap 'rm -f "$REPLY_FILE" "$PROMPT_FILE"' EXIT
 set +e
 flat-cyborg --extract --extract-structural --no-jitter --auto-approve --wrap-input 72 \
   --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" \
   --timeout-ms "${FLAT_CYBORG_TIMEOUT_MS:-180000}" \
-  --cmd "$PROMPT" -- claude > "$REPLY_FILE"
+  --cmd-file "$PROMPT_FILE" -- claude > "$REPLY_FILE"
 FC_RC=$?
 set -e
 [ "$FC_RC" -eq 0 ] || exit "$FC_RC"

--- a/tools/test-github-implementation-robustness.sh
+++ b/tools/test-github-implementation-robustness.sh
@@ -14,6 +14,13 @@
 #          GETs the existing ref and emits it as success (exit 0). Any OTHER
 #          failure must still propagate.
 #
+#   #1172  get-file must decode the base64 `.content` of an existing file to
+#          stdout, return empty + exit 0 on a 404 (so the caller treats "no
+#          existing content" as "new file"), and propagate other HTTP errors.
+#          code_writer.ag must fetch existing content (get-file) before the
+#          code-gen prompt so an EDIT preserves the file instead of clobbering
+#          it (grep-level wiring assertion).
+#
 # Unlike test-github-implementation-normalize.sh (which sources just the
 # function defs and exercises the normalizers), this test drives the full CMD
 # dispatcher against a STUBBED curl placed on PATH — the same stub-curl idiom
@@ -247,6 +254,103 @@ if [ "$CB3_RC" -eq 0 ]; then
     esac
 else
     fail "#1150 create-branch: clean 201 create regressed to exit $CB3_RC"
+fi
+
+# =============================================================================
+# #1172: get-file decodes base64 content; 404 -> empty + exit 0.
+# =============================================================================
+reset_routes
+# Build a base64-encoded GitHub contents response for an existing file.
+GETFILE_BODY=$(python3 - <<'PY'
+import json, base64
+content = "line one\nline two\n"
+b64 = base64.b64encode(content.encode()).decode()
+print(json.dumps({"content": b64, "encoding": "base64", "path": "src/foo.py"}), end="")
+PY
+)
+add_route GET "/contents/src/foo.py" 200 "$GETFILE_BODY"
+
+GF_ERR_FILE="$FAKE_ROOT/gf-err"
+GF_OUT="$(run_api get-file --path src/foo.py --ref main 2>"$GF_ERR_FILE")"
+GF_RC=$?
+GF_ERR="$(cat "$GF_ERR_FILE")"
+
+if [ "$GF_RC" -eq 0 ]; then
+    pass "#1172 get-file: existing file decodes to exit 0"
+else
+    fail "#1172 get-file: expected exit 0 on existing file, got $GF_RC (stderr: $GF_ERR)"
+fi
+
+case "$GF_OUT" in
+    *"line one"*)
+        pass "#1172 get-file: base64 .content decoded to raw stdout" ;;
+    *)
+        fail "#1172 get-file: expected decoded content on stdout, got '$GF_OUT'" ;;
+esac
+
+# 404: file does not exist on this ref -> empty output, exit 0.
+reset_routes
+add_route GET "/contents/src/missing.py" 404 "{\"message\":\"Not Found\"}"
+
+GF2_ERR_FILE="$FAKE_ROOT/gf2-err"
+GF2_OUT="$(run_api get-file --path src/missing.py --ref main 2>"$GF2_ERR_FILE")"
+GF2_RC=$?
+GF2_ERR="$(cat "$GF2_ERR_FILE")"
+
+if [ "$GF2_RC" -eq 0 ]; then
+    pass "#1172 get-file: 404 (missing file) treated as success (exit 0)"
+else
+    fail "#1172 get-file: expected exit 0 on 404, got $GF2_RC (stderr: $GF2_ERR)"
+fi
+
+if [ -z "$GF2_OUT" ]; then
+    pass "#1172 get-file: 404 (missing file) emits empty stdout (caller -> new file)"
+else
+    fail "#1172 get-file: expected empty stdout on 404, got '$GF2_OUT'"
+fi
+
+# A non-404 HTTP error must still propagate (not be masked as a missing file).
+reset_routes
+add_route GET "/contents/src/boom.py" 500 "{\"message\":\"server error\"}"
+
+run_api get-file --path src/boom.py --ref main >/dev/null 2>/dev/null
+GF3_RC=$?
+if [ "$GF3_RC" -ne 0 ]; then
+    pass "#1172 get-file: non-404 HTTP error still propagates as failure (rc=$GF3_RC)"
+else
+    fail "#1172 get-file: a 500 was masked as success (should propagate)"
+fi
+
+# Unknown flag -> exit 2 (verb-parser contract parity with the other arms).
+reset_routes
+run_api get-file --path src/foo.py --bogus x >/dev/null 2>/dev/null
+GF4_RC=$?
+if [ "$GF4_RC" -eq 2 ]; then
+    pass "#1172 get-file: unknown flag exits 2"
+else
+    fail "#1172 get-file: expected exit 2 on unknown flag, got $GF4_RC"
+fi
+
+# =============================================================================
+# #1172: code_writer.ag wires get-file into the code-gen context (grep-level).
+# =============================================================================
+CW_AG="$REPO_ROOT/dev-apprenticeship/implementation/agents/code_writer.ag"
+if grep -q "get-file --path" "$CW_AG"; then
+    pass "#1172 code_writer.ag: fetches existing content via 'get-file --path' before code-gen"
+else
+    fail "#1172 code_writer.ag: no 'get-file --path' fetch found before code-gen"
+fi
+
+if grep -q "EDIT this" "$CW_AG"; then
+    pass "#1172 code_writer.ag: existing-file block instructs the model to EDIT and preserve"
+else
+    fail "#1172 code_writer.ag: existing-file EDIT instruction missing from code_context"
+fi
+
+if grep -q "If an existing file is shown, EDIT it" "$CW_AG"; then
+    pass "#1172 code_writer.ag: code-gen prompt updated to EDIT-when-existing"
+else
+    fail "#1172 code_writer.ag: code-gen prompt not updated for the EDIT path"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #1171. Closes #1172.

Two robustness fixes found **dogfooding the federation on this repo** (review-gated run; the release/planning agents hit #1171 within seconds, and #1172 was caught before it could clobber a file).

## #1171 — flat-cyborg wrapper overflowed ARG_MAX on large prompts
`tools/flat-cyborg-claude.sh` passed the prompt as `--cmd "$PROMPT"` (argv). A multi-MB context (MR diffs + history) overflows `ARG_MAX` → `exec flat-cyborg` fails E2BIG (`Argument list too long`). The wrapper now writes the prompt to a temp file and passes `--cmd-file` (trap-cleaned, byte-identical). **Requires flat-cyborg >= 0.11.0** (the `--cmd-file` flag — Replikanti/flat-cyborg#57, released v0.11.0); CHANGELOG + README floor updated.

## #1172 — code_writer can now EDIT existing files
The autonomous code-gen built context from issue+plan+patterns but **never read the existing file**, so it would clobber an existing file on an edit task (most real work). New `get-file --path <p> [--ref <b>]` in `github-api.sh` + `gitlab-api.sh` (base64-decode; **404 → empty + exit 0**; other errors propagate). `code_writer` fetches the primary file's current content before code-gen and instructs the LLM to **edit** (full updated file, preserve the rest). Single-file for now (documented limitation).

## Verification
- colony-lint: **421 passed, 0 failed, 5 skipped**
- robustness test 18/0 (9 new); normalize 52/0; mr-handoff 15/0 — regression-clean.
- QA: ⚠️→✅ (the only caveat — missing #1171 CHANGELOG/floor docs — fixed inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)