### PR TITLE
feat(code-edit-in-checkout): verify-and-fix loop [complex-task M2]

### DIFF
--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -209,7 +209,7 @@ chmod 700 "$ASKPASS"
 # A task file for flat-cyborg --cmd-file (a multi-KB instruction must not ride
 # argv — ARG_MAX, same lesson as #1171). Cleaned up on exit alongside ASKPASS.
 TASKFILE="$(mktemp)"
-trap 'rm -f "$ASKPASS" "$TASKFILE"' EXIT
+trap 'rm -f "$ASKPASS" "$TASKFILE" "${VERIFY_OUT:-}"' EXIT
 
 # git wrappers that thread the askpass helper + non-interactive terminal so a
 # missing/invalid token fails fast instead of hanging on a prompt.
@@ -317,6 +317,33 @@ staged_line_count() {
         | awk '{ a = ($1 == "-" ? 0 : $1); d = ($2 == "-" ? 0 : $2); s += a + d } END { print s + 0 }'
 }
 
+# detect_verify_cmd (#1253): the command (run in $WS) that decides whether the
+# change is CORRECT, not just present. Explicit CODE_EDIT_VERIFY_CMD wins;
+# otherwise auto-detect a common gate; empty = "no verifier" -> the loop degrades
+# to M1 (a settled session is treated as done). Set CODE_EDIT_VERIFY_CMD=true to
+# force-skip verification.
+detect_verify_cmd() {
+    if [ -n "${CODE_EDIT_VERIFY_CMD:-}" ]; then printf '%s' "$CODE_EDIT_VERIFY_CMD"; return 0; fi
+    if [ -x "$WS/tools/colony-lint.sh" ]; then printf '%s' './tools/colony-lint.sh'; return 0; fi
+    if [ -f "$WS/package.json" ] && grep -q '"test"' "$WS/package.json" 2>/dev/null; then printf '%s' 'npm test --silent'; return 0; fi
+    if [ -f "$WS/Makefile" ] && grep -qE '^test:' "$WS/Makefile" 2>/dev/null; then printf '%s' 'make test'; return 0; fi
+    if [ -d "$WS/tests" ] && command -v pytest >/dev/null 2>&1; then printf '%s' 'pytest -q'; return 0; fi
+    printf '%s' ''
+}
+
+# run_verify <cmd>: run the gate inside $WS, time-bounded and token-scrubbed (the
+# gate never needs forge creds), combined output captured to $VERIFY_OUT. Returns
+# the gate's exit code.
+run_verify() {
+    _vt_s=$(( VERIFY_TIMEOUT_MS / 1000 ))
+    [ "$_vt_s" -lt 1 ] && _vt_s=1
+    if command -v timeout >/dev/null 2>&1; then
+        ( cd "$WS" && env -u GITHUB_TOKEN -u GITLAB_TOKEN timeout "${_vt_s}s" sh -c "$1" ) >"$VERIFY_OUT" 2>&1
+    else
+        ( cd "$WS" && env -u GITHUB_TOKEN -u GITLAB_TOKEN sh -c "$1" ) >"$VERIFY_OUT" 2>&1
+    fi
+}
+
 # Bounded continue-on-incomplete loop (#1251). A single fixed-timeout shot was
 # the main limiter on complex tasks: claude was interrupted mid-edit (exit 124)
 # with a partial diff, or simply ran out of one turn, and nobody told it to keep
@@ -335,10 +362,19 @@ case "$MAX_ATTEMPTS"   in ''|*[!0-9]*) MAX_ATTEMPTS=3 ;; esac
 case "$TOTAL_BUDGET_MS" in ''|*[!0-9]*) TOTAL_BUDGET_MS=1500000 ;; esac
 case "$PER_ATTEMPT_MS"  in ''|*[!0-9]*) PER_ATTEMPT_MS=600000 ;; esac
 if [ "$MAX_ATTEMPTS" -lt 1 ]; then MAX_ATTEMPTS=1; fi
+# Verify gate (#1253): run the repo's gate after a settled attempt and only stop
+# when it passes; feed failures back as another iteration (bounded by the same
+# attempts/budget). Empty VERIFY_CMD -> no gate -> M1 behaviour.
+VERIFY_CMD="$(detect_verify_cmd)"
+VERIFY_TIMEOUT_MS="${CODE_EDIT_VERIFY_TIMEOUT_MS:-300000}"
+case "$VERIFY_TIMEOUT_MS" in ''|*[!0-9]*) VERIFY_TIMEOUT_MS=300000 ;; esac
+VERIFY_OUT="$(mktemp)"
+[ -n "$VERIFY_CMD" ] && echo "[code-edit] verification gate: $VERIFY_CMD" >&2
 loop_start="$(date +%s)"
 attempt=0
 prev_lines=0
 FC_RC=0
