### PR TITLE
feat(self-observe): trigger-label filed findings + log-only observations

### DIFF
--- a/tools/self-observe.sh
+++ b/tools/self-observe.sh
@@ -43,13 +43,22 @@ REPO="${SELF_OBSERVE_REPO:-Replikanti/agentis-colonies}"
 MAX_NEW="${SELF_OBSERVE_MAX_NEW:-5}"
 case "$MAX_NEW" in ''|*[!0-9]*) MAX_NEW=5 ;; esac
 LABELS="${SELF_OBSERVE_LABELS:-dev-apprenticeship}"
+# Trigger label applied to every FILED issue so the federation's own SDLC picks
+# it up and processes it autonomously — the #1266 self-improving loop closing on
+# itself (find -> file -> implement -> review -> merge). Defaults to the
+# implementation trigger label; set SELF_OBSERVE_TRIGGER_LABEL="" to file an
+# untriggered, operator-triaged issue instead.
+TRIGGER_LABEL="${SELF_OBSERVE_TRIGGER_LABEL-implementation}"
+if [ -n "$TRIGGER_LABEL" ]; then FILE_LABELS="$LABELS,$TRIGGER_LABEL"; else FILE_LABELS="$LABELS"; fi
 GH="${SELF_OBSERVE_GH:-gh}"
-# Detector kinds that are observed + logged but NOT filed as issues. Raw TODO
-# markers are author notes, not work items — filing a GitHub issue per marker is
-# pure noise (proven repeatedly), so `todo-marker` is log-only by DEFAULT. The
-# higher-signal detectors (doc-drift, agent-failure) still file. Override with a
-# comma-separated SELF_OBSERVE_NOFILE_KINDS (set to "" to file every kind).
-NOFILE_KINDS="${SELF_OBSERVE_NOFILE_KINDS-todo-marker}"
+# Detector kinds that are observed + logged but NOT filed as issues. These are
+# OBSERVATIONS, not actionable code tasks, so auto-filing them — and now
+# auto-triggering the SDLC on them — would be noise: raw TODO markers are author
+# notes, and agent-failure findings are cumulative health counts (a monotonic
+# counter that files a fresh issue per increment). The one actionable detector,
+# doc-drift, still files + triggers. Override with a comma-separated
+# SELF_OBSERVE_NOFILE_KINDS (set to "" to file every kind).
+NOFILE_KINDS="${SELF_OBSERVE_NOFILE_KINDS-todo-marker,agent-failure}"
 
 # Short, portable fingerprint of stdin (first 12 hex of sha256).
 fp_of() {
@@ -108,7 +117,7 @@ while IFS="$tab" read -r tag kind loc text; do
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "[self-observe] WOULD FILE: $title  [$fp]"
         filed=$((filed + 1))
-    elif url="$("$GH" issue create --repo "$REPO" --title "$title" --body "$body" --label "$LABELS" 2>/dev/null)" && [ -n "$url" ]; then
+    elif url="$("$GH" issue create --repo "$REPO" --title "$title" --body "$body" --label "$FILE_LABELS" 2>/dev/null)" && [ -n "$url" ]; then
         echo "[self-observe] FILED: $title -> $url  [$fp]"
         filed=$((filed + 1))
     else

--- a/tools/test-self-observe.sh
+++ b/tools/test-self-observe.sh
@@ -46,7 +46,13 @@ write_gh() {
     cat > "$WORK/gh" <<EOF
 #!/usr/bin/env bash
 if [ "\$1" = "issue" ] && [ "\$2" = "list" ]; then echo "$1"; exit 0; fi
-if [ "\$1" = "issue" ] && [ "\$2" = "create" ]; then echo "create" >> "$WORK/create.log"; echo "https://example.test/issues/1"; exit 0; fi
+if [ "\$1" = "issue" ] && [ "\$2" = "create" ]; then
+    L=""
+    while [ \$# -gt 0 ]; do case "\$1" in --label) L="\$2"; shift 2 ;; *) shift ;; esac; done
+    echo "create label=\$L" >> "$WORK/create.log"
+    echo "https://example.test/issues/1"
+    exit 0
+fi
 exit 0
 EOF
     chmod +x "$WORK/gh"
@@ -122,6 +128,30 @@ if printf '%s\n' "$OUT" | grep -q 'log-only (todo-marker' && [ "$(creates)" = "0
     pass "log-only: todo-marker finding is logged, not filed (NOFILE_KINDS default)"
 else
     fail "log-only" "out=$(printf '%s\n' "$OUT" | tail -3) creates=$(creates)"
+fi
+
+# ---- Test 7: a FILED issue carries the implementation trigger label so the
+# federation's SDLC auto-processes it (default SELF_OBSERVE_TRIGGER_LABEL) ----
+write_detector 1; write_gh 0; rm -f "$WORK/create.log"
+OUT="$(run_so --file)"
+if grep -q 'label=.*implementation' "$WORK/create.log" 2>/dev/null; then
+    pass "trigger label: filed issue gets --label including the implementation trigger"
+else
+    fail "trigger label" "create.log=$(cat "$WORK/create.log" 2>/dev/null)"
+fi
+
+# ---- Test 8: agent-failure findings are log-only by default (NOFILE_KINDS) ----
+cat > "$WORK/tools/detect-stub.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'DRIFT\tagent-failure\twatchdog+restarting:14\twatchdog restart count\n'
+STUB
+chmod +x "$WORK/tools/detect-stub.sh"
+write_gh 0; rm -f "$WORK/create.log"
+OUT="$(run_so --file)"
+if printf '%s\n' "$OUT" | grep -q 'log-only (agent-failure' && [ "$(creates)" = "0" ]; then
+    pass "log-only: agent-failure finding is logged, not filed (NOFILE_KINDS default)"
+else
+    fail "agent-failure log-only" "out=$(printf '%s\n' "$OUT" | tail -3) creates=$(creates)"
 fi
 
 echo


### PR DESCRIPTION
Completes the #1266 self-improving loop **on itself**: a self-observe finding is now filed **with the federation's implementation trigger label** (`SELF_OBSERVE_TRIGGER_LABEL`, default `implementation`), so the federation's own SDLC (code_writer → PR → review → auto-merge) picks it up and fixes it autonomously — *find → file → implement → review → merge*, no operator.

Non-actionable **observations** become log-only by default (`agent-failure` joins `todo-marker` in `NOFILE_KINDS`): agent-failure findings are cumulative health counts (a monotonic counter that filed a fresh issue per increment = the count-climb noise), and neither is a code task code_writer could fix. They stay in the log as a signal. So the only auto-filed+triggered kind is the actionable **doc-drift** detector.

Tests: `test-self-observe` **8/0** (trigger-label on file + agent-failure log-only). colony-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)