### PR TITLE
test(trading-binance): cross-sectional momentum refinement — sweep + drawdown-aware sizing (#1197)

### DIFF
--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,13 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Cross-sectional momentum refinement (#1197): swept rebalance x top-K x
+  lookback + applied drawdown-aware trailing-vol-target sizing. The #1194 config
+  (weekly / top-4 / 30d) is confirmed the best risk-adjusted sweet spot. Sizing
+  to a 20% vol target tames the raw +43%/yr/33%-DD high-octane book to a
+  **deployable ~+20%/yr at ~18% max DD, Sharpe ~0.8** -- return is a dial via
+  target vol. Sizing controls risk, not alpha (sized Sharpe < raw).
+  (`runs/20260620T-xs-refine/`)
 - Carry paper-trade harness (#1190): `tools/carry-paper.py` -- the last gate
   before real money. Periodic snapshots track what the regime-gated, UNLEVERED
   delta-neutral carry book would do live, accumulating a forward out-of-sample

--- a/trading-binance/runs/20260620T-xs-refine/comparison.md
+++ b/trading-binance/runs/20260620T-xs-refine/comparison.md
@@ -1,0 +1,47 @@
+# Cross-sectional momentum — sweep + drawdown-aware sizing (#1197)
+
+Refining the trading edge from #1194 (~+43 %/yr @60 bps, but **max DD 30–35 %**). Two questions: is weekly/top-4 the best config, and can the scary drawdown be tamed by sizing? 18 alts, 2024-01 → 2026-06, daily klines, 60 bps, walk-forward, momentum.
+
+## 1. Config sweep (rebalance × top-K × lookback), ranked by sized Sharpe
+
+| reb | K | lookback | RAW ann | RAW Sharpe | RAW vol | RAW DD | SIZED ann | SIZED Sharpe | SIZED DD | turnover |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **7 d** | **4** | **30 d** | +43.0 % | 0.93 | 47 % | 32.6 % | **+19.5 %** | **0.81** | **18.0 %** | 0.36 |
+| 7 d | 4 | 14 d | +41.2 % | 0.84 | 49 % | 51.4 % | +23.6 % | 0.79 | 30.9 % | 0.52 |
+| 14 d | 4 | 14 d | +44.7 % | 0.82 | 55 % | 43.8 % | +29.0 % | 0.69 | 28.2 % | 0.71 |
+| 7 d | 6 | 30 d | +34.3 % | 0.82 | 42 % | 26.8 % | +14.9 % | 0.60 | 16.7 % | 0.30 |
+| 7 d | 3 | 30 d | +56.6 % | 0.98 | 58 % | 45.4 % | +14.8 % | 0.56 | 21.2 % | 0.42 |
+
+(18 configs swept; bottom ones — 3-day rebalance, K=6, 14-day lookback — degrade to single-digit or negative sized return on turnover + dilution.)
+
+**The original #1194 config (weekly / top-4 / 30-day) is the best risk-adjusted choice** — confirmed as the sweet spot, not a lucky first pick. Higher frequency (3-day) burns turnover; wider K (6) dilutes the signal; shorter lookback (14-day) raises DD. The raw +56.6 % (7d/K3/30d) is tempting but rides 58 % vol / 45 % DD and a thin 3-name book — its sized return collapses to +14.8 %.
+
+## 2. Drawdown-aware sizing (trailing-vol target 20 %, 3× cap, no look-ahead)
+
+For the best config (7d / K4 / 30d):
+
+| | RAW gross book | SIZED to 20 % vol |
+|---|---|---|
+| annualised | +43.0 % | **+19.5 %** |
+| Sharpe | 0.93 | 0.81 |
+| annualised vol | 47 % | 24 % |
+| max drawdown | 32.6 % | **18.0 %** |
+
+The headline +43 %/yr is **high-octane** — 47 % annualised vol, un-sizable for most. Vol-targeting deleverages it (the raw vol is ~2.3× the 20 % target, so exposure scales to ~0.4×): the deployable profile is **~+20 %/yr at ~18 % max DD, Sharpe ~0.8.** Return is a **dial** — set a higher target vol for more return and proportionally more drawdown.
+
+## Verdict
+
+The refinement sharpens the honest picture: the deployable cross-sectional-momentum strategy is **weekly / top-4 / 30-day lookback, vol-targeted to a chosen risk level — ~+20 %/yr at ~18 % max DD (Sharpe ~0.8) at a 20 % vol target.** Still an excellent active-trading return, now risk-controlled rather than the raw +43 %/33 %-DD high-octane number.
+
+## Honest caveats
+
+- **Sizing controls risk, it does not add alpha.** Sized Sharpe (0.81) is slightly *below* raw (0.93) — trailing-vol estimation lags, costing a little. Vol-targeting is a risk dial, not an edge.
+- **The deployable number is ~half the headline.** ~20 %/yr (sized) vs +43 %/yr (raw) — the difference is the risk you choose not to take.
+- All #1194 caveats still hold: single 2.5-y path, factor decay as it crowds, thin-alt slippage that 60 bps may under-state, daily-close execution.
+- The 3× leverage cap matters: vol-targeting in calm stretches would otherwise demand more leverage (= liquidation risk, #1188); the cap binds rarely here but is a deliberate guard.
+
+## Next
+
+Long-short paper-trade harness (carry-paper.py pattern) on this config — periodic snapshot ranks trailing returns, picks the vol-targeted long-K/short-K book, settles the prior against realised forward, accumulates a live forward record before any real size.
+
+Reproduce: `run-meta.json` (daily klines fetched live; not committed).

--- a/trading-binance/runs/20260620T-xs-refine/cross-sectional-sweep.py
+++ b/trading-binance/runs/20260620T-xs-refine/cross-sectional-sweep.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""cross-sectional-sweep.py -- refine the cross-sectional momentum edge (#1197):
+(1) sweep rebalance frequency x top-K x lookback to find the best risk-adjusted
+config, and (2) apply drawdown-aware TRAILING-VOL TARGETING to tame the 30-35 %
+max DD found in #1194.
+
+Same walk-forward as #1194 (rank by trailing return, long top-K / short bottom-K,
+dollar-neutral, hold forward, no look-ahead), momentum only (reversal lost).
+
+Sizing: scale each rebalance return by target_per_period_vol / trailing_realised
+_vol, using only PAST returns (no look-ahead), capped at --max-leverage (high
+leverage = liquidation risk, #1188). This holds the book near a chosen annualised
+vol so the drawdown is a deliberate risk choice, not an artifact of raw exposure.
+
+Standard library only. Daily perp klines from fapi.binance.com.
+"""
+import argparse
+import datetime
+import json
+import math
+import sys
+import urllib.request
+
+DAY_MS = 86400000
+
+
+def epoch_ms(s):
+    if s.isdigit():
+        return int(s)
+    return int(datetime.datetime.strptime(s, "%Y-%m-%d").replace(
+        tzinfo=datetime.timezone.utc).timestamp() * 1000)
+
+
+def daily_closes(symbol, start, end):
+    out = {}
+    cur = start
+    while cur < end:
+        url = ("https://fapi.binance.com/fapi/v1/klines?symbol=%s&interval=1d&startTime=%d&endTime=%d&limit=1000"
+               % (symbol, cur, end))
+        try:
+            with urllib.request.urlopen(url, timeout=30) as r:
+                batch = json.load(r)
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write("klines %s err: %s\n" % (symbol, e))
+            return out
+        if not batch:
+            break
+        for k in batch:
+            out[k[0]] = float(k[4])
+        cur = batch[-1][0] + 1
+        if len(batch) < 1000:
+            break
+    return out
+
+
+def stdev(xs):
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    m = sum(xs) / n
+    return math.sqrt(sum((x - m) ** 2 for x in xs) / (n - 1))
+
+
+def sharpe_ann(returns, reb_per_year):
+    if len(returns) < 2:
+        return 0.0
+    sd = stdev(returns)
+    if sd == 0:
+        return 0.0
+    return (sum(returns) / len(returns)) / sd * math.sqrt(reb_per_year)
+
+
+def ann_vol(returns, reb_per_year):
+    return stdev(returns) * math.sqrt(reb_per_year) * 100
+
+
+def max_dd(returns):
+    peak, mdd, acc = 0.0, 0.0, 0.0
+    for r in returns:
+        acc += r
+        peak = max(peak, acc)
+        mdd = max(mdd, peak - acc)
+    return mdd * 100
+
+
+def walk_forward(series, days_sorted, lookback_d, rebalance_d, top_k, cost_rt, t_start, t_end):
+    cost = cost_rt / 10000.0
+    rets, turns = [], []
+    prev_long, prev_short = set(), set()
+    t = t_start + lookback_d * DAY_MS
+
+    def close_at(ts):
+        best = None
+        for d in days_sorted:
+            if d <= ts:
+                best = d
+            else:
+                break
+        return best
+
+    while t + rebalance_d * DAY_MS <= t_end:
+        t_lb, t_now, t_fwd = close_at(t - lookback_d * DAY_MS), close_at(t), close_at(t + rebalance_d * DAY_MS)
+        if not (t_lb and t_now and t_fwd) or t_fwd <= t_now:
+            t += rebalance_d * DAY_MS
+            continue
+        trailing, forward = {}, {}
+        for s, cl in series.items():
+            if t_lb in cl and t_now in cl and t_fwd in cl and cl[t_lb] > 0 and cl[t_now] > 0:
+                trailing[s] = cl[t_now] / cl[t_lb] - 1.0
+                forward[s] = cl[t_fwd] / cl[t_now] - 1.0
+        if len(trailing) < 2 * top_k:
+            t += rebalance_d * DAY_MS
+            continue
+        ranked = sorted(trailing, key=lambda s: trailing[s], reverse=True)
+        longs, shorts = set(ranked[:top_k]), set(ranked[-top_k:])
+        gross = sum(forward[s] for s in longs) / len(longs) - sum(forward[s] for s in shorts) / len(shorts)
+        changed = len(longs ^ prev_long) + len(shorts ^ prev_short)
+        turn = (changed / 2.0) / (2.0 * top_k)
+        rets.append(gross - cost * turn)
+        turns.append(turn)
+        prev_long, prev_short = longs, shorts
+        t += rebalance_d * DAY_MS
+    return rets, turns
+
+
+def vol_target(returns, reb_per_year, target_ann_vol_pct, window, max_lev):
+    """Size each period by target / trailing realised vol, using only PAST
+    returns (no look-ahead), capped at max_lev. Returns sized series."""
+    tgt_per = (target_ann_vol_pct / 100.0) / math.sqrt(reb_per_year)
+    sized = []
+    for i in range(len(returns)):
+        hist = returns[max(0, i - window):i]
+        tv = stdev(hist) if len(hist) >= 2 else 0.0
+        lev = min(max_lev, tgt_per / tv) if tv > 0 else 1.0
+        sized.append(returns[i] * lev)
+    return sized
+
+
+def summarise(returns, reb_per_year, t_span_days):
+    total = sum(returns)
+    return {
+        "ann_pct": round(total / t_span_days * 365 * 100, 2) if t_span_days else 0.0,
+        "sharpe": round(sharpe_ann(returns, reb_per_year), 2),
+        "ann_vol_pct": round(ann_vol(returns, reb_per_year), 1),
+        "max_dd_pct": round(max_dd(returns), 1),
+    }
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--symbols", required=True)
+    ap.add_argument("--start", required=True)
+    ap.add_argument("--end", required=True)
+    ap.add_argument("--cost-bps-roundtrip", type=float, default=60.0)
+    ap.add_argument("--rebalances", default="3,7,14")
+    ap.add_argument("--top-ks", default="3,4,6")
+    ap.add_argument("--lookbacks", default="14,30")
+    ap.add_argument("--target-vol-pct", type=float, default=20.0)
+    ap.add_argument("--vol-window", type=int, default=8)
+    ap.add_argument("--max-leverage", type=float, default=3.0)
+    args = ap.parse_args(argv)
+
+    symbols = [s.strip().upper() for s in args.symbols.split(",") if s.strip()]
+    start, end = epoch_ms(args.start), epoch_ms(args.end)
+    series = {}
+    for s in symbols:
+        cl = daily_closes(s, start, end)
+        if len(cl) > 60:
+            series[s] = cl
+    if len(series) < 6:
+        sys.stderr.write("not enough symbols\n")
+        return 2
+    days_sorted = sorted(set().union(*[set(c) for c in series.values()]))
+
+    out = {"symbols_loaded": len(series), "cost_bps": args.cost_bps_roundtrip,
+           "target_vol_pct": args.target_vol_pct, "max_leverage": args.max_leverage, "results": []}
+    for reb in [int(x) for x in args.rebalances.split(",")]:
+        reb_per_year = 365.0 / reb
+        for k in [int(x) for x in args.top_ks.split(",")]:
+            for lb in [int(x) for x in args.lookbacks.split(",")]:
+                rets, turns = walk_forward(series, days_sorted, lb, reb, k, args.cost_bps_roundtrip, start, end)
+                if len(rets) < 5:
+                    continue
+                span = (end - (start + lb * DAY_MS)) / float(DAY_MS)
+                raw = summarise(rets, reb_per_year, span)
+                sized = summarise(vol_target(rets, reb_per_year, args.target_vol_pct, args.vol_window, args.max_leverage), reb_per_year, span)
+                out["results"].append({
+                    "rebalance_d": reb, "top_k": k, "lookback_d": lb,
+                    "rebalances": len(rets),
+                    "avg_turnover": round(sum(turns) / len(turns), 3),
+                    "raw": raw, "sized": sized,
+                })
+    out["results"].sort(key=lambda r: -r["sized"]["sharpe"])
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/trading-binance/runs/20260620T-xs-refine/results.json
+++ b/trading-binance/runs/20260620T-xs-refine/results.json
@@ -1,0 +1,350 @@
+{
+  "symbols_loaded": 18,
+  "cost_bps": 60.0,
+  "target_vol_pct": 20.0,
+  "max_leverage": 3.0,
+  "results": [
+    {
+      "rebalance_d": 7,
+      "top_k": 4,
+      "lookback_d": 30,
+      "rebalances": 124,
+      "avg_turnover": 0.365,
+      "raw": {
+        "ann_pct": 43.05,
+        "sharpe": 0.93,
+        "ann_vol_pct": 46.7,
+        "max_dd_pct": 32.6
+      },
+      "sized": {
+        "ann_pct": 19.46,
+        "sharpe": 0.81,
+        "ann_vol_pct": 24.2,
+        "max_dd_pct": 18.0
+      }
+    },
+    {
+      "rebalance_d": 7,
+      "top_k": 4,
+      "lookback_d": 14,
+      "rebalances": 126,
+      "avg_turnover": 0.521,
+      "raw": {
+        "ann_pct": 41.18,
+        "sharpe": 0.84,
+        "ann_vol_pct": 49.2,
+        "max_dd_pct": 51.4
+      },
+      "sized": {
+        "ann_pct": 23.57,
+        "sharpe": 0.79,
+        "ann_vol_pct": 29.9,
+        "max_dd_pct": 30.9
+      }
+    },
+    {
+      "rebalance_d": 14,
+      "top_k": 4,
+      "lookback_d": 14,
+      "rebalances": 63,
+      "avg_turnover": 0.714,
+      "raw": {
+        "ann_pct": 44.74,
+        "sharpe": 0.82,
+        "ann_vol_pct": 54.9,
+        "max_dd_pct": 43.8
+      },
+      "sized": {
+        "ann_pct": 29.04,
+        "sharpe": 0.69,
+        "ann_vol_pct": 42.4,
+        "max_dd_pct": 28.2
+      }
+    },
+    {
+      "rebalance_d": 7,
+      "top_k": 6,
+      "lookback_d": 30,
+      "rebalances": 124,
+      "avg_turnover": 0.304,
+      "raw": {
+        "ann_pct": 34.33,
+        "sharpe": 0.82,
+        "ann_vol_pct": 42.0,
+        "max_dd_pct": 26.8
+      },
+      "sized": {
+        "ann_pct": 14.94,
+        "sharpe": 0.6,
+        "ann_vol_pct": 24.9,
+        "max_dd_pct": 16.7
+      }
+    },
+    {
+      "rebalance_d": 7,
+      "top_k": 3,
+      "lookback_d": 30,
+      "rebalances": 124,
+      "avg_turnover": 0.417,
+      "raw": {
+        "ann_pct": 56.6,
+        "sharpe": 0.98,
+        "ann_vol_pct": 57.8,
+        "max_dd_pct": 45.4
+      },
+      "sized": {
+        "ann_pct": 14.84,
+        "sharpe": 0.56,
+        "ann_vol_pct": 26.8,
+        "max_dd_pct": 21.2
+      }
+    },
+    {
+      "rebalance_d": 14,
+      "top_k": 4,
+      "lookback_d": 30,
+      "rebalances": 62,
+      "avg_turnover": 0.526,
+      "raw": {
+        "ann_pct": 17.73,
+        "sharpe": 0.44,
+        "ann_vol_pct": 40.3,
+        "max_dd_pct": 50.5
+      },
+      "sized": {
+        "ann_pct": 16.05,
+        "sharpe": 0.43,
+        "ann_vol_pct": 37.9,
+        "max_dd_pct": 33.9
+      }
+    },
+    {
+      "rebalance_d": 14,
+      "top_k": 3,
+      "lookback_d": 14,
+      "rebalances": 63,
+      "avg_turnover": 0.775,
+      "raw": {
+        "ann_pct": 40.99,
+        "sharpe": 0.66,
+        "ann_vol_pct": 62.9,
+        "max_dd_pct": 53.4
+      },
+      "sized": {
+        "ann_pct": 11.46,
+        "sharpe": 0.38,
+        "ann_vol_pct": 30.5,
+        "max_dd_pct": 34.9
+      }
+    },
+    {
+      "rebalance_d": 3,
+      "top_k": 3,
+      "lookback_d": 14,
+      "rebalances": 295,
+      "avg_turnover": 0.386,
+      "raw": {
+        "ann_pct": 48.03,
+        "sharpe": 0.84,
+        "ann_vol_pct": 57.4,
+        "max_dd_pct": 59.6
+      },
+      "sized": {
+        "ann_pct": 9.82,
+        "sharpe": 0.37,
+        "ann_vol_pct": 26.3,
+        "max_dd_pct": 28.5
+      }
+    },
+    {
+      "rebalance_d": 3,
+      "top_k": 4,
+      "lookback_d": 30,
+      "rebalances": 290,
+      "avg_turnover": 0.259,
+      "raw": {
+        "ann_pct": 11.28,
+        "sharpe": 0.23,
+        "ann_vol_pct": 50.2,
+        "max_dd_pct": 52.9
+      },
+      "sized": {
+        "ann_pct": 10.1,
+        "sharpe": 0.37,
+        "ann_vol_pct": 27.0,
+        "max_dd_pct": 23.3
+      }
+    },
+    {
+      "rebalance_d": 14,
+      "top_k": 3,
+      "lookback_d": 30,
+      "rebalances": 62,
+      "avg_turnover": 0.565,
+      "raw": {
+        "ann_pct": 31.15,
+        "sharpe": 0.57,
+        "ann_vol_pct": 55.1,
+        "max_dd_pct": 66.3
+      },
+      "sized": {
+        "ann_pct": 12.95,
+        "sharpe": 0.36,
+        "ann_vol_pct": 36.1,
+        "max_dd_pct": 41.2
+      }
+    },
+    {
+      "rebalance_d": 3,
+      "top_k": 6,
+      "lookback_d": 14,
+      "rebalances": 295,
+      "avg_turnover": 0.295,
+      "raw": {
+        "ann_pct": 31.9,
+        "sharpe": 0.82,
+        "ann_vol_pct": 39.2,
+        "max_dd_pct": 47.9
+      },
+      "sized": {
+        "ann_pct": 8.31,
+        "sharpe": 0.34,
+        "ann_vol_pct": 24.8,
+        "max_dd_pct": 31.2
+      }
+    },
+    {
+      "rebalance_d": 3,
+      "top_k": 4,
+      "lookback_d": 14,
+      "rebalances": 295,
+      "avg_turnover": 0.348,
+      "raw": {
+        "ann_pct": 38.91,
+        "sharpe": 0.77,
+        "ann_vol_pct": 50.6,
+        "max_dd_pct": 49.8
+      },
+      "sized": {
+        "ann_pct": 6.79,
+        "sharpe": 0.27,
+        "ann_vol_pct": 25.6,
+        "max_dd_pct": 28.2
+      }
+    },
+    {
+      "rebalance_d": 14,
+      "top_k": 6,
+      "lookback_d": 14,
+      "rebalances": 63,
+      "avg_turnover": 0.627,
+      "raw": {
+        "ann_pct": 38.54,
+        "sharpe": 0.96,
+        "ann_vol_pct": 40.3,
+        "max_dd_pct": 32.3
+      },
+      "sized": {
+        "ann_pct": 6.86,
+        "sharpe": 0.2,
+        "ann_vol_pct": 33.9,
+        "max_dd_pct": 33.9
+      }
+    },
+    {
+      "rebalance_d": 14,
+      "top_k": 6,
+      "lookback_d": 30,
+      "rebalances": 62,
+      "avg_turnover": 0.437,
+      "raw": {
+        "ann_pct": 12.14,
+        "sharpe": 0.31,
+        "ann_vol_pct": 39.1,
+        "max_dd_pct": 34.5
+      },
+      "sized": {
+        "ann_pct": 6.76,
+        "sharpe": 0.2,
+        "ann_vol_pct": 34.6,
+        "max_dd_pct": 31.2
+      }
+    },
+    {
+      "rebalance_d": 3,
+      "top_k": 6,
+      "lookback_d": 30,
+      "rebalances": 290,
+      "avg_turnover": 0.209,
+      "raw": {
+        "ann_pct": 0.94,
+        "sharpe": 0.02,
+        "ann_vol_pct": 39.4,
+        "max_dd_pct": 60.8
+      },
+      "sized": {
+        "ann_pct": 2.74,
+        "sharpe": 0.1,
+        "ann_vol_pct": 26.6,
+        "max_dd_pct": 29.2
+      }
+    },
+    {
+      "rebalance_d": 7,
+      "top_k": 3,
+      "lookback_d": 14,
+      "rebalances": 126,
+      "avg_turnover": 0.571,
+      "raw": {
+        "ann_pct": 27.45,
+        "sharpe": 0.49,
+        "ann_vol_pct": 56.0,
+        "max_dd_pct": 68.9
+      },
+      "sized": {
+        "ann_pct": 1.14,
+        "sharpe": 0.04,
+        "ann_vol_pct": 27.4,
+        "max_dd_pct": 43.1
+      }
+    },
+    {
+      "rebalance_d": 7,
+      "top_k": 6,
+      "lookback_d": 14,
+      "rebalances": 126,
+      "avg_turnover": 0.448,
+      "raw": {
+        "ann_pct": 0.74,
+        "sharpe": 0.02,
+        "ann_vol_pct": 43.3,
+        "max_dd_pct": 67.4
+      },
+      "sized": {
+        "ann_pct": -3.04,
+        "sharpe": -0.1,
+        "ann_vol_pct": 30.0,
+        "max_dd_pct": 44.9
+      }
+    },
+    {
+      "rebalance_d": 3,
+      "top_k": 3,
+      "lookback_d": 30,
+      "rebalances": 290,
+      "avg_turnover": 0.286,
+      "raw": {
+        "ann_pct": -8.48,
+        "sharpe": -0.14,
+        "ann_vol_pct": 60.6,
+        "max_dd_pct": 92.3
+      },
+      "sized": {
+        "ann_pct": -3.84,
+        "sharpe": -0.14,
+        "ann_vol_pct": 28.0,
+        "max_dd_pct": 34.9
+      }
+    }
+  ]
+}

--- a/trading-binance/runs/20260620T-xs-refine/run-meta.json
+++ b/trading-binance/runs/20260620T-xs-refine/run-meta.json
@@ -1,0 +1,6 @@
+{"run_id":"20260620T-xs-refine","issue":1197,"kind":"cross-sectional-momentum-sweep-and-vol-target-sizing",
+ "universe_size":18,"span":"2024-01..2026-06 daily","cost_bps":60,
+ "sweep":"rebalance {3,7,14}d x top-K {3,4,6} x lookback {14,30}d, momentum, walk-forward",
+ "sizing":"trailing-vol target 20% ann, 8-period window, 3x leverage cap, no look-ahead",
+ "best_config":"7d rebalance / top-4 / 30d lookback","base_commit":"67e32ddfc2fa693b45ee99e7d9551f34c259d668",
+ "reproduce":"python3 runs/20260620T-xs-refine/cross-sectional-sweep.py --symbols <universe> --start 2024-01-01 --end 2026-06-20 --cost-bps-roundtrip 60 --rebalances 3,7,14 --top-ks 3,4,6 --lookbacks 14,30 --target-vol-pct 20 --vol-window 8 --max-leverage 3"}


### PR DESCRIPTION
Refining the #1194 trading edge (~+43%/yr@60bps but 33% DD). Swept rebalance × top-K × lookback + trailing-vol-target sizing (no look-ahead).

**Findings:** (1) the #1194 config (**weekly / top-4 / 30d**) is **confirmed the best risk-adjusted sweet spot** (sized Sharpe 0.81) — not a lucky pick. (2) **Drawdown-aware sizing works**: the raw +43%/yr / 33%-DD / 47%-vol book is high-octane; vol-targeting to 20% deleverages it to a **deployable ~+20%/yr at ~18% max DD, Sharpe ~0.8** — return is a dial via target vol. (3) **Honest:** sizing controls risk not alpha (sized Sharpe < raw); deployable ~20%/yr is ~half the headline. #1194 caveats hold. Docs/run artifact; klines fetched live. #1197.