### PR TITLE
feat(code-edit-in-checkout): decompose epics into per-subtask edits [complex-task M3]

### DIFF
--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -401,16 +401,21 @@ if [ "$DECOMPOSE" -eq 1 ]; then
     # discard any stray edits the decomposition step made; the subtask loop owns edits.
     run_git -C "$WS" reset --hard >/dev/null 2>&1 || true
     run_git -C "$WS" clean -fd >/dev/null 2>&1 || true
-    awk 'NF' "$SUBTASKS_LIST" 2>/dev/null | sed 's/^[[:space:]]*[-*0-9.)]\{0,4\}[[:space:]]*//' | head -n "$MAX_SUBTASKS" > "$SUBTASKS_FILE"
+    # Each parsed line becomes a NUL-separated record. NUL (not newline) is the
+    # subtask delimiter so the no-decompose fallback below can hold the WHOLE
+    # multi-line $TASK as a SINGLE record — the production caller's task_text is
+    # always multi-line, and splitting it per line would feed claude fragments.
+    awk 'NF' "$SUBTASKS_LIST" 2>/dev/null | sed 's/^[[:space:]]*[-*0-9.)]\{0,4\}[[:space:]]*//' | head -n "$MAX_SUBTASKS" | tr '\n' '\0' > "$SUBTASKS_FILE"
 fi
 if [ ! -s "$SUBTASKS_FILE" ]; then
-    printf '%s\n' "$TASK" > "$SUBTASKS_FILE"
+    # Single record = the whole task (newlines preserved) -> one subtask -> M1/M2.
+    printf '%s\0' "$TASK" > "$SUBTASKS_FILE"
 fi
-SUBTASK_COUNT="$(awk 'END { print NR }' "$SUBTASKS_FILE")"
+SUBTASK_COUNT="$(tr -cd '\0' < "$SUBTASKS_FILE" | wc -c | tr -d ' ')"
 [ "$SUBTASK_COUNT" -gt 1 ] && echo "[code-edit] decomposed issue #$ISSUE into $SUBTASK_COUNT subtasks" >&2
 
 subtask_idx=0
-while IFS= read -r CUR_TASK <&3; do
+while IFS= read -r -d '' CUR_TASK <&3; do
     [ -z "$CUR_TASK" ] && continue
     subtask_idx=$((subtask_idx + 1))
     [ "$SUBTASK_COUNT" -gt 1 ] && echo "[code-edit] subtask $subtask_idx/$SUBTASK_COUNT: $CUR_TASK" >&2

--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -49,9 +49,10 @@ ISSUE=""
 BRANCH=""
 TITLE=""
 TASK=""
+DECOMPOSE=0
 
 usage() {
-    echo "usage: code-edit-in-checkout.sh --owner <o> --repo <r> --issue <iid> --branch <name> --title <t> --task <text>" >&2
+    echo "usage: code-edit-in-checkout.sh --owner <o> --repo <r> --issue <iid> --branch <name> --title <t> --task <text> [--decompose]" >&2
 }
 
 while [ $# -gt 0 ]; do
@@ -62,6 +63,7 @@ while [ $# -gt 0 ]; do
         --branch) BRANCH="${2:-}"; shift 2 ;;
         --title)  TITLE="${2:-}";  shift 2 ;;
         --task)   TASK="${2:-}";   shift 2 ;;
+        --decompose) DECOMPOSE=1; shift ;;
         *) echo "code-edit-in-checkout.sh: unknown flag: $1" >&2; usage; exit 2 ;;
     esac
 done
@@ -209,7 +211,7 @@ chmod 700 "$ASKPASS"
 # A task file for flat-cyborg --cmd-file (a multi-KB instruction must not ride
 # argv — ARG_MAX, same lesson as #1171). Cleaned up on exit alongside ASKPASS.
 TASKFILE="$(mktemp)"
-trap 'rm -f "$ASKPASS" "$TASKFILE" "${VERIFY_OUT:-}"' EXIT
+trap 'rm -f "$ASKPASS" "$TASKFILE" "${VERIFY_OUT:-}" "${SUBTASKS_FILE:-}" "${SUBTASKS_LIST:-}"' EXIT
 
 # git wrappers that thread the askpass helper + non-interactive terminal so a
 # missing/invalid token fails fast instead of hanging on a prompt.
