### PR TITLE
feat(code_writer): bounded CI-failure recovery loop (fix-if-red)

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -17,6 +17,25 @@ is asserted until multi-version CI is in place.
 
 ### Added
 
+- **Bounded CI-failure recovery loop (`fix-if-red`).** The federation opened
+  PRs and auto-merged green ones but had no reaction to a RED CI: when
+  `code_writer`'s edit job exhausted its local verify budget it committed
+  anyway ("CI is the backstop"), and the then-red PR sat forever (the merge
+  gate refuses it; the draft path won't re-touch the issue due to its
+  `last_drafted_iid` staleness gate). A new read-only `pr-checks <iid>` verb in
+  the code-review AND implementation `github-api.sh` / `gitlab-api.sh` reports
+  `STATE=<red|green|pending> REF=<head-branch>` (same check-runs / pipeline
+  verdict logic as the `merge` gate, including the pagination fail-safe). Early
+  in its autonomous-tier tick — before the draft path — `code_writer` lists its
+  OWN open PRs (head starts `fix/issue-`), and for the first one whose CI is
+  `red` it re-drives the EXISTING branch via `code-edit-in-checkout.sh
+  --recover` (checks out the existing head branch, forces the verify gate ON,
+  iterates the verify-and-fix loop, then PUSHES the branch only — never opens a
+  second PR). A retry cap of 2 per PR (the `ci_fix:attempts:<iid>` memo, bumped
+  before each launch) gives up + logs "needs human" afterwards; recovery acts
+  only on `STATE=red` (never `pending` — no CI race) and one re-drive per tick
+  ([#1332](https://github.com/Replikanti/agentis-colonies/issues/1332)).
+
 - **Opt-in autonomous PR auto-merge for the code-review colony.** The
   federation reviewed and approved PRs but never merged them. A new `merge`
   verb in `code-review/scripts/github-api.sh` and `gitlab-api.sh` closes the

--- a/dev-apprenticeship/code-review/scripts/github-api.sh
+++ b/dev-apprenticeship/code-review/scripts/github-api.sh
@@ -23,6 +23,9 @@
 #   github-api.sh approve <number>
 #   github-api.sh merge <number>   (gated: refuses unless mergeable=true AND
 #                                   CI all-green; squash + delete-branch; #1317)
+#   github-api.sh pr-checks <number>  (CI verdict for the red-PR recovery loop;
+#                                   prints `STATE=<red|green|pending> REF=<branch>`
+#                                   on stdout; #1332)
 #   github-api.sh get-issue <number>
 #
 # Views (opt-in projection; byte-identical to gitlab-api.sh):
@@ -578,6 +581,68 @@ print("GREEN")
             gh_call DELETE "$API/git/refs/heads/$HEAD_REF" >/dev/null 2>&1 || true
         fi
         printf '%s' "$merge_resp"
+        ;;
+
+    pr-checks)
+        # #1332: CI verdict read for the bounded red-PR recovery loop. Prints
+        # exactly two space-separated tokens on stdout:
+        #   STATE=<red|green|pending> REF=<head-branch>
+        # so the .ag can branch on STATE and re-drive the EXISTING head branch.
+        # This is the SAME check-runs verdict logic as the #1317 merge gate,
+        # but read-only (no merge) and reporting `red`/`pending` instead of a
+        # binary refuse — recovery only acts on `red`, never `pending`.
+        NUM="${1:?Usage: github-api.sh pr-checks <number>}"
+        case "$NUM" in
+            ''|*[!0-9]*) emit_error "pr number must be numeric: $NUM"; exit 2 ;;
+        esac
+
+        # GET the pull to read head.ref (the branch to re-drive) + head.sha
+        # (the commit the check-runs gate queries).
+        pull_json="$(gh_get "$API/pulls/$NUM")" || exit $?
+        PR_META="$(printf '%s' "$pull_json" | python3 -c '
+import sys, json
+d = json.loads(sys.stdin.read())
+print("HEAD_SHA=" + str((d.get("head") or {}).get("sha") or ""))
+print("HEAD_REF=" + str((d.get("head") or {}).get("ref") or ""))
+')" || { emit_error "PR #$NUM: failed to parse pull metadata"; exit 4; }
+        HEAD_SHA="$(printf '%s\n' "$PR_META" | sed -n 's/^HEAD_SHA=//p')"
+        HEAD_REF="$(printf '%s\n' "$PR_META" | sed -n 's/^HEAD_REF=//p')"
+        if [ -z "$HEAD_SHA" ]; then
+            emit_error "PR #$NUM: missing head.sha; cannot read CI"
+            exit 4
+        fi
+
+        # Read the check-runs for the head commit. Pagination fail-safe mirrors
+        # the merge gate: if total_count exceeds what we fetched, a red check
+        # could hide on a later page, so report `pending` (never `green`).
+        # Verdict: any check not `completed` => pending; any completed check
+        # whose conclusion is not success/neutral/skipped => red; all green =>
+        # green; empty check_runs => pending (CI not verified yet).
+        checks_json="$(gh_get_q "$API/commits/$HEAD_SHA/check-runs" --data-urlencode "per_page=100")" || exit $?
+        STATE="$(printf '%s' "$checks_json" | python3 -c '
+import sys, json
+d = json.loads(sys.stdin.read())
+runs = d.get("check_runs") or []
+total = d.get("total_count")
+if total is None:
+    total = len(runs)
+if not runs:
+    print("pending")
+    sys.exit(0)
+if total > len(runs):
+    print("pending")
+    sys.exit(0)
+ok_conclusions = {"success", "neutral", "skipped"}
+state = "green"
+for r in runs:
+    if r.get("status") != "completed":
+        print("pending")
+        sys.exit(0)
+    if r.get("conclusion") not in ok_conclusions:
+        state = "red"
+print(state)
+')" || { emit_error "PR #$NUM: failed to parse check-runs"; exit 4; }
+        printf 'STATE=%s REF=%s\n' "$STATE" "$HEAD_REF"
         ;;
 
     get-issue)

--- a/dev-apprenticeship/code-review/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/code-review/scripts/gitlab-api.sh
@@ -16,6 +16,9 @@
 #   gitlab-api.sh merge <iid>   (gated: refuses unless merge_status ==
 #                                can_be_merged AND head pipeline succeeded;
 #                                squash + remove source branch; #1317)
+#   gitlab-api.sh pr-checks <iid>  (CI verdict for the red-PR recovery loop;
+#                                prints `STATE=<red|green|pending> REF=<branch>`
+#                                on stdout; #1332)
 #   gitlab-api.sh get-issue <iid>
 #
 # Views (opt-in projection; default is full JSON):
@@ -378,6 +381,39 @@ print("OK")
         # Body via python3 json.dumps (repo convention).
         MERGE_BODY="$(python3 -c 'import json; print(json.dumps({"squash": True, "should_remove_source_branch": True}))')"
         gl_put "$API/merge_requests/$IID/merge" "$MERGE_BODY"
+        ;;
+
+    pr-checks)
+        # #1332: CI verdict read for the bounded red-PR recovery loop. Prints
+        # exactly two space-separated tokens on stdout:
+        #   STATE=<red|green|pending> REF=<source-branch>
+        # so the .ag can branch on STATE and re-drive the EXISTING source
+        # branch. Read-only mirror of the #1317 merge gate's pipeline check:
+        # head-pipeline pending/running => pending, failed/canceled => red,
+        # success => green, missing pipeline => pending (CI not verified yet).
+        IID="${1:?Usage: gitlab-api.sh pr-checks <iid>}"
+        case "$IID" in
+            ''|*[!0-9]*) emit_error "iid must be numeric: $IID"; exit 2 ;;
+        esac
+
+        mr_json="$(gl_get "$API/merge_requests/$IID")" || exit $?
+        VERDICT="$(printf '%s' "$mr_json" | python3 -c '
+import sys, json
+d = json.loads(sys.stdin.read())
+ref = d.get("source_branch") or ""
+pipeline = d.get("head_pipeline") or d.get("pipeline") or {}
+pstatus = pipeline.get("status")
+if pstatus in ("pending", "running", "created", "waiting_for_resource", "preparing", "scheduled"):
+    state = "pending"
+elif pstatus in ("failed", "canceled", "cancelled"):
+    state = "red"
+elif pstatus == "success":
+    state = "green"
+else:
+    state = "pending"
+print("STATE=%s REF=%s" % (state, ref))
+')" || { emit_error "MR !$IID: failed to parse pipeline metadata"; exit 4; }
+        printf '%s\n' "$VERDICT"
         ;;
 
     get-issue)

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -282,7 +282,148 @@ fn should_learn_from_mr(owner: string, repo: string, mr_iid: int) -> bool {
     return false;
 }
 
