### PR TITLE
fix(federation): flat-cyborg large-file edit — prompt-timeout + whitespace-robust apply-edits (#1203, #1204)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,32 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Large existing-file edits now survive the flat-cyborg backend end-to-end**
+  (#1203, #1204). Two fixes that together let the federation edit a large
+  existing file (e.g. a ~47KB README) on the flat-cyborg default backend.
+  (1) Every colony's `start-colony.sh` now splices `--prompt-timeout-s
+  "$PROMPT_TIMEOUT_S"` onto both daemon launch paths (the normal per-agent loop
+  AND the `--restart-agent` respawn). The daemon's `--prompt-timeout-s` flag
+  (#649) defaults to 120s and OVERRIDES `llm.cli_timeout_ms`, so large-context
+  flat-cyborg round-trips (>120s) were being killed mid-prompt as
+  `[llm.cancelled]`. The cap is resolved from `[colony].prompt_timeout_s` when
+  set (positive integer), else defaults to 300s — consistent across all five
+  colonies. (2) `tools/apply-edits.py` now falls back to a whitespace-normalized
+  match when an `old_str` does not match the file content exactly. On
+  flat-cyborg the returned `old_str` drifts (trailing whitespace, CRLF), so
+  exact match kept failing. The fallback strips trailing whitespace per line and
+  normalizes CRLF→LF on both sides (no leading/internal collapse, which would
+  mis-locate the anchor), maps a unique normalized span back to the original
+  content, and replaces it — preserving every original byte outside the matched
+  span. The exactly-once requirement is enforced at BOTH steps: zero or >1
+  matches still loud-fails (non-zero, JSON error on stderr, no stdout), so an
+  ambiguous or absent anchor never applies. The `code_writer` existing-file
+  code-gen prompt now also instructs the model to copy `old_str` VERBATIM from
+  the shown current content (no paraphrase/reflow) with enough surrounding
+  context to be unique.
+
 ### Changed
 
 - **`code_writer` edits existing files via search/replace, not full rewrites**

--- a/dev-apprenticeship/code-review/scripts/start-colony.sh
+++ b/dev-apprenticeship/code-review/scripts/start-colony.sh
@@ -290,6 +290,21 @@ cb_per_tick_for() {
     echo "$CB_PER_TICK_DEFAULT"
 }
 
+# Per-daemon prompt-timeout-s cap (#1203). The `agentis daemon`
+# `--prompt-timeout-s` flag (#649) defaults to 120s and OVERRIDES
+# `llm.cli_timeout_ms`, so a large-context flat-cyborg round-trip (>120s, e.g.
+# editing a ~47KB README) gets killed mid-prompt and surfaces as
+# `[llm.cancelled]`. We resolve a wall-clock cap from `[colony].prompt_timeout_s`
+# when set (positive integer), else default 300s — generous enough for big
+# files on the flat-cyborg backend — and splice it onto every `agentis daemon`
+# launch as `--prompt-timeout-s "$PROMPT_TIMEOUT_S"` (a real daemon flag, like
+# `--cb-per-tick`). Mirrors the CB_PER_TICK_DEFAULT validation shape.
+PROMPT_TIMEOUT_S="$(parse_toml colony prompt_timeout_s)"
+case "$PROMPT_TIMEOUT_S" in
+    ''|*[!0-9]*) PROMPT_TIMEOUT_S=300 ;;
+    *) [ "$PROMPT_TIMEOUT_S" -gt 0 ] || PROMPT_TIMEOUT_S=300 ;;
+esac
+
 # #319 PR 1 + #318: combined LLM-config override emitter.
 #
 # Precedence (highest first):
@@ -421,6 +436,7 @@ for d in daemons:
         --enable-messaging \
         --tick-interval "$tick" \
         --cb-per-tick "$cb" \
+        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} </dev/null >/dev/null 2>&1 &
     agent_pid=$!
     sleep 0.5
@@ -453,6 +469,7 @@ for agent in "${AGENTS[@]}"; do
         --enable-messaging \
         --tick-interval "$interval" \
         --cb-per-tick "$cb" \
+        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -348,7 +348,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                         let edit_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec) +
                             "\nCurrent content of " + primary_path + " (edit THIS file):\n" + existing_content;
                         let edits_json = prompt(
-                            "You are a code writer editing an EXISTING file. Make the smallest edits that satisfy the task. Return a JSON array of edits, each object with: file_path (string), old_str (string, an EXACT, UNIQUE substring of the shown current file content — it must occur exactly once, copy it verbatim including whitespace), new_str (string, the replacement). Do NOT return the whole file. Return ONLY the raw JSON array — no markdown code fences, no ```json wrapper, no prose.",
+                            "You are a code writer editing an EXISTING file. Make the smallest edits that satisfy the task. Return a JSON array of edits, each object with: file_path (string), old_str (string), new_str (string, the replacement). For old_str: copy it VERBATIM from the shown current file content — character for character, including every space, tab, indentation, and line break exactly as displayed. Do NOT paraphrase, reflow, re-indent, trim, or otherwise alter it. Each old_str must be UNIQUE in the file (occur exactly once); include enough surrounding lines of context to guarantee uniqueness. Do NOT return the whole file. Return ONLY the raw JSON array — no markdown code fences, no ```json wrapper, no prose.",
                             edit_context
                         ) -> string;
                         // Deterministic apply: old_str must match the real file

--- a/dev-apprenticeship/implementation/scripts/start-colony.sh
+++ b/dev-apprenticeship/implementation/scripts/start-colony.sh
@@ -352,6 +352,21 @@ cb_per_tick_for() {
     echo "$CB_PER_TICK_DEFAULT"
 }
 
+# Per-daemon prompt-timeout-s cap (#1203). The `agentis daemon`
+# `--prompt-timeout-s` flag (#649) defaults to 120s and OVERRIDES
+# `llm.cli_timeout_ms`, so a large-context flat-cyborg round-trip (>120s, e.g.
+# editing a ~47KB README) gets killed mid-prompt and surfaces as
+# `[llm.cancelled]`. We resolve a wall-clock cap from `[colony].prompt_timeout_s`
+# when set (positive integer), else default 300s — generous enough for big
+# files on the flat-cyborg backend — and splice it onto every `agentis daemon`
+# launch as `--prompt-timeout-s "$PROMPT_TIMEOUT_S"` (a real daemon flag, like
+# `--cb-per-tick`). Mirrors the CB_PER_TICK_DEFAULT validation shape.
+PROMPT_TIMEOUT_S="$(parse_toml colony prompt_timeout_s)"
+case "$PROMPT_TIMEOUT_S" in
+    ''|*[!0-9]*) PROMPT_TIMEOUT_S=300 ;;
+    *) [ "$PROMPT_TIMEOUT_S" -gt 0 ] || PROMPT_TIMEOUT_S=300 ;;
+esac
+
 # #319 PR 1 + #318: combined LLM-config override emitter.
 #
 # Precedence (highest first):
