### PR TITLE
Add a small, dependency-free shared bash helper that appends and reads structured issue-candidate records as JSONL over a single agentis memo key, using python3 json.dumps for safe encoding of titles and bodies that contain quotes or newlines. Ship it alongside a focused test that appends three records and asserts the round-trip preserves all fields and counts. This is the queue primitive that the issue_creator will later consume for #1266 M1.

### DIFF
--- a/tools/lib/candidate-queue.sh
+++ b/tools/lib/candidate-queue.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# tools/lib/candidate-queue.sh — shared, dependency-free helper for
+# appending and reading structured issue-candidate records as JSONL over
+# a single agentis memo key. Queue primitive that the issue_creator will
+# consume for #1266 M1 (added in #1273).
+#
+# Record shape — one JSON object per line (JSONL):
+#   {"title": <str>, "body": <str>, "labels": <str>,
+#    "fingerprint": <str>, "source": <str>}
+#
+# Titles and bodies routinely contain quotes and newlines; every field is
+# encoded with python3 json.dumps so the on-the-wire JSONL stays valid and
+# survives the read-modify-write round trip.
+#
+# Storage: a single agentis memo key holds the whole JSONL blob. Default
+# `issue_creator:candidates`, overridable via CANDIDATE_QUEUE_KEY. Append is
+# a read-modify-write against that one key.
+#
+# Dependencies: bash + python3 + the `agentis memo get/set` CLI. Nothing else.
+#
+# Usage: source this file, then:
+#   candidate_queue_append "<title>" "<body>" "<labels>" "<fingerprint>" "<source>"
+#   candidate_queue_read   # prints the stored JSONL to stdout
+
+CANDIDATE_QUEUE_KEY="${CANDIDATE_QUEUE_KEY:-issue_creator:candidates}"
+
+# candidate_queue_read: print all stored records (the raw JSONL) to stdout.
+# Empty/unset key prints nothing. Command substitution callers get a blob
+# with trailing newlines stripped, which is exactly what append wants.
+candidate_queue_read() {
+    agentis memo get "$CANDIDATE_QUEUE_KEY" 2>/dev/null || true
+}
+
+# candidate_queue_append <title> <body> <labels> <fingerprint> <source>
+# Encode one JSONL record (fields passed through the environment so no shell
+# quoting can break json.dumps' safe encoding) and append it to the queue.
+candidate_queue_append() {
+    local line existing updated
+    line="$(CQ_TITLE="${1-}" CQ_BODY="${2-}" CQ_LABELS="${3-}" \
+            CQ_FP="${4-}" CQ_SRC="${5-}" python3 -c '
+import json, os
+print(json.dumps({
+    "title":       os.environ.get("CQ_TITLE", ""),
+    "body":        os.environ.get("CQ_BODY", ""),
+    "labels":      os.environ.get("CQ_LABELS", ""),
+    "fingerprint": os.environ.get("CQ_FP", ""),
+    "source":      os.environ.get("CQ_SRC", ""),
+}, ensure_ascii=False))
+')" || return 1
+
+    existing="$(candidate_queue_read)"
+    if [ -n "$existing" ]; then
+        updated="$existing
+$line"
+    else
+        updated="$line"
+    fi
+
+    agentis memo set "$CANDIDATE_QUEUE_KEY" "$updated"
+}