+// #1332: red-PR recovery helpers. The federation opens PRs and (#1317)
+// auto-merges green ones, but had NO reaction to a RED CI: when code_writer's
+// edit job exhausts its local verify budget it commits anyway ("CI is the
+// backstop"), and the then-red PR sits forever (the merge gate refuses it; the
+// draft path won't re-touch the issue due to its last_drafted_iid staleness
+// gate). These helpers add the missing fix-if-red edge. The CI gate IS the
+// local verify gate (colony-lint), so recovery re-drives the edit job on the
+// EXISTING branch with the verify-and-fix loop (which reproduces the failure
+// locally and iterates) — it never needs to fetch CI logs.
+
+// open_pr_field: extract [idx].<field> (a scalar string) from the open-PR
+// list JSON. The raw JSON rides $J (env var, off-argv) so ARG_MAX never bites.
+// Total: missing index / field / malformed JSON all collapse to "".
+fn open_pr_field(raw: string, idx: int, field: string) -> string {
+    let cmd = "J=" + shell_escape(raw) + " I=" + to_string(idx) + " F=" + shell_escape(field) +
+        " python3 -c 'import os,json,sys" +
+        "\ntry:" +
+        "\n    d=json.loads(os.environ[\"J\"])" +
+        "\nexcept Exception:" +
+        "\n    print(\"\"); sys.exit(0)" +
+        "\ni=int(os.environ[\"I\"]); f=os.environ[\"F\"]" +
+        "\nif not isinstance(d,list) or not (0<=i<len(d)):" +
+        "\n    print(\"\"); sys.exit(0)" +
+        "\nv=d[i].get(f) if isinstance(d[i],dict) else None" +
+        "\nprint(v if isinstance(v,str) else (\"\" if v is None else str(v)))'";
+    let out = try { exec sh cmd; } catch e { ""; };
+    return out;
+}
+
+// pr_check_token: pull the value of KEY out of a `STATE=<x> REF=<y>` line (the
+// forge pr-checks verb output). Value rides $L (env var, off-argv). Total: "".
+fn pr_check_token(out: string, key: string) -> string {
+    let cmd = "L=" + shell_escape(out) + " K=" + shell_escape(key) +
+        " python3 -c 'import os,sys" +
+        "\ns=os.environ[\"L\"].strip(); k=os.environ[\"K\"]+\"=\"" +
+        "\nfor tok in s.split():" +
+        "\n    if tok.startswith(k):" +
+        "\n        print(tok[len(k):]); sys.exit(0)" +
+        "\nprint(\"\")'";
+    let res = try { exec sh cmd; } catch e { ""; };
+    return res;
+}
+
+// recover_attempts: how many recovery re-drives we have already launched for
+// this PR (read from the ci_fix:attempts:<iid> memo). Missing => 0.
+fn recover_attempts(owner: string, repo: string, iid_str: string) -> int {
+    let raw = recall_latest(scoped_memo(owner, repo, "ci_fix:attempts:" + iid_str));
+    if len(raw) == 0 { return 0; };
+    return parse_int(raw);
+}
+
+// recover_at: process the open PR at index `idx`. Returns 1 if it LAUNCHED a
+// recovery re-drive (the caller then returns for this tick — one job per tick,
+// do not also draft), 0 otherwise (skip + keep scanning). Own PRs only: the
+// head branch must start `fix/issue-` (the federation's own). Acts only on
+// STATE=red, never pending (don't race CI). Retry cap 2 per PR via the
+// ci_fix:attempts:<iid> memo; after that, give up + log (needs human).
+fn recover_at(owner: string, repo: string, raw: string, idx: int) -> int {
+    let iid_str = open_pr_field(raw, idx, "iid");
+    if len(iid_str) == 0 { return 0; };
+    if iid_str == "void" { return 0; };
+    let src = open_pr_field(raw, idx, "source_branch");
+    // Own PRs only: never touch a PR we did not open.
+    if index_of(src, "fix/issue-") != 0 { return 0; };
+
+    // colony-lint: safe-exec-concat
+    let checks_cmd = "$COLONY_DIR/scripts/forge-api.sh pr-checks " + shell_escape(iid_str) + repo_arg(owner, repo);
+    let checks_out = try { exec sh checks_cmd; } catch e { ""; };
+    let state = pr_check_token(checks_out, "STATE");
+    // Only act on a confirmed red CI; pending => don't race, green => merge gate.
+    if state != "red" { return 0; };
+
+    let attempts = recover_attempts(owner, repo, iid_str);
+    if attempts >= 2 {
+        print("[code_writer] CI-fix gave up on PR", iid_str, "after 2 attempts — needs human");
+        return 0;
+    };
+
+    // Bump the attempt memo BEFORE launching so a crash mid-launch still counts
+    // against the cap (fail-closed: never exceed 2 re-drives).
+    let next_attempt = attempts + 1;
+    memo_write(scoped_memo(owner, repo, "ci_fix:attempts:" + iid_str), to_string(next_attempt));
+
+    let branch_name = "fix/issue-" + iid_str;
+    let recover_title = "fix: recover CI for #" + iid_str;
+    let recover_task = "The CI gate (colony-lint) is failing on this PR. Reproduce the failure locally, fix it with a MINIMAL change, and do not touch unrelated code.";
+    // colony-lint: safe-exec-concat
+    let job_cmd = "$COLONY_DIR/../../tools/code-edit-job.sh --owner " + shell_escape(owner) + " --repo " + shell_escape(repo) + " --issue " + shell_escape(iid_str) + " --branch " + shell_escape(branch_name) + " --title " + shell_escape(recover_title) + " --task " + shell_escape(recover_task) + " --recover";
+    let job_out = try { exec sh job_cmd; } catch e {
+        print("[code_writer] CI-fix launcher failed for PR", iid_str, ":", e);
+        "";
+    };
+    let job_state = job_word(job_out);
+    if job_state == "DONE" {
+        print("[code_writer] CI-fix pushed a fix to red PR", iid_str, "(attempt", next_attempt, "/2)");
+    } else {
+        print("[code_writer] re-driving red PR", iid_str, "(attempt", next_attempt, "/2)");
+    };
+    // One recovery job per tick: signal the caller to return without drafting.
+    // The launcher's pid check gives idempotency so a re-poll won't double-launch.
+    return 1;
+}
+
+// recover_scan: recurse over the open-PR list, launching at most ONE recovery
+// re-drive per tick. Returns 1 once a job is launched (stop scanning), else 0.
+fn recover_scan(owner: string, repo: string, raw: string, idx: int) -> int {
+    let iid_str = open_pr_field(raw, idx, "iid");
+    if len(iid_str) == 0 { return 0; };
+    let did = recover_at(owner, repo, raw, idx);
+    if did == 1 { return 1; };
+    return recover_scan(owner, repo, raw, idx + 1);
+}
+
+// recover_red_prs: list the federation's own open PRs and, at the autonomous
+// tier only, re-drive the FIRST red one whose head is a fix/issue- branch we
+// opened. Returns 1 if it launched a recovery job (the caller returns for this
+// tick — one job per tick, do not also draft).
+fn recover_red_prs(owner: string, repo: string) -> int {
+    // Autonomous-only: re-pushing to PRs is a terminal write.
+    if repo_tier("code_writer", owner, repo) != "autonomous" { return 0; };
+    // Raw (no --view): the normalized GitLab-shape list carries both `iid` and
+    // `source_branch`, the two fields recover_at needs. The implementation
+    // colony's `impl` view drops source_branch, so we read the raw shape here.
+    // colony-lint: safe-exec-concat
+    let list_cmd = "$COLONY_DIR/scripts/forge-api.sh merge-requests --state opened" + repo_arg(owner, repo);
+    let raw = try { exec sh list_cmd; } catch e { ""; };
+    if len(raw) < 5 { return 0; };
+    return recover_scan(owner, repo, raw, 0);
+}
+
 fn tick_for_repo(owner: string, repo: string) -> void {
+    // #1332: red-PR recovery runs FIRST (autonomous tier only), BEFORE the
+    // draft path. If a red PR we own is re-driven this tick, return without
+    // drafting — one code-edit job per tick.
+    if recover_red_prs(owner, repo) == 1 {
+        let now_r = try { exec sh "date -u +%Y-%m-%dT%H:%M:%SZ"; } catch e { ""; };
+        if len(now_r) > 0 {
+            memo_write(scoped_memo(owner, repo, "code_writer:last_check"), now_r);
+        };
+        return;
+    };
+
     // 1. Learn from recently merged MRs
     let cmd = merged_mr_cmd(owner, repo);
     let raw = try {

--- a/dev-apprenticeship/implementation/scripts/github-api.sh
+++ b/dev-apprenticeship/implementation/scripts/github-api.sh
@@ -516,6 +516,61 @@ PY
         printf '%s' "$body" | normalize_mr_commits
         ;;
 
+    pr-checks)
+        # #1332: CI verdict read for the bounded red-PR recovery loop (code_writer
+        # re-drives its OWN red PRs). Prints exactly two space-separated tokens on
+        # stdout: `STATE=<red|green|pending> REF=<head-branch>`. Same check-runs
+        # verdict logic as the code-review colony's #1317 merge gate, but read-only
+        # and reporting red/pending/green instead of a binary refuse — recovery
+        # acts only on `red`, never `pending` (don't race CI). Pagination fail-safe:
+        # if total_count exceeds the fetched page a red check could hide on a later
+        # page, so report `pending` (never `green`).
+        NUM="${1:?Usage: github-api.sh pr-checks <number>}"
+        case "$NUM" in
+            ''|*[!0-9]*) emit_error "pr number must be numeric: $NUM"; exit 2 ;;
+        esac
+
+        pull_json="$(gh_get "$API/pulls/$NUM")" || exit $?
+        PR_META="$(printf '%s' "$pull_json" | python3 -c '
+import sys, json
+d = json.loads(sys.stdin.read())
+print("HEAD_SHA=" + str((d.get("head") or {}).get("sha") or ""))
+print("HEAD_REF=" + str((d.get("head") or {}).get("ref") or ""))
+')" || { emit_error "PR #$NUM: failed to parse pull metadata"; exit 4; }
+        HEAD_SHA="$(printf '%s\n' "$PR_META" | sed -n 's/^HEAD_SHA=//p')"
+        HEAD_REF="$(printf '%s\n' "$PR_META" | sed -n 's/^HEAD_REF=//p')"
+        if [ -z "$HEAD_SHA" ]; then
+            emit_error "PR #$NUM: missing head.sha; cannot read CI"
+            exit 4
+        fi
+
+        checks_json="$(gh_get_q "$API/commits/$HEAD_SHA/check-runs" --data-urlencode "per_page=100")" || exit $?
+        STATE="$(printf '%s' "$checks_json" | python3 -c '
+import sys, json
+d = json.loads(sys.stdin.read())
+runs = d.get("check_runs") or []
+total = d.get("total_count")
+if total is None:
+    total = len(runs)
+if not runs:
+    print("pending")
+    sys.exit(0)
+if total > len(runs):
+    print("pending")
+    sys.exit(0)
+ok_conclusions = {"success", "neutral", "skipped"}
+state = "green"
+for r in runs:
+    if r.get("status") != "completed":
+        print("pending")
+        sys.exit(0)
+    if r.get("conclusion") not in ok_conclusions:
+        state = "red"
+print(state)
+')" || { emit_error "PR #$NUM: failed to parse check-runs"; exit 4; }
+        printf 'STATE=%s REF=%s\n' "$STATE" "$HEAD_REF"
+        ;;
+
     issue)
         IID="${1:?Usage: github-api.sh issue <number>}"
         case "$IID" in

