### PR TITLE
Add a tiny, dependency-free `tools/lib/candidate-fingerprint.sh` that prints a stable 12-hex-char sha256 fingerprint over (source, location, normalized-title), mirroring the shape and header conventions of `tools/lib/candidate-queue.sh`. Normalizing the title (trim + collapse whitespace + lowercase) before hashing collapses trivially-different titles onto the same dedup key, which is exactly what the #1266 issue_creator gate consumes. Ship it with `tools/test-candidate-fingerprint.sh` covering stability, sensitivity, normalization, and output shape.

### DIFF
--- a/tools/lib/candidate-fingerprint.sh
+++ b/tools/lib/candidate-fingerprint.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# tools/lib/candidate-fingerprint.sh — shared, dependency-free helper that
+# prints a stable short fingerprint over an issue candidate's
+# (source, location, normalized-title). The dedup key the issue_creator gate
+# consumes for #1266 M2 (companion to the candidate queue added in #1273).
+#
+# candidate_fingerprint <source> <location> <title>
+#   Prints the first 12 hex chars of the sha256 of the three inputs joined by
+#   a US (0x1f) unit separator. Deterministic: same inputs → same output,
+#   different inputs → different output. The title is normalized first
+#   (lowercase, fold every whitespace run — including tabs/newlines — to one
+#   space, trim) so trivially-different titles collapse onto the same key.
+#
+# Dependencies: bash + a sha256 tool only — `sha256sum`, falling back to
+# `shasum -a 256` (portable across Linux + macOS). No python3, no agentis
+# binary; this file is meant to be sourced, so it sets no shell options.
+#
+# Usage: source this file, then:
+#   fp="$(candidate_fingerprint "router" "src/foo.rs:42" "Null deref in parser")"
+
+# candidate_fingerprint <source> <location> <title>
+candidate_fingerprint() {
+    local src="${1-}" location="${2-}" title="${3-}"
+    local sep norm payload digest
+    sep=$'\037'  # US (unit separator), 0x1f — collision-resistant join char
+
+    # Normalize the title: lowercase, fold any whitespace run to a single
+    # space, then trim the (now single) leading/trailing space.
+    norm="$(printf '%s' "$title" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ')"
+    norm="${norm# }"
+    norm="${norm% }"
+
+    payload="${src}${sep}${location}${sep}${norm}"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        digest="$(printf '%s' "$payload" | sha256sum)"
+    else
+        digest="$(printf '%s' "$payload" | shasum -a 256)"
+    fi
+    digest="${digest%% *}"  # drop the trailing "  -" filename column
+
+    printf '%s\n' "${digest:0:12}"
+}

--- a/tools/test-candidate-fingerprint.sh
+++ b/tools/test-candidate-fingerprint.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# tools/test-candidate-fingerprint.sh: unit test for
+# tools/lib/candidate-fingerprint.sh (M2 of #1266). Covers the stable dedup
+# key the issue_creator gate consumes:
+#
+#   1. Stability    — same (source, location, title) twice → identical hash.
+#   2. Sensitivity  — changing source, location, or title each changes it.
+#   3. Normalization — extra/leading/trailing whitespace, internal whitespace
+#      runs (incl. tabs/newlines), and case differences in the title all
+#      fingerprint the same.
+#   4. Output shape — exactly 12 lowercase hex characters.
+#
+# Dependency-free: only bash + the sha256 tool the lib itself needs (no
+# agentis binary, no python3), so it runs on the CI runners unchanged.
+#
+# Usage: ./tools/test-candidate-fingerprint.sh
+# Exit 0 on full pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/candidate-fingerprint.sh"
+
+# --- 1. Stability: identical inputs yield identical output. ---
+a="$(candidate_fingerprint "router" "src/foo.rs:42" "Null deref in parser")"
+b="$(candidate_fingerprint "router" "src/foo.rs:42" "Null deref in parser")"
+if [ "$a" = "$b" ]; then
+    pass "1: stable — same inputs twice produce the same fingerprint ($a)"
+else
+    fail "1: stability" "$a != $b"
+fi
+
+# --- 2. Sensitivity: changing each field in turn changes the hash. ---
+base="$(candidate_fingerprint "router" "src/foo.rs:42" "Null deref in parser")"
+diff_src="$(candidate_fingerprint "labeler" "src/foo.rs:42" "Null deref in parser")"
+diff_loc="$(candidate_fingerprint "router" "src/foo.rs:43" "Null deref in parser")"
+diff_title="$(candidate_fingerprint "router" "src/foo.rs:42" "Use-after-free in parser")"
+if [ "$base" != "$diff_src" ] && [ "$base" != "$diff_loc" ] && [ "$base" != "$diff_title" ]; then
+    pass "2: sensitive — changing source, location, or title each changes the fingerprint"
+else
+    fail "2: sensitivity" "src=$diff_src loc=$diff_loc title=$diff_title vs base=$base"
+fi
+
+# --- 3. Normalization: whitespace + case variants of the title collapse. ---
+canon="$(candidate_fingerprint "router" "src/foo.rs:42" "Null deref in parser")"
+spaced="$(candidate_fingerprint "router" "src/foo.rs:42" "  Null   deref  in parser  ")"
+cased="$(candidate_fingerprint "router" "src/foo.rs:42" "NULL DEREF IN PARSER")"
+tabbed="$(candidate_fingerprint "router" "src/foo.rs:42" "$(printf 'Null\tderef\nin   parser')")"
+if [ "$canon" = "$spaced" ] && [ "$canon" = "$cased" ] && [ "$canon" = "$tabbed" ]; then
+    pass "3: normalized — extra/leading/trailing/internal whitespace + case fold to one key"
+else
+    fail "3: normalization" "canon=$canon spaced=$spaced cased=$cased tabbed=$tabbed"
+fi
+
+# --- 4. A genuinely different title must NOT collide after normalization. ---
+other="$(candidate_fingerprint "router" "src/foo.rs:42" "null   deref  in lexer")"
+if [ "$canon" != "$other" ]; then
+    pass "4: normalization is not lossy — a different title stays distinct"
+else
+    fail "4: normalization over-collapse" "canon=$canon == other=$other"
+fi
+
+# --- 5. Output shape: exactly 12 lowercase hex characters. ---
+shape="$(candidate_fingerprint "router" "src/foo.rs:42" "Null deref in parser")"
+if printf '%s' "$shape" | grep -Eq '^[0-9a-f]{12}$'; then
+    pass "5: output is exactly 12 lowercase hex chars ($shape)"
+else
+    fail "5: output shape" "got '$shape'"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements #1279.

