### PR TITLE
Add tools/human-to-ms.sh as the dash-safe, integer-only inverse of the existing ms-to-human.sh, parsing the compact h/m/s/ms duration format back into total milliseconds and printing 0 for any missing or malformed input so the helper never crashes. Mirror the repo's test convention in tools/test-human-to-ms.sh, covering every emitted format row plus the guard cases; both files are made executable and the test is auto-discovered by colony-lint.sh, which stays green.

### DIFF
--- a/tools/human-to-ms.sh
+++ b/tools/human-to-ms.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+# tools/human-to-ms.sh (#1260): parse a compact human-readable duration string
+# back into total integer milliseconds -- the inverse of tools/ms-to-human.sh.
+#
+# Accepts exactly the shapes ms-to-human.sh emits (and, generally, any sum of
+# h/m/s/ms tokens):
+#
+#   Input     Output (ms)
+#   500ms     500
+#   2s        2000
+#   1m30s     90000
+#   1h30m     5400000
+#   59s       59000
+#   1m0s      60000
+#   1h0m      3600000
+#
+# $1 is the duration string. Each <digits><unit> token contributes
+# hours*3600000 + minutes*60000 + seconds*1000 + milliseconds, summed left to
+# right. The `ms` suffix is matched before `m`, so 500ms is 500 milliseconds
+# while 5m is 5 minutes (300000).
+#
+# Any missing, empty, or malformed input (a shape that does not fully tokenize
+# into <digits>{h|m|s|ms} runs) prints "0" and exits 0 -- the helper is total
+# and never crashes. POSIX sh, dash-safe: no bashisms, integer math only, no
+# printf '\xNN'.
+set -eu
+
+rest="${1:-}"
+
+total=0
+ok=1
+
+# Empty / missing input is not a valid duration -> fall through to "0".
+[ -n "$rest" ] || ok=0
+
+while [ -n "$rest" ]; do
+    # Peel the leading run of ASCII digits. If the token does not start with a
+    # digit, the input is malformed.
+    digits="${rest%%[!0-9]*}"
+    if [ -z "$digits" ]; then
+        ok=0
+        break
+    fi
+    rest="${rest#"$digits"}"
+
+    # Strip leading zeros so $(( )) never sees an invalid octal literal such as
+    # "08"; always keep at least one digit.
+    while [ "${digits#0}" != "$digits" ] && [ "${#digits}" -gt 1 ]; do
+        digits="${digits#0}"
+    done
+
+    # Classify the unit suffix and add its contribution. `ms` MUST be tested
+    # before `m` so "500ms" is milliseconds, not minutes.
+    case "$rest" in
+        ms*) total=$((total + digits))          ; rest="${rest#ms}" ;;
+        h*)  total=$((total + digits * 3600000)); rest="${rest#h}"  ;;
+        m*)  total=$((total + digits * 60000))  ; rest="${rest#m}"  ;;
+        s*)  total=$((total + digits * 1000))   ; rest="${rest#s}"  ;;
+        *)   ok=0; break ;;
+    esac
+done
+
+[ "$ok" -eq 1 ] || total=0
+
+echo "$total"

--- a/tools/test-human-to-ms.sh
+++ b/tools/test-human-to-ms.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# tools/test-human-to-ms.sh (#1260): unit-test the human-duration parser
+# tools/human-to-ms.sh -- the inverse of tools/ms-to-human.sh.
+#
+# Contract under test -- one assertion per emitted format row:
+#   500ms   -> 500
+#   2s      -> 2000
+#   1m30s   -> 90000
+#   1h30m   -> 5400000
+#   59s     -> 59000
+#   1m0s    -> 60000
+#   1h0m    -> 3600000
+# plus the `ms`-before-`m` distinction (5m -> 300000) and the guard cases:
+# missing / empty / garbage all -> 0, exit 0 (the helper is total -- it never
+# crashes).
+#
+# Auto-discovered by tools/colony-lint.sh's tools-test loop. Exit 0 if all pass.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PARSE="$SCRIPT_DIR/human-to-ms.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# SKIP cleanly (exit 0) if the helper is not present yet.
+if [ ! -f "$PARSE" ]; then
+    echo "[SKIP] test-human-to-ms.sh: $PARSE absent"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (skipped)"
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# assert_eq <description> <expected> [args...]
+# Runs the helper under `sh` (proves dash-safety) with the given args and
+# compares stdout to <expected>, also requiring a clean exit.
+assert_eq() {
+    desc="$1"; expected="$2"; shift 2
+    out="$(sh "$PARSE" "$@" 2>/dev/null)" && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ] && [ "$out" = "$expected" ]; then
+        pass "$desc"
+    else
+        fail "$desc" "rc=$rc out=$(printf '%q' "$out") want=$(printf '%q' "$expected")"
+    fi
+}
+
+# --- one assertion per emitted format row ---
+assert_eq "500ms -> 500"       "500"     "500ms"
+assert_eq "2s -> 2000"         "2000"    "2s"
+assert_eq "1m30s -> 90000"     "90000"   "1m30s"
+assert_eq "1h30m -> 5400000"   "5400000" "1h30m"
+assert_eq "59s -> 59000"       "59000"   "59s"
+assert_eq "1m0s -> 60000"      "60000"   "1m0s"
+assert_eq "1h0m -> 3600000"    "3600000" "1h0m"
+
+# --- ms must be distinguished from m ---
+assert_eq "5m -> 300000"       "300000"  "5m"
+
+# --- guard cases: all -> 0, exit 0 ---
+assert_eq "missing arg -> 0"   "0"            # no $1 at all
+assert_eq "empty arg -> 0"     "0" ""         # explicit empty string
+assert_eq "garbage arg -> 0"   "0" "1.5abc"   # not a valid duration shape
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements #1260.