--- a/dev-apprenticeship/implementation/scripts/gitlab-api.sh
+++ b/dev-apprenticeship/implementation/scripts/gitlab-api.sh
@@ -330,6 +330,38 @@ case "$CMD" in
         gl_get "$API/merge_requests/$IID/commits?per_page=100"
         ;;
 
+    pr-checks)
+        # #1332: CI verdict read for the bounded red-PR recovery loop (code_writer
+        # re-drives its OWN red MRs). Prints exactly two space-separated tokens on
+        # stdout: `STATE=<red|green|pending> REF=<source-branch>`. Read-only mirror
+        # of the code-review colony's #1317 merge gate pipeline check: head-pipeline
+        # pending/running => pending, failed/canceled => red, success => green,
+        # missing pipeline => pending (CI not verified yet). Recovery acts only on
+        # `red`, never `pending` (don't race CI).
+        IID="${1:?Usage: gitlab-api.sh pr-checks <iid>}"
+        case "$IID" in
+            ''|*[!0-9]*) emit_error "iid must be numeric: $IID"; exit 2 ;;
+        esac
+        mr_json="$(gl_get "$API/merge_requests/$IID")" || exit $?
+        VERDICT="$(printf '%s' "$mr_json" | python3 -c '
+import sys, json
+d = json.loads(sys.stdin.read())
+ref = d.get("source_branch") or ""
+pipeline = d.get("head_pipeline") or d.get("pipeline") or {}
+pstatus = pipeline.get("status")
+if pstatus in ("pending", "running", "created", "waiting_for_resource", "preparing", "scheduled"):
+    state = "pending"
+elif pstatus in ("failed", "canceled", "cancelled"):
+    state = "red"
+elif pstatus == "success":
+    state = "green"
+else:
+    state = "pending"
+print("STATE=%s REF=%s" % (state, ref))
+')" || { emit_error "MR !$IID: failed to parse pipeline metadata"; exit 4; }
+        printf '%s\n' "$VERDICT"
+        ;;
+
     issue)
         IID="${1:?Usage: gitlab-api.sh issue <iid>}"
         gl_get "$API/$ISSUE_COLLECTION/$IID"

--- a/tools/code-edit-in-checkout.sh
+++ b/tools/code-edit-in-checkout.sh
@@ -14,13 +14,22 @@
 #
 # Usage:
 #   code-edit-in-checkout.sh --owner <o> --repo <r> --issue <iid> \
-#       --branch <name> --title <t> --task <text> [--decompose]
+#       --branch <name> --title <t> --task <text> [--decompose] [--recover]
 #
 #   --decompose first drives claude to split <task> into an ordered list of
 #   sub-edits, then runs the edit+verify loop once per subtask on the same
 #   branch -> one commit/PR (code_writer passes it for epic-labelled issues).
 #   Set FORGE_TYPE=gitlab to run the same clone -> edit -> verify -> commit ->
 #   MR loop against GitLab (GITHUB_* / GITLAB_* env supplies the host + token).
+#
+#   --recover (#1332) re-drives an EXISTING PR's branch whose CI went red.
+#   Instead of cutting a fresh branch off the default branch, it checks OUT the
+#   existing remote head branch (which already carries the prior commit), FORCES
+#   the verify gate ON (an empty CODE_EDIT_VERIFY_CMD cannot skip it — the gate
+#   reproduces the red CI locally and the loop iterates to fix it), and on a new
+#   commit it PUSHES the branch only — the PR already exists, so it NEVER opens a
+#   second PR. Exit 0 if it pushed a fix, 3 (NO_EDITS) if the loop produced
+#   nothing new.
 #
 # The forge token is read from the environment (GITHUB_TOKEN). It is NEVER
 # embedded in a remote URL on disk, never echoed, and never visible under
@@ -64,9 +73,10 @@ BRANCH=""
 TITLE=""
 TASK=""
 DECOMPOSE=0
+RECOVER=0
 
 usage() {
-    echo "usage: code-edit-in-checkout.sh --owner <o> --repo <r> --issue <iid> --branch <name> --title <t> --task <text> [--decompose]" >&2
+    echo "usage: code-edit-in-checkout.sh --owner <o> --repo <r> --issue <iid> --branch <name> --title <t> --task <text> [--decompose] [--recover]" >&2
 }
 
 while [ $# -gt 0 ]; do
@@ -78,6 +88,7 @@ while [ $# -gt 0 ]; do
         --title)  TITLE="${2:-}";  shift 2 ;;
         --task)   TASK="${2:-}";   shift 2 ;;
         --decompose) DECOMPOSE=1; shift ;;
+        --recover) RECOVER=1; shift ;;
         *) echo "code-edit-in-checkout.sh: unknown flag: $1" >&2; usage; exit 2 ;;
     esac
 done
@@ -295,9 +306,21 @@ run_git -C "$WS" reset --hard "origin/$DEFAULT_BRANCH"
 run_git -C "$WS" clean -fd
 
 # ---------------------------------------------------------------------------
-# 2. Branch: deterministic per-issue (reuse, no empty-branch litter).
+# 2. Branch.
+#   normal mode  : deterministic per-issue branch cut off the default branch
+#                  (reuse, no empty-branch litter).
+#   recover mode (#1332): check OUT the EXISTING remote head branch — it
+#                  already carries the prior (now-red-on-CI) commit, so we
+#                  build the fix ON TOP of it rather than off a clean default.
+#                  Reset hard to origin/<branch> so the local tree matches the
+#                  pushed state (idempotent across recovery re-drives).
 # ---------------------------------------------------------------------------
-run_git -C "$WS" checkout -B "$BRANCH" "origin/$DEFAULT_BRANCH"
+if [ "$RECOVER" -eq 1 ]; then
+    run_git -C "$WS" checkout -B "$BRANCH" "origin/$BRANCH"
+    run_git -C "$WS" reset --hard "origin/$BRANCH"
+else
+    run_git -C "$WS" checkout -B "$BRANCH" "origin/$DEFAULT_BRANCH"
+fi
 
 # Reap any process still rooted in THIS job's per-issue workspace (#1249).
 # flat-cyborg's --timeout-ms ends the editing session but does NOT kill claude's
@@ -446,6 +469,18 @@ if [ "$MAX_SUBTASKS" -lt 1 ]; then MAX_SUBTASKS=1; fi
 # when it passes; feed failures back as another iteration (bounded by the same
 # attempts/budget). Empty VERIFY_CMD -> no gate -> M1 behaviour.
 VERIFY_CMD="$(detect_verify_cmd)"