@@ -482,6 +497,7 @@ for d in daemons:
         --enable-messaging \
         --tick-interval "$tick" \
         --cb-per-tick "$cb" \
+        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} </dev/null >/dev/null 2>&1 &
     agent_pid=$!
     sleep 0.5
@@ -514,6 +530,7 @@ for agent in "${AGENTS[@]}"; do
         --enable-messaging \
         --tick-interval "$interval" \
         --cb-per-tick "$cb" \
+        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/planning/scripts/start-colony.sh
+++ b/dev-apprenticeship/planning/scripts/start-colony.sh
@@ -334,6 +334,21 @@ cb_per_tick_for() {
     echo "$CB_PER_TICK_DEFAULT"
 }
 
+# Per-daemon prompt-timeout-s cap (#1203). The `agentis daemon`
+# `--prompt-timeout-s` flag (#649) defaults to 120s and OVERRIDES
+# `llm.cli_timeout_ms`, so a large-context flat-cyborg round-trip (>120s, e.g.
+# editing a ~47KB README) gets killed mid-prompt and surfaces as
+# `[llm.cancelled]`. We resolve a wall-clock cap from `[colony].prompt_timeout_s`
+# when set (positive integer), else default 300s — generous enough for big
+# files on the flat-cyborg backend — and splice it onto every `agentis daemon`
+# launch as `--prompt-timeout-s "$PROMPT_TIMEOUT_S"` (a real daemon flag, like
+# `--cb-per-tick`). Mirrors the CB_PER_TICK_DEFAULT validation shape.
+PROMPT_TIMEOUT_S="$(parse_toml colony prompt_timeout_s)"
+case "$PROMPT_TIMEOUT_S" in
+    ''|*[!0-9]*) PROMPT_TIMEOUT_S=300 ;;
+    *) [ "$PROMPT_TIMEOUT_S" -gt 0 ] || PROMPT_TIMEOUT_S=300 ;;
+esac
+
 # #319 PR 1 + #318: combined LLM-config override emitter.
 #
 # Precedence (highest first):
