### PR TITLE
feat(tools): self-observe.sh — deterministic self-improvement driver (#1266 M3)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,21 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Added
+
+- **`tools/self-observe.sh` — deterministic self-improvement driver**
+  ([#1266](https://github.com/Replikanti/agentis-colonies/issues/1266) M3). Runs
+  every `tools/detect-*.sh`, fingerprints each finding, **dedups** it against
+  open issues, **rate-limits** (`SELF_OBSERVE_MAX_NEW`, default 5), and proposes
+  a small single-purpose tracking issue per finding — **dry-run by default**,
+  `--file` to create them. Observation is deterministic (a shell scan, no LLM →
+  no over-exploration or flakiness), and every finding becomes a small issue the
+  proven small-issue pipeline can fix rather than one monolithic epic — the
+  robust shape of self-tuning. Pairs with the `tools/detect-*.sh` family
+  (`detect-doc-drift` #1267, `detect-todo-markers` #1272, `detect-agent-failures`
+  forthcoming #1278). Knobs: `SELF_OBSERVE_REPO` / `SELF_OBSERVE_MAX_NEW` /
+  `SELF_OBSERVE_LABELS` / `SELF_OBSERVE_GH`.
+
 ### Fixed
 
 - **`code_writer` epic auto-decompose (#1257) now actually fires**

--- a/tools/self-observe.sh
+++ b/tools/self-observe.sh
@@ -97,11 +97,14 @@ while IFS="$tab" read -r tag kind loc text; do
     body="$(printf 'Auto-detected by tools/self-observe.sh (%s detector).\n\n- **finding:** %s\n- **location:** %s\n\nA small, single-purpose self-improvement task for the federation.\n\n<!-- self-observe-fingerprint: %s -->\n' "$kind" "$text" "$loc" "$fp")"
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "[self-observe] WOULD FILE: $title  [$fp]"
+        filed=$((filed + 1))
+    elif url="$("$GH" issue create --repo "$REPO" --title "$title" --body "$body" --label "$LABELS" 2>/dev/null)" && [ -n "$url" ]; then
+        echo "[self-observe] FILED: $title -> $url  [$fp]"
+        filed=$((filed + 1))
     else
-        url="$("$GH" issue create --repo "$REPO" --title "$title" --body "$body" --label "$LABELS" 2>/dev/null || true)"
-        echo "[self-observe] FILED: $title -> ${url:-<create-failed>}  [$fp]"
+        # A failed create does NOT consume a rate-limit slot — retried next run.
+        echo "[self-observe] create FAILED (will retry next run): $title  [$fp]"
     fi
-    filed=$((filed + 1))
 done < "$FINDINGS"
 
 if [ "$DRY_RUN" -eq 1 ]; then

--- a/tools/self-observe.sh
+++ b/tools/self-observe.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# tools/self-observe.sh — the federation's self-improvement driver (#1266 M3).
+#
+# Runs every tools/detect-*.sh, turns each finding into a SMALL, deduplicated,
+# rate-limited tracking issue, and (dry-run by default) proposes them. This is
+# the robust shape of self-tuning: observation is DETERMINISTIC (a shell scan,
+# no LLM — so no over-exploration or flakiness), and every finding becomes ONE
+# small issue the proven small-issue pipeline (code_writer) can fix — never a
+# giant epic.
+#
+# Each detector prints TSV findings on stdout:
+#   DRIFT<TAB><kind><TAB><location><TAB><text>
+# (see tools/detect-doc-drift.sh, tools/detect-todo-markers.sh, and
+#  tools/detect-agent-failures.sh once it lands).
+#
+# For each finding we compute a stable fingerprint, skip it when an open issue
+# already carries that fingerprint (dedup), cap new issues per run, and file a
+# small tracking issue with the fingerprint embedded in the body so the next run
+# dedups against it.
+#
+# Usage:
+#   tools/self-observe.sh            # DRY RUN: print what WOULD be filed
+#   tools/self-observe.sh --file     # actually create the issues
+#
+# Knobs (env):
+#   SELF_OBSERVE_REPO     owner/repo to file into (default Replikanti/agentis-colonies)
+#   SELF_OBSERVE_MAX_NEW  cap on new issues per run (default 5)
+#   SELF_OBSERVE_LABELS   comma-separated labels for filed issues (default dev-apprenticeship)
+#   SELF_OBSERVE_GH       gh binary (default gh; overridable for tests)
+#
+# Exit: 0 on success (even when there is nothing to file).
+set -eu
+
+DRY_RUN=1
+case "${1:-}" in
+    --file) DRY_RUN=0 ;;
+    "")     ;;
+    *)      echo "usage: self-observe.sh [--file]" >&2; exit 2 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="${SELF_OBSERVE_REPO:-Replikanti/agentis-colonies}"
+MAX_NEW="${SELF_OBSERVE_MAX_NEW:-5}"
+case "$MAX_NEW" in ''|*[!0-9]*) MAX_NEW=5 ;; esac
+LABELS="${SELF_OBSERVE_LABELS:-dev-apprenticeship}"
+GH="${SELF_OBSERVE_GH:-gh}"
+
+# Short, portable fingerprint of stdin (first 12 hex of sha256).
+fp_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum | cut -c1-12
+    else
+        shasum -a 256 | cut -c1-12
+    fi
+}
+
+# Normalize a finding's text: lowercase, collapse whitespace, trim — so
+# trivially-different wording fingerprints the same.
+normalize() {
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//'
+}
+
+# True when an open issue already carries this fingerprint in its body/text.
+issue_exists() {
+    local n
+    n="$("$GH" issue list --repo "$REPO" --state open --search "$1" --json number --jq 'length' 2>/dev/null || echo 0)"
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    [ "$n" -gt 0 ]
+}
+
+FINDINGS="$(mktemp)"
+trap 'rm -f "$FINDINGS"' EXIT
+
+# Collect findings from every detector (each self-resolves its own repo root).
+for det in "$SCRIPT_DIR"/detect-*.sh; do
+    [ -x "$det" ] || continue
+    "$det" 2>/dev/null >> "$FINDINGS" || true
+done
+
+filed=0
+considered=0
+tab="$(printf '\t')"
+# Read from the file (not a pipe) so the counters survive in this shell.
+while IFS="$tab" read -r tag kind loc text; do
+    [ "$tag" = "DRIFT" ] || continue
+    considered=$((considered + 1))
+    fp="$(printf '%s|~|%s|~|%s' "$kind" "$loc" "$(normalize "$text")" | fp_of)"
+    if issue_exists "$fp"; then
+        echo "[self-observe] skip (open issue exists): $kind $loc [$fp]"
+        continue
+    fi
+    if [ "$filed" -ge "$MAX_NEW" ]; then
+        echo "[self-observe] rate-limit reached ($MAX_NEW) — deferring: $kind $loc"
+        continue
+    fi
+    title="[self-observe] $kind: $loc"
+    body="$(printf 'Auto-detected by tools/self-observe.sh (%s detector).\n\n- **finding:** %s\n- **location:** %s\n\nA small, single-purpose self-improvement task for the federation.\n\n<!-- self-observe-fingerprint: %s -->\n' "$kind" "$text" "$loc" "$fp")"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "[self-observe] WOULD FILE: $title  [$fp]"
+    else
+        url="$("$GH" issue create --repo "$REPO" --title "$title" --body "$body" --label "$LABELS" 2>/dev/null || true)"
+        echo "[self-observe] FILED: $title -> ${url:-<create-failed>}  [$fp]"
+    fi
+    filed=$((filed + 1))
+done < "$FINDINGS"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[self-observe] done (dry-run): considered=$considered, would-file=$filed (cap $MAX_NEW). Re-run with --file to create them."
+else
+    echo "[self-observe] done: considered=$considered, filed=$filed (cap $MAX_NEW)."
+fi