+# Recover mode (#1332): the verify gate MUST run — it is the local reproduction
+# of the red CI we are recovering from. Neutralise the two ways the gate can be
+# skipped: an explicit `CODE_EDIT_VERIFY_CMD=true` force-skip collapses to the
+# built-in light change-scoped gate (empty VERIFY_CMD), and the loop below never
+# treats a settled-but-unverified attempt as done. detect_verify_cmd's
+# auto-detect (npm/make/pytest) is still honoured when present.
+if [ "$RECOVER" -eq 1 ]; then
+    case "$VERIFY_CMD" in
+        true|:) VERIFY_CMD="" ;;
+    esac
+    echo "[code-edit] recover mode: verify gate forced ON" >&2
+fi
 VERIFY_TIMEOUT_MS="${CODE_EDIT_VERIFY_TIMEOUT_MS:-300000}"
 case "$VERIFY_TIMEOUT_MS" in ''|*[!0-9]*) VERIFY_TIMEOUT_MS=300000 ;; esac
 VERIFY_OUT="$(mktemp)"
@@ -619,6 +654,17 @@ fi
 
 run_git -C "$WS" commit -m "$TITLE (#$ISSUE)"
 run_git -C "$WS" push --force-with-lease origin "$BRANCH"
+
+# Recover mode (#1332): the PR already exists, so we ONLY push the fix — we do
+# NOT open a second PR. A new commit landed (the diff check above proved it), so
+# this is a successful recovery push. The same `--force-with-lease` push as the
+# normal path (no destructive force-push). Keep the per-issue workspace so a
+# subsequent recovery re-drive of the same red PR reuses it (fetch+reset).
+if [ "$RECOVER" -eq 1 ]; then
+    echo "[code-edit] recover: pushed fix to existing branch $BRANCH (PR already open — not creating a new PR)" >&2
+    echo "RECOVERED $BRANCH"
+    exit 0
+fi
 
 # ---------------------------------------------------------------------------
 # 5. Open the PR/MR via the colony's forge API wrapper create-mr verb. The

--- a/tools/code-edit-job.sh
+++ b/tools/code-edit-job.sh
@@ -61,9 +61,10 @@ BRANCH=""
 TITLE=""
 TASK=""
 DECOMPOSE=0
+RECOVER=0
 
 usage() {
-    echo "usage: code-edit-job.sh --owner <o> --repo <r> --issue <iid> --branch <name> --title <t> --task <text> [--decompose]" >&2
+    echo "usage: code-edit-job.sh --owner <o> --repo <r> --issue <iid> --branch <name> --title <t> --task <text> [--decompose] [--recover]" >&2
 }
 
 while [ $# -gt 0 ]; do
@@ -75,6 +76,7 @@ while [ $# -gt 0 ]; do
         --title)  TITLE="${2:-}";  shift 2 ;;
         --task)   TASK="${2:-}";   shift 2 ;;
         --decompose) DECOMPOSE=1; shift ;;
+        --recover) RECOVER=1; shift ;;
         *) echo "code-edit-job.sh: unknown flag: $1" >&2; usage; exit 2 ;;
     esac
 done
@@ -199,6 +201,7 @@ export CEJ_JOBDIR="$JOBDIR"
 export CEJ_OWNER="$OWNER" CEJ_REPO="$REPO" CEJ_ISSUE="$ISSUE"
 export CEJ_BRANCH="$BRANCH" CEJ_TITLE="$TITLE" CEJ_TASK="$TASK"
 export CEJ_DECOMPOSE="$DECOMPOSE"
+export CEJ_RECOVER="$RECOVER"
 
 # SC2016: the $CEJ_* refs are deliberately INSIDE single quotes — they must
 # expand in the DETACHED child from its inherited env, NOT in this launcher.
@@ -208,6 +211,7 @@ setsid bash -c '
     set -- --owner "$CEJ_OWNER" --repo "$CEJ_REPO" --issue "$CEJ_ISSUE" \
         --branch "$CEJ_BRANCH" --title "$CEJ_TITLE" --task "$CEJ_TASK"
     [ "$CEJ_DECOMPOSE" = "1" ] && set -- "$@" --decompose
+    [ "$CEJ_RECOVER" = "1" ] && set -- "$@" --recover
     "$CEJ_ORCH" "$@" > "$CEJ_JOBDIR/out" 2> "$CEJ_JOBDIR/log"
     rc=$?
     if [ "$rc" -eq 0 ]; then