@@ -362,6 +364,11 @@ case "$MAX_ATTEMPTS"   in ''|*[!0-9]*) MAX_ATTEMPTS=3 ;; esac
 case "$TOTAL_BUDGET_MS" in ''|*[!0-9]*) TOTAL_BUDGET_MS=1500000 ;; esac
 case "$PER_ATTEMPT_MS"  in ''|*[!0-9]*) PER_ATTEMPT_MS=600000 ;; esac
 if [ "$MAX_ATTEMPTS" -lt 1 ]; then MAX_ATTEMPTS=1; fi
+# Cap on the number of decomposed sub-edits (#1254). A non-integer / empty
+# override falls back to 8; never below 1.
+MAX_SUBTASKS="${CODE_EDIT_MAX_SUBTASKS:-8}"
+case "$MAX_SUBTASKS" in ''|*[!0-9]*) MAX_SUBTASKS=8 ;; esac
+if [ "$MAX_SUBTASKS" -lt 1 ]; then MAX_SUBTASKS=1; fi
 # Verify gate (#1253): run the repo's gate after a settled attempt and only stop
 # when it passes; feed failures back as another iteration (bounded by the same
 # attempts/budget). Empty VERIFY_CMD -> no gate -> M1 behaviour.
@@ -370,11 +377,48 @@ VERIFY_TIMEOUT_MS="${CODE_EDIT_VERIFY_TIMEOUT_MS:-300000}"
 case "$VERIFY_TIMEOUT_MS" in ''|*[!0-9]*) VERIFY_TIMEOUT_MS=300000 ;; esac
 VERIFY_OUT="$(mktemp)"
 [ -n "$VERIFY_CMD" ] && echo "[code-edit] verification gate: $VERIFY_CMD" >&2
-loop_start="$(date +%s)"
-attempt=0
-prev_lines=0
-FC_RC=0
-continuation_mode="interrupted"
+
+# Decompose (#1254): for a large/epic task, split it into an ORDERED list of
+# small sub-edits and run the edit loop once per subtask on the SAME branch,
+# accumulating into ONE commit/PR. Without --decompose (or if decomposition
+# yields nothing) the whole task is the single "subtask" -> identical to M1/M2.
+SUBTASKS_FILE="$(mktemp)"
+if [ "$DECOMPOSE" -eq 1 ]; then
+    SUBTASKS_LIST="$(mktemp)"
+    : > "$SUBTASKS_LIST"
+    {
+        printf 'Decompose issue #%s (%s) into an ORDERED list of small, self-contained sub-edits, each about the size of one focused change.\n\n' "$ISSUE" "$TITLE"
+        printf 'Write ONLY the list to this exact file with your file-writing tool: %s\n' "$SUBTASKS_LIST"
+        printf 'One sub-edit per line, plain text, no numbering and no markdown. Do NOT edit any repository files in this step.\n\nIssue task:\n%s\n' "$TASK"
+    } > "$TASKFILE"
+    echo "[code-edit] decomposing issue #$ISSUE into subtasks" >&2
+    set +e
+    flat-cyborg --extract --extract-structural --no-jitter --auto-approve --wrap-input 72 --cwd "$WS" \
+        --idle-ms "${FLAT_CYBORG_IDLE_MS:-8000}" --timeout-ms "$PER_ATTEMPT_MS" \
+        --cmd-file "$TASKFILE" -- claude >&2
+    set -e
+    reap_editing_strays
+    # discard any stray edits the decomposition step made; the subtask loop owns edits.
+    run_git -C "$WS" reset --hard >/dev/null 2>&1 || true
+    run_git -C "$WS" clean -fd >/dev/null 2>&1 || true
+    awk 'NF' "$SUBTASKS_LIST" 2>/dev/null | sed 's/^[[:space:]]*[-*0-9.)]\{0,4\}[[:space:]]*//' | head -n "$MAX_SUBTASKS" > "$SUBTASKS_FILE"
+fi
+if [ ! -s "$SUBTASKS_FILE" ]; then
+    printf '%s\n' "$TASK" > "$SUBTASKS_FILE"
+fi
+SUBTASK_COUNT="$(awk 'END { print NR }' "$SUBTASKS_FILE")"
+[ "$SUBTASK_COUNT" -gt 1 ] && echo "[code-edit] decomposed issue #$ISSUE into $SUBTASK_COUNT subtasks" >&2
+
+subtask_idx=0
+while IFS= read -r CUR_TASK <&3; do
+    [ -z "$CUR_TASK" ] && continue
+    subtask_idx=$((subtask_idx + 1))
+    [ "$SUBTASK_COUNT" -gt 1 ] && echo "[code-edit] subtask $subtask_idx/$SUBTASK_COUNT: $CUR_TASK" >&2
+    loop_start="$(date +%s)"
+    attempt=0
+    prev_lines=0
+    FC_RC=0
+    continuation_mode="interrupted"
 
 while :; do
     attempt=$((attempt + 1))
