### PR TITLE
fix(tools): flat-cyborg-claude reads reply from a result file, not TUI scrape (#1219)

### DIFF
--- a/tools/flat-cyborg-claude.sh
+++ b/tools/flat-cyborg-claude.sh
@@ -5,7 +5,8 @@
 # metered `claude -p` API path). agentis invokes the configured llm.command with
 # the prompt as a trailing positional arg; this wrapper takes the prompt from
 # "$1" (falling back to stdin) and returns only the model's reply on stdout
-# (flat-cyborg --extract).
+# (read from a result file claude writes; see the RESULT-FILE channel note
+# below, with a flat-cyborg --extract screen-scrape as fallback).
 #
 # This generalizes the proven dark-factory/flat-cyborg-claude.sh into shared,
 # path-independent tooling so every dev-apprenticeship colony can use the same
@@ -19,10 +20,34 @@
 # an installed copy self-updates with `flat-cyborg update`).
 #
 # Knobs (env vars): FLAT_CYBORG_IDLE_MS, FLAT_CYBORG_TIMEOUT_MS.
+#
+# RESULT-FILE channel (#1219): the historical extraction path reads claude's
+# reply off the rendered TUI via --extract / --extract-structural. That is a
+# screen-scrape: a reply taller than the screen scrolls the start sentinel out
+# of view, so --extract returns nothing and --extract-structural falls back to
+# whatever chrome/prose is on screen — the caller then decodes invalid JSON.
+# (Observed live: drafting prompts intermittently failed "CLI returned invalid
+# JSON".) The fix is to stop trusting the screen: we ask claude to write its
+# COMPLETE reply to a temp file with its file-write tool and read THAT. claude's
+# Write tool emits exact bytes (no scroll, no line-wrap, no chrome). The
+# screen-scrape path is kept as a FALLBACK for when claude does not write the
+# file, so this is strictly >= the old behaviour. A non-empty result file even
+# after a flat-cyborg non-zero exit (idle/timeout that still produced the answer)
+# is honoured — same spirit as commit-on-diff in code-edit-in-checkout.sh (#1216).
 set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROMPT="${1:-}"
 if [ -z "$PROMPT" ]; then PROMPT="$(cat)"; fi
+# The authoritative output channel: a file claude writes its reply to. Created
+# empty up front; claude is told (below) to overwrite it with the raw reply.
+RESULT_FILE="$(mktemp)"
+# Append the output-channel directive to the caller's prompt. It is additive and
+# backend-generic (JSON and prose consumers alike): claude writes its exact reply
+# to RESULT_FILE; if it doesn't, the screen-scrape fallback preserves old behaviour.
+PROMPT="$PROMPT
+
+[OUTPUT CHANNEL] Write your COMPLETE reply — and nothing else — to this exact file path using your file-writing tool: $RESULT_FILE
+Write the raw reply content only: for a JSON reply, the raw JSON object with NO markdown code fences; for prose, the prose itself. This file is the authoritative channel for your answer — write it before you finish."
 # --wrap-input 72: fold the (often single-line, ~700-char) instruction block so it
 # does not overflow claude's editor input.
 # --extract-structural (needs flat-cyborg >=0.10.2): claude INTERMITTENTLY omits the
@@ -54,7 +79,7 @@ REPLY_FILE="$(mktemp)"
 # >= 0.11.0 (the --cmd-file flag).
 PROMPT_FILE="$(mktemp)"
 printf '%s' "$PROMPT" > "$PROMPT_FILE"
-trap 'rm -f "$REPLY_FILE" "$PROMPT_FILE"' EXIT
+trap 'rm -f "$REPLY_FILE" "$PROMPT_FILE" "$RESULT_FILE"' EXIT
 set +e
 flat-cyborg --extract --extract-structural --no-jitter --auto-approve --wrap-input 72 \
   --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" \
@@ -62,5 +87,14 @@ flat-cyborg --extract --extract-structural --no-jitter --auto-approve --wrap-inp
   --cmd-file "$PROMPT_FILE" -- claude > "$REPLY_FILE"
 FC_RC=$?
 set -e
+# Prefer the result-file channel: if claude wrote a non-empty reply there, that
+# is authoritative — even when flat-cyborg exited non-zero (an idle/timeout that
+# still produced the answer; claude's Write is atomic so a non-empty file is a
+# complete reply, not a partial one). Only when the file is empty do we fall back
+# to the screen-scrape reply, and only then does a flat-cyborg failure propagate.
+if [ -s "$RESULT_FILE" ] && grep -q '[^[:space:]]' "$RESULT_FILE"; then
+    python3 "$SCRIPT_DIR/flat-cyborg-unwrap.py" < "$RESULT_FILE"
+    exit 0
+fi
 [ "$FC_RC" -eq 0 ] || exit "$FC_RC"
 python3 "$SCRIPT_DIR/flat-cyborg-unwrap.py" < "$REPLY_FILE"

--- a/tools/test-flat-cyborg-claude.sh
+++ b/tools/test-flat-cyborg-claude.sh
@@ -104,6 +104,97 @@ else
          "out=[$OUT3]"
 fi
 
+# ===========================================================================
+# RESULT-FILE channel (#1219): exercise the WRAPPER's channel-selection logic
+# with a STUB `flat-cyborg` on PATH (no real flat-cyborg / claude needed). The
+# stub parses the --cmd-file prompt for the RESULT_FILE path the wrapper told
+# claude to write to, then — per FCSTUB_MODE — writes the result file and/or the
+# screen reply and exits with FCSTUB_RC. We assert the wrapper:
+#   1. prefers the result-file reply when claude wrote it (exit 0),
+#   2. falls back to the screen-scrape reply when the file is empty,
+#   3. honours a non-empty result file even on a flat-cyborg non-zero exit,
+#   4. propagates the flat-cyborg exit code when nothing was produced.
+# ===========================================================================
+WRAPPER="$SCRIPT_DIR/flat-cyborg-claude.sh"
+if [ ! -f "$WRAPPER" ]; then
+    fail "missing wrapper: $WRAPPER"
+else
+    STUB_DIR="$(mktemp -d)"
+    cat > "$STUB_DIR/flat-cyborg" <<'STUB_EOF'
+#!/usr/bin/env bash
+set -eu
+CMDFILE=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cmd-file) CMDFILE="$2"; shift 2 ;;
+        --) shift; break ;;
+        *) shift ;;
+    esac
+done
+# Recover the path the wrapper asked claude to write its reply to.
+RESULT_FILE="$(grep -F 'file-writing tool:' "$CMDFILE" 2>/dev/null | sed 's/.*file-writing tool: //' | head -1)"
+case "${FCSTUB_MODE:-file}" in
+    file)        printf '%s' "$FCSTUB_FILE_REPLY"   > "$RESULT_FILE" ;;
+    screen-only) printf '%s\n' "$FCSTUB_SCREEN_REPLY" ;;            # screen (stdout) only, no file
+    file-and-rc) printf '%s' "$FCSTUB_FILE_REPLY"   > "$RESULT_FILE" ;;
+    none)        : ;;                                               # neither file nor screen
+esac
+exit "${FCSTUB_RC:-0}"
+STUB_EOF
+    chmod +x "$STUB_DIR/flat-cyborg"
+
+    run_wrapper() {  # $1=mode $2=rc ; reads FCSTUB_FILE_REPLY/FCSTUB_SCREEN_REPLY from env
+        PATH="$STUB_DIR:$PATH" FCSTUB_MODE="$1" FCSTUB_RC="$2" \
+            sh "$WRAPPER" "draft something. Return ONLY the raw JSON object."
+    }
+
+    # 1. result file written -> wrapper returns the file reply (exit 0)
+    FILE_JSON='{"action":"LONG","size":0.5,"setup":"file_channel"}'
+    OUTW="$(FCSTUB_FILE_REPLY="$FILE_JSON" run_wrapper file 0 2>/dev/null)"; RCW=$?
+    if [ "$RCW" -eq 0 ] && printf '%s' "$OUTW" | python3 -c '
+import json,sys
+d=json.load(sys.stdin); assert d["setup"]=="file_channel", d
+' >/dev/null 2>&1; then
+        pass "test 4: wrapper returns the result-file reply when claude wrote it"
+    else
+        fail "test 4: result-file reply preferred" "rc=$RCW out=[$OUTW]"
+    fi
+
+    # 2. no file written, screen has the reply -> fallback to screen-scrape
+    OUTW="$(FCSTUB_SCREEN_REPLY='{"action":"FLAT","setup":"screen_fallback"}' run_wrapper screen-only 0 2>/dev/null)"; RCW=$?
+    if [ "$RCW" -eq 0 ] && printf '%s' "$OUTW" | python3 -c '
+import json,sys
+d=json.load(sys.stdin); assert d["setup"]=="screen_fallback", d
+' >/dev/null 2>&1; then
+        pass "test 5: wrapper falls back to the screen reply when no result file"
+    else
+        fail "test 5: screen-scrape fallback" "rc=$RCW out=[$OUTW]"
+    fi
+
+    # 3. flat-cyborg exits non-zero BUT the result file was written -> use it, exit 0
+    OUTW="$(FCSTUB_FILE_REPLY='{"setup":"file_despite_timeout"}' run_wrapper file-and-rc 124 2>/dev/null)"; RCW=$?
+    if [ "$RCW" -eq 0 ] && printf '%s' "$OUTW" | python3 -c '
+import json,sys
+d=json.load(sys.stdin); assert d["setup"]=="file_despite_timeout", d
+' >/dev/null 2>&1; then
+        pass "test 6: non-empty result file honoured even on flat-cyborg non-zero exit"
+    else
+        fail "test 6: result file beats a non-zero exit" "rc=$RCW out=[$OUTW]"
+    fi
+
+    # 4. nothing produced + non-zero exit -> propagate the flat-cyborg exit code
+    set +e
+    OUTW="$(run_wrapper none 17 2>/dev/null)"; RCW=$?
+    set -e
+    if [ "$RCW" -eq 17 ]; then
+        pass "test 7: flat-cyborg exit code propagates when no reply is produced"
+    else
+        fail "test 7: propagate exit on empty reply" "rc=$RCW (expected 17) out=[$OUTW]"
+    fi
+
+    rm -rf "$STUB_DIR"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fixes #1219.

