### PR TITLE
fix(self-observe): clean detectors for unattended --file (recency window + test/md/self-log excludes) (#1293)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -40,6 +40,18 @@ is asserted until multi-version CI is in place.
 
 ### Fixed
 
+- **self-observe detectors are clean enough for unattended `--file`**
+  ([#1293](https://github.com/Replikanti/agentis-colonies/issues/1293)) — the
+  last noise gate, surfaced by a controlled live `--file` run. `detect-todo-markers.sh`
+  now also excludes `test-*.sh` files (it was matching TODO literals inside test
+  fixtures, including its own) and `*.md` files (README/scaffold placeholder
+  TODOs). `detect-agent-failures.sh` gained a **recency window**
+  (`AGENT_LOG_WINDOW_LINES`, default 800): it counts only failures within the
+  last N lines of each log, so historical/cumulative churn (e.g. a since-fixed
+  `watchdog+restarting` incident) is no longer re-filed as if current — and it
+  **excludes the self-observe sidecar's own log** (its echoed proposals contain
+  the very failure phrases it counts). Tests: agent-failures 5/5 (recency +
+  self-exclude), todo-markers 8/8 (test-file + markdown excludes).
 - **`detect-todo-markers.sh` also excludes run-dir state and vendored crate
   targets** ([#1287](https://github.com/Replikanti/agentis-colonies/issues/1287)).
   Surfaced by the live `self-observe.sh` sidecar: the TODO scan still reported

--- a/tools/detect-agent-failures.sh
+++ b/tools/detect-agent-failures.sh
@@ -29,8 +29,24 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 LOG_DIR="${AGENT_LOG_DIR:-$REPO_ROOT/.agentis/logs}"
 REPEAT_THRESHOLD="${REPEAT_THRESHOLD:-3}"
+# Recency window (#1293): only count failures within the last N lines of each
+# log, so historical/cumulative churn (e.g. a since-fixed incident) is not
+# re-reported as if it were happening now.
+WINDOW="${AGENT_LOG_WINDOW_LINES:-800}"
+case "$WINDOW" in ''|*[!0-9]*) WINDOW=800 ;; esac
 
 [ -d "$LOG_DIR" ] || exit 0
+
+# Build a "recent" stream = the last WINDOW lines of each *.log, EXCLUDING the
+# self-observe sidecar's own log (#1293): its echoed proposals contain the very
+# failure phrases we count, which would be self-referential noise.
+RECENT="$(mktemp)"
+trap 'rm -f "$RECENT"' EXIT
+for _f in "$LOG_DIR"/*.log; do
+    [ -f "$_f" ] || continue
+    case "$(basename "$_f")" in self-observe.log) continue ;; esac
+    tail -n "$WINDOW" "$_f" 2>/dev/null >> "$RECENT" || true
+done
 
 # Emit a DRIFT line for <pattern> only when its count clears the threshold.
 report() {
@@ -46,15 +62,15 @@ report() {
 # Simple fixed-string substring patterns (case-sensitive).
 for pattern in 'produced no edits' 'ERROR job-failed' 'create-mr failed' \
                'monolithic fallback' 'memo write limit'; do
-    matches="$(grep -rhF -- "$pattern" "$LOG_DIR" 2>/dev/null || true)"
-    [ -n "$matches" ] || continue
-    count="$(printf '%s\n' "$matches" | grep -cF -- "$pattern")"
-    sample="$(printf '%s\n' "$matches" | head -n1)"
+    count="$(grep -cF -- "$pattern" "$RECENT" 2>/dev/null || true)"
+    case "$count" in ''|*[!0-9]*) count=0 ;; esac
+    [ "$count" -gt 0 ] || continue
+    sample="$(grep -F -- "$pattern" "$RECENT" 2>/dev/null | head -n1)"
     report "$pattern" "$count" "$sample"
 done
 
 # Combined pattern: lines containing BOTH `watchdog` and `restarting`.
-matches="$(grep -rhF -- 'watchdog' "$LOG_DIR" 2>/dev/null | grep -F -- 'restarting' || true)"
+matches="$(grep -F -- 'watchdog' "$RECENT" 2>/dev/null | grep -F -- 'restarting' || true)"
 if [ -n "$matches" ]; then
     count="$(printf '%s\n' "$matches" | grep -c .)"
     sample="$(printf '%s\n' "$matches" | head -n1)"

--- a/tools/detect-todo-markers.sh
+++ b/tools/detect-todo-markers.sh
@@ -48,6 +48,8 @@ grep -rInE 'TODO|FIXME|XXX' \
     --exclude-dir=vendor \
     --exclude-dir=.agentis \
     --exclude-dir=targets \
+    --exclude='test-*.sh' \
+    --exclude='*.md' \
     . 2>/dev/null | while IFS= read -r hit; do
     # grep output is "<file>:<line>:<content>"; peel the first two colon fields.
     file="${hit%%:*}"

--- a/tools/test-detect-agent-failures.sh
+++ b/tools/test-detect-agent-failures.sh
@@ -60,6 +60,28 @@ else
     fail "exit" "rc=$RC"
 fi
 
+# ----- Test 4: recency window — matches older than the window are not counted (#1293) -----
+WIN_DIR="$(mktemp -d)"
+printf 'create-mr failed once\ncreate-mr failed twice\ncreate-mr failed thrice\nrecent line A\nrecent line B\n' > "$WIN_DIR/agent.log"
+OUT_W="$(AGENT_LOG_DIR="$WIN_DIR" AGENT_LOG_WINDOW_LINES=2 "$DETECTOR")"
+rm -rf "$WIN_DIR"
+if printf '%s\n' "$OUT_W" | grep -q 'create-mr failed'; then
+    fail "recency" "window=2 must exclude the 3 older matches, got <$OUT_W>"
+else
+    pass "recency: matches older than the window are not counted"
+fi
+
+# ----- Test 5: the self-observe sidecar's own log is excluded (#1293) -----
+SO_DIR="$(mktemp -d)"
+printf 'produced no edits\nproduced no edits\nproduced no edits\n' > "$SO_DIR/self-observe.log"
+OUT_SO="$(AGENT_LOG_DIR="$SO_DIR" "$DETECTOR")"
+rm -rf "$SO_DIR"
+if printf '%s\n' "$OUT_SO" | grep -q 'produced no edits'; then
+    fail "self-exclude" "self-observe.log must be excluded, got <$OUT_SO>"
+else
+    pass "self-exclude: skips the self-observe sidecar's own log"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tools/test-detect-todo-markers.sh
+++ b/tools/test-detect-todo-markers.sh
@@ -40,6 +40,8 @@ mkdir -p "$TMPDIR_TEST/.agentis/workspaces/x"
 printf 'TODO: run-dir clone noise\n' > "$TMPDIR_TEST/.agentis/workspaces/x/foo.sh"
 mkdir -p "$TMPDIR_TEST/targets/vendored-crate/src"
 printf 'TODO: vendored crate noise\n' > "$TMPDIR_TEST/targets/vendored-crate/src/lib.rs"
+printf 'TODO: test fixture literal\n' > "$TMPDIR_TEST/test-something.sh"
+printf '# TODO: scaffold readme placeholder\n' > "$TMPDIR_TEST/notes.md"
 
 OUT="$(DETECT_TODO_ROOT="$TMPDIR_TEST" "$DETECTOR")"
 RC=$?
@@ -85,6 +87,20 @@ if printf '%s\n' "$OUT" | grep -q 'targets/'; then
     fail "targets" "expected no line for targets/, got <$OUT>"
 else
     pass "targets: skips the TODO inside targets/"
+fi
+
+# ----- Test 7: TODO inside a test-*.sh file is excluded (#1293) -----
+if printf '%s\n' "$OUT" | grep -q 'test-something.sh'; then
+    fail "test-file" "expected no line for test-*.sh, got <$OUT>"
+else
+    pass "test-file: skips the TODO inside a test-*.sh file"
+fi
+
+# ----- Test 8: TODO inside a .md file (README/doc placeholder) is excluded (#1293) -----
+if printf '%s\n' "$OUT" | grep -q 'notes.md'; then
+    fail "markdown" "expected no line for *.md, got <$OUT>"
+else
+    pass "markdown: skips the TODO inside a .md file"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #1293 — the last noise gate before the self-observe sidecar can run `--file` unattended, surfaced by a controlled live `--file` run.

- **`detect-todo-markers.sh`**: also `--exclude='test-*.sh'` (it matched TODO literals inside test fixtures — including its own test's) and `--exclude='*.md'` (README/scaffold placeholder TODOs).
- **`detect-agent-failures.sh`**: added a **recency window** (`AGENT_LOG_WINDOW_LINES`, default 800) — counts only failures within the last N lines of each log, so historical/cumulative churn (e.g. a since-fixed `watchdog+restarting` incident) is not re-filed as if current; and it **excludes `self-observe.log`** (the sidecar's echoed proposals contain the very failure phrases it counts → self-reference).

Tests: `test-detect-agent-failures.sh` 5/5 (adds recency-window + self-log-exclude), `test-detect-todo-markers.sh` 8/8 (adds test-file + markdown excludes). `bash -n` + `shellcheck` clean; colony-lint 437/0.

With this merged + deployed, the `start-federation.sh` self-observe sidecar can be flipped to autonomous filing (`SELF_OBSERVE_FILE=1`) without filing vendored/test/historical noise — the final close of the #1266 self-tuning loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)