### PR TITLE
fix(detect-todo-markers): exclude .agentis run-dir + targets vendored crates (#1287)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -40,6 +40,15 @@ is asserted until multi-version CI is in place.
 
 ### Fixed
 
+- **`detect-todo-markers.sh` also excludes run-dir state and vendored crate
+  targets** ([#1287](https://github.com/Replikanti/agentis-colonies/issues/1287)).
+  Surfaced by the live `self-observe.sh` sidecar: the TODO scan still reported
+  markers inside `.agentis/` (run-dir state + per-issue workspace clones) and
+  `targets/` (tribes-bench vendored crates). Added both to the `--exclude-dir`
+  set (alongside the node_modules/.solc-cache/… excludes from #1283), so
+  self-observation no longer proposes vendored/run-dir noise — the gate that
+  makes autonomous `--file` filing clean. Test extended with `.agentis/` and
+  `targets/` fixtures (6/6).
 - **`code_writer` epic auto-decompose (#1257) now actually fires**
   ([#1271](https://github.com/Replikanti/agentis-colonies/issues/1271)). Two
   stacked defects kept `--decompose` from ever being passed for an epic: (1) the

--- a/tools/detect-todo-markers.sh
+++ b/tools/detect-todo-markers.sh
@@ -46,6 +46,8 @@ grep -rInE 'TODO|FIXME|XXX' \
     --exclude-dir=target \
     --exclude-dir=__pycache__ \
     --exclude-dir=vendor \
+    --exclude-dir=.agentis \
+    --exclude-dir=targets \
     . 2>/dev/null | while IFS= read -r hit; do
     # grep output is "<file>:<line>:<content>"; peel the first two colon fields.
     file="${hit%%:*}"

--- a/tools/test-detect-todo-markers.sh
+++ b/tools/test-detect-todo-markers.sh
@@ -36,6 +36,10 @@ printf 'TODO: wire this up\n' > "$TMPDIR_TEST/marked.txt"
 printf 'all good here\n' > "$TMPDIR_TEST/clean.txt"
 mkdir -p "$TMPDIR_TEST/node_modules/some-pkg"
 printf 'TODO: third-party noise\n' > "$TMPDIR_TEST/node_modules/some-pkg/index.js"
+mkdir -p "$TMPDIR_TEST/.agentis/workspaces/x"
+printf 'TODO: run-dir clone noise\n' > "$TMPDIR_TEST/.agentis/workspaces/x/foo.sh"
+mkdir -p "$TMPDIR_TEST/targets/vendored-crate/src"
+printf 'TODO: vendored crate noise\n' > "$TMPDIR_TEST/targets/vendored-crate/src/lib.rs"
 
 OUT="$(DETECT_TODO_ROOT="$TMPDIR_TEST" "$DETECTOR")"
 RC=$?
@@ -67,6 +71,20 @@ if printf '%s\n' "$OUT" | grep -q 'node_modules'; then
     fail "vendored" "expected no line for node_modules/, got <$OUT>"
 else
     pass "vendored: skips the TODO inside node_modules/"
+fi
+
+# ----- Test 5: TODO inside .agentis/ (run-dir state + workspace clones) excluded (#1287) -----
+if printf '%s\n' "$OUT" | grep -q '\.agentis'; then
+    fail "run-dir" "expected no line for .agentis/, got <$OUT>"
+else
+    pass "run-dir: skips the TODO inside .agentis/"
+fi
+
+# ----- Test 6: TODO inside targets/ (vendored crate targets) excluded (#1287) -----
+if printf '%s\n' "$OUT" | grep -q 'targets/'; then
+    fail "targets" "expected no line for targets/, got <$OUT>"
+else
+    pass "targets: skips the TODO inside targets/"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #1287. Surfaced live by the `self-observe.sh` sidecar.

`detect-todo-markers.sh` still reported TODO/FIXME inside `.agentis/` (run-dir state + per-issue workspace clones) and `targets/` (tribes-bench vendored crates). Added both to the `--exclude-dir` set alongside the node_modules/.solc-cache/dist/build/target/__pycache__/vendor excludes from #1283. This is the noise gate that makes autonomous `--file` self-observation clean.

Test extended with `.agentis/` and `targets/` fixtures asserting both are skipped (6/6). `bash -n` + `shellcheck` clean; colony-lint 437/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)