@@ -464,6 +479,7 @@ for d in daemons:
         --enable-messaging \
         --tick-interval "$tick" \
         --cb-per-tick "$cb" \
+        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} </dev/null >/dev/null 2>&1 &
     agent_pid=$!
     sleep 0.5
@@ -496,6 +512,7 @@ for agent in "${AGENTS[@]}"; do
         --enable-messaging \
         --tick-interval "$interval" \
         --cb-per-tick "$cb" \
+        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/release/scripts/start-colony.sh
+++ b/dev-apprenticeship/release/scripts/start-colony.sh
@@ -297,6 +297,21 @@ cb_per_tick_for() {
     echo "$CB_PER_TICK_DEFAULT"
 }
 
+# Per-daemon prompt-timeout-s cap (#1203). The `agentis daemon`
+# `--prompt-timeout-s` flag (#649) defaults to 120s and OVERRIDES
+# `llm.cli_timeout_ms`, so a large-context flat-cyborg round-trip (>120s, e.g.
+# editing a ~47KB README) gets killed mid-prompt and surfaces as
+# `[llm.cancelled]`. We resolve a wall-clock cap from `[colony].prompt_timeout_s`
+# when set (positive integer), else default 300s — generous enough for big
+# files on the flat-cyborg backend — and splice it onto every `agentis daemon`
+# launch as `--prompt-timeout-s "$PROMPT_TIMEOUT_S"` (a real daemon flag, like
+# `--cb-per-tick`). Mirrors the CB_PER_TICK_DEFAULT validation shape.
+PROMPT_TIMEOUT_S="$(parse_toml colony prompt_timeout_s)"
+case "$PROMPT_TIMEOUT_S" in
+    ''|*[!0-9]*) PROMPT_TIMEOUT_S=300 ;;
+    *) [ "$PROMPT_TIMEOUT_S" -gt 0 ] || PROMPT_TIMEOUT_S=300 ;;
+esac
+
 # #319 PR 1 + #318: combined LLM-config override emitter.
 #
 # Precedence (highest first):
@@ -427,6 +442,7 @@ for d in daemons:
         --enable-messaging \
         --tick-interval "$tick" \
         --cb-per-tick "$cb" \
+        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} </dev/null >/dev/null 2>&1 &
     agent_pid=$!
     sleep 0.5
@@ -459,6 +475,7 @@ for agent in "${AGENTS[@]}"; do
         --enable-messaging \
         --tick-interval "$interval" \
         --cb-per-tick "$cb" \
+        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/dev-apprenticeship/triage/scripts/start-colony.sh
+++ b/dev-apprenticeship/triage/scripts/start-colony.sh
@@ -386,6 +386,21 @@ cb_per_tick_for() {
     echo "$CB_PER_TICK_DEFAULT"
 }
 
