### PR TITLE
fix(implementation): code_writer edits existing files via search/replace, not full regen (#1195)

### DIFF
--- a/dev-apprenticeship/BUNDLE.manifest
+++ b/dev-apprenticeship/BUNDLE.manifest
@@ -80,6 +80,12 @@ tools/flat-cyborg-claude.sh
 # #1163: the wrapper invokes this at runtime to unwrap JSON-shaped replies that
 # --extract-structural's TUI screen-scrape line-wrapped (newline inside JSON).
 tools/flat-cyborg-unwrap.py
+# #1195: deterministic search/replace applier. code_writer's autonomous edit
+# path asks the LLM for small old_str/new_str edits (small output works on
+# flat-cyborg) and this assembles the full file before commit-files — letting
+# the federation edit large existing files (e.g. a ~47KB README) without
+# regenerating the whole thing.
+tools/apply-edits.py
 
 # ----- Federation dashboard -----
 # Extracted to a separately-versioned standalone component in #252.

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,22 @@ is asserted until multi-version CI is in place.
 
 ### Changed
 
+- **`code_writer` edits existing files via search/replace, not full rewrites**
+  (#1195). The autonomous path used to fetch an existing file (#1172) and then
+  ask the LLM to return the FULL updated file content. For a large file (e.g. a
+  ~47KB README) that times out the LLM call (`[llm.cancelled]`) and, on the
+  flat-cyborg screen-scrape backend, line-wrap-corrupts the big JSON. Now, when
+  the planned primary file already exists, the code-gen prompt asks only for a
+  small JSON array of `{old_str, new_str}` edits (each `old_str` an EXACT,
+  unique substring), and a new deterministic helper `tools/apply-edits.py`
+  assembles the full file before `commit-files`. This keeps the LLM output
+  SMALL — so the edit path now works on the flat-cyborg backend (the federation
+  default), not just `claude -p` — and lets the federation edit large real
+  files. `apply-edits.py` fails loudly (non-zero, no partial output) when an
+  `old_str` matches zero or more than one time, which doubles as the corruption
+  guard: a mangled edit won't match the real file, so the agent retries
+  (#1185) instead of committing silent garbage. New files keep the existing
+  from-scratch full-content path unchanged.
 - **Documented the code-generation fidelity constraint** (#1152). flat-cyborg's
   `--extract` is a TUI screen-scrape: great for prose (the observe / suggest /
   review workflow), but it corrupts the fidelity-critical structured JSON the

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -94,6 +94,33 @@ fn primary_file_path(files: string) -> string {
     return out;
 }
 
+// #1195: deterministically turn (existing content, LLM search/replace edits)
+// into the `--actions` JSON commit-files expects, WITHOUT the LLM ever having
+// to emit the full file. tools/apply-edits.py reads the original content on
+// stdin and the edits JSON from $APPLY_EDITS, replaces each edit's old_str
+// (which must be an EXACT, unique substring) and prints the new full content;
+// we then json.dumps a single-element [{action:"update", file_path, content}]
+// array. Large values (the fetched file + the edits) ride env vars / a pipe
+// fed by `printf` (a shell builtin), never argv, so ARG_MAX never bites. If
+// apply-edits.py exits non-zero (mangled / ambiguous / missing old_str — the
+// flat-cyborg screen-scrape corruption guard) the whole `exec sh` exits
+// non-zero and the caller's `try` collapses to "" => treated as a failed
+// code-gen, no commit. `path` is shell_escape'd; `orig` and `edits` are passed
+// as env vars so the body itself carries no untrusted concatenation.
+fn apply_edits_to_actions(path: string, orig: string, edits: string) -> string {
+    // colony-lint: safe-exec-concat
+    let cmd = "ORIG=" + shell_escape(orig) + " APPLY_EDITS=" + shell_escape(edits) +
+        " FP=" + shell_escape(path) +
+        " python3 -c 'import os,sys,subprocess,json" +
+        "\ntools=os.path.join(os.environ[\"COLONY_DIR\"], \"..\", \"..\", \"tools\", \"apply-edits.py\")" +
+        "\np=subprocess.run([sys.executable, tools], input=os.environ[\"ORIG\"], capture_output=True, text=True, env=os.environ)" +
+        "\nif p.returncode != 0:" +
+        "\n    sys.stderr.write(p.stderr); sys.exit(1)" +
+        "\nprint(json.dumps([{\"action\": \"update\", \"file_path\": os.environ[\"FP\"], \"content\": p.stdout}]))'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
 fn merged_mr_cmd(owner: string, repo: string) -> string {
     let ts = recall_latest(scoped_memo(owner, repo, "code_writer:last_check"));
     // colony-lint: safe-exec-concat
@@ -301,36 +328,65 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                     // the file is new. Single-file fetch only — see
                     // primary_file_path() for why multi-file is out of scope.
                     let primary_path = primary_file_path(draft.files);
-                    let existing_block = if len(primary_path) > 0 {
+                    let existing_content = if len(primary_path) > 0 {
                         // colony-lint: safe-exec-concat
                         let getfile_cmd = "$COLONY_DIR/scripts/forge-api.sh get-file --path " + shell_escape(primary_path) + " --ref main" + repo_arg(owner, repo);
-                        let existing_content = try { exec sh getfile_cmd; } catch e { ""; };
-                        if len(existing_content) > 0 {
-                            "\nExisting file " + primary_path + " (EDIT this — return the full updated file, preserve everything you are not changing):\n" + existing_content;
-                        } else {
-                            "\nExisting file " + primary_path + ": (file does not exist yet — create it)";
-                        };
+                        try { exec sh getfile_cmd; } catch e { ""; };
                     } else {
                         "";
                     };
 
-                    let code_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec) + existing_block;
+                    // #1195: when the primary file ALREADY EXISTS, do NOT ask the
+                    // LLM to regenerate the whole file (large output -> timeout on
+                    // claude, line-wrap corruption on flat-cyborg). Ask only for a
+                    // small JSON array of search/replace edits, then assemble the
+                    // full file deterministically via apply-edits.py. The actions
+                    // JSON is built by json.dumps, not the LLM, so the committed
+                    // content is fragility-free. For a NEW file we keep the
+                    // from-scratch full-content path unchanged.
+                    let actions_json = if len(existing_content) > 0 {
+                        let edit_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec) +
+                            "\nCurrent content of " + primary_path + " (edit THIS file):\n" + existing_content;
+                        let edits_json = prompt(
+                            "You are a code writer editing an EXISTING file. Make the smallest edits that satisfy the task. Return a JSON array of edits, each object with: file_path (string), old_str (string, an EXACT, UNIQUE substring of the shown current file content — it must occur exactly once, copy it verbatim including whitespace), new_str (string, the replacement). Do NOT return the whole file. Return ONLY the raw JSON array — no markdown code fences, no ```json wrapper, no prose.",
+                            edit_context
+                        ) -> string;
+                        // Deterministic apply: old_str must match the real file
+                        // exactly-once or apply-edits.py fails loudly and this
+                        // returns "" => treated as a failed code-gen below (no
+                        // commit; #1185 retry re-runs the issue next tick).
+                        let assembled = apply_edits_to_actions(primary_path, existing_content, edits_json);
+                        if len(assembled) > 0 {
+                            assembled;
+                        } else {
+                            print("[code_writer] apply-edits failed (old_str did not match exactly once) — not committing; will retry");
+                            "";
+                        };
+                    } else {
+                        let code_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec) +
+                            "\nFile " + primary_path + ": (does not exist yet — create it)";
+                        prompt(
+                            "You are a code writer. Generate the actual file contents for this implementation plan. Create the file(s) from scratch. Return a JSON array of objects, each with: action (string, 'create' or 'update'), file_path (string), content (string, the full file content). Follow the learned naming and structure patterns. Only return the JSON array, nothing else.",
+                            code_context
+                        ) -> string;
+                    };
 
-                    let actions_json = prompt(
-                        "You are a code writer. Generate the actual file contents for this implementation plan. If an existing file is shown, EDIT it — return the FULL updated file content with only the necessary changes, preserving everything else. Only create from scratch when no existing content is shown. Return a JSON array of objects, each with: action (string, 'create' or 'update'), file_path (string), content (string, the full file content). Follow the learned naming and structure patterns. Only return the JSON array, nothing else.",
-                        code_context
-                    ) -> string;
-
-                    // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-                    let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json) + repo_arg(owner, repo);
-                    let commit_result = try { exec sh commit_cmd; } catch e {
-                        print("[code_writer] Commit failed:", e);
-                        // #1152: a recurring cause is an unparseable --actions JSON.
-                        // Code generation is fidelity-critical: a TUI screen-scrape
-                        // backend (flat-cyborg) corrupts the structured JSON of file
-                        // contents. Run code-gen on the metered `claude -p` backend
-                        // (see README "Code-generation fidelity"), not flat-cyborg.
-                        print("[code_writer] hint: if this is an '--actions JSON' parse error, code-gen needs a fidelity backend (claude -p), not the flat-cyborg screen-scrape — see README");
+                    let commit_result = if len(actions_json) > 0 {
+                        // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
+                        let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json) + repo_arg(owner, repo);
+                        try { exec sh commit_cmd; } catch e {
+                            print("[code_writer] Commit failed:", e);
+                            // #1152: a recurring cause is an unparseable --actions JSON.
+                            // Code generation is fidelity-critical: a TUI screen-scrape
+                            // backend (flat-cyborg) corrupts the structured JSON of file
+                            // contents. The #1195 search/replace edit path keeps LLM
+                            // output small (works on flat-cyborg); a from-scratch NEW
+                            // file still wants the metered `claude -p` backend for the
+                            // large content (see README "Code-generation fidelity").
+                            print("[code_writer] hint: if this is an '--actions JSON' parse error, code-gen needs a fidelity backend (claude -p), not the flat-cyborg screen-scrape — see README");
+                            "";
+                        };
+                    } else {
                         "";
                     };
 

--- a/tools/apply-edits.py
+++ b/tools/apply-edits.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# tools/apply-edits.py (#1195): deterministically apply a list of
+# search/replace edits to a file's content and emit the new full content.
+#
+# Why this exists: code_writer's autonomous path used to ask the LLM to
+# return the FULL new content of an existing file. For a large file (e.g. a
+# ~47KB README) that means regenerating ~47KB, which (a) times out the LLM
+# call and (b) on the flat-cyborg TUI screen-scrape backend gets
+# line-wrap-corrupted. Instead the LLM now emits SMALL targeted edits
+# (`[{"old_str": ..., "new_str": ...}]`) and THIS script assembles the full
+# file deterministically — no large LLM output, so it works on flat-cyborg.
+#
+# Contract:
+#   - The original file content arrives on stdin (large content travels via
+#     a pipe, never argv, to dodge ARG_MAX).
+#   - The edits JSON array arrives in the APPLY_EDITS env var (also off-argv;
+#     edits can themselves be large).
+#   - On success: the new full content is written to stdout, exit 0.
+#   - On any failure: a JSON `{"error": "..."}` is written to stderr naming
+#     which edit failed, exit non-zero, and NOTHING is written to stdout
+#     (no partial/garbage content).
+#
+# Edits are applied sequentially. For each edit, `old_str` MUST occur
+# EXACTLY ONCE in the current (post-previous-edits) content. Zero matches or
+# more than one match is a loud, non-zero failure. This exact-match-or-fail
+# rule is the corruption guard: if flat-cyborg's screen-scrape mangles an
+# edit, `old_str` won't match the real file -> loud failure -> the agent
+# retries, and we never commit silent garbage.
+
+import json
+import os
+import sys
+
+
+def fail(msg):
+    sys.stderr.write(json.dumps({"error": msg}))
+    sys.stderr.write("\n")
+    sys.exit(1)
+
+
+def main():
+    content = sys.stdin.read()
+
+    raw = os.environ.get("APPLY_EDITS", "")
+    if raw.strip() == "":
+        fail("APPLY_EDITS env var is empty (expected a JSON array of edits)")
+
+    try:
+        edits = json.loads(raw)
+    except Exception as e:
+        fail("APPLY_EDITS is not valid JSON: " + str(e))
+
+    if not isinstance(edits, list):
+        fail("APPLY_EDITS must be a JSON array of edits")
+
+    if len(edits) == 0:
+        fail("APPLY_EDITS is an empty array (no edits to apply)")
+
+    for i, edit in enumerate(edits):
+        if not isinstance(edit, dict):
+            fail("edit %d is not an object" % i)
+        if "old_str" not in edit or "new_str" not in edit:
+            fail("edit %d is missing 'old_str' or 'new_str'" % i)
+        old_str = edit["old_str"]
+        new_str = edit["new_str"]
+        if not isinstance(old_str, str) or not isinstance(new_str, str):
+            fail("edit %d 'old_str'/'new_str' must be strings" % i)
+        if old_str == "":
+            fail("edit %d has an empty 'old_str' (would match everywhere)" % i)
+
+        count = content.count(old_str)
+        if count == 0:
+            fail("edit %d: old_str not found in current content: %r" % (i, old_str))
+        if count > 1:
+            fail("edit %d: old_str occurs %d times (must be unique): %r"
+                 % (i, count, old_str))
+
+        content = content.replace(old_str, new_str, 1)
+
+    sys.stdout.write(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test-apply-edits.sh
+++ b/tools/test-apply-edits.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# tools/test-apply-edits.sh (#1195): unit-test the deterministic search/replace
+# applier tools/apply-edits.py.
+#
+# Background (#1195): code_writer's autonomous path used to ask the LLM to emit
+# the FULL new content of an existing file. For a large file (e.g. a ~47KB
+# README) that (a) times out the LLM call and (b) gets line-wrap-corrupted on
+# the flat-cyborg TUI screen-scrape backend. The fix is to have the LLM emit
+# small search/replace edits and assemble the full file deterministically with
+# apply-edits.py — small LLM output, so it works on flat-cyborg.
+#
+# Contract under test:
+#   - original content on stdin, edits JSON in $APPLY_EDITS, new content on
+#     stdout (large values ride a pipe / env var, never argv -> no ARG_MAX).
+#   - each edit's old_str must occur EXACTLY ONCE; zero or >1 matches is a loud,
+#     non-zero failure with a JSON {"error": ...} on stderr and NO stdout.
+#   - edits apply sequentially.
+#
+# Cases:
+#   1. single edit replaces a unique substring.
+#   2. multiple sequential edits apply in order.
+#   3. zero-match old_str fails loudly (non-zero, JSON error, no stdout).
+#   4. ambiguous (multi-match) old_str fails loudly (non-zero, JSON error).
+#   5. large content (simulated big file) round-trips via the env/stdin path.
+#
+# Auto-discovered by tools/colony-lint.sh's tools-test loop. Exit 0 if all pass.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APPLY="$SCRIPT_DIR/apply-edits.py"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[SKIP] test-apply-edits.sh: python3 not on PATH"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (skipped)"
+    exit 0
+fi
+if [ ! -f "$APPLY" ]; then
+    fail "missing applier: $APPLY"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Case 1: single edit replaces a unique substring.
+# -----------------------------------------------------------------------------
+OUT="$(printf 'hello world\n' | APPLY_EDITS='[{"old_str":"world","new_str":"there"}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+if [ "$RC" -eq 0 ] && [ "$OUT" = "hello there" ]; then
+    pass "single edit replaces a unique substring"
+else
+    fail "single edit" "rc=$RC out=$(printf '%q' "$OUT")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 2: multiple sequential edits apply in order.
+# -----------------------------------------------------------------------------
+OUT="$(printf 'a b c' | APPLY_EDITS='[{"old_str":"a","new_str":"X"},{"old_str":"c","new_str":"Z"}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+if [ "$RC" -eq 0 ] && [ "$OUT" = "X b Z" ]; then
+    pass "multiple sequential edits apply in order"
+else
+    fail "multiple edits" "rc=$RC out=$(printf '%q' "$OUT")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 3: zero-match old_str fails loudly (non-zero, JSON error, no stdout).
+# -----------------------------------------------------------------------------
+ERR_FILE="$(mktemp)"
+OUT="$(printf 'hello\n' | APPLY_EDITS='[{"old_str":"nope","new_str":"x"}]' python3 "$APPLY" 2>"$ERR_FILE")" && RC=0 || RC=$?
+ERR="$(cat "$ERR_FILE")"; rm -f "$ERR_FILE"
+if [ "$RC" -ne 0 ] && [ -z "$OUT" ] && printf '%s' "$ERR" | grep -q '"error"'; then
+    pass "zero-match old_str fails loudly (non-zero, JSON error, no stdout)"
+else
+    fail "zero-match" "rc=$RC out=$(printf '%q' "$OUT") err=$(printf '%q' "$ERR")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 4: ambiguous (multi-match) old_str fails loudly.
+# -----------------------------------------------------------------------------
+ERR_FILE="$(mktemp)"
+OUT="$(printf 'aa\n' | APPLY_EDITS='[{"old_str":"a","new_str":"b"}]' python3 "$APPLY" 2>"$ERR_FILE")" && RC=0 || RC=$?
+ERR="$(cat "$ERR_FILE")"; rm -f "$ERR_FILE"
+if [ "$RC" -ne 0 ] && [ -z "$OUT" ] && printf '%s' "$ERR" | grep -q '"error"'; then
+    pass "ambiguous (multi-match) old_str fails loudly"
+else
+    fail "ambiguous old_str" "rc=$RC out=$(printf '%q' "$OUT") err=$(printf '%q' "$ERR")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 5: large content (simulated big file) round-trips via env/stdin.
+# Build ~50KB of unique lines, splice in a unique marker, edit just the marker,
+# and confirm the marker changed while everything else is preserved verbatim.
+# Content travels via a pipe (stdin); the edits via $APPLY_EDITS — never argv.
+# -----------------------------------------------------------------------------
+BIG="$(python3 -c 'print("\n".join("line %05d filler text here" % i for i in range(2000)))')"
+BIG="$BIG
+UNIQUE_MARKER_TOKEN_XYZ
+$BIG"
+EXPECTED="${BIG/UNIQUE_MARKER_TOKEN_XYZ/REPLACED_MARKER_TOKEN}"
+OUT="$(printf '%s' "$BIG" | APPLY_EDITS='[{"old_str":"UNIQUE_MARKER_TOKEN_XYZ","new_str":"REPLACED_MARKER_TOKEN"}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+if [ "$RC" -eq 0 ] && [ "$OUT" = "$EXPECTED" ]; then
+    pass "large content round-trips via env/stdin (>50KB, marker edit, rest preserved)"
+else
+    fail "large content" "rc=$RC bytes_in=$(printf '%s' "$BIG" | wc -c) bytes_out=$(printf '%s' "$OUT" | wc -c)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-github-implementation-robustness.sh
+++ b/tools/test-github-implementation-robustness.sh
@@ -332,7 +332,10 @@ else
 fi
 
 # =============================================================================
-# #1172: code_writer.ag wires get-file into the code-gen context (grep-level).
+# #1172 / #1195: code_writer.ag wires get-file into the code-gen context AND,
+# when the file already exists, requests SMALL search/replace edits (not a
+# whole-file regeneration) and applies them deterministically before commit.
+# Grep-level wiring assertions.
 # =============================================================================
 CW_AG="$REPO_ROOT/dev-apprenticeship/implementation/agents/code_writer.ag"
 if grep -q "get-file --path" "$CW_AG"; then
@@ -341,16 +344,24 @@ else
     fail "#1172 code_writer.ag: no 'get-file --path' fetch found before code-gen"
 fi
 
-if grep -q "EDIT this" "$CW_AG"; then
-    pass "#1172 code_writer.ag: existing-file block instructs the model to EDIT and preserve"
+# #1195: the existing-file code-gen prompt must request search/replace edits
+# (old_str / new_str), NOT a full-file rewrite — small LLM output is what makes
+# the path work on flat-cyborg's screen-scrape backend.
+if grep -q "old_str" "$CW_AG" && grep -q "new_str" "$CW_AG"; then
+    pass "#1195 code_writer.ag: existing-file path requests search/replace edits (old_str/new_str)"
 else
-    fail "#1172 code_writer.ag: existing-file EDIT instruction missing from code_context"
+    fail "#1195 code_writer.ag: existing-file edit prompt missing old_str/new_str search-replace request"
 fi
 
-if grep -q "If an existing file is shown, EDIT it" "$CW_AG"; then
-    pass "#1172 code_writer.ag: code-gen prompt updated to EDIT-when-existing"
+# #1195: those edits must be applied deterministically (apply_edits_to_actions
+# -> tools/apply-edits.py) to assemble the full file BEFORE commit-files runs,
+# so the committed content never depends on fragile large LLM output.
+apply_line="$(grep -n "apply_edits_to_actions(" "$CW_AG" | tail -1 | cut -d: -f1)"
+commit_line="$(grep -n "commit-files --branch" "$CW_AG" | head -1 | cut -d: -f1)"
+if [ -n "$apply_line" ] && [ -n "$commit_line" ] && [ "$apply_line" -lt "$commit_line" ]; then
+    pass "#1195 code_writer.ag: applies edits (apply_edits_to_actions) before commit-files"
 else
-    fail "#1172 code_writer.ag: code-gen prompt not updated for the EDIT path"
+    fail "#1195 code_writer.ag: edits not deterministically applied before commit-files"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #1195.

code_writer regenerated the WHOLE file for an edit → a large file (README ~47KB) overflowed the prompt timeout (`[llm.cancelled]`) and, on the **flat-cyborg** screen-scrape backend, the big JSON got line-wrap-corrupted. Both vanish with small targeted edits + deterministic assembly.

- **`tools/apply-edits.py`**: original content (stdin) + edits `[{old_str,new_str}]` (env) → new full content. Each `old_str` must occur **exactly once**; zero/multi-match → loud fail (non-zero, `{"error"}` on stderr, **no stdout**). This is the corruption guard — a mangled flat-cyborg edit becomes a no-match → no commit → #1185 retry, **never a silent bad commit**.
- **`code_writer.ag`**: existing-file path requests `[{file_path,old_str,new_str}]` edits (small output → flat-cyborg-safe), applies via apply-edits.py, commits the deterministically-assembled content. New-file path unchanged. Large content via env/stdin (ARG_MAX-safe).

**This restores the flat-cyborg flat-rate default for code-gen** (the small output is what made flat-cyborg unsafe before).

## Verification
- colony-lint **425 passed, 0 failed, 5 skipped**; apply-edits 5/0, robustness 18/0 (GitHub) + 9/0 (GitLab), completion-markers 7/0, bundle 11/0.
- QA: ✅ ship-it, no findings (corruption guard verified: no partial stdout on any failure path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)