### PR TITLE
Add a small, self-contained `tools/detect-doc-drift.sh` that compares the version shields badge in `dev-apprenticeship/README.md` against `dev-apprenticeship/VERSION` and prints a TSV `DRIFT` line on mismatch, exiting 0 either way. Ship it with a matching `tools/test-detect-doc-drift.sh` covering the drift and no-drift cases. Keep it bash + grep/sed only with the repo root resolved relative to the script, per the issue scope.

### DIFF
--- a/tools/detect-doc-drift.sh
+++ b/tools/detect-doc-drift.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# tools/detect-doc-drift.sh: documentation drift detector (M1 of #1266, step 1).
+#
+# Compares ONE documented fact against reality and prints a TSV line per drift
+# on stdout, then exits 0. It is a DETECTOR, not a gate: it prints nothing when
+# there is no drift and never fails the build.
+#
+# Check: the `version-X.Y.Z` shields badge in dev-apprenticeship/README.md vs
+# the version in dev-apprenticeship/VERSION. On mismatch it prints:
+#
+#   DRIFT<TAB>version-badge<TAB><documented><TAB><actual>
+#
+# where documented = the badge value and actual = the VERSION value.
+#
+# Dependency-free (bash + grep/sed only). The repo root is resolved relative to
+# this script's location so it runs from anywhere.
+#
+# Usage: ./tools/detect-doc-drift.sh
+# Exit code: always 0.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+README="$REPO_ROOT/dev-apprenticeship/README.md"
+VERSION_FILE="$REPO_ROOT/dev-apprenticeship/VERSION"
+
+# Allow overriding the inputs (used by the test harness with fixtures).
+README="${DETECT_DOC_DRIFT_README:-$README}"
+VERSION_FILE="${DETECT_DOC_DRIFT_VERSION:-$VERSION_FILE}"
+
+# Extract the first `version-X.Y.Z` shields badge value from the README.
+badge_version=""
+if [ -f "$README" ]; then
+    badge_version="$(grep -oE 'badge/version-[0-9]+\.[0-9]+\.[0-9]+' "$README" \
+        | head -n1 \
+        | sed -E 's#badge/version-##')"
+fi
+
+# Read the declared version (first non-empty line, trimmed).
+actual_version=""
+if [ -f "$VERSION_FILE" ]; then
+    actual_version="$(sed -e 's/[[:space:]]//g' "$VERSION_FILE" | grep -m1 '.' || true)"
+fi
+
+# Only report a drift when both facts are present and they disagree.
+if [ -n "$badge_version" ] && [ -n "$actual_version" ] && \
+   [ "$badge_version" != "$actual_version" ]; then
+    printf 'DRIFT\tversion-badge\t%s\t%s\n' "$badge_version" "$actual_version"
+fi
+
+exit 0