+# Per-daemon prompt-timeout-s cap (#1203). The `agentis daemon`
+# `--prompt-timeout-s` flag (#649) defaults to 120s and OVERRIDES
+# `llm.cli_timeout_ms`, so a large-context flat-cyborg round-trip (>120s, e.g.
+# editing a ~47KB README) gets killed mid-prompt and surfaces as
+# `[llm.cancelled]`. We resolve a wall-clock cap from `[colony].prompt_timeout_s`
+# when set (positive integer), else default 300s — generous enough for big
+# files on the flat-cyborg backend — and splice it onto every `agentis daemon`
+# launch as `--prompt-timeout-s "$PROMPT_TIMEOUT_S"` (a real daemon flag, like
+# `--cb-per-tick`). Mirrors the CB_PER_TICK_DEFAULT validation shape.
+PROMPT_TIMEOUT_S="$(parse_toml colony prompt_timeout_s)"
+case "$PROMPT_TIMEOUT_S" in
+    ''|*[!0-9]*) PROMPT_TIMEOUT_S=300 ;;
+    *) [ "$PROMPT_TIMEOUT_S" -gt 0 ] || PROMPT_TIMEOUT_S=300 ;;
+esac
+
 # #319 PR 1 + #318: combined LLM-config override emitter.
 #
 # Precedence (highest first):
@@ -516,6 +531,7 @@ for d in daemons:
         --enable-messaging \
         --tick-interval "$tick" \
         --cb-per-tick "$cb" \
+        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} </dev/null >/dev/null 2>&1 &
     agent_pid=$!
     sleep 0.5
@@ -548,6 +564,7 @@ for agent in "${AGENTS[@]}"; do
         --enable-messaging \
         --tick-interval "$interval" \
         --cb-per-tick "$cb" \
+        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \
         ${CC_ARGS[@]+"${CC_ARGS[@]}"} &
     sleep 2  # stagger starts to reduce API contention
 done

--- a/tools/apply-edits.py
+++ b/tools/apply-edits.py
@@ -20,12 +20,21 @@
 #     which edit failed, exit non-zero, and NOTHING is written to stdout
 #     (no partial/garbage content).
 #
-# Edits are applied sequentially. For each edit, `old_str` MUST occur
-# EXACTLY ONCE in the current (post-previous-edits) content. Zero matches or
-# more than one match is a loud, non-zero failure. This exact-match-or-fail
-# rule is the corruption guard: if flat-cyborg's screen-scrape mangles an
-# edit, `old_str` won't match the real file -> loud failure -> the agent
-# retries, and we never commit silent garbage.
+# Edits are applied sequentially. For each edit:
+#   Step 1 (exact): `old_str` MUST occur EXACTLY ONCE in the current
+#   (post-previous-edits) content. One match -> replace, done.
+#   Step 2 (normalized fallback, #1204): if the exact match is not
+#   exactly-once, retry under whitespace normalization — strip trailing
+#   whitespace per line and normalize line endings (CRLF -> LF) on BOTH the
+#   file and `old_str`. Leading/internal whitespace is preserved (collapsing
+#   it would mis-locate the anchor). If the normalized `old_str` block matches
+#   EXACTLY ONCE in the normalized file, the matching ORIGINAL line span is
+#   replaced with `new_str`.
+# Zero matches or more than one match at BOTH steps is a loud, non-zero
+# failure. This exactly-once requirement is the corruption guard: if
+# flat-cyborg's screen-scrape mangles an edit beyond whitespace drift,
+# `old_str` won't match the real file -> loud failure -> the agent retries,
+# and we never commit silent garbage on an ambiguous/absent anchor.
 
 import json
 import os
@@ -36,6 +45,81 @@ def fail(msg):
     sys.stderr.write(json.dumps({"error": msg}))
     sys.stderr.write("\n")
     sys.exit(1)
