### PR TITLE
Generalise the Status-tab healthy verdict summary in `renderFedHealthBanner()` so it rolls up liveness across all entries in `data.sidecars[]` (counting healthy/silent as alive, down as not) rather than echoing only the auto-promote sidecar. The change is purely display-side since #1227 already populates `data.sidecars[]` with all four sidecars; the auto-promote-gated install/disabled/orphan/misconfigured branches are preserved, and federations with zero or only-auto-promote sidecars still render a sensible line. A multi-sidecar test in the timeline-rendering suite and an [Unreleased] CHANGELOG note lock in the behaviour, with `./tools/colony-lint.sh` expected at 0 failed.

### DIFF
--- a/federation-dashboard/CHANGELOG.md
+++ b/federation-dashboard/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **dashboard**: the Status-tab verdict summary line (status-meta) now rolls up liveness across **all** sidecars in `data.sidecars[]` instead of echoing only auto-promote. Follow-up to [#1227](https://github.com/Replikanti/agentis-colonies/issues/1227) / [#1228](https://github.com/Replikanti/agentis-colonies/issues/1228): that change generalised the sidecar status **panel** but left the one-line summary pushing a single `sidecar ticked Xm ago` (the auto-promote object only), so an operator reading `21/21 running daemons alive · sidecar ticked 24m ago` reasonably concluded only one sidecar was monitored even though snapshot-refresh + cost-rate were live below. `renderFedHealthBanner()`'s healthy branch now pushes `N/M sidecars healthy` (counting `status` `healthy`/`silent` as alive, `down` as not) whenever `data.sidecars[]` carries anything beyond auto-promote, and falls back to the existing auto-promote-keyed single-sidecar lines (`sidecar ticked Xm ago` / `installed but interval_s misconfigured` / `installed but disabled` / `running but install file missing` / `not installed`) only when the array is empty or holds nothing but auto-promote. Purely display-side — `data.sidecars[]` already carries all four sidecars since #1227; the auto-promote install/disabled/orphan/misconfigured branches and degraded-path severity are unchanged. ([#1231](https://github.com/Replikanti/agentis-colonies/issues/1231))
+
 ## [0.11.0] — 2026-06-21
 
 ### Added

--- a/federation-dashboard/lib/federation-dashboard.html.template
+++ b/federation-dashboard/lib/federation-dashboard.html.template
@@ -2097,7 +2097,20 @@ function renderFedHealthBanner(data) {
     // "N/N alive" is the truthful denominator (agents.length includes
     // intentionally-stopped agents and would render a misleading ratio).
     const parts = [running.length + '/' + running.length + ' running daemons alive'];
-    if (sidecarWatched && sidecarAge !== null) {
+    // #1231: roll up liveness across ALL federation sidecars from
+    // data.sidecars[] (auto-promote, cost-cap, snapshot-refresh, cost-rate
+    // since #1227) instead of echoing only the auto-promote object — the old
+    // 'sidecar ticked Xm ago' push implied a single monitored sidecar.
+    // healthy/silent count as alive, down as not. Fall back to the
+    // auto-promote-keyed single-sidecar lines below only when data.sidecars[]
+    // is empty or holds nothing but auto-promote.
+    const allSidecars = (data && data.sidecars) || sidecars || [];
+    const hasOtherSidecars = allSidecars.some(s => s.name !== 'auto-promote');
+    if (hasOtherSidecars) {
+      const aliveSidecars = allSidecars.filter(
+        s => s.status === 'healthy' || s.status === 'silent').length;
+      parts.push(aliveSidecars + '/' + allSidecars.length + ' sidecars healthy');
+    } else if (sidecarWatched && sidecarAge !== null) {
       const mins = Math.round(Math.max(0, sidecarAge) / 60);
       parts.push('sidecar ticked ' + mins + 'm ago');
     } else if (sidecar.installed && sidecar.enabled) {

--- a/tools/test-timeline-rendering.sh
+++ b/tools/test-timeline-rendering.sh
@@ -2481,6 +2481,145 @@ else
          "offending: $(grep -nE 'time\.time\(\)' "$TIMELINE_PY" 2>/dev/null | tr '\n' ' ')"
 fi
 
+# --- #1231: the Status-tab status-meta verdict summary rolls up liveness
+#     across ALL sidecars in data.sidecars[] (healthy/silent count as alive,
+#     down as not), instead of echoing only the auto-promote object. Follow-up
+#     to #1227 / #1228, which generalised the sidecar status PANEL
+#     (renderSidecarStatus) but left this one-line summary pushing a single
+#     'sidecar ticked Xm ago' (the auto-promote object only) — so an operator
+#     reading '21/21 running daemons alive · sidecar ticked 24m ago'
+#     reasonably concluded only one sidecar was monitored. We extract
+#     renderFedHealthBanner() from the template and execute it under a DOM
+#     stub: a 3-healthy-sidecar fixture must read '3/3 sidecars healthy' and
+#     NEVER the single 'sidecar ticked' phrasing; a mixed fixture proves
+#     silent counts alive / down counts not; and the auto-promote
+#     install/disabled/orphan/not-installed fallback branches must still
+#     render when data.sidecars[] is empty or holds nothing but auto-promote.
+#     Behavioural (node) when available; static template guard otherwise. ---
+T67_ERR="$TMPDIR_TEST/t67.err"
+if command -v node >/dev/null 2>&1; then
+    if TEMPLATE_HTML="$TEMPLATE_HTML" node <<'JS' 2>"$T67_ERR"
+const fs = require('fs');
+const tpl = fs.readFileSync(process.env.TEMPLATE_HTML, 'utf8');
+const start = tpl.indexOf('function renderFedHealthBanner');
+const end = tpl.indexOf('// --- Stats Row ---', start);
+if (start < 0 || end < 0) { process.stderr.write('could not extract renderFedHealthBanner\n'); process.exit(2); }
+const fnSrc = tpl.slice(start, end);
+
+const elStub = { classList: { remove() {}, add() {} }, innerHTML: '' };
+globalThis.document = { getElementById: () => elStub };
+globalThis.esc = s => String(s);
+globalThis.nowEpoch = 1000000;
+const runningAgents = [
+  { state: 'running', pid: 0, pid_alive: true, name: 'a' },
+  { state: 'running', pid: 0, pid_alive: true, name: 'b' },
+];
+
+function render(data, sidecarObj) {
+  globalThis.agents = runningAgents;
+  globalThis.sidecar = sidecarObj;
+  globalThis.sidecars = (data && data.sidecars) || [];
+  globalThis.__data = data;
+  elStub.innerHTML = '';
+  // Direct sloppy eval: defines renderFedHealthBanner in this scope and runs
+  // it against the fixture; the function's free vars resolve to the globals
+  // set above. Returns the rendered detail HTML.
+  eval(fnSrc + '\nrenderFedHealthBanner(globalThis.__data);');
+  return elStub.innerHTML;
+}
+
+const fails = [];
+function check(cond, msg) { if (!cond) fails.push(msg); }
+
+// 1. Three healthy sidecars -> "3/3 sidecars healthy"; never single phrasing.
+const multi = render(
+  { sidecars: [
+    { name: 'auto-promote', status: 'healthy' },
+    { name: 'snapshot-refresh', status: 'healthy' },
+    { name: 'cost-rate', status: 'healthy' },
+  ] },
+  { installed: false, enabled: false, interval_s: null, last_tick_ts: null }
+);
+check(/3\/3 sidecars healthy/.test(multi), 'multi-healthy: expected "3/3 sidecars healthy", got: ' + multi);
+check(!/sidecar ticked/.test(multi), 'multi-healthy: must NOT use single "sidecar ticked" phrasing, got: ' + multi);
+check(/Healthy/.test(multi), 'multi-healthy: verdict should be Healthy, got: ' + multi);
+
+// 2. silent counts alive, down counts not-alive -> "2/3 sidecars healthy".
+const mixed = render(
+  { sidecars: [
+    { name: 'auto-promote', status: 'healthy' },
+    { name: 'snapshot-refresh', status: 'silent' },
+    { name: 'cost-rate', status: 'down' },
+  ] },
+  { installed: false, enabled: false }
+);
+check(/2\/3 sidecars healthy/.test(mixed), 'mixed: expected "2/3 sidecars healthy" (silent alive, down not), got: ' + mixed);
+
+// 3. auto-promote fallback branches still render when data.sidecars[] is empty
+//    or holds nothing but auto-promote.
+const disabled = render({ sidecars: [] }, { installed: true, enabled: false, interval_s: 1800 });
+check(/sidecar installed but disabled/.test(disabled), 'disabled fallback regressed, got: ' + disabled);
+
+const orphan = render({ sidecars: [] }, { installed: false, enabled: false, running_orphan: true });
+check(/sidecar running but install file missing/.test(orphan), 'orphan fallback regressed, got: ' + orphan);
+
+const notInstalled = render({ sidecars: [] }, { installed: false, enabled: false });
+check(/sidecar not installed/.test(notInstalled), 'not-installed fallback regressed, got: ' + notInstalled);
+
+// only auto-promote, watched + ticked -> terse single line stays, no roll-up.
+const onlyAp = render(
+  { sidecars: [{ name: 'auto-promote', status: 'healthy' }] },
+  { installed: true, enabled: true, interval_s: 1800, last_tick_ts: 1000000 - 600 }
+);
+check(/sidecar ticked 10m ago/.test(onlyAp), 'only-auto-promote should keep terse "sidecar ticked", got: ' + onlyAp);
+check(!/sidecars healthy/.test(onlyAp), 'only-auto-promote must not imply a multi-sidecar roll-up, got: ' + onlyAp);
+
+if (fails.length) { process.stderr.write(fails.join('\n') + '\n'); process.exit(1); }
+process.exit(0);
+JS
+    then
+        pass "67: status-meta summary rolls up all sidecars (3/3 healthy), auto-promote fallback branches preserved (#1231)"
+    else
+        fail "67: status-meta summary did not roll up data.sidecars[] correctly (#1231)" \
+             "$(tr '\n' ' ' < "$T67_ERR" 2>/dev/null)"
+    fi
+else
+    # node unavailable on this runner: static template guard on the
+    # renderFedHealthBanner() body so the roll-up intent can't silently regress.
+    if python3 - "$TEMPLATE_HTML" <<'PY' 2>"$T67_ERR"
+import sys, re
+with open(sys.argv[1]) as f:
+    html = f.read()
+m = re.search(r'function renderFedHealthBanner\b.*?// --- Stats Row ---', html, re.DOTALL)
+if not m:
+    sys.stderr.write('renderFedHealthBanner not found\n'); sys.exit(2)
+body = m.group(0)
+if 'sidecars healthy' not in body:
+    sys.stderr.write('roll-up "N/M sidecars healthy" missing from healthy branch\n'); sys.exit(3)
+if "status === 'healthy'" not in body or "status === 'silent'" not in body:
+    sys.stderr.write('alive predicate (healthy/silent) missing\n'); sys.exit(4)
+if 'data.sidecars' not in body and 'allSidecars' not in body:
+    sys.stderr.write('roll-up does not read data.sidecars[]\n'); sys.exit(5)
+# The roll-up must precede the single-sidecar "sidecar ticked" fallback.
+i_roll = body.find('sidecars healthy')
+i_tick = body.find('sidecar ticked')
+if i_tick != -1 and i_tick < i_roll:
+    sys.stderr.write('single "sidecar ticked" still precedes the roll-up branch\n'); sys.exit(6)
+for needle in ('sidecar installed but disabled',
+               'sidecar running but install file missing',
+               'sidecar not installed'):
+    if needle not in body:
+        sys.stderr.write('auto-promote fallback branch missing: %r\n' % needle); sys.exit(7)
+sys.exit(0)
+PY
+    then
+        pass "67: status-meta roll-up over data.sidecars[] present, auto-promote fallbacks preserved (static; node absent) (#1231)"
+    else
+        fail "67: status-meta roll-up template guard failed (#1231)" \
+             "$(tr '\n' ' ' < "$T67_ERR" 2>/dev/null)"
+    fi
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements #1231.

Issue:
{"iid": 1231, "title": "dashboard: status-meta summary still says '1 sidecar' \u2014 roll it up over all sidecars (follow-up #1227)", "description": "## Problem\n\nFollow-up to #1227. That PR (#1228) generalised the **sidecar status panel** (`data.sidecars[]` \u2192 `renderSidecarStatus()`) to show all four sidecars, but it did **not** touch the **status-meta verdict summary line** at the top of the Status tab. That summary still references a single sidecar:\n\n```js\nconst parts = [running.length + '/' + running.length + ' running daemons alive'];\nif (sidecarWatched && sidecarAge !== null) {\n  const mins = Math.round(Math.max(0, sidecarAge) / 60);\n  parts.push('sidecar ticked ' + mins + 'm ago');     // <-- auto-promote only\n} else if (sidecar.installed && sidecar.enabled) {\n  ...\n```\n\n`sidecar` / `sidecarWatched` / `sidecarAge` here are the **auto-promote** object only. So an operator reading the one-line status-meta sees e.g. `21/21 running daemons alive \u00b7 sidecar ticked 24m ago` and reasonably concludes **only one sidecar is monitored**, even though the panel below now shows snapshot-refresh + cost-rate too. (Reported live: \"monitoruje to jenom 1 sidecar\".)\n\n## Required\n\nGeneralise the status-meta summary so it reflects **all** sidecars from `data.sidecars[]`, not just auto-promote. Suggested: replace the single `'sidecar ticked Xm ago'` push with a roll-up over `data.sidecars[]`, e.g. `'N/M sidecars healthy'` (count `status === 'healthy'` / `'silent'` as alive vs `'down'`), and keep a compact per-sidecar age only if it stays terse. The existing degraded/install/disabled branches that key off the auto-promote object should be preserved (auto-promote is the only install-gated one), but the **healthy summary** must not imply a single sidecar.\n\nKeep it display-only (no new data \u2014 `data.sidecars[]` already carries everything since #1227). Federations with no sidecars (or only auto-promote) must still render a sensible line.\n\n## Done (checkable)\n- The Status-tab status-meta summary reflects all sidecars in `data.sidecars[]` (a federation running 3 healthy sidecars does not read as \"1 sidecar\").\n- auto-promote install/disabled/orphan branches still work.\n- `federation-dashboard/CHANGELOG.md` `[Unreleased]` notes the change; `test-timeline-rendering.sh` (or the relevant template test) covers the multi-sidecar summary.\n- `./tools/colony-lint.sh` 0 failed.\n", "state": "opened", "labels": ["dev-apprenticeship", "implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-21T13:56:38Z", "updated_at": "2026-06-21T13:56:40Z", "user_notes_count": 0, "priority": null}

Plan:
- `federation-dashboard/lib/federation-dashboard.html.template` — In `renderFedHealthBanner()`'s healthy-detail branch (~lines 2099-2117), replace the single auto-promote `'sidecar ticked Xm ago'` push with a roll-up over `data.sidecars[]`: count records whose `status` is `healthy` or `silent` as alive vs `down`, and push `'N/M sidecars healthy'` (optionally a terse oldest-tick age). Keep the existing auto-promote-keyed branches (`sidecar installed but interval_s misconfigured`, `installed but disabled`, `running_orphan`, `not installed`) since auto-promote is the only install-gated sidecar, and fall back to a sensible line when `data.sidecars[]` is empty or holds only auto-promote. Display-only; no new data.
- `federation-dashboard/CHANGELOG.md` — Add a `### Fixed` bullet under `[Unreleased]` noting the Status-tab status-meta verdict summary now rolls up all sidecars from `data.sidecars[]` instead of implying a single sidecar (follow-up to #1227 / #1228), referencing #1231.
- `tools/test-timeline-rendering.sh` — Add a check that, given a fixture with 3 healthy sidecars in `data.sidecars[]`, the healthy summary reads as a multi-sidecar roll-up (e.g. `3/3 sidecars healthy`) and never `sidecar ticked Xm ago` / a single-sidecar phrasing; assert the auto-promote install/disabled/orphan branches still render when appropriate.

Generalise the Status-tab healthy verdict summary in `renderFedHealthBanner()` so it rolls up liveness across all entries in `data.sidecars[]` (counting healthy/silent as alive, down as not) rather than echoing only the auto-promote sidecar. The change is purely display-side since #1227 already populates `data.sidecars[]` with all four sidecars; the auto-promote-gated install/disabled/orphan/misconfigured branches are preserved, and federations with zero or only-auto-promote sidecars still render a sensible line. A multi-sidecar test in the timeline-rendering suite and an [Unreleased] CHANGELOG note lock in the behaviour, with `./tools/colony-lint.sh` expected at 0 failed.