+continuation_mode="interrupted"
 
 while :; do
     attempt=$((attempt + 1))
@@ -351,6 +387,17 @@ while :; do
     if [ "$attempt" -eq 1 ]; then
         printf 'Implement issue #%s in this repository by editing the files directly with your tools. %s\n\n%s\n\nMake the change and stop; do not run git or open a PR.' \
             "$ISSUE" "$TITLE" "$TASK" > "$TASKFILE"
+    elif [ "$continuation_mode" = "verify" ]; then
+        # Continuation prompt: the change does not pass the verification gate.
+        {
+            printf 'You are CONTINUING work on issue #%s: %s\n\n' "$ISSUE" "$TITLE"
+            printf 'Your change so far does NOT pass the project verification gate: %s\n\nFiles changed in this checkout:\n\n' "$VERIFY_CMD"
+            git_capture -C "$WS" diff --cached --stat 2>/dev/null || true
+            printf '\nThe gate output (tail):\n\n'
+            tail -c 4000 "$VERIFY_OUT" 2>/dev/null || true
+            printf '\n\nFix the change so the gate passes, then stop. Do not run git or open a PR.\n\nIssue task:\n%s\n' "$TASK"
+        } > "$TASKFILE"
+        echo "[code-edit] continuing editing session (verify-fix, attempt $attempt/$MAX_ATTEMPTS, ${remaining_ms}ms budget left)" >&2
     else
         # Continuation prompt: claude was interrupted; show what changed so far.
         {
@@ -375,9 +422,30 @@ while :; do
     reap_editing_strays
     cur_lines="$(staged_line_count)"
 
-    # Settled (claude finished its turn) -> stop, whatever it produced.
-    [ "$FC_RC" -eq 0 ] && break
+    # Settled (claude finished its turn). With a verifier configured + a non-empty
+    # diff, "settled" is not "done": run the gate and only stop when it's GREEN;
+    # otherwise feed the failure back as another iteration (#1253).
+    if [ "$FC_RC" -eq 0 ]; then
+        if [ -z "$VERIFY_CMD" ] || [ "$cur_lines" -eq 0 ]; then
+            break
+        fi
+        echo "[code-edit] verifying ($VERIFY_CMD) ..." >&2
+        set +e; run_verify "$VERIFY_CMD"; verify_rc=$?; set -e
+        if [ "$verify_rc" -eq 0 ]; then
+            echo "[code-edit] verification PASSED" >&2
+            break
+        fi
+        if [ "$attempt" -ge "$MAX_ATTEMPTS" ] || [ "$(( ($(date +%s) - loop_start) * 1000 ))" -ge "$TOTAL_BUDGET_MS" ]; then
+            echo "[code-edit] verification still FAILING after $attempt attempt(s) (gate exit $verify_rc) — committing anyway; the PR's own CI is the backstop" >&2
+            break
+        fi
+        echo "[code-edit] verification FAILED (gate exit $verify_rc) — feeding the failure back (attempt $attempt -> $((attempt + 1)))" >&2
+        continuation_mode="verify"
+        prev_lines="$cur_lines"
+        continue
+    fi
     # Timed out / errored: stop unless we made progress AND budget+attempts remain.
+    continuation_mode="interrupted"
     if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
         echo "[code-edit] reached max attempts ($MAX_ATTEMPTS) — committing whatever was produced" >&2
         break

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -919,6 +919,163 @@ else
     fail "run 11 (bound): exit 0 + PR url after cap" "rc=$RC11 out=$(cat "$OUT11_FILE" 2>/dev/null)"
 fi
 
+# ===========================================================================
+# Run 12 (#1253 verify-and-fix): claude SETTLES each attempt, but the change
+# fails the verification gate on attempt 1 (no DONE.marker) and passes on
+# attempt 2 (marker written). The orchestrator must run the gate, feed the
+# failure back, iterate, and only commit once GREEN.
+# ===========================================================================
+rm -rf "$FED_DIR" "$REMOTE_BASE" "$SEED" "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+mkdir -p "$COLONY_DIR/scripts"
+cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+{ echo "create-mr called"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/12"}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/github-api.sh"
+
+CNT_FILE3="$WORK/fc-attempt-count-3"; rm -f "$CNT_FILE3"
+cat > "$STUB_BIN/flat-cyborg" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "\$*" >> "$FC_FLAGS_LOG"
+CWD=""
+while [ \$# -gt 0 ]; do case "\$1" in --cwd) CWD="\$2"; shift 2 ;; --) shift; break ;; *) shift ;; esac; done
+n=\$(cat "$CNT_FILE3" 2>/dev/null || echo 0); n=\$((n + 1)); printf '%s' "\$n" > "$CNT_FILE3"
+# Always settle (exit 0). Attempt 1 leaves the gate failing (no marker);
+# attempt 2 writes the marker the gate checks for.
+if [ "\$n" -eq 1 ]; then
+    printf 'work\n' > "\$CWD/WORK.txt"
+else
+    printf 'done\n' > "\$CWD/DONE.marker"
+fi
+exit 0
+STUB_EOF
+chmod +x "$STUB_BIN/flat-cyborg"
+
+mkdir -p "$BARE"
+git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null || git init --quiet --bare "$BARE"
+git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+(
+    cd "$SEED" || exit 1
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    printf 'hello\n' > README.md
+    git add -A
+    git commit --quiet -m "seed: initial commit"
+    git branch -M main 2>/dev/null || true
+    git remote add origin "$BARE"
+    git push --quiet origin main
+)
+git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+
+OUT12_FILE="$WORK/out12.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    GITHUB_URL="file://$REMOTE_BASE" \
+    GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    CODE_EDIT_MAX_ATTEMPTS=3 \
+    CODE_EDIT_VERIFY_CMD="test -f DONE.marker" \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue 120 \
+        --branch "fix/issue-120" --title "verify gate" \
+        --task "Write the change and the DONE.marker." >"$OUT12_FILE" 2>"$WORK/err12.txt"
+RC12=$?
+ATTEMPTS3="$(cat "$CNT_FILE3" 2>/dev/null || echo 0)"
+
+if [ "$RC12" -eq 0 ] && [ "$(cat "$OUT12_FILE")" = "https://example.test/pr/12" ]; then
+    pass "run 12 (verify): exits 0 + opens PR only after the gate passes"
+else
+    fail "run 12 (verify): exit 0 + PR url" "rc=$RC12 out=$(cat "$OUT12_FILE" 2>/dev/null) err=$(tail -3 "$WORK/err12.txt" 2>/dev/null)"
+fi
+if [ "$ATTEMPTS3" = "2" ]; then
+    pass "run 12 (verify): iterated after a failing gate (drove twice: fail -> fix -> pass)"
+else
+    fail "run 12 (verify): expected 2 attempts" "got $ATTEMPTS3"
+fi
+if grep -q "verify-fix" "$WORK/err12.txt" 2>/dev/null && grep -q "verification PASSED" "$WORK/err12.txt" 2>/dev/null; then
+    pass "run 12 (verify): took the verify-fix path then verification PASSED"
+else
+    fail "run 12 (verify): verify-fix + PASSED log lines" "err=$(tail -6 "$WORK/err12.txt" 2>/dev/null)"
+fi
+if git --git-dir="$BARE" cat-file -e "refs/heads/fix/issue-120:DONE.marker" 2>/dev/null; then
+    pass "run 12 (verify): committed only after the gate-satisfying marker was added"
+else
+    fail "run 12 (verify): DONE.marker in pushed commit"
+fi
+
+# ===========================================================================
+# Run 13 (#1253 verify-budget): the gate NEVER passes. The orchestrator must
+# stop at MAX_ATTEMPTS, log that verification is still failing, and commit
+# anyway (the PR's own CI is the backstop) rather than loop forever.
+# ===========================================================================
+rm -rf "$FED_DIR" "$REMOTE_BASE" "$SEED" "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+mkdir -p "$COLONY_DIR/scripts"
+cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+{ echo "create-mr called"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/13"}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/github-api.sh"
+
+CNT_FILE4="$WORK/fc-attempt-count-4"; rm -f "$CNT_FILE4"
+cat > "$STUB_BIN/flat-cyborg" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "\$*" >> "$FC_FLAGS_LOG"
+CWD=""
+while [ \$# -gt 0 ]; do case "\$1" in --cwd) CWD="\$2"; shift 2 ;; --) shift; break ;; *) shift ;; esac; done
+n=\$(cat "$CNT_FILE4" 2>/dev/null || echo 0); n=\$((n + 1)); printf '%s' "\$n" > "$CNT_FILE4"
+printf 'chunk %s\n' "\$n" > "\$CWD/WORK_\$n.txt"
+exit 0
+STUB_EOF
+chmod +x "$STUB_BIN/flat-cyborg"
+
+mkdir -p "$BARE"
+git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null || git init --quiet --bare "$BARE"
+git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+(
+    cd "$SEED" || exit 1
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    printf 'hello\n' > README.md
+    git add -A
+    git commit --quiet -m "seed: initial commit"
+    git branch -M main 2>/dev/null || true
+    git remote add origin "$BARE"
+    git push --quiet origin main
+)
+git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+
+OUT13_FILE="$WORK/out13.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    GITHUB_URL="file://$REMOTE_BASE" \
+    GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    CODE_EDIT_MAX_ATTEMPTS=2 \
+    CODE_EDIT_VERIFY_CMD="test -f NEVER_EXISTS.marker" \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue 121 \
+        --branch "fix/issue-121" --title "always failing gate" \
+        --task "Add work." >"$OUT13_FILE" 2>"$WORK/err13.txt"
+RC13=$?
+ATTEMPTS4="$(cat "$CNT_FILE4" 2>/dev/null || echo 0)"
+
+if [ "$ATTEMPTS4" = "2" ]; then
+    pass "run 13 (verify-budget): stopped at MAX_ATTEMPTS=2 instead of looping on a never-passing gate"
+else
+    fail "run 13 (verify-budget): expected 2 attempts" "got $ATTEMPTS4 (rc=$RC13)"
+fi
+if [ "$RC13" -eq 0 ] && [ "$(cat "$OUT13_FILE")" = "https://example.test/pr/13" ] && grep -q "still FAILING" "$WORK/err13.txt" 2>/dev/null; then
+    pass "run 13 (verify-budget): logged 'still FAILING' and committed anyway (CI is the backstop)"
+else
+    fail "run 13 (verify-budget): commit-anyway + warning" "rc=$RC13 out=$(cat "$OUT13_FILE" 2>/dev/null) err=$(tail -4 "$WORK/err13.txt" 2>/dev/null)"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1253 · M2 of the complex-task arc (M1 #1251 merged; M3 #1254 next).

## Problem

After M1, a **settled** editing session was treated as done even if the change didn't build or pass the repo's gate — "settled ≠ correct". A broken diff would get committed and a red PR opened.

## Fix — fold a verification gate into the M1 loop

- After a **settled** attempt with a non-empty diff, run the repo's gate **inside the per-issue workspace** (time-bounded, `cwd` = the checkout, **token-scrubbed**: `env -u GITHUB_TOKEN -u GITLAB_TOKEN` — the gate never needs forge creds).
- **GREEN** → done → commit/push/PR.
- **RED** + attempts/budget remain → re-drive with a continuation prompt carrying the gate's **failure output** ("fix it"), then re-verify. Bounded by M1's `MAX_ATTEMPTS` / `TOTAL_BUDGET_MS`, so it always terminates.
- Out of attempts/budget while RED → **commit anyway** (the PR's own CI is the backstop) + log `verification still FAILING`.

### Verifier (configurable, safe default)
`CODE_EDIT_VERIFY_CMD` (explicit) → else auto-detect (`tools/colony-lint.sh` / `npm test` / `make test` / `pytest`) → else **skip** (degrade to M1; never invent a gate). Knob `CODE_EDIT_VERIFY_TIMEOUT_MS` (300000). `CODE_EDIT_VERIFY_CMD=true` force-skips.

## Tests

- **Run 12**: gate fails on attempt 1 (no marker), claude fixes it, gate passes on attempt 2 → asserts it iterated via the verify-fix path and committed **only after GREEN** (the marker is in the pushed commit).
- **Run 13**: gate **never** passes → stops at `MAX_ATTEMPTS`, logs `still FAILING`, commits anyway (proves termination + the backstop).
- Runs 1–11 unchanged (no verifier detected in the test WS → exact M1 behaviour).

**53/53 pass**; `colony-lint.sh` **430 passed, 0 failed** (shellcheck clean — verified with the real exit code, not a pipe-masked one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)