--- a/tools/test-detect-doc-drift.sh
+++ b/tools/test-detect-doc-drift.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# tools/test-detect-doc-drift.sh: unit tests for tools/detect-doc-drift.sh (#1267).
+#
+# Validates:
+#   Test 1: badge and VERSION disagree -> prints exactly the DRIFT TSV line
+#   Test 2: badge and VERSION match     -> prints nothing
+#   Test 3: detector always exits 0 (it is a detector, not a gate)
+#
+# Inputs are driven through DETECT_DOC_DRIFT_README / DETECT_DOC_DRIFT_VERSION
+# so the assertions use throwaway fixtures and never touch the live repo files.
+#
+# Usage: ./tools/test-detect-doc-drift.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DETECTOR="$SCRIPT_DIR/detect-doc-drift.sh"
+
+if [ ! -x "$DETECTOR" ]; then
+    echo "[FAIL] tools/detect-doc-drift.sh missing or not executable"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Build a README fixture carrying a version badge for the given version.
+make_readme() {
+    local path="$1" ver="$2"
+    cat > "$path" <<EOF
+# dev-apprenticeship
+
+![Version: $ver](https://img.shields.io/badge/version-$ver-blue) ![Agents: 21](https://img.shields.io/badge/agents-21-green)
+EOF
+}
+
+run_detector() {
+    DETECT_DOC_DRIFT_README="$1" DETECT_DOC_DRIFT_VERSION="$2" "$DETECTOR"
+}
+
+# ----- Test 1: drift case (badge 2.0.0 vs VERSION 2.1.0) -----
+make_readme "$TMPDIR_TEST/r1.md" "2.0.0"
+printf '2.1.0\n' > "$TMPDIR_TEST/v1"
+OUT="$(run_detector "$TMPDIR_TEST/r1.md" "$TMPDIR_TEST/v1")"
+RC=$?
+EXPECTED="$(printf 'DRIFT\tversion-badge\t2.0.0\t2.1.0')"
+if [ "$OUT" = "$EXPECTED" ]; then
+    pass "drift: prints DRIFT line with documented=badge, actual=VERSION"
+else
+    fail "drift" "expected <$EXPECTED>, got <$OUT>"
+fi
+if [ "$RC" -eq 0 ]; then
+    pass "drift: exit 0 (detector, not gate)"
+else
+    fail "drift-exit" "rc=$RC"
+fi
+
+# ----- Test 2: no-drift case (badge 2.1.0 == VERSION 2.1.0) -----
+make_readme "$TMPDIR_TEST/r2.md" "2.1.0"
+printf '2.1.0\n' > "$TMPDIR_TEST/v2"
+OUT="$(run_detector "$TMPDIR_TEST/r2.md" "$TMPDIR_TEST/v2")"
+RC=$?
+if [ -z "$OUT" ]; then
+    pass "no-drift: prints nothing when badge matches VERSION"
+else
+    fail "no-drift" "expected empty output, got <$OUT>"
+fi
+if [ "$RC" -eq 0 ]; then
+    pass "no-drift: exit 0"
+else
+    fail "no-drift-exit" "rc=$RC"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements #1267.

Issue:
{"iid": 1267, "title": "tools/detect-doc-drift.sh: version-badge vs VERSION drift check (M1 of #1266, step 1)", "description": "Small, self-contained first slice of #1266 M1. No dependencies on other #1266 work \u2014 just detect + print.\n\n**Add `tools/detect-doc-drift.sh`** (bash, ~40\u201370 lines). It compares ONE documented fact against reality and prints a TSV line per drift on stdout, then exits 0 (it is a detector, not a gate \u2014 print nothing when there is no drift):\n\n```\nDRIFT<TAB>version-badge<TAB><documented><TAB><actual>\n```\n\nCheck: the `version-X.Y.Z` shields badge in `dev-apprenticeship/README.md` vs the version in `dev-apprenticeship/VERSION`. If they differ, print the DRIFT line with documented=badge value, actual=VERSION value.\n\nKeep it dependency-free (bash + grep/sed only). Resolve the repo root relative to the script location so it runs from anywhere.\n\n**Add `tools/test-detect-doc-drift.sh`** following the existing `tools/test-*.sh` style (plain bash, pass/fail counts, non-zero exit on failure): one fixture where badge and VERSION disagree (assert the DRIFT line is printed) and one where they match (assert empty output).\n\nScope is deliberately tiny \u2014 one check + its test. Further checks (federation count, dashboard tab count) are separate follow-ups under #1266.", "state": "opened", "labels": ["dev-apprenticeship", "implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-22T17:31:57Z", "updated_at": "2026-06-22T17:31:57Z", "user_notes_count": 0, "priority": null}

Plan:
- `tools/detect-doc-drift.sh` — new dependency-free bash detector (~40-70 lines). Resolves repo root relative to its own script location so it runs from anywhere. Greps the `version-X.Y.Z` shields badge out of `dev-apprenticeship/README.md` (via grep/sed), reads `dev-apprenticeship/VERSION`, and when they differ prints `DRIFT\tversion-badge\t<badge>\t<version>` to stdout (nothing when they match). Always exits 0 — detector, not gate.
- `tools/test-detect-doc-drift.sh` — new test following the existing `tools/test-*.sh` style (plain bash, pass/fail counters, non-zero exit on failure). Uses temp fixtures with README.md + VERSION: case 1 badge and VERSION disagree (asserts the single DRIFT line is printed), case 2 they match (asserts empty output).

Add a small, self-contained `tools/detect-doc-drift.sh` that compares the version shields badge in `dev-apprenticeship/README.md` against `dev-apprenticeship/VERSION` and prints a TSV `DRIFT` line on mismatch, exiting 0 either way. Ship it with a matching `tools/test-detect-doc-drift.sh` covering the drift and no-drift cases. Keep it bash + grep/sed only with the repo root resolved relative to the script, per the issue scope.