### PR TITLE
fix(code-edit-in-checkout): make --decompose reliable, not a silent monolithic fallback

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,22 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`code-edit-in-checkout.sh --decompose` now reliably splits epic-sized tasks
+  instead of silently falling back to a monolithic run**
+  ([#1269](https://github.com/Replikanti/agentis-colonies/issues/1269)). The
+  decompose-generation step let the editing agent explore the repository before
+  listing sub-edits, so on a large task it spent its whole budget exploring and
+  wrote an empty list — which fell through to "whole task = one subtask" and then
+  timed out mid-exploration with zero edits (observed live on an epic). The
+  decompose prompt now instructs the agent to base the sub-edit list **solely on
+  the task description** (no repo exploration, write the list immediately); the
+  first-attempt editing prompt tells it to **begin editing immediately and keep
+  exploration minimal**; and the monolithic fallback is now logged instead of
+  silent. Prompt/logging only — no control-flow change; the stub-based
+  orchestration tests are unchanged (64/0).
+
 ## [2.1.0] — 2026-06-22
 
 **Requires:** agentis >= 1.8.0 (crystallizer builtins, #1235)

--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -444,8 +444,9 @@ if [ "$DECOMPOSE" -eq 1 ]; then
     : > "$SUBTASKS_LIST"
     {
         printf 'Decompose issue #%s (%s) into an ORDERED list of small, self-contained sub-edits, each about the size of one focused change.\n\n' "$ISSUE" "$TITLE"
+        printf 'Base the list SOLELY on the task description below. Do NOT read, search, or explore repository files in this step, and do NOT edit any files — just produce the list immediately.\n'
         printf 'Write ONLY the list to this exact file with your file-writing tool: %s\n' "$SUBTASKS_LIST"
-        printf 'One sub-edit per line, plain text, no numbering and no markdown. Do NOT edit any repository files in this step.\n\nIssue task:\n%s\n' "$TASK"
+        printf 'One sub-edit per line, plain text, no numbering and no markdown.\n\nIssue task:\n%s\n' "$TASK"
     } > "$TASKFILE"
     echo "[code-edit] decomposing issue #$ISSUE into subtasks" >&2
     set +e
@@ -465,6 +466,7 @@ if [ "$DECOMPOSE" -eq 1 ]; then
 fi
 if [ ! -s "$SUBTASKS_FILE" ]; then
     # Single record = the whole task (newlines preserved) -> one subtask -> M1/M2.
+    [ "$DECOMPOSE" -eq 1 ] && echo "[code-edit] decomposition produced no subtasks — running the whole task as one (monolithic fallback)" >&2
     printf '%s\0' "$TASK" > "$SUBTASKS_FILE"
 fi
 SUBTASK_COUNT="$(tr -cd '\0' < "$SUBTASKS_FILE" | wc -c | tr -d ' ')"
@@ -490,7 +492,7 @@ while :; do
     [ "$this_timeout" -gt "$remaining_ms" ] && this_timeout="$remaining_ms"
 
     if [ "$attempt" -eq 1 ]; then
-        printf 'Implement issue #%s in this repository by editing the files directly with your tools. %s\n\n%s\n\nMake the change and stop; do not run git or open a PR.' \
+        printf 'Implement issue #%s in this repository by editing the files directly with your tools. %s\n\nBegin editing immediately and keep exploration minimal — the task below already specifies the change; read only the specific files you must modify.\n\n%s\n\nMake the change and stop; do not run git or open a PR.' \
             "$ISSUE" "$TITLE" "$CUR_TASK" > "$TASKFILE"
     elif [ "$continuation_mode" = "verify" ]; then
         # Continuation prompt: the change does not pass the verification gate.


### PR DESCRIPTION
Closes #1269.

## Problem (observed live on an epic)

The federation auto-`--decompose`d an epic but it ran **monolithically** and the editing agent timed out (exit 124) with **zero staged edits** — three identical failures, while small single-purpose tasks (e.g. #1267) succeed in one attempt. The gap is purely task size.

## Root cause

In `tools/code-edit-in-checkout.sh`, the decompose-generation step let the editing agent **explore the repository** before listing sub-edits. On a large task it spent its whole budget exploring and wrote **nothing** to the subtask list → `awk` yielded empty → the code fell back to "whole task = one subtask" (monolithic) **silently**. The monolithic attempt then over-explored the same way and timed out with no edits.

## Fix (prompt + visibility only — no control-flow change)

- **decompose-gen prompt**: base the sub-edit list **solely on the task description**; do not read/search/explore repo files; write the list immediately.
- **first-attempt editing prompt**: begin editing immediately, keep exploration minimal, read only the files that must change.
- **visibility**: log the monolithic fallback instead of leaving it silent (it hid this root cause).

## Validation

- `bash -n` + `shellcheck`: clean.
- Stub-based orchestration suite `tools/test-code-edit-in-checkout.sh`: **64 passed, 0 failed** (prompt-text changes are behavioural, not structural — control flow unchanged).
- colony-lint: 431/0.
- **Behavioural validation** = a live epic re-run after deploy (decomposition should produce split markers + each small subtask should land like #1267). Noted, not claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)