### PR TITLE
Add `.agentis` and `targets` to the directory exclusion list in `detect-todo-markers.sh` so the scanner stops flagging TODO/FIXME markers inside run-dir workspace clones and vendored tribes-bench crate build outputs. Cover both with fixture-backed tests mirroring the existing node_modules exclusion test. Scope is tiny and self-contained, matching the precedent set by #1283.

### DIFF
--- a/tools/detect-todo-markers.sh
+++ b/tools/detect-todo-markers.sh
@@ -7,7 +7,9 @@
 #
 # Vendored and generated directories are skipped so third-party / build output
 # does not surface as noise: .git, node_modules, .solc-cache, dist, build,
-# target, __pycache__, vendor (#1283).
+# target, __pycache__, vendor (#1283), plus .agentis (run-dir state +
+# per-issue workspace clones) and targets (tribes-bench vendored crate
+# builds) (#1287).
 #
 # For every TODO, FIXME, or XXX marker it prints:
 #
@@ -46,6 +48,8 @@ grep -rInE 'TODO|FIXME|XXX' \
     --exclude-dir=target \
     --exclude-dir=__pycache__ \
     --exclude-dir=vendor \
+    --exclude-dir=.agentis \
+    --exclude-dir=targets \
     . 2>/dev/null | while IFS= read -r hit; do
     # grep output is "<file>:<line>:<content>"; peel the first two colon fields.
     file="${hit%%:*}"

--- a/tools/test-detect-todo-markers.sh
+++ b/tools/test-detect-todo-markers.sh
@@ -6,6 +6,8 @@
 #   Test 2: a clean file                  -> no line is emitted for it
 #   Test 3: detector always exits 0 (it is a detector, not a gate)
 #   Test 4: a TODO inside node_modules/   -> excluded, not reported (#1283)
+#   Test 5: a TODO inside .agentis/        -> excluded, not reported (#1287)
+#   Test 6: a TODO inside targets/         -> excluded, not reported (#1287)
 #
 # The scanned tree is driven through DETECT_TODO_ROOT so the assertions use a
 # throwaway fixture dir and never depend on the live repo contents.
@@ -36,6 +38,10 @@ printf 'TODO: wire this up\n' > "$TMPDIR_TEST/marked.txt"
 printf 'all good here\n' > "$TMPDIR_TEST/clean.txt"
 mkdir -p "$TMPDIR_TEST/node_modules/some-pkg"
 printf 'TODO: third-party noise\n' > "$TMPDIR_TEST/node_modules/some-pkg/index.js"
+mkdir -p "$TMPDIR_TEST/.agentis/workspaces/implementation/issue-1/src"
+printf 'TODO: run-dir clone noise\n' > "$TMPDIR_TEST/.agentis/workspaces/implementation/issue-1/src/foo.rs"
+mkdir -p "$TMPDIR_TEST/tribes-bench/targets/stage1/deps"
+printf 'TODO: vendored crate noise\n' > "$TMPDIR_TEST/tribes-bench/targets/stage1/deps/bar.rs"
 
 OUT="$(DETECT_TODO_ROOT="$TMPDIR_TEST" "$DETECTOR")"
 RC=$?
@@ -67,6 +73,20 @@ if printf '%s\n' "$OUT" | grep -q 'node_modules'; then
     fail "vendored" "expected no line for node_modules/, got <$OUT>"
 else
     pass "vendored: skips the TODO inside node_modules/"
+fi
+
+# ----- Test 5: TODO inside .agentis/ is excluded (#1287) -----
+if printf '%s\n' "$OUT" | grep -q '.agentis'; then
+    fail "run-dir" "expected no line for .agentis/, got <$OUT>"
+else
+    pass "run-dir: skips the TODO inside .agentis/ workspace clones"
+fi
+
+# ----- Test 6: TODO inside targets/ is excluded (#1287) -----
+if printf '%s\n' "$OUT" | grep -q 'targets'; then
+    fail "crate-targets" "expected no line for targets/, got <$OUT>"
+else
+    pass "crate-targets: skips the TODO inside tribes-bench targets/"
 fi
 
 echo ""


### PR DESCRIPTION
Implements #1287.

Issue:
{"iid": 1287, "title": "tools/detect-todo-markers.sh: also exclude vendored crate targets + run-dir workspaces (.agentis/workspaces, tribes-bench/targets)", "description": "Surfaced by the live `self-observe.sh` sidecar running against the federation run dir: `detect-todo-markers.sh` still reports TODO/FIXME in vendored Rust crate targets (`tribes-bench/targets/stage*/.../*.rs`) and in per-issue workspace clones under `.agentis/workspaces/`. Same noise class as #1283 (node_modules).\n\n**Fix:** extend the `--exclude-dir` set in `tools/detect-todo-markers.sh` to also skip `.agentis` (the run-dir state + workspace clones) and `targets` (tribes-bench vendored crates), alongside the node_modules/.solc-cache/dist/build/target/__pycache__/vendor already excluded in #1283. Add a fixture-backed test case for a TODO under `.agentis/` and under `targets/` asserting both are skipped.\n\nTiny scope. Found by the federation self-observing in production (#1266 M3 loop).", "state": "opened", "labels": ["dev-apprenticeship"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-22T22:00:17Z", "updated_at": "2026-06-22T22:08:09Z", "user_notes_count": 0, "priority": null}

Plan:
- `tools/detect-todo-markers.sh` — extend the `--exclude-dir` set to also skip `.agentis` (run-dir state + per-issue workspace clones) and `targets` (tribes-bench vendored Rust crate builds), alongside the existing node_modules/.solc-cache/dist/build/target/__pycache__/vendor exclusions from #1283.
- `tools/detect-todo-markers.test.sh` — add two fixture-backed cases: a TODO under `.agentis/workspaces/.../foo.rs` and a TODO under `tribes-bench/targets/stage1/.../bar.rs`, each asserting the marker is NOT reported, reusing the temp-fixture harness from the #1283 node_modules case.

Add `.agentis` and `targets` to the directory exclusion list in `detect-todo-markers.sh` so the scanner stops flagging TODO/FIXME markers inside run-dir workspace clones and vendored tribes-bench crate build outputs. Cover both with fixture-backed tests mirroring the existing node_modules exclusion test. Scope is tiny and self-contained, matching the precedent set by #1283.