--- a/tools/test-candidate-queue.sh
+++ b/tools/test-candidate-queue.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# tools/test-candidate-queue.sh: unit test for tools/lib/candidate-queue.sh
+# (#1273, M1 of #1266). Covers the queue primitive the issue_creator will
+# consume:
+#
+#   1. Appending 3 records and reading back exactly 3 well-formed JSON lines.
+#   2. Round-trip preservation of every field — including a title that
+#      carries an embedded double-quote and newline — proving the python3
+#      json.dumps encoding survives the memo read-modify-write cycle.
+#   3. CANDIDATE_QUEUE_KEY override is honoured (the test points it at a
+#      throwaway key).
+#
+# Hermetic: stubs `agentis memo get/set` with a file-backed shim on PATH so
+# the test does not require a real agentis binary (mirrors the CI runners,
+# where agentis is not installed).
+#
+# Usage: ./tools/test-candidate-queue.sh
+# Exit 0 on full pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# --- Stub `agentis`: a file-backed `memo get/set` so the lib runs without
+#     a real binary. One file per key under $STORE; keys are slugified so
+#     `:` / `/` are filesystem-safe. ---
+STORE="$TMPDIR_TEST/memo"
+mkdir -p "$STORE"
+cat > "$TMPDIR_TEST/agentis" <<'STUB'
+#!/bin/bash
+STORE_DIR="$AGENTIS_STUB_STORE"
+slug() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
+if [ "${1:-}" = "memo" ] && [ "${2:-}" = "get" ]; then
+    f="$STORE_DIR/$(slug "${3:-}")"
+    [ -f "$f" ] && cat "$f"
+    exit 0
+fi
+if [ "${1:-}" = "memo" ] && [ "${2:-}" = "set" ]; then
+    f="$STORE_DIR/$(slug "${3:-}")"
+    printf '%s' "${4:-}" > "$f"
+    exit 0
+fi
+echo "agentis-stub: unsupported args: $*" >&2
+exit 2
+STUB
+chmod +x "$TMPDIR_TEST/agentis"
+export AGENTIS_STUB_STORE="$STORE"
+export PATH="$TMPDIR_TEST:$PATH"
+
+# Point the queue at a throwaway key and load the lib under test.
+export CANDIDATE_QUEUE_KEY="test:candidate-queue:throwaway"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/candidate-queue.sh"
+
+# --- Append 3 records. Record 2's title carries a double-quote and a
+#     newline — the adversarial case for safe JSON encoding. ---
+TRICKY_TITLE='He said "ship it"
+on the next line'
+candidate_queue_append "Plain title"      "body one"   "bug,triage"  "fp-aaa" "router"
+candidate_queue_append "$TRICKY_TITLE"    "body\ntwo"  "enhancement" "fp-bbb" "labeler"
+candidate_queue_append "Third & last <x>" "body three" "chore"       "fp-ccc" "prioritizer"
+
+# --- Verify: read back, parse every non-empty line as JSON, assert the
+#     count and that all fields round-tripped intact (the tricky title most
+#     of all). Python does the structural assertions; the shell checks its
+#     exit status. ---
+if candidate_queue_read | python3 -c '
+import json, sys
+
+lines = [ln for ln in sys.stdin.read().split("\n") if ln != ""]
+assert len(lines) == 3, "expected 3 JSONL lines, got %d" % len(lines)
+
+recs = [json.loads(ln) for ln in lines]  # raises on any malformed line
+fields = {"title", "body", "labels", "fingerprint", "source"}
+for i, r in enumerate(recs):
+    assert set(r) == fields, "record %d has fields %s" % (i, sorted(r))
+
+assert recs[0]["title"] == "Plain title"
+assert recs[0]["labels"] == "bug,triage"
+assert recs[0]["fingerprint"] == "fp-aaa"
+assert recs[0]["source"] == "router"
+
+assert recs[1]["title"] == "He said \"ship it\"\non the next line", repr(recs[1]["title"])
+assert recs[1]["body"] == "body\\ntwo"
+assert recs[1]["source"] == "labeler"
+
+assert recs[2]["title"] == "Third & last <x>"
+assert recs[2]["body"] == "body three"
+assert recs[2]["fingerprint"] == "fp-ccc"
+'; then
+    pass "1: 3 records append + read back as 3 well-formed JSON lines, fields intact (quote/newline safe)"
+else
+    fail "1: round-trip" "candidate_queue_read did not yield 3 intact records"
+fi
+
+# --- The override key actually holds the data; the default key is untouched. ---
+if [ -f "$STORE/test_candidate-queue_throwaway" ] && [ ! -f "$STORE/issue_creator_candidates" ]; then
+    pass "2: CANDIDATE_QUEUE_KEY override honoured (default key untouched)"
+else
+    fail "2: key override" "data not stored under the throwaway key"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements #1273.

Issue:
{"iid": 1273, "title": "tools/lib/candidate-queue.sh: append/read structured issue-candidate records (M1 of #1266)", "description": "Small, self-contained shared helper. No dependencies beyond the `agentis memo` CLI.\n\n**Add `tools/lib/candidate-queue.sh`** (bash, sourceable) exposing two functions over a single agentis memo key (default `issue_creator:candidates`, overridable via `CANDIDATE_QUEUE_KEY`):\n- `candidate_queue_append \"<title>\" \"<body>\" \"<labels>\" \"<fingerprint>\" \"<source>\"` \u2014 append one record (encode as one JSON object per line / JSONL; use python3 -c json.dumps for safe encoding).\n- `candidate_queue_read` \u2014 print all stored records (the JSONL) to stdout.\n\nKeep it dependency-free beyond bash + python3 + the `agentis memo get/set` CLI. Document the record shape in a header comment.\n\n**Add `tools/test-candidate-queue.sh`** (existing `tools/test-*.sh` style): point `CANDIDATE_QUEUE_KEY` at a throwaway key, append 3 records, assert `candidate_queue_read` returns 3 well-formed JSON lines with the fields intact, including a title containing a quote/newline to prove safe encoding.\n\nTiny scope: one lib + its test. Part of #1266 M1 (the queue `issue_creator` will consume).", "state": "opened", "labels": ["dev-apprenticeship", "implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-22T18:04:36Z", "updated_at": "2026-06-22T18:04:36Z", "user_notes_count": 0, "priority": null}

Plan:
- `tools/lib/candidate-queue.sh` — sourceable bash helper exposing `candidate_queue_append <title> <body> <labels> <fingerprint> <source>` (encodes one JSONL record via `python3 -c json.dumps`, then reads the current value, appends the line, and re-stores it via `agentis memo set`) and `candidate_queue_read` (prints the stored JSONL via `agentis memo get`). Key defaults to `issue_creator:candidates`, overridable with `CANDIDATE_QUEUE_KEY`. A header comment documents the record shape.
- `tools/test-candidate-queue.sh` — test in the existing `tools/test-*.sh` style (pass/fail counts, non-zero exit on failure). Points `CANDIDATE_QUEUE_KEY` at a throwaway key, appends 3 records (one title containing a quote and a newline), then asserts `candidate_queue_read` returns exactly 3 well-formed JSON lines with all fields intact, proving safe encoding.

Add a small, dependency-free shared bash helper that appends and reads structured issue-candidate records as JSONL over a single agentis memo key, using python3 json.dumps for safe encoding of titles and bodies that contain quotes or newlines. Ship it alongside a focused test that appends three records and asserts the round-trip preserves all fields and counts. This is the queue primitive that the issue_creator will later consume for #1266 M1.