### PR TITLE
Implement the self-contained `tools/ms-to-human.sh` POSIX-shell helper that converts a millisecond count into a compact human-readable duration using floor-division integer math across the four documented ranges, defaulting to `0ms` for any missing or invalid input so it never crashes. Add `tools/test-ms-to-human.sh` covering one assertion per range plus all guard cases, following the repo's existing tools-test convention so `colony-lint.sh` auto-discovers it. Verify with a passing `./tools/test-ms-to-human.sh` and a green `./tools/colony-lint.sh` run.

### DIFF
--- a/tools/ms-to-human.sh
+++ b/tools/ms-to-human.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+# tools/ms-to-human.sh (#1246): format a millisecond duration as a compact
+# human-readable string using integer (floor-division) math only -- no decimals.
+#
+#   Input range (ms)         Output      Example
+#   < 1000                   <N>ms       500     -> 500ms
+#   >= 1000,    < 60000      <S>s        2000    -> 2s
+#   >= 60000,   < 3600000    <M>m<S>s    90000   -> 1m30s
+#   >= 3600000               <H>h<M>m    5400000 -> 1h30m
+#
+# S / M are the *remainder* seconds / minutes: 90000 -> 1 minute 30 seconds ->
+# 1m30s; 5400000 -> 1 hour 30 minutes -> 1h30m.
+#
+# $1 is a non-negative integer count of milliseconds. Any missing, empty,
+# negative, or non-integer input prints "0ms" and exits 0 -- the helper is
+# total and never crashes. POSIX sh, dash-safe: no bashisms, no printf '\xNN'.
+set -eu
+
+ms="${1:-}"
+
+# Guard: accept only a non-empty run of ASCII digits. This rejects the missing
+# arg (empty), explicit empty string, negatives (the '-' is non-digit), and any
+# non-integer (decimals, letters). Leading zeros are harmless to the math below.
+case "$ms" in
+    ''|*[!0-9]*)
+        echo "0ms"
+        exit 0
+        ;;
+esac
+
+if [ "$ms" -lt 1000 ]; then
+    echo "${ms}ms"
+elif [ "$ms" -lt 60000 ]; then
+    echo "$((ms / 1000))s"
+elif [ "$ms" -lt 3600000 ]; then
+    echo "$((ms / 60000))m$((ms / 1000 % 60))s"
+else
+    echo "$((ms / 3600000))h$((ms / 60000 % 60))m"
+fi

--- a/tools/test-ms-to-human.sh
+++ b/tools/test-ms-to-human.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# tools/test-ms-to-human.sh (#1246): unit-test the millisecond-duration
+# formatter tools/ms-to-human.sh.
+#
+# Contract under test -- one assertion per documented range:
+#   < 1000                 -> <N>ms     (500     -> 500ms)
+#   >= 1000,  < 60000      -> <S>s      (2000    -> 2s)
+#   >= 60000, < 3600000    -> <M>m<S>s  (90000   -> 1m30s)
+#   >= 3600000             -> <H>h<M>m  (5400000 -> 1h30m)
+# plus the guard cases: missing / empty / negative / non-integer all -> 0ms,
+# exit 0 (the helper is total -- it never crashes).
+#
+# Auto-discovered by tools/colony-lint.sh's tools-test loop. Exit 0 if all pass.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FMT="$SCRIPT_DIR/ms-to-human.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# SKIP cleanly (exit 0) if the helper is not present yet.
+if [ ! -f "$FMT" ]; then
+    echo "[SKIP] test-ms-to-human.sh: $FMT absent"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (skipped)"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# assert_eq <description> <expected> [args...]
+# Runs the helper under `sh` (proves dash-safety) with the given args and
+# compares stdout to <expected>, also requiring a clean exit.
+assert_eq() {
+    desc="$1"; expected="$2"; shift 2
+    out="$(sh "$FMT" "$@" 2>/dev/null)" && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ] && [ "$out" = "$expected" ]; then
+        pass "$desc"
+    else
+        fail "$desc" "rc=$rc out=$(printf '%q' "$out") want=$(printf '%q' "$expected")"
+    fi
+}
+
+# --- one assertion per documented range ---
+assert_eq "< 1000 -> <N>ms (500 -> 500ms)"                   "500ms" 500
+assert_eq ">= 1000, < 60000 -> <S>s (2000 -> 2s)"            "2s"    2000
+assert_eq ">= 60000, < 3600000 -> <M>m<S>s (90000 -> 1m30s)" "1m30s" 90000
+assert_eq ">= 3600000 -> <H>h<M>m (5400000 -> 1h30m)"        "1h30m" 5400000
+
+# --- guard cases: all -> 0ms, exit 0 ---
+assert_eq "missing arg -> 0ms"     "0ms"            # no $1 at all
+assert_eq "empty arg -> 0ms"       "0ms" ""         # explicit empty string
+assert_eq "negative arg -> 0ms"    "0ms" -5         # '-' is non-digit
+assert_eq "non-integer arg -> 0ms" "0ms" "1.5abc"   # decimals / letters
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements #1246.

