### PR TITLE
Add a single condensed Quickstart section to dev-apprenticeship/README.md that walks a new operator from prerequisites through their first autonomous PR in six numbered steps, each anchor-linking to the existing detailed sections. The change is purely additive (one new section plus one Contents entry) and is validated by ./tools/colony-lint.sh reporting 0 failures so all markdown anchors resolve.

### DIFF
--- a/dev-apprenticeship/README.md
+++ b/dev-apprenticeship/README.md
@@ -37,8 +37,50 @@ graph LR
     style RE fill:#1a1e24,stroke:#57ab5a,color:#adbac7
 ```
 
+## Quickstart
+
+The zero-to-first-PR happy path. Each step links to the detailed section below.
+
+**1. Prerequisites** ([What you need](#what-you-need)) — on `PATH`: the [`agentis`](https://github.com/Replikanti/agentis) runtime and [`flat-cyborg`](https://github.com/Replikanti/flat-cyborg) (the default LLM backend — a PTY wrapper over Claude Code), plus a logged-in `~/.claude` session so agents bill against your Claude subscription instead of the metered API. Also `python3`, `git`, and `gh` (GitHub) or `glab` (GitLab). You need a repo, a personal access token, and a **bot account** to assign work to.
+
+**2. Install** ([Installation](#installation)) — from a clone or the release tarball:
+
+```bash
+cd dev-apprenticeship
+./install.sh        # checks prereqs, writes configs + credentials, seeds confidence, wires the flat-cyborg backend
+```
+
+**3. Start** ([Starting and stopping](#starting-and-stopping)):
+
+```bash
+./start-federation.sh       # 5 colonies, 21 agents
+./dashboard.sh 8420         # optional web dashboard at http://localhost:8420
+```
+
+**4. Give it work** ([How work enters the system](#how-work-enters-the-system)) — assign an issue to the bot account and add the colony's trigger label:
+
+```bash
+gh issue create --repo <owner>/<repo> --title "..." --body "..." --label implementation
+gh issue edit <N> --repo <owner>/<repo> --add-assignee <bot-account>
+```
+
+On its next 60-second tick the implementation colony drafts a plan, edits the files in a local checkout, commits, pushes, and opens a PR for you to review and merge. (Planning work uses the `needs-planning` label instead.)
+
+**5. Unlock autonomy** ([Confidence tiers](#confidence-tiers)) — agents start silent (`shadow`) and only watch. An agent opens PRs on its own only at the `autonomous` tier (confidence >= 0.95). Let it climb on good outcomes via [auto-promote](#auto-promote-and-auto-evolve-148), or bump it directly:
+
+```bash
+agentis memo set code_writer:confidence 0.97
+```
+
+**6. Stop** when you are done:
+
+```bash
+./kill-federation.sh
+```
+
 ## Contents
 
+- [Quickstart](#quickstart)
 - [What you need](#what-you-need)
 - [Installation](#installation)
 - [Starting and stopping](#starting-and-stopping)


### PR DESCRIPTION
Implements #1225.

Issue:
{"iid": 1225, "title": "docs: add a Quickstart section to dev-apprenticeship/README (zero-to-first-PR happy path)", "description": "## Goal\n\n`dev-apprenticeship/README.md` has detailed sections (What you need, Installation, Starting and stopping, How work enters the system, Confidence tiers) but no single condensed **Quickstart** that walks a new operator from zero to their first autonomous PR in one place. Add one.\n\n## Required edit\n\nInsert a new `## Quickstart` section in `dev-apprenticeship/README.md` **immediately after the introductory ```mermaid \u2026``` diagram block near the top, and immediately before the `## Contents` heading**. Also add `- [Quickstart](#quickstart)` as the **first** item in the `## Contents` list.\n\nInsert this section **verbatim**:\n\n```markdown\n## Quickstart\n\nThe zero-to-first-PR happy path. Each step links to the detailed section below.\n\n**1. Prerequisites** ([What you need](#what-you-need)) \u2014 on `PATH`: the [`agentis`](https://github.com/Replikanti/agentis) runtime and [`flat-cyborg`](https://github.com/Replikanti/flat-cyborg) (the default LLM backend \u2014 a PTY wrapper over Claude Code), plus a logged-in `~/.claude` session so agents bill against your Claude subscription instead of the metered API. Also `python3`, `git`, and `gh` (GitHub) or `glab` (GitLab). You need a repo, a personal access token, and a **bot account** to assign work to.\n\n**2. Install** ([Installation](#installation)) \u2014 from a clone or the release tarball:\n\n```bash\ncd dev-apprenticeship\n./install.sh        # checks prereqs, writes configs + credentials, seeds confidence, wires the flat-cyborg backend\n```\n\n**3. Start** ([Starting and stopping](#starting-and-stopping)):\n\n```bash\n./start-federation.sh       # 5 colonies, 21 agents\n./dashboard.sh 8420         # optional web dashboard at http://localhost:8420\n```\n\n**4. Give it work** ([How work enters the system](#how-work-enters-the-system)) \u2014 assign an issue to the bot account and add the colony's trigger label:\n\n```bash\ngh issue create --repo <owner>/<repo> --title \"...\" --body \"...\" --label implementation\ngh issue edit <N> --repo <owner>/<repo> --add-assignee <bot-account>\n```\n\nOn its next 60-second tick the implementation colony drafts a plan, edits the files in a local checkout, commits, pushes, and opens a PR for you to review and merge. (Planning work uses the `needs-planning` label instead.)\n\n**5. Unlock autonomy** ([Confidence tiers](#confidence-tiers)) \u2014 agents start silent (`shadow`) and only watch. An agent opens PRs on its own only at the `autonomous` tier (confidence >= 0.95). Let it climb on good outcomes via [auto-promote](#auto-promote-and-auto-evolve-148), or bump it directly:\n\n```bash\nagentis memo set code_writer:confidence 0.97\n```\n\n**6. Stop** when you are done:\n\n```bash\n./kill-federation.sh\n```\n```\n\nDo not change any other section; this is purely additive (one new section + one Contents line).\n\n## Done (checkable)\n\n- `dev-apprenticeship/README.md` has a `## Quickstart` section between the intro mermaid diagram and `## Contents`, with the six numbered steps above.\n- `## Contents` lists `- [Quickstart](#quickstart)` as its first entry.\n- `./tools/colony-lint.sh` reports 0 failed (all markdown links resolve).\n", "state": "opened", "labels": ["dev-apprenticeship", "implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-21T09:21:22Z", "updated_at": "2026-06-21T09:21:36Z", "user_notes_count": 0, "priority": null}

Plan:
- `dev-apprenticeship/README.md` — Insert a new `## Quickstart` section verbatim immediately after the introductory ```mermaid``` diagram block and immediately before the `## Contents` heading; add `- [Quickstart](#quickstart)` as the first item in the `## Contents` list. No other sections changed.

Add a single condensed Quickstart section to dev-apprenticeship/README.md that walks a new operator from prerequisites through their first autonomous PR in six numbered steps, each anchor-linking to the existing detailed sections. The change is purely additive (one new section plus one Contents entry) and is validated by ./tools/colony-lint.sh reporting 0 failures so all markdown anchors resolve.