### PR TITLE
fix(tools): code-edit editing agent uses --extract to reliably drive Claude (#1221)

### DIFF
--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -198,21 +198,31 @@ run_git -C "$WS" checkout -B "$BRANCH" "origin/$DEFAULT_BRANCH"
 
 # ---------------------------------------------------------------------------
 # 3. Edit: run claude (via flat-cyborg) as an editing agent inside the
-#    checkout. We mirror flat-cyborg-claude.sh's flags MINUS --extract /
-#    --extract-structural: here claude EDITS files with its own tools, so we do
-#    not need to scrape a reply off the screen. --cwd points it at the checkout;
-#    --auto-approve lets it write without an interactive confirm; --no-jitter +
-#    the idle/timeout knobs keep behaviour identical to the wrapper.
+#    checkout. We mirror flat-cyborg-claude.sh's FULL flag set, including
+#    --extract --extract-structural --wrap-input 72. Earlier this path dropped
+#    those flags on the theory that an editing agent makes file changes with its
+#    own tools and never needs a scraped reply — but #1221 showed that without
+#    --extract flat-cyborg does NOT reliably drive the interactive Claude session
+#    to submit-and-act: the prompt is typed but never executed, so claude sits
+#    idle at the input bar until --timeout-ms and produces NO edit (reproduced
+#    live, even for a one-line edit). --extract is what makes flat-cyborg wait
+#    for the session to be ready, submit the prompt, and let claude run to a
+#    settled screen. We do NOT consume its scraped reply here (the artifact is
+#    the git diff), and we redirect flat-cyborg's stdout to stderr so the
+#    scraped screen text can never contaminate this script's stdout, which must
+#    stay the PR URL alone. --wrap-input 72 folds the (large) task prompt so it
+#    does not overflow claude's input editor; --cwd points claude at the
+#    checkout; --auto-approve writes without an interactive confirm.
 # ---------------------------------------------------------------------------
 printf 'Implement issue #%s in this repository by editing the files directly with your tools. %s\n\n%s\n\nMake the change and stop; do not run git or open a PR.' \
     "$ISSUE" "$TITLE" "$TASK" > "$TASKFILE"
 
 echo "[code-edit] running flat-cyborg editing agent in $WS" >&2
 set +e
-flat-cyborg --no-jitter --auto-approve --cwd "$WS" \
+flat-cyborg --extract --extract-structural --no-jitter --auto-approve --wrap-input 72 --cwd "$WS" \
     --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" \
     --timeout-ms "${CODE_EDIT_TIMEOUT_MS:-600000}" \
-    --cmd-file "$TASKFILE" -- claude
+    --cmd-file "$TASKFILE" -- claude >&2
 FC_RC=$?
 set -e
 

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -124,7 +124,8 @@ chmod +x "$COLONY_DIR/scripts/github-api.sh"
 #   edit    : parse --cwd, write a new file there (simulate an editing agent)
 #   no-edit : touch nothing (simulate claude making no change)
 # It also records the flags it was given so we can confirm the orchestrator
-# passed --cwd / --auto-approve / --no-jitter and NOT --extract.
+# passed the full driving set --cwd / --auto-approve / --no-jitter / --extract /
+# --wrap-input (#1221).
 # ---------------------------------------------------------------------------
 STUB_BIN="$WORK/bin"
 mkdir -p "$STUB_BIN"

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -234,8 +234,12 @@ else
     fail "run 1: token passed to create-mr via env"
 fi
 
-# flat-cyborg was driven as an editing agent: --cwd + --auto-approve +
-# --no-jitter, and NOT --extract (we don't scrape a reply here).
+# flat-cyborg was driven as an editing agent with the FULL driving flag set:
+# --cwd + --auto-approve + --no-jitter AND --extract + --wrap-input. Without
+# --extract flat-cyborg does not reliably submit-and-run the interactive Claude
+# session, so the prompt is typed but never executed and no edit is produced
+# (#1221). We don't consume the scraped reply (the artifact is the git diff) —
+# --extract is here purely to drive the session.
 FC_FLAGS="$(cat "$FC_FLAGS_LOG" 2>/dev/null || echo '')"
 if printf '%s' "$FC_FLAGS" | grep -q -- '--cwd' \
     && printf '%s' "$FC_FLAGS" | grep -q -- '--auto-approve' \
@@ -244,10 +248,11 @@ if printf '%s' "$FC_FLAGS" | grep -q -- '--cwd' \
 else
     fail "run 1: flat-cyborg editing-agent flags" "flags=[$FC_FLAGS]"
 fi
-if printf '%s' "$FC_FLAGS" | grep -q -- '--extract'; then
-    fail "run 1: flat-cyborg must NOT run in --extract mode (editing agent, no reply scrape)"
+if printf '%s' "$FC_FLAGS" | grep -q -- '--extract' \
+    && printf '%s' "$FC_FLAGS" | grep -q -- '--wrap-input'; then
+    pass "run 1: flat-cyborg driven with --extract + --wrap-input (reliable session submit, #1219)"
 else
-    pass "run 1: flat-cyborg not run in --extract mode (editing agent)"
+    fail "run 1: flat-cyborg must drive with --extract + --wrap-input" "flags=[$FC_FLAGS]"
 fi
 
 # ===========================================================================


### PR DESCRIPTION
Fixes #1221.

## Root cause
`tools/code-edit-in-checkout.sh` drove the editing Claude session via flat-cyborg **without** `--extract` / `--wrap-input` (the comment claimed an editing agent needs no scraped reply). But that flag set does not reliably **submit-and-run** the interactive session: the prompt is typed but never executed → claude sits idle at `❯ ⏵⏵ auto mode on …` until `--timeout-ms` → **no edit**. This is why the federation's #1192 re-run kept failing at the edit stage while drafting succeeded.

Reproduced in isolation:
| Invocation | Result |
|------------|--------|
| orchestrator's flags (no `--extract`), one-line edit task | rc=124, **no edit** |
| same + `--extract --extract-structural --wrap-input 72` | rc=0, **edit applied** ("Done. Appended …") |

## Fix
Add `--extract --extract-structural --wrap-input 72` to the editing invocation — purely to **drive** the session (wait for readiness, submit, run to a settled screen). The scraped reply is **not** consumed (the artifact is the `git diff`), and flat-cyborg's stdout is redirected to stderr so screen text never contaminates this script's stdout, which must stay the PR URL alone (also stops TUI chrome leaking into the job result — observed earlier).

Pairs with #1216 (commit-on-diff) and #1219 (result-file channel for the drafting prompt) to make the autonomous edit path reliable end to end.

## Tests
`tools/test-code-edit-in-checkout.sh` run-1 flag assertion flips from "must NOT be `--extract`" to "must drive with `--extract` + `--wrap-input`". `23 passed, 0 failed`; `colony-lint 428 passed, 0 failed, 5 skipped`. Validated live: editing probe edits with the new flags, sits idle without them.