### PR TITLE
feat(code-edit-in-checkout): continue-on-incomplete editing loop [complex-task M1]

### DIFF
--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -328,6 +328,13 @@ staged_line_count() {
 MAX_ATTEMPTS="${CODE_EDIT_MAX_ATTEMPTS:-3}"
 TOTAL_BUDGET_MS="${CODE_EDIT_TOTAL_BUDGET_MS:-1500000}"
 PER_ATTEMPT_MS="${CODE_EDIT_TIMEOUT_MS:-600000}"
+# Harden the numeric knobs: a non-integer / empty override would otherwise make
+# `[ -ge ]` print "integer expected" (silently bypassing the attempt gate) or
+# abort an `$(( ))` under set -e. Fall back to the defaults on any non-digit value.
+case "$MAX_ATTEMPTS"   in ''|*[!0-9]*) MAX_ATTEMPTS=3 ;; esac
+case "$TOTAL_BUDGET_MS" in ''|*[!0-9]*) TOTAL_BUDGET_MS=1500000 ;; esac
+case "$PER_ATTEMPT_MS"  in ''|*[!0-9]*) PER_ATTEMPT_MS=600000 ;; esac
+if [ "$MAX_ATTEMPTS" -lt 1 ]; then MAX_ATTEMPTS=1; fi
 loop_start="$(date +%s)"
 attempt=0
 prev_lines=0

