### PR TITLE
fix(code-edit-in-checkout): light change-scoped verify gate, not full colony-lint

### DIFF
--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -319,14 +319,15 @@ staged_line_count() {
         | awk '{ a = ($1 == "-" ? 0 : $1); d = ($2 == "-" ? 0 : $2); s += a + d } END { print s + 0 }'
 }
 
-# detect_verify_cmd (#1253): the command (run in $WS) that decides whether the
-# change is CORRECT, not just present. Explicit CODE_EDIT_VERIFY_CMD wins;
-# otherwise auto-detect a common gate; empty = "no verifier" -> the loop degrades
-# to M1 (a settled session is treated as done). Set CODE_EDIT_VERIFY_CMD=true to
-# force-skip verification.
+# detect_verify_cmd (#1253, #1262): the explicit verify command run in $WS.
+# CODE_EDIT_VERIFY_CMD wins; else a FAST project gate (npm/make/pytest). We do
+# NOT auto-pick the repo's full lint (e.g. tools/colony-lint.sh) — it is heavy
+# and flaky under the federation's load and false-fails (#1262, found live on
+# #1260). Empty result means "use the built-in LIGHT, change-scoped gate"
+# (run_light_verify); the PR's own CI remains the authoritative full gate.
+# CODE_EDIT_VERIFY_CMD=true force-skips (always passes).
 detect_verify_cmd() {
     if [ -n "${CODE_EDIT_VERIFY_CMD:-}" ]; then printf '%s' "$CODE_EDIT_VERIFY_CMD"; return 0; fi
-    if [ -x "$WS/tools/colony-lint.sh" ]; then printf '%s' './tools/colony-lint.sh'; return 0; fi
     if [ -f "$WS/package.json" ] && grep -q '"test"' "$WS/package.json" 2>/dev/null; then printf '%s' 'npm test --silent'; return 0; fi
     if [ -f "$WS/Makefile" ] && grep -qE '^test:' "$WS/Makefile" 2>/dev/null; then printf '%s' 'make test'; return 0; fi
     if [ -d "$WS/tests" ] && command -v pytest >/dev/null 2>&1; then printf '%s' 'pytest -q'; return 0; fi
@@ -344,6 +345,47 @@ run_verify() {
     else
         ( cd "$WS" && env -u GITHUB_TOKEN -u GITLAB_TOKEN sh -c "$1" ) >"$VERIFY_OUT" 2>&1
     fi
+}
+
+# run_light_verify (#1262): the built-in change-scoped gate used when no explicit
+# CODE_EDIT_VERIFY_CMD / fast project gate is detected. Over the STAGED changed
+# files only: `bash -n` + `shellcheck` on changed *.sh, and RUN any changed
+# test-*.sh (token-scrubbed + time-bounded). Fast and flake-free vs the full repo
+# lint; the PR's own CI is the authoritative full gate. Output -> $VERIFY_OUT,
+# returns 0 (all clean) or 1.
+run_light_verify() {
+    : > "$VERIFY_OUT"
+    _lv_rc=0
+    _lv_tt=$(( VERIFY_TIMEOUT_MS / 1000 ))
+    [ "$_lv_tt" -lt 1 ] && _lv_tt=1
+    _lv_list="$(mktemp)"
+    git_capture -C "$WS" diff --cached --name-only --diff-filter=d > "$_lv_list" 2>/dev/null || true
+    # FD 8 so the inner test runs do not consume this list.
+    while IFS= read -r _lv_f <&8; do
+        [ -n "$_lv_f" ] || continue
+        case "$_lv_f" in
+            *.sh)
+                echo "[light-verify] check $_lv_f" >> "$VERIFY_OUT"
+                if ! bash -n "$WS/$_lv_f" >>"$VERIFY_OUT" 2>&1; then _lv_rc=1; fi
+                if command -v shellcheck >/dev/null 2>&1; then
+                    if ! ( cd "$WS" && shellcheck "$_lv_f" ) >>"$VERIFY_OUT" 2>&1; then _lv_rc=1; fi
+                fi
+                case "$_lv_f" in
+                    */test-*.sh|test-*.sh)
+                        echo "[light-verify] run $_lv_f" >> "$VERIFY_OUT"
+                        if command -v timeout >/dev/null 2>&1; then
+                            if ! ( cd "$WS" && env -u GITHUB_TOKEN -u GITLAB_TOKEN timeout "${_lv_tt}s" sh "$_lv_f" ) >>"$VERIFY_OUT" 2>&1; then _lv_rc=1; fi
+                        else
+                            if ! ( cd "$WS" && env -u GITHUB_TOKEN -u GITLAB_TOKEN sh "$_lv_f" ) >>"$VERIFY_OUT" 2>&1; then _lv_rc=1; fi
+                        fi
+                        ;;
+                esac
+                ;;
+        esac
+    done 8< "$_lv_list"
+    rm -f "$_lv_list"
+    if [ "$_lv_rc" -eq 0 ]; then echo "[light-verify] no shell issues in changed files" >> "$VERIFY_OUT"; fi
+    return "$_lv_rc"
 }
 
 # Bounded continue-on-incomplete loop (#1251). A single fixed-timeout shot was
@@ -475,11 +517,16 @@ while :; do
     # diff, "settled" is not "done": run the gate and only stop when it's GREEN;
     # otherwise feed the failure back as another iteration (#1253).
     if [ "$FC_RC" -eq 0 ]; then
-        if [ -z "$VERIFY_CMD" ] || [ "$cur_lines" -eq 0 ]; then
+        if [ "$cur_lines" -eq 0 ]; then
             break
         fi
