### PR TITLE
fix(self-observe): match TODO marker-form + stop filing raw todo-markers

### DIFF
--- a/tools/detect-todo-markers.sh
+++ b/tools/detect-todo-markers.sh
@@ -37,7 +37,7 @@ ROOT="${DETECT_TODO_ROOT:-$REPO_ROOT}"
 # files, -n adds line numbers, -E enables the alternation. Vendored/generated
 # directories are excluded so third-party / build output is not reported.
 cd "$ROOT" || exit 0
-grep -rInE 'TODO|FIXME|XXX' \
+grep -rInE '(TODO|FIXME|XXX)[:(]' \
     --exclude-dir=.git \
     --exclude-dir=node_modules \
     --exclude-dir=.solc-cache \

--- a/tools/self-observe.sh
+++ b/tools/self-observe.sh
@@ -44,6 +44,12 @@ MAX_NEW="${SELF_OBSERVE_MAX_NEW:-5}"
 case "$MAX_NEW" in ''|*[!0-9]*) MAX_NEW=5 ;; esac
 LABELS="${SELF_OBSERVE_LABELS:-dev-apprenticeship}"
 GH="${SELF_OBSERVE_GH:-gh}"
+# Detector kinds that are observed + logged but NOT filed as issues. Raw TODO
+# markers are author notes, not work items — filing a GitHub issue per marker is
+# pure noise (proven repeatedly), so `todo-marker` is log-only by DEFAULT. The
+# higher-signal detectors (doc-drift, agent-failure) still file. Override with a
+# comma-separated SELF_OBSERVE_NOFILE_KINDS (set to "" to file every kind).
+NOFILE_KINDS="${SELF_OBSERVE_NOFILE_KINDS-todo-marker}"
 
 # Short, portable fingerprint of stdin (first 12 hex of sha256).
 fp_of() {
@@ -84,6 +90,10 @@ tab="$(printf '\t')"
 while IFS="$tab" read -r tag kind loc text; do
     [ "$tag" = "DRIFT" ] || continue
     considered=$((considered + 1))
+    # Some detector kinds are log-only (NOFILE_KINDS) — observe + log, never file.
+    case ",$NOFILE_KINDS," in
+        *",$kind,"*) echo "[self-observe] log-only ($kind, not filed): $loc"; continue ;;
+    esac
     fp="$(printf '%s|~|%s|~|%s' "$kind" "$loc" "$(normalize "$text")" | fp_of)"
     if issue_exists "$fp"; then
         echo "[self-observe] skip (open issue exists): $kind $loc [$fp]"

--- a/tools/test-detect-todo-markers.sh
+++ b/tools/test-detect-todo-markers.sh
@@ -44,6 +44,7 @@ printf 'TODO: test fixture literal\n' > "$TMPDIR_TEST/test-something.sh"
 printf '# TODO: scaffold readme placeholder\n' > "$TMPDIR_TEST/notes.md"
 printf '# TODO: scaffold template placeholder\n' > "$TMPDIR_TEST/new-thing.sh"
 printf '# TODO: leaked colony-lint temp artifact\n' > "$TMPDIR_TEST/tmp.AbC123"
+printf 'this file describes the TODO/FIXME/XXX detector, not a marker\n' > "$TMPDIR_TEST/mention.txt"
 
 OUT="$(DETECT_TODO_ROOT="$TMPDIR_TEST" "$DETECTOR")"
 RC=$?
@@ -119,6 +120,15 @@ if printf '%s\n' "$OUT" | grep -q 'tmp\.'; then
     fail "tmp-leak" "expected no line for tmp.*, got <$OUT>"
 else
     pass "tmp-leak: skips the TODO inside a leaked tmp.* file"
+fi
+
+# ----- Test 11: a bare MENTION (word not in marker form) is NOT reported -----
+# The marker convention is `TODO:` / `FIXME:` / `XXX:` / `TODO(...)`. A prose
+# mention like "TODO/FIXME/XXX detector" must not be flagged (self-reference).
+if printf '%s\n' "$OUT" | grep -q 'mention.txt'; then
+    fail "mention" "expected no line for a bare-word mention, got <$OUT>"
+else
+    pass "mention: bare-word TODO/FIXME/XXX mention (no colon/paren) is not reported"
 fi
 
 echo ""

--- a/tools/test-self-observe.sh
+++ b/tools/test-self-observe.sh
@@ -110,6 +110,20 @@ else
     fail "create-failure" "$(printf '%s\n' "$OUT" | tail -3)"
 fi
 
+# ---- Test 6: a log-only kind (todo-marker) is observed but NOT filed ----
+cat > "$WORK/tools/detect-stub.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'DRIFT\ttodo-marker\ttools/x.sh:5\tTODO: do the thing\n'
+STUB
+chmod +x "$WORK/tools/detect-stub.sh"
+write_gh 0; rm -f "$WORK/create.log"
+OUT="$(run_so --file)"
+if printf '%s\n' "$OUT" | grep -q 'log-only (todo-marker' && [ "$(creates)" = "0" ]; then
+    pass "log-only: todo-marker finding is logged, not filed (NOFILE_KINDS default)"
+else
+    fail "log-only" "out=$(printf '%s\n' "$OUT" | tail -3) creates=$(creates)"
+fi
+
 echo
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
The self-observe loop kept filing low-value `[self-observe] todo-marker` issues — including, absurdly, flagging the detector's **own header comment** (`TODO/FIXME/XXX marker detector`). Two root causes:

1. **detect-todo-markers matched bare words** `TODO|FIXME|XXX` anywhere → every *mention* (the detector's description, its grep pattern, doc prose) was a false positive. Now requires **marker form** `(TODO|FIXME|XXX)[:(]` → 187 bare hits → ~52 real markers; self-reference no longer matches.
2. **Even real TODO markers are notes, not work items.** self-observe now treats `todo-marker` as **log-only by default** (`SELF_OBSERVE_NOFILE_KINDS`, set to `""` to file all) — observed + logged, never filed. doc-drift + agent-failure still file (this honours 'keep filing the valuable signals').

Tests: detect-todo-markers **11/0**, self-observe **6/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)