--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -308,37 +308,99 @@ reap_editing_strays() {
 #    does not overflow claude's input editor; --cwd points claude at the
 #    checkout; --auto-approve writes without an interactive confirm.
 # ---------------------------------------------------------------------------
-printf 'Implement issue #%s in this repository by editing the files directly with your tools. %s\n\n%s\n\nMake the change and stop; do not run git or open a PR.' \
-    "$ISSUE" "$TITLE" "$TASK" > "$TASKFILE"
+# staged_line_count: total churn (added+removed) of the staged diff; 0 when the
+# tree is clean. Used to detect PROGRESS between attempts. Binary files report
+# numstat "-" for added/removed, treated as 0.
+staged_line_count() {
+    run_git -C "$WS" add -A
+    git_capture -C "$WS" diff --cached --numstat 2>/dev/null \
+        | awk '{ a = ($1 == "-" ? 0 : $1); d = ($2 == "-" ? 0 : $2); s += a + d } END { print s + 0 }'
+}
 
-echo "[code-edit] running flat-cyborg editing agent in $WS" >&2
-set +e
-flat-cyborg --extract --extract-structural --no-jitter --auto-approve --wrap-input 72 --cwd "$WS" \
-    --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" \
-    --timeout-ms "${CODE_EDIT_TIMEOUT_MS:-600000}" \
-    --cmd-file "$TASKFILE" -- claude >&2
-FC_RC=$?
-set -e
+# Bounded continue-on-incomplete loop (#1251). A single fixed-timeout shot was
+# the main limiter on complex tasks: claude was interrupted mid-edit (exit 124)
+# with a partial diff, or simply ran out of one turn, and nobody told it to keep
+# going. Now, if a session TIMES OUT but made PROGRESS (the staged diff grew) and
+# attempts/budget remain, we re-drive with a "continue, finish it" prompt that
+# carries the diff-so-far. A SETTLED session (FC_RC == 0) means claude finished
+# its turn — stop looping. Backward-compatible: a task that settles on attempt 1
+# behaves exactly as the old single shot (one drive -> commit).
+MAX_ATTEMPTS="${CODE_EDIT_MAX_ATTEMPTS:-3}"
+TOTAL_BUDGET_MS="${CODE_EDIT_TOTAL_BUDGET_MS:-1500000}"
+PER_ATTEMPT_MS="${CODE_EDIT_TIMEOUT_MS:-600000}"
+loop_start="$(date +%s)"
+attempt=0
+prev_lines=0
+FC_RC=0
 
-# Reap orphaned editing-session descendants immediately — before commit/exit —
-# so a wedged claude child can never outlive its job and peg the CPU (#1249).
-reap_editing_strays
+while :; do
+    attempt=$((attempt + 1))
+    elapsed_ms=$(( ($(date +%s) - loop_start) * 1000 ))
+    remaining_ms=$(( TOTAL_BUDGET_MS - elapsed_ms ))
+    [ "$remaining_ms" -lt 1000 ] && remaining_ms=1000
+    this_timeout="$PER_ATTEMPT_MS"
+    [ "$this_timeout" -gt "$remaining_ms" ] && this_timeout="$remaining_ms"
+
+    if [ "$attempt" -eq 1 ]; then
+        printf 'Implement issue #%s in this repository by editing the files directly with your tools. %s\n\n%s\n\nMake the change and stop; do not run git or open a PR.' \
+            "$ISSUE" "$TITLE" "$TASK" > "$TASKFILE"
+    else
+        # Continuation prompt: claude was interrupted; show what changed so far.
+        {
+            printf 'You are CONTINUING work on issue #%s: %s\n\n' "$ISSUE" "$TITLE"
+            printf 'Your previous turn was interrupted before the change was finished. Files changed so far in this checkout:\n\n'
+            git_capture -C "$WS" diff --cached --stat 2>/dev/null || true
+            printf '\nReview the current state, COMPLETE the remaining work for the issue below, and stop. Do not run git or open a PR.\n\nIssue task:\n%s\n' "$TASK"
+        } > "$TASKFILE"
+        echo "[code-edit] continuing editing session (attempt $attempt/$MAX_ATTEMPTS, ${remaining_ms}ms budget left)" >&2
+    fi
+
+    echo "[code-edit] running flat-cyborg editing agent in $WS (attempt $attempt)" >&2
+    set +e
+    flat-cyborg --extract --extract-structural --no-jitter --auto-approve --wrap-input 72 --cwd "$WS" \
+        --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" \
+        --timeout-ms "$this_timeout" \
+        --cmd-file "$TASKFILE" -- claude >&2
+    FC_RC=$?
+    set -e
+
+    # Reap orphaned editing-session descendants before measuring/looping (#1249).
+    reap_editing_strays
+    cur_lines="$(staged_line_count)"
+
+    # Settled (claude finished its turn) -> stop, whatever it produced.
+    [ "$FC_RC" -eq 0 ] && break
+    # Timed out / errored: stop unless we made progress AND budget+attempts remain.
+    if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+        echo "[code-edit] reached max attempts ($MAX_ATTEMPTS) — committing whatever was produced" >&2
+        break
+    fi
+    if [ "$(( ($(date +%s) - loop_start) * 1000 ))" -ge "$TOTAL_BUDGET_MS" ]; then
+        echo "[code-edit] exhausted total edit budget — committing whatever was produced" >&2
+        break
+    fi
+    if [ "$cur_lines" -le "$prev_lines" ]; then
+        echo "[code-edit] attempt $attempt timed out (exit $FC_RC) with no new progress (staged churn $cur_lines <= $prev_lines) — stopping" >&2
+        break
+    fi
+    echo "[code-edit] attempt $attempt timed out (exit $FC_RC) but made progress (staged churn $prev_lines -> $cur_lines) — continuing" >&2
+    prev_lines="$cur_lines"
+done
 
 # ---------------------------------------------------------------------------
 # 4. Commit the diff. The ARTIFACT is the edit, not the editing session's exit
 #    code: flat-cyborg drives an interactive Claude Code TUI that frequently
-#    never settles to its idle prompt, so flat-cyborg rides to its --timeout-ms
-#    and returns non-zero EVEN WHEN claude finished editing correctly. So we
-#    stage first and decide on the diff:
+#    never settles to its idle prompt. After the loop above we decide on the
+#    final staged diff:
 #      * staged change present  -> commit + push + PR, regardless of FC_RC
 #        (a timeout that still produced edits is a success, not a failure).
-#      * no change + FC_RC == 0 -> NO_EDITS  => exit 3 (retry, not error).
-#      * no change + FC_RC != 0 -> the session genuinely failed => exit FC_RC.
+#      * no change + last FC_RC == 0 -> NO_EDITS  => exit 3 (retry, not error).
+#      * no change + last FC_RC != 0 -> the session genuinely failed => exit FC_RC.
 # ---------------------------------------------------------------------------
 run_git -C "$WS" add -A
 if run_git -C "$WS" diff --cached --quiet; then
     if [ "$FC_RC" -ne 0 ]; then
-        echo "[code-edit] flat-cyborg editing agent failed (exit $FC_RC) and produced no edits" >&2
+        echo "[code-edit] editing agent failed (last exit $FC_RC) and produced no edits" >&2
         exit "$FC_RC"
     fi
     echo "NO_EDITS"
@@ -347,7 +409,7 @@ if run_git -C "$WS" diff --cached --quiet; then
 fi
 
 if [ "$FC_RC" -ne 0 ]; then
-    echo "[code-edit] flat-cyborg exited non-zero (exit $FC_RC, likely idle/timeout) but edits were produced — committing the diff" >&2
+    echo "[code-edit] last attempt exited non-zero (exit $FC_RC, likely idle/timeout) but edits were produced — committing the diff" >&2
 fi
 
 run_git -C "$WS" commit -m "feat: $TITLE (#$ISSUE)"

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -749,6 +749,102 @@ else
     pass "run 9 (reap): orphaned editing-session child was reaped (#1249)"
 fi
 
+# ===========================================================================
+# Run 10 (#1251 continue-on-incomplete): a stateful stub flat-cyborg times out
+# (exit 124) on attempt 1 with a PARTIAL edit, then settles (exit 0) on attempt
+# 2 completing the change. The orchestrator must ITERATE — re-drive with the
+# continuation prompt, building on attempt 1's checkout — then commit the FULL
+# result. This is the loop that lets big tasks finish across turns.
+# ===========================================================================
+rm -rf "$FED_DIR" "$REMOTE_BASE" "$SEED" "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+mkdir -p "$COLONY_DIR/scripts"
+cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+{ echo "create-mr called"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/10"}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/github-api.sh"
+
+# Stateful editing stub: attempt 1 -> partial edit + timeout (124); attempt 2 ->
+# finish the change + settle (0). The counter persists across the two
+# invocations within this single orchestrator run.
+CNT_FILE="$WORK/fc-attempt-count"; rm -f "$CNT_FILE"
+cat > "$STUB_BIN/flat-cyborg" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "\$*" >> "$FC_FLAGS_LOG"
+CWD=""
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        --cwd) CWD="\$2"; shift 2 ;;
+        --) shift; break ;;
+        *) shift ;;
+    esac
+done
+n=\$(cat "$CNT_FILE" 2>/dev/null || echo 0); n=\$((n + 1)); printf '%s' "\$n" > "$CNT_FILE"
+if [ "\$n" -eq 1 ]; then
+    printf 'part one\n' > "\$CWD/PART1.txt"
+    exit 124
+fi
+printf 'part two\n' > "\$CWD/PART2.txt"
+exit 0
+STUB_EOF
+chmod +x "$STUB_BIN/flat-cyborg"
+
+mkdir -p "$BARE"
+git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null || git init --quiet --bare "$BARE"
+git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+(
+    cd "$SEED" || exit 1
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    printf 'hello\n' > README.md
+    git add -A
+    git commit --quiet -m "seed: initial commit"
+    git branch -M main 2>/dev/null || true
+    git remote add origin "$BARE"
+    git push --quiet origin main
+)
+git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+
+OUT10_FILE="$WORK/out10.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    GITHUB_URL="file://$REMOTE_BASE" \
+    GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    CODE_EDIT_MAX_ATTEMPTS=3 \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue 88 \
+        --branch "fix/issue-88" --title "add two files" \
+        --task "Create PART1.txt and PART2.txt." >"$OUT10_FILE" 2>"$WORK/err10.txt"
+RC10=$?
+ATTEMPTS="$(cat "$CNT_FILE" 2>/dev/null || echo 0)"
+
+if [ "$RC10" -eq 0 ] && [ "$(cat "$OUT10_FILE")" = "https://example.test/pr/10" ]; then
+    pass "run 10 (continue): orchestrator exits 0 + opens the PR after iterating"
+else
+    fail "run 10 (continue): exit 0 + PR url" "rc=$RC10 out=$(cat "$OUT10_FILE" 2>/dev/null) err=$(tail -3 "$WORK/err10.txt" 2>/dev/null)"
+fi
+if [ "$ATTEMPTS" = "2" ]; then
+    pass "run 10 (continue): drove the editing session TWICE (timeout -> continue -> settle)"
+else
+    fail "run 10 (continue): expected 2 attempts" "got $ATTEMPTS"
+fi
+if grep -q "continuing editing session (attempt 2" "$WORK/err10.txt" 2>/dev/null; then
+    pass "run 10 (continue): took the continuation-prompt path on attempt 2"
+else
+    fail "run 10 (continue): continuation log line" "err=$(tail -5 "$WORK/err10.txt" 2>/dev/null)"
+fi
+# attempt 2 built on attempt 1's checkout: BOTH files must be in the pushed commit.
+if git --git-dir="$BARE" cat-file -e "refs/heads/fix/issue-88:PART1.txt" 2>/dev/null \
+   && git --git-dir="$BARE" cat-file -e "refs/heads/fix/issue-88:PART2.txt" 2>/dev/null; then
+    pass "run 10 (continue): final commit has BOTH partial + completed files (built on prior attempt)"
+else
+    fail "run 10 (continue): both PART1.txt + PART2.txt in pushed commit"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -845,6 +845,80 @@ else
     fail "run 10 (continue): both PART1.txt + PART2.txt in pushed commit"
 fi
 
