### PR TITLE
feat(code-edit-in-checkout): forge-agnostic GitLab parity

### DIFF
--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -81,6 +81,20 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Forge selection (#1213). The orchestrator is forge-agnostic: github (default)
+# or gitlab. Exported so the GIT_ASKPASS helper (a subprocess of git) can branch
+# on it. The per-repo token resolution and clone/auth/create-mr blocks below all
+# key off $FORGE_TYPE.
+FORGE_TYPE="${FORGE_TYPE:-github}"
+export FORGE_TYPE
+case "$FORGE_TYPE" in
+    github|gitlab) ;;
+    *)
+        echo "code-edit-in-checkout.sh: unknown FORGE_TYPE '$FORGE_TYPE' (expected github|gitlab)" >&2
+        exit 2
+        ;;
+esac
+
 # Per-repo token re-resolution (#1212). In multi-repo mode (#316) start-colony
 # exports GITHUB_TOKEN as the FIRST repo's token, so cloning/pushing/opening a
 # PR for a NON-first repo would auth with the wrong credential. Mirror
@@ -103,15 +117,22 @@ if [ "${FORGE_TYPE:-github}" = "github" ] && [ -n "${GITHUB_REPOS_JSON:-}" ]; th
     export GITHUB_OWNER GITHUB_REPO GITHUB_TOKEN GITHUB_URL GITHUB_ME
 fi
 
-# Presence-only check via `${GITHUB_TOKEN:+x}` so the token VALUE is never
-# expanded onto a command line (stays out of any external `set -x` trace): the
-# expansion yields the literal `x` when the token is set+non-empty, empty
-# otherwise. The value itself is only ever read by the GIT_ASKPASS helper and
-# inherited by github-api.sh — never named in this script. In multi-repo mode
-# this validates the RESOLVED per-repo token (the block above ran first).
-if [ -z "${GITHUB_TOKEN:+x}" ]; then
-    echo "code-edit-in-checkout.sh: GITHUB_TOKEN must be set in the environment" >&2
-    exit 1
+# Presence-only check via `${VAR:+x}` so the token VALUE is never expanded onto a
+# command line (stays out of any external `set -x` trace): the expansion yields
+# the literal `x` when the token is set+non-empty, empty otherwise. The value
+# itself is only ever read by the GIT_ASKPASS helper and inherited by the forge
+# API wrapper — never named in this script. In multi-repo (github) mode this
+# validates the RESOLVED per-repo token (the block above ran first).
+if [ "$FORGE_TYPE" = "gitlab" ]; then
+    if [ -z "${GITLAB_TOKEN:+x}" ]; then
+        echo "code-edit-in-checkout.sh: GITLAB_TOKEN must be set in the environment" >&2
+        exit 1
+    fi
+else
+    if [ -z "${GITHUB_TOKEN:+x}" ]; then
+        echo "code-edit-in-checkout.sh: GITHUB_TOKEN must be set in the environment" >&2
+        exit 1
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -130,20 +151,28 @@ else
 fi
 
 GITHUB_URL="${GITHUB_URL:-https://api.github.com}"
-# Derive the git host base from the API base. api.github.com -> github.com;
-# a GHE API base like https://ghe.example.com/api/v3 -> https://ghe.example.com.
-# A schemeless-host URL (file:// — used by the offline test harness, never in
-# production) forwards its path verbatim so a local bare repo can stand in for
-# the remote.
-GIT_HOST="$(GH_URL="$GITHUB_URL" python3 -c '
+# Pick the API base per forge. github: the API base (api.github.com or a GHE
+# /api/v3 base). gitlab: the INSTANCE url (e.g. https://gitlab.com) — gitlab-api.sh
+# itself appends /api/v4/projects/<id>.
+if [ "$FORGE_TYPE" = "gitlab" ]; then
+    API_BASE="${GITLAB_URL:-https://gitlab.com}"
+else
+    API_BASE="$GITHUB_URL"
+fi
+# Derive the git host base from the API base. github api.github.com -> github.com;
+# a GHE / GitLab base like https://host/api/<v> -> https://host (the else-branch
+# drops the /api path). A schemeless-host URL (file:// — used by the offline test
+# harness, never in production) forwards its path verbatim so a local bare repo
+# can stand in for the remote.
+GIT_HOST="$(API_BASE="$API_BASE" FORGE_TYPE="$FORGE_TYPE" python3 -c '
 import os
 from urllib.parse import urlsplit