--- a/tools/test-self-observe.sh
+++ b/tools/test-self-observe.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# tools/test-self-observe.sh: unit tests for tools/self-observe.sh (#1266 M3).
+#
+# Hermetic: runs self-observe.sh from a sandbox tools dir containing a single
+# stub detector, and points SELF_OBSERVE_GH at a stub `gh` whose search count
+# and create-log are controllable. No real gh / network / agentis needed.
+#
+#   1. dry-run: findings are reported as WOULD FILE; gh issue create is NOT called
+#   2. --file: each new finding triggers exactly one gh issue create
+#   3. dedup: when an open issue already carries the fingerprint, the finding is skipped
+#   4. rate-limit: no more than SELF_OBSERVE_MAX_NEW issues created per run
+#
+# Usage: ./tools/test-self-observe.sh   (exit 0 = all pass, 1 = failure)
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SELF_OBSERVE="$SCRIPT_DIR/self-observe.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/tools"
+cp "$SELF_OBSERVE" "$WORK/tools/self-observe.sh"
+chmod +x "$WORK/tools/self-observe.sh"
+SO="$WORK/tools/self-observe.sh"
+
+# Stub detector emitting $1 TSV findings. Lives alongside the copied
+# self-observe.sh so its detect-*.sh glob picks up only this one.
+write_detector() {
+    cat > "$WORK/tools/detect-stub.sh" <<EOF
+#!/usr/bin/env bash
+for i in \$(seq 1 $1); do
+    printf 'DRIFT\ttest-kind\tloc-%s\tsome finding text %s\n' "\$i" "\$i"
+done
+EOF
+    chmod +x "$WORK/tools/detect-stub.sh"
+}
+
+# Stub gh whose 'issue list' search returns the count baked in $1, and whose
+# 'issue create' appends to $WORK/create.log and prints a URL.
+write_gh() {
+    cat > "$WORK/gh" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "issue" ] && [ "\$2" = "list" ]; then echo "$1"; exit 0; fi
+if [ "\$1" = "issue" ] && [ "\$2" = "create" ]; then echo "create" >> "$WORK/create.log"; echo "https://example.test/issues/1"; exit 0; fi
+exit 0
+EOF
+    chmod +x "$WORK/gh"
+}
+
+run_so() {  # args passed to self-observe
+    SELF_OBSERVE_GH="$WORK/gh" SELF_OBSERVE_REPO="o/r" SELF_OBSERVE_LABELS="dev-apprenticeship" \
+        "$SO" "$@" 2>&1
+}
+creates() { [ -f "$WORK/create.log" ] && wc -l < "$WORK/create.log" | tr -d ' ' || echo 0; }
+
+# ---- Test 1: dry-run reports WOULD FILE and creates nothing ----
+write_detector 2; write_gh 0; rm -f "$WORK/create.log"
+OUT="$(run_so)"
+if [ "$(printf '%s\n' "$OUT" | grep -c 'WOULD FILE')" = "2" ] && [ "$(creates)" = "0" ]; then
+    pass "dry-run: 2 findings reported as WOULD FILE, gh create not called"
+else
+    fail "dry-run" "would=$(printf '%s\n' "$OUT" | grep -c 'WOULD FILE') creates=$(creates)"
+fi
+
+# ---- Test 2: --file creates one issue per new finding ----
+write_detector 2; write_gh 0; rm -f "$WORK/create.log"
+OUT="$(run_so --file)"
+if [ "$(creates)" = "2" ] && [ "$(printf '%s\n' "$OUT" | grep -c 'FILED:')" = "2" ]; then
+    pass "--file: 2 new findings -> 2 gh issue create calls"
+else
+    fail "--file create count" "creates=$(creates) filed=$(printf '%s\n' "$OUT" | grep -c 'FILED:')"
+fi
+
+# ---- Test 3: dedup skips findings whose fingerprint already has an open issue ----
+write_detector 2; write_gh 1; rm -f "$WORK/create.log"
+OUT="$(run_so --file)"
+if [ "$(creates)" = "0" ] && [ "$(printf '%s\n' "$OUT" | grep -c 'skip (open issue exists)')" = "2" ]; then
+    pass "dedup: existing-fingerprint findings are skipped, nothing created"
+else
+    fail "dedup" "creates=$(creates) skips=$(printf '%s\n' "$OUT" | grep -c 'skip')"
+fi
+
+# ---- Test 4: rate-limit caps creations at SELF_OBSERVE_MAX_NEW ----
+write_detector 5; write_gh 0; rm -f "$WORK/create.log"
+OUT="$(SELF_OBSERVE_MAX_NEW=2 run_so --file)"
+if [ "$(creates)" = "2" ] && printf '%s\n' "$OUT" | grep -q 'rate-limit reached'; then
+    pass "rate-limit: 5 findings, cap 2 -> exactly 2 created + rate-limit notice"
+else
+    fail "rate-limit" "creates=$(creates)"
+fi
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-self-observe.sh
+++ b/tools/test-self-observe.sh
@@ -94,6 +94,22 @@ else
     fail "rate-limit" "creates=$(creates)"
 fi
 