@@ -386,7 +430,7 @@ while :; do
 
     if [ "$attempt" -eq 1 ]; then
         printf 'Implement issue #%s in this repository by editing the files directly with your tools. %s\n\n%s\n\nMake the change and stop; do not run git or open a PR.' \
-            "$ISSUE" "$TITLE" "$TASK" > "$TASKFILE"
+            "$ISSUE" "$TITLE" "$CUR_TASK" > "$TASKFILE"
     elif [ "$continuation_mode" = "verify" ]; then
         # Continuation prompt: the change does not pass the verification gate.
         {
@@ -395,7 +439,7 @@ while :; do
             git_capture -C "$WS" diff --cached --stat 2>/dev/null || true
             printf '\nThe gate output (tail):\n\n'
             tail -c 4000 "$VERIFY_OUT" 2>/dev/null || true
-            printf '\n\nFix the change so the gate passes, then stop. Do not run git or open a PR.\n\nIssue task:\n%s\n' "$TASK"
+            printf '\n\nFix the change so the gate passes, then stop. Do not run git or open a PR.\n\nIssue task:\n%s\n' "$CUR_TASK"
         } > "$TASKFILE"
         echo "[code-edit] continuing editing session (verify-fix, attempt $attempt/$MAX_ATTEMPTS, ${remaining_ms}ms budget left)" >&2
     else
@@ -404,7 +448,7 @@ while :; do
             printf 'You are CONTINUING work on issue #%s: %s\n\n' "$ISSUE" "$TITLE"
             printf 'Your previous turn was interrupted before the change was finished. Files changed so far in this checkout:\n\n'
             git_capture -C "$WS" diff --cached --stat 2>/dev/null || true
-            printf '\nReview the current state, COMPLETE the remaining work for the issue below, and stop. Do not run git or open a PR.\n\nIssue task:\n%s\n' "$TASK"
+            printf '\nReview the current state, COMPLETE the remaining work for the issue below, and stop. Do not run git or open a PR.\n\nIssue task:\n%s\n' "$CUR_TASK"
         } > "$TASKFILE"
         echo "[code-edit] continuing editing session (attempt $attempt/$MAX_ATTEMPTS, ${remaining_ms}ms budget left)" >&2
     fi
@@ -461,6 +505,7 @@ while :; do
     echo "[code-edit] attempt $attempt timed out (exit $FC_RC) but made progress (staged churn $prev_lines -> $cur_lines) — continuing" >&2
     prev_lines="$cur_lines"
 done
+done 3< "$SUBTASKS_FILE"
 
 # ---------------------------------------------------------------------------
 # 4. Commit the diff. The ARTIFACT is the edit, not the editing session's exit

--- a/tools/code-edit-job.sh
+++ b/tools/code-edit-job.sh
@@ -60,9 +60,10 @@ ISSUE=""
 BRANCH=""
 TITLE=""
 TASK=""
+DECOMPOSE=0
 
 usage() {
-    echo "usage: code-edit-job.sh --owner <o> --repo <r> --issue <iid> --branch <name> --title <t> --task <text>" >&2
+    echo "usage: code-edit-job.sh --owner <o> --repo <r> --issue <iid> --branch <name> --title <t> --task <text> [--decompose]" >&2
 }
 
 while [ $# -gt 0 ]; do
@@ -73,6 +74,7 @@ while [ $# -gt 0 ]; do
         --branch) BRANCH="${2:-}"; shift 2 ;;
         --title)  TITLE="${2:-}";  shift 2 ;;
         --task)   TASK="${2:-}";   shift 2 ;;
