### PR TITLE
fix(federation): pickup operability — env passthrough, bounded learning, completion markers (#1185)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -33,6 +33,29 @@ is asserted until multi-version CI is in place.
 
 ### Fixed
 
+- **Three pickup/operability fixes for autonomous runs on a mature repo**
+  (#1185), found dogfooding the federation. (1) **Trigger-label env passthrough:**
+  `install.sh`'s `exec.env_passthrough` allowlist did not include
+  `IMPLEMENTATION_TRIGGER_LABEL` / `PLANNING_TRIGGER_LABEL`, so agentis stripped
+  a `colony.toml` `trigger_label` override before `exec sh forge-api.sh` and the
+  forge fell back to the default `implementation` / `needs-planning` label. Both
+  vars are now in the allowlist, and an in-place migration upgrades an existing
+  `.agentis/config` so re-running `install.sh` on a live federation picks it up.
+  (2) **First-run MR-learning is bounded:** `code_writer`'s `merged_mr_cmd()`
+  returned the no-`--since` form on the first tick (empty `last_check`), learning
+  from the WHOLE merged-MR history — one `prompt()` per MR per tick — which
+  starved the drafting step on a mature repo. The first-run query is now bounded
+  to the single most recent merged MR (`--per-page 1`; both forge backends sort
+  `updated_at desc`), and the existing at-most-once-per-iid memo gate still caps
+  duplicate learning. (3) **Half-completed autonomous flows are retried, not
+  stranded:** the #200 staleness markers (`code_writer:last_drafted_iid` /
+  `:last_drafted_updated_at`) were written right after the draft prompt, BEFORE
+  the autonomous `create-branch` / `commit-files`, so a branch-created-but-commit-
+  failed tick still marked the issue "drafted" and the #200 gate skipped it
+  forever, stranding an empty branch. The autonomous path now sets the markers
+  only inside the commit-success block; the review-gated / propose / shadow paths
+  still mark after their terminal draft comment / emit, so each path sets the
+  marker exactly when its own action has completed.
 - **GitLab `commit-files` now tolerates raw control chars in `--actions`
   content** (#1169). The `commit-files` handler in
   `implementation/scripts/gitlab-api.sh` parsed the actions payload with a

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -100,8 +100,15 @@ fn merged_mr_cmd(owner: string, repo: string) -> string {
     if len(ts) > 0 {
         return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --since " + shell_escape(ts) + " --view impl" + repo_arg(owner, repo);
     };
+    // #1185: first run has no `last_check`, so without a bound the no-since
+    // query learns from the WHOLE merged-MR history — one prompt() per MR per
+    // tick, starving the drafting step on a mature repo. Bound the first run to
+    // the single most recent merged MR via --per-page 1 (both forge backends
+    // sort by updated_at desc and accept --per-page). The should_learn_from_mr
+    // memo gate still caps learning at at-most-once per distinct MR iid; this
+    // just stops the very first tick from fanning out across the full backlog.
     // colony-lint: safe-exec-concat
-    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --view impl" + repo_arg(owner, repo);
+    return "$COLONY_DIR/scripts/forge-api.sh merge-requests --state merged --per-page 1 --view impl" + repo_arg(owner, repo);
 }
 
 // #291: the forge wrappers' assigned-issues* subcommands gate on BOTH the
@@ -253,8 +260,14 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         let first_iid_str = to_string(json_get(issues_raw, "[0].iid"));
         let first_upd = to_string(json_get(issues_raw, "[0].updated_at"));
         if should_draft_code(owner, repo, first_iid_str, first_upd) {
-            memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_iid"), first_iid_str);
-            memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_updated_at"), first_upd);
+            // #1185: the staleness markers (last_drafted_iid / _updated_at)
+            // are NOT set here. The #200 gate must only short-circuit once an
+            // action for this issue has actually COMPLETED. The autonomous
+            // path sets them after commit-files succeeds; the review-gated /
+            // propose / shadow paths set them after their own terminal action
+            // (the draft comment / emit). A branch-created-but-commit-failed
+            // tick leaves the markers unset so the next tick retries instead
+            // of stranding an empty branch.
             let rec = recommend("code_write", ["accuracy"]);
             let context = "Assigned issues: " + issues_raw + "\nLearned code patterns: " + to_string(rec);
 
@@ -322,6 +335,13 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                     };
 
                     if len(commit_result) > 0 {
+                        // #1185: mark drafted only now that the commit landed.
+                        // If create-branch succeeded but commit-files failed,
+                        // we never reach here, so the markers stay unset and
+                        // the next tick retries the issue instead of skipping
+                        // it forever behind the #200 gate with an empty branch.
+                        memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_iid"), first_iid_str);
+                        memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_updated_at"), first_upd);
                         print("[code_writer] Committed code to", draft.branch_name);
                         emit("implementation:code_draft", draft);
                         // #1151: durable single-slot handoff to commit_composer.
@@ -374,6 +394,14 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                         };
                     };
                 };
