### PR TITLE
fix(federation): assignment-based work pickup, not label-event gated (#1181)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -33,6 +33,20 @@ is asserted until multi-version CI is in place.
 
 ### Fixed
 
+- **Work pickup is now assignment-based, not gated on label events** (#1181).
+  The five agents that "check assigned issues" — `implementation/code_writer`
+  and `planning/{risk_assessor, plan_reviewer, task_decomposer,
+  scope_estimator}` — used to switch to a `...-by-label-events --since
+  <last_check>` query once `last_check` was set, so after the first tick they
+  only saw issues whose label had changed since the last poll. A stably-assigned
+  issue with no recent label churn went invisible on every subsequent tick, so
+  on a mature repo the federation never picked up assigned work. Each agent now
+  always queries the current-state snapshot (`assigned-issues --view assigned` /
+  `issues --needs-planning --view planning`), keeping its existing staleness
+  gate (`code_writer`'s #200 `last_drafted_iid`/`updated_at`, the planning
+  agents' #223/#227 `:posted` markers) so the snapshot query does not re-pay the
+  LLM cost on a sticky assignment. Found dogfooding the federation on a mature
+  repo (assigned issues were never drafted after tick 1).
 - **flat-cyborg wrapper no longer overflows ARG_MAX on large prompts** (#1171).
   `tools/flat-cyborg-claude.sh` passed the prompt to flat-cyborg as `--cmd
   "$PROMPT"` (an argv value); a multi-MB prompt — which agents build on a real

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -229,18 +229,14 @@ fn tick_for_repo(owner: string, repo: string) -> void {
     };
 
     // 2. Check for assigned issues needing implementation.
-    // #235: use events-aware query when we have a prior window so short-
-    // lived trigger labels (e.g. "DEV::not started" transitioning through
-    // scoped states in seconds) aren't missed. The first tick falls back
-    // to the current-state snapshot — byte-identical to pre-#235 boot.
-    let prev_check = recall_latest(scoped_memo(owner, repo, "code_writer:last_check"));
+    // #1181: pickup keys on ASSIGNMENT, not label events. Always query the
+    // current-state `assigned-issues` snapshot so a stably-assigned issue
+    // (no recent label churn) stays visible on every tick, not just the
+    // first. The #200 `should_draft_code` staleness gate below prevents
+    // re-paying the LLM cost now that the snapshot is queried each tick.
     let unassigned_flag = include_unassigned_flag();
     // colony-lint: safe-exec-concat
-    let issues_cmd = if len(prev_check) > 0 {
-        "$COLONY_DIR/scripts/forge-api.sh assigned-issues-by-label-events --since " + shell_escape(prev_check) + " --view assigned" + unassigned_flag + repo_arg(owner, repo);
-    } else {
-        "$COLONY_DIR/scripts/forge-api.sh assigned-issues --view assigned" + unassigned_flag + repo_arg(owner, repo);
-    };
+    let issues_cmd = "$COLONY_DIR/scripts/forge-api.sh assigned-issues --view assigned" + unassigned_flag + repo_arg(owner, repo);
     let issues_raw = try {
         exec sh issues_cmd;
     } catch e {

--- a/dev-apprenticeship/planning/agents/plan_reviewer.ag
+++ b/dev-apprenticeship/planning/agents/plan_reviewer.ag
@@ -190,16 +190,13 @@ fn tick_for_repo(owner: string, repo: string) -> void {
     // issue already has a plan, so we early-exit before the assembly
     // prompt(). last_check is refreshed so the agent's liveness signal
     // advances on quiet projects.
-    // #235: use issues-by-label-events when we have a prior window so
-    // short-lived trigger labels aren't missed; fall back to the current-
-    // state snapshot on first tick (byte-identical to pre-#235 boot).
-    let prev_check = recall_latest(scoped_memo(owner, repo, "plan_reviewer:last_check"));
+    // #1181: pickup keys on ASSIGNMENT, not label events. Always query the
+    // current-state `issues --needs-planning` snapshot so an unplanned
+    // issue stays visible on every tick, not just the first. The #223
+    // `:posted` idempotency guard below prevents re-prompting once a plan
+    // has been assembled.
     // colony-lint: safe-exec-concat
-    let issues_cmd = if len(prev_check) > 0 {
-        "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(prev_check) + " --view planning" + repo_arg(owner, repo);
-    } else {
-        "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning" + repo_arg(owner, repo);
-    };
+    let issues_cmd = "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning" + repo_arg(owner, repo);
     let issues_raw = try {
         exec sh issues_cmd;
     } catch e {

--- a/dev-apprenticeship/planning/agents/risk_assessor.ag
+++ b/dev-apprenticeship/planning/agents/risk_assessor.ag
@@ -137,18 +137,11 @@ fn rl_is_limited(owner: string, repo: string) -> int {
 }
 
 fn unplanned_cmd(owner: string, repo: string) -> string {
-    let ts = recall_latest(scoped_memo(owner, repo, "risk_assessor:last_check"));
-    // colony-lint: safe-exec-concat
-    if len(ts) > 0 {
-        // #235: events-aware query closes the short-lived-label gap.
-        // issues-by-label-events unions currently-labeled + issues where
-        // the trigger label was added at any point in [ts, now] per
-        // resource_label_events. Catches transitions we'd miss between
-        // 60 s polls with a pure current-state snapshot.
-        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning" + repo_arg(owner, repo);
-    };
-    // First-tick fallback: no prior window to diff against; the snapshot
-    // preserves pre-#235 boot behavior byte-identically.
+    // #1181: pickup keys on ASSIGNMENT, not label events. Always query the
+    // current-state `issues --needs-planning` snapshot so an unplanned
+    // issue (no recent label churn) stays visible on every tick, not just
+    // the first. The #227 `:posted` idempotency guard in tick_for_repo
+    // prevents re-prompting once the assessment has been posted.
     // colony-lint: safe-exec-concat
     return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning" + repo_arg(owner, repo);
 }

--- a/dev-apprenticeship/planning/agents/scope_estimator.ag
+++ b/dev-apprenticeship/planning/agents/scope_estimator.ag
@@ -69,13 +69,10 @@ fn repo_field(line: string, idx: int) -> string {
 }
 
 fn unplanned_cmd(owner: string, repo: string) -> string {
-    let ts = recall_latest(scoped_memo(owner, repo, "scope_estimator:last_check"));
-    // colony-lint: safe-exec-concat
-    if len(ts) > 0 {
-        // #235: events-aware query — see risk_assessor.ag for rationale.
-        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning" + repo_arg(owner, repo);
-    };
-    // First-tick fallback: no prior window; snapshot preserves pre-#235 boot behavior.
+    // #1181: pickup keys on ASSIGNMENT, not label events — see
+    // risk_assessor.ag for rationale. Always query the current-state
+    // `issues --needs-planning` snapshot so an unplanned issue stays
+    // visible on every tick; the #227 `:posted` guard prevents re-prompting.
     // colony-lint: safe-exec-concat
     return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning" + repo_arg(owner, repo);
 }

--- a/dev-apprenticeship/planning/agents/task_decomposer.ag
+++ b/dev-apprenticeship/planning/agents/task_decomposer.ag
@@ -69,13 +69,10 @@ fn repo_field(line: string, idx: int) -> string {
 }
 
 fn unplanned_cmd(owner: string, repo: string) -> string {
-    let ts = recall_latest(scoped_memo(owner, repo, "task_decomposer:last_check"));
-    // colony-lint: safe-exec-concat
-    if len(ts) > 0 {
-        // #235: events-aware query — see risk_assessor.ag for rationale.
-        return "$COLONY_DIR/scripts/forge-api.sh issues-by-label-events --since " + shell_escape(ts) + " --view planning" + repo_arg(owner, repo);
-    };
-    // First-tick fallback: no prior window; snapshot preserves pre-#235 boot behavior.
+    // #1181: pickup keys on ASSIGNMENT, not label events — see
+    // risk_assessor.ag for rationale. Always query the current-state
+    // `issues --needs-planning` snapshot so an unplanned issue stays
+    // visible on every tick; the #227 `:posted` guard prevents re-prompting.
     // colony-lint: safe-exec-concat
     return "$COLONY_DIR/scripts/forge-api.sh issues --needs-planning --view planning" + repo_arg(owner, repo);
 }

--- a/tools/test-assignment-based-pickup.sh
+++ b/tools/test-assignment-based-pickup.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# test-assignment-based-pickup.sh: #1181 wiring + parse assertions for the
+# assignment-based work-pickup change. The 5 agents that "check assigned
+# issues" (implementation/code_writer + planning/{risk_assessor, plan_reviewer,
+# task_decomposer, scope_estimator}) used to gate pickup on a label event once
+# `last_check` was set: after tick 1 they switched to the
+# `...-by-label-events --since <last_check>` query, so a stably-assigned issue
+# with no recent label churn went invisible on a mature repo. The fix makes
+# pickup always query the current-state snapshot.
+#
+# This test asserts, per agent (grep-level wiring):
+#   1. the pickup command builds the current-state snapshot
+#      (`assigned-issues ... --view` / `issues --needs-planning --view`).
+#   2. pickup is no longer gated behind `...-by-label-events --since` (the
+#      label-events branch and its `--since <last_check>` are gone). The
+#      code_writer "learn from merged MR" step keeps its own
+#      `merge-requests --since` query — that is a separate code path and is
+#      explicitly excluded from this assertion.
+# Plus a parse check: all 5 .ag files commit cleanly under `agentis commit`
+# (skipped when the agentis binary is not on PATH, mirroring colony-lint).
+#
+# Matches the test style of tools/test-implementation-assignee-filter.sh
+# (bash 3.2, [PASS]/[FAIL] lines, `Results: N passed, M failed`). Exit 0
+# all-pass, 1 any-fail. Related: #1181.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+AGENTS_DIR="$REPO_ROOT/dev-apprenticeship"
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# -----------------------------------------------------------------------------
+# Per-agent pickup wiring. Each row is:
+#   <relative .ag path> | <snapshot-verb grep> | <forbidden label-events grep>
+# The snapshot grep is the current-state query the agent must now build; the
+# forbidden grep is the label-events pickup query that must be gone. Both are
+# fixed-string greps (grep -F) so the `+ ... + repo_arg(...)` concat noise
+# around them does not matter.
+# -----------------------------------------------------------------------------
+AGENTS=(
+  "implementation/agents/code_writer.ag|assigned-issues --view assigned|assigned-issues-by-label-events --since "
+  "planning/agents/plan_reviewer.ag|issues --needs-planning --view planning|issues-by-label-events --since "
+  "planning/agents/risk_assessor.ag|issues --needs-planning --view planning|issues-by-label-events --since "
+  "planning/agents/task_decomposer.ag|issues --needs-planning --view planning|issues-by-label-events --since "
+  "planning/agents/scope_estimator.ag|issues --needs-planning --view planning|issues-by-label-events --since "
+)
+
+for row in "${AGENTS[@]}"; do
+  rel="${row%%|*}"
+  rest="${row#*|}"
+  snapshot="${rest%%|*}"
+  forbidden="${rest#*|}"
+  ag="$AGENTS_DIR/$rel"
+  name="$(basename "$rel")"
+
+  if [ ! -f "$ag" ]; then
+    fail "$name: agent file present" "missing $ag"
+    continue
+  fi
+
+  if grep -F -q -- "$snapshot" "$ag"; then
+    pass "$name: builds snapshot pickup ($snapshot)"
+  else
+    fail "$name: builds snapshot pickup ($snapshot)" "not found in $rel"
+  fi
+
+  if grep -F -q -- "$forbidden" "$ag"; then
+    fail "$name: pickup no longer gated on label events" "still references '$forbidden' in $rel"
+  else
+    pass "$name: pickup no longer gated on label events (no '$forbidden')"
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# Parse check: each agent commits cleanly under `agentis commit`, same as the
+# per-agent syntax pass in colony-lint.sh. Skipped (not failed) when agentis is
+# not installed, matching the CI runner contract.
+# -----------------------------------------------------------------------------
+if command -v agentis >/dev/null 2>&1; then
+  LINT_TMP="$(mktemp -d)"
+  trap 'rm -rf "$LINT_TMP"' EXIT
+  (cd "$LINT_TMP" && agentis init) >/dev/null 2>&1
+  for row in "${AGENTS[@]}"; do
+    rel="${row%%|*}"
+    ag="$AGENTS_DIR/$rel"
+    name="$(basename "$rel")"
+    if (cd "$LINT_TMP" && agentis commit "$ag") >/dev/null 2>&1; then
+      pass "$name: parses (agentis commit)"
+    else
+      fail "$name: parses (agentis commit)" "syntax error in $rel"
+    fi
+  done
+else
+  echo "[SKIP] agentis not on PATH — skipping .ag parse checks"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1181.

Found dogfooding the federation on a mature repo: 5 agents (code_writer + the 4 planning agents) gated their work pickup on **label events** — after tick 1 they only saw issues whose label changed since `last_check`, so a **stably-assigned issue** with no recent label churn was never picked up. On a repo with history the federation never engaged assigned work.

Each agent now **always queries the current-state snapshot** (`assigned-issues --view assigned` / `issues --needs-planning --view planning`) — assignment is the signal, not a transient label event. Each agent's existing per-issue staleness gate (#200 `last_drafted_iid`; #223/#227 `:posted`) is intact and prevents re-processing an unchanged top issue every tick (QA-verified). Dead `prev_check`/`ts` removed; code_writer's MR-learning `--since` path untouched.

## Verification
- colony-lint **422 passed, 0 failed, 5 skipped**; new test 15/0; planning 34/0 + impl 52/0 regression-clean.
- QA: ✅ ship-it (the re-processing-loop risk is fully mitigated).

**Follow-up:** skip an assigned issue that already has an open bot PR so the queue advances (noted, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)