+        --decompose) DECOMPOSE=1; shift ;;
         *) echo "code-edit-job.sh: unknown flag: $1" >&2; usage; exit 2 ;;
     esac
 done
@@ -196,16 +198,17 @@ export CEJ_ORCH="$ORCH"
 export CEJ_JOBDIR="$JOBDIR"
 export CEJ_OWNER="$OWNER" CEJ_REPO="$REPO" CEJ_ISSUE="$ISSUE"
 export CEJ_BRANCH="$BRANCH" CEJ_TITLE="$TITLE" CEJ_TASK="$TASK"
+export CEJ_DECOMPOSE="$DECOMPOSE"
 
 # SC2016: the $CEJ_* refs are deliberately INSIDE single quotes — they must
 # expand in the DETACHED child from its inherited env, NOT in this launcher.
 # shellcheck disable=SC2016
 setsid bash -c '
     set +e
-    "$CEJ_ORCH" \
-        --owner "$CEJ_OWNER" --repo "$CEJ_REPO" --issue "$CEJ_ISSUE" \
-        --branch "$CEJ_BRANCH" --title "$CEJ_TITLE" --task "$CEJ_TASK" \
-        > "$CEJ_JOBDIR/out" 2> "$CEJ_JOBDIR/log"
+    set -- --owner "$CEJ_OWNER" --repo "$CEJ_REPO" --issue "$CEJ_ISSUE" \
+        --branch "$CEJ_BRANCH" --title "$CEJ_TITLE" --task "$CEJ_TASK"
+    [ "$CEJ_DECOMPOSE" = "1" ] && set -- "$@" --decompose
+    "$CEJ_ORCH" "$@" > "$CEJ_JOBDIR/out" 2> "$CEJ_JOBDIR/log"
     rc=$?
     if [ "$rc" -eq 0 ]; then
         # Last non-empty line of stdout is the PR URL.

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -1076,6 +1076,112 @@ else
     fail "run 13 (verify-budget): commit-anyway + warning" "rc=$RC13 out=$(cat "$OUT13_FILE" 2>/dev/null) err=$(tail -4 "$WORK/err13.txt" 2>/dev/null)"
 fi
 