+                // #1185: for the review-gated / propose / shadow paths the
+                // draft comment / emit IS the terminal action and it has just
+                // run, so mark drafted now to preserve their per-tick
+                // idempotency (they must not re-post / re-emit every tick).
+                // The autonomous path deliberately does NOT fall through here
+                // — it sets the markers only after commit-files succeeds.
+                memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_iid"), first_iid_str);
+                memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_updated_at"), first_upd);
             };
         };
     };

--- a/dev-apprenticeship/install.sh
+++ b/dev-apprenticeship/install.sh
@@ -607,7 +607,18 @@ if [ -d "$AGENTIS_DIR" ]; then
     #                                 (to resolve $COLONY_DIR/scripts/...
     #                                 paths) and GITLAB_* (so gitlab-api.sh
     #                                 authenticates against the instance
-    #                                 configured by start-colony.sh).
+    #                                 configured by start-colony.sh). The
+    #                                 trigger-label vars
+    #                                 IMPLEMENTATION_TRIGGER_LABEL /
+    #                                 PLANNING_TRIGGER_LABEL must pass through
+    #                                 too (#1185): start-colony.sh exports a
+    #                                 colony.toml `trigger_label` override,
+    #                                 but without them in the allowlist
+    #                                 agentis strips the override before
+    #                                 `exec sh forge-api.sh` and the forge
+    #                                 falls back to the default
+    #                                 `implementation` / `needs-planning`
+    #                                 label.
     #   exec.default_timeout_ms     — gitlab-api.sh calls curl with a
     #                                 per-attempt `--max-time` of
     #                                 `$GITLAB_CURL_MAX_TIME` (default
@@ -696,11 +707,22 @@ if [ -d "$AGENTIS_DIR" ]; then
     if [ -f "$AGENTIS_CONFIG" ] && grep -qxF 'exec.env_passthrough = COLONY_DIR,GITLAB_*' "$AGENTIS_CONFIG"; then
         # Use a tmp file + mv for atomicity; no sed -i (BSD vs GNU portability).
         awk '/^exec\.env_passthrough = COLONY_DIR,GITLAB_\*$/ \
-             { print "exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*"; next } { print }' \
+             { print "exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*,IMPLEMENTATION_TRIGGER_LABEL,PLANNING_TRIGGER_LABEL"; next } { print }' \
             "$AGENTIS_CONFIG" > "$AGENTIS_CONFIG.tmp" && mv "$AGENTIS_CONFIG.tmp" "$AGENTIS_CONFIG"
         ok "upgraded exec.env_passthrough (#277)"
     fi
-    write_key 'exec.env_passthrough'         'COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*'
+    # Migrate #1185 pre-fix literal in-place. Upgrades the #277-era value to
+    # also pass through the trigger-label vars so a colony.toml
+    # `trigger_label` override survives the env strip before `exec sh`.
+    # Exact-match only — any operator customization is preserved untouched.
+    if [ -f "$AGENTIS_CONFIG" ] && grep -qxF 'exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*' "$AGENTIS_CONFIG"; then
+        # Use a tmp file + mv for atomicity; no sed -i (BSD vs GNU portability).
+        awk '/^exec\.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_\*,GITHUB_\*$/ \
+             { print "exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*,IMPLEMENTATION_TRIGGER_LABEL,PLANNING_TRIGGER_LABEL"; next } { print }' \
+            "$AGENTIS_CONFIG" > "$AGENTIS_CONFIG.tmp" && mv "$AGENTIS_CONFIG.tmp" "$AGENTIS_CONFIG"
+        ok "upgraded exec.env_passthrough (#1185)"
+    fi
+    write_key 'exec.env_passthrough'         'COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*,IMPLEMENTATION_TRIGGER_LABEL,PLANNING_TRIGGER_LABEL'
     write_key 'exec.default_timeout_ms'      '120000'
     write_key 'pii_transmit'                 'allow'
     write_key 'knowledge.enabled'            'true'

