### PR TITLE
fix(detect-todo-markers): exclude scaffolding templates + leaked tmp files

### DIFF
--- a/tools/detect-todo-markers.sh
+++ b/tools/detect-todo-markers.sh
@@ -50,6 +50,8 @@ grep -rInE 'TODO|FIXME|XXX' \
     --exclude-dir=targets \
     --exclude='test-*.sh' \
     --exclude='*.md' \
+    --exclude='new-*.sh' \
+    --exclude='tmp.*' \
     . 2>/dev/null | while IFS= read -r hit; do
     # grep output is "<file>:<line>:<content>"; peel the first two colon fields.
     file="${hit%%:*}"

--- a/tools/test-detect-todo-markers.sh
+++ b/tools/test-detect-todo-markers.sh
@@ -42,6 +42,8 @@ mkdir -p "$TMPDIR_TEST/targets/vendored-crate/src"
 printf 'TODO: vendored crate noise\n' > "$TMPDIR_TEST/targets/vendored-crate/src/lib.rs"
 printf 'TODO: test fixture literal\n' > "$TMPDIR_TEST/test-something.sh"
 printf '# TODO: scaffold readme placeholder\n' > "$TMPDIR_TEST/notes.md"
+printf '# TODO: scaffold template placeholder\n' > "$TMPDIR_TEST/new-thing.sh"
+printf '# TODO: leaked colony-lint temp artifact\n' > "$TMPDIR_TEST/tmp.AbC123"
 
 OUT="$(DETECT_TODO_ROOT="$TMPDIR_TEST" "$DETECTOR")"
 RC=$?
@@ -101,6 +103,22 @@ if printf '%s\n' "$OUT" | grep -q 'notes.md'; then
     fail "markdown" "expected no line for *.md, got <$OUT>"
 else
     pass "markdown: skips the TODO inside a .md file"
+fi
+
+# ----- Test 9: TODO inside a new-*.sh scaffolding template is excluded -----
+# new-federation.sh / new-colony.sh carry intentional TODO placeholders in their
+# heredoc templates; filing an issue per template TODO is pure noise.
+if printf '%s\n' "$OUT" | grep -q 'new-thing.sh'; then
+    fail "scaffold" "expected no line for new-*.sh scaffolding, got <$OUT>"
+else
+    pass "scaffold: skips the TODO inside a new-*.sh scaffolding template"
+fi
+
+# ----- Test 10: TODO inside a leaked tmp.* file is excluded (#1300 leak) -----
+if printf '%s\n' "$OUT" | grep -q 'tmp\.'; then
+    fail "tmp-leak" "expected no line for tmp.*, got <$OUT>"
+else
+    pass "tmp-leak: skips the TODO inside a leaked tmp.* file"
 fi
 
 echo ""


### PR DESCRIPTION
The self-observe loop was filing a flood of low-value `[self-observe] todo-marker` issues (e.g. #1311/#1312 tmp leaks, #1318-#1322 scaffolding) from files that contain TODO placeholders **by design**: the `new-federation.sh` / `new-colony.sh` scaffolding templates (TODO placeholders in their heredocs) and leaked colony-lint `tmp.*` artifacts.

Excludes `new-*.sh` + `tmp.*` from the `detect-todo-markers.sh` scan so the detector only reports actionable in-tree TODOs. Tests 9-10 added; detector test 10/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)