-u = urlsplit(os.environ["GH_URL"])
+u = urlsplit(os.environ["API_BASE"])
 host = u.netloc
 if u.scheme == "file":
     # file:///path -> file:///path (path carries the location, no netloc).
     print("file://" + u.path.rstrip("/"))
-elif host == "api.github.com":
+elif os.environ["FORGE_TYPE"] == "github" and host == "api.github.com":
     print("https://github.com")
 else:
     print(u.scheme + "://" + host)
@@ -156,14 +185,24 @@ CLONE_URL="$GIT_HOST/$OWNER/$REPO.git"
 # ---------------------------------------------------------------------------
 ASKPASS="$(mktemp)"
 # The helper distinguishes git's two prompts ("Username for ..." vs
-# "Password for ...") and answers each. Token rides $GITHUB_TOKEN in the env it
-# inherits; it is never written into this file.
+# "Password for ...") and answers each. It branches on FORGE_TYPE (a non-secret
+# var, inherited from the env): GitHub uses username "x-access-token" + the PAT;
+# GitLab uses username "oauth2" + the PAT. The token rides $GITHUB_TOKEN /
+# $GITLAB_TOKEN in the env this helper inherits and is read ONLY here, in a
+# subprocess — it is never written into this file nor named in the parent script.
 cat > "$ASKPASS" <<'ASKPASS_EOF'
 #!/usr/bin/env sh
-case "$1" in
-    *Username*|*username*) printf '%s' "x-access-token" ;;
-    *) printf '%s' "${GITHUB_TOKEN}" ;;
-esac
+if [ "${FORGE_TYPE:-github}" = "gitlab" ]; then
+    case "$1" in
+        *Username*|*username*) printf '%s' "oauth2" ;;
+        *) printf '%s' "${GITLAB_TOKEN}" ;;
+    esac
+else
+    case "$1" in
+        *Username*|*username*) printf '%s' "x-access-token" ;;
+        *) printf '%s' "${GITHUB_TOKEN}" ;;
+    esac
+fi
 ASKPASS_EOF
 chmod 700 "$ASKPASS"
 
@@ -279,33 +318,50 @@ run_git -C "$WS" commit -m "feat: $TITLE (#$ISSUE)"
 run_git -C "$WS" push --force-with-lease origin "$BRANCH"
 
 # ---------------------------------------------------------------------------
-# 5. Open the PR via the colony's github-api.sh create-mr verb. That wrapper
-#    reads GITHUB_TOKEN/OWNER/REPO from the env (already present here) and prints
-#    the GitHub PR JSON; we extract html_url and print it on stdout.
+# 5. Open the PR/MR via the colony's forge API wrapper create-mr verb. The
+#    wrapper reads its token from the env (already present here) and prints the
+#    forge's PR/MR JSON; we extract the URL and print it on stdout. The verb +
+#    flags (--source/--title/--description) are forge-symmetric; only the env
+#    contract differs (github: OWNER/REPO/URL; gitlab: PROJECT/URL).
 # ---------------------------------------------------------------------------
-GITHUB_API="$FED_DIR/$COLONY_NAME/scripts/github-api.sh"
 DESCRIPTION="Implements #$ISSUE.
 
 $TASK"
 
-if [ ! -x "$GITHUB_API" ]; then
-    echo "[code-edit] github-api.sh not found/executable at $GITHUB_API" >&2
+if [ "$FORGE_TYPE" = "gitlab" ]; then
+    FORGE_API="$FED_DIR/$COLONY_NAME/scripts/gitlab-api.sh"
+else
+    FORGE_API="$FED_DIR/$COLONY_NAME/scripts/github-api.sh"
+fi
+if [ ! -x "$FORGE_API" ]; then
+    echo "[code-edit] $FORGE_TYPE-api.sh not found/executable at $FORGE_API" >&2
     exit 1
 fi
 
