### PR TITLE
Add a small, self-contained `tools/detect-todo-markers.sh` that scans the repo tree (skipping `.git/`) for TODO/FIXME/XXX markers and emits one `DRIFT<TAB>todo-marker<TAB><file>:<line><TAB><text>` TSV line per hit on stdout, always exiting 0 as a detector rather than a gate. It mirrors the shipped `detect-doc-drift.sh` conventions including a `DETECT_TODO_ROOT` override, and ships with `tools/test-detect-todo-markers.sh` covering one marked file and one clean file. Implements M1 of #1266 with no dependencies.

### DIFF
--- a/tools/detect-todo-markers.sh
+++ b/tools/detect-todo-markers.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# tools/detect-todo-markers.sh: in-tree TODO/FIXME/XXX marker detector (M1 of #1266).
+#
+# Walks the repo tree (skipping .git/) and prints one TSV line per marker on
+# stdout, then exits 0. It is a DETECTOR, not a gate: it prints nothing when
+# there are no markers and never fails the build.
+#
+# For every TODO, FIXME, or XXX marker it prints:
+#
+#   DRIFT<TAB>todo-marker<TAB><file>:<line><TAB><trimmed marker text>
+#
+# where <file> is relative to the scanned root and <trimmed marker text> is the
+# matched source line with leading/trailing whitespace stripped.
+#
+# Dependency-free (bash + grep/sed only). The repo root is resolved relative to
+# this script's location so it runs from anywhere. Set DETECT_TODO_ROOT to scan
+# a different tree (used by the test harness with fixtures).
+#
+# Usage: ./tools/detect-todo-markers.sh
+# Exit code: always 0.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Allow overriding the scanned root (used by the test harness with fixtures).
+ROOT="${DETECT_TODO_ROOT:-$REPO_ROOT}"
+
+[ -d "$ROOT" ] || exit 0
+
+# Scan from inside the root so grep emits paths relative to it. -I skips binary
+# files, -n adds line numbers, -E enables the alternation. .git/ is excluded.
+cd "$ROOT" || exit 0
+grep -rInE 'TODO|FIXME|XXX' --exclude-dir=.git . 2>/dev/null | while IFS= read -r hit; do
+    # grep output is "<file>:<line>:<content>"; peel the first two colon fields.
+    file="${hit%%:*}"
+    rest="${hit#*:}"
+    line="${rest%%:*}"
+    text="${rest#*:}"
+    file="${file#./}"
+    text="$(printf '%s' "$text" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    printf 'DRIFT\ttodo-marker\t%s:%s\t%s\n' "$file" "$line" "$text"
+done
+
+exit 0

--- a/tools/test-detect-todo-markers.sh
+++ b/tools/test-detect-todo-markers.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# tools/test-detect-todo-markers.sh: unit tests for tools/detect-todo-markers.sh (M1 of #1266).
+#
+# Validates:
+#   Test 1: a file carrying a TODO marker -> prints exactly the DRIFT TSV line
+#   Test 2: a clean file                  -> no line is emitted for it
+#   Test 3: detector always exits 0 (it is a detector, not a gate)
+#
+# The scanned tree is driven through DETECT_TODO_ROOT so the assertions use a
+# throwaway fixture dir and never depend on the live repo contents.
+#
+# Usage: ./tools/test-detect-todo-markers.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DETECTOR="$SCRIPT_DIR/detect-todo-markers.sh"
+
+if [ ! -x "$DETECTOR" ]; then
+    echo "[FAIL] tools/detect-todo-markers.sh missing or not executable"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# ----- Fixture tree: one marked file, one clean file -----
+printf 'TODO: wire this up\n' > "$TMPDIR_TEST/marked.txt"
+printf 'all good here\n' > "$TMPDIR_TEST/clean.txt"
+
+OUT="$(DETECT_TODO_ROOT="$TMPDIR_TEST" "$DETECTOR")"
+RC=$?
+
+# ----- Test 1: marked file emits the exact DRIFT TSV line -----
+EXPECTED="$(printf 'DRIFT\ttodo-marker\tmarked.txt:1\tTODO: wire this up')"
+if printf '%s\n' "$OUT" | grep -qxF "$EXPECTED"; then
+    pass "marked: prints DRIFT line for the TODO marker"
+else
+    fail "marked" "expected line <$EXPECTED>, got <$OUT>"
+fi
+
+# ----- Test 2: clean file produces no line -----
+if printf '%s\n' "$OUT" | grep -q 'clean.txt'; then
+    fail "clean" "expected no line for clean.txt, got <$OUT>"
+else
+    pass "clean: emits nothing for the marker-free file"
+fi
+
+# ----- Test 3: detector exits 0 -----
+if [ "$RC" -eq 0 ]; then
+    pass "exit 0 (detector, not gate)"
+else
+    fail "exit" "rc=$RC"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements #1272.

Issue:
{"iid": 1272, "title": "tools/detect-todo-markers.sh: emit candidates for TODO/FIXME without a tracking issue (M1 of #1266)", "description": "Small, self-contained, mirrors the shipped `tools/detect-doc-drift.sh` (#1267). No dependencies.\n\n**Add `tools/detect-todo-markers.sh`** (bash, grep/sed only). Scan the repo tree for `TODO`/`FIXME`/`XXX` markers and print one TSV line per marker on stdout, then exit 0 (detector, not a gate):\n\n```\nDRIFT<TAB>todo-marker<TAB><file>:<line><TAB><trimmed marker text>\n```\n\nSkip the scan of `.git/`. Resolve the repo root relative to the script. Allow an env override `DETECT_TODO_ROOT` for the scanned root (used by the test). Print nothing if no markers.\n\n**Add `tools/test-detect-todo-markers.sh`** in the existing `tools/test-*.sh` style (plain bash, pass/fail counts, non-zero exit on failure): a fixture dir containing one file with a `TODO` (assert the TSV line) and one clean file (assert no line for it).\n\nTiny scope: one detector + its test. Part of #1266 M1.", "state": "opened", "labels": ["dev-apprenticeship", "implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-22T18:04:33Z", "updated_at": "2026-06-22T18:04:33Z", "user_notes_count": 0, "priority": null}

Plan:
- `tools/detect-todo-markers.sh` — new bash detector (grep/sed only); resolves the repo root relative to the script, honors a `DETECT_TODO_ROOT` env override for the scanned root, walks the tree skipping `.git/`, and prints one TSV line per marker as `DRIFT\ttodo-marker\t<file>:<line>\t<trimmed text>` for each `TODO`/`FIXME`/`XXX`, then exits 0; prints nothing when clean.
- `tools/test-detect-todo-markers.sh` — new unit test in the existing `test-*.sh` style (PASS/FAIL counters, non-zero exit on failure); builds a fixture dir under a temp `DETECT_TODO_ROOT` with one file containing a TODO (asserts the exact TSV line) and one clean file (asserts no line is emitted for it).

Add a small, self-contained `tools/detect-todo-markers.sh` that scans the repo tree (skipping `.git/`) for TODO/FIXME/XXX markers and emits one `DRIFT<TAB>todo-marker<TAB><file>:<line><TAB><text>` TSV line per hit on stdout, always exiting 0 as a detector rather than a gate. It mirrors the shipped `detect-doc-drift.sh` conventions including a `DETECT_TODO_ROOT` override, and ships with `tools/test-detect-todo-markers.sh` covering one marked file and one clean file. Implements M1 of #1266 with no dependencies.