### PR TITLE
fix(implementation): line-numbered range edits — model can't reproduce exact markdown anchors (#1208)

### DIFF
--- a/dev-apprenticeship/BUNDLE.manifest
+++ b/dev-apprenticeship/BUNDLE.manifest
@@ -86,6 +86,13 @@ tools/flat-cyborg-unwrap.py
 # the federation edit large existing files (e.g. a ~47KB README) without
 # regenerating the whole thing.
 tools/apply-edits.py
+# #1208: deterministic line-NUMBERED range applier. code_writer's autonomous
+# existing-file path now shows a `N|`-prefixed numbered view and asks the LLM
+# for line-range edits ({start_line,end_line,new_text}) — so the model never
+# has to reproduce exact source bytes (the markdown `**`-drop failure mode of
+# the search/replace anchors). This validates + splices the ranges into the
+# full file before commit-files.
+tools/apply-line-edits.py
 
 # ----- Federation dashboard -----
 # Extracted to a separately-versioned standalone component in #252.

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,29 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Changed
+
+- **`code_writer` edits existing files via line-numbered ranges, not byte-exact
+  search/replace** (#1208). The autonomous existing-file path used to fetch a
+  file (#1172) and ask the LLM for `{old_str, new_str}` edits whose `old_str`
+  had to reproduce the file's source BYTE-FOR-BYTE (#1195/#1204). On markdown
+  that fails: the model drops `**` markdown from the anchor, so `old_str` never
+  matches and the edit is silently dropped. Now the prompt shows a line-NUMBERED
+  view of the file (each line prefixed with `N|`, its 1-based line number) and
+  asks for the smallest set of NON-OVERLAPPING line-range replacements
+  (`{file_path, start_line, end_line, new_text}`; empty `new_text` deletes the
+  span) — so the model never reproduces exact source bytes, it only names line
+  numbers. A new deterministic helper `tools/apply-line-edits.py` reads the
+  UN-numbered content on stdin and the edits from `$LINE_EDITS`, validates
+  `1 <= start <= end <= nlines` and non-overlap, applies the ranges DESCENDING
+  by start_line (so an earlier replacement never shifts a later range's line
+  numbers), preserves every line outside the edited ranges byte-verbatim, and
+  prints the new full content. On any validation failure it fails loudly
+  (non-zero, JSON error on stderr, NO stdout — the corruption guard) so the
+  edit is dropped and `code_writer` does not commit (#1185 retries next tick).
+  New files keep the from-scratch full-content path unchanged. The old
+  search/replace `apply-edits.py` stays in the tree for other potential callers.
+
 ### Fixed
 
 - **Large existing-file edits now survive the flat-cyborg backend end-to-end**

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -121,6 +121,51 @@ fn apply_edits_to_actions(path: string, orig: string, edits: string) -> string {
     return out;
 }
 
+// #1208: render a line-NUMBERED view of the file content for the edit prompt.
+// Each line gets an `N|` prefix (N = 1-based line number) so the LLM can name
+// line-range edits without ever reproducing exact source bytes (the markdown
+// `**`-drop failure mode of the search/replace path). The UN-numbered content
+// rides $C (env var, off-argv) so ARG_MAX never bites; splitlines() keepends is
+// not needed here because the numbered view is a display artifact, not content.
+fn numbered_view(content: string) -> string {
+    // colony-lint: safe-exec-concat
+    let cmd = "C=" + shell_escape(content) +
+        " python3 -c 'import os,sys" +
+        "\ntext=os.environ[\"C\"]" +
+        "\nlines=text.splitlines()" +
+        "\nsys.stdout.write(\"\\n\".join(\"%d|%s\" % (i+1, ln) for i,ln in enumerate(lines)))'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+// #1208: deterministically turn (existing UN-numbered content, LLM line-range
+// edits) into the `--actions` JSON commit-files expects, WITHOUT the LLM ever
+// reproducing source bytes. tools/apply-line-edits.py reads the original content
+// on stdin and the edits JSON from $LINE_EDITS ([{start_line,end_line,new_text}],
+// 1-based inclusive; empty new_text deletes), validates 1<=start<=end<=nlines and
+// NON-OVERLAPPING, applies descending-by-start so earlier replacements don't shift
+// later ranges, and prints the new full content; we then json.dumps a single
+// [{action:"update", file_path, content}] array. Large values (fetched file +
+// edits) ride env vars / a pipe (`printf`, a shell builtin), never argv. If
+// apply-line-edits.py exits non-zero (out-of-bounds / overlapping — the
+// validation guard) the whole `exec sh` exits non-zero and the caller's `try`
+// collapses to "" => treated as a failed code-gen, no commit. `path` is
+// shell_escape'd; `orig` and `edits` are passed as env vars so the body itself
+// carries no untrusted concatenation.
+fn apply_line_edits_to_actions(path: string, orig: string, edits: string) -> string {
+    // colony-lint: safe-exec-concat
+    let cmd = "ORIG=" + shell_escape(orig) + " LINE_EDITS=" + shell_escape(edits) +
+        " FP=" + shell_escape(path) +
+        " python3 -c 'import os,sys,subprocess,json" +
+        "\ntools=os.path.join(os.environ[\"COLONY_DIR\"], \"..\", \"..\", \"tools\", \"apply-line-edits.py\")" +
+        "\np=subprocess.run([sys.executable, tools], input=os.environ[\"ORIG\"], capture_output=True, text=True, env=os.environ)" +
+        "\nif p.returncode != 0:" +
+        "\n    sys.stderr.write(p.stderr); sys.exit(1)" +
+        "\nprint(json.dumps([{\"action\": \"update\", \"file_path\": os.environ[\"FP\"], \"content\": p.stdout}]))'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
 fn merged_mr_cmd(owner: string, repo: string) -> string {
     let ts = recall_latest(scoped_memo(owner, repo, "code_writer:last_check"));
     // colony-lint: safe-exec-concat
@@ -336,30 +381,34 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                         "";
                     };
 
-                    // #1195: when the primary file ALREADY EXISTS, do NOT ask the
+                    // #1208: when the primary file ALREADY EXISTS, do NOT ask the
                     // LLM to regenerate the whole file (large output -> timeout on
-                    // claude, line-wrap corruption on flat-cyborg). Ask only for a
-                    // small JSON array of search/replace edits, then assemble the
-                    // full file deterministically via apply-edits.py. The actions
-                    // JSON is built by json.dumps, not the LLM, so the committed
-                    // content is fragility-free. For a NEW file we keep the
-                    // from-scratch full-content path unchanged.
+                    // claude, line-wrap corruption on flat-cyborg) NOR to reproduce
+                    // exact source bytes as a search/replace anchor (the model drops
+                    // `**` markdown from anchors, so old_str never matched). Instead
+                    // show a line-NUMBERED view (`N|` prefix) and ask for line-RANGE
+                    // edits ({start_line,end_line,new_text}); apply-line-edits.py
+                    // splices them in deterministically. The actions JSON is built by
+                    // json.dumps, not the LLM, so the committed content is
+                    // fragility-free. For a NEW file we keep the from-scratch
+                    // full-content path unchanged.
                     let actions_json = if len(existing_content) > 0 {
+                        let numbered = numbered_view(existing_content);
                         let edit_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec) +
-                            "\nCurrent content of " + primary_path + " (edit THIS file):\n" + existing_content;
+                            "\nCurrent content of " + primary_path + " (edit THIS file; each line is prefixed with its 1-based line number as `N|`):\n" + numbered;
                         let edits_json = prompt(
-                            "You are a code writer editing an EXISTING file. Make the smallest edits that satisfy the task. Return a JSON array of edits, each object with: file_path (string), old_str (string), new_str (string, the replacement). For old_str: copy it VERBATIM from the shown current file content — character for character, including every space, tab, indentation, and line break exactly as displayed. Do NOT paraphrase, reflow, re-indent, trim, or otherwise alter it. Each old_str must be UNIQUE in the file (occur exactly once); include enough surrounding lines of context to guarantee uniqueness. Do NOT return the whole file. Return ONLY the raw JSON array — no markdown code fences, no ```json wrapper, no prose.",
+                            "You are a code writer editing an EXISTING file. Make the smallest edits that satisfy the task. Use the line numbers shown (the `N|` prefix; the `N|` is NOT part of the file content). Return the smallest set of NON-OVERLAPPING line-range replacements as a JSON array, each object with: file_path (string), start_line (int), end_line (int), new_text (string). new_text is the FULL replacement for lines start_line..end_line (inclusive); empty new_text deletes them. Do NOT include the `N|` prefix in new_text. Do NOT return the whole file. Return ONLY the raw JSON array — no markdown code fences, no ```json wrapper, no prose.",
                             edit_context
                         ) -> string;
-                        // Deterministic apply: old_str must match the real file
-                        // exactly-once or apply-edits.py fails loudly and this
+                        // Deterministic apply: line ranges must be in-bounds and
+                        // non-overlapping or apply-line-edits.py fails loudly and this
                         // returns "" => treated as a failed code-gen below (no
                         // commit; #1185 retry re-runs the issue next tick).
-                        let assembled = apply_edits_to_actions(primary_path, existing_content, edits_json);
+                        let assembled = apply_line_edits_to_actions(primary_path, existing_content, edits_json);
                         if len(assembled) > 0 {
                             assembled;
                         } else {
-                            print("[code_writer] apply-edits failed (old_str did not match exactly once) — not committing; will retry");
+                            print("[code_writer] apply-line-edits failed (out-of-bounds or overlapping ranges) — not committing; will retry");
                             "";
                         };
                     } else {
@@ -379,10 +428,10 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                             // #1152: a recurring cause is an unparseable --actions JSON.
                             // Code generation is fidelity-critical: a TUI screen-scrape
                             // backend (flat-cyborg) corrupts the structured JSON of file
-                            // contents. The #1195 search/replace edit path keeps LLM
-                            // output small (works on flat-cyborg); a from-scratch NEW
-                            // file still wants the metered `claude -p` backend for the
-                            // large content (see README "Code-generation fidelity").
+                            // contents. The #1208 line-range edit path keeps LLM output
+                            // small (works on flat-cyborg); a from-scratch NEW file still
+                            // wants the metered `claude -p` backend for the large content
+                            // (see README "Code-generation fidelity").
                             print("[code_writer] hint: if this is an '--actions JSON' parse error, code-gen needs a fidelity backend (claude -p), not the flat-cyborg screen-scrape — see README");
                             "";
                         };

--- a/tools/apply-line-edits.py
+++ b/tools/apply-line-edits.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# tools/apply-line-edits.py (#1208): deterministically apply a list of
+# line-numbered RANGE edits to a file's content and emit the new full content.
+#
+# Why this exists: code_writer's autonomous existing-file path used to ask the
+# LLM for search/replace edits whose `old_str` had to reproduce the file's
+# source BYTE-FOR-BYTE (apply-edits.py, #1195/#1204). On markdown that fails:
+# the model drops `**` markdown from the anchor, so old_str never matches and
+# the edit is dropped. Line-NUMBERED range edits remove the failure mode
+# entirely — the model never has to reproduce exact source bytes, it only
+# names the line numbers to replace (the prompt shows a `N|`-prefixed view).
+# THIS script then splices the replacement text in deterministically.
+#
+# Contract:
+#   - The original file content arrives on stdin (large content travels via
+#     a pipe, never argv, to dodge ARG_MAX).
+#   - The edits JSON array arrives in the LINE_EDITS env var (also off-argv;
+#     edits can themselves be large). Each edit is
+#       {"start_line": int, "end_line": int, "new_text": str}
+#     with 1-based, inclusive line numbers; new_text may be multi-line, or
+#     empty to DELETE the [start_line, end_line] span.
+#   - On success: the new full content is written to stdout, exit 0.
+#   - On any validation failure: a JSON `{"error": "..."}` is written to
+#     stderr, exit non-zero, and NOTHING is written to stdout (no partial /
+#     garbage content — the corruption guard).
+#
+# Validation (any failure -> loud, non-zero, NO stdout):
+#   - LINE_EDITS is a non-empty JSON array of objects, each carrying integer
+#     start_line / end_line and a string new_text.
+#   - 1 <= start_line <= end_line <= len(lines) for every edit.
+#   - Edits are NON-OVERLAPPING (sorted by start_line, no span intersects the
+#     next). Overlap is ambiguous -> fail rather than guess.
+#
+# Application: edits are applied sorted DESCENDING by start_line, so replacing
+# an earlier range never shifts the (already-validated) line numbers of a
+# later range. For each edit, lines[start-1 : end] is replaced by new_text
+# split back into lines; the original span's trailing newline boundary is
+# preserved so a multi-line block edit keeps the file's line structure and we
+# neither drop nor double a newline at the splice. Every line OUTSIDE an edited
+# range stays byte-verbatim.
+
+import json
+import os
+import sys
+
+
+def fail(msg):
+    sys.stderr.write(json.dumps({"error": msg}))
+    sys.stderr.write("\n")
+    sys.exit(1)
+
+
+def _split_replacement(new_text, trailer):
+    # Turn new_text into the list of replacement lines to splice in, preserving
+    # the spliced block's trailing newline boundary. We mirror apply-edits.py's
+    # careful trailer handling: re-attach the original span's terminator only
+    # when new_text does not already supply one, so the edited block neither
+    # drops nor doubles a trailing newline.
+    #
+    # `trailer` is "\r\n", "\n", or "" — the line terminator of the LAST
+    # original line in the replaced span. An empty new_text yields no lines
+    # (a pure deletion of the span).
+    if new_text == "":
+        return []
+    if trailer and not new_text.endswith(("\r\n", "\n")):
+        new_text = new_text + trailer
+    return new_text.splitlines(keepends=True)
+
+
+def main():
+    content = sys.stdin.read()
+
+    raw = os.environ.get("LINE_EDITS", "")
+    if raw.strip() == "":
+        fail("LINE_EDITS env var is empty (expected a JSON array of edits)")
+
+    try:
+        edits = json.loads(raw)
+    except Exception as e:
+        fail("LINE_EDITS is not valid JSON: " + str(e))
+
+    if not isinstance(edits, list):
+        fail("LINE_EDITS must be a JSON array of edits")
+
+    if len(edits) == 0:
+        fail("LINE_EDITS is an empty array (no edits to apply)")
+
+    # Preserve each original line's exact terminator so every line OUTSIDE an
+    # edited range is rebuilt byte-verbatim.
+    lines = content.splitlines(keepends=True)
+    n = len(lines)
+
+    # Validate and normalize every edit before touching the content. We build a
+    # list of (start, end, new_text) tuples with 1-based inclusive bounds.
+    norm = []
+    for i, edit in enumerate(edits):
+        if not isinstance(edit, dict):
+            fail("edit %d is not an object" % i)
+        if "start_line" not in edit or "end_line" not in edit or "new_text" not in edit:
+            fail("edit %d is missing 'start_line', 'end_line', or 'new_text'" % i)
+        start = edit["start_line"]
+        end = edit["end_line"]
+        new_text = edit["new_text"]
+        # bool is a subclass of int; reject it so True/False can't pose as a
+        # line number.
+        if isinstance(start, bool) or not isinstance(start, int):
+            fail("edit %d 'start_line' must be an integer" % i)
+        if isinstance(end, bool) or not isinstance(end, int):
+            fail("edit %d 'end_line' must be an integer" % i)
+        if not isinstance(new_text, str):
+            fail("edit %d 'new_text' must be a string" % i)
+        if start < 1:
+            fail("edit %d: start_line %d is < 1 (lines are 1-based)" % (i, start))
+        if end < start:
+            fail("edit %d: end_line %d < start_line %d" % (i, end, start))
+        if end > n:
+            fail("edit %d: end_line %d exceeds file line count %d" % (i, end, n))
+        norm.append((start, end, new_text))
+
+    # Non-overlap check: sort by start_line, then assert each span ends strictly
+    # before the next one begins. Equal/overlapping spans are ambiguous -> fail.
+    by_start = sorted(norm, key=lambda t: t[0])
+    for j in range(1, len(by_start)):
+        prev_end = by_start[j - 1][1]
+        cur_start = by_start[j][0]
+        if cur_start <= prev_end:
+            fail("edits overlap: span ending at line %d intersects span starting "
+                 "at line %d (edits must be non-overlapping)" % (prev_end, cur_start))
+
+    # Apply DESCENDING by start_line so replacing an earlier range never shifts
+    # the line indices of a later (not-yet-applied) range.
+    for start, end, new_text in sorted(by_start, key=lambda t: t[0], reverse=True):
+        span_last = lines[end - 1]
+        if span_last.endswith("\r\n"):
+            trailer = "\r\n"
+        elif span_last.endswith("\n"):
+            trailer = "\n"
+        else:
+            trailer = ""
+        replacement = _split_replacement(new_text, trailer)
+        lines[start - 1:end] = replacement
+
+    sys.stdout.write("".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test-apply-line-edits.sh
+++ b/tools/test-apply-line-edits.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# tools/test-apply-line-edits.sh (#1208): unit-test the deterministic
+# line-numbered range applier tools/apply-line-edits.py.
+#
+# Background (#1208): code_writer's autonomous existing-file path used to ask
+# the LLM for search/replace edits whose `old_str` had to reproduce the file's
+# source BYTE-FOR-BYTE. On markdown that fails — the model drops `**` markdown
+# from the anchor, so old_str never matches. The fix is line-NUMBERED range
+# edits: the model names the line numbers to replace (a `N|`-prefixed view is
+# shown in the prompt) and never reproduces exact source bytes. apply-line-
+# edits.py splices the replacement text in deterministically.
+#
+# Contract under test:
+#   - original content on stdin, edits JSON in $LINE_EDITS, new content on
+#     stdout (large values ride a pipe / env var, never argv -> no ARG_MAX).
+#   - edits = [{"start_line": int, "end_line": int, "new_text": str}], 1-based
+#     inclusive; new_text may be multi-line or empty (deletion).
+#   - validation: 1 <= start <= end <= nlines, NON-OVERLAPPING. Any failure ->
+#     non-zero exit, JSON {"error": ...} on stderr, and NO stdout.
+#   - edits apply DESCENDING by start_line so an earlier replacement never
+#     shifts a later range's line numbers; lines outside ranges stay verbatim.
+#
+# Cases:
+#   1. single in-range replace.
+#   2. multiple in-range replaces (two disjoint single-line spans).
+#   3. descending-apply offset correctness: a multi-line replace at an earlier
+#      line must NOT shift the later edit's line numbers.
+#   4. deletion (empty new_text) drops the span.
+#   5. out-of-bounds start<1 loud-fails (non-zero, JSON error, no stdout).
+#   6. out-of-bounds end>nlines loud-fails.
+#   7. overlapping ranges loud-fail.
+#   8. large (~50KB) content round-trips; one mid-file line edited, rest verbatim.
+#   9. lines outside the edited range are byte-verbatim (terminators preserved).
+#
+# Auto-discovered by tools/colony-lint.sh's tools-test loop. Exit 0 if all pass.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APPLY="$SCRIPT_DIR/apply-line-edits.py"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[SKIP] test-apply-line-edits.sh: python3 not on PATH"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (skipped)"
+    exit 0
+fi
+if [ ! -f "$APPLY" ]; then
+    fail "missing applier: $APPLY"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Case 1: single in-range replace.
+# -----------------------------------------------------------------------------
+OUT="$(printf 'one\ntwo\nthree\n' | LINE_EDITS='[{"start_line":2,"end_line":2,"new_text":"TWO"}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+EXP1="$(printf 'one\nTWO\nthree')"
+if [ "$RC" -eq 0 ] && [ "$OUT" = "$EXP1" ]; then
+    pass "single in-range replace"
+else
+    fail "single in-range replace" "rc=$RC out=$(printf '%q' "$OUT")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 2: multiple in-range replaces (two disjoint single-line spans).
+# -----------------------------------------------------------------------------
+OUT="$(printf 'a\nb\nc\nd\n' | LINE_EDITS='[{"start_line":1,"end_line":1,"new_text":"A"},{"start_line":3,"end_line":3,"new_text":"C"}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+EXP2="$(printf 'A\nb\nC\nd')"
+if [ "$RC" -eq 0 ] && [ "$OUT" = "$EXP2" ]; then
+    pass "multiple in-range replaces apply correctly"
+else
+    fail "multiple replaces" "rc=$RC out=$(printf '%q' "$OUT")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 3: descending-apply offset correctness. Replace line 1 with a THREE-line
+# block AND replace line 3 with one line, in a single call. If edits applied
+# ascending, growing line 1 would shift line 3's target; applying descending
+# (line 3 first, then line 1) keeps both anchored to the ORIGINAL numbers.
+# Original: a/b/c -> edit1 {1,1 -> "X\nY\nZ"}, edit2 {3,3 -> "C"}.
+# Correct result: X/Y/Z/b/C  (NOT X/Y/Z/C/b or a shifted "c").
+# -----------------------------------------------------------------------------
+OUT="$(printf 'a\nb\nc\n' | LINE_EDITS='[{"start_line":1,"end_line":1,"new_text":"X\nY\nZ"},{"start_line":3,"end_line":3,"new_text":"C"}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+EXP3="$(printf 'X\nY\nZ\nb\nC')"
+if [ "$RC" -eq 0 ] && [ "$OUT" = "$EXP3" ]; then
+    pass "descending-apply: earlier multi-line replace does not shift later edit's line numbers"
+else
+    fail "descending-apply offset" "rc=$RC out=$(printf '%q' "$OUT") exp=$(printf '%q' "$EXP3")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 4: deletion (empty new_text) drops the span.
+# -----------------------------------------------------------------------------
+OUT="$(printf 'keep1\ndrop\nkeep2\n' | LINE_EDITS='[{"start_line":2,"end_line":2,"new_text":""}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+EXP4="$(printf 'keep1\nkeep2')"
+if [ "$RC" -eq 0 ] && [ "$OUT" = "$EXP4" ]; then
+    pass "deletion (empty new_text) drops the span"
+else
+    fail "deletion" "rc=$RC out=$(printf '%q' "$OUT")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 5: out-of-bounds start<1 loud-fails (non-zero, JSON error, NO stdout).
+# -----------------------------------------------------------------------------
+ERR_FILE="$(mktemp)"
+OUT="$(printf 'one\ntwo\n' | LINE_EDITS='[{"start_line":0,"end_line":1,"new_text":"x"}]' python3 "$APPLY" 2>"$ERR_FILE")" && RC=0 || RC=$?
+ERR="$(cat "$ERR_FILE")"; rm -f "$ERR_FILE"
+if [ "$RC" -ne 0 ] && [ -z "$OUT" ] && printf '%s' "$ERR" | grep -q '"error"'; then
+    pass "out-of-bounds start<1 fails loudly (non-zero, JSON error, no stdout)"
+else
+    fail "start<1 out-of-bounds" "rc=$RC out=$(printf '%q' "$OUT") err=$(printf '%q' "$ERR")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 6: out-of-bounds end>nlines loud-fails.
+# -----------------------------------------------------------------------------
+ERR_FILE="$(mktemp)"
+OUT="$(printf 'one\ntwo\n' | LINE_EDITS='[{"start_line":1,"end_line":5,"new_text":"x"}]' python3 "$APPLY" 2>"$ERR_FILE")" && RC=0 || RC=$?
+ERR="$(cat "$ERR_FILE")"; rm -f "$ERR_FILE"
+if [ "$RC" -ne 0 ] && [ -z "$OUT" ] && printf '%s' "$ERR" | grep -q '"error"'; then
+    pass "out-of-bounds end>nlines fails loudly (non-zero, JSON error, no stdout)"
+else
+    fail "end>nlines out-of-bounds" "rc=$RC out=$(printf '%q' "$OUT") err=$(printf '%q' "$ERR")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 7: overlapping ranges loud-fail (ambiguous -> never guess, NO stdout).
+# Spans [1,2] and [2,3] share line 2.
+# -----------------------------------------------------------------------------
+ERR_FILE="$(mktemp)"
+OUT="$(printf 'a\nb\nc\n' | LINE_EDITS='[{"start_line":1,"end_line":2,"new_text":"x"},{"start_line":2,"end_line":3,"new_text":"y"}]' python3 "$APPLY" 2>"$ERR_FILE")" && RC=0 || RC=$?
+ERR="$(cat "$ERR_FILE")"; rm -f "$ERR_FILE"
+if [ "$RC" -ne 0 ] && [ -z "$OUT" ] && printf '%s' "$ERR" | grep -q '"error"'; then
+    pass "overlapping ranges fail loudly (non-zero, JSON error, no stdout)"
+else
+    fail "overlapping ranges" "rc=$RC out=$(printf '%q' "$OUT") err=$(printf '%q' "$ERR")"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 8: large content (~50KB) round-trips via env/stdin. Build 2000 unique
+# lines, edit one mid-file line by NUMBER, confirm that line changed and every
+# other line is preserved verbatim. Content rides a pipe (stdin); edits ride
+# $LINE_EDITS — never argv.
+# -----------------------------------------------------------------------------
+BIG="$(python3 -c 'import sys; sys.stdout.write("".join("line %05d filler text here\n" % i for i in range(2000)))')"
+# Edit line 1000 (1-based). Expected: that one line becomes EDITED_MARKER.
+EXP8="$(python3 -c 'import sys
+lines=["line %05d filler text here" % i for i in range(2000)]
+lines[999]="EDITED_MARKER"
+sys.stdout.write("\n".join(lines)+"\n")')"
+OUT="$(printf '%s' "$BIG" | LINE_EDITS='[{"start_line":1000,"end_line":1000,"new_text":"EDITED_MARKER"}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+if [ "$RC" -eq 0 ] && [ "$OUT" = "$EXP8" ]; then
+    pass "large content round-trips via env/stdin (~50KB, line-1000 edit, rest preserved)"
+else
+    fail "large content" "rc=$RC bytes_in=$(printf '%s' "$BIG" | wc -c) bytes_out=$(printf '%s' "$OUT" | wc -c)"
+fi
+
+# -----------------------------------------------------------------------------
+# Case 9: lines OUTSIDE the edited range are byte-verbatim, terminators and all.
+# Use a mix of content + a no-final-newline last line; edit only the middle and
+# confirm the head/tail bytes are untouched.
+# -----------------------------------------------------------------------------
+IN9="$(printf 'header line\nmiddle to change\nfooter line')"
+OUT="$(printf '%s' "$IN9" | LINE_EDITS='[{"start_line":2,"end_line":2,"new_text":"CHANGED"}]' python3 "$APPLY" 2>/dev/null)"
+RC=$?
+EXP9="$(printf 'header line\nCHANGED\nfooter line')"
+if [ "$RC" -eq 0 ] && [ "$OUT" = "$EXP9" ]; then
+    pass "lines outside the edited range stay byte-verbatim (no-final-newline tail preserved)"
+else
+    fail "outside-range verbatim" "rc=$RC out=$(printf '%q' "$OUT") exp=$(printf '%q' "$EXP9")"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-github-implementation-robustness.sh
+++ b/tools/test-github-implementation-robustness.sh
@@ -332,10 +332,11 @@ else
 fi
 
 # =============================================================================
-# #1172 / #1195: code_writer.ag wires get-file into the code-gen context AND,
-# when the file already exists, requests SMALL search/replace edits (not a
-# whole-file regeneration) and applies them deterministically before commit.
-# Grep-level wiring assertions.
+# #1172 / #1208: code_writer.ag wires get-file into the code-gen context AND,
+# when the file already exists, shows a line-NUMBERED view and requests
+# line-RANGE edits (not a whole-file regeneration, not byte-exact search/replace
+# anchors) and applies them deterministically before commit. Grep-level wiring
+# assertions.
 # =============================================================================
 CW_AG="$REPO_ROOT/dev-apprenticeship/implementation/agents/code_writer.ag"
 if grep -q "get-file --path" "$CW_AG"; then
@@ -344,24 +345,25 @@ else
     fail "#1172 code_writer.ag: no 'get-file --path' fetch found before code-gen"
 fi
 
-# #1195: the existing-file code-gen prompt must request search/replace edits
-# (old_str / new_str), NOT a full-file rewrite — small LLM output is what makes
-# the path work on flat-cyborg's screen-scrape backend.
-if grep -q "old_str" "$CW_AG" && grep -q "new_str" "$CW_AG"; then
-    pass "#1195 code_writer.ag: existing-file path requests search/replace edits (old_str/new_str)"
+# #1208: the existing-file path must present a line-NUMBERED view of the file
+# (numbered_view -> `N|` prefix) and request line-RANGE edits
+# (start_line / end_line / new_text), so the model never reproduces exact source
+# bytes (the markdown `**`-drop failure mode of the old old_str/new_str path).
+if grep -q "numbered_view(" "$CW_AG" && grep -q "start_line" "$CW_AG" && grep -q "end_line" "$CW_AG" && grep -q "new_text" "$CW_AG"; then
+    pass "#1208 code_writer.ag: existing-file path shows a numbered view and requests line-range edits (start_line/end_line/new_text)"
 else
-    fail "#1195 code_writer.ag: existing-file edit prompt missing old_str/new_str search-replace request"
+    fail "#1208 code_writer.ag: existing-file edit prompt missing numbered_view / line-range fields"
 fi
 
-# #1195: those edits must be applied deterministically (apply_edits_to_actions
-# -> tools/apply-edits.py) to assemble the full file BEFORE commit-files runs,
-# so the committed content never depends on fragile large LLM output.
-apply_line="$(grep -n "apply_edits_to_actions(" "$CW_AG" | tail -1 | cut -d: -f1)"
+# #1208: those edits must be applied deterministically (apply_line_edits_to_actions
+# -> tools/apply-line-edits.py) to assemble the full file BEFORE commit-files
+# runs, so the committed content never depends on fragile large LLM output.
+apply_line="$(grep -n "apply_line_edits_to_actions(" "$CW_AG" | tail -1 | cut -d: -f1)"
 commit_line="$(grep -n "commit-files --branch" "$CW_AG" | head -1 | cut -d: -f1)"
 if [ -n "$apply_line" ] && [ -n "$commit_line" ] && [ "$apply_line" -lt "$commit_line" ]; then
-    pass "#1195 code_writer.ag: applies edits (apply_edits_to_actions) before commit-files"
+    pass "#1208 code_writer.ag: applies line edits (apply_line_edits_to_actions) before commit-files"
 else
-    fail "#1195 code_writer.ag: edits not deterministically applied before commit-files"
+    fail "#1208 code_writer.ag: line edits not deterministically applied before commit-files"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #1208.

**Diagnosed root cause** of the apply-edits failures editing a markdown README: the model doesn't reproduce exact source bytes in `old_str` — it drops markdown `**` from anchors (returned `GitLab polling:` where the file has `**GitLab polling**:`). Search/replace exact-match fails. Model-faithfulness limit (would fail on `claude -p` too), **not** flat-cyborg corruption; fuzzy-matching markdown would erode the uniqueness guard.

## Fix — line-numbered range edits (model never reproduces existing bytes)
- `code_writer` shows the fetched file as `N|`-prefixed numbered lines and requests `[{start_line,end_line,new_text}]` non-overlapping range replacements. The model **names line numbers + writes only the replacement**; the file's own bytes are kept for everything outside the ranges → markdown faithfulness is a non-issue.
- `tools/apply-line-edits.py`: validates `1<=start<=end<=nlines` + non-overlap, applies **descending** (no offset shift), lines outside ranges **byte-verbatim**. Loud-fail (rc≠0, **no stdout**) on any bad range → no commit → #1185 retry (corruption guard holds).
- New-file from-scratch path unchanged; old `apply-edits.py` kept (no #1195 regression).

## Verification
- colony-lint **426 passed, 0 failed, 5 skipped**; apply-line-edits 9/0, robustness 18/0, completion-markers 7/0, bundle 11/0.
- QA: ✅ ship-it, no findings (23 scenarios: byte-identity outside ranges, descending-apply offset, loud-fail-no-stdout on all paths, `**bold**` survives, `N|` never in committed content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)