### PR TITLE
feat(implementation): Approach A — Claude Code edits a local checkout, federation commits the diff (#1210)

### DIFF
--- a/dev-apprenticeship/BUNDLE.manifest
+++ b/dev-apprenticeship/BUNDLE.manifest
@@ -93,6 +93,12 @@ tools/apply-edits.py
 # the search/replace anchors). This validates + splices the ranges into the
 # full file before commit-files.
 tools/apply-line-edits.py
+# #1210: checkout-edit orchestrator. code_writer's autonomous path now drives
+# Claude Code (via flat-cyborg) to edit files DIRECTLY in a local git checkout,
+# then commits the `git diff` and opens the PR — sidestepping flat-cyborg's TUI
+# screen-scrape corruption of large structured-JSON file content (#1152 /
+# #1195 / #1208). Runtime dep: code_writer.ag invokes it via exec sh.
+tools/code-edit-in-checkout.sh
 
 # ----- Federation dashboard -----
 # Extracted to a separately-versioned standalone component in #252.

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,33 @@ is asserted until multi-version CI is in place.
 
 ### Changed
 
+- **`code_writer`'s autonomous path edits a local checkout and commits the
+  `git diff`, instead of generating edit-JSON and committing via the forge API**
+  (#1210, Approach A). The old autonomous chain (`create-branch` → `get-file` →
+  line-numbered view → line-range `prompt()` → `apply-line-edits.py` →
+  `commit-files` through the GitHub Git Database API) round-tripped file CONTENT
+  through flat-cyborg's TUI screen-scrape, which line-wraps and corrupts large
+  files (#1152 / #1195 / #1208). The new path drives Claude Code (via
+  flat-cyborg, still the ONLY backend — `claude -p` is not used) as an EDITING
+  agent inside a real git checkout: a new orchestrator
+  `tools/code-edit-in-checkout.sh` clones/refreshes a per-colony workspace
+  (`<fed>/.agentis/workspaces/<colony>/<owner>-<repo>`), checks out a
+  deterministic per-issue branch (`fix/issue-<iid>`, reused on retry), runs
+  `flat-cyborg --no-jitter --auto-approve --cwd <checkout> --cmd-file <task>
+  -- claude` so claude's own file tools touch the working tree, then `git add -A`
+  + commits the diff and opens the PR. If claude changed nothing it prints
+  `NO_EDITS` and exits 3 (the caller retries, no empty PR); the token is read
+  from `GITHUB_TOKEN` and never embedded in a remote URL, argv, or any `set -x`
+  trace (it flows only through a `GIT_ASKPASS` helper and the inherited
+  environment). `code_writer.ag`'s autonomous branch now makes a single
+  `exec sh` call to the orchestrator, emits `implementation:mr_ready` on
+  success, and sets the #1185 completion markers only when a PR was opened
+  (NO_EDITS / failure leaves them unset so the next tick retries). New files are
+  handled by the same orchestrator (claude creates them in the checkout) — no
+  separate from-scratch path. The autonomous path no longer hands off to
+  `commit_composer` via `implementation:pending_mr` (it opens the PR itself);
+  the durable-handoff machinery stays in `commit_composer` for other callers.
+  The review-gated / propose / shadow paths are unchanged.
 - **`code_writer` edits existing files via line-numbered ranges, not byte-exact
   search/replace** (#1208). The autonomous existing-file path used to fetch a
   file (#1172) and ask the LLM for `{old_str, new_str}` edits whose `old_str`

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -352,117 +352,55 @@ fn tick_for_repo(owner: string, repo: string) -> void {
             print("[code_writer] Drafted code for issue", draft.issue_id, "(tier:", my_tier, ")");
 
             if my_tier == "autonomous" {
-                // Create branch
+                // #1210: Approach A — edit files DIRECTLY in a local checkout via
+                // Claude Code (flat-cyborg), then commit the `git diff` and open
+                // the PR. This replaces the old "create-branch -> get-file ->
+                // numbered_view -> line-range prompt() -> apply-line-edits.py ->
+                // commit-files via the forge Git Database API" chain. That chain
+                // round-tripped file CONTENT through flat-cyborg's TUI screen-
+                // scrape, which line-wraps and corrupts large files (#1152 /
+                // #1195 / #1208). Editing in a real checkout sidesteps the
+                // screen-scrape: claude's own file tools touch the working tree
+                // and we commit whatever git shows. The editing prompt now lives
+                // INSIDE the orchestrator's flat-cyborg invocation, NOT as an .ag
+                // prompt() — so this branch has no prompt() at all. flat-cyborg
+                // stays the only backend; `claude -p` is not used.
+                //
+                // Deterministic per-issue branch (fix/issue-<iid>) so a retry
+                // reuses the same branch instead of littering empty branches.
+                let issue_iid = to_string(draft.issue_id);
+                let branch_name = "fix/issue-" + issue_iid;
                 // colony-lint: safe-exec-concat
-                let branch_cmd = "$COLONY_DIR/scripts/forge-api.sh create-branch --name " + shell_escape(draft.branch_name) + " --ref main" + repo_arg(owner, repo);
-                let branch_result = try { exec sh branch_cmd; } catch e {
-                    print("[code_writer] Branch creation failed:", e);
+                let issue_cmd = "$COLONY_DIR/scripts/forge-api.sh issue " + to_string(draft.issue_id) + repo_arg(owner, repo);
+                let issue_detail = try { exec sh issue_cmd; } catch e { ""; };
+                // Task text = issue body + the drafted plan. The orchestrator
+                // wraps this into the claude editing instruction.
+                let task_text = "Issue:\n" + issue_detail + "\n\nPlan:\n" + draft.files + "\n\n" + draft.summary;
+                // The orchestrator handles both new-file and existing-file cases
+                // (claude creates or edits files in the checkout). It exits 0 with
+                // the PR URL on success, 3 (no edits) when claude changed nothing,
+                // and non-zero otherwise — `exec sh` throws on any non-zero, so
+                // the catch covers both NO_EDITS and hard failures; either way we
+                // leave the #1185 markers unset so the next tick retries.
+                // colony-lint: safe-exec-concat
+                let edit_cmd = "$COLONY_DIR/../../tools/code-edit-in-checkout.sh --owner " + shell_escape(owner) + " --repo " + shell_escape(repo) + " --issue " + shell_escape(issue_iid) + " --branch " + shell_escape(branch_name) + " --title " + shell_escape(draft.summary) + " --task " + shell_escape(task_text);
+                let edit_result = try { exec sh edit_cmd; } catch e {
+                    print("[code_writer] code-edit-in-checkout failed or produced no edits (NO_EDITS / error) — not marking drafted, will retry:", e);
                     "";
                 };
 
-                if len(branch_result) > 0 {
-                    // Generate actual code and commit it to the branch
-                    // colony-lint: safe-exec-concat
-                    let issue_cmd = "$COLONY_DIR/scripts/forge-api.sh issue " + to_string(draft.issue_id) + repo_arg(owner, repo);
-                    let issue_detail = try { exec sh issue_cmd; } catch e { ""; };
-
-                    // #1172: before generating file contents from scratch, fetch
-                    // the existing content of the plan's primary file so an EDIT
-                    // task preserves everything it is not changing instead of
-                    // clobbering the file. get-file returns empty (exit 0) when
-                    // the file is new. Single-file fetch only — see
-                    // primary_file_path() for why multi-file is out of scope.
-                    let primary_path = primary_file_path(draft.files);
-                    let existing_content = if len(primary_path) > 0 {
-                        // colony-lint: safe-exec-concat
-                        let getfile_cmd = "$COLONY_DIR/scripts/forge-api.sh get-file --path " + shell_escape(primary_path) + " --ref main" + repo_arg(owner, repo);
-                        try { exec sh getfile_cmd; } catch e { ""; };
+                if len(edit_result) > 0 {
+                    // #1185: mark drafted only now that the PR opened. A NO_EDITS
+                    // (exit 3) or any failure leaves edit_result == "" so the
+                    // markers stay unset and the next tick retries the issue.
+                    memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_iid"), first_iid_str);
+                    memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_updated_at"), first_upd);
+                    print("[code_writer] Opened PR via checkout-edit for issue", draft.issue_id, ":", edit_result);
+                    emit("implementation:mr_ready", draft);
+                    if len(owner) > 0 {
+                        learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation", repo_tag(owner, repo)]);
                     } else {
-                        "";
-                    };
-
-                    // #1208: when the primary file ALREADY EXISTS, do NOT ask the
-                    // LLM to regenerate the whole file (large output -> timeout on
-                    // claude, line-wrap corruption on flat-cyborg) NOR to reproduce
-                    // exact source bytes as a search/replace anchor (the model drops
-                    // `**` markdown from anchors, so old_str never matched). Instead
-                    // show a line-NUMBERED view (`N|` prefix) and ask for line-RANGE
-                    // edits ({start_line,end_line,new_text}); apply-line-edits.py
-                    // splices them in deterministically. The actions JSON is built by
-                    // json.dumps, not the LLM, so the committed content is
-                    // fragility-free. For a NEW file we keep the from-scratch
-                    // full-content path unchanged.
-                    let actions_json = if len(existing_content) > 0 {
-                        let numbered = numbered_view(existing_content);
-                        let edit_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec) +
-                            "\nCurrent content of " + primary_path + " (edit THIS file; each line is prefixed with its 1-based line number as `N|`):\n" + numbered;
-                        let edits_json = prompt(
-                            "You are a code writer editing an EXISTING file. Make the smallest edits that satisfy the task. Use the line numbers shown (the `N|` prefix; the `N|` is NOT part of the file content). Return the smallest set of NON-OVERLAPPING line-range replacements as a JSON array, each object with: file_path (string), start_line (int), end_line (int), new_text (string). new_text is the FULL replacement for lines start_line..end_line (inclusive); empty new_text deletes them. Do NOT include the `N|` prefix in new_text. Do NOT return the whole file. Return ONLY the raw JSON array — no markdown code fences, no ```json wrapper, no prose.",
-                            edit_context
-                        ) -> string;
-                        // Deterministic apply: line ranges must be in-bounds and
-                        // non-overlapping or apply-line-edits.py fails loudly and this
-                        // returns "" => treated as a failed code-gen below (no
-                        // commit; #1185 retry re-runs the issue next tick).
-                        let assembled = apply_line_edits_to_actions(primary_path, existing_content, edits_json);
-                        if len(assembled) > 0 {
-                            assembled;
-                        } else {
-                            print("[code_writer] apply-line-edits failed (out-of-bounds or overlapping ranges) — not committing; will retry");
-                            "";
-                        };
-                    } else {
-                        let code_context = "Issue: " + issue_detail + "\nPlan: " + draft.files + "\nPatterns: " + to_string(rec) +
-                            "\nFile " + primary_path + ": (does not exist yet — create it)";
-                        prompt(
-                            "You are a code writer. Generate the actual file contents for this implementation plan. Create the file(s) from scratch. Return a JSON array of objects, each with: action (string, 'create' or 'update'), file_path (string), content (string, the full file content). Follow the learned naming and structure patterns. Only return the JSON array, nothing else.",
-                            code_context
-                        ) -> string;
-                    };
-
-                    let commit_result = if len(actions_json) > 0 {
-                        // colony-lint: safe-exec-concat (all dynamic values wrapped in shell_escape)
-                        let commit_cmd = "$COLONY_DIR/scripts/forge-api.sh commit-files --branch " + shell_escape(draft.branch_name) + " --message " + shell_escape("feat: implement #" + to_string(draft.issue_id) + " - " + draft.summary) + " --actions " + shell_escape(actions_json) + repo_arg(owner, repo);
-                        try { exec sh commit_cmd; } catch e {
-                            print("[code_writer] Commit failed:", e);
-                            // #1152: a recurring cause is an unparseable --actions JSON.
-                            // Code generation is fidelity-critical: a TUI screen-scrape
-                            // backend (flat-cyborg) corrupts the structured JSON of file
-                            // contents. The #1208 line-range edit path keeps LLM output
-                            // small (works on flat-cyborg); a from-scratch NEW file still
-                            // wants the metered `claude -p` backend for the large content
-                            // (see README "Code-generation fidelity").
-                            print("[code_writer] hint: if this is an '--actions JSON' parse error, code-gen needs a fidelity backend (claude -p), not the flat-cyborg screen-scrape — see README");
-                            "";
-                        };
-                    } else {
-                        "";
-                    };
-
-                    if len(commit_result) > 0 {
-                        // #1185: mark drafted only now that the commit landed.
-                        // If create-branch succeeded but commit-files failed,
-                        // we never reach here, so the markers stay unset and
-                        // the next tick retries the issue instead of skipping
-                        // it forever behind the #200 gate with an empty branch.
-                        memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_iid"), first_iid_str);
-                        memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_updated_at"), first_upd);
-                        print("[code_writer] Committed code to", draft.branch_name);
-                        emit("implementation:code_draft", draft);
-                        // #1151: durable single-slot handoff to commit_composer.
-                        // The live `code_draft` bus event above is the fast path,
-                        // but commit_composer only catches it inside a 100ms
-                        // listen() window; a missed event left the branch
-                        // committed with no MR ever opened. Persist a durable
-                        // tab-delimited (issue_id, branch_name, summary) signal
-                        // so commit_composer's no-event branch can recover it.
-                        memo_write(scoped_memo(owner, repo, "implementation:pending_mr"),
-                            to_string(draft.issue_id) + "\t" + draft.branch_name + "\t" + draft.summary);
-                        if len(owner) > 0 {
-                            learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation", repo_tag(owner, repo)]);
-                        } else {
-                            learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation"]);
-                        };
+                        learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation"]);
                     };
                 };
             } else {

--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# tools/code-edit-in-checkout.sh (#1210): drive Claude Code (via flat-cyborg) to
+# edit files DIRECTLY in a local git checkout, then commit the resulting
+# `git diff` and open a PR.
+#
+# This replaces the brittle "generate edit-JSON -> apply-line-edits.py ->
+# commit-files via the forge Git Database API" path that code_writer used on the
+# autonomous tier. That path round-trips file CONTENT through flat-cyborg's TUI
+# screen-scrape, which line-wraps and corrupts the structured JSON for large
+# files (#1152 / #1195 / #1208). Editing in a real checkout sidesteps the
+# screen-scrape entirely: claude's own file tools touch the working tree, and we
+# commit whatever `git diff` shows. flat-cyborg stays the ONLY backend; the
+# metered `claude -p` API is NOT used here.
+#
+# Usage:
+#   code-edit-in-checkout.sh --owner <o> --repo <r> --issue <iid> \
+#       --branch <name> --title <t> --task <text>
+#
+# The forge token is read from the environment (GITHUB_TOKEN). It is NEVER
+# embedded in a remote URL on disk, never echoed, and never visible under
+# `set -x` (we deliberately do not enable `set -x`, and the token only flows
+# through GIT_ASKPASS — see below).
+#
+# Token auth WITHOUT leaking the token:
+#   We point git at a one-line GIT_ASKPASS helper (a temp script) that prints
+#   the token from the environment when git asks for the HTTPS password, and a
+#   constant ("x-access-token") for the username. The remote URL stored in the
+#   checkout's `.git/config` is the plain https://<host>/<owner>/<repo>.git with
+#   NO credentials in it. git invokes the helper out-of-band over a pipe, so the
+#   token never appears in argv, in the remote URL, in `ps`, or in any log line.
+#
+# Exit codes:
+#   0  PR opened (URL printed on stdout)
+#   3  NO_EDITS — claude made no change to the tree (caller retries later; this
+#      is NOT an error and must NOT open an empty PR)
+#   other  failure (clone/branch/edit/commit/push/PR-open)
+#
+# Knobs (env vars): FLAT_CYBORG_IDLE_MS, FLAT_CYBORG_TIMEOUT_MS,
+#                   CODE_EDIT_TIMEOUT_MS (overall flat-cyborg edit timeout,
+#                   default 600000).
+set -eu
+
+# ---------------------------------------------------------------------------
+# Arg parsing.
+# ---------------------------------------------------------------------------
+OWNER=""
+REPO=""
+ISSUE=""
+BRANCH=""
+TITLE=""
+TASK=""
+
+usage() {
+    echo "usage: code-edit-in-checkout.sh --owner <o> --repo <r> --issue <iid> --branch <name> --title <t> --task <text>" >&2
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --owner)  OWNER="${2:-}";  shift 2 ;;
+        --repo)   REPO="${2:-}";   shift 2 ;;
+        --issue)  ISSUE="${2:-}";  shift 2 ;;
+        --branch) BRANCH="${2:-}"; shift 2 ;;
+        --title)  TITLE="${2:-}";  shift 2 ;;
+        --task)   TASK="${2:-}";   shift 2 ;;
+        *) echo "code-edit-in-checkout.sh: unknown flag: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+# Legacy single-block fan-out (#316): the .ag passes empty --owner/--repo (the
+# iter-repos sentinel) and the colony env carries the real values in
+# GITHUB_OWNER/GITHUB_REPO. Resolve them here so the multi-repo and legacy paths
+# share one orchestrator.
+if [ -z "$OWNER" ]; then OWNER="${GITHUB_OWNER:-}"; fi
+if [ -z "$REPO" ]; then REPO="${GITHUB_REPO:-}"; fi
+
+if [ -z "$OWNER" ] || [ -z "$REPO" ] || [ -z "$ISSUE" ] || [ -z "$BRANCH" ] || [ -z "$TITLE" ] || [ -z "$TASK" ]; then
+    echo "code-edit-in-checkout.sh: --owner, --repo, --issue, --branch, --title, --task are all required" >&2
+    usage
+    exit 2
+fi
+
+# Presence-only check via `${GITHUB_TOKEN:+x}` so the token VALUE is never
+# expanded onto a command line (stays out of any external `set -x` trace): the
+# expansion yields the literal `x` when the token is set+non-empty, empty
+# otherwise. The value itself is only ever read by the GIT_ASKPASS helper and
+# inherited by github-api.sh — never named in this script.
+if [ -z "${GITHUB_TOKEN:+x}" ]; then
+    echo "code-edit-in-checkout.sh: GITHUB_TOKEN must be set in the environment" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Resolve FED_DIR + colony name the same way the rest of the federation does.
+# The colony's .ag agents run with COLONY_DIR exported (e.g.
+# <fed>/implementation); FED_DIR is its grandparent. We derive a colony label
+# from COLONY_DIR's basename so the per-colony workspace path is stable. Both
+# fall back to cwd-relative values so the script is testable standalone.
+# ---------------------------------------------------------------------------
+if [ -n "${COLONY_DIR:-}" ]; then
+    FED_DIR="$(cd "$COLONY_DIR/.." && pwd)"
+    COLONY_NAME="$(basename "$COLONY_DIR")"
+else
+    FED_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+    COLONY_NAME="implementation"
+fi
+
+GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
+# Derive the git host base from the API base. api.github.com -> github.com;
+# a GHE API base like https://ghe.example.com/api/v3 -> https://ghe.example.com.
+# A schemeless-host URL (file:// — used by the offline test harness, never in
+# production) forwards its path verbatim so a local bare repo can stand in for
+# the remote.
+GIT_HOST="$(GH_URL="$GITHUB_URL" python3 -c '
+import os
+from urllib.parse import urlsplit
+u = urlsplit(os.environ["GH_URL"])
+host = u.netloc
+if u.scheme == "file":
+    # file:///path -> file:///path (path carries the location, no netloc).
+    print("file://" + u.path.rstrip("/"))
+elif host == "api.github.com":
+    print("https://github.com")
+else:
+    print(u.scheme + "://" + host)
+')"
+CLONE_URL="$GIT_HOST/$OWNER/$REPO.git"
+
+# ---------------------------------------------------------------------------
+# Token auth: a GIT_ASKPASS helper that prints the token from the env. The
+# token never lands in the remote URL, argv, or any log line.
+# ---------------------------------------------------------------------------
+ASKPASS="$(mktemp)"
+# The helper distinguishes git's two prompts ("Username for ..." vs
+# "Password for ...") and answers each. Token rides $GITHUB_TOKEN in the env it
+# inherits; it is never written into this file.
+cat > "$ASKPASS" <<'ASKPASS_EOF'
+#!/usr/bin/env sh
+case "$1" in
+    *Username*|*username*) printf '%s' "x-access-token" ;;
+    *) printf '%s' "${GITHUB_TOKEN}" ;;
+esac
+ASKPASS_EOF
+chmod 700 "$ASKPASS"
+
+# A task file for flat-cyborg --cmd-file (a multi-KB instruction must not ride
+# argv — ARG_MAX, same lesson as #1171). Cleaned up on exit alongside ASKPASS.
+TASKFILE="$(mktemp)"
+trap 'rm -f "$ASKPASS" "$TASKFILE"' EXIT
+
+# git wrappers that thread the askpass helper + non-interactive terminal so a
+# missing/invalid token fails fast instead of hanging on a prompt.
+#   run_git      : side-effecting commands — git's chatter ("Your branch is up
+#                  to date", "branch ... set up to track ...") is routed to
+#                  stderr so ONLY the final PR URL ever reaches our stdout.
+#   git_capture  : commands whose stdout we need to read (e.g. symbolic-ref).
+run_git() {
+    GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 git "$@" >&2
+}
+git_capture() {
+    GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 git "$@"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Workspace: idempotent fresh clone/reset.
+# ---------------------------------------------------------------------------
+WS="$FED_DIR/.agentis/workspaces/$COLONY_NAME/$OWNER-$REPO"
+
+if [ -d "$WS/.git" ]; then
+    echo "[code-edit] reusing workspace $WS" >&2
+    run_git -C "$WS" remote set-url origin "$CLONE_URL"
+    run_git -C "$WS" fetch origin
+else
+    echo "[code-edit] cloning $OWNER/$REPO into $WS" >&2
+    rm -rf "$WS"
+    mkdir -p "$(dirname "$WS")"
+    run_git clone "$CLONE_URL" "$WS"
+fi
+
+# Resolve the default branch from the remote HEAD (origin/HEAD -> origin/<def>).
+DEFAULT_BRANCH="$(git_capture -C "$WS" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+if [ -z "$DEFAULT_BRANCH" ]; then
+    # Fall back to GITLAB_DEFAULT_BRANCH (the cross-backend default-branch env
+    # the federation already exports), then to main.
+    DEFAULT_BRANCH="${GITLAB_DEFAULT_BRANCH:-main}"
+fi
+
+# Idempotent fresh state on the default branch.
+run_git -C "$WS" checkout "$DEFAULT_BRANCH"
+run_git -C "$WS" reset --hard "origin/$DEFAULT_BRANCH"
+run_git -C "$WS" clean -fd
+
+# ---------------------------------------------------------------------------
+# 2. Branch: deterministic per-issue (reuse, no empty-branch litter).
+# ---------------------------------------------------------------------------
+run_git -C "$WS" checkout -B "$BRANCH" "origin/$DEFAULT_BRANCH"
+
+# ---------------------------------------------------------------------------
+# 3. Edit: run claude (via flat-cyborg) as an editing agent inside the
+#    checkout. We mirror flat-cyborg-claude.sh's flags MINUS --extract /
+#    --extract-structural: here claude EDITS files with its own tools, so we do
+#    not need to scrape a reply off the screen. --cwd points it at the checkout;
+#    --auto-approve lets it write without an interactive confirm; --no-jitter +
+#    the idle/timeout knobs keep behaviour identical to the wrapper.
+# ---------------------------------------------------------------------------
+printf 'Implement issue #%s in this repository by editing the files directly with your tools. %s\n\n%s\n\nMake the change and stop; do not run git or open a PR.' \
+    "$ISSUE" "$TITLE" "$TASK" > "$TASKFILE"
+
+echo "[code-edit] running flat-cyborg editing agent in $WS" >&2
+set +e
+flat-cyborg --no-jitter --auto-approve --cwd "$WS" \
+    --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" \
+    --timeout-ms "${CODE_EDIT_TIMEOUT_MS:-600000}" \
+    --cmd-file "$TASKFILE" -- claude
+FC_RC=$?
+set -e
+if [ "$FC_RC" -ne 0 ]; then
+    echo "[code-edit] flat-cyborg editing agent failed (exit $FC_RC)" >&2
+    exit "$FC_RC"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Commit the diff. No staged change => NO_EDITS => exit 3 (retry, not error).
+# ---------------------------------------------------------------------------
+run_git -C "$WS" add -A
+if run_git -C "$WS" diff --cached --quiet; then
+    echo "NO_EDITS"
+    echo "[code-edit] claude produced no file changes — not committing, not opening a PR" >&2
+    exit 3
+fi
+
+run_git -C "$WS" commit -m "feat: $TITLE (#$ISSUE)"
+run_git -C "$WS" push --force-with-lease origin "$BRANCH"
+
+# ---------------------------------------------------------------------------
+# 5. Open the PR via the colony's github-api.sh create-mr verb. That wrapper
+#    reads GITHUB_TOKEN/OWNER/REPO from the env (already present here) and prints
+#    the GitHub PR JSON; we extract html_url and print it on stdout.
+# ---------------------------------------------------------------------------
+GITHUB_API="$FED_DIR/$COLONY_NAME/scripts/github-api.sh"
+DESCRIPTION="Implements #$ISSUE.
+
+$TASK"
+
+if [ ! -x "$GITHUB_API" ]; then
+    echo "[code-edit] github-api.sh not found/executable at $GITHUB_API" >&2
+    exit 1
+fi
+
+# `env` (not a plain VAR=val prefix on the assignment) so the github-api.sh
+# subprocess inherits OWNER/REPO/URL/default-branch cleanly. GITHUB_TOKEN is
+# deliberately NOT named here: it is already in this script's inherited
+# environment, so the child inherits it automatically. Never referencing
+# $GITHUB_TOKEN as an expanded word keeps the token out of any external `set -x`
+# trace of this script (the token never appears on a command line).
+PR_JSON="$(env \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" GITHUB_URL="$GITHUB_URL" \
+    GITLAB_DEFAULT_BRANCH="$DEFAULT_BRANCH" \
+    "$GITHUB_API" create-mr --source "$BRANCH" --title "$TITLE" --description "$DESCRIPTION")" || {
+        echo "[code-edit] create-mr failed" >&2
+        exit 1
+    }
+
+PR_URL="$(PR="$PR_JSON" python3 -c '
+import os, json, sys
+try:
+    d = json.loads(os.environ["PR"])
+except Exception:
+    sys.exit(1)
+print(d.get("html_url") or d.get("url") or "")
+')" || true
+
+if [ -z "$PR_URL" ]; then
+    echo "[code-edit] PR opened but could not parse html_url from create-mr response" >&2
+    exit 1
+fi
+
+echo "$PR_URL"
+exit 0

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# test-code-edit-in-checkout.sh (#1210): exercise the git orchestration of
+# tools/code-edit-in-checkout.sh WITHOUT a real Claude Code session. The
+# claude-edit step is replaced by a STUB `flat-cyborg` on PATH that simulates an
+# editing agent (writes a file into --cwd); the GitHub PR-open step is replaced
+# by a STUB github-api.sh that echoes a canned PR JSON. The "remote" is a local
+# bare git repo reached via a file:// GITHUB_URL (the orchestrator forwards a
+# file:// base verbatim, never used in production).
+#
+# Asserts:
+#   1. clone + deterministic per-issue branch setup
+#   2. the claude-edit diff is committed (commit message + file present)
+#   3. the PR-open call fires and the orchestrator prints the PR URL on stdout
+#   4. NO_EDITS path: when the stub makes no change, exit 3 + "NO_EDITS", no
+#      commit, no PR
+#   5. the token NEVER appears in the orchestrator's combined stdout+stderr
+#      (incl. with `set -x` enabled in the orchestrator's environment)
+#
+# Auto-discovered by tools/colony-lint.sh's tools-test loop. Exit 0 if all pass.
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+ORCH="$REPO_ROOT/tools/code-edit-in-checkout.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "[SKIP] test-code-edit-in-checkout.sh: git not on PATH"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (skipped)"
+    exit 0
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[SKIP] test-code-edit-in-checkout.sh: python3 not on PATH"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (skipped)"
+    exit 0
+fi
+if [ ! -f "$ORCH" ]; then
+    fail "orchestrator missing: $ORCH"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FAKE_TOKEN="ghp_FAKE_TOKEN_DO_NOT_LEAK_abcdef0123456789"
+OWNER="acme"
+REPO="widget"
+
+# git identity for commits inside the harness (CI has no global config).
+export GIT_AUTHOR_NAME="test" GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="test" GIT_COMMITTER_EMAIL="test@example.com"
+
+# ---------------------------------------------------------------------------
+# A local "remote": a bare repo seeded with one commit on main. The
+# orchestrator clones file://$REMOTE_BASE/<owner>/<repo>.git.
+# ---------------------------------------------------------------------------
+REMOTE_BASE="$WORK/remote"
+BARE="$REMOTE_BASE/$OWNER/$REPO.git"
+SEED="$WORK/seed"
+mkdir -p "$BARE"
+git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null \
+    || git init --quiet --bare "$BARE"
+git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+(
+    cd "$SEED" || exit 1
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    printf 'hello\n' > README.md
+    git add -A
+    git commit --quiet -m "seed: initial commit"
+    git branch -M main 2>/dev/null || true
+    git remote add origin "$BARE"
+    git push --quiet origin main
+)
+# Point the bare repo's HEAD at main so origin/HEAD resolves on clone.
+git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+
+# ---------------------------------------------------------------------------
+# A fake colony tree so the orchestrator resolves COLONY_DIR/FED_DIR and finds
+# a stub github-api.sh under <fed>/<colony>/scripts/.
+# ---------------------------------------------------------------------------
+FED_DIR="$WORK/fed"
+COLONY_DIR="$FED_DIR/implementation"
+mkdir -p "$COLONY_DIR/scripts"
+
+# Stub github-api.sh: only the create-mr verb is needed. It records that it was
+# invoked (with which --source/--title) and echoes a canned PR JSON. It also
+# asserts GITHUB_TOKEN reached it via the env (never argv).
+CREATE_MR_LOG="$WORK/create-mr.log"
+cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+if [ "\${1:-}" != "create-mr" ]; then
+    echo "stub github-api.sh: unexpected verb \${1:-}" >&2
+    exit 1
+fi
+shift
+SRC=""; TITLE=""
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        --source) SRC="\$2"; shift 2 ;;
+        --title) TITLE="\$2"; shift 2 ;;
+        --description) shift 2 ;;
+        *) shift ;;
+    esac
+done
+{
+    echo "create-mr source=\$SRC title=\$TITLE"
+    echo "token_seen=\${GITHUB_TOKEN:-MISSING}"
+    echo "owner=\${GITHUB_OWNER:-} repo=\${GITHUB_REPO:-}"
+} >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/1", "number": 1}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/github-api.sh"
+
+# ---------------------------------------------------------------------------
+# Stub flat-cyborg on PATH. Two modes via FC_STUB_MODE:
+#   edit    : parse --cwd, write a new file there (simulate an editing agent)
+#   no-edit : touch nothing (simulate claude making no change)
+# It also records the flags it was given so we can confirm the orchestrator
+# passed --cwd / --auto-approve / --no-jitter and NOT --extract.
+# ---------------------------------------------------------------------------
+STUB_BIN="$WORK/bin"
+mkdir -p "$STUB_BIN"
+FC_FLAGS_LOG="$WORK/fc-flags.log"
+cat > "$STUB_BIN/flat-cyborg" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "\$*" >> "$FC_FLAGS_LOG"
+CWD=""
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        --cwd) CWD="\$2"; shift 2 ;;
+        --) shift; break ;;
+        *) shift ;;
+    esac
+done
+if [ "\${FC_STUB_MODE:-edit}" = "edit" ] && [ -n "\$CWD" ]; then
+    printf 'generated by claude\n' > "\$CWD/NEWFILE.txt"
+fi
+exit 0
+STUB_EOF
+chmod +x "$STUB_BIN/flat-cyborg"
+export PATH="$STUB_BIN:$PATH"
+
+# Common env for an orchestrator run.
+run_orch() {
+    env \
+        PATH="$STUB_BIN:$PATH" \
+        COLONY_DIR="$COLONY_DIR" \
+        GITHUB_URL="file://$REMOTE_BASE" \
+        GITHUB_TOKEN="$FAKE_TOKEN" \
+        GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+        FC_STUB_MODE="${1:-edit}" \
+        bash "$ORCH" \
+            --owner "$OWNER" --repo "$REPO" --issue 42 \
+            --branch "fix/issue-42" --title "add new file" \
+            --task "Create NEWFILE.txt with a greeting."
+}
+
+# ===========================================================================
+# Run 1: editing agent makes a change -> commit + PR opened, URL on stdout.
+# ===========================================================================
+OUT1_FILE="$WORK/out1.txt"
+run_orch edit >"$OUT1_FILE" 2>"$WORK/err1.txt"
+RC1=$?
+OUT1="$(cat "$OUT1_FILE")"
+
+if [ "$RC1" -eq 0 ]; then
+    pass "run 1: orchestrator exits 0 on a successful edit"
+else
+    fail "run 1: orchestrator exit 0 on success" "rc=$RC1 err=$(cat "$WORK/err1.txt")"
+fi
+
+if [ "$OUT1" = "https://example.test/pr/1" ]; then
+    pass "run 1: prints the PR URL (from stub create-mr) on stdout"
+else
+    fail "run 1: prints PR URL on stdout" "stdout=[$OUT1]"
+fi
+
+# Workspace cloned to the derived path with a deterministic per-issue branch.
+WS="$FED_DIR/.agentis/workspaces/implementation/$OWNER-$REPO"
+if [ -d "$WS/.git" ]; then
+    pass "run 1: cloned the repo into the per-colony workspace path"
+else
+    fail "run 1: workspace checkout exists" "expected $WS/.git"
+fi
+
+CUR_BRANCH="$(git -C "$WS" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+if [ "$CUR_BRANCH" = "fix/issue-42" ]; then
+    pass "run 1: checked out the deterministic fix/issue-42 branch"
+else
+    fail "run 1: deterministic branch fix/issue-42" "on $CUR_BRANCH"
+fi
+
+# The edit diff is committed: the new file is in the tip tree + commit message.
+if git -C "$WS" cat-file -e "HEAD:NEWFILE.txt" 2>/dev/null; then
+    pass "run 1: committed the editing agent's NEWFILE.txt"
+else
+    fail "run 1: NEWFILE.txt present in HEAD commit"
+fi
+HEAD_MSG="$(git -C "$WS" log -1 --pretty=%s 2>/dev/null || echo '')"
+case "$HEAD_MSG" in
+    "feat: add new file (#42)") pass "run 1: commit message is feat: <title> (#<iid>)" ;;
+    *) fail "run 1: commit message format" "got [$HEAD_MSG]" ;;
+esac
+
+# The branch was pushed to the bare remote.
+if git --git-dir="$BARE" rev-parse --verify --quiet refs/heads/fix/issue-42 >/dev/null; then
+    pass "run 1: pushed fix/issue-42 to the remote"
+else
+    fail "run 1: pushed branch present on remote"
+fi
+
+# create-mr was called with the right source + title and saw the token via env.
+if [ -f "$CREATE_MR_LOG" ] && grep -q "create-mr source=fix/issue-42 title=add new file" "$CREATE_MR_LOG"; then
+    pass "run 1: invoked github-api.sh create-mr with the branch + title"
+else
+    fail "run 1: create-mr invocation recorded" "log=$(cat "$CREATE_MR_LOG" 2>/dev/null)"
+fi
+if grep -q "token_seen=$FAKE_TOKEN" "$CREATE_MR_LOG"; then
+    pass "run 1: token reached create-mr via the environment (never argv)"
+else
+    fail "run 1: token passed to create-mr via env"
+fi
+
+# flat-cyborg was driven as an editing agent: --cwd + --auto-approve +
+# --no-jitter, and NOT --extract (we don't scrape a reply here).
+FC_FLAGS="$(cat "$FC_FLAGS_LOG" 2>/dev/null || echo '')"
+if printf '%s' "$FC_FLAGS" | grep -q -- '--cwd' \
+    && printf '%s' "$FC_FLAGS" | grep -q -- '--auto-approve' \
+    && printf '%s' "$FC_FLAGS" | grep -q -- '--no-jitter'; then
+    pass "run 1: flat-cyborg invoked with --cwd / --auto-approve / --no-jitter"
+else
+    fail "run 1: flat-cyborg editing-agent flags" "flags=[$FC_FLAGS]"
+fi
+if printf '%s' "$FC_FLAGS" | grep -q -- '--extract'; then
+    fail "run 1: flat-cyborg must NOT run in --extract mode (editing agent, no reply scrape)"
+else
+    pass "run 1: flat-cyborg not run in --extract mode (editing agent)"
+fi
+
+# ===========================================================================
+# Token never leaks in run 1's output (stdout + stderr), even though the
+# orchestrator handles the token internally. Belt-and-suspenders: also run the
+# orchestrator under `set -x` and confirm the token still does not appear.
+# ===========================================================================
+if grep -q "$FAKE_TOKEN" "$OUT1_FILE" "$WORK/err1.txt"; then
+    fail "run 1: token LEAKED into orchestrator stdout/stderr"
+else
+    pass "run 1: token never appears in orchestrator stdout/stderr"
+fi
+
+XTRACE_OUT="$WORK/xtrace.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    GITHUB_URL="file://$REMOTE_BASE" \
+    GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    FC_STUB_MODE="edit" \
+    bash -x "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue 42 \
+        --branch "fix/issue-42" --title "add new file" \
+        --task "Create NEWFILE.txt with a greeting." >"$XTRACE_OUT" 2>&1 || true
+if grep -q "$FAKE_TOKEN" "$XTRACE_OUT"; then
+    fail "token: appears under bash -x trace (set -x leak)"
+else
+    pass "token: never appears under bash -x trace (set -x safe)"
+fi
+
+# ===========================================================================
+# Run 2 (fresh remote): editing agent makes NO change -> NO_EDITS, exit 3,
+# no commit, no PR.
+# ===========================================================================
+# Reset the harness state so run 2 starts clean.
+rm -rf "$FED_DIR" "$REMOTE_BASE" "$SEED" "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+mkdir -p "$COLONY_DIR/scripts"
+# Re-create the stub github-api.sh (lost with the rm -rf above).
+cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+{ echo "create-mr called with: \$*"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/SHOULD-NOT-OPEN"}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/github-api.sh"
+
+mkdir -p "$BARE"
+git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null || git init --quiet --bare "$BARE"
+git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+(
+    cd "$SEED" || exit 1
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    printf 'hello\n' > README.md
+    git add -A
+    git commit --quiet -m "seed: initial commit"
+    git branch -M main 2>/dev/null || true
+    git remote add origin "$BARE"
+    git push --quiet origin main
+)
+git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+
+OUT2_FILE="$WORK/out2.txt"
+run_orch no-edit >"$OUT2_FILE" 2>"$WORK/err2.txt"
+RC2=$?
+
+if [ "$RC2" -eq 3 ]; then
+    pass "run 2 (no-edit): orchestrator exits 3 (NO_EDITS -> retry, not error)"
+else
+    fail "run 2 (no-edit): exit 3 on no edits" "rc=$RC2"
+fi
+if grep -q '^NO_EDITS$' "$OUT2_FILE"; then
+    pass "run 2 (no-edit): prints NO_EDITS sentinel on stdout"
+else
+    fail "run 2 (no-edit): NO_EDITS on stdout" "stdout=[$(cat "$OUT2_FILE")]"
+fi
+if [ ! -f "$CREATE_MR_LOG" ]; then
+    pass "run 2 (no-edit): no PR opened (create-mr never invoked)"
+else
+    fail "run 2 (no-edit): create-mr must NOT be invoked" "log=$(cat "$CREATE_MR_LOG")"
+fi
+# No branch should have been pushed for the no-edit run.
+if git --git-dir="$BARE" rev-parse --verify --quiet refs/heads/fix/issue-42 >/dev/null; then
+    fail "run 2 (no-edit): a branch was pushed despite no edits"
+else
+    pass "run 2 (no-edit): no branch pushed to the remote"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-code-writer-completion-markers.sh
+++ b/tools/test-code-writer-completion-markers.sh
@@ -14,16 +14,17 @@
 #
 #   Part 3 (don't strand a half-completed autonomous flow). The #200 staleness
 #   markers (last_drafted_iid / _updated_at) used to be written right after the
-#   draft prompt, BEFORE the autonomous create-branch / commit-files. A
-#   branch-created-but-commit-failed tick still marked the issue "drafted", so
-#   the #200 gate skipped it forever and stranded an empty branch. The fix sets
-#   the markers only once the path's own action has COMPLETED: the autonomous
-#   path sets them inside the commit-success block; the non-autonomous
+#   draft prompt, BEFORE the autonomous action ran. A half-completed tick still
+#   marked the issue "drafted", so the #200 gate skipped it forever. The fix
+#   sets the markers only once the path's own action has COMPLETED: the
+#   autonomous path (#1210: Approach A — edit in a local checkout via
+#   code-edit-in-checkout.sh, then commit the diff + open the PR) sets them only
+#   inside the PR-opened block (`if len(edit_result) > 0`); the non-autonomous
 #   (review-gated / propose / shadow) paths still set them after their terminal
 #   draft comment / emit. We assert, structurally:
 #     - the markers are NOT written before the tier branch (no write between
 #       `should_draft_code(...)` and the `if my_tier == "autonomous"` branch);
-#     - a marker write appears inside the `if len(commit_result) > 0` block;
+#     - a marker write appears inside the `if len(edit_result) > 0` block;
 #     - a marker write still exists on the non-autonomous side.
 #
 # Matches the test style of tools/test-assignment-based-pickup.sh (bash,
@@ -74,7 +75,7 @@ fi
 # three regions delimited by the structural anchors, so we assert *where* the
 # marker writes live, not just that they exist somewhere.
 #   region A: from `should_draft_code(` up to (not incl.) the autonomous branch
-#   region B: from `if len(commit_result) > 0` to its closing scope
+#   region B: from `if len(edit_result) > 0` to its closing scope
 #   region C: from the non-autonomous `} else {` (the tier else) to end
 # -----------------------------------------------------------------------------
 MARKER='memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_iid")'
@@ -93,38 +94,39 @@ else
   pass "marker NOT set before the tier branch (autonomous flow can retry)"
 fi
 
-# Region B: inside the commit-success block. The autonomous path must mark
-# only after commit-files lands.
+# Region B: inside the PR-opened block. The autonomous path must mark only
+# after code-edit-in-checkout.sh returns success (the PR URL).
 region_b="$(awk '
-  /if len\(commit_result\) > 0/ { grab=1 }
+  /if len\(edit_result\) > 0/ { grab=1 }
   grab { print }
-  /emit\("implementation:code_draft", draft\)/ { if (grab) exit }
+  /emit\("implementation:mr_ready", draft\)/ { if (grab) exit }
 ' "$AG")"
 if printf '%s\n' "$region_b" | grep -F -q -- "$MARKER"; then
-  pass "autonomous path sets the marker inside the commit-success block"
+  pass "autonomous path sets the marker inside the PR-opened block"
 else
   fail "autonomous marker placement" \
-    "last_drafted_iid not written inside the 'if len(commit_result) > 0' block"
+    "last_drafted_iid not written inside the 'if len(edit_result) > 0' block"
 fi
 
-# The autonomous branch must NOT mark before create-branch: assert the marker
-# write occurs after the create-branch command line within the file.
-branch_line="$(grep -n -F -- 'create-branch --name' "$AG" | head -1 | cut -d: -f1)"
+# The autonomous branch must NOT mark before the checkout-edit orchestrator
+# runs: assert the marker write occurs after the code-edit-in-checkout.sh
+# command line within the file.
+edit_line="$(grep -n -F -- 'code-edit-in-checkout.sh' "$AG" | head -1 | cut -d: -f1)"
 marker_lines="$(grep -n -F -- "$MARKER" "$AG" | cut -d: -f1)"
-autonomous_marker_after_branch=0
-if [ -n "$branch_line" ]; then
+autonomous_marker_after_edit=0
+if [ -n "$edit_line" ]; then
   for ln in $marker_lines; do
-    if [ "$ln" -gt "$branch_line" ]; then
-      autonomous_marker_after_branch=1
+    if [ "$ln" -gt "$edit_line" ]; then
+      autonomous_marker_after_edit=1
       break
     fi
   done
 fi
-if [ "$autonomous_marker_after_branch" = "1" ]; then
-  pass "a marker write follows create-branch (not before it)"
+if [ "$autonomous_marker_after_edit" = "1" ]; then
+  pass "a marker write follows the code-edit-in-checkout.sh call (not before it)"
 else
-  fail "marker vs create-branch ordering" \
-    "no last_drafted_iid write found after the create-branch line"
+  fail "marker vs checkout-edit ordering" \
+    "no last_drafted_iid write found after the code-edit-in-checkout.sh line"
 fi
 
 # Region C: the non-autonomous paths (review-gated / propose / shadow) must

--- a/tools/test-github-implementation-robustness.sh
+++ b/tools/test-github-implementation-robustness.sh
@@ -332,38 +332,38 @@ else
 fi
 
 # =============================================================================
-# #1172 / #1208: code_writer.ag wires get-file into the code-gen context AND,
-# when the file already exists, shows a line-NUMBERED view and requests
-# line-RANGE edits (not a whole-file regeneration, not byte-exact search/replace
-# anchors) and applies them deterministically before commit. Grep-level wiring
-# assertions.
+# #1210 (Approach A): code_writer.ag's AUTONOMOUS path no longer round-trips
+# file content through the forge API. It drives tools/code-edit-in-checkout.sh,
+# which edits files DIRECTLY in a local checkout (via flat-cyborg/Claude Code)
+# and commits the `git diff`. The old get-file -> numbered_view -> line-range
+# prompt() -> apply-line-edits.py -> commit-files chain is gone from the
+# autonomous path (it corrupted large files on flat-cyborg's screen-scrape;
+# #1152 / #1195 / #1208). The github-api.sh `get-file` / `commit-files` backend
+# verbs themselves are unchanged and still validated above for other callers.
+# Grep-level wiring assertions.
 # =============================================================================
 CW_AG="$REPO_ROOT/dev-apprenticeship/implementation/agents/code_writer.ag"
-if grep -q "get-file --path" "$CW_AG"; then
-    pass "#1172 code_writer.ag: fetches existing content via 'get-file --path' before code-gen"
+if grep -q "code-edit-in-checkout.sh" "$CW_AG"; then
+    pass "#1210 code_writer.ag: autonomous path drives tools/code-edit-in-checkout.sh (edit-in-checkout)"
 else
-    fail "#1172 code_writer.ag: no 'get-file --path' fetch found before code-gen"
+    fail "#1210 code_writer.ag: no code-edit-in-checkout.sh orchestrator call found"
 fi
 
-# #1208: the existing-file path must present a line-NUMBERED view of the file
-# (numbered_view -> `N|` prefix) and request line-RANGE edits
-# (start_line / end_line / new_text), so the model never reproduces exact source
-# bytes (the markdown `**`-drop failure mode of the old old_str/new_str path).
-if grep -q "numbered_view(" "$CW_AG" && grep -q "start_line" "$CW_AG" && grep -q "end_line" "$CW_AG" && grep -q "new_text" "$CW_AG"; then
-    pass "#1208 code_writer.ag: existing-file path shows a numbered view and requests line-range edits (start_line/end_line/new_text)"
+# The orchestrator handles both new and existing files (claude creates/edits in
+# the checkout), so the autonomous path must NOT still go through the old
+# commit-files forge API call.
+if grep -q "commit-files --branch" "$CW_AG"; then
+    fail "#1210 code_writer.ag: still commits via the forge commit-files API (the checkout-edit path commits the git diff instead)"
 else
-    fail "#1208 code_writer.ag: existing-file edit prompt missing numbered_view / line-range fields"
+    pass "#1210 code_writer.ag: autonomous path no longer commits via the forge commit-files API"
 fi
 
-# #1208: those edits must be applied deterministically (apply_line_edits_to_actions
-# -> tools/apply-line-edits.py) to assemble the full file BEFORE commit-files
-# runs, so the committed content never depends on fragile large LLM output.
-apply_line="$(grep -n "apply_line_edits_to_actions(" "$CW_AG" | tail -1 | cut -d: -f1)"
-commit_line="$(grep -n "commit-files --branch" "$CW_AG" | head -1 | cut -d: -f1)"
-if [ -n "$apply_line" ] && [ -n "$commit_line" ] && [ "$apply_line" -lt "$commit_line" ]; then
-    pass "#1208 code_writer.ag: applies line edits (apply_line_edits_to_actions) before commit-files"
+# A deterministic per-issue branch (fix/issue-<iid>) is passed to the
+# orchestrator so a retry reuses the branch instead of littering empty ones.
+if grep -q '"fix/issue-"' "$CW_AG"; then
+    pass "#1210 code_writer.ag: uses a deterministic fix/issue-<iid> branch for the checkout edit"
 else
-    fail "#1208 code_writer.ag: line edits not deterministically applied before commit-files"
+    fail "#1210 code_writer.ag: missing the deterministic fix/issue-<iid> branch"
 fi
 
 echo ""

--- a/tools/test-mr-handoff-durable.sh
+++ b/tools/test-mr-handoff-durable.sh
@@ -33,32 +33,42 @@ pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
 fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
 
 # =============================================================================
-# code_writer: persists the durable pending_mr memo after a successful commit.
+# code_writer: #1210 (Approach A) — the autonomous path now edits files in a
+# local checkout and opens the PR DIRECTLY (via tools/code-edit-in-checkout.sh),
+# emitting implementation:mr_ready itself. It therefore no longer hands off to
+# commit_composer via the durable implementation:pending_mr memo — writing that
+# memo would make commit_composer open a DUPLICATE MR for the same branch. The
+# durable handoff machinery stays in commit_composer (asserted below) for any
+# pending_mr written by other code paths; code_writer just no longer feeds it.
 # =============================================================================
 if [ -f "$CODE_WRITER" ]; then
-    if grep -q 'implementation:pending_mr' "$CODE_WRITER"; then
-        pass "#1151 code_writer: writes the durable implementation:pending_mr memo"
+    # The autonomous path must NOT write the pending_mr handoff (it opens the PR
+    # itself). The only remaining mention of `implementation:pending_mr` in
+    # code_writer would be a memo_write, so assert there is none.
+    if grep -q 'memo_write(scoped_memo(owner, repo, "implementation:pending_mr")' "$CODE_WRITER"; then
+        fail "#1210 code_writer: still writes implementation:pending_mr (would double-open MR; the autonomous path now opens the PR directly)"
     else
-        fail "#1151 code_writer: missing implementation:pending_mr memo write"
+        pass "#1210 code_writer: no pending_mr handoff (autonomous path opens the PR directly, no double-open)"
     fi
 
-    # The durable write must live in the committed-code path: it sits between
-    # the `Committed code to` log line and the success learn() tags.
+    # The autonomous path opens the PR via the checkout-edit orchestrator and
+    # emits implementation:mr_ready itself.
+    if grep -q 'code-edit-in-checkout.sh' "$CODE_WRITER"; then
+        pass "#1210 code_writer: autonomous path drives tools/code-edit-in-checkout.sh"
+    else
+        fail "#1210 code_writer: missing the code-edit-in-checkout.sh orchestrator call"
+    fi
+
+    # The mr_ready emit must sit on the PR-opened path (inside the
+    # `if len(edit_result) > 0` block).
     if awk '
-        /Committed code to/ { seen_commit = 1 }
-        seen_commit && /implementation:pending_mr/ { found = 1 }
+        /if len\(edit_result\) > 0/ { grab = 1 }
+        grab && /emit\("implementation:mr_ready", draft\)/ { found = 1 }
         END { exit(found ? 0 : 1) }
     ' "$CODE_WRITER"; then
-        pass "#1151 code_writer: pending_mr memo written after the successful commit"
+        pass "#1210 code_writer: emits implementation:mr_ready on the PR-opened path"
     else
-        fail "#1151 code_writer: pending_mr memo not on the post-commit path"
-    fi
-
-    # Tab-delimited (issue_id, branch_name, summary) payload.
-    if grep -Eq 'to_string\(draft\.issue_id\)[[:space:]]*\+[[:space:]]*"\\t"[[:space:]]*\+[[:space:]]*draft\.branch_name[[:space:]]*\+[[:space:]]*"\\t"[[:space:]]*\+[[:space:]]*draft\.summary' "$CODE_WRITER"; then
-        pass "#1151 code_writer: pending_mr payload is tab-delimited issue/branch/summary"
-    else
-        fail "#1151 code_writer: pending_mr payload is not the tab-delimited issue/branch/summary triple"
+        fail "#1210 code_writer: does not emit implementation:mr_ready after opening the PR"
     fi
 else
     fail "#1151 code_writer: agent file not found at $CODE_WRITER"


### PR DESCRIPTION
Closes #1210.

flat-cyborg's `--extract` screen-scrape corrupts large structured output at any PTY width (diagnosed #1195/#1208). flat-cyborg is mandatory (no `claude -p`). **Approach A:** drive Claude Code (via flat-cyborg, `--cwd` the checkout, `--auto-approve`) to **edit files directly in a local checkout** with its own tools, then commit the `git diff` + open the PR. The scrape reply no longer carries file bytes → corruption is irrelevant.

- **`tools/code-edit-in-checkout.sh`**: idempotent workspace under `.agentis/workspaces/…` (gitignored), deterministic `fix/issue-<iid>` branch, flat-cyborg editing agent, **NO_EDITS → exit 3** (no empty PR), commit + `push --force-with-lease` + `create-mr`. **Token via GIT_ASKPASS** — never in URL/argv/logs (verified under `bash -x`), temp file `chmod 700` + trap-cleaned. Only the PR URL hits stdout.
- **`code_writer.ag`** autonomous: one `exec sh` to the orchestrator; #1185 markers set only on PR-URL success (NO_EDITS/fail → retry); no `pending_mr` (no double-open); review-gated unchanged.

## Verification
- colony-lint **427 passed, 0 failed, 5 skipped**; new test 17/0; completion-markers 7/0, robustness 18/0, mr-handoff 15/0, bundle 11/0.
- QA: ✅ ship-it — token airtight, NO_EDITS contract holds, idempotency + force-with-lease + stdout-discipline verified.

## Follow-ups (tracked, not blocking)
- Multi-repo (#316) per-repo token: orchestrator uses the inherited `GITHUB_TOKEN` (= first repo's) instead of `forge-api.sh --repo` resolution — fails loud, **single-repo default unaffected**, no leak.
- GitLab parity (orchestrator is GitHub-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)