### PR TITLE
feat(implementation): detached checkout-edit orchestrator — survives the 120s exec-sh cap (#1214)

### DIFF
--- a/dev-apprenticeship/BUNDLE.manifest
+++ b/dev-apprenticeship/BUNDLE.manifest
@@ -97,8 +97,15 @@ tools/apply-line-edits.py
 # Claude Code (via flat-cyborg) to edit files DIRECTLY in a local git checkout,
 # then commits the `git diff` and opens the PR — sidestepping flat-cyborg's TUI
 # screen-scrape corruption of large structured-JSON file content (#1152 /
-# #1195 / #1208). Runtime dep: code_writer.ag invokes it via exec sh.
+# #1195 / #1208). Runtime dep: code-edit-job.sh launches it detached.
 tools/code-edit-in-checkout.sh
+# #1214: fast detached launcher/poller for the orchestrator above. agentis caps
+# a single `exec sh` at ~120000ms, but the orchestrator runs for minutes, so a
+# synchronous call was killed mid-edit. code_writer.ag now invokes this launcher
+# via exec sh: it runs code-edit-in-checkout.sh DETACHED (setsid) in a per-issue
+# job dir and returns fast, and code_writer polls its LAUNCHED/RUNNING/DONE/
+# NO_EDITS/ERROR state across ticks. Runtime dep: code_writer.ag invokes it.
+tools/code-edit-job.sh
 
 # ----- Federation dashboard -----
 # Extracted to a separately-versioned standalone component in #252.

--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,33 @@ is asserted until multi-version CI is in place.
 
 ### Changed
 
+- **`code_writer`'s autonomous checkout-edit now runs DETACHED and is polled
+  across ticks, instead of one synchronous `exec sh` that the runtime killed
+  mid-edit** (#1214). agentis caps a single `exec sh` at ~120000ms (the
+  `exec.default_timeout_ms` knob is ignored), but the checkout-edit orchestrator
+  (#1210: clone + flat-cyborg/claude edit + commit + push + open PR) routinely
+  runs for minutes, so the synchronous call from #1210 hit `ExecTimeout after
+  120000ms` and the orchestrator was SIGKILLed mid-edit. A new fast launcher
+  `tools/code-edit-job.sh` now wraps `tools/code-edit-in-checkout.sh`: it runs
+  the orchestrator DETACHED (`setsid … </dev/null &`) inside a per-issue job dir
+  (`<fed>/.agentis/jobs/<colony>/issue-<iid>/` with `status` / `result` / `pid`
+  / `log`) and returns in well under 120s on every call, printing one poll-state
+  line: `LAUNCHED` (just started), `RUNNING` (still alive — a re-poll never
+  starts a second clone/edit, guarded by the recorded pid's liveness), `DONE
+  <pr-url>`, `NO_EDITS` (claude changed nothing → retry), or `ERROR <short>`. A
+  detached worker captures the orchestrator's exit code (0 → `done` + PR URL,
+  3 → `no_edits`, other → `error`) and writes the terminal status atomically
+  (temp file + `mv`); a terminal poll consumes/clears the job dir so the next
+  call relaunches. A crashed job (`status=running` but the pid is dead) is
+  reported as `ERROR job-died` and cleared rather than hung on. The token is
+  inherited via the environment exactly as before — never named on a command
+  line, never echoed, never written to the job dir (the orchestrator's
+  `GIT_ASKPASS` path is untouched). `code_writer.ag`'s autonomous branch now
+  calls the launcher (no `prompt()` in this branch) and runs the poll-state
+  machine: `LAUNCHED`/`RUNNING` leave the #1185 completion markers unset so the
+  same assigned issue is re-polled next tick; only `DONE` sets the markers and
+  emits `implementation:mr_ready`; `NO_EDITS`/`ERROR` retry. The review-gated /
+  propose / shadow paths are unchanged.
 - **`code_writer`'s autonomous path edits a local checkout and commits the
   `git diff`, instead of generating edit-JSON and committing via the forge API**
   (#1210, Approach A). The old autonomous chain (`create-branch` → `get-file` →

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -69,6 +69,27 @@ fn repo_field(line: string, idx: int) -> string {
     return out;
 }
 
+// #1214: code-edit-job.sh prints ONE line of the form `<KEYWORD>` or
+// `<KEYWORD> <payload>` (e.g. `LAUNCHED`, `RUNNING`, `DONE <pr-url>`,
+// `NO_EDITS`, `ERROR <short>`). job_word returns the leading keyword (the
+// poll-state) and job_rest returns everything after the first space (the
+// payload — a PR URL on DONE, a short reason on ERROR). The value rides $L
+// (env var, off-argv) so ARG_MAX never bites and there is no untrusted
+// concatenation in the body. Both are total: missing/garbled input -> "".
+fn job_word(out: string) -> string {
+    let cmd = "L=" + shell_escape(out) +
+        " python3 -c 'import os; s=os.environ[\"L\"].strip(); print(s.split(None,1)[0] if s else \"\")'";
+    let res = try { exec sh cmd; } catch e { ""; };
+    return res;
+}
+
+fn job_rest(out: string) -> string {
+    let cmd = "L=" + shell_escape(out) +
+        " python3 -c 'import os; p=os.environ[\"L\"].strip().split(None,1); print(p[1] if len(p)>1 else \"\")'";
+    let res = try { exec sh cmd; } catch e { ""; };
+    return res;
+}
+
 // #1172: pull the primary file path out of `draft.files` (a markdown list of
 // "file path + what each does" lines). We fetch the existing content of that
 // one file so the code-gen prompt can EDIT it rather than clobber it. Multi-
@@ -366,6 +387,21 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 // prompt() — so this branch has no prompt() at all. flat-cyborg
                 // stays the only backend; `claude -p` is not used.
                 //
+                // #1214: the orchestrator's job (clone + flat-cyborg edit +
+                // commit + push + PR) runs for MINUTES, but agentis caps a single
+                // `exec sh` at ~120000ms (the exec.default_timeout_ms knob is
+                // ignored), so a synchronous call was killed mid-edit with
+                // ExecTimeout. Instead we call tools/code-edit-job.sh — a FAST
+                // launcher that runs code-edit-in-checkout.sh DETACHED (setsid)
+                // and tracks it in a per-issue job dir. It returns in well under
+                // 120s on every tick, printing one of: LAUNCHED (just started),
+                // RUNNING (still going), DONE <url> (PR opened), NO_EDITS (claude
+                // changed nothing), or ERROR <short>. code_writer polls it across
+                // ticks: while LAUNCHED/RUNNING it leaves the #1185 markers unset
+                // so the same assigned issue is re-polled next tick (a re-poll
+                // does NOT start a second clone/edit — the launcher's pid check
+                // guards idempotency). Only DONE sets the markers + emits.
+                //
                 // Deterministic per-issue branch (fix/issue-<iid>) so a retry
                 // reuses the same branch instead of littering empty branches.
                 let issue_iid = to_string(draft.issue_id);
@@ -376,31 +412,46 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 // Task text = issue body + the drafted plan. The orchestrator
                 // wraps this into the claude editing instruction.
                 let task_text = "Issue:\n" + issue_detail + "\n\nPlan:\n" + draft.files + "\n\n" + draft.summary;
-                // The orchestrator handles both new-file and existing-file cases
-                // (claude creates or edits files in the checkout). It exits 0 with
-                // the PR URL on success, 3 (no edits) when claude changed nothing,
-                // and non-zero otherwise — `exec sh` throws on any non-zero, so
-                // the catch covers both NO_EDITS and hard failures; either way we
-                // leave the #1185 markers unset so the next tick retries.
+                // The launcher manages the detached orchestrator's lifecycle and
+                // prints the current poll-state on stdout. It never blocks on the
+                // slow job, so this `exec sh` returns fast and never hits the
+                // 120s cap. A non-zero exit (a usage / launch error) collapses
+                // the `try` to "" => job_word "" => the ERROR/else branch retries.
                 // colony-lint: safe-exec-concat
-                let edit_cmd = "$COLONY_DIR/../../tools/code-edit-in-checkout.sh --owner " + shell_escape(owner) + " --repo " + shell_escape(repo) + " --issue " + shell_escape(issue_iid) + " --branch " + shell_escape(branch_name) + " --title " + shell_escape(draft.summary) + " --task " + shell_escape(task_text);
-                let edit_result = try { exec sh edit_cmd; } catch e {
-                    print("[code_writer] code-edit-in-checkout failed or produced no edits (NO_EDITS / error) — not marking drafted, will retry:", e);
+                let job_cmd = "$COLONY_DIR/../../tools/code-edit-job.sh --owner " + shell_escape(owner) + " --repo " + shell_escape(repo) + " --issue " + shell_escape(issue_iid) + " --branch " + shell_escape(branch_name) + " --title " + shell_escape(draft.summary) + " --task " + shell_escape(task_text);
+                let job_out = try { exec sh job_cmd; } catch e {
+                    print("[code_writer] code-edit-job launcher failed — not marking drafted, will retry:", e);
                     "";
                 };
+                let job_state = job_word(job_out);
 
-                if len(edit_result) > 0 {
-                    // #1185: mark drafted only now that the PR opened. A NO_EDITS
-                    // (exit 3) or any failure leaves edit_result == "" so the
-                    // markers stay unset and the next tick retries the issue.
+                if job_state == "DONE" {
+                    // #1185: mark drafted only now that the PR opened. LAUNCHED /
+                    // RUNNING / NO_EDITS / ERROR all leave the markers unset so
+                    // the next tick re-polls (or retries) the same issue.
+                    let pr_url = job_rest(job_out);
                     memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_iid"), first_iid_str);
                     memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_updated_at"), first_upd);
-                    print("[code_writer] Opened PR via checkout-edit for issue", draft.issue_id, ":", edit_result);
+                    print("[code_writer] Opened PR via detached checkout-edit for issue", draft.issue_id, ":", pr_url);
                     emit("implementation:mr_ready", draft);
                     if len(owner) > 0 {
                         learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation", repo_tag(owner, repo)]);
                     } else {
                         learn("code_write", "issue " + to_string(draft.issue_id), draft.summary, "success", ["acted", "implementation"]);
+                    };
+                } else {
+                    if job_state == "LAUNCHED" {
+                        print("[code_writer] Launched detached checkout-edit for issue", draft.issue_id, "— will poll next tick");
+                    } else {
+                        if job_state == "RUNNING" {
+                            print("[code_writer] Detached checkout-edit still running for issue", draft.issue_id, "— will poll next tick");
+                        } else {
+                            if job_state == "NO_EDITS" {
+                                print("[code_writer] Detached checkout-edit produced no edits for issue", draft.issue_id, "— will retry");
+                            } else {
+                                print("[code_writer] Detached checkout-edit error for issue", draft.issue_id, ":", job_out, "— will retry");
+                            };
+                        };
                     };
                 };
             } else {

--- a/tools/code-edit-job.sh
+++ b/tools/code-edit-job.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# tools/code-edit-job.sh (#1214): a FAST launcher/poller for the slow
+# checkout-edit orchestrator (tools/code-edit-in-checkout.sh).
+#
+# Why this exists: agentis caps a single `exec sh` invocation at ~120000ms
+# (the `exec.default_timeout_ms` knob is ignored), but the orchestrator's job
+# (clone + flat-cyborg/claude edit + commit + push + open PR) routinely runs for
+# minutes. Run synchronously, the orchestrator gets `ExecTimeout after 120000ms`
+# and is killed mid-edit. So the long job MUST run DETACHED and code_writer must
+# POLL a result file across ticks.
+#
+# This launcher returns in well under 120s on EVERY invocation:
+#   - First call for an issue: create a per-issue job dir, mark it `running`,
+#     and launch code-edit-in-checkout.sh DETACHED (setsid, fully redirected,
+#     </dev/null). Print `LAUNCHED` and exit 0 immediately — does NOT wait.
+#   - A later call while the detached job is still alive: print `RUNNING`,
+#     exit 0. It does NOT start a second clone/edit (the whole point — the old
+#     synchronous version re-cloned every tick).
+#   - A later call after the job finished: print the terminal state read from
+#     the job dir — `DONE <pr-url>` / `NO_EDITS` / `ERROR <short>` — and exit 0.
+#
+# Job dir: <fed>/.agentis/jobs/<colony>/issue-<iid>/ with files:
+#   status  : running | done | no_edits | error
+#   result  : the PR URL (only when status=done)
+#   pid      : pid of the detached orchestrator (the setsid leader)
+#   log      : combined stdout+stderr of the detached orchestrator
+#
+# Job-dir lifecycle / consumption: this launcher does NOT delete the job dir.
+# On a terminal poll (`DONE`/`NO_EDITS`/`ERROR`) it CLEARS the dir so the next
+# invocation for the same iid starts a fresh job (a retry after ERROR/NO_EDITS,
+# or a brand-new edit if the issue changed). code_writer consumes the terminal
+# line on the tick it observes it. Idempotency while running is preserved by the
+# pid-liveness check, not by the dir's persistence.
+#
+# Dead/crashed job: if status=running but the recorded pid is no longer alive,
+# the job is treated as `error` (the detached orchestrator died without writing
+# a terminal status — e.g. OOM/SIGKILL). We report `ERROR job-died` and clear
+# the dir so the next poll relaunches; we never hang waiting on a dead pid.
+#
+# Token handling: the detached child inherits GITHUB_TOKEN from this launcher's
+# environment exactly as the synchronous path did. The token VALUE is never
+# expanded onto a command line, never echoed, and never written to the job dir.
+# The orchestrator's own GIT_ASKPASS path keeps it out of argv / the remote URL.
+#
+# Usage (identical identifying args to code-edit-in-checkout.sh):
+#   code-edit-job.sh --owner <o> --repo <r> --issue <iid> \
+#       --branch <name> --title <t> --task <text>
+#
+# Override (testing): CODE_EDIT_ORCH points at a stub orchestrator instead of
+# tools/code-edit-in-checkout.sh. The stub must honour the same exit-code
+# contract (0 -> PR URL on stdout, 3 -> NO_EDITS, other -> failure).
+set -eu
+
+# ---------------------------------------------------------------------------
+# Arg parsing (mirrors code-edit-in-checkout.sh).
+# ---------------------------------------------------------------------------
+OWNER=""
+REPO=""
+ISSUE=""
+BRANCH=""
+TITLE=""
+TASK=""
+
+usage() {
+    echo "usage: code-edit-job.sh --owner <o> --repo <r> --issue <iid> --branch <name> --title <t> --task <text>" >&2
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --owner)  OWNER="${2:-}";  shift 2 ;;
+        --repo)   REPO="${2:-}";   shift 2 ;;
+        --issue)  ISSUE="${2:-}";  shift 2 ;;
+        --branch) BRANCH="${2:-}"; shift 2 ;;
+        --title)  TITLE="${2:-}";  shift 2 ;;
+        --task)   TASK="${2:-}";   shift 2 ;;
+        *) echo "code-edit-job.sh: unknown flag: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+# Legacy single-block fan-out (#316): empty --owner/--repo means the colony env
+# carries the real values in GITHUB_OWNER/GITHUB_REPO. Resolve them here so the
+# job-dir key and the orchestrator both see the same owner/repo.
+if [ -z "$OWNER" ]; then OWNER="${GITHUB_OWNER:-}"; fi
+if [ -z "$REPO" ]; then REPO="${GITHUB_REPO:-}"; fi
+
+if [ -z "$OWNER" ] || [ -z "$REPO" ] || [ -z "$ISSUE" ] || [ -z "$BRANCH" ] || [ -z "$TITLE" ] || [ -z "$TASK" ]; then
+    echo "code-edit-job.sh: --owner, --repo, --issue, --branch, --title, --task are all required" >&2
+    usage
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Resolve FED_DIR + colony name exactly like code-edit-in-checkout.sh so the
+# job dir lives under the same federation tree the orchestrator clones into.
+# ---------------------------------------------------------------------------
+if [ -n "${COLONY_DIR:-}" ]; then
+    FED_DIR="$(cd "$COLONY_DIR/.." && pwd)"
+    COLONY_NAME="$(basename "$COLONY_DIR")"
+else
+    FED_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+    COLONY_NAME="implementation"
+fi
+
+# The slow orchestrator. Overridable for tests via CODE_EDIT_ORCH.
+ORCH="${CODE_EDIT_ORCH:-$SCRIPT_DIR/code-edit-in-checkout.sh}"
+
+JOBDIR="$FED_DIR/.agentis/jobs/$COLONY_NAME/issue-$ISSUE"
+
+# pid_alive <pid>: 0 (true) if the pid names a live process, 1 otherwise.
+pid_alive() {
+    [ -n "${1:-}" ] && kill -0 "$1" 2>/dev/null
+}
+
+# clear_job: remove the job dir so the next invocation starts fresh.
+clear_job() {
+    rm -rf "$JOBDIR"
+}
+
+# read_status / read_result: total reads — empty when the file is absent.
+read_status() {
+    [ -f "$JOBDIR/status" ] && cat "$JOBDIR/status" 2>/dev/null || true
+}
+read_result() {
+    [ -f "$JOBDIR/result" ] && cat "$JOBDIR/result" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Poll an existing job dir before launching anything.
+# ---------------------------------------------------------------------------
+if [ -d "$JOBDIR" ]; then
+    STATUS="$(read_status)"
+    case "$STATUS" in
+        running)
+            PID="$([ -f "$JOBDIR/pid" ] && cat "$JOBDIR/pid" 2>/dev/null || true)"
+            if pid_alive "$PID"; then
+                # Job still in flight — do NOT start a second clone/edit.
+                echo "RUNNING"
+                exit 0
+            fi
+            # status=running but the orchestrator is gone: it died without
+            # writing a terminal status. Report error + clear so the next poll
+            # relaunches; never hang on a dead pid.
+            clear_job
+            echo "ERROR job-died"
+            exit 0
+            ;;
+        done)
+            URL="$(read_result)"
+            clear_job
+            if [ -n "$URL" ]; then
+                echo "DONE $URL"
+            else
+                # done with no URL recorded — treat as an error so the caller
+                # retries rather than silently succeeding with no PR.
+                echo "ERROR done-without-url"
+            fi
+            exit 0
+            ;;
+        no_edits)
+            clear_job
+            echo "NO_EDITS"
+            exit 0
+            ;;
+        error)
+            clear_job
+            echo "ERROR job-failed"
+            exit 0
+            ;;
+        *)
+            # Unknown / empty status (a stale or half-written dir): drop it and
+            # fall through to a fresh launch below.
+            clear_job
+            ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# No live job for this iid — launch one DETACHED and return immediately.
+# ---------------------------------------------------------------------------
+mkdir -p "$JOBDIR"
+printf 'running' > "$JOBDIR/status"
+
+# The detached worker runs the slow orchestrator, captures its exit code, and
+# writes the terminal status + result ATOMICALLY (write to a temp file, then
+# mv) so a poll never observes a half-written status. The orchestrator's stdout
+# (the PR URL on success) is captured to "$JOBDIR/out"; its combined log goes
+# to "$JOBDIR/log". The token is inherited via the environment — never named on
+# a command line here, so it stays out of any `set -x` trace and the job dir.
+#
+# We export the identifying args + ORCH/JOBDIR for the worker subshell so the
+# detached `setsid bash -c` body carries no untrusted concatenation.
+export CEJ_ORCH="$ORCH"
+export CEJ_JOBDIR="$JOBDIR"
+export CEJ_OWNER="$OWNER" CEJ_REPO="$REPO" CEJ_ISSUE="$ISSUE"
+export CEJ_BRANCH="$BRANCH" CEJ_TITLE="$TITLE" CEJ_TASK="$TASK"
+
+# SC2016: the $CEJ_* refs are deliberately INSIDE single quotes — they must
+# expand in the DETACHED child from its inherited env, NOT in this launcher.
+# shellcheck disable=SC2016
+setsid bash -c '
+    set +e
+    "$CEJ_ORCH" \
+        --owner "$CEJ_OWNER" --repo "$CEJ_REPO" --issue "$CEJ_ISSUE" \
+        --branch "$CEJ_BRANCH" --title "$CEJ_TITLE" --task "$CEJ_TASK" \
+        > "$CEJ_JOBDIR/out" 2> "$CEJ_JOBDIR/log"
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        # Last non-empty line of stdout is the PR URL.
+        url="$(grep -v "^$" "$CEJ_JOBDIR/out" 2>/dev/null | tail -n 1)"
+        printf "%s" "$url" > "$CEJ_JOBDIR/result.tmp"
+        mv -f "$CEJ_JOBDIR/result.tmp" "$CEJ_JOBDIR/result"
+        printf "done" > "$CEJ_JOBDIR/status.tmp"
+    elif [ "$rc" -eq 3 ]; then
+        printf "no_edits" > "$CEJ_JOBDIR/status.tmp"
+    else
+        printf "error" > "$CEJ_JOBDIR/status.tmp"
+    fi
+    mv -f "$CEJ_JOBDIR/status.tmp" "$CEJ_JOBDIR/status"
+' </dev/null >/dev/null 2>&1 &
+
+CHILD_PID=$!
+printf '%s' "$CHILD_PID" > "$JOBDIR/pid"
+# Detach from the job so this launcher can exit without leaving a tracked child.
+disown "$CHILD_PID" 2>/dev/null || true
+
+echo "LAUNCHED"
+exit 0

--- a/tools/code-edit-job.sh
+++ b/tools/code-edit-job.sh
@@ -120,10 +120,10 @@ clear_job() {
 
 # read_status / read_result: total reads — empty when the file is absent.
 read_status() {
-    [ -f "$JOBDIR/status" ] && cat "$JOBDIR/status" 2>/dev/null || true
+    if [ -f "$JOBDIR/status" ]; then cat "$JOBDIR/status" 2>/dev/null || true; fi
 }
 read_result() {
-    [ -f "$JOBDIR/result" ] && cat "$JOBDIR/result" 2>/dev/null || true
+    if [ -f "$JOBDIR/result" ]; then cat "$JOBDIR/result" 2>/dev/null || true; fi
 }
 
 # ---------------------------------------------------------------------------
@@ -133,7 +133,8 @@ if [ -d "$JOBDIR" ]; then
     STATUS="$(read_status)"
     case "$STATUS" in
         running)
-            PID="$([ -f "$JOBDIR/pid" ] && cat "$JOBDIR/pid" 2>/dev/null || true)"
+            PID=""
+            if [ -f "$JOBDIR/pid" ]; then PID="$(cat "$JOBDIR/pid" 2>/dev/null || true)"; fi
             if pid_alive "$PID"; then
                 # Job still in flight — do NOT start a second clone/edit.
                 echo "RUNNING"

--- a/tools/test-code-edit-job.sh
+++ b/tools/test-code-edit-job.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# test-code-edit-job.sh (#1214): exercise the FAST detached launcher
+# tools/code-edit-job.sh WITHOUT a real Claude Code / git session. The slow
+# orchestrator (code-edit-in-checkout.sh) is replaced by a STUB pointed at via
+# the CODE_EDIT_ORCH override env. The stub sleeps briefly (so the launcher must
+# return WHILE it is still running) then writes a known result keyed by exit code.
+#
+# Asserts:
+#   1. first call returns LAUNCHED, creates a job dir with status=running, a
+#      recorded pid, and a LIVE detached process (returns fast, < a few sec)
+#   2. a second call while running returns RUNNING and does NOT start a second
+#      orchestrator (exactly one child observed)
+#   3. after the stub finishes:
+#        exit 0 -> DONE <url>   (url from the stub's stdout)
+#        exit 3 -> NO_EDITS
+#        exit 7 -> ERROR ...
+#   4. dead-pid-with-running-status -> ERROR (no hang)
+#   5. the token NEVER appears in the launcher's stdout/stderr
+#
+# Auto-discovered by tools/colony-lint.sh's tools-test loop. Exit 0 if all pass.
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+LAUNCHER="$REPO_ROOT/tools/code-edit-job.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$LAUNCHER" ]; then
+    fail "launcher missing: $LAUNCHER"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FAKE_TOKEN="ghp_FAKE_TOKEN_DO_NOT_LEAK_abcdef0123456789"
+OWNER="acme"
+REPO="widget"
+
+# A fake colony tree so the launcher resolves COLONY_DIR -> FED_DIR -> the job
+# dir under <fed>/.agentis/jobs/<colony>/issue-<iid>/.
+FED_DIR="$WORK/fed"
+COLONY_DIR="$FED_DIR/implementation"
+mkdir -p "$COLONY_DIR"
+
+# ---------------------------------------------------------------------------
+# Stub orchestrator. Behaviour driven by env so a single file covers all modes:
+#   STUB_SLEEP    : seconds to sleep before exiting (default 2) — long enough
+#                   that the launcher must return while it is still running.
+#   STUB_EXIT     : exit code (0 -> success, 3 -> NO_EDITS, other -> error).
+#   STUB_URL      : PR URL printed on stdout (success path).
+#   STUB_MARKER   : a file the stub touches on start, so the test can count how
+#                   many orchestrator instances actually launched.
+# It also asserts GITHUB_TOKEN reached it via the inherited env (never argv).
+# ---------------------------------------------------------------------------
+STUB="$WORK/stub-orch.sh"
+cat > "$STUB" <<'STUB_EOF'
+#!/usr/bin/env bash
+set -u
+# Record one start (append) so the harness can count launches.
+if [ -n "${STUB_MARKER:-}" ]; then echo "start $$ token=${GITHUB_TOKEN:-MISSING}" >> "$STUB_MARKER"; fi
+sleep "${STUB_SLEEP:-2}"
+if [ "${STUB_EXIT:-0}" -eq 0 ]; then
+    printf '%s\n' "${STUB_URL:-https://example.test/pr/1}"
+fi
+exit "${STUB_EXIT:-0}"
+STUB_EOF
+chmod +x "$STUB"
+
+# run_launcher <issue> : invoke the launcher with the colony env + the stub
+# orchestrator override. Identifying args are constant; the issue iid keys the
+# job dir. STUB_* knobs are inherited from the caller's env.
+run_launcher() {
+    local iid="$1"
+    env \
+        COLONY_DIR="$COLONY_DIR" \
+        CODE_EDIT_ORCH="$STUB" \
+        GITHUB_TOKEN="$FAKE_TOKEN" \
+        GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+        STUB_SLEEP="${STUB_SLEEP:-2}" STUB_EXIT="${STUB_EXIT:-0}" \
+        STUB_URL="${STUB_URL:-https://example.test/pr/1}" \
+        STUB_MARKER="${STUB_MARKER:-}" \
+        bash "$LAUNCHER" \
+            --owner "$OWNER" --repo "$REPO" --issue "$iid" \
+            --branch "fix/issue-$iid" --title "implement thing" \
+            --task "Edit the files to implement the thing."
+}
+
+job_dir_for() { echo "$FED_DIR/.agentis/jobs/implementation/issue-$1"; }
+
+# ===========================================================================
+# Scenario A (exit 0 -> DONE): launch, observe RUNNING, then DONE <url>.
+# ===========================================================================
+IID=42
+MARKER_A="$WORK/marker-a.log"
+export STUB_SLEEP=2 STUB_EXIT=0 STUB_URL="https://example.test/pr/42" STUB_MARKER="$MARKER_A"
+
+OUTA1="$WORK/a1.out"; ERRA1="$WORK/a1.err"
+run_launcher "$IID" >"$OUTA1" 2>"$ERRA1"
+RCA1=$?
+A1="$(cat "$OUTA1")"
+
+if [ "$RCA1" -eq 0 ] && [ "$A1" = "LAUNCHED" ]; then
+    pass "A: first call returns LAUNCHED and exits 0 (fast)"
+else
+    fail "A: first call LAUNCHED" "rc=$RCA1 stdout=[$A1] err=$(cat "$ERRA1")"
+fi
+
+JD="$(job_dir_for "$IID")"
+if [ -d "$JD" ] && [ "$(cat "$JD/status" 2>/dev/null)" = "running" ]; then
+    pass "A: job dir created with status=running"
+else
+    fail "A: job dir status=running" "dir=$JD status=$(cat "$JD/status" 2>/dev/null)"
+fi
+
+JPID="$(cat "$JD/pid" 2>/dev/null || echo '')"
+if [ -n "$JPID" ] && kill -0 "$JPID" 2>/dev/null; then
+    pass "A: a live detached pid is recorded"
+else
+    fail "A: live detached pid recorded" "pid=[$JPID]"
+fi
+
+# Token must not appear in the launcher's own stdout/stderr.
+if grep -q "$FAKE_TOKEN" "$OUTA1" "$ERRA1"; then
+    fail "A: token LEAKED into launcher stdout/stderr"
+else
+    pass "A: token never appears in launcher stdout/stderr"
+fi
+
+# Second call WHILE running -> RUNNING, and must NOT start a second job.
+OUTA2="$WORK/a2.out"; ERRA2="$WORK/a2.err"
+run_launcher "$IID" >"$OUTA2" 2>"$ERRA2"
+A2="$(cat "$OUTA2")"
+if [ "$A2" = "RUNNING" ]; then
+    pass "A: second call while running returns RUNNING"
+else
+    fail "A: second call RUNNING" "stdout=[$A2]"
+fi
+
+# Exactly ONE orchestrator instance ever started (idempotency).
+STARTS="$(grep -c '^start ' "$MARKER_A" 2>/dev/null || echo 0)"
+if [ "$STARTS" -eq 1 ]; then
+    pass "A: idempotent — exactly one orchestrator launched despite two calls"
+else
+    fail "A: only one orchestrator launched" "starts=$STARTS"
+fi
+
+# Wait for the detached stub to finish (sleep 2 + margin), then poll -> DONE.
+i=0
+while kill -0 "$JPID" 2>/dev/null && [ "$i" -lt 50 ]; do sleep 0.2; i=$((i + 1)); done
+# Give the worker a beat to write the terminal status atomically.
+sleep 0.3
+
+OUTA3="$WORK/a3.out"; ERRA3="$WORK/a3.err"
+run_launcher "$IID" >"$OUTA3" 2>"$ERRA3"
+A3="$(cat "$OUTA3")"
+if [ "$A3" = "DONE https://example.test/pr/42" ]; then
+    pass "A: poll after finish returns DONE <pr-url>"
+else
+    fail "A: DONE <pr-url>" "stdout=[$A3] log=$(cat "$JD/log" 2>/dev/null)"
+fi
+
+# Terminal poll consumes/clears the job dir so the next call would relaunch.
+if [ ! -d "$JD" ]; then
+    pass "A: terminal poll cleared the job dir (consumed)"
+else
+    fail "A: job dir cleared after DONE" "still exists: $JD"
+fi
+
+# The stub saw the token via the inherited environment (never argv).
+if grep -q "token=$FAKE_TOKEN" "$MARKER_A"; then
+    pass "A: detached child inherited GITHUB_TOKEN via env"
+else
+    fail "A: token inherited by detached child" "marker=$(cat "$MARKER_A" 2>/dev/null)"
+fi
+
+# ===========================================================================
+# Scenario B (exit 3 -> NO_EDITS).
+# ===========================================================================
+IID=43
+MARKER_B="$WORK/marker-b.log"
+export STUB_SLEEP=1 STUB_EXIT=3 STUB_MARKER="$MARKER_B"
+run_launcher "$IID" >/dev/null 2>&1
+JD="$(job_dir_for "$IID")"
+JPID="$(cat "$JD/pid" 2>/dev/null || echo '')"
+i=0
+while kill -0 "$JPID" 2>/dev/null && [ "$i" -lt 50 ]; do sleep 0.2; i=$((i + 1)); done
+sleep 0.3
+B="$(run_launcher "$IID" 2>/dev/null)"
+if [ "$B" = "NO_EDITS" ]; then
+    pass "B: exit-3 orchestrator -> NO_EDITS"
+else
+    fail "B: NO_EDITS on exit 3" "stdout=[$B]"
+fi
+
+# ===========================================================================
+# Scenario C (exit 7 -> ERROR).
+# ===========================================================================
+IID=44
+MARKER_C="$WORK/marker-c.log"
+export STUB_SLEEP=1 STUB_EXIT=7 STUB_MARKER="$MARKER_C"
+run_launcher "$IID" >/dev/null 2>&1
+JD="$(job_dir_for "$IID")"
+JPID="$(cat "$JD/pid" 2>/dev/null || echo '')"
+i=0
+while kill -0 "$JPID" 2>/dev/null && [ "$i" -lt 50 ]; do sleep 0.2; i=$((i + 1)); done
+sleep 0.3
+C="$(run_launcher "$IID" 2>/dev/null)"
+case "$C" in
+    ERROR*) pass "C: non-0/non-3 orchestrator exit -> ERROR" ;;
+    *) fail "C: ERROR on exit 7" "stdout=[$C]" ;;
+esac
+
+# ===========================================================================
+# Scenario D (dead pid + status=running -> ERROR, no hang). Forge a job dir by
+# hand: status=running but pid points at a definitely-dead process.
+# ===========================================================================
+IID=45
+JD="$(job_dir_for "$IID")"
+mkdir -p "$JD"
+printf 'running' > "$JD/status"
+# A pid that is not alive: spawn `true`, reap it, reuse its (now-dead) pid.
+( exec true ) & DEAD=$!
+wait "$DEAD" 2>/dev/null || true
+# In the unlikely event the pid was recycled, fall back to a huge unused pid.
+if kill -0 "$DEAD" 2>/dev/null; then DEAD=2147480000; fi
+printf '%s' "$DEAD" > "$JD/pid"
+
+# A poll of an existing (forged) running-but-dead job never launches the stub,
+# so the STUB_* knobs are irrelevant here; the launcher must return on its own.
+export STUB_SLEEP=1 STUB_EXIT=0 STUB_MARKER=''
+D="$(run_launcher "$IID" 2>/dev/null)" || true
+case "$D" in
+    ERROR*) pass "D: dead-pid + status=running -> ERROR (no hang)" ;;
+    *) fail "D: ERROR on dead pid" "stdout=[$D]" ;;
+esac
+if [ ! -d "$JD" ]; then
+    pass "D: stale dead-pid job dir cleared for relaunch"
+else
+    fail "D: dead-pid job dir cleared" "still exists: $JD"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-code-writer-completion-markers.sh
+++ b/tools/test-code-writer-completion-markers.sh
@@ -17,14 +17,15 @@
 #   draft prompt, BEFORE the autonomous action ran. A half-completed tick still
 #   marked the issue "drafted", so the #200 gate skipped it forever. The fix
 #   sets the markers only once the path's own action has COMPLETED: the
-#   autonomous path (#1210: Approach A — edit in a local checkout via
-#   code-edit-in-checkout.sh, then commit the diff + open the PR) sets them only
-#   inside the PR-opened block (`if len(edit_result) > 0`); the non-autonomous
-#   (review-gated / propose / shadow) paths still set them after their terminal
-#   draft comment / emit. We assert, structurally:
+#   autonomous path (#1210: Approach A — edit in a local checkout, then commit
+#   the diff + open the PR; #1214: the slow orchestrator runs DETACHED via
+#   code-edit-job.sh and code_writer polls its state across ticks) sets them
+#   only inside the PR-opened block (`if job_state == "DONE"`); the
+#   non-autonomous (review-gated / propose / shadow) paths still set them after
+#   their terminal draft comment / emit. We assert, structurally:
 #     - the markers are NOT written before the tier branch (no write between
 #       `should_draft_code(...)` and the `if my_tier == "autonomous"` branch);
-#     - a marker write appears inside the `if len(edit_result) > 0` block;
+#     - a marker write appears inside the `if job_state == "DONE"` block;
 #     - a marker write still exists on the non-autonomous side.
 #
 # Matches the test style of tools/test-assignment-based-pickup.sh (bash,
@@ -75,7 +76,7 @@ fi
 # three regions delimited by the structural anchors, so we assert *where* the
 # marker writes live, not just that they exist somewhere.
 #   region A: from `should_draft_code(` up to (not incl.) the autonomous branch
-#   region B: from `if len(edit_result) > 0` to its closing scope
+#   region B: from `if job_state == "DONE"` to its closing scope
 #   region C: from the non-autonomous `} else {` (the tier else) to end
 # -----------------------------------------------------------------------------
 MARKER='memo_write(scoped_memo(owner, repo, "code_writer:last_drafted_iid")'
@@ -94,24 +95,25 @@ else
   pass "marker NOT set before the tier branch (autonomous flow can retry)"
 fi
 
-# Region B: inside the PR-opened block. The autonomous path must mark only
-# after code-edit-in-checkout.sh returns success (the PR URL).
+# Region B: inside the PR-opened block. The autonomous path must mark only when
+# the detached job reports DONE (the poll-state machine, #1214) — never on
+# LAUNCHED / RUNNING / NO_EDITS / ERROR.
 region_b="$(awk '
-  /if len\(edit_result\) > 0/ { grab=1 }
+  /if job_state == "DONE"/ { grab=1 }
   grab { print }
   /emit\("implementation:mr_ready", draft\)/ { if (grab) exit }
 ' "$AG")"
 if printf '%s\n' "$region_b" | grep -F -q -- "$MARKER"; then
-  pass "autonomous path sets the marker inside the PR-opened block"
+  pass "autonomous path sets the marker inside the job_state == \"DONE\" block"
 else
   fail "autonomous marker placement" \
-    "last_drafted_iid not written inside the 'if len(edit_result) > 0' block"
+    "last_drafted_iid not written inside the 'if job_state == \"DONE\"' block"
 fi
 
-# The autonomous branch must NOT mark before the checkout-edit orchestrator
-# runs: assert the marker write occurs after the code-edit-in-checkout.sh
-# command line within the file.
-edit_line="$(grep -n -F -- 'code-edit-in-checkout.sh' "$AG" | head -1 | cut -d: -f1)"
+# The autonomous branch must NOT mark before the detached launcher runs: assert
+# the marker write occurs after the code-edit-job.sh command line within the
+# file (#1214 moved the slow orchestrator behind this fast launcher).
+edit_line="$(grep -n -F -- 'tools/code-edit-job.sh --owner' "$AG" | head -1 | cut -d: -f1)"
 marker_lines="$(grep -n -F -- "$MARKER" "$AG" | cut -d: -f1)"
 autonomous_marker_after_edit=0
 if [ -n "$edit_line" ]; then
@@ -123,10 +125,10 @@ if [ -n "$edit_line" ]; then
   done
 fi
 if [ "$autonomous_marker_after_edit" = "1" ]; then
-  pass "a marker write follows the code-edit-in-checkout.sh call (not before it)"
+  pass "a marker write follows the code-edit-job.sh launcher call (not before it)"
 else
-  fail "marker vs checkout-edit ordering" \
-    "no last_drafted_iid write found after the code-edit-in-checkout.sh line"
+  fail "marker vs launcher ordering" \
+    "no last_drafted_iid write found after the code-edit-job.sh line"
 fi
 
 # Region C: the non-autonomous paths (review-gated / propose / shadow) must

--- a/tools/test-mr-handoff-durable.sh
+++ b/tools/test-mr-handoff-durable.sh
@@ -33,13 +33,16 @@ pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
 fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
 
 # =============================================================================
-# code_writer: #1210 (Approach A) — the autonomous path now edits files in a
-# local checkout and opens the PR DIRECTLY (via tools/code-edit-in-checkout.sh),
-# emitting implementation:mr_ready itself. It therefore no longer hands off to
-# commit_composer via the durable implementation:pending_mr memo — writing that
-# memo would make commit_composer open a DUPLICATE MR for the same branch. The
-# durable handoff machinery stays in commit_composer (asserted below) for any
-# pending_mr written by other code paths; code_writer just no longer feeds it.
+# code_writer: #1210 (Approach A) — the autonomous path edits files in a local
+# checkout and opens the PR DIRECTLY, emitting implementation:mr_ready itself.
+# #1214 — the slow orchestrator (tools/code-edit-in-checkout.sh) now runs
+# DETACHED behind a fast launcher (tools/code-edit-job.sh) that code_writer
+# polls across ticks (LAUNCHED/RUNNING/DONE/NO_EDITS/ERROR). The path still does
+# NOT hand off to commit_composer via the durable implementation:pending_mr memo
+# — writing that memo would make commit_composer open a DUPLICATE MR for the
+# same branch. The durable handoff machinery stays in commit_composer (asserted
+# below) for any pending_mr written by other code paths; code_writer never feeds
+# it. The mr_ready emit sits on the DONE poll-state (the PR-opened path).
 # =============================================================================
 if [ -f "$CODE_WRITER" ]; then
     # The autonomous path must NOT write the pending_mr handoff (it opens the PR
@@ -51,24 +54,24 @@ if [ -f "$CODE_WRITER" ]; then
         pass "#1210 code_writer: no pending_mr handoff (autonomous path opens the PR directly, no double-open)"
     fi
 
-    # The autonomous path opens the PR via the checkout-edit orchestrator and
-    # emits implementation:mr_ready itself.
-    if grep -q 'code-edit-in-checkout.sh' "$CODE_WRITER"; then
-        pass "#1210 code_writer: autonomous path drives tools/code-edit-in-checkout.sh"
+    # The autonomous path drives the slow orchestrator via the #1214 detached
+    # launcher (tools/code-edit-job.sh) and emits implementation:mr_ready itself.
+    if grep -q 'tools/code-edit-job.sh --owner' "$CODE_WRITER"; then
+        pass "#1214 code_writer: autonomous path drives the detached tools/code-edit-job.sh launcher"
     else
-        fail "#1210 code_writer: missing the code-edit-in-checkout.sh orchestrator call"
+        fail "#1214 code_writer: missing the code-edit-job.sh launcher call"
     fi
 
     # The mr_ready emit must sit on the PR-opened path (inside the
-    # `if len(edit_result) > 0` block).
+    # `if job_state == "DONE"` block, #1214's poll-state machine).
     if awk '
-        /if len\(edit_result\) > 0/ { grab = 1 }
+        /if job_state == "DONE"/ { grab = 1 }
         grab && /emit\("implementation:mr_ready", draft\)/ { found = 1 }
         END { exit(found ? 0 : 1) }
     ' "$CODE_WRITER"; then
-        pass "#1210 code_writer: emits implementation:mr_ready on the PR-opened path"
+        pass "#1214 code_writer: emits implementation:mr_ready on the DONE (PR-opened) path"
     else
-        fail "#1210 code_writer: does not emit implementation:mr_ready after opening the PR"
+        fail "#1214 code_writer: does not emit implementation:mr_ready after opening the PR"
     fi
 else
     fail "#1151 code_writer: agent file not found at $CODE_WRITER"


### PR DESCRIPTION
Closes #1214.

agentis caps a single `exec sh` at **120000ms** (config above it is ignored — confirmed live). The Approach-A orchestrator (clone + claude edit + commit + PR = minutes) ran synchronously and got killed mid-edit → empty branch → retry loop. **Fix: run it detached, poll across ticks.**

- **`tools/code-edit-job.sh`** (fast launcher, <1s): per-issue job dir under `.agentis/jobs/…`; prints `LAUNCHED` (setsid the detached orchestrator, record pid), `RUNNING` (alive → no second clone), `DONE <url>`/`NO_EDITS`/`ERROR` (terminal → clear). Dead-pid → `ERROR job-died` (no hang). Token via env, never logged.
- **`code_writer.ag`**: poll-state machine — DONE → #1185 markers + mr_ready + learn; LAUNCHED/RUNNING → unset, re-poll next tick (no double-launch); NO_EDITS/ERROR → retry. One `tier()`/tick; no `prompt()` in the branch.

## Verification
- colony-lint **428 passed, 0 failed, 5 skipped**; new test 13/0; completion-markers 7/0, mr-handoff 15/0.
- QA: ✅ ship-it (Linux host: no-double-launch, fast-return, terminal mapping, dead-pid, token-safe all verified). ⚠️ setsid on non-Linux + truly-concurrent-same-iid are out-of-scope follow-ups (unreachable in single-daemon serial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)