+# ===========================================================================
+# Run 11 (#1251 loop bound + knob hardening): a stub that ALWAYS times out (124)
+# AND always makes NEW progress (a fresh file each attempt) would loop until the
+# 25-min budget if the attempt cap failed. Combined with a GARBAGE
+# CODE_EDIT_MAX_ATTEMPTS ("not-a-number"), this proves (a) the non-integer knob
+# is sanitized to the default and (b) the loop is hard-bounded by MAX_ATTEMPTS
+# (default 3), then commits whatever was produced.
+# ===========================================================================
+rm -rf "$FED_DIR" "$REMOTE_BASE" "$SEED" "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+mkdir -p "$COLONY_DIR/scripts"
+cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+{ echo "create-mr called"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/11"}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/github-api.sh"
+
+CNT_FILE2="$WORK/fc-attempt-count-2"; rm -f "$CNT_FILE2"
+cat > "$STUB_BIN/flat-cyborg" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "\$*" >> "$FC_FLAGS_LOG"
+CWD=""
+while [ \$# -gt 0 ]; do case "\$1" in --cwd) CWD="\$2"; shift 2 ;; --) shift; break ;; *) shift ;; esac; done
+n=\$(cat "$CNT_FILE2" 2>/dev/null || echo 0); n=\$((n + 1)); printf '%s' "\$n" > "$CNT_FILE2"
+# Always new progress + always time out: without a working attempt cap this
+# loops until the budget. The sanitized MAX_ATTEMPTS must bound it.
+printf 'chunk %s\n' "\$n" > "\$CWD/CHUNK_\$n.txt"
+exit 124
+STUB_EOF
+chmod +x "$STUB_BIN/flat-cyborg"
+
+mkdir -p "$BARE"
+git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null || git init --quiet --bare "$BARE"
+git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+(
+    cd "$SEED" || exit 1
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    printf 'hello\n' > README.md
+    git add -A
+    git commit --quiet -m "seed: initial commit"
+    git branch -M main 2>/dev/null || true
+    git remote add origin "$BARE"
+    git push --quiet origin main
+)
+git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+
+OUT11_FILE="$WORK/out11.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    GITHUB_URL="file://$REMOTE_BASE" \
+    GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    CODE_EDIT_MAX_ATTEMPTS="not-a-number" \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue 99 \
+        --branch "fix/issue-99" --title "perpetual progress" \
+        --task "Keep adding chunks." >"$OUT11_FILE" 2>"$WORK/err11.txt"
+RC11=$?
+ATTEMPTS2="$(cat "$CNT_FILE2" 2>/dev/null || echo 0)"
+
+if [ "$ATTEMPTS2" = "3" ]; then
+    pass "run 11 (bound): loop hard-capped at MAX_ATTEMPTS=3 despite perpetual progress + garbage knob"
+else
+    fail "run 11 (bound): expected exactly 3 attempts" "got $ATTEMPTS2 (rc=$RC11)"
+fi
+if [ "$RC11" -eq 0 ] && [ "$(cat "$OUT11_FILE")" = "https://example.test/pr/11" ]; then
+    pass "run 11 (bound): committed what was produced + opened the PR after the cap"
+else
+    fail "run 11 (bound): exit 0 + PR url after cap" "rc=$RC11 out=$(cat "$OUT11_FILE" 2>/dev/null)"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1251 · M1 of the complex-task arc (M2 verify-and-fix, M3 decompose epics to follow).

## Problem

The orchestrator drove flat-cyborg/claude **once** (`--timeout-ms`, default 10 min) and committed whatever diff existed — no iteration. Big tasks routinely didn't finish in one timed shot: **#1212** was interrupted by the exit-124 timeout **mid-"Edit 3"** with a correct partial diff; **#1235/#1238** never settled. claude can do the work; it just ran out of one turn with nobody telling it to continue.

## Fix — bounded continue-on-incomplete loop

- Drive claude (per-attempt timeout = `min(CODE_EDIT_TIMEOUT_MS, remaining budget)`), reap strays (#1249), measure staged churn.
- **Settled** (`FC_RC == 0`) → claude finished its turn → stop.
- **Timed out** (`FC_RC != 0`) → if it made **progress** (staged diff grew) and attempts + budget remain → re-drive with a **continuation prompt** carrying `git diff --cached --stat` so-far + "you were interrupted; finish it". Else stop.
- Terminal decision **unchanged**: non-empty diff → commit/push/PR; empty + last-settled → `NO_EDITS` (exit 3); empty + last-timed-out → exit `FC_RC`.

Knobs: `CODE_EDIT_MAX_ATTEMPTS` (3), `CODE_EDIT_TOTAL_BUDGET_MS` (25 min), per-attempt `CODE_EDIT_TIMEOUT_MS` (existing). **Backward-compatible**: a task that settles on attempt 1 behaves exactly as the old single shot.

## Test

New **run 10**: a stateful stub times out with a **partial** edit on attempt 1, then settles **completing** the change on attempt 2. Asserts the orchestrator (a) drove the session **twice**, (b) took the continuation-prompt path, and (c) committed **both** files — i.e. attempt 2 built on attempt 1's checkout, not from scratch. Existing runs 1–9 unchanged (settled-on-attempt-1 still one drive).

**45/45 pass**; `colony-lint.sh` **430 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)