### PR TITLE
Federation PRs open with `Implements #<n>`, which GitHub/GitLab treat as a bare mention — no linked-issue/development link is created and the issue never auto-closes on merge. The fix swaps the leading keyword in code-edit-in-checkout.sh's DESCRIPTION (line 613) to the closing keyword `Closes #<n>`, valid on both forges, and adds an assertion to the existing test harness that the generated create-mr description leads with `Closes`. Picked over the more severe #1301 because that one already has open PR #1307 in flight.

### DIFF
--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -610,7 +610,7 @@ run_git -C "$WS" push --force-with-lease origin "$BRANCH"
 #    flags (--source/--title/--description) are forge-symmetric; only the env
 #    contract differs (github: OWNER/REPO/URL; gitlab: PROJECT/URL).
 # ---------------------------------------------------------------------------
-DESCRIPTION="Implements #$ISSUE.
+DESCRIPTION="Closes #$ISSUE.
 
 $TASK"
 

--- a/tools/test-code-edit-in-checkout.sh
+++ b/tools/test-code-edit-in-checkout.sh
@@ -101,17 +101,20 @@ if [ "\${1:-}" != "create-mr" ]; then
     exit 1
 fi
 shift
-SRC=""; TITLE=""
+SRC=""; TITLE=""; DESC=""
 while [ \$# -gt 0 ]; do
     case "\$1" in
         --source) SRC="\$2"; shift 2 ;;
         --title) TITLE="\$2"; shift 2 ;;
-        --description) shift 2 ;;
+        --description) DESC="\$2"; shift 2 ;;
         *) shift ;;
     esac
 done
 {
     echo "create-mr source=\$SRC title=\$TITLE"
+    # Record only the leading line of the description so the harness can assert
+    # it opens with a recognised closing keyword (#1308).
+    echo "desc_firstline=\$(printf '%s' "\$DESC" | head -n1)"
     echo "token_seen=\${GITHUB_TOKEN:-MISSING}"
     echo "owner=\${GITHUB_OWNER:-} repo=\${GITHUB_REPO:-}"
 } >> "$CREATE_MR_LOG"
@@ -242,6 +245,20 @@ if grep -q "token_seen=$FAKE_TOKEN" "$CREATE_MR_LOG"; then
     pass "run 1: token reached create-mr via the environment (never argv)"
 else
     fail "run 1: token passed to create-mr via env"
+fi
+# The PR/MR description must lead with a recognised closing keyword so the forge
+# creates the linked-issue/development link and auto-closes the issue on merge
+# (#1308). `Closes #<iid>` is valid on both GitHub and GitLab; `Implements` is
+# not and must never reappear.
+if grep -q "^desc_firstline=Closes #42\." "$CREATE_MR_LOG"; then
+    pass "run 1: create-mr description leads with the closing keyword (Closes #<iid>)"
+else
+    fail "run 1: description must lead with 'Closes #<iid>'" "log=$(cat "$CREATE_MR_LOG" 2>/dev/null)"
+fi
+if grep -q "^desc_firstline=Implements" "$CREATE_MR_LOG"; then
+    fail "run 1: description must NOT lead with the non-closing 'Implements' keyword"
+else
+    pass "run 1: description does not regress to the non-closing 'Implements' keyword"
 fi
 
 # flat-cyborg was driven as an editing agent with the FULL driving flag set:


### PR DESCRIPTION
Implements #1308.

Issue:
{"iid": 1308, "title": "code-edit-in-checkout.sh: PR body uses 'Implements #N' (not a closing keyword) \u2014 federation PRs never link/auto-close their issue", "description": "## Summary\n\nThe PR/MR body that the implementation colony opens uses **`Implements #<issue>`**, which GitHub treats only as a *mention*, not a *closing keyword*. As a result every federation PR:\n\n- does **not** create a linked-issue / development link, and\n- does **not** auto-close its issue on merge.\n\n## Root cause\n\n`tools/code-edit-in-checkout.sh` builds the PR description as:\n\n```sh\nDESCRIPTION=\"Implements #$ISSUE. ...\"\n```\n\nGitHub only links + auto-closes on `close|closes|closed`, `fix|fixes|fixed`, or `resolve|resolves|resolved` followed by `#<n>`. `Implements #<n>` is none of these, so `closedByPullRequestsReferences` for the issue stays empty.\n\n## Suggested fix\n\nChange the leading keyword to a closing one, e.g. `Closes #$ISSUE.` (keep the rest of the description). One-line change in `tools/code-edit-in-checkout.sh`.\n\nMind the GitLab path too: GitLab auto-closes MRs on `Closes #<iid>` / `Closes <project>#<iid>` in the MR description, so `Closes` works for both forges (the current `Implements` does not auto-close on either).\n\n## Test\n\nExtend `tools/test-code-edit-in-checkout.sh` to assert the generated description begins with a recognised closing keyword (`Closes #<n>`), not `Implements`.\n\n_Found by dogfooding: PR #1307 (for #1301) opened with `Implements #1301` and showed no linked issue until the body was hand-edited to `Closes #1301`._\n", "state": "opened", "labels": ["bug", "needs-implementation", "dev-apprenticeship", "implementation"], "assignees": [{"username": "ylohnitram"}], "author": {"username": "ylohnitram"}, "created_at": "2026-06-23T22:47:48Z", "updated_at": "2026-06-23T22:47:50Z", "user_notes_count": 0, "priority": null}

Plan:
- `tools/code-edit-in-checkout.sh` — change the PR/MR `DESCRIPTION` at line 613 from `Implements #$ISSUE.` to `Closes #$ISSUE.` so the body leads with a recognised closing keyword; GitHub then creates the linked-issue/development link and auto-closes on merge, and GitLab auto-closes the MR on `Closes #<iid>` too. The trailing `\n\n$TASK` body is left unchanged, so only the leading keyword moves.
- `tools/test-code-edit-in-checkout.sh` — extend the existing run-1 create-mr assertions (the harness already records the wrapper invocation, including `--description`, in `$CREATE_MR_LOG`) to assert the captured description begins with `Closes #<iid>` and is not `Implements`, locking the fix against regression on both forges.

Federation PRs open with `Implements #<n>`, which GitHub/GitLab treat as a bare mention — no linked-issue/development link is created and the issue never auto-closes on merge. The fix swaps the leading keyword in code-edit-in-checkout.sh's DESCRIPTION (line 613) to the closing keyword `Closes #<n>`, valid on both forges, and adds an assertion to the existing test harness that the generated create-mr description leads with `Closes`. Picked over the more severe #1301 because that one already has open PR #1307 in flight.