### PR TITLE
feat(triage): crystallizer rule-distillation pilot in labeler (#1235)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,28 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Added
+
+- **`labeler` (triage) now distils deterministic label rules and replays them
+  without an LLM call — the first crystallizer-substrate pilot in this
+  federation** ([#1235](https://github.com/Replikanti/agentis-colonies/issues/1235),
+  epic [#1234](https://github.com/Replikanti/agentis-colonies/issues/1234)).
+  Before `prompt()`, labeler builds a deterministic keyword-signature context
+  for the chosen unlabeled issue and calls
+  `crystallizer_lookup_with_confidence("label", ctx, min_conf)`; on a hit ≥
+  confidence it applies the rule's labels deterministically (all four tier
+  branches) and skips the LLM. The LLM path distils its decision
+  (`distill("label", coarse_ctx, sorted_labels)` + `knowledge_validate()`), and
+  the existing reality-check (`evaluate_label_verdict` / autonomous soak) now
+  threads the `rule_id` and calls `crystallizer_record_use(rule_id, kept?,
+  +0.1/-0.15)` — operator-kept labels reinforce the rule, changed labels demote
+  it, and agentis-core compaction retires rules at `success_rate < 0.5 &&
+  use_count ≥ 20`. Requires **agentis ≥ 1.8.0** (crystallizer builtins).
+  Rollback: `LABELER_RULE_FIRST=0` restores pre-pilot behaviour;
+  `LABELER_RULE_CONFIDENCE` (default 0.85) tunes the replay threshold. Host-run
+  `.agentis` persists rules on disk across restarts, so no extra persistence
+  wiring is needed.
+
 ### Changed
 
 - **`code_writer`'s autonomous checkout-edit now runs DETACHED and is polled

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -118,7 +118,7 @@ fn repo_field(line: string, idx: int) -> string {
 fn canonical_label_context(issues_raw: string, me: string) -> string {
     let cmd = "RAW=" + shell_escape(issues_raw) + " ME=" + shell_escape(me) +
         " python3 -c '" +
-        "import os, json\n" +
+        "import os, json, re\n" +
         "VOCAB=[\"bug\",\"crash\",\"error\",\"fail\",\"segfault\",\"panic\",\"exception\",\"docs\",\"documentation\",\"readme\",\"feature\",\"enhancement\",\"request\",\"question\",\"security\",\"vuln\",\"cve\",\"performance\",\"perf\",\"slow\",\"test\",\"ci\",\"build\",\"regression\",\"refactor\",\"dependency\"]\n" +
         "me=os.environ.get(\"ME\",\"\").strip()\n" +
         "try:\n" +
@@ -139,7 +139,8 @@ fn canonical_label_context(issues_raw: string, me: string) -> string {
         "    print(\"\"); raise SystemExit\n" +
         "author=((chosen.get(\"author\") or {}).get(\"username\")) or \"\"\n" +
         "text=((chosen.get(\"title\") or \"\")+\" \"+(chosen.get(\"description\") or \"\")).lower()\n" +
-        "hits=sorted({w for w in VOCAB if w in text})\n" +
+        "toks=set(re.findall(r\"[a-z]+\", text))\n" +
+        "hits=sorted({w for w in VOCAB if w in toks})\n" +
         "scope=\"personal\" if (me and author==me) else \"team\"\n" +
         "ctx=\"kw=\"+\",\".join(hits)+\" scope=\"+scope\n" +
         "print(str(iid)+\"\\t\"+author+\"\\t\"+ctx)" +
@@ -857,20 +858,30 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         // there are >= 3 successful "label" records, so it is guarded;
         // knowledge_validate() bumps empirical_validations toward the
         // crystallize threshold.
+        // #1235 QA #6b: only distill when the LLM labeled the SAME issue the
+        // canonical_ctx was built for (canon_iid = first unlabeled). The LLM
+        // picks the "most important" unlabeled issue, which may differ from
+        // canon_iid; distilling canonical_ctx (issue A keywords) against
+        // action.labels (issue B labels) would mint a mis-scoped rule that
+        // Stage 1 later replays onto the wrong keyword class. When they
+        // diverge we skip distillation this tick (slower crystallization, but
+        // no rule-store poisoning); the reality-check still scores the write.
         if rule_first_enabled {
             if len(canonical_ctx) > 0 {
-                let canonical_action = normalize_labels_csv(action.labels);
-                if len(canonical_action) > 0 {
-                    let scope_at = index_of(canonical_ctx, " scope=");
-                    let coarse_ctx = if scope_at > 0 { substring(canonical_ctx, 0, scope_at); } else { canonical_ctx; };
-                    if len(owner) > 0 {
-                        learn("label", canonical_ctx, canonical_action, "success", ["distilled", "triage", repo_tag(owner, repo)]);
-                    } else {
-                        learn("label", canonical_ctx, canonical_action, "success", ["distilled", "triage"]);
-                    };
-                    let did = try { distill("label", coarse_ctx, canonical_action, "heuristic"); } catch e { ""; };
-                    if len(did) > 0 {
-                        knowledge_validate(did);
+                if action.issue_id == canon_iid {
+                    let canonical_action = normalize_labels_csv(action.labels);
+                    if len(canonical_action) > 0 {
+                        let scope_at = index_of(canonical_ctx, " scope=");
+                        let coarse_ctx = if scope_at > 0 { substring(canonical_ctx, 0, scope_at); } else { canonical_ctx; };
+                        if len(owner) > 0 {
+                            learn("label", canonical_ctx, canonical_action, "success", ["distilled", "triage", repo_tag(owner, repo)]);
+                        } else {
+                            learn("label", canonical_ctx, canonical_action, "success", ["distilled", "triage"]);
+                        };
+                        let did = try { distill("label", coarse_ctx, canonical_action, "heuristic"); } catch e { ""; };
+                        if len(did) > 0 {
+                            knowledge_validate(did);
+                        };
                     };
                 };
             };

--- a/dev-apprenticeship/triage/agents/labeler.ag
+++ b/dev-apprenticeship/triage/agents/labeler.ag
@@ -5,6 +5,17 @@
 //
 // Run as daemon: agentis daemon agents/labeler.ag --colony triage
 // Requires: exec_foreign capability, GITLAB_* env vars
+//
+// #1235 crystallizer pilot: repeat label decisions on the same canonical
+// context CLASS crystallize into a "label" rule the agent replays without
+// prompt() (Stage 1), and the reality-check demotes rules that stop
+// matching what the operator keeps (crystallizer_record_use). Requires the
+// agentis crystallizer builtins (agentis >= 1.8.0; host is v1.19.0).
+// Operator knobs (process env, read via getenv — mirror noticer's):
+//   - LABELER_RULE_FIRST=0       short-circuits Stage 1 to the LLM path
+//                                (byte-identical to pre-pilot behaviour).
+//   - LABELER_RULE_CONFIDENCE=<float>  overrides the default 0.85 minimum
+//                                confidence for a rule-first hit.
 
 cb 400;
 
@@ -88,6 +99,63 @@ fn repo_field(line: string, idx: int) -> string {
         " python3 -c 'import os; parts=os.environ[\"L\"].split(\"\t\"); i=int(os.environ[\"I\"]); print(parts[i] if 0<=i<len(parts) else \"\")'";
     let out = try { exec sh cmd; } catch e { ""; };
     return out;
+}
+
+// #1235 crystallizer pilot: deterministic, prompt-free canonical context
+// for the first unlabeled issue in `raw` (the labeler-view JSON the LLM
+// path consumes). Emits a single tab-separated line:
+//   "<iid>\t<author>\t<canonical_ctx>"
+// where canonical_ctx is "kw=" + sorted_csv + " scope=" + scope. The
+// keyword signature lowercases the issue title (+description when the
+// view carries one) and matches a FIXED triage vocabulary; the sorted
+// matched set is stable across repeats so the crystallized rule id is
+// identical tick-to-tick. scope mirrors scope_for_author: "personal"
+// when the issue's author matches the operator's GitLab username (memo
+// gitlab:me), "team" otherwise. An issue with no vocab hit yields
+// "kw= scope=<scope>" (still valid; rarely crystallizes, which is fine).
+// Total-on-failure: any python/exec failure returns "" so the caller
+// falls through to the LLM path and is never starved.
+fn canonical_label_context(issues_raw: string, me: string) -> string {
+    let cmd = "RAW=" + shell_escape(issues_raw) + " ME=" + shell_escape(me) +
+        " python3 -c '" +
+        "import os, json\n" +
+        "VOCAB=[\"bug\",\"crash\",\"error\",\"fail\",\"segfault\",\"panic\",\"exception\",\"docs\",\"documentation\",\"readme\",\"feature\",\"enhancement\",\"request\",\"question\",\"security\",\"vuln\",\"cve\",\"performance\",\"perf\",\"slow\",\"test\",\"ci\",\"build\",\"regression\",\"refactor\",\"dependency\"]\n" +
+        "me=os.environ.get(\"ME\",\"\").strip()\n" +
+        "try:\n" +
+        "    data=json.loads(os.environ[\"RAW\"])\n" +
+        "except Exception:\n" +
+        "    print(\"\"); raise SystemExit\n" +
+        "if not isinstance(data, list):\n" +
+        "    print(\"\"); raise SystemExit\n" +
+        "chosen=None\n" +
+        "for x in data:\n" +
+        "    if not isinstance(x, dict): continue\n" +
+        "    if not x.get(\"labels\"):\n" +
+        "        chosen=x; break\n" +
+        "if chosen is None:\n" +
+        "    print(\"\"); raise SystemExit\n" +
+        "iid=chosen.get(\"iid\")\n" +
+        "if iid is None:\n" +
+        "    print(\"\"); raise SystemExit\n" +
+        "author=((chosen.get(\"author\") or {}).get(\"username\")) or \"\"\n" +
+        "text=((chosen.get(\"title\") or \"\")+\" \"+(chosen.get(\"description\") or \"\")).lower()\n" +
+        "hits=sorted({w for w in VOCAB if w in text})\n" +
+        "scope=\"personal\" if (me and author==me) else \"team\"\n" +
+        "ctx=\"kw=\"+\",\".join(hits)+\" scope=\"+scope\n" +
+        "print(str(iid)+\"\\t\"+author+\"\\t\"+ctx)" +
+        "'";
+    return try { exec sh cmd; } catch e { ""; };
+}
+
+// #1235 crystallizer pilot: sorted, de-duplicated labels CSV. The
+// crystallized rule's `action` slot stores this so the KnowledgeEntry id
+// is identical across repeats of the same decision (NOT free-form LLM
+// prose). Sort is deterministic; empty / whitespace tokens dropped.
+// Total-on-failure returns "" (caller treats "" as no usable action).
+fn normalize_labels_csv(csv: string) -> string {
+    let cmd = "CSV=" + shell_escape(csv) +
+        " python3 -c 'import os; toks=sorted({t.strip() for t in os.environ[\"CSV\"].split(\",\") if t.strip()}); print(\",\".join(toks))'";
+    return try { exec sh cmd; } catch e { ""; };
 }
 
 // #1111: is the shared per-colony issues snapshot fresh enough to read?
@@ -221,6 +289,42 @@ fn signal_to_outcome(signal: int) -> string {
     return "fail";
 }
 
+// #1235: map the reality-check signal to the crystallizer demote/reinforce
+// delta. Kept labels reinforce the rule (+0.1 on full match), changed
+// labels demote it (-0.15 on mismatch), partial overlap is neutral
+// (0.0). Core compaction retires a rule at success_rate < 0.5 &&
+// use_count >= 20, so sustained mismatches eventually drop it.
+fn rule_feedback_delta(signal: int) -> float {
+    if signal == 1 {
+        return 0.1;
+    };
+    if signal == 3 {
+        return 0.0 - 0.15;
+    };
+    return 0.0;
+}
+
+// #1235: thread the crystallizer demote/reinforce feedback. `blob` is the
+// pending-verdict array; its 4th field is the rule_id ("" for LLM-path
+// verdicts). When non-empty, credit / penalise the rule the reality-check
+// just scored. No-op on LLM-path verdicts (empty rule_id) so the
+// LABELER_RULE_FIRST=0 path never touches the crystallizer.
+fn record_rule_feedback(blob: string, signal: int) -> void {
+    let rule_id = to_string(json_get(blob, "[3]"));
+    // Empty rule_id = LLM-path verdict. "void" = an in-flight 3-field blob
+    // written before this pilot deployed (json_get on the missing [3] index
+    // yields Void -> "void"); ignore it so the transition across the deploy
+    // boundary never feeds a bogus rule id to the crystallizer.
+    if len(rule_id) == 0 {
+        return;
+    };
+    if rule_id == "void" {
+        return;
+    };
+    crystallizer_record_use(rule_id, signal == 1, rule_feedback_delta(signal));
+    print("[labeler] crystallizer feedback: rule", rule_id, "signal", signal);
+}
+
 // #316 M4: per-repo write target. `get_confidence()` continues reading the
 // legacy unscoped key (intentional — see plan §8: bounded by clamp_auto's
 // 0.85 cap, so per-repo drift cannot push past the autonomy threshold from
@@ -233,13 +337,18 @@ fn apply_feedback(delta: float, owner: string, repo: string) -> void {
     print("[labeler] feedback delta", delta, "confidence", cur, "->", target);
 }
 
-// Record a pending verdict. Stored as JSON array [t, iid, "labels_csv"] —
-// the three fields are ASCII-safe (epoch int, iid int, label names have
-// no quotes/newlines/backslashes in practice on GitLab) so naive
-// concatenation is sufficient and we skip a JSON encoder.
-fn record_label_verdict(owner: string, repo: string, issue_id: int, labels_csv: string) -> void {
+// Record a pending verdict. Stored as JSON array
+// [t, iid, "labels_csv", "rule_id"] — the four fields are ASCII-safe
+// (epoch int, iid int, label names + crystallizer rule ids have no
+// quotes/newlines/backslashes in practice) so naive concatenation is
+// sufficient and we skip a JSON encoder. #1235: the 4th `rule_id` field
+// is "" for LLM-path verdicts and the crystallized rule id for rule-hit
+// verdicts; evaluate_label_verdict feeds it to crystallizer_record_use
+// after the reality-check signal settles (kept labels reinforce, changed
+// labels demote).
+fn record_label_verdict(owner: string, repo: string, issue_id: int, labels_csv: string, rule_id: string) -> void {
     let ts_raw = try { exec sh "date +%s"; } catch e { "0"; };
-    let blob = "[" + ts_raw + "," + to_string(issue_id) + ",\"" + labels_csv + "\"]";
+    let blob = "[" + ts_raw + "," + to_string(issue_id) + ",\"" + labels_csv + "\",\"" + rule_id + "\"]";
     memo_write(scoped_memo(owner, repo, "labeler:pending_verdict"), blob);
     print("[labeler] verdict recorded: issue", issue_id, "suggested", labels_csv);
 }
@@ -288,6 +397,9 @@ fn evaluate_label_verdict(owner: string, repo: string) -> void {
         return;
     };
     apply_feedback(signal_to_delta(signal), owner, repo);
+    // #1235: credit / penalise the crystallized rule (no-op on LLM-path
+    // verdicts whose blob carries an empty rule_id).
+    record_rule_feedback(blob, signal);
     // #195: emit the reality-check outcome to the experience store so
     // auto-promote's fitness gates (#186) see an honest acting-path
     // reject rate. Tagged "acted" regardless of the original tier so
@@ -373,9 +485,9 @@ fn append_autonomous_index(owner: string, repo: string, iid: int) -> void {
 // in the index; an `append_autonomous_index` failure means the blob
 // is unreachable from the scanner and gets GC'd on drift-cleanup when
 // it eventually expires.
-fn record_autonomous_verdict(owner: string, repo: string, issue_id: int, labels_csv: string) -> void {
+fn record_autonomous_verdict(owner: string, repo: string, issue_id: int, labels_csv: string, rule_id: string) -> void {
     let ts_raw = try { exec sh "date +%s"; } catch e { "0"; };
-    let blob = "[" + ts_raw + "," + to_string(issue_id) + ",\"" + labels_csv + "\"]";
+    let blob = "[" + ts_raw + "," + to_string(issue_id) + ",\"" + labels_csv + "\",\"" + rule_id + "\"]";
     memo_write(scoped_memo(owner, repo, "labeler:autonomous_verdict:" + to_string(issue_id)), blob);
     append_autonomous_index(owner, repo, issue_id);
     print("[labeler] autonomous verdict recorded: issue", issue_id, "labels", labels_csv);
@@ -431,6 +543,9 @@ fn score_one_autonomous(owner: string, repo: string, issue_id: int) -> string {
     let match_cmd = "SUGGESTED=" + shell_escape(suggested) + " RAW=" + shell_escape(cur_raw) + " python3 -c 'import os, json; sug={s.strip() for s in os.environ[\"SUGGESTED\"].split(\",\") if s.strip()}; act=set(json.loads(os.environ[\"RAW\"]).get(\"labels\", [])); print(1 if sug and sug.issubset(act) else (2 if sug & act else 3))'";
     let signal_raw = try { exec sh match_cmd; } catch e { "3"; };
     let signal = parse_int(signal_raw);
+    // #1235: credit / penalise the crystallized rule (no-op on LLM-path
+    // verdicts whose blob carries an empty rule_id).
+    record_rule_feedback(blob, signal);
     let outcome = signal_to_outcome(signal);
     let cur_author = to_string(json_get(cur_raw, "author.username"));
     let scope = scope_for_author(cur_author);
@@ -506,6 +621,79 @@ fn evaluate_autonomous_verdicts(owner: string, repo: string) -> void {
     };
     let new_index = eval_autonomous_at(owner, repo, index_csv, 0, "");
     memo_write(key, new_index);
+}
+
+// #1235 crystallizer pilot: rule-hit application. Mirror of the LLM
+// tier-block in tick_for_repo, but takes primitive fields because the
+// .ag grammar disallows inline LabelAction struct literals (so the
+// rule-hit path cannot synthesize a LabelAction to feed the existing
+// block). The tier semantics are byte-identical to the LLM path
+// (autonomous applies via update-issue, review-gated posts a draft note,
+// propose prints + emits, shadow/dormant observes); only the source of
+// the decision differs (crystallized rule vs prompt). Every learn() row
+// on this path carries "rule-hit" + "distilled" so auto-promote and the
+// dashboard can separate replayed decisions from LLM-driven ones, and
+// the verdict recorders thread rule_id so the reality-check later
+// credits / penalises the rule via crystallizer_record_use. The
+// emit payload is a JSON string of the LabelAction shape (the LLM path
+// emits the struct directly; triage:label_suggestion is an extension
+// point with no internal listener, so the loose shape is fine).
+fn apply_label_rule_hit(owner: string, repo: string, my_tier: string, issue_id: int, labels: string, reasoning: string, author: string, rule_id: string) -> void {
+    let scope = scope_for_author(author);
+    let conf_str = recall_latest("labeler:confidence");
+    let action_json = "{\"issue_id\":" + to_string(issue_id) + ",\"labels\":\"" + labels + "\",\"reasoning\":\"" + reasoning + "\",\"author\":\"" + author + "\",\"confidence\":" + conf_str + ",\"rule_id\":\"" + rule_id + "\"}";
+    if my_tier == "autonomous" {
+        // colony-lint: safe-exec-concat
+        let update_cmd = "$COLONY_DIR/scripts/forge-api.sh update-issue " + to_string(issue_id) + " --add-labels " + shell_escape(labels) + repo_arg(owner, repo);
+        let result = try { exec sh update_cmd; } catch e {
+            print("[labeler] Failed to apply labels (rule-hit):", e);
+            "";
+        };
+        if len(result) > 0 {
+            print("[labeler] Applied labels to issue", issue_id, "(rule-hit):", labels);
+            emit("triage:label_suggestion", action_json);
+            record_autonomous_verdict(owner, repo, issue_id, labels, rule_id);
+            if len(owner) > 0 {
+                learn("label", "issue " + to_string(issue_id), labels, "success", [scope, "triage", "acted", "rule-hit", "distilled", repo_tag(owner, repo)]);
+            } else {
+                learn("label", "issue " + to_string(issue_id), labels, "success", [scope, "triage", "acted", "rule-hit", "distilled"]);
+            };
+        };
+    } else {
+        if my_tier == "review-gated" {
+            let note = "[draft-labels] **Label Suggestion** (automated, pending approval): " + labels + "\n\n" + reasoning;
+            // colony-lint: safe-exec-concat
+            let post_cmd = "$COLONY_DIR/scripts/forge-api.sh add-note " + to_string(issue_id) + " --body " + shell_escape(note) + repo_arg(owner, repo);
+            try { exec sh post_cmd; } catch e {
+                print("[labeler] Failed to post draft note (rule-hit):", e);
+            };
+            emit("triage:label_suggestion", action_json);
+            record_label_verdict(owner, repo, issue_id, labels, rule_id);
+            if len(owner) > 0 {
+                learn("label", "issue " + to_string(issue_id), labels, "partial", [scope, "triage", "review-gated", "rule-hit", "distilled", repo_tag(owner, repo)]);
+            } else {
+                learn("label", "issue " + to_string(issue_id), labels, "partial", [scope, "triage", "review-gated", "rule-hit", "distilled"]);
+            };
+        } else {
+            if my_tier == "propose" {
+                print("[labeler] Suggesting labels for issue", issue_id, "(rule-hit):", labels);
+                emit("triage:label_suggestion", action_json);
+                record_label_verdict(owner, repo, issue_id, labels, rule_id);
+                if len(owner) > 0 {
+                    learn("label", "issue " + to_string(issue_id), labels, "partial", [scope, "triage", "emitted", "rule-hit", "distilled", repo_tag(owner, repo)]);
+                } else {
+                    learn("label", "issue " + to_string(issue_id), labels, "partial", [scope, "triage", "emitted", "rule-hit", "distilled"]);
+                };
+            } else {
+                print("[labeler] Observing rule-hit (tier:", my_tier, ")");
+                if len(owner) > 0 {
+                    learn("label", "issue " + to_string(issue_id), labels, "partial", [scope, "triage", "observed", "rule-hit", "distilled", repo_tag(owner, repo)]);
+                } else {
+                    learn("label", "issue " + to_string(issue_id), labels, "partial", [scope, "triage", "observed", "rule-hit", "distilled"]);
+                };
+            };
+        };
+    };
 }
 
 fn tick_for_repo(owner: string, repo: string) -> void {
@@ -586,10 +774,107 @@ fn tick_for_repo(owner: string, repo: string) -> void {
         let labels_raw = try { exec sh labels_cmd; } catch e { "[]"; };
         let context = "Unlabeled issues: " + analysis.unlabeled_issues + "\nAvailable labels: " + labels_raw + "\nPast learning: " + to_string(rec);
 
+        // #1235 Stage 1: rule-first lookup. Build the deterministic,
+        // prompt-free canonical context for the first unlabeled issue in
+        // `raw` (same selection rule the LLM uses for "most important":
+        // first listed). If a crystallized "label" rule matches at
+        // >= LABELER_RULE_CONFIDENCE, replay it without prompt() and skip
+        // Stage 2 entirely. Rollback knob: LABELER_RULE_FIRST=0
+        // short-circuits BOTH stages to the LLM path -- byte-identical to
+        // pre-pilot behaviour, including no extra exec sh subprocess (the
+        // canonical-context build is itself behind the flag). The
+        // crystallizer category is "label", matching the learn()/recommend()
+        // topic this agent already uses.
+        let rule_first_flag = getenv("LABELER_RULE_FIRST");
+        let rule_first_enabled = rule_first_flag != "0";
+        let min_conf_str = getenv("LABELER_RULE_CONFIDENCE");
+        let min_conf = if len(min_conf_str) > 0 { parse_float(min_conf_str); } else { 0.85; };
+        let me_for_ctx = if rule_first_enabled { recall_latest("gitlab:me"); } else { ""; };
+        let canon_line = if rule_first_enabled { canonical_label_context(raw, me_for_ctx); } else { ""; };
+        let canon_iid = if rule_first_enabled { parse_int(repo_field(canon_line, 0)); } else { 0; };
+        let canon_author = if rule_first_enabled { repo_field(canon_line, 1); } else { ""; };
+        let canonical_ctx = if rule_first_enabled { repo_field(canon_line, 2); } else { ""; };
+
+        if rule_first_enabled {
+            if len(canon_line) > 0 {
+                if len(canonical_ctx) > 0 {
+                    if canon_iid > 0 {
+                        let rule = crystallizer_lookup_with_confidence("label", canonical_ctx, min_conf);
+                        if len(rule) > 0 {
+                            // #843: crystallizer_lookup_with_confidence returns
+                            // map<string,string> (Value::Map). Read fields with
+                            // get() (the map accessor); json_get() expects a JSON
+                            // string and raises "expected string, got map" on a map.
+                            let rule_id = to_string(get(rule, "rule_id"));
+                            let rule_action = to_string(get(rule, "action"));
+                            let rule_conf_str = to_string(get(rule, "confidence"));
+                            let rule_conf = if len(rule_conf_str) > 0 { parse_float(rule_conf_str); } else { min_conf; };
+                            let rule_labels = normalize_labels_csv(rule_action);
+                            if len(rule_labels) > 0 {
+                                let rule_reasoning = "rule-first: crystallized label rule @conf " + to_string(rule_conf) + ". Context: " + canonical_ctx;
+                                // Optimistic at-write reinforcement; the
+                                // reality-check (evaluate_label_verdict /
+                                // score_one_autonomous) later corrects via the
+                                // threaded rule_id (+0.1 kept / -0.15 changed).
+                                crystallizer_record_use(rule_id, true, 0.1);
+                                apply_label_rule_hit(owner, repo, my_tier, canon_iid, rule_labels, rule_reasoning, canon_author, rule_id);
+                                memo_write(scoped_memo(owner, repo, "labeler:rule_ctx"), canonical_ctx);
+                                memo_write(scoped_memo(owner, repo, "labeler:rule_id"), rule_id);
+                                if len(cur_hash) > 0 {
+                                    memo_write(scoped_memo(owner, repo, "labeler:snapshot_hash"), cur_hash);
+                                };
+                                let now_s1 = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+                                if len(now_s1) > 0 {
+                                    memo_write(scoped_memo(owner, repo, "labeler:last_check"), now_s1);
+                                };
+                                return;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+
         let action = prompt(
             "You are a labeling agent. Suggest labels for the most important unlabeled issue. Return JSON: issue_id (int), labels (comma-separated string), reasoning (string), author (string, the GitLab username from the issue's author.username field in the context — empty string if absent), confidence (float 0-1).",
             context
         ) -> LabelAction;
+
+        // #1235 Stage 2: distill the LLM decision so repeat decisions on
+        // the same context CLASS crystallize into a rule Stage 1 replays.
+        // The crystallized rule's `action` slot stores the sorted,
+        // de-duplicated labels CSV (canonical_action) -- NOT free-form LLM
+        // prose -- so the KnowledgeEntry id is identical across repeats and
+        // empirical_validations accumulates toward crystallization. The
+        // distilled CONDITION (coarse_ctx) is a literal prefix of
+        // canonical_ctx (the "kw=<sorted_csv>" part, dropping the
+        // " scope=<scope>" tail) so the same keyword class crystallizes
+        // regardless of author and CrystallizedRule.matches_context
+        // (ctx.starts_with(condition)) still matches the full canonical_ctx
+        // Stage 1 passes. Gated behind LABELER_RULE_FIRST so the rollback
+        // knob produces byte-identical behaviour (no extra learn rows, no
+        // distill side-effects) when set to "0". distill() raises until
+        // there are >= 3 successful "label" records, so it is guarded;
+        // knowledge_validate() bumps empirical_validations toward the
+        // crystallize threshold.
+        if rule_first_enabled {
+            if len(canonical_ctx) > 0 {
+                let canonical_action = normalize_labels_csv(action.labels);
+                if len(canonical_action) > 0 {
+                    let scope_at = index_of(canonical_ctx, " scope=");
+                    let coarse_ctx = if scope_at > 0 { substring(canonical_ctx, 0, scope_at); } else { canonical_ctx; };
+                    if len(owner) > 0 {
+                        learn("label", canonical_ctx, canonical_action, "success", ["distilled", "triage", repo_tag(owner, repo)]);
+                    } else {
+                        learn("label", canonical_ctx, canonical_action, "success", ["distilled", "triage"]);
+                    };
+                    let did = try { distill("label", coarse_ctx, canonical_action, "heuristic"); } catch e { ""; };
+                    if len(did) > 0 {
+                        knowledge_validate(did);
+                    };
+                };
+            };
+        };
 
         if my_tier == "autonomous" {
             // colony-lint: safe-exec-concat
@@ -610,7 +895,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 // row still lands (acceptable asymmetry — a missing soak
                 // row means no reality-check adjustment for this iid, not a
                 // phantom success).
-                record_autonomous_verdict(owner, repo, action.issue_id, action.labels);
+                record_autonomous_verdict(owner, repo, action.issue_id, action.labels, "");
                 if len(owner) > 0 {
                     learn("label", "issue " + to_string(action.issue_id), action.labels, "success", [scope, "triage", "acted", repo_tag(owner, repo)]);
                 } else {
@@ -629,7 +914,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                 // #106: stash the verdict so the next tick can score this
                 // suggestion against whatever the operator eventually applies
                 // to the issue.
-                record_label_verdict(owner, repo, action.issue_id, action.labels);
+                record_label_verdict(owner, repo, action.issue_id, action.labels, "");
                 let scope = scope_for_author(action.author);
                 if len(owner) > 0 {
                     learn("label", "issue " + to_string(action.issue_id), action.labels, "partial", [scope, "triage", "review-gated", repo_tag(owner, repo)]);
@@ -645,7 +930,7 @@ fn tick_for_repo(owner: string, repo: string) -> void {
                     // to the issue. Only records at propose/review-gated level —
                     // at autonomous the agent writes its own labels, so there's
                     // no separable operator signal to score against.
-                    record_label_verdict(owner, repo, action.issue_id, action.labels);
+                    record_label_verdict(owner, repo, action.issue_id, action.labels, "");
                     let scope = scope_for_author(action.author);
                     if len(owner) > 0 {
                         learn("label", "issue " + to_string(action.issue_id), action.labels, "partial", [scope, "triage", "emitted", repo_tag(owner, repo)]);


### PR DESCRIPTION
Implements #1235 (part of epic #1234). Ports the agentis-core **crystallizer** rule-distillation substrate into `triage/labeler.ag` — the first dev-apprenticeship agent that learns deterministic rules, replays them without an LLM call, and demotes them when they stop performing.

## What
- **Stage-1 rule-first** (before `prompt()`): deterministic keyword-signature `canonical_ctx` → `crystallizer_lookup_with_confidence('label', ctx, min_conf)`; on hit ≥ conf, apply the rule's labels deterministically (all 4 tier branches via `apply_label_rule_hit`), `crystallizer_record_use(+0.1)`, **skip `prompt()`**.
- **Stage-2 distill** (after the LLM path): `distill('label', coarse_ctx, sorted_labels)` + `knowledge_validate()` (guarded — raises until ≥3 records). Crystallizes after the same keyword-class+labels recurs.
- **Demote feedback**: the pending-verdict blob gains a 4th `rule_id`; the existing reality-check (`evaluate_label_verdict` + autonomous soak scorer) calls `crystallizer_record_use(rule_id, kept?, +0.1/-0.15)` — operator keeps labels → reinforce, changes them → demote → core compaction retires bad rules. **The verifier was already wired** (labeler's reality-check); that's why labeler is the pilot.
- **Rollback**: `LABELER_RULE_FIRST=0` → byte-identical pre-pilot behaviour.

No container-style persistence wiring: host-run `.agentis/objects`+`knowledge` persist on disk across restarts.

## Tests
`./tools/colony-lint.sh` → **428 passed, 0 failed, 5 skipped** (= baseline; `labeler.ag` syntax + tier-branch passes). Crystallizer builtins runtime-probed on host agentis v1.19.0 (lookup→empty map on miss, distill raises <3 records, record_use no-ops on unknown id). `test-labeler-autonomous-verdict.sh` still passes.

## Notes for review
- Canonical context is built from issue **title** (the pre-`prompt()` `--view labeler` JSON drops `description`) + author scope; rule-hit targets the first unlabeled issue deterministically (LLM-path picks 'most important'). Closest prompt-free mirror of noticer's `build_canonical_context` given pre-prompt inputs.
- In-flight 3-field verdict blobs across the deploy boundary are guarded (`rule_id == 'void'` → skip).
- Crystallization is intentionally rare (needs the same keyword-class+labels ≥3×) — expected on low-volume repos.