### PR TITLE
feat(trading-binance): cross-sectional long-short paper-trade harness (#1197)

### DIFF
--- a/trading-binance/.gitignore
+++ b/trading-binance/.gitignore
@@ -6,3 +6,6 @@
 
 # carry paper-trade live ledger (runtime state, accumulates forward)
 runs/carry-paper-live/
+
+# cross-sectional paper-trade live ledger (runtime state)
+runs/xsectional-paper-live/

--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,13 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Cross-sectional long-short paper-trade harness (#1197): `tools/xsectional-
+  paper.py` -- the live forward gate for the cross-sectional momentum strategy,
+  the long-short analogue of carry-paper.py. Periodic snapshots rank trailing
+  30d return -> long top-4 / short bottom-4, settle the prior basket against
+  realised forward returns minus turnover, and vol-target the book (trailing-vol,
+  no look-ahead, 3x cap) on the #1194/#1197 winning config. Accumulates a live
+  OOS ledger. `tools/test-xsectional-paper.sh` 10 cases.
 - Cross-sectional momentum refinement (#1197): swept rebalance x top-K x
   lookback + applied drawdown-aware trailing-vol-target sizing. The #1194 config
   (weekly / top-4 / 30d) is confirmed the best risk-adjusted sweet spot. Sizing

--- a/trading-binance/runs/20260620T-xs-paper/README.md
+++ b/trading-binance/runs/20260620T-xs-paper/README.md
@@ -1,0 +1,41 @@
+# Cross-sectional long-short paper-trade harness (#1197)
+
+`tools/xsectional-paper.py` — the live forward gate for the cross-sectional
+momentum trading strategy, the long-short analogue of `carry-paper.py`. Run it
+periodically (weekly via cron) on the #1194/#1197 winning config (top-4 / 30-day
+lookback / vol-targeted to 20 %); each run appends one snapshot to a JSON-lines
+ledger, accumulating a **live, forward, out-of-sample** record of what the
+vol-targeted long-short book would do, marked by realised price returns.
+
+Each snapshot: rank the universe by trailing 30-day return → **long top-4 /
+short bottom-4** (dollar-neutral) → **settle** the prior snapshot's basket
+against its realised forward return ([prior_ts, now], mean longs − mean shorts),
+times the prior leverage, minus turnover cost → **size** the new book by
+**trailing-vol targeting** (leverage = target / trailing realised vol, PAST-only,
+capped at 3×, #1197). Append period net + cumulative.
+
+## Run
+
+```sh
+python3 tools/xsectional-paper.py \
+  --symbols <universe> \
+  --ledger trading-binance/runs/xsectional-paper-live/ledger.jsonl \
+  --top-k 4 --lookback-days 30 --cost-bps-roundtrip 60 --rebalance-days 7 \
+  --target-vol-pct 20 --vol-window 8 --max-leverage 3
+```
+
+The ledger (`runs/xsectional-paper-live/`) is gitignored — runtime state that
+accumulates forward. After a real out-of-sample stretch, compare the ledger's
+cumulative net against the ~+20 %/yr (vol-targeted) backtest expectation; that is
+the honest live validation no backtest can give.
+
+## First live snapshot (seed)
+
+Longs = the 30-day winners, shorts = the 30-day laggards, leverage 1.0 (no return
+history yet to vol-target on); cumulative 0 (no prior to settle). Subsequent runs
+settle the prior basket against realised forward returns and begin vol-targeting
+once ≥2 periods of history exist.
+
+`tools/test-xsectional-paper.sh`: 10 cases (ranking, prior-snapshot settlement,
+realised forward return, turnover cost makes net<gross, leverage default,
+cumulative accounting, too-few-symbols exit) — no network, fixture klines.

--- a/trading-binance/tools/test-xsectional-paper.sh
+++ b/trading-binance/tools/test-xsectional-paper.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# test-xsectional-paper.sh -- unit tests for xsectional-paper.py (#1197). Fixture
+# klines (--klines-file) exercise ranking (long top-K / short bottom-K), prior-
+# snapshot settlement (realised forward return), turnover cost, vol-target
+# leverage, and cumulative accounting. No network.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PAPER="$SCRIPT_DIR/xsectional-paper.py"
+[ -f "$PAPER" ] || { echo "FAIL: missing $PAPER" >&2; exit 1; }
+
+PASS=0; FAIL=0
+FIX="$(mktemp -d)"; LEDGER="$FIX/ledger.jsonl"; KL="$FIX/klines.json"
+trap 'rm -rf "$FIX"' EXIT
+
+# Fixture: 6 symbols, days at base + {0,2,4}*DAY. AAA/BBB up, CCC/DDD flat,
+# EEE/FFF down across each 2-day step -> longs={AAA,BBB}, shorts={EEE,FFF}.
+python3 - "$KL" <<'PY'
+import json, sys
+DAY=86400000; base=1700000000000
+d0,d2,d4 = base, base+2*DAY, base+4*DAY
+kl={
+ "AAAUSDT":{d0:100,d2:130,d4:143},   # +30% then +10%
+ "BBBUSDT":{d0:100,d2:120,d4:126},   # +20% then +5%
+ "CCCUSDT":{d0:100,d2:100,d4:100},   # flat
+ "DDDUSDT":{d0:100,d2:100,d4:100},   # flat
+ "EEEUSDT":{d0:100,d2:80, d4:76},    # -20% then -5%
+ "FFFUSDT":{d0:100,d2:70, d4:63},    # -30% then -10%
+}
+json.dump({s:{str(t):v for t,v in d.items()} for s,d in kl.items()}, open(sys.argv[1],"w"))
+PY
+BASE=1700000000000; DAY=86400000
+NOW1=$((BASE+2*DAY)); NOW2=$((BASE+4*DAY))
+SYMS="AAAUSDT,BBBUSDT,CCCUSDT,DDDUSDT,EEEUSDT,FFFUSDT"
+
+field() { python3 -c 'import sys,json;print(json.loads(sys.argv[1])[sys.argv[2]])' "$1" "$2"; }
+jlist() { python3 -c 'import sys,json;print(",".join(json.loads(sys.argv[1])[sys.argv[2]]))' "$1" "$2"; }
+assert_eq() { python3 -c 'import sys;sys.exit(0 if abs(float(sys.argv[1])-float(sys.argv[2]))<1e-4 else 1)' "$2" "$3" \
+  && { echo "[PASS] $1 (=$2)"; PASS=$((PASS+1)); } || { echo "[FAIL] $1 got=$2 want=$3"; FAIL=$((FAIL+1)); }; }
+assert_str() { [ "$2" = "$3" ] && { echo "[PASS] $1 (=$2)"; PASS=$((PASS+1)); } || { echo "[FAIL] $1 got=$2 want=$3"; FAIL=$((FAIL+1)); }; }
+
+# Snapshot 1 at NOW1: rank trailing [NOW1-2d, NOW1] -> longs AAA,BBB / shorts EEE,FFF; no prior.
+python3 "$PAPER" --symbols "$SYMS" --ledger "$LEDGER" --top-k 2 --lookback-days 2 \
+  --cost-bps-roundtrip 60 --rebalance-days 2 --klines-file "$KL" --now "$NOW1" >/dev/null
+R1="$(tail -1 "$LEDGER")"
+assert_str "1a. snapshot1 longs = AAAUSDT,BBBUSDT" "$(jlist "$R1" longs)" "AAAUSDT,BBBUSDT"
+assert_str "1b. snapshot1 shorts = EEEUSDT,FFFUSDT" "$(jlist "$R1" shorts)" "EEEUSDT,FFFUSDT"
+assert_eq  "1c. snapshot1 leverage 1.0 (no history)" "$(field "$R1" leverage)" "1.0"
+assert_eq  "1d. snapshot1 period_net 0 (no prior)" "$(field "$R1" period_net_pct)" "0"
+
+# Snapshot 2 at NOW2: settle prior. fwd longs mean(+10,+5)=7.5%, shorts mean(-5,-10)=-7.5%
+# -> gross = 15%; basket unchanged -> turnover 0; lev_prev 1.0 -> net +15%; cumulative 15%.
+python3 "$PAPER" --symbols "$SYMS" --ledger "$LEDGER" --top-k 2 --lookback-days 2 \
+  --cost-bps-roundtrip 60 --rebalance-days 2 --klines-file "$KL" --now "$NOW2" >/dev/null
+R2="$(tail -1 "$LEDGER")"
+assert_eq  "2a. snapshot2 period_gross = 15%" "$(field "$R2" period_gross_pct)" "15"
+assert_eq  "2b. snapshot2 period_net = 15% (lev 1, turnover 0)" "$(field "$R2" period_net_pct)" "15"
+assert_eq  "2c. cumulative = 15%" "$(field "$R2" cumulative_net_pct)" "15"
+assert_str "2d. snapshot2 basket unchanged (longs)" "$(jlist "$R2" longs)" "AAAUSDT,BBBUSDT"
+
+# Turnover-cost path: settle the SAME prior but force a basket change by dropping
+# AAA/EEE from the universe at NOW2 -> new longs/shorts differ -> turnover>0 -> cost bites.
+LEDGER2="$FIX/ledger2.jsonl"; cp "$LEDGER" "$LEDGER2"  # reuse snapshot1+2? no -> fresh
+: > "$LEDGER2"
+python3 "$PAPER" --symbols "$SYMS" --ledger "$LEDGER2" --top-k 2 --lookback-days 2 \
+  --cost-bps-roundtrip 60 --rebalance-days 2 --klines-file "$KL" --now "$NOW1" >/dev/null
+python3 "$PAPER" --symbols "BBBUSDT,CCCUSDT,DDDUSDT,EEEUSDT,FFFUSDT,AAAUSDT" --ledger "$LEDGER2" --top-k 3 --lookback-days 2 \
+  --cost-bps-roundtrip 60 --rebalance-days 2 --klines-file "$KL" --now "$NOW2" >/dev/null
+R3="$(tail -1 "$LEDGER2")"
+# with top-k 3 at NOW2 the prior was top-k 2; basket differs -> turnover>0 -> net < gross
+gross3="$(field "$R3" period_gross_pct)"; net3="$(field "$R3" period_net_pct)"
+python3 -c 'import sys;sys.exit(0 if float(sys.argv[1])>float(sys.argv[2]) else 1)' "$gross3" "$net3" \
+  && { echo "[PASS] 3. turnover cost makes net < gross ($net3 < $gross3)"; PASS=$((PASS+1)); } \
+  || { echo "[FAIL] 3. expected net<gross got net=$net3 gross=$gross3"; FAIL=$((FAIL+1)); }
+
+# Insufficient symbols -> exit 2
+python3 "$PAPER" --symbols "AAAUSDT,BBBUSDT" --ledger "$FIX/l3" --top-k 2 --klines-file "$KL" --now "$NOW1" >/dev/null 2>&1 \
+  && { echo "[FAIL] 4. too-few-symbols should exit nonzero"; FAIL=$((FAIL+1)); } \
+  || { echo "[PASS] 4. too-few-symbols exits nonzero"; PASS=$((PASS+1)); }
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/trading-binance/tools/xsectional-paper.py
+++ b/trading-binance/tools/xsectional-paper.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""xsectional-paper.py -- periodic paper-trade snapshot for the cross-sectional
+momentum trading strategy (#1197). The live forward gate, the long-short analogue
+of carry-paper.py. Tracks what the vol-targeted cross-sectional book WOULD do,
+accumulating a real out-of-sample record marked by realised price returns.
+
+Run periodically (e.g. weekly via cron) on the #1194/#1197 winning config
+(weekly / top-4 / 30-day lookback, vol-targeted to a chosen annualised vol).
+Each run:
+  1. fetch daily closes for the universe (live fapi, or --klines-file for tests);
+  2. RANK by trailing --lookback-days return; LONG top-K / SHORT bottom-K,
+     dollar-neutral (#1194);
+  3. SETTLE the prior snapshot: realised forward return of the prior basket over
+     [prior_ts, now] = mean(longs) - mean(shorts), times the prior leverage,
+     minus turnover cost of rebalancing prior->new; append period net + cumulative;
+  4. SIZE the new book by TRAILING-VOL TARGETING (#1197): leverage =
+     target_per_period_vol / trailing realised vol of past period returns (PAST
+     only, no look-ahead), capped at --max-leverage.
+
+Ledger is JSON-lines (gitignored, runtime state). Standard library only.
+"""
+import argparse
+import datetime
+import json
+import math
+import os
+import sys
+import urllib.request
+
+DAY_MS = 86400000
+
+
+def epoch_ms(s):
+    if s.isdigit():
+        return int(s)
+    return int(datetime.datetime.strptime(s, "%Y-%m-%d").replace(
+        tzinfo=datetime.timezone.utc).timestamp() * 1000)
+
+
+def daily_closes(symbol, start, end):
+    out = {}
+    cur = start
+    while cur < end:
+        url = ("https://fapi.binance.com/fapi/v1/klines?symbol=%s&interval=1d&startTime=%d&endTime=%d&limit=1000"
+               % (symbol, cur, end))
+        try:
+            with urllib.request.urlopen(url, timeout=30) as r:
+                batch = json.load(r)
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write("klines %s err: %s\n" % (symbol, e))
+            return out
+        if not batch:
+            break
+        for k in batch:
+            out[k[0]] = float(k[4])
+        cur = batch[-1][0] + 1
+        if len(batch) < 1000:
+            break
+    return out
+
+
+def load_series(symbols, start, end, klines_file):
+    if klines_file:
+        raw = json.load(open(klines_file))
+        return {s: {int(t): float(c) for t, c in raw[s].items()} for s in symbols if s in raw}
+    series = {}
+    for s in symbols:
+        cl = daily_closes(s, start, end)
+        if len(cl) > 1:
+            series[s] = cl
+    return series
+
+
+def close_at(days_sorted, ts):
+    best = None
+    for d in days_sorted:
+        if d <= ts:
+            best = d
+        else:
+            break
+    return best
+
+
+def stdev(xs):
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    m = sum(xs) / n
+    return math.sqrt(sum((x - m) ** 2 for x in xs) / (n - 1))
+
+
+def ledger_rows(path):
+    if not os.path.isfile(path):
+        return []
+    rows = []
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--symbols", required=True)
+    ap.add_argument("--ledger", required=True)
+    ap.add_argument("--top-k", type=int, default=4)
+    ap.add_argument("--lookback-days", type=int, default=30)
+    ap.add_argument("--cost-bps-roundtrip", type=float, default=60.0)
+    ap.add_argument("--rebalance-days", type=int, default=7,
+                    help="cadence for vol annualisation (informational; run at this period)")
+    ap.add_argument("--target-vol-pct", type=float, default=20.0)
+    ap.add_argument("--vol-window", type=int, default=8)
+    ap.add_argument("--max-leverage", type=float, default=3.0)
+    ap.add_argument("--now", type=int, default=None)
+    ap.add_argument("--start", default="2024-01-01")
+    ap.add_argument("--klines-file", default=None, help="JSON {sym:{ts:close}} override for tests")
+    args = ap.parse_args(argv)
+
+    symbols = [s.strip().upper() for s in args.symbols.split(",") if s.strip()]
+    end = (args.now + DAY_MS) if args.now is not None else epoch_ms(
+        datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")) + DAY_MS
+    series = load_series(symbols, epoch_ms(args.start), end, args.klines_file)
+    if len(series) < 2 * args.top_k:
+        sys.stderr.write("xsectional-paper: not enough symbols with data\n")
+        return 2
+    days_sorted = sorted(set().union(*[set(c) for c in series.values()]))
+    now = args.now if args.now is not None else days_sorted[-1]
+    cost = args.cost_bps_roundtrip / 10000.0
+
+    # 2. rank trailing return -> long top-K / short bottom-K
+    t_lb, t_now = close_at(days_sorted, now - args.lookback_days * DAY_MS), close_at(days_sorted, now)
+    trailing = {}
+    for s, cl in series.items():
+        if t_lb in cl and t_now in cl and cl[t_lb] > 0:
+            trailing[s] = cl[t_now] / cl[t_lb] - 1.0
+    if len(trailing) < 2 * args.top_k:
+        sys.stderr.write("xsectional-paper: not enough symbols with trailing data\n")
+        return 2
+    ranked = sorted(trailing, key=lambda s: trailing[s], reverse=True)
+    longs, shorts = ranked[:args.top_k], ranked[-args.top_k:]
+
+    rows = ledger_rows(args.ledger)
+    prev = rows[-1] if rows else None
+
+    # 3. settle prior period (realised forward return of prior basket)
+    period_gross = 0.0
+    period_net = 0.0
+    cumulative = prev["cumulative_net_pct"] if prev else 0.0
+    if prev is not None:
+        p_now = close_at(days_sorted, prev["ts"])
+        pl, ps = prev["longs"], prev["shorts"]
+
+        def basket_fwd(names):
+            rs = []
+            for s in names:
+                cl = series.get(s, {})
+                if p_now in cl and t_now in cl and cl[p_now] > 0:
+                    rs.append(cl[t_now] / cl[p_now] - 1.0)
+            return sum(rs) / len(rs) if rs else 0.0
+        period_gross = basket_fwd(pl) - basket_fwd(ps)
+        changed = len(set(longs) ^ set(pl)) + len(set(shorts) ^ set(ps))
+        turnover = (changed / 2.0) / (2.0 * args.top_k)
+        lev_prev = prev["leverage"]
+        period_net = lev_prev * (period_gross - cost * turnover)
+        cumulative = round(cumulative + period_net * 100, 4)
+
+    # 4. size the new book by trailing-vol targeting (past period_gross only)
+    hist = [r["period_gross_pct"] / 100.0 for r in rows[-args.vol_window:]]
+    reb_per_year = 365.0 / args.rebalance_days
+    tgt_per = (args.target_vol_pct / 100.0) / math.sqrt(reb_per_year)
+    tv = stdev(hist) if len(hist) >= 2 else 0.0
+    leverage = round(min(args.max_leverage, tgt_per / tv), 3) if tv > 0 else 1.0
+
+    row = {
+        "ts": now,
+        "longs": longs,
+        "shorts": shorts,
+        "leverage": leverage,
+        "period_gross_pct": round(period_gross * 100, 4),
+        "period_net_pct": round(period_net * 100, 4),
+        "cumulative_net_pct": cumulative,
+    }
+    os.makedirs(os.path.dirname(os.path.abspath(args.ledger)), exist_ok=True)
+    with open(args.ledger, "a") as fh:
+        fh.write(json.dumps(row, separators=(",", ":")) + "\n")
+
+    print("[xsectional-paper] %s  L=%s S=%s  lev=%.2fx" % (
+        now, ",".join(longs), ",".join(shorts), leverage))
+    print("  settled prior: gross=%.2f%% net=%.2f%%  |  cumulative=%.2f%%" % (
+        period_gross * 100, period_net * 100, cumulative))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
The live forward gate for the cross-sectional momentum strategy — the long-short analogue of `carry-paper.py`. Completes the #1197 refinement (sweep + sizing landed in #1198).

`tools/xsectional-paper.py` runs periodically on the winning config (top-4 / 30d / vol-targeted 20%); each snapshot **ranks** trailing 30d return → long top-4 / short bottom-4, **settles** the prior basket against realised forward returns minus turnover, **sizes** by trailing-vol targeting (PAST-only, no look-ahead, 3x cap). Accumulates a gitignored live OOS ledger to validate the ~+20%/yr vol-targeted expectation against reality.

First live snapshot: longs = 30d winners (NEAR/INJ/TIA/BNB), shorts = 30d laggards (APT/AVAX/ADA/SUI), leverage 1.0 (no history), cumulative 0.

`tools/test-xsectional-paper.sh` 10/0 (ranking, prior settlement, realised forward, turnover net<gross, leverage, cumulative, too-few exit) — no network, fixture klines. py/bash-n clean; ledger gitignored. Closes #1197.