### PR TITLE
feat(trading-binance): carry paper-trade harness — live regime-gated unlevered OOS tracker (#1190)

### DIFF
--- a/trading-binance/.gitignore
+++ b/trading-binance/.gitignore
@@ -3,3 +3,6 @@
 # tools/binance-feed-download.py. Keep the directory present via .gitkeep.
 /data/*
 !/data/.gitkeep
+
+# carry paper-trade live ledger (runtime state, accumulates forward)
+runs/carry-paper-live/

--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,13 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Carry paper-trade harness (#1190): `tools/carry-paper.py` -- the last gate
+  before real money. Periodic snapshots track what the regime-gated, UNLEVERED
+  delta-neutral carry book would do live, accumulating a forward out-of-sample
+  ledger marked by carry-verify.sh. Regime-gate (deploy only if expected carry
+  clears the cost hurdle, else CASH, #1184) + unlevered (#1188) + the #1174
+  basket rule. First live snapshot chose CASH (calm regime, ~2.4%/yr < hurdle).
+  `tools/test-carry-paper.sh` 12 cases.
 - Carry cost-realism sensitivity (#1183): swept the merged carry backtest across
   all-in round-trip costs (20-120 bps) over 2.5y + regimes
   (`runs/20260620T-carry-cost/`). The edge **survives realistic costs in

--- a/trading-binance/runs/20260620T-carry-paper/README.md
+++ b/trading-binance/runs/20260620T-carry-paper/README.md
@@ -1,0 +1,43 @@
+# Carry paper-trade harness (#1190)
+
+`tools/carry-paper.py` — the last gate before real money. Run it periodically
+(e.g. daily via cron); each run appends one snapshot to a JSON-lines ledger,
+accumulating a **live, forward, out-of-sample** record of what the regime-gated,
+unlevered delta-neutral funding-carry book would do, marked by the deterministic
+`carry-verify.sh` (#1175 M1).
+
+Each snapshot: score trailing funding → select the persistent-positive basket
+(top-K, mean>0 & pos-ratio≥0.55, the #1174 rule) → **regime-gate** (deploy only
+if expected annualised carry clears the cost hurdle, else CASH — #1184) →
+**unlevered** 1:1 (no short-leg leverage, #1188) → settle the prior snapshot's
+basket against the funding accrued since, minus turnover cost, append the period
+net + cumulative.
+
+## Run
+
+```sh
+python3 tools/funding-download.py --symbols <universe> --start <recent> --end <today>
+python3 tools/carry-paper.py --universe <universe> \
+  --funding-dir trading-binance/data/funding \
+  --ledger trading-binance/runs/carry-paper-live/ledger.jsonl \
+  --verifier trading-binance/tools/carry-verify.sh \
+  --top-k 6 --lookback-days 21 --min-pos-ratio 0.55 \
+  --cost-bps-roundtrip 40 --min-annual-carry-pct 3
+```
+
+The ledger (`runs/carry-paper-live/`) is gitignored — it is runtime state that
+accumulates forward. After a real out-of-sample stretch, compare the ledger's
+realised cumulative net carry against the ~5 %/yr backtest expectation; that is
+the honest live validation no backtest can give.
+
+## First live snapshot (seed)
+
+At seed time the current funding regime was **calm**: expected annualised carry
+~2.4 %/yr, below the 3 % deploy hurdle → the harness correctly chose **CASH**
+(don't pay ~40 bps round-trip to harvest thin carry — the #1184 regime-gate
+lesson in action). It deploys the basket only when funding is hot enough to
+clear costs.
+
+`tools/test-carry-paper.sh`: 12 cases (DEPLOY/CASH selection, regime gate,
+prior-snapshot settlement, cumulative accounting, negative-universe → cash,
+missing-data exit).

--- a/trading-binance/tools/carry-paper.py
+++ b/trading-binance/tools/carry-paper.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""carry-paper.py -- periodic paper-trade snapshot for the funding-carry strategy
+(#1190). The last gate before real money: track what the regime-gated, unlevered
+delta-neutral carry book WOULD do, live, accumulating a real forward
+out-of-sample record marked by the deterministic verifier.
+
+Run periodically (e.g. daily via cron). Each run:
+  1. score per-symbol TRAILING funding (annualised + positive-event ratio over
+     --lookback-days) from <funding-dir>/<SYM>.csv (refresh it first via
+     funding-download.py);
+  2. select the persistent-positive basket: mean funding > 0 AND pos-ratio >=
+     --min-pos-ratio, top --top-k by mean (the #1174 rule);
+  3. REGIME GATE (#1184): deploy the basket ONLY if its expected annualised carry
+     clears --min-annual-carry-pct; else CASH (calm regimes lose at real cost);
+  4. positions are UNLEVERED 1:1 delta-neutral (#1188 -- >2.4x liquidates), so a
+     deployed basket is equal-weight summing to 1.0 (cash = empty);
+  5. SETTLE the prior snapshot: realised funding the prior basket accrued over
+     [prior_ts, now) via tools/carry-verify.sh, minus the turnover cost of
+     rebalancing prior->new; append the period net + cumulative to the ledger.
+
+Ledger is JSON-lines (gitignored). Reuses carry-verify.sh (#1175 M1) for
+settlement. Standard library only.
+"""
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+
+
+def load_funding(funding_dir, symbols):
+    series = {}
+    for sym in symbols:
+        path = os.path.join(funding_dir, sym + ".csv")
+        if not os.path.isfile(path):
+            continue
+        rows = []
+        with open(path, newline="") as fh:
+            for r in csv.DictReader(fh):
+                rows.append((int(r["fundingTime"]), float(r["fundingRate"])))
+        rows.sort()
+        if rows:
+            series[sym] = rows
+    return series
+
+
+def trailing_stats(rows, t0, t1):
+    vals = [fr for (t, fr) in rows if t0 <= t < t1]
+    if not vals:
+        return None
+    mean = sum(vals) / len(vals)
+    pos = sum(1 for v in vals if v > 0)
+    return mean, pos / len(vals)
+
+
+def carry_verify(verifier, funding_dir, positions, prev, t0, t1, cost_rt):
+    env = dict(os.environ)
+    env["DECISION_JSON"] = json.dumps({"positions": [{"symbol": s, "weight": w} for s, w in positions.items()]})
+    env["FUNDING_DIR"] = funding_dir
+    env["SETTLE_START"] = str(int(t0))
+    env["SETTLE_END"] = str(int(t1))
+    env["COST_BPS_ROUNDTRIP"] = str(cost_rt)
+    env["PREV_POSITIONS_JSON"] = json.dumps({"positions": [{"symbol": s, "weight": w} for s, w in prev.items()]})
+    p = subprocess.run(["bash", verifier], env=env, capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError("carry-verify rc=%d: %s" % (p.returncode, p.stderr.strip()))
+    return json.loads(p.stdout.strip())
+
+
+def last_ledger_row(path):
+    if not os.path.isfile(path):
+        return None
+    last = None
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                last = line
+    return json.loads(last) if last else None
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--universe", required=True)
+    ap.add_argument("--funding-dir", required=True)
+    ap.add_argument("--ledger", required=True)
+    ap.add_argument("--verifier", required=True)
+    ap.add_argument("--top-k", type=int, default=6)
+    ap.add_argument("--lookback-days", type=float, default=21.0)
+    ap.add_argument("--min-pos-ratio", type=float, default=0.55)
+    ap.add_argument("--cost-bps-roundtrip", type=float, default=40.0)
+    ap.add_argument("--min-annual-carry-pct", type=float, default=3.0,
+                    help="regime gate: deploy only if expected annualised carry clears this")
+    ap.add_argument("--now", type=int, default=None, help="epoch ms override (default: latest funding time)")
+    args = ap.parse_args(argv)
+
+    symbols = [s.strip().upper() for s in args.universe.split(",") if s.strip()]
+    series = load_funding(args.funding_dir, symbols)
+    if not series:
+        sys.stderr.write("carry-paper: no funding data\n")
+        return 2
+    now = args.now if args.now is not None else max(rows[-1][0] for rows in series.values())
+    lookback_ms = int(args.lookback_days * 86400000)
+
+    # 1-3. score + select + regime-gate
+    scored = []
+    for s in series:
+        st = trailing_stats(series[s], now - lookback_ms, now)
+        if not st:
+            continue
+        mean, pos_ratio = st
+        if mean > 0 and pos_ratio >= args.min_pos_ratio:
+            scored.append((mean, s))
+    scored.sort(reverse=True)
+    chosen = [s for (_, s) in scored[:args.top_k]]
+    exp_annual_pct = (sum(m for (m, s) in scored[:args.top_k]) / len(chosen) * 3 * 365 * 100) if chosen else 0.0
+    deploy = bool(chosen) and exp_annual_pct >= args.min_annual_carry_pct
+    if deploy:
+        w = round(1.0 / len(chosen), 4)
+        positions = {s: w for s in chosen}
+        regime = "DEPLOY"
+    else:
+        positions = {}
+        regime = "CASH"
+
+    # 5. settle prior + cumulative
+    prior = last_ledger_row(args.ledger)
+    period_carry_bps = 0.0
+    period_turnover_bps = 0.0
+    cumulative = 0.0
+    if prior is not None:
+        prior_pos = {p["symbol"]: p["weight"] for p in prior.get("positions", [])}
+        prior_ts = prior["ts"]
+        # realised carry of the prior basket over [prior_ts, now) (no turnover within hold)
+        rv = carry_verify(args.verifier, args.funding_dir, prior_pos, prior_pos, prior_ts, now, args.cost_bps_roundtrip)
+        period_carry_bps = rv["carry_bps"]
+        # turnover cost of rebalancing prior -> new (zero-width window => carry 0, cost only)
+        tv = carry_verify(args.verifier, args.funding_dir, positions, prior_pos, now, now, args.cost_bps_roundtrip)
+        period_turnover_bps = tv["turnover_cost_bps"]
+        cumulative = prior.get("cumulative_net_bps", 0.0)
+    else:
+        # first snapshot: charge entry cost from cash into the new basket
+        tv = carry_verify(args.verifier, args.funding_dir, positions, {}, now, now, args.cost_bps_roundtrip)
+        period_turnover_bps = tv["turnover_cost_bps"]
+
+    period_net_bps = round(period_carry_bps - period_turnover_bps, 4)
+    cumulative = round(cumulative + period_net_bps, 4)
+
+    row = {
+        "ts": now,
+        "regime": regime,
+        "expected_annual_carry_pct": round(exp_annual_pct, 3),
+        "positions": [{"symbol": s, "weight": w} for s, w in positions.items()],
+        "period_carry_bps": round(period_carry_bps, 4),
+        "period_turnover_bps": round(period_turnover_bps, 4),
+        "period_net_bps": period_net_bps,
+        "cumulative_net_bps": cumulative,
+    }
+    os.makedirs(os.path.dirname(os.path.abspath(args.ledger)), exist_ok=True)
+    with open(args.ledger, "a") as fh:
+        fh.write(json.dumps(row, separators=(",", ":")) + "\n")
+
+    print("[carry-paper] %s  regime=%s  exp_annual=%.2f%%  basket=%s" % (
+        now, regime, exp_annual_pct, ",".join(positions.keys()) or "CASH"))
+    print("  period: carry=%.2f turnover=%.2f net=%.2f bps  |  cumulative=%.2f bps" % (
+        period_carry_bps, period_turnover_bps, period_net_bps, cumulative))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/trading-binance/tools/test-carry-paper.sh
+++ b/trading-binance/tools/test-carry-paper.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# test-carry-paper.sh -- unit tests for carry-paper.py (#1190). Fixture funding +
+# the merged carry-verify.sh; exercises basket selection, the regime gate
+# (DEPLOY vs CASH), settlement of the prior snapshot, and cumulative accounting.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PAPER="$SCRIPT_DIR/carry-paper.py"
+VERIFIER="$SCRIPT_DIR/carry-verify.sh"
+[ -f "$PAPER" ] || { echo "FAIL: missing $PAPER" >&2; exit 1; }
+[ -x "$VERIFIER" ] || { echo "FAIL: carry-verify not executable" >&2; exit 1; }
+
+PASS=0; FAIL=0
+FIX="$(mktemp -d)"; LEDGER="$FIX/ledger.jsonl"
+trap 'rm -rf "$FIX"' EXIT
+
+# AAAUSDT: persistent positive funding; events for the first snapshot's lookback
+# (1000-5000) and for the settlement period (7000-9000). 0.0003/8h -> ~32.85%/yr.
+printf 'fundingTime,fundingRate\n1000,0.0003\n2000,0.0003\n3000,0.0003\n4000,0.0003\n5000,0.0003\n7000,0.0003\n8000,0.0003\n9000,0.0003\n' > "$FIX/AAAUSDT.csv"
+# BBBUSDT: negative funding -> never selected.
+printf 'fundingTime,fundingRate\n1000,-0.0002\n2000,-0.0002\n3000,-0.0002\n4000,-0.0002\n5000,-0.0002\n' > "$FIX/BBBUSDT.csv"
+
+field() { python3 -c 'import sys,json; print(json.loads(sys.argv[1])[sys.argv[2]])' "$1" "$2"; }
+lastrow() { tail -1 "$LEDGER"; }
+assert_eq() {
+  local label="$1" got="$2" want="$3"
+  if python3 -c 'import sys;sys.exit(0 if abs(float(sys.argv[1])-float(sys.argv[2]))<1e-6 else 1)' "$got" "$want"; then
+    echo "[PASS] $label (=$got)"; PASS=$((PASS+1))
+  else echo "[FAIL] $label got=$got want=$want"; FAIL=$((FAIL+1)); fi
+}
+assert_str() {
+  local label="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then echo "[PASS] $label (=$got)"; PASS=$((PASS+1))
+  else echo "[FAIL] $label got=$got want=$want"; FAIL=$((FAIL+1)); fi
+}
+
+# 1. First snapshot at now=6000: trailing sees AAA(+)/BBB(-) -> DEPLOY AAA only,
+#    weight 1.0; entry cost from cash (turnover 1.0 * 40bps/2 = 20bps).
+python3 "$PAPER" --universe AAAUSDT,BBBUSDT --funding-dir "$FIX" --ledger "$LEDGER" \
+  --verifier "$VERIFIER" --top-k 6 --lookback-days 21 --min-pos-ratio 0.55 \
+  --cost-bps-roundtrip 40 --min-annual-carry-pct 3 --now 6000 >/dev/null
+R="$(lastrow)"
+assert_str "1a. snapshot1 regime DEPLOY" "$(field "$R" regime)" "DEPLOY"
+assert_str "1b. snapshot1 basket = AAAUSDT" "$(python3 -c 'import sys,json;print(",".join(p["symbol"] for p in json.loads(sys.argv[1])["positions"]))' "$R")" "AAAUSDT"
+assert_eq  "1c. snapshot1 entry turnover cost = 20bps" "$(field "$R" period_turnover_bps)" "20.0"
+assert_eq  "1d. snapshot1 period_net = -20 (entry cost, no carry yet)" "$(field "$R" period_net_bps)" "-20.0"
+
+# 2. Second snapshot at now=10000: settles AAA over [6000,10000) = funding
+#    7000+8000+9000 = 0.0009 -> 9 bps carry at weight 1.0; AAA->AAA no turnover.
+python3 "$PAPER" --universe AAAUSDT,BBBUSDT --funding-dir "$FIX" --ledger "$LEDGER" \
+  --verifier "$VERIFIER" --top-k 6 --lookback-days 21 --min-pos-ratio 0.55 \
+  --cost-bps-roundtrip 40 --min-annual-carry-pct 3 --now 10000 >/dev/null
+R="$(lastrow)"
+assert_eq  "2a. snapshot2 realised carry = 9 bps" "$(field "$R" period_carry_bps)" "9.0"
+assert_eq  "2b. snapshot2 turnover = 0 (unchanged basket)" "$(field "$R" period_turnover_bps)" "0.0"
+assert_eq  "2c. snapshot2 period_net = +9" "$(field "$R" period_net_bps)" "9.0"
+assert_eq  "2d. cumulative = -20 + 9 = -11" "$(field "$R" cumulative_net_bps)" "-11.0"
+
+# 3. REGIME GATE: same data, but min-annual-carry impossibly high -> CASH.
+LEDGER2="$FIX/ledger2.jsonl"
+python3 "$PAPER" --universe AAAUSDT,BBBUSDT --funding-dir "$FIX" --ledger "$LEDGER2" \
+  --verifier "$VERIFIER" --min-annual-carry-pct 9999 --now 6000 >/dev/null
+R="$(tail -1 "$LEDGER2")"
+assert_str "3a. high carry-hurdle -> regime CASH" "$(field "$R" regime)" "CASH"
+assert_str "3b. CASH basket empty" "$(python3 -c 'import sys,json;print(len(json.loads(sys.argv[1])["positions"]))' "$R")" "0"
+
+# 4. negative-only universe -> CASH (no symbol clears pos-ratio).
+LEDGER3="$FIX/ledger3.jsonl"
+python3 "$PAPER" --universe BBBUSDT --funding-dir "$FIX" --ledger "$LEDGER3" \
+  --verifier "$VERIFIER" --min-annual-carry-pct 3 --now 6000 >/dev/null
+assert_str "4. negative-only universe -> CASH" "$(field "$(tail -1 "$LEDGER3")" regime)" "CASH"
+
+# 5. missing funding dir -> exit 2
+if python3 "$PAPER" --universe AAAUSDT --funding-dir "$FIX/nope" --ledger "$FIX/l4" --verifier "$VERIFIER" >/dev/null 2>&1; then
+  echo "[FAIL] 5. missing funding dir should be non-zero"; FAIL=$((FAIL+1))
+else echo "[PASS] 5. missing funding dir exits non-zero"; PASS=$((PASS+1)); fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
The last gate before real money. `tools/carry-paper.py` runs periodically; each snapshot selects the persistent-positive basket (#1174), **regime-gates** it (deploy only if expected carry clears the cost hurdle, else CASH — #1184), holds it **unlevered** 1:1 (#1188), and **settles** the prior snapshot via `carry-verify.sh` (M1) — appending period net + cumulative to a gitignored JSON-lines ledger. Accumulates a live forward OOS record no backtest can give.

**First live snapshot chose CASH** — current funding regime is calm (expected ~2.4%/yr < the 3% hurdle), so it sits in cash rather than paying ~40bps to harvest thin carry (the #1184 regime-gate in action).

`tools/test-carry-paper.sh` 12/0 (DEPLOY/CASH, regime gate, prior-snapshot settlement, cumulative, negative→cash, missing-data exit). py/bash-n clean; live ledger gitignored. Closes #1190 / part of #1175.