+# ---- Test 5: a failed gh issue create does NOT consume a rate-limit slot ----
+write_detector 2
+cat > "$WORK/gh" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "issue" ] && [ "\$2" = "list" ]; then echo 0; exit 0; fi
+if [ "\$1" = "issue" ] && [ "\$2" = "create" ]; then exit 1; fi
+exit 0
+EOF
+chmod +x "$WORK/gh"
+OUT="$(run_so --file)"
+if [ "$(printf '%s\n' "$OUT" | grep -c 'create FAILED')" = "2" ] && printf '%s\n' "$OUT" | grep -q 'filed=0'; then
+    pass "create-failure: reported as FAILED and does not consume a rate-limit slot (filed=0)"
+else
+    fail "create-failure" "$(printf '%s\n' "$OUT" | tail -3)"
+fi
+
 echo
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Part of #1266 (the self-improving loop). The **robust** shape of self-tuning, learned from the epic-in-one-job dead end: observation is **deterministic** (a shell scan, no LLM → no over-exploration/flakiness), and every finding becomes ONE small issue the proven small-issue pipeline can fix — never a monolithic epic.

## What it does

`tools/self-observe.sh` runs every `tools/detect-*.sh`, and for each `DRIFT<TAB>kind<TAB>location<TAB>text` finding:
1. computes a stable fingerprint (sha256 of kind/location/normalized-text, first 12 hex);
2. **dedups** — skips it if an open issue already carries that fingerprint;
3. **rate-limits** — at most `SELF_OBSERVE_MAX_NEW` (default 5) new issues per run;
4. files a small single-purpose tracking issue with the fingerprint embedded for next-run dedup.

**Dry-run by default** (prints what it WOULD file); `--file` actually creates them. This is the operator-safe equivalent of shadow/propose — eyeball the proposals before letting it file.

Knobs: `SELF_OBSERVE_REPO` / `SELF_OBSERVE_MAX_NEW` / `SELF_OBSERVE_LABELS` / `SELF_OBSERVE_GH`.

## Validation
- `bash -n` + `shellcheck`: clean.
- `tools/test-self-observe.sh` (stub `gh` + stub detector): **4/4** — dry-run files nothing, `--file` creates one per new finding, dedup skips existing fingerprints, rate-limit caps creations.
- colony-lint: 435/0.

Pairs with the `tools/detect-*.sh` family (`detect-doc-drift` #1267, `detect-todo-markers` #1272, `detect-agent-failures` #1278). Not yet wired as a federation sidecar — operator/cron runnable now; sidecar scheduling is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)