+
+
+def _normalize_line(line):
+    # Strip the line ending (CRLF or LF) and any trailing whitespace. Leading
+    # and internal whitespace is preserved so the anchor cannot drift; only
+    # trailing-whitespace + CRLF/LF drift is absorbed. rstrip("\r\n") drops the
+    # line terminator first, then rstrip() removes trailing spaces/tabs.
+    return line.rstrip("\r\n").rstrip()
+
+
+def _normalized_block(text):
+    # Return the list of trailing-whitespace-stripped, CRLF-normalized lines for
+    # an arbitrary text block. splitlines() handles CRLF and LF uniformly and
+    # does not emit a spurious trailing empty element for a final newline.
+    return [_normalize_line(line) for line in text.splitlines()]
+
+
+def _apply_normalized(content, old_str, new_str):
+    # Whitespace-normalized fallback. Match `old_str` as a contiguous block of
+    # normalized lines inside the normalized file, then map that block back to
+    # the ORIGINAL line span and splice in `new_str` — preserving every original
+    # byte (line endings included) OUTSIDE the matched span.
+    #
+    # Returns the new content on a unique normalized match, or None when the
+    # normalized match count is not exactly one (caller fails loudly).
+    #
+    # Original lines keep their terminators via keepends=True so the rebuilt
+    # file is byte-identical to the original everywhere except the replaced
+    # span. The normalized view (terminator + trailing whitespace stripped) is
+    # what we match on, and it is index-aligned 1:1 with `orig_lines`.
+    orig_lines = content.splitlines(keepends=True)
+    norm_file = [_normalize_line(line) for line in orig_lines]
+    norm_old = _normalized_block(old_str)
+
+    block = len(norm_old)
+    if block == 0:
+        return None
+
+    # Scan every window of `block` consecutive normalized file lines for an
+    # exact match against the normalized old_str lines. Count all matches; only
+    # a unique match is allowed to apply.
+    matches = []
+    last = len(norm_file) - block
+    i = 0
+    while i <= last:
+        if norm_file[i:i + block] == norm_old:
+            matches.append(i)
+        i += 1
+
+    if len(matches) != 1:
+        return None
+
+    start = matches[0]
+    end = start + block
+    # Map the normalized span [start, end) back onto the ORIGINAL lines. The
+    # head and tail keep their original terminators verbatim; only the matched
+    # span is replaced by new_str. Preserve the original span's trailing
+    # terminator: if the last original line in the span ended in a newline, the
+    # replacement should too (so a multi-line block edit keeps the file's line
+    # structure). new_str is inserted verbatim and may itself contain newlines.
+    head = "".join(orig_lines[:start])
+    tail = "".join(orig_lines[end:])
+    span_last = orig_lines[end - 1]
+    if span_last.endswith("\r\n"):
+        trailer = "\r\n"
+    elif span_last.endswith("\n"):
+        trailer = "\n"
+    else:
+        trailer = ""
+    # Only re-attach the span terminator when new_str does not already supply
+    # one, so we neither drop nor double a trailing newline on the edited block.
+    replacement = new_str
+    if trailer and not new_str.endswith(("\r\n", "\n")):
+        replacement = new_str + trailer
+    return head + replacement + tail
 
 
 def main():
@@ -68,14 +152,27 @@ def main():
         if old_str == "":
             fail("edit %d has an empty 'old_str' (would match everywhere)" % i)
 
+        # Step 1: exact match (exactly-once -> apply).
         count = content.count(old_str)
-        if count == 0:
-            fail("edit %d: old_str not found in current content: %r" % (i, old_str))
-        if count > 1:
-            fail("edit %d: old_str occurs %d times (must be unique): %r"
-                 % (i, count, old_str))
+        if count == 1:
+            content = content.replace(old_str, new_str, 1)
+            continue
 
-        content = content.replace(old_str, new_str, 1)
+        # Step 2: whitespace-normalized fallback. Only reached when the exact
+        # match was absent (0) or ambiguous (>1). A unique normalized match
+        # re-anchors the edit; anything else falls through to a loud failure.
+        rebuilt = _apply_normalized(content, old_str, new_str)
+        if rebuilt is not None:
+            content = rebuilt
+            continue
+
+        if count == 0:
+            fail("edit %d: old_str not found in current content (exact or "
+                 "whitespace-normalized): %r" % (i, old_str))
+        else:
+            fail("edit %d: old_str occurs %d times (must be unique; not "
+                 "uniquely resolvable under whitespace normalization "
+                 "either): %r" % (i, count, old_str))
 
     sys.stdout.write(content)
 