Issue:
{"iid": 1279, "title": "tools/lib/candidate-fingerprint.sh: stable fingerprint for issue candidates (M2 of #1266)", "description": "Small, self-contained sourceable helper (like `tools/lib/candidate-queue.sh`, #1273). No deps beyond bash + sha256.\n\n**Add `tools/lib/candidate-fingerprint.sh`** exposing one function:\n- `candidate_fingerprint \"<source>\" \"<location>\" \"<title>\"` \u2014 print a stable short hash (first 12 hex chars of the sha256 of the three inputs joined by a NUL or `\\x1f` separator). Deterministic: same inputs \u2192 same output; different inputs \u2192 different output. Normalize the title (trim + collapse internal whitespace + lowercase) before hashing so trivially-different titles fingerprint the same. Use `sha256sum` with a `shasum -a 256` fallback (portable).\n\n**Add `tools/test-candidate-fingerprint.sh`** (existing `tools/test-*.sh` style): assert stability (same inputs twice \u2192 identical), assert sensitivity (changing source/location/title changes the hash), assert title-normalization (same title with extra spaces / different case \u2192 same hash), assert 12-hex-char output shape.\n\nTiny scope: one lib + its test. Part of #1266 M2 (the dedup key the issue_creator gate will use).", "state": "opened", "labels": ["dev-apprenticeship", "implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-22T19:33:19Z", "updated_at": "2026-06-22T19:33:19Z", "user_notes_count": 0, "priority": null}

Plan:
- `tools/lib/candidate-fingerprint.sh` — new dependency-free sourceable helper (bash + sha256 only) exposing `candidate_fingerprint <source> <location> <title>`: normalizes the title (trim, collapse internal whitespace, lowercase), joins the three fields with a `\x1f` (US) separator, hashes via `sha256sum` with a `shasum -a 256` fallback, and prints the first 12 hex chars. Header-comment block + `set -eu`, mirroring `tools/lib/candidate-queue.sh`.
- `tools/test-candidate-fingerprint.sh` — new unit test in the existing `tools/test-*.sh` style (SKIP-if-absent guard, pass/fail counters, exit 0 when green, auto-discovered by `colony-lint.sh`): asserts stability (same inputs twice → identical), sensitivity (changing source, location, or title each changes the hash), title normalization (extra spaces / differing case → same hash), and 12-hex-char output shape.

Add a tiny, dependency-free `tools/lib/candidate-fingerprint.sh` that prints a stable 12-hex-char sha256 fingerprint over (source, location, normalized-title), mirroring the shape and header conventions of `tools/lib/candidate-queue.sh`. Normalizing the title (trim + collapse whitespace + lowercase) before hashing collapses trivially-different titles onto the same dedup key, which is exactly what the #1266 issue_creator gate consumes. Ship it with `tools/test-candidate-fingerprint.sh` covering stability, sensitivity, normalization, and output shape.