### PR TITLE
test(trading-binance): intraday cross-sectional reversal (hourly) — strong signal, dies on cost (#1201)

### DIFF
--- a/trading-binance/CHANGELOG.md
+++ b/trading-binance/CHANGELOG.md
@@ -16,6 +16,14 @@ Every release declares its runtime floor as `**Requires:** agentis >= X.Y.Z`.
 
 ### Added
 
+- Intraday cross-sectional reversal study (#1201, hourly bars): there IS a
+  strong raw intraday reversal signal (long losers / short winners, gross Sharpe
+  ~2.9, +126%/yr at 0bps) -- reversal dominates momentum at short horizons -- but
+  it does **NOT survive realistic taker cost**: 0 of 24 configs positive at 8bps
+  round-trip. The per-trade edge (~5.75bps) is smaller than the cost of capturing
+  it as a taker; the edge belongs to the liquidity provider (maker), not the
+  taker. Dividing line: per-trade edge > per-trade cost -- daily momentum wins
+  (rare trades), intraday reversal loses (frequent). (`runs/20260620T-intraday/`)
 - Cross-sectional long-short paper-trade harness (#1197): `tools/xsectional-
   paper.py` -- the live forward gate for the cross-sectional momentum strategy,
   the long-short analogue of carry-paper.py. Periodic snapshots rank trailing

--- a/trading-binance/runs/20260620T-intraday/comparison.md
+++ b/trading-binance/runs/20260620T-intraday/comparison.md
@@ -17,7 +17,7 @@ The intraday counterpart to the daily cross-sectional momentum (#1194): at short
 
 | cost (round-trip) | best config | result | configs still positive |
 |---|---|---|---|
-| 0 bps | reversal 4h/4h | +126 %/yr, Sharpe 2.92 | 24 / 24 |
+| 0 bps | reversal 4h/4h | +126 %/yr, Sharpe 2.92 | 12 / 24 (11 of 12 reversal; momentum mirror negative) |
 | **8 bps** (liquid perp taker) | reversal 4h/6h | **−9.3 %/yr, Sharpe −0.21** | **0 / 24** |
 | 12 bps (thin alts) | reversal 4h/6h | −54 %/yr | 0 / 24 |
 

--- a/trading-binance/runs/20260620T-intraday/comparison.md
+++ b/trading-binance/runs/20260620T-intraday/comparison.md
@@ -1,0 +1,40 @@
+# Intraday cross-sectional reversal (hourly) — strong signal, dies on cost (#1201)
+
+The intraday counterpart to the daily cross-sectional momentum (#1194): at short horizons crypto's documented cross-sectional edge flips to **reversal** (overreaction snapback). Rank 18 alts by trailing L-hour return, **long the losers / short the winners**, hold H hours, rebalance, walk-forward. 2025-09 → 2026-06, ~7000 hourly bars.
+
+## There IS a strong raw intraday reversal signal (0 bps)
+
+| signal | lookback | hold | ann/yr | Sharpe | per-rebalance |
+|---|---|---|---|---|---|
+| **reversal** | 4 h | 4 h | +126 % | **2.92** | +5.75 bps |
+| reversal | 4 h | 1 h | +136 % | 2.86 | +1.56 bps |
+| reversal | 4 h | 2 h | +116 % | 2.47 | +2.65 bps |
+| reversal | 6 h | 1 h | +102 % | 2.16 | +1.17 bps |
+
+**Reversal dominates** — every top config is reversal, none is momentum, confirming the short-horizon sign flip vs the daily-momentum edge. The market over-reacts intraday and snaps back. Gross Sharpe ~2.9 is real.
+
+## …but it does NOT survive realistic cost
+
+| cost (round-trip) | best config | result | configs still positive |
+|---|---|---|---|
+| 0 bps | reversal 4h/4h | +126 %/yr, Sharpe 2.92 | 24 / 24 |
+| **8 bps** (liquid perp taker) | reversal 4h/6h | **−9.3 %/yr, Sharpe −0.21** | **0 / 24** |
+| 12 bps (thin alts) | reversal 4h/6h | −54 %/yr | 0 / 24 |
+
+At 8 bps round-trip, **every one of 24 configs is negative.** The best gross edge was ~+5.75 bps per rebalance; the cost of capturing it (≈ cost × turnover ≈ 8 bps × ~0.7) is larger. The signal is real but **smaller than the cost of trading it as a taker.**
+
+## Why — the edge is the liquidity provider's, not the taker's
+
+The intraday reversal you measure IS the overreaction-and-snapback. But to capture it you must **cross the spread as a taker** at entry and exit — and the spread/fee you pay is essentially the same overreaction you are trying to harvest. The edge is the compensation a **market maker** earns for providing liquidity into the overreaction (posting limit orders, earning the spread/rebate). As a taker you pay exactly that. This is why intraday is dominated by makers with fee rebates and latency, and why a retail taker nets negative.
+
+## The dividing line — per-trade edge vs per-trade cost
+
+This sharpens the whole effort: a cross-sectional strategy wins iff **per-trade edge > per-trade cost.**
+- **Daily/weekly momentum (#1194)** wins: the edge per rebalance is large and you trade rarely (weekly) — cost is a small fraction.
+- **Intraday reversal** loses (as a taker): the edge per rebalance is a few bps and you trade many times a day — cost dominates.
+
+## Verdict
+
+Intraday cross-sectional reversal on hourly bars has a **strong, real raw signal (gross Sharpe ~2.9)** but **does not survive realistic taker costs — 0 of 24 configs positive at 8 bps.** For a retail taker on klines, intraday here is a net loser; the edge belongs to the liquidity provider. Capturing it would require **maker execution** (limit orders, rebates, queue management — a market-making problem, not a signal problem) and/or finer tick/order-book data + latency, which is a different and far harder game. The honest, deployable cross-sectional edge remains the **daily/weekly** one (#1194/#1197).
+
+Reproduce: `run-meta.json` (hourly klines fetched live; not committed).

--- a/trading-binance/runs/20260620T-intraday/intraday-xs.py
+++ b/trading-binance/runs/20260620T-intraday/intraday-xs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""intraday-xs.py -- intraday cross-sectional long-short backtest on HOURLY bars
+(#1201). The intraday counterpart to the daily cross-sectional momentum (#1194):
+at short horizons crypto's documented cross-sectional edge flips from momentum to
+REVERSAL (overreaction snapback). Rank alts by trailing L-hour return, long the
+losers / short the winners (reversal) -- and the momentum sign for contrast --
+hold H hours, rebalance, walk-forward.
+
+Honest prior: intraday is the most arbed timeframe and turnover cost (many
+rebalances/day) dominates -- the per-trade reversal edge is a few bps and a
+~6-10 bps round-trip can eat it. This tests, after realistic intraday cost,
+whether anything survives.
+
+Walk-forward on a regular hourly grid (no look-ahead): at bar i, selection return
+= close[i]/close[i-L] (PAST); realised = close[i+H]/close[i] (FUTURE); step i by
+H. Standard library only. Hourly perp klines from fapi.binance.com.
+"""
+import argparse
+import datetime
+import json
+import math
+import sys
+import urllib.request
+
+HOUR_MS = 3600000
+
+
+def epoch_ms(s):
+    if s.isdigit():
+        return int(s)
+    return int(datetime.datetime.strptime(s, "%Y-%m-%d").replace(
+        tzinfo=datetime.timezone.utc).timestamp() * 1000)
+
+
+def hourly_closes(symbol, start, end):
+    out = {}
+    cur = start
+    while cur < end:
+        url = ("https://fapi.binance.com/fapi/v1/klines?symbol=%s&interval=1h&startTime=%d&endTime=%d&limit=1000"
+               % (symbol, cur, end))
+        try:
+            with urllib.request.urlopen(url, timeout=30) as r:
+                batch = json.load(r)
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write("klines %s err: %s\n" % (symbol, e))
+            return out
+        if not batch:
+            break
+        for k in batch:
+            out[k[0]] = float(k[4])
+        cur = batch[-1][0] + 1
+        if len(batch) < 1000:
+            break
+    return out
+
+
+def stdev(xs):
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    m = sum(xs) / n
+    return math.sqrt(sum((x - m) ** 2 for x in xs) / (n - 1))
+
+
+def run(closes, grid, lookback_h, hold_h, top_k, reversal, cost_rt):
+    cost = cost_rt / 10000.0
+    rets = []
+    prev_long, prev_short = set(), set()
+    i = lookback_h
+    n = len(grid)
+    while i + hold_h < n:
+        t_lb, t_now, t_fwd = grid[i - lookback_h], grid[i], grid[i + hold_h]
+        trailing, forward = {}, {}
+        for s, cl in closes.items():
+            if t_lb in cl and t_now in cl and t_fwd in cl and cl[t_lb] > 0 and cl[t_now] > 0:
+                trailing[s] = cl[t_now] / cl[t_lb] - 1.0
+                forward[s] = cl[t_fwd] / cl[t_now] - 1.0
+        if len(trailing) < 2 * top_k:
+            i += hold_h
+            continue
+        # reversal: long the LOSERS (bottom), short the WINNERS (top)
+        ranked = sorted(trailing, key=lambda s: trailing[s])  # ascending = losers first
+        if reversal:
+            longs, shorts = set(ranked[:top_k]), set(ranked[-top_k:])
+        else:  # momentum
+            longs, shorts = set(ranked[-top_k:]), set(ranked[:top_k])
+        gross = sum(forward[s] for s in longs) / len(longs) - sum(forward[s] for s in shorts) / len(shorts)
+        changed = len(longs ^ prev_long) + len(shorts ^ prev_short)
+        turn = (changed / 2.0) / (2.0 * top_k)
+        rets.append(gross - cost * turn)
+        prev_long, prev_short = longs, shorts
+        i += hold_h
+    if len(rets) < 10:
+        return None
+    total = sum(rets)
+    reb_per_year = (365.0 * 24.0) / hold_h
+    sd = stdev(rets)
+    sharpe = (total / len(rets)) / sd * math.sqrt(reb_per_year) if sd > 0 else 0.0
+    peak = mdd = acc = 0.0
+    for r in rets:
+        acc += r
+        peak = max(peak, acc)
+        mdd = max(mdd, peak - acc)
+    return {
+        "rebalances": len(rets),
+        "ann_pct": round(total * reb_per_year / len(rets) * 100, 2),
+        "sharpe": round(sharpe, 2),
+        "max_dd_pct": round(mdd * 100, 1),
+        "avg_per_reb_bps": round(total / len(rets) * 10000, 2),
+    }
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--symbols", required=True)
+    ap.add_argument("--start", required=True)
+    ap.add_argument("--end", required=True)
+    ap.add_argument("--top-k", type=int, default=4)
+    ap.add_argument("--cost-bps-roundtrip", type=float, default=8.0)
+    ap.add_argument("--lookbacks", default="1,2,4,6")
+    ap.add_argument("--holds", default="1,2,4")
+    args = ap.parse_args(argv)
+
+    symbols = [s.strip().upper() for s in args.symbols.split(",") if s.strip()]
+    start, end = epoch_ms(args.start), epoch_ms(args.end)
+    closes = {}
+    for s in symbols:
+        cl = hourly_closes(s, start, end)
+        if len(cl) > 200:
+            closes[s] = cl
+    if len(closes) < 6:
+        sys.stderr.write("not enough symbols\n")
+        return 2
+    grid = sorted(set().union(*[set(c) for c in closes.values()]))
+
+    out = {"symbols_loaded": len(closes), "hours": len(grid), "cost_bps": args.cost_bps_roundtrip, "results": []}
+    for lb in [int(x) for x in args.lookbacks.split(",")]:
+        for h in [int(x) for x in args.holds.split(",")]:
+            for reversal in (True, False):
+                r = run(closes, grid, lb, h, args.top_k, reversal, args.cost_bps_roundtrip)
+                if r:
+                    r["lookback_h"], r["hold_h"] = lb, h
+                    r["signal"] = "reversal" if reversal else "momentum"
+                    out["results"].append(r)
+    out["results"].sort(key=lambda r: -r["sharpe"])
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/trading-binance/runs/20260620T-intraday/results.json
+++ b/trading-binance/runs/20260620T-intraday/results.json
@@ -1,0 +1,247 @@
+{
+  "symbols_loaded": 18,
+  "hours": 7009,
+  "cost_bps": 8.0,
+  "results": [
+    {
+      "rebalances": 1167,
+      "ann_pct": -9.29,
+      "sharpe": -0.21,
+      "max_dd_pct": 46.3,
+      "avg_per_reb_bps": -0.64,
+      "lookback_h": 4,
+      "hold_h": 6,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 1751,
+      "ann_pct": -9.91,
+      "sharpe": -0.23,
+      "max_dd_pct": 73.7,
+      "avg_per_reb_bps": -0.45,
+      "lookback_h": 4,
+      "hold_h": 4,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 1167,
+      "ann_pct": -39.28,
+      "sharpe": -0.94,
+      "max_dd_pct": 53.8,
+      "avg_per_reb_bps": -2.69,
+      "lookback_h": 1,
+      "hold_h": 6,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 1167,
+      "ann_pct": -43.49,
+      "sharpe": -1.04,
+      "max_dd_pct": 53.7,
+      "avg_per_reb_bps": -2.98,
+      "lookback_h": 2,
+      "hold_h": 6,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 1167,
+      "ann_pct": -66.04,
+      "sharpe": -1.6,
+      "max_dd_pct": 71.1,
+      "avg_per_reb_bps": -4.52,
+      "lookback_h": 6,
+      "hold_h": 6,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 3502,
+      "ann_pct": -77.88,
+      "sharpe": -1.66,
+      "max_dd_pct": 74.1,
+      "avg_per_reb_bps": -1.78,
+      "lookback_h": 4,
+      "hold_h": 2,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 1751,
+      "ann_pct": -71.57,
+      "sharpe": -1.74,
+      "max_dd_pct": 75.5,
+      "avg_per_reb_bps": -3.27,
+      "lookback_h": 2,
+      "hold_h": 4,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 1751,
+      "ann_pct": -74.71,
+      "sharpe": -1.76,
+      "max_dd_pct": 92.4,
+      "avg_per_reb_bps": -3.41,
+      "lookback_h": 1,
+      "hold_h": 4,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 1750,
+      "ann_pct": -89.9,
+      "sharpe": -1.98,
+      "max_dd_pct": 80.9,
+      "avg_per_reb_bps": -4.1,
+      "lookback_h": 6,
+      "hold_h": 4,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 3501,
+      "ann_pct": -105.32,
+      "sharpe": -2.31,
+      "max_dd_pct": 96.0,
+      "avg_per_reb_bps": -2.4,
+      "lookback_h": 6,
+      "hold_h": 2,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 1167,
+      "ann_pct": -112.84,
+      "sharpe": -2.73,
+      "max_dd_pct": 101.1,
+      "avg_per_reb_bps": -7.73,
+      "lookback_h": 6,
+      "hold_h": 6,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 1750,
+      "ann_pct": -132.91,
+      "sharpe": -2.93,
+      "max_dd_pct": 114.9,
+      "avg_per_reb_bps": -6.07,
+      "lookback_h": 6,
+      "hold_h": 4,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 1167,
+      "ann_pct": -132.31,
+      "sharpe": -3.17,
+      "max_dd_pct": 116.9,
+      "avg_per_reb_bps": -9.06,
+      "lookback_h": 2,
+      "hold_h": 6,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 1167,
+      "ann_pct": -137.37,
+      "sharpe": -3.3,
+      "max_dd_pct": 116.6,
+      "avg_per_reb_bps": -9.41,
+      "lookback_h": 1,
+      "hold_h": 6,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 1167,
+      "ann_pct": -169.58,
+      "sharpe": -3.83,
+      "max_dd_pct": 135.6,
+      "avg_per_reb_bps": -11.62,
+      "lookback_h": 4,
+      "hold_h": 6,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 3503,
+      "ann_pct": -176.53,
+      "sharpe": -4.1,
+      "max_dd_pct": 150.6,
+      "avg_per_reb_bps": -4.03,
+      "lookback_h": 1,
+      "hold_h": 2,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 1751,
+      "ann_pct": -191.34,
+      "sharpe": -4.5,
+      "max_dd_pct": 158.6,
+      "avg_per_reb_bps": -8.74,
+      "lookback_h": 1,
+      "hold_h": 4,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 3501,
+      "ann_pct": -216.66,
+      "sharpe": -4.76,
+      "max_dd_pct": 174.6,
+      "avg_per_reb_bps": -4.95,
+      "lookback_h": 6,
+      "hold_h": 2,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 1751,
+      "ann_pct": -197.13,
+      "sharpe": -4.79,
+      "max_dd_pct": 163.4,
+      "avg_per_reb_bps": -9.0,
+      "lookback_h": 2,
+      "hold_h": 4,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 3503,
+      "ann_pct": -238.2,
+      "sharpe": -5.18,
+      "max_dd_pct": 196.2,
+      "avg_per_reb_bps": -5.44,
+      "lookback_h": 2,
+      "hold_h": 2,
+      "signal": "reversal"
+    },
+    {
+      "rebalances": 1751,
+      "ann_pct": -261.82,
+      "sharpe": -6.07,
+      "max_dd_pct": 209.3,
+      "avg_per_reb_bps": -11.96,
+      "lookback_h": 4,
+      "hold_h": 4,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 3503,
+      "ann_pct": -296.2,
+      "sharpe": -6.44,
+      "max_dd_pct": 240.9,
+      "avg_per_reb_bps": -6.76,
+      "lookback_h": 2,
+      "hold_h": 2,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 3502,
+      "ann_pct": -310.41,
+      "sharpe": -6.6,
+      "max_dd_pct": 248.5,
+      "avg_per_reb_bps": -7.09,
+      "lookback_h": 4,
+      "hold_h": 2,
+      "signal": "momentum"
+    },
+    {
+      "rebalances": 3503,
+      "ann_pct": -357.07,
+      "sharpe": -8.29,
+      "max_dd_pct": 288.2,
+      "avg_per_reb_bps": -8.15,
+      "lookback_h": 1,
+      "hold_h": 2,
+      "signal": "momentum"
+    }
+  ]
+}

--- a/trading-binance/runs/20260620T-intraday/run-meta.json
+++ b/trading-binance/runs/20260620T-intraday/run-meta.json
@@ -1,0 +1,4 @@
+{"run_id":"20260620T-intraday","issue":1201,"kind":"intraday-cross-sectional-reversal-hourly",
+ "universe_size":18,"span":"2025-09-01..2026-06-20 hourly (~7000 bars)","cost_bps_canonical":8,
+ "sweep":"lookback {1,2,4,6}h x hold {2,4,6}h x signal {reversal,momentum}, top-4, walk-forward","base_commit":"0af3e377e6910ec3ec051709b083e1cc153c9de3",
+ "reproduce":"python3 runs/20260620T-intraday/intraday-xs.py --symbols <universe> --start 2025-09-01 --end 2026-06-20 --top-k 4 --cost-bps-roundtrip 8 --lookbacks 1,2,4,6 --holds 2,4,6 (hourly klines fetched live)"}


### PR DESCRIPTION
Intraday counterpart to the daily momentum (#1194): rank alts by trailing L-hour return, long losers / short winners (reversal), hold H hours, walk-forward, ~7000 hourly bars.

**Findings:** (1) there IS a **strong raw intraday reversal signal** — +126%/yr gross **Sharpe 2.92** at 0bps; reversal dominates momentum at short horizons. (2) It **does NOT survive realistic cost** — at **8bps round-trip, 0 of 24 configs are positive** (best −9.3%/yr); 12bps all deeply negative. The per-trade edge (~5.75bps) < the cost of capturing it as a taker. (3) **Why:** the edge is the liquidity **provider's** (maker), not the taker's — as a taker you pay exactly the overreaction you try to harvest. (4) **Dividing line:** per-trade edge > per-trade cost — daily momentum wins (rare trades), intraday reversal loses (frequent). Deployable edge stays daily/weekly (#1194/#1197). Docs/run artifact; klines fetched live. Closes #1201.