--- a/tools/colony-lint.sh
+++ b/tools/colony-lint.sh
@@ -276,7 +276,7 @@ if errors:
                 # miscompiles backslash-newline inside case-pattern labels
                 # (#121). Keep all alternatives on a single line.
                 case "$flag" in
-                    --tick-interval|--cb-per-tick|--colony|--deadline|--priority|--enable-migration|--enable-replication|--allow-replica-replication|--enable-exec|--enable-messaging|--deny-exec|--config-override|--help|-h) ;;
+                    --tick-interval|--cb-per-tick|--prompt-timeout-s|--colony|--deadline|--priority|--enable-migration|--enable-replication|--allow-replica-replication|--enable-exec|--enable-messaging|--deny-exec|--config-override|--help|-h) ;;
                     *) echo "$flag" ;;
                 esac
             done)

--- a/tools/test-apply-edits.sh
+++ b/tools/test-apply-edits.sh
@@ -12,16 +12,23 @@
 # Contract under test:
 #   - original content on stdin, edits JSON in $APPLY_EDITS, new content on
 #     stdout (large values ride a pipe / env var, never argv -> no ARG_MAX).
-#   - each edit's old_str must occur EXACTLY ONCE; zero or >1 matches is a loud,
-#     non-zero failure with a JSON {"error": ...} on stderr and NO stdout.
+#   - each edit's old_str must resolve to EXACTLY ONE span — first by exact
+#     match, then (#1204) by a whitespace-normalized fallback (trailing
+#     whitespace stripped per line + CRLF->LF, no leading/internal collapse).
+#     Zero or >1 matches at BOTH steps is a loud, non-zero failure with a JSON
+#     {"error": ...} on stderr and NO stdout.
 #   - edits apply sequentially.
 #
 # Cases:
-#   1. single edit replaces a unique substring.
+#   1. single edit replaces a unique substring (exact match).
 #   2. multiple sequential edits apply in order.
 #   3. zero-match old_str fails loudly (non-zero, JSON error, no stdout).
 #   4. ambiguous (multi-match) old_str fails loudly (non-zero, JSON error).
 #   5. large content (simulated big file) round-trips via the env/stdin path.
+#   6. (#1204) trailing-whitespace drift matches via the normalized fallback.
+#   7. (#1204) CRLF-vs-LF drift matches via the normalized fallback.
+#   8. (#1204) genuinely absent old_str still loud-fails (no normalized match).
+#   9. (#1204) ambiguous-under-normalization old_str still loud-fails.
 #
 # Auto-discovered by tools/colony-lint.sh's tools-test loop. Exit 0 if all pass.
 