+# ===========================================================================
+# Run 14 (#1254 decompose): with --decompose, the orchestrator first asks claude
+# to split the epic into an ORDERED subtask list (written to a file, no repo
+# edits), then runs the edit loop ONCE PER SUBTASK on the SAME branch,
+# accumulating into ONE commit/PR. The stateful stub recognises the decompose
+# drive by the word "Decompose" in the cmd-file, writes a 3-line list, and edits
+# nothing; each subsequent EDIT invocation writes a unique SUB_<n>.txt file.
+# Asserts: exit 0 + PR url; exactly 3 EDIT invocations (one per subtask); all
+# three SUB_*.txt in the pushed commit; the decomposed-into-3 log line.
+# ===========================================================================
+rm -rf "$FED_DIR" "$REMOTE_BASE" "$SEED" "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+mkdir -p "$COLONY_DIR/scripts"
+cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+{ echo "create-mr called"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/14"}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/github-api.sh"
+
+# Stateful decompose-aware stub: if the cmd-file contains "Decompose" it is the
+# decomposition drive -> write a 3-line subtask list to the target path the
+# prompt names ("this exact file: <path>") and make NO repo edit. Otherwise it
+# is an edit drive -> bump an EDIT counter and write a unique SUB_<n>.txt.
+EDIT_CNT_FILE="$WORK/fc-edit-count-14"; rm -f "$EDIT_CNT_FILE"
+cat > "$STUB_BIN/flat-cyborg" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "\$*" >> "$FC_FLAGS_LOG"
+CWD=""; CMDFILE=""
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        --cwd) CWD="\$2"; shift 2 ;;
+        --cmd-file) CMDFILE="\$2"; shift 2 ;;
+        --) shift; break ;;
+        *) shift ;;
+    esac
+done
+if [ -n "\$CMDFILE" ] && grep -q "Decompose" "\$CMDFILE" 2>/dev/null; then
+    # Extract the target list path from the "this exact file: <path>" line.
+    TARGET="\$(grep "this exact file" "\$CMDFILE" | grep -oE '/[^ ]+' | head -n1)"
+    if [ -n "\$TARGET" ]; then
+        printf 'subtask one\nsubtask two\nsubtask three\n' > "\$TARGET"
+    fi
+    exit 0
+fi
+n=\$(cat "$EDIT_CNT_FILE" 2>/dev/null || echo 0); n=\$((n + 1)); printf '%s' "\$n" > "$EDIT_CNT_FILE"
+if [ -n "\$CWD" ]; then
+    printf 'edit %s\n' "\$n" > "\$CWD/SUB_\$n.txt"
+fi
+exit 0
+STUB_EOF
+chmod +x "$STUB_BIN/flat-cyborg"
+
+mkdir -p "$BARE"
+git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null || git init --quiet --bare "$BARE"
+git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+(
+    cd "$SEED" || exit 1
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    printf 'hello\n' > README.md
+    git add -A
+    git commit --quiet -m "seed: initial commit"
+    git branch -M main 2>/dev/null || true
+    git remote add origin "$BARE"
+    git push --quiet origin main
+)
+git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+
+OUT14_FILE="$WORK/out14.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    GITHUB_URL="file://$REMOTE_BASE" \
+    GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue 130 \
+        --branch "fix/issue-130" --title "epic task" \
+        --task "Do a big multi-part change." --decompose >"$OUT14_FILE" 2>"$WORK/err14.txt"
+RC14=$?
+EDIT_CALLS="$(cat "$EDIT_CNT_FILE" 2>/dev/null || echo 0)"
+
+if [ "$RC14" -eq 0 ] && [ "$(cat "$OUT14_FILE")" = "https://example.test/pr/14" ]; then
+    pass "run 14 (decompose): exits 0 + opens the PR after running per-subtask"
+else
+    fail "run 14 (decompose): exit 0 + PR url" "rc=$RC14 out=$(cat "$OUT14_FILE" 2>/dev/null) err=$(tail -4 "$WORK/err14.txt" 2>/dev/null)"
+fi
+if [ "$EDIT_CALLS" = "3" ]; then
+    pass "run 14 (decompose): ran the edit loop ONCE PER SUBTASK (3 edit invocations)"
+else
+    fail "run 14 (decompose): expected 3 edit invocations" "got $EDIT_CALLS"
+fi
+if grep -q "decomposed issue #130 into 3 subtasks" "$WORK/err14.txt" 2>/dev/null; then
+    pass "run 14 (decompose): logged the 3-subtask decomposition"
+else
+    fail "run 14 (decompose): decomposed-into-3 log line" "err=$(tail -6 "$WORK/err14.txt" 2>/dev/null)"
+fi
+if git --git-dir="$BARE" cat-file -e "refs/heads/fix/issue-130:SUB_1.txt" 2>/dev/null \
+   && git --git-dir="$BARE" cat-file -e "refs/heads/fix/issue-130:SUB_2.txt" 2>/dev/null \
+   && git --git-dir="$BARE" cat-file -e "refs/heads/fix/issue-130:SUB_3.txt" 2>/dev/null; then
+    pass "run 14 (decompose): all THREE subtask files in ONE pushed commit (same branch)"
+else
+    fail "run 14 (decompose): SUB_1.txt + SUB_2.txt + SUB_3.txt in pushed commit"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -1182,6 +1182,83 @@ else
     fail "run 14 (decompose): SUB_1.txt + SUB_2.txt + SUB_3.txt in pushed commit"
 fi
 