-# `env` (not a plain VAR=val prefix on the assignment) so the github-api.sh
-# subprocess inherits OWNER/REPO/URL/default-branch cleanly. GITHUB_TOKEN is
-# deliberately NOT named here: it is already in this script's inherited
-# environment, so the child inherits it automatically. Never referencing
-# $GITHUB_TOKEN as an expanded word keeps the token out of any external `set -x`
+# `env` (not a plain VAR=val prefix on the assignment) so the wrapper subprocess
+# inherits OWNER/REPO/PROJECT/URL/default-branch cleanly. The token (GITHUB_TOKEN
+# / GITLAB_TOKEN) is deliberately NOT named here: it is already in this script's
+# inherited environment, so the child inherits it automatically. Never
+# referencing the token as an expanded word keeps it out of any external `set -x`
 # trace of this script (the token never appears on a command line).
-PR_JSON="$(env \
-    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" GITHUB_URL="$GITHUB_URL" \
-    GITLAB_DEFAULT_BRANCH="$DEFAULT_BRANCH" \
-    "$GITHUB_API" create-mr --source "$BRANCH" --title "$TITLE" --description "$DESCRIPTION")" || {
-        echo "[code-edit] create-mr failed" >&2
-        exit 1
-    }
+if [ "$FORGE_TYPE" = "gitlab" ]; then
+    # gitlab-api.sh wants GITLAB_PROJECT = URL-encoded namespace/project path.
+    PR_JSON="$(env \
+        GITLAB_URL="$API_BASE" GITLAB_PROJECT="$OWNER%2F$REPO" \
+        GITLAB_DEFAULT_BRANCH="$DEFAULT_BRANCH" \
+        "$FORGE_API" create-mr --source "$BRANCH" --title "$TITLE" --description "$DESCRIPTION")" || {
+            echo "[code-edit] create-mr failed" >&2
+            exit 1
+        }
+else
+    PR_JSON="$(env \
+        GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" GITHUB_URL="$GITHUB_URL" \
+        GITLAB_DEFAULT_BRANCH="$DEFAULT_BRANCH" \
+        "$FORGE_API" create-mr --source "$BRANCH" --title "$TITLE" --description "$DESCRIPTION")" || {
+            echo "[code-edit] create-mr failed" >&2
+            exit 1
+        }
+fi
 
 PR_URL="$(PR="$PR_JSON" python3 -c '
 import os, json, sys
@@ -313,11 +369,11 @@ try:
     d = json.loads(os.environ["PR"])
 except Exception:
     sys.exit(1)
-print(d.get("html_url") or d.get("url") or "")
+print(d.get("html_url") or d.get("web_url") or d.get("url") or "")
 ')" || true
 
 if [ -z "$PR_URL" ]; then
-    echo "[code-edit] PR opened but could not parse html_url from create-mr response" >&2
+    echo "[code-edit] PR/MR opened but could not parse its URL from the create-mr response" >&2
     exit 1
 fi
 

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -562,6 +562,116 @@ else
     fail "run 6 (multi-repo miss): create-mr must NOT be invoked" "log=$(cat "$CREATE_MR_LOG")"
 fi
 