Issue:
{"iid": 1260, "title": "tools: add human-to-ms.sh \u2014 parse a human duration string back to milliseconds", "description": "## Task\n\nAdd `tools/human-to-ms.sh` \u2014 the inverse of the existing `tools/ms-to-human.sh`. It takes a single argument `$1`, a compact human-readable duration, and prints the equivalent **integer milliseconds** on stdout, then a newline. Accept exactly the formats `ms-to-human.sh` emits:\n\n| Input         | Output (ms) |\n|---------------|-------------|\n| `500ms`       | `500`       |\n| `2s`          | `2000`      |\n| `1m30s`       | `90000`     |\n| `1h30m`       | `5400000`   |\n| `59s`         | `59000`     |\n| `1m0s`        | `60000`     |\n| `1h0m`        | `3600000`   |\n\nRules:\n- `#!/usr/bin/env sh` + `set -eu`. **Dash-safe** \u2014 no bashisms, integer math only, no `printf '\\xNN'`.\n- Parse the unit suffixes `h`, `m`, `s`, `ms` and sum them: hours\u00d73600000 + minutes\u00d760000 + seconds\u00d71000 + milliseconds. (`ms` must be distinguished from `m` \u2014 `500ms` is 500 milliseconds, `5m` is 5 minutes.)\n- Any missing/empty/malformed input (not one of the above shapes) \u2192 print `0` and exit 0 (total \u2014 never crash).\n\n## Test\n\nAdd `tools/test-human-to-ms.sh` following this repo's test convention (`set -eu`; `mktemp -d` + `EXIT` trap; `pass`/`fail` counters; **SKIP + exit 0** if the helper is absent; final `Results: <N> passed, <M> failed` line; end with `[ \"$FAIL\" -eq 0 ]`). It is auto-discovered by `colony-lint.sh`'s tools-test loop. Cover each row above plus the guard cases (missing/empty/garbage \u2192 `0`).\n\n## Done\n- `tools/human-to-ms.sh` + `tools/test-human-to-ms.sh` exist and are executable.\n- `./tools/test-human-to-ms.sh` passes.\n- `./tools/colony-lint.sh` stays green (0 failed).", "state": "opened", "labels": ["implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-22T07:21:28Z", "updated_at": "2026-06-22T07:21:28Z", "user_notes_count": 0, "priority": null}

Plan:
- `tools/human-to-ms.sh` — new helper: `#!/usr/bin/env sh` + `set -eu`, dash-safe, integer math only. Inverse of `ms-to-human.sh`. Reads the compact duration in `$1`, tokenizes the `h`/`m`/`s`/`ms` suffixes via a POSIX `case`/glob loop (matching `ms` before `m` so `500ms`=500 and `5m`=300000), and sums hours×3600000 + minutes×60000 + seconds×1000 + ms; prints the integer total + newline. Total/never-crash: missing, empty, or any malformed shape prints `0` and exits 0. Made executable (chmod +x).
- `tools/test-human-to-ms.sh` — new test mirroring `tools/test-ms-to-human.sh`: `set -eu`, `SCRIPT_DIR`/helper-path resolution, SKIP + exit 0 if the helper is absent, `mktemp -d` + `EXIT` trap, `pass`/`fail` counters, and an `assert_eq` that runs the helper under `sh` (proving dash-safety) comparing stdout. Covers every table row (`500ms`→500, `2s`→2000, `1m30s`→90000, `1h30m`→5400000, `59s`→59000, `1m0s`→60000, `1h0m`→3600000) plus guard cases (missing/empty/garbage→`0`). Ends with the `Results: <N> passed, <M> failed` line and `[ "$FAIL" -eq 0 ]`. Made executable; auto-discovered by `colony-lint.sh`'s tools-test loop.

Add tools/human-to-ms.sh as the dash-safe, integer-only inverse of the existing ms-to-human.sh, parsing the compact h/m/s/ms duration format back into total milliseconds and printing 0 for any missing or malformed input so the helper never crashes. Mirror the repo's test convention in tools/test-human-to-ms.sh, covering every emitted format row plus the guard cases; both files are made executable and the test is auto-discovered by colony-lint.sh, which stays green.