### PR TITLE
Add a self-observation detector that mirrors the shipped `detect-doc-drift.sh` and `detect-todo-markers.sh`: scan the federation's own agent logs for a fixed list of failure patterns and emit a TSV DRIFT line for each pattern recurring at least REPEAT_THRESHOLD (default 3) times, always exiting 0. Ship it alongside a fixture-based test that verifies a 3x pattern is reported with count 3 and a 1x pattern is suppressed.

### DIFF
--- a/tools/detect-agent-failures.sh
+++ b/tools/detect-agent-failures.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# tools/detect-agent-failures.sh: recurring federation self-failure detector (M3 of #1266).
+#
+# The self-observation detector: the federation watches its OWN agent logs for
+# recurring failure-pattern lines and prints one TSV line per pattern that
+# recurs at least REPEAT_THRESHOLD (default 3) times on stdout, then exits 0. It
+# is a DETECTOR, not a gate: it prints nothing when nothing recurs and never
+# fails the build.
+#
+# For each recurring pattern it prints:
+#
+#   DRIFT<TAB>agent-failure<TAB><pattern>:<count><TAB><a sample matching line>
+#
+# Fixed, case-sensitive substring patterns counted across the logs:
+#   produced no edits, ERROR job-failed, create-mr failed, monolithic fallback,
+#   memo write limit, and lines containing both `watchdog` and `restarting`.
+#
+# Dependency-free (bash + grep/sed only). The repo root is resolved relative to
+# this script's location so it runs from anywhere. Scans
+# ${AGENT_LOG_DIR:-<repo-root>/.agentis/logs} (env override used by the test).
+#
+# Usage: ./tools/detect-agent-failures.sh
+# Exit code: always 0.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LOG_DIR="${AGENT_LOG_DIR:-$REPO_ROOT/.agentis/logs}"
+REPEAT_THRESHOLD="${REPEAT_THRESHOLD:-3}"
+
+[ -d "$LOG_DIR" ] || exit 0
+
+# Emit a DRIFT line for <pattern> only when its count clears the threshold.
+report() {
+    pattern="$1"
+    count="$2"
+    sample="$3"
+    if [ "$count" -ge "$REPEAT_THRESHOLD" ]; then
+        sample="$(printf '%s' "$sample" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+        printf 'DRIFT\tagent-failure\t%s:%s\t%s\n' "$pattern" "$count" "$sample"
+    fi
+}
+
+# Simple fixed-string substring patterns (case-sensitive).
+for pattern in 'produced no edits' 'ERROR job-failed' 'create-mr failed' \
+               'monolithic fallback' 'memo write limit'; do
+    matches="$(grep -rhF -- "$pattern" "$LOG_DIR" 2>/dev/null || true)"
+    [ -n "$matches" ] || continue
+    count="$(printf '%s\n' "$matches" | grep -cF -- "$pattern")"
+    sample="$(printf '%s\n' "$matches" | head -n1)"
+    report "$pattern" "$count" "$sample"
+done
+
+# Combined pattern: lines containing BOTH `watchdog` and `restarting`.
+matches="$(grep -rhF -- 'watchdog' "$LOG_DIR" 2>/dev/null | grep -F -- 'restarting' || true)"
+if [ -n "$matches" ]; then
+    count="$(printf '%s\n' "$matches" | grep -c .)"
+    sample="$(printf '%s\n' "$matches" | head -n1)"
+    report 'watchdog+restarting' "$count" "$sample"
+fi
+
+exit 0