--- a/tools/test-code-writer-completion-markers.sh
+++ b/tools/test-code-writer-completion-markers.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# test-code-writer-completion-markers.sh: #1185 grep-level wiring assertions
+# for implementation/code_writer.ag.
+#
+# Two operability fixes are covered here:
+#
+#   Part 2 (first-run MR-learning bound). merged_mr_cmd() returns the
+#   no-`--since` form on the first tick (empty `last_check`). Without a bound
+#   that learns from the WHOLE merged-MR history — one prompt() per MR per
+#   tick — starving the drafting step on a mature repo. The fix bounds the
+#   first-run query to a small recent window (`--per-page 1`, both forge
+#   backends sort updated_at desc), so the first run never learns more than a
+#   bounded window. We assert the no-since branch carries that bound.
+#
+#   Part 3 (don't strand a half-completed autonomous flow). The #200 staleness
+#   markers (last_drafted_iid / _updated_at) used to be written right after the
+#   draft prompt, BEFORE the autonomous create-branch / commit-files. A
+#   branch-created-but-commit-failed tick still marked the issue "drafted", so
+#   the #200 gate skipped it forever and stranded an empty branch. The fix sets
+#   the markers only once the path's own action has COMPLETED: the autonomous
+#   path sets them inside the commit-success block; the non-autonomous
+#   (review-gated / propose / shadow) paths still set them after their terminal
+#   draft comment / emit. We assert, structurally:
+#     - the markers are NOT written before the tier branch (no write between
+#       `should_draft_code(...)` and the `if my_tier == "autonomous"` branch);
+#     - a marker write appears inside the `if len(commit_result) > 0` block;
+#     - a marker write still exists on the non-autonomous side.
+#
+# Matches the test style of tools/test-assignment-based-pickup.sh (bash,
+# [PASS]/[FAIL] lines, `Results: N passed, M failed`). Exit 0 all-pass, 1
+# any-fail. Related: #1185.
+
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+AG="$REPO_ROOT/dev-apprenticeship/implementation/agents/code_writer.ag"
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$AG" ]; then
+  echo "[FAIL] code_writer.ag present: missing $AG"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Part 2: first-run MR-learning bound.
+# -----------------------------------------------------------------------------
+
+# The no-since merged-requests query (the first-run branch) must carry a bound
+# so the very first tick cannot fan out over the whole merged history.
+if grep -F -q -- 'merge-requests --state merged --per-page 1 --view impl' "$AG"; then
+  pass "merged_mr_cmd bounds first-run (no last_check) learning (--per-page 1)"
+else
+  fail "merged_mr_cmd first-run bound" \
+    "no-since merge-requests query missing a --per-page bound in code_writer.ag"
+fi
+
+# The since-gated query (sticky ticks) must stay unbounded so a real
+# last_check window still learns from every MR merged since then.
+if grep -F -q -- 'merge-requests --state merged --since ' "$AG"; then
+  pass "merged_mr_cmd keeps the --since query for sticky ticks"
+else
+  fail "merged_mr_cmd since-query" \
+    "expected a '--since'-gated merge-requests query in code_writer.ag"
+fi
+
+# -----------------------------------------------------------------------------
+# Part 3: completion-time staleness markers. Use awk to slice the file into the
+# three regions delimited by the structural anchors, so we assert *where* the
+# marker writes live, not just that they exist somewhere.
+#   region A: from `should_draft_code(` up to (not incl.) the autonomous branch
+#   region B: from `if len(commit_result) > 0` to its closing scope
+#   region C: from the non-autonomous `} else {` (the tier else) to end
+# -----------------------------------------------------------------------------
+MARKER='memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_iid")'
+
+# Region A: between the should_draft_code gate and the autonomous branch.
+# A marker write here would be the pre-fix bug (mark before any action runs).
+region_a="$(awk '
+  /if should_draft_code\(/ { grab=1 }
+  /if my_tier == "autonomous"/ { grab=0 }
+  grab { print }
+' "$AG")"
+if printf '%s\n' "$region_a" | grep -F -q -- "$MARKER"; then
+  fail "marker not set before the tier branch" \
+    "last_drafted_iid written between should_draft_code and the autonomous branch (pre-#1185 bug)"
+else
+  pass "marker NOT set before the tier branch (autonomous flow can retry)"
+fi
+
+# Region B: inside the commit-success block. The autonomous path must mark
+# only after commit-files lands.
+region_b="$(awk '
+  /if len\(commit_result\) > 0/ { grab=1 }
+  grab { print }
+  /emit\("implementation:code_draft", draft\)/ { if (grab) exit }
+' "$AG")"
+if printf '%s\n' "$region_b" | grep -F -q -- "$MARKER"; then
+  pass "autonomous path sets the marker inside the commit-success block"
+else
+  fail "autonomous marker placement" \
+    "last_drafted_iid not written inside the 'if len(commit_result) > 0' block"
+fi
+
+# The autonomous branch must NOT mark before create-branch: assert the marker
+# write occurs after the create-branch command line within the file.
+branch_line="$(grep -n -F -- 'create-branch --name' "$AG" | head -1 | cut -d: -f1)"
+marker_lines="$(grep -n -F -- "$MARKER" "$AG" | cut -d: -f1)"
+autonomous_marker_after_branch=0
+if [ -n "$branch_line" ]; then
+  for ln in $marker_lines; do
+    if [ "$ln" -gt "$branch_line" ]; then
+      autonomous_marker_after_branch=1
+      break
+    fi
+  done
+fi
+if [ "$autonomous_marker_after_branch" = "1" ]; then
+  pass "a marker write follows create-branch (not before it)"
+else
+  fail "marker vs create-branch ordering" \
+    "no last_drafted_iid write found after the create-branch line"
+fi
+
+# Region C: the non-autonomous paths (review-gated / propose / shadow) must
+# still mark after their terminal draft comment / emit, so they stay
+# idempotent and do not re-post every tick. We assert the marker exists after
+# the review-gated add-note post.
+post_line="$(grep -n -F -- 'add-note ' "$AG" | head -1 | cut -d: -f1)"
+nonauto_marker_after_post=0
+if [ -n "$post_line" ]; then
+  for ln in $marker_lines; do
+    if [ "$ln" -gt "$post_line" ]; then
+      nonauto_marker_after_post=1
+      break
+    fi
+  done
+fi
+if [ "$nonauto_marker_after_post" = "1" ]; then
+  pass "non-autonomous paths still mark after their terminal post/emit (idempotent)"
+else
+  fail "non-autonomous marker placement" \
+    "no last_drafted_iid write found after the review-gated add-note post"
+fi
+
+# -----------------------------------------------------------------------------
+# Parse check: the agent commits cleanly under `agentis commit`, same as the
+# per-agent syntax pass in colony-lint.sh. Skipped (not failed) when agentis is
+# not installed, matching the CI runner contract.
+# -----------------------------------------------------------------------------
+if command -v agentis >/dev/null 2>&1; then
+  LINT_TMP="$(mktemp -d)"
+  trap 'rm -rf "$LINT_TMP"' EXIT
+  (cd "$LINT_TMP" && agentis init) >/dev/null 2>&1
+  if (cd "$LINT_TMP" && agentis commit "$AG") >/dev/null 2>&1; then
+    pass "code_writer.ag parses (agentis commit)"
+  else
+    fail "code_writer.ag parses (agentis commit)" "syntax error in code_writer.ag"
+  fi
+else
+  echo "[SKIP] agentis not on PATH — skipping .ag parse check"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-install-env-passthrough.sh
+++ b/tools/test-install-env-passthrough.sh
@@ -15,6 +15,9 @@
 #   Test 7: GITHUB_ME (GITLAB_ME unset) seeds gitlab:me on github backend
 #   Test 8: GITLAB_ME (GITHUB_ME unset) seeds gitlab:me on gitlab backend
 #   Test 9: Both unset — gitlab:me memo left unset
+#   Test 10: Fresh install env_passthrough carries the trigger-label vars (#1185)
+#   Test 11: #1185 upgrade rewrites the #277-era literal to add trigger-labels
+#   Test 12: #277-era pre-fix literal also migrates straight to the #1185 value
 #
 # Usage: ./tools/test-install-env-passthrough.sh
 # Exit code 0 if all tests pass, 1 otherwise.
@@ -48,13 +51,21 @@ run_install_fragment() {
     # customization (extra vars, reordering) is preserved untouched.
     if [ -f "$AGENTIS_CONFIG" ] && grep -qxF 'exec.env_passthrough = COLONY_DIR,GITLAB_*' "$AGENTIS_CONFIG"; then
         awk '/^exec\.env_passthrough = COLONY_DIR,GITLAB_\*$/ \
-             { print "exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*"; next } { print }' \
+             { print "exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*,IMPLEMENTATION_TRIGGER_LABEL,PLANNING_TRIGGER_LABEL"; next } { print }' \
             "$AGENTIS_CONFIG" > "$AGENTIS_CONFIG.tmp" && mv "$AGENTIS_CONFIG.tmp" "$AGENTIS_CONFIG"
     fi
-    write_key 'exec.env_passthrough' 'COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*'
+    # Migrate #1185 pre-fix literal in-place. Upgrades the #277-era value to
+    # also pass through the trigger-label vars. Exact-match only.
+    if [ -f "$AGENTIS_CONFIG" ] && grep -qxF 'exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*' "$AGENTIS_CONFIG"; then
+        awk '/^exec\.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_\*,GITHUB_\*$/ \
+             { print "exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*,IMPLEMENTATION_TRIGGER_LABEL,PLANNING_TRIGGER_LABEL"; next } { print }' \
+            "$AGENTIS_CONFIG" > "$AGENTIS_CONFIG.tmp" && mv "$AGENTIS_CONFIG.tmp" "$AGENTIS_CONFIG"
+    fi
+    write_key 'exec.env_passthrough' 'COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*,IMPLEMENTATION_TRIGGER_LABEL,PLANNING_TRIGGER_LABEL'
 }
 
-EXPECTED_NEW='exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*'
+EXPECTED_NEW='exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*,IMPLEMENTATION_TRIGGER_LABEL,PLANNING_TRIGGER_LABEL'
+EXPECTED_277='exec.env_passthrough = COLONY_DIR,FORGE_TYPE,GITLAB_*,GITHUB_*'
 EXPECTED_OLD='exec.env_passthrough = COLONY_DIR,GITLAB_*'
 OPERATOR_TUNED='exec.env_passthrough = COLONY_DIR,GITLAB_*,MY_CUSTOM'
 
@@ -67,7 +78,7 @@ T1_CONFIG="$T1_DIR/config"
 run_install_fragment "$T1_CONFIG"
 
 if grep -qxF "$EXPECTED_NEW" "$T1_CONFIG"; then
-    pass "fresh install writes exec.env_passthrough with FORGE_TYPE + GITHUB_*"
+    pass "fresh install writes exec.env_passthrough with FORGE_TYPE + GITHUB_* + trigger labels"
 else
     fail "fresh install — expected '$EXPECTED_NEW', got:"
     cat "$T1_CONFIG"
@@ -103,6 +114,62 @@ if grep -qxF "$OPERATOR_TUNED" "$T3_CONFIG" \
 else
     fail "operator-tuned preservation — expected '$OPERATOR_TUNED' untouched, got:"
     cat "$T3_CONFIG"
+fi
+
+# ----- Trigger-label env passthrough (#1185) -----
+
+# ----- Test 10: Fresh install carries the trigger-label vars -----
+# A colony.toml `trigger_label` override is exported by start-colony.sh as
+# IMPLEMENTATION_TRIGGER_LABEL / PLANNING_TRIGGER_LABEL; without them in the
+# allowlist agentis strips the override before `exec sh forge-api.sh`.
+T10_DIR="$FAKE_ROOT/t10"
+mkdir -p "$T10_DIR"
+T10_CONFIG="$T10_DIR/config"
+: > "$T10_CONFIG"
+
+run_install_fragment "$T10_CONFIG"
+
+if grep -q 'IMPLEMENTATION_TRIGGER_LABEL' "$T10_CONFIG" \
+    && grep -q 'PLANNING_TRIGGER_LABEL' "$T10_CONFIG"; then
+    pass "fresh install env_passthrough carries IMPLEMENTATION_TRIGGER_LABEL + PLANNING_TRIGGER_LABEL (#1185)"
+else
+    fail "fresh install trigger labels — expected both trigger-label vars, got:"
+    cat "$T10_CONFIG"
+fi
+
+# ----- Test 11: #1185 upgrade rewrites the #277-era literal -----
+T11_DIR="$FAKE_ROOT/t11"
+mkdir -p "$T11_DIR"
+T11_CONFIG="$T11_DIR/config"
+printf '%s\n' "$EXPECTED_277" > "$T11_CONFIG"
+
+run_install_fragment "$T11_CONFIG"
+
+if grep -qxF "$EXPECTED_NEW" "$T11_CONFIG" \
+    && ! grep -qxF "$EXPECTED_277" "$T11_CONFIG"; then
+    pass "#1185 upgrade rewrites #277-era literal to add the trigger-label vars"
+else
+    fail "#1185 upgrade — expected '$EXPECTED_NEW' and no bare '$EXPECTED_277', got:"
+    cat "$T11_CONFIG"
+fi
+
+# ----- Test 12: #277-era pre-fix literal migrates straight to the #1185 value -----
+# The #277 migration's awk target now emits the full #1185 value, so an even
+# older `COLONY_DIR,GITLAB_*` config lands on the trigger-label value in one
+# install run (no second pass needed).
+T12_DIR="$FAKE_ROOT/t12"
+mkdir -p "$T12_DIR"
+T12_CONFIG="$T12_DIR/config"
+printf '%s\n' "$EXPECTED_OLD" > "$T12_CONFIG"
+
+run_install_fragment "$T12_CONFIG"
+
+if grep -qxF "$EXPECTED_NEW" "$T12_CONFIG" \
+    && ! grep -qxF "$EXPECTED_OLD" "$T12_CONFIG"; then
+    pass "#277-era literal migrates straight to the #1185 trigger-label value"
+else
+    fail "#277->#1185 migration — expected '$EXPECTED_NEW', got:"
+    cat "$T12_CONFIG"
 fi
 
 # ----- Heartbeat interval (#280) -----


### PR DESCRIPTION
Closes #1185.

Three operability fixes that made the federation hard to run autonomously on a **mature** repo (found dogfooding — separate from the capability fixes #1171/#1172/#1181):

1. **Trigger-label env passthrough.** `exec.env_passthrough` now includes `IMPLEMENTATION_TRIGGER_LABEL`,`PLANNING_TRIGGER_LABEL` (install.sh + idempotent migration) — a `colony.toml` `trigger_label` override now reaches the forge calls instead of being stripped at the `exec sh` boundary.
2. **Bounded first-run learning.** `code_writer.merged_mr_cmd` appends `--per-page 1` when `last_check` is empty (both backends sort merged MRs `updated_at desc`), so a first run learns from the most-recent MR instead of walking the whole history one `prompt()` per MR. Since-gated branch unchanged.
3. **No stranded half-completed flow.** The `last_drafted_iid`/`updated_at` staleness markers moved to per-path completion: autonomous sets them only **after commit success**; non-autonomous after their terminal post/emit. A branch-created-but-commit-failed tick no longer marks the issue drafted → it retries instead of leaving an empty branch (QA-verified across every tier path: no re-draft loop, no double-mark).

## Verification
- colony-lint **424 passed, 0 failed, 5 skipped**; new test 7/0 + env-passthrough 12/0; cost-cap 7/0, auto-promote 13/0, assignment-pickup 15/0 regression-clean.
- QA: ✅ ship-it (both ⚠️ awareness-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)