+# ===========================================================================
+# Run 15 (#1254 backward-compat regression): a MULTI-LINE --task WITHOUT
+# --decompose must be treated as ONE task (one edit invocation receiving the
+# whole task), NOT split one-subtask-per-line. The production caller always
+# sends a multi-line task_text, so this is the common path.
+# ===========================================================================
+rm -rf "$FED_DIR" "$REMOTE_BASE" "$SEED" "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+mkdir -p "$COLONY_DIR/scripts"
+cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+{ echo "create-mr called"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/15"}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/github-api.sh"
+
+CNT_FILE5="$WORK/fc-attempt-count-5"; rm -f "$CNT_FILE5"
+CMD_LOG="$WORK/fc-cmdfile-5.log"; rm -f "$CMD_LOG"
+cat > "$STUB_BIN/flat-cyborg" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "\$*" >> "$FC_FLAGS_LOG"
+CWD=""; CMDF=""
+while [ \$# -gt 0 ]; do case "\$1" in --cwd) CWD="\$2"; shift 2 ;; --cmd-file) CMDF="\$2"; shift 2 ;; --) shift; break ;; *) shift ;; esac; done
+n=\$(cat "$CNT_FILE5" 2>/dev/null || echo 0); n=\$((n + 1)); printf '%s' "\$n" > "$CNT_FILE5"
+[ -n "\$CMDF" ] && cat "\$CMDF" >> "$CMD_LOG"
+printf 'edit %s\n' "\$n" > "\$CWD/EDIT.txt"
+exit 0
+STUB_EOF
+chmod +x "$STUB_BIN/flat-cyborg"
+
+mkdir -p "$BARE"
+git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null || git init --quiet --bare "$BARE"
+git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+(
+    cd "$SEED" || exit 1
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    printf 'hello\n' > README.md
+    git add -A
+    git commit --quiet -m "seed: initial commit"
+    git branch -M main 2>/dev/null || true
+    git remote add origin "$BARE"
+    git push --quiet origin main
+)
+git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+
+MULTI_TASK="$(printf 'Line one of the task.\nLine two of the task.\nLine three of the task.')"
+OUT15_FILE="$WORK/out15.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    GITHUB_URL="file://$REMOTE_BASE" \
+    GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue 140 \
+        --branch "fix/issue-140" --title "multi-line task" \
+        --task "$MULTI_TASK" >"$OUT15_FILE" 2>"$WORK/err15.txt"
+RC15=$?
+EDITS5="$(cat "$CNT_FILE5" 2>/dev/null || echo 0)"
+
+if [ "$RC15" -eq 0 ] && [ "$EDITS5" = "1" ]; then
+    pass "run 15 (multi-line no-decompose): ONE edit invocation (task not split per line)"
+else
+    fail "run 15 (multi-line no-decompose): expected exactly 1 edit invocation" "rc=$RC15 edits=$EDITS5 err=$(tail -3 "$WORK/err15.txt" 2>/dev/null)"
+fi
+if grep -q "Line one of the task" "$CMD_LOG" 2>/dev/null && grep -q "Line two of the task" "$CMD_LOG" 2>/dev/null && grep -q "Line three of the task" "$CMD_LOG" 2>/dev/null; then
+    pass "run 15 (multi-line no-decompose): the WHOLE multi-line task reached claude in one drive"
+else
+    fail "run 15 (multi-line no-decompose): whole task in the prompt" "cmdlog=$(tail -8 "$CMD_LOG" 2>/dev/null)"
+fi
+if grep -q "decomposed issue" "$WORK/err15.txt" 2>/dev/null; then
+    fail "run 15 (multi-line no-decompose): wrongly decomposed a non --decompose run"
+else
+    pass "run 15 (multi-line no-decompose): did NOT decompose (no --decompose flag)"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-code-edit-job.sh
+++ b/tools/test-code-edit-job.sh
@@ -63,7 +63,7 @@ cat > "$STUB" <<'STUB_EOF'
 #!/usr/bin/env bash
 set -u
 # Record one start (append) so the harness can count launches.
-if [ -n "${STUB_MARKER:-}" ]; then echo "start $$ token=${GITHUB_TOKEN:-MISSING}" >> "$STUB_MARKER"; fi
+if [ -n "${STUB_MARKER:-}" ]; then echo "start $$ token=${GITHUB_TOKEN:-MISSING} args=[$*]" >> "$STUB_MARKER"; fi
 sleep "${STUB_SLEEP:-2}"
 if [ "${STUB_EXIT:-0}" -eq 0 ]; then
     printf '%s\n' "${STUB_URL:-https://example.test/pr/1}"
@@ -243,6 +243,45 @@ if [ ! -d "$JD" ]; then
     pass "D: stale dead-pid job dir cleared for relaunch"
 else
     fail "D: dead-pid job dir cleared" "still exists: $JD"
+fi
+
+# ===========================================================================
+# Scenario E (#1254): --decompose is forwarded to the orchestrator; a normal
+# run omits it. The stub records its argv to a marker file.
+# ===========================================================================
+poll_done() {
+    _jd="$1"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        [ -f "$_jd/status" ] && grep -q "done" "$_jd/status" 2>/dev/null && return 0
+        sleep 1
+    done
+    return 1
+}
+
+DEC_MARKER="$WORK/dec-marker"; : > "$DEC_MARKER"
+env COLONY_DIR="$COLONY_DIR" CODE_EDIT_ORCH="$STUB" GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    STUB_SLEEP=0 STUB_EXIT=0 STUB_URL="https://example.test/pr/dec" STUB_MARKER="$DEC_MARKER" \
+    bash "$LAUNCHER" --owner "$OWNER" --repo "$REPO" --issue 700 \
+        --branch "fix/issue-700" --title "epic" --task "do it" --decompose >/dev/null 2>&1
+poll_done "$(job_dir_for 700)" || true
+if grep -q -- '--decompose' "$DEC_MARKER" 2>/dev/null; then
+    pass "E: --decompose is forwarded to the orchestrator"
+else
+    fail "E: --decompose passthrough" "marker=$(cat "$DEC_MARKER" 2>/dev/null)"
+fi
+
+NEG_MARKER="$WORK/neg-marker"; : > "$NEG_MARKER"
+env COLONY_DIR="$COLONY_DIR" CODE_EDIT_ORCH="$STUB" GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    STUB_SLEEP=0 STUB_EXIT=0 STUB_URL="https://example.test/pr/nodec" STUB_MARKER="$NEG_MARKER" \
+    bash "$LAUNCHER" --owner "$OWNER" --repo "$REPO" --issue 701 \
+        --branch "fix/issue-701" --title "normal" --task "do it" >/dev/null 2>&1
+poll_done "$(job_dir_for 701)" || true
+if grep -q -- '--decompose' "$NEG_MARKER" 2>/dev/null; then
+    fail "E: normal run wrongly forwarded --decompose" "marker=$(cat "$NEG_MARKER" 2>/dev/null)"
+else
+    pass "E: a normal run does NOT pass --decompose"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #1254 · M3 (final) of the complex-task arc — M1 #1251 (iterate) + M2 #1253 (verify-and-fix) merged.

## Problem

Even with M1 (iterate) + M2 (verify-and-fix), a genuinely large epic is one monolithic editing target. claude does best on small, self-contained changes (proven: #1117, #1246).

## Fix — orchestrator-internal decomposition

New `--decompose` flag on `tools/code-edit-in-checkout.sh`:

1. **Decompose**: drive claude to write an ORDERED list of small sub-edits to a file **outside** the workspace (so it never lands in the diff), parse + cap it (`CODE_EDIT_MAX_SUBTASKS`, default 8). Stray edits from this step are reset.
2. **Implement each subtask** through the existing **M1+M2 continue-on-incomplete + verify loop**, run **once per subtask on the SAME branch**, accumulating into **ONE commit/PR**.
3. The per-subtask wrapper reads the list from **FD 3** (not stdin, so the inner flat-cyborg's stdin is untouched) and resets the attempt/budget state per subtask.
4. **Backward-compatible**: without `--decompose` (or if decomposition yields nothing) the whole task is the single subtask → behaviour **identical to M1/M2** (runs 1–13 unchanged).

`tools/code-edit-job.sh` forwards `--decompose` to the orchestrator (built via `set -- "$@"` to stay shellcheck-clean).

## Tests

- **code-edit run 14**: a stub decomposes an epic into 3 subtasks; asserts the edit loop ran **once per subtask** (3 edit invocations) and **all three files land in ONE pushed commit on one branch**.
- **code-edit-job scenario E**: `--decompose` is forwarded to the orchestrator; a normal run omits it.

`test-code-edit-in-checkout.sh` **57/57**, `test-code-edit-job.sh` **15/15**, `colony-lint.sh` **430 passed, 0 failed** (shellcheck clean, real exit code checked).

## Follow-up (not in this PR)
The `code_writer.ag` epic-label **auto-trigger** (pass `--decompose` when an issue carries the epic label) is the policy layer on the live agent — tracked separately. This PR delivers the end-to-end decompose **capability**, invokable via `--decompose` through the launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)