### PR TITLE
test(trading-binance): carry tail-risk — does not wipe the year if unlevered (#1188)

### DIFF
--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,13 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Carry tail-risk study (#1188): measured the basis-blowout / funding-flip /
+  liquidation tails a funding-only backtest can't see, over 2.5y for the carry
+  basket. **Tail does NOT wipe the year if run UNLEVERED**: perp-spot basis never
+  widened >0.35% (tight peg, even through crashes), worst sustained negative-
+  funding run -84bps; fully-funded 1:1 residual tail ~0.55% (mean) vs ~5%/yr
+  carry. But adverse up-days hit +22-42% -> short leg MUST be unlevered (>2.4x
+  liquidates). Remaining gate: paper-trade for real slippage (`runs/20260620T-carry-tail/`).
 - Carry cost-realism sensitivity (#1183): swept the merged carry backtest across
   all-in round-trip costs (20-120 bps) over 2.5y + regimes
   (`runs/20260620T-carry-cost/`). The edge **survives realistic costs in

--- a/trading-binance/runs/20260620T-carry-tail/comparison.md
+++ b/trading-binance/runs/20260620T-carry-tail/comparison.md
@@ -1,0 +1,39 @@
+# Carry tail-risk — does one event wipe the year? (#1188)
+
+The carry backtests model funding accrual − cost only. They cannot see the tails that wipe a delta-neutral book in one event. Measured over **2.5 years** (2024-01 → 2026-06, daily) for the persistent-positive carry basket (LINK/AVAX/DOGE/SUI/NEAR/AAVE/ARB), using perp + spot klines + funding.
+
+## The three tails
+
+| Symbol | max basis (perp−spot) | worst adverse up-day | max safe leverage | worst sustained −funding run |
+|---|---|---|---|---|
+| LINKUSDT | +0.18 % / −0.20 % | +42.2 % | 2.4× | −15 bps |
+| AVAXUSDT | +0.21 % / −0.35 % | +21.8 % | 4.6× | **−84 bps** |
+| DOGEUSDT | +0.20 % / −0.19 % | +36.1 % | 2.8× | −13 bps |
+| SUIUSDT | +0.17 % / −0.31 % | +39.9 % | 2.5× | −47 bps |
+| NEARUSDT | +0.16 % / −0.22 % | +41.5 % | 2.4× | −21 bps |
+| AAVEUSDT | +0.21 % / −0.23 % | +30.0 % | 3.3× | −16 bps |
+| ARBUSDT | +0.19 % / −0.25 % | +31.3 % | 3.2× | −12 bps |
+| **basket** | **worst 0.35 %, mean 0.25 %** | up to +42 % | **min 2.4×** | worst −84, mean −30 bps |
+
+## Findings
+
+1. **Basis blowout — negligible.** The perp–spot basis never widened beyond ~**0.35 %** over 2.5 years *including* every crash and squeeze — these are liquid alts with a tight perp/spot peg. A forced unwind at the worst basis costs ~0.2–0.35 %.
+2. **Funding sign-flip — small.** The worst sustained negative-funding run was **−84 bps** (AVAX), mean ~−30 bps. A slow-rotating book pays ~0.3–0.8 % through a regime flip before the trailing filter rotates to cash.
+3. **Leverage is the killer.** The worst adverse up-day was **+22 % to +42 %**. Any short-leg leverage above ~**2.4×** would have been **liquidated** at least once in 2.5 years. Fully-funded (1:1, unlevered) there is no liquidation and the directional move cancels.
+
+## Verdict — the tail does NOT wipe the year, *if run unlevered*
+
+- **Fully-funded 1:1 (no leverage): the residual tail is ~0.55 % (mean), ~1.2 % (worst symbol)** — basis (~0.25 %) + funding-flip (~0.30 %). Against ~5 %/yr carry that is **~6 weeks (mean) to ~3 months (worst) of carry — not a year-wiper.** The ~5 %/yr carry **survives the observed tail comfortably**, because the basis is tight and the funding-flip cost is small relative to a year of accrual.
+- **The binding constraint is leverage.** The +22–42 % adverse spikes mean the short leg **must be unlevered** (≤ ~2.4× is the empirical liquidation floor, and that's cutting it fine). Unlevered means **full capital on both legs** (the ~5 %/yr is on 100 % capital, not amplified) — no capital efficiency, but a benign tail.
+
+## Remaining real-world unknowns (NOT in this analysis)
+
+- **Execution slippage** on the thinner alts (SUI/ARB/NEAR) at entry/exit — the cost-realism study (#1184) used 40 bps; thin-alt reality is the 80–150 bps end, which is where the survivorship caveat (#1180) bites.
+- Exchange/custody/counterparty risk (holding spot + a short perp on a venue).
+- This is daily-bar data; an intraday flash-squeeze + liquidation cascade can be worse than the daily high captures.
+
+## Conclusion
+
+The tail-risk gate **passes for an unlevered, fully-funded delta-neutral carry**: no single basis/funding event in 2.5 years would have wiped more than ~3 months of carry, and the basis peg held tight even through crashes. The ~5 %/yr (regime-gated, liquid-name) carry is a **real, deployable, modest yield** — provided it is run **unlevered** and the operator accepts the capital-intensity. The honest next gate is no longer analysis but a **paper-trade on the live funding feed** (to measure real entry slippage + the operational reality), then tiny real size.
+
+Reproduce: `run-meta.json` (price/funding data gitignored).

--- a/trading-binance/runs/20260620T-carry-tail/results.json
+++ b/trading-binance/runs/20260620T-carry-tail/results.json
@@ -1,0 +1,90 @@
+{
+  "window": {
+    "start": "2024-01-01",
+    "end": "2026-06-20"
+  },
+  "reference_annual_carry_pct": 5.0,
+  "per_symbol": [
+    {
+      "symbol": "LINKUSDT",
+      "max_basis_pct": 0.183,
+      "min_basis_pct": -0.202,
+      "max_abs_basis_pct": 0.202,
+      "worst_adverse_day_up_pct": 42.16,
+      "max_safe_leverage": 2.4,
+      "worst_negative_funding_run_bps": -15.35,
+      "days": 902
+    },
+    {
+      "symbol": "AVAXUSDT",
+      "max_basis_pct": 0.212,
+      "min_basis_pct": -0.348,
+      "max_abs_basis_pct": 0.348,
+      "worst_adverse_day_up_pct": 21.82,
+      "max_safe_leverage": 4.6,
+      "worst_negative_funding_run_bps": -84.37,
+      "days": 902
+    },
+    {
+      "symbol": "DOGEUSDT",
+      "max_basis_pct": 0.198,
+      "min_basis_pct": -0.191,
+      "max_abs_basis_pct": 0.198,
+      "worst_adverse_day_up_pct": 36.07,
+      "max_safe_leverage": 2.8,
+      "worst_negative_funding_run_bps": -12.6,
+      "days": 902
+    },
+    {
+      "symbol": "SUIUSDT",
+      "max_basis_pct": 0.173,
+      "min_basis_pct": -0.307,
+      "max_abs_basis_pct": 0.307,
+      "worst_adverse_day_up_pct": 39.88,
+      "max_safe_leverage": 2.5,
+      "worst_negative_funding_run_bps": -46.98,
+      "days": 902
+    },
+    {
+      "symbol": "NEARUSDT",
+      "max_basis_pct": 0.158,
+      "min_basis_pct": -0.221,
+      "max_abs_basis_pct": 0.221,
+      "worst_adverse_day_up_pct": 41.5,
+      "max_safe_leverage": 2.4,
+      "worst_negative_funding_run_bps": -20.54,
+      "days": 902
+    },
+    {
+      "symbol": "AAVEUSDT",
+      "max_basis_pct": 0.215,
+      "min_basis_pct": -0.232,
+      "max_abs_basis_pct": 0.232,
+      "worst_adverse_day_up_pct": 29.97,
+      "max_safe_leverage": 3.3,
+      "worst_negative_funding_run_bps": -16.07,
+      "days": 902
+    },
+    {
+      "symbol": "ARBUSDT",
+      "max_basis_pct": 0.188,
+      "min_basis_pct": -0.25,
+      "max_abs_basis_pct": 0.25,
+      "worst_adverse_day_up_pct": 31.27,
+      "max_safe_leverage": 3.2,
+      "worst_negative_funding_run_bps": -11.99,
+      "days": 902
+    }
+  ],
+  "basket": {
+    "worst_single_symbol_basis_pct": 0.348,
+    "mean_worst_basis_pct": 0.251,
+    "worst_negative_funding_run_bps": -84.37,
+    "mean_worst_negative_funding_run_bps": -29.7,
+    "min_safe_leverage_across_basket": 2.4
+  },
+  "interpretation": {
+    "fully_funded_1to1_tail_pct": 0.548,
+    "note": "fully-funded tail = mean worst basis (forced-unwind) + mean worst sustained negative-funding run; directional cancels (no liquidation). leveraged adds liquidation at moves > 1/L."
+  }
+}

--- a/trading-binance/runs/20260620T-carry-tail/run-meta.json
+++ b/trading-binance/runs/20260620T-carry-tail/run-meta.json
@@ -1,0 +1,4 @@
+{"run_id":"20260620T-carry-tail","issue":1188,"kind":"carry-tail-risk-basis-funding-liquidation",
+ "basket":"LINK,AVAX,DOGE,SUI,NEAR,AAVE,ARB (persistent-positive carriers)","span":"2024-01..2026-06 daily",
+ "data":"perp klines (fapi) + spot klines (api) + funding (reused)","base_commit":"8c7d34aeb59435bdef902f8b312587db2a79da19",
+ "reproduce":"python3 tools/funding-download.py --symbols <basket> --start 2024-01-01 --end 2026-06-20 && python3 runs/20260620T-carry-tail/tail-risk.py --symbols <basket> --start 2024-01-01 --end 2026-06-20 --funding-dir data/funding"}

--- a/trading-binance/runs/20260620T-carry-tail/tail-risk.py
+++ b/trading-binance/runs/20260620T-carry-tail/tail-risk.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""tail-risk.py -- measure the tails a funding-only carry backtest cannot see
+(#1188). For a delta-neutral carry (short perp + long spot), directional PnL
+hedges, but three tails can wipe a book in one event:
+
+  1. BASIS BLOWOUT -- pair PnL at a forced unwind = -(basis_now - basis_entry),
+     basis = (perp - spot)/spot. A perp-spot squeeze you're forced to close into
+     costs the basis widening. Measure max basis dislocation (perp vs spot daily).
+  2. FUNDING SIGN-FLIP -- in a crash funding flips hard negative (short-perp
+     PAYS); the trailing filter lags ~lookback days, so the book pays through the
+     flip. Measure the worst sustained negative-funding run per symbol.
+  3. LIQUIDATION -- a perp short margined at leverage L liquidates on an adverse
+     up-move > ~1/L. Measure the worst adverse daily perp move -> max safe L.
+
+Framing: a FULLY-FUNDED 1:1 book (spot fully held, short fully margined, no
+leverage) has no liquidation risk and directional cancels through any move -> its
+residual tail is only basis + funding-flips (small for liquid alts). A LEVERAGED
+book frees capital but adds the liquidation tail. The report gives both.
+
+Perp klines: fapi.binance.com /fapi/v1/klines ; spot: api.binance.com /api/v3/klines.
+Funding reused from <funding-dir>/<SYM>.csv. Standard library only.
+"""
+import argparse
+import csv
+import datetime
+import json
+import os
+import sys
+import urllib.request
+
+
+def epoch_ms(s):
+    if s.isdigit():
+        return int(s)
+    return int(datetime.datetime.strptime(s, "%Y-%m-%d").replace(
+        tzinfo=datetime.timezone.utc).timestamp() * 1000)
+
+
+def klines(host, path, symbol, interval, start, end):
+    out = []
+    cur = start
+    while cur < end:
+        url = ("https://%s%s?symbol=%s&interval=%s&startTime=%d&endTime=%d&limit=1000"
+               % (host, path, symbol, interval, cur, end))
+        try:
+            with urllib.request.urlopen(url, timeout=30) as r:
+                batch = json.load(r)
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write("klines %s %s err: %s\n" % (host, symbol, e))
+            return out
+        if not batch:
+            break
+        out.extend(batch)
+        cur = batch[-1][0] + 1
+        if len(batch) < 1000:
+            break
+    return out
+
+
+def load_funding(funding_dir, sym):
+    path = os.path.join(funding_dir, sym + ".csv")
+    if not os.path.isfile(path):
+        return []
+    rows = []
+    with open(path, newline="") as fh:
+        for r in csv.DictReader(fh):
+            rows.append((int(r["fundingTime"]), float(r["fundingRate"])))
+    rows.sort()
+    return rows
+
+
+def worst_negative_run(funding_rows):
+    """Largest-magnitude sum of a consecutive negative-funding streak (what a
+    short-perp book PAYS through a sustained flip), in bps."""
+    worst = 0.0
+    cur = 0.0
+    for _, fr in funding_rows:
+        if fr < 0:
+            cur += fr
+            worst = min(worst, cur)
+        else:
+            cur = 0.0
+    return worst * 10000.0
+
+
+def analyse_symbol(sym, start, end, funding_dir):
+    perp = klines("fapi.binance.com", "/fapi/v1/klines", sym, "1d", start, end)
+    spot = klines("api.binance.com", "/api/v3/klines", sym, "1d", start, end)
+    if not perp or not spot:
+        return None
+    # align by openTime: close = index 4, high = 2
+    pmap = {k[0]: (float(k[4]), float(k[2])) for k in perp}
+    smap = {k[0]: float(k[4]) for k in spot}
+    bases = []
+    for t in sorted(set(pmap) & set(smap)):
+        pc, _ = pmap[t]
+        sc = smap[t]
+        if sc > 0:
+            bases.append((pc - sc) / sc)
+    if not bases:
+        return None
+    max_basis = max(bases)
+    min_basis = min(bases)
+    # worst adverse up-move on the perp (high vs prior close), for liquidation
+    pk = sorted(pmap)
+    worst_up = 0.0
+    for i in range(1, len(pk)):
+        prev_close = pmap[pk[i - 1]][0]
+        hi = pmap[pk[i]][1]
+        if prev_close > 0:
+            worst_up = max(worst_up, (hi - prev_close) / prev_close)
+    fr = load_funding(funding_dir, sym)
+    return {
+        "symbol": sym,
+        "max_basis_pct": round(max_basis * 100, 3),
+        "min_basis_pct": round(min_basis * 100, 3),
+        "max_abs_basis_pct": round(max(abs(max_basis), abs(min_basis)) * 100, 3),
+        "worst_adverse_day_up_pct": round(worst_up * 100, 2),
+        "max_safe_leverage": round(1.0 / worst_up, 1) if worst_up > 0 else None,
+        "worst_negative_funding_run_bps": round(worst_negative_run(fr), 2),
+        "days": len(bases),
+    }
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--symbols", required=True)
+    ap.add_argument("--start", required=True)
+    ap.add_argument("--end", required=True)
+    ap.add_argument("--funding-dir", required=True)
+    ap.add_argument("--annual-carry-pct", type=float, default=5.0,
+                    help="reference annual carry to compare the tail against")
+    args = ap.parse_args(argv)
+
+    symbols = [s.strip().upper() for s in args.symbols.split(",") if s.strip()]
+    start, end = epoch_ms(args.start), epoch_ms(args.end)
+    per = []
+    for s in symbols:
+        r = analyse_symbol(s, start, end, args.funding_dir)
+        if r:
+            per.append(r)
+    if not per:
+        sys.stderr.write("no data\n")
+        return 2
+
+    # basket (equal-weight) tail aggregates
+    basket_worst_basis = max(p["max_abs_basis_pct"] for p in per)
+    basket_mean_worst_basis = round(sum(p["max_abs_basis_pct"] for p in per) / len(per), 3)
+    basket_worst_negfund = min(p["worst_negative_funding_run_bps"] for p in per)
+    basket_mean_negfund = round(sum(p["worst_negative_funding_run_bps"] for p in per) / len(per), 2)
+    basket_min_safe_lev = min((p["max_safe_leverage"] for p in per if p["max_safe_leverage"]), default=None)
+
+    out = {
+        "window": {"start": args.start, "end": args.end},
+        "reference_annual_carry_pct": args.annual_carry_pct,
+        "per_symbol": per,
+        "basket": {
+            "worst_single_symbol_basis_pct": basket_worst_basis,
+            "mean_worst_basis_pct": basket_mean_worst_basis,
+            "worst_negative_funding_run_bps": basket_worst_negfund,
+            "mean_worst_negative_funding_run_bps": basket_mean_negfund,
+            "min_safe_leverage_across_basket": basket_min_safe_lev,
+        },
+        "interpretation": {
+            "fully_funded_1to1_tail_pct": round(basket_mean_worst_basis + abs(basket_mean_negfund) / 100.0, 3),
+            "note": "fully-funded tail = mean worst basis (forced-unwind) + mean worst sustained negative-funding run; directional cancels (no liquidation). leveraged adds liquidation at moves > 1/L.",
+        },
+    }
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Measured the basis-blowout / funding-flip / liquidation tails a funding-only backtest can't see, over 2.5y for the carry basket (perp+spot klines+funding).

**Findings:** (1) perp-spot **basis never widened >0.35%** over 2.5y incl. crashes (tight peg) → forced-unwind loss tiny; (2) worst sustained **negative-funding run −84bps** (mean −30); (3) worst adverse up-day **+22-42%** → short leg **must be unlevered** (>2.4x liquidates).

**Verdict:** fully-funded 1:1 residual tail **~0.55% mean / ~1.2% worst vs ~5%/yr carry** = ~6 weeks to ~3 months of carry, **NOT a year-wiper**. The carry **survives the tail IF run unlevered** (full capital, no amplification). Remaining gates not modelled: thin-alt execution slippage (#1180/#1184), exchange/custody, intraday flash-squeezes. Next: paper-trade for real slippage. Docs/run artifact; data gitignored. #1188 / #1175.