-        echo "[code-edit] verifying ($VERIFY_CMD) ..." >&2
-        set +e; run_verify "$VERIFY_CMD"; verify_rc=$?; set -e
+        if [ -n "$VERIFY_CMD" ]; then
+            echo "[code-edit] verifying ($VERIFY_CMD) ..." >&2
+            set +e; run_verify "$VERIFY_CMD"; verify_rc=$?; set -e
+        else
+            echo "[code-edit] verifying (light change-scoped gate) ..." >&2
+            set +e; run_light_verify; verify_rc=$?; set -e
+        fi
         if [ "$verify_rc" -eq 0 ]; then
             echo "[code-edit] verification PASSED" >&2
             break

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -1259,6 +1259,94 @@ else
     pass "run 15 (multi-line no-decompose): did NOT decompose (no --decompose flag)"
 fi
 
+# ===========================================================================
+# Run 16 (#1262 light verify gate): with NO CODE_EDIT_VERIFY_CMD (and no fast
+# project gate in the WS), the built-in light gate runs — it executes any
+# changed test-*.sh. The stub writes a test-*.sh that EXITS 1 on attempt 1
+# (light gate fails -> feed back) then EXITS 0 on attempt 2 (passes -> commit).
+# Proves the light gate runs change-scoped checks + iterates, without the heavy
+# full-repo lint.
+# ===========================================================================
+rm -rf "$FED_DIR" "$REMOTE_BASE" "$SEED" "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+mkdir -p "$COLONY_DIR/scripts"
+cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+{ echo "create-mr called"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/16"}'
+STUB_EOF
+chmod +x "$COLONY_DIR/scripts/github-api.sh"
+
+CNT_FILE6="$WORK/fc-attempt-count-6"; rm -f "$CNT_FILE6"
+cat > "$STUB_BIN/flat-cyborg" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "\$*" >> "$FC_FLAGS_LOG"
+CWD=""
+while [ \$# -gt 0 ]; do case "\$1" in --cwd) CWD="\$2"; shift 2 ;; --) shift; break ;; *) shift ;; esac; done
+n=\$(cat "$CNT_FILE6" 2>/dev/null || echo 0); n=\$((n + 1)); printf '%s' "\$n" > "$CNT_FILE6"
+# A changed test-*.sh that the light gate will RUN. Attempt 1 exits 1 (gate
+# fails); attempt 2 exits 0 (gate passes). Both are shellcheck-clean.
+if [ "\$n" -eq 1 ]; then
+    printf '#!/usr/bin/env sh\nexit 1\n' > "\$CWD/test-lvprobe.sh"
+else
+    printf '#!/usr/bin/env sh\nexit 0\n' > "\$CWD/test-lvprobe.sh"
+fi
+exit 0
+STUB_EOF
+chmod +x "$STUB_BIN/flat-cyborg"
+
+mkdir -p "$BARE"
+git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null || git init --quiet --bare "$BARE"
+git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+(
+    cd "$SEED" || exit 1
+    git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+    printf 'hello\n' > README.md
+    git add -A
+    git commit --quiet -m "seed: initial commit"
+    git branch -M main 2>/dev/null || true
+    git remote add origin "$BARE"
+    git push --quiet origin main
+)
+git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+
+OUT16_FILE="$WORK/out16.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    GITHUB_URL="file://$REMOTE_BASE" \
+    GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    CODE_EDIT_MAX_ATTEMPTS=3 \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue 150 \
+        --branch "fix/issue-150" --title "light gate" \
+        --task "Add a test." >"$OUT16_FILE" 2>"$WORK/err16.txt"
+RC16=$?
+ATTEMPTS6="$(cat "$CNT_FILE6" 2>/dev/null || echo 0)"
+
+if [ "$RC16" -eq 0 ] && [ "$(cat "$OUT16_FILE")" = "https://example.test/pr/16" ]; then
+    pass "run 16 (light gate): exits 0 + opens PR after the light gate passes"
+else
+    fail "run 16 (light gate): exit 0 + PR url" "rc=$RC16 out=$(cat "$OUT16_FILE" 2>/dev/null) err=$(tail -4 "$WORK/err16.txt" 2>/dev/null)"
+fi
+if [ "$ATTEMPTS6" = "2" ]; then
+    pass "run 16 (light gate): iterated after the light gate failed (ran the changed test-*.sh twice)"
+else
+    fail "run 16 (light gate): expected 2 attempts" "got $ATTEMPTS6"
+fi
+if grep -q "light change-scoped gate" "$WORK/err16.txt" 2>/dev/null && grep -q "verification PASSED" "$WORK/err16.txt" 2>/dev/null; then
+    pass "run 16 (light gate): used the built-in light gate (not full colony-lint) and PASSED on retry"
+else
+    fail "run 16 (light gate): light-gate + PASSED log lines" "err=$(tail -6 "$WORK/err16.txt" 2>/dev/null)"
+fi
+if git --git-dir="$BARE" cat-file -e "refs/heads/fix/issue-150:test-lvprobe.sh" 2>/dev/null; then
+    pass "run 16 (light gate): committed only after the changed test passed"
+else
+    fail "run 16 (light gate): test-lvprobe.sh in pushed commit"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1262. M2's verify gate auto-picked the full `colony-lint.sh` (heavy + flaky under load — false-failed twice on #1260's correct code). Now: drop the colony-lint auto-pick; add a built-in **light change-scoped gate** (`bash -n` + shellcheck changed `*.sh`, run changed `test-*.sh`, token-scrubbed + timeout-bounded) used when no explicit/fast gate is detected. Explicit `CODE_EDIT_VERIFY_CMD` + npm/make/pytest auto-detects unchanged; PR CI stays the authoritative full gate. New run 16 proves the light gate runs+iterates. 64/64; colony-lint 431/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)