### PR TITLE
Harden the in-tree TODO detector so it stops surfacing markers from third-party and generated code: in tools/detect-todo-markers.sh, broaden the grep scan's --exclude-dir set beyond .git to also skip node_modules, .solc-cache, dist, build, target, __pycache__, and vendor. Add a unit test proving a TODO inside node_modules/ is not reported while a TODO in a normal file still is, keeping scope to one detector tweak plus one test as the issue specifies.

### DIFF
--- a/tools/detect-todo-markers.sh
+++ b/tools/detect-todo-markers.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 # tools/detect-todo-markers.sh: in-tree TODO/FIXME/XXX marker detector (M1 of #1266).
 #
-# Walks the repo tree (skipping .git/) and prints one TSV line per marker on
-# stdout, then exits 0. It is a DETECTOR, not a gate: it prints nothing when
-# there are no markers and never fails the build.
+# Walks the repo tree and prints one TSV line per marker on stdout, then exits
+# 0. It is a DETECTOR, not a gate: it prints nothing when there are no markers
+# and never fails the build.
+#
+# Vendored and generated directories are skipped so third-party / build output
+# does not surface as noise: .git, node_modules, .solc-cache, dist, build,
+# target, __pycache__, vendor (#1283).
 #
 # For every TODO, FIXME, or XXX marker it prints:
 #
@@ -30,9 +34,19 @@ ROOT="${DETECT_TODO_ROOT:-$REPO_ROOT}"
 [ -d "$ROOT" ] || exit 0
 
 # Scan from inside the root so grep emits paths relative to it. -I skips binary
-# files, -n adds line numbers, -E enables the alternation. .git/ is excluded.
+# files, -n adds line numbers, -E enables the alternation. Vendored/generated
+# directories are excluded so third-party / build output is not reported.
 cd "$ROOT" || exit 0
-grep -rInE 'TODO|FIXME|XXX' --exclude-dir=.git . 2>/dev/null | while IFS= read -r hit; do
+grep -rInE 'TODO|FIXME|XXX' \
+    --exclude-dir=.git \
+    --exclude-dir=node_modules \
+    --exclude-dir=.solc-cache \
+    --exclude-dir=dist \
+    --exclude-dir=build \
+    --exclude-dir=target \
+    --exclude-dir=__pycache__ \
+    --exclude-dir=vendor \
+    . 2>/dev/null | while IFS= read -r hit; do
     # grep output is "<file>:<line>:<content>"; peel the first two colon fields.
     file="${hit%%:*}"
     rest="${hit#*:}"

--- a/tools/test-detect-todo-markers.sh
+++ b/tools/test-detect-todo-markers.sh
@@ -5,6 +5,7 @@
 #   Test 1: a file carrying a TODO marker -> prints exactly the DRIFT TSV line
 #   Test 2: a clean file                  -> no line is emitted for it
 #   Test 3: detector always exits 0 (it is a detector, not a gate)
+#   Test 4: a TODO inside node_modules/   -> excluded, not reported (#1283)
 #
 # The scanned tree is driven through DETECT_TODO_ROOT so the assertions use a
 # throwaway fixture dir and never depend on the live repo contents.
@@ -30,9 +31,11 @@ fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
 TMPDIR_TEST="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_TEST"' EXIT
 
-# ----- Fixture tree: one marked file, one clean file -----
+# ----- Fixture tree: one marked file, one clean file, one vendored marker -----
 printf 'TODO: wire this up\n' > "$TMPDIR_TEST/marked.txt"
 printf 'all good here\n' > "$TMPDIR_TEST/clean.txt"
+mkdir -p "$TMPDIR_TEST/node_modules/some-pkg"
+printf 'TODO: third-party noise\n' > "$TMPDIR_TEST/node_modules/some-pkg/index.js"
 
 OUT="$(DETECT_TODO_ROOT="$TMPDIR_TEST" "$DETECTOR")"
 RC=$?
@@ -57,6 +60,13 @@ if [ "$RC" -eq 0 ]; then
     pass "exit 0 (detector, not gate)"
 else
     fail "exit" "rc=$RC"
+fi
+
+# ----- Test 4: TODO inside node_modules/ is excluded (#1283) -----
+if printf '%s\n' "$OUT" | grep -q 'node_modules'; then
+    fail "vendored" "expected no line for node_modules/, got <$OUT>"
+else
+    pass "vendored: skips the TODO inside node_modules/"
 fi
 
 echo ""


### PR DESCRIPTION
Implements #1283.

Issue:
{"iid": 1283, "title": "tools/detect-todo-markers.sh: exclude vendored/generated dirs (node_modules, .solc-cache, dist, .git)", "description": "Surfaced by a live `tools/self-observe.sh` dry-run: `detect-todo-markers.sh` reports TODO/FIXME/XXX markers inside `node_modules/` and `.solc-cache/` (third-party / generated code), which are noise and must not become self-improvement issues.\n\n**Fix:** in `tools/detect-todo-markers.sh`, exclude vendored/generated directories from the scan. Extend the `grep -r` exclusions beyond `.git` to also skip: `node_modules`, `.solc-cache`, `dist`, `build`, `target`, `__pycache__`, `vendor`. Use repeated `--exclude-dir=<name>` flags (already uses `--exclude-dir=.git`).\n\n**Test:** extend `tools/test-detect-todo-markers.sh` \u2014 add a fixture with a `TODO` inside a `node_modules/` subdir and assert it is NOT reported, while a `TODO` in a normal file still is.\n\nTiny scope: one detector tweak + a test case. Found by the federation observing itself (#1266 M3).", "state": "opened", "labels": ["dev-apprenticeship", "implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-22T20:50:32Z", "updated_at": "2026-06-22T20:50:32Z", "user_notes_count": 0, "priority": null}

Plan:
- `tools/detect-todo-markers.sh` — extend the `grep -rInE` scan to skip vendored/generated trees by adding repeated `--exclude-dir=` flags for `node_modules`, `.solc-cache`, `dist`, `build`, `target`, `__pycache__`, and `vendor` alongside the existing `--exclude-dir=.git`; update the header comment to document the excluded directories.
- `tools/test-detect-todo-markers.sh` — new self-contained unit test (the file does not yet exist despite the issue saying "extend"); builds a fixture tree under a temp `DETECT_TODO_ROOT`, asserts a `TODO` planted inside a `node_modules/` subdir is NOT emitted, asserts a `TODO` in a normal source file IS still emitted, and follows the existing `test-check-exec-sh.sh` PASS/FAIL + mktemp/trap-cleanup convention.

Harden the in-tree TODO detector so it stops surfacing markers from third-party and generated code: in tools/detect-todo-markers.sh, broaden the grep scan's --exclude-dir set beyond .git to also skip node_modules, .solc-cache, dist, build, target, __pycache__, and vendor. Add a unit test proving a TODO inside node_modules/ is not reported while a TODO in a normal file still is, keeping scope to one detector tweak plus one test as the issue specifies.