### PR TITLE
fix(code_writer): CI-recovery must re-drive the PR's real head branch

### DIFF
--- a/dev-apprenticeship/CHANGELOG.md
+++ b/dev-apprenticeship/CHANGELOG.md
@@ -15,6 +15,17 @@ is asserted until multi-version CI is in place.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI-failure recovery re-drove the wrong branch.** `code_writer`'s recovery
+  path built the branch from the PR number (`fix/issue-<PR-iid>`) instead of the
+  PR's actual head branch. A PR for issue N has its own number M != N, so the
+  re-drive always targeted a non-existent branch and could never apply a fix
+  (the bounded retry then gave up). Now it passes the PR's real `source_branch`
+  (already validated to start `fix/issue-`). Caught by the #1330 live dogfood
+  test, which the source-grep unit tests (coincidental matching fixtures)
+  missed; the regression test now asserts `--branch src`.
+
 ### Added
 
 - **Bounded CI-failure recovery loop (`fix-if-red`).** The federation opened

--- a/dev-apprenticeship/implementation/agents/code_writer.ag
+++ b/dev-apprenticeship/implementation/agents/code_writer.ag
@@ -365,7 +365,11 @@ fn recover_at(owner: string, repo: string, raw: string, idx: int) -> int {
     let next_attempt = attempts + 1;
     memo_write(scoped_memo(owner, repo, "ci_fix:attempts:" + iid_str), to_string(next_attempt));
 
-    let branch_name = "fix/issue-" + iid_str;
+    // Re-drive the PR's ACTUAL head branch (source_branch), NOT a branch
+    // reconstructed from the PR number: a PR for issue N has its own PR number
+    // M != N, so "fix/issue-" + <PR iid> would target a non-existent branch.
+    // `src` was already validated to start with "fix/issue-" (own-PRs guard).
+    let branch_name = src;
     let recover_title = "fix: recover CI for #" + iid_str;
     let recover_task = "The CI gate (colony-lint) is failing on this PR. Reproduce the failure locally, fix it with a MINIMAL change, and do not touch unrelated code.";
     // colony-lint: safe-exec-concat

--- a/tools/test-code-writer-ci-recovery.sh
+++ b/tools/test-code-writer-ci-recovery.sh
@@ -114,17 +114,21 @@ else
 fi
 
 # 5. Launches code-edit-job.sh with --recover (push-only; no new PR), with the
-# deterministic fix/issue-<iid> branch + the minimal-change recovery task.
+# minimal-change recovery task.
 if printf '%s' "$RECOVER_AT" | grep -q 'code-edit-job.sh' \
    && printf '%s' "$RECOVER_AT" | grep -q -- '--recover'; then
     pass "launches code-edit-job.sh --recover (re-drive existing branch, push only)"
 else
     fail "--recover launch" "recover_at must launch code-edit-job.sh with --recover"
 fi
-if printf '%s' "$RECOVER_AT" | grep -q 'let branch_name = "fix/issue-" + iid_str'; then
-    pass "re-drives the deterministic fix/issue-<iid> branch"
+# Re-drives the PR's ACTUAL head branch (source_branch / src), NOT a branch
+# reconstructed from the PR number: a PR for issue N has its own number M != N,
+# so "fix/issue-" + <PR iid> targets a non-existent branch (the bug #1330 hit).
+if printf '%s' "$RECOVER_AT" | grep -q 'let branch_name = src' \
+   && ! printf '%s' "$RECOVER_AT" | grep -q 'let branch_name = "fix/issue-" + iid_str'; then
+    pass "re-drives the PR's actual head branch (src), not a reconstructed fix/issue-<PR-iid>"
 else
-    fail "deterministic branch" "recover_at must target fix/issue-<iid>"
+    fail "head branch" "recover_at must pass --branch src (the PR's real source_branch), never fix/issue-<PR-iid>"
 fi
 if printf '%s' "$RECOVER_AT" | grep -q 'colony-lint) is failing' \
    && printf '%s' "$RECOVER_AT" | grep -q 'MINIMAL change'; then


### PR DESCRIPTION
Follow-up to #1334. The CI-recovery path built the re-drive branch from the **PR number** (`fix/issue-<PR-iid>`) instead of the PR's actual `source_branch`. Since a PR for issue N has its own number M≠N, the re-drive always targeted a **non-existent branch** → checkout failed → no fix → bounded retry gave up empty.

**Live proof:** #1330 (PR for issue #1316, branch `fix/issue-1316`) — recovery tried `fix/issue-1330` and both attempts no-op'd before giving up.

Fix: pass `src` (the real `source_branch`, already validated to start `fix/issue-`). Regression test now asserts `--branch src`.

**This is the #1330 live dogfood test catching a bug the source-grep unit tests + adversarial QA missed** (their fixtures coincidentally had PR-iid == branch number). colony-lint green; ci-recovery test 16/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)