@@ -111,6 +118,73 @@ if [ "$RC" -eq 0 ] && [ "$OUT" = "$EXPECTED" ]; then
     pass "large content round-trips via env/stdin (>50KB, marker edit, rest preserved)"
 else
     fail "large content" "rc=$RC bytes_in=$(printf '%s' "$BIG" | wc -c) bytes_out=$(printf '%s' "$OUT" | wc -c)"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 6 (#1204): trailing-whitespace drift matches via the normalized fallback.
+# The file's anchor line has no trailing whitespace; the LLM-returned old_str
+# carries trailing spaces (flat-cyborg TUI line-wrap drift). Exact match fails
+# (0 occurrences), but the whitespace-normalized fallback finds the unique span
+# and edits the RIGHT line — leaving the surrounding lines verbatim.
+# -----------------------------------------------------------------------------
+IN6="$(printf 'alpha\nbeta gamma\ndelta\n')"
+OUT="$(printf '%s' "$IN6" | APPLY_EDITS='[{"old_str":"beta gamma   ","new_str":"BETA GAMMA"}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+EXP6="$(printf 'alpha\nBETA GAMMA\ndelta')"
+if [ "$RC" -eq 0 ] && [ "$OUT" = "$EXP6" ]; then
+    pass "trailing-whitespace drift matches via normalized fallback (#1204)"
+else
+    fail "trailing-ws drift" "rc=$RC out=$(printf '%q' "$OUT")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 7 (#1204): CRLF-vs-LF drift matches via the normalized fallback. The file
+# uses CRLF line endings; the returned old_str spans two lines with LF endings.
+# Exact match fails; the normalized (CRLF->LF) fallback locates the unique span.
+# -----------------------------------------------------------------------------
+IN7="$(printf 'one\r\ntwo\r\nthree\r\n')"
+OUT="$(printf '%s' "$IN7" | APPLY_EDITS='[{"old_str":"one\ntwo","new_str":"ONE\nTWO"}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+# Expected: the matched two-line span is replaced by new_str (LF); the untouched
+# tail line keeps its original CRLF.
+EXP7="$(printf 'ONE\nTWO\r\nthree\r\n')"
+if [ "$RC" -eq 0 ] && [ "$OUT" = "$EXP7" ]; then
+    pass "CRLF-vs-LF drift matches via normalized fallback (#1204)"
+else
+    fail "CRLF/LF drift" "rc=$RC out=$(printf '%q' "$OUT") exp=$(printf '%q' "$EXP7")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 8 (#1204): genuinely absent old_str still loud-fails. No exact match AND
+# no normalized match -> non-zero exit, JSON error on stderr, NO stdout.
+# -----------------------------------------------------------------------------
+ERR_FILE="$(mktemp)"
+OUT="$(printf 'alpha\nbeta\n' | APPLY_EDITS='[{"old_str":"totally absent line","new_str":"x"}]' python3 "$APPLY" 2>"$ERR_FILE")" && RC=0 || RC=$?
+ERR="$(cat "$ERR_FILE")"; rm -f "$ERR_FILE"
+if [ "$RC" -ne 0 ] && [ -z "$OUT" ] && printf '%s' "$ERR" | grep -q '"error"'; then
+    pass "genuinely absent old_str still loud-fails under normalization (#1204)"
+else
+    fail "absent under normalization" "rc=$RC out=$(printf '%q' "$OUT") err=$(printf '%q' "$ERR")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 9 (#1204): ambiguous-under-normalization old_str still loud-fails. Two
+# file lines are identical except for trailing whitespace, so they collapse to
+# the same normalized line: a normalized old_str matching that line resolves to
+# >1 span -> loud failure, NO stdout. Uniqueness is the correctness guard.
+# -----------------------------------------------------------------------------
+ERR_FILE="$(mktemp)"
+# Lines 1 and 3 both normalize to "dup line" (each carries a DIFFERENT amount of
+# trailing whitespace: 1 space vs 2). The old_str "dup line   " (3 trailing
+# spaces) is a substring of NEITHER line, so exact match is 0; under
+# normalization it matches BOTH lines -> 2 spans -> loud failure, NO stdout.
+IN9="$(printf 'dup line \nmiddle\ndup line  \n')"
+OUT="$(printf '%s' "$IN9" | APPLY_EDITS='[{"old_str":"dup line   ","new_str":"X"}]' python3 "$APPLY" 2>"$ERR_FILE")" && RC=0 || RC=$?
+ERR="$(cat "$ERR_FILE")"; rm -f "$ERR_FILE"
+if [ "$RC" -ne 0 ] && [ -z "$OUT" ] && printf '%s' "$ERR" | grep -q '"error"'; then
+    pass "ambiguous-under-normalization old_str still loud-fails (#1204)"
+else
+    fail "ambiguous under normalization" "rc=$RC out=$(printf '%q' "$OUT") err=$(printf '%q' "$ERR")"
 fi
 
 echo ""

--- a/tools/test-start-colony-restart.sh
+++ b/tools/test-start-colony-restart.sh
@@ -385,6 +385,50 @@ SHIM
 
 test_no_duplicate_on_restart triage labeler
 
+# #1203: every colony's start-colony.sh must splice --prompt-timeout-s onto
+# BOTH daemon launch paths (the --restart-agent single-agent respawn AND the
+# normal per-agent loop). The daemon's --prompt-timeout-s (#649) defaults to
+# 120s and OVERRIDES llm.cli_timeout_ms; without it, large-context flat-cyborg
+# prompts (>120s, e.g. editing a ~47KB README) are killed as [llm.cancelled].
+# Pure source grep — no agentis runtime needed. We assert each script:
+#   - resolves a PROMPT_TIMEOUT_S value (the [colony].prompt_timeout_s parse).
+#   - carries `--prompt-timeout-s "$PROMPT_TIMEOUT_S"` on exactly TWO actual
+#     daemon-launch lines (restart path + normal-loop path), excluding the
+#     comment that documents the splice.
+test_prompt_timeout_flag() {
+    local colony="$1"
+    local script="$REPO_ROOT/dev-apprenticeship/$colony/scripts/start-colony.sh"
+
+    if [ ! -f "$script" ]; then
+        fail "$colony: start-colony.sh missing for prompt-timeout-s check" "$script"
+        return
+    fi
+
+    # shellcheck disable=SC2016  # grep pattern matching the literal source line; $ must not expand.
+    if ! grep -qF 'PROMPT_TIMEOUT_S="$(parse_toml colony prompt_timeout_s)"' "$script"; then
+        fail "$colony: start-colony.sh does not resolve [colony].prompt_timeout_s into PROMPT_TIMEOUT_S (#1203)"
+        return
+    fi
+
+    # Count the launch-line splices only (anchored to the indented continuation
+    # form `        --prompt-timeout-s "$PROMPT_TIMEOUT_S" \`), so the resolver
+    # comment that mentions the flag inline is not miscounted.
+    local launch_count
+    # shellcheck disable=SC2016  # grep pattern matching the literal source line; $ must not expand.
+    launch_count=$(grep -c '^        --prompt-timeout-s "\$PROMPT_TIMEOUT_S" \\$' "$script" || true)
+    if [ "$launch_count" = "2" ]; then
+        pass "$colony: --prompt-timeout-s spliced onto both daemon launch paths (#1203)"
+    else
+        fail "$colony: expected 2 --prompt-timeout-s launch splices (restart + normal), got $launch_count (#1203)"
+    fi
+}
+
+test_prompt_timeout_flag triage
+test_prompt_timeout_flag planning
+test_prompt_timeout_flag implementation
+test_prompt_timeout_flag code-review
+test_prompt_timeout_flag release
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1203. Closes #1204.

Two fixes that together let the federation edit large existing files end-to-end on **flat-cyborg** (found dogfooding a 47KB README edit; #1195 was necessary but not sufficient).

## #1203 — prompt timeout
`start-colony.sh` never passed `--prompt-timeout-s`, so the daemon used the 120s default (#649), which **overrides** `llm.cli_timeout_ms`. flat-cyborg large-context prompts round-trip >120s → killed (`[llm.cancelled]`). All 5 colonies now splice `--prompt-timeout-s` (both launch paths), resolved from `[colony].prompt_timeout_s` (default **300**). Flag added to colony-lint's allowlist.

## #1204 — apply-edits robust to whitespace drift
`apply-edits.py` required an EXACT byte match; flat-cyborg's screen-scrape drifts whitespace (trailing spaces, CRLF) → exact match failed every time (guard refused to commit — safe — but no completion). Added a **whitespace-normalized fallback** after the exact step: strip per-line trailing ws + CRLF→LF on both sides, match the normalized line-block, map the single match back to the **original** span and replace byte-verbatim outside it. **Exactly-once required at both steps** (uniqueness = correctness; absent/ambiguous still loud-fails, no stdout); leading/internal whitespace **not** collapsed (no mis-location). `code_writer` prompt tightened to copy `old_str` VERBATIM.

## Verification
- colony-lint **425 passed, 0 failed, 5 skipped**; apply-edits 9/0; start-colony-restart 31/0.
- QA: ✅ ship-it — span-mapping byte-correct, uniqueness preserved, loud-fail-no-stdout intact across absent/ambiguous/leading-indent probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)