### PR TITLE
Issue #1223 is a documentation-only correction to the LLM backend Caveat in CLAUDE.md, which still claims reply fidelity tracks the flat-cyborg TUI screen-scrape. The fix rewrites just that paragraph per #1219: the host-run flat-cyborg-claude.sh wrapper now reads exact bytes from a result file claude writes, demoting --extract to a fallback, while noting native-backend container federations still screen-scrape and should keep a metered fallback. Verification is a clean ./tools/colony-lint.sh run with 0 failed.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Federations default to **flat-cyborg** ([`Replikanti/flat-cyborg`](https://githu
 
 A colony's `[llm] backend` in `colony.example.toml` is `"cli"` — meaning "use the agentis daemon default", which **inherits** the federation-level backend from `.agentis/config`. **Do not hardcode `"flat-cyborg"` there**: it would override the federation default and break the host wrapper path. The federation default (orchestrator hermetic config, or `install.sh`-written `.agentis/config`) is the single source of truth.
 
-Caveat: flat-cyborg's `--extract` is a TUI screen-scrape (output fidelity tracks the TUI layout). Keep the metered `claude` backend available for fidelity-critical paths. Deployment prereq: a `flat-cyborg` >= 0.9.0 binary with `--no-jitter` on PATH plus a logged-in `~/.claude`.
+Caveat: the host-run `flat-cyborg-claude.sh` wrapper (`dev-apprenticeship`, `dark-factory`) now reads the model's reply from a **result file claude writes** with its file-write tool ([#1219](https://github.com/Replikanti/agentis-colonies/issues/1219)), so reply fidelity no longer tracks the TUI layout; the `--extract` screen-scrape is only a **fallback** for when claude does not write the file. Container federations that use the **native** `flat-cyborg` backend with `--extract` still screen-scrape, so keeping a metered `claude`/`openai` fallback available there remains sensible. Deployment prereq: a `flat-cyborg` >= 0.9.0 binary with `--no-jitter` on PATH plus a logged-in `~/.claude`.
 
 ## Colony structure
 


### PR DESCRIPTION
Implements #1223.

Issue:
{"iid": 1223, "title": "docs: CLAUDE.md LLM-backend caveat is stale \u2014 host wrapper now reads replies from a result file, not the TUI scrape", "description": "## Problem\n\nThe **LLM backend** section in `CLAUDE.md` carries this caveat:\n\n> Caveat: flat-cyborg's `--extract` is a TUI screen-scrape (output fidelity tracks the TUI layout). Keep the metered `claude` backend available for fidelity-critical paths.\n\nAs of #1219 this is no longer accurate for the **host-run wrapper** path. `tools/flat-cyborg-claude.sh` now appends an output-channel directive to the prompt telling claude to write its complete reply to a result file with its file-write tool, and reads **that file** (exact bytes). The `--extract` screen-scrape is only a **fallback** for when claude does not write the file. So for the host-run `dev-apprenticeship` / `dark-factory` wrapper, reply fidelity no longer 'tracks the TUI layout'.\n\n## Required edit\n\nIn `CLAUDE.md`, **LLM backend** section, update the Caveat sentence so it is accurate:\n- The host-run `flat-cyborg-claude.sh` wrapper reads the model's reply from a **result file claude writes** ([#1219](https://github.com/Replikanti/agentis-colonies/issues/1219)); reply fidelity no longer depends on the TUI screen-scrape, which remains only a fallback.\n- Container federations that use the **native** `flat-cyborg` backend with `--extract` still screen-scrape, so keeping a metered `claude`/`openai` fallback available there is still sensible.\n\nKeep the edit to that Caveat paragraph; do not rewrite the rest of the section.\n\n## Done (checkable)\n- The Caveat mentions the result-file channel (#1219) and that fidelity no longer tracks the TUI layout for the host-run wrapper path.\n- It still notes the native-backend `--extract` container path screen-scrapes.\n- `./tools/colony-lint.sh` reports 0 failed (markdown links resolve).", "state": "opened", "labels": ["dev-apprenticeship", "implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-21T08:45:27Z", "updated_at": "2026-06-21T08:45:51Z", "user_notes_count": 0, "priority": null}

Plan:
- `CLAUDE.md` (LLM backend section, the Caveat paragraph at line 61) — Revise only this paragraph: state that the host-run `flat-cyborg-claude.sh` wrapper for `dev-apprenticeship`/`dark-factory` reads the model's reply from a result file claude writes with its file-write tool ([#1219](https://github.com/Replikanti/agentis-colonies/issues/1219)), so reply fidelity no longer tracks the TUI layout and the `--extract` screen-scrape is only a fallback; keep the note that container federations using the native `flat-cyborg` backend with `--extract` still screen-scrape, so keeping a metered `claude`/`openai` fallback there remains sensible; leave the deployment-prereq sentence and the rest of the section unchanged.
- `tools/colony-lint.sh` (run only, no edit) — Execute `./tools/colony-lint.sh` to confirm 0 failed and that the new markdown link resolves.

Issue #1223 is a documentation-only correction to the LLM backend Caveat in CLAUDE.md, which still claims reply fidelity tracks the flat-cyborg TUI screen-scrape. The fix rewrites just that paragraph per #1219: the host-run flat-cyborg-claude.sh wrapper now reads exact bytes from a result file claude writes, demoting --extract to a fallback, while noting native-backend container federations still screen-scrape and should keep a metered fallback. Verification is a clean ./tools/colony-lint.sh run with 0 failed.