Issue:
{"iid": 1246, "title": "tools: add ms-to-human.sh \u2014 format a millisecond duration as a compact human string", "description": "## Task\n\nAdd a small, self-contained POSIX-shell helper `tools/ms-to-human.sh` that takes a single argument `$1` (a non-negative integer count of milliseconds) and prints a compact human-readable duration on stdout, then a newline. Integer math only \u2014 no decimals:\n\n| Input range (ms)          | Output format | Example            |\n|---------------------------|---------------|--------------------|\n| `< 1000`                  | `<N>ms`       | `500`     \u2192 `500ms`|\n| `>= 1000`, `< 60000`      | `<S>s`        | `2000`    \u2192 `2s`   |\n| `>= 60000`, `< 3600000`   | `<M>m<S>s`    | `90000`   \u2192 `1m30s`|\n| `>= 3600000`              | `<H>h<M>m`    | `5400000` \u2192 `1h30m`|\n\nWhere `S`/`M` are the *remainder* seconds/minutes (floor division): `90000` \u2192 1 minute 30 seconds \u2192 `1m30s`; `5400000` \u2192 1 hour 30 minutes \u2192 `1h30m`.\n\nRules:\n- `#!/usr/bin/env sh` + `set -eu`. **Dash-safe** \u2014 no bashisms, no `printf '\\xNN'`.\n- If `$1` is missing, empty, negative, or not a non-negative integer, print `0ms` and exit 0 (total \u2014 never crash).\n- Make the script executable (`chmod +x`).\n\n## Test\n\nAdd `tools/test-ms-to-human.sh` following this repo's test convention: `set -eu`; `mktemp -d` + an `EXIT` trap to clean up; `PASS`/`FAIL` counters with `pass()`/`fail()` helpers; **SKIP and exit 0** if `tools/ms-to-human.sh` is absent; a final `Results: <N> passed, <M> failed` line; end with `[ \"$FAIL\" -eq 0 ]`. It is auto-discovered by `colony-lint.sh`'s tools-test loop. Assert one case per bracket above (e.g. `500ms`, `2s`, `1m30s`, `1h30m`) plus the guard cases (missing/empty/negative/non-integer all \u2192 `0ms`).\n\n## Done\n- `tools/ms-to-human.sh` and `tools/test-ms-to-human.sh` exist.\n- `./tools/test-ms-to-human.sh` passes.\n- `./tools/colony-lint.sh` stays green (0 failed).", "state": "opened", "labels": ["implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-21T22:44:47Z", "updated_at": "2026-06-21T22:44:47Z", "user_notes_count": 0, "priority": null}

Plan:
- `tools/ms-to-human.sh` — new POSIX `sh` helper (`#!/usr/bin/env sh`, `set -eu`, dash-safe, integer-only math) that reads `$1` as a millisecond count and prints a compact duration on stdout: `<N>ms` for `<1000`, `<S>s` for `<60000`, `<M>m<S>s` for `<3600000`, and `<H>h<M>m` otherwise, using floor-division remainders. Guards missing/empty/negative/non-integer input by printing `0ms` and exiting 0; made executable via `chmod +x`.
- `tools/test-ms-to-human.sh` — new test following the repo convention (`set -eu`, `mktemp -d` + EXIT trap cleanup, `PASS`/`FAIL` counters with `pass()`/`fail()` helpers, SKIP and exit 0 when the script is absent, final `Results: <N> passed, <M> failed` line, ends with `[ "$FAIL" -eq 0 ]`). Asserts one case per range (`500ms`, `2s`, `1m30s`, `1h30m`) plus the four guard cases; auto-discovered by `colony-lint.sh`'s tools-test loop.

Implement the self-contained `tools/ms-to-human.sh` POSIX-shell helper that converts a millisecond count into a compact human-readable duration using floor-division integer math across the four documented ranges, defaulting to `0ms` for any missing or invalid input so it never crashes. Add `tools/test-ms-to-human.sh` covering one assertion per range plus all guard cases, following the repo's existing tools-test convention so `colony-lint.sh` auto-discovers it. Verify with a passing `./tools/test-ms-to-human.sh` and a green `./tools/colony-lint.sh` run.