## Root cause
`tools/flat-cyborg-claude.sh` extracted claude's reply by **screen-scraping the TUI** (`--extract`/`--extract-structural`). For any reply taller than the screen the start sentinel scrolls off → `--extract` returns nothing, `--extract-structural` returns on-screen chrome/prose → the agentis caller decodes **invalid JSON**. This is the root cause of the dev-apprenticeship federation's intermittent `CLI returned invalid JSON` drafting failures and the `❯ ⏵⏵ auto mode on …` chrome leaking into a task — clean scrape succeeded, corrupted scrape failed, so runs were nondeterministically unreliable.

## Fix
Stop trusting the screen: append an output-channel directive telling claude to write its **complete reply** to a temp file with its file-write tool, and read **that file**. claude's Write emits exact bytes — no scroll, no line-wrap, no chrome.

| State | Behaviour |
|-------|-----------|
| result file non-empty | authoritative reply, **even on a flat-cyborg non-zero exit** (idle/timeout that still produced the answer; Write is atomic → non-empty = complete). Same spirit as commit-on-diff in #1216. |
| result file empty | fall back to the existing screen-scrape path → **strictly ≥ old behaviour** |

Backend-generic (JSON + prose); no flat-cyborg binary change.

## Tests
`tools/test-flat-cyborg-claude.sh` gains a stubbed-`flat-cyborg` section (CI-runnable, no real flat-cyborg/claude): result-file preferred (4), screen fallback when no file (5), non-empty file honoured on non-zero exit (6), exit-code propagates when nothing produced (7). `7 passed, 0 failed`; `colony-lint 428 passed, 0 failed, 5 skipped`. Validated live: the real wrapper returns valid JSON via the file channel on a prompt where the screen-extract returned prose.