--- a/tools/test-detect-agent-failures.sh
+++ b/tools/test-detect-agent-failures.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# tools/test-detect-agent-failures.sh: unit tests for tools/detect-agent-failures.sh (M3 of #1266).
+#
+# Validates:
+#   Test 1: a pattern repeated 3x -> reported with count 3 (exact DRIFT TSV line)
+#   Test 2: a pattern appearing 1x -> NOT reported (below REPEAT_THRESHOLD)
+#   Test 3: detector always exits 0 (it is a detector, not a gate)
+#
+# The scanned logs dir is driven through AGENT_LOG_DIR so the assertions use a
+# throwaway fixture dir and never depend on the live federation logs.
+#
+# Usage: ./tools/test-detect-agent-failures.sh
+# Exit code 0 if all tests pass, 1 otherwise.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DETECTOR="$SCRIPT_DIR/detect-agent-failures.sh"
+
+if [ ! -x "$DETECTOR" ]; then
+    echo "[FAIL] tools/detect-agent-failures.sh missing or not executable"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# ----- Fixture logs: one pattern 3x (recurs), one pattern 1x (suppressed) -----
+printf 'ERROR job-failed at tick 1\nERROR job-failed at tick 2\nERROR job-failed at tick 3\n' \
+    > "$TMPDIR_TEST/agent-a.log"
+printf 'code_writer produced no edits this round\n' > "$TMPDIR_TEST/agent-b.log"
+
+OUT="$(AGENT_LOG_DIR="$TMPDIR_TEST" "$DETECTOR")"
+RC=$?
+
+# ----- Test 1: the 3x pattern is reported with count 3 -----
+EXPECTED="$(printf 'DRIFT\tagent-failure\tERROR job-failed:3\tERROR job-failed at tick 1')"
+if printf '%s\n' "$OUT" | grep -qxF "$EXPECTED"; then
+    pass "recurring: reports DRIFT line with count 3 for the 3x pattern"
+else
+    fail "recurring" "expected line <$EXPECTED>, got <$OUT>"
+fi
+
+# ----- Test 2: the 1x pattern is NOT reported -----
+if printf '%s\n' "$OUT" | grep -q 'produced no edits'; then
+    fail "suppressed" "expected no line for the 1x pattern, got <$OUT>"
+else
+    pass "suppressed: emits nothing for the pattern below REPEAT_THRESHOLD"
+fi
+
+# ----- Test 3: detector exits 0 -----
+if [ "$RC" -eq 0 ]; then
+    pass "exit 0 (detector, not gate)"
+else
+    fail "exit" "rc=$RC"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements #1278.

Issue:
{"iid": 1278, "title": "tools/detect-agent-failures.sh: detect recurring federation self-failures from agent logs (M3 of #1266)", "description": "Small, self-contained, mirrors the shipped `tools/detect-doc-drift.sh` (#1267) and `tools/detect-todo-markers.sh` (#1272). This is the **self-observation** detector: the federation watches its OWN logs for recurring failures.\n\n**Add `tools/detect-agent-failures.sh`** (bash + grep/sed only). Scan a logs directory for recurring failure-pattern lines and print one TSV line per pattern that recurs at least `REPEAT_THRESHOLD` (default 3) times:\n\n```\nDRIFT<TAB>agent-failure<TAB><pattern>:<count><TAB><a sample matching line>\n```\n\nPatterns to count (fixed list, case-sensitive substring): `produced no edits`, `ERROR job-failed`, `create-mr failed`, `monolithic fallback`, `memo write limit`, `watchdog`+`restarting`. Exit 0 always (detector, not a gate); print nothing if nothing recurs.\n\nScan `${AGENT_LOG_DIR:-<repo-root>/.agentis/logs}` (env override used by the test). Resolve repo root relative to the script.\n\n**Add `tools/test-detect-agent-failures.sh`** (existing `tools/test-*.sh` style): a fixture log dir with one pattern repeated 3x (assert it is reported with count 3) and one pattern appearing once (assert it is NOT reported). \n\nTiny scope: one detector + its test. Part of #1266 M3.", "state": "opened", "labels": ["dev-apprenticeship", "implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-22T19:33:17Z", "updated_at": "2026-06-22T19:33:17Z", "user_notes_count": 0, "priority": null}

Plan:
- `tools/detect-agent-failures.sh` — new bash+grep/sed detector. Resolves repo root relative to the script, scans `${AGENT_LOG_DIR:-<repo-root>/.agentis/logs}`, counts case-sensitive substring occurrences of the fixed pattern list (`produced no edits`, `ERROR job-failed`, `create-mr failed`, `monolithic fallback`, `memo write limit`, and lines containing both `watchdog` and `restarting`), and for each pattern recurring at least `REPEAT_THRESHOLD` (default 3) times prints one TSV line `DRIFT<TAB>agent-failure<TAB><pattern>:<count><TAB><sample matching line>`. Prints nothing when nothing recurs; always exits 0.
- `tools/test-detect-agent-failures.sh` — new test in the existing `tools/test-*.sh` style. Creates a temp fixture log dir with one pattern repeated 3x and another appearing once, runs the detector via `AGENT_LOG_DIR` override, asserts the 3x pattern is reported with count 3, asserts the 1x pattern is NOT reported, and cleans up the fixture.

Add a self-observation detector that mirrors the shipped `detect-doc-drift.sh` and `detect-todo-markers.sh`: scan the federation's own agent logs for a fixed list of failure patterns and emit a TSV DRIFT line for each pattern recurring at least REPEAT_THRESHOLD (default 3) times, always exiting 0. Ship it alongside a fixture-based test that verifies a 3x pattern is reported with count 3 and a 1x pattern is suppressed.