+# ===========================================================================
+# Run 7 (GitLab parity #1213): FORGE_TYPE=gitlab. The orchestrator must drive
+# the GitLab backend (gitlab-api.sh, NOT github-api.sh), pass GITLAB_PROJECT as
+# the URL-encoded owner%2Frepo, let GITLAB_TOKEN reach the backend via env, and
+# parse `web_url` from the MR response. A github-api.sh stub is also planted to
+# prove it is NOT the one invoked.
+# ===========================================================================
+rm -rf "$FED_DIR" "$REMOTE_BASE" "$SEED" "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+mkdir -p "$COLONY_DIR/scripts"
+# GitLab backend stub: records the token/project/url it saw, echoes MR JSON.
+cat > "$COLONY_DIR/scripts/gitlab-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+shift
+{ echo "gitlab token_seen=\${GITLAB_TOKEN:-MISSING} project=\${GITLAB_PROJECT:-} url=\${GITLAB_URL:-}"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"web_url": "https://gitlab.example.test/acme/widget/-/merge_requests/7"}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/gitlab-api.sh"
+# Wrong-backend tripwire: if the orchestrator ignores FORGE_TYPE it would call
+# this and pollute the log with WRONG-BACKEND.
+cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+{ echo "WRONG-BACKEND github-api.sh called"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/WRONG"}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/github-api.sh"
+
+mkdir -p "$BARE"
+git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null || git init --quiet --bare "$BARE"
+git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+(
+    cd "$SEED" || exit 1
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    printf 'hello\n' > README.md
+    git add -A
+    git commit --quiet -m "seed: initial commit"
+    git branch -M main 2>/dev/null || true
+    git remote add origin "$BARE"
+    git push --quiet origin main
+)
+git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+
+GITLAB_FAKE_TOKEN="glpat-FAKE_TOKEN_DO_NOT_LEAK_abcdef0123456789"
+OUT7_FILE="$WORK/out7.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    FORGE_TYPE="gitlab" \
+    GITLAB_URL="file://$REMOTE_BASE" \
+    GITLAB_TOKEN="$GITLAB_FAKE_TOKEN" \
+    FC_STUB_MODE="edit" \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue 42 \
+        --branch "fix/issue-42" --title "add new file" \
+        --task "Create NEWFILE.txt with a greeting." >"$OUT7_FILE" 2>"$WORK/err7.txt"
+RC7=$?
+OUT7="$(cat "$OUT7_FILE")"
+
+if [ "$RC7" -eq 0 ]; then
+    pass "run 7 (gitlab): orchestrator exits 0 on the GitLab path"
+else
+    fail "run 7 (gitlab): exit 0 on GitLab path" "rc=$RC7 err=$(cat "$WORK/err7.txt")"
+fi
+if [ "$OUT7" = "https://gitlab.example.test/acme/widget/-/merge_requests/7" ]; then
+    pass "run 7 (gitlab): parses web_url from the MR response"
+else
+    fail "run 7 (gitlab): web_url on stdout" "stdout=[$OUT7]"
+fi
+if grep -q "^gitlab token_seen=$GITLAB_FAKE_TOKEN " "$CREATE_MR_LOG" 2>/dev/null; then
+    pass "run 7 (gitlab): GITLAB_TOKEN reached gitlab-api.sh via env"
+else
+    fail "run 7 (gitlab): GITLAB_TOKEN to backend" "log=$(cat "$CREATE_MR_LOG" 2>/dev/null)"
+fi
+if grep -q "project=acme%2Fwidget" "$CREATE_MR_LOG" 2>/dev/null; then
+    pass "run 7 (gitlab): GITLAB_PROJECT URL-encoded as owner%2Frepo"
+else
+    fail "run 7 (gitlab): GITLAB_PROJECT encoding" "log=$(cat "$CREATE_MR_LOG" 2>/dev/null)"
+fi
+if grep -q "WRONG-BACKEND" "$CREATE_MR_LOG" 2>/dev/null; then
+    fail "run 7 (gitlab): github-api.sh was wrongly invoked for a gitlab forge"
+else
+    pass "run 7 (gitlab): github-api.sh was NOT invoked (forge backend selected correctly)"
+fi
+if grep -q "$GITLAB_FAKE_TOKEN" "$OUT7_FILE" "$WORK/err7.txt" 2>/dev/null; then
+    fail "run 7 (gitlab): token LEAKED into orchestrator stdout/stderr"
+else
+    pass "run 7 (gitlab): token never appears in orchestrator stdout/stderr"
+fi
+
+# Run 8 (gitlab presence check): FORGE_TYPE=gitlab with no GITLAB_TOKEN must fail
+# loudly (exit 1) and name GITLAB_TOKEN, not GITHUB_TOKEN.
+OUT8_FILE="$WORK/out8.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    FORGE_TYPE="gitlab" \
+    GITLAB_URL="file://$REMOTE_BASE" \
+    FC_STUB_MODE="edit" \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue 42 \
+        --branch "fix/issue-42" --title "add new file" \
+        --task "Create NEWFILE.txt with a greeting." >"$OUT8_FILE" 2>"$WORK/err8.txt"
+RC8=$?
+if [ "$RC8" -eq 1 ] && grep -q "GITLAB_TOKEN must be set" "$WORK/err8.txt" 2>/dev/null; then
+    pass "run 8 (gitlab no-token): fails loudly naming GITLAB_TOKEN"
+else
+    fail "run 8 (gitlab no-token): exit 1 + GITLAB_TOKEN message" "rc=$RC8 err=$(cat "$WORK/err8.txt" 2>/dev/null)"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1213

## Problem

`tools/code-edit-in-checkout.sh` hardcoded `github-api.sh` + GitHub clone-URL math and ignored `FORGE_TYPE`, so the checkout-edit path (Approach A) only worked for GitHub. GitLab repos couldn't use it — a gap for the GitLab target.

## Fix

Make the orchestrator forge-agnostic via `FORGE_TYPE` (default `github`). The colony's `gitlab-api.sh` already ships a forge-symmetric `create-mr` verb (same `--source/--title/--description` flags, reads `GITLAB_DEFAULT_BRANCH`), so this is orchestrator-side plumbing only:

- **FORGE_TYPE** resolved + validated (`github`|`gitlab`, else exit 2) + `export`ed so the `GIT_ASKPASS` helper can branch on it.
- **Token presence check** branches: `GITLAB_TOKEN` (gitlab) vs `GITHUB_TOKEN` (github).
- **Clone-URL host math** picks the API base per forge (`GITHUB_URL` default `api.github.com`; `GITLAB_URL` default `gitlab.com`); the existing `scheme://host` else-branch already maps `gitlab.com/api/v4 → gitlab.com` and forwards `file://` verbatim for the test harness.
- **GIT_ASKPASS helper** branches: username `oauth2` + `$GITLAB_TOKEN` (gitlab) vs `x-access-token` + `$GITHUB_TOKEN` (github). The token is read **only inside the helper** (a subprocess) from the env — never named as a word in the parent script (no `set -x` leak).
- **create-mr backend**: `gitlab-api.sh` vs `github-api.sh`. GitLab env: `GITLAB_URL` (instance), `GITLAB_PROJECT=owner%2Frepo` (URL-encoded), `GITLAB_DEFAULT_BRANCH`; `GITLAB_TOKEN` inherited (never named).
- **PR-URL parse** also reads `web_url` (the GitLab MR field).

### Scope notes
- Per-repo token resolution (#1212) stays **github-only** (already guarded by `FORGE_TYPE = github`); GitLab multi-repo is a future follow-up.
- The GitLab clone-auth username (`oauth2`) is exercised only against real HTTPS GitLab — a `file://` remote needs no auth — same status as GitHub's `x-access-token`.
- `GITLAB_PROJECT` is encoded as `owner%2Frepo` (2-segment); nested GitLab group paths would need fuller encoding (out of scope).

## Tests

`tools/test-code-edit-in-checkout.sh`:
- **Run 7** (GitLab happy path, `gitlab-api.sh` stub + `file://` remote): asserts the gitlab backend is selected **over a planted `github-api.sh` tripwire**, `GITLAB_PROJECT` is the URL-encoded `acme%2Fwidget`, `GITLAB_TOKEN` reaches the backend via env, `web_url` is parsed onto stdout, and the token never leaks.
- **Run 8** (gitlab, no `GITLAB_TOKEN`): fails loudly with exit 1 naming `GITLAB_TOKEN`.
- GitHub runs 1–6 unchanged.

**38/38 pass**; `colony-lint.sh` **429 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)