--- a/tools/test-code-edit-recover.sh
+++ b/tools/test-code-edit-recover.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# test-code-edit-recover.sh (#1332): exercise the --recover mode of
+# tools/code-edit-in-checkout.sh AND the --recover passthrough +
+# retry-cap-adjacent behaviour of tools/code-edit-job.sh, WITHOUT a real Claude
+# Code session. The claude-edit step is a STUB flat-cyborg on PATH; the "remote"
+# is a local bare git repo reached via a file:// GITHUB_URL.
+#
+# --recover re-drives an EXISTING red PR's branch: it checks OUT the existing
+# remote head branch (which already carries the prior commit), forces the verify
+# gate ON, drives the verify-and-fix loop, and on a new commit PUSHES the branch
+# ONLY — it NEVER opens a second PR (the PR already exists).
+#
+# Asserts (orchestrator, code-edit-in-checkout.sh):
+#   R1. recover checks out the EXISTING branch (the prior commit's file survives
+#       in the pushed tip) — i.e. it did NOT cut a fresh branch off main.
+#   R2. the fix is committed on top + pushed; exit 0; stdout = RECOVERED <branch>
+#   R3. create-mr is NEVER invoked in recover mode (no second PR)
+#   R4. the verify gate RAN (forced ON even with CODE_EDIT_VERIFY_CMD=true)
+#   R5. a no-edit recover run ⇒ exit 3 (NO_EDITS), no new commit pushed
+#
+# Asserts (launcher, code-edit-job.sh):
+#   J1. --recover is forwarded to the orchestrator (stub records its argv)
+#   J2. a normal run does NOT forward --recover
+#
+# Auto-discovered by tools/colony-lint.sh's tools-test loop. Exit 0 if all pass.
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+ORCH="$REPO_ROOT/tools/code-edit-in-checkout.sh"
+LAUNCHER="$REPO_ROOT/tools/code-edit-job.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "[SKIP] test-code-edit-recover.sh: git not on PATH"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (skipped)"
+    exit 0
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[SKIP] test-code-edit-recover.sh: python3 not on PATH"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (skipped)"
+    exit 0
+fi
+if [ ! -f "$ORCH" ] || [ ! -f "$LAUNCHER" ]; then
+    fail "tool missing" "orch=$ORCH launcher=$LAUNCHER"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FAKE_TOKEN="ghp_FAKE_TOKEN_DO_NOT_LEAK_abcdef0123456789"
+OWNER="acme"
+REPO="widget"
+
+export GIT_AUTHOR_NAME="test" GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="test" GIT_COMMITTER_EMAIL="test@example.com"
+
+REMOTE_BASE="$WORK/remote"
+BARE="$REMOTE_BASE/$OWNER/$REPO.git"
+SEED="$WORK/seed"
+
+FED_DIR="$WORK/fed"
+COLONY_DIR="$FED_DIR/implementation"
+
+CREATE_MR_LOG="$WORK/create-mr.log"
+FC_FLAGS_LOG="$WORK/fc-flags.log"
+
+STUB_BIN="$WORK/bin"
+mkdir -p "$STUB_BIN"
+
+# seed_remote: fresh bare remote with main + a `fix/issue-<iid>` branch that
+# already carries a PRIOR commit (the red-on-CI commit recovery builds on top of).
+# $1 = issue iid, $2 = prior-commit filename.
+seed_remote() {
+    local iid="$1" prior="$2"
+    rm -rf "$BARE" "$SEED"
+    mkdir -p "$BARE"
+    git init --quiet --bare --initial-branch=main "$BARE" 2>/dev/null || git init --quiet --bare "$BARE"
+    git init --quiet --initial-branch=main "$SEED" 2>/dev/null || git init --quiet "$SEED"
+    (
+        cd "$SEED" || exit 1
+        git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+        printf 'hello\n' > README.md
+        git add -A
+        git commit --quiet -m "seed: initial commit"
+        git branch -M main 2>/dev/null || true
+        git remote add origin "$BARE"
+        git push --quiet origin main
+        # The existing red PR branch with a prior commit.
+        git checkout --quiet -b "fix/issue-$iid"
+        printf 'prior change\n' > "$prior"
+        git add -A
+        git commit --quiet -m "fix: prior work (#$iid)"
+        git push --quiet origin "fix/issue-$iid"
+    )
+    git --git-dir="$BARE" symbolic-ref HEAD refs/heads/main
+}
+
+# install_create_mr_stub: a github-api.sh stub that RECORDS any create-mr call
+# (so we can assert recover mode never opens a PR) and echoes canned JSON.
+install_create_mr_stub() {
+    mkdir -p "$COLONY_DIR/scripts"
+    cat > "$COLONY_DIR/scripts/github-api.sh" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+{ echo "create-mr called with: \$*"; } >> "$CREATE_MR_LOG"
+printf '%s\n' '{"html_url": "https://example.test/pr/SHOULD-NOT-OPEN"}'
+STUB_EOF
+    chmod +x "$COLONY_DIR/scripts/github-api.sh"
+}
+
+# install_fc_stub: flat-cyborg stub. FC_STUB_MODE=edit writes $FC_FIX_FILE into
+# --cwd (simulate the recovery fix); no-edit touches nothing. Records its flags.
+install_fc_stub() {
+    cat > "$STUB_BIN/flat-cyborg" <<STUB_EOF
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "\$*" >> "$FC_FLAGS_LOG"
+CWD=""
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        --cwd) CWD="\$2"; shift 2 ;;
+        --) shift; break ;;
+        *) shift ;;
+    esac
+done
+if [ "\${FC_STUB_MODE:-edit}" = "edit" ] && [ -n "\$CWD" ]; then
+    printf 'recovery fix\n' > "\$CWD/\${FC_FIX_FILE:-FIX.txt}"
+fi
+exit "\${FC_STUB_RC:-0}"
+STUB_EOF
+    chmod +x "$STUB_BIN/flat-cyborg"
+}
+
+export PATH="$STUB_BIN:$PATH"
+
+# ===========================================================================
+# R1-R4: recover mode builds on the existing branch, pushes the fix, opens NO
+# PR, runs the gate. CODE_EDIT_VERIFY_CMD=true would normally SKIP the gate;
+# recover must force it ON anyway.
+# ===========================================================================
+IID=50
+PRIOR="PRIOR_50.txt"
+FIXFILE="FIX_50.txt"
+rm -f "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+seed_remote "$IID" "$PRIOR"
+install_create_mr_stub
+install_fc_stub
+
+OUTR_FILE="$WORK/outR.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    GITHUB_URL="file://$REMOTE_BASE" \
+    GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    FC_STUB_MODE="edit" FC_FIX_FILE="$FIXFILE" \
+    CODE_EDIT_VERIFY_CMD="true" \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue "$IID" \
+        --branch "fix/issue-$IID" --title "fix: recover CI for #$IID" \
+        --task "Reproduce and fix the CI failure." --recover >"$OUTR_FILE" 2>"$WORK/errR.txt"
+RCR=$?
+OUTR="$(cat "$OUTR_FILE")"
+
+if [ "$RCR" -eq 0 ]; then
+    pass "R2: recover exits 0 after pushing a fix"
+else
+    fail "R2: recover exit 0" "rc=$RCR err=$(tail -5 "$WORK/errR.txt")"
+fi
+case "$OUTR" in
+    "RECOVERED fix/issue-$IID") pass "R2: prints RECOVERED <branch> on stdout (no PR URL)" ;;
+    *) fail "R2: RECOVERED <branch> on stdout" "stdout=[$OUTR]" ;;
+esac
+
+# R1: the pushed branch tip carries BOTH the prior commit's file AND the new fix
+# — proving recover checked out the EXISTING branch, not a fresh one off main.
+if git --git-dir="$BARE" cat-file -e "refs/heads/fix/issue-$IID:$PRIOR" 2>/dev/null \
+   && git --git-dir="$BARE" cat-file -e "refs/heads/fix/issue-$IID:$FIXFILE" 2>/dev/null; then
+    pass "R1: pushed tip has the prior commit's file + the fix (built on the EXISTING branch)"
+else
+    fail "R1: existing branch + fix in pushed commit"
+fi
+
+# R3: create-mr must NEVER fire in recover mode.
+if [ ! -f "$CREATE_MR_LOG" ]; then
+    pass "R3: recover NEVER invoked create-mr (no second PR opened)"
+else
+    fail "R3: create-mr must NOT be invoked in recover mode" "log=$(cat "$CREATE_MR_LOG")"
+fi
+
+# R4: the verify gate ran even though CODE_EDIT_VERIFY_CMD=true would skip it.
+if grep -q "verify gate forced ON" "$WORK/errR.txt" 2>/dev/null; then
+    pass "R4: verify gate forced ON in recover mode (CODE_EDIT_VERIFY_CMD=true did NOT skip it)"
+else
+    fail "R4: gate forced ON" "err=$(tail -8 "$WORK/errR.txt" 2>/dev/null)"
+fi
+
+# Recover does NOT use checkout -B off the default branch — it checks out the
+# existing origin/<branch>. Assert the orchestrator referenced origin/<branch>.
+if grep -q "recover mode" "$WORK/errR.txt" 2>/dev/null; then
+    pass "R1b: recover took the existing-branch checkout path (logged 'recover mode')"
+else
+    fail "R1b: recover-mode log line" "err=$(tail -8 "$WORK/errR.txt" 2>/dev/null)"
+fi
+
+# ===========================================================================
+# R5: a no-edit recover run ⇒ exit 3 (NO_EDITS), no NEW commit pushed (the
+# branch tip stays at the prior commit).
+# ===========================================================================
+IID=51
+PRIOR="PRIOR_51.txt"
+rm -f "$CREATE_MR_LOG" "$FC_FLAGS_LOG"
+seed_remote "$IID" "$PRIOR"
+install_create_mr_stub
+install_fc_stub
+PRIOR_TIP="$(git --git-dir="$BARE" rev-parse "refs/heads/fix/issue-$IID")"
+
+OUTR5_FILE="$WORK/outR5.txt"
+env \
+    PATH="$STUB_BIN:$PATH" \
+    COLONY_DIR="$COLONY_DIR" \
+    GITHUB_URL="file://$REMOTE_BASE" \
+    GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    FC_STUB_MODE="no-edit" \
+    bash "$ORCH" \
+        --owner "$OWNER" --repo "$REPO" --issue "$IID" \
+        --branch "fix/issue-$IID" --title "fix: recover CI for #$IID" \
+        --task "Reproduce and fix the CI failure." --recover >"$OUTR5_FILE" 2>"$WORK/errR5.txt"
+RCR5=$?
+
+if [ "$RCR5" -eq 3 ] && grep -q '^NO_EDITS$' "$OUTR5_FILE"; then
+    pass "R5: no-edit recover ⇒ exit 3 (NO_EDITS)"
+else
+    fail "R5: NO_EDITS exit 3" "rc=$RCR5 stdout=[$(cat "$OUTR5_FILE")]"
+fi
+NEW_TIP="$(git --git-dir="$BARE" rev-parse "refs/heads/fix/issue-$IID")"
+if [ "$NEW_TIP" = "$PRIOR_TIP" ]; then
+    pass "R5: no new commit pushed (branch tip unchanged on a no-edit recover)"
+else
+    fail "R5: branch tip must be unchanged" "prior=$PRIOR_TIP new=$NEW_TIP"
+fi
+if [ ! -f "$CREATE_MR_LOG" ]; then
+    pass "R5: no-edit recover opened no PR"
+else
+    fail "R5: create-mr must NOT fire on no-edit recover" "log=$(cat "$CREATE_MR_LOG")"
+fi
+
+# ===========================================================================
+# J1 / J2: code-edit-job.sh forwards --recover (and a normal run does not). The
+# slow orchestrator is replaced by a stub pointed at via CODE_EDIT_ORCH that
+# records its argv.
+# ===========================================================================
+STUB_ORCH="$WORK/stub-orch.sh"
+cat > "$STUB_ORCH" <<'STUB_EOF'
+#!/usr/bin/env bash
+set -u
+if [ -n "${STUB_MARKER:-}" ]; then echo "args=[$*]" >> "$STUB_MARKER"; fi
+printf '%s\n' "RECOVERED fix/issue-${STUB_IID:-0}"
+exit 0
+STUB_EOF
+chmod +x "$STUB_ORCH"
+
+job_dir_for() { echo "$FED_DIR/.agentis/jobs/implementation/issue-$1"; }
+poll_done() {
+    _jd="$1"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        [ -f "$_jd/status" ] && grep -q "done" "$_jd/status" 2>/dev/null && return 0
+        sleep 1
+    done
+    return 1
+}
+
+REC_MARKER="$WORK/rec-marker"; : > "$REC_MARKER"
+env COLONY_DIR="$COLONY_DIR" CODE_EDIT_ORCH="$STUB_ORCH" GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    STUB_MARKER="$REC_MARKER" STUB_IID=60 \
+    bash "$LAUNCHER" --owner "$OWNER" --repo "$REPO" --issue 60 \
+        --branch "fix/issue-60" --title "fix: recover CI for #60" \
+        --task "Fix CI." --recover >/dev/null 2>&1
+poll_done "$(job_dir_for 60)" || true
+if grep -q -- '--recover' "$REC_MARKER" 2>/dev/null; then
+    pass "J1: code-edit-job.sh forwards --recover to the orchestrator"
+else
+    fail "J1: --recover passthrough" "marker=$(cat "$REC_MARKER" 2>/dev/null)"
+fi
+
+NOREC_MARKER="$WORK/norec-marker"; : > "$NOREC_MARKER"
+env COLONY_DIR="$COLONY_DIR" CODE_EDIT_ORCH="$STUB_ORCH" GITHUB_TOKEN="$FAKE_TOKEN" \
+    GITHUB_OWNER="$OWNER" GITHUB_REPO="$REPO" \
+    STUB_MARKER="$NOREC_MARKER" STUB_IID=61 \
+    bash "$LAUNCHER" --owner "$OWNER" --repo "$REPO" --issue 61 \
+        --branch "fix/issue-61" --title "normal" --task "do it" >/dev/null 2>&1
+poll_done "$(job_dir_for 61)" || true
+if grep -q -- '--recover' "$NOREC_MARKER" 2>/dev/null; then
+    fail "J2: normal run wrongly forwarded --recover" "marker=$(cat "$NOREC_MARKER" 2>/dev/null)"
+else
+    pass "J2: a normal run does NOT forward --recover"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-code-writer-ci-recovery.sh
+++ b/tools/test-code-writer-ci-recovery.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# test-code-writer-ci-recovery.sh (#1332): structural wiring assertions for the
+# bounded CI-failure recovery loop in implementation/code_writer.ag.
+#
+# The .ag has no runtime unit harness (colony-lint's per-agent `agentis commit`
+# parse is its gate), so — exactly like tools/test-code-writer-completion-
+# markers.sh — we assert the recovery-path wiring at the grep level plus a parse
+# check. The SAFETY invariants that MUST hold (this path re-pushes to PRs):
+#
+#   1. Recovery runs at the autonomous tier ONLY (re-pushing is a terminal write)
+#      AND BEFORE the draft path (it returns without drafting on a launch).
+#   2. Own PRs only: head branch must start `fix/issue-` (never touch a PR we
+#      did not open).
+#   3. Acts ONLY on STATE=red (never pending — don't race CI).
+#   4. Retry cap 2 per PR via the ci_fix:attempts:<iid> memo; after that it
+#      gives up + logs (needs human) and does NOT launch a 3rd job.
+#   5. Recover launches code-edit-job.sh with --recover (push-only; no new PR).
+#   6. Every dynamic exec-sh value is shell_escape'd (exec-sh safety is also
+#      enforced federation-wide by check-exec-sh.sh; asserted here for the
+#      recovery-specific commands too).
+#
+# Matches the test style of tools/test-code-writer-completion-markers.sh (bash,
+# [PASS]/[FAIL] lines, `Results: N passed, M failed`). Exit 0 all-pass, 1 any-fail.
+set -u
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+AG="$REPO_ROOT/dev-apprenticeship/implementation/agents/code_writer.ag"
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1${2:+: $2}"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$AG" ]; then
+    echo "[FAIL] code_writer.ag present: missing $AG"
+    echo ""
+    echo "Results: 0 passed, 1 failed"
+    exit 1
+fi
+
+# Body of the recover_at function (where the per-PR safety logic lives).
+RECOVER_AT="$(awk '/^fn recover_at\(/{f=1} f{print} /^}/{if(f) f=0}' "$AG")"
+RECOVER_REDPRS="$(awk '/^fn recover_red_prs\(/{f=1} f{print} /^}/{if(f) f=0}' "$AG")"
+
+# 1a. Autonomous-only gate in recover_red_prs.
+if printf '%s' "$RECOVER_REDPRS" | grep -q 'repo_tier("code_writer", owner, repo) != "autonomous"'; then
+    pass "recovery is gated on the autonomous tier (terminal-write guard)"
+else
+    fail "autonomous-only gate" "recover_red_prs must early-return when tier != autonomous"
+fi
+
+# 1b. recover_red_prs is CALLED at the top of tick_for_repo, BEFORE step 1
+# (learn from merged MRs), and returns without drafting on a launch.
+# The recover call line number must precede the "1. Learn from recently merged" marker.
+rec_line="$(grep -n 'recover_red_prs(owner, repo) == 1' "$AG" | head -n1 | cut -d: -f1)"
+learn_line="$(grep -n '1. Learn from recently merged MRs' "$AG" | head -n1 | cut -d: -f1)"
+draft_line="$(grep -n 'should_draft_code(owner, repo' "$AG" | head -n1 | cut -d: -f1)"
+if [ -n "$rec_line" ] && [ -n "$learn_line" ] && [ "$rec_line" -lt "$learn_line" ]; then
+    pass "recover_red_prs runs at the TOP of tick_for_repo (before learn + draft)"
+else
+    fail "recover runs before draft" "rec_line=$rec_line learn_line=$learn_line draft_line=$draft_line"
+fi
+# It returns for the tick on a launch (one job per tick, do not also draft):
+# a `return;` must appear within the few lines after the recover_red_prs==1
+# guard, before the next blank line / step-1 marker.
+if [ -n "$rec_line" ] && sed -n "${rec_line},$((rec_line + 8))p" "$AG" | grep -q 'return;'; then
+    pass "a recovery launch returns for the tick (does not also draft)"
+else
+    fail "return-without-draft" "the recover_red_prs==1 branch must return;"
+fi
+
+# 2. Own PRs only: head must start fix/issue- (index_of == 0).
+if printf '%s' "$RECOVER_AT" | grep -q 'index_of(src, "fix/issue-") != 0'; then
+    pass "own-PRs-only guard: head branch must start fix/issue- (index_of == 0)"
+else
+    fail "own-PRs-only guard" "recover_at must reject branches not starting fix/issue-"
+fi
+
+# 3. Acts only on STATE=red.
+if printf '%s' "$RECOVER_AT" | grep -q 'if state != "red" { return 0; }'; then
+    pass "acts ONLY on STATE=red (pending/green are skipped — no CI race)"
+else
+    fail "red-only guard" "recover_at must early-return unless state == red"
+fi
+# The state is read from the pr-checks verb.
+if printf '%s' "$RECOVER_AT" | grep -q 'pr-checks ' && printf '%s' "$RECOVER_AT" | grep -q 'pr_check_token(checks_out, "STATE")'; then
+    pass "state comes from the forge pr-checks verb (STATE token)"
+else
+    fail "pr-checks wiring" "recover_at must call forge-api.sh pr-checks and parse STATE"
+fi
+
+# 4a. Retry cap 2: give up after >= 2 attempts with the human-needed log.
+if printf '%s' "$RECOVER_AT" | grep -q 'if attempts >= 2' \
+   && printf '%s' "$RECOVER_AT" | grep -q 'CI-fix gave up on PR' \
+   && printf '%s' "$RECOVER_AT" | grep -q 'needs human'; then
+    pass "retry cap 2: gives up + logs 'needs human' after 2 attempts"
+else
+    fail "retry cap give-up" "recover_at must stop + log at attempts >= 2"
+fi
+# 4b. The give-up branch returns 0 (NO 3rd launch) — the launch (return 1) is
+# only reached when attempts < 2.
+GIVEUP_BLOCK="$(printf '%s' "$RECOVER_AT" | awk '/if attempts >= 2/{f=1} f{print} /};/{if(f){exit}}')"
+if printf '%s' "$GIVEUP_BLOCK" | grep -q 'return 0;'; then
+    pass "the give-up branch returns 0 (no 3rd code-edit-job launched)"
+else
+    fail "give-up returns 0" "after the cap the function must return 0, not launch"
+fi
+# 4c. The attempt memo is BUMPED (+1) before launch (fail-closed: never exceed 2).
+if printf '%s' "$RECOVER_AT" | grep -q 'ci_fix:attempts:' \
+   && printf '%s' "$RECOVER_AT" | grep -q 'let next_attempt = attempts + 1' \
+   && printf '%s' "$RECOVER_AT" | grep -q 'memo_write(scoped_memo(owner, repo, "ci_fix:attempts:" + iid_str), to_string(next_attempt))'; then
+    pass "attempt memo ci_fix:attempts:<iid> bumped (+1) before launch"
+else
+    fail "attempt memo bump" "recover_at must bump ci_fix:attempts:<iid> before launching"
+fi
+
+# 5. Launches code-edit-job.sh with --recover (push-only; no new PR), with the
+# deterministic fix/issue-<iid> branch + the minimal-change recovery task.
+if printf '%s' "$RECOVER_AT" | grep -q 'code-edit-job.sh' \
+   && printf '%s' "$RECOVER_AT" | grep -q -- '--recover'; then
+    pass "launches code-edit-job.sh --recover (re-drive existing branch, push only)"
+else
+    fail "--recover launch" "recover_at must launch code-edit-job.sh with --recover"
+fi
+if printf '%s' "$RECOVER_AT" | grep -q 'let branch_name = "fix/issue-" + iid_str'; then
+    pass "re-drives the deterministic fix/issue-<iid> branch"
+else
+    fail "deterministic branch" "recover_at must target fix/issue-<iid>"
+fi
+if printf '%s' "$RECOVER_AT" | grep -q 'colony-lint) is failing' \
+   && printf '%s' "$RECOVER_AT" | grep -q 'MINIMAL change'; then
+    pass "recovery task instructs a MINIMAL, scoped fix (colony-lint gate)"
+else
+    fail "recovery task text" "the recover task must name colony-lint + a MINIMAL change"
+fi
+# Logs the re-drive with the attempt counter.
+if printf '%s' "$RECOVER_AT" | grep -q 're-driving red PR'; then
+    pass "logs 're-driving red PR <iid> (attempt N/2)'"
+else
+    fail "re-drive log line" "recover_at must log the re-drive with the attempt number"
+fi
+
+# 6. exec-sh safety: every dynamic value in the recovery exec-sh commands is
+# wrapped in shell_escape(). The pr-checks + job commands are the writes here.
+if printf '%s' "$RECOVER_AT" | grep -q 'pr-checks " + shell_escape(iid_str) + repo_arg' \
+   && printf '%s' "$RECOVER_AT" | grep -q 'shell_escape(iid_str)' \
+   && printf '%s' "$RECOVER_AT" | grep -q 'shell_escape(owner)' \
+   && printf '%s' "$RECOVER_AT" | grep -q 'shell_escape(repo)'; then
+    pass "dynamic exec-sh values are shell_escape'd (iid/owner/repo)"
+else
+    fail "exec-sh shell_escape" "recovery exec-sh commands must shell_escape dynamic values"
+fi
+# The two recovery exec-sh lines carry the safe-exec-concat lint pragma.
+if grep -B1 'pr-checks " + shell_escape' "$AG" | grep -q 'colony-lint: safe-exec-concat' \
+   && grep -B1 'code-edit-job.sh --owner " + shell_escape(owner) + " --repo " + shell_escape(repo) + " --issue " + shell_escape(iid_str)' "$AG" | grep -q 'colony-lint: safe-exec-concat'; then
+    pass "recovery exec-sh lines carry the safe-exec-concat lint pragma"
+else
+    fail "safe-exec-concat pragma" "the recovery exec-sh command lines need the lint pragma"
+fi
+
+# Parse check: the agent commits cleanly under `agentis commit` (same as the
+# per-agent syntax pass in colony-lint.sh). Skipped (not failed) when agentis
+# is not installed.
+if command -v agentis >/dev/null 2>&1; then
+    LINT_TMP="$(mktemp -d)"
+    (cd "$LINT_TMP" && agentis init) >/dev/null 2>&1
+    if (cd "$LINT_TMP" && agentis commit "$AG") >/dev/null 2>&1; then
+        pass "code_writer.ag parses (agentis commit) with the recovery path"
+    else
+        fail "code_writer.ag parses (agentis commit)" "syntax error in code_writer.ag"
+    fi
+    rm -rf "$LINT_TMP"
+else
+    echo "[SKIP] agentis not on PATH — skipping .ag parse check"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/test-pr-checks-verb.sh
+++ b/tools/test-pr-checks-verb.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# test-pr-checks-verb.sh (#1332): tests for the `pr-checks` verb in the
+# code-review AND implementation colony forge wrappers (github-api.sh /
+# gitlab-api.sh).
+#
+# pr-checks is the read-only CI verdict the bounded red-PR recovery loop reads
+# to decide whether to re-drive a PR's branch. It prints exactly two
+# space-separated tokens on stdout:
+#     STATE=<red|green|pending> REF=<head-branch>
+# Recovery acts ONLY on STATE=red (never pending — don't race CI). The verdict
+# logic mirrors the #1317 merge gate's check-runs parsing, including the
+# pagination fail-safe (total_count > fetched ⇒ pending, never green).
+#
+# This test stubs the forge API via a curl shim that serves canned JSON keyed
+# on the request URL (same harness shape as test-merge-verb.sh).
+#
+# Cases (GitHub + implementation github-api.sh):
+#   red      : a failing/cancelled check ⇒ STATE=red
+#   pending  : an in_progress check, and (separately) an empty check_runs list
+#   green    : all checks success/skipped ⇒ STATE=green
+#   pagination: total_count > fetched ⇒ STATE=pending (never green)
+#   REF      : head.ref echoed correctly
+# Cases (GitLab):
+#   pipeline failed ⇒ red; running ⇒ pending; success ⇒ green; source_branch ⇒ REF
+#
+# Exit 0 all-pass, 1 any-fail.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[SKIP] test-pr-checks-verb.sh: python3 not on PATH"
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (skipped)"
+    exit 0
+fi
+
+TMPDIR_SHIM="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_SHIM"' EXIT
+
+# ---------------------------------------------------------------------------
+# GitHub curl shim: serves canned JSON per URL. The pull / check-runs payloads
+# for the current scenario live in $SHIM_FIXTURES.
+# ---------------------------------------------------------------------------
+cat > "$TMPDIR_SHIM/curl-github" <<'CURL_SHIM'
+#!/usr/bin/env bash
+URL=""
+OUT=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -X) shift 2 ;;
+        -d|--data) shift 2 ;;
+        -H) shift 2 ;;
+        -G) shift ;;
+        --data-urlencode) shift 2 ;;
+        -sS|-S|-s|-f) shift ;;
+        -w|--max-time) shift 2 ;;
+        -o) OUT="$2"; shift 2 ;;
+        *) URL="$1"; shift ;;
+    esac
+done
+body=""
+code="200"
+case "$URL" in
+    */commits/*/check-runs)
+        body="$(cat "$SHIM_FIXTURES/checks.json")"
+        ;;
+    */pulls/*)
+        body="$(cat "$SHIM_FIXTURES/pull.json")"
+        ;;
+    *)
+        body='{}'
+        ;;
+esac
+if [ -n "$OUT" ]; then
+    printf '%s' "$body" > "$OUT"
+fi
+printf '%s' "$code"
+CURL_SHIM
+chmod +x "$TMPDIR_SHIM/curl-github"
+
+# ---------------------------------------------------------------------------
+# GitLab curl shim: serves the MR JSON for the current scenario.
+# ---------------------------------------------------------------------------
+cat > "$TMPDIR_SHIM/curl-gitlab" <<'CURL_SHIM'
+#!/usr/bin/env bash
+URL=""
+OUT=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -X) shift 2 ;;
+        -d|--data) shift 2 ;;
+        -H) shift 2 ;;
+        -G) shift ;;
+        --data-urlencode) shift 2 ;;
+        -sS|-S|-s|-f) shift ;;
+        -w|--max-time) shift 2 ;;
+        -o) OUT="$2"; shift 2 ;;
+        *) URL="$1"; shift ;;
+    esac
+done
+body=""
+code="200"
+case "$URL" in
+    */merge_requests/*)
+        body="$(cat "$SHIM_FIXTURES/mr.json")"
+        ;;
+    *)
+        body='{}'
+        ;;
+esac
+if [ -n "$OUT" ]; then
+    printf '%s' "$body" > "$OUT"
+fi
+printf '%s' "$code"
+CURL_SHIM
+chmod +x "$TMPDIR_SHIM/curl-gitlab"
+
+# Install both shims under the name `curl`; the active one is symlinked per call.
+make_curl() {
+    # $1 = github|gitlab
+    rm -f "$TMPDIR_SHIM/curl"
+    ln -s "$TMPDIR_SHIM/curl-$1" "$TMPDIR_SHIM/curl"
+}
+
+# Each GitHub fixture dir carries pull.json + checks.json.
+mk_gh_fixture() {
+    # $1 = dir, $2 = pull.json, $3 = checks.json
+    mkdir -p "$1"
+    printf '%s' "$2" > "$1/pull.json"
+    printf '%s' "$3" > "$1/checks.json"
+}
+mk_gl_fixture() {
+    # $1 = dir, $2 = mr.json
+    mkdir -p "$1"
+    printf '%s' "$2" > "$1/mr.json"
+}
+
+run_github() {
+    # $1 = script path, $2 = fixtures dir
+    make_curl github
+    SHIM_FIXTURES="$2" PATH="$TMPDIR_SHIM:$PATH" \
+        GITHUB_URL=https://api.github.test GITHUB_TOKEN=tok \
+        GITHUB_OWNER=acme GITHUB_REPO=widget \
+        "$1" pr-checks 7 2>/dev/null
+}
+run_gitlab() {
+    make_curl gitlab
+    SHIM_FIXTURES="$2" PATH="$TMPDIR_SHIM:$PATH" \
+        GITLAB_URL=https://gitlab.test GITLAB_TOKEN=tok \
+        GITLAB_PROJECT=acme%2Fwidget \
+        "$1" pr-checks 7 2>/dev/null
+}
+
+# ===========================================================================
+# GitHub scenarios, run against BOTH the code-review and implementation
+# colony github-api.sh (the verb must be byte-equivalent in both).
+# ===========================================================================
+GH_PULL='{"head": {"sha": "abc123", "ref": "fix/issue-7"}}'
+GH_GREEN='{"check_runs": [{"name": "ci", "status": "completed", "conclusion": "success"}, {"name": "lint", "status": "completed", "conclusion": "skipped"}]}'
+GH_RED='{"check_runs": [{"name": "ci", "status": "completed", "conclusion": "failure"}]}'
+GH_PENDING='{"check_runs": [{"name": "ci", "status": "completed", "conclusion": "success"}, {"name": "e2e", "status": "in_progress", "conclusion": null}]}'
+GH_EMPTY='{"check_runs": []}'
+GH_PAGINATED='{"total_count": 31, "check_runs": [{"name": "ci", "status": "completed", "conclusion": "success"}, {"name": "lint", "status": "completed", "conclusion": "success"}]}'
+
+for SCRIPT in \
+    "$REPO_ROOT/dev-apprenticeship/code-review/scripts/github-api.sh" \
+    "$REPO_ROOT/dev-apprenticeship/implementation/scripts/github-api.sh"; do
+
+    label="$(basename "$(dirname "$(dirname "$SCRIPT")")")"
+    if [ ! -x "$SCRIPT" ]; then
+        fail "github-api.sh ($label)" "not found/executable: $SCRIPT"
+        continue
+    fi
+
+    # red
+    D="$TMPDIR_SHIM/$label-red"; mk_gh_fixture "$D" "$GH_PULL" "$GH_RED"
+    out="$(run_github "$SCRIPT" "$D")"
+    if [ "$out" = "STATE=red REF=fix/issue-7" ]; then
+        pass "github/$label: failing check ⇒ STATE=red (REF echoed)"
+    else
+        fail "github/$label: red" "got [$out]"
+    fi
+
+    # pending (in_progress)
+    D="$TMPDIR_SHIM/$label-pending"; mk_gh_fixture "$D" "$GH_PULL" "$GH_PENDING"
+    out="$(run_github "$SCRIPT" "$D")"
+    if [ "$out" = "STATE=pending REF=fix/issue-7" ]; then
+        pass "github/$label: in_progress check ⇒ STATE=pending"
+    else
+        fail "github/$label: pending (in_progress)" "got [$out]"
+    fi
+
+    # pending (empty check_runs)
+    D="$TMPDIR_SHIM/$label-empty"; mk_gh_fixture "$D" "$GH_PULL" "$GH_EMPTY"
+    out="$(run_github "$SCRIPT" "$D")"
+    if [ "$out" = "STATE=pending REF=fix/issue-7" ]; then
+        pass "github/$label: empty check_runs ⇒ STATE=pending (CI not verified)"
+    else
+        fail "github/$label: pending (empty)" "got [$out]"
+    fi
+
+    # green
+    D="$TMPDIR_SHIM/$label-green"; mk_gh_fixture "$D" "$GH_PULL" "$GH_GREEN"
+    out="$(run_github "$SCRIPT" "$D")"
+    if [ "$out" = "STATE=green REF=fix/issue-7" ]; then
+        pass "github/$label: all success/skipped ⇒ STATE=green"
+    else
+        fail "github/$label: green" "got [$out]"
+    fi
+
+    # pagination (total_count > fetched, all green) ⇒ pending (never green)
+    D="$TMPDIR_SHIM/$label-page"; mk_gh_fixture "$D" "$GH_PULL" "$GH_PAGINATED"
+    out="$(run_github "$SCRIPT" "$D")"
+    if [ "$out" = "STATE=pending REF=fix/issue-7" ]; then
+        pass "github/$label: pagination (total_count 31 > 2 fetched) ⇒ STATE=pending (fail-safe)"
+    else
+        fail "github/$label: pagination fail-safe" "got [$out]"
+    fi
+
+    # non-numeric ⇒ exit 2
+    make_curl github
+    set +e
+    out="$(SHIM_FIXTURES="$D" PATH="$TMPDIR_SHIM:$PATH" \
+        GITHUB_URL=https://api.github.test GITHUB_TOKEN=tok \
+        GITHUB_OWNER=acme GITHUB_REPO=widget \
+        "$SCRIPT" pr-checks abc 2>&1)"
+    rc=$?
+    set -e 2>/dev/null || true
+    if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qi 'numeric'; then
+        pass "github/$label: non-numeric pr number ⇒ exit 2 + clear error"
+    else
+        fail "github/$label: non-numeric" "rc=$rc out=$out"
+    fi
+done
+
+# ===========================================================================
+# GitLab scenarios (code-review + implementation gitlab-api.sh).
+# ===========================================================================
+GL_FAILED='{"source_branch": "fix/issue-7", "head_pipeline": {"status": "failed"}}'
+GL_RUNNING='{"source_branch": "fix/issue-7", "head_pipeline": {"status": "running"}}'
+GL_SUCCESS='{"source_branch": "fix/issue-7", "head_pipeline": {"status": "success"}}'
+GL_MISSING='{"source_branch": "fix/issue-7"}'
+
+for SCRIPT in \
+    "$REPO_ROOT/dev-apprenticeship/code-review/scripts/gitlab-api.sh" \
+    "$REPO_ROOT/dev-apprenticeship/implementation/scripts/gitlab-api.sh"; do
+
+    label="$(basename "$(dirname "$(dirname "$SCRIPT")")")"
+    if [ ! -x "$SCRIPT" ]; then
+        fail "gitlab-api.sh ($label)" "not found/executable: $SCRIPT"
+        continue
+    fi
+
+    D="$TMPDIR_SHIM/$label-gl-failed"; mk_gl_fixture "$D" "$GL_FAILED"
+    out="$(run_gitlab "$SCRIPT" "$D")"
+    if [ "$out" = "STATE=red REF=fix/issue-7" ]; then
+        pass "gitlab/$label: pipeline failed ⇒ STATE=red (REF echoed)"
+    else
+        fail "gitlab/$label: red" "got [$out]"
+    fi
+
+    D="$TMPDIR_SHIM/$label-gl-running"; mk_gl_fixture "$D" "$GL_RUNNING"
+    out="$(run_gitlab "$SCRIPT" "$D")"
+    if [ "$out" = "STATE=pending REF=fix/issue-7" ]; then
+        pass "gitlab/$label: pipeline running ⇒ STATE=pending"
+    else
+        fail "gitlab/$label: pending (running)" "got [$out]"
+    fi
+
+    D="$TMPDIR_SHIM/$label-gl-success"; mk_gl_fixture "$D" "$GL_SUCCESS"
+    out="$(run_gitlab "$SCRIPT" "$D")"
+    if [ "$out" = "STATE=green REF=fix/issue-7" ]; then
+        pass "gitlab/$label: pipeline success ⇒ STATE=green"
+    else
+        fail "gitlab/$label: green" "got [$out]"
+    fi
+
+    D="$TMPDIR_SHIM/$label-gl-missing"; mk_gl_fixture "$D" "$GL_MISSING"
+    out="$(run_gitlab "$SCRIPT" "$D")"
+    if [ "$out" = "STATE=pending REF=fix/issue-7" ]; then
+        pass "gitlab/$label: missing pipeline ⇒ STATE=pending (CI not verified)"
+    else
+        fail "gitlab/$label: pending (missing)" "got [$out]"
+    fi
+
+    make_curl gitlab
+    set +e
+    out="$(SHIM_FIXTURES="$D" PATH="$TMPDIR_SHIM:$PATH" \
+        GITLAB_URL=https://gitlab.test GITLAB_TOKEN=tok GITLAB_PROJECT=acme%2Fwidget \
+        "$SCRIPT" pr-checks abc 2>&1)"
+    rc=$?
+    set -e 2>/dev/null || true
+    if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qi 'numeric'; then
+        pass "gitlab/$label: non-numeric iid ⇒ exit 2 + clear error"
+    else
+        fail "gitlab/$label: non-numeric" "rc=$rc out=$out"
+    fi
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1332. Adds the missing `fix-if-red` SDLC edge — the federation now detects its OWN red PRs and re-drives a fix, bounded.

## Pieces
- **`pr-checks <iid>`** verb (both colonies, github+gitlab): `STATE=red|green|pending REF=<branch>`, reusing the #1317 check-runs gate (pagination ⇒ pending, never green on a partial page).
- **`code-edit-in-checkout.sh --recover`**: checks out the EXISTING PR branch, forces the verify gate ON, re-drives the verify-fix loop, pushes `--force-with-lease`, exits before create-mr (**never a 2nd PR**).
- **`code_writer.ag`**: before drafting, scans its OWN open `fix/issue-*` PRs, re-drives the first **red** one under a **retry cap of 2** (`ci_fix:attempts:<iid>` memo bumped before launch = fail-closed), then gives up ("needs human").

## Safety (adversarial QA ✅ ship-it, [#1332 comment](https://github.com/Replikanti/agentis-colonies/issues/1332#issuecomment-4785290953))
No path to an unbounded re-push loop (hard cap 2, monotonic never-reset memo, proven: tick 1-2 launch, tick 3+ permanent give-up). No non-own-PR write (`fix/issue-` prefix only). `--force-with-lease` on a throwaway workspace. colony-lint 0 failed; pr-checks 22/0, recover 11/0, ci-recovery 16/0; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)