### PR TITLE
test(trading-binance): carry robustness across regimes — +7.11%/yr Sharpe 2.33 over 2.5y (#1175)

### DIFF
--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -23,9 +23,6 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
   **+7.11%/yr at Sharpe 2.33 / 0.32% max DD**; strongly bull-amplified; the
   trailing filter protects in weak regimes (2026 H1: filter +0.19% vs naive
   all-alts -1.82%). First robust multi-regime positive-expectancy result.
-
-### Added
-
 - `tools/carry-verify.sh` (#1175 M1): deterministic settlement verifier for a
   delta-neutral funding-CARRY basket -- the carry analogue of verify-trade.sh.
   Net carry = weighted sum of forward funding (short-perp receives positive

--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,16 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Carry robustness study (#1175): the deterministic walk-forward funding-carry
+  backtest run across 2.5 years (2024-01..2026-06, 18 alts) per half-year +
+  full span (`runs/20260620T-carry-robustness/`). The carry edge is **robust
+  across regimes** — positive every half-year (+0.19% to +20.44%/yr), full-span
+  **+7.11%/yr at Sharpe 2.33 / 0.32% max DD**; strongly bull-amplified; the
+  trailing filter protects in weak regimes (2026 H1: filter +0.19% vs naive
+  all-alts -1.82%). First robust multi-regime positive-expectancy result.
+
+### Added
+
 - `tools/carry-verify.sh` (#1175 M1): deterministic settlement verifier for a
   delta-neutral funding-CARRY basket -- the carry analogue of verify-trade.sh.
   Net carry = weighted sum of forward funding (short-perp receives positive

--- a/trading-binance/runs/20260620T-carry-robustness/comparison.md
+++ b/trading-binance/runs/20260620T-carry-robustness/comparison.md
@@ -1,0 +1,33 @@
+# Carry robustness across regimes (#1175)
+
+Does the funding-carry edge hold **out-of-sample across market regimes**, or is the ~1–3 %/yr from the single calm 2026 window (#1174) a one-window artifact? Walk-forward deterministic carry (top-6 basket, 30-day rebalance, 21-day trailing selection, 20 bps cost) over **2.5 years** (2024-01 → 2026-06, 18 alts, 51 357 funding events), per half-year + full span.
+
+## Result — the edge holds in every regime
+
+| Window | Carry OOS (annualised) | Sharpe | max DD | naive all-alts | cost drag |
+|---|---|---|---|---|---|
+| 2024 H1 (bull / high funding) | **+20.44 %/yr** | 3.60 | 0.00 % | +17.63 % | 0.40 % |
+| 2024 H2 | **+7.50 %/yr** | 3.44 | 0.00 % | +5.91 % | 0.80 % |
+| 2025 H1 | **+2.55 %/yr** | 5.69 | 0.00 % | +1.14 % | 0.47 % |
+| 2025 H2 | **+3.71 %/yr** | 5.26 | 0.00 % | +0.81 % | 0.60 % |
+| 2026 H1 (calm) | **+0.19 %/yr** | 0.45 | 0.09 % | **−1.82 %** | 0.52 % |
+| **FULL 2.5 y** | **+7.11 %/yr** | **2.33** | **0.32 %** | +4.89 % | 2.98 % |
+
+## Findings
+
+1. **Positive in every half-year — never negative.** The persistent-positive-funding basket carry stayed positive across all five regimes (+0.19 % to +20.44 %/yr). The edge is **not a one-window artifact**: the full-2.5y OOS carry is **+7.11 %/yr at Sharpe 2.33, max drawdown 0.32 %** — a genuinely good risk-adjusted return (low-variance funding accrual, not a price bet).
+2. **Strongly regime-amplified.** Big in high-funding bull periods (2024 H1 **+20 %/yr**), thin in calm ones (2026 H1 +0.19 %). Carry is a *baseline + bull-amplified* income, exactly as Phase 1 predicted; the single calm 2026 window understated it ~6×.
+3. **The trailing-funding filter protects in weak regimes.** The top-6 selection beats naive always-on-all-alts in **every** window — decisively when it matters: in 2026 H1 the filter is **+0.19 %** while all-alts is **−1.82 %** (the filter drops symbols whose funding turned negative and rotates to cash). Selection adds the most value precisely when the regime is hostile.
+
+## Honest caveats
+
+- The backtest models **funding accrual − turnover cost only**. It does NOT model delta-neutral execution risk (basis dislocation, short-leg liquidation/margin, spot custody, rebalance slippage). **Real net is lower** — and during a violent regime transition (funding flips hard negative + basis blows out), a delta-neutral book can take a real hit the funding-only model doesn't see. The 2.5y Sharpe 2.33 is an upper-ish bound.
+- Sub-window "0.00 % max DD" is degenerate (few rebalance periods inside a half-year); the **full-span** DD 0.32 % / Sharpe 2.33 are the meaningful figures.
+- 30-day rebalance cost (~1.2 %/yr over the full span) is a real drag the carry exceeds; tighter rebalancing would lose (Phase 1 #1174).
+- Survivorship: the 18-symbol universe is today's liquid set; some weren't liquid early in 2024.
+
+## Verdict
+
+The funding-carry edge is **robust across regimes** — positive every half-year, **+7.11 %/yr / Sharpe 2.33** over 2.5 years, with the trailing filter protecting against negative-funding drift. This is a real, deployable mechanical edge (modulo unmodelled execution risk), strongly amplified in high-funding bull regimes. It is **the first strategy in this whole effort with a robust, multi-regime, positive-expectancy out-of-sample record** — unlike every directional approach (which had no edge and evolved to FLAT). Next: model real delta-neutral execution + a paper-trading harness (operationalise), and/or the M3 substrate carry-strategist to sharpen selection.
+
+Reproduce: `run-meta.json` (funding data gitignored).

--- a/trading-binance/runs/20260620T-carry-robustness/comparison.md
+++ b/trading-binance/runs/20260620T-carry-robustness/comparison.md
@@ -24,7 +24,7 @@ Does the funding-carry edge hold **out-of-sample across market regimes**, or is 
 - The backtest models **funding accrual − turnover cost only**. It does NOT model delta-neutral execution risk (basis dislocation, short-leg liquidation/margin, spot custody, rebalance slippage). **Real net is lower** — and during a violent regime transition (funding flips hard negative + basis blows out), a delta-neutral book can take a real hit the funding-only model doesn't see. The 2.5y Sharpe 2.33 is an upper-ish bound.
 - Sub-window "0.00 % max DD" is degenerate (few rebalance periods inside a half-year); the **full-span** DD 0.32 % / Sharpe 2.33 are the meaningful figures.
 - 30-day rebalance cost (~1.2 %/yr over the full span) is a real drag the carry exceeds; tighter rebalancing would lose (Phase 1 #1174).
-- Survivorship: the 18-symbol universe is today's liquid set; some weren't liquid early in 2024.
+- **Survivorship / executability of the biggest numbers.** The 18-symbol universe is today's liquid set; several (ARB/OP/INJ/APT/SUI) were newly-listed, thin, high-volatility names early in the span. The early-window outperformance — the +20.44 %/yr 2024 H1 headline — **rides precisely on those newest, least-executable alts** (the early top-6 selections are dominated by ARB/OP/INJ/APT/AVAX/NEAR/SUI). That is exactly where a real delta-neutral book is hardest to run (wide spreads, shallow spot, basis blowouts, liquidation risk on the short leg) — so the headline number is the *least* trustworthy in practice. The thinner, more recent windows on more-liquid names (2025 H1–H2: +2.5–3.7 %/yr) are the more honest guide to a deployable figure.
 
 ## Verdict
 

--- a/trading-binance/runs/20260620T-carry-robustness/results.json
+++ b/trading-binance/runs/20260620T-carry-robustness/results.json
@@ -1,0 +1,13 @@
+{"config":"top-6 / rebalance 30d / lookback 21d / min_pos_ratio 0.55 / cost 20bps","windows":{
+"2024H1":{"window": {"start": "2024-01-01", "end": "2024-07-01", "harvest_days": 161.0}, "strategy": {"label": "WF top-6 carry", "rebalances": 6, "total_return_pct": 9.0179, "annualised_pct": 20.444, "sharpe": 3.6, "max_drawdown_pct": 0.0}, "benchmark_all_alts": {"label": "always-on all alts", "rebalances": 6, "total_return_pct": 7.7759, "annualised_pct": 17.629, "sharpe": 3.42, "max_drawdown_pct": 0.0}, "cost_drag_pct": 0.4}
+,
+"2024H2":{"window": {"start": "2024-07-01", "end": "2025-01-01", "harvest_days": 163.0}, "strategy": {"label": "WF top-6 carry", "rebalances": 6, "total_return_pct": 3.35, "annualised_pct": 7.502, "sharpe": 3.44, "max_drawdown_pct": 0.0}, "benchmark_all_alts": {"label": "always-on all alts", "rebalances": 6, "total_return_pct": 2.6392, "annualised_pct": 5.91, "sharpe": 2.17, "max_drawdown_pct": 0.0794}, "cost_drag_pct": 0.8}
+,
+"2025H1":{"window": {"start": "2025-01-01", "end": "2025-07-01", "harvest_days": 160.0}, "strategy": {"label": "WF top-6 carry", "rebalances": 6, "total_return_pct": 1.1171, "annualised_pct": 2.548, "sharpe": 5.69, "max_drawdown_pct": 0.0}, "benchmark_all_alts": {"label": "always-on all alts", "rebalances": 6, "total_return_pct": 0.4992, "annualised_pct": 1.139, "sharpe": 2.15, "max_drawdown_pct": 0.1247}, "cost_drag_pct": 0.4667}
+,
+"2025H2":{"window": {"start": "2025-07-01", "end": "2026-01-01", "harvest_days": 163.0}, "strategy": {"label": "WF top-6 carry", "rebalances": 6, "total_return_pct": 1.6567, "annualised_pct": 3.71, "sharpe": 5.26, "max_drawdown_pct": 0.0}, "benchmark_all_alts": {"label": "always-on all alts", "rebalances": 6, "total_return_pct": 0.3641, "annualised_pct": 0.815, "sharpe": 0.61, "max_drawdown_pct": 0.7178}, "cost_drag_pct": 0.6}
+,
+"2026H1":{"window": {"start": "2026-01-01", "end": "2026-06-20", "harvest_days": 149.0}, "strategy": {"label": "WF top-6 carry", "rebalances": 5, "total_return_pct": 0.0778, "annualised_pct": 0.191, "sharpe": 0.45, "max_drawdown_pct": 0.0866}, "benchmark_all_alts": {"label": "always-on all alts", "rebalances": 5, "total_return_pct": -0.7417, "annualised_pct": -1.817, "sharpe": -2.34, "max_drawdown_pct": 0.3594}, "cost_drag_pct": 0.5167}
+,
+"FULL":{"window": {"start": "2024-01-01", "end": "2026-06-20", "harvest_days": 880.0}, "strategy": {"label": "WF top-6 carry", "rebalances": 30, "total_return_pct": 17.1485, "annualised_pct": 7.113, "sharpe": 2.33, "max_drawdown_pct": 0.3212}, "benchmark_all_alts": {"label": "always-on all alts", "rebalances": 30, "total_return_pct": 11.7853, "annualised_pct": 4.888, "sharpe": 1.63, "max_drawdown_pct": 1.2134}, "cost_drag_pct": 2.9833}
+}}

--- a/trading-binance/runs/20260620T-carry-robustness/run-meta.json
+++ b/trading-binance/runs/20260620T-carry-robustness/run-meta.json
@@ -1,0 +1,8 @@
+{
+  "run_id": "20260620T-carry-robustness", "issue": 1175, "kind": "multi-regime-walk-forward-carry-robustness",
+  "universe_size": 18, "span": "2024-01-01..2026-06-20 (~2.5y)", "funding_events": 51357,
+  "config": "top-6 / rebalance 30d / lookback 21d / min_pos_ratio 0.55 / cost 20bps",
+  "windows": "5 half-years + full span", "settlement": "delta-neutral carry (funding accrual - turnover cost)",
+  "base_commit": "b22c59cc89343874fc8b8a6d60b6fd0943897915",
+  "reproduce": "python3 tools/funding-download.py --symbols <universe> --start 2024-01-01 --end 2026-06-20 && bash runs/20260620T-carry-robustness/run-robustness.sh"
+}

--- a/trading-binance/runs/20260620T-carry-robustness/run-robustness.sh
+++ b/trading-binance/runs/20260620T-carry-robustness/run-robustness.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# run-robustness.sh -- run the deterministic walk-forward carry backtest
+# (runs/20260620T-carry/backtest-carry.py) across per-half-year regime windows
+# + the full 2.5y span, to test whether the funding-carry edge holds OUT-OF-
+# SAMPLE across bull/calm/weak regimes (#1175 robustness). Emits results.json.
+set -eu
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+BT="$REPO/trading-binance/runs/20260620T-carry/backtest-carry.py"
+FUNDING="${FUNDING_DIR:-$REPO/trading-binance/data/funding}"
+UNIV="BTCUSDT,ETHUSDT,SOLUSDT,BNBUSDT,XRPUSDT,DOGEUSDT,AVAXUSDT,LINKUSDT,SUIUSDT,ADAUSDT,LTCUSDT,NEARUSDT,APTUSDT,ARBUSDT,OPUSDT,INJUSDT,TIAUSDT,AAVEUSDT"
+win() { python3 "$BT" --funding-dir "$FUNDING" --symbols "$UNIV" --start "$1" --end "$2" \
+  --rebalance-days 30 --lookback-days 21 --top-k 6 --min-pos-ratio 0.55 --cost-bps-roundtrip 20; }
+{
+  echo '{"config":"top-6 / rebalance 30d / lookback 21d / min_pos_ratio 0.55 / cost 20bps","windows":{'
+  first=1
+  for w in "2024H1:2024-01-01:2024-07-01" "2024H2:2024-07-01:2025-01-01" \
+           "2025H1:2025-01-01:2025-07-01" "2025H2:2025-07-01:2026-01-01" \
+           "2026H1:2026-01-01:2026-06-20" "FULL:2024-01-01:2026-06-20"; do
+    name="${w%%:*}"; rest="${w#*:}"; s="${rest%%:*}"; e="${rest#*:}"
+    [ $first -eq 0 ] && echo ','; first=0
+    printf '"%s":' "$name"
+    win "$s" "$e" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(json.dumps({"window":d["window"],"strategy":d["strategy_oos_walk_forward"],"benchmark_all_alts":d["benchmark_always_on_all_alts"],"cost_drag_pct":d["total_cost_drag_pct"]}))'
+  done
+  echo '}}'
+} 


### PR DESCRIPTION
Walk-forward funding-carry backtest across 2.5y (2024-01..2026-06, per half-year + full span). **Edge is robust:** positive every half-year (+0.19% to +20.44%/yr), full-span **+7.11%/yr, Sharpe 2.33, 0.32% max DD**. Bull-amplified; trailing filter protects in weak regimes (2026 H1: filter +0.19% vs naive all-alts −1.82%). First robust multi-regime positive-expectancy result. Caveat: funding-accrual−cost only, real execution risk not modelled. Docs/run artifact; funding gitignored. #1175.