### PR TITLE
feat(start-federation): self-observe sidecar — close the self-tuning loop (#1266 M3)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -29,6 +29,14 @@ is asserted until multi-version CI is in place.
   (`detect-doc-drift` #1267, `detect-todo-markers` #1272, `detect-agent-failures`
   forthcoming #1278). Knobs: `SELF_OBSERVE_REPO` / `SELF_OBSERVE_MAX_NEW` /
   `SELF_OBSERVE_LABELS` / `SELF_OBSERVE_GH`.
+- **`start-federation.sh` self-observe sidecar** ([#1266](https://github.com/Replikanti/agentis-colonies/issues/1266)
+  M3) — closes the loop. An **opt-in** (`SELF_OBSERVE_SIDECAR=1`) background loop
+  that runs `tools/self-observe.sh` every `SELF_OBSERVE_INTERVAL_S` (default
+  3600s) so the federation continuously proposes its own work. **Dry-run by
+  default**; `SELF_OBSERVE_FILE=1` lets it actually file (dedup + rate-limit
+  bound the volume). Mirrors the auto-promote / cost-cap sidecar shape:
+  tick-first loop, self-terminates when no daemons run, EXIT/TERM/INT trap.
+  Points the self-failure detector at the federation's own `.agentis/logs`.
 
 ### Fixed
 

--- a/dev-apprenticeship/start-federation.sh
+++ b/dev-apprenticeship/start-federation.sh
@@ -360,4 +360,69 @@ else
     echo ""
 fi
 
+# --- Self-observe sidecar (#1266 M3) ---
+#
+# Periodically runs tools/self-observe.sh so the federation proposes its OWN
+# work — documentation drift, untracked TODOs, and recurring self-failures
+# scanned from its own .agentis/logs — as small, deduplicated, rate-limited
+# tracking issues. The robust shape of self-tuning: observation is a
+# deterministic shell scan (no LLM, no over-exploration), and every finding
+# becomes a SMALL issue the proven small-issue pipeline can fix.
+#
+# Opt-in: runs only when SELF_OBSERVE_SIDECAR=1 (default off — autonomous
+# issue filing on a shared tracker is a deliberate choice). DRY-RUN by default
+# (proposals go to the log only); set SELF_OBSERVE_FILE=1 to actually create
+# issues — dedup + the SELF_OBSERVE_MAX_NEW rate-limit bound the volume.
+# Mirrors the other sidecars: tick-first loop, self-terminate when the
+# federation has zero running daemons, EXIT/TERM/INT trap.
+SELF_OBSERVE_PID=""
+if [ "${SELF_OBSERVE_SIDECAR:-0}" = "1" ]; then
+    SO_INTERVAL="${SELF_OBSERVE_INTERVAL_S:-3600}"
+    case "$SO_INTERVAL" in
+        ''|*[!0-9]*) SO_INTERVAL=3600 ;;
+        *) [ "$SO_INTERVAL" -gt 0 ] || SO_INTERVAL=3600 ;;
+    esac
+    SO_SCRIPT="$SCRIPT_DIR/../tools/self-observe.sh"
+    if [ ! -x "$SO_SCRIPT" ]; then
+        echo "[!!] Self-observe sidecar: tools/self-observe.sh not executable, skipping."
+    else
+        SO_LOG_DIR="$FED_DIR/.agentis/logs"
+        SO_LOG="$SO_LOG_DIR/self-observe.log"
+        mkdir -p "$SO_LOG_DIR"
+        if [ "${SELF_OBSERVE_FILE:-0}" = "1" ]; then SO_MODE_LABEL="--file"; else SO_MODE_LABEL="dry-run"; fi
+        date +%s > "$SO_LOG_DIR/self-observe.sidecar_started_at"
+        (
+            # First action is a tick (not a sleep) so a proposal pass appears
+            # immediately after spawn. AGENT_LOG_DIR points the self-failure
+            # detector at this federation's own daemon logs. GH auth rides the
+            # forge token already in the environment.
+            while :; do
+                if ! agentis daemon list --json 2>/dev/null | grep -Fq '"state":"running"'; then
+                    printf '=== %s: no running daemons; sidecar exiting ===\n' \
+                        "$(date -Iseconds)" >> "$SO_LOG"
+                    exit 0
+                fi
+                {
+                    printf '=== %s: self-observe tick (%s) ===\n' "$(date -Iseconds)" "$SO_MODE_LABEL"
+                    if [ "${SELF_OBSERVE_FILE:-0}" = "1" ]; then
+                        AGENT_LOG_DIR="$SO_LOG_DIR" GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" \
+                            "$SO_SCRIPT" --file 2>&1 \
+                            || printf '[sidecar] self-observe.sh exited %s\n' "$?"
+                    else
+                        AGENT_LOG_DIR="$SO_LOG_DIR" GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" \
+                            "$SO_SCRIPT" 2>&1 \
+                            || printf '[sidecar] self-observe.sh exited %s\n' "$?"
+                    fi
+                } >> "$SO_LOG"
+                sleep "$SO_INTERVAL"
+            done
+        ) &
+        SELF_OBSERVE_PID=$!
+        # shellcheck disable=SC2064  # Expand PID at trap-install time, not at trigger time.
+        trap "[ -n \"\${AUTO_PROMOTE_PID:-}\" ] && kill \"\$AUTO_PROMOTE_PID\" 2>/dev/null; [ -n \"\${COST_CAP_PID:-}\" ] && kill \"\$COST_CAP_PID\" 2>/dev/null; [ -n \"\${SNAPSHOT_REFRESH_PID:-}\" ] && kill \"\$SNAPSHOT_REFRESH_PID\" 2>/dev/null; [ -n \"\${COST_RATE_PID:-}\" ] && kill \"\$COST_RATE_PID\" 2>/dev/null; [ -n \"$SELF_OBSERVE_PID\" ] && kill \"$SELF_OBSERVE_PID\" 2>/dev/null; exit" EXIT TERM INT
+        echo "Self-observe sidecar: PID $SELF_OBSERVE_PID, every ${SO_INTERVAL}s ($SO_MODE_LABEL) (log: .agentis/logs/self-observe.log)"
+        echo ""
+    fi
+fi
+
 wait


### PR DESCRIPTION
Closes the #1266 self-improving loop: a periodic, deterministic self-observation pass wired as a `start-federation.sh` sidecar.

## What
An **opt-in** (`SELF_OBSERVE_SIDECAR=1`, default off) background loop that runs `tools/self-observe.sh` every `SELF_OBSERVE_INTERVAL_S` (default 3600s) so the federation continuously proposes its own work (doc drift, untracked TODOs, recurring self-failures scanned from its own `.agentis/logs`) as small, deduplicated, rate-limited tracking issues.

- **Dry-run by default**; `SELF_OBSERVE_FILE=1` lets it actually file (dedup + `SELF_OBSERVE_MAX_NEW` bound the volume) — autonomous filing on a shared tracker is a deliberate switch.
- Mirrors the existing auto-promote / cost-cap / snapshot-refresh / cost-rate sidecars exactly: tick-first loop, self-terminates when no daemons run, EXIT/TERM/INT trap (extended to include `SELF_OBSERVE_PID` alongside the other four).

## Safety / scope
- When `SELF_OBSERVE_SIDECAR` is unset (the default), the block is a no-op — **zero behaviour change** to the existing launch.
- `bash -n` + `shellcheck` clean (the only shellcheck output is the two pre-existing SC1091 `source` infos on the auto-promote/cost-cap blocks, unrelated to this change).
- colony-lint: 437/0.

The loop already closed end-to-end once today (self-observe found `node_modules` TODO noise → #1283 filed → the federation fixed it autonomously in